### PR TITLE
Allow {Dimension,Level,Member} name to have special character int 

### DIFF
--- a/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/OlapDiscoverResource.java
+++ b/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/OlapDiscoverResource.java
@@ -15,6 +15,8 @@
  */
 package org.saiku.web.rest.resources;
 
+import java.net.URLDecoder;
+
 import java.io.Serializable;
 import java.sql.SQLException;
 import java.util.ArrayList;
@@ -24,8 +26,6 @@ import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
-
-import java.net.URLDecoder;
 
 import org.saiku.olap.dto.SaikuConnection;
 import org.saiku.olap.dto.SaikuCube;
@@ -105,8 +105,8 @@ public class OlapDiscoverResource implements Serializable {
     @Path("/{connection}/refresh")
      public List<SaikuConnection> refreshConnection( @PathParam("connection") String connectionName) {
     	try {
-			olapDiscoverService.refreshConnection(URLDecoder.decode(connectionName, "UTF-8"));
-			return olapDiscoverService.getConnection(URLDecoder.decode(connectionName, "UTF-8"));
+			olapDiscoverService.refreshConnection(connectionName);
+			return olapDiscoverService.getConnection(connectionName);
 		} catch (Exception e) {
 			log.error(this.getClass().getName(),e);
 			return new ArrayList<SaikuConnection>();
@@ -125,9 +125,8 @@ public class OlapDiscoverResource implements Serializable {
 		if ("null".equals(schemaName)) {
 			schemaName = "";
 		}
+		SaikuCube cube = new SaikuCube(connectionName, cubeName,cubeName,cubeName, catalogName, schemaName);
 		try {
-		SaikuCube cube = new SaikuCube(URLDecoder.decode(connectionName, "UTF-8"), URLDecoder.decode(cubeName, "UTF-8"), URLDecoder.decode(cubeName, "UTF-8") , URLDecoder.decode(cubeName, "UTF-8"), URLDecoder.decode(catalogName, "UTF-8"), URLDecoder.decode(schemaName, "UTF-8"));
-
 			return olapDiscoverService.getAllDimensions(cube);
 		} catch (Exception e) {
 			log.error(this.getClass().getName(),e);
@@ -148,8 +147,8 @@ public class OlapDiscoverResource implements Serializable {
 		if ("null".equals(schemaName)) {
 			schemaName = "";
 		}
+		SaikuCube cube = new SaikuCube(connectionName, cubeName,cubeName,cubeName, catalogName, schemaName);
 		try {
-		SaikuCube cube = new SaikuCube(URLDecoder.decode(connectionName, "UTF-8"), URLDecoder.decode(cubeName, "UTF-8"), URLDecoder.decode(cubeName, "UTF-8") , URLDecoder.decode(cubeName, "UTF-8"), URLDecoder.decode(catalogName, "UTF-8"), URLDecoder.decode(schemaName, "UTF-8"));
 			return olapDiscoverService.getDimension(cube, URLDecoder.decode(dimensionName, "UTF-8"));
 		} catch (Exception e) {
 			log.error(this.getClass().getName(),e);
@@ -168,9 +167,9 @@ public class OlapDiscoverResource implements Serializable {
 		if ("null".equals(schemaName)) {
 			schemaName = "";
 		}
+		SaikuCube cube = new SaikuCube(connectionName, cubeName,cubeName,cubeName, catalogName, schemaName);
 		try {
-		SaikuCube cube = new SaikuCube(URLDecoder.decode(connectionName, "UTF-8"), URLDecoder.decode(cubeName, "UTF-8"), URLDecoder.decode(cubeName, "UTF-8") , URLDecoder.decode(cubeName, "UTF-8"), URLDecoder.decode(catalogName, "UTF-8"), URLDecoder.decode(schemaName, "UTF-8"));
-			return olapDiscoverService.getAllDimensionHierarchies(cube, URLDecoder.decode(dimensionName));
+			return olapDiscoverService.getAllDimensionHierarchies(cube, URLDecoder.decode(dimensionName, "UTF-8"));
 		} catch (Exception e) {
 			log.error(this.getClass().getName(),e);
 		}
@@ -190,8 +189,8 @@ public class OlapDiscoverResource implements Serializable {
 		if ("null".equals(schemaName)) {
 			schemaName = "";
 		}
+		SaikuCube cube = new SaikuCube(connectionName, cubeName,cubeName,cubeName, catalogName, schemaName);
 		try {
-		SaikuCube cube = new SaikuCube(URLDecoder.decode(connectionName, "UTF-8"), URLDecoder.decode(cubeName, "UTF-8"), URLDecoder.decode(cubeName, "UTF-8") , URLDecoder.decode(cubeName, "UTF-8"), URLDecoder.decode(catalogName, "UTF-8"), URLDecoder.decode(schemaName, "UTF-8"));
 			return olapDiscoverService.getAllHierarchyLevels(cube, URLDecoder.decode(dimensionName, "UTF-8"), URLDecoder.decode(hierarchyName, "UTF-8"));
 		} catch (Exception e) {
 			log.error(this.getClass().getName(),e);
@@ -218,9 +217,11 @@ public class OlapDiscoverResource implements Serializable {
 		if ("null".equals(schemaName)) {
 			schemaName = "";
 		}
+
+		SaikuCube cube = new SaikuCube(connectionName, cubeName,cubeName,cubeName, catalogName, schemaName);
+
 		try {
-		SaikuCube cube = new SaikuCube(URLDecoder.decode(connectionName, "UTF-8"), URLDecoder.decode(cubeName, "UTF-8"), URLDecoder.decode(cubeName, "UTF-8") , URLDecoder.decode(cubeName, "UTF-8"), URLDecoder.decode(catalogName, "UTF-8"), URLDecoder.decode(schemaName, "UTF-8"));
-			return olapDiscoverService.getLevelMembers(cube, URLDecoder.decode(dimensionName), URLDecoder.decode(hierarchyName), URLDecoder.decode(levelName));
+			return olapDiscoverService.getLevelMembers(cube, URLDecoder.decode(dimensionName, "UTF-8"), URLDecoder.decode(hierarchyName, "UTF-8"), URLDecoder.decode(levelName, "UTF-8"));
 		} catch (Exception e) {
 			log.error(this.getClass().getName(),e);
 		}
@@ -244,8 +245,8 @@ public class OlapDiscoverResource implements Serializable {
 		if ("null".equals(schemaName)) {
 			schemaName = "";
 		}
+		SaikuCube cube = new SaikuCube(connectionName, cubeName,cubeName,cubeName, catalogName, schemaName);
 		try {
-		SaikuCube cube = new SaikuCube(URLDecoder.decode(connectionName, "UTF-8"), URLDecoder.decode(cubeName, "UTF-8"), URLDecoder.decode(cubeName, "UTF-8") , URLDecoder.decode(cubeName, "UTF-8"), URLDecoder.decode(catalogName, "UTF-8"), URLDecoder.decode(schemaName, "UTF-8"));
 			return olapDiscoverService.getHierarchyRootMembers(cube, URLDecoder.decode(hierarchyName, "UTF-8"));
 		} catch (Exception e) {
 			log.error(this.getClass().getName(),e);
@@ -264,8 +265,8 @@ public class OlapDiscoverResource implements Serializable {
 		if ("null".equals(schemaName)) {
 			schemaName = "";
 		}
+		SaikuCube cube = new SaikuCube(connectionName, cubeName,cubeName,cubeName, catalogName, schemaName);
 		try {
-		SaikuCube cube = new SaikuCube(URLDecoder.decode(connectionName, "UTF-8"), URLDecoder.decode(cubeName, "UTF-8"), URLDecoder.decode(cubeName, "UTF-8") , URLDecoder.decode(cubeName, "UTF-8"), URLDecoder.decode(catalogName, "UTF-8"), URLDecoder.decode(schemaName, "UTF-8"));
 			return olapDiscoverService.getAllHierarchies(cube);
 		} catch (Exception e) {
 			log.error(this.getClass().getName(),e);
@@ -283,8 +284,8 @@ public class OlapDiscoverResource implements Serializable {
 		if ("null".equals(schemaName)) {
 			schemaName = "";
 		}
+		SaikuCube cube = new SaikuCube(connectionName, cubeName,cubeName,cubeName, catalogName, schemaName);
 		try {
-		SaikuCube cube = new SaikuCube(URLDecoder.decode(connectionName, "UTF-8"), URLDecoder.decode(cubeName, "UTF-8"), URLDecoder.decode(cubeName, "UTF-8") , URLDecoder.decode(cubeName, "UTF-8"), URLDecoder.decode(catalogName, "UTF-8"), URLDecoder.decode(schemaName, "UTF-8"));
 			return olapDiscoverService.getMeasures(cube);
 		} catch (Exception e) {
 			log.error(this.getClass().getName(),e);
@@ -309,8 +310,8 @@ public class OlapDiscoverResource implements Serializable {
 		if ("null".equals(schemaName)) {
 			schemaName = "";
 		}
+		SaikuCube cube = new SaikuCube(connectionName, cubeName,cubeName,cubeName, catalogName, schemaName);
 		try {
-		SaikuCube cube = new SaikuCube(URLDecoder.decode(connectionName, "UTF-8"), URLDecoder.decode(cubeName, "UTF-8"), URLDecoder.decode(cubeName, "UTF-8") , URLDecoder.decode(cubeName, "UTF-8"), URLDecoder.decode(catalogName, "UTF-8"), URLDecoder.decode(schemaName, "UTF-8"));
 			return olapDiscoverService.getMember(cube, URLDecoder.decode(memberName, "UTF-8"));
 		} catch (Exception e) {
 			log.error(this.getClass().getName(),e);
@@ -335,8 +336,8 @@ public class OlapDiscoverResource implements Serializable {
 		if ("null".equals(schemaName)) {
 			schemaName = "";
 		}
+		SaikuCube cube = new SaikuCube(connectionName, cubeName,cubeName,cubeName, catalogName, schemaName);
 		try {
-		SaikuCube cube = new SaikuCube(URLDecoder.decode(connectionName, "UTF-8"), URLDecoder.decode(cubeName, "UTF-8"), URLDecoder.decode(cubeName, "UTF-8") , URLDecoder.decode(cubeName, "UTF-8"), URLDecoder.decode(catalogName, "UTF-8"), URLDecoder.decode(schemaName, "UTF-8"));
 			return olapDiscoverService.getMemberChildren(cube, URLDecoder.decode(memberName, "UTF-8"));
 		} catch (Exception e) {
 			log.error(this.getClass().getName(),e);

--- a/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/QueryResource.java
+++ b/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/QueryResource.java
@@ -15,6 +15,8 @@
  */
 package org.saiku.web.rest.resources;
 
+import java.net.URLDecoder;
+
 import java.io.StringReader;
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -24,8 +26,6 @@ import java.util.Date;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Properties;
-
-import java.net.URLDecoder;
 
 import javax.servlet.ServletException;
 import javax.ws.rs.Consumes;
@@ -729,11 +729,10 @@ public class QueryResource {
 		  if (log.isDebugEnabled()) {
 			  log.debug("TRACK\t"  + "\t/query/" + queryName + "/axis/"+axis+"/dimension/"+URLDecoder.decode(dimension, "UTF-8")+"\tGET");
 		  }
-
 		  return olapQueryService.getAxisDimensionSelections(queryName, axis, URLDecoder.decode(dimension, "UTF-8"));
     } catch (Exception e) {
-      log.error("Cannot decode dimension "+ dimension + " for query (" + queryName + ")", e);
-      return olapQueryService.getAxisDimensionSelections(queryName, axis, dimension);
+      log.error("Cannot decode dimension " + dimension + " for query (" + queryName + ")", e);
+		  return olapQueryService.getAxisDimensionSelections(queryName, axis, dimension);
     }
 	}
 
@@ -757,10 +756,9 @@ public class QueryResource {
 	{
 		try{
 		  if (log.isDebugEnabled()) {
-			  log.debug("TRACK\t"  + "\t/query/" + queryName + "/axis/"+axisName+"/dimension/"+URLDecoder.decode(dimensionName)+"\tPOST");
+			  log.debug("TRACK\t"  + "\t/query/" + queryName + "/axis/"+axisName+"/dimension/"+URLDecoder.decode(dimensionName, "UTF-8")+"\tPOST");
 		  }
-
-			olapQueryService.moveDimension(queryName, axisName, URLDecoder.decode(dimensionName), position);
+			olapQueryService.moveDimension(queryName, axisName, URLDecoder.decode(dimensionName, "UTF-8"), position);
 			return Status.OK;
 		} catch(Exception e) {
 			log.error("Cannot move dimension "+ dimensionName+ " for query (" + queryName + ")",e);
@@ -781,10 +779,9 @@ public class QueryResource {
 	{
 		try{
 		  if (log.isDebugEnabled()) {
-			  log.debug("TRACK\t"  + "\t/query/" + queryName + "/axis/"+axisName+"/dimension/"+URLDecoder.decode(dimensionName)+"\tDELETE");
+			  log.debug("TRACK\t"  + "\t/query/" + queryName + "/axis/"+axisName+"/dimension/"+URLDecoder.decode(dimensionName, "UTF-8")+"\tDELETE");
 		  }
-
-			olapQueryService.removeDimension(queryName, axisName, URLDecoder.decode(dimensionName));
+			olapQueryService.removeDimension(queryName, axisName, URLDecoder.decode(dimensionName, "UTF-8"));
 			return Status.OK;
 		}catch(Exception e){
 			log.error("Cannot remove dimension "+ dimensionName+ " for query (" + queryName + ")",e);
@@ -802,12 +799,12 @@ public class QueryResource {
 			@FormParam("selections") String selectionJSON) {
 		try{
 		  if (log.isDebugEnabled()) {
-			  log.debug("TRACK\t"  + "\t/query/" + queryName + "/axis/"+axisName+"/dimension/"+URLDecoder.decode(dimensionName, "UTF-8")+"\tPUT\t" + selectionJSON);
+			  log.debug("TRACK\t"  + "\t/query/" + queryName + "/axis/"+axisName+"/dimension/"+URLDecoder.decode(dimensionName,"UTF-8")+"\tPUT\t" + URLDecoder.decode(selectionJSON, "UTF-8"));
 		  }
 
 			if (selectionJSON != null) {
 				ObjectMapper mapper = new ObjectMapper();
-				List<SelectionRestObject> selections = mapper.readValue(selectionJSON, TypeFactory.collectionType(ArrayList.class, SelectionRestObject.class));
+				List<SelectionRestObject> selections = mapper.readValue(URLDecoder.decode(selectionJSON, "UTF-8"), TypeFactory.collectionType(ArrayList.class, SelectionRestObject.class));
 
 
 
@@ -862,7 +859,6 @@ public class QueryResource {
 		  if (log.isDebugEnabled()) {
 			  log.debug("TRACK\t"  + "\t/query/" + queryName + "/axis/"+axisName+"/dimension/"+URLDecoder.decode(dimensionName, "UTF-8")+"\tPUT");
 		  }
-
 			if (formParams.containsKey("selections")) {
 				LinkedList<String> sels = (LinkedList<String>) formParams.get("selections");
 				String selectionJSON = (String) sels.getFirst();
@@ -899,7 +895,6 @@ public class QueryResource {
 		  if (log.isDebugEnabled()) {
 			  log.debug("TRACK\t"  + "\t/query/" + queryName + "/axis/"+axisName+"/dimension/"+URLDecoder.decode(dimensionName, "UTF-8")+"/member/"+URLDecoder.decode(uniqueMemberName, "UTF-8")+"\tPOST");
 		  }
-
 			olapQueryService.moveDimension(queryName, axisName, URLDecoder.decode(dimensionName, "UTF-8"), position);
 
 			boolean ret = olapQueryService.includeMember(queryName, URLDecoder.decode(dimensionName, "UTF-8"), URLDecoder.decode(uniqueMemberName, "UTF-8"), selectionType, memberposition);
@@ -907,11 +902,11 @@ public class QueryResource {
 				return Status.CREATED;
 			}
 			else{
-				log.error("Cannot include member "+ URLDecoder.decode(dimensionName, "UTF-8")+ " for query (" + queryName + ")");
+				log.error("Cannot include member "+ dimensionName+ " for query (" + queryName + ")");
 				return Status.INTERNAL_SERVER_ERROR;
 			}
 		} catch (Exception e){
-			log.error("Cannot include member "+ dimensionName + " for query (" + queryName + ")",e);
+			log.error("Cannot include member "+ dimensionName+ " for query (" + queryName + ")",e);
 			return Status.INTERNAL_SERVER_ERROR;
 		}
 	}
@@ -925,25 +920,25 @@ public class QueryResource {
 			@PathParam("dimension") String dimensionName, 
 			@PathParam("member") String uniqueMemberName)
 	{
+
 		try{
 		  if (log.isDebugEnabled()) {
 			  log.debug("TRACK\t"  + "\t/query/" + queryName + "/axis/"+axisName+"/dimension/"+URLDecoder.decode(dimensionName, "UTF-8")+"/member/"+URLDecoder.decode(uniqueMemberName, "UTF-8")+"\tDELETE");
 		  }
-
 			boolean ret = olapQueryService.removeMember(queryName, URLDecoder.decode(dimensionName, "UTF-8"), URLDecoder.decode(uniqueMemberName, "UTF-8"), selectionType);
 			if(ret == true){
 				SaikuDimensionSelection dimsels = olapQueryService.getAxisDimensionSelections(queryName, axisName, URLDecoder.decode(dimensionName, "UTF-8"));
 				if (dimsels != null && dimsels.getSelections().size() == 0) {
-					olapQueryService.moveDimension(queryName, "UNUSED", URLDecoder.decode(dimensionName, "UTF-8"), -1);
+					olapQueryService.moveDimension(queryName, "UNUSED", dimensionName, -1);
 				}
 				return Status.OK;
 			}
 			else{
-				log.error("Cannot remove member "+ URLDecoder.decode(dimensionName, "UTF-8")+ " for query (" + queryName + ")");
+				log.error("Cannot remove member "+ dimensionName+ " for query (" + queryName + ")");
 				return Status.INTERNAL_SERVER_ERROR;
 			}
 		} catch (Exception e){
-			log.error("Cannot remove member "+ dimensionName + " for query (" + queryName + ")",e);
+			log.error("Cannot remove member "+ dimensionName+ " for query (" + queryName + ")",e);
 			return Status.INTERNAL_SERVER_ERROR;
 		}
 	}
@@ -964,14 +959,13 @@ public class QueryResource {
 		  if (log.isDebugEnabled()) {
 			  log.debug("TRACK\t"  + "\t/query/" + queryName + "/axis/"+axisName+"/dimension/"+URLDecoder.decode(dimensionName, "UTF-8")+"/hierarchy/"+URLDecoder.decode(uniqueHierarchyName, "UTF-8")+"/"+URLDecoder.decode(uniqueLevelName, "UTF-8")+"\tPOST");
 		  }
-
 			olapQueryService.moveDimension(queryName, axisName, URLDecoder.decode(dimensionName, "UTF-8"), position);
 			boolean ret = olapQueryService.includeLevel(queryName, URLDecoder.decode(dimensionName, "UTF-8"), URLDecoder.decode(uniqueHierarchyName, "UTF-8"), URLDecoder.decode(uniqueLevelName, "UTF-8"));
 			if(ret == true){
 				return Status.CREATED;
 			}
 			else{
-				log.error("Cannot include level of hierarchy "+ URLDecoder.decode(uniqueHierarchyName, "UTF-8")+ " for query (" + queryName + ")");
+				log.error("Cannot include level of hierarchy "+ uniqueHierarchyName+ " for query (" + queryName + ")");
 				return Status.INTERNAL_SERVER_ERROR;
 			}
 		} catch (Exception e){
@@ -993,7 +987,6 @@ public class QueryResource {
 		  if (log.isDebugEnabled()) {
 			  log.debug("TRACK\t"  + "\t/query/" + queryName + "/axis/"+axisName+"/dimension/"+URLDecoder.decode(dimensionName, "UTF-8")+"/hierarchy/"+URLDecoder.decode(uniqueHierarchyName, "UTF-8")+"/"+URLDecoder.decode(uniqueLevelName, "UTF-8")+"\tDELETE");
 		  }
-
 			boolean ret = olapQueryService.removeLevel(queryName, URLDecoder.decode(dimensionName, "UTF-8"), URLDecoder.decode(uniqueHierarchyName, "UTF-8"), URLDecoder.decode(uniqueLevelName, "UTF-8"));
 			
 			if(ret == true){


### PR DESCRIPTION
With this patch, and it's corresponding patch in saiku-ui, the Dimensions, Levels and Members can have special character in their name.

Before a level couldn't be name black/white, the level name not beeing encoded the '/' in the level name would have break everything. It doesn't happen anymore. So far I only tested it with '?' and '/'
