### PR TITLE
ACL: changed root for file resolving in setResourceAcl...

### DIFF
--- a/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/objects/acl/Acl.java
+++ b/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/objects/acl/Acl.java
@@ -347,4 +347,8 @@ public class Acl {
 		return accessFile;
 	}
 
+	public FileObject resolveFile(String file) throws FileSystemException {
+		return repoRoot.resolveFile(file);
+	}
+
 }

--- a/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/BasicRepositoryResource2.java
+++ b/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/BasicRepositoryResource2.java
@@ -197,7 +197,7 @@ public class BasicRepositoryResource2 implements ISaikuRepository {
 			AclEntry ae = mapper.readValue(aclEntry, AclEntry.class);
 			String username = sessionService.getAllSessionObjects().get("username").toString();
 			List<String> roles = (List<String> ) sessionService.getAllSessionObjects().get("roles");
-			FileObject repoFile = repo.resolveFile(file);
+			FileObject repoFile = acl.resolveFile(file);
 			if (repoFile.exists() && acl.canGrant(file, username, roles) ) {
 				acl.addEntry(file, ae);
 				return Response.ok().build();


### PR DESCRIPTION
now uses aclroot instead of reporoot to have 2 different level one for Acl (highter) and one for Repository(deeper) this is useful to extend the acl security model to other extending features that should be not visible in repository browser.
