### PR TITLE
Refactor to clear cache from pool

### DIFF
--- a/saiku-core/saiku-service/src/main/java/org/saiku/datasources/connection/SaikuOlapConnection.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/datasources/connection/SaikuOlapConnection.java
@@ -92,7 +92,7 @@ public class SaikuOlapConnection implements ISaikuConnection {
 		if (olapConnection.isWrapperFor(RolapConnection.class)) {
 			System.out.println("Clearing cache");
 			RolapConnection rcon = olapConnection.unwrap(RolapConnection.class);
-			rcon.getCacheControl(null).flushSchemaCache();
+			rcon.getCacheControl(null).flushSchema(rcon.getSchema());
 		}
 		return true;
 	}


### PR DESCRIPTION
Change to clear the cache from the pool instead only for current session to ensure the data correctness for every user after ETL.