### PR TITLE
PDF export font configuration

### DIFF
--- a/saiku-core/saiku-service/src/main/java/org/saiku/olap/util/SaikuProperties.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/olap/util/SaikuProperties.java
@@ -237,6 +237,11 @@ public class SaikuProperties extends Properties{
 	public static final String  webExportExcelName = getPropString("saiku.web.export.excel.name","saiku-export");
 	public static final String  webExportExcelFormat = getPropString("saiku.web.export.excel.format","xlsx");
 	public static final String  webExportExcelDefaultNumberFormat = getPropString("saiku.web.export.excel.numberformat","#,##0.00");	
+	public static final String  webExportPdfFontName = getPropString("saiku.web.export.pdf.font.name", "Helvetica");
+	public static final String  webExportPdfFontSize = getPropString("saiku.web.export.pdf.font.size", "8");
+	public static final String  webExportPdfFontEncoding = getPropString("saiku.web.export.pdf.font.encoding", "UTF-8");
+	public static final String  webExportPdfFontStyle = getPropString("saiku.web.export.pdf.font.style", "NORMAL");
+	public static final String  webExportPdfFontColor = getPropString("saiku.web.export.pdf.font.color", "#ffffff");
 	public static final String  formatDefautNumberFormat = getPropString("saiku.format.numberformat","#,##0.00");
 	public static final Locale  locale = getLocale();
 	public static final Boolean olapConvertQuery = getPropBoolean("saiku.olap.convert.query","false");

--- a/saiku-webapp/src/main/webapp/WEB-INF/classes/saiku.properties
+++ b/saiku-webapp/src/main/webapp/WEB-INF/classes/saiku.properties
@@ -23,4 +23,12 @@ saiku.olap.convert.query=false
 #saiku.format.default.locale=en
 #saiku.format.default.locale=lt
 
-
+# set a font for PDF export
+# name can be an iText-recognizable font name (i.e. Helvetica) or
+# an absolute/relative path to TTF, OTF or other font file that
+# iText supports
+saiku.web.export.pdf.font.name = Helvetica
+saiku.web.export.pdf.font.size = 8
+saiku.web.export.pdf.font.encoding = windows-1257
+saiku.web.export.pdf.font.style = NORMAL
+saiku.web.export.pdf.font.color = #000000


### PR DESCRIPTION
PDF export can now be configured to use any font in saiku.properties.
Font will be embedded to the PDF so that any user can open the resulting file even if he/she does not have the font in their system.