### PR TITLE
add the dependency of hadoop-common

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -250,6 +250,11 @@
                 <version>0.13.1</version>
             </dependency>
             <dependency>
+                <groupId>org.apache.hadoop</groupId>
+                <artifactId>hadoop-common</artifactId>
+                <version>2.4.0</version>
+            </dependency>
+            <dependency>
                 <groupId>org.springframework.security</groupId>
                 <artifactId>spring-security-cas</artifactId>
                 <version>${spring.version}</version>


### PR DESCRIPTION
the hadoop-common-2.4.0.jar is necessary for connecting to hive database(version0.12.0 and 0.13.1).
without it,the following error occurs:
Caused by: java.lang.ClassNotFoundException: org.apache.hadoop.conf.Configuration
        at org.apache.catalina.loader.WebappClassLoader.loadClass(WebappClassLoader.java:1484)
        at org.apache.catalina.loader.WebappClassLoader.loadClass(WebappClassLoader.java:1329)