### PR TITLE
add the dependency of hadoop-common

### DIFF
--- a/saiku-webapp/pom.xml
+++ b/saiku-webapp/pom.xml
@@ -275,6 +275,10 @@
             <artifactId>hive-jdbc</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.apache.hadoop</groupId>
+            <artifactId>hadoop-common</artifactId>
+        </dependency>
+        <dependency>
             <groupId>com.fasterxml.jackson.jaxrs</groupId>
             <artifactId>jackson-jaxrs-json-provider</artifactId>
         </dependency>


### PR DESCRIPTION
the hadoop-common dependency is necessary for creating datasource of Hive databases(verison0.12.0,0.13.1)
without it,the following error occurs:
Caused by: java.lang.ClassNotFoundException: org.apache.hadoop.conf.Configuration
        at org.apache.catalina.loader.WebappClassLoader.loadClass(WebappClassLoader.java:1484)
        at org.apache.catalina.loader.WebappClassLoader.loadClass(WebappClassLoader.java:1329)