### PR TITLE
Use full path to api in stead of relatieve path

### DIFF
--- a/saiku-bi-platform-plugin-p5/src/main/plugin/components/saikuWidget/SaikuWidgetComponent.js
+++ b/saiku-bi-platform-plugin-p5/src/main/plugin/components/saikuWidget/SaikuWidgetComponent.js
@@ -32,7 +32,7 @@ var saikuWidgetComponent = BaseComponent.extend({
 			htmlId = t;
 		}
 		var myClient = new SaikuClient({
-		    server: "../../../plugin/saiku/api",
+		    server: "/pentaho/plugin/saiku/api",
 		    path: "/cde-component"
 		});
 


### PR DESCRIPTION
At this moment a relative path is used (../../../), for the cde saikuWidget. But the preview of the dashboard and the 'normal' view are on a different directory level, so one of them needs an extra ../ Fixed by using the full path /pentaho/plugin/saiku/api But this won't work if somebody use a different 'directory' for pentaho. But I guess that is not a big problem...