### PR TITLE
drillthrough functionality is broken after SKU-1556 patch

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <groupId>org.saikuanalytics</groupId>
     <artifactId>saiku</artifactId>
     <packaging>pom</packaging>
-    <version>3.9-SNAPSHOT</version> 
+    <version>3.14-SNAPSHOT</version> 
     <name>Saiku Module Project</name>
     <scm>
         <developerConnection>

--- a/saiku-bi-platform-plugin-p5/pom.xml
+++ b/saiku-bi-platform-plugin-p5/pom.xml
@@ -2,12 +2,12 @@
     <parent>
         <artifactId>saiku</artifactId>
         <groupId>org.saikuanalytics</groupId>
-        <version>3.2-SNAPSHOT</version>
+        <version>3.14-SNAPSHOT</version>
     </parent>
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>saiku-bi-platform-plugin-p5</artifactId>
 	<packaging>jar</packaging>
-	<version>3.2-SNAPSHOT</version>
+	<version>3.14-SNAPSHOT</version>
 	<name>saiku biserver plugin</name>
 
 	<build>

--- a/saiku-bi-platform-plugin-p6/pom.xml
+++ b/saiku-bi-platform-plugin-p6/pom.xml
@@ -2,12 +2,12 @@
     <parent>
         <artifactId>saiku</artifactId>
         <groupId>org.saikuanalytics</groupId>
-        <version>3.2-SNAPSHOT</version> 
+        <version>3.14-SNAPSHOT</version> 
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>saiku-bi-platform-plugin-p6</artifactId>
     <packaging>jar</packaging>
-    <version>3.2-SNAPSHOT</version>
+    <version>3.14-SNAPSHOT</version>
     <name>saiku biserver plugin</name>
 
     <build>

--- a/saiku-bi-platform-plugin-p7/pom.xml
+++ b/saiku-bi-platform-plugin-p7/pom.xml
@@ -2,12 +2,12 @@
     <parent>
         <artifactId>saiku</artifactId>
         <groupId>org.saikuanalytics</groupId>
-        <version>3.2-SNAPSHOT</version> 
+        <version>3.14-SNAPSHOT</version> 
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>saiku-bi-platform-plugin-p7</artifactId>
     <packaging>jar</packaging>
-    <version>3.2-SNAPSHOT</version> 
+    <version>3.14-SNAPSHOT</version> 
     <name>saiku biserver plugin</name>
 
     <build>

--- a/saiku-core/pom.xml
+++ b/saiku-core/pom.xml
@@ -2,14 +2,14 @@
     <parent>
         <artifactId>saiku</artifactId>
         <groupId>org.saikuanalytics</groupId>
-        <version>3.2-SNAPSHOT</version>
+        <version>3.14-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>
     <artifactId>saiku-core</artifactId>
     <packaging>pom</packaging>
     <name>saiku - core libraries</name>
-    <version>3.2-SNAPSHOT</version>
+    <version>3.14-SNAPSHOT</version>
 
     <modules>
         <module>saiku-olap-util</module>

--- a/saiku-core/saiku-olap-util/pom.xml
+++ b/saiku-core/saiku-olap-util/pom.xml
@@ -3,11 +3,11 @@
     <parent>
         <artifactId>saiku-core</artifactId>
         <groupId>org.saikuanalytics</groupId>
-        <version>3.2-SNAPSHOT</version>
+        <version>3.14-SNAPSHOT</version>
     </parent>
 	<artifactId>saiku-olap-util</artifactId>
 	<packaging>jar</packaging>
-	<version>3.2-SNAPSHOT</version>
+	<version>3.14-SNAPSHOT</version>
 	<name>saiku olap util</name>
 	<properties>
 		<maven.compiler.source>1.5</maven.compiler.source>

--- a/saiku-core/saiku-service/pom.xml
+++ b/saiku-core/saiku-service/pom.xml
@@ -2,12 +2,12 @@
     <parent>
         <artifactId>saiku-core</artifactId>
         <groupId>org.saikuanalytics</groupId>
-        <version>3.2-SNAPSHOT</version>
+        <version>3.14-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>jar</packaging>
     <artifactId>saiku-service</artifactId>
-    <version>3.2-SNAPSHOT</version>
+    <version>3.14-SNAPSHOT</version>
     <name>saiku - services</name>
     <build>
         <plugins>

--- a/saiku-core/saiku-web/pom.xml
+++ b/saiku-core/saiku-web/pom.xml
@@ -2,11 +2,11 @@
     <parent>
         <artifactId>saiku-core</artifactId>
         <groupId>org.saikuanalytics</groupId>
-        <version>3.2-SNAPSHOT</version>
+        <version>3.14-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>saiku-web</artifactId>
-    <version>3.2-SNAPSHOT</version>
+    <version>3.14-SNAPSHOT</version>
     <name>saiku - web</name>
     <packaging>jar</packaging>
 

--- a/saiku-server/pom.xml
+++ b/saiku-server/pom.xml
@@ -2,13 +2,13 @@
         <parent>
                 <artifactId>saiku</artifactId>
                 <groupId>org.saikuanalytics</groupId>
-                <version>3.2-SNAPSHOT</version>
+                <version>3.14-SNAPSHOT</version>
         </parent>
 	
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>saiku-server</artifactId>
 	<packaging>pom</packaging>
-    <version>3.2-SNAPSHOT</version>
+    <version>3.14-SNAPSHOT</version>
 	<properties>
 		<min>nomin</min>
 	</properties>

--- a/saiku-ui/js/saiku/views/SplashScreen.js
+++ b/saiku-ui/js/saiku/views/SplashScreen.js
@@ -209,7 +209,7 @@ var SplashScreen = Backbone.View.extend({
     },
 	getNews: function(){
 		var that = this;
-		$.ajax({
+		/*$.ajax({
 			type: 'GET',
 			url: "http://meteorite.bi/news.json",
 			async: false,
@@ -226,7 +226,7 @@ var SplashScreen = Backbone.View.extend({
 			error: function(e) {
 				console.log(e.message);
 			}
-		});
+		});*/
 	},
     getContent: function(){
         var that =this;

--- a/saiku-ui/pom.xml
+++ b/saiku-ui/pom.xml
@@ -3,11 +3,11 @@
 <parent>
 		<artifactId>saiku</artifactId>
 		<groupId>org.saikuanalytics</groupId>
-	<version>3.2-SNAPSHOT</version>
+	<version>3.14-SNAPSHOT</version>
 	</parent>
 	<artifactId>saiku-ui</artifactId>
 	<packaging>pom</packaging>
-	<version>3.2-SNAPSHOT</version>
+	<version>3.14-SNAPSHOT</version>
         <properties>
 	<checkstyle.skip>true</checkstyle.skip>
 	 <build.prod>false</build.prod>

--- a/saiku-webapp/pom.xml
+++ b/saiku-webapp/pom.xml
@@ -2,11 +2,11 @@
     <parent>
         <artifactId>saiku</artifactId>
         <groupId>org.saikuanalytics</groupId>
-        <version>3.2-SNAPSHOT</version>
+        <version>3.14-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>saiku-webapp</artifactId>
-    <version>3.2-SNAPSHOT</version>
+    <version>3.14-SNAPSHOT</version>
     <name>saiku - webapp</name>
     <packaging>war</packaging>
     <build>


### PR DESCRIPTION
allData.query is not instantiated during drillthrough:

```
diff --git a/saiku-ui/js/saiku/render/SaikuTableRenderer.js b/saiku-ui/js/saiku/render/SaikuTableRenderer.js
index 7de25e1..5943f2a 100755
--- a/saiku-ui/js/saiku/render/SaikuTableRenderer.js
+++ b/saiku-ui/js/saiku/render/SaikuTableRenderer.js
@@ -444,10 +444,14 @@ SaikuTableRenderer.prototype.internalRender = function(allData, options) {
 
     var dirs = [ROWS, COLUMNS];
 
-    var hasMeasures = allData.query.queryModel.details
-                   ? allData.query.queryModel.details.measures.length
-                   : 0;
-
+    if(allData.query === null) {
+        hasMeasures = 0;
+    } else {
+        var hasMeasures = allData.query.queryModel.details
+            ? allData.query.queryModel.details.measures.length
+            : 0;
+    }
+                 
```