### PR TITLE
D3 Library script doesn't work if you're running via https.

### DIFF
--- a/saiku-ui/index.html
+++ b/saiku-ui/index.html
@@ -124,7 +124,7 @@
 <script type="text/javascript" src="js/logger/Logger.js" defer></script>
 
 <!-- D3 Library -->
-<script src="http://d3js.org/d3.v3.min.js"></script>
+<script src="//d3js.org/d3.v3.min.js"></script>
 
 <!-- Saiku Project -->
 <script type="text/javascript" src="js/saiku/Settings.js"></script>


### PR DESCRIPTION
Saiku breaks if you're running via HTTPS due to the D3 library being requested via http. The https version is valid and works so we can go schemeless (you could also just go explicitly https and everything would be fine). 