### PR TITLE
Build fixes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -496,6 +496,12 @@
                 <groupId>eigenbase</groupId>
                 <artifactId>eigenbase-xom</artifactId>
                 <version>1.3.4</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>xerces</groupId>
+                        <artifactId>xercesImpl</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.olap4j</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -374,15 +374,14 @@
                 <groupId>org.jasig.cas.client</groupId>
                 <artifactId>cas-client-core</artifactId>
                 <version>3.3.2</version>
-            </dependency>
-            <dependency>
-                <groupId>org.opensaml</groupId>
-                <artifactId>xmltooling</artifactId>
-                <version>1.3.2-1</version>
                 <exclusions>
                     <exclusion>
                         <groupId>org.bouncycastle</groupId>
                         <artifactId>bcprov-jdk15</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.slf4j</groupId>
+                        <artifactId>log4j-over-slf4j</artifactId>
                     </exclusion>
                 </exclusions>
             </dependency>
@@ -594,6 +593,13 @@
                 <groupId>net.serenity-bdd</groupId>
                 <artifactId>serenity-core</artifactId>
                 <version>1.0.58</version>
+                <exclusions>
+                    <exclusion>
+                        <!-- pdfbox-app ships it's own bcprov, causing cyclic dependencies errors -->
+                        <groupId>org.bouncycastle</groupId>
+                        <artifactId>bcprov-jdk15on</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>net.serenity-bdd</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -376,6 +376,17 @@
                 <version>3.3.2</version>
             </dependency>
             <dependency>
+                <groupId>org.opensaml</groupId>
+                <artifactId>xmltooling</artifactId>
+                <version>1.3.2-1</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.bouncycastle</groupId>
+                        <artifactId>bcprov-jdk15</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+            <dependency>
                 <groupId>org.jasig.cas.client</groupId>
                 <artifactId>cas-client-integration-tomcat-common</artifactId>
                 <version>3.3.2</version>

--- a/saiku-webapp/src/main/webapp/WEB-INF/saiku-beans.xml
+++ b/saiku-webapp/src/main/webapp/WEB-INF/saiku-beans.xml
@@ -96,7 +96,6 @@
         <property name="userService" ref="userServiceBean"/>
         <property name="dataSourceManager" ref="repositoryDsManager"/>
         <property name="sessionService" ref="sessionService"/>
-        <property name="userService" ref="userServiceBean"/>
     </bean>
 
     <bean id="datasourceServiceBean" class="org.saiku.service.datasource.DatasourceService">


### PR DESCRIPTION
This PR fixes a couple of problems running the webapp built from development.

I've added exclusions for `org.bouncycastle:bcprov-jsk15` and `xerces:xercesImpl`. 

The first was causing: 
```
java.lang.IllegalStateException: Unable to complete the scan for annotations for web application [/saiku] due to a StackOverflowError. Possible root causes include a too low setting for -Xss and illegal cyclic inheritance dependencies. The class hierarchy being processed was [org.bouncycastle.asn1.ASN1Boolean->org.bouncycastle.asn1.DERBoolean->org.bouncycastle.asn1.ASN1Boolean]
```

The second was causing:
```
org.apache.tika.utils.XMLReaderUtils.trySetSAXFeature Cannot set SAX feature because outdated XML parser in classpath: http://apache.org/xml/features/nonvalidating/load-dtd-grammar
```

And finally I removed a duplicate property from `saiku-beans.xml`