### PR TITLE
Mondrian now stripped from saiku-query jar before packaging into webapp

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,6 +50,7 @@
         <pentaho.platform.version>5.0.0</pentaho.platform.version>
         <serenity.version>1.0.58</serenity.version>
         <jbehave.version>3.9.3</jbehave.version>
+        <saiku-query.version>0.4-SNAPSHOT</saiku-query.version>
     </properties>
     <pluginRepositories>
         <pluginRepository>
@@ -699,7 +700,7 @@
             <dependency>
                 <groupId>org.saiku</groupId>
                 <artifactId>saiku-query</artifactId>
-                <version>0.4-SNAPSHOT</version>
+                <version>${saiku-query.version}</version>
             </dependency>
             <dependency>
                 <groupId>pentaho</groupId>

--- a/saiku-webapp/pom.xml
+++ b/saiku-webapp/pom.xml
@@ -86,7 +86,7 @@
                             <goal>war</goal>
                         </goals>
                         <configuration>
-                            <packagingExcludes>WEB-INF/lib/saiku-query-0.4-SNAPSHOT.jar</packagingExcludes>
+                            <packagingExcludes>WEB-INF/lib/saiku-query-${saiku-query.version}.jar</packagingExcludes>
                         </configuration>
                     </execution>
                 </executions>
@@ -140,8 +140,8 @@
                                 <!-- Remove mondrian from saiku-query jar
                                      See https://groups.google.com/a/saiku.meteorite.bi/forum/#!topic/user/oER6gEqc46w
                                 -->
-                                <jar destfile="${basedir}/target/saiku-webapp-${project.version}/WEB-INF/lib/saiku-query-0.4-SNAPSHOT-stripped.jar">
-                                    <zipfileset src="${basedir}/target/saiku-webapp-${project.version}/WEB-INF/lib/saiku-query-0.4-SNAPSHOT.jar"
+                                <jar destfile="${basedir}/target/saiku-webapp-${project.version}/WEB-INF/lib/saiku-query-${saiku-query.version}-nomondrian.jar">
+                                    <zipfileset src="${basedir}/target/saiku-webapp-${project.version}/WEB-INF/lib/saiku-query-${saiku-query.version}.jar"
                                                 excludes="mondrian/"/>
                                 </jar>
                             </target>

--- a/saiku-webapp/pom.xml
+++ b/saiku-webapp/pom.xml
@@ -60,7 +60,6 @@
                     </execution>
                 </executions>
             </plugin>
-
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-war-plugin</artifactId>
@@ -86,6 +85,9 @@
                         <goals>
                             <goal>war</goal>
                         </goals>
+                        <configuration>
+                            <packagingExcludes>WEB-INF/lib/saiku-query-0.4-SNAPSHOT.jar</packagingExcludes>
+                        </configuration>
                     </execution>
                 </executions>
                 <configuration>
@@ -119,6 +121,30 @@
                                     </includes>
                                 </resource>
                             </resources>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-antrun-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>remove.saiku-query.mondrian</id>
+                        <phase>prepare-package</phase>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                        <configuration>
+                            <target>
+                                <!-- Remove mondrian from saiku-query jar
+                                     See https://groups.google.com/a/saiku.meteorite.bi/forum/#!topic/user/oER6gEqc46w
+                                -->
+                                <jar destfile="${basedir}/target/saiku-webapp-${project.version}/WEB-INF/lib/saiku-query-0.4-SNAPSHOT-stripped.jar">
+                                    <zipfileset src="${basedir}/target/saiku-webapp-${project.version}/WEB-INF/lib/saiku-query-0.4-SNAPSHOT.jar"
+                                                excludes="mondrian/"/>
+                                </jar>
+                            </target>
                         </configuration>
                     </execution>
                 </executions>


### PR DESCRIPTION
This PR adds a packaging task to remove the `/mondrian` directory from the saiku-query JAR before building the saiku-webapp WAR file. This fixes ClassNotFound errors as described at: https://groups.google.com/a/saiku.meteorite.bi/forum/#!topic/user/oER6gEqc46w