### PR TITLE
Fixed user's home folder not getting deleted when user deleted

### DIFF
--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/user/UserService.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/user/UserService.java
@@ -101,7 +101,7 @@ public class UserService implements IUserManager, Serializable {
 
         uDAO.deleteUser(username);
 
-        iDatasourceManager.deleteFolder("homes/" + u.getUsername());
+        iDatasourceManager.deleteFolder("homes/home:" + u.getUsername());
 
     }
 


### PR DESCRIPTION
Currently if you delete a user their home folder is not removed. If you subsequently try and add a user with the same name it fails because the folder already exists. It looks like a simple typo, which this PR fixes.
