### PR TITLE
Added ability to inject PasswordEncoder into JdbcUserDAO

### DIFF
--- a/saiku-core/saiku-service/src/main/java/org/saiku/database/JdbcUserDAO.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/database/JdbcUserDAO.java
@@ -9,6 +9,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.jdbc.core.RowMapper;
 import org.springframework.jdbc.core.support.JdbcDaoSupport;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -29,7 +30,7 @@ public class JdbcUserDAO
 
     private final Properties prop = new Properties();
     private final ClassLoader loader = Thread.currentThread().getContextClassLoader();
-    private final BCryptPasswordEncoder passwordEncoder = new BCryptPasswordEncoder();
+    private PasswordEncoder passwordEncoder = new BCryptPasswordEncoder();
 
     @Autowired
     private ServletContext servletContext;
@@ -207,5 +208,9 @@ public class JdbcUserDAO
 
     public void setServletContext(ServletContext servletContext) {
         this.servletContext = servletContext;
+    }
+
+    public void setPasswordEncoder(PasswordEncoder passwordEncoder) {
+        this.passwordEncoder = passwordEncoder;
     }
 }

--- a/saiku-core/saiku-service/src/main/java/org/saiku/security/NoReHashPasswordEncoder.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/security/NoReHashPasswordEncoder.java
@@ -1,0 +1,37 @@
+package org.saiku.security;
+
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import java.util.regex.Pattern;
+
+public class NoReHashPasswordEncoder implements PasswordEncoder {
+    private PasswordEncoder encoder;
+    private Pattern pattern;
+
+    public NoReHashPasswordEncoder() {
+        this(new BCryptPasswordEncoder(), "\\A\\$2a?\\$\\d\\d\\$[./0-9A-Za-z]{53}");
+    }
+
+    public NoReHashPasswordEncoder(PasswordEncoder encoder, String pattern) {
+        this.encoder = encoder;
+        this.pattern = Pattern.compile(pattern);
+    }
+
+    @Override
+    public String encode(CharSequence charSequence) {
+        if (isHash(charSequence)) {
+            return charSequence.toString();
+        }
+        return encoder.encode(charSequence);
+    }
+
+    @Override
+    public boolean matches(CharSequence charSequence, String s) {
+        return encoder.matches(charSequence, s);
+    }
+
+    private boolean isHash(CharSequence charSequence) {
+        return pattern.matcher(charSequence).matches();
+    }
+}

--- a/saiku-core/saiku-service/src/test/java/org/saiku/security/NoReHashPasswordEncoderTest.java
+++ b/saiku-core/saiku-service/src/test/java/org/saiku/security/NoReHashPasswordEncoderTest.java
@@ -8,9 +8,9 @@ import java.util.regex.Pattern;
 import static org.junit.Assert.*;
 
 public class NoReHashPasswordEncoderTest {
-    NoReHashPasswordEncoder encoder = new NoReHashPasswordEncoder();
-    String hash = "$2a$10$X7TU2pKkR6sOCeotubuxjOsmYMCuPbLGfN1/yk2yRoUObAykZ.//K";
-    Pattern pattern;
+    private NoReHashPasswordEncoder encoder = new NoReHashPasswordEncoder();
+    private String hash = "$2a$10$X7TU2pKkR6sOCeotubuxjOsmYMCuPbLGfN1/yk2yRoUObAykZ.//K";
+    private Pattern pattern;
 
     public NoReHashPasswordEncoderTest() {
         String regex = "\\A\\$2a?\\$\\d\\d\\$[./0-9A-Za-z]{53}";

--- a/saiku-core/saiku-service/src/test/java/org/saiku/security/NoReHashPasswordEncoderTest.java
+++ b/saiku-core/saiku-service/src/test/java/org/saiku/security/NoReHashPasswordEncoderTest.java
@@ -1,0 +1,36 @@
+package org.saiku.security;
+
+import org.junit.Test;
+import org.saiku.security.NoReHashPasswordEncoder;
+
+import java.util.regex.Pattern;
+
+import static org.junit.Assert.*;
+
+public class NoReHashPasswordEncoderTest {
+    NoReHashPasswordEncoder encoder = new NoReHashPasswordEncoder();
+    String hash = "$2a$10$X7TU2pKkR6sOCeotubuxjOsmYMCuPbLGfN1/yk2yRoUObAykZ.//K";
+    Pattern pattern;
+
+    public NoReHashPasswordEncoderTest() {
+        String regex = "\\A\\$2a?\\$\\d\\d\\$[./0-9A-Za-z]{53}";
+        pattern = Pattern.compile(regex);
+    }
+
+    @Test
+    public void testEncodeReturnsEncoded() {
+        String actual = encoder.encode("foo");
+        assertTrue(pattern.matcher(actual).matches());
+    }
+
+    @Test
+    public void testEncoderReturnsUnchanged() {
+        String actual = encoder.encode(hash);
+        assertEquals(hash, actual);
+    }
+
+    @Test
+    public void testMatchesReturnsTrue() {
+        assertTrue(encoder.matches("foo", hash));
+    }
+}


### PR DESCRIPTION
This PR addresses #685. It adds the ability to inject an alternate password encoder to use when hashing user passwords, and adds an implementation that checks if the existing password looks like it's been BCrypt-ed before hashing it. The latter is not the default.

Initially I considered passing an extra parameter to the REST endpoint to indicate this was the desired behaviour. But there's a few problems with that: a lot more files to change, and always the chance some idiot would use it with an un-hashed password.

This approach also opens up the possibility of injecting a [DelegatingPasswordEncoder](https://docs.spring.io/spring-security/site/docs/current/api/org/springframework/security/crypto/password/DelegatingPasswordEncoder.html) if / when you upgrade to spring security 5, which at first glance might provide a more elegant solution.

To wire in the `NoReHashPasswordEncoder`, edit `saiku-beans.xml`:

```
    <bean id="passwordEncoderBean" class="org.saiku.security.NoReHashPasswordEncoder"/>

    <bean id="userDAO" class="org.saiku.database.JdbcUserDAO">
        <property name="dataSource" ref="userDaoDataSource" />
        <property name="passwordEncoder" ref="passwordEncoderBean" />
    </bean>
```