### PR TITLE
Phase 1D: dep refresh (Spring 4.3.30, Jackson 2.17, SLF4J 1.7)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,9 +22,9 @@
         <maven.compiler.source>21</maven.compiler.source>
         <maven.compiler.target>21</maven.compiler.target>
         <top.dir>${project.basedir}</top.dir>
-        <spring.version>4.1.6.RELEASE</spring.version>
-        <spring.security.version>4.0.1.RELEASE</spring.security.version>
-        <slf4j.version>1.6.4</slf4j.version>
+        <spring.version>4.3.30.RELEASE</spring.version>
+        <spring.security.version>4.2.20.RELEASE</spring.security.version>
+        <slf4j.version>1.7.36</slf4j.version>
         <jersey.version>1.19</jersey.version>
         <tomcat.version>apache-tomcat-9.0.8</tomcat.version>
         <tomcat.source>target/stage/tomcat/</tomcat.source>
@@ -35,6 +35,7 @@
         <serenity.version>1.0.58</serenity.version>
         <jbehave.version>3.9.3</jbehave.version>
         <saiku-query.version>0.4-SNAPSHOT</saiku-query.version>
+        <jackson.version>2.17.3</jackson.version>
     </properties>
     <repositories>
         <repository>

--- a/saiku-bom/pom.xml
+++ b/saiku-bom/pom.xml
@@ -13,9 +13,9 @@
 
     <properties>
         <!-- Shared third-party versions. Child poms reference these via ${...}. -->
-        <spring.version>4.1.6.RELEASE</spring.version>
-        <spring.security.version>4.0.1.RELEASE</spring.security.version>
-        <slf4j.version>1.6.4</slf4j.version>
+        <spring.version>4.3.30.RELEASE</spring.version>
+        <spring.security.version>4.2.20.RELEASE</spring.security.version>
+        <slf4j.version>1.7.36</slf4j.version>
         <jersey.version>1.19</jersey.version>
         <calcite.version>0.9.2-incubating-SNAPSHOT</calcite.version>
         <pentaho.libs.version>TRUNK-SNAPSHOT</pentaho.libs.version>
@@ -23,6 +23,7 @@
         <serenity.version>1.0.58</serenity.version>
         <jbehave.version>3.9.3</jbehave.version>
         <saiku-query.version>0.4-SNAPSHOT</saiku-query.version>
+        <jackson.version>2.17.3</jackson.version>
     </properties>
 
     <dependencyManagement>
@@ -128,12 +129,12 @@
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-databind</artifactId>
-                <version>2.5.1</version>
+                <version>${jackson.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.fasterxml.jackson.jaxrs</groupId>
                 <artifactId>jackson-jaxrs-json-provider</artifactId>
-                <version>2.5.1</version>
+                <version>${jackson.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.poi</groupId>
@@ -288,12 +289,12 @@
             <!--dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-core</artifactId>
-                <version>2.5.1</version>
+                <version>${jackson.version}</version>
             </dependency-->
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-annotations</artifactId>
-                <version>2.5.1</version>
+                <version>${jackson.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.saikuanalytics</groupId>
@@ -699,7 +700,7 @@
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-core</artifactId>
-                <version>2.5.1</version>
+                <version>${jackson.version}</version>
             </dependency>
             <dependency>
                 <groupId>javax.servlet.jsp</groupId>


### PR DESCRIPTION
## Summary

Refresh the 2014-era pins to the last javax.* releases before Spring Boot 4 / jakarta lands. Each artefact stays on its latest compatible 4.x or 2.x release so the underlying programming model doesn't shift — smallest possible step that removes ten years of rot.

| Dep | From | To | Reason |
|---|---|---|---|
| `spring-*` | 4.1.6.RELEASE (2015) | 4.3.30.RELEASE (2021) | Last Spring 4 |
| `spring-security-*` | 4.0.1.RELEASE (2015) | 4.2.20.RELEASE (2020) | Last Spring Security 4 |
| `jackson-*` (databind, core, annotations, jaxrs) | 2.5.1 (2015) | 2.17.3 (2024) | JDK 21 compat, CVE-heavy series |
| `slf4j-*` | 1.6.4 (2012) | 1.7.36 (2022) | Last SLF4J 1.x — stays compatible with the \`slf4j-log4j12\` binding (SLF4J 2 + reload4j is a bigger swap deferred with Spring Boot) |

All bumps live in `saiku-bom` (and the mirrored property block in the root pom).

## Test plan

- [x] `mvn verify` green locally on JDK 21
- [x] 10 existing tests pass (`NoReHashPasswordEncoderTest`, `RepositoryDatasourceManagerTest`)

Stacking note: GitHub Actions CI is still broken by the local-fork dependencies (mondrian-saiku, olap4j Spicule, eigenbase) discussed in #740 / #749; not addressed in this PR. Local build is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)