### PR TITLE
Phase 2c: unblock webapp boot after Jackrabbit rip

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -451,3 +451,4 @@ nbdist/
 .nb-gradle/
 
 # End of https://www.gitignore.io/api/vim,git,node,java,linux,macos,maven,windows,webstorm,jetbrains,sublimetext,jetbrains+all,visualstudiocode,eclipse,netbeans
+data/

--- a/saiku-core/saiku-service/src/main/java/org/saiku/database/JdbcUserDAO.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/database/JdbcUserDAO.java
@@ -29,7 +29,7 @@ public class JdbcUserDAO extends JdbcDaoSupport implements UserDAO {
     private ServletContext servletContext;
 
     public JdbcUserDAO() {
-        InputStream stream = loader.getResourceAsStream("../database-queries.properties");
+        InputStream stream = loader.getResourceAsStream("database-queries.properties");
         try {
             prop.load(stream);
         } catch (IOException e) {

--- a/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/BasicRepositoryResource2.java
+++ b/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/BasicRepositoryResource2.java
@@ -41,9 +41,6 @@ import javax.ws.rs.core.Response.Status;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang.exception.ExceptionUtils;
-import org.apache.commons.vfs.FileObject;
-import org.apache.commons.vfs.FileSystemManager;
-import org.apache.commons.vfs.VFS;
 import org.saiku.repository.AclEntry;
 import org.saiku.repository.IRepositoryObject;
 import org.saiku.service.ISessionService;
@@ -68,28 +65,22 @@ public class BasicRepositoryResource2 implements ISaikuRepository {
 
     // private Acl acl;
     private DatasourceService datasourceService;
-    private FileObject repo;
+    private File repo;
 
     public void setDatasourceService(DatasourceService ds) {
         datasourceService = ds;
     }
 
     public void setPath(String path) throws Exception {
-        FileSystemManager fileSystemManager;
         try {
             if (!path.endsWith("" + File.separatorChar)) {
                 path += File.separatorChar;
             }
-            fileSystemManager = VFS.getManager();
-            FileObject fileObject;
-            fileObject = fileSystemManager.resolveFile(path);
-            if (fileObject == null) {
-                throw new IOException("File cannot be resolved: " + path);
-            }
-            if (!fileObject.exists()) {
+            File file = new File(path);
+            if (!file.exists()) {
                 throw new IOException("File does not exist: " + path);
             }
-            repo = fileObject;
+            repo = file;
         } catch (Exception e) {
             log.error("Error setting path for repository: " + path, e);
         }

--- a/saiku-webapp/src/main/resources/database-queries.properties
+++ b/saiku-webapp/src/main/resources/database-queries.properties
@@ -1,0 +1,19 @@
+insertUser=INSERT INTO users(username,password,email, enabled) VALUES (?,?,?,?);
+insertRole=INSERT INTO user_roles(user_id,username, role) VALUES (?,?,?);
+maxUser=SELECT MAX(USER_ID) from USERS where username = ?
+updateRole=UPDATE USER_ROLES set user_id = ? where user_id = ?
+deleteRole=DELETE FROM user_roles where user_id = ?
+deleteRoleByUserName=DELETE FROM USER_ROLES where USER_ID IN(SELECT USER_ID FROM USERS where USERS.USERNAME = ?);
+deleteRoleByUserId=DELETE FROM USER_ROLES where USER_ID = ?;
+deleteUserByUserName=DELETE FROM USERS where USERNAME=?
+deleteUserById=DELETE from USERS where USER_ID = ?
+deleteRoleByRoleAndUser=DELETE FROM USER_ROLES where USER_ID = ? and ROLE = ?
+getRole=SELECT GROUP_CONCAT(ROLE) as ROLES from USER_ROLES where USER_ID = ?
+getUserById=select T.USER_ID, t.USERNAME, t.PASSWORD, t.email, t.ENABLED,GROUP_CONCAT(ROLE) as ROLES from USERS t \
+  inner join (\nselect MAX(USERS.USER_ID) ID, USERS.USERNAME from USERS group by USERS.USERNAME) tm on t.USER_ID = tm\
+  .ID left join (select USER_ID, ROLE from USER_ROLES) ur on t.USER_ID = ur.USER_ID where t.user_id = ? GROUP BY t.USER_ID;
+getAllUsers=select T.USER_ID, t.USERNAME, t.PASSWORD, t.email, t.ENABLED,GROUP_CONCAT(ROLE) as ROLES from USERS t \
+  inner join (\nselect MAX(USERS.USER_ID) ID, USERS.USERNAME from USERS group by USERS.USERNAME) tm on t.USER_ID = tm\
+  .ID left join (select USER_ID, ROLE from USER_ROLES) ur on t.USER_ID = ur.USER_ID GROUP BY t.USER_ID
+updateUserWithPassword=UPDATE users set username = ?,password =?,email =? , enabled = ? where user_id = ?
+updateUser=UPDATE users set username = ?,email =? , enabled = ? where user_id = ?;

--- a/saiku-webapp/src/main/webapp/WEB-INF/applicationContext-saiku.xml
+++ b/saiku-webapp/src/main/webapp/WEB-INF/applicationContext-saiku.xml
@@ -5,7 +5,7 @@
 	xmlns:context="http://www.springframework.org/schema/context"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="
-              http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security-4.0.xsd
+              http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security-4.2.xsd
 			   http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.0.xsd
 			   http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.0.xsd">
 

--- a/saiku-webapp/src/main/webapp/WEB-INF/applicationContext-spring-security-memory.xml
+++ b/saiku-webapp/src/main/webapp/WEB-INF/applicationContext-spring-security-memory.xml
@@ -2,7 +2,7 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:security="http://www.springframework.org/schema/security"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xsi:schemaLocation="http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security-4.0.xsd
+       xsi:schemaLocation="http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security-4.2.xsd
        		   http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.0.xsd">
 
 

--- a/saiku-webapp/src/main/webapp/WEB-INF/saiku-beans.xml
+++ b/saiku-webapp/src/main/webapp/WEB-INF/saiku-beans.xml
@@ -81,11 +81,8 @@
     </bean>
 
     <bean id="securityContextPersistenceFilter" class="org.springframework.security.web.context.SecurityContextPersistenceFilter"/>
-    <bean class="org.saiku.datasources.connection.MondrianVFS" init-method="init" id="mondrianVFS">
-        <property name="datasourceManager" ref="repositoryDsManager"/>
-    </bean>
     <bean id="connectionManager" class="org.saiku.web.core.SecurityAwareConnectionManager" init-method="init"
-          destroy-method="destroy" depends-on="mondrianVFS">
+          destroy-method="destroy">
         <property name="userService" ref="userServiceBean"/>
         <property name="dataSourceManager" ref="repositoryDsManager"/>
         <property name="sessionService" ref="sessionService"/>

--- a/saiku-webapp/src/main/webapp/WEB-INF/web.xml
+++ b/saiku-webapp/src/main/webapp/WEB-INF/web.xml
@@ -172,33 +172,8 @@
     </listener>
 
 
-    <!-- ====================================================================== -->
-    <!-- W E B D A V S E R V L E T -->
-    <!-- ====================================================================== -->
-    <servlet>
-        <servlet-name>Webdav</servlet-name>
-        <description>
-            The webdav servlet that connects HTTP request to the repository.
-        </description>
-        <servlet-class>org.saiku.repository.SaikuWebdavServlet</servlet-class>
-        <init-param>
-            <param-name>resource-path-prefix</param-name>
-            <param-value>/repository</param-value>
-            <description>
-                defines the prefix for spooling resources out of the repository.
-            </description>
-        </init-param>
-        <init-param>
-            <param-name>resource-config</param-name>
-            <param-value>/WEB-INF/config.xml</param-value>
-            <description>
-                Defines various dav-resource configuration parameters.
-            </description>
-        </init-param>
+    <!-- Phase 2: Jackrabbit WebDAV servlet removed. -->
 
-
-        <load-on-startup>4</load-on-startup>
-    </servlet>
     <!-- ====================================================================== -->
     <!-- J C R R E M O T I N G S E R V L E T -->
     <!-- ====================================================================== -->
@@ -236,10 +211,6 @@
     <!-- ====================================================================== -->
     <!-- S E R V L E T M A P P I N G -->
     <!-- ====================================================================== -->
-    <servlet-mapping>
-        <servlet-name>Webdav</servlet-name>
-        <url-pattern>/repository/*</url-pattern>
-    </servlet-mapping>
   <!--  <servlet-mapping>
         <servlet-name>JCRWebdavServer</servlet-name>
         <url-pattern>/server/*</url-pattern>


### PR DESCRIPTION
## Summary

Runtime fallout that only surfaced when actually launching the WAR under Jetty 10 + JDK 21. Eight small fixes; **+29 / −50 lines**.

### Unblockers in this PR

- **web.xml**: delete WebDAV servlet + mapping (class already gone in #754; xml reference was stale)
- **saiku-beans.xml**: delete \`mondrianVFS\` bean + \`depends-on\` reference
- **applicationContext-*.xml**: bump Spring Security XSD 4.0 → 4.2 to match the bumped library (Spring Security 4.2 refuses 4.0 XSDs)
- **BasicRepositoryResource2.java**: drop \`org.apache.commons.vfs\` imports, replace \`FileObject\` with \`java.io.File\` (VFS was removed with Jackrabbit)
- **JdbcUserDAO.java**: fix \`../database-queries.properties\` classpath lookup — \`..\` doesn't work for classloader resources. Copy of the file into \`src/main/resources/\` so it lands on the classpath root
- **.gitignore**: add \`data/\` (runtime H2/foodmart artefacts)

### What's still wrong

The demo datasources (\`foodmart4\`, \`earthquakes\`) wire Mondrian catalog URLs as \`mondrian:///datasources/*.xml\` — that scheme was served by the \`MondrianVFS\` class deleted with Jackrabbit. Spring's \`SecurityAwareConnectionManager.init()\` throws on context load and the webapp returns 503.

Fix in follow-up: either rewrite datasource URLs to plain \`file:\` paths or reintroduce a ~50-line filesystem-backed \`MondrianVFS\` replacement.

### How I know the rest works

Jetty 10 starts. Spring context loads 20+ beans. cglib reflection unblocked via \`--add-opens\`. Spring Security XSD accepted. JdbcUserDAO initialises. Jersey 1.19 scans the REST packages. Demo H2 init scripts run. Sample-reports dir scaffold. **Progress stopped exactly at the one class we deleted for a principled reason, not an accidental one.**

## Test plan

- [x] \`mvn verify\` green
- [ ] Next session: restore datasource URL resolution, expect 200 from \`GET /saiku/rest/saiku/api/info\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)