### PR TITLE
Phase 2d: demo datasource URLs use file: URIs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
         <spring.version>4.3.30.RELEASE</spring.version>
         <spring.security.version>4.2.20.RELEASE</spring.security.version>
         <slf4j.version>1.7.36</slf4j.version>
-        <jersey.version>1.19</jersey.version>
+        <jersey.version>1.19.4</jersey.version>
         <tomcat.version>apache-tomcat-9.0.8</tomcat.version>
         <tomcat.source>target/stage/tomcat/</tomcat.source>
         <maven.build.timestamp.format>yyyyMMdd-HHmm</maven.build.timestamp.format>

--- a/saiku-bom/pom.xml
+++ b/saiku-bom/pom.xml
@@ -16,7 +16,7 @@
         <spring.version>4.3.30.RELEASE</spring.version>
         <spring.security.version>4.2.20.RELEASE</spring.security.version>
         <slf4j.version>1.7.36</slf4j.version>
-        <jersey.version>1.19</jersey.version>
+        <jersey.version>1.19.4</jersey.version>
         <calcite.version>0.9.2-incubating-SNAPSHOT</calcite.version>
         <pentaho.libs.version>TRUNK-SNAPSHOT</pentaho.libs.version>
         <pentaho.platform.version>5.0.0</pentaho.platform.version>

--- a/saiku-core/saiku-service/src/main/java/org/saiku/database/Database.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/database/Database.java
@@ -108,7 +108,8 @@ public class Database {
                 p.setProperty(
                         "location",
                         "jdbc:mondrian:Jdbc=jdbc:h2:" + dsm.getFoodmartdir() + "/foodmart;"
-                                + "Catalog=mondrian:///datasources/foodmart4.xml;JdbcDrivers=org.h2.Driver");
+                                + "Catalog=" + new java.io.File(dsm.getFoodmartschema()).toURI()
+                                + ";JdbcDrivers=org.h2.Driver");
                 p.setProperty("username", "sa");
                 p.setProperty("password", "");
                 p.setProperty("id", "4432dd20-fcae-11e3-a3ac-0800200c9a66");
@@ -167,7 +168,8 @@ public class Database {
                 p.setProperty(
                         "location",
                         "jdbc:mondrian:Jdbc=jdbc:h2:" + dsm.getEarthquakeDir() + "/earthquakes;MODE=MySQL;"
-                                + "Catalog=mondrian:///datasources/earthquakes.xml;JdbcDrivers=org.h2.Driver");
+                                + "Catalog=" + new java.io.File(dsm.getEarthquakeSchema()).toURI()
+                                + ";JdbcDrivers=org.h2.Driver");
                 p.setProperty("username", "sa");
                 p.setProperty("password", "");
                 p.setProperty("id", "4432dd20-fcae-11e3-a3ac-0800200c9a67");


### PR DESCRIPTION
## Summary

Patch the two demo datasource URLs (\`foodmart\`, \`earthquakes\`) to use \`file:\` URIs built from the configured schema paths, replacing the \`mondrian:///datasources/*.xml\` VFS scheme that died with \`MondrianVFS\` in #754.

Also bumps \`jersey.version\` 1.19 → 1.19.4 (last 1.x release).

## What this fixes

\`SecurityAwareConnectionManager.init()\` no longer throws \"Virtual file is not readable: mondrian:///datasources/foodmart4.xml\" on first boot.

## What's still wrong

The webapp still returns 503 because **Jersey 1.19's bundled ASM \`ClassReader\` can't parse JDK 17+ class-file format** — classic Jersey 1.x + modern JDK incompatibility. \`com.sun.jersey.spi.container.servlet.ServletContainer.init()\` throws \`IllegalArgumentException\` during classpath scan.

Proper fix is Jersey 1 → Jersey 3 migration (Phase 1 Group C core work — 13 REST resources × jakarta namespace). Not this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)