### PR TITLE
docs: bite-sized plans for Phase 1 D/E and Phases 3–7

### DIFF
--- a/docs/plans/2026-04-19-phase-1-group-d-packaging.md
+++ b/docs/plans/2026-04-19-phase-1-group-d-packaging.md
@@ -1,0 +1,89 @@
+# Phase 1 Group D — Packaging & CLI (implementation plan)
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to execute task-by-task.
+
+**Goal:** `java -jar saiku.jar` starts the server in < 5 seconds. `saiku serve` works as a CLI.
+
+**Base branch:** `development` (post Phase 1 Group C merge).
+
+**Tech stack:** Spring Boot 4.x, Picocli 4.7+, embedded Jetty (bundled by Spring Boot), YAML config.
+
+**Effort:** ~2 sessions.
+
+---
+
+## Tasks
+
+### Task 1D.1 — Parent pom to `spring-boot-starter-parent`
+
+Change root `pom.xml` to inherit from `org.springframework.boot:spring-boot-starter-parent:4.0.x`. This brings in managed versions for Spring Framework 7, Jackson, embedded Jetty, Jakarta APIs, logging, and the `spring-boot-maven-plugin` for fat-JAR packaging. Delete duplicate `<properties>` for versions Spring Boot already manages.
+
+### Task 1D.2 — New `saiku-server` module (Spring Boot app)
+
+Recreate `saiku-server/` as a module:
+- `SaikuApplication.java` with `@SpringBootApplication` + `public static void main`
+- `@ImportResource("classpath:saiku-beans.xml")` to keep existing bean wiring (or migrate beans to `@Configuration` classes incrementally)
+- Dep on `spring-boot-starter-web` (replaces the old `saiku-webapp` WAR assembly)
+- Servlet config: merge `saiku-webapp/src/main/webapp/WEB-INF/` contents into `saiku-server/src/main/resources/` (Spring Boot's embedded Jetty serves from classpath by default)
+
+### Task 1D.3 — `application.yml`
+
+Replace `saiku-beans.properties` + environment variables with a single `application.yml` at `saiku-server/src/main/resources/application.yml`. Document every property. Spring Boot's `@ConfigurationProperties` or `${saiku.*}` placeholders reference it.
+
+Example shape:
+```yaml
+saiku:
+  server:
+    port: 8080
+  repository:
+    data-dir: ./saiku-data
+  foodmart:
+    url: jdbc:h2:./data/foodmart;MODE=MySQL
+    schema: ./data/FoodMart4.xml
+```
+
+### Task 1D.4 — Picocli CLI
+
+Add Picocli as dep. Wire a top-level `saiku` command with subcommands:
+- `saiku serve [--port N] [--data <dir>]` — delegates to `SpringApplication.run(SaikuApplication.class, args)`
+- `saiku version` — prints Maven-filtered build info
+- `saiku config validate [path]` — parses the YAML and reports errors
+
+Set `Main-Class` in the fat JAR manifest to the Picocli entry point, not the Spring Boot one.
+
+### Task 1D.5 — Drop WAR packaging
+
+Delete the `saiku-webapp` module entirely (its contents merged into `saiku-server` in 1D.2). Update root pom `<modules>`. Delete `web.xml`, `saiku-beans.xml` (or move to `saiku-server/src/main/resources/`), all `WEB-INF/` artefacts.
+
+### Task 1D.6 — Fix runtime file paths
+
+Paths like `../../data/foodmart_h2.sql` (relative to servlet container CWD) become unreliable in a fat JAR. Resolve from the JAR location or an explicit `saiku.data.dir` config:
+- Data init scripts: read from classpath via `@Value("classpath:data/foodmart_h2.sql")` or `ResourceLoader`
+- User datadir: `saiku.repository.data-dir` defaults to `./saiku-data`, created on first launch
+
+### Task 1D.7 — Fat JAR + smoke test
+
+`mvn -pl saiku-server package` should produce `saiku-server/target/saiku-server-*.jar`. Test: `java -jar saiku-server-*.jar serve --port 18080` and hit `GET /saiku/rest/saiku/api/info/release`.
+
+---
+
+## Exit criteria
+
+- `java -jar saiku-server-*.jar` starts in < 5 seconds and serves `/saiku/rest/saiku/api/info/release` with HTTP 200
+- `saiku version` prints a Maven-filtered version string
+- `saiku config validate` exits 0 on the default `application.yml`
+- `saiku-webapp` module deleted; no more `web.xml`
+- CI builds and publishes the fat JAR on tag
+- Phase 0 test suite still green
+
+## Risk-ordered task list
+
+| # | Risk | Reversible? | Ship independently? |
+|---|------|-------------|---------------------|
+| 1D.1 Parent pom | Med (version cascades) | Yes | Yes |
+| 1D.2 saiku-server module | Low | Yes | Yes |
+| 1D.3 application.yml | Low | Yes | Yes |
+| 1D.4 Picocli CLI | Low | Yes | Yes |
+| 1D.5 Drop WAR | Med | Yes | Land AFTER 1D.2 is proven |
+| 1D.6 Runtime paths | Low | Yes | Yes |
+| 1D.7 Fat JAR smoke | Low | Yes | Last |

--- a/docs/plans/2026-04-19-phase-1-group-e-distribution.md
+++ b/docs/plans/2026-04-19-phase-1-group-e-distribution.md
@@ -1,0 +1,79 @@
+# Phase 1 Group E — Distribution (implementation plan)
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to execute task-by-task.
+
+**Goal:** A single `docker run saiku/saiku` works. GitHub tag → automated JAR + Docker image release. Optional Homebrew tap.
+
+**Base branch:** `development` (post Phase 1 Group D merge).
+
+**Tech stack:** Docker (distroless), GitHub Actions, Homebrew tap.
+
+**Effort:** ~1 session.
+
+---
+
+## Tasks
+
+### Task 1E.1 — Multi-stage Dockerfile
+
+Create `Dockerfile` at repo root:
+- Stage 1: `maven:3.9-eclipse-temurin-21` → `mvn -pl saiku-server -am -DskipTests package`
+- Stage 2: `gcr.io/distroless/java21-debian12:nonroot` → copy the fat JAR, `ENTRYPOINT ["java","-jar","/app/saiku.jar"]`, default `CMD ["serve"]`
+- `HEALTHCHECK` hits `/actuator/health` (Spring Boot actuator)
+- `EXPOSE 8080`
+- Image size target: < 250MB
+
+### Task 1E.2 — `.dockerignore`
+
+Exclude `target/`, `.git/`, `node_modules/`, `data/`, `saiku-data/`, IDE files. Keeps the build context small and deterministic.
+
+### Task 1E.3 — GitHub Actions release workflow
+
+New `.github/workflows/release.yml`:
+- Trigger: `push` on `v*` tags
+- Build the fat JAR with `mvn -B -ntp -DskipTests package`
+- Build the Docker image (docker/build-push-action@v5) with multi-arch amd64/arm64
+- Push to GHCR (`ghcr.io/osbi/saiku:$TAG` + `:latest`)
+- Attach JAR to a GitHub Release via `softprops/action-gh-release`
+- Sign the Docker image + JAR with Sigstore cosign (keyless, OIDC)
+
+### Task 1E.4 — Version-stamp the JAR
+
+Ensure the built JAR's MANIFEST.MF carries `Implementation-Version` and Git SHA. `saiku version` reads this.
+
+### Task 1E.5 — (Optional) Homebrew tap
+
+Separate repo `osbi/homebrew-saiku` with a Ruby formula that downloads the released JAR and installs a `saiku` shell shim. Published tap: `brew tap osbi/saiku && brew install saiku`.
+
+### Task 1E.6 — Quickstart section in README
+
+Three-line install doc:
+```bash
+docker run -p 8080:8080 ghcr.io/osbi/saiku:latest
+# or
+curl -LO https://github.com/OSBI/saiku/releases/latest/download/saiku.jar && java -jar saiku.jar serve
+# or
+brew install osbi/saiku/saiku && saiku serve
+```
+
+---
+
+## Exit criteria
+
+- `docker run -p 8080:8080 ghcr.io/osbi/saiku:latest` works end-to-end; `curl localhost:8080/saiku/rest/saiku/api/info/release` returns 200
+- GitHub Actions release workflow green on a test tag (e.g. `v3.18-rc1`)
+- Docker image signed; `cosign verify ghcr.io/osbi/saiku:<tag>` passes
+- (If Homebrew in scope) `brew install osbi/saiku/saiku` works on a clean Mac
+- Image size < 250MB
+- README quickstart works on a fresh machine
+
+## Risk-ordered task list
+
+| # | Risk | Reversible? | Ship independently? |
+|---|------|-------------|---------------------|
+| 1E.1 Dockerfile | Low | Yes | Yes |
+| 1E.2 .dockerignore | Trivial | Yes | Yes |
+| 1E.3 Release workflow | Low | Yes | Yes |
+| 1E.4 Version stamp | Low | Yes | Yes |
+| 1E.5 Homebrew tap | Low | Yes | Can defer indefinitely |
+| 1E.6 README quickstart | Trivial | Yes | Last |

--- a/docs/plans/2026-04-19-phase-3-yaml-semantic-layer.md
+++ b/docs/plans/2026-04-19-phase-3-yaml-semantic-layer.md
@@ -1,0 +1,129 @@
+# Phase 3 — YAML semantic layer (implementation plan)
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to execute task-by-task.
+
+**Goal:** Cubes defined in ~20 lines of YAML. Mondrian XML becomes a compile target, not an authoring surface. New users go from "Postgres DB" to "working cube in UI" in < 10 min.
+
+**Base branch:** `development` (post Phase 2 merge; Phase 1 Group D/E optional but convenient — the CLI hosts `saiku infer/lint/convert`).
+
+**Tech stack:** Jackson YAML, Jakarta Validation, Picocli CLI, JSON Schema (for IDE autocompletion), optional OpenRewrite for import tools.
+
+**Effort:** 3–4 focused sessions.
+
+---
+
+## Tasks
+
+### Task 3.1 — Internal IR (Java records)
+
+Create a clean schema IR in a new package `org.saiku.semantic.model`:
+- `CubeDefinition(name, source, dimensions, measures, security)`
+- `DimensionDefinition(name, source, levels[], hierarchy?)`
+- `LevelDefinition(name, column, type)`
+- `MeasureDefinition(name, agg | expr, format?)`
+- `JoinDefinition(fk, pk)`
+- `SecurityDefinition(rowFilter, roleMap)`
+
+Immutable records, builder-style constructors, Jackson-bindable.
+
+### Task 3.2 — YAML parser + validator
+
+Jackson's `YAMLMapper` with strict mode. Validate with Jakarta Bean Validation (`@NotBlank`, `@Pattern`, etc.) + a small custom `SchemaValidator` that checks:
+- No duplicate dimension/measure names
+- Every foreign key has a matching dimension source
+- Measure `expr` references existing measures
+- Security predicates are valid SQL/template strings
+
+Line-accurate error messages via `JsonLocation`.
+
+### Task 3.3 — Mondrian compiler (YAML → Mondrian XML)
+
+New class `MondrianCompiler` in `org.saiku.semantic.compile`. Consumes `CubeDefinition`, emits valid Mondrian 4 schema XML.
+
+Golden-file test harness: `src/test/resources/semantic/compiler/<case>/input.yml` + `expected.xml`. `mvn verify` diff-fails on drift.
+
+### Task 3.4 — `saiku lint cubes/`
+
+Picocli subcommand. For each YAML in the directory:
+- Parse + validate (3.2)
+- Open a JDBC connection to the cube's source (from `datasource.ref` in the YAML)
+- Verify every referenced table/column exists via `DatabaseMetaData`
+- Report missing references with file + line number
+
+Exit 0 on success, 1 on any lint errors.
+
+### Task 3.5 — `saiku infer --source <connection> --table <name>`
+
+Pull table metadata from the connection. Heuristics:
+- Numeric columns → measure with `sum` aggregation
+- FK-shaped columns (name ends in `_id`, `_fk`, or type is foreign-key via JDBC metadata) → dimension with the referenced table as source
+- Date/time columns → dimension with levels `[Year, Quarter, Month, Day]`
+
+Emit starter YAML to stdout (or `-o <file>`). Not perfect; documented as "a seed, not a spec."
+
+### Task 3.6 — `saiku convert mondrian-to-yaml <schema.xml>`
+
+Parse a Mondrian 3 or 4 schema XML, emit equivalent YAML. Round-trip test:
+1. Convert sample Mondrian XML → YAML
+2. Compile that YAML → Mondrian XML
+3. Parse both XMLs into Mondrian's `MondrianSchema` objects
+4. Compare semantic trees (not text)
+
+Passes iff no semantic drift.
+
+### Task 3.7 — Hot reload
+
+A `WatchService` on the `cubes/` directory. On change:
+- Recompile affected cubes
+- Swap the in-memory schema via Mondrian's cache invalidation API
+- UI picks up the new schema within ~2s without server restart
+
+### Task 3.8 — Import tools
+
+- `saiku import dbt <dbt-project-dir>` — read `models/**/schema.yml` or `semantic_models/**/*.yml`, emit equivalent Saiku YAML
+- `saiku import cube <cube-dir>` — read Cube.js `.js`/`.yml` schema files, emit Saiku YAML
+
+LookML is a stretch; skip unless someone asks.
+
+### Task 3.9 — Docs cookbook
+
+`docs/semantic-layer/` with pages for:
+- Getting started (point at a DB, run `infer`, edit, serve)
+- Slowly-changing dimensions
+- Degenerate dimensions
+- Virtual cubes
+- Role-playing dimensions
+- Security predicates + row-level filters
+
+### Task 3.10 — Reference adapter: DuckDB
+
+Working example at `examples/duckdb-sales/`:
+- A DuckDB file seeded via SQL
+- `cubes/sales.yml`
+- 3-minute demo script showing point-infer-edit-serve
+
+---
+
+## Exit criteria
+
+- A new user points `saiku infer` at a live Postgres table, edits one measure, runs `saiku serve`, and drags fields in the UI within 10 minutes
+- `saiku lint cubes/` catches every common schema error class (unknown column, orphan join, duplicate names, invalid measure expr)
+- Golden-file suite covers YAML → Mondrian XML compilation with zero drift
+- Hot reload: edit YAML, see change in UI within 2 seconds
+- 3-minute demo video recorded
+- `saiku import dbt` works on at least one non-trivial dbt project
+
+## Risk-ordered task list
+
+| # | Risk | Reversible? | Ship independently? |
+|---|------|-------------|---------------------|
+| 3.1 IR records | Trivial | Yes | Yes |
+| 3.2 Parser/validator | Low | Yes | Yes |
+| 3.3 Mondrian compiler | Med (semantic drift) | Yes | Yes |
+| 3.4 lint | Low | Yes | Yes |
+| 3.5 infer | Low | Yes | Yes |
+| 3.6 convert (round-trip) | Med | Yes | Yes |
+| 3.7 Hot reload | Med | Yes | Yes |
+| 3.8 Importers | Low | Yes | Ship one at a time |
+| 3.9 Docs | Trivial | Yes | Yes |
+| 3.10 DuckDB example | Low | Yes | Last |

--- a/docs/plans/2026-04-19-phase-4-frontend-foundation.md
+++ b/docs/plans/2026-04-19-phase-4-frontend-foundation.md
@@ -1,0 +1,85 @@
+# Phase 4 — Frontend foundation (implementation plan)
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to execute task-by-task.
+
+**Goal:** Modernise the UI's bones without a rewrite. Vite + TypeScript build, AG Grid pivot, Monaco MDX editor, ECharts, dark mode. Bridge phase before the Svelte rewrite in Phase 6.
+
+**Base branch:** `development` (post Phase 3 merge). Note Phase 1 Group A deleted `saiku-ui` entirely; Phase 4 reintroduces a new `saiku-ui/` module scaffolded from scratch with Vite.
+
+**Tech stack:** Vite 5, TypeScript, AG Grid Community (MIT), Monaco Editor, ECharts, Playwright.
+
+**Effort:** 3–4 focused sessions.
+
+---
+
+## Tasks
+
+### Task 4.1 — New `saiku-ui` module with Vite + TypeScript
+
+Scaffold from `npm create vite@latest saiku-ui -- --template vanilla-ts`. Replace vanilla-ts with the minimum of the legacy Backbone app's HTML skeleton to prove the pipeline. Serve dev via `npm run dev`; production `npm run build` emits static assets to `dist/`.
+
+Wire Maven: `saiku-ui/pom.xml` uses `frontend-maven-plugin` to install Node, run `npm ci`, `npm run build`. Output `dist/` embedded in the fat JAR under `classpath:/ui/`.
+
+### Task 4.2 — Shared API client (TypeScript, generated)
+
+Use `openapi-typescript` to generate TS types from Saiku's REST OpenAPI spec (produced in Phase 1 Group C / Phase 6). Single `src/api/client.ts` wraps `fetch`, handles auth, retries.
+
+### Task 4.3 — AG Grid Community pivot grid
+
+Replace the ancient HTML table rendering with AG Grid:
+- Install `ag-grid-community` + `ag-grid-vanilla` bindings
+- Component `PivotGrid.ts` consumes Saiku's CellSet-JSON (or Arrow when Phase 5 lands)
+- Virtualised row model handles 100k+ rows
+- Drag-drop from the dim/measure tree onto AG Grid's pivot panel
+
+### Task 4.4 — Monaco editor for MDX + SQL
+
+- Install `monaco-editor`
+- Custom language service for MDX:
+  - Token highlighting
+  - Autocomplete from `/rest/saiku/api/discover/<cube>` (dims, levels, measures)
+  - Hover docs
+- Same for SQL, but with a simpler completion from `information_schema`
+
+### Task 4.5 — ECharts chart rendering
+
+Replace Highcharts one chart type at a time. Chart types: bar, column, line, area, pie, treemap, heatmap, scatter.
+
+Each migration = Playwright visual-regression test that screenshots the chart pre/post and gates on pixel diff < 1%.
+
+### Task 4.6 — Design tokens + dark mode
+
+`tokens.css` with CSS custom properties for colours, spacing, typography. Dark mode via `[data-theme="dark"]` selector + a toggle in the header. Persist preference to `localStorage`.
+
+### Task 4.7 — Accessibility pass (touched components)
+
+Keyboard navigation on the pivot grid. ARIA labels on drag-drop. Focus management in dialogs. Axe-core lint in CI.
+
+### Task 4.8 — Playwright smoke suite
+
+At least one test per touched screen. Run in CI on every PR. Covers login, open cube, drag dim, see result.
+
+---
+
+## Exit criteria
+
+- `npm run dev` HMR under 200ms
+- Grid renders 100k rows without visible lag (< 16ms frame time)
+- MDX editor autocomplete working against live metadata
+- Highcharts fully removed; all charts on ECharts
+- Dark mode shipped
+- Lighthouse: > 85 performance, > 90 accessibility on the pivot page
+- Playwright suite green in CI
+
+## Risk-ordered task list
+
+| # | Risk | Reversible? | Ship independently? |
+|---|------|-------------|---------------------|
+| 4.1 Vite/TS scaffold | Low | Yes | Yes |
+| 4.2 API client | Low | Yes | Yes |
+| 4.3 AG Grid | Med | Yes | Yes |
+| 4.4 Monaco | Low | Yes | Yes |
+| 4.5 ECharts | Med (visual regressions) | Yes | Per-chart-type |
+| 4.6 Design tokens | Low | Yes | Yes |
+| 4.7 A11y | Low | Yes | Yes |
+| 4.8 Playwright | Low | Yes | Last |

--- a/docs/plans/2026-04-19-phase-5-query-pipeline.md
+++ b/docs/plans/2026-04-19-phase-5-query-pipeline.md
@@ -1,0 +1,95 @@
+# Phase 5 — Query pipeline (implementation plan)
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to execute task-by-task.
+
+**Goal:** Large results and long queries stop feeling painful. Arrow IPC on the wire, async job model with cancellation, Caffeine cache, query profile, Parquet export.
+
+**Base branch:** `development` (post Phase 4 merge).
+
+**Tech stack:** Apache Arrow Java + JS, Caffeine, Spring Boot 4 (already in place from Phase 1 Group D), Server-Sent Events, JDK 21 virtual threads.
+
+**Effort:** 2–3 focused sessions.
+
+---
+
+## Tasks
+
+### Task 5.1 — Arrow IPC transport (server)
+
+New `ArrowCellSetFormatter` alongside the existing `CellSetFormatter`. Serialises Mondrian `CellSet` into Arrow record batches:
+- Dimension axes → dictionary-encoded string columns
+- Measure axis → typed numeric columns (Float64 / Int64 / Decimal depending on measure type)
+- Streams record batches over HTTP chunked responses via `VectorSchemaRoot` + `ArrowStreamWriter`
+
+Content-Type: `application/vnd.apache.arrow.stream`
+
+### Task 5.2 — Arrow transport (client)
+
+Install `apache-arrow` in `saiku-ui`. Replace JSON cellset parsing with Arrow IPC streaming reader. Feed directly into AG Grid's row model with zero-copy where possible.
+
+### Task 5.3 — Async job API
+
+New endpoints:
+- `POST /rest/saiku/api/queries` — accepts `{mdx, cubeName}`, returns `{jobId}` immediately (HTTP 202)
+- `GET /rest/saiku/api/queries/{jobId}/stream` — SSE with events `{status, batchIndex, metadata}` + chunked Arrow body
+- `DELETE /rest/saiku/api/queries/{jobId}` — cancels the underlying `olap4j.Statement.cancel()`
+- `GET /rest/saiku/api/queries/{jobId}/profile` — returns the timing breakdown
+
+### Task 5.4 — Virtual-thread executor
+
+`Executors.newVirtualThreadPerTaskExecutor()` for query submission. One thread per in-flight query; JDK 21 handles scheduling. No pool tuning required.
+
+### Task 5.5 — Caffeine query cache
+
+`com.github.ben-manes.caffeine:caffeine` added to BOM. Wrap `ThinQueryService`:
+- Key: `(schemaVersion, mdxNormalised, userRoles[])`
+- Value: Arrow bytes + metadata
+- Eviction: size-based (configurable max-bytes) + TTL (default 10 min)
+- Metrics: exposed at `/actuator/metrics/saiku.query.cache.{hit,miss,evict}`
+
+### Task 5.6 — Query profile drawer (UI)
+
+New UI component shows per-query:
+- Generated SQL (from Mondrian's SQL log; add a `MondrianLogInterceptor` to capture)
+- Timing breakdown: MDX parse / plan / SQL gen / SQL exec / format
+- Cache hit/miss
+- Row count
+
+### Task 5.7 — Cancel button (UI)
+
+Button on the running-query spinner sends `DELETE /rest/saiku/api/queries/{jobId}`. Server invokes `Statement.cancel()`. Playwright test asserts cancellation completes within 1 second and the DB connection is returned to the pool.
+
+### Task 5.8 — Back-pressure (max cells)
+
+Server enforces `saiku.query.max-cells` (default 1,000,000). Above limit, the query still runs but the SSE stream ends with `{status: "too-large", downloadUrl}` and the client offers a Parquet export instead of rendering.
+
+### Task 5.9 — Parquet export
+
+`GET /rest/saiku/api/queries/{jobId}/export?format=parquet`. Converts the Arrow result to Parquet via `parquet-arrow`. Streams the Parquet file with `Content-Disposition: attachment`.
+
+Also expose `format=csv` and `format=xlsx` (POI, already in the tree).
+
+---
+
+## Exit criteria
+
+- 1M-cell result streams incrementally into the grid; first rows visible within 500ms
+- Cancel button kills upstream Mondrian query within 1 second (Playwright verified)
+- Profile drawer shows SQL + timings on every query
+- Cache hit rate visible in `/actuator/metrics`
+- Parquet / CSV / XLSX export endpoints work and produce correct files
+- Arrow wire format saves > 50% bytes vs. the legacy JSON format on a typical sales cube query
+
+## Risk-ordered task list
+
+| # | Risk | Reversible? | Ship independently? |
+|---|------|-------------|---------------------|
+| 5.1 Arrow server | Med | Yes | Yes |
+| 5.2 Arrow client | Med | Yes | Pair with 5.1 |
+| 5.3 Async API | Low | Yes | Yes |
+| 5.4 Virtual threads | Low | Yes | Yes |
+| 5.5 Caffeine cache | Low | Yes | Yes |
+| 5.6 Profile drawer | Low | Yes | Yes |
+| 5.7 Cancel button | Low | Yes | Yes |
+| 5.8 Back-pressure | Med (behaviour change) | Yes | After 5.9 |
+| 5.9 Parquet export | Low | Yes | Yes |

--- a/docs/plans/2026-04-19-phase-6-svelte-rewrite.md
+++ b/docs/plans/2026-04-19-phase-6-svelte-rewrite.md
@@ -1,0 +1,104 @@
+# Phase 6 — Svelte rewrite (implementation plan)
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to execute task-by-task.
+
+**Goal:** Kill the residual legacy UI from Phase 4. Rewrite the front-end in SvelteKit + TypeScript, preserving parity with the old screens. Bundle < 200KB gz. Accessibility > 95.
+
+**Base branch:** `development` (post Phase 5 merge).
+
+**Tech stack:** SvelteKit 2, TypeScript, Vite (already from Phase 4), `svelte-dnd-action`, Storybook, Playwright.
+
+**Effort:** 4–6 focused sessions, biggest of all phases.
+
+---
+
+## Tasks
+
+### Task 6.1 — SvelteKit scaffold alongside legacy
+
+`saiku-ui-next/` new module. Same Spring Boot app serves both:
+- Legacy Phase 4 UI at `/ui/`
+- SvelteKit dev+build at `/ui-next/`
+- Feature flag `saiku.ui=next` switches the default
+
+### Task 6.2 — Finalise OpenAPI spec
+
+Complete `saiku-core/saiku-web/src/main/resources/openapi.yaml`. Generate TypeScript client via `openapi-typescript-codegen`. Both UIs use the generated client.
+
+### Task 6.3 — Design system `@saiku/ui`
+
+New Svelte component library:
+- Tokens from Phase 4 (`tokens.css`)
+- Core components: Button, Dialog, Tree, Table, Tabs, Menu, Toast, Spinner
+- Storybook catalog with dark-mode toggle
+- Published to npm internal registry (or consumed locally via `npm link`)
+
+### Task 6.4 — Screen migration order (low-risk first)
+
+Vertical slices, one per PR:
+
+1. **Login + home** — smallest surface, tests all plumbing (auth, routing, theming).
+2. **Datasource admin** — CRUD + list + form validation.
+3. **Query workspace** (biggest) — broken into:
+   - 6.4.3a Basic drag-drop of dims/measures onto axes
+   - 6.4.3b Pivot grid (reuse AG Grid from Phase 4)
+   - 6.4.3c Monaco MDX editor tab
+   - 6.4.3d Calculated members + filters + drill-through
+   - 6.4.3e Query profile drawer
+   - 6.4.3f Chart panel
+4. **Dashboards** — grid layout + parameters + cross-filter.
+5. **Admin / users** — last, touches auth.
+
+### Task 6.5 — Drag-and-drop
+
+`svelte-dnd-action` for the dim/measure → axis drop targets. Keyboard drag-and-drop and screen-reader announcements for free. Playwright a11y test per drop zone.
+
+### Task 6.6 — State management
+
+Svelte stores, no external state lib. Centralise query-workspace state in `queryStore` (derived stores for axes, filters, measures). Time-travel via store snapshots enables undo/redo.
+
+### Task 6.7 — Undo/redo
+
+Keyboard shortcuts ⌘Z / ⌘⇧Z. Persists through the session; not across page reload.
+
+### Task 6.8 — Mobile responsive read-only
+
+Dashboards render on phone with a tap-to-drill gesture. Authoring screens show a "desktop required" notice.
+
+### Task 6.9 — Delete legacy UI
+
+Once the SvelteKit version reaches feature parity:
+- Flip default to `saiku.ui=next`
+- Remove `/ui/` mount and the Phase 4 `saiku-ui/` module
+- Rename `saiku-ui-next/` → `saiku-ui/`
+- Big net-negative diff
+
+### Task 6.10 — Pre-release flag
+
+From week 2, ship `saiku serve --ui=next` as an opt-in flag so early adopters can sanity-check. Feedback channel: GitHub Discussions.
+
+---
+
+## Exit criteria
+
+- Every screen present in the old UI has a Svelte equivalent at feature parity
+- Playwright suite passes on the new UI at same coverage as the old
+- Lighthouse: > 90 performance, > 95 accessibility on the main pages
+- Initial route bundle < 200KB gzipped
+- Legacy `saiku-ui` module deleted
+- Mobile read-only dashboards functional on iOS Safari + Chrome Android
+
+## Risk-ordered task list
+
+| # | Risk | Reversible? | Ship independently? |
+|---|------|-------------|---------------------|
+| 6.1 Scaffold | Low | Yes | Yes |
+| 6.2 OpenAPI | Low | Yes | Yes |
+| 6.3 Design system | Low | Yes | Yes |
+| 6.4 Screens | Med (UX regressions) | Yes | One PR per screen |
+| 6.5 DnD | Low | Yes | Yes |
+| 6.6 Stores | Low | Yes | Yes |
+| 6.7 Undo/redo | Low | Yes | Yes |
+| 6.8 Mobile | Low | Yes | Yes |
+| 6.9 Delete legacy | **High** — point of no return | No | Absolute last |
+| 6.10 Feature flag | Low | Yes | First |

--- a/docs/plans/2026-04-19-phase-7-platform-features.md
+++ b/docs/plans/2026-04-19-phase-7-platform-features.md
@@ -1,0 +1,64 @@
+# Phase 7 — Platform features (menu)
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans when picking an item off this menu.
+
+**Goal:** Independent features built on top of the modernised stack. Not a phase with a fixed scope — a menu of tickets picked by user demand. Each item gets expanded into its own bite-sized plan before execution.
+
+**Base branch:** `development` (post Phase 6 merge).
+
+**Effort:** each item = 1–3 focused sessions. Pick based on which users are shouting loudest.
+
+---
+
+## Menu
+
+### Authoring & collaboration
+- **Query notebooks** — MDX + markdown + chart cells, saved as `.saiku.md` files. Jupyter-for-cubes UX.
+- **Dashboards 2.0** — grid layout, parameters, cross-filter between tiles, drill-through.
+- **Embeddable iframes** — signed-URL auth, one-line `<iframe src="…/embed/query/abc123?token=…">`. Post-message API for host → embed.
+- **Comments + @mentions** — threaded comments on query cells. Files on disk; git-blame-friendly.
+- **Version history UI** — surface `git log` diffs of schemas, queries, dashboards directly in Saiku.
+
+### Delivery
+- **Scheduled exports** — cron-like scheduler. Outputs: CSV / Parquet / PDF / XLSX. Destinations: email (SMTP), Slack (webhook), S3, arbitrary webhook.
+- **Alerts** — threshold rules on measures ("revenue < 80% of 7-day avg"). Notify via the scheduled-export destinations.
+- **Printable PDF dashboards** — one-click render. Clean layout, page breaks, footer with timestamp + filter summary.
+
+### Auth & ops
+- **OIDC / SAML** — drop the in-memory users.properties for a real SSO. Spring Security OAuth2 Client + SAML2 starters.
+- **Row-level security** — wire the YAML `security` block (Phase 3) to the query-time `SecurityAwareConnectionManager`.
+- **Audit log** — structured JSON events to stdout (or a sink). Every query, every config change, every login.
+- **Multi-tenant** — one deployment, many isolated workspaces, shared auth. Per-workspace data dir, per-workspace ACL.
+
+### AI (opt-in, pluggable)
+- **NL → MDX** — Claude tool-use call with the cube metadata as tools. User types "sales by region last quarter", gets MDX + results.
+- **Auto-explain** — "what drove the March spike?" walks drill-downs, summarises findings.
+- **Schema summariser** — for onboarding to a new cube, produce a human-readable overview.
+- **Chart suggestion** — given result shape, recommend chart type (line for time-series, stacked-bar for part-of-whole, etc.).
+
+All AI features require a pluggable `LlmProvider` abstraction. Built-in providers: Anthropic, OpenAI, local Ollama. **No API key required to run Saiku itself.**
+
+---
+
+## Per-item process
+
+Before picking any item:
+1. Confirm with stakeholders the item is still the priority.
+2. Write a bite-sized plan: `docs/plans/YYYY-MM-DD-phase-7-<item>.md`.
+3. Create a worktree: `../saiku-phase-7-<item>`.
+4. Execute per `superpowers:executing-plans`.
+5. Ship one item per PR.
+
+## Acceptance criteria (per item)
+
+Every Phase 7 item must:
+- Have documentation (README section + 1-page guide for non-obvious items).
+- Have tests (unit + at least one Playwright/integration).
+- Be off by default if it introduces security surface (OIDC, multi-tenant, AI) — user opts in via config.
+- Not break any existing phase 0–6 behaviour.
+
+## Not in scope for Phase 7
+
+- New query engine (that's Phase 8 Calcite).
+- New frontend framework (Svelte is set by Phase 6).
+- Breaking changes to the YAML semantic layer (additive only).


### PR DESCRIPTION
## Summary

Fills in the remaining plan-doc coverage of the modernisation roadmap so any phase can be picked up and executed without re-brainstorming.

**7 new plan docs.**

| Phase | Doc |
|---|---|
| 1D Packaging | \`docs/plans/2026-04-19-phase-1-group-d-packaging.md\` |
| 1E Distribution | \`docs/plans/2026-04-19-phase-1-group-e-distribution.md\` |
| 3 YAML semantic layer | \`docs/plans/2026-04-19-phase-3-yaml-semantic-layer.md\` |
| 4 Frontend foundation | \`docs/plans/2026-04-19-phase-4-frontend-foundation.md\` |
| 5 Query pipeline | \`docs/plans/2026-04-19-phase-5-query-pipeline.md\` |
| 6 Svelte rewrite | \`docs/plans/2026-04-19-phase-6-svelte-rewrite.md\` |
| 7 Platform features | \`docs/plans/2026-04-19-phase-7-platform-features.md\` |

Each one follows the template established in the Phase 2 plan: goal, base branch, tech stack, numbered tasks with file paths, exit criteria, risk-ordered task table.

Phase 1 A/B/C coverage already exists in \`2026-04-19-phase-1-build-hygiene.md\`. Phase 2 plan already in tree.

Docs-only. Safe to merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)