### PR TITLE
chore(security): risky JDBC-driver bumps — pg/mysql/hive/hadoop

### DIFF
--- a/saiku-bom/pom.xml
+++ b/saiku-bom/pom.xml
@@ -60,20 +60,26 @@
                 <artifactId>jtds</artifactId>
                 <version>1.3.1</version>
             </dependency>
+            <!-- postgresql 9.3 (2014) had ~10 open CVEs. 42.7.x is the
+                 maintained JDBC4-driver line; pure-API drop-in. -->
             <dependency>
                 <groupId>org.postgresql</groupId>
                 <artifactId>postgresql</artifactId>
-                <version>9.3-1102-jdbc41</version>
+                <version>42.7.4</version>
             </dependency>
+            <!-- hive-jdbc 0.13 (2014) had ~3 CVEs. 2.3.x is the last
+                 widely-deployed line with a stable JDBC surface. -->
             <dependency>
                 <groupId>org.apache.hive</groupId>
                 <artifactId>hive-jdbc</artifactId>
-                <version>0.13.1</version>
+                <version>2.3.9</version>
             </dependency>
+            <!-- hadoop-common 2.4 (2014) had ~12 CVEs. 2.10.2 is the last
+                 2.x release with active patches; transitive-only via hive. -->
             <dependency>
                 <groupId>org.apache.hadoop</groupId>
                 <artifactId>hadoop-common</artifactId>
-                <version>2.4.0</version>
+                <version>2.10.2</version>
             </dependency>
             <dependency>
                 <groupId>org.mozilla</groupId>
@@ -462,10 +468,16 @@
                 <artifactId>hsqldb</artifactId>
                 <version>2.7.4</version>
             </dependency>
+            <!-- mysql-connector-java 5.1 (2011) had ~7 CVEs. 8.x is the
+                 maintained line, repackaged under com.mysql:mysql-connector-j.
+                 The driver registers both legacy class name
+                 (com.mysql.jdbc.Driver) and the new
+                 (com.mysql.cj.jdbc.Driver) so existing datasource configs
+                 keep working without a runtime config change. -->
             <dependency>
-                <groupId>mysql</groupId>
-                <artifactId>mysql-connector-java</artifactId>
-                <version>5.1.17</version>
+                <groupId>com.mysql</groupId>
+                <artifactId>mysql-connector-j</artifactId>
+                <version>8.4.0</version>
             </dependency>
             <dependency>
                 <groupId>commons-dbcp</groupId>
@@ -562,7 +574,7 @@
             <dependency>
                 <groupId>org.apache.hive</groupId>
                 <artifactId>hive-cli</artifactId>
-                <version>1.0.0</version>
+                <version>2.3.9</version>
             </dependency>
 
             <!-- Calcite dependencyManagement removed: Saiku doesn't import org.apache.calcite

--- a/saiku-webapp/pom.xml
+++ b/saiku-webapp/pom.xml
@@ -340,8 +340,8 @@
             <artifactId>hsqldb</artifactId>
         </dependency>
         <dependency>
-            <groupId>mysql</groupId>
-            <artifactId>mysql-connector-java</artifactId>
+            <groupId>com.mysql</groupId>
+            <artifactId>mysql-connector-j</artifactId>
         </dependency>
         <dependency>
             <groupId>org.postgresql</groupId>
@@ -355,6 +355,11 @@
                 <exclusion><groupId>net.hydromatic</groupId><artifactId>linq4j</artifactId></exclusion>
                 <exclusion><groupId>org.pentaho</groupId><artifactId>pentaho-aggdesigner-algorithm</artifactId></exclusion>
                 <exclusion><groupId>org.apache.hive</groupId><artifactId>hive-exec</artifactId></exclusion>
+                <!-- hive-jdbc 2.3 → hive-metastore → hbase-client → hbase-annotations
+                     → jdk.tools:1.7 (system-scope ref to JDK 8 tools.jar). Same
+                     gone-on-JDK-21 issue as hadoop-common's transitive. -->
+                <exclusion><groupId>jdk.tools</groupId><artifactId>jdk.tools</artifactId></exclusion>
+                <exclusion><groupId>org.apache.hbase</groupId><artifactId>*</artifactId></exclusion>
             </exclusions>
         </dependency>
         <dependency>


### PR DESCRIPTION
## Summary
Bumps the legacy JDBC stacks that were deferred from PR #760 due to higher break risk:

| Driver | From | To |
|---|---|---|
| postgresql | 9.3-1102-jdbc41 | **42.7.4** |
| mysql:mysql-connector-java | 5.1.17 | **com.mysql:mysql-connector-j 8.4.0** |
| hive-jdbc | 0.13.1 | **2.3.9** |
| hive-cli | 1.0.0 | **2.3.9** |
| hadoop-common | 2.4.0 | **2.10.2** (transitive via hive) |

## Notes
- MySQL 8.x auto-registers both `com.mysql.jdbc.Driver` (legacy) and `com.mysql.cj.jdbc.Driver` — existing `.sds` configs keep working unchanged.
- hive-jdbc 2.3.9 → metastore → hbase-client → hbase-annotations drags `jdk.tools:1.7` (system-scope ref to JDK 8 tools.jar); excluded along with the rest of the `org.apache.hbase.*` transitives saiku doesn't use.
- Skipped: **h2 1.4.188 → 2.x** — H2 2.x has SQL-syntax changes that would require migrating the seeded foodmart H2 fixture; handled in a future PR.

## Test plan
- [x] Local: `mvn test` green across all 9 reactor modules
- [ ] CI green on this PR