### PR TITLE
chore(build): modernise Maven plugins + drop stale pom properties

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,16 +30,9 @@
              with saiku-bom/pom.xml to remove the footgun. -->
         <spring.version>6.2.8</spring.version>
         <spring.security.version>6.5.1</spring.security.version>
-        <slf4j.version>1.7.36</slf4j.version>
+        <slf4j.version>2.0.16</slf4j.version>
         <jersey.version>3.1.9</jersey.version>
-        <tomcat.version>apache-tomcat-9.0.8</tomcat.version>
-        <tomcat.source>target/stage/tomcat/</tomcat.source>
         <maven.build.timestamp.format>yyyyMMdd-HHmm</maven.build.timestamp.format>
-        <calcite.version>0.9.2-incubating-SNAPSHOT</calcite.version>
-        <pentaho.libs.version>TRUNK-SNAPSHOT</pentaho.libs.version>
-        <pentaho.platform.version>5.0.0</pentaho.platform.version>
-        <serenity.version>1.0.58</serenity.version>
-        <jbehave.version>3.9.3</jbehave.version>
         <saiku-query.version>0.4-SNAPSHOT</saiku-query.version>
         <jackson.version>2.18.6</jackson.version>
     </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -189,7 +189,16 @@
                 <executions>
                     <execution>
                         <id>attach-sources</id>
-                        <phase>verify</phase>
+                        <!-- Bound to `package` (not `verify`) so reactor
+                             invocations that stop at package — like the
+                             release.yml bundle job's
+                             `mvn -pl saiku-launcher -am package` — still
+                             see the source jars. saiku-webapp's
+                             dependency-plugin:copy step references
+                             {sibling}:jar:sources at process-resources,
+                             which is downstream of package within a
+                             reactor build. -->
+                        <phase>package</phase>
                         <goals>
                             <goal>jar-no-fork</goal>
                             <goal>test-jar-no-fork</goal>

--- a/saiku-bom/pom.xml
+++ b/saiku-bom/pom.xml
@@ -36,11 +36,6 @@
         <!-- Batik 1.8 has CVE-2022-38398/40146/41704/42890/44729/44730. 1.17 fixes them. -->
         <batik.version>1.17</batik.version>
         <jersey.version>3.1.9</jersey.version>
-        <calcite.version>0.9.2-incubating-SNAPSHOT</calcite.version>
-        <pentaho.libs.version>TRUNK-SNAPSHOT</pentaho.libs.version>
-        <pentaho.platform.version>5.0.0</pentaho.platform.version>
-        <serenity.version>1.0.58</serenity.version>
-        <jbehave.version>3.9.3</jbehave.version>
         <saiku-query.version>0.4-SNAPSHOT</saiku-query.version>
         <jackson.version>2.18.6</jackson.version>
         <arrow.version>18.2.0</arrow.version>

--- a/saiku-core/pom.xml
+++ b/saiku-core/pom.xml
@@ -64,7 +64,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jxr-plugin</artifactId>
-                <version>2.1</version>
+                <version>3.4.0</version>
                 <configuration>
                     <aggregate>true</aggregate>
                 </configuration>

--- a/saiku-core/saiku-service/pom.xml
+++ b/saiku-core/saiku-service/pom.xml
@@ -33,7 +33,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.19.1</version>
+                <version>3.5.2</version>
                 <configuration>
                     <argLine>-Xmx512m --add-opens=java.base/java.nio=ALL-UNNAMED</argLine>
                 </configuration>
@@ -78,7 +78,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-antrun-plugin</artifactId>
-                <version>1.2</version>
+                <version>3.1.0</version>
                 <executions>
                     <execution>
                         <id>test</id>
@@ -87,7 +87,10 @@
                             <goal>run</goal>
                         </goals>
                         <configuration>
-                            <tasks>
+                            <!-- antrun 3.x renamed <tasks> to <target>.
+                                 Also dropped the stray ">>>>>>> tag-3.16.1"
+                                 merge marker that lived here for years. -->
+                            <target>
                                 <echo message="Prepare Test. Unzipping foodmart" />
                                 <unzip dest="target/test-classes/">
                                     <fileset dir="target/">
@@ -105,43 +108,36 @@
                                         <include name="FoodMart.xml" />
                                     </fileset>
                                 </copy>
->>>>>>> tag-3.16.1
-
-								<copy todir="target/test-classes/org/saiku/" overwrite="true">
-									<fileset dir="target/test/">
-										<include name="foodmart_hsql.script" />
-									</fileset>
-								</copy>
-
-							</tasks>
-						</configuration>
-					</execution>
-				</executions>
-			</plugin>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-compiler-plugin</artifactId>
-				<version>3.13.0</version>
-				<configuration>
-					<release>${maven.compiler.source}</release>
-					<encoding>UTF-8</encoding>
-				</configuration>
-			</plugin>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-resources-plugin</artifactId>
-				<version>2.4</version>
-				<!-- set encoding to something not platform dependent -->
-				<configuration>
-					<encoding>UTF-8</encoding>
-				</configuration>
-			</plugin>
-			<!--<plugin> <groupId>net.thucydides.maven.plugins</groupId> <artifactId>maven-thucydides-plugin</artifactId> 
-				<version>0.9.229</version> <executions> <execution> <id>thucydides-reports</id> 
-				<phase>post-integration-test</phase> <goals> <goal>aggregate</goal> </goals> 
-				</execution> </executions> </plugin> -->
-		</plugins>
-	</build>
+                                <copy todir="target/test-classes/org/saiku/" overwrite="true">
+                                    <fileset dir="target/test/">
+                                        <include name="foodmart_hsql.script" />
+                                    </fileset>
+                                </copy>
+                            </target>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.13.0</version>
+                <configuration>
+                    <release>${maven.compiler.source}</release>
+                    <encoding>UTF-8</encoding>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-resources-plugin</artifactId>
+                <version>3.3.1</version>
+                <!-- set encoding to something not platform dependent -->
+                <configuration>
+                    <encoding>UTF-8</encoding>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 	<dependencies>
 		<!-- @NotNull / @Nullable annotations used in ObjectUtil + Acl2.
 		     Was previously dragged in transitively (probably via a removed

--- a/saiku-core/saiku-service/pom.xml
+++ b/saiku-core/saiku-service/pom.xml
@@ -62,19 +62,9 @@
                     </execution>
                 </executions>
             </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-source-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>attach-sources</id>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>jar</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
+            <!-- maven-source-plugin attach-sources is already declared in
+                 the root pom's <executions>; re-declaring it here triggers
+                 'duplicated artifacts attached' under source-plugin 3.x. -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-antrun-plugin</artifactId>

--- a/saiku-core/saiku-web/pom.xml
+++ b/saiku-core/saiku-web/pom.xml
@@ -20,20 +20,9 @@
             </resource>
         </resources>
         <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-source-plugin</artifactId>
-                <version>3.3.1</version>
-                <executions>
-                    <execution>
-                        <id>attach-sources</id>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>jar</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
+            <!-- maven-source-plugin attach-sources is already declared in
+                 the root pom's <executions>; re-declaring it here triggers
+                 'duplicated artifacts attached' under source-plugin 3.x. -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>

--- a/saiku-core/saiku-web/pom.xml
+++ b/saiku-core/saiku-web/pom.xml
@@ -23,7 +23,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
-                <version>2.1.2</version>
+                <version>3.3.1</version>
                 <executions>
                     <execution>
                         <id>attach-sources</id>
@@ -37,26 +37,19 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>2.0.2</version>
+                <version>3.13.0</version>
                 <configuration>
-                    <source>${maven.compiler.source}</source>
-                    <target>${maven.compiler.target}</target>
+                    <release>${maven.compiler.source}</release>
                     <encoding>UTF-8</encoding>
                 </configuration>
             </plugin>
-
-
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.19.1</version>
+                <version>3.5.2</version>
                 <configuration>
                     <argLine>-Xmx512m --add-opens=java.base/java.nio=ALL-UNNAMED</argLine>
                 </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.mortbay.jetty</groupId>
-                <artifactId>maven-jetty-plugin</artifactId>
             </plugin>
             <!--<plugin>
                 <groupId>org.apache.felix</groupId>

--- a/saiku-webapp/pom.xml
+++ b/saiku-webapp/pom.xml
@@ -14,7 +14,7 @@
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
-                <version>2.3.7</version>
+                <version>5.1.9</version>
                 <extensions>true</extensions>
 
                 <configuration>
@@ -126,7 +126,7 @@
             </plugin>
             <plugin>
                 <artifactId>maven-resources-plugin</artifactId>
-                <version>2.7</version>
+                <version>3.3.1</version>
                 <executions>
                     <execution>
                         <id>copy-resources</id>
@@ -410,7 +410,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jxr-plugin</artifactId>
-                <version>2.1</version>
+                <version>3.4.0</version>
                 <configuration>
                     <aggregate>true</aggregate>
                 </configuration>


### PR DESCRIPTION
## Summary
Stack of build-only modernisation following the security PRs (#760 #762 #763).

### Plugin bumps
| Module | Plugin | From | To |
|---|---|---|---|
| `saiku-core`, `saiku-webapp` | maven-jxr-plugin | 2.1 | **3.4.0** |
| `saiku-core/saiku-web` | maven-source-plugin | 2.1.2 | **3.3.1** |
| `saiku-core/saiku-web` | maven-compiler-plugin | 2.0.2 | **3.13.0** |
| `saiku-core/saiku-web` | maven-surefire-plugin | 2.19.1 | **3.5.2** |
| `saiku-core/saiku-service` | maven-surefire-plugin | 2.19.1 | **3.5.2** |
| `saiku-core/saiku-service` | maven-antrun-plugin | 1.2 | **3.1.0** (renamed `<tasks>` → `<target>`) |
| `saiku-core/saiku-service` | maven-compiler-plugin | 2.0.2 | **3.13.0** |
| `saiku-core/saiku-service` | maven-resources-plugin | 2.4 | **3.3.1** |
| `saiku-webapp` | maven-bundle-plugin | 2.3.7 | **5.1.9** |
| `saiku-webapp` | maven-resources-plugin | 2.7 | **3.3.1** |

Also dropped `org.mortbay.jetty:maven-jetty-plugin` from saiku-web (mortbay-era Jetty 6, declared without a version).

Cleaned up a leftover `>>>>>>> tag-3.16.1` merge-conflict marker that had been living inside the saiku-service antrun block for years.

### Stale property cleanup
After the dep-removal PRs landed, several properties pointed at deps that no longer exist. Removed from both root pom and `saiku-bom`:

- `serenity.version` (serenity-bdd deleted)
- `jbehave.version` (jbehave-core deleted)
- `pentaho.libs.version`, `pentaho.platform.version` (pentaho-platform-* deleted)
- `tomcat.version`, `tomcat.source` (no consumer)
- `calcite.version` (saiku doesn't import calcite directly)
- Root pom's stray `slf4j.version 1.7.36` synced to 2.0.16 to match the BOM.

## Test plan
- [x] Local: `mvn test` green across all 9 reactor modules
- [ ] CI green on this PR