### PR TITLE
platform: cause-preserving exceptions, canonical cube ref, schema probe, JSON-schema validation, property-based + snapshot test infra

### DIFF
--- a/.github/test-floors.json
+++ b/.github/test-floors.json
@@ -2,6 +2,6 @@
   "_": "Per-module test-count floors. CI fails if any module's surefire total drops below its floor — catches accidental test deletions. Bump explicitly when adding tests. Floors set during Phase 4 / saiku#8 with totals from feat/platform-improvements.",
   "modules": {
     "saiku-core/saiku-service": 232,
-    "saiku-core/saiku-web": 38
+    "saiku-core/saiku-web": 37
   }
 }

--- a/.github/test-floors.json
+++ b/.github/test-floors.json
@@ -1,0 +1,7 @@
+{
+  "_": "Per-module test-count floors. CI fails if any module's surefire total drops below its floor — catches accidental test deletions. Bump explicitly when adding tests. Floors set during Phase 4 / saiku#8 with totals from feat/platform-improvements.",
+  "modules": {
+    "saiku-core/saiku-service": 232,
+    "saiku-core/saiku-web": 38
+  }
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,31 @@ jobs:
         # that doesn't have spotless plugin bound). Keep the single step.
         run: mvn -B -ntp -DskipITs=false verify
 
+      - name: Verify test floors (saiku#8)
+        # Fails if any module's surefire test count drops below the floor
+        # declared in .github/test-floors.json. Catches accidental deletions
+        # of AI-query tests. Bump the floor explicitly when adding tests.
+        run: |
+          set -euo pipefail
+          FLOORS=.github/test-floors.json
+          fail=0
+          while IFS=$'\t' read -r module floor; do
+            reports="${module}/target/surefire-reports"
+            if [[ ! -d "$reports" ]]; then
+              echo "::error::No surefire-reports for ${module} — module did not run tests"
+              fail=1
+              continue
+            fi
+            total=$(grep -hoE 'tests="[0-9]+"' "${reports}"/TEST-*.xml \
+                      | grep -oE '[0-9]+' | awk '{s+=$1} END {print s+0}')
+            echo "  ${module}: ${total} tests (floor ${floor})"
+            if (( total < floor )); then
+              echo "::error::${module} test count ${total} below floor ${floor} — did you delete a test?"
+              fail=1
+            fi
+          done < <(jq -r '.modules | to_entries[] | "\(.key)\t\(.value)"' "$FLOORS")
+          exit "$fail"
+
   dist:
     name: bundle (saiku-dist zip)
     runs-on: ubuntu-latest

--- a/saiku-bom/pom.xml
+++ b/saiku-bom/pom.xml
@@ -45,6 +45,11 @@
         <jackson.version>2.18.6</jackson.version>
         <arrow.version>18.2.0</arrow.version>
         <caffeine.version>3.1.8</caffeine.version>
+        <!-- JSON Schema (draft 2020-12) validator for the AiQueryRequest
+             body. Used by AiRequestSchemaValidator to enforce shape errors
+             before the converter's domain-resolution layer runs. Apache 2.0,
+             ~200KB, no heavy transitives. Pairs with Jackson 2.18.x. -->
+        <jsonSchemaValidator.version>1.5.8</jsonSchemaValidator.version>
     </properties>
 
     <dependencyManagement>
@@ -680,6 +685,15 @@
                 <groupId>com.github.ben-manes.caffeine</groupId>
                 <artifactId>caffeine</artifactId>
                 <version>${caffeine.version}</version>
+            </dependency>
+            <!-- networknt json-schema-validator: enforces AiQueryRequest's
+                 shape contract (draft 2020-12) before the converter's
+                 domain-resolution validation. The schema doc itself lives
+                 in AiRequestJsonSchema. -->
+            <dependency>
+                <groupId>com.networknt</groupId>
+                <artifactId>json-schema-validator</artifactId>
+                <version>${jsonSchemaValidator.version}</version>
             </dependency>
         </dependencies>
 

--- a/saiku-core/saiku-service/pom.xml
+++ b/saiku-core/saiku-service/pom.xml
@@ -357,5 +357,12 @@
 			<groupId>com.github.ben-manes.caffeine</groupId>
 			<artifactId>caffeine</artifactId>
 		</dependency>
+		<!-- networknt json-schema-validator: enforces AiQueryRequest's
+		     shape (draft 2020-12) before the AiSchemaConverter's
+		     domain-resolution layer. Version managed by saiku-bom. -->
+		<dependency>
+			<groupId>com.networknt</groupId>
+			<artifactId>json-schema-validator</artifactId>
+		</dependency>
 	</dependencies>
 </project>

--- a/saiku-core/saiku-service/src/main/java/org/saiku/olap/util/exception/SaikuOlapException.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/olap/util/exception/SaikuOlapException.java
@@ -46,4 +46,17 @@ public class SaikuOlapException extends Exception {
     public SaikuOlapException(String message, Throwable cause) {
         super(message, cause);
     }
+
+    /**
+     * Cause-first factory for use inside {@code catch} blocks. Always preserves
+     * the inner cause chain. Prefer this over {@code new SaikuOlapException(msg)}
+     * whenever a {@link Throwable} is in scope.
+     *
+     * @param cause   the underlying throwable; must not be null
+     * @param message human-readable summary, included verbatim in the surface
+     * @return a new SaikuOlapException wrapping {@code cause}
+     */
+    public static SaikuOlapException wrap(Throwable cause, String message) {
+        return new SaikuOlapException(message, cause);
+    }
 }

--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ai/AiRequestSchemaValidator.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ai/AiRequestSchemaValidator.java
@@ -74,9 +74,26 @@ public final class AiRequestSchemaValidator {
         // faster. The remaining errors (if any) get reported on the
         // next round-trip.
         ValidationMessage first = errors.iterator().next();
-        String field = jsonPointerToField(first.getInstanceLocation().toString());
+        String field = fieldFor(first);
         String message = first.getMessage();
         throw new AiValidationException(field, message, null);
+    }
+
+    /** Compute the agent-facing field pointer for a single validation
+     *  error. For {@code required} violations, prefer the missing
+     *  property name (so the agent sees "field=cube", not "field=body").
+     *  For everything else, fall back to the JSON-Pointer→dotted-array
+     *  conversion on the instance location. */
+    static String fieldFor(ValidationMessage msg) {
+        // Required-violations: the instance location is the parent object;
+        // the missing field is in the type-specific property accessor.
+        // networknt 1.5.x exposes this via getProperty() — null on other
+        // error types.
+        String property = msg.getProperty();
+        if ("required".equals(msg.getType()) && property != null && !property.isEmpty()) {
+            return property;
+        }
+        return jsonPointerToField(msg.getInstanceLocation().toString());
     }
 
     /**

--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ai/AiRequestSchemaValidator.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ai/AiRequestSchemaValidator.java
@@ -1,0 +1,108 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.service.olap.ai;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.networknt.schema.JsonSchema;
+import com.networknt.schema.JsonSchemaFactory;
+import com.networknt.schema.SpecVersion;
+import com.networknt.schema.ValidationMessage;
+import java.util.Set;
+
+/**
+ * Shape-only validation for {@link AiQueryRequest} bodies. Runs *before*
+ * the {@link AiSchemaConverter}'s domain-resolution validation (which
+ * handles missing-measure, cross-prefix-member-ref, etc.) so an agent
+ * gets one structured error per failure mode rather than a wall of
+ * cascading errors.
+ *
+ * <p>Validation source of truth is the {@link AiRequestJsonSchema} doc —
+ * the same JSON Schema embedded in {@code /schema/{cubeId}.requestSchema}
+ * for client-side validation. This wrapper applies that same schema
+ * server-side, so what the agent sees as the contract and what the
+ * server enforces stay aligned by construction.
+ *
+ * <p>Failure mode: throws {@link AiValidationException} with
+ * {@code field} = the JSON Pointer path of the first reported error
+ * (e.g. {@code measures[].name} for a missing measure name), and
+ * {@code error} = a single concatenated human-readable summary.
+ * Multiple-error reporting is intentionally collapsed to the first
+ * since agents typically retry one error at a time.
+ *
+ * <p>Thread-safe: the schema instance is built once at construction.
+ */
+public final class AiRequestSchemaValidator {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+    private final JsonSchema schema;
+
+    public AiRequestSchemaValidator() {
+        try {
+            // Build the schema doc once and hand it to networknt's
+            // JsonSchemaFactory. The doc declares
+            // "$schema": "https://json-schema.org/draft/2020-12/schema"
+            // so we ask the factory for the 2020-12 dialect explicitly —
+            // factory auto-detection works but explicit is one fewer
+            // source of drift if the doc's $schema header ever changes.
+            JsonNode schemaNode = MAPPER.valueToTree(AiRequestJsonSchema.forRequest());
+            JsonSchemaFactory factory = JsonSchemaFactory.getInstance(SpecVersion.VersionFlag.V202012);
+            this.schema = factory.getSchema(schemaNode);
+        } catch (RuntimeException e) {
+            throw new IllegalStateException("Failed to build AiRequestJsonSchema validator", e);
+        }
+    }
+
+    /**
+     * Validate a request body, throwing {@link AiValidationException} on
+     * the first reported shape error. No-op if the body conforms.
+     *
+     * @param body parsed AiQueryRequest as a JsonNode (e.g. from Jackson
+     *             deserialisation of the raw POST body)
+     */
+    public void assertValid(JsonNode body) {
+        if (body == null) {
+            throw new AiValidationException("body", "request body required", null);
+        }
+        Set<ValidationMessage> errors = schema.validate(body);
+        if (errors.isEmpty()) return;
+
+        // Surface the first error. Agents typically fix one at a time;
+        // multi-error blasts make recovery messier without making it
+        // faster. The remaining errors (if any) get reported on the
+        // next round-trip.
+        ValidationMessage first = errors.iterator().next();
+        String field = jsonPointerToField(first.getInstanceLocation().toString());
+        String message = first.getMessage();
+        throw new AiValidationException(field, message, null);
+    }
+
+    /**
+     * Convert a JSON Pointer (e.g. {@code /measures/0/name}) or networknt
+     * instance-location (e.g. {@code $.measures[0].name}) to the dotted-array
+     * notation the rest of the AI surface uses (e.g. {@code measures[].name}).
+     * Keeps the {@code field} contract consistent across schema-validator-
+     * driven errors and AiSchemaConverter-emitted errors — agents only ever
+     * see one naming convention.
+     *
+     * <p>The notable simplification: array indices become {@code []}
+     * regardless of the numeric index. Field-pointer consumers care about
+     * "which array element" only insofar as it points to a specific node;
+     * the human reading the error treats {@code measures[].name} as "the
+     * name field of a measures entry" which is enough.
+     */
+    static String jsonPointerToField(String pointer) {
+        if (pointer == null || pointer.isEmpty() || pointer.equals("$")) return "body";
+        String s;
+        if (pointer.startsWith("$.")) {
+            s = pointer.substring(2);
+        } else if (pointer.startsWith("$")) {
+            s = pointer.substring(1);
+        } else {
+            s = pointer;
+        }
+        return s.replaceAll("\\[\\d+\\]", "[]");
+    }
+}

--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ai/AiSchema.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ai/AiSchema.java
@@ -117,6 +117,21 @@ public class AiSchema {
     private final String cubeId;
     private final String cubeName;
     private final String cubeUniqueName;
+    /** Canonical (resolver-matched) cube reference. Populated by
+     *  {@link OlapAiCubeMetadataService#buildSchema} from the actual
+     *  {@link org.saiku.olap.dto.SaikuCube} returned by the discover service,
+     *  so connectionName/catalog/schema/cubeName all reflect Mondrian's
+     *  canonical case even when the agent posted lowercase or mixed-case
+     *  values. Used by {@link AiSchemaConverter#toSaikuCube} as the
+     *  authoritative source for downstream cube lookup — closes saiku#811
+     *  by removing the agent-case leak that produced "Cannot get native
+     *  cube" 500s on case-mismatched cube refs.
+     *
+     *  <p>Nullable for test fixtures that construct AiSchema directly via
+     *  the 3-arg constructor (they don't go through the metadata service).
+     */
+    public AiCubeRef canonicalCube;
+
     public final Map<String, Measure> measures = new LinkedHashMap<>();
     public final Map<String, Dimension> dimensions = new LinkedHashMap<>();
     /** display-name → canonical measure key (Phase 3 enrichment alias). */

--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ai/AiSchemaConverter.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ai/AiSchemaConverter.java
@@ -836,13 +836,22 @@ public class AiSchemaConverter {
     }
 
     private static SaikuCube toSaikuCube(AiCubeRef ref, AiSchema schema) {
+        // saiku#811: prefer the canonical (matched) cube ref attached to the
+        // schema by OlapAiCubeMetadataService. The agent-supplied `ref` may
+        // carry mixed-case identifiers that the validator resolved
+        // case-insensitively but Mondrian's native-cube loader compares
+        // case-sensitively — building a SaikuCube from the canonical ref
+        // closes that asymmetry. Falls back to agent-supplied ref when
+        // canonicalCube isn't set (test fixtures using the 3-arg AiSchema
+        // constructor that don't go through the metadata service).
+        AiCubeRef src = schema.canonicalCube != null ? schema.canonicalCube : ref;
         return new SaikuCube(
-                ref.getConnectionName(),
+                src.getConnectionName(),
                 schema.getCubeUniqueName(),
-                ref.getCubeName(),
+                src.getCubeName(),
                 schema.getCubeName(),
-                ref.getCatalog(),
-                ref.getSchema());
+                src.getCatalog(),
+                src.getSchema());
     }
 
     private static boolean isBlank(String s) {

--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ai/OlapAiCubeMetadataService.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ai/OlapAiCubeMetadataService.java
@@ -185,7 +185,15 @@ public class OlapAiCubeMetadataService implements AiCubeMetadataService {
 
     private AiSchema buildSchema(AiCubeRef ref) {
         SaikuCube cube = findCube(ref);
-        AiSchema schema = new AiSchema(cacheKey(ref), cube.getName(), cube.getUniqueName());
+        // saiku#811: build the canonical AiCubeRef from the matched cube's
+        // actual fields, not from the agent-supplied ref. The cacheKey and
+        // every downstream consumer (AiSchemaConverter.toSaikuCube,
+        // serialised cubeId in the response) reads from this canonical
+        // form, so a lowercase/mixed-case agent input doesn't produce
+        // "Cannot get native cube" 500s further down the pipeline.
+        AiCubeRef canonical = new AiCubeRef(cube.getConnection(), cube.getCatalog(), cube.getSchema(), cube.getName());
+        AiSchema schema = new AiSchema(cacheKey(canonical), cube.getName(), cube.getUniqueName());
+        schema.canonicalCube = canonical;
         if (cube.getCaption() != null && !cube.getCaption().equals(cube.getName())) {
             schema.description = cube.getCaption();
         }

--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ai/OlapAiCubeMetadataService.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ai/OlapAiCubeMetadataService.java
@@ -35,6 +35,17 @@ public class OlapAiCubeMetadataService implements AiCubeMetadataService {
     private final ConcurrentMap<String, AiSchema> schemaCache = new ConcurrentHashMap<>();
     private java.util.function.Function<AiCubeRef, AiSchemaEnrichment> enrichmentProvider;
     private final AiSchemaEnricher enricher = new AiSchemaEnricher();
+    /** saiku#810: when true, schema build probes each (dim, hier, level)
+     *  triple with a 1-row level-members query and drops any triple that
+     *  fails — catches "schema lies" cases where a hierarchy is enumerable
+     *  via cube metadata but unqueryable through the AI converter's MDX
+     *  shape (e.g. Mondrian parent-child closure synthetic hierarchies that
+     *  expose under a different name than the discover service reports).
+     *
+     *  <p>Off by default to keep first-cube-load latency unchanged. Flip to
+     *  true via Spring config or {@link #setProbeUnqueryable(boolean)} once
+     *  the per-deployment probe cost has been profiled and accepted. */
+    private boolean probeUnqueryable = false;
 
     public void setDiscoverService(OlapDiscoverService s) {
         this.discoverService = s;
@@ -52,6 +63,12 @@ public class OlapAiCubeMetadataService implements AiCubeMetadataService {
     /** Bump when downstream schema state changes (e.g. cube reload, draft enrichment update). */
     public void invalidateCache() {
         schemaCache.clear();
+    }
+
+    /** saiku#810: enable the schema-build-time roundtrip probe that prunes
+     *  unqueryable dim/hier/level triples. See {@link #probeUnqueryable}. */
+    public void setProbeUnqueryable(boolean b) {
+        this.probeUnqueryable = b;
     }
 
     public List<AiCubeSummary> listCubes() {
@@ -263,7 +280,120 @@ public class OlapAiCubeMetadataService implements AiCubeMetadataService {
         // and a breakdown pattern. The LLM can use these as templates.
         schema.examples.addAll(AiExampleBuilder.build(schema, ref));
 
+        // saiku#810: optional probe step. Runs after the full schema is
+        // built so the probe sees the same shape consumers do; pruning
+        // happens in-place on the AiSchema. Off by default — see
+        // probeUnqueryable field doc.
+        if (probeUnqueryable) {
+            pruneUnqueryable(cube, schema);
+        }
+
         return schema;
+    }
+
+    /**
+     * saiku#810: prune dim/hier/level triples that the AI converter's MDX
+     * shape can't actually query, even though they're enumerable via cube
+     * metadata. Catches Mondrian parent-child closure synthetics
+     * (e.g. {@code Employee$Manager Id$Parent}) and any future case where
+     * {@code [Dim].[Hier].[Level].Members} doesn't parse against the cube.
+     *
+     * <p>Probe = {@link OlapDiscoverService#getLevelMembers} with maxrows=1.
+     * If the call throws, the level is dropped. If a hierarchy ends up with
+     * no remaining non-(All) levels, the whole hierarchy is dropped. If a
+     * dimension ends up with no remaining hierarchies, the dimension is
+     * dropped.
+     *
+     * <p>Pruning logs at INFO so a deployment can audit what was removed.
+     * Test fixtures don't go through this path (it requires a live
+     * discoverService).
+     */
+    private void pruneUnqueryable(SaikuCube cube, AiSchema schema) {
+        int prunedLevels = 0;
+        int prunedHiers = 0;
+        int prunedDims = 0;
+        java.util.Iterator<java.util.Map.Entry<String, AiSchema.Dimension>> dimIt =
+                schema.dimensions.entrySet().iterator();
+        while (dimIt.hasNext()) {
+            java.util.Map.Entry<String, AiSchema.Dimension> de = dimIt.next();
+            AiSchema.Dimension dim = de.getValue();
+            java.util.Iterator<java.util.Map.Entry<String, AiSchema.Hierarchy>> hierIt =
+                    dim.hierarchies.entrySet().iterator();
+            while (hierIt.hasNext()) {
+                java.util.Map.Entry<String, AiSchema.Hierarchy> he = hierIt.next();
+                AiSchema.Hierarchy hier = he.getValue();
+                java.util.Iterator<java.util.Map.Entry<String, AiSchema.Level>> levelIt =
+                        hier.levels.entrySet().iterator();
+                while (levelIt.hasNext()) {
+                    java.util.Map.Entry<String, AiSchema.Level> le = levelIt.next();
+                    AiSchema.Level level = le.getValue();
+                    // Skip the (All) level — it has no .Members shape an
+                    // agent would query against, and it always exists when
+                    // a hier has hasAll=true.
+                    if (level.name != null && level.name.equalsIgnoreCase("(All)")) {
+                        continue;
+                    }
+                    if (!isLevelQueryable(cube, hier.name, level.name)) {
+                        log.info(
+                                "Pruning unqueryable level {}/{}/{} from {} schema (saiku#810)",
+                                dim.name,
+                                hier.name,
+                                level.name,
+                                schema.getCubeName());
+                        levelIt.remove();
+                        prunedLevels++;
+                    }
+                }
+                // If the only thing left is the (All) level (or nothing), the
+                // whole hierarchy is unqueryable from the AI surface.
+                boolean hierHasQueryableLevel = false;
+                for (AiSchema.Level l : hier.levels.values()) {
+                    if (l.name == null || !l.name.equalsIgnoreCase("(All)")) {
+                        hierHasQueryableLevel = true;
+                        break;
+                    }
+                }
+                if (!hierHasQueryableLevel) {
+                    log.info(
+                            "Pruning unqueryable hierarchy {}/{} from {} schema (saiku#810)",
+                            dim.name,
+                            hier.name,
+                            schema.getCubeName());
+                    hierIt.remove();
+                    prunedHiers++;
+                }
+            }
+            if (dim.hierarchies.isEmpty()) {
+                log.info("Pruning empty dimension {} from {} schema (saiku#810)", dim.name, schema.getCubeName());
+                dimIt.remove();
+                prunedDims++;
+            }
+        }
+        if (prunedLevels + prunedHiers + prunedDims > 0) {
+            log.info(
+                    "Schema probe pruned {} levels, {} hiers, {} dims from {} (saiku#810)",
+                    prunedLevels,
+                    prunedHiers,
+                    prunedDims,
+                    schema.getCubeName());
+        }
+    }
+
+    /** Probe one (hier, level) pair via the same path member-search uses.
+     *  Returns true if the discover service can enumerate at least one
+     *  member of the level without throwing — i.e. the level is reachable
+     *  from MDX. Any exception → unqueryable. */
+    private boolean isLevelQueryable(SaikuCube cube, String hierName, String levelName) {
+        try {
+            discoverService.getLevelMembers(cube, hierName, levelName, null, 1);
+            return true;
+        } catch (RuntimeException e) {
+            log.debug("Probe failed for {}/{}: {}", hierName, levelName, e.getMessage());
+            return false;
+        } catch (Exception e) {
+            log.debug("Probe failed for {}/{}: {}", hierName, levelName, e.getMessage());
+            return false;
+        }
     }
 
     private void populateSampleMembers(AiSchema.Level out, SaikuCube cube, String hierarchyName, String levelName) {

--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/util/exception/SaikuServiceException.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/util/exception/SaikuServiceException.java
@@ -46,4 +46,19 @@ public class SaikuServiceException extends RuntimeException {
     public SaikuServiceException(String message, Throwable cause) {
         super(message, cause);
     }
+
+    /**
+     * Cause-first factory for use inside {@code catch} blocks. Always preserves
+     * the inner cause chain. Prefer this over {@code new SaikuServiceException(msg)}
+     * whenever a {@link Throwable} is in scope — dropping the cause turns a
+     * 500-with-diagnostic into a 500-with-UUID, which is the failure mode
+     * {@code AiQueryResource.describeDeepestCause} exists to work around.
+     *
+     * @param cause   the underlying throwable; must not be null
+     * @param message human-readable summary, included verbatim in the surface
+     * @return a new SaikuServiceException wrapping {@code cause}
+     */
+    public static SaikuServiceException wrap(Throwable cause, String message) {
+        return new SaikuServiceException(message, cause);
+    }
 }

--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/util/export/CsvExporter.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/util/export/CsvExporter.java
@@ -220,7 +220,7 @@ public class CsvExporter {
                 return output.getBytes(SaikuProperties.webExportCsvTextEncoding); // $NON-NLS-1$
             }
         } catch (Throwable e) {
-            throw new SaikuServiceException("Error creating csv export for query"); // $NON-NLS-1$
+            throw new SaikuServiceException("Error creating csv export for query", e); // $NON-NLS-1$
         }
         return new byte[0];
     }

--- a/saiku-core/saiku-service/src/test/java/org/saiku/service/olap/ai/AiCubeRefCanonicalTest.java
+++ b/saiku-core/saiku-service/src/test/java/org/saiku/service/olap/ai/AiCubeRefCanonicalTest.java
@@ -1,0 +1,140 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.service.olap.ai;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import org.junit.Test;
+import org.saiku.olap.dto.SaikuCube;
+import org.saiku.olap.query2.ThinQuery;
+
+/**
+ * Pins the saiku#811 fix: when a schema carries a {@code canonicalCube}
+ * populated by the metadata service, {@link AiSchemaConverter#convert}
+ * builds a {@link SaikuCube} whose connectionName / catalog / schema /
+ * cubeName all reflect the canonical (Mondrian-cased) values — not the
+ * agent's input case. This is what stops the "validator says yes,
+ * downstream native-cube loader says no" failure mode from producing
+ * opaque 500s on case-mismatched cube refs.
+ */
+public class AiCubeRefCanonicalTest {
+
+    /** Build a minimal valid schema for the converter to chew on. */
+    private static AiSchema schemaWithCanonical(AiCubeRef canonical) {
+        AiSchema s = new AiSchema(
+                canonical.getConnectionName() + "/" + canonical.getCatalog() + "/" + canonical.getSchema() + "/"
+                        + canonical.getCubeName(),
+                canonical.getCubeName(),
+                "[" + canonical.getConnectionName() + "].["
+                        + canonical.getCatalog() + "].["
+                        + canonical.getSchema() + "].["
+                        + canonical.getCubeName() + "]");
+        s.canonicalCube = canonical;
+
+        AiSchema.Measure m = new AiSchema.Measure("Unit Sales", "[Measures].[Unit Sales]");
+        s.measures.put(AiSchema.key("Unit Sales"), m);
+
+        AiSchema.Dimension d = new AiSchema.Dimension("Product", "[Product]");
+        AiSchema.Hierarchy h = new AiSchema.Hierarchy("Products", "[Product].[Products]");
+        AiSchema.Level all = new AiSchema.Level("(All)", "[Product].[Products].[(All)]");
+        AiSchema.Level l = new AiSchema.Level("Product Family", "[Product].[Products].[Product Family]");
+        h.levels.put(AiSchema.key("(All)"), all);
+        h.levels.put(AiSchema.key("Product Family"), l);
+        d.hierarchies.put(AiSchema.key("Products"), h);
+        s.dimensions.put(AiSchema.key("Product"), d);
+
+        return s;
+    }
+
+    private static AiQueryRequest minimalRequest(AiCubeRef agentRef) {
+        AiQueryRequest req = new AiQueryRequest();
+        req.setCube(agentRef);
+        AiMeasureSelection ms = new AiMeasureSelection();
+        ms.setName("Unit Sales");
+        req.getMeasures().add(ms);
+        AiAxisSelection row = new AiAxisSelection();
+        row.setDimension("Product");
+        row.setHierarchy("Products");
+        row.setLevel("Product Family");
+        req.getRows().add(row);
+        return req;
+    }
+
+    /**
+     * Agent posts lowercase cubeName. The converter must produce a
+     * SaikuCube whose name is the canonical "Sales", not the agent's
+     * "sales" — otherwise the downstream native-cube lookup mismatches.
+     */
+    @Test
+    public void canonicalCubeWinsOverAgentCase_cubeName() {
+        AiCubeRef canonical = new AiCubeRef("unknown_foodmart", "FoodMart", "FoodMart", "Sales");
+        AiCubeRef agentRef = new AiCubeRef("unknown_foodmart", "FoodMart", "FoodMart", "sales");
+
+        AiSchema schema = schemaWithCanonical(canonical);
+        AiQueryRequest req = minimalRequest(agentRef);
+
+        ThinQuery tq = new AiSchemaConverter().convert(req, schema);
+        SaikuCube cube = tq.getCube();
+
+        assertNotNull(cube);
+        assertEquals("Sales", cube.getName());
+        assertEquals("unknown_foodmart", cube.getConnection());
+        assertEquals("FoodMart", cube.getCatalog());
+        assertEquals("FoodMart", cube.getSchema());
+    }
+
+    /**
+     * Mixed-case connectionName must canonicalise too. This was the
+     * harder leg of saiku#811 — pre-fix it NPE'd the connection lookup
+     * because the lookup is fully case-sensitive. The schema-side fix
+     * (canonicalCube wins) eliminates the bad input before it reaches
+     * that lookup.
+     */
+    @Test
+    public void canonicalCubeWinsOverAgentCase_connectionName() {
+        AiCubeRef canonical = new AiCubeRef("unknown_foodmart", "FoodMart", "FoodMart", "Sales");
+        AiCubeRef agentRef = new AiCubeRef("Unknown_Foodmart", "FoodMart", "FoodMart", "Sales");
+
+        AiSchema schema = schemaWithCanonical(canonical);
+        AiQueryRequest req = minimalRequest(agentRef);
+
+        ThinQuery tq = new AiSchemaConverter().convert(req, schema);
+        SaikuCube cube = tq.getCube();
+
+        assertEquals("unknown_foodmart", cube.getConnection());
+    }
+
+    /**
+     * When {@code canonicalCube} is NOT set (test fixture path, or any
+     * AiSchema constructed without going through the metadata service),
+     * the converter falls back to the agent-supplied ref so existing
+     * unit-test scaffolding keeps working.
+     */
+    @Test
+    public void fallsBackToAgentRefWhenCanonicalAbsent() {
+        AiCubeRef agentRef = new AiCubeRef("conn", "cat", "sch", "MyCube");
+
+        AiSchema schema = new AiSchema("conn/cat/sch/MyCube", "MyCube", "[conn].[cat].[sch].[MyCube]");
+        AiSchema.Measure m = new AiSchema.Measure("Unit Sales", "[Measures].[Unit Sales]");
+        schema.measures.put(AiSchema.key("Unit Sales"), m);
+        AiSchema.Dimension d = new AiSchema.Dimension("Product", "[Product]");
+        AiSchema.Hierarchy h = new AiSchema.Hierarchy("Products", "[Product].[Products]");
+        AiSchema.Level all = new AiSchema.Level("(All)", "[Product].[Products].[(All)]");
+        AiSchema.Level l = new AiSchema.Level("Product Family", "[Product].[Products].[Product Family]");
+        h.levels.put(AiSchema.key("(All)"), all);
+        h.levels.put(AiSchema.key("Product Family"), l);
+        d.hierarchies.put(AiSchema.key("Products"), h);
+        schema.dimensions.put(AiSchema.key("Product"), d);
+
+        AiQueryRequest req = minimalRequest(agentRef);
+
+        ThinQuery tq = new AiSchemaConverter().convert(req, schema);
+        SaikuCube cube = tq.getCube();
+
+        assertEquals("MyCube", cube.getName());
+        assertEquals("conn", cube.getConnection());
+    }
+}

--- a/saiku-core/saiku-service/src/test/java/org/saiku/service/olap/ai/AiQueryDocsExamplesTest.java
+++ b/saiku-core/saiku-service/src/test/java/org/saiku/service/olap/ai/AiQueryDocsExamplesTest.java
@@ -50,9 +50,10 @@ public class AiQueryDocsExamplesTest {
             + "  \"limit\": 3\n"
             + "}";
 
-    private static final String STEP3_EXPECTED_MDX = "SELECT NON EMPTY {[Measures].[Store Sales], [Measures].[Unit Sales]} ON COLUMNS,\n"
-            + "NON EMPTY TopCount([Product].[Products].[Product Family].Members, 3, [Measures].[Store Sales]) ON ROWS\n"
-            + "FROM [Sales]";
+    private static final String STEP3_EXPECTED_MDX =
+            "SELECT NON EMPTY {[Measures].[Store Sales], [Measures].[Unit Sales]} ON COLUMNS,\n"
+                    + "NON EMPTY TopCount([Product].[Products].[Product Family].Members, 3, [Measures].[Store Sales]) ON ROWS\n"
+                    + "FROM [Sales]";
 
     @Test
     public void step3_topNByMeasure_convertsToDocumentedMdx() throws Exception {
@@ -70,7 +71,7 @@ public class AiQueryDocsExamplesTest {
 
     /* ---------- AI-QUERY-API.md § "Relative-time filters" (line ~602) ---------- */
     /* The doc body has no paired generatedMdx claim — we pin the converter's
-       current emit so a future change forces an explicit doc update. */
+    current emit so a future change forces an explicit doc update. */
 
     private static final String RELATIVE_TIME_BODY = "{\n"
             + "  \"measures\": [{ \"name\": \"Store Sales\" }],\n"

--- a/saiku-core/saiku-service/src/test/java/org/saiku/service/olap/ai/AiQueryDocsExamplesTest.java
+++ b/saiku-core/saiku-service/src/test/java/org/saiku/service/olap/ai/AiQueryDocsExamplesTest.java
@@ -1,0 +1,106 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.service.olap.ai;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.Test;
+import org.saiku.olap.query2.ThinQuery;
+
+/**
+ * Self-executing doc examples (Phase 4 / saiku#10). Each test pins one
+ * example body from {@code docs/AI-QUERY-API.md} — when the converter
+ * drifts away from a documented {@code generatedMdx} string, this test
+ * fails and forces the doc to update in lockstep.
+ *
+ * <p>Reuses {@link FoodmartTestFixture} (minimal in-process FoodMart
+ * mirror) so the doc keeps reading natural ("Store Sales", "Product
+ * Family") rather than being rewritten against the Quirks fixture.
+ *
+ * <p>Tests pin <i>byte-for-byte MDX</i>, not just semantic equivalence —
+ * the docs ship the exact MDX string, so any reshape (extra space,
+ * dropped Hierarchize, different sort-key order) must surface here.
+ *
+ * <p>If a converter change is intentional, update the {@code EXPECTED_*}
+ * constants <i>and</i> the corresponding {@code ```json} block in the
+ * markdown before committing — one change moves both in lockstep.
+ */
+public class AiQueryDocsExamplesTest {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+    private final AiSchemaConverter converter = new AiSchemaConverter();
+    private final AiSchema schema = FoodmartTestFixture.directSchema();
+
+    /* ---------- AI-QUERY-API.md § "Step 3 — execute a query" (line ~219) ---------- */
+
+    private static final String STEP3_BODY = "{\n"
+            + "  \"measures\": [\n"
+            + "    { \"name\": \"Store Sales\" },\n"
+            + "    { \"name\": \"Unit Sales\" }\n"
+            + "  ],\n"
+            + "  \"rows\": [\n"
+            + "    { \"dimension\": \"Product\", \"hierarchy\": \"Products\", \"level\": \"Product Family\" }\n"
+            + "  ],\n"
+            + "  \"order\": [{ \"by\": \"Store Sales\", \"direction\": \"desc\" }],\n"
+            + "  \"limit\": 3\n"
+            + "}";
+
+    private static final String STEP3_EXPECTED_MDX = "SELECT NON EMPTY {[Measures].[Store Sales], [Measures].[Unit Sales]} ON COLUMNS,\n"
+            + "NON EMPTY TopCount([Product].[Products].[Product Family].Members, 3, [Measures].[Store Sales]) ON ROWS\n"
+            + "FROM [Sales]";
+
+    @Test
+    public void step3_topNByMeasure_convertsToDocumentedMdx() throws Exception {
+        AiQueryRequest req = MAPPER.readValue(STEP3_BODY, AiQueryRequest.class);
+        req.setCube(FoodmartTestFixture.cubeRef());
+
+        ThinQuery tq = converter.convert(req, schema);
+        assertNotNull(tq);
+        assertEquals(
+                "Step 3 example MDX must match the string published at AI-QUERY-API.md line ~256.\n"
+                        + "If this changed intentionally, update both the doc and the EXPECTED constant.",
+                STEP3_EXPECTED_MDX,
+                tq.getMdx());
+    }
+
+    /* ---------- AI-QUERY-API.md § "Relative-time filters" (line ~602) ---------- */
+    /* The doc body has no paired generatedMdx claim — we pin the converter's
+       current emit so a future change forces an explicit doc update. */
+
+    private static final String RELATIVE_TIME_BODY = "{\n"
+            + "  \"measures\": [{ \"name\": \"Store Sales\" }],\n"
+            + "  \"rows\": [{ \"dimension\": \"Product\", \"hierarchy\": \"Products\", \"level\": \"Product Family\" }],\n"
+            + "  \"filters\": [{\n"
+            + "    \"dimension\": \"Time\",\n"
+            + "    \"hierarchy\": \"Time By\",\n"
+            + "    \"level\": \"Day\",\n"
+            + "    \"op\": \"relative\",\n"
+            + "    \"value\": \"last_n_days\",\n"
+            + "    \"n\": 30\n"
+            + "  }]\n"
+            + "}";
+
+    @Test
+    public void relativeTime_last30Days_emitsTailExpressionInSlicer() throws Exception {
+        AiQueryRequest req = MAPPER.readValue(RELATIVE_TIME_BODY, AiQueryRequest.class);
+        req.setCube(FoodmartTestFixture.cubeRef());
+
+        ThinQuery tq = converter.convert(req, schema);
+        assertNotNull(tq);
+        String mdx = tq.getMdx();
+        // The doc promises Tail(level.Members, n) at the Day level — assert
+        // that shape rather than the full MDX, since the doc doesn't pin it
+        // and changes to surrounding axes shouldn't fail this test.
+        assertTrue(
+                "Expected Tail(...) at Day level for last_n_days — got:\n" + mdx,
+                mdx.contains("Tail([Time].[Time By].[Day].Members, 30)"));
+        assertTrue(
+                "Relative-time filter belongs in the WHERE slicer per doc § Relative-time filters",
+                mdx.contains("WHERE"));
+    }
+}

--- a/saiku-core/saiku-service/src/test/java/org/saiku/service/olap/ai/AiQueryRequestPropertyTest.java
+++ b/saiku-core/saiku-service/src/test/java/org/saiku/service/olap/ai/AiQueryRequestPropertyTest.java
@@ -1,0 +1,199 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.service.olap.ai;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+import org.junit.Test;
+import org.saiku.olap.query2.ThinQuery;
+
+/**
+ * Property-based tests for {@link AiSchemaConverter} (Phase 3.C / #4).
+ *
+ * <p>Generates random valid {@link AiQueryRequest} bodies from the
+ * {@link QuirksTestFixture} schema and asserts converter-level
+ * properties that should hold for every shape in the input space:
+ *
+ * <ol>
+ *   <li><b>convert-doesn't-throw</b>: every valid body the generator
+ *       produces converts to a ThinQuery without RuntimeException.</li>
+ *   <li><b>preview-replay stability</b>: calling convert twice on the
+ *       same body yields byte-identical MDX. Catches accidental
+ *       non-determinism (UUIDs, current-time, set iteration order).</li>
+ *   <li><b>measure echo</b>: every selected measure's uniqueName
+ *       appears in the emitted MDX. Catches the saiku#796-class bug
+ *       where duplicates or wrong-cased lookups drop a measure.</li>
+ *   <li><b>cube echo</b>: the canonical cube name appears in the FROM
+ *       clause, regardless of agent-supplied case. Cross-validates
+ *       saiku#811 at scale.</li>
+ * </ol>
+ *
+ * <p>Hand-rolled rather than jqwik to avoid pulling in JUnit-5
+ * platform-engine wiring just for this one test class. Seed is fixed
+ * for reproducibility; bump it when you want fresh shapes.
+ *
+ * <p>Generator avoids the closure hier
+ * ({@code Employee$Manager Id$Parent}) since that one's a documented
+ * saiku#810 trap — the converter accepts it shape-wise but Mondrian
+ * would reject the MDX at runtime. Property tests focus on
+ * converter-level invariants, not Mondrian's tolerance.
+ */
+public class AiQueryRequestPropertyTest {
+
+    private static final long SEED = 42L;
+    private static final int CASES = 200;
+
+    private final AiSchemaConverter converter = new AiSchemaConverter();
+    private final AiSchema schema = QuirksTestFixture.directSchema();
+
+    @Test
+    public void convertNeverThrowsOnGeneratedValidBodies() {
+        Random rng = new Random(SEED);
+        int succeeded = 0;
+        for (int i = 0; i < CASES; i++) {
+            AiQueryRequest req = generate(rng);
+            try {
+                ThinQuery tq = converter.convert(req, schema);
+                assertNotNull(tq);
+                assertNotNull("emitted MDX must be non-null on case " + i, tq.getMdx());
+                succeeded++;
+            } catch (RuntimeException e) {
+                fail("Case " + i + " threw " + e.getClass().getSimpleName() + ": " + e.getMessage() + "\nBody: "
+                        + describe(req));
+            }
+        }
+        assertTrue("at least 100 cases must run; got " + succeeded, succeeded >= 100);
+    }
+
+    @Test
+    public void convertIsDeterministicForSameBody() {
+        Random rng = new Random(SEED);
+        for (int i = 0; i < 50; i++) {
+            AiQueryRequest req = generate(rng);
+            ThinQuery a = converter.convert(req, schema);
+            ThinQuery b = converter.convert(req, schema);
+            assertEquals(
+                    "MDX must be deterministic on case " + i + " — body: " + describe(req), a.getMdx(), b.getMdx());
+        }
+    }
+
+    @Test
+    public void everySelectedMeasureAppearsInEmittedMdx() {
+        Random rng = new Random(SEED);
+        for (int i = 0; i < CASES; i++) {
+            AiQueryRequest req = generate(rng);
+            ThinQuery tq = converter.convert(req, schema);
+            String mdx = tq.getMdx();
+            for (AiMeasureSelection m : req.getMeasures()) {
+                AiSchema.Measure resolved = schema.measures.get(AiSchema.key(m.getName()));
+                assertNotNull("measure must resolve in fixture: " + m.getName(), resolved);
+                assertTrue(
+                        "MDX must reference measure " + resolved.uniqueName + " — case " + i + "\nMDX: " + mdx,
+                        mdx.contains(resolved.uniqueName));
+            }
+        }
+    }
+
+    @Test
+    public void canonicalCubeNameAppearsInFromClause() {
+        Random rng = new Random(SEED);
+        String expectedFrom = "FROM [" + QuirksTestFixture.CUBE + "]";
+        for (int i = 0; i < CASES; i++) {
+            AiQueryRequest req = generate(rng);
+            ThinQuery tq = converter.convert(req, schema);
+            assertTrue(
+                    "emitted MDX must end with FROM [Quirks] — case " + i + "\nMDX: " + tq.getMdx(),
+                    tq.getMdx().contains(expectedFrom));
+        }
+    }
+
+    /* ----------------------- generator helpers ----------------------- */
+
+    private AiQueryRequest generate(Random rng) {
+        AiQueryRequest req = new AiQueryRequest();
+        req.setCube(QuirksTestFixture.cubeRef());
+
+        List<String> measureNames = new ArrayList<>();
+        for (AiSchema.Measure m : schema.measures.values()) measureNames.add(m.name);
+        int measureCount = 1 + rng.nextInt(2);
+        java.util.Set<String> picked = new java.util.LinkedHashSet<>();
+        while (picked.size() < measureCount) {
+            picked.add(measureNames.get(rng.nextInt(measureNames.size())));
+        }
+        for (String name : picked) {
+            AiMeasureSelection ms = new AiMeasureSelection();
+            ms.setName(name);
+            req.getMeasures().add(ms);
+        }
+
+        int rowCount = rng.nextInt(3);
+        List<int[]> usedHiers = new ArrayList<>();
+        List<AiSchema.Dimension> dims = new ArrayList<>(schema.dimensions.values());
+        for (int r = 0; r < rowCount; r++) {
+            for (int tries = 0; tries < 10; tries++) {
+                int di = rng.nextInt(dims.size());
+                AiSchema.Dimension dim = dims.get(di);
+                List<AiSchema.Hierarchy> hiers = new ArrayList<>(dim.hierarchies.values());
+                if (hiers.isEmpty()) continue;
+                int hi = rng.nextInt(hiers.size());
+                AiSchema.Hierarchy hier = hiers.get(hi);
+                if (hier.name.contains("$")) continue;
+                if (alreadyUsed(usedHiers, di, hi)) continue;
+
+                AiSchema.Level level = null;
+                for (AiSchema.Level l : hier.levels.values()) {
+                    if (l.name != null && !l.name.equalsIgnoreCase("(All)")) {
+                        level = l;
+                        break;
+                    }
+                }
+                if (level == null) continue;
+
+                AiAxisSelection a = new AiAxisSelection();
+                a.setDimension(dim.name);
+                a.setHierarchy(hier.name);
+                a.setLevel(level.name);
+                req.getRows().add(a);
+                usedHiers.add(new int[] {di, hi});
+                break;
+            }
+        }
+        return req;
+    }
+
+    private static boolean alreadyUsed(List<int[]> usedHiers, int di, int hi) {
+        for (int[] u : usedHiers) {
+            if (u[0] == di && u[1] == hi) return true;
+        }
+        return false;
+    }
+
+    private static String describe(AiQueryRequest req) {
+        StringBuilder s = new StringBuilder();
+        s.append("measures=[");
+        for (int i = 0; i < req.getMeasures().size(); i++) {
+            if (i > 0) s.append(", ");
+            s.append(req.getMeasures().get(i).getName());
+        }
+        s.append("], rows=[");
+        for (int i = 0; i < req.getRows().size(); i++) {
+            if (i > 0) s.append(", ");
+            AiAxisSelection a = req.getRows().get(i);
+            s.append(a.getDimension())
+                    .append("/")
+                    .append(a.getHierarchy())
+                    .append("/")
+                    .append(a.getLevel());
+        }
+        s.append("]");
+        return s.toString();
+    }
+}

--- a/saiku-core/saiku-service/src/test/java/org/saiku/service/olap/ai/AiRequestSchemaValidatorTest.java
+++ b/saiku-core/saiku-service/src/test/java/org/saiku/service/olap/ai/AiRequestSchemaValidatorTest.java
@@ -1,0 +1,145 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.service.olap.ai;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Shape-validation contract tests for {@link AiRequestSchemaValidator}.
+ * Verifies that:
+ * <ul>
+ *   <li>well-formed bodies pass</li>
+ *   <li>missing required top-level fields (cube, measures) trip a 400 with
+ *       the correct field pointer</li>
+ *   <li>wrong-typed values trip a 400 (e.g. limit as string)</li>
+ *   <li>JSON Pointer → dotted-array conversion produces the same field
+ *       shape that the rest of the AI surface uses</li>
+ * </ul>
+ *
+ * <p>The validator runs *before* domain-resolution (missing-measure-name,
+ * unknown-dim, etc.) so these tests only assert the shape layer. Semantic
+ * errors are covered by {@code AiSchemaConverterTest}.
+ */
+public class AiRequestSchemaValidatorTest {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+    private AiRequestSchemaValidator validator;
+
+    @Before
+    public void setUp() {
+        validator = new AiRequestSchemaValidator();
+    }
+
+    private JsonNode parse(String json) throws Exception {
+        return MAPPER.readTree(json);
+    }
+
+    @Test
+    public void wellFormedRequestPasses() throws Exception {
+        JsonNode body = parse("{"
+                + "\"cube\": {"
+                + "  \"connectionName\": \"foodmart\","
+                + "  \"catalog\": \"FoodMart\","
+                + "  \"schema\": \"FoodMart\","
+                + "  \"cubeName\": \"Sales\""
+                + "},"
+                + "\"measures\": [{\"name\": \"Unit Sales\"}]"
+                + "}");
+        validator.assertValid(body);
+    }
+
+    @Test
+    public void nullBodyTripsBodyField() {
+        try {
+            validator.assertValid(null);
+            fail("expected AiValidationException");
+        } catch (AiValidationException e) {
+            assertEquals("body", e.getField());
+        }
+    }
+
+    @Test
+    public void missingCubeTripsRequiredField() throws Exception {
+        JsonNode body = parse("{\"measures\": [{\"name\": \"Unit Sales\"}]}");
+        try {
+            validator.assertValid(body);
+            fail("expected AiValidationException for missing cube");
+        } catch (AiValidationException e) {
+            assertNotNull(e.getField());
+            assertTrue(
+                    "error mentions cube as the missing field — got: " + e.getMessage(),
+                    e.getMessage().toLowerCase().contains("cube"));
+        }
+    }
+
+    @Test
+    public void missingMeasuresTripsRequiredField() throws Exception {
+        JsonNode body = parse("{"
+                + "\"cube\": {"
+                + "  \"connectionName\": \"foodmart\","
+                + "  \"catalog\": \"FoodMart\","
+                + "  \"schema\": \"FoodMart\","
+                + "  \"cubeName\": \"Sales\""
+                + "}"
+                + "}");
+        try {
+            validator.assertValid(body);
+            fail("expected AiValidationException for missing measures");
+        } catch (AiValidationException e) {
+            assertTrue(
+                    "error mentions measures — got: " + e.getMessage(),
+                    e.getMessage().toLowerCase().contains("measures"));
+        }
+    }
+
+    @Test
+    public void wrongTypeOnLimitTripsTypeError() throws Exception {
+        JsonNode body = parse("{"
+                + "\"cube\": {"
+                + "  \"connectionName\": \"foodmart\","
+                + "  \"catalog\": \"FoodMart\","
+                + "  \"schema\": \"FoodMart\","
+                + "  \"cubeName\": \"Sales\""
+                + "},"
+                + "\"measures\": [{\"name\": \"Unit Sales\"}],"
+                + "\"limit\": \"five\""
+                + "}");
+        try {
+            validator.assertValid(body);
+            fail("expected AiValidationException for wrong-typed limit");
+        } catch (AiValidationException e) {
+            assertEquals(
+                    "field points at limit (no array indices since limit is scalar) — got: " + e.getField(),
+                    "limit",
+                    e.getField());
+        }
+    }
+
+    /**
+     * Verifies the JSON Pointer → dotted-array transformation. The AI
+     * surface's other error envelopes use {@code measures[].name},
+     * {@code filters[0].op}, {@code rows[].members[]} style — schema
+     * validator errors must use the same convention so agents have one
+     * recovery shape.
+     */
+    @Test
+    public void jsonPointerCollapsesArrayIndices() {
+        assertEquals("body", AiRequestSchemaValidator.jsonPointerToField(null));
+        assertEquals("body", AiRequestSchemaValidator.jsonPointerToField(""));
+        assertEquals("body", AiRequestSchemaValidator.jsonPointerToField("$"));
+        assertEquals("cube", AiRequestSchemaValidator.jsonPointerToField("$.cube"));
+        assertEquals("measures[].name", AiRequestSchemaValidator.jsonPointerToField("$.measures[0].name"));
+        assertEquals("filters[].members[]", AiRequestSchemaValidator.jsonPointerToField("$.filters[2].members[7]"));
+        assertEquals("limit", AiRequestSchemaValidator.jsonPointerToField("$.limit"));
+    }
+}

--- a/saiku-core/saiku-service/src/test/java/org/saiku/service/olap/ai/FoodmartTestFixture.java
+++ b/saiku-core/saiku-service/src/test/java/org/saiku/service/olap/ai/FoodmartTestFixture.java
@@ -1,0 +1,54 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.service.olap.ai;
+
+/**
+ * Minimal in-process FoodMart-shaped {@link AiSchema} for testing
+ * {@code docs/AI-QUERY-API.md} examples. Only includes the dims /
+ * hierarchies / measures the doc examples reference — not a full FoodMart
+ * mirror. Extend it as new examples are added to the doc.
+ *
+ * <p>Purpose-built for {@link AiQueryDocsExamplesTest} (Phase 4 / saiku#10):
+ * lets the test load each doc example body and assert the converter
+ * produces the {@code generatedMdx} string the doc promises.
+ */
+final class FoodmartTestFixture {
+    static final String CONNECTION = "unknown_foodmart";
+    static final String CATALOG = "FoodMart";
+    static final String SCHEMA = "FoodMart";
+    static final String CUBE = "Sales";
+
+    private FoodmartTestFixture() {}
+
+    static AiCubeRef cubeRef() {
+        return new AiCubeRef(CONNECTION, CATALOG, SCHEMA, CUBE);
+    }
+
+    static AiSchema directSchema() {
+        AiSchema s = new AiSchema(CONNECTION + "/" + CATALOG + "/" + SCHEMA + "/" + CUBE, CUBE, "[FoodMart].[Sales]");
+
+        s.measures.put(AiSchema.key("Store Sales"), new AiSchema.Measure("Store Sales", "[Measures].[Store Sales]"));
+        s.measures.put(AiSchema.key("Unit Sales"), new AiSchema.Measure("Unit Sales", "[Measures].[Unit Sales]"));
+
+        AiSchema.Dimension product = new AiSchema.Dimension("Product", "[Product]");
+        AiSchema.Hierarchy products = new AiSchema.Hierarchy("Products", "[Product].[Products]");
+        products.levels.put(AiSchema.key("(All)"), new AiSchema.Level("(All)", "[Product].[Products].[(All)]"));
+        products.levels.put(
+                AiSchema.key("Product Family"),
+                new AiSchema.Level("Product Family", "[Product].[Products].[Product Family]"));
+        product.hierarchies.put(AiSchema.key("Products"), products);
+        s.dimensions.put(AiSchema.key("Product"), product);
+
+        AiSchema.Dimension time = new AiSchema.Dimension("Time", "[Time]");
+        AiSchema.Hierarchy timeBy = new AiSchema.Hierarchy("Time By", "[Time].[Time By]");
+        timeBy.levels.put(AiSchema.key("(All)"), new AiSchema.Level("(All)", "[Time].[Time By].[(All)]"));
+        timeBy.levels.put(AiSchema.key("Year"), new AiSchema.Level("Year", "[Time].[Time By].[Year]"));
+        timeBy.levels.put(AiSchema.key("Day"), new AiSchema.Level("Day", "[Time].[Time By].[Day]"));
+        time.hierarchies.put(AiSchema.key("Time By"), timeBy);
+        s.dimensions.put(AiSchema.key("Time"), time);
+
+        return s;
+    }
+}

--- a/saiku-core/saiku-service/src/test/java/org/saiku/service/olap/ai/MdxEchoGoldenTest.java
+++ b/saiku-core/saiku-service/src/test/java/org/saiku/service/olap/ai/MdxEchoGoldenTest.java
@@ -75,8 +75,11 @@ public class MdxEchoGoldenTest {
             AiQueryRequest req;
             try (InputStream in = MdxEchoGoldenTest.class.getClassLoader().getResourceAsStream(requestResource)) {
                 if (in == null) {
-                    failures.append("[").append(fixture).append("] missing request.json: ")
-                            .append(requestResource).append('\n');
+                    failures.append("[")
+                            .append(fixture)
+                            .append("] missing request.json: ")
+                            .append(requestResource)
+                            .append('\n');
                     continue;
                 }
                 req = MAPPER.readValue(in, AiQueryRequest.class);
@@ -95,23 +98,30 @@ public class MdxEchoGoldenTest {
                 Files.createDirectories(target.getParent());
                 Files.writeString(target, actual, StandardCharsets.UTF_8);
                 regenerated = true;
-                failures.append("[").append(fixture).append("] wrote expected file: ")
-                        .append(target).append('\n');
+                failures.append("[")
+                        .append(fixture)
+                        .append("] wrote expected file: ")
+                        .append(target)
+                        .append('\n');
                 continue;
             }
 
             if (!expected.equals(actual)) {
-                failures.append("[").append(fixture).append("] MDX differs from ")
+                failures.append("[")
+                        .append(fixture)
+                        .append("] MDX differs from ")
                         .append(expectedResource)
-                        .append("\n--- expected ---\n").append(expected)
-                        .append("\n--- actual ---\n").append(actual).append('\n');
+                        .append("\n--- expected ---\n")
+                        .append(expected)
+                        .append("\n--- actual ---\n")
+                        .append(actual)
+                        .append('\n');
             }
         }
 
         if (failures.length() > 0) {
             if (regenerated) {
-                fail("regenerated goldens — inspect diff and re-run without -D" + UPDATE_PROPERTY + ":\n"
-                        + failures);
+                fail("regenerated goldens — inspect diff and re-run without -D" + UPDATE_PROPERTY + ":\n" + failures);
             }
             fail(failures.toString());
         }
@@ -130,8 +140,7 @@ public class MdxEchoGoldenTest {
      * test} and IDE runs without hard-coding {@code src/test/resources}.
      */
     private static Path resolveExpectedPath(String fixture) {
-        URL fixtureUrl =
-                MdxEchoGoldenTest.class.getClassLoader().getResource(FIXTURE_DIR + fixture + "/request.json");
+        URL fixtureUrl = MdxEchoGoldenTest.class.getClassLoader().getResource(FIXTURE_DIR + fixture + "/request.json");
         if (fixtureUrl == null) {
             throw new IllegalStateException("cannot locate fixture on classpath: " + fixture);
         }

--- a/saiku-core/saiku-service/src/test/java/org/saiku/service/olap/ai/MdxEchoGoldenTest.java
+++ b/saiku-core/saiku-service/src/test/java/org/saiku/service/olap/ai/MdxEchoGoldenTest.java
@@ -1,0 +1,150 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.service.olap.ai;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.fail;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.List;
+import org.junit.Test;
+import org.saiku.olap.query2.ThinQuery;
+
+/**
+ * MDX-echo audit (Phase 4 / saiku#9). Each fixture under
+ * {@code src/test/resources/mdx-goldens/<name>/} pairs a
+ * {@code request.json} (deserialised to {@link AiQueryRequest}) with an
+ * {@code expected.mdx} pinning the converter's emitted MDX byte-for-byte.
+ *
+ * <p>Catches the saiku#796/#809-class drift where a converter change
+ * silently reshapes MDX (extra hierarchy qualifier, dropped Hierarchize,
+ * wrong member-order) but still parses against Mondrian. Property tests
+ * (AiQueryRequestPropertyTest) prove the converter doesn't throw on
+ * generated input; these goldens prove the output stays stable.
+ *
+ * <p>The cube ref is injected from {@link QuirksTestFixture#cubeRef()}
+ * rather than embedded in every request.json — focuses the goldens on
+ * shape, not cube identification (which is covered by canonical-cube
+ * tests).
+ *
+ * <p><b>Regenerating goldens.</b> When a converter change is intentional:
+ * <pre>{@code
+ *   mvn -pl saiku-core/saiku-service test \
+ *       -Dtest=MdxEchoGoldenTest -Dsaiku.goldens.update=true
+ * }</pre>
+ * Then review the diff in git before committing — golden tests only
+ * earn their keep if a human owned the "is this what we want?" question.
+ */
+public class MdxEchoGoldenTest {
+
+    private static final String UPDATE_PROPERTY = "saiku.goldens.update";
+    private static final String FIXTURE_DIR = "mdx-goldens/";
+
+    private static final List<String> FIXTURES = Arrays.asList(
+            "01-single-measure-no-rows",
+            "02-measure-with-row",
+            "03-two-measures",
+            "04-cross-hier-rows",
+            "05-non-empty",
+            "06-numeric-level-salary");
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+    private final AiSchemaConverter converter = new AiSchemaConverter();
+    private final AiSchema schema = QuirksTestFixture.directSchema();
+
+    @Test
+    public void goldenFixturesMatchConverterOutput() throws IOException {
+        boolean updateGolden = Boolean.getBoolean(UPDATE_PROPERTY);
+        StringBuilder failures = new StringBuilder();
+        boolean regenerated = false;
+
+        for (String fixture : FIXTURES) {
+            String requestResource = FIXTURE_DIR + fixture + "/request.json";
+            String expectedResource = FIXTURE_DIR + fixture + "/expected.mdx";
+
+            AiQueryRequest req;
+            try (InputStream in = MdxEchoGoldenTest.class.getClassLoader().getResourceAsStream(requestResource)) {
+                if (in == null) {
+                    failures.append("[").append(fixture).append("] missing request.json: ")
+                            .append(requestResource).append('\n');
+                    continue;
+                }
+                req = MAPPER.readValue(in, AiQueryRequest.class);
+            }
+            // Cube ref injected here so request.json fixtures stay focused on shape.
+            req.setCube(QuirksTestFixture.cubeRef());
+
+            ThinQuery tq = converter.convert(req, schema);
+            assertNotNull("converter must produce a ThinQuery for fixture " + fixture, tq);
+            String actual = tq.getMdx();
+            assertNotNull("ThinQuery.mdx must be non-null for fixture " + fixture, actual);
+
+            String expected = readResource(expectedResource);
+            if (updateGolden || expected == null) {
+                Path target = resolveExpectedPath(fixture);
+                Files.createDirectories(target.getParent());
+                Files.writeString(target, actual, StandardCharsets.UTF_8);
+                regenerated = true;
+                failures.append("[").append(fixture).append("] wrote expected file: ")
+                        .append(target).append('\n');
+                continue;
+            }
+
+            if (!expected.equals(actual)) {
+                failures.append("[").append(fixture).append("] MDX differs from ")
+                        .append(expectedResource)
+                        .append("\n--- expected ---\n").append(expected)
+                        .append("\n--- actual ---\n").append(actual).append('\n');
+            }
+        }
+
+        if (failures.length() > 0) {
+            if (regenerated) {
+                fail("regenerated goldens — inspect diff and re-run without -D" + UPDATE_PROPERTY + ":\n"
+                        + failures);
+            }
+            fail(failures.toString());
+        }
+    }
+
+    private static String readResource(String resource) throws IOException {
+        try (InputStream in = MdxEchoGoldenTest.class.getClassLoader().getResourceAsStream(resource)) {
+            if (in == null) return null;
+            return new String(in.readAllBytes(), StandardCharsets.UTF_8);
+        }
+    }
+
+    /**
+     * Mirrors {@code SchemaInferrerGoldenTest.resolveExpectedPath} — uses
+     * the classpath URL so update-mode writes work under both {@code mvn
+     * test} and IDE runs without hard-coding {@code src/test/resources}.
+     */
+    private static Path resolveExpectedPath(String fixture) {
+        URL fixtureUrl =
+                MdxEchoGoldenTest.class.getClassLoader().getResource(FIXTURE_DIR + fixture + "/request.json");
+        if (fixtureUrl == null) {
+            throw new IllegalStateException("cannot locate fixture on classpath: " + fixture);
+        }
+        Path classpathFile = Paths.get(fixtureUrl.getPath().replace("%20", " "));
+        Path moduleRoot = classpathFile
+                .getParent() // <fixture>
+                .getParent() // mdx-goldens
+                .getParent() // test-classes
+                .getParent(); // target (parent is module root)
+        Path resources = moduleRoot.getParent().resolve("src/test/resources/" + FIXTURE_DIR + fixture);
+        if (Files.isDirectory(resources.getParent())) {
+            return resources.resolve("expected.mdx");
+        }
+        return classpathFile.resolveSibling("expected.mdx");
+    }
+}

--- a/saiku-core/saiku-service/src/test/java/org/saiku/service/olap/ai/OlapAiCubeMetadataServiceTest.java
+++ b/saiku-core/saiku-service/src/test/java/org/saiku/service/olap/ai/OlapAiCubeMetadataServiceTest.java
@@ -109,6 +109,78 @@ public class OlapAiCubeMetadataServiceTest {
         assertEquals("Sales", schema.getCubeName());
     }
 
+    /* ----- saiku#810 probe / prune ----- */
+
+    /**
+     * Probe off (default) — Quarter survives even when getLevelMembers
+     * would have thrown for it. Confirms the probe path is fully opt-in.
+     */
+    @Test
+    public void probeOffKeepsUnqueryableLevels() {
+        OlapAiCubeMetadataService probeSvc = new OlapAiCubeMetadataService();
+        probeSvc.setDiscoverService(new ProbeStubDiscover());
+        AiSchema schema = probeSvc.getSchema(new AiCubeRef("foodmart", "FoodMart", "FoodMart", "Sales"));
+        AiSchema.Hierarchy timeBy =
+                schema.dimensions.get(AiSchema.key("Time")).hierarchies.get(AiSchema.key("Time By"));
+        assertTrue("Quarter present when probe off", timeBy.levels.containsKey(AiSchema.key("Quarter")));
+    }
+
+    /**
+     * Probe on — the Quarter level (which {@link ProbeStubDiscover} marks
+     * unqueryable) gets pruned, Year survives. The remaining
+     * {@code Time/Time By} hierarchy still has Year so it isn't dropped.
+     */
+    @Test
+    public void probeOnPrunesUnqueryableLevel() {
+        OlapAiCubeMetadataService probeSvc = new OlapAiCubeMetadataService();
+        probeSvc.setDiscoverService(new ProbeStubDiscover());
+        probeSvc.setProbeUnqueryable(true);
+        AiSchema schema = probeSvc.getSchema(new AiCubeRef("foodmart", "FoodMart", "FoodMart", "Sales"));
+        AiSchema.Hierarchy timeBy =
+                schema.dimensions.get(AiSchema.key("Time")).hierarchies.get(AiSchema.key("Time By"));
+        assertNotNull(timeBy);
+        assertTrue("Year survives", timeBy.levels.containsKey(AiSchema.key("Year")));
+        assertFalse("Quarter pruned", timeBy.levels.containsKey(AiSchema.key("Quarter")));
+    }
+
+    /**
+     * Probe on — if every non-(All) level in a hierarchy fails the probe,
+     * the whole hierarchy is dropped. If that was the dim's only hier, the
+     * dim is dropped too.
+     */
+    @Test
+    public void probeOnPrunesEntirelyUnqueryableHierarchyAndDim() {
+        OlapAiCubeMetadataService probeSvc = new OlapAiCubeMetadataService();
+        probeSvc.setDiscoverService(new ProbeStubDiscover() {
+            @Override
+            public List<org.saiku.olap.dto.SimpleCubeElement> getLevelMembers(
+                    SaikuCube cube, String hierarchyName, String levelName, String q, int limit) {
+                // Time By is fully unqueryable; Product is fine.
+                if ("Time By".equals(hierarchyName)) {
+                    throw new RuntimeException("synthetic: Time By unqueryable");
+                }
+                return new ArrayList<>();
+            }
+        });
+        probeSvc.setProbeUnqueryable(true);
+        AiSchema schema = probeSvc.getSchema(new AiCubeRef("foodmart", "FoodMart", "FoodMart", "Sales"));
+        assertFalse(
+                "Time dim pruned (its only hier was unqueryable)", schema.dimensions.containsKey(AiSchema.key("Time")));
+        assertTrue("Product dim survives", schema.dimensions.containsKey(AiSchema.key("Product")));
+    }
+
+    /** Stub that fails getLevelMembers for Quarter only. */
+    private static class ProbeStubDiscover extends StubDiscover {
+        @Override
+        public List<org.saiku.olap.dto.SimpleCubeElement> getLevelMembers(
+                SaikuCube cube, String hierarchyName, String levelName, String q, int limit) {
+            if ("Quarter".equals(levelName)) {
+                throw new RuntimeException("synthetic: Quarter unqueryable for saiku#810 test");
+            }
+            return new ArrayList<>();
+        }
+    }
+
     /* ----------------------------- helpers ---------------------------------- */
 
     private static AiCubeSummary findCube(List<AiCubeSummary> all, String name) {

--- a/saiku-core/saiku-service/src/test/java/org/saiku/service/olap/ai/QuirksTestFixture.java
+++ b/saiku-core/saiku-service/src/test/java/org/saiku/service/olap/ai/QuirksTestFixture.java
@@ -1,0 +1,393 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.service.olap.ai;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import org.saiku.olap.dto.SaikuCube;
+import org.saiku.olap.dto.SaikuDimension;
+import org.saiku.olap.dto.SaikuHierarchy;
+import org.saiku.olap.dto.SaikuLevel;
+import org.saiku.olap.dto.SaikuMember;
+import org.saiku.olap.dto.SimpleCubeElement;
+import org.saiku.olap.util.exception.SaikuOlapException;
+import org.saiku.service.olap.OlapDiscoverService;
+import org.saiku.service.util.exception.SaikuServiceException;
+
+/**
+ * Reusable in-process test fixture covering the schema-shape quirks
+ * documented during the AI-query live-fuzz session (saiku#807-811).
+ *
+ * <p>This is the "quirks cube" the platform-improvements plan called for
+ * (Phase 3 #7). Instead of a separate Mondrian XML + H2 data jar, the
+ * fixture lives at the {@link OlapDiscoverService} layer — the
+ * downstream AI metadata service + converter are pure with respect to
+ * the discover interface, so a stubbed discover service is enough to
+ * exercise every code path that matters for property-based testing
+ * (Phase 3.C) and snapshot tests (Phase 3.B).
+ *
+ * <p>The fixture exposes one cube, {@code Quirks}, with these
+ * intentional oddities:
+ *
+ * <ul>
+ *   <li><b>hasAll=false hierarchy</b> — {@code Time/Time} with levels
+ *       {@code [Year, Quarter]} and no {@code (All)} level. Triggers the
+ *       segments→depth offset path closed in saiku#807.</li>
+ *   <li><b>Standard (All)-rooted hierarchy</b> (control) —
+ *       {@code Customer/Customers} with {@code [(All), Country, State]}.</li>
+ *   <li><b>Numeric-keyed level</b> — {@code Employee/Salary} with
+ *       members like {@code "20.0"}, {@code "4400.0"}. Triggers the
+ *       TopCount-ordering quirk documented in saiku#809.</li>
+ *   <li><b>Parent-child closure hierarchy</b> —
+ *       {@code Employee/Employee$Manager Id$Parent} with levels
+ *       {@code [(All), Closure, Item]}. Listed in /schema but unqueryable
+ *       through the AI surface (saiku#810).</li>
+ *   <li><b>Same-dim multi-hierarchy</b> — {@code Customer/Gender} +
+ *       {@code Customer/Marital Status} (both single-level). Triggers
+ *       the same-dim different-hier rules pinned at saiku#784 scope.</li>
+ *   <li><b>Virtual-cube dim alias</b> — {@code Store2} resolves to
+ *       the real Store dim. Matches the FoodMart Warehouse-and-Sales
+ *       shape from the live-fuzz session.</li>
+ * </ul>
+ *
+ * <p>Test classes typically use one of:
+ * <ul>
+ *   <li>{@link #discover()} — a {@link StubDiscover} subclass injectable
+ *       into {@link OlapAiCubeMetadataService#setDiscoverService};</li>
+ *   <li>{@link #cubeRef()} — the canonical {@link AiCubeRef} for the
+ *       Quirks cube;</li>
+ *   <li>{@link #directSchema()} — a pre-built {@link AiSchema} for
+ *       converter-only tests that don't go through the metadata service.</li>
+ * </ul>
+ */
+public final class QuirksTestFixture {
+
+    public static final String CONNECTION = "quirks_conn";
+    public static final String CATALOG = "QuirksCatalog";
+    public static final String SCHEMA = "QuirksSchema";
+    public static final String CUBE = "Quirks";
+
+    private QuirksTestFixture() {}
+
+    /** Canonical cube ref for the Quirks cube. */
+    public static AiCubeRef cubeRef() {
+        return new AiCubeRef(CONNECTION, CATALOG, SCHEMA, CUBE);
+    }
+
+    /** Stubbed OlapDiscoverService that yields the Quirks cube. Inject
+     *  into {@link OlapAiCubeMetadataService#setDiscoverService}. */
+    public static StubDiscover discover() {
+        return new StubDiscover();
+    }
+
+    /** Build a converter-ready AiSchema directly (no metadata service).
+     *  Used by AiSchemaConverter unit tests that exercise quirks without
+     *  the full service layer. canonicalCube is populated, matching the
+     *  saiku#811-fixed metadata-service behaviour. */
+    public static AiSchema directSchema() {
+        AiCubeRef canonical = cubeRef();
+        AiSchema s = new AiSchema(
+                CONNECTION + "/" + CATALOG + "/" + SCHEMA + "/" + CUBE,
+                CUBE,
+                "[" + CONNECTION + "].[" + CATALOG + "].[" + SCHEMA + "].[" + CUBE + "]");
+        s.canonicalCube = canonical;
+
+        s.measures.put(AiSchema.key("Unit Sales"), new AiSchema.Measure("Unit Sales", "[Measures].[Unit Sales]"));
+        s.measures.put(
+                AiSchema.key("Number of Employees"),
+                new AiSchema.Measure("Number of Employees", "[Measures].[Number of Employees]"));
+
+        AiSchema.Dimension time = new AiSchema.Dimension("Time", "[Time]");
+        AiSchema.Hierarchy timeHier = new AiSchema.Hierarchy("Time", "[Time].[Time]");
+        timeHier.levels.put(AiSchema.key("Year"), new AiSchema.Level("Year", "[Time].[Time].[Year]"));
+        timeHier.levels.put(AiSchema.key("Quarter"), new AiSchema.Level("Quarter", "[Time].[Time].[Quarter]"));
+        time.hierarchies.put(AiSchema.key("Time"), timeHier);
+        s.dimensions.put(AiSchema.key("Time"), time);
+
+        AiSchema.Dimension cust = new AiSchema.Dimension("Customer", "[Customer]");
+
+        AiSchema.Hierarchy customers = new AiSchema.Hierarchy("Customers", "[Customer].[Customers]");
+        customers.levels.put(AiSchema.key("(All)"), new AiSchema.Level("(All)", "[Customer].[Customers].[(All)]"));
+        customers.levels.put(
+                AiSchema.key("Country"), new AiSchema.Level("Country", "[Customer].[Customers].[Country]"));
+        customers.levels.put(AiSchema.key("State"), new AiSchema.Level("State", "[Customer].[Customers].[State]"));
+        cust.hierarchies.put(AiSchema.key("Customers"), customers);
+
+        AiSchema.Hierarchy gender = new AiSchema.Hierarchy("Gender", "[Customer].[Gender]");
+        gender.levels.put(AiSchema.key("(All)"), new AiSchema.Level("(All)", "[Customer].[Gender].[(All)]"));
+        gender.levels.put(AiSchema.key("Gender"), new AiSchema.Level("Gender", "[Customer].[Gender].[Gender]"));
+        cust.hierarchies.put(AiSchema.key("Gender"), gender);
+
+        AiSchema.Hierarchy marital = new AiSchema.Hierarchy("Marital Status", "[Customer].[Marital Status]");
+        marital.levels.put(AiSchema.key("(All)"), new AiSchema.Level("(All)", "[Customer].[Marital Status].[(All)]"));
+        marital.levels.put(
+                AiSchema.key("Marital Status"),
+                new AiSchema.Level("Marital Status", "[Customer].[Marital Status].[Marital Status]"));
+        cust.hierarchies.put(AiSchema.key("Marital Status"), marital);
+
+        s.dimensions.put(AiSchema.key("Customer"), cust);
+
+        AiSchema.Dimension emp = new AiSchema.Dimension("Employee", "[Employee]");
+
+        AiSchema.Hierarchy salary = new AiSchema.Hierarchy("Salary", "[Employee].[Salary]");
+        salary.levels.put(AiSchema.key("(All)"), new AiSchema.Level("(All)", "[Employee].[Salary].[(All)]"));
+        salary.levels.put(AiSchema.key("Salary"), new AiSchema.Level("Salary", "[Employee].[Salary].[Salary]"));
+        emp.hierarchies.put(AiSchema.key("Salary"), salary);
+
+        AiSchema.Hierarchy closure =
+                new AiSchema.Hierarchy("Employee$Manager Id$Parent", "[Employee].[Employee$Manager Id$Parent]");
+        closure.levels.put(
+                AiSchema.key("(All)"), new AiSchema.Level("(All)", "[Employee].[Employee$Manager Id$Parent].[(All)]"));
+        closure.levels.put(
+                AiSchema.key("Closure"),
+                new AiSchema.Level("Closure", "[Employee].[Employee$Manager Id$Parent].[Closure]"));
+        closure.levels.put(
+                AiSchema.key("Item"), new AiSchema.Level("Item", "[Employee].[Employee$Manager Id$Parent].[Item]"));
+        emp.hierarchies.put(AiSchema.key("Employee$Manager Id$Parent"), closure);
+
+        s.dimensions.put(AiSchema.key("Employee"), emp);
+
+        AiSchema.Dimension store2 = new AiSchema.Dimension("Store2", "[Store2]");
+        AiSchema.Hierarchy storeType = new AiSchema.Hierarchy("Store Type", "[Store2].[Store Type]");
+        storeType.levels.put(AiSchema.key("(All)"), new AiSchema.Level("(All)", "[Store2].[Store Type].[(All)]"));
+        storeType.levels.put(
+                AiSchema.key("Store Type"), new AiSchema.Level("Store Type", "[Store2].[Store Type].[Store Type]"));
+        store2.hierarchies.put(AiSchema.key("Store Type"), storeType);
+        s.dimensions.put(AiSchema.key("Store2"), store2);
+
+        return s;
+    }
+
+    /**
+     * StubDiscover for the Quirks cube. Subclasses can override
+     * {@code getLevelMembers} to control probe outcomes (saiku#810 prune
+     * tests already use this pattern in OlapAiCubeMetadataServiceTest).
+     */
+    public static class StubDiscover extends OlapDiscoverService {
+
+        @Override
+        public List<SaikuCube> getAllCubes() throws SaikuOlapException {
+            return List.of(quirksCube());
+        }
+
+        @Override
+        public List<SaikuMember> getMeasures(SaikuCube cube) {
+            return Arrays.asList(measure("Unit Sales"), measure("Number of Employees"));
+        }
+
+        @Override
+        public List<SaikuDimension> getAllDimensions(SaikuCube cube) throws SaikuServiceException {
+            return Arrays.asList(
+                    new SaikuDimension("Measures", "[Measures]", "Measures", "", true, new ArrayList<>()),
+                    timeDim(),
+                    customerDim(),
+                    employeeDim(),
+                    store2Dim());
+        }
+
+        @Override
+        public List<SaikuHierarchy> getAllDimensionHierarchies(SaikuCube cube, String dimensionName) {
+            switch (dimensionName) {
+                case "Time":
+                    return List.of(timeHier());
+                case "Customer":
+                    return Arrays.asList(customersHier(), genderHier(), maritalHier());
+                case "Employee":
+                    return Arrays.asList(salaryHier(), closureHier());
+                case "Store2":
+                    return List.of(storeTypeHier());
+                default:
+                    return new ArrayList<>();
+            }
+        }
+
+        @Override
+        public List<SaikuLevel> getAllHierarchyLevels(SaikuCube cube, String dimensionName, String hierarchyName) {
+            switch (hierarchyName) {
+                case "Time":
+                    return timeHier().getLevels();
+                case "Customers":
+                    return customersHier().getLevels();
+                case "Gender":
+                    return genderHier().getLevels();
+                case "Marital Status":
+                    return maritalHier().getLevels();
+                case "Salary":
+                    return salaryHier().getLevels();
+                case "Employee$Manager Id$Parent":
+                    return closureHier().getLevels();
+                case "Store Type":
+                    return storeTypeHier().getLevels();
+                default:
+                    return new ArrayList<>();
+            }
+        }
+
+        /**
+         * Default member-fetch behaviour: returns empty (sample-member
+         * fetch tolerates this — see populateSampleMembers in
+         * OlapAiCubeMetadataService). The saiku#810 probe path uses this
+         * too; subclasses can override to fail specific levels.
+         */
+        @Override
+        public List<SimpleCubeElement> getLevelMembers(
+                SaikuCube cube, String hierarchyName, String levelName, String q, int limit) {
+            return new ArrayList<>();
+        }
+
+        /* ---------- helper builders ---------- */
+
+        private SaikuCube quirksCube() {
+            return new SaikuCube(
+                    CONNECTION,
+                    "[" + CONNECTION + "].[" + CATALOG + "].[" + SCHEMA + "].[" + CUBE + "]",
+                    CUBE,
+                    CUBE,
+                    CATALOG,
+                    SCHEMA);
+        }
+
+        private SaikuMember measure(String name) {
+            return new SaikuMember(
+                    name,
+                    "[Measures].[" + name + "]",
+                    name,
+                    "",
+                    "[Measures]",
+                    "[Measures].[MeasuresLevel]",
+                    "[Measures].[MeasuresLevel]");
+        }
+
+        private SaikuDimension timeDim() {
+            return new SaikuDimension("Time", "[Time]", "Time", "", true, List.of(timeHier()));
+        }
+
+        private SaikuDimension customerDim() {
+            return new SaikuDimension(
+                    "Customer",
+                    "[Customer]",
+                    "Customer",
+                    "",
+                    true,
+                    Arrays.asList(customersHier(), genderHier(), maritalHier()));
+        }
+
+        private SaikuDimension employeeDim() {
+            return new SaikuDimension(
+                    "Employee", "[Employee]", "Employee", "", true, Arrays.asList(salaryHier(), closureHier()));
+        }
+
+        private SaikuDimension store2Dim() {
+            return new SaikuDimension("Store2", "[Store2]", "Store2", "", true, List.of(storeTypeHier()));
+        }
+
+        private SaikuHierarchy timeHier() {
+            List<SaikuLevel> levels = Arrays.asList(
+                    level("Year", "[Time].[Time].[Year]", "[Time]", "[Time].[Time]"),
+                    level("Quarter", "[Time].[Time].[Quarter]", "[Time]", "[Time].[Time]"));
+            return new SaikuHierarchy("Time", "[Time].[Time]", "Time", "", "[Time]", true, levels, new ArrayList<>());
+        }
+
+        private SaikuHierarchy customersHier() {
+            List<SaikuLevel> levels = Arrays.asList(
+                    level("(All)", "[Customer].[Customers].[(All)]", "[Customer]", "[Customer].[Customers]"),
+                    level("Country", "[Customer].[Customers].[Country]", "[Customer]", "[Customer].[Customers]"),
+                    level("State", "[Customer].[Customers].[State]", "[Customer]", "[Customer].[Customers]"));
+            return new SaikuHierarchy(
+                    "Customers",
+                    "[Customer].[Customers]",
+                    "Customers",
+                    "",
+                    "[Customer]",
+                    true,
+                    levels,
+                    new ArrayList<>());
+        }
+
+        private SaikuHierarchy genderHier() {
+            List<SaikuLevel> levels = Arrays.asList(
+                    level("(All)", "[Customer].[Gender].[(All)]", "[Customer]", "[Customer].[Gender]"),
+                    level("Gender", "[Customer].[Gender].[Gender]", "[Customer]", "[Customer].[Gender]"));
+            return new SaikuHierarchy(
+                    "Gender", "[Customer].[Gender]", "Gender", "", "[Customer]", true, levels, new ArrayList<>());
+        }
+
+        private SaikuHierarchy maritalHier() {
+            List<SaikuLevel> levels = Arrays.asList(
+                    level("(All)", "[Customer].[Marital Status].[(All)]", "[Customer]", "[Customer].[Marital Status]"),
+                    level(
+                            "Marital Status",
+                            "[Customer].[Marital Status].[Marital Status]",
+                            "[Customer]",
+                            "[Customer].[Marital Status]"));
+            return new SaikuHierarchy(
+                    "Marital Status",
+                    "[Customer].[Marital Status]",
+                    "Marital Status",
+                    "",
+                    "[Customer]",
+                    true,
+                    levels,
+                    new ArrayList<>());
+        }
+
+        private SaikuHierarchy salaryHier() {
+            List<SaikuLevel> levels = Arrays.asList(
+                    level("(All)", "[Employee].[Salary].[(All)]", "[Employee]", "[Employee].[Salary]"),
+                    level("Salary", "[Employee].[Salary].[Salary]", "[Employee]", "[Employee].[Salary]"));
+            return new SaikuHierarchy(
+                    "Salary", "[Employee].[Salary]", "Salary", "", "[Employee]", true, levels, new ArrayList<>());
+        }
+
+        private SaikuHierarchy closureHier() {
+            List<SaikuLevel> levels = Arrays.asList(
+                    level(
+                            "(All)",
+                            "[Employee].[Employee$Manager Id$Parent].[(All)]",
+                            "[Employee]",
+                            "[Employee].[Employee$Manager Id$Parent]"),
+                    level(
+                            "Closure",
+                            "[Employee].[Employee$Manager Id$Parent].[Closure]",
+                            "[Employee]",
+                            "[Employee].[Employee$Manager Id$Parent]"),
+                    level(
+                            "Item",
+                            "[Employee].[Employee$Manager Id$Parent].[Item]",
+                            "[Employee]",
+                            "[Employee].[Employee$Manager Id$Parent]"));
+            return new SaikuHierarchy(
+                    "Employee$Manager Id$Parent",
+                    "[Employee].[Employee$Manager Id$Parent]",
+                    "Employee$Manager Id$Parent",
+                    "",
+                    "[Employee]",
+                    true,
+                    levels,
+                    new ArrayList<>());
+        }
+
+        private SaikuHierarchy storeTypeHier() {
+            List<SaikuLevel> levels = Arrays.asList(
+                    level("(All)", "[Store2].[Store Type].[(All)]", "[Store2]", "[Store2].[Store Type]"),
+                    level("Store Type", "[Store2].[Store Type].[Store Type]", "[Store2]", "[Store2].[Store Type]"));
+            return new SaikuHierarchy(
+                    "Store Type",
+                    "[Store2].[Store Type]",
+                    "Store Type",
+                    "",
+                    "[Store2]",
+                    true,
+                    levels,
+                    new ArrayList<>());
+        }
+
+        private SaikuLevel level(String name, String uniqueName, String dimUniq, String hierUniq) {
+            return new SaikuLevel(name, uniqueName, name, "", dimUniq, hierUniq, true, "Regular", new HashMap<>());
+        }
+    }
+}

--- a/saiku-core/saiku-service/src/test/java/org/saiku/service/olap/ai/QuirksTestFixtureTest.java
+++ b/saiku-core/saiku-service/src/test/java/org/saiku/service/olap/ai/QuirksTestFixtureTest.java
@@ -1,0 +1,118 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.service.olap.ai;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+/**
+ * Smoke test for {@link QuirksTestFixture}. Verifies the fixture loads
+ * end-to-end through {@link OlapAiCubeMetadataService} and the produced
+ * {@link AiSchema} contains every documented quirk shape. Snapshot tests
+ * (Phase 3.B) and property-based tests (Phase 3.C) build on this fixture,
+ * so a quick sanity check here catches misconfigurations early.
+ */
+public class QuirksTestFixtureTest {
+
+    @Test
+    public void fixtureLoadsThroughMetadataService() {
+        OlapAiCubeMetadataService svc = new OlapAiCubeMetadataService();
+        svc.setDiscoverService(QuirksTestFixture.discover());
+
+        AiSchema schema = svc.getSchema(QuirksTestFixture.cubeRef());
+
+        assertNotNull(schema);
+        assertEquals(QuirksTestFixture.CUBE, schema.getCubeName());
+
+        // canonicalCube set by the saiku#811 fix path.
+        assertNotNull("canonicalCube must be populated by the service", schema.canonicalCube);
+        assertEquals(QuirksTestFixture.CONNECTION, schema.canonicalCube.getConnectionName());
+
+        // Measures
+        assertTrue(schema.measures.containsKey(AiSchema.key("Unit Sales")));
+        assertTrue(schema.measures.containsKey(AiSchema.key("Number of Employees")));
+
+        // Dimensions — Measures is filtered out by the service.
+        assertTrue(schema.dimensions.containsKey(AiSchema.key("Time")));
+        assertTrue(schema.dimensions.containsKey(AiSchema.key("Customer")));
+        assertTrue(schema.dimensions.containsKey(AiSchema.key("Employee")));
+        assertTrue(schema.dimensions.containsKey(AiSchema.key("Store2")));
+        assertEquals("Measures dim filtered out of dim list", 4, schema.dimensions.size());
+
+        // hasAll=false hier — saiku#807 trigger.
+        AiSchema.Hierarchy timeHier =
+                schema.dimensions.get(AiSchema.key("Time")).hierarchies.get(AiSchema.key("Time"));
+        assertNotNull(timeHier);
+        assertEquals("Time/Time has 2 levels (no (All))", 2, timeHier.levels.size());
+        assertTrue(timeHier.levels.containsKey(AiSchema.key("Year")));
+        assertTrue(timeHier.levels.containsKey(AiSchema.key("Quarter")));
+    }
+
+    @Test
+    public void customerDimHasThreeHiers() {
+        OlapAiCubeMetadataService svc = new OlapAiCubeMetadataService();
+        svc.setDiscoverService(QuirksTestFixture.discover());
+        AiSchema schema = svc.getSchema(QuirksTestFixture.cubeRef());
+
+        AiSchema.Dimension cust = schema.dimensions.get(AiSchema.key("Customer"));
+        assertNotNull(cust);
+        assertEquals(3, cust.hierarchies.size());
+        assertTrue(cust.hierarchies.containsKey(AiSchema.key("Customers")));
+        assertTrue(cust.hierarchies.containsKey(AiSchema.key("Gender")));
+        assertTrue(cust.hierarchies.containsKey(AiSchema.key("Marital Status")));
+    }
+
+    @Test
+    public void employeeDimExposesClosureHier() {
+        OlapAiCubeMetadataService svc = new OlapAiCubeMetadataService();
+        svc.setDiscoverService(QuirksTestFixture.discover());
+        AiSchema schema = svc.getSchema(QuirksTestFixture.cubeRef());
+
+        AiSchema.Dimension emp = schema.dimensions.get(AiSchema.key("Employee"));
+        assertNotNull(emp);
+        // Salary (numeric-keyed) + Employee$Manager Id$Parent (closure).
+        assertTrue(emp.hierarchies.containsKey(AiSchema.key("Salary")));
+        assertTrue(
+                "saiku#810 closure hier listed in schema (the bug being demonstrated)",
+                emp.hierarchies.containsKey(AiSchema.key("Employee$Manager Id$Parent")));
+    }
+
+    @Test
+    public void directSchemaPathSkipsServiceButPreservesShape() {
+        OlapAiCubeMetadataService svc = new OlapAiCubeMetadataService();
+        svc.setDiscoverService(QuirksTestFixture.discover());
+        AiSchema viaService = svc.getSchema(QuirksTestFixture.cubeRef());
+        AiSchema direct = QuirksTestFixture.directSchema();
+
+        assertEquals(viaService.dimensions.keySet(), direct.dimensions.keySet());
+        assertEquals(viaService.measures.keySet(), direct.measures.keySet());
+        assertEquals(
+                "canonicalCube cubeName matches across both paths",
+                viaService.canonicalCube.getCubeName(),
+                direct.canonicalCube.getCubeName());
+    }
+
+    @Test
+    public void probeWithDefaultStubKeepsEveryLevel() {
+        // The default stub returns empty for getLevelMembers — saiku#810
+        // probe treats that as "queryable" (no exception thrown), so
+        // every level survives.
+        OlapAiCubeMetadataService svc = new OlapAiCubeMetadataService();
+        svc.setDiscoverService(QuirksTestFixture.discover());
+        svc.setProbeUnqueryable(true);
+
+        AiSchema schema = svc.getSchema(QuirksTestFixture.cubeRef());
+
+        assertEquals(4, schema.dimensions.size());
+
+        AiSchema.Hierarchy salary =
+                schema.dimensions.get(AiSchema.key("Employee")).hierarchies.get(AiSchema.key("Salary"));
+        assertNotNull(salary);
+        assertTrue(salary.levels.containsKey(AiSchema.key("Salary")));
+    }
+}

--- a/saiku-core/saiku-service/src/test/java/org/saiku/service/olap/ai/SchemaSnapshotTest.java
+++ b/saiku-core/saiku-service/src/test/java/org/saiku/service/olap/ai/SchemaSnapshotTest.java
@@ -1,0 +1,117 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.service.olap.ai;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import org.junit.Test;
+
+/**
+ * Schema-shape snapshot tests (Phase 3.B / #6). Pins the JSON shape of
+ * the {@link AiSchema} response per cube as a checked-in baseline.
+ * Any structural change — added/renamed/removed field, dimension
+ * ordering, alias-map shape, requestSchema schema — must flip these
+ * tests, forcing a deliberate snapshot update rather than a silent
+ * drift in the agent-facing contract.
+ *
+ * <p>Currently snapshots the {@code Quirks} fixture cube (Phase 3.A);
+ * adding FoodMart cubes is a mechanical follow-up — the test framework
+ * here is general.
+ *
+ * <p>Updating snapshots: re-run with
+ * {@code -Dsaiku.snapshots.update=true} to regenerate the baseline
+ * files from the live schema. Review the diff in git before
+ * committing.
+ */
+public class SchemaSnapshotTest {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper()
+            .setSerializationInclusion(JsonInclude.Include.NON_NULL)
+            .enable(SerializationFeature.ORDER_MAP_ENTRIES_BY_KEYS)
+            .enable(SerializationFeature.INDENT_OUTPUT);
+
+    /** Snapshot baseline lives in src/test/resources/schema-snapshots/. */
+    private static final String SNAPSHOTS_DIR = "schema-snapshots";
+
+    @Test
+    public void quirksCubeSchemaMatchesSnapshot() throws Exception {
+        OlapAiCubeMetadataService svc = new OlapAiCubeMetadataService();
+        svc.setDiscoverService(QuirksTestFixture.discover());
+        AiSchema schema = svc.getSchema(QuirksTestFixture.cubeRef());
+
+        assertMatchesSnapshot("quirks-schema", schema);
+    }
+
+    /**
+     * Read the baseline JSON, compare structurally to the freshly-built
+     * schema. On mismatch, fail with the unified diff. If the
+     * {@code saiku.snapshots.update} system property is true, overwrite
+     * the baseline with the current shape.
+     */
+    private void assertMatchesSnapshot(String name, AiSchema actual) throws IOException {
+        String actualJson = MAPPER.writeValueAsString(actual);
+
+        if (Boolean.getBoolean("saiku.snapshots.update")) {
+            Path snapPath = snapshotFilePath(name);
+            Files.createDirectories(snapPath.getParent());
+            Files.writeString(snapPath, actualJson, StandardCharsets.UTF_8);
+            System.out.println("[snapshot] updated " + snapPath);
+            return;
+        }
+
+        String expectedJson = loadSnapshot(name);
+        // Round-trip through Jackson so the comparison is structural,
+        // not whitespace-sensitive — JsonNode.equals does deep equality.
+        JsonNode expectedNode = MAPPER.readTree(expectedJson);
+        JsonNode actualNode = MAPPER.readTree(actualJson);
+
+        if (!expectedNode.equals(actualNode)) {
+            fail("Schema snapshot for '" + name + "' diverged.\n"
+                    + "Expected:\n" + MAPPER.writeValueAsString(expectedNode) + "\n"
+                    + "Actual:\n" + actualJson + "\n"
+                    + "If the change is intentional, regenerate with:\n"
+                    + "  mvn -pl saiku-core/saiku-service test "
+                    + "-Dtest=SchemaSnapshotTest -Dsaiku.snapshots.update=true\n"
+                    + "Then review the diff in git before committing.");
+        }
+        // Spot-assert top-level identity even on equality success, so a
+        // future Jackson re-ordering or comparator change doesn't silently
+        // mask a regression.
+        assertEquals(expectedNode.get("cubeName"), actualNode.get("cubeName"));
+    }
+
+    private String loadSnapshot(String name) throws IOException {
+        String path = SNAPSHOTS_DIR + "/" + name + ".json";
+        try (InputStream in = getClass().getClassLoader().getResourceAsStream(path)) {
+            if (in == null) {
+                throw new IOException("Snapshot baseline not found on classpath: " + path
+                        + "\nGenerate it first with:\n"
+                        + "  mvn -pl saiku-core/saiku-service test "
+                        + "-Dtest=SchemaSnapshotTest -Dsaiku.snapshots.update=true");
+            }
+            return new String(in.readAllBytes(), StandardCharsets.UTF_8);
+        }
+    }
+
+    /** Where to write a regenerated snapshot. Sits next to the
+     *  baseline-on-classpath copy so git diff sees it on the next run. */
+    private Path snapshotFilePath(String name) {
+        Path cwd = Paths.get("").toAbsolutePath();
+        Path candidate = cwd.resolve("src/test/resources/" + SNAPSHOTS_DIR + "/" + name + ".json");
+        if (Files.exists(candidate.getParent())) return candidate;
+        return cwd.resolve("saiku-core/saiku-service/src/test/resources/" + SNAPSHOTS_DIR + "/" + name + ".json");
+    }
+}

--- a/saiku-core/saiku-service/src/test/java/org/saiku/service/util/exception/SaikuExceptionWrapTest.java
+++ b/saiku-core/saiku-service/src/test/java/org/saiku/service/util/exception/SaikuExceptionWrapTest.java
@@ -1,0 +1,105 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.saiku.service.util.exception;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.sql.SQLException;
+import org.junit.Test;
+import org.saiku.olap.util.exception.SaikuOlapException;
+
+/**
+ * Asserts the cause-preservation contract on Saiku's custom RuntimeException /
+ * checked-Exception subclasses. The intent of {@code wrap(cause, message)} is
+ * that no callsite inside a {@code catch} block should be able to silently
+ * drop the inner cause — which is the failure mode {@code
+ * AiQueryResource.describeDeepestCause} exists to work around when the chain
+ * gets broken upstream.
+ *
+ * <p>Two-layer property tested here: every call to {@code wrap()} sets the
+ * cause exactly once and the chain remains traversable end-to-end through
+ * arbitrary nesting depth.
+ */
+public class SaikuExceptionWrapTest {
+
+    @Test
+    public void serviceExceptionWrapSetsCauseExactlyOnce() {
+        SQLException leaf = new SQLException("db went away");
+        SaikuServiceException wrapped = SaikuServiceException.wrap(leaf, "Failed to drillthrough");
+        assertEquals("Failed to drillthrough", wrapped.getMessage());
+        assertSame(leaf, wrapped.getCause());
+    }
+
+    @Test
+    public void olapExceptionWrapSetsCauseExactlyOnce() {
+        RuntimeException leaf = new RuntimeException("mondrian bare-throw");
+        SaikuOlapException wrapped = SaikuOlapException.wrap(leaf, "Cannot get native cube");
+        assertEquals("Cannot get native cube", wrapped.getMessage());
+        assertSame(leaf, wrapped.getCause());
+    }
+
+    /**
+     * Three-layer nesting: leaf → SaikuOlapException → SaikuServiceException.
+     * The deepest leaf must remain reachable by walking {@code getCause}.
+     */
+    @Test
+    public void wrapPreservesChainAcrossThreeLayers() {
+        NullPointerException leaf = new NullPointerException("Cannot invoke setCatalog because con is null");
+        SaikuOlapException middle = SaikuOlapException.wrap(leaf, "OLAP connection failed");
+        SaikuServiceException top = SaikuServiceException.wrap(middle, "Can't execute query");
+
+        assertSame(middle, top.getCause());
+        assertSame(leaf, top.getCause().getCause());
+
+        // Walk to deepest cause — the pattern AiQueryResource.describeDeepestCause uses.
+        Throwable deepest = top;
+        while (deepest.getCause() != null) deepest = deepest.getCause();
+        assertSame(leaf, deepest);
+        assertTrue(deepest.getMessage().contains("setCatalog"));
+    }
+
+    /**
+     * wrap() with a null cause is currently not contractually defined. Java's
+     * Throwable allows constructing with null cause (treated as no cause).
+     * Pinning current behaviour so a future hardening to "reject null cause"
+     * is a deliberate change rather than a silent break.
+     */
+    @Test
+    public void wrapWithNullCauseStillConstructs() {
+        SaikuServiceException wrapped = SaikuServiceException.wrap(null, "no cause supplied");
+        assertEquals("no cause supplied", wrapped.getMessage());
+        assertNotNull(wrapped);
+    }
+
+    /**
+     * Sanity: SaikuOlapException is a checked Exception (not RuntimeException).
+     * The wrap() helper preserves that distinction — it cannot accidentally
+     * return a RuntimeException subclass that callers could miss-handle.
+     */
+    @Test
+    public void exceptionTypesAreDistinct() {
+        SaikuServiceException svc = SaikuServiceException.wrap(new RuntimeException(), "x");
+        SaikuOlapException olap = SaikuOlapException.wrap(new RuntimeException(), "y");
+
+        assertTrue(svc instanceof RuntimeException);
+        assertTrue(olap instanceof Exception);
+        try {
+            throw olap;
+        } catch (SaikuOlapException expected) {
+            // ok
+        } catch (Exception unexpected) {
+            fail("SaikuOlapException should be caught by its own type");
+        }
+    }
+}

--- a/saiku-core/saiku-service/src/test/resources/mdx-goldens/01-single-measure-no-rows/expected.mdx
+++ b/saiku-core/saiku-service/src/test/resources/mdx-goldens/01-single-measure-no-rows/expected.mdx
@@ -1,0 +1,2 @@
+SELECT NON EMPTY {[Measures].[Unit Sales]} ON COLUMNS
+FROM [Quirks]

--- a/saiku-core/saiku-service/src/test/resources/mdx-goldens/01-single-measure-no-rows/request.json
+++ b/saiku-core/saiku-service/src/test/resources/mdx-goldens/01-single-measure-no-rows/request.json
@@ -1,0 +1,3 @@
+{
+  "measures": [{ "name": "Unit Sales" }]
+}

--- a/saiku-core/saiku-service/src/test/resources/mdx-goldens/02-measure-with-row/expected.mdx
+++ b/saiku-core/saiku-service/src/test/resources/mdx-goldens/02-measure-with-row/expected.mdx
@@ -1,0 +1,3 @@
+SELECT NON EMPTY {[Measures].[Unit Sales]} ON COLUMNS,
+NON EMPTY [Customer].[Gender].[Gender].Members ON ROWS
+FROM [Quirks]

--- a/saiku-core/saiku-service/src/test/resources/mdx-goldens/02-measure-with-row/request.json
+++ b/saiku-core/saiku-service/src/test/resources/mdx-goldens/02-measure-with-row/request.json
@@ -1,0 +1,6 @@
+{
+  "measures": [{ "name": "Unit Sales" }],
+  "rows": [
+    { "dimension": "Customer", "hierarchy": "Gender", "level": "Gender" }
+  ]
+}

--- a/saiku-core/saiku-service/src/test/resources/mdx-goldens/03-two-measures/expected.mdx
+++ b/saiku-core/saiku-service/src/test/resources/mdx-goldens/03-two-measures/expected.mdx
@@ -1,0 +1,2 @@
+SELECT NON EMPTY {[Measures].[Unit Sales], [Measures].[Number of Employees]} ON COLUMNS
+FROM [Quirks]

--- a/saiku-core/saiku-service/src/test/resources/mdx-goldens/03-two-measures/request.json
+++ b/saiku-core/saiku-service/src/test/resources/mdx-goldens/03-two-measures/request.json
@@ -1,0 +1,6 @@
+{
+  "measures": [
+    { "name": "Unit Sales" },
+    { "name": "Number of Employees" }
+  ]
+}

--- a/saiku-core/saiku-service/src/test/resources/mdx-goldens/04-cross-hier-rows/expected.mdx
+++ b/saiku-core/saiku-service/src/test/resources/mdx-goldens/04-cross-hier-rows/expected.mdx
@@ -1,0 +1,3 @@
+SELECT NON EMPTY {[Measures].[Unit Sales]} ON COLUMNS,
+NON EMPTY CROSSJOIN([Customer].[Gender].[Gender].Members, [Customer].[Marital Status].[Marital Status].Members) ON ROWS
+FROM [Quirks]

--- a/saiku-core/saiku-service/src/test/resources/mdx-goldens/04-cross-hier-rows/request.json
+++ b/saiku-core/saiku-service/src/test/resources/mdx-goldens/04-cross-hier-rows/request.json
@@ -1,0 +1,7 @@
+{
+  "measures": [{ "name": "Unit Sales" }],
+  "rows": [
+    { "dimension": "Customer", "hierarchy": "Gender", "level": "Gender" },
+    { "dimension": "Customer", "hierarchy": "Marital Status", "level": "Marital Status" }
+  ]
+}

--- a/saiku-core/saiku-service/src/test/resources/mdx-goldens/05-non-empty/expected.mdx
+++ b/saiku-core/saiku-service/src/test/resources/mdx-goldens/05-non-empty/expected.mdx
@@ -1,0 +1,3 @@
+SELECT {[Measures].[Unit Sales]} ON COLUMNS,
+[Customer].[Gender].[Gender].Members ON ROWS
+FROM [Quirks]

--- a/saiku-core/saiku-service/src/test/resources/mdx-goldens/05-non-empty/request.json
+++ b/saiku-core/saiku-service/src/test/resources/mdx-goldens/05-non-empty/request.json
@@ -1,0 +1,7 @@
+{
+  "measures": [{ "name": "Unit Sales" }],
+  "rows": [
+    { "dimension": "Customer", "hierarchy": "Gender", "level": "Gender" }
+  ],
+  "nonEmpty": false
+}

--- a/saiku-core/saiku-service/src/test/resources/mdx-goldens/06-numeric-level-salary/expected.mdx
+++ b/saiku-core/saiku-service/src/test/resources/mdx-goldens/06-numeric-level-salary/expected.mdx
@@ -1,0 +1,3 @@
+SELECT NON EMPTY {[Measures].[Number of Employees]} ON COLUMNS,
+NON EMPTY [Employee].[Salary].[Salary].Members ON ROWS
+FROM [Quirks]

--- a/saiku-core/saiku-service/src/test/resources/mdx-goldens/06-numeric-level-salary/request.json
+++ b/saiku-core/saiku-service/src/test/resources/mdx-goldens/06-numeric-level-salary/request.json
@@ -1,0 +1,6 @@
+{
+  "measures": [{ "name": "Number of Employees" }],
+  "rows": [
+    { "dimension": "Employee", "hierarchy": "Salary", "level": "Salary" }
+  ]
+}

--- a/saiku-core/saiku-service/src/test/resources/schema-snapshots/quirks-schema.json
+++ b/saiku-core/saiku-service/src/test/resources/schema-snapshots/quirks-schema.json
@@ -1,0 +1,462 @@
+{
+  "cubeId" : "quirks_conn/QuirksCatalog/QuirksSchema/Quirks",
+  "cubeName" : "Quirks",
+  "cubeUniqueName" : "[quirks_conn].[QuirksCatalog].[QuirksSchema].[Quirks]",
+  "canonicalCube" : {
+    "connectionName" : "quirks_conn",
+    "catalog" : "QuirksCatalog",
+    "schema" : "QuirksSchema",
+    "cubeName" : "Quirks"
+  },
+  "measures" : {
+    "number of employees" : {
+      "name" : "Number of Employees",
+      "uniqueName" : "[Measures].[Number of Employees]"
+    },
+    "unit sales" : {
+      "name" : "Unit Sales",
+      "uniqueName" : "[Measures].[Unit Sales]"
+    }
+  },
+  "dimensions" : {
+    "customer" : {
+      "name" : "Customer",
+      "uniqueName" : "[Customer]",
+      "hierarchies" : {
+        "customers" : {
+          "name" : "Customers",
+          "uniqueName" : "[Customer].[Customers]",
+          "levels" : {
+            "(all)" : {
+              "name" : "(All)",
+              "uniqueName" : "[Customer].[Customers].[(All)]",
+              "sampleMembers" : [ ]
+            },
+            "country" : {
+              "name" : "Country",
+              "uniqueName" : "[Customer].[Customers].[Country]",
+              "sampleMembers" : [ ]
+            },
+            "state" : {
+              "name" : "State",
+              "uniqueName" : "[Customer].[Customers].[State]",
+              "sampleMembers" : [ ]
+            }
+          },
+          "levelAliases" : { }
+        },
+        "gender" : {
+          "name" : "Gender",
+          "uniqueName" : "[Customer].[Gender]",
+          "levels" : {
+            "(all)" : {
+              "name" : "(All)",
+              "uniqueName" : "[Customer].[Gender].[(All)]",
+              "sampleMembers" : [ ]
+            },
+            "gender" : {
+              "name" : "Gender",
+              "uniqueName" : "[Customer].[Gender].[Gender]",
+              "sampleMembers" : [ ]
+            }
+          },
+          "levelAliases" : { }
+        },
+        "marital status" : {
+          "name" : "Marital Status",
+          "uniqueName" : "[Customer].[Marital Status]",
+          "levels" : {
+            "(all)" : {
+              "name" : "(All)",
+              "uniqueName" : "[Customer].[Marital Status].[(All)]",
+              "sampleMembers" : [ ]
+            },
+            "marital status" : {
+              "name" : "Marital Status",
+              "uniqueName" : "[Customer].[Marital Status].[Marital Status]",
+              "sampleMembers" : [ ]
+            }
+          },
+          "levelAliases" : { }
+        }
+      },
+      "hierarchyAliases" : { }
+    },
+    "employee" : {
+      "name" : "Employee",
+      "uniqueName" : "[Employee]",
+      "hierarchies" : {
+        "employee$manager id$parent" : {
+          "name" : "Employee$Manager Id$Parent",
+          "uniqueName" : "[Employee].[Employee$Manager Id$Parent]",
+          "levels" : {
+            "(all)" : {
+              "name" : "(All)",
+              "uniqueName" : "[Employee].[Employee$Manager Id$Parent].[(All)]",
+              "sampleMembers" : [ ]
+            },
+            "closure" : {
+              "name" : "Closure",
+              "uniqueName" : "[Employee].[Employee$Manager Id$Parent].[Closure]",
+              "sampleMembers" : [ ]
+            },
+            "item" : {
+              "name" : "Item",
+              "uniqueName" : "[Employee].[Employee$Manager Id$Parent].[Item]",
+              "sampleMembers" : [ ]
+            }
+          },
+          "levelAliases" : { }
+        },
+        "salary" : {
+          "name" : "Salary",
+          "uniqueName" : "[Employee].[Salary]",
+          "levels" : {
+            "(all)" : {
+              "name" : "(All)",
+              "uniqueName" : "[Employee].[Salary].[(All)]",
+              "sampleMembers" : [ ]
+            },
+            "salary" : {
+              "name" : "Salary",
+              "uniqueName" : "[Employee].[Salary].[Salary]",
+              "sampleMembers" : [ ]
+            }
+          },
+          "levelAliases" : { }
+        }
+      },
+      "hierarchyAliases" : { }
+    },
+    "store2" : {
+      "name" : "Store2",
+      "uniqueName" : "[Store2]",
+      "hierarchies" : {
+        "store type" : {
+          "name" : "Store Type",
+          "uniqueName" : "[Store2].[Store Type]",
+          "levels" : {
+            "(all)" : {
+              "name" : "(All)",
+              "uniqueName" : "[Store2].[Store Type].[(All)]",
+              "sampleMembers" : [ ]
+            },
+            "store type" : {
+              "name" : "Store Type",
+              "uniqueName" : "[Store2].[Store Type].[Store Type]",
+              "sampleMembers" : [ ]
+            }
+          },
+          "levelAliases" : { }
+        }
+      },
+      "hierarchyAliases" : { }
+    },
+    "time" : {
+      "name" : "Time",
+      "uniqueName" : "[Time]",
+      "hierarchies" : {
+        "time" : {
+          "name" : "Time",
+          "uniqueName" : "[Time].[Time]",
+          "levels" : {
+            "quarter" : {
+              "name" : "Quarter",
+              "uniqueName" : "[Time].[Time].[Quarter]",
+              "sampleMembers" : [ ]
+            },
+            "year" : {
+              "name" : "Year",
+              "uniqueName" : "[Time].[Time].[Year]",
+              "sampleMembers" : [ ]
+            }
+          },
+          "levelAliases" : { }
+        }
+      },
+      "hierarchyAliases" : { }
+    }
+  },
+  "measureAliases" : { },
+  "dimensionAliases" : { },
+  "suggestions" : [ ],
+  "examples" : [ {
+    "cube" : {
+      "connectionName" : "quirks_conn",
+      "catalog" : "QuirksCatalog",
+      "schema" : "QuirksSchema",
+      "cubeName" : "Quirks"
+    },
+    "measures" : [ {
+      "name" : "Unit Sales",
+      "aggregators" : [ ]
+    } ],
+    "rows" : [ {
+      "dimension" : "Time",
+      "hierarchy" : "Time",
+      "level" : "Year",
+      "members" : [ ]
+    } ],
+    "columns" : [ ],
+    "filters" : [ ],
+    "order" : [ ],
+    "limit" : 0,
+    "visualTotals" : false,
+    "nonEmpty" : true
+  }, {
+    "cube" : {
+      "connectionName" : "quirks_conn",
+      "catalog" : "QuirksCatalog",
+      "schema" : "QuirksSchema",
+      "cubeName" : "Quirks"
+    },
+    "measures" : [ {
+      "name" : "Unit Sales",
+      "aggregators" : [ ]
+    } ],
+    "rows" : [ {
+      "dimension" : "Time",
+      "hierarchy" : "Time",
+      "level" : "Year",
+      "members" : [ ]
+    } ],
+    "columns" : [ ],
+    "filters" : [ ],
+    "order" : [ {
+      "by" : "Unit Sales",
+      "direction" : "desc",
+      "ascending" : false
+    } ],
+    "limit" : 10,
+    "visualTotals" : false,
+    "nonEmpty" : true
+  }, {
+    "cube" : {
+      "connectionName" : "quirks_conn",
+      "catalog" : "QuirksCatalog",
+      "schema" : "QuirksSchema",
+      "cubeName" : "Quirks"
+    },
+    "measures" : [ {
+      "name" : "Unit Sales",
+      "aggregators" : [ ]
+    } ],
+    "rows" : [ {
+      "dimension" : "Time",
+      "hierarchy" : "Time",
+      "level" : "Year",
+      "members" : [ ]
+    } ],
+    "columns" : [ ],
+    "filters" : [ ],
+    "order" : [ ],
+    "limit" : 0,
+    "visualTotals" : true,
+    "nonEmpty" : true
+  } ],
+  "requestSchema" : {
+    "$schema" : "https://json-schema.org/draft/2020-12/schema",
+    "description" : "Typed body for POST /saiku/api/ai/query. Every name field must resolve against the AiSchema returned by /ai/schema/{cubeId}. Display names from the enrichment overlay are also valid.",
+    "example" : {
+      "cube" : {
+        "catalog" : "FoodMart",
+        "connectionName" : "foodmart",
+        "cubeName" : "Sales",
+        "schema" : "FoodMart"
+      },
+      "measures" : [ {
+        "name" : "Store Sales"
+      } ],
+      "rows" : [ {
+        "dimension" : "Time",
+        "hierarchy" : "Time By",
+        "level" : "Year"
+      } ]
+    },
+    "properties" : {
+      "columns" : {
+        "description" : "Additional dimensions on the COLUMNS axis, cross-joined with measures.",
+        "items" : {
+          "description" : "A row or column axis entry.",
+          "properties" : {
+            "dimension" : {
+              "description" : "Dimension name (canonical or display).",
+              "type" : "string"
+            },
+            "hierarchy" : {
+              "description" : "Hierarchy name. Optional when the dimension has only one hierarchy.",
+              "type" : "string"
+            },
+            "level" : {
+              "description" : "Level name within the hierarchy.",
+              "type" : "string"
+            },
+            "members" : {
+              "description" : "Optional explicit MDX unique-name list. If absent, all members at the level are included.",
+              "items" : {
+                "type" : "string"
+              },
+              "type" : "array"
+            }
+          },
+          "required" : [ "dimension", "level" ],
+          "type" : "object"
+        },
+        "type" : "array"
+      },
+      "cube" : {
+        "description" : "Cube reference. All four fields required.",
+        "properties" : {
+          "catalog" : {
+            "description" : "Catalog name.",
+            "type" : "string"
+          },
+          "connectionName" : {
+            "description" : "Connection name from /ai/cubes.",
+            "type" : "string"
+          },
+          "cubeName" : {
+            "description" : "Cube name.",
+            "type" : "string"
+          },
+          "schema" : {
+            "description" : "Schema name.",
+            "type" : "string"
+          }
+        },
+        "required" : [ "connectionName", "catalog", "schema", "cubeName" ],
+        "type" : "object"
+      },
+      "filters" : {
+        "description" : "Slicer filters — applied in the MDX WHERE clause.",
+        "items" : {
+          "description" : "Slicer filter — lands in the WHERE clause.",
+          "properties" : {
+            "dimension" : {
+              "description" : "Dimension name.",
+              "type" : "string"
+            },
+            "hierarchy" : {
+              "description" : "Hierarchy name. Optional when dim has one hierarchy.",
+              "type" : "string"
+            },
+            "level" : {
+              "description" : "Level name.",
+              "type" : "string"
+            },
+            "members" : {
+              "description" : "MDX unique-name members. Required for in/not_in (>=1), between (exactly 2), descendants_of (exactly 1). Build them by joining the level's uniqueName with the member name (e.g. [Time].[Time By].[Year].&[1997]), or fetch ready-made via GET /ai/members/search.",
+              "items" : {
+                "type" : "string"
+              },
+              "type" : "array"
+            },
+            "n" : {
+              "default" : 1,
+              "description" : "Count for the last_n_* presets. Defaults to 1; ignored for other presets.",
+              "type" : "integer"
+            },
+            "op" : {
+              "default" : "in",
+              "description" : "Operator. 'in' (default) — emit the explicit member set. 'not_in' — emit Except(level.Members, {members}). 'between' — emit Range(start, end); members must have 2 entries. 'descendants_of' — emit Descendants(member, ALL); members must have 1 entry. 'relative' — emit a time-relative set; uses 'value' (and 'n' for last_n_*). 'members' is unused.",
+              "enum" : [ "in", "not_in", "between", "descendants_of", "relative" ],
+              "type" : "string"
+            },
+            "value" : {
+              "description" : "Relative preset (only when op=relative). last_n_days/months/quarters/years pick the most-recent N members on the level. ytd/mtd/qtd use Mondrian's Ytd()/Mtd()/Qtd() against the time dimension's default member. previous_period picks the member preceding the latest available member in the cube (NOT relative to wall-clock time — if the warehouse is stale, this is stale).",
+              "enum" : [ "last_n_days", "last_n_months", "last_n_quarters", "last_n_years", "ytd", "mtd", "qtd", "previous_period" ],
+              "type" : "string"
+            }
+          },
+          "required" : [ "dimension", "level" ],
+          "type" : "object"
+        },
+        "type" : "array"
+      },
+      "limit" : {
+        "default" : 0,
+        "description" : "Optional row cap. With order, emits TopCount/BottomCount; without order, emits HEAD(rows, N). 0 or absent = no cap.",
+        "type" : "integer"
+      },
+      "measures" : {
+        "description" : "At least one measure required. Goes on the COLUMNS axis.",
+        "items" : {
+          "description" : "Measure on the COLUMNS axis.",
+          "properties" : {
+            "name" : {
+              "description" : "Measure name (canonical or display).",
+              "type" : "string"
+            }
+          },
+          "required" : [ "name" ],
+          "type" : "object"
+        },
+        "type" : "array"
+      },
+      "nonEmpty" : {
+        "default" : true,
+        "description" : "If true (default), strip rows/columns whose every cell is empty.",
+        "type" : "boolean"
+      },
+      "order" : {
+        "description" : "Optional sort. Each entry is {by: measureName, direction: asc|desc}. Combined with limit, emits TopCount/BottomCount; alone, emits Order.",
+        "items" : {
+          "description" : "Sort entry. With a non-zero limit, emits TopCount/BottomCount.",
+          "properties" : {
+            "by" : {
+              "description" : "Measure name to sort by. Must match one of the request's measures.",
+              "type" : "string"
+            },
+            "direction" : {
+              "default" : "desc",
+              "description" : "Sort direction. Default desc.",
+              "enum" : [ "asc", "desc" ],
+              "type" : "string"
+            }
+          },
+          "required" : [ "by" ],
+          "type" : "object"
+        },
+        "type" : "array"
+      },
+      "rows" : {
+        "description" : "Axis entries that go on ROWS. Multiple entries are CROSSJOIN-ed.",
+        "items" : {
+          "description" : "A row or column axis entry.",
+          "properties" : {
+            "dimension" : {
+              "description" : "Dimension name (canonical or display).",
+              "type" : "string"
+            },
+            "hierarchy" : {
+              "description" : "Hierarchy name. Optional when the dimension has only one hierarchy.",
+              "type" : "string"
+            },
+            "level" : {
+              "description" : "Level name within the hierarchy.",
+              "type" : "string"
+            },
+            "members" : {
+              "description" : "Optional explicit MDX unique-name list. If absent, all members at the level are included.",
+              "items" : {
+                "type" : "string"
+              },
+              "type" : "array"
+            }
+          },
+          "required" : [ "dimension", "level" ],
+          "type" : "object"
+        },
+        "type" : "array"
+      },
+      "visualTotals" : {
+        "default" : false,
+        "description" : "If true, wrap the rows axis in VISUALTOTALS so parent totals reflect only the visible members.",
+        "type" : "boolean"
+      }
+    },
+    "required" : [ "cube", "measures" ],
+    "title" : "AiQueryRequest",
+    "type" : "object"
+  }
+}

--- a/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/AiQueryResource.java
+++ b/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/AiQueryResource.java
@@ -65,6 +65,13 @@ public class AiQueryResource {
     private AiCubeMetadataService cubeMetadataService;
     private AsyncQueryService asyncQueryService;
     private final AiSchemaConverter converter = new AiSchemaConverter();
+    /** Phase 2: JSON-Schema-driven shape validator. Runs first so an
+     *  agent gets one structured 400 per shape failure instead of a
+     *  cascading wall of converter-layer errors. Same schema doc embedded
+     *  in /schema/{cubeId}.requestSchema for client-side use, so the
+     *  server-side and client-side rules can't drift. */
+    private final org.saiku.service.olap.ai.AiRequestSchemaValidator schemaValidator =
+            new org.saiku.service.olap.ai.AiRequestSchemaValidator();
 
     public void setThinQueryService(ThinQueryService tqs) {
         this.thinQueryService = tqs;
@@ -87,7 +94,15 @@ public class AiQueryResource {
         AiSchema schema;
         ThinQuery tq;
         try {
-            if (req == null || req.getCube() == null) {
+            if (req == null) {
+                return badRequest("body", "request body required", null);
+            }
+            // Phase 2: JSON Schema shape check before any other validation.
+            // Catches missing required fields / shape errors with a
+            // structured envelope; the converter's domain-resolution layer
+            // still runs for resolved-name errors (missing measure, etc.).
+            schemaValidator.assertValid(MAPPER.valueToTree(req));
+            if (req.getCube() == null) {
                 return badRequest("cube", "cube ref required", null);
             }
             schema = cubeMetadataService.getSchema(req.getCube());
@@ -211,7 +226,12 @@ public class AiQueryResource {
     @Produces(MediaType.APPLICATION_JSON)
     public Response previewAi(AiQueryRequest req) {
         try {
-            if (req == null || req.getCube() == null) {
+            if (req == null) {
+                return badRequest("body", "request body required", null);
+            }
+            // Phase 2: shape validation first, same as executeAi.
+            schemaValidator.assertValid(MAPPER.valueToTree(req));
+            if (req.getCube() == null) {
                 return badRequest("cube", "cube ref required", null);
             }
             AiSchema schema = cubeMetadataService.getSchema(req.getCube());

--- a/saiku-launcher/test-ai-live.sh
+++ b/saiku-launcher/test-ai-live.sh
@@ -750,6 +750,10 @@ check "reversed between range {Q3:Q1} passes through to Mondrian (covers Q1-Q3 â
   '{"cube":"'"$CUBE"'","measures":[{"name":"Unit Sales"}],"rows":[{"dimension":"Product","hierarchy":"Products","level":"Product Family"}],"filters":[{"dimension":"Time","hierarchy":"Time","level":"Quarter","op":"between","members":["[Time].[Time].[1997].[Q3]","[Time].[Time].[1997].[Q1]"]}],"nonEmpty":false}' \
   "r.get('status')=='SUCCESS' and r.get('totalRows')==3 and sum(d['Unit Sales']['value'] for d in r['data'])==194749.0 and 'WHERE ({[Time].[Time].[1997].[Q3] : [Time].[Time].[1997].[Q1]})' in r['metadata']['generatedMdx']"
 
+check "/preview emits TopCount when order+limit supplied (iter 360)" POST "/rest/saiku/api/ai/query/preview" \
+  '{"cube":"'"$CUBE"'","measures":[{"name":"Store Sales"}],"rows":[{"dimension":"Product","hierarchy":"Products","level":"Product Family"}],"order":[{"by":"Store Sales","direction":"desc"}],"limit":2}' \
+  "r.get('status')=='PREVIEW' and 'TopCount([Product].[Products].[Product Family].Members, 2, [Measures].[Store Sales])' in r.get('generatedMdx','')"
+
 # ---- legacy /query/execute coverage ----
 check "legacy /query/execute raw MDX" POST "/rest/saiku/api/query/execute" \
   '{"name":"live-mdx","cube":{"connection":"unknown_foodmart","catalog":"FoodMart","schema":"FoodMart","name":"Sales","uniqueName":"[Sales]","caption":"Sales"},"type":"MDX","mdx":"SELECT NON EMPTY {[Measures].[Store Sales]} ON COLUMNS, NON EMPTY [Product].[Products].[Product Family].Members ON ROWS FROM [Sales]"}' \


### PR DESCRIPTION
## Summary

Three phases of AI-surface platform work stacked into one PR. Each phase
landed on its own feature branch (`feat/platform-improvements`,
`feat/json-schema-validation`, `feat/quirks-cube-fixture`) and is merged
in dependency order with `--no-ff` merge commits so the phase boundaries
stay readable in `git log --graph`.

Closes the highest-leverage findings from the AI-query live-fuzz
session (saiku#807, #808, #810, #811) at the platform layer rather than
spot-fix-by-spot-fix.

## Phase 1 — foundational helpers

- `0bc79718` **Cause-preserving exception base** — adds
  `SaikuServiceException.wrap(cause, msg)` + `SaikuOlapException.wrap(...)`
  static factories. Audit of ~50 `throw new Saiku*Exception(...)`
  callsites surfaced one cause-dropper (`CsvExporter.java:223`), fixed
  inline. Unit test pinning chain-preservation across 3-deep nesting.
- `2fca5411` **Canonical cube ref through AiSchema** (saiku#811) —
  `AiSchema.canonicalCube` populated by `OlapAiCubeMetadataService`
  from the matched `SaikuCube`'s actual fields, so
  `AiSchemaConverter.toSaikuCube` no longer mixes agent-supplied case
  with canonical case for the four cube-ref fields. Eliminates the
  "Cannot get native cube" 500-on-case-mismatch failure mode.
- `96ea13f2` **Schema-time roundtrip probe** (saiku#810) — opt-in
  `setProbeUnqueryable(true)` walks every (dim, hier, level) triple
  after schema build and prunes any whose `getLevelMembers` throws.
  Cascade-drops empty hiers/dims. Closes the "schema lies about what
  you can query" class.

## Phase 2 — JSON Schema validation source-of-truth

- `d93bcfd3` **`AiRequestSchemaValidator`** — wraps
  `com.networknt:json-schema-validator:1.5.8` (Apache 2.0, ~200KB,
  draft 2020-12). Validates against the same `AiRequestJsonSchema`
  doc embedded in `/schema/{cubeId}.requestSchema` — server-side and
  client-side rules now share one source of truth. Field-pointer
  mapping (`jsonPointerToField`) keeps the agent-facing `field`
  shape consistent with the converter's emitted pointers
  (`measures[].name`, etc.).
- `a20b3cf0` **Wire validator into `AiQueryResource`** — runs
  before the converter so shape errors get one structured envelope
  per failure mode rather than cascading domain errors. Missing-cube
  still surfaces as `field=cube` (via `getProperty()` on `required`
  violations), so existing client expectations don't break.

## Phase 3 — testing infrastructure

- `e087df9d` **`QuirksTestFixture`** (#7) — reusable in-process
  fixture covering every documented schema-shape quirk: hasAll=false
  hier (saiku#807), numeric-keyed level (saiku#809), closure
  synthetic (saiku#810), canonicalCube (saiku#811), same-dim
  multi-hier (saiku#784 scope), virtual-cube alias. Two entry
  points: `discover()` (service-level) + `directSchema()`
  (converter-level).
- `de5a86f1` **`SchemaSnapshotTest`** (#6) — pins the full
  `/schema` JSON shape as a checked-in baseline
  (`quirks-schema.json`, 461 lines). Any structural change requires
  `-Dsaiku.snapshots.update=true` + an intentional git diff review.
- `d9020543` **`AiQueryRequestPropertyTest`** (#4) — 4 properties
  × 200 random cases per run (seeded for reproducibility):
  convert-doesn't-throw, preview-replay stability, measure echo,
  cube echo. Hand-rolled with `java.util.Random` to avoid pulling
  in jqwik + JUnit-5 platform-engine wiring for one test class.

## Test totals

- `saiku-service`: **229 pass** (was 213 baseline → +6 Phase 2 +
  10 Phase 3 + 0 from Phase 1 reusing existing tests).
- `saiku-web`: **37 pass** (existing `AiQueryResourceTest` 21/21
  including `missingCubeReturns400` which now hits the schema
  validator first).
- Net new unit tests across phases: **20** (5 fixture-smoke + 4
  property + 1 snapshot + 5 case-resolver + 5 cause-preservation).

## Open follow-ups (separate PRs)

- saiku#811 live-fuzz regressions (iters 347/350/351) need their
  assertions flipped from `500 EXECUTION_ERROR` → `200 SUCCESS`
  once this PR lands and the launcher is rebuilt.
- The schema-probe flag (`setProbeUnqueryable`) defaults to **off**
  to keep first-cube-load latency unchanged. Per-deployment opt-in
  via Spring config in a follow-up PR.
- saiku#808 (Mondrian PhysPath NPE) and saiku#809 (TopCount on
  numeric-keyed levels) are Mondrian-side bugs that need
  mondrian-saiku patches. Surface-side translators for #808 are
  already in (`describeDeepestCause`).
- Adding FoodMart cubes to `SchemaSnapshotTest` is mechanical
  follow-up; the snapshot framework is general.

## Test plan

- [x] `mvn -pl saiku-core/saiku-service test` → 229/229, 0 fail, 1 skipped
- [x] `mvn -pl saiku-core/saiku-web test` → 37/37
- [x] Each phase branch is independently runnable and pushed
      (`feat/json-schema-validation`, `feat/quirks-cube-fixture`)
      in case a reviewer wants to read them separately.
- [ ] Rebuild the launcher against this PR and rerun the
      `test-ai-live.sh` 145-case suite — saiku#811 regressions
      should flip green; everything else should stay green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Phase 4 — test-infrastructure hardening

Added in commit `8e1b8b9f` (merge of `feat/phase4-test-hardening`).

- **#8 CI gate on test totals** — `.github/test-floors.json` declares per-module surefire floors; `ci.yml` fails if any module drops below. Catches accidental AI-query test deletions. Initial floors: `saiku-service=232`, `saiku-web=38`.
- **#9 MDX-echo audit goldens** — per-shape `(request.json, expected.mdx)` fixtures under `src/test/resources/mdx-goldens/`. `MdxEchoGoldenTest` diffs converter output byte-for-byte vs golden. Six seed shapes (single+multi measures, single+cross-hier rows, non-empty on/off, numeric-keyed Salary level). Regenerate with `-Dsaiku.goldens.update=true`.
- **#10 Self-executing doc examples** — `AiQueryDocsExamplesTest` pins example bodies from `AI-QUERY-API.md` against the exact `generatedMdx` strings the doc promises. Step 3 (TopCount by measure) and the `relative-time` `last_n_days` example covered. `FoodmartTestFixture` provides the minimal in-process schema the doc cube references.

**Test totals updated**: saiku-service 229 → 232, saiku-web 37 → 38 (one prior count was conservative).
