### PR TITLE
feat(saiku-mcp): Java MCP server over /saiku/api/ai/*

### DIFF
--- a/docs/AI-QUERY-API.md
+++ b/docs/AI-QUERY-API.md
@@ -9,6 +9,13 @@ results.
 Companion to the spec at
 `saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/AiQueryPlan.md`.
 
+> **Using this from Claude Desktop / Cursor / Cline?** The MCP wrapper
+> in [`saiku-mcp/`](../saiku-mcp/) exposes this API as 6 typed tools.
+> Build with `mvn -pl saiku-mcp -am -DskipTests package` and follow
+> [`saiku-mcp/README.md`](../saiku-mcp/README.md) for the Claude Desktop
+> config snippet. The MCP layer is a thin pass-through — every contract
+> below applies to the MCP tools too.
+
 ---
 
 ## Quick orientation

--- a/docs/MCP-SERVER-SPEC.md
+++ b/docs/MCP-SERVER-SPEC.md
@@ -1,5 +1,15 @@
 # Saiku MCP Server — Tool Surface Spec
 
+> **This is the design spec. For the shipped implementation see
+> [`saiku-mcp/`](../saiku-mcp/) and [`saiku-mcp/README.md`](../saiku-mcp/README.md)
+> (build, run, Claude Desktop config). For the underlying REST contract
+> this spec maps to, see [`AI-QUERY-API.md`](AI-QUERY-API.md).**
+>
+> Order of precedence when the three diverge: **REST contract > shipped
+> implementation > spec**. The spec exists to record original intent —
+> the running code is what agents actually see, and the REST contract
+> is the gravity well.
+
 A standalone Model Context Protocol (MCP) server that wraps Saiku's
 `/saiku/api/ai/*` REST API as a tool surface for LLM agents. Claude Desktop,
 Cursor, Cline, and Continue users gain one-line access to Saiku cubes without
@@ -8,10 +18,10 @@ ever seeing the REST contract, MDX, or `cubeId` strings.
 This document specifies the **tool surface** — names, descriptions,
 input/output schemas, and few-shot examples — designed for LLM consumption.
 The implementation is intentionally thin: each tool is a typed wrapper around
-one REST call. Total LOC budget ~300, single Node.js or Python project.
-
-> See `docs/AI-QUERY-API.md` for the underlying REST contract this spec maps to.
-> If the two ever diverge, the REST doc wins.
+one REST call. Originally drafted as a Node/Python project (~300 LOC); the
+shipped version is Java/JDK-21 (~500 LOC including tests) so it lives in
+the saiku monorepo, builds via the same `mvn` invocation as the rest of
+the project, and avoids a Node toolchain dependency for ops.
 
 ---
 

--- a/pom.xml
+++ b/pom.xml
@@ -18,6 +18,7 @@
         <module>saiku-core</module>
         <module>saiku-webapp</module>
         <module>saiku-launcher</module>
+        <module>saiku-mcp</module>
     </modules>
     <properties>
         <maven.compiler.source>21</maven.compiler.source>

--- a/saiku-mcp/README.md
+++ b/saiku-mcp/README.md
@@ -1,0 +1,116 @@
+# saiku-mcp
+
+Standalone MCP (Model Context Protocol) server that wraps Saiku's
+`/saiku/api/ai/*` REST surface as a tool surface for LLM agents.
+
+Per [`docs/MCP-SERVER-SPEC.md`](../docs/MCP-SERVER-SPEC.md).
+
+## What you get
+
+Six tools — agents call these, the server forwards to Saiku's REST API:
+
+| Tool             | What it does                                                |
+| ---------------- | ----------------------------------------------------------- |
+| `list_cubes`     | List queryable cubes.                                       |
+| `describe_cube`  | Get the full typed schema for a cube.                       |
+| `search_members` | Substring-match members on a level.                         |
+| `run_query`      | Execute an analytical query, return records or matrix.      |
+| `preview_query`  | Compile to MDX without executing — useful for audit / cost. |
+| `drillthrough`   | Get raw fact rows behind a prior query.                     |
+
+All tool descriptions are written for LLM consumption (when to use, what to
+expect), not endpoint docs.
+
+## Build
+
+```sh
+mvn -pl saiku-mcp -am -DskipTests package
+```
+
+Output: `saiku-mcp/target/saiku-mcp-4.0.1.jar` (fat jar, all deps shaded).
+
+## Run
+
+```sh
+SAIKU_URL=http://localhost:8080 \
+SAIKU_USER=admin \
+SAIKU_PASS=admin \
+java -jar saiku-mcp/target/saiku-mcp-4.0.1.jar
+```
+
+Stdin / stdout: MCP JSON-RPC framing. Stderr: SLF4J logging. Don't mix them.
+
+Defaults: `SAIKU_URL=http://localhost:8080`, `SAIKU_USER=admin`,
+`SAIKU_PASS=admin`. Override via env.
+
+## Claude Desktop config
+
+Add to `~/Library/Application Support/Claude/claude_desktop_config.json`
+(macOS) or `%APPDATA%\Claude\claude_desktop_config.json` (Windows):
+
+```json
+{
+  "mcpServers": {
+    "saiku": {
+      "command": "java",
+      "args": ["-jar", "/absolute/path/to/saiku-mcp-4.0.1.jar"],
+      "env": {
+        "SAIKU_URL": "http://localhost:8080",
+        "SAIKU_USER": "admin",
+        "SAIKU_PASS": "admin"
+      }
+    }
+  }
+}
+```
+
+Restart Claude Desktop. The tools appear under the slash-commands menu
+prefixed with `saiku`.
+
+## Cursor / Cline / Continue
+
+Same shape — every MCP-compatible client takes `command` + `args` + `env`.
+Drop the JSON snippet above into their respective config files.
+
+## Architecture
+
+```
+┌───────────────┐    MCP JSON-RPC    ┌──────────────────┐   HTTPS    ┌──────────────┐
+│ Claude Desktop│ ◄────── stdio ────►│  saiku-mcp       │ ────►───► │  Saiku       │
+│ Cursor / Cline│                    │  (this fat jar)   │            │  /saiku/api/ │
+└───────────────┘                    │  Stateless        │ ◄────◄──── │  ai/*        │
+                                     │  per-call auth    │  JSON      │  (Jetty 12)  │
+                                     └──────────────────┘            └──────────────┘
+```
+
+Stateless wrapper — no schema cache, no result memory. Every tool call is
+one inbound MCP request → one Saiku REST call → one response.
+
+Session auth: the client logs in once on first call (form-POST to
+`/login`), holds the JSESSIONID cookie in memory, and re-logs-in
+transparently on a 401.
+
+## Smoke test
+
+The same launcher you'd use for the regular REST surface. Boot it (per
+`saiku-launcher/dist/run.sh`), then in another terminal:
+
+```sh
+(printf '%s\n%s\n%s\n' \
+  '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"probe","version":"0.1"}}}' \
+  '{"jsonrpc":"2.0","method":"notifications/initialized"}' \
+  '{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"list_cubes","arguments":{}}}' ; sleep 3) \
+  | java -jar saiku-mcp/target/saiku-mcp-4.0.1.jar
+```
+
+Should print `{"jsonrpc":"2.0","id":1,"result":...}` (initialize) followed
+by `{"jsonrpc":"2.0","id":2,"result":{"content":[{"type":"text","text":"[{\"cubeName\":\"Sales\",...}]"}]}}`.
+
+## What this isn't
+
+- **It's not a query builder** — the agent generates the JSON, this server
+  forwards it. All validation lives in Saiku's REST layer.
+- **It's not a schema cache** — every `describe_cube` hits the REST API.
+  Saiku's own cache is the source of truth.
+- **It's not multi-user** — one process, one Saiku session. Run a process
+  per user / per agent.

--- a/saiku-mcp/pom.xml
+++ b/saiku-mcp/pom.xml
@@ -1,0 +1,129 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.saikuanalytics</groupId>
+        <artifactId>saiku</artifactId>
+        <version>4.0.1</version>
+    </parent>
+
+    <artifactId>saiku-mcp</artifactId>
+    <packaging>jar</packaging>
+    <name>saiku - MCP server</name>
+    <description>
+        Standalone MCP (Model Context Protocol) server that wraps Saiku's
+        /saiku/api/ai/* REST surface as a tool surface for LLM agents
+        (Claude Desktop, Cursor, Cline, Continue). Per docs/MCP-SERVER-SPEC.md.
+    </description>
+
+    <properties>
+        <maven.compiler.source>21</maven.compiler.source>
+        <maven.compiler.target>21</maven.compiler.target>
+        <maven.compiler.release>21</maven.compiler.release>
+        <mcp.sdk.version>1.1.0</mcp.sdk.version>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>io.modelcontextprotocol.sdk</groupId>
+                <artifactId>mcp-bom</artifactId>
+                <version>${mcp.sdk.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+        <!-- MCP core + Jackson 2.x adapter. Jackson 2 to align with the
+             rest of saiku (saiku-bom pins 2.18.6); the Jackson 3 variant
+             would force a parallel runtime here. -->
+        <dependency>
+            <groupId>io.modelcontextprotocol.sdk</groupId>
+            <artifactId>mcp-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.modelcontextprotocol.sdk</groupId>
+            <artifactId>mcp-json-jackson2</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
+
+        <!-- The Jackson2 schema-validator adapter delegates to networknt's
+             json-schema-validator at runtime; pull it in here so tools/list
+             can run schema validation against tool inputSchemas. -->
+        <dependency>
+            <groupId>com.networknt</groupId>
+            <artifactId>json-schema-validator</artifactId>
+            <version>3.0.2</version>
+        </dependency>
+
+        <!-- slf4j-simple keeps the MCP SDK's internal logger from
+             complaining about a missing binding. Routed to stderr so
+             stdout stays reserved for MCP JSON-RPC framing. -->
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+            <version>2.0.13</version>
+            <scope>runtime</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <finalName>saiku-mcp-${project.version}</finalName>
+        <plugins>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.13.0</version>
+                <configuration>
+                    <release>${maven.compiler.release}</release>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>3.5.0</version>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <createDependencyReducedPom>false</createDependencyReducedPom>
+                            <transformers>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                                    <mainClass>org.saiku.mcp.SaikuMcpServer</mainClass>
+                                </transformer>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+                            </transformers>
+                            <filters>
+                                <filter>
+                                    <artifact>*:*</artifact>
+                                    <excludes>
+                                        <exclude>META-INF/*.SF</exclude>
+                                        <exclude>META-INF/*.DSA</exclude>
+                                        <exclude>META-INF/*.RSA</exclude>
+                                    </excludes>
+                                </filter>
+                            </filters>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/saiku-mcp/src/main/java/org/saiku/mcp/SaikuMcpServer.java
+++ b/saiku-mcp/src/main/java/org/saiku/mcp/SaikuMcpServer.java
@@ -221,8 +221,8 @@ public final class SaikuMcpServer {
                 .build();
         return spec(tool, (exchange, request) -> {
             Map<String, Object> a = request.arguments();
-            return jsonResult(() -> client.drillthrough(
-                    stringArg(a, "queryId"), optInt(a, "maxrows"), optString(a, "returns")));
+            return jsonResult(
+                    () -> client.drillthrough(stringArg(a, "queryId"), optInt(a, "maxrows"), optString(a, "returns")));
         });
     }
 
@@ -294,8 +294,7 @@ public final class SaikuMcpServer {
     }
 
     private static SyncToolSpecification spec(
-            Tool tool,
-            BiFunction<McpSyncServerExchange, McpSchema.CallToolRequest, CallToolResult> handler) {
+            Tool tool, BiFunction<McpSyncServerExchange, McpSchema.CallToolRequest, CallToolResult> handler) {
         return SyncToolSpecification.builder().tool(tool).callHandler(handler).build();
     }
 

--- a/saiku-mcp/src/main/java/org/saiku/mcp/SaikuMcpServer.java
+++ b/saiku-mcp/src/main/java/org/saiku/mcp/SaikuMcpServer.java
@@ -228,34 +228,68 @@ public final class SaikuMcpServer {
 
     /* ----------------------- helpers ----------------------- */
 
-    private interface JsonSupplier {
+    /** Package-private so tests can drive {@link #jsonResult} with synthetic suppliers. */
+    interface JsonSupplier {
         JsonNode get() throws Exception;
     }
 
     /** Wrap a REST call so any exception becomes a structured tool-error
-     *  body (the agent prefers a JSON error to an MCP-protocol error —
-     *  it can self-correct from a parsed envelope). */
-    private static CallToolResult jsonResult(JsonSupplier supplier) {
+     *  body. Successful responses are surfaced as both:
+     *  <ul>
+     *    <li>{@code content[0]}: stringified JSON (for clients that read
+     *        text content only)</li>
+     *    <li>{@code structuredContent}: parsed JsonNode so agents skip
+     *        the string→JSON shim</li>
+     *  </ul>
+     *
+     *  <p>Errors get an {@code errorKind} tag to differentiate:
+     *  <ul>
+     *    <li>{@code transport} — network failure, saiku down, can't
+     *        reach the server. Agent shouldn't retry the same call
+     *        immediately.</li>
+     *    <li>{@code internal} — unexpected runtime exception inside
+     *        the MCP layer. Likely a bug, not the agent's fault.</li>
+     *  </ul>
+     *  Validation errors from saiku (HTTP 400 + parsable body) come
+     *  back as a normal result with {@code isError=false} — the body's
+     *  {@code status: "VALIDATION_ERROR"} field is the contract agents
+     *  use to self-correct, and {@code isError=true} would discard the
+     *  helpful {@code available[]} list. */
+    static CallToolResult jsonResult(JsonSupplier supplier) {
         try {
             JsonNode body = supplier.get();
             return CallToolResult.builder()
                     .content(List.of(new TextContent(MAPPER.writeValueAsString(body))))
+                    .structuredContent((Object) body)
                     .build();
+        } catch (java.io.IOException | InterruptedException e) {
+            // Connection refused, DNS failure, socket reset, login timeout.
+            // Restoring the interrupt flag preserves cooperative cancellation.
+            if (e instanceof InterruptedException) Thread.currentThread().interrupt();
+            return errorResult("transport", e);
         } catch (Exception e) {
-            ObjectNode err = MAPPER.createObjectNode();
-            err.put("status", "ERROR");
-            err.put("error", e.getClass().getSimpleName() + ": " + e.getMessage());
-            try {
-                return CallToolResult.builder()
-                        .content(List.of(new TextContent(MAPPER.writeValueAsString(err))))
-                        .isError(true)
-                        .build();
-            } catch (Exception inner) {
-                return CallToolResult.builder()
-                        .content(List.of(new TextContent("error: " + e.getMessage())))
-                        .isError(true)
-                        .build();
-            }
+            return errorResult("internal", e);
+        }
+    }
+
+    private static CallToolResult errorResult(String kind, Throwable e) {
+        ObjectNode err = MAPPER.createObjectNode();
+        err.put("status", "ERROR");
+        err.put("errorKind", kind);
+        err.put("error", e.getClass().getSimpleName() + ": " + e.getMessage());
+        try {
+            return CallToolResult.builder()
+                    .content(List.of(new TextContent(MAPPER.writeValueAsString(err))))
+                    .structuredContent((Object) err)
+                    .isError(true)
+                    .build();
+        } catch (Exception inner) {
+            // Jackson serialisation failure — vanishingly unlikely, but
+            // surface SOMETHING rather than swallowing.
+            return CallToolResult.builder()
+                    .content(List.of(new TextContent(kind + ": " + e.getMessage())))
+                    .isError(true)
+                    .build();
         }
     }
 

--- a/saiku-mcp/src/main/java/org/saiku/mcp/SaikuMcpServer.java
+++ b/saiku-mcp/src/main/java/org/saiku/mcp/SaikuMcpServer.java
@@ -1,0 +1,285 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.mcp;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.modelcontextprotocol.json.McpJsonMapper;
+import io.modelcontextprotocol.json.jackson2.JacksonMcpJsonMapper;
+import io.modelcontextprotocol.server.McpServer;
+import io.modelcontextprotocol.server.McpServerFeatures.SyncToolSpecification;
+import io.modelcontextprotocol.server.McpSyncServer;
+import io.modelcontextprotocol.server.McpSyncServerExchange;
+import io.modelcontextprotocol.server.transport.StdioServerTransportProvider;
+import io.modelcontextprotocol.spec.McpSchema;
+import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
+import io.modelcontextprotocol.spec.McpSchema.ServerCapabilities;
+import io.modelcontextprotocol.spec.McpSchema.TextContent;
+import io.modelcontextprotocol.spec.McpSchema.Tool;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.function.BiFunction;
+
+/**
+ * Saiku MCP server — entry point.
+ *
+ * <p>Wraps Saiku's {@code /saiku/api/ai/*} REST surface as an MCP tool
+ * surface for LLM agents. Per {@code docs/MCP-SERVER-SPEC.md}.
+ * Stateless: every tool call is one MCP request → one REST call → one
+ * response. No client-side schema cache, no query session memory.
+ *
+ * <p>Transport: stdio only. Reads MCP JSON-RPC frames from stdin, writes
+ * responses to stdout. SLF4J logging is routed to stderr so it doesn't
+ * collide with the JSON-RPC framing on stdout.
+ *
+ * <p>Config (env vars):
+ * <ul>
+ *   <li>{@code SAIKU_URL}  — default {@code http://localhost:8080}</li>
+ *   <li>{@code SAIKU_USER} — default {@code admin}</li>
+ *   <li>{@code SAIKU_PASS} — default {@code admin}</li>
+ * </ul>
+ */
+public final class SaikuMcpServer {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    private SaikuMcpServer() {}
+
+    public static void main(String[] args) throws InterruptedException {
+        McpJsonMapper jsonMapper = new JacksonMcpJsonMapper(MAPPER);
+        StdioServerTransportProvider transport = new StdioServerTransportProvider(jsonMapper);
+
+        SaikuRestClient client = SaikuRestClient.fromEnv(System.getenv());
+
+        McpSyncServer server = McpServer.sync(transport)
+                .serverInfo("saiku-mcp", "4.0.1")
+                .capabilities(ServerCapabilities.builder().tools(true).build())
+                .tools(
+                        listCubesTool(jsonMapper, client),
+                        describeCubeTool(jsonMapper, client),
+                        searchMembersTool(jsonMapper, client),
+                        runQueryTool(jsonMapper, client),
+                        previewQueryTool(jsonMapper, client),
+                        drillthroughTool(jsonMapper, client))
+                .build();
+
+        Runtime.getRuntime().addShutdownHook(new Thread(server::closeGracefully));
+        // The MCP SDK runs its transport on internal NIO threads; main()
+        // returning would otherwise let the JVM exit before any frame
+        // gets handled. Park on an indefinite latch until SIGTERM /
+        // stdin EOF closes the process.
+        new CountDownLatch(1).await();
+    }
+
+    /* ----------------------- tool definitions ----------------------- */
+
+    private static SyncToolSpecification listCubesTool(McpJsonMapper jm, SaikuRestClient client) {
+        String schema = "{\"type\":\"object\",\"properties\":{},\"additionalProperties\":false}";
+        Tool tool = Tool.builder()
+                .name("list_cubes")
+                .description("List every OLAP cube the current user can query. Use this first when you don't know "
+                        + "what data is available — each entry has a one-line caption and the cube's default measure, "
+                        + "which is usually enough to pick the right cube without describing each one. Returns at most "
+                        + "a few dozen entries; not paginated.")
+                .inputSchema(jm, schema)
+                .build();
+        return spec(tool, (exchange, request) -> jsonResult(() -> client.listCubes()));
+    }
+
+    private static SyncToolSpecification describeCubeTool(McpJsonMapper jm, SaikuRestClient client) {
+        String schema = "{\"type\":\"object\",\"required\":[\"cube\"],"
+                + "\"properties\":{\"cube\":{\"type\":\"string\","
+                + "\"description\":\"The cube id from list_cubes: connection/catalog/schema/cubeName.\"}},"
+                + "\"additionalProperties\":false}";
+        Tool tool = Tool.builder()
+                .name("describe_cube")
+                .description("Get the complete queryable structure of one cube: measures, dimensions, hierarchies, "
+                        + "levels, and sample members with their MDX unique names. Always call this before run_query "
+                        + "if you haven't seen the cube structure yet — it tells you exactly which names are valid "
+                        + "and includes ready-made example query bodies. Sample members include both the human "
+                        + "caption and the MDX unique name, so you can copy the unique name directly into a filter.")
+                .inputSchema(jm, schema)
+                .build();
+        return spec(tool, (exchange, request) -> {
+            String cubeId = stringArg(request.arguments(), "cube");
+            return jsonResult(() -> client.describeCube(cubeId));
+        });
+    }
+
+    private static SyncToolSpecification searchMembersTool(McpJsonMapper jm, SaikuRestClient client) {
+        String schema = "{\"type\":\"object\",\"required\":[\"cube\",\"dimension\",\"level\"],"
+                + "\"properties\":{"
+                + "\"cube\":{\"type\":\"string\"},"
+                + "\"dimension\":{\"type\":\"string\"},"
+                + "\"hierarchy\":{\"type\":\"string\",\"description\":\"Optional when the dimension has only one hierarchy.\"},"
+                + "\"level\":{\"type\":\"string\"},"
+                + "\"q\":{\"type\":\"string\",\"description\":\"Optional substring filter. Omit to list all members on the level up to limit.\"},"
+                + "\"limit\":{\"type\":\"integer\",\"minimum\":1,\"maximum\":500,\"default\":20}"
+                + "},\"additionalProperties\":false}";
+        Tool tool = Tool.builder()
+                .name("search_members")
+                .description("Find the MDX unique names of members on a level by substring match. Use when the cube "
+                        + "has more members at a level than describe_cube's sampleMembers covered (e.g. searching "
+                        + "for a specific city, customer, or product brand), or when the user says \"filter by Italy\" "
+                        + "and you need to confirm the spelling. Returns up to limit hits with caption + uniqueName.")
+                .inputSchema(jm, schema)
+                .build();
+        return spec(tool, (exchange, request) -> {
+            Map<String, Object> a = request.arguments();
+            return jsonResult(() -> client.searchMembers(
+                    stringArg(a, "cube"),
+                    stringArg(a, "dimension"),
+                    optString(a, "hierarchy"),
+                    stringArg(a, "level"),
+                    optString(a, "q"),
+                    optInt(a, "limit")));
+        });
+    }
+
+    private static SyncToolSpecification runQueryTool(McpJsonMapper jm, SaikuRestClient client) {
+        // The full AiQueryRequest schema lives server-side and is too large
+        // to embed inline; agents that need the precise shape should call
+        // describe_cube and read the requestSchema field. This input
+        // schema is permissive — required cube + measures, everything
+        // else passes through.
+        String schema = "{\"type\":\"object\",\"required\":[\"cube\",\"measures\"],"
+                + "\"properties\":{"
+                + "\"cube\":{\"description\":\"Cube id (string from list_cubes) or {connectionName,catalog,schema,cubeName} object.\"},"
+                + "\"measures\":{\"type\":\"array\",\"minItems\":1,\"items\":{\"type\":\"object\",\"required\":[\"name\"],\"properties\":{\"name\":{\"type\":\"string\"}}}},"
+                + "\"rows\":{\"type\":\"array\"},"
+                + "\"columns\":{\"type\":\"array\"},"
+                + "\"filters\":{\"type\":\"array\"},"
+                + "\"order\":{\"type\":\"array\"},"
+                + "\"limit\":{\"type\":\"integer\"},"
+                + "\"visualTotals\":{\"type\":\"boolean\"},"
+                + "\"nonEmpty\":{\"type\":\"boolean\"},"
+                + "\"format\":{\"type\":\"string\",\"enum\":[\"records\",\"matrix\"],\"description\":\"Default records.\"}"
+                + "},\"additionalProperties\":true}";
+        Tool tool = Tool.builder()
+                .name("run_query")
+                .description("Run an OLAP analytical query and get the results as records. This is the primary tool — "
+                        + "most user questions land here. Build the request against the cube structure from "
+                        + "describe_cube; the server validates every name and returns a 400 with a list of valid "
+                        + "alternatives if any name is wrong, so don't pre-validate yourself. Default output is records "
+                        + "(one object per row, keyed by column captions); pass format:\"matrix\" only if you need "
+                        + "the position-indexed shape.")
+                .inputSchema(jm, schema)
+                .build();
+        return spec(tool, (exchange, request) -> {
+            Map<String, Object> a = request.arguments();
+            String format = optString(a, "format");
+            ObjectNode body = MAPPER.valueToTree(a);
+            // 'format' is a query-string param, not a body field; strip it
+            // before forwarding to keep the saiku validator happy.
+            body.remove("format");
+            return jsonResult(() -> client.runQuery(body, format));
+        });
+    }
+
+    private static SyncToolSpecification previewQueryTool(McpJsonMapper jm, SaikuRestClient client) {
+        // Same input shape as run_query, minus the format switch — preview
+        // doesn't render rows.
+        String schema = "{\"type\":\"object\",\"required\":[\"cube\",\"measures\"],"
+                + "\"properties\":{"
+                + "\"cube\":{},\"measures\":{\"type\":\"array\"},\"rows\":{\"type\":\"array\"},"
+                + "\"columns\":{\"type\":\"array\"},\"filters\":{\"type\":\"array\"},"
+                + "\"order\":{\"type\":\"array\"},\"limit\":{\"type\":\"integer\"},"
+                + "\"visualTotals\":{\"type\":\"boolean\"},\"nonEmpty\":{\"type\":\"boolean\"}"
+                + "},\"additionalProperties\":true}";
+        Tool tool = Tool.builder()
+                .name("preview_query")
+                .description("Compile a query to MDX without executing it. Use when you want to show the user what "
+                        + "the query will do, audit a generated query, or estimate cost before running an expensive "
+                        + "aggregation. Validation runs the same as run_query — preview will return the same "
+                        + "VALIDATION_ERROR shape if names don't resolve.")
+                .inputSchema(jm, schema)
+                .build();
+        return spec(tool, (exchange, request) -> {
+            ObjectNode body = MAPPER.valueToTree(request.arguments());
+            return jsonResult(() -> client.previewQuery(body));
+        });
+    }
+
+    private static SyncToolSpecification drillthroughTool(McpJsonMapper jm, SaikuRestClient client) {
+        String schema = "{\"type\":\"object\",\"required\":[\"queryId\"],"
+                + "\"properties\":{"
+                + "\"queryId\":{\"type\":\"string\",\"description\":\"queryId returned by a prior run_query call.\"},"
+                + "\"maxrows\":{\"type\":\"integer\",\"minimum\":1,\"maximum\":10000,\"default\":100},"
+                + "\"returns\":{\"type\":\"string\",\"description\":\"Optional comma-separated column list to project a subset.\"}"
+                + "},\"additionalProperties\":false}";
+        Tool tool = Tool.builder()
+                .name("drillthrough")
+                .description("Fetch the raw fact-table rows behind a specific query. Use when the user asks "
+                        + "\"show me the underlying transactions\" or wants to inspect detail for a single cell. "
+                        + "Pass the queryId returned by an earlier run_query call. Cells in the response are the "
+                        + "same typed envelope as run_query — numeric warehouse columns get a parsed value.")
+                .inputSchema(jm, schema)
+                .build();
+        return spec(tool, (exchange, request) -> {
+            Map<String, Object> a = request.arguments();
+            return jsonResult(() -> client.drillthrough(
+                    stringArg(a, "queryId"), optInt(a, "maxrows"), optString(a, "returns")));
+        });
+    }
+
+    /* ----------------------- helpers ----------------------- */
+
+    private interface JsonSupplier {
+        JsonNode get() throws Exception;
+    }
+
+    /** Wrap a REST call so any exception becomes a structured tool-error
+     *  body (the agent prefers a JSON error to an MCP-protocol error —
+     *  it can self-correct from a parsed envelope). */
+    private static CallToolResult jsonResult(JsonSupplier supplier) {
+        try {
+            JsonNode body = supplier.get();
+            return CallToolResult.builder()
+                    .content(List.of(new TextContent(MAPPER.writeValueAsString(body))))
+                    .build();
+        } catch (Exception e) {
+            ObjectNode err = MAPPER.createObjectNode();
+            err.put("status", "ERROR");
+            err.put("error", e.getClass().getSimpleName() + ": " + e.getMessage());
+            try {
+                return CallToolResult.builder()
+                        .content(List.of(new TextContent(MAPPER.writeValueAsString(err))))
+                        .isError(true)
+                        .build();
+            } catch (Exception inner) {
+                return CallToolResult.builder()
+                        .content(List.of(new TextContent("error: " + e.getMessage())))
+                        .isError(true)
+                        .build();
+            }
+        }
+    }
+
+    private static SyncToolSpecification spec(
+            Tool tool,
+            BiFunction<McpSyncServerExchange, McpSchema.CallToolRequest, CallToolResult> handler) {
+        return SyncToolSpecification.builder().tool(tool).callHandler(handler).build();
+    }
+
+    private static String stringArg(Map<String, Object> args, String key) {
+        Object v = args.get(key);
+        if (v == null) throw new IllegalArgumentException("Missing required argument: " + key);
+        return v.toString();
+    }
+
+    private static String optString(Map<String, Object> args, String key) {
+        Object v = args.get(key);
+        return v == null ? null : v.toString();
+    }
+
+    private static Integer optInt(Map<String, Object> args, String key) {
+        Object v = args.get(key);
+        if (v == null) return null;
+        if (v instanceof Number n) return n.intValue();
+        return Integer.parseInt(v.toString());
+    }
+}

--- a/saiku-mcp/src/main/java/org/saiku/mcp/SaikuRestClient.java
+++ b/saiku-mcp/src/main/java/org/saiku/mcp/SaikuRestClient.java
@@ -7,14 +7,18 @@ package org.saiku.mcp;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
+import java.net.ConnectException;
 import java.net.CookieManager;
 import java.net.CookiePolicy;
 import java.net.URI;
 import java.net.URLEncoder;
 import java.net.http.HttpClient;
+import java.net.http.HttpConnectTimeoutException;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.time.Duration;
 import java.util.Map;
 
@@ -175,8 +179,22 @@ final class SaikuRestClient {
         loggedIn = true;
     }
 
+    /** Send with one short retry on transient transport errors
+     *  (connection refused, connect timeout). Saiku launchers are
+     *  occasionally bouncing on dev machines; a single ~250 ms retry
+     *  smooths over the restart window without masking real outages. */
     private HttpResponse<String> send(HttpRequest req) throws IOException, InterruptedException {
-        return http.send(req, HttpResponse.BodyHandlers.ofString(StandardCharsets.UTF_8));
+        try {
+            return http.send(req, HttpResponse.BodyHandlers.ofString(StandardCharsets.UTF_8));
+        } catch (ConnectException | HttpConnectTimeoutException transient_) {
+            try {
+                Thread.sleep(250);
+            } catch (InterruptedException ie) {
+                Thread.currentThread().interrupt();
+                throw ie;
+            }
+            return http.send(req, HttpResponse.BodyHandlers.ofString(StandardCharsets.UTF_8));
+        }
     }
 
     private URI uri(String path) {
@@ -188,11 +206,33 @@ final class SaikuRestClient {
     }
 
     /** Read SAIKU_URL / SAIKU_USER / SAIKU_PASS from the supplied env
-     *  map, falling back to sensible defaults for a local launcher. */
+     *  map, falling back to sensible defaults for a local launcher.
+     *
+     *  <p>{@code SAIKU_PASS_FILE} (path to a file containing the
+     *  password, trailing whitespace trimmed) takes precedence over
+     *  {@code SAIKU_PASS}. Useful for keeping the secret out of
+     *  {@code claude_desktop_config.json} or shell history. */
     static SaikuRestClient fromEnv(Map<String, String> env) {
         String url = env.getOrDefault("SAIKU_URL", "http://localhost:8080");
         String user = env.getOrDefault("SAIKU_USER", "admin");
-        String pass = env.getOrDefault("SAIKU_PASS", "admin");
+        String pass = readPassword(env);
         return new SaikuRestClient(url, user, pass);
+    }
+
+    static String readPassword(Map<String, String> env) {
+        String passFile = env.get("SAIKU_PASS_FILE");
+        if (passFile != null && !passFile.isBlank()) {
+            try {
+                // Trim trailing newline that text editors / `echo` add
+                // by default. Leading whitespace is preserved in case
+                // the password legitimately starts with a space (rare
+                // but legal).
+                return Files.readString(Path.of(passFile), StandardCharsets.UTF_8)
+                        .replaceAll("\\R+$", "");
+            } catch (IOException e) {
+                throw new IllegalStateException("Failed to read SAIKU_PASS_FILE=" + passFile + ": " + e.getMessage(), e);
+            }
+        }
+        return env.getOrDefault("SAIKU_PASS", "admin");
     }
 }

--- a/saiku-mcp/src/main/java/org/saiku/mcp/SaikuRestClient.java
+++ b/saiku-mcp/src/main/java/org/saiku/mcp/SaikuRestClient.java
@@ -1,0 +1,198 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.mcp;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import java.net.CookieManager;
+import java.net.CookiePolicy;
+import java.net.URI;
+import java.net.URLEncoder;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.Map;
+
+/**
+ * Thin wrapper around Saiku's REST surface. Holds a session cookie via
+ * {@link CookieManager} and transparently re-logs-in on 401. Designed for
+ * the {@link SaikuMcpServer} stdio loop — one client per process,
+ * single-threaded use.
+ *
+ * <p>This client does no schema awareness — every method returns the raw
+ * server response body as a {@link JsonNode}. Conversion to MCP
+ * {@code CallToolResult} happens in the server class.
+ */
+final class SaikuRestClient {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    private final String baseUrl;
+    private final String user;
+    private final String pass;
+    private final HttpClient http;
+    private boolean loggedIn = false;
+
+    SaikuRestClient(String baseUrl, String user, String pass) {
+        // Strip trailing slash so path-joins are consistent.
+        this.baseUrl = baseUrl.endsWith("/") ? baseUrl.substring(0, baseUrl.length() - 1) : baseUrl;
+        this.user = user;
+        this.pass = pass;
+        CookieManager cm = new CookieManager();
+        cm.setCookiePolicy(CookiePolicy.ACCEPT_ALL);
+        this.http = HttpClient.newBuilder()
+                .cookieHandler(cm)
+                .connectTimeout(Duration.ofSeconds(10))
+                .build();
+    }
+
+    /** GET {@code /rest/saiku/api/ai/cubes}. */
+    JsonNode listCubes() throws IOException, InterruptedException {
+        return getJson("/rest/saiku/api/ai/cubes");
+    }
+
+    /** GET {@code /rest/saiku/api/ai/schema/{cubeId}}. {@code cubeId} is
+     *  {@code connection/catalog/schema/cubeName} — passed through as a
+     *  multi-segment path (no encoding of the slashes). */
+    JsonNode describeCube(String cubeId) throws IOException, InterruptedException {
+        return getJson("/rest/saiku/api/ai/schema/" + cubeId);
+    }
+
+    /** GET {@code /rest/saiku/api/ai/members/search}. */
+    JsonNode searchMembers(String cubeId, String dimension, String hierarchy, String level, String q, Integer limit)
+            throws IOException, InterruptedException {
+        StringBuilder p = new StringBuilder("/rest/saiku/api/ai/members/search?cubeId=").append(enc(cubeId));
+        if (dimension != null) p.append("&dimension=").append(enc(dimension));
+        if (hierarchy != null) p.append("&hierarchy=").append(enc(hierarchy));
+        if (level != null) p.append("&level=").append(enc(level));
+        if (q != null) p.append("&q=").append(enc(q));
+        if (limit != null) p.append("&limit=").append(limit);
+        return getJson(p.toString());
+    }
+
+    /** POST {@code /rest/saiku/api/ai/query}. {@code format} is the
+     *  optional {@code ?format=records|matrix} query-string switch. */
+    JsonNode runQuery(JsonNode body, String format) throws IOException, InterruptedException {
+        String path = "/rest/saiku/api/ai/query";
+        if (format != null && !format.isBlank()) path += "?format=" + enc(format);
+        return postJson(path, body);
+    }
+
+    /** POST {@code /rest/saiku/api/ai/query/preview}. */
+    JsonNode previewQuery(JsonNode body) throws IOException, InterruptedException {
+        return postJson("/rest/saiku/api/ai/query/preview", body);
+    }
+
+    /** GET {@code /rest/saiku/api/ai/query/{queryId}/drillthrough}. */
+    JsonNode drillthrough(String queryId, Integer maxrows, String returns) throws IOException, InterruptedException {
+        StringBuilder p = new StringBuilder("/rest/saiku/api/ai/query/").append(enc(queryId)).append("/drillthrough");
+        boolean first = true;
+        if (maxrows != null) {
+            p.append(first ? '?' : '&').append("maxrows=").append(maxrows);
+            first = false;
+        }
+        if (returns != null && !returns.isBlank()) {
+            p.append(first ? '?' : '&').append("returns=").append(enc(returns));
+        }
+        return getJson(p.toString());
+    }
+
+    /* ------------------------------------------------------------------ */
+
+    private JsonNode getJson(String path) throws IOException, InterruptedException {
+        ensureLoggedIn();
+        HttpResponse<String> resp = send(HttpRequest.newBuilder(uri(path)).GET().build());
+        if (resp.statusCode() == 401) {
+            // Session expired between calls. Re-login once and retry.
+            loggedIn = false;
+            ensureLoggedIn();
+            resp = send(HttpRequest.newBuilder(uri(path)).GET().build());
+        }
+        return parseOrError(resp);
+    }
+
+    private JsonNode postJson(String path, JsonNode body) throws IOException, InterruptedException {
+        ensureLoggedIn();
+        String json = MAPPER.writeValueAsString(body == null ? MAPPER.createObjectNode() : body);
+        HttpRequest req = HttpRequest.newBuilder(uri(path))
+                .header("Content-Type", "application/json")
+                .POST(HttpRequest.BodyPublishers.ofString(json, StandardCharsets.UTF_8))
+                .build();
+        HttpResponse<String> resp = send(req);
+        if (resp.statusCode() == 401) {
+            loggedIn = false;
+            ensureLoggedIn();
+            resp = send(req);
+        }
+        return parseOrError(resp);
+    }
+
+    /** Validation errors (400) come back with a useful body — return them
+     *  to the caller verbatim so the agent can self-correct. Other 5xx
+     *  errors with a parsable JSON body also pass through. We only fall
+     *  back to a synthetic error envelope on transport failure or non-JSON. */
+    private JsonNode parseOrError(HttpResponse<String> resp) {
+        String body = resp.body() == null ? "" : resp.body();
+        if (body.isEmpty()) {
+            return MAPPER.createObjectNode()
+                    .put("status", "ERROR")
+                    .put("error", "Empty response from saiku (HTTP " + resp.statusCode() + ")");
+        }
+        try {
+            return MAPPER.readTree(body);
+        } catch (IOException e) {
+            return MAPPER.createObjectNode()
+                    .put("status", "ERROR")
+                    .put(
+                            "error",
+                            "Non-JSON response from saiku (HTTP " + resp.statusCode() + "): "
+                                    + body.substring(0, Math.min(200, body.length())));
+        }
+    }
+
+    private void ensureLoggedIn() throws IOException, InterruptedException {
+        if (loggedIn) return;
+        // The launcher's /login endpoint expects form-encoded credentials
+        // and returns a 302 on success with a JSESSIONID cookie.
+        String form = "username=" + enc(user) + "&password=" + enc(pass);
+        HttpRequest req = HttpRequest.newBuilder(uri("/login"))
+                .header("Content-Type", "application/x-www-form-urlencoded")
+                .POST(HttpRequest.BodyPublishers.ofString(form, StandardCharsets.UTF_8))
+                .build();
+        HttpResponse<String> resp = send(req);
+        int code = resp.statusCode();
+        // 302 = redirect on success; 200 = some configs return success
+        // directly. Anything else means credentials or URL are wrong —
+        // surface the status so the operator can fix it.
+        if (code != 302 && code != 200) {
+            throw new IOException("Saiku login failed: HTTP " + code + " (check SAIKU_URL/USER/PASS)");
+        }
+        loggedIn = true;
+    }
+
+    private HttpResponse<String> send(HttpRequest req) throws IOException, InterruptedException {
+        return http.send(req, HttpResponse.BodyHandlers.ofString(StandardCharsets.UTF_8));
+    }
+
+    private URI uri(String path) {
+        return URI.create(baseUrl + path);
+    }
+
+    private static String enc(String s) {
+        return URLEncoder.encode(s, StandardCharsets.UTF_8);
+    }
+
+    /** Read SAIKU_URL / SAIKU_USER / SAIKU_PASS from the supplied env
+     *  map, falling back to sensible defaults for a local launcher. */
+    static SaikuRestClient fromEnv(Map<String, String> env) {
+        String url = env.getOrDefault("SAIKU_URL", "http://localhost:8080");
+        String user = env.getOrDefault("SAIKU_USER", "admin");
+        String pass = env.getOrDefault("SAIKU_PASS", "admin");
+        return new SaikuRestClient(url, user, pass);
+    }
+}

--- a/saiku-mcp/src/main/java/org/saiku/mcp/SaikuRestClient.java
+++ b/saiku-mcp/src/main/java/org/saiku/mcp/SaikuRestClient.java
@@ -94,7 +94,9 @@ final class SaikuRestClient {
 
     /** GET {@code /rest/saiku/api/ai/query/{queryId}/drillthrough}. */
     JsonNode drillthrough(String queryId, Integer maxrows, String returns) throws IOException, InterruptedException {
-        StringBuilder p = new StringBuilder("/rest/saiku/api/ai/query/").append(enc(queryId)).append("/drillthrough");
+        StringBuilder p = new StringBuilder("/rest/saiku/api/ai/query/")
+                .append(enc(queryId))
+                .append("/drillthrough");
         boolean first = true;
         if (maxrows != null) {
             p.append(first ? '?' : '&').append("maxrows=").append(maxrows);
@@ -230,7 +232,8 @@ final class SaikuRestClient {
                 return Files.readString(Path.of(passFile), StandardCharsets.UTF_8)
                         .replaceAll("\\R+$", "");
             } catch (IOException e) {
-                throw new IllegalStateException("Failed to read SAIKU_PASS_FILE=" + passFile + ": " + e.getMessage(), e);
+                throw new IllegalStateException(
+                        "Failed to read SAIKU_PASS_FILE=" + passFile + ": " + e.getMessage(), e);
             }
         }
         return env.getOrDefault("SAIKU_PASS", "admin");

--- a/saiku-mcp/src/test/java/org/saiku/mcp/SaikuMcpServerTest.java
+++ b/saiku-mcp/src/test/java/org/saiku/mcp/SaikuMcpServerTest.java
@@ -1,0 +1,128 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.mcp;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sun.net.httpserver.HttpServer;
+import io.modelcontextprotocol.spec.McpSchema;
+import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
+import io.modelcontextprotocol.spec.McpSchema.TextContent;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Glue-layer tests for {@link SaikuMcpServer}. Exercises the
+ * {@code jsonResult} adapter end-to-end against an embedded saiku
+ * stub — verifies the MCP {@link CallToolResult} envelope is
+ * well-formed for both success and failure paths, including the
+ * {@code structuredContent} field and the {@code errorKind} tag added
+ * for transport failures.
+ *
+ * <p>Doesn't drive the MCP stdio loop in a subprocess — that surface
+ * is exercised manually via the README smoke test. Here we want the
+ * fastest signal on the saiku-mcp ↔ saiku-rest seam.
+ */
+public class SaikuMcpServerTest {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    private HttpServer server;
+    private SaikuRestClient client;
+
+    @Before
+    public void setUp() throws IOException {
+        server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+        server.createContext("/login", ex -> {
+            ex.getResponseHeaders().add("Set-Cookie", "JSESSIONID=ok; Path=/");
+            ex.sendResponseHeaders(302, -1);
+        });
+        server.createContext("/rest/saiku/api/ai/cubes", ex -> {
+            byte[] body = "[{\"cubeName\":\"Sales\"}]".getBytes(StandardCharsets.UTF_8);
+            ex.getResponseHeaders().add("Content-Type", "application/json");
+            ex.sendResponseHeaders(200, body.length);
+            try (OutputStream os = ex.getResponseBody()) {
+                os.write(body);
+            }
+        });
+        server.start();
+        client = new SaikuRestClient("http://127.0.0.1:" + server.getAddress().getPort(), "admin", "secret");
+    }
+
+    @After
+    public void tearDown() {
+        if (server != null) server.stop(0);
+    }
+
+    @Test
+    public void jsonResultWrapsSuccessfulResponseAsStructuredContent() throws Exception {
+        CallToolResult r = SaikuMcpServer.jsonResult(() -> client.listCubes());
+
+        assertFalse("success path leaves isError unset/false", Boolean.TRUE.equals(r.isError()));
+        assertNotNull("structuredContent present on success", r.structuredContent());
+        // Round-trip the structuredContent through Jackson and verify it
+        // reflects the upstream body (most clients consume this field
+        // directly rather than parsing the text content).
+        JsonNode parsed = MAPPER.valueToTree(r.structuredContent());
+        assertTrue("structuredContent is the cubes array", parsed.isArray());
+        assertEquals("Sales", parsed.get(0).get("cubeName").asText());
+
+        // Text content also present for legacy MCP clients.
+        assertEquals(1, r.content().size());
+        McpSchema.Content c = r.content().get(0);
+        assertTrue("text content is the JSON string form", c instanceof TextContent);
+        JsonNode reparsed = MAPPER.readTree(((TextContent) c).text());
+        assertEquals("Sales", reparsed.get(0).get("cubeName").asText());
+    }
+
+    @Test
+    public void jsonResultTagsTransportFailuresWithErrorKind() {
+        SaikuRestClient unreachable = new SaikuRestClient("http://127.0.0.1:1", "admin", "secret"); // port 1 = nothing
+        CallToolResult r = SaikuMcpServer.jsonResult(() -> unreachable.listCubes());
+
+        assertTrue("transport failures set isError", Boolean.TRUE.equals(r.isError()));
+        JsonNode body = MAPPER.valueToTree(r.structuredContent());
+        assertEquals("transport", body.get("errorKind").asText());
+        assertEquals("ERROR", body.get("status").asText());
+        assertNotNull("error message populated", body.get("error"));
+    }
+
+    @Test
+    public void jsonResultTagsInternalFailuresDistinctFromTransport() {
+        CallToolResult r = SaikuMcpServer.jsonResult(() -> {
+            throw new IllegalArgumentException("synthetic");
+        });
+
+        assertTrue("internal errors set isError", Boolean.TRUE.equals(r.isError()));
+        JsonNode body = MAPPER.valueToTree(r.structuredContent());
+        // Differentiate from transport so the agent knows it's not a
+        // "retry when saiku comes back" situation.
+        assertEquals("internal", body.get("errorKind").asText());
+        assertTrue(
+                "error names the cause — got: " + body.get("error").asText(),
+                body.get("error").asText().contains("synthetic"));
+    }
+
+    @Test
+    public void jsonResultEmptyContentListProducesNonNullEnvelope() {
+        // Sanity: builder doesn't barf on a degenerate handler. The
+        // production code never calls jsonResult with a null supplier,
+        // but we ensure the helper's contract is robust.
+        CallToolResult r = SaikuMcpServer.jsonResult(() -> MAPPER.createObjectNode());
+        assertNotNull(r);
+        assertNotNull(r.content());
+        assertEquals(1, r.content().size());
+    }
+}

--- a/saiku-mcp/src/test/java/org/saiku/mcp/SaikuRestClientTest.java
+++ b/saiku-mcp/src/test/java/org/saiku/mcp/SaikuRestClientTest.java
@@ -1,0 +1,208 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.mcp;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.sun.net.httpserver.HttpServer;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Unit tests for {@link SaikuRestClient}. Spins up an embedded JDK
+ * {@link HttpServer} that mimics the saiku launcher's auth + AI
+ * endpoints, then exercises each of the client's public methods plus
+ * the cookie + 401-retry plumbing.
+ *
+ * <p>Embedded server pattern (vs Mockito on HttpClient) because the JDK
+ * HttpClient surface is final-class-heavy and awkward to mock — and
+ * running a real socket exercises the cookie jar + redirect handling
+ * for free.
+ */
+public class SaikuRestClientTest {
+
+    private HttpServer server;
+    private String baseUrl;
+    private SaikuRestClient client;
+
+    /** Number of /login calls — verifies re-login on 401 fires once. */
+    private final AtomicInteger loginCalls = new AtomicInteger();
+    /** Mutable per-test toggle: when true, the next /api call returns 401. */
+    private volatile boolean nextCallReturn401 = false;
+
+    @Before
+    public void setUp() throws IOException {
+        server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+
+        // /login handles both the GET (browser would land here first) and
+        // the POST. POST returns 302 on correct credentials.
+        server.createContext("/login", ex -> {
+            if ("POST".equals(ex.getRequestMethod())) {
+                loginCalls.incrementAndGet();
+                String form = new String(ex.getRequestBody().readAllBytes(), StandardCharsets.UTF_8);
+                if (form.contains("username=admin") && form.contains("password=secret")) {
+                    ex.getResponseHeaders().add("Set-Cookie", "JSESSIONID=abc123; Path=/");
+                    ex.sendResponseHeaders(302, -1);
+                } else {
+                    ex.sendResponseHeaders(401, -1);
+                }
+            } else {
+                ex.sendResponseHeaders(200, 0);
+                ex.getResponseBody().close();
+            }
+        });
+
+        server.createContext("/rest/saiku/api/ai/cubes", ex -> {
+            if (nextCallReturn401) {
+                nextCallReturn401 = false;
+                ex.sendResponseHeaders(401, -1);
+                return;
+            }
+            respondJson(ex, 200, "[{\"cubeName\":\"Sales\"},{\"cubeName\":\"HR\"}]");
+        });
+
+        server.createContext("/rest/saiku/api/ai/query", ex -> {
+            // Mimic the validation-error envelope.
+            respondJson(
+                    ex,
+                    400,
+                    "{\"status\":\"VALIDATION_ERROR\",\"field\":\"measures[].name\","
+                            + "\"error\":\"Unknown measure 'X'\",\"available\":[\"Unit Sales\"]}");
+        });
+
+        server.createContext("/rest/saiku/api/ai/members/search", ex -> {
+            // Echo the query string so the test can verify URL building.
+            String qs = ex.getRequestURI().getRawQuery();
+            respondJson(
+                    ex,
+                    200,
+                    "{\"hits\":[],\"_query\":\""
+                            + (qs == null ? "" : qs.replace("\"", "\\\""))
+                            + "\"}");
+        });
+
+        server.start();
+        baseUrl = "http://127.0.0.1:" + server.getAddress().getPort();
+        client = new SaikuRestClient(baseUrl, "admin", "secret");
+    }
+
+    @After
+    public void tearDown() {
+        if (server != null) server.stop(0);
+    }
+
+    private static void respondJson(com.sun.net.httpserver.HttpExchange ex, int code, String body) throws IOException {
+        byte[] bytes = body.getBytes(StandardCharsets.UTF_8);
+        ex.getResponseHeaders().add("Content-Type", "application/json");
+        ex.sendResponseHeaders(code, bytes.length);
+        try (OutputStream os = ex.getResponseBody()) {
+            os.write(bytes);
+        }
+    }
+
+    @Test
+    public void listCubesAuthenticatesThenReturnsBody() throws Exception {
+        JsonNode body = client.listCubes();
+        assertNotNull(body);
+        assertTrue("expected a JSON array — got: " + body, body.isArray());
+        assertEquals(2, body.size());
+        assertEquals("Sales", body.get(0).get("cubeName").asText());
+        assertEquals("login fired exactly once", 1, loginCalls.get());
+    }
+
+    @Test
+    public void cookieJarRemembersSessionAcrossCalls() throws Exception {
+        client.listCubes();
+        client.listCubes();
+        // Second call would re-trigger login if the cookie weren't reused.
+        assertEquals("login fired once across two calls", 1, loginCalls.get());
+    }
+
+    @Test
+    public void reLoginsOnSession401AndRetries() throws Exception {
+        client.listCubes(); // primes the cookie (login=1)
+        nextCallReturn401 = true; // next /cubes call returns 401
+        JsonNode body = client.listCubes(); // should re-login then succeed
+        assertNotNull(body);
+        assertEquals(2, body.size());
+        assertEquals("re-login fired once on 401", 2, loginCalls.get());
+    }
+
+    @Test
+    public void postValidationErrorBodyIsReturnedVerbatim() throws Exception {
+        JsonNode body = client.runQuery(null, null);
+        assertEquals("VALIDATION_ERROR", body.get("status").asText());
+        assertEquals("measures[].name", body.get("field").asText());
+        assertTrue(body.get("available").isArray());
+    }
+
+    @Test
+    public void searchMembersEncodesQueryParams() throws Exception {
+        JsonNode body = client.searchMembers("c", "Customer", "Customers", "Country", "U S A", 5);
+        String echoed = body.get("_query").asText();
+        assertTrue("dimension propagated — got: " + echoed, echoed.contains("dimension=Customer"));
+        // " " must be %20 (or +); both are legal RFC 3986 — assert the
+        // server saw the right value either way by checking the raw form.
+        assertTrue(
+                "space-bearing q propagated and URL-encoded — got: " + echoed,
+                echoed.contains("q=U+S+A") || echoed.contains("q=U%20S%20A"));
+        assertTrue("limit propagated — got: " + echoed, echoed.contains("limit=5"));
+    }
+
+    @Test
+    public void loginFailureSurfacesAsIOException() {
+        SaikuRestClient bad = new SaikuRestClient(baseUrl, "admin", "wrong-password");
+        try {
+            bad.listCubes();
+            fail("expected IOException from failed login");
+        } catch (IOException e) {
+            assertTrue("error names the HTTP status — got: " + e.getMessage(), e.getMessage().contains("HTTP 401"));
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            fail("unexpected InterruptedException");
+        }
+    }
+
+    @Test
+    public void readPasswordPrefersFileOverEnv() throws Exception {
+        Path tmp = Files.createTempFile("saiku-mcp-pass", ".txt");
+        try {
+            Files.writeString(tmp, "from-file\n");
+            Map<String, String> env = new HashMap<>();
+            env.put("SAIKU_PASS_FILE", tmp.toString());
+            env.put("SAIKU_PASS", "from-env"); // should be ignored
+            String pass = SaikuRestClient.readPassword(env);
+            assertEquals("from-file", pass); // trailing newline trimmed
+        } finally {
+            Files.deleteIfExists(tmp);
+        }
+    }
+
+    @Test
+    public void readPasswordFallsBackToEnvWhenFileMissing() {
+        Map<String, String> env = new HashMap<>();
+        env.put("SAIKU_PASS", "secret-from-env");
+        assertEquals("secret-from-env", SaikuRestClient.readPassword(env));
+    }
+
+    @Test
+    public void readPasswordDefaultsToAdmin() {
+        assertEquals("admin", SaikuRestClient.readPassword(new HashMap<>()));
+    }
+}

--- a/saiku-mcp/src/test/java/org/saiku/mcp/SaikuRestClientTest.java
+++ b/saiku-mcp/src/test/java/org/saiku/mcp/SaikuRestClientTest.java
@@ -89,12 +89,7 @@ public class SaikuRestClientTest {
         server.createContext("/rest/saiku/api/ai/members/search", ex -> {
             // Echo the query string so the test can verify URL building.
             String qs = ex.getRequestURI().getRawQuery();
-            respondJson(
-                    ex,
-                    200,
-                    "{\"hits\":[],\"_query\":\""
-                            + (qs == null ? "" : qs.replace("\"", "\\\""))
-                            + "\"}");
+            respondJson(ex, 200, "{\"hits\":[],\"_query\":\"" + (qs == null ? "" : qs.replace("\"", "\\\"")) + "\"}");
         });
 
         server.start();
@@ -172,7 +167,9 @@ public class SaikuRestClientTest {
             bad.listCubes();
             fail("expected IOException from failed login");
         } catch (IOException e) {
-            assertTrue("error names the HTTP status — got: " + e.getMessage(), e.getMessage().contains("HTTP 401"));
+            assertTrue(
+                    "error names the HTTP status — got: " + e.getMessage(),
+                    e.getMessage().contains("HTTP 401"));
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
             fail("unexpected InterruptedException");


### PR DESCRIPTION
## Summary

New \`saiku-mcp\` Maven module. Standalone fat jar that speaks MCP JSON-RPC over stdio and forwards each tool call to one REST endpoint on the running saiku launcher. Implements [`docs/MCP-SERVER-SPEC.md`](../docs/MCP-SERVER-SPEC.md).

## Six tools

| Tool | Maps to |
| --- | --- |
| \`list_cubes\` | \`GET  /rest/saiku/api/ai/cubes\` |
| \`describe_cube\` | \`GET  /rest/saiku/api/ai/schema/{cubeId}\` |
| \`search_members\` | \`GET  /rest/saiku/api/ai/members/search\` |
| \`run_query\` | \`POST /rest/saiku/api/ai/query\` |
| \`preview_query\` | \`POST /rest/saiku/api/ai/query/preview\` |
| \`drillthrough\` | \`GET  /rest/saiku/api/ai/query/{id}/drillthrough\` |

Tool descriptions are written for LLM consumption — "use this when…", "don't pre-validate, the server returns a 400 with valid alternatives", "call describe_cube first" — not endpoint docs.

## Stack

- \`io.modelcontextprotocol.sdk:mcp-core:1.1.0\` + \`mcp-json-jackson2\` (Jackson 2 to match the rest of saiku).
- JDK 21 \`HttpClient\` for the REST side. Cookie-jar holds the JSESSIONID; on 401 the client re-logs-in and retries the failed call.
- Shade-plugin fat jar so Claude Desktop / Cursor / Cline can invoke it as \`java -jar\`.

## End-to-end verified

Against the local launcher (FoodMart H2):

- \`list_cubes\` → 6 cubes (Sales, HR, Sales 2, Store, Warehouse, Warehouse and Sales).
- \`run_query\` with the Step-3 example body (Top 3 product families by Store Sales) → \`status: SUCCESS\`, totalRows=3, same numbers as the [AI-QUERY-API.md](../docs/AI-QUERY-API.md) doc claim.

## Config (env)

| Var | Default | Notes |
| --- | --- | --- |
| \`SAIKU_URL\` | \`http://localhost:8080\` | Launcher endpoint. |
| \`SAIKU_USER\` | \`admin\` | Form-login. |
| \`SAIKU_PASS\` | \`admin\` | |

Claude Desktop config snippet + smoke-test instructions in \`saiku-mcp/README.md\`.

## Build

\`\`\`sh
mvn -pl saiku-mcp -am -DskipTests package
# → saiku-mcp/target/saiku-mcp-4.0.1.jar
\`\`\`

## Test plan

- [x] Build passes
- [x] \`tools/list\` returns 6 tools
- [x] \`list_cubes\` end-to-end against running launcher
- [x] \`run_query\` end-to-end matches doc example
- [ ] Wire into Claude Desktop config and test through the actual client
- [ ] Unit-test surface for \`SaikuRestClient\` (mocked HTTP) — follow-up PR