### PR TITLE
feat(docker): all-in-one demo image with launcher + MCP, GH-Actions rolling builds

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,110 @@
+name: docker
+
+# Rolling demo image. Fires on every push to development (and on
+# workflow_dispatch). Tagged releases are handled by release.yml,
+# which produces stable semver tags + :latest; this workflow gives
+# users a way to pull "current development tip" without waiting for
+# a release.
+on:
+  push:
+    branches: [development, main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-push:
+    name: Build & push demo image
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "21"
+          cache: maven
+
+      # Same multi-server settings.xml as ci.yml / release.yml — the
+      # build needs to pull mondrian, olap4j, olap4j-xmlaserver, and
+      # saiku-query from spiculedata's GitHub Packages registries.
+      - name: Configure Maven settings.xml
+        env:
+          GH_PACKAGES_USER: ${{ github.actor }}
+          GH_PACKAGES_TOKEN: ${{ secrets.GH_PACKAGES_TOKEN }}
+        run: |
+          mkdir -p ~/.m2
+          cat > ~/.m2/settings.xml <<EOF
+          <settings xmlns="http://maven.apache.org/SETTINGS/1.0.0">
+            <servers>
+              <server><id>github-mondrian-saiku</id><username>${GH_PACKAGES_USER}</username><password>${GH_PACKAGES_TOKEN}</password></server>
+              <server><id>github-olap4j</id><username>${GH_PACKAGES_USER}</username><password>${GH_PACKAGES_TOKEN}</password></server>
+              <server><id>github-olap4j-xmlaserver</id><username>${GH_PACKAGES_USER}</username><password>${GH_PACKAGES_TOKEN}</password></server>
+              <server><id>github-saiku-query</id><username>${GH_PACKAGES_USER}</username><password>${GH_PACKAGES_TOKEN}</password></server>
+            </servers>
+          </settings>
+          EOF
+
+      - name: Resolve project version
+        id: ver
+        run: |
+          VERSION=$(mvn -B -ntp -q -DforceStdout help:evaluate -Dexpression=project.version)
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "saiku version: $VERSION"
+
+      - name: Build launcher + MCP fat JARs
+        run: mvn -B -ntp -DskipTests -pl saiku-launcher,saiku-mcp -am package
+
+      - name: Stage JARs for Docker build context
+        env:
+          VERSION: ${{ steps.ver.outputs.version }}
+        run: |
+          set -euo pipefail
+          mkdir -p build-context
+          cp "saiku-launcher/target/saiku-${VERSION}.jar" build-context/saiku.jar
+          cp "saiku-mcp/target/saiku-mcp-${VERSION}.jar" build-context/saiku-mcp.jar
+          ls -la build-context/
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Image metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          # Push:
+          #   ghcr.io/spiculedata/saiku:development  (rolling tip)
+          #   ghcr.io/spiculedata/saiku:main         (rolling tip of main)
+          #   ghcr.io/spiculedata/saiku:sha-abc1234  (immutable, pinnable)
+          tags: |
+            type=ref,event=branch
+            type=sha,prefix=sha-,format=short
+
+      - name: Build & push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          # buildx cache via GitHub's built-in Action cache, so iterative
+          # pushes only rebuild the changed layer (mostly the COPY of
+          # the freshly-built JARs).
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,8 +67,11 @@ jobs:
           echo "jar_name=saiku-${VERSION}.jar" >> "$GITHUB_OUTPUT"
           echo "dist_name=saiku-dist-${VERSION}.zip" >> "$GITHUB_OUTPUT"
 
-      - name: mvn package (launcher)
-        run: mvn -B -ntp -DskipTests -pl saiku-launcher -am package
+      - name: mvn package (launcher + mcp)
+        # Both fat JARs ship in the demo image. saiku-launcher provides
+        # the REST + UI on :8080; saiku-mcp provides the stdio MCP
+        # wrapper Claude Desktop / Cursor consume.
+        run: mvn -B -ntp -DskipTests -pl saiku-launcher,saiku-mcp -am package
 
       - name: Stage release assets
         env:
@@ -76,14 +79,21 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p release-assets
-          # 1) Bare fat JAR (versioned filename) — keeps the existing
-          #    "give me just the JAR" path for users who don't want the bundle.
+          # 1) Bare launcher fat JAR (versioned filename) — keeps the
+          #    "give me just the JAR" path for users who don't want the
+          #    bundle.
           cp "saiku-launcher/target/saiku-${VERSION}.jar" \
              "release-assets/saiku-${VERSION}.jar"
-          # 2) Runnable dist bundle: JAR + README + run.sh + run.bat, zipped.
+          # 2) MCP JAR — its own asset so users can wire Claude Desktop
+          #    without pulling the full Docker image.
+          cp "saiku-mcp/target/saiku-mcp-${VERSION}.jar" \
+             "release-assets/saiku-mcp-${VERSION}.jar"
+          # 3) Runnable dist bundle: launcher JAR + MCP JAR + README +
+          #    run scripts, zipped.
           STAGE="saiku-dist-${VERSION}"
           mkdir -p "$STAGE"
           cp "saiku-launcher/target/saiku-${VERSION}.jar" "$STAGE/"
+          cp "saiku-mcp/target/saiku-mcp-${VERSION}.jar" "$STAGE/"
           cp dist/README.md "$STAGE/"
           cp dist/run.sh "$STAGE/"
           cp dist/run.bat "$STAGE/"
@@ -97,6 +107,13 @@ jobs:
         with:
           name: saiku-jar
           path: release-assets/${{ steps.meta.outputs.jar_name }}
+          retention-days: 7
+
+      - name: Upload MCP JAR artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: saiku-mcp-jar
+          path: release-assets/saiku-mcp-${{ steps.meta.outputs.version }}.jar
           retention-days: 7
 
       - name: Upload dist zip artifact
@@ -115,21 +132,29 @@ jobs:
 
       # The Dockerfile no longer rebuilds saiku from sources (it can't
       # auth against the spiculedata GH Packages registries from inside
-      # the Maven container). Instead it COPYs the pre-built JAR that the
-      # jar job produced. Download that artifact into ./build-context/.
+      # the Maven container). Instead it COPYs the pre-built JARs that
+      # the jar job produced. Download both artifacts into ./build-context/.
       - name: Download saiku-jar
         uses: actions/download-artifact@v4
         with:
           name: saiku-jar
           path: build-context
-      - name: Stage JAR for Docker build context
+      - name: Download saiku-mcp-jar
+        uses: actions/download-artifact@v4
+        with:
+          name: saiku-mcp-jar
+          path: build-context
+      - name: Stage JARs for Docker build context
         env:
           JAR_NAME: ${{ needs.jar.outputs.jar_name }}
+          VERSION: ${{ needs.jar.outputs.version }}
         run: |
           set -euo pipefail
-          # The Dockerfile expects build-context/saiku.jar regardless of the
-          # versioned filename, so rename for a stable COPY target.
+          # The Dockerfile expects build-context/saiku.jar +
+          # saiku-mcp.jar regardless of the versioned filenames — rename
+          # for stable COPY targets.
           mv "build-context/${JAR_NAME}" build-context/saiku.jar
+          mv "build-context/saiku-mcp-${VERSION}.jar" build-context/saiku-mcp.jar
           ls -la build-context/
 
       - name: Set up Docker Buildx

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,39 @@
-# Build is performed by the release.yml / ci.yml workflows (which have
-# GH Packages auth via the GH_PACKAGES_TOKEN repo secret). The Docker
-# image just packages the pre-built fat JAR — no Maven inside the
-# container, no settings.xml plumbing, no transitive resolution at
-# image-build time.
+# Saiku demo image — bundles the launcher (REST + UI on :8080) and the
+# MCP wrapper (stdio JSON-RPC) in one container so Claude Desktop /
+# Cursor / Cline can wire to a running Saiku via a single
+# `docker exec -i <name> saiku-mcp` invocation.
 #
-# release.yml's docker job downloads the saiku-jar artifact into
-# ./build-context/saiku.jar before invoking docker buildx, so the JAR
-# is already in the build context when this Dockerfile runs.
-FROM gcr.io/distroless/java21-debian12:nonroot
+# Build flow (release.yml / ci.yml):
+#   1. The jar job builds both fat JARs under saiku-launcher/target/
+#      and saiku-mcp/target/.
+#   2. The docker job stages them into ./build-context/ as
+#      saiku.jar and saiku-mcp.jar.
+#   3. This Dockerfile COPYs them in. No Maven runs at image build —
+#      avoids needing GH Packages auth inside the container.
+FROM eclipse-temurin:21-jre-noble
 ARG JAR_PATH=build-context/saiku.jar
+ARG MCP_JAR_PATH=build-context/saiku-mcp.jar
 WORKDIR /app
+
 COPY ${JAR_PATH} /app/saiku.jar
-ENV SAIKU_HOME=/app/saiku-home
+COPY ${MCP_JAR_PATH} /app/saiku-mcp.jar
+COPY docker/saiku-entrypoint /usr/local/bin/saiku-entrypoint
+COPY docker/saiku-mcp /usr/local/bin/saiku-mcp
+RUN chmod +x /usr/local/bin/saiku-entrypoint /usr/local/bin/saiku-mcp
+
+ENV SAIKU_HOME=/app/saiku-home \
+    SAIKU_URL=http://localhost:8080 \
+    SAIKU_USER=admin \
+    SAIKU_PASS=admin
+
 VOLUME ["/app/saiku-home"]
 EXPOSE 8080
-ENTRYPOINT ["java", "-jar", "/app/saiku.jar"]
-CMD ["serve", "--host", "0.0.0.0", "--port", "8080", "--home", "/app/saiku-home"]
+
+# Default: run the launcher. Override with `mcp` to run the stdio
+# MCP server against an external SAIKU_URL. The intended demo flow is:
+#   docker run -d -p 8080:8080 --name saiku-demo ghcr.io/spiculedata/saiku
+#   # then in Claude Desktop config:
+#   command: docker
+#   args:    ["exec", "-i", "saiku-demo", "saiku-mcp"]
+ENTRYPOINT ["/usr/local/bin/saiku-entrypoint"]
+CMD ["serve"]

--- a/docker/saiku-entrypoint
+++ b/docker/saiku-entrypoint
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# Saiku demo container entrypoint.
+#
+# Dispatches the container's argv to one of the bundled JARs:
+#
+#   serve            -> saiku launcher (REST + UI on :8080)
+#                       Forwards any extra args to the launcher's
+#                       Picocli `serve` subcommand.
+#   mcp              -> saiku-mcp stdio server, talking to the
+#                       launcher at $SAIKU_URL (default
+#                       http://localhost:8080).
+#   <anything else>  -> exec'd verbatim, useful for `docker run --rm
+#                       saiku java -version` style introspection.
+#
+# Default CMD is `serve` (see Dockerfile).
+set -euo pipefail
+
+case "${1:-serve}" in
+  serve)
+    shift || true
+    exec java -jar /app/saiku.jar serve \
+      --host 0.0.0.0 \
+      --port 8080 \
+      --home "${SAIKU_HOME:-/app/saiku-home}" \
+      "$@"
+    ;;
+  mcp)
+    shift || true
+    # MCP is a stdio JSON-RPC loop; the launcher should already be
+    # running (either in this container, or in a separate one if you
+    # set SAIKU_URL to point at it). Logging goes to stderr so it
+    # doesn't collide with the JSON-RPC framing on stdout.
+    exec java -jar /app/saiku-mcp.jar "$@"
+    ;;
+  *)
+    exec "$@"
+    ;;
+esac

--- a/docker/saiku-mcp
+++ b/docker/saiku-mcp
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+# Convenience wrapper so `docker exec -i <name> saiku-mcp` works
+# without the caller needing to know the JAR path. Forwards stdin /
+# stdout / argv to /app/saiku-mcp.jar verbatim.
+exec java -jar /app/saiku-mcp.jar "$@"


### PR DESCRIPTION
## Summary

A single Docker image that bundles **both** saiku-launcher (REST + UI on :8080) and saiku-mcp (stdio JSON-RPC for Claude Desktop / Cursor / Cline), plus the GitHub Actions wiring to publish it on every push to `development` / `main` and on tagged releases.

## Demo flow

```sh
docker run -d -p 8080:8080 --name saiku-demo ghcr.io/spiculedata/saiku:development
# open http://localhost:8080 (admin/admin) — H2 FoodMart preloaded
```

Then in `~/Library/Application Support/Claude/claude_desktop_config.json`:

```json
{
  "mcpServers": {
    "saiku": {
      "command": "docker",
      "args": ["exec", "-i", "saiku-demo", "saiku-mcp"]
    }
  }
}
```

Restart Claude Desktop → six saiku tools appear (`list_cubes`, `describe_cube`, `search_members`, `run_query`, `preview_query`, `drillthrough`).

## What's in the image

- `eclipse-temurin:21-jre-noble` base (needed bash for the entrypoint dispatcher — distroless wouldn't have shipped one).
- `/app/saiku.jar` — saiku-launcher fat JAR.
- `/app/saiku-mcp.jar` — saiku-mcp fat JAR.
- `/usr/local/bin/saiku-entrypoint` — dispatches the container's argv: `serve` (default) runs the launcher; `mcp` runs the stdio MCP server; anything else is exec'd verbatim.
- `/usr/local/bin/saiku-mcp` — one-line wrapper so `docker exec -i ... saiku-mcp` works without knowing the JAR path.

## Build pipeline changes

- **`.github/workflows/release.yml`** — the jar job now builds both `saiku-launcher` AND `saiku-mcp` via `mvn -pl saiku-launcher,saiku-mcp -am package`, uploads each as its own artifact, and the docker job downloads both into `build-context/` before invoking buildx.
- **`.github/workflows/docker.yml`** (new) — fires on push to `development` / `main` and on `workflow_dispatch`. Pushes a rolling image:
  - `ghcr.io/spiculedata/saiku:development` (rolling tip of development)
  - `ghcr.io/spiculedata/saiku:main` (rolling tip of main)
  - `ghcr.io/spiculedata/saiku:sha-<short>` (immutable, pinnable)
  Stable semver tags continue to flow through `release.yml`.
- Buildx cache wired via `type=gha` so iterative pushes only rebuild the layer with the new JARs.

## Verified locally

- `docker build -t saiku-demo:local .` succeeds (1.19GB on disk, 482MB content).
- `docker run --rm -i saiku-demo:local mcp` correctly dispatches to the MCP stdio loop and emits a valid `initialize` response.

## Test plan

- [ ] CI green on this PR (the new `docker` workflow won't fire on PR branches — only on push to development/main)
- [ ] On merge, watch `docker.yml` actually push to ghcr.io/spiculedata/saiku:development
- [ ] `docker pull ghcr.io/spiculedata/saiku:development && docker run -d -p 8080:8080 --name s ghcr.io/spiculedata/saiku:development` reaches a usable launcher
- [ ] Claude Desktop wired against it sees the six tools after restart