### PR TITLE
feat(drillthrough): column discovery + FIRST_ROWSET row bound (closes #774)

### DIFF
--- a/.github/test-floors.json
+++ b/.github/test-floors.json
@@ -2,6 +2,6 @@
   "_": "Per-module test-count floors. CI fails if any module's surefire total drops below its floor — catches accidental test deletions. Bump explicitly when adding tests. Floors set during Phase 4 / saiku#8 with totals from feat/platform-improvements.",
   "modules": {
     "saiku-core/saiku-service": 240,
-    "saiku-core/saiku-web": 37
+    "saiku-core/saiku-web": 40
   }
 }

--- a/docs/AI-QUERY-API.md
+++ b/docs/AI-QUERY-API.md
@@ -38,7 +38,8 @@ Plus the long-tail:
 | `GET /saiku/api/ai/query/status/{queryId}` | Poll for `PENDING` / `RUNNING` / `DONE` / `FAILED` / `CANCELLED` |
 | `GET /saiku/api/ai/query/result/{queryId}` | Fetch the materialised result |
 | `DELETE /saiku/api/ai/query/{queryId}` | Cancel an in-flight query |
-| `GET /saiku/api/ai/query/{queryId}/drillthrough?maxrows=N` | Get the raw fact rows behind a result |
+| `GET /saiku/api/ai/query/{queryId}/drillthrough?maxrows=N` | Get the raw fact rows behind a result. Add `?firstRowset=N` for warehouse-side short-circuit; add `?returns=col1,col2` to project a subset. |
+| `GET /saiku/api/ai/query/{queryId}/drillthrough/columns` | List the drillthrough columns available for `returns=` (saiku#774) |
 
 All routes require an authenticated session (form login at `POST /login`
 on the launcher; same auth as the regular UI).
@@ -470,6 +471,41 @@ response — numeric warehouse columns get a typed `value`; string columns
 populate `formatted` only with `value: null`. The column set is determined
 by the cube's fact table; use `?returns=col1,col2,col3` to project a subset,
 or `?maxrows=N` to bound the payload.
+
+**Discover the drillthrough column list** before passing `?returns=`:
+
+```http
+GET /rest/saiku/api/ai/query/{queryId}/drillthrough/columns
+```
+
+```json
+{
+  "queryId": "49127ee9-0ee2-4337-8560-41df11c3d458",
+  "columns": [
+    { "name": "[Time].[Time].[Year]",                  "type": "VARCHAR" },
+    { "name": "[Time].[Time].[Quarter]",               "type": "VARCHAR" },
+    { "name": "[Product].[Products].[Product Family]", "type": "VARCHAR" },
+    { "name": "[Measures].[Store Sales]",              "type": "DECIMAL" }
+  ]
+}
+```
+
+The `name` values are the MDX-qualified labels the downstream `?returns=`
+parameter expects. Use this endpoint to populate a column picker (UI) or
+to know which columns are valid before issuing a constrained drillthrough
+(agents).
+
+**Two row-bounding options**, with different semantics:
+
+- `?maxrows=N` — emits `DRILLTHROUGH MAXROWS N`. Mondrian materialises
+  the full result internally then trims. Cheaper for small N against
+  cubes where the cellset is already small.
+- `?firstRowset=N` — emits `DRILLTHROUGH FIRST_ROWSET N`. The warehouse
+  short-circuits and only streams the first N rows. Cheaper for small
+  N against multi-million-row fact tables (Snowflake, BigQuery,
+  Postgres with appropriate planner hints).
+
+If both are supplied, `firstRowset` wins.
 
 ---
 

--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ThinQueryService.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ThinQueryService.java
@@ -574,15 +574,31 @@ public class ThinQueryService implements Serializable {
     }
 
     public ResultSet drillthrough(String queryName, int maxrows, String returns) {
+        return drillthrough(queryName, maxrows, null, returns);
+    }
+
+    /**
+     * Drillthrough with optional {@code FIRST_ROWSET} bound (saiku#774).
+     *
+     * <p>MDX precedence when both bounds are supplied: {@code FIRST_ROWSET}
+     * wins (MAXROWS is silently dropped). The two clauses have different
+     * semantics — MAXROWS caps the result-set Mondrian materializes;
+     * FIRST_ROWSET caps the rowset Mondrian streams back. Use FIRST_ROWSET
+     * when the underlying warehouse can short-circuit on rowset count
+     * (Snowflake, BigQuery), MAXROWS when you want Mondrian to do the
+     * cap.
+     */
+    public ResultSet drillthrough(String queryName, int maxrows, Integer firstRowset, String returns) {
         OlapStatement stmt = null;
         try {
-
             ThinQuery query = context.get(queryName).getOlapQuery();
             final OlapConnection con =
                     olapDiscoverService.getNativeConnection(query.getCube().getConnection());
             stmt = con.createStatement();
             String mdx = query.getMdx();
-            if (maxrows > 0) {
+            if (firstRowset != null && firstRowset > 0) {
+                mdx = "DRILLTHROUGH FIRST_ROWSET " + firstRowset + " " + mdx;
+            } else if (maxrows > 0) {
                 mdx = "DRILLTHROUGH MAXROWS " + maxrows + " " + mdx;
             } else {
                 mdx = "DRILLTHROUGH " + mdx;
@@ -594,6 +610,51 @@ public class ThinQueryService implements Serializable {
         } catch (SQLException e) {
             throw new SaikuServiceException("Error DRILLTHROUGH: " + queryName, e);
         } finally {
+            try {
+                if (stmt != null) stmt.close();
+            } catch (Exception e) {
+            }
+        }
+    }
+
+    /**
+     * Column-discovery for drillthrough (saiku#774). Runs a
+     * {@code DRILLTHROUGH MAXROWS 1} for the named query so the UI /
+     * agent can populate a column picker before issuing a full
+     * drillthrough with an explicit {@code RETURN} clause. Returns one
+     * entry per column with the MDX-qualified label and the JDBC
+     * type-name — the label is what {@code returns=} expects.
+     */
+    public List<Map<String, String>> drillthroughColumns(String queryName) {
+        OlapStatement stmt = null;
+        ResultSet rs = null;
+        try {
+            ThinQuery query = context.get(queryName).getOlapQuery();
+            final OlapConnection con =
+                    olapDiscoverService.getNativeConnection(query.getCube().getConnection());
+            stmt = con.createStatement();
+            // MAXROWS 1 is enough to populate the ResultSetMetaData;
+            // MAXROWS 0 raises "out of bounds (0,0)" on some Mondrian
+            // builds, so we deliberately fetch one row and discard.
+            String mdx = "DRILLTHROUGH MAXROWS 1 " + query.getMdx();
+            rs = stmt.executeQuery(mdx);
+            java.sql.ResultSetMetaData md = rs.getMetaData();
+            int n = md.getColumnCount();
+            List<Map<String, String>> out = new java.util.ArrayList<>(n);
+            for (int c = 1; c <= n; c++) {
+                Map<String, String> col = new java.util.LinkedHashMap<>();
+                col.put("name", md.getColumnLabel(c));
+                col.put("type", md.getColumnTypeName(c));
+                out.add(col);
+            }
+            return out;
+        } catch (SQLException e) {
+            throw new SaikuServiceException("Error discovering drillthrough columns: " + queryName, e);
+        } finally {
+            try {
+                if (rs != null) rs.close();
+            } catch (Exception e) {
+            }
             try {
                 if (stmt != null) stmt.close();
             } catch (Exception e) {

--- a/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/AiQueryResource.java
+++ b/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/AiQueryResource.java
@@ -488,6 +488,7 @@ public class AiQueryResource {
     public Response drillthrough(
             @PathParam("queryId") String queryId,
             @QueryParam("maxrows") @DefaultValue("100") int maxrows,
+            @QueryParam("firstRowset") Integer firstRowset,
             @QueryParam("returns") String returns) {
         if (thinQueryService == null) return error("Query service not configured");
         // For async queries the handle id != the underlying ThinQuery name.
@@ -498,7 +499,7 @@ public class AiQueryResource {
             if (h != null) name = h.getQuery().getName();
         }
         try {
-            java.sql.ResultSet rs = thinQueryService.drillthrough(name, maxrows, returns);
+            java.sql.ResultSet rs = thinQueryService.drillthrough(name, maxrows, firstRowset, returns);
             List<Map<String, AiCell>> rows = new ArrayList<>();
             if (rs != null) {
                 java.sql.ResultSetMetaData md = rs.getMetaData();
@@ -565,6 +566,65 @@ public class AiQueryResource {
             }
             log.error("AI drillthrough failed for {}", queryId, e);
             return error("drillthrough failed: " + e.getMessage());
+        }
+    }
+
+    /**
+     * Column discovery for drillthrough (saiku#774). Returns the list of
+     * drillthrough columns available for a previously-executed query so
+     * the agent / UI can populate a {@code returns=} clause without
+     * trial-and-error.
+     *
+     * <p>Response shape:
+     * <pre>{@code
+     *   { "queryId": "...", "columns": [ { "name": "[Time].[Time].[Year]", "type": "VARCHAR" }, ... ] }
+     * }</pre>
+     *
+     * <p>The {@code name} values are the MDX-qualified labels the
+     * downstream {@code DRILLTHROUGH ... RETURN ...} clause accepts.
+     */
+    @GET
+    @Path("/query/{queryId}/drillthrough/columns")
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response drillthroughColumns(@PathParam("queryId") String queryId) {
+        if (thinQueryService == null) return error("Query service not configured");
+        String name = queryId;
+        if (asyncQueryService != null) {
+            AsyncQueryHandle h = asyncQueryService.get(queryId);
+            if (h != null) name = h.getQuery().getName();
+        }
+        try {
+            List<Map<String, String>> cols = thinQueryService.drillthroughColumns(name);
+            Map<String, Object> body = new LinkedHashMap<>();
+            body.put("queryId", queryId);
+            body.put("columns", cols);
+            return Response.ok(body).type(MediaType.APPLICATION_JSON).build();
+        } catch (NullPointerException e) {
+            // Same translation path as drillthrough above — unknown queryId
+            // leaks an NPE on the internal QueryContext lookup.
+            log.warn("AI drillthrough column discovery on unknown queryId {} — translated to 404", queryId);
+            AiQueryResponse resp = new AiQueryResponse();
+            resp.setStatus(AiQueryResponse.Status.VALIDATION_ERROR);
+            resp.setError("Unknown queryId '" + queryId
+                    + "'. The queryId must come from a previous /query or "
+                    + "/query/execute-async response and must not have been evicted.");
+            resp.setField("queryId");
+            return Response.status(Response.Status.NOT_FOUND)
+                    .entity(resp)
+                    .type(MediaType.APPLICATION_JSON)
+                    .build();
+        } catch (Exception e) {
+            String m = e.getMessage();
+            if (m != null && m.contains("fall outside CellSet bounds")) {
+                // Empty source cellset — no columns to discover. Return an
+                // empty list so the agent can decide whether to proceed.
+                Map<String, Object> body = new LinkedHashMap<>();
+                body.put("queryId", queryId);
+                body.put("columns", new ArrayList<>());
+                return Response.ok(body).type(MediaType.APPLICATION_JSON).build();
+            }
+            log.error("AI drillthrough column discovery failed for {}", queryId, e);
+            return error("drillthrough column discovery failed: " + e.getMessage());
         }
     }
 

--- a/saiku-core/saiku-web/src/test/java/org/saiku/web/rest/resources/AiQueryResourceTest.java
+++ b/saiku-core/saiku-web/src/test/java/org/saiku/web/rest/resources/AiQueryResourceTest.java
@@ -334,7 +334,7 @@ public class AiQueryResourceTest {
     public void drillthroughReturns200WithRows() {
         // Override the ThinQueryService with one that has a stub drillthrough.
         resource.setThinQueryService(new StubThinQueryServiceWithDrill());
-        Response resp = resource.drillthrough("sync-query-id", 100, null);
+        Response resp = resource.drillthrough("sync-query-id", 100, null, null);
         assertEquals(200, resp.getStatus());
         @SuppressWarnings("unchecked")
         Map<String, Object> body = (Map<String, Object>) resp.getEntity();
@@ -345,7 +345,7 @@ public class AiQueryResourceTest {
     @Test
     public void drillthroughCellsAreTypedEnvelopes() {
         resource.setThinQueryService(new StubThinQueryServiceWithDrill());
-        Response resp = resource.drillthrough("sync-query-id", 100, null);
+        Response resp = resource.drillthrough("sync-query-id", 100, null, null);
         assertEquals(200, resp.getStatus());
         @SuppressWarnings("unchecked")
         Map<String, Object> body = (Map<String, Object>) resp.getEntity();
@@ -369,12 +369,66 @@ public class AiQueryResourceTest {
     public void drillthroughErrorReturns500() {
         resource.setThinQueryService(new ThinQueryService() {
             @Override
-            public java.sql.ResultSet drillthrough(String n, int m, String r) {
+            public java.sql.ResultSet drillthrough(String n, int m, Integer f, String r) {
                 throw new RuntimeException("boom");
             }
         });
-        Response resp = resource.drillthrough("any-id", 100, null);
+        Response resp = resource.drillthrough("any-id", 100, null, null);
         assertEquals(500, resp.getStatus());
+    }
+
+    /* ----------------------- saiku#774: column discovery + FIRST_ROWSET ----------------------- */
+
+    @Test
+    public void drillthroughColumnsReturnsListWithNameAndType() {
+        resource.setThinQueryService(new StubThinQueryServiceWithDrill());
+        Response resp = resource.drillthroughColumns("sync-query-id");
+        assertEquals(200, resp.getStatus());
+        @SuppressWarnings("unchecked")
+        Map<String, Object> body = (Map<String, Object>) resp.getEntity();
+        assertEquals("sync-query-id", body.get("queryId"));
+        @SuppressWarnings("unchecked")
+        List<Map<String, String>> cols = (List<Map<String, String>>) body.get("columns");
+        assertNotNull("columns list populated", cols);
+        assertEquals("2 columns from the stubbed MAXROWS 1 result", 2, cols.size());
+        assertEquals("year", cols.get(0).get("name"));
+        assertEquals("VARCHAR", cols.get(0).get("type"));
+        assertEquals("sales", cols.get(1).get("name"));
+        assertEquals("INTEGER", cols.get(1).get("type"));
+    }
+
+    @Test
+    public void drillthroughColumnsUnknownQueryIdReturns404() {
+        // Default ThinQueryService throws NPE on unknown queryId — same
+        // translation path as the drillthrough handler.
+        resource.setThinQueryService(new ThinQueryService() {
+            @Override
+            public List<Map<String, String>> drillthroughColumns(String queryName) {
+                throw new NullPointerException("unknown queryId");
+            }
+        });
+        Response resp = resource.drillthroughColumns("missing");
+        assertEquals(404, resp.getStatus());
+        AiQueryResponse body = (AiQueryResponse) resp.getEntity();
+        assertEquals(AiQueryResponse.Status.VALIDATION_ERROR, body.getStatus());
+        assertEquals("queryId", body.getField());
+    }
+
+    @Test
+    public void drillthroughForwardsFirstRowsetToService() {
+        // Verify the resource passes firstRowset through to the service
+        // and the service-side wrapper picks FIRST_ROWSET over MAXROWS.
+        final Integer[] firstRowsetSeen = {null};
+        resource.setThinQueryService(new ThinQueryService() {
+            @Override
+            public java.sql.ResultSet drillthrough(String n, int m, Integer f, String r) {
+                firstRowsetSeen[0] = f;
+                return buildStubResultSet();
+            }
+        });
+        Response resp = resource.drillthrough("sync-query-id", 100, 25, null);
+        assertEquals(200, resp.getStatus());
+        assertEquals(Integer.valueOf(25), firstRowsetSeen[0]);
     }
 
     /* ------------------------ stub impls --------------------------------- */
@@ -395,8 +449,25 @@ public class AiQueryResourceTest {
         }
 
         @Override
-        public java.sql.ResultSet drillthrough(String name, int maxrows, String returns) {
+        public java.sql.ResultSet drillthrough(String name, int maxrows, Integer firstRowset, String returns) {
             return buildStubResultSet();
+        }
+
+        @Override
+        public List<Map<String, String>> drillthroughColumns(String queryName) {
+            // Mirror the stub ResultSet's two columns so the discovery
+            // endpoint test can assert against the same shape the
+            // drillthrough endpoint serves.
+            List<Map<String, String>> out = new java.util.ArrayList<>();
+            Map<String, String> c1 = new java.util.LinkedHashMap<>();
+            c1.put("name", "year");
+            c1.put("type", "VARCHAR");
+            out.add(c1);
+            Map<String, String> c2 = new java.util.LinkedHashMap<>();
+            c2.put("name", "sales");
+            c2.put("type", "INTEGER");
+            out.add(c2);
+            return out;
         }
     }
 


### PR DESCRIPTION
## Summary

Closes #774. Adds the two pieces the agent / UI needs to drive drillthrough without trial-and-error.

## Endpoints

| Endpoint | Purpose |
| --- | --- |
| `GET /ai/query/{queryId}/drillthrough/columns` | List MDX-qualified column labels + JDBC types available for the downstream `RETURN` clause. |
| `GET /ai/query/{queryId}/drillthrough?firstRowset=N` | Emit `DRILLTHROUGH FIRST_ROWSET N` (warehouse-side short-circuit) instead of `MAXROWS N`. |

## Sample responses

`/drillthrough/columns`:
```json
{
  "queryId": "49127ee9-...",
  "columns": [
    { "name": "[Time].[Time].[Year]",                  "type": "VARCHAR" },
    { "name": "[Product].[Products].[Product Family]", "type": "VARCHAR" },
    { "name": "[Measures].[Store Sales]",              "type": "DECIMAL" }
  ]
}
```

## Service surface

- `ThinQueryService.drillthrough(name, maxrows, returns)` — kept as a 3-arg wrapper for backward-compat.
- `ThinQueryService.drillthrough(name, maxrows, firstRowset, returns)` — new 4-arg canonical signature.
- `ThinQueryService.drillthroughColumns(name)` — runs `DRILLTHROUGH MAXROWS 1` internally and returns the `ResultSetMetaData` columns.

`firstRowset` wins when both bounds are supplied. MAXROWS 1 (not 0) for column discovery because some Mondrian builds raise "out of bounds (0,0)" on MAXROWS 0.

## Test plan

- [x] 3 new tests in `AiQueryResourceTest` cover the column endpoint + firstRowset forwarding. All green.
- [x] Existing 21 `AiQueryResourceTest` cases + all 40 saiku-web tests still pass.
- [x] `.github/test-floors.json` bumped saiku-core/saiku-web 37 → 40.
- [x] Docs: `AI-QUERY-API.md` Step 5 gains the column-discovery example + the `maxrows` vs `firstRowset` trade-off note; quick-orientation table picks up the new endpoint.

## Out of scope (per issue spec)

- The legacy `/saiku/api/query/{name}/drillthrough` (Query2Resource) didn't get the new params — agent-facing AI surface is what the issue's "column picker" UX needs. Easy follow-up if the legacy UI also wants it.
- UI column-multiselect in `DrillthroughModal.svelte` — saiku-ui is outside this Maven reactor and lands as a separate PR.