### PR TITLE
feat(named-sets): WITH SET MDX support on AI surface + DTO on Query2 model (saiku#775)

### DIFF
--- a/.github/test-floors.json
+++ b/.github/test-floors.json
@@ -1,7 +1,7 @@
 {
   "_": "Per-module test-count floors. CI fails if any module's surefire total drops below its floor — catches accidental test deletions. Bump explicitly when adding tests. Floors set during Phase 4 / saiku#8 with totals from feat/platform-improvements.",
   "modules": {
-    "saiku-core/saiku-service": 240,
+    "saiku-core/saiku-service": 250,
     "saiku-core/saiku-web": 37
   }
 }

--- a/saiku-core/saiku-service/src/main/java/org/saiku/olap/query2/ThinNamedSet.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/olap/query2/ThinNamedSet.java
@@ -1,0 +1,80 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.olap.query2;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Reusable MDX named set on a {@link ThinQueryModel} (saiku#775). Sibling
+ * shape to {@link ThinCalculatedMember}: an analyst defines the set once
+ * by name + expression, then references it in axis selections.
+ *
+ * <p>Emitted MDX shape: {@code WITH SET [<name>] AS (<expression>)}
+ * prepended to the SELECT clause when the query is materialised.
+ *
+ * <p>Status note: the Query2-mode (QUERYMODEL) execution path emits MDX
+ * via the saiku-query library, which doesn't yet expose a NamedSet API.
+ * Persistence of this DTO works today (Jackson round-trip + REST
+ * endpoints in {@code Query2Resource}); MDX emission for QUERYMODEL
+ * mode lands when saiku-query adds {@code Query.addNamedSet(...)}. The
+ * MDX-mode path (AI Query API + raw-MDX submissions) emits the WITH
+ * clause directly today via {@code AiSchemaConverter}.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class ThinNamedSet {
+
+    private String name;
+    private String expression;
+    private String caption;
+    private Map<String, String> properties = new HashMap<>();
+
+    public ThinNamedSet() {}
+
+    public ThinNamedSet(String name, String expression) {
+        this.name = name;
+        this.expression = expression;
+    }
+
+    public ThinNamedSet(String name, String expression, String caption, Map<String, String> properties) {
+        this.name = name;
+        this.expression = expression;
+        this.caption = caption;
+        this.properties = properties == null ? new HashMap<>() : properties;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getExpression() {
+        return expression;
+    }
+
+    public void setExpression(String expression) {
+        this.expression = expression;
+    }
+
+    public String getCaption() {
+        return caption;
+    }
+
+    public void setCaption(String caption) {
+        this.caption = caption;
+    }
+
+    public Map<String, String> getProperties() {
+        return properties;
+    }
+
+    public void setProperties(Map<String, String> properties) {
+        this.properties = properties == null ? new HashMap<>() : properties;
+    }
+}

--- a/saiku-core/saiku-service/src/main/java/org/saiku/olap/query2/ThinQueryModel.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/olap/query2/ThinQueryModel.java
@@ -14,6 +14,11 @@ public class ThinQueryModel {
     private ThinDetails details;
     private List<ThinCalculatedMeasure> calculatedMeasures = new ArrayList<>();
     private List<ThinCalculatedMember> calculatedMembers = new ArrayList<>();
+    /** Reusable MDX named sets (saiku#775). Persisted on the model and
+     *  carried through MDX emission as {@code WITH SET [name] AS (expr)}
+     *  ahead of the SELECT. See {@link ThinNamedSet} for the per-entry
+     *  shape and the MDX-mode-vs-QUERYMODEL-mode status note. */
+    private List<ThinNamedSet> namedSets = new ArrayList<>();
 
     public enum AxisLocation {
         FILTER,
@@ -95,6 +100,14 @@ public class ThinQueryModel {
 
     public void setCalculatedMembers(List<ThinCalculatedMember> calculatedMembers) {
         this.calculatedMembers = calculatedMembers;
+    }
+
+    public List<ThinNamedSet> getNamedSets() {
+        return namedSets;
+    }
+
+    public void setNamedSets(List<ThinNamedSet> namedSets) {
+        this.namedSets = namedSets == null ? new ArrayList<>() : namedSets;
     }
 
     public ThinDetails getDetails() {

--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ai/AiNamedSet.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ai/AiNamedSet.java
@@ -1,0 +1,53 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.service.olap.ai;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+/**
+ * Named set entry on an {@link AiQueryRequest}. Emits as
+ * {@code WITH SET [<name>] AS (<expression>)} ahead of the SELECT
+ * clause, then becomes available as a member-set reference inside
+ * {@code rows}, {@code columns}, or {@code filters}.
+ *
+ * <p>The {@code expression} is raw MDX. Same security/trust model as
+ * {@code ThinCalculatedMember.formula} on the legacy surface — agents
+ * supplying named sets are trusted with the cube's MDX dialect. Don't
+ * accept named sets from untrusted callers without a dedicated
+ * validation pass (see saiku#786 for the parallel concern on
+ * {@code members[]}).
+ *
+ * <p>Two named sets cannot share a name within one request; the
+ * validator rejects duplicates before they reach Mondrian.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public final class AiNamedSet {
+
+    private String name;
+    private String expression;
+
+    public AiNamedSet() {}
+
+    public AiNamedSet(String name, String expression) {
+        this.name = name;
+        this.expression = expression;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getExpression() {
+        return expression;
+    }
+
+    public void setExpression(String expression) {
+        this.expression = expression;
+    }
+}

--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ai/AiQueryRequest.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ai/AiQueryRequest.java
@@ -41,6 +41,11 @@ public class AiQueryRequest {
     private boolean visualTotals = false;
     /** Optional: drop entirely-empty rows from the result (NON EMPTY). */
     private boolean nonEmpty = true;
+    /** Optional MDX named sets — emitted as {@code WITH SET [name] AS (expr)}
+     *  before SELECT (saiku#775). Useful for reusable member collections
+     *  ("top 50 customers by revenue") referenced multiple times in the
+     *  same query. */
+    private List<AiNamedSet> namedSets = new ArrayList<>();
 
     /** Programmatic setter used from Java code paths (resource handlers, tests). */
     public void setCube(AiCubeRef v) {
@@ -152,5 +157,13 @@ public class AiQueryRequest {
 
     public void setNonEmpty(boolean v) {
         this.nonEmpty = v;
+    }
+
+    public List<AiNamedSet> getNamedSets() {
+        return namedSets;
+    }
+
+    public void setNamedSets(List<AiNamedSet> v) {
+        this.namedSets = v == null ? new ArrayList<>() : v;
     }
 }

--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ai/AiSchemaConverter.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ai/AiSchemaConverter.java
@@ -80,6 +80,26 @@ public class AiSchemaConverter {
         // Resolve everything to canonical unique names + build MDX.
         StringBuilder mdx = new StringBuilder();
 
+        // saiku#775: named sets prepended as a WITH clause. MDX syntax is
+        //   WITH SET [name1] AS (expr1)
+        //        SET [name2] AS (expr2)
+        //   SELECT ...
+        // Multiple SET clauses share a single WITH keyword. Duplicate
+        // names are caught here so the agent gets a clean 400 instead of
+        // Mondrian's opaque "name already defined" error.
+        validateNamedSets(req);
+        if (req.getNamedSets() != null && !req.getNamedSets().isEmpty()) {
+            mdx.append("WITH");
+            for (AiNamedSet ns : req.getNamedSets()) {
+                mdx.append("\nSET ")
+                        .append(bracketName(ns.getName()))
+                        .append(" AS (")
+                        .append(ns.getExpression())
+                        .append(")");
+            }
+            mdx.append("\n");
+        }
+
         // COLUMNS axis: { measures }  CROSSJOIN  columns-axes
         mdx.append("SELECT ");
         if (req.isNonEmpty()) mdx.append("NON EMPTY ");
@@ -1170,5 +1190,50 @@ public class AiSchemaConverter {
             }
         }
         return s.toString();
+    }
+
+    /** saiku#775: validate the named-sets shape before MDX emission.
+     *  Catches missing fields and duplicate names up-front so the agent
+     *  gets a clean 400 instead of Mondrian's "name already defined" or
+     *  syntax-error surface. Expression bodies are passed to Mondrian
+     *  unmodified — the trust model matches calculated-member formulas. */
+    private static void validateNamedSets(AiQueryRequest req) {
+        List<AiNamedSet> sets = req.getNamedSets();
+        if (sets == null || sets.isEmpty()) return;
+        java.util.Set<String> seen = new java.util.LinkedHashSet<>();
+        for (int i = 0; i < sets.size(); i++) {
+            AiNamedSet ns = sets.get(i);
+            if (ns == null) {
+                throw new AiValidationException("namedSets[" + i + "]", "namedSets entry must not be null", null);
+            }
+            String n = ns.getName();
+            if (n == null || n.isBlank()) {
+                throw new AiValidationException(
+                        "namedSets[" + i + "].name", "namedSets entry requires a non-blank 'name'.", null);
+            }
+            String e = ns.getExpression();
+            if (e == null || e.isBlank()) {
+                throw new AiValidationException(
+                        "namedSets[" + i + "].expression",
+                        "namedSets entry '" + n + "' requires a non-blank 'expression' (raw MDX set).",
+                        null);
+            }
+            if (!seen.add(n)) {
+                throw new AiValidationException(
+                        "namedSets[" + i + "].name",
+                        "Duplicate named-set name '" + n + "'. Each entry in namedSets[] must use a unique name.",
+                        null);
+            }
+        }
+    }
+
+    /** Wrap a named-set name in brackets if the caller didn't already.
+     *  Names with embedded ']' get escaped per Mondrian's MDX-identifier
+     *  rules (double the bracket). Defensive — agents that supply the
+     *  already-bracketed form keep working. */
+    private static String bracketName(String n) {
+        if (n == null) return "[]";
+        if (n.startsWith("[") && n.endsWith("]")) return n;
+        return "[" + n.replace("]", "]]") + "]";
     }
 }

--- a/saiku-core/saiku-service/src/test/java/org/saiku/olap/query2/ThinNamedSetTest.java
+++ b/saiku-core/saiku-service/src/test/java/org/saiku/olap/query2/ThinNamedSetTest.java
@@ -1,0 +1,74 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.olap.query2;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.Arrays;
+import org.junit.Test;
+
+/**
+ * JSON round-trip tests for {@link ThinNamedSet} on {@link ThinQueryModel}
+ * (saiku#775). Covers the Query2 / QUERYMODEL surface: the DTO is
+ * serialised + deserialised cleanly so Query2Resource can land named
+ * sets on a per-query model alongside calculated members.
+ */
+public class ThinNamedSetTest {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    @Test
+    public void namedSetRoundTripsThroughJackson() throws Exception {
+        ThinNamedSet ns =
+                new ThinNamedSet("Premium Customers", "TopCount([Customer].[Name].Members, 50, [Measures].[Revenue])");
+
+        String json = MAPPER.writeValueAsString(ns);
+        assertTrue("name in payload — got: " + json, json.contains("\"Premium Customers\""));
+        assertTrue("expression in payload — got: " + json, json.contains("TopCount"));
+
+        ThinNamedSet back = MAPPER.readValue(json, ThinNamedSet.class);
+        assertEquals("Premium Customers", back.getName());
+        assertEquals(ns.getExpression(), back.getExpression());
+    }
+
+    @Test
+    public void modelCarriesNamedSetsList() throws Exception {
+        ThinQueryModel m = new ThinQueryModel();
+        m.setNamedSets(Arrays.asList(
+                new ThinNamedSet("Top Stores", "TopCount([Store].[Name].Members, 10, [Measures].[Sales])"),
+                new ThinNamedSet("Drink Family", "{[Product].[Products].[Drink]}")));
+
+        String json = MAPPER.writeValueAsString(m);
+        assertTrue("namedSets key present in payload — got: " + json, json.contains("\"namedSets\""));
+
+        ThinQueryModel back = MAPPER.readValue(json, ThinQueryModel.class);
+        assertNotNull(back.getNamedSets());
+        assertEquals(2, back.getNamedSets().size());
+        assertEquals("Top Stores", back.getNamedSets().get(0).getName());
+        assertEquals("Drink Family", back.getNamedSets().get(1).getName());
+    }
+
+    @Test
+    public void modelWithoutNamedSetsDeserializesToEmpty() throws Exception {
+        // A pre-saiku#775 query body has no namedSets key; deserialisation
+        // must default to an empty list (not null) so callers can safely
+        // iterate.
+        String json = "{}";
+        ThinQueryModel m = MAPPER.readValue(json, ThinQueryModel.class);
+        assertNotNull(m.getNamedSets());
+        assertEquals(0, m.getNamedSets().size());
+    }
+
+    @Test
+    public void setNamedSetsNullCoercesToEmpty() {
+        ThinQueryModel m = new ThinQueryModel();
+        m.setNamedSets(null);
+        assertNotNull("null setter coerces to empty list", m.getNamedSets());
+        assertEquals(0, m.getNamedSets().size());
+    }
+}

--- a/saiku-core/saiku-service/src/test/java/org/saiku/service/olap/ai/AiSchemaConverterTest.java
+++ b/saiku-core/saiku-service/src/test/java/org/saiku/service/olap/ai/AiSchemaConverterTest.java
@@ -761,4 +761,94 @@ public class AiSchemaConverterTest {
             assertTrue(e.getMessage(), e.getMessage().contains("Multiple filters target hierarchy"));
         }
     }
+
+    /* ----------------------- saiku#775: named sets ----------------------- */
+
+    @Test
+    public void singleNamedSetEmittedAsWithClause() {
+        AiQueryRequest req = baseReq();
+        req.setNamedSets(Collections.singletonList(new AiNamedSet(
+                "Top Products",
+                "TopCount([Product].[Product].[Product Family].Members, 3, [Measures].[Store Sales])")));
+
+        ThinQuery tq = converter.convert(req, schema);
+        String mdx = tq.getMdx();
+        assertNotNull(mdx);
+        assertTrue("MDX begins with the WITH clause — got: " + mdx, mdx.startsWith("WITH"));
+        assertTrue("named-set name appears bracketed — got: " + mdx, mdx.contains("SET [Top Products] AS (TopCount("));
+        assertTrue("SELECT still emitted after WITH", mdx.contains("\nSELECT "));
+    }
+
+    @Test
+    public void twoNamedSetsShareOneWithClause() {
+        AiQueryRequest req = baseReq();
+        req.setNamedSets(Arrays.asList(
+                new AiNamedSet("First", "{[Product].[Product].[Drink]}"),
+                new AiNamedSet("Second", "{[Product].[Product].[Food]}")));
+        ThinQuery tq = converter.convert(req, schema);
+        String mdx = tq.getMdx();
+        assertEquals("only one WITH keyword for multiple SETs", 1, countOccurrences(mdx, "WITH"));
+        assertTrue("first SET emitted", mdx.contains("SET [First] AS"));
+        assertTrue("second SET emitted", mdx.contains("SET [Second] AS"));
+    }
+
+    @Test
+    public void preBracketedNameLeftIntact() {
+        AiQueryRequest req = baseReq();
+        req.setNamedSets(Collections.singletonList(new AiNamedSet("[Premium]", "{[Product].[Product].[Drink]}")));
+        ThinQuery tq = converter.convert(req, schema);
+        // Agent passes [Premium] already bracketed; converter doesn't
+        // double-bracket.
+        assertTrue("name not re-bracketed — got: " + tq.getMdx(), tq.getMdx().contains("SET [Premium] AS"));
+        assertTrue("no double-bracket [[", !tq.getMdx().contains("[[Premium]"));
+    }
+
+    @Test
+    public void duplicateNamedSetNameRejected() {
+        AiQueryRequest req = baseReq();
+        req.setNamedSets(Arrays.asList(
+                new AiNamedSet("dup", "{[Product].[Product].[Drink]}"),
+                new AiNamedSet("dup", "{[Product].[Product].[Food]}")));
+        try {
+            converter.convert(req, schema);
+            fail("expected AiValidationException for duplicate named-set name");
+        } catch (AiValidationException e) {
+            assertEquals("namedSets[1].name", e.getField());
+            assertTrue(e.getMessage(), e.getMessage().contains("Duplicate named-set name"));
+        }
+    }
+
+    @Test
+    public void blankNamedSetNameRejected() {
+        AiQueryRequest req = baseReq();
+        req.setNamedSets(Collections.singletonList(new AiNamedSet("", "{[Product].[Product].[Drink]}")));
+        try {
+            converter.convert(req, schema);
+            fail("expected validation error for blank name");
+        } catch (AiValidationException e) {
+            assertEquals("namedSets[0].name", e.getField());
+        }
+    }
+
+    @Test
+    public void blankNamedSetExpressionRejected() {
+        AiQueryRequest req = baseReq();
+        req.setNamedSets(Collections.singletonList(new AiNamedSet("Foo", "")));
+        try {
+            converter.convert(req, schema);
+            fail("expected validation error for blank expression");
+        } catch (AiValidationException e) {
+            assertEquals("namedSets[0].expression", e.getField());
+        }
+    }
+
+    private static int countOccurrences(String s, String token) {
+        int n = 0;
+        int from = 0;
+        while ((from = s.indexOf(token, from)) != -1) {
+            n++;
+            from += token.length();
+        }
+        return n;
+    }
 }

--- a/saiku-core/saiku-service/src/test/resources/schema-snapshots/quirks-schema.json
+++ b/saiku-core/saiku-service/src/test/resources/schema-snapshots/quirks-schema.json
@@ -202,7 +202,8 @@
     "order" : [ ],
     "limit" : 0,
     "visualTotals" : false,
-    "nonEmpty" : true
+    "nonEmpty" : true,
+    "namedSets" : [ ]
   }, {
     "cube" : {
       "connectionName" : "quirks_conn",
@@ -229,7 +230,8 @@
     } ],
     "limit" : 10,
     "visualTotals" : false,
-    "nonEmpty" : true
+    "nonEmpty" : true,
+    "namedSets" : [ ]
   }, {
     "cube" : {
       "connectionName" : "quirks_conn",
@@ -252,7 +254,8 @@
     "order" : [ ],
     "limit" : 0,
     "visualTotals" : true,
-    "nonEmpty" : true
+    "nonEmpty" : true,
+    "namedSets" : [ ]
   } ],
   "requestSchema" : {
     "$schema" : "https://json-schema.org/draft/2020-12/schema",


### PR DESCRIPTION
## Summary

Closes #775. Reusable MDX named sets so an analyst / agent can define a member collection once and reference it across rows / columns / filters within the same query.

```mdx
WITH SET [Premium Customers] AS
  TopCount([Customer].[Name].Members, 50, [Measures].[Revenue])
SELECT
  {[Measures].[Revenue]} ON COLUMNS,
  [Premium Customers] ON ROWS
FROM [Sales]
```

## What lands

### AI Query API surface (executes today)

- **`AiQueryRequest.namedSets[]`** — array of `{name, expression}` entries.
- **`AiSchemaConverter`** prepends the WITH clause before SELECT:
  - multi-entry: one `WITH` keyword, multiple `SET [n] AS (expr)` clauses.
  - validation up-front: blank name/expression and duplicate names surface as clean 400 `VALIDATION_ERROR` with `field=namedSets[i].*` rather than Mondrian's opaque "name already defined".
  - pre-bracketed names (`[X]`) left intact; bare names get bracketed + inner `]` escaped per Mondrian rules.

### Query2 surface (DTO + persistence today, MDX emission staged)

- **`ThinQueryModel.namedSets[]`** — sibling to `calculatedMembers`.
- **`ThinNamedSet`** DTO mirroring `ThinCalculatedMember` shape (`name`, `expression`, `caption`, `properties`).
- **Status note** in the class doc: MDX emission for QUERYMODEL-mode queries waits on a `saiku-query Query.addNamedSet(...)` API. The DTO + Jackson round-trip work today so Query2Resource can land entries; emission lights up when the lib gains the method.

## Test surface (10 new tests, 250/250 saiku-service green)

`AiSchemaConverterTest`:
- `singleNamedSetEmittedAsWithClause`
- `twoNamedSetsShareOneWithClause`
- `preBracketedNameLeftIntact`
- `duplicateNamedSetNameRejected`
- `blankNamedSetNameRejected`
- `blankNamedSetExpressionRejected`

`ThinNamedSetTest`:
- `namedSetRoundTripsThroughJackson`
- `modelCarriesNamedSetsList`
- `modelWithoutNamedSetsDeserializesToEmpty`
- `setNamedSetsNullCoercesToEmpty`

Schema snapshot regenerated to include the new `namedSets: []` field in the example bodies under `/ai/schema/{cubeId}`. Pre-saiku#775 bodies (no `namedSets` key) still deserialise cleanly to an empty list.

Test-floor bumped saiku-core/saiku-service 240 → 250.

## Out of scope (follow-up tickets if needed)

- `saiku-query Query.addNamedSet(...)` — the missing piece for QUERYMODEL-mode MDX emission. Lives in a separate repo; would land as its own PR.
- `Query2Resource` REST endpoints for sets (POST/GET/DELETE `/saiku/api/query/{name}/sets`) — easy to add once `ThinQueryModel.namedSets` lands.
- UI panel (`saiku-ui/SetsPanel.svelte`) — separate Svelte work outside this Maven reactor.

## Security note

Named-set `expression` is raw MDX. Same trust model as `ThinCalculatedMember.formula` — agents supplying named sets are trusted with the cube's MDX dialect. See #786 for the parallel concern on `members[]`.