### PR TITLE
feat(cell-properties): surface olap4j StandardCellProperty values through formatters + AI surface (closes #773)

### DIFF
--- a/.github/test-floors.json
+++ b/.github/test-floors.json
@@ -1,7 +1,7 @@
 {
   "_": "Per-module test-count floors. CI fails if any module's surefire total drops below its floor — catches accidental test deletions. Bump explicitly when adding tests. Floors set during Phase 4 / saiku#8 with totals from feat/platform-improvements.",
   "modules": {
-    "saiku-core/saiku-service": 240,
+    "saiku-core/saiku-service": 246,
     "saiku-core/saiku-web": 37
   }
 }

--- a/saiku-core/saiku-service/src/main/java/org/saiku/olap/util/formatter/CellPropertyExtractor.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/olap/util/formatter/CellPropertyExtractor.java
@@ -1,0 +1,97 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.olap.util.formatter;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import org.olap4j.Cell;
+import org.olap4j.metadata.Property;
+
+/**
+ * Pulls the standard olap4j {@link Property.StandardCellProperty} values
+ * off a {@link Cell} and surfaces them as a flat {@code Map<String,String>}.
+ * Powers saiku#773 — Mondrian computes these but the formatters used to
+ * discard them.
+ *
+ * <p>What we surface (lowercase keys for stable JSON/Arrow contracts):
+ * <ul>
+ *   <li><b>formatString</b> — Mondrian format string (e.g. {@code "$#,##0.00"}).</li>
+ *   <li><b>foreColor</b> / <b>backColor</b> — schema-driven cell colours
+ *       (RGB-encoded integer; clients decode with the same convention
+ *       Mondrian uses).</li>
+ *   <li><b>fontFlags</b> / <b>fontName</b> / <b>fontSize</b> — typography hints.</li>
+ *   <li><b>actionType</b> — schema-defined action binding (drill / nav).</li>
+ *   <li><b>updateable</b> — write-back permission flag.</li>
+ *   <li><b>datatype</b> — Mondrian's declared cell type.</li>
+ *   <li><b>solveOrder</b> — calculation precedence for the cell.</li>
+ *   <li><b>language</b> — locale identifier.</li>
+ *   <li><b>error</b> — populated when the cell is an error cell.</li>
+ * </ul>
+ *
+ * <p>Properties not propagated (deliberately — they're either internal
+ * or already covered by other DTO fields):
+ * <ul>
+ *   <li>{@code VALUE} / {@code FORMATTED_VALUE} — already on
+ *       {@code DataCell.rawNumber} + the format-result string.</li>
+ *   <li>{@code CELL_ORDINAL} — addressing-only, exposed via
+ *       {@code DataCell.coordinates}.</li>
+ *   <li>{@code CELL_EVALUATION_LIST}, {@code NON_EMPTY_BEHAVIOR} —
+ *       Mondrian internals, no rendering value.</li>
+ * </ul>
+ *
+ * <p>Null values are skipped — the returned map only contains keys that
+ * Mondrian actually populated for this cell. Clients can rely on
+ * "key present ⇒ schema set it explicitly".
+ */
+public final class CellPropertyExtractor {
+
+    private CellPropertyExtractor() {}
+
+    /** Read every supported {@link Property.StandardCellProperty} on the
+     *  cell. Returns an insertion-ordered map so JSON serialisation is
+     *  deterministic across runs. */
+    public static Map<String, String> extract(Cell cell) {
+        Map<String, String> out = new LinkedHashMap<>();
+        if (cell == null) return out;
+
+        putIfNonNull(out, "formatString", cell, Property.StandardCellProperty.FORMAT_STRING);
+        putIfNonNull(out, "foreColor", cell, Property.StandardCellProperty.FORE_COLOR);
+        putIfNonNull(out, "backColor", cell, Property.StandardCellProperty.BACK_COLOR);
+        putIfNonNull(out, "fontFlags", cell, Property.StandardCellProperty.FONT_FLAGS);
+        putIfNonNull(out, "fontName", cell, Property.StandardCellProperty.FONT_NAME);
+        putIfNonNull(out, "fontSize", cell, Property.StandardCellProperty.FONT_SIZE);
+        putIfNonNull(out, "actionType", cell, Property.StandardCellProperty.ACTION_TYPE);
+        putIfNonNull(out, "updateable", cell, Property.StandardCellProperty.UPDATEABLE);
+        putIfNonNull(out, "datatype", cell, Property.StandardCellProperty.DATATYPE);
+        putIfNonNull(out, "solveOrder", cell, Property.StandardCellProperty.SOLVE_ORDER);
+        putIfNonNull(out, "language", cell, Property.StandardCellProperty.LANGUAGE);
+
+        // Error cells: surface the error text under a stable 'error' key
+        // even though it's not a StandardCellProperty per se.
+        if (cell.isError()) {
+            try {
+                Object v = cell.getValue();
+                if (v != null) out.put("error", v.toString());
+            } catch (RuntimeException ignored) {
+                // Mondrian sometimes throws here; the cell stays untagged.
+            }
+        }
+
+        return out;
+    }
+
+    private static void putIfNonNull(Map<String, String> out, String key, Cell cell, Property.StandardCellProperty p) {
+        try {
+            Object v = cell.getPropertyValue(p);
+            if (v == null) return;
+            String s = v.toString();
+            if (s.isEmpty()) return;
+            out.put(key, s);
+        } catch (RuntimeException ignored) {
+            // Some properties throw if Mondrian's evaluator hasn't
+            // materialised them for the cell — treat as absent.
+        }
+    }
+}

--- a/saiku-core/saiku-service/src/main/java/org/saiku/olap/util/formatter/CellSetFormatter.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/olap/util/formatter/CellSetFormatter.java
@@ -283,6 +283,11 @@ public class CellSetFormatter implements ICellSetFormatter {
             if (coordList.size() > 1) y += coordList.get(1);
             final DataCell cellInfo = new DataCell(true, false, coordList);
             cellInfo.setCoordinates(cell.getCoordinateList());
+            // saiku#773: surface the full set of olap4j StandardCellProperty
+            // values (format string, fore/back colour, font flags, action
+            // type, error text, etc.) Mondrian computes for this cell so
+            // the REST/Arrow consumers can read them.
+            cellInfo.setProperties(CellPropertyExtractor.extract(cell));
 
             if (cell.getValue() != null) {
                 try {

--- a/saiku-core/saiku-service/src/main/java/org/saiku/olap/util/formatter/FlattenedCellSetFormatter.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/olap/util/formatter/FlattenedCellSetFormatter.java
@@ -376,6 +376,8 @@ public class FlattenedCellSetFormatter implements ICellSetFormatter {
 
             final DataCell cellInfo = new DataCell(true, false, coordList);
             cellInfo.setCoordinates(cell.getCoordinateList());
+            // saiku#773: surface olap4j StandardCellProperty values.
+            cellInfo.setProperties(CellPropertyExtractor.extract(cell));
 
             if (cell.getValue() != null) {
                 try {

--- a/saiku-core/saiku-service/src/main/java/org/saiku/olap/util/formatter/HierarchicalCellSetFormatter.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/olap/util/formatter/HierarchicalCellSetFormatter.java
@@ -282,6 +282,8 @@ public class HierarchicalCellSetFormatter implements ICellSetFormatter {
             if (coordList.size() > 1) y += coordList.get(1);
             final DataCell cellInfo = new DataCell(true, false, coordList);
             cellInfo.setCoordinates(cell.getCoordinateList());
+            // saiku#773: surface olap4j StandardCellProperty values.
+            cellInfo.setProperties(CellPropertyExtractor.extract(cell));
 
             if (cell.getValue() != null) {
                 try {

--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ai/AiCell.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ai/AiCell.java
@@ -4,6 +4,9 @@
  */
 package org.saiku.service.olap.ai;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+import java.util.Map;
+
 /**
  * Typed cell envelope. Replaces the v1 "pre-formatted string" cell shape
  * so an LLM can compute on {@link #value} without re-parsing locale-
@@ -18,6 +21,14 @@ public class AiCell {
     private String formatted;
     /** Optional unit / currency hint sniffed from the format string. */
     private String unit;
+    /** olap4j {@code StandardCellProperty} values surfaced from the
+     *  cellset — formatString, foreColor, backColor, fontFlags, actionType,
+     *  error, etc. (saiku#773). Map keys are camelCase per the extractor
+     *  contract; the field is {@link JsonInclude.Include#NON_EMPTY} so
+     *  cells with no Mondrian-set properties stay lean in the wire
+     *  representation. */
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    private Map<String, String> properties;
 
     public AiCell() {}
 
@@ -25,6 +36,13 @@ public class AiCell {
         this.value = value;
         this.formatted = formatted;
         this.unit = unit;
+    }
+
+    public AiCell(Double value, String formatted, String unit, Map<String, String> properties) {
+        this.value = value;
+        this.formatted = formatted;
+        this.unit = unit;
+        this.properties = properties;
     }
 
     public Double getValue() {
@@ -49,6 +67,14 @@ public class AiCell {
 
     public void setUnit(String v) {
         this.unit = v;
+    }
+
+    public Map<String, String> getProperties() {
+        return properties;
+    }
+
+    public void setProperties(Map<String, String> v) {
+        this.properties = v;
     }
 
     /** Best-effort: parse a Mondrian-formatted string back into a Double,

--- a/saiku-core/saiku-service/src/test/java/org/saiku/olap/util/formatter/CellPropertyExtractorTest.java
+++ b/saiku-core/saiku-service/src/test/java/org/saiku/olap/util/formatter/CellPropertyExtractorTest.java
@@ -1,0 +1,138 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.olap.util.formatter;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.Test;
+import org.olap4j.Cell;
+import org.olap4j.metadata.Property;
+
+/**
+ * Unit tests for {@link CellPropertyExtractor} — pulls every supported
+ * {@link Property.StandardCellProperty} value off an olap4j {@link Cell}
+ * and surfaces them as a stable camelCase map (saiku#773).
+ *
+ * <p>Uses a JDK {@link Proxy} stub so the test doesn't need a real
+ * Mondrian cellset — we just need to assert the extractor reads the
+ * right properties and short-circuits cleanly on nulls / errors.
+ */
+public class CellPropertyExtractorTest {
+
+    @Test
+    public void extractsPopulatedStandardProperties() {
+        Map<Property.StandardCellProperty, Object> values = new HashMap<>();
+        values.put(Property.StandardCellProperty.FORMAT_STRING, "$#,##0.00");
+        values.put(Property.StandardCellProperty.FORE_COLOR, 255);
+        values.put(Property.StandardCellProperty.BACK_COLOR, 16777215);
+        values.put(Property.StandardCellProperty.FONT_FLAGS, 1);
+        values.put(Property.StandardCellProperty.ACTION_TYPE, "Drill");
+
+        Cell cell = stubCell(values, false, null);
+        Map<String, String> out = CellPropertyExtractor.extract(cell);
+
+        assertEquals("$#,##0.00", out.get("formatString"));
+        assertEquals("255", out.get("foreColor"));
+        assertEquals("16777215", out.get("backColor"));
+        assertEquals("1", out.get("fontFlags"));
+        assertEquals("Drill", out.get("actionType"));
+    }
+
+    @Test
+    public void absentPropertiesAreOmitted() {
+        // Only FORMAT_STRING set; every other property returns null.
+        Map<Property.StandardCellProperty, Object> values = new HashMap<>();
+        values.put(Property.StandardCellProperty.FORMAT_STRING, "#,##0");
+
+        Cell cell = stubCell(values, false, null);
+        Map<String, String> out = CellPropertyExtractor.extract(cell);
+
+        assertTrue("formatString present", out.containsKey("formatString"));
+        assertFalse("foreColor not in map when null", out.containsKey("foreColor"));
+        assertFalse("backColor not in map when null", out.containsKey("backColor"));
+        assertEquals(1, out.size());
+    }
+
+    @Test
+    public void emptyStringValueIsTreatedAsAbsent() {
+        Map<Property.StandardCellProperty, Object> values = new HashMap<>();
+        values.put(Property.StandardCellProperty.FORMAT_STRING, "");
+
+        Cell cell = stubCell(values, false, null);
+        Map<String, String> out = CellPropertyExtractor.extract(cell);
+
+        assertTrue("empty-string property dropped", out.isEmpty());
+    }
+
+    @Test
+    public void errorCellSurfacesErrorKey() {
+        Cell cell = stubCell(new HashMap<>(), true, "division by zero");
+        Map<String, String> out = CellPropertyExtractor.extract(cell);
+
+        assertEquals("division by zero", out.get("error"));
+    }
+
+    @Test
+    public void nullCellReturnsEmptyMap() {
+        Map<String, String> out = CellPropertyExtractor.extract(null);
+        assertNotNull(out);
+        assertEquals(0, out.size());
+    }
+
+    @Test
+    public void thrownPropertyAccessSilentlyOmits() {
+        // A cell whose getPropertyValue() throws for FORE_COLOR should
+        // still surface other properties cleanly.
+        Cell cell = (Cell) Proxy.newProxyInstance(
+                CellPropertyExtractorTest.class.getClassLoader(), new Class<?>[] {Cell.class}, new InvocationHandler() {
+                    @Override
+                    public Object invoke(Object proxy, Method method, Object[] args) {
+                        String name = method.getName();
+                        if ("getPropertyValue".equals(name) && args != null && args.length == 1) {
+                            Property p = (Property) args[0];
+                            if (p == Property.StandardCellProperty.FORE_COLOR) {
+                                throw new RuntimeException("evaluator not materialised");
+                            }
+                            if (p == Property.StandardCellProperty.FORMAT_STRING) return "#,##0.00";
+                            return null;
+                        }
+                        if ("isError".equals(name)) return Boolean.FALSE;
+                        return null;
+                    }
+                });
+
+        Map<String, String> out = CellPropertyExtractor.extract(cell);
+        assertEquals("formatString still extracted", "#,##0.00", out.get("formatString"));
+        assertFalse("foreColor that threw is silently absent", out.containsKey("foreColor"));
+    }
+
+    /* ------------------------ test helpers ------------------------ */
+
+    private static Cell stubCell(
+            Map<Property.StandardCellProperty, Object> values, boolean isError, String errorValue) {
+        return (Cell) Proxy.newProxyInstance(
+                CellPropertyExtractorTest.class.getClassLoader(), new Class<?>[] {Cell.class}, new InvocationHandler() {
+                    @Override
+                    public Object invoke(Object proxy, Method method, Object[] args) {
+                        String name = method.getName();
+                        if ("getPropertyValue".equals(name) && args != null && args.length == 1) {
+                            Property p = (Property) args[0];
+                            return values.get(p);
+                        }
+                        if ("isError".equals(name)) return isError;
+                        if ("getValue".equals(name)) return errorValue;
+                        return null;
+                    }
+                });
+    }
+}

--- a/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/AiQueryResource.java
+++ b/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/AiQueryResource.java
@@ -713,13 +713,20 @@ public class AiQueryResource {
         String formatted = safe(c.getFormattedValue());
         // Prefer the engine's raw numeric when DataCell carries one.
         Double value = null;
+        java.util.Map<String, String> props = null;
         if (c instanceof org.saiku.olap.dto.resultset.DataCell) {
-            Number raw = ((org.saiku.olap.dto.resultset.DataCell) c).getRawNumber();
+            org.saiku.olap.dto.resultset.DataCell dc = (org.saiku.olap.dto.resultset.DataCell) c;
+            Number raw = dc.getRawNumber();
             if (raw != null) value = raw.doubleValue();
+            // saiku#773: thread the cellset's olap4j StandardCellProperty
+            // values out to the agent. Empty -> stays null and Jackson
+            // drops the field per AiCell's NON_EMPTY include policy.
+            java.util.Map<String, String> p = dc.getProperties();
+            if (p != null && !p.isEmpty()) props = p;
         }
         if (value == null) value = AiCell.parseValueFromFormatted(formatted);
         String unit = AiCell.sniffUnit(formatted);
-        return new AiCell(value, formatted, unit);
+        return new AiCell(value, formatted, unit, props);
     }
 
     /**


### PR DESCRIPTION
## Summary

Closes #773. Mondrian computes a chunk of useful cell metadata per cell (format string, fore/back colour, font flags, action type, error text, etc.) but saiku's formatters discarded everything except `FORMAT_STRING`. Now propagated end-to-end on both surfaces (Query2 + AI) so clients can drive conditional formatting, action bindings, and schema-driven number rendering from the cube definition.

## What lands

- **`CellPropertyExtractor`** helper reads olap4j `Cell.getPropertyValue()` for every `StandardCellProperty` we want surfaced, returns a stable camelCase `Map<String,String>`:

  | Key | Source |
  | --- | --- |
  | `formatString` | `FORMAT_STRING` |
  | `foreColor` / `backColor` | `FORE_COLOR` / `BACK_COLOR` |
  | `fontFlags` / `fontName` / `fontSize` | `FONT_*` |
  | `actionType` / `updateable` | `ACTION_TYPE` / `UPDATEABLE` |
  | `datatype` / `solveOrder` / `language` | corresponding `StandardCellProperty` |
  | `error` | synthesised when `cell.isError()` |

  Empty / null property values omitted from the map — clients can rely on "key present ⇒ Mondrian set it explicitly".

- **All three `CellSetFormatter` implementations** (`CellSetFormatter`, `FlattenedCellSetFormatter`, `HierarchicalCellSetFormatter`) call the extractor right after constructing each `DataCell`. Same one-line addition; existing `setFormatString(...)` logic is untouched (it stays for backwards compat).

- **`AiCell.properties`** — optional `Map<String,String>` with `@JsonInclude(NON_EMPTY)` so cells without Mondrian-set properties don't bloat the wire format. `AiQueryResource.toCell()` copies properties through.

## Test surface (6 new, 246/246 saiku-service green)

`CellPropertyExtractorTest`:
- `extractsPopulatedStandardProperties` — populated map matches camelCase keys
- `absentPropertiesAreOmitted` — null values aren't keys
- `emptyStringValueIsTreatedAsAbsent`
- `errorCellSurfacesErrorKey`
- `nullCellReturnsEmptyMap`
- `thrownPropertyAccessSilentlyOmits` — one bad property doesn't drop the whole map

The extractor is silent-fail per property: some Mondrian builds raise when an evaluator hasn't materialised a specific property; the extractor catches per-property so the rest of the map still surfaces.

## Out of scope (per the issue's "future work" framing)

- **Member-level properties** via `Member.getPropertyValue(...)` — separate follow-up. The cell-set already carries the bulk of what clients need; member properties layer on top.
- **`ArrowCellsetWriter`** column additions — the writer ships `raw` + `fmt` per data column today; we can add optional property columns once a consumer needs them, without breaking the current arrow shape.

## Test plan

- [x] 6 new unit tests in `CellPropertyExtractorTest`
- [x] All 246 saiku-service tests pass
- [x] All 37 saiku-web tests pass
- [x] Test-floor bumped saiku-core/saiku-service 240 → 246
- [ ] CI on this PR