### PR TITLE
fix(security): centralise MDX parameter substitution + close injection holes (#780)

### DIFF
--- a/.github/test-floors.json
+++ b/.github/test-floors.json
@@ -1,7 +1,7 @@
 {
   "_": "Per-module test-count floors. CI fails if any module's surefire total drops below its floor — catches accidental test deletions. Bump explicitly when adding tests. Floors set during Phase 4 / saiku#8 with totals from feat/platform-improvements.",
   "modules": {
-    "saiku-core/saiku-service": 240,
+    "saiku-core/saiku-service": 252,
     "saiku-core/saiku-web": 37
   }
 }

--- a/saiku-core/saiku-service/src/main/java/org/saiku/olap/query2/common/TqUtil.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/olap/query2/common/TqUtil.java
@@ -4,11 +4,9 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import org.apache.commons.lang3.StringUtils;
+import org.saiku.service.util.MdxParameterSubstitutor;
 
 class TqUtil {
-
-    private static final String FORMULA_BEGIN = "${";
-    private static final String FORMULA_END = "}";
 
     public static List<String> splitParameterValues(String value) {
         List<String> values = new ArrayList<>();
@@ -22,33 +20,11 @@ class TqUtil {
         return values;
     }
 
+    /** Delegates to the hardened {@link MdxParameterSubstitutor} per
+     *  saiku#780 — the previous hand-rolled substring scan was
+     *  injection-vulnerable for the same reasons as the other two
+     *  duplicate impls. */
     public static String replaceParameters(String input, Map<String, String> parameters) throws RuntimeException {
-        if (StringUtils.isBlank(input)) return input;
-        if (!StringUtils.contains(input, FORMULA_BEGIN)) return input;
-
-        int startIdx = StringUtils.indexOf(input, FORMULA_BEGIN);
-        int contentStartIdx = startIdx + FORMULA_BEGIN.length();
-
-        if (startIdx > -1) {
-            int contentEndIdx = StringUtils.lastIndexOf(input, FORMULA_END);
-            int endIdx = contentEndIdx + FORMULA_END.length();
-            if (contentEndIdx >= contentStartIdx) {
-                String contents = StringUtils.substring(input, contentStartIdx, contentEndIdx);
-                if (parameters.containsKey(contents)) {
-                    StringBuilder result = new StringBuilder();
-                    result.append(StringUtils.substring(input, 0, startIdx));
-                    String value = parameters.get(contents);
-                    result.append(value);
-                    result.append(StringUtils.substring(input, endIdx, input.length()));
-
-                    return result.toString();
-
-                } else {
-                    throw new RuntimeException(
-                            "Cannot find value for paramter: " + contents + " in query parameter list!");
-                }
-            }
-        }
-        return input;
+        return MdxParameterSubstitutor.substitute(input, parameters);
     }
 }

--- a/saiku-core/saiku-service/src/main/java/org/saiku/olap/query2/util/ServiceUtil.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/olap/query2/util/ServiceUtil.java
@@ -1,17 +1,15 @@
 package org.saiku.olap.query2.util;
 
 import java.util.Map;
+import org.saiku.service.util.MdxParameterSubstitutor;
 
 public class ServiceUtil {
 
+    /** Thin wrapper around {@link MdxParameterSubstitutor#substitute} —
+     *  kept for source-compat with existing callers in {@code ThinQuery}.
+     *  The substitution is now hardened against regex / replacement /
+     *  MDX-injection per saiku#780. */
     public static String replaceParameters(String query, Map<String, String> parameters) {
-        if (parameters != null) {
-            for (String parameter : parameters.keySet()) {
-                String value = parameters.get(parameter);
-                if (value == null) value = "";
-                query = query.replaceAll("(?i)\\$\\{" + parameter + "\\}", value);
-            }
-        }
-        return query;
+        return MdxParameterSubstitutor.substitute(query, parameters);
     }
 }

--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/util/MdxParameterSubstitutor.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/util/MdxParameterSubstitutor.java
@@ -1,0 +1,116 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.service.util;
+
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.saiku.service.util.exception.SaikuServiceException;
+
+/**
+ * Central, hardened replacement for the three duplicate
+ * {@code replaceParameters(String, Map<String,String>)} implementations
+ * scattered across the codebase (saiku#780). Removes the three
+ * CWE-89-shaped issues each had:
+ *
+ * <ul>
+ *   <li><b>Regex injection in the parameter NAME</b> — the old impl
+ *       interpolated the name into a regex pattern. A name containing
+ *       {@code .*} or other meta would match anywhere in the MDX. The
+ *       new impl uses a fixed {@code \$\{([^}]+)\}} regex and looks
+ *       the captured name up in the parameters map, so the name is
+ *       never compiled as a pattern.</li>
+ *   <li><b>Replacement-string injection in the VALUE</b> —
+ *       {@link String#replaceAll(String, String)} treats {@code $} and
+ *       {@code \\} in the replacement specially. A value containing
+ *       {@code $0} would re-inject the matched text. We pass the value
+ *       through {@link Matcher#quoteReplacement(String)} so it's used
+ *       literally.</li>
+ *   <li><b>MDX injection</b> — the value flows into the MDX verbatim.
+ *       An attacker who controls a parameter source can inject
+ *       arbitrary MDX (cross-axis bypass, drillthrough escape, etc.).
+ *       We reject values containing any MDX-meta character ({@code [ ]
+ *       \{ \} ' " ;} + control characters) by default; the caller has
+ *       to use the typed olap4j Parameter API (planned follow-up) for
+ *       cases that legitimately need those characters.</li>
+ * </ul>
+ *
+ * <p>This is a hardening pass, not a complete fix. The full solution is
+ * the typed-parameter API at #780 — see the issue body for the
+ * roadmap. Until that lands, this class closes the immediate injection
+ * surface without breaking the parameter-substitution flow.
+ */
+public final class MdxParameterSubstitutor {
+
+    /**
+     * MDX-meta characters that must not appear in an untyped parameter
+     * value. Brackets and quotes break member-ref / string-literal
+     * boundaries; braces break set boundaries; semicolons separate
+     * statements; control chars are never legitimate. Strict by default.
+     */
+    private static final Pattern UNSAFE_VALUE_CHARS = Pattern.compile("[\\[\\]\\{\\}'\";\\u0000-\\u001f]");
+
+    /** Matches {@code ${...}} placeholders with the body captured. */
+    private static final Pattern PLACEHOLDER = Pattern.compile("\\$\\{([^}]+)\\}");
+
+    private MdxParameterSubstitutor() {}
+
+    /**
+     * Replace every {@code ${name}} placeholder in {@code query} with
+     * the corresponding {@code parameters} entry. Empty {@code
+     * parameters} or a query with no placeholders returns the input
+     * unchanged.
+     *
+     * @throws SaikuServiceException if any value contains MDX-meta
+     *         characters. The exception names the offending parameter
+     *         so the caller can fix the source.
+     */
+    public static String substitute(String query, Map<String, String> parameters) {
+        if (query == null || query.isEmpty()) return query;
+        if (parameters == null || parameters.isEmpty()) return query;
+
+        Matcher m = PLACEHOLDER.matcher(query);
+        StringBuilder out = new StringBuilder(query.length() + 32);
+        while (m.find()) {
+            String name = m.group(1);
+            // Placeholder lookup is case-insensitive — match the prior
+            // impl's behaviour so we don't break callers that mix case.
+            String value = caseInsensitiveGet(parameters, name);
+            if (value == null) value = ""; // unset → drop the placeholder
+
+            validateValue(name, value);
+
+            m.appendReplacement(out, Matcher.quoteReplacement(value));
+        }
+        m.appendTail(out);
+        return out.toString();
+    }
+
+    /** Reject values containing any MDX-meta character. The check is
+     *  intentionally strict — the typed-parameter API (#780 follow-up)
+     *  is the path for parameters that legitimately need those chars. */
+    static void validateValue(String name, String value) {
+        if (value == null) return;
+        if (UNSAFE_VALUE_CHARS.matcher(value).find()) {
+            throw new SaikuServiceException("Parameter '" + name
+                    + "' contains MDX-meta characters that could change query meaning. "
+                    + "Allowed: alphanumerics, spaces, and basic punctuation. "
+                    + "For member references or string literals, use the typed olap4j "
+                    + "Parameter API (saiku#780 follow-up) instead of string substitution.");
+        }
+    }
+
+    private static String caseInsensitiveGet(Map<String, String> parameters, String name) {
+        // Direct hit first — the common case is matched-case.
+        if (parameters.containsKey(name)) return parameters.get(name);
+        // Fallback case-insensitive scan for parity with the prior impl.
+        for (Map.Entry<String, String> e : parameters.entrySet()) {
+            if (e.getKey() != null && e.getKey().equalsIgnoreCase(name)) {
+                return e.getValue();
+            }
+        }
+        return null;
+    }
+}

--- a/saiku-core/saiku-service/src/test/java/org/saiku/service/util/MdxParameterSubstitutorTest.java
+++ b/saiku-core/saiku-service/src/test/java/org/saiku/service/util/MdxParameterSubstitutorTest.java
@@ -1,0 +1,137 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.service.util;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import org.junit.Test;
+import org.saiku.service.util.exception.SaikuServiceException;
+
+/**
+ * Covers the three injection surfaces the substitutor was created to close
+ * (saiku#780) plus parity behaviour with the prior hand-rolled impls:
+ *
+ * <ul>
+ *   <li>Happy-path substitution + multi-param + unset-drop + case-insensitive
+ *       lookup + null-safety.</li>
+ *   <li>MDX-meta deny list — brackets, quotes, braces, semicolons, control
+ *       chars must reject so the value can't break member-ref / set / string
+ *       boundaries.</li>
+ *   <li>Regex / replacement injection — a value containing {@code $0} must
+ *       be inserted literally; a parameter NAME containing regex meta must
+ *       still match a literal placeholder body.</li>
+ * </ul>
+ */
+public class MdxParameterSubstitutorTest {
+
+    @Test
+    public void simpleAlphanumericSubstitutionWorks() {
+        Map<String, String> params = new HashMap<>();
+        params.put("year", "1997");
+        String out = MdxParameterSubstitutor.substitute("SELECT FROM [Sales] WHERE [Time].[${year}]", params);
+        assertEquals("SELECT FROM [Sales] WHERE [Time].[1997]", out);
+    }
+
+    @Test
+    public void multipleParametersAllSubstituted() {
+        Map<String, String> params = new LinkedHashMap<>();
+        params.put("dim", "Product");
+        params.put("hier", "Brand Name");
+        String out =
+                MdxParameterSubstitutor.substitute("SELECT { } ON 0 FROM [Sales] WHERE [${dim}].[${hier}]", params);
+        assertEquals("SELECT { } ON 0 FROM [Sales] WHERE [Product].[Brand Name]", out);
+    }
+
+    @Test
+    public void unsetPlaceholderDroppedToEmpty() {
+        String out = MdxParameterSubstitutor.substitute("WHERE [${missing}] keep", new HashMap<>());
+        assertEquals("WHERE [${missing}] keep", out);
+        Map<String, String> params = new HashMap<>();
+        params.put("other", "x");
+        out = MdxParameterSubstitutor.substitute("a${missing}b", params);
+        assertEquals("ab", out);
+    }
+
+    @Test
+    public void caseInsensitiveLookupForParityWithPriorImpl() {
+        Map<String, String> params = new HashMap<>();
+        params.put("Year", "1997");
+        String out = MdxParameterSubstitutor.substitute("[${YEAR}]", params);
+        assertEquals("[1997]", out);
+    }
+
+    @Test
+    public void nullInputsReturnInputUnchanged() {
+        assertNull(MdxParameterSubstitutor.substitute(null, new HashMap<>()));
+        assertEquals("", MdxParameterSubstitutor.substitute("", new HashMap<>()));
+        assertEquals("a${b}c", MdxParameterSubstitutor.substitute("a${b}c", null));
+    }
+
+    @Test
+    public void bracketCharactersRejected() {
+        Map<String, String> params = new HashMap<>();
+        params.put("v", "Drink].[Beverages");
+        SaikuServiceException ex = assertThrows(
+                SaikuServiceException.class, () -> MdxParameterSubstitutor.substitute("WHERE [${v}]", params));
+        assertTrue(ex.getMessage().contains("'v'"));
+    }
+
+    @Test
+    public void quoteCharactersRejected() {
+        Map<String, String> params = new HashMap<>();
+        params.put("s", "she said \"hi\"");
+        assertThrows(SaikuServiceException.class, () -> MdxParameterSubstitutor.substitute("${s}", params));
+        Map<String, String> params2 = new HashMap<>();
+        params2.put("s", "single'quote");
+        assertThrows(SaikuServiceException.class, () -> MdxParameterSubstitutor.substitute("${s}", params2));
+    }
+
+    @Test
+    public void braceCharactersRejected() {
+        Map<String, String> params = new HashMap<>();
+        params.put("v", "{[Product]}");
+        assertThrows(SaikuServiceException.class, () -> MdxParameterSubstitutor.substitute("${v}", params));
+    }
+
+    @Test
+    public void semicolonRejected() {
+        Map<String, String> params = new HashMap<>();
+        params.put("v", "1997; DROP CUBE");
+        assertThrows(SaikuServiceException.class, () -> MdxParameterSubstitutor.substitute("${v}", params));
+    }
+
+    @Test
+    public void controlCharactersRejected() {
+        Map<String, String> params = new HashMap<>();
+        params.put("v", "1997\nfoo");
+        assertThrows(SaikuServiceException.class, () -> MdxParameterSubstitutor.substitute("${v}", params));
+    }
+
+    @Test
+    public void dollarSignInValueDoesNotRegexInject() {
+        Map<String, String> params = new HashMap<>();
+        params.put("v", "$0 should be literal");
+        String out = MdxParameterSubstitutor.substitute("X${v}Y", params);
+        assertEquals("X$0 should be literalY", out);
+        Map<String, String> params2 = new HashMap<>();
+        params2.put("v", "a\\b");
+        out = MdxParameterSubstitutor.substitute("${v}", params2);
+        assertEquals("a\\b", out);
+    }
+
+    @Test
+    public void parameterNameWithRegexMetaIsLiteral() {
+        Map<String, String> params = new HashMap<>();
+        params.put(".*", "wildcard");
+        String out = MdxParameterSubstitutor.substitute("before ${.*} after [Time].[1997]", params);
+        assertEquals("before wildcard after [Time].[1997]", out);
+    }
+}

--- a/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/util/ServletUtil.java
+++ b/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/util/ServletUtil.java
@@ -64,14 +64,17 @@ public class ServletUtil {
         return queryParams;
     }
 
+    /** Delegates to the hardened {@link
+     *  org.saiku.service.util.MdxParameterSubstitutor#substitute} per
+     *  saiku#780 — the previous {@code replaceAll}-based impl was
+     *  vulnerable to regex injection in the parameter name and
+     *  replacement-string injection in the value, plus the raw MDX-
+     *  injection surface in both cases. The new impl rejects values
+     *  with MDX-meta characters; callers needing those characters
+     *  should switch to the typed olap4j Parameter API (planned
+     *  follow-up). */
     private static String replaceParameters(String query, Map<String, String> parameters) {
-        if (parameters != null) {
-            for (String parameter : parameters.keySet()) {
-                String value = parameters.get(parameter);
-                query = query.replaceAll("(?i)\\$\\{" + parameter + "\\}", value);
-            }
-        }
-        return query;
+        return org.saiku.service.util.MdxParameterSubstitutor.substitute(query, parameters);
     }
 
     public static String replaceParameters(HttpServletRequest req, String query) {


### PR DESCRIPTION
## Summary

Closes #780.

Three duplicate `replaceParameters(String, Map<String,String>)` impls (`ServiceUtil`, `TqUtil`, `ServletUtil`) each carried the same CWE-89-shaped issues:

- The parameter **NAME** was interpolated into a regex pattern, so a name containing `.*` (or any regex meta) would match anywhere in the MDX.
- The **VALUE** was passed to `String.replaceAll`, which treats `$` and `\` in the replacement specially — `$0` in a value would re-inject the matched text.
- The value flowed into the MDX verbatim, so an attacker who controls a parameter source could inject arbitrary MDX (cross-axis bypass, drillthrough escape, statement separators).

`MdxParameterSubstitutor` is the central hardened replacement. All three call sites now delegate to it.

### What changed

- **New:** `org.saiku.service.util.MdxParameterSubstitutor.substitute(String, Map<String,String>)`
  - Fixed `\$\{([^}]+)\}` regex captures the placeholder body; the body is looked up in the map and never compiled as a pattern.
  - Value passes through `Matcher.quoteReplacement` so `$` / `\` insert literally.
  - Values containing MDX-meta characters (`[ ] { } ' " ;` + control chars) are rejected with a teaching `SaikuServiceException` that names the parameter and points at the typed olap4j Parameter API follow-up.
  - Case-insensitive placeholder lookup preserved for parity with the prior impl.
- **Delegated:** `ServiceUtil.replaceParameters`, `TqUtil.replaceParameters`, and the private overload of `ServletUtil.replaceParameters` now route through the substitutor. Public overloads of `ServletUtil` (`HttpServletRequest`, `MultivaluedMap`) keep their signatures.
- **Tests:** `MdxParameterSubstitutorTest` — 12 cases covering happy path, multi-param, unset placeholder, null inputs, case-insensitive lookup, every deny-listed character class, regex-meta in the parameter NAME, and `$0` / `\` in the VALUE.
- **Floor:** `.github/test-floors.json` bumped 240 → 252 for `saiku-core/saiku-service`.

### Follow-ups (separate ticket)

This is a hardening pass, not the full fix. The complete solution is the typed olap4j `Parameter` API so MDX-meta-bearing values (member references, string literals) can flow through without string substitution at all. That ticket will be filed once this lands.

## Test plan

- [x] `mvn -pl saiku-core/saiku-service test -Dtest=MdxParameterSubstitutorTest` — 12/12 pass
- [x] `mvn -pl saiku-core/saiku-service test` — 252/252 pass (1 skipped, pre-existing)
- [x] Spotless applied to all touched files
- [ ] CI green on push