### PR TITLE
feat(discover): expose calculated-member visible flag + filter API (#778)

### DIFF
--- a/.github/test-floors.json
+++ b/.github/test-floors.json
@@ -1,7 +1,7 @@
 {
   "_": "Per-module test-count floors. CI fails if any module's surefire total drops below its floor — catches accidental test deletions. Bump explicitly when adding tests. Floors set during Phase 4 / saiku#8 with totals from feat/platform-improvements.",
   "modules": {
-    "saiku-core/saiku-service": 240,
-    "saiku-core/saiku-web": 37
+    "saiku-core/saiku-service": 246,
+    "saiku-core/saiku-web": 39
   }
 }

--- a/saiku-core/saiku-service/src/main/java/org/saiku/olap/dto/SaikuMeasure.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/olap/dto/SaikuMeasure.java
@@ -25,7 +25,8 @@ public class SaikuMeasure extends SaikuMember {
                 dimensionUniqueName,
                 hierarchyUniqueName,
                 levelUniqueName,
-                calculated);
+                calculated,
+                visible);
         this.measureGroup = measuregroup;
     }
 

--- a/saiku-core/saiku-service/src/main/java/org/saiku/olap/dto/SaikuMember.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/olap/dto/SaikuMember.java
@@ -23,6 +23,13 @@ public class SaikuMember extends AbstractSaikuObject {
     private String levelUniqueName;
     private String hierarchyUniqueName;
     private Boolean calculated;
+    /** Whether the member should appear in analyst-facing UIs. Defaults to
+     *  true so legacy callers that don't pass the flag get the safe
+     *  (always-show) behaviour. saiku#778 surfaces this from the
+     *  schema-level {@code visible="false"} attribute on
+     *  {@code <CalculatedMember>} so cubes that ship helper measures can
+     *  hide them from the member tree. */
+    private Boolean visible = true;
 
     SaikuMember() {}
 
@@ -35,6 +42,28 @@ public class SaikuMember extends AbstractSaikuObject {
             String hierarchyUniqueName,
             String levelUniqueName,
             boolean calculated) {
+        this(
+                name,
+                uniqueName,
+                caption,
+                description,
+                dimensionUniqueName,
+                hierarchyUniqueName,
+                levelUniqueName,
+                calculated,
+                true);
+    }
+
+    public SaikuMember(
+            String name,
+            String uniqueName,
+            String caption,
+            String description,
+            String dimensionUniqueName,
+            String hierarchyUniqueName,
+            String levelUniqueName,
+            boolean calculated,
+            boolean visible) {
         super(uniqueName, name);
         this.caption = caption;
         this.description = description;
@@ -42,6 +71,7 @@ public class SaikuMember extends AbstractSaikuObject {
         this.levelUniqueName = levelUniqueName;
         this.hierarchyUniqueName = hierarchyUniqueName;
         this.calculated = calculated;
+        this.visible = visible;
     }
 
     public SaikuMember(
@@ -59,6 +89,7 @@ public class SaikuMember extends AbstractSaikuObject {
         this.levelUniqueName = levelUniqueName;
         this.hierarchyUniqueName = hierarchyUniqueName;
         this.calculated = false;
+        this.visible = true;
     }
 
     public String getCaption() {
@@ -87,5 +118,14 @@ public class SaikuMember extends AbstractSaikuObject {
 
     public void setCalculated(Boolean calculated) {
         this.calculated = calculated;
+    }
+
+    /** @see #visible */
+    public Boolean isVisible() {
+        return visible;
+    }
+
+    public void setVisible(Boolean visible) {
+        this.visible = visible;
     }
 }

--- a/saiku-core/saiku-service/src/main/java/org/saiku/olap/query2/ThinCalculatedMember.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/olap/query2/ThinCalculatedMember.java
@@ -21,6 +21,12 @@ public class ThinCalculatedMember {
     private String formula;
     private String hierarchyName;
     private String assignedLevel;
+    /** Whether the calculated member should appear in analyst-facing UIs.
+     *  Mirrors the schema-level {@code visible="false"} attribute on
+     *  {@code <CalculatedMember>} (saiku#778). Defaults to true so legacy
+     *  WITH-MEMBER bodies that don't set it keep the existing
+     *  always-show behaviour. */
+    private Boolean visible = true;
 
     public ThinCalculatedMember() {}
 
@@ -157,5 +163,14 @@ public class ThinCalculatedMember {
 
     public void setAssignedLevel(String assignedLevel) {
         this.assignedLevel = assignedLevel;
+    }
+
+    /** @see #visible */
+    public Boolean isVisible() {
+        return visible;
+    }
+
+    public void setVisible(Boolean visible) {
+        this.visible = visible;
     }
 }

--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ai/AiSchema.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ai/AiSchema.java
@@ -27,6 +27,12 @@ public class AiSchema {
         /** Optional free-text description (from olap4j Member.getDescription()
          *  or the schema-gen sidecar). Helps the LLM ground its choices. */
         public String description;
+        /** Whether the measure should appear in analyst-facing UIs. Mirrors
+         *  the schema-level {@code visible="false"} attribute on
+         *  {@code <CalculatedMember>} (saiku#778). Defaults to true so
+         *  existing snapshots and tests don't shift; hidden measures are
+         *  surfaced on the wire so admin clients can opt in to seeing them. */
+        public Boolean visible = true;
 
         public Measure(String name, String uniqueName) {
             this.name = name;

--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ai/OlapAiCubeMetadataService.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ai/OlapAiCubeMetadataService.java
@@ -222,6 +222,12 @@ public class OlapAiCubeMetadataService implements AiCubeMetadataService {
                 if (m.getDescription() != null && !m.getDescription().isEmpty()) {
                     measure.description = m.getDescription();
                 }
+                // saiku#778: surface the schema-level visible flag so admin
+                // tooling can see hidden helper measures while analyst clients
+                // filter them out. Null → assume visible (legacy fixtures).
+                if (m.isVisible() != null) {
+                    measure.visible = m.isVisible();
+                }
                 schema.measures.put(AiSchema.key(n), measure);
             }
         } catch (RuntimeException e) {

--- a/saiku-core/saiku-service/src/test/java/org/saiku/olap/dto/SaikuMeasureVisibleTest.java
+++ b/saiku-core/saiku-service/src/test/java/org/saiku/olap/dto/SaikuMeasureVisibleTest.java
@@ -1,0 +1,86 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.olap.dto;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.Test;
+
+/**
+ * saiku#778 — the {@code visible} flag added to {@link SaikuMember} (and
+ * inherited by {@link SaikuMeasure}) must survive Jackson round-trip so the
+ * REST contract is durable. Two surfaces are tested:
+ *
+ * <ul>
+ *   <li>The 10-arg {@link SaikuMeasure} ctor — already accepted a
+ *       {@code visible} arg but used to silently drop it; this test pins
+ *       that the field now lands on the wire.</li>
+ *   <li>Legacy callers that build via the 7-arg {@link SaikuMember} ctor
+ *       (no visible parameter) — they must default to {@code visible=true}
+ *       so existing snapshots / older clients keep their behaviour.</li>
+ * </ul>
+ */
+public class SaikuMeasureVisibleTest {
+
+    private final ObjectMapper json = new ObjectMapper();
+
+    @Test
+    public void saikuMeasureVisibleFalseRoundTrips() throws Exception {
+        SaikuMeasure hidden = new SaikuMeasure(
+                "Hidden Helper",
+                "[Measures].[Hidden Helper]",
+                "Hidden Helper",
+                "",
+                "[Measures]",
+                "[Measures].[MeasuresLevel]",
+                "[Measures].[MeasuresLevel]",
+                false, // visible
+                true, // calculated
+                null);
+        String wire = json.writeValueAsString(hidden);
+        assertTrue("visible serialised", wire.contains("\"visible\":false"));
+
+        SaikuMeasure back = json.readValue(wire, SaikuMeasure.class);
+        assertFalse("visible=false survives round-trip", back.isVisible());
+        assertEquals("Hidden Helper", back.getName());
+        assertTrue("calculated=true preserved", back.isCalculated());
+    }
+
+    @Test
+    public void saikuMeasureVisibleTrueIsTheDefault() throws Exception {
+        SaikuMeasure shown = new SaikuMeasure(
+                "Store Sales",
+                "[Measures].[Store Sales]",
+                "Store Sales",
+                "",
+                "[Measures]",
+                "[Measures].[MeasuresLevel]",
+                "[Measures].[MeasuresLevel]",
+                true,
+                false,
+                null);
+        SaikuMeasure back = json.readValue(json.writeValueAsString(shown), SaikuMeasure.class);
+        assertTrue("visible=true preserved", back.isVisible());
+    }
+
+    @Test
+    public void legacySaikuMemberCtorDefaultsToVisibleTrue() throws Exception {
+        // 7-arg legacy ctor (no calculated, no visible) — pre-saiku#778 clients
+        // must keep the always-show behaviour they had before this change.
+        SaikuMember legacy = new SaikuMember(
+                "Drink",
+                "[Product].[Drink]",
+                "Drink",
+                "",
+                "[Product]",
+                "[Product].[Products]",
+                "[Product].[Products].[Product Family]");
+        SaikuMember back = json.readValue(json.writeValueAsString(legacy), SaikuMember.class);
+        assertTrue("legacy ctor → visible=true", back.isVisible());
+    }
+}

--- a/saiku-core/saiku-service/src/test/java/org/saiku/olap/query2/ThinCalculatedMemberVisibleTest.java
+++ b/saiku-core/saiku-service/src/test/java/org/saiku/olap/query2/ThinCalculatedMemberVisibleTest.java
@@ -1,0 +1,44 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.olap.query2;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.Test;
+
+/**
+ * saiku#778 — the {@code visible} flag added to {@link ThinCalculatedMember}
+ * must survive Jackson round-trip so query-time WITH-MEMBER bodies can carry
+ * the same visibility intent as schema-level calculated members.
+ *
+ * <p>Pre-#778 bodies omit the field entirely; those must deserialise to
+ * {@code visible=true} so legacy clients aren't silently hidden.
+ */
+public class ThinCalculatedMemberVisibleTest {
+
+    private final ObjectMapper json = new ObjectMapper();
+
+    @Test
+    public void visibleFalseRoundTrips() throws Exception {
+        ThinCalculatedMember hidden = new ThinCalculatedMember();
+        hidden.setVisible(false);
+        String wire = json.writeValueAsString(hidden);
+        assertTrue("visible serialised", wire.contains("\"visible\":false"));
+
+        ThinCalculatedMember back = json.readValue(wire, ThinCalculatedMember.class);
+        assertFalse("visible=false survives", back.isVisible());
+    }
+
+    @Test
+    public void absentFieldDeserialisesAsVisibleTrue() throws Exception {
+        // Pre-saiku#778 wire format — no "visible" key. Default must be true
+        // so a body issued by a pre-#778 client doesn't get silently hidden.
+        String legacyBody = "{\"name\":\"YoY\",\"formula\":\"...\"}";
+        ThinCalculatedMember back = json.readValue(legacyBody, ThinCalculatedMember.class);
+        assertTrue("absent visible → true (legacy compat)", back.isVisible());
+    }
+}

--- a/saiku-core/saiku-service/src/test/java/org/saiku/service/olap/ai/OlapAiCubeMetadataServiceTest.java
+++ b/saiku-core/saiku-service/src/test/java/org/saiku/service/olap/ai/OlapAiCubeMetadataServiceTest.java
@@ -169,6 +169,58 @@ public class OlapAiCubeMetadataServiceTest {
         assertTrue("Product dim survives", schema.dimensions.containsKey(AiSchema.key("Product")));
     }
 
+    /* ----- saiku#778 visible flag ----- */
+
+    /**
+     * AI schema must surface the {@code visible} flag from
+     * {@link SaikuMember#isVisible()} so admin tooling can see hidden helper
+     * measures (e.g. ratios that exist only to support visible measures).
+     * Defaults remain {@code true} for unset legacy fixtures.
+     */
+    @Test
+    public void buildSchemaSurfacesVisibleFlagFromDiscoverMember() {
+        OlapAiCubeMetadataService visSvc = new OlapAiCubeMetadataService();
+        visSvc.setDiscoverService(new StubDiscover() {
+            @Override
+            public List<SaikuMember> getMeasures(SaikuCube cube) {
+                if ("HR".equals(cube.getName())) {
+                    return super.getMeasures(cube);
+                }
+                // Sales: Store Sales visible, helper "Hidden Helper" invisible.
+                return Arrays.asList(
+                        new org.saiku.olap.dto.SaikuMeasure(
+                                "Store Sales",
+                                "[Measures].[Store Sales]",
+                                "Store Sales",
+                                "",
+                                "[Measures]",
+                                "[Measures].[MeasuresLevel]",
+                                "[Measures].[MeasuresLevel]",
+                                true, // visible
+                                false, // calculated
+                                null), // measureGroup
+                        new org.saiku.olap.dto.SaikuMeasure(
+                                "Hidden Helper",
+                                "[Measures].[Hidden Helper]",
+                                "Hidden Helper",
+                                "",
+                                "[Measures]",
+                                "[Measures].[MeasuresLevel]",
+                                "[Measures].[MeasuresLevel]",
+                                false, // visible
+                                true, // calculated
+                                null));
+            }
+        });
+        AiSchema schema = visSvc.getSchema(new AiCubeRef("foodmart", "FoodMart", "FoodMart", "Sales"));
+        AiSchema.Measure storeSales = schema.measures.get(AiSchema.key("Store Sales"));
+        AiSchema.Measure hidden = schema.measures.get(AiSchema.key("Hidden Helper"));
+        assertNotNull(storeSales);
+        assertNotNull(hidden);
+        assertTrue("visible measure carries visible=true", Boolean.TRUE.equals(storeSales.visible));
+        assertFalse("hidden measure carries visible=false", Boolean.TRUE.equals(hidden.visible));
+    }
+
     /** Stub that fails getLevelMembers for Quarter only. */
     private static class ProbeStubDiscover extends StubDiscover {
         @Override

--- a/saiku-core/saiku-service/src/test/resources/schema-snapshots/quirks-schema.json
+++ b/saiku-core/saiku-service/src/test/resources/schema-snapshots/quirks-schema.json
@@ -11,11 +11,13 @@
   "measures" : {
     "number of employees" : {
       "name" : "Number of Employees",
-      "uniqueName" : "[Measures].[Number of Employees]"
+      "uniqueName" : "[Measures].[Number of Employees]",
+      "visible" : true
     },
     "unit sales" : {
       "name" : "Unit Sales",
-      "uniqueName" : "[Measures].[Unit Sales]"
+      "uniqueName" : "[Measures].[Unit Sales]",
+      "visible" : true
     }
   },
   "dimensions" : {

--- a/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/OlapDiscoverResource.java
+++ b/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/OlapDiscoverResource.java
@@ -15,10 +15,12 @@
  */
 package org.saiku.web.rest.resources;
 
+import jakarta.ws.rs.DefaultValue;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
@@ -380,13 +382,29 @@ public class OlapDiscoverResource implements Serializable {
             @PathParam("connection") String connectionName,
             @PathParam("catalog") String catalogName,
             @PathParam("schema") String schemaName,
-            @PathParam("cube") String cubeName) {
+            @PathParam("cube") String cubeName,
+            @QueryParam("includeHidden") @DefaultValue("false") boolean includeHidden) {
         if ("null".equals(schemaName)) {
             schemaName = "";
         }
         SaikuCube cube = new SaikuCube(connectionName, cubeName, cubeName, cubeName, catalogName, schemaName);
         try {
-            return olapDiscoverService.getMeasures(cube);
+            List<SaikuMember> measures = olapDiscoverService.getMeasures(cube);
+            // saiku#778: analyst UIs get visible-only by default; admin tooling
+            // passes includeHidden=true to inspect helper measures the schema
+            // author marked visible="false". Server-side filtering so a
+            // misconfigured client can't accidentally show what it shouldn't.
+            if (!includeHidden && measures != null) {
+                List<SaikuMember> filtered = new ArrayList<>(measures.size());
+                for (SaikuMember m : measures) {
+                    // Null → treat as visible (legacy fixtures / pre-#778 data).
+                    if (m.isVisible() == null || m.isVisible()) {
+                        filtered.add(m);
+                    }
+                }
+                return filtered;
+            }
+            return measures;
         } catch (Exception e) {
             log.error(this.getClass().getName(), e);
         }

--- a/saiku-core/saiku-web/src/test/java/org/saiku/web/rest/resources/OlapDiscoverResourceVisibleFilterTest.java
+++ b/saiku-core/saiku-web/src/test/java/org/saiku/web/rest/resources/OlapDiscoverResourceVisibleFilterTest.java
@@ -1,0 +1,76 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.web.rest.resources;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Arrays;
+import java.util.List;
+import org.junit.Before;
+import org.junit.Test;
+import org.saiku.olap.dto.SaikuCube;
+import org.saiku.olap.dto.SaikuMeasure;
+import org.saiku.olap.dto.SaikuMember;
+import org.saiku.service.olap.OlapDiscoverService;
+
+/**
+ * saiku#778 — server-side filtering of hidden measures in
+ * {@link OlapDiscoverResource#getCubeMeasures}. Default ({@code includeHidden=false})
+ * must drop measures marked {@code visible=false}; admin clients pass
+ * {@code includeHidden=true} to see them all.
+ */
+public class OlapDiscoverResourceVisibleFilterTest {
+
+    private OlapDiscoverResource resource;
+
+    @Before
+    public void setUp() {
+        resource = new OlapDiscoverResource();
+        resource.setOlapDiscoverService(new OlapDiscoverService() {
+            @Override
+            public List<SaikuMember> getMeasures(SaikuCube cube) {
+                return Arrays.asList(
+                        measure("Store Sales", true), measure("Hidden Helper", false), measure("Unit Sales", true));
+            }
+        });
+    }
+
+    @Test
+    public void hiddenMeasuresFilteredByDefault() {
+        List<SaikuMember> out = resource.getCubeMeasures("foodmart", "FoodMart", "FoodMart", "Sales", false);
+        assertEquals("two visible measures kept", 2, out.size());
+        assertTrue("Store Sales present", contains(out, "Store Sales"));
+        assertTrue("Unit Sales present", contains(out, "Unit Sales"));
+    }
+
+    @Test
+    public void includeHiddenTrueReturnsAll() {
+        List<SaikuMember> out = resource.getCubeMeasures("foodmart", "FoodMart", "FoodMart", "Sales", true);
+        assertEquals("all three measures kept", 3, out.size());
+        assertTrue("Hidden Helper present when includeHidden=true", contains(out, "Hidden Helper"));
+    }
+
+    private static SaikuMember measure(String name, boolean visible) {
+        return new SaikuMeasure(
+                name,
+                "[Measures].[" + name + "]",
+                name,
+                "",
+                "[Measures]",
+                "[Measures].[MeasuresLevel]",
+                "[Measures].[MeasuresLevel]",
+                visible,
+                false,
+                null);
+    }
+
+    private static boolean contains(List<SaikuMember> list, String name) {
+        for (SaikuMember m : list) {
+            if (name.equals(m.getName())) return true;
+        }
+        return false;
+    }
+}


### PR DESCRIPTION
## Summary

Closes #778. The `visible` flag from schema-level `<CalculatedMember visible="false">` was being read off `Measure.isVisible()` by `ObjectUtil.convertMeasure` but **silently dropped** by the `SaikuMeasure` constructor (10-arg signature accepted it, body discarded it). This PR lands the flag on the wire across both REST surfaces.

## Surfaces covered

- **AI Query API** (`AiSchema.Measure`) — agents introspecting cube metadata see exactly what saiku sees.
- **Query2 DTO** (`ThinCalculatedMember`) — query-time WITH-MEMBER bodies can carry the same visibility intent as schema calc-members.
- **Discovery REST** (`OlapDiscoverResource.getCubeMeasures`) — new `?includeHidden={true|false}` query param. Default `false` filters hidden measures server-side; admin tooling opts in with `includeHidden=true`.

## Why server-side filtering

Putting the filter in the REST layer (rather than a client-side `m => m.visible !== false`) means a misconfigured analyst client can't accidentally surface helper measures the schema author hid. Admin clients still see everything via `includeHidden=true`.

## Tests (6 new tests across 3 new classes + 1 amended)

- `SaikuMeasureVisibleTest` — Jackson round-trip of visible=false; legacy 7-arg ctor still defaults to true.
- `ThinCalculatedMemberVisibleTest` — same for the Query2 DTO; legacy bodies without the field deserialise to true.
- `OlapDiscoverResourceVisibleFilterTest` — drives `getCubeMeasures` with a stub discover service, asserts default filters and includeHidden=true returns all.
- `OlapAiCubeMetadataServiceTest.buildSchemaSurfacesVisibleFlagFromDiscoverMember` — AI schema carries the flag.

Test-floor bumped: saiku-service **240 → 246**, saiku-web **37 → 39**. `quirks-schema.json` snapshot regenerated to include the new `visible` field on each measure.

## Out of scope (follow-ups)

- UI checkbox in saiku-ui to expose `includeHidden` as an admin-only toggle on the discover view.
- Generic Member visibility for non-Measure hierarchy members (olap4j `Member` doesn't expose `isVisible()` — would need `StandardMemberProperty.MEMBER_VISIBLE` plumbing).

Both follow-ups will be filed as new tickets once this lands.

## Test plan

- [x] `mvn -pl saiku-core/saiku-service test` — 246/246 pass (1 skipped, pre-existing)
- [x] `mvn -pl saiku-core/saiku-web test` — 39/39 pass
- [x] Spotless applied to all touched files
- [x] AI schema snapshot regenerated and reviewed in diff
- [ ] CI green on push