### PR TITLE
feat(ai): resolve bare-caption returns= to qualified MDX (#782)

### DIFF
--- a/.github/test-floors.json
+++ b/.github/test-floors.json
@@ -1,7 +1,7 @@
 {
   "_": "Per-module test-count floors. CI fails if any module's surefire total drops below its floor — catches accidental test deletions. Bump explicitly when adding tests. Floors set during Phase 4 / saiku#8 with totals from feat/platform-improvements.",
   "modules": {
-    "saiku-core/saiku-service": 240,
+    "saiku-core/saiku-service": 248,
     "saiku-core/saiku-web": 37
   }
 }

--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ai/AiReturnsResolver.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ai/AiReturnsResolver.java
@@ -1,0 +1,124 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.service.olap.ai;
+
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Resolves a {@code returns=} drillthrough query-string into the fully-
+ * qualified MDX form Mondrian's {@code DRILLTHROUGH ... RETURN ...} clause
+ * expects. Closes saiku#782 — the AI contract promise is "agents never see
+ * MDX", but the row JSON returned from a drillthrough keys cells by bare
+ * caption, leaving no way for an agent to construct a follow-up
+ * {@code returns=} from a previous result.
+ *
+ * <p>Rules per comma-separated entry:
+ *
+ * <ul>
+ *   <li>Already bracketed ({@code [...]}) → passed through verbatim. Agents
+ *       that already speak MDX aren't surprised.</li>
+ *   <li>Bare token → matched (case-insensitively) against:
+ *     <ol>
+ *       <li>{@link AiSchema#measures} by canonical name and
+ *           {@link AiSchema#measureAliases}.</li>
+ *       <li>Every {@link AiSchema.Level} across every hierarchy by canonical
+ *           name and level aliases.</li>
+ *     </ol>
+ *     The first match wins and its {@code uniqueName} is substituted in.</li>
+ *   <li>No match → {@link AiValidationException} naming the offending token
+ *       and listing the candidate set (measure names + level names) so an
+ *       agent can self-correct without scraping the schema endpoint.</li>
+ * </ul>
+ *
+ * <p>Stateless and pure — no olap4j, no Mondrian dependency — so the
+ * resolver is testable in isolation from the live cube.
+ */
+public final class AiReturnsResolver {
+
+    private AiReturnsResolver() {}
+
+    /**
+     * Resolve a comma-separated {@code returns=} value against the given
+     * schema. {@code null}/blank inputs return {@code null} so the caller
+     * can pass-through to the downstream drillthrough unchanged.
+     *
+     * @throws AiValidationException if any non-bracketed token can't be
+     *         matched to a measure or level in the schema.
+     */
+    public static String resolve(String returns, AiSchema schema) {
+        if (returns == null || returns.trim().isEmpty()) return returns;
+        if (schema == null) return returns; // legacy/test path — leave alone.
+        String[] parts = returns.split(",");
+        StringBuilder out = new StringBuilder(returns.length() + 32);
+        boolean first = true;
+        for (String part : parts) {
+            String raw = part.trim();
+            if (raw.isEmpty()) continue; // tolerate stray commas
+            if (!first) out.append(',');
+            first = false;
+            if (raw.startsWith("[")) {
+                // Already MDX-qualified — pass through. We deliberately don't
+                // validate further; if it's wrong, Mondrian will say so and
+                // the caller's existing 400-translation logic surfaces it.
+                out.append(raw);
+            } else {
+                out.append(resolveBare(raw, schema));
+            }
+        }
+        return out.toString();
+    }
+
+    private static String resolveBare(String token, AiSchema schema) {
+        String key = AiSchema.key(token);
+
+        // 1. Measure direct hit.
+        AiSchema.Measure m = schema.measures.get(key);
+        if (m != null) return m.uniqueName;
+
+        // 2. Measure alias (Phase-3 enrichment displayName).
+        String mAlias = schema.measureAliases.get(key);
+        if (mAlias != null) {
+            AiSchema.Measure aliased = schema.measures.get(mAlias);
+            if (aliased != null) return aliased.uniqueName;
+        }
+
+        // 3. Level name across every hierarchy. We walk the dimension map in
+        //    insertion order so the resolver's behaviour is deterministic
+        //    when (rarely) two hierarchies share a level name.
+        for (AiSchema.Dimension dim : schema.dimensions.values()) {
+            for (AiSchema.Hierarchy hier : dim.hierarchies.values()) {
+                AiSchema.Level level = hier.levels.get(key);
+                if (level != null) return level.uniqueName;
+                String lAlias = hier.levelAliases.get(key);
+                if (lAlias != null) {
+                    AiSchema.Level aliased = hier.levels.get(lAlias);
+                    if (aliased != null) return aliased.uniqueName;
+                }
+            }
+        }
+
+        throw new AiValidationException(
+                "returns",
+                "Unknown returns column '" + token + "'. Use either a bare measure/level caption "
+                        + "or a fully-qualified MDX identifier like [Time].[Time].[Year].",
+                candidates(schema));
+    }
+
+    /** Build the candidate list surfaced in the validation error so an agent
+     *  can self-correct from the response without a separate schema fetch. */
+    private static List<String> candidates(AiSchema schema) {
+        Set<String> all = new LinkedHashSet<>();
+        for (AiSchema.Measure m : schema.measures.values()) all.add(m.name);
+        for (AiSchema.Dimension dim : schema.dimensions.values()) {
+            for (AiSchema.Hierarchy hier : dim.hierarchies.values()) {
+                for (AiSchema.Level level : hier.levels.values()) all.add(level.name);
+            }
+        }
+        return new ArrayList<>(all);
+    }
+}

--- a/saiku-core/saiku-service/src/test/java/org/saiku/service/olap/ai/AiReturnsResolverTest.java
+++ b/saiku-core/saiku-service/src/test/java/org/saiku/service/olap/ai/AiReturnsResolverTest.java
@@ -1,0 +1,114 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.service.olap.ai;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * saiku#782 — resolve bare-caption {@code returns=} tokens into the fully
+ * qualified MDX form Mondrian's {@code DRILLTHROUGH ... RETURN} expects.
+ */
+public class AiReturnsResolverTest {
+
+    private AiSchema schema;
+
+    @Before
+    public void setUp() {
+        // Mini FoodMart-shape: Time / Time By / Year + Quarter; Product /
+        // Products / Product Family; measures Store Sales + Unit Sales.
+        schema = new AiSchema("cube-1", "Sales", "[Sales]");
+
+        schema.measures.put(AiSchema.key("Store Sales"), measure("Store Sales", "[Measures].[Store Sales]"));
+        schema.measures.put(AiSchema.key("Unit Sales"), measure("Unit Sales", "[Measures].[Unit Sales]"));
+
+        AiSchema.Dimension time = new AiSchema.Dimension("Time", "[Time]");
+        AiSchema.Hierarchy timeBy = new AiSchema.Hierarchy("Time By", "[Time].[Time By]");
+        timeBy.levels.put(AiSchema.key("Year"), new AiSchema.Level("Year", "[Time].[Time By].[Year]"));
+        timeBy.levels.put(AiSchema.key("Quarter"), new AiSchema.Level("Quarter", "[Time].[Time By].[Quarter]"));
+        time.hierarchies.put(AiSchema.key("Time By"), timeBy);
+        schema.dimensions.put(AiSchema.key("Time"), time);
+
+        AiSchema.Dimension product = new AiSchema.Dimension("Product", "[Product]");
+        AiSchema.Hierarchy products = new AiSchema.Hierarchy("Products", "[Product].[Products]");
+        products.levels.put(
+                AiSchema.key("Product Family"),
+                new AiSchema.Level("Product Family", "[Product].[Products].[Product Family]"));
+        product.hierarchies.put(AiSchema.key("Products"), products);
+        schema.dimensions.put(AiSchema.key("Product"), product);
+    }
+
+    private static AiSchema.Measure measure(String name, String uniqueName) {
+        return new AiSchema.Measure(name, uniqueName);
+    }
+
+    @Test
+    public void nullReturnsPassesThroughUnchanged() {
+        assertNull(AiReturnsResolver.resolve(null, schema));
+        assertEquals("", AiReturnsResolver.resolve("", schema));
+        assertEquals("  ", AiReturnsResolver.resolve("  ", schema));
+    }
+
+    @Test
+    public void bareCaptionsResolveToQualifiedMdx() {
+        String out = AiReturnsResolver.resolve("Year,Product Family,Store Sales", schema);
+        assertEquals("[Time].[Time By].[Year],[Product].[Products].[Product Family],[Measures].[Store Sales]", out);
+    }
+
+    @Test
+    public void bracketedTokensPassThrough() {
+        String input = "[Time].[Time By].[Year],[Measures].[Store Sales]";
+        assertEquals("pass-through preserves MDX form", input, AiReturnsResolver.resolve(input, schema));
+    }
+
+    @Test
+    public void mixedFormsResolvePerToken() {
+        // First token bracketed (kept), second bare (rewritten).
+        String out = AiReturnsResolver.resolve("[Time].[Time By].[Year],Store Sales", schema);
+        assertEquals("[Time].[Time By].[Year],[Measures].[Store Sales]", out);
+    }
+
+    @Test
+    public void resolutionIsCaseInsensitive() {
+        String out = AiReturnsResolver.resolve("YEAR,store sales", schema);
+        assertEquals("[Time].[Time By].[Year],[Measures].[Store Sales]", out);
+    }
+
+    @Test
+    public void unknownTokenRaisesValidationErrorWithCandidates() {
+        try {
+            AiReturnsResolver.resolve("Year,No Such Column", schema);
+            fail("expected AiValidationException");
+        } catch (AiValidationException e) {
+            assertEquals("returns", e.getField());
+            assertTrue("message names the offending token", e.getMessage().contains("No Such Column"));
+            assertNotNull(e.getAvailable());
+            assertTrue("candidates include 'Store Sales'", e.getAvailable().contains("Store Sales"));
+            assertTrue("candidates include 'Product Family'", e.getAvailable().contains("Product Family"));
+        }
+    }
+
+    @Test
+    public void straySpacesAndEmptyEntriesTolerated() {
+        // Trailing comma and surrounding whitespace must not crash and must
+        // not produce empty MDX entries.
+        String out = AiReturnsResolver.resolve(" Year , , Product Family ,", schema);
+        assertEquals("[Time].[Time By].[Year],[Product].[Products].[Product Family]", out);
+    }
+
+    @Test
+    public void nullSchemaPassesThrough() {
+        // Defensive: when no schema is available the resolver must leave the
+        // value alone — the caller's existing Mondrian-error translation
+        // path handles whatever the raw value produces.
+        assertEquals("Year,Quarter", AiReturnsResolver.resolve("Year,Quarter", null));
+    }
+}

--- a/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/AiQueryResource.java
+++ b/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/AiQueryResource.java
@@ -37,6 +37,7 @@ import org.saiku.service.olap.ai.AiCubeSummary;
 import org.saiku.service.olap.ai.AiQueryMetadata;
 import org.saiku.service.olap.ai.AiQueryRequest;
 import org.saiku.service.olap.ai.AiQueryResponse;
+import org.saiku.service.olap.ai.AiReturnsResolver;
 import org.saiku.service.olap.ai.AiSchema;
 import org.saiku.service.olap.ai.AiSchemaConverter;
 import org.saiku.service.olap.ai.AiValidationException;
@@ -497,8 +498,43 @@ public class AiQueryResource {
             AsyncQueryHandle h = asyncQueryService.get(queryId);
             if (h != null) name = h.getQuery().getName();
         }
+        // saiku#782: agents only have bare captions (the keys of each row in
+        // a drillthrough response) — accept those and rewrite to the fully
+        // qualified MDX form Mondrian's RETURN clause expects. Tokens that
+        // are already bracketed pass through unchanged, so callers that
+        // already speak MDX aren't surprised. Validation errors from the
+        // resolver carry the candidate list so the agent can self-correct
+        // without scraping /schema.
+        String resolvedReturns = returns;
+        if (returns != null && !returns.trim().isEmpty() && cubeMetadataService != null) {
+            try {
+                org.saiku.service.util.QueryContext qc = thinQueryService.getContext(name);
+                if (qc != null && qc.getOlapQuery() != null && qc.getOlapQuery().getCube() != null) {
+                    org.saiku.olap.dto.SaikuCube cube = qc.getOlapQuery().getCube();
+                    AiCubeRef ref =
+                            new AiCubeRef(cube.getConnection(), cube.getCatalog(), cube.getSchema(), cube.getName());
+                    AiSchema schema = cubeMetadataService.getSchema(ref);
+                    resolvedReturns = AiReturnsResolver.resolve(returns, schema);
+                }
+            } catch (AiValidationException ve) {
+                AiQueryResponse resp = new AiQueryResponse();
+                resp.setStatus(AiQueryResponse.Status.VALIDATION_ERROR);
+                resp.setError(ve.getMessage());
+                resp.setField(ve.getField());
+                if (ve.getAvailable() != null) resp.setAvailable(ve.getAvailable());
+                return Response.status(Response.Status.BAD_REQUEST)
+                        .entity(resp)
+                        .type(MediaType.APPLICATION_JSON)
+                        .build();
+            } catch (RuntimeException ignored) {
+                // Schema lookup failure shouldn't poison the drillthrough —
+                // fall through with the raw returns value and let Mondrian
+                // report whatever it reports. The 400-translation block
+                // below handles the typical "in RETURN clause" message.
+            }
+        }
         try {
-            java.sql.ResultSet rs = thinQueryService.drillthrough(name, maxrows, returns);
+            java.sql.ResultSet rs = thinQueryService.drillthrough(name, maxrows, resolvedReturns);
             List<Map<String, AiCell>> rows = new ArrayList<>();
             if (rs != null) {
                 java.sql.ResultSetMetaData md = rs.getMetaData();


### PR DESCRIPTION
## Summary

Closes #782. Restores the AI contract promise — *agents never see MDX* — on the drillthrough endpoint. Previously `?returns=col1,col2` required fully-qualified MDX identifiers, but the row JSON from a drillthrough keys cells by bare caption, leaving no way for an agent to construct a follow-up `returns=` from a previous result short of guessing or re-fetching the schema.

## Before / after

\`\`\`bash
# Before — fails with Mondrian parse error
curl \".../ai/query/\$QID/drillthrough?returns=Year,Product+Family,Store+Sales\"
# → HTTP 500: Mondrian Error: Syntax error at line 4, column 22, token 'Family'

# After — bare captions resolve and succeed
curl \".../ai/query/\$QID/drillthrough?returns=Year,Product+Family,Store+Sales\"
# → HTTP 200 with the projected columns
\`\`\`

Already-bracketed forms still pass through unchanged so callers that already speak MDX aren't surprised.

## How

`AiReturnsResolver` (stateless, pure) rewrites the comma-separated `returns=` value against the cached `AiSchema` for the query's cube. Per-token rules:

- Bracketed (`[...]`) → pass through verbatim.
- Bare token → case-insensitive match against measures (canonical + aliases) then every level across every hierarchy (canonical + aliases). First match wins; its `uniqueName` is substituted.
- No match → typed `AiValidationException` with `field=returns` and a candidate list (every measure + level name) so the agent can self-correct without scraping `/schema`.

`AiQueryResource.drillthrough` looks up the query's cube via `ThinQueryService.getContext(name).getOlapQuery().getCube()`, fetches the `AiSchema`, and resolves `returns` before delegating downstream. Validation errors return a typed 400.

Defensive: if the cube ref is no longer resolvable (e.g. evicted query), the resolver leaves the value alone — the caller's existing \"in RETURN clause\" → 400 translation handles whatever Mondrian reports.

## Tests

`AiReturnsResolverTest` — 8 cases covering null/blank pass-through, bare → qualified, bracketed pass-through, mixed forms, case-insensitivity, unknown-token validation, stray-space tolerance, null-schema fallback.

Test-floor bumped: saiku-core/saiku-service **240 → 248**.

## Out of scope (follow-ups filed separately)

- Same resolver on the Query2 surface (`Query2Resource.drillthrough`) — that path doesn't use `AiSchema` today.
- `docs/AI-QUERY-API.md` documentation of both forms.

## Test plan

- [x] `mvn -pl saiku-core/saiku-service test -Dtest=AiReturnsResolverTest` — 8/8
- [x] `mvn -pl saiku-core/saiku-service test` — 248/248 (1 skipped, pre-existing)
- [x] `mvn -pl saiku-core/saiku-web test` — 37/37
- [x] Spotless applied
- [ ] CI green on push