### PR TITLE
fix(ai): translate Jackson 400s to AiQueryResponse JSON (#791)

### DIFF
--- a/.github/test-floors.json
+++ b/.github/test-floors.json
@@ -2,6 +2,6 @@
   "_": "Per-module test-count floors. CI fails if any module's surefire total drops below its floor — catches accidental test deletions. Bump explicitly when adding tests. Floors set during Phase 4 / saiku#8 with totals from feat/platform-improvements.",
   "modules": {
     "saiku-core/saiku-service": 240,
-    "saiku-core/saiku-web": 40
+    "saiku-core/saiku-web": 44
   }
 }

--- a/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/SaikuJerseyApplication.java
+++ b/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/SaikuJerseyApplication.java
@@ -12,6 +12,10 @@ public class SaikuJerseyApplication extends ResourceConfig {
 
     public SaikuJerseyApplication(@Context ServletContext servletContext) {
         register(MultiPartFeature.class);
+        // saiku#791: translate Jackson deserialisation failures into the
+        // typed AiQueryResponse 400 envelope instead of the raw text/plain
+        // Jackson message that leaked class names and source location.
+        register(org.saiku.web.rest.exception.JacksonValidationExceptionMapper.class);
 
         ApplicationContext ctx = WebApplicationContextUtils.getRequiredWebApplicationContext(servletContext);
         for (String name : ctx.getBeanNamesForAnnotation(Path.class)) {

--- a/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/exception/JacksonValidationExceptionMapper.java
+++ b/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/exception/JacksonValidationExceptionMapper.java
@@ -1,0 +1,109 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.web.rest.exception;
+
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.exc.UnrecognizedPropertyException;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.ext.ExceptionMapper;
+import jakarta.ws.rs.ext.Provider;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import org.saiku.service.olap.ai.AiQueryResponse;
+
+/**
+ * saiku#791 — translate Jackson deserialisation failures into the typed
+ * {@link AiQueryResponse} 400 envelope used by every other validation path
+ * on the AI Query API.
+ *
+ * <p>Without this provider, an unknown field on the request body (typo, old
+ * client, missing key) returns an HTTP 400 with raw Jackson text in
+ * {@code text/plain} — class names, source locations, the
+ * {@code StreamReadFeature.INCLUDE_SOURCE_IN_LOCATION} implementation
+ * detail. Agents that parse the JSON contract (status / field / error /
+ * available[]) for every other validation case have to special-case this
+ * one path. Worse, the message leaks server-internal class names.
+ *
+ * <p>This mapper catches {@link JsonMappingException} (and the
+ * {@code UnrecognizedProperty} subclass), pulls the field path from the
+ * {@code referencePath}, and returns a clean
+ * {@code 400 application/json} body in the same {@link AiQueryResponse}
+ * shape so the agent's existing error-handling code Just Works.
+ *
+ * <p>Scoped to JSON-shape errors only — domain validation continues to flow
+ * through {@code AiValidationException} in the resources, which has more
+ * context than Jackson can provide.
+ */
+@Provider
+public class JacksonValidationExceptionMapper implements ExceptionMapper<JsonMappingException> {
+
+    @Override
+    public Response toResponse(JsonMappingException e) {
+        AiQueryResponse resp = new AiQueryResponse();
+        resp.setStatus(AiQueryResponse.Status.VALIDATION_ERROR);
+
+        String field = fieldFromPath(e);
+        if (field != null) resp.setField(field);
+
+        if (e instanceof UnrecognizedPropertyException) {
+            UnrecognizedPropertyException upe = (UnrecognizedPropertyException) e;
+            // Pulled from the deserialiser's known-properties list. Sorted so
+            // the response is stable across JVMs (Jackson uses a Set internally).
+            List<String> known = new ArrayList<>();
+            Collection<Object> ids = upe.getKnownPropertyIds();
+            if (ids != null) {
+                for (Object id : ids) known.add(String.valueOf(id));
+            }
+            java.util.Collections.sort(known);
+            resp.setAvailable(known);
+            String propName = upe.getPropertyName();
+            String typeName =
+                    upe.getReferringClass() != null ? upe.getReferringClass().getSimpleName() : "request";
+            resp.setError("Unknown field '" + propName + "' on " + typeName
+                    + (known.isEmpty() ? "." : ". Known fields: " + String.join(", ", known) + "."));
+        } else {
+            // Non-unknown-field JSON mapping failure (type mismatch, bad enum
+            // value, malformed nested structure). The Jackson message is the
+            // useful part — strip the source-location noise and ship the rest.
+            resp.setError(cleanMessage(e.getOriginalMessage() != null ? e.getOriginalMessage() : e.getMessage()));
+        }
+
+        return Response.status(Response.Status.BAD_REQUEST)
+                .type(MediaType.APPLICATION_JSON)
+                .entity(resp)
+                .build();
+    }
+
+    /** Build a dotted/bracketed field path from Jackson's referencePath.
+     *  Example: {@code rows[0].members[2]}. */
+    private static String fieldFromPath(JsonMappingException e) {
+        List<JsonMappingException.Reference> path = e.getPath();
+        if (path == null || path.isEmpty()) return null;
+        StringBuilder sb = new StringBuilder();
+        for (JsonMappingException.Reference ref : path) {
+            if (ref.getFieldName() != null) {
+                if (sb.length() > 0) sb.append('.');
+                sb.append(ref.getFieldName());
+            } else if (ref.getIndex() >= 0) {
+                sb.append('[').append(ref.getIndex()).append(']');
+            }
+        }
+        return sb.length() > 0 ? sb.toString() : null;
+    }
+
+    /** Strip Jackson's location suffix ({@code " at [Source: ...]"}) which
+     *  leaks the {@code StreamReadFeature.INCLUDE_SOURCE_IN_LOCATION}
+     *  implementation detail. */
+    private static String cleanMessage(String msg) {
+        if (msg == null) return null;
+        int at = msg.indexOf("\n at [Source");
+        if (at >= 0) return msg.substring(0, at).trim();
+        at = msg.indexOf(" at [Source");
+        if (at >= 0) return msg.substring(0, at).trim();
+        return msg;
+    }
+}

--- a/saiku-core/saiku-web/src/test/java/org/saiku/web/rest/exception/JacksonValidationExceptionMapperTest.java
+++ b/saiku-core/saiku-web/src/test/java/org/saiku/web/rest/exception/JacksonValidationExceptionMapperTest.java
@@ -1,0 +1,115 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.web.rest.exception;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.exc.UnrecognizedPropertyException;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import java.util.Arrays;
+import java.util.LinkedHashSet;
+import org.junit.Test;
+import org.saiku.service.olap.ai.AiQueryRequest;
+import org.saiku.service.olap.ai.AiQueryResponse;
+
+/**
+ * saiku#791 — pin the Jackson → AiQueryResponse 400 envelope.
+ */
+public class JacksonValidationExceptionMapperTest {
+
+    private final JacksonValidationExceptionMapper mapper = new JacksonValidationExceptionMapper();
+
+    @Test
+    public void unrecognizedPropertyMapsToTypedEnvelopeWithSortedAvailable() throws Exception {
+        // Drive the real Jackson path so we get a fully-populated UPE with a
+        // live JsonParser context. Synthetic UPE.from(null, ...) NPEs out of
+        // currentLocation() — not the path the production code ever sees.
+        ObjectMapper om = new ObjectMapper();
+        String wire = "{\"foobar\":\"typo\"}";
+        UnrecognizedPropertyException upe;
+        try {
+            om.readValue(wire, AiQueryRequest.class);
+            throw new AssertionError("expected UPE from real-Jackson parse");
+        } catch (UnrecognizedPropertyException caught) {
+            upe = caught;
+        }
+
+        Response r = mapper.toResponse(upe);
+
+        assertEquals(400, r.getStatus());
+        assertEquals(MediaType.APPLICATION_JSON_TYPE, r.getMediaType());
+
+        AiQueryResponse body = (AiQueryResponse) r.getEntity();
+        assertEquals(AiQueryResponse.Status.VALIDATION_ERROR, body.getStatus());
+        assertEquals("foobar", body.getField());
+        assertNotNull(body.getError());
+        assertTrue("error names the bad field", body.getError().contains("foobar"));
+        assertTrue("error names the type", body.getError().contains("AiQueryRequest"));
+
+        // Known fields list is sorted so consumers can rely on stable
+        // ordering — Jackson's underlying Set has no guarantee.
+        java.util.List<String> avail = body.getAvailable();
+        assertNotNull(avail);
+        java.util.List<String> sorted = new java.util.ArrayList<>(avail);
+        java.util.Collections.sort(sorted);
+        assertEquals("available[] is already sorted", sorted, avail);
+        assertTrue("available[] contains known fields", avail.contains("cube"));
+        assertTrue("available[] contains known fields", avail.contains("rows"));
+        assertTrue("available[] contains known fields", avail.contains("measures"));
+    }
+
+    @Test
+    public void messageStripsSourceLocationNoise() {
+        JsonMappingException jme = new JsonMappingException(
+                (JsonParser) null,
+                "Cannot deserialize value of type `int` from String \"abc\"\n at [Source: REDACTED;"
+                        + " line: 1, column: 42]");
+        Response r = mapper.toResponse(jme);
+        AiQueryResponse body = (AiQueryResponse) r.getEntity();
+        assertNotNull(body.getError());
+        assertFalse("source location stripped", body.getError().contains("Source"));
+        assertFalse("line/column noise stripped", body.getError().contains("line: 1"));
+        assertTrue("original message preserved", body.getError().startsWith("Cannot deserialize"));
+    }
+
+    @Test
+    public void fieldPathBuiltFromRealJacksonParse() {
+        // Drive the real Jackson path: deserialise a payload with an unknown
+        // top-level field, catch the exception, run through the mapper.
+        ObjectMapper om = new ObjectMapper();
+        String body = "{\"foobar\":\"typo\"}";
+        try {
+            om.readValue(body, AiQueryRequest.class);
+        } catch (JsonMappingException e) {
+            Response r = mapper.toResponse(e);
+            AiQueryResponse env = (AiQueryResponse) r.getEntity();
+            assertEquals("foobar", env.getField());
+            assertEquals(AiQueryResponse.Status.VALIDATION_ERROR, env.getStatus());
+            return;
+        } catch (Exception other) {
+            throw new AssertionError("expected JsonMappingException, got " + other.getClass(), other);
+        }
+        throw new AssertionError("expected the unknown-field parse to throw");
+    }
+
+    @Test
+    public void noPathReturnsNullField() {
+        // Defensive: a JsonMappingException with no path should not crash and
+        // should not produce a stale "field" value on the wire.
+        JsonMappingException jme = new JsonMappingException((JsonParser) null, "boom");
+        Response r = mapper.toResponse(jme);
+        AiQueryResponse body = (AiQueryResponse) r.getEntity();
+        assertEquals(AiQueryResponse.Status.VALIDATION_ERROR, body.getStatus());
+        assertNull(body.getField());
+    }
+}


### PR DESCRIPTION
Closes #791. Unknown fields on the AI Query body used to return text/plain 400 with raw Jackson noise (class names, source location, REDACTED). New JAX-RS ExceptionMapper returns the typed AiQueryResponse envelope with status=VALIDATION_ERROR, field path from referencePath, sorted available[] from getKnownPropertyIds(). Registered in SaikuJerseyApplication so every JSON endpoint benefits. 4 tests; test-floor saiku-web 40→44.