### PR TITLE
fix(ai-async): distinguish ALREADY_COMPLETED from CANCELLED (#792)

### DIFF
--- a/.github/test-floors.json
+++ b/.github/test-floors.json
@@ -2,6 +2,6 @@
   "_": "Per-module test-count floors. CI fails if any module's surefire total drops below its floor — catches accidental test deletions. Bump explicitly when adding tests. Floors set during Phase 4 / saiku#8 with totals from feat/platform-improvements.",
   "modules": {
     "saiku-core/saiku-service": 240,
-    "saiku-core/saiku-web": 40
+    "saiku-core/saiku-web": 43
   }
 }

--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/async/AsyncQueryService.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/async/AsyncQueryService.java
@@ -211,6 +211,15 @@ public class AsyncQueryService {
         return h;
     }
 
+    /** Register a pre-built handle. Used by tests that need to exercise
+     *  resource-layer logic against a known {@link AsyncQueryHandle.Status}
+     *  without driving a real executor — production submission flows through
+     *  {@link #submit(ThinQuery)}, never this. */
+    public void register(AsyncQueryHandle h) {
+        if (h == null) return;
+        handles.put(h.getId(), h);
+    }
+
     /**
      * Fetch the completed CellSet for {@code id}. Marks the handle as
      * result-fetched so the sweeper can evict it after the idle window.

--- a/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/AiQueryResource.java
+++ b/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/AiQueryResource.java
@@ -465,10 +465,30 @@ public class AiQueryResource {
     @Produces(MediaType.APPLICATION_JSON)
     public Response asyncCancel(@PathParam("queryId") String queryId) {
         if (asyncQueryService == null) return error("Async service not configured");
-        boolean ok = asyncQueryService.cancel(queryId);
-        if (!ok) return Response.status(Response.Status.NOT_FOUND).build();
+        // saiku#792: probe the current state BEFORE attempting cancel so an
+        // already-finished query reports ALREADY_COMPLETED / ALREADY_FAILED
+        // instead of a misleading CANCELLED. Idempotent retries on an
+        // already-cancelled handle still return CANCELLED (so the response
+        // shape stays stable for "I asked twice").
+        AsyncQueryHandle h = asyncQueryService.get(queryId);
+        if (h == null) return Response.status(Response.Status.NOT_FOUND).build();
+        AsyncQueryHandle.Status before = h.getStatus();
         Map<String, Object> body = new LinkedHashMap<>();
         body.put("queryId", queryId);
+        if (before == AsyncQueryHandle.Status.DONE) {
+            body.put("status", "ALREADY_COMPLETED");
+            return Response.ok(body).type(MediaType.APPLICATION_JSON).build();
+        }
+        if (before == AsyncQueryHandle.Status.FAILED) {
+            body.put("status", "ALREADY_FAILED");
+            return Response.ok(body).type(MediaType.APPLICATION_JSON).build();
+        }
+        if (before == AsyncQueryHandle.Status.CANCELLED) {
+            body.put("status", "CANCELLED");
+            return Response.ok(body).type(MediaType.APPLICATION_JSON).build();
+        }
+        boolean ok = asyncQueryService.cancel(queryId);
+        if (!ok) return Response.status(Response.Status.NOT_FOUND).build();
         body.put("status", "CANCELLED");
         return Response.ok(body).type(MediaType.APPLICATION_JSON).build();
     }

--- a/saiku-core/saiku-web/src/test/java/org/saiku/web/rest/resources/AiQueryResourceTest.java
+++ b/saiku-core/saiku-web/src/test/java/org/saiku/web/rest/resources/AiQueryResourceTest.java
@@ -321,6 +321,72 @@ public class AiQueryResourceTest {
         }
     }
 
+    /** saiku#792: cancel on a DONE handle must report ALREADY_COMPLETED, not
+     *  the misleading CANCELLED the legacy path used to return. */
+    @Test
+    public void asyncCancelReturnsAlreadyCompletedForFinishedQuery() {
+        org.saiku.service.async.AsyncQueryService async = new org.saiku.service.async.AsyncQueryService();
+        async.setThinQueryService(new StubThinQueryService());
+        try {
+            resource.setAsyncQueryService(async);
+            org.saiku.olap.query2.ThinQuery tq = new org.saiku.olap.query2.ThinQuery();
+            tq.setName("done-query");
+            org.saiku.service.async.AsyncQueryHandle h = new org.saiku.service.async.AsyncQueryHandle("done-id", tq);
+            h.setStatus(org.saiku.service.async.AsyncQueryHandle.Status.DONE);
+            async.register(h);
+            Response resp = resource.asyncCancel("done-id");
+            assertEquals(200, resp.getStatus());
+            @SuppressWarnings("unchecked")
+            Map<String, Object> body = (Map<String, Object>) resp.getEntity();
+            assertEquals("ALREADY_COMPLETED", body.get("status"));
+        } finally {
+            async.shutdown();
+        }
+    }
+
+    @Test
+    public void asyncCancelReturnsAlreadyFailedForFailedQuery() {
+        org.saiku.service.async.AsyncQueryService async = new org.saiku.service.async.AsyncQueryService();
+        async.setThinQueryService(new StubThinQueryService());
+        try {
+            resource.setAsyncQueryService(async);
+            org.saiku.olap.query2.ThinQuery tq = new org.saiku.olap.query2.ThinQuery();
+            tq.setName("failed-query");
+            org.saiku.service.async.AsyncQueryHandle h = new org.saiku.service.async.AsyncQueryHandle("failed-id", tq);
+            h.setStatus(org.saiku.service.async.AsyncQueryHandle.Status.FAILED);
+            async.register(h);
+            Response resp = resource.asyncCancel("failed-id");
+            assertEquals(200, resp.getStatus());
+            @SuppressWarnings("unchecked")
+            Map<String, Object> body = (Map<String, Object>) resp.getEntity();
+            assertEquals("ALREADY_FAILED", body.get("status"));
+        } finally {
+            async.shutdown();
+        }
+    }
+
+    @Test
+    public void asyncCancelIsIdempotentForCancelledQuery() {
+        org.saiku.service.async.AsyncQueryService async = new org.saiku.service.async.AsyncQueryService();
+        async.setThinQueryService(new StubThinQueryService());
+        try {
+            resource.setAsyncQueryService(async);
+            org.saiku.olap.query2.ThinQuery tq = new org.saiku.olap.query2.ThinQuery();
+            tq.setName("cancelled-query");
+            org.saiku.service.async.AsyncQueryHandle h =
+                    new org.saiku.service.async.AsyncQueryHandle("cancelled-id", tq);
+            h.setStatus(org.saiku.service.async.AsyncQueryHandle.Status.CANCELLED);
+            async.register(h);
+            Response resp = resource.asyncCancel("cancelled-id");
+            assertEquals(200, resp.getStatus());
+            @SuppressWarnings("unchecked")
+            Map<String, Object> body = (Map<String, Object>) resp.getEntity();
+            assertEquals("CANCELLED", body.get("status"));
+        } finally {
+            async.shutdown();
+        }
+    }
+
     @Test
     public void executeAiAsyncReturns500WithoutAsyncService() {
         resource.setAsyncQueryService(null);


### PR DESCRIPTION
Closes #792. asyncCancel probes the handle's current state and returns ALREADY_COMPLETED / ALREADY_FAILED / idempotent CANCELLED instead of always CANCELLED. 3 new tests; test-floor saiku-web 40→43.