### PR TITLE
fix(ai-drillthrough): disambiguate duplicate column labels (#800)

### DIFF
--- a/.github/test-floors.json
+++ b/.github/test-floors.json
@@ -2,6 +2,6 @@
   "_": "Per-module test-count floors. CI fails if any module's surefire total drops below its floor — catches accidental test deletions. Bump explicitly when adding tests. Floors set during Phase 4 / saiku#8 with totals from feat/platform-improvements.",
   "modules": {
     "saiku-core/saiku-service": 240,
-    "saiku-core/saiku-web": 40
+    "saiku-core/saiku-web": 44
   }
 }

--- a/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/AiQueryResource.java
+++ b/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/AiQueryResource.java
@@ -501,14 +501,26 @@ public class AiQueryResource {
         try {
             java.sql.ResultSet rs = thinQueryService.drillthrough(name, maxrows, firstRowset, returns);
             List<Map<String, AiCell>> rows = new ArrayList<>();
+            List<String> columnLabels = new ArrayList<>();
             if (rs != null) {
                 java.sql.ResultSetMetaData md = rs.getMetaData();
                 int colCount = md.getColumnCount();
+                // saiku#800: Mondrian's drillthrough sometimes returns the same
+                // getColumnLabel() for multiple columns within a hierarchy
+                // (e.g. Year + Quarter + Month all labelled "Quarter"). Pre-
+                // compute disambiguated keys ONCE before the row loop so:
+                //   * the first occurrence keeps its raw label (back-compat)
+                //   * subsequent duplicates fall back to getColumnName(c) when
+                //     that differs, else to a positional suffix _2, _3, ...
+                // Without this, every row's Map.put silently overwrote the
+                // earlier column, leaving the first column labelled with the
+                // LAST column's value — silent data corruption.
+                columnLabels = disambiguateColumnLabels(md);
                 while (rs.next()) {
                     Map<String, AiCell> row = new LinkedHashMap<>();
                     for (int c = 1; c <= colCount; c++) {
                         Object v = rs.getObject(c);
-                        row.put(md.getColumnLabel(c), toCellFromObject(v));
+                        row.put(columnLabels.get(c - 1), toCellFromObject(v));
                     }
                     rows.add(row);
                 }
@@ -517,6 +529,9 @@ public class AiQueryResource {
             Map<String, Object> body = new LinkedHashMap<>();
             body.put("queryId", queryId);
             body.put("rowCount", rows.size());
+            // saiku#800: explicit columns[] so agents can read by position
+            // when the label heuristic still leaves ambiguity.
+            body.put("columns", columnLabels);
             body.put("rows", rows);
             return Response.ok(body).type(MediaType.APPLICATION_JSON).build();
         } catch (NullPointerException e) {
@@ -765,6 +780,48 @@ public class AiQueryResource {
         Double parsed = AiCell.parseValueFromFormatted(s);
         String unit = AiCell.sniffUnit(s);
         return new AiCell(parsed, s, unit);
+    }
+
+    /**
+     * saiku#800: build a per-column key list that survives Mondrian's habit
+     * of returning the same {@code getColumnLabel(c)} for multiple drill-
+     * through columns within a hierarchy (e.g. Year/Quarter/Month all
+     * labelled "Quarter"). First occurrence keeps its raw label; subsequent
+     * collisions try {@code getColumnName(c)} as a tiebreaker and finally
+     * fall back to a {@code _N} positional suffix. Order-preserving so the
+     * returned list aligns with column indexes 1..colCount.
+     */
+    static List<String> disambiguateColumnLabels(java.sql.ResultSetMetaData md) throws java.sql.SQLException {
+        int colCount = md.getColumnCount();
+        List<String> out = new ArrayList<>(colCount);
+        java.util.Set<String> seen = new java.util.LinkedHashSet<>();
+        for (int c = 1; c <= colCount; c++) {
+            String label = md.getColumnLabel(c);
+            if (label == null || label.isEmpty()) label = "col_" + c;
+            String chosen = label;
+            if (seen.contains(chosen)) {
+                String alt = null;
+                try {
+                    alt = md.getColumnName(c);
+                } catch (java.sql.SQLException ignore) {
+                    // Some drivers don't implement getColumnName — fall through.
+                }
+                if (alt != null && !alt.isEmpty() && !seen.contains(alt) && !alt.equals(label)) {
+                    chosen = alt;
+                } else {
+                    int n = 2;
+                    String candidate;
+                    do {
+                        candidate = label + "_" + n;
+                        n++;
+                    } while (seen.contains(candidate));
+                    chosen = candidate;
+                }
+            }
+            seen.add(chosen);
+            out.add(chosen);
+        }
+        return out;
     }
 
     /** Convert a raw {@link AbstractBaseCell} into an {@link AiCell}. */

--- a/saiku-core/saiku-web/src/test/java/org/saiku/web/rest/resources/AiQueryResourceColumnDisambiguationTest.java
+++ b/saiku-core/saiku-web/src/test/java/org/saiku/web/rest/resources/AiQueryResourceColumnDisambiguationTest.java
@@ -1,0 +1,91 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.web.rest.resources;
+
+import static org.junit.Assert.assertEquals;
+
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+import java.sql.ResultSetMetaData;
+import java.util.Arrays;
+import java.util.List;
+import org.junit.Test;
+
+/**
+ * saiku#800 — pin the drillthrough column-label disambiguation. Mondrian
+ * sometimes returns the same {@code getColumnLabel(c)} for several
+ * time-hierarchy columns (e.g. Year + Quarter + Month all labelled
+ * "Quarter"). Before the fix the row Map.put silently overwrote earlier
+ * columns. Now the first occurrence keeps its label; later collisions fall
+ * back to {@code getColumnName(c)} when distinct, else to a positional
+ * suffix.
+ */
+public class AiQueryResourceColumnDisambiguationTest {
+
+    @Test
+    public void distinctLabelsPassThrough() throws Exception {
+        List<String> out = AiQueryResource.disambiguateColumnLabels(md(
+                new String[] {"Year", "Quarter", "Month", "Store Sales"},
+                new String[] {"Year", "Quarter", "Month", "Store Sales"}));
+        assertEquals(Arrays.asList("Year", "Quarter", "Month", "Store Sales"), out);
+    }
+
+    @Test
+    public void duplicateLabelFallsBackToColumnNameWhenDistinct() throws Exception {
+        // Label collision on "Quarter" — but the underlying column NAME
+        // (a different metadata field) differs and isn't itself a duplicate
+        // of the label, so the tiebreaker uses it. First col keeps the raw
+        // label so we don't yank back-compat from existing consumers.
+        List<String> out = AiQueryResource.disambiguateColumnLabels(md(
+                new String[] {"Quarter", "Quarter", "Quarter"},
+                new String[] {"yearCol", "quarterCol", "monthCol"}));
+        assertEquals(Arrays.asList("Quarter", "quarterCol", "monthCol"), out);
+    }
+
+    @Test
+    public void duplicateLabelFallsBackToPositionalSuffix() throws Exception {
+        // Both label and name collide — only the positional suffix saves us.
+        List<String> out = AiQueryResource.disambiguateColumnLabels(
+                md(new String[] {"Quarter", "Quarter", "Quarter"}, new String[] {"Quarter", "Quarter", "Quarter"}));
+        assertEquals(Arrays.asList("Quarter", "Quarter_2", "Quarter_3"), out);
+    }
+
+    @Test
+    public void nullOrEmptyLabelGetsColPlaceholder() throws Exception {
+        List<String> out = AiQueryResource.disambiguateColumnLabels(
+                md(new String[] {null, "", "Store Sales"}, new String[] {"a", "b", "Store Sales"}));
+        assertEquals(Arrays.asList("col_1", "col_2", "Store Sales"), out);
+    }
+
+    /** Build a Proxy-based ResultSetMetaData backed by parallel label/name arrays. */
+    private static ResultSetMetaData md(final String[] labels, final String[] names) {
+        InvocationHandler h = new InvocationHandler() {
+            @Override
+            public Object invoke(Object p, Method m, Object[] args) {
+                switch (m.getName()) {
+                    case "getColumnCount":
+                        return labels.length;
+                    case "getColumnLabel":
+                        return labels[((Integer) args[0]) - 1];
+                    case "getColumnName":
+                        return names[((Integer) args[0]) - 1];
+                    case "toString":
+                        return "ResultSetMetaData@fake";
+                    case "equals":
+                        return p == args[0];
+                    case "hashCode":
+                        return System.identityHashCode(p);
+                    default:
+                        return null;
+                }
+            }
+        };
+        return (ResultSetMetaData) Proxy.newProxyInstance(
+                AiQueryResourceColumnDisambiguationTest.class.getClassLoader(),
+                new Class<?>[] {ResultSetMetaData.class},
+                h);
+    }
+}


### PR DESCRIPTION
Closes #800. Mondrian's drillthrough metadata returns the same getColumnLabel() for multiple columns in a hierarchy — Year/Quarter/Month all labelled 'Quarter' — and the row Map.put silently overwrote earlier columns. New disambiguateColumnLabels(md) precomputes unique keys before the row loop, with column-name tiebreaker and positional suffix fallback. Response also adds a columns[] array so agents can read positionally. 4 new tests; test-floor saiku-web 40→44.