### PR TITLE
fix(ai): flatten measures-only response to single record (#803)

### DIFF
--- a/.github/test-floors.json
+++ b/.github/test-floors.json
@@ -2,6 +2,6 @@
   "_": "Per-module test-count floors. CI fails if any module's surefire total drops below its floor — catches accidental test deletions. Bump explicitly when adding tests. Floors set during Phase 4 / saiku#8 with totals from feat/platform-improvements.",
   "modules": {
     "saiku-core/saiku-service": 240,
-    "saiku-core/saiku-web": 40
+    "saiku-core/saiku-web": 41
   }
 }

--- a/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/AiQueryResource.java
+++ b/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/AiQueryResource.java
@@ -708,7 +708,41 @@ public class AiQueryResource {
                 }
             }
 
-            if (body != null) {
+            // saiku#803: measures-only queries (no rows axis on the request)
+            // render with the measure captions as a header row that lands in
+            // body[0] and the values in body[1]. The standard renderer below
+            // treats both as row-headers, producing the awkward
+            // {row0:"Unit Sales", row1:"Store Sales"} / {row0:"266,773"}
+            // shape. Detect that case and flatten to a single record keyed by
+            // measure caption with typed AiCell values — matching every other
+            // query shape on the API.
+            boolean measuresOnly = body != null
+                    && body.length == 2
+                    && rowHeaderCount == totalWidth
+                    && totalWidth > 0
+                    && body[0] != null
+                    && body[1] != null
+                    && allMemberCells(body[0])
+                    && allDataCells(body[1]);
+            if (measuresOnly) {
+                if (useMatrix) {
+                    Map<String, AiCell> cells = new LinkedHashMap<>();
+                    for (int c = 0; c < totalWidth; c++) {
+                        cells.put(String.valueOf(c), toCell(body[1][c]));
+                    }
+                    matrix.add(cells);
+                    rows.add(new AiQueryMetadata.Caption("", ""));
+                } else {
+                    Map<String, Object> record = new LinkedHashMap<>();
+                    for (int c = 0; c < totalWidth; c++) {
+                        String key = body[0][c] == null ? ("col" + c) : safe(body[0][c].getFormattedValue());
+                        if (key.isEmpty()) key = "col" + c;
+                        record.put(key, toCell(body[1][c]));
+                    }
+                    records.add(record);
+                    rows.add(new AiQueryMetadata.Caption("", ""));
+                }
+            } else if (body != null) {
                 for (AbstractBaseCell[] row : body) {
                     rows.add(
                             new AiQueryMetadata.Caption(rowName(row, rowHeaderCount), rowCaption(row, rowHeaderCount)));
@@ -793,6 +827,26 @@ public class AiQueryResource {
         int n = 0;
         while (n < first.length && first[n] instanceof MemberCell) n++;
         return n;
+    }
+
+    /** saiku#803: every cell in the row is a MemberCell (caption). Used to
+     *  detect the measures-only header-leaked-into-body shape. */
+    private static boolean allMemberCells(AbstractBaseCell[] row) {
+        if (row == null || row.length == 0) return false;
+        for (AbstractBaseCell c : row) {
+            if (!(c instanceof MemberCell)) return false;
+        }
+        return true;
+    }
+
+    /** saiku#803: every cell in the row is a DataCell. Paired with
+     *  {@link #allMemberCells} to identify the measures-only flatten case. */
+    private static boolean allDataCells(AbstractBaseCell[] row) {
+        if (row == null || row.length == 0) return false;
+        for (AbstractBaseCell c : row) {
+            if (!(c instanceof org.saiku.olap.dto.resultset.DataCell)) return false;
+        }
+        return true;
     }
 
     private static String rowName(AbstractBaseCell[] row, int rowHeaderCount) {

--- a/saiku-core/saiku-web/src/test/java/org/saiku/web/rest/resources/AiQueryResourceTest.java
+++ b/saiku-core/saiku-web/src/test/java/org/saiku/web/rest/resources/AiQueryResourceTest.java
@@ -5,6 +5,7 @@
 package org.saiku.web.rest.resources;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
@@ -308,6 +309,46 @@ public class AiQueryResourceTest {
         }
     }
 
+    /** saiku#803: measures-only query (no rows) must flatten to a single
+     *  record keyed by measure caption with typed AiCell values, not the
+     *  awkward row0/row1 two-record header-+-data shape. */
+    @Test
+    public void measuresOnlyQueryFlattensToSingleRecordWithTypedCells() {
+        // Extend the fixture schema with Unit Sales for this test only.
+        schema.measures.put(AiSchema.key("Unit Sales"), new AiSchema.Measure("Unit Sales", "[Measures].[Unit Sales]"));
+        resource.setThinQueryService(new ThinQueryService() {
+            @Override
+            public CellDataSet execute(ThinQuery tq) {
+                return buildMeasuresOnlyCellDataSet();
+            }
+        });
+        AiQueryRequest req = new AiQueryRequest();
+        req.setCube(new AiCubeRef("foodmart", "FoodMart", "FoodMart", "Sales"));
+        req.setMeasures(
+                java.util.Arrays.asList(new AiMeasureSelection("Unit Sales"), new AiMeasureSelection("Store Sales")));
+        // No rows — measures-only.
+
+        Response resp = resource.executeAi(req, "records");
+        // Surface the error message if anything ahead of the renderer bounced it.
+        if (resp.getStatus() != 200) {
+            AiQueryResponse bad = (AiQueryResponse) resp.getEntity();
+            throw new AssertionError(
+                    "expected 200, got " + resp.getStatus() + " field=" + bad.getField() + " error=" + bad.getError());
+        }
+
+        AiQueryResponse body = (AiQueryResponse) resp.getEntity();
+        assertEquals("single record (not 2)", 1, body.getData().size());
+        Map<String, Object> rec = body.getData().get(0);
+        assertTrue("Unit Sales keyed by caption", rec.containsKey("Unit Sales"));
+        assertTrue("Store Sales keyed by caption", rec.containsKey("Store Sales"));
+        AiCell us = (AiCell) rec.get("Unit Sales");
+        assertEquals("typed AiCell with formatted", "266,773", us.getFormatted());
+        AiCell ss = (AiCell) rec.get("Store Sales");
+        assertEquals("typed AiCell with formatted", "565,238.13", ss.getFormatted());
+        assertFalse("no row0/row1 keys leaked", rec.containsKey("row0"));
+        assertFalse("no row0/row1 keys leaked", rec.containsKey("row1"));
+    }
+
     @Test
     public void asyncCancelReturns404OnUnknownId() {
         org.saiku.service.async.AsyncQueryService async = new org.saiku.service.async.AsyncQueryService();
@@ -535,6 +576,27 @@ public class AiQueryResourceTest {
         if (rt == double.class) return 0.0;
         if (rt == void.class) return null;
         return null;
+    }
+
+    /** saiku#803: measures-only body shape — body[0] is all MemberCells
+     *  (measure captions), body[1] is all DataCells (the values). */
+    static CellDataSet buildMeasuresOnlyCellDataSet() {
+        CellDataSet cds = new CellDataSet(2, 2);
+        cds.setCellSetHeaders(new AbstractBaseCell[][] {});
+        AbstractBaseCell h0 = new MemberCell(false, false);
+        h0.setFormattedValue("Unit Sales");
+        AbstractBaseCell h1 = new MemberCell(false, false);
+        h1.setFormattedValue("Store Sales");
+        AbstractBaseCell d0 = new DataCell(true, false, null);
+        d0.setFormattedValue("266,773");
+        d0.setRawValue("266773");
+        AbstractBaseCell d1 = new DataCell(true, false, null);
+        d1.setFormattedValue("565,238.13");
+        d1.setRawValue("565238.13");
+        cds.setCellSetBody(new AbstractBaseCell[][] {
+            new AbstractBaseCell[] {h0, h1}, new AbstractBaseCell[] {d0, d1},
+        });
+        return cds;
     }
 
     static CellDataSet buildStubCellDataSet() {


### PR DESCRIPTION
Closes #803. Measures-only queries used to return two records (captions + raw-string values). Now flattens to a single record keyed by measure caption with typed AiCell values, matching every other query shape. Test-floor saiku-web 40→41.