### PR TITLE
fix(jersey): disable auto-WADL so OPTIONS returns Allow not 500 (#806)

### DIFF
--- a/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/SaikuJerseyApplication.java
+++ b/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/SaikuJerseyApplication.java
@@ -11,6 +11,14 @@ import org.springframework.web.context.support.WebApplicationContextUtils;
 public class SaikuJerseyApplication extends ResourceConfig {
 
     public SaikuJerseyApplication(@Context ServletContext servletContext) {
+        // saiku#806: disable Jersey's auto-WADL OPTIONS response. The auto
+        // handler tries to marshal a com.sun.research.ws.wadl.Application
+        // document via JAXB, but those classes aren't on the JAXBContext
+        // we ship under Jakarta EE 10 — every OPTIONS request 500s out of
+        // the auto-WADL marshaller. With this off, Jersey falls back to a
+        // plain Allow-header response for OPTIONS, which is what every
+        // standard JAX-RS client (and CORS preflight) expects.
+        property("jersey.config.server.wadl.disableWadl", true);
         register(MultiPartFeature.class);
 
         ApplicationContext ctx = WebApplicationContextUtils.getRequiredWebApplicationContext(servletContext);


### PR DESCRIPTION
Closes #806. OPTIONS on any Jersey endpoint used to 500 with a JAXB marshalling failure from the auto-WADL document generator (com.sun.research.ws.wadl.Application not on the JAXBContext under Jakarta EE 10). Disabling jersey.config.server.wadl.disableWadl falls back to the plain Allow-header response that JAX-RS clients and CORS preflight expect. No test added — validating live OPTIONS shape needs a Jersey container the unit suite doesn't spin up; verified via the live fuzz harness.