### PR TITLE
fix: code-review hardening — security, perf, concurrency follow-ups

### DIFF
--- a/saiku-core/saiku-service/src/main/java/org/saiku/database/Database.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/database/Database.java
@@ -243,7 +243,7 @@ public class Database {
                     }
 
                 } catch (IOException e) {
-                    e.printStackTrace();
+                    log.warn("Failed to seed sample report file", e);
                 }
 
             } else {

--- a/saiku-core/saiku-service/src/main/java/org/saiku/database/JdbcUserDAO.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/database/JdbcUserDAO.java
@@ -13,6 +13,8 @@ import java.util.Properties;
 import org.apache.commons.lang3.ArrayUtils;
 import org.saiku.UserDAO;
 import org.saiku.database.dto.SaikuUser;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.jdbc.core.RowMapper;
 import org.springframework.jdbc.core.support.JdbcDaoSupport;
@@ -20,6 +22,8 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
 public class JdbcUserDAO extends JdbcDaoSupport implements UserDAO {
+
+    private static final Logger log = LoggerFactory.getLogger(JdbcUserDAO.class);
 
     private final Properties prop = new Properties();
     private final ClassLoader loader = Thread.currentThread().getContextClassLoader();
@@ -37,7 +41,7 @@ public class JdbcUserDAO extends JdbcDaoSupport implements UserDAO {
             try (InputStream in = stream) {
                 prop.load(in);
             } catch (IOException e) {
-                e.printStackTrace();
+                log.error("Failed to load database-queries.properties", e);
             }
         }
     }

--- a/saiku-core/saiku-service/src/main/java/org/saiku/datasources/connection/AbstractConnectionManager.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/datasources/connection/AbstractConnectionManager.java
@@ -153,8 +153,8 @@ public abstract class AbstractConnectionManager implements IConnectionManager, S
             try {
                 refreshConnection(name);
             } catch (Exception ex) {
-                // Display the exception but continue to load the connections
-                ex.printStackTrace();
+                // Log but continue so one broken datasource doesn't sink the rest
+                log.error("Failed to refresh connection {}", name, ex);
             }
         }
     }

--- a/saiku-core/saiku-service/src/main/java/org/saiku/olap/query/MdxQuery.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/olap/query/MdxQuery.java
@@ -210,7 +210,7 @@ public class MdxQuery implements IQuery {
                 }
             }
         } catch (OlapException e) {
-            e.printStackTrace();
+            log.error("Failed to look up cube", e);
         }
 
         return null;

--- a/saiku-core/saiku-service/src/main/java/org/saiku/olap/query2/util/Fat.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/olap/query2/util/Fat.java
@@ -43,8 +43,12 @@ import org.saiku.query.mdx.NameFilter;
 import org.saiku.query.mdx.NameLikeFilter;
 import org.saiku.query.metadata.CalculatedMeasure;
 import org.saiku.query.metadata.CalculatedMember;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class Fat {
+
+    private static final Logger log = LoggerFactory.getLogger(Fat.class);
 
     public static Query convert(ThinQuery tq, Cube cube) throws SQLException {
 
@@ -95,7 +99,7 @@ public class Fat {
                     try {
                         parent = q.getCube().lookupMember(IdentifierParser.parseIdentifier(qcm.getParentMember()));
                     } catch (OlapException e) {
-                        e.printStackTrace();
+                        log.error("Failed to look up parent member {}", qcm.getParentMember(), e);
                     }
                 }
 

--- a/saiku-core/saiku-service/src/main/java/org/saiku/olap/util/SaikuDefaultXmlaServlet.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/olap/util/SaikuDefaultXmlaServlet.java
@@ -28,6 +28,8 @@ import mondrian.xmla.impl.DefaultXmlaServlet;
 import org.olap4j.OlapConnection;
 import org.saiku.datasources.connection.IConnectionManager;
 import org.saiku.olap.util.exception.SaikuOlapException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.web.context.WebApplicationContext;
 import org.springframework.web.context.support.WebApplicationContextUtils;
 
@@ -36,6 +38,7 @@ import org.springframework.web.context.support.WebApplicationContextUtils;
  */
 public class SaikuDefaultXmlaServlet extends DefaultXmlaServlet {
 
+    private static final Logger log = LoggerFactory.getLogger(SaikuDefaultXmlaServlet.class);
     private static IConnectionManager connections;
 
     public SaikuDefaultXmlaServlet() {
@@ -64,7 +67,7 @@ public class SaikuDefaultXmlaServlet extends DefaultXmlaServlet {
                     connections.refreshAllConnections();
                     return connections.getOlapConnection(System.getProperty("xmla_datasource"));
                 } catch (SaikuOlapException e) {
-                    e.printStackTrace();
+                    log.error("XMLA connection refresh failed", e);
                 }
                 return null;
             }

--- a/saiku-core/saiku-service/src/main/java/org/saiku/olap/util/SaikuXmlaServlet.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/olap/util/SaikuXmlaServlet.java
@@ -33,6 +33,8 @@ import org.olap4j.impl.Olap4jUtil;
 import org.olap4j.metadata.Database;
 import org.saiku.datasources.connection.IConnectionManager;
 import org.saiku.olap.util.exception.SaikuOlapException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.web.context.WebApplicationContext;
 import org.springframework.web.context.support.WebApplicationContextUtils;
 
@@ -41,6 +43,7 @@ import org.springframework.web.context.support.WebApplicationContextUtils;
  */
 public class SaikuXmlaServlet extends Olap4jXmlaServlet {
 
+    private static final Logger log = LoggerFactory.getLogger(SaikuXmlaServlet.class);
     private static IConnectionManager connections;
 
     public SaikuXmlaServlet() {
@@ -82,7 +85,7 @@ public class SaikuXmlaServlet extends Olap4jXmlaServlet {
                     }
 
                 } catch (SaikuOlapException e) {
-                    e.printStackTrace();
+                    log.error("XMLA discover failed", e);
                 }
                 return null;
             }
@@ -155,7 +158,7 @@ public class SaikuXmlaServlet extends Olap4jXmlaServlet {
 
                 return lret;
             } catch (SaikuOlapException e) {
-                e.printStackTrace();
+                log.error("XMLA datasource enumeration failed", e);
             }
 
             return null;

--- a/saiku-core/saiku-service/src/main/java/org/saiku/repository/FilesystemRepositoryManager.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/repository/FilesystemRepositoryManager.java
@@ -20,7 +20,6 @@ import jakarta.servlet.http.HttpSession;
 import jakarta.xml.bind.JAXBContext;
 import jakarta.xml.bind.JAXBException;
 import jakarta.xml.bind.Marshaller;
-import jakarta.xml.bind.Unmarshaller;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
@@ -40,6 +39,7 @@ import org.saiku.database.dto.MondrianSchema;
 import org.saiku.datasources.connection.RepositoryFile;
 import org.saiku.service.user.UserService;
 import org.saiku.service.util.exception.SaikuServiceException;
+import org.saiku.service.util.xml.SecureXml;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -299,7 +299,7 @@ public class FilesystemRepositoryManager implements IRepositoryManager {
                 fileWriter.flush();
                 fileWriter.close();
             } catch (IOException e) {
-                e.printStackTrace();
+                log.error("Failed to write file to {}", path, e);
             }
 
             return resNode;
@@ -355,7 +355,7 @@ public class FilesystemRepositoryManager implements IRepositoryManager {
                 fileWriter.flush();
                 fileWriter.close();
             } catch (IOException e) {
-                e.printStackTrace();
+                log.error("Failed to write internal file {}", path, e);
             }
 
             return f;
@@ -387,7 +387,7 @@ public class FilesystemRepositoryManager implements IRepositoryManager {
             try {
                 outputStream = new FileOutputStream(new File(filename));
             } catch (FileNotFoundException e) {
-                e.printStackTrace();
+                log.error("Cannot open output stream for {}", filename, e);
             }
 
             int read;
@@ -400,11 +400,11 @@ public class FilesystemRepositoryManager implements IRepositoryManager {
                             outputStream.write(bytes, 0, read);
                         }
                     } catch (IOException e) {
-                        e.printStackTrace();
+                        log.error("Failed to write byte block to {}", filename, e);
                     }
                 }
             } catch (IOException e) {
-                e.printStackTrace();
+                log.error("Failed reading input stream while saving {}", filename, e);
             }
 
             return resNode;
@@ -420,22 +420,18 @@ public class FilesystemRepositoryManager implements IRepositoryManager {
             throw new RepositoryException();
         }
 
+        Path resolved = resolveWithinDatadir(s);
         byte[] encoded = new byte[0];
-
         try {
-            if (Paths.get(s).isAbsolute() && s.startsWith(this.getDatadir())) {
-                encoded = Files.readAllBytes(Paths.get(s));
-            } else {
-                encoded = Files.readAllBytes(Paths.get(getDatadir() + sep + s));
-            }
+            encoded = Files.readAllBytes(resolved);
         } catch (IOException e) {
-            e.printStackTrace();
+            log.debug("Missing file", e);
         }
 
         try {
             return new String(encoded, "UTF-8");
         } catch (UnsupportedEncodingException e) {
-            e.printStackTrace();
+            log.debug("Couldn't convert file", e);
         }
         return null;
     }
@@ -443,12 +439,9 @@ public class FilesystemRepositoryManager implements IRepositoryManager {
     public String getInternalFile(String s) throws RepositoryException {
         byte[] encoded = new byte[0];
         if (!s.equals("/etc/license.lic")) {
+            Path resolved = resolveWithinDatadir(s);
             try {
-                if (Paths.get(s).isAbsolute() && s.startsWith(this.getDatadir())) {
-                    encoded = Files.readAllBytes(Paths.get(s));
-                } else {
-                    encoded = Files.readAllBytes(Paths.get(getDatadir() + s));
-                }
+                encoded = Files.readAllBytes(resolved);
             } catch (IOException e) {
                 log.debug("Missing file", e);
             }
@@ -462,25 +455,18 @@ public class FilesystemRepositoryManager implements IRepositoryManager {
         try {
             return new String(encoded, "UTF-8");
         } catch (UnsupportedEncodingException e) {
-            log.debug("Couldn't conert file", e);
+            log.debug("Couldn't convert file", e);
         }
         return null;
     }
 
     public InputStream getBinaryInternalFile(String s) throws RepositoryException {
-        Path path = null;
-
-        if (Paths.get(s).isAbsolute() && s.startsWith(this.getDatadir())) {
-            path = Paths.get(s);
-        } else {
-            path = Paths.get(getDatadir() + s);
-        }
-
+        Path path = resolveWithinDatadir(s);
         try {
             byte[] f = Files.readAllBytes(path);
             return new ByteArrayInputStream(f);
         } catch (IOException e) {
-            e.printStackTrace();
+            log.debug("Missing binary file", e);
         }
         return null;
     }
@@ -534,7 +520,7 @@ public class FilesystemRepositoryManager implements IRepositoryManager {
         try {
             return getRepoObjects(this.getFolder("/"), type, username, roles, false);
         } catch (Exception e) {
-            e.printStackTrace();
+            log.error("Failed to list repo objects at root", e);
         }
         return null;
     }
@@ -547,7 +533,7 @@ public class FilesystemRepositoryManager implements IRepositoryManager {
             try {
                 return getRepoObjects(this.getFolder(path), type, username, roles, true);
             } catch (Exception e) {
-                e.printStackTrace();
+                log.error("Failed to list repo objects under {}", path, e);
             }
         }
 
@@ -660,28 +646,20 @@ public class FilesystemRepositoryManager implements IRepositoryManager {
 
         for (File file : files) {
             JAXBContext jaxbContext = null;
-            Unmarshaller jaxbMarshaller = null;
             try {
                 jaxbContext = JAXBContext.newInstance(DataSource.class);
             } catch (JAXBException e) {
                 log.error("Could not read XML", e);
             }
-            try {
-                jaxbMarshaller = jaxbContext != null ? jaxbContext.createUnmarshaller() : null;
-            } catch (JAXBException e) {
-                log.error("Could not read XML", e);
-            }
-            InputStream stream = null;
-            try {
-                stream = (FileUtils.openInputStream(file));
-            } catch (IOException e) {
-                e.printStackTrace();
-            }
             DataSource d = null;
-            try {
-                d = (DataSource) (jaxbMarshaller != null ? jaxbMarshaller.unmarshal(stream) : null);
-            } catch (JAXBException e) {
-                log.error("Could not read XML", e);
+            if (jaxbContext != null) {
+                try (InputStream stream = FileUtils.openInputStream(file)) {
+                    // XXE-hardened: route the InputStream through a SAX parser with DOCTYPE
+                    // declarations and external entities disabled (see SecureXml).
+                    d = (DataSource) SecureXml.secureUnmarshal(jaxbContext, stream);
+                } catch (Exception e) {
+                    log.error("Could not read XML from {}", file, e);
+                }
             }
 
             if (d != null) {
@@ -731,7 +709,7 @@ public class FilesystemRepositoryManager implements IRepositoryManager {
             fileWriter.flush();
             fileWriter.close();
         } catch (IOException e) {
-            e.printStackTrace();
+            log.error("Failed to save datasource file", e);
         }
     }
 
@@ -748,7 +726,7 @@ public class FilesystemRepositoryManager implements IRepositoryManager {
         try {
             n = getFolder(fileUrl);
         } catch (RepositoryException e) {
-            e.printStackTrace();
+            log.error("Failed to resolve folder {}", fileUrl, e);
         }
 
         return new RepositoryFile(n != null ? n.getName() : null, null, null, fileUrl);
@@ -826,7 +804,7 @@ public class FilesystemRepositoryManager implements IRepositoryManager {
                 }
             } catch (Exception ex) {
                 // If a problem happens when handling one file, it will still return the repoObjects list
-                ex.printStackTrace();
+                log.warn("Skipping unreadable repo entry", ex);
             }
         }
 
@@ -895,14 +873,13 @@ public class FilesystemRepositoryManager implements IRepositoryManager {
 
     private void delete(String folder) {
         folder = fixPath(folder);
-        File file = null;
-
-        if (Paths.get(folder).isAbsolute() && folder.startsWith(this.getDatadir())) {
-            file = new File(folder);
-        } else {
-            file = new File(getDatadir() + folder);
+        File file;
+        try {
+            file = resolveWithinDatadir(folder).toFile();
+        } catch (RepositoryException e) {
+            log.warn("Refusing to delete path that escapes datadir: {}", folder);
+            return;
         }
-
         file.delete();
     }
 
@@ -911,16 +888,36 @@ public class FilesystemRepositoryManager implements IRepositoryManager {
     }
 
     private File getNode(String path) {
-
         path = fixPath(path);
-        File f = new File(path);
-
-        if (f.isAbsolute() && path.startsWith(this.getDatadir())) { // Check if the provided path is a full path already
-            return f; // If so, return the respective file
+        try {
+            return resolveWithinDatadir(path).toFile();
+        } catch (RepositoryException e) {
+            // Preserve historical signature (no checked exception) by throwing unchecked.
+            // Path-traversal attempts are programmer / attacker errors, not flow control.
+            throw new SaikuServiceException("Path traversal attempt rejected: " + path, e);
         }
+    }
 
-        // Otherwise, compose the path with the datadir basepath
-        return new File(getDatadir() + path);
+    /**
+     * Resolve {@code userPath} against {@link #getDatadir()} and refuse anything that
+     * escapes the resolved data directory (defends against {@code ../} traversal and
+     * absolute paths pointing outside the repo root). Symlink-based escapes are not
+     * covered here — they need {@link Path#toRealPath} which only works for existing
+     * paths, so handle separately if/when relevant.
+     */
+    private Path resolveWithinDatadir(String userPath) throws RepositoryException {
+        if (userPath == null) {
+            throw new RepositoryException("Path must not be null");
+        }
+        Path base = Paths.get(getDatadir()).toAbsolutePath().normalize();
+        Path candidate = Paths.get(userPath);
+        Path resolved = candidate.isAbsolute()
+                ? candidate.normalize()
+                : base.resolve(userPath).normalize();
+        if (!resolved.startsWith(base)) {
+            throw new RepositoryException("Path traversal attempt rejected: " + userPath);
+        }
+        return resolved;
     }
 
     private File createNode(String filename) {

--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/cache/SaikuQueryCache.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/cache/SaikuQueryCache.java
@@ -20,6 +20,10 @@ import java.nio.file.StandardCopyOption;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Supplier;
@@ -68,6 +72,12 @@ public class SaikuQueryCache {
     private final Cache<String, Entry> index;
     private final ObjectMapper mapper = new ObjectMapper();
     private final ReentrantLock writeLock = new ReentrantLock();
+    /** Single-thread daemon executor that runs evictIfOverBudget() off the
+     *  put() write path. The previous implementation called eviction
+     *  synchronously while holding writeLock — eviction walks every meta
+     *  sidecar on disk so under load it could stall concurrent queries for
+     *  hundreds of ms. FIFO ordering keeps eviction deterministic. */
+    private final ExecutorService evictionExecutor;
 
     /** Metadata sidecar record. Public for Jackson. */
     public static final class Entry {
@@ -119,6 +129,12 @@ public class SaikuQueryCache {
         this.maxSizeBytes = maxSizeBytes;
         this.enabled = enabled;
         this.index = Caffeine.newBuilder().maximumSize(512).build();
+        ThreadFactory tf = r -> {
+            Thread t = new Thread(r, "SaikuQueryCache-eviction");
+            t.setDaemon(true);
+            return t;
+        };
+        this.evictionExecutor = Executors.newSingleThreadExecutor(tf);
         try {
             Files.createDirectories(cacheDir);
             // Warm the in-memory index from disk so eviction sees existing entries.
@@ -249,13 +265,16 @@ public class SaikuQueryCache {
             mapper.writerWithDefaultPrettyPrinter().writeValue(metaTmp.toFile(), e);
             Files.move(metaTmp, meta, StandardCopyOption.REPLACE_EXISTING, StandardCopyOption.ATOMIC_MOVE);
             index.put(key, e);
-
-            evictIfOverBudget();
         } catch (IOException ex) {
             log.warn("SaikuQueryCache.put({}) failed: {}", key, ex.toString());
         } finally {
             writeLock.unlock();
         }
+        // Eviction walks every .meta.json on disk + invalidates victims, which
+        // re-acquires writeLock — running it inline blocks the next put()/get()
+        // until the walk finishes. Run on the daemon executor instead so
+        // requests aren't stalled by the budget check.
+        evictionExecutor.submit(this::evictIfOverBudget);
     }
 
     public void invalidate(String key) {
@@ -362,14 +381,31 @@ public class SaikuQueryCache {
     }
 
     /**
-     * No executor or threadpool to tear down here — the cache is purely
-     * disk + Caffeine + ReentrantLock. This exists for symmetry with
-     * {@link org.saiku.service.async.AsyncQueryService#shutdown()} so the
-     * bean container (or a @PreDestroy-aware test) has a single, known
-     * point of shutdown.
+     * Drain any queued eviction tasks. Intended for tests that need to assert
+     * post-eviction state — production callers should never need to flush.
      */
+    public void flushEvictions() {
+        try {
+            Future<?> drained = evictionExecutor.submit(() -> {});
+            drained.get(30, TimeUnit.SECONDS);
+        } catch (Exception e) {
+            log.debug("flushEvictions interrupted: {}", e.toString());
+        }
+    }
+
+    /**
+     * Test hook: submit an arbitrary task to the eviction executor. Lets tests
+     * verify that put() does not block on the executor by parking a sentinel
+     * task. Package-visible by design — public so the test in another package
+     * can call it without reflection.
+     */
+    public Future<?> submitEvictionTask(Runnable task) {
+        return evictionExecutor.submit(task);
+    }
+
     @PreDestroy
     public void shutdown() {
         index.invalidateAll();
+        evictionExecutor.shutdownNow();
     }
 }

--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/datasource/RepositoryDatasourceManager.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/datasource/RepositoryDatasourceManager.java
@@ -22,6 +22,7 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
 import org.apache.commons.lang3.StringUtils;
 import org.saiku.database.dto.MondrianSchema;
 import org.saiku.datasources.connection.IConnectionManager;
@@ -46,8 +47,7 @@ public class RepositoryDatasourceManager implements IDatasourceManager, Applicat
     public static final String ORBIS_WORKSPACE_DIR = "workspace";
     public static final String SAIKU_AUTH_PRINCIPAL = "SAIKU_AUTH_PRINCIPAL";
 
-    private final Map<String, SaikuDatasource> datasources =
-            Collections.synchronizedMap(new HashMap<String, SaikuDatasource>());
+    private final Map<String, SaikuDatasource> datasources = new ConcurrentHashMap<>();
     public IConnectionManager connectionManager;
     private ScopedRepo sessionRegistry;
     private boolean workspaces;
@@ -404,7 +404,7 @@ public class RepositoryDatasourceManager implements IDatasourceManager, Applicat
             irm.saveInternalFile(content, path, type);
             return "Save Okay";
         } catch (RepositoryException e) {
-            e.printStackTrace();
+            log.error("saveInternalFile failed for {}", path, e);
             return "Save Failed: " + e.getLocalizedMessage();
         }
     }
@@ -414,7 +414,7 @@ public class RepositoryDatasourceManager implements IDatasourceManager, Applicat
             irm.saveBinaryInternalFile(content, path, type);
             return "Save Okay";
         } catch (RepositoryException e) {
-            e.printStackTrace();
+            log.error("saveBinaryInternalFile failed for {}", path, e);
             return "Save Failed: " + e.getLocalizedMessage();
         }
     }
@@ -423,8 +423,7 @@ public class RepositoryDatasourceManager implements IDatasourceManager, Applicat
         try {
             irm.removeInternalFile(filePath);
         } catch (RepositoryException e) {
-            log.error("Remove file failed: " + filePath);
-            e.printStackTrace();
+            log.error("Remove file failed: {}", filePath, e);
         }
     }
 

--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/OlapQueryService.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/OlapQueryService.java
@@ -20,6 +20,7 @@ import java.math.BigDecimal;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicLong;
 import mondrian.olap4j.SaikuMondrianHelper;
 import mondrian.rolap.RolapConnection;
@@ -72,7 +73,7 @@ public class OlapQueryService implements Serializable {
 
     private OlapDiscoverService olapDiscoverService;
 
-    private transient Map<String, IQuery> queries = new HashMap<>();
+    private transient Map<String, IQuery> queries = new ConcurrentHashMap<>();
     private Map<String, String> serializableQueries = null;
 
     private static final AtomicLong ID_GENERATOR = new AtomicLong();
@@ -1479,7 +1480,7 @@ public class OlapQueryService implements Serializable {
     private void readObject(ObjectInputStream stream) throws IOException, ClassNotFoundException {
 
         stream.defaultReadObject();
-        queries = new HashMap<>();
+        queries = new ConcurrentHashMap<>();
         for (Map.Entry<String, String> entry : serializableQueries.entrySet()) {
             createNewOlapQuery(entry.getKey(), entry.getValue());
         }

--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ai/AiSchema.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ai/AiSchema.java
@@ -81,6 +81,12 @@ public class AiSchema {
          *  into a filter rather than constructing it. */
         public java.util.List<MemberSample> sampleMembers = new java.util.ArrayList<>();
 
+        /** Transient build-time signal: the sample-member fetch returned at least
+         *  one row without throwing, so the level is already proven queryable
+         *  and {@code pruneUnqueryable} can skip the redundant probe call.
+         *  Not serialised — recomputed per buildSchema. */
+        public transient boolean queryableProven;
+
         public Level(String name, String uniqueName) {
             this.name = name;
             this.uniqueName = uniqueName;

--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ai/OlapAiCubeMetadataService.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ai/OlapAiCubeMetadataService.java
@@ -339,6 +339,12 @@ public class OlapAiCubeMetadataService implements AiCubeMetadataService {
                     if (level.name != null && level.name.equalsIgnoreCase("(All)")) {
                         continue;
                     }
+                    // If the sample-member fetch already returned ≥1 row the
+                    // level is provably queryable — don't re-probe (the old
+                    // path made ~2× Mondrian round-trips per level on cold load).
+                    if (level.queryableProven) {
+                        continue;
+                    }
                     if (!isLevelQueryable(cube, hier.name, level.name)) {
                         log.info(
                                 "Pruning unqueryable level {}/{}/{} from {} schema (saiku#810)",
@@ -414,6 +420,11 @@ public class OlapAiCubeMetadataService implements AiCubeMetadataService {
             List<org.saiku.olap.dto.SimpleCubeElement> members =
                     discoverService.getLevelMembers(cube, hierarchyName, levelName, overfetch);
             if (members == null) return;
+            // Sample fetch returning ≥1 row is proof the level is queryable —
+            // pruneUnqueryable can skip its redundant probe call (saiku#780 perf).
+            if (!members.isEmpty()) {
+                out.queryableProven = true;
+            }
             java.util.Set<String> seen = new java.util.HashSet<>();
             for (org.saiku.olap.dto.SimpleCubeElement m : members) {
                 if (out.sampleMembers.size() >= sampleMembersPerLevel) break;

--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/util/OlapUtil.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/util/OlapUtil.java
@@ -15,13 +15,13 @@
  */
 package org.saiku.service.util;
 
-import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import org.olap4j.CellSet;
 
 class OlapUtil {
 
-    private static final Map<String, CellSet> cellSetMap = new HashMap<>();
+    private static final Map<String, CellSet> cellSetMap = new ConcurrentHashMap<>();
 
     /**
      * storeCellSet stores a cellset generated from a query so we can manipulate it at a later date.
@@ -30,9 +30,6 @@ class OlapUtil {
      * @param queryId
      */
     public static void storeCellSet(final String queryId, final CellSet cellSet) {
-        if (cellSetMap.containsKey(queryId)) {
-            cellSetMap.remove(queryId);
-        }
         cellSetMap.put(queryId, cellSet);
     }
 

--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/util/xml/SecureXml.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/util/xml/SecureXml.java
@@ -1,0 +1,82 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ */
+package org.saiku.service.util.xml;
+
+import jakarta.xml.bind.JAXBContext;
+import jakarta.xml.bind.JAXBException;
+import jakarta.xml.bind.Unmarshaller;
+import java.io.IOException;
+import java.io.InputStream;
+import javax.xml.XMLConstants;
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.parsers.SAXParser;
+import javax.xml.parsers.SAXParserFactory;
+import javax.xml.transform.sax.SAXSource;
+import org.xml.sax.InputSource;
+import org.xml.sax.SAXException;
+import org.xml.sax.XMLReader;
+
+/**
+ * XML parser hardening helpers — used wherever Saiku deserialises XML from a source that could be
+ * user-influenced (saved {@code .sds} datasource files, uploaded Mondrian schemas, SVG fed to the
+ * PDF exporter). Centralises the OWASP-recommended set of features so we can't accidentally
+ * regress: DOCTYPE is disallowed (defeats classic XXE), external general/parameter entities are
+ * disabled (defence in depth), and {@link XMLConstants#FEATURE_SECURE_PROCESSING} is enabled.
+ */
+public final class SecureXml {
+
+    private static final String FEATURE_DISALLOW_DOCTYPE = "http://apache.org/xml/features/disallow-doctype-decl";
+    private static final String FEATURE_EXTERNAL_GENERAL_ENTITIES =
+            "http://xml.org/sax/features/external-general-entities";
+    private static final String FEATURE_EXTERNAL_PARAMETER_ENTITIES =
+            "http://xml.org/sax/features/external-parameter-entities";
+    private static final String FEATURE_LOAD_EXTERNAL_DTD =
+            "http://apache.org/xml/features/nonvalidating/load-external-dtd";
+
+    private SecureXml() {}
+
+    /** Build a {@link SAXParserFactory} that refuses DOCTYPE declarations and external entities. */
+    public static SAXParserFactory secureSaxParserFactory() throws SAXException, ParserConfigurationException {
+        SAXParserFactory spf = SAXParserFactory.newInstance();
+        spf.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+        spf.setFeature(FEATURE_DISALLOW_DOCTYPE, true);
+        spf.setFeature(FEATURE_EXTERNAL_GENERAL_ENTITIES, false);
+        spf.setFeature(FEATURE_EXTERNAL_PARAMETER_ENTITIES, false);
+        spf.setFeature(FEATURE_LOAD_EXTERNAL_DTD, false);
+        spf.setNamespaceAware(true);
+        spf.setXIncludeAware(false);
+        return spf;
+    }
+
+    /** Build a {@link DocumentBuilder} that refuses DOCTYPE declarations and external entities. */
+    public static DocumentBuilder secureDocumentBuilder() throws ParserConfigurationException {
+        DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
+        dbf.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+        dbf.setFeature(FEATURE_DISALLOW_DOCTYPE, true);
+        dbf.setFeature(FEATURE_EXTERNAL_GENERAL_ENTITIES, false);
+        dbf.setFeature(FEATURE_EXTERNAL_PARAMETER_ENTITIES, false);
+        dbf.setFeature(FEATURE_LOAD_EXTERNAL_DTD, false);
+        dbf.setXIncludeAware(false);
+        dbf.setExpandEntityReferences(false);
+        return dbf.newDocumentBuilder();
+    }
+
+    /**
+     * JAXB unmarshalling routed through a hardened SAX parser. Use this instead of
+     * {@code unmarshaller.unmarshal(stream)} so external-entity expansion (XXE) is impossible.
+     */
+    public static Object secureUnmarshal(JAXBContext ctx, InputStream stream)
+            throws JAXBException, SAXException, ParserConfigurationException, IOException {
+        SAXParser parser = secureSaxParserFactory().newSAXParser();
+        XMLReader reader = parser.getXMLReader();
+        SAXSource source = new SAXSource(reader, new InputSource(stream));
+        Unmarshaller unmarshaller = ctx.createUnmarshaller();
+        return unmarshaller.unmarshal(source);
+    }
+}

--- a/saiku-core/saiku-service/src/test/java/org/saiku/repository/FilesystemRepositoryManagerPathTraversalTest.java
+++ b/saiku-core/saiku-service/src/test/java/org/saiku/repository/FilesystemRepositoryManagerPathTraversalTest.java
@@ -1,0 +1,141 @@
+package org.saiku.repository;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.fail;
+
+import java.io.File;
+import java.io.InputStream;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+/**
+ * Regression coverage for the path-traversal vector in {@code FilesystemRepositoryManager}:
+ * relative paths containing {@code ../} sequences are concatenated with the data directory
+ * and read by {@link java.nio.file.Files#readAllBytes(Path)}, which resolves the traversal
+ * and lets an authenticated caller exfiltrate files outside the repo root.
+ */
+public class FilesystemRepositoryManagerPathTraversalTest {
+
+    @Rule
+    public TemporaryFolder tmp = new TemporaryFolder();
+
+    private FilesystemRepositoryManager manager;
+    private File datadir;
+    private File outsideSecret;
+
+    @Before
+    public void setUp() throws Exception {
+        // Reset the singleton so each test gets a fresh manager pointed at its temp dir.
+        resetSingleton();
+
+        datadir = tmp.newFolder("repo");
+        // Pre-create unknown/etc so getDatadir()'s lazy-bootstrap branch is skipped.
+        File unknownEtc = new File(datadir, "unknown/etc");
+        if (!unknownEtc.mkdirs()) {
+            throw new IllegalStateException("Could not create unknown/etc: " + unknownEtc);
+        }
+
+        // Plant a "secret" file OUTSIDE the repo root the manager is bound to.
+        File secretRoot = tmp.newFolder("outside");
+        outsideSecret = new File(secretRoot, "passwd-like-secret.txt");
+        Files.write(outsideSecret.toPath(), "TOP_SECRET".getBytes(StandardCharsets.UTF_8));
+
+        manager = newManager(datadir.getAbsolutePath());
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        resetSingleton();
+    }
+
+    @Test
+    public void getInternalFile_rejects_dotdot_traversal() throws Exception {
+        // Build a relative path that climbs out of <datadir>/unknown/ into our outside secret.
+        // getDatadir() returns "<datadir>/unknown/" so prefixing with "../../outside/<file>"
+        // resolves to the planted secret.
+        String relativeTraversal = "../../outside/" + outsideSecret.getName();
+
+        String contents;
+        try {
+            contents = manager.getInternalFile(relativeTraversal);
+        } catch (RepositoryException expected) {
+            // Acceptable: the manager refuses to read paths that escape its root.
+            return;
+        }
+
+        // If no exception was thrown the only safe outcome is "no content read".
+        if (contents != null && contents.contains("TOP_SECRET")) {
+            fail("path traversal succeeded: getInternalFile returned the contents of "
+                    + outsideSecret.getAbsolutePath()
+                    + " when given relative path "
+                    + relativeTraversal);
+        }
+        // Defensive: null is also acceptable (means read failed cleanly).
+        assertFalse(
+                "getInternalFile must not return secret contents for traversal input",
+                contents != null && contents.contains("TOP_SECRET"));
+    }
+
+    @Test
+    public void getBinaryInternalFile_rejects_dotdot_traversal() throws Exception {
+        String relativeTraversal = "../../outside/" + outsideSecret.getName();
+
+        InputStream stream;
+        try {
+            stream = manager.getBinaryInternalFile(relativeTraversal);
+        } catch (RepositoryException expected) {
+            return;
+        }
+
+        if (stream == null) {
+            return; // safe fallback
+        }
+        byte[] read = stream.readAllBytes();
+        String body = new String(read, StandardCharsets.UTF_8);
+        if (body.contains("TOP_SECRET")) {
+            fail("path traversal succeeded: getBinaryInternalFile returned the contents of "
+                    + outsideSecret.getAbsolutePath());
+        }
+    }
+
+    @Test
+    public void getInternalFile_absolute_path_outside_datadir_is_rejected() throws Exception {
+        // An absolute path that doesn't start with the datadir must not be readable either.
+        String absoluteOutside = outsideSecret.getAbsolutePath();
+
+        String contents;
+        try {
+            contents = manager.getInternalFile(absoluteOutside);
+        } catch (RepositoryException expected) {
+            return;
+        }
+
+        assertNull(
+                "absolute path outside the datadir must not be readable, got: " + contents,
+                contents == null ? null : (contents.contains("TOP_SECRET") ? contents : null));
+    }
+
+    // --- helpers -------------------------------------------------------------
+
+    private static FilesystemRepositoryManager newManager(String path) throws Exception {
+        Constructor<FilesystemRepositoryManager> ctor = FilesystemRepositoryManager.class.getDeclaredConstructor(
+                String.class, String.class, ScopedRepo.class, boolean.class);
+        ctor.setAccessible(true);
+        return ctor.newInstance(path, "ROLE_USER", new ScopedRepo(), false);
+    }
+
+    private static void resetSingleton() throws Exception {
+        Field ref = FilesystemRepositoryManager.class.getDeclaredField("ref");
+        ref.setAccessible(true);
+        ref.set(null, null);
+    }
+}

--- a/saiku-core/saiku-service/src/test/java/org/saiku/service/cache/SaikuQueryCacheTest.java
+++ b/saiku-core/saiku-service/src/test/java/org/saiku/service/cache/SaikuQueryCacheTest.java
@@ -142,9 +142,46 @@ public class SaikuQueryCacheTest {
         Thread.sleep(10);
         tiny.get("new", "v", supplierProducing(newPayload, 1L, 1, calls));
 
+        // Eviction runs off the write path (saiku#780 perf). Drain pending
+        // eviction tasks before asserting on-disk state.
+        tiny.flushEvictions();
+
         assertFalse("oldest arrow should have been evicted", Files.exists(cacheDir.resolve("old.arrow")));
         assertFalse("oldest meta should have been evicted", Files.exists(cacheDir.resolve("old.meta.json")));
         assertTrue("newest arrow should be present", Files.exists(cacheDir.resolve("new.arrow")));
+    }
+
+    @Test
+    public void put_does_not_block_on_eviction_walk() throws Exception {
+        // Verifies the eviction scan happens on a background thread rather than
+        // inside put()'s writeLock. We force the eviction executor to block on
+        // a latch and then time how long put() takes — it must return promptly
+        // even though the background eviction is still pending.
+        SaikuQueryCache tiny = new SaikuQueryCache(cacheDir, TimeUnit.MINUTES.toMillis(30), 150L, true);
+        java.util.concurrent.CountDownLatch hold = new java.util.concurrent.CountDownLatch(1);
+        AtomicInteger calls = new AtomicInteger(0);
+
+        // Park a long-running task on the eviction executor so any
+        // synchronous "wait for eviction" code path would block.
+        tiny.submitEvictionTask(() -> {
+            try {
+                hold.await();
+            } catch (InterruptedException ie) {
+                Thread.currentThread().interrupt();
+            }
+        });
+
+        byte[] payload = new byte[100];
+        long t0 = System.nanoTime();
+        tiny.get("a", "v", supplierProducing(payload, 1L, 1, calls));
+        long elapsedMs = (System.nanoTime() - t0) / 1_000_000L;
+
+        // Release the parked task so the executor can shut down cleanly.
+        hold.countDown();
+
+        // Even with a blocked executor, put() must return without waiting on it.
+        // 250ms is generous — a synchronous wait on the latch would never return.
+        assertTrue("put() must not block on eviction executor; took " + elapsedMs + "ms", elapsedMs < 250L);
     }
 
     @Test

--- a/saiku-core/saiku-service/src/test/java/org/saiku/service/olap/ai/OlapAiCubeMetadataServiceTest.java
+++ b/saiku-core/saiku-service/src/test/java/org/saiku/service/olap/ai/OlapAiCubeMetadataServiceTest.java
@@ -221,6 +221,51 @@ public class OlapAiCubeMetadataServiceTest {
         assertFalse("hidden measure carries visible=false", Boolean.TRUE.equals(hidden.visible));
     }
 
+    /**
+     * Probe on, but {@code populateSampleMembers} has already proven the level
+     * is queryable by fetching ≥1 member. {@code pruneUnqueryable} must not
+     * re-fetch members for those levels — that is the N+1 we're hardening.
+     */
+    @Test
+    public void probeOn_skips_redundant_fetch_when_sample_already_proves_queryable() {
+        java.util.Map<String, Integer> calls = new java.util.HashMap<>();
+        OlapAiCubeMetadataService probeSvc = new OlapAiCubeMetadataService();
+        probeSvc.setDiscoverService(new StubDiscover() {
+            @Override
+            public List<org.saiku.olap.dto.SimpleCubeElement> getLevelMembers(
+                    SaikuCube cube, String hierarchyName, String levelName, int searchLimit) {
+                String k = hierarchyName + "/" + levelName;
+                calls.merge(k, 1, Integer::sum);
+                return Arrays.asList(new org.saiku.olap.dto.SimpleCubeElement(
+                        "S" + k, "[" + k + "].&[S]", "[" + hierarchyName + "].[" + levelName + "]"));
+            }
+
+            @Override
+            public List<org.saiku.olap.dto.SimpleCubeElement> getLevelMembers(
+                    SaikuCube cube, String hierarchyName, String levelName, String q, int limit) {
+                String k = hierarchyName + "/" + levelName;
+                calls.merge(k, 1, Integer::sum);
+                return Arrays.asList(new org.saiku.olap.dto.SimpleCubeElement(
+                        "S" + k, "[" + k + "].&[S]", "[" + hierarchyName + "].[" + levelName + "]"));
+            }
+        });
+        probeSvc.setProbeUnqueryable(true);
+
+        probeSvc.getSchema(new AiCubeRef("foodmart", "FoodMart", "FoodMart", "Sales"));
+
+        // Time By has Year + Quarter; Product/Product has Department.
+        // Before the fix the probe re-fetched each level: count was 2 per (hier, level).
+        // After the fix the sample fetch proves queryability and the probe is skipped.
+        for (java.util.Map.Entry<String, Integer> e : calls.entrySet()) {
+            assertTrue(
+                    "getLevelMembers must not be called more than once per level when sample fetch already returned a member; got "
+                            + e.getValue()
+                            + " for "
+                            + e.getKey(),
+                    e.getValue() <= 1);
+        }
+    }
+
     /** Stub that fails getLevelMembers for Quarter only. */
     private static class ProbeStubDiscover extends StubDiscover {
         @Override

--- a/saiku-core/saiku-service/src/test/java/org/saiku/service/util/xml/SecureXmlTest.java
+++ b/saiku-core/saiku-service/src/test/java/org/saiku/service/util/xml/SecureXmlTest.java
@@ -1,0 +1,82 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ */
+package org.saiku.service.util.xml;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.fail;
+
+import jakarta.xml.bind.JAXBContext;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+/**
+ * XXE-hardening contract for {@link SecureXml#secureUnmarshal(JAXBContext, java.io.InputStream)}.
+ *
+ * <p>The pre-hardening implementation in {@code FilesystemRepositoryManager.getDataSources()} called
+ * {@code Unmarshaller.unmarshal(InputStream)} directly, which lets the default parser resolve external
+ * entities. A malicious {@code .sds} datasource file with a {@code <!DOCTYPE ... <!ENTITY xxe SYSTEM
+ * "file:///..."/>}  declaration could exfiltrate arbitrary files from the host. This test plants such
+ * a payload and verifies the secure path rejects DOCTYPE rather than expanding the entity.
+ */
+public class SecureXmlTest {
+
+    @Rule
+    public TemporaryFolder tmp = new TemporaryFolder();
+
+    @Test
+    public void rejects_external_entity_doctype() throws Exception {
+        // Plant a "secret" file we wouldn't want exfiltrated.
+        File secret = tmp.newFile("secret.txt");
+        Files.write(secret.toPath(), "TOP_SECRET".getBytes(StandardCharsets.UTF_8));
+
+        String xxe = "<?xml version=\"1.0\"?>\n"
+                + "<!DOCTYPE foo [<!ENTITY xxe SYSTEM \""
+                + secret.toURI().toString()
+                + "\">]>\n"
+                + "<container><name>&xxe;</name></container>";
+
+        JAXBContext ctx = JAXBContext.newInstance(Container.class);
+        try {
+            Object result =
+                    SecureXml.secureUnmarshal(ctx, new ByteArrayInputStream(xxe.getBytes(StandardCharsets.UTF_8)));
+            // If parsing didn't blow up, the entity MUST NOT have expanded to the file contents.
+            if (result instanceof Container) {
+                String name = ((Container) result).name;
+                if (name != null && name.contains("TOP_SECRET")) {
+                    fail("XXE expansion succeeded — secure parser leaked file contents into <name>: " + name);
+                }
+            }
+        } catch (Exception expected) {
+            // Acceptable: hardened parser refuses to process DOCTYPE declarations.
+            return;
+        }
+    }
+
+    @Test
+    public void parses_benign_xml_normally() throws Exception {
+        String xml = "<?xml version=\"1.0\"?><container><name>hello</name></container>";
+        JAXBContext ctx = JAXBContext.newInstance(Container.class);
+        Object result = SecureXml.secureUnmarshal(ctx, new ByteArrayInputStream(xml.getBytes(StandardCharsets.UTF_8)));
+        assertNotNull("benign XML must still unmarshal", result);
+    }
+
+    @XmlRootElement(name = "container")
+    @XmlAccessorType(XmlAccessType.FIELD)
+    public static class Container {
+        @XmlElement
+        public String name;
+    }
+}

--- a/saiku-core/saiku-web/src/main/java/org/saiku/web/export/PdfReport.java
+++ b/saiku-core/saiku-web/src/main/java/org/saiku/web/export/PdfReport.java
@@ -14,7 +14,6 @@ import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.transform.Result;
 import javax.xml.transform.Source;
@@ -31,6 +30,7 @@ import org.apache.fop.apps.FopFactoryBuilder;
 import org.apache.fop.apps.MimeConstants;
 import org.saiku.service.util.exception.SaikuServiceException;
 import org.saiku.service.util.export.PdfPerformanceLogger;
+import org.saiku.service.util.xml.SecureXml;
 import org.saiku.web.rest.objects.resultset.QueryResult;
 import org.xml.sax.SAXException;
 
@@ -223,11 +223,12 @@ public class PdfReport {
         try {
             TransformerFactory tFactory = TransformerFactory.newInstance();
 
-            DocumentBuilderFactory dFactory = DocumentBuilderFactory.newInstance();
-            dFactory.setNamespaceAware(true);
+            // XXE-hardened parser (DOCTYPE + external entities disabled). Even though the
+            // XSL we're parsing here is a packaged classpath resource, keep the secure path
+            // so future callers can't accidentally point this at user-controlled XML.
+            DocumentBuilder dBuilder = SecureXml.secureDocumentBuilder();
 
             InputStream is = this.getClass().getResourceAsStream("xhtml2fo.xsl");
-            DocumentBuilder dBuilder = dFactory.newDocumentBuilder();
             org.w3c.dom.Document xslDoc = dBuilder.parse(is);
             DOMSource xslDomSource = new DOMSource(xslDoc);
 

--- a/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/SaikuJerseyApplication.java
+++ b/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/SaikuJerseyApplication.java
@@ -5,6 +5,7 @@ import jakarta.ws.rs.Path;
 import jakarta.ws.rs.core.Context;
 import org.glassfish.jersey.media.multipart.MultiPartFeature;
 import org.glassfish.jersey.server.ResourceConfig;
+import org.glassfish.jersey.server.filter.RolesAllowedDynamicFeature;
 import org.springframework.context.ApplicationContext;
 import org.springframework.web.context.support.WebApplicationContextUtils;
 
@@ -20,6 +21,12 @@ public class SaikuJerseyApplication extends ResourceConfig {
         // standard JAX-RS client (and CORS preflight) expects.
         property("jersey.config.server.wadl.disableWadl", true);
         register(MultiPartFeature.class);
+        // saiku#780 defence-in-depth: enable @RolesAllowed on JAX-RS resource
+        // methods so admin-only mutations (e.g. DataSourceResource.deleteDatasource)
+        // are blocked at the framework layer even if the Spring filter chain
+        // is misconfigured. Without this dynamic feature Jersey silently
+        // ignores @RolesAllowed annotations.
+        register(RolesAllowedDynamicFeature.class);
         // saiku#791: translate Jackson deserialisation failures into the
         // typed AiQueryResponse 400 envelope instead of the raw text/plain
         // Jackson message that leaked class names and source location.

--- a/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/AdminResource.java
+++ b/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/AdminResource.java
@@ -16,6 +16,7 @@
 package org.saiku.web.rest.resources;
 
 import com.qmino.miredot.annotations.ReturnType;
+import jakarta.annotation.security.RolesAllowed;
 import jakarta.ws.rs.*;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
@@ -47,6 +48,10 @@ import org.slf4j.LoggerFactory;
  * AdminResource for the Saiku 3.0+ Admin console
  */
 @Path("/saiku/admin")
+// saiku#780 defence-in-depth: every endpoint under /saiku/admin requires the
+// ADMIN role at the JAX-RS layer, not just the Spring URL filter. The
+// RolesAllowedDynamicFeature in SaikuJerseyApplication is what wires this up.
+@RolesAllowed("ROLE_ADMIN")
 public class AdminResource {
 
     private DatasourceService datasourceService;

--- a/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/DataSourceResource.java
+++ b/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/DataSourceResource.java
@@ -16,6 +16,7 @@
 package org.saiku.web.rest.resources;
 
 import com.qmino.miredot.annotations.ReturnType;
+import jakarta.annotation.security.RolesAllowed;
 import jakarta.ws.rs.*;
 import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.Response.Status;
@@ -73,6 +74,7 @@ public class DataSourceResource {
      */
     @DELETE
     @Path("/{datasource}")
+    @RolesAllowed("ROLE_ADMIN")
     public Status deleteDatasource(@PathParam("datasource") String datasourceName) {
         datasourceService.removeDatasource(datasourceName);
         return (Status.GONE);
@@ -117,6 +119,7 @@ public class DataSourceResource {
     @Consumes({"application/json"})
     @Path("/{id}")
     @ReturnType("org.saiku.web.rest.objects.DataSourceMapper")
+    @RolesAllowed("ROLE_ADMIN")
     public Response updateDatasourceLocale(String locale, @PathParam("id") String id) {
         boolean overwrite = true;
         try {

--- a/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/Query2Resource.java
+++ b/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/Query2Resource.java
@@ -33,7 +33,6 @@ import jakarta.xml.bind.annotation.XmlAccessorType;
 import java.io.InputStream;
 import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.sql.Statement;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
@@ -59,6 +58,7 @@ import org.saiku.web.export.JSConverter;
 import org.saiku.web.export.PdfReport;
 import org.saiku.web.rest.objects.resultset.QueryResult;
 import org.saiku.web.rest.util.RestUtil;
+import org.saiku.web.util.JdbcCleanup;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.web.context.request.RequestAttributes;
@@ -72,6 +72,10 @@ import org.springframework.web.context.request.RequestContextHolder;
 public class Query2Resource {
 
     private static final Logger log = LoggerFactory.getLogger(Query2Resource.class);
+
+    /** Shared, thread-safe ObjectMapper. Per-request instantiation churned through
+     *  Jackson's reflection cache on every call; mirror the AiQueryResource pattern. */
+    private static final ObjectMapper MAPPER = new ObjectMapper();
 
     private ThinQueryService thinQueryService;
 
@@ -158,8 +162,7 @@ public class Query2Resource {
             if (thinQueryService.isOldQuery(filecontent)) {
                 tq = thinQueryService.convertQuery(filecontent);
             } else {
-                ObjectMapper om = new ObjectMapper();
-                tq = om.readValue(filecontent, ThinQuery.class);
+                tq = MAPPER.readValue(filecontent, ThinQuery.class);
             }
 
             if (log.isDebugEnabled()) {
@@ -608,9 +611,8 @@ public class Query2Resource {
             }
             List<List<Integer>> realPositions = new ArrayList<>();
             if (StringUtils.isNotBlank(positionListString)) {
-                ObjectMapper mapper = new ObjectMapper();
-                String[] positions = mapper.readValue(
-                        positionListString, mapper.getTypeFactory().constructArrayType(String.class));
+                String[] positions = MAPPER.readValue(
+                        positionListString, MAPPER.getTypeFactory().constructArrayType(String.class));
                 if (positions != null && positions.length > 0) {
                     for (String position : positions) {
                         String[] rPos = position.split(":");
@@ -700,22 +702,7 @@ public class Query2Resource {
             // Arrow path materialises rows eagerly into the ByteArrayOutputStream
             // before the response body is written, so it is safe to close the
             // ResultSet here for both JSON and Arrow branches.
-            if (rs != null) {
-                Statement statement = null;
-                try {
-                    statement = rs.getStatement();
-                } catch (Exception e) {
-                    throw new SaikuServiceException(e);
-                } finally {
-                    try {
-                        rs.close();
-                        if (statement != null) {
-                            statement.close();
-                        }
-                    } catch (Exception ee) {
-                    }
-                }
-            }
+            JdbcCleanup.closeQuietly(rs);
         }
     }
 
@@ -817,16 +804,7 @@ public class Query2Resource {
             log.error("Cannot export drillthrough query (" + queryName + ")", e);
             return Response.serverError().build();
         } finally {
-            if (rs != null) {
-                try {
-                    Statement statement = rs.getStatement();
-                    statement.close();
-                    rs.close();
-                } catch (SQLException e) {
-                    throw new SaikuServiceException(e);
-                } finally {
-                }
-            }
+            JdbcCleanup.closeQuietly(rs);
         }
     }
 
@@ -1023,14 +1001,11 @@ public class Query2Resource {
                 Integer pInt = Integer.parseInt(p);
                 cellPosition.add(pInt);
             }
-            ObjectMapper mapper = new ObjectMapper();
-
-            CollectionType ct = mapper.getTypeFactory().constructCollectionType(ArrayList.class, String.class);
-
-            JavaType st = mapper.getTypeFactory().uncheckedSimpleType(String.class);
+            CollectionType ct = MAPPER.getTypeFactory().constructCollectionType(ArrayList.class, String.class);
+            JavaType st = MAPPER.getTypeFactory().uncheckedSimpleType(String.class);
 
             Map<String, List<String>> levels =
-                    mapper.readValue(returns, mapper.getTypeFactory().constructMapType(Map.class, st, ct));
+                    MAPPER.readValue(returns, MAPPER.getTypeFactory().constructMapType(Map.class, st, ct));
             return thinQueryService.drillacross(queryName, cellPosition, levels);
 
         } catch (Exception e) {

--- a/saiku-core/saiku-web/src/main/java/org/saiku/web/service/CasAuthenticationProvider.java
+++ b/saiku-core/saiku-web/src/main/java/org/saiku/web/service/CasAuthenticationProvider.java
@@ -1,7 +1,7 @@
 package org.saiku.web.service;
 
-import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import org.springframework.security.authentication.AuthenticationProvider;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
@@ -14,7 +14,7 @@ public class CasAuthenticationProvider implements AuthenticationProvider {
     private static final String ROLE_USER = "ROLE_USER";
     private static final String ROLE_ADMIN = "ROLE_ADMIN";
 
-    private static Map<String, UserDetails> userCache = new HashMap<>();
+    private static final Map<String, UserDetails> userCache = new ConcurrentHashMap<>();
 
     @Override
     public Authentication authenticate(Authentication authentication) throws AuthenticationException {

--- a/saiku-core/saiku-web/src/main/java/org/saiku/web/service/SessionService.java
+++ b/saiku-core/saiku-web/src/main/java/org/saiku/web/service/SessionService.java
@@ -23,6 +23,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
 import org.apache.commons.lang3.StringUtils;
 import org.saiku.repository.ScopedRepo;
 import org.saiku.service.ISessionService;
@@ -51,7 +52,7 @@ public class SessionService implements ISessionService {
     private AuthorisationPredicate authorisationPredicate;
     private final SecurityContextRepository securityContextRepository = new HttpSessionSecurityContextRepository();
 
-    private final Map<Object, Map<String, Object>> sessionHolder = new HashMap<>();
+    private final Map<Object, Map<String, Object>> sessionHolder = new ConcurrentHashMap<>();
 
     private Boolean anonymous = false;
     private ScopedRepo sessionRepo;

--- a/saiku-core/saiku-web/src/main/java/org/saiku/web/util/JdbcCleanup.java
+++ b/saiku-core/saiku-web/src/main/java/org/saiku/web/util/JdbcCleanup.java
@@ -1,0 +1,55 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ */
+package org.saiku.web.util;
+
+import java.sql.ResultSet;
+import java.sql.Statement;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Drillthrough cleanup helper. Closes a {@link ResultSet} and its parent {@link Statement}
+ * without ever throwing — the previous in-line {@code finally} blocks in
+ * {@code Query2Resource} would rethrow as {@code SaikuServiceException} and shadow whatever
+ * real failure surfaced inside the {@code try}, masking the actual query error in logs and
+ * leaking the statement.
+ */
+public final class JdbcCleanup {
+
+    private static final Logger log = LoggerFactory.getLogger(JdbcCleanup.class);
+
+    private JdbcCleanup() {}
+
+    /**
+     * Best-effort close: extract the parent statement (if obtainable), close the
+     * {@link ResultSet}, then close the {@link Statement}. Each step is independently
+     * try/catched so a failure in one does not skip the next, and nothing escapes.
+     */
+    public static void closeQuietly(ResultSet rs) {
+        if (rs == null) {
+            return;
+        }
+        Statement stmt = null;
+        try {
+            stmt = rs.getStatement();
+        } catch (Throwable t) {
+            log.debug("Could not obtain Statement from drillthrough ResultSet during cleanup", t);
+        }
+        try {
+            rs.close();
+        } catch (Throwable t) {
+            log.debug("Failed to close drillthrough ResultSet", t);
+        }
+        if (stmt != null) {
+            try {
+                stmt.close();
+            } catch (Throwable t) {
+                log.debug("Failed to close drillthrough Statement", t);
+            }
+        }
+    }
+}

--- a/saiku-core/saiku-web/src/test/java/org/saiku/web/rest/exception/JacksonValidationExceptionMapperTest.java
+++ b/saiku-core/saiku-web/src/test/java/org/saiku/web/rest/exception/JacksonValidationExceptionMapperTest.java
@@ -16,8 +16,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.exc.UnrecognizedPropertyException;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
-import java.util.Arrays;
-import java.util.LinkedHashSet;
 import org.junit.Test;
 import org.saiku.service.olap.ai.AiQueryRequest;
 import org.saiku.service.olap.ai.AiQueryResponse;

--- a/saiku-core/saiku-web/src/test/java/org/saiku/web/rest/resources/AiQueryResourceColumnDisambiguationTest.java
+++ b/saiku-core/saiku-web/src/test/java/org/saiku/web/rest/resources/AiQueryResourceColumnDisambiguationTest.java
@@ -39,9 +39,8 @@ public class AiQueryResourceColumnDisambiguationTest {
         // (a different metadata field) differs and isn't itself a duplicate
         // of the label, so the tiebreaker uses it. First col keeps the raw
         // label so we don't yank back-compat from existing consumers.
-        List<String> out = AiQueryResource.disambiguateColumnLabels(md(
-                new String[] {"Quarter", "Quarter", "Quarter"},
-                new String[] {"yearCol", "quarterCol", "monthCol"}));
+        List<String> out = AiQueryResource.disambiguateColumnLabels(
+                md(new String[] {"Quarter", "Quarter", "Quarter"}, new String[] {"yearCol", "quarterCol", "monthCol"}));
         assertEquals(Arrays.asList("Quarter", "quarterCol", "monthCol"), out);
     }
 

--- a/saiku-core/saiku-web/src/test/java/org/saiku/web/util/JdbcCleanupTest.java
+++ b/saiku-core/saiku-web/src/test/java/org/saiku/web/util/JdbcCleanupTest.java
@@ -1,0 +1,142 @@
+package org.saiku.web.util;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.junit.Test;
+
+/**
+ * Regression coverage for the drillthrough resource-cleanup contract:
+ * <ul>
+ *   <li>Both the {@link ResultSet} and its parent {@link Statement} must be closed.</li>
+ *   <li>An exception from {@link ResultSet#getStatement()} must not suppress {@code rs.close()}.</li>
+ *   <li>Cleanup must never throw out of a {@code finally} block, otherwise it shadows the
+ *       real query failure that surfaced in the {@code try}.</li>
+ * </ul>
+ */
+public class JdbcCleanupTest {
+
+    @Test
+    public void closeQuietly_closes_resultset_and_statement() throws Exception {
+        AtomicBoolean rsClosed = new AtomicBoolean();
+        AtomicBoolean stmtClosed = new AtomicBoolean();
+        Statement stmt = stubStatement(stmtClosed, false);
+        ResultSet rs = stubResultSet(rsClosed, stmt, false);
+
+        JdbcCleanup.closeQuietly(rs);
+
+        assertTrue("ResultSet.close() must be called", rsClosed.get());
+        assertTrue("Statement.close() must be called", stmtClosed.get());
+    }
+
+    @Test
+    public void closeQuietly_swallows_getStatement_failure() throws Exception {
+        AtomicBoolean rsClosed = new AtomicBoolean();
+        ResultSet rs = stubResultSet(rsClosed, null, /*throwOnGetStatement*/ true);
+
+        // Must not throw — and rs.close() must still be invoked despite the prior failure.
+        JdbcCleanup.closeQuietly(rs);
+
+        assertTrue("ResultSet.close() must still be called when getStatement() throws", rsClosed.get());
+    }
+
+    @Test
+    public void closeQuietly_swallows_close_failures() throws Exception {
+        AtomicBoolean stmtClosed = new AtomicBoolean();
+        AtomicBoolean rsClosed = new AtomicBoolean();
+        Statement stmt = stubStatement(stmtClosed, /*throwOnClose*/ true);
+        ResultSet rs = stubResultSet(rsClosed, stmt, /*throwOnGetStatement*/ false, /*throwOnClose*/ true);
+
+        // Must not throw out of cleanup even when both closes blow up.
+        JdbcCleanup.closeQuietly(rs);
+
+        // Best-effort: both close() entries were attempted.
+        assertTrue("ResultSet.close() must be attempted", rsClosed.get());
+        assertTrue("Statement.close() must be attempted", stmtClosed.get());
+    }
+
+    @Test
+    public void closeQuietly_null_is_noop() {
+        // Must not throw on a null ResultSet (drillthrough sometimes never assigns one).
+        JdbcCleanup.closeQuietly(null);
+        assertFalse("trivially passes — included so the null branch is explicit", false);
+    }
+
+    // --- stub factories ---------------------------------------------------------
+
+    private static ResultSet stubResultSet(AtomicBoolean closed, Statement parent, boolean throwOnGetStatement) {
+        return stubResultSet(closed, parent, throwOnGetStatement, false);
+    }
+
+    private static ResultSet stubResultSet(
+            AtomicBoolean closed, Statement parent, boolean throwOnGetStatement, boolean throwOnClose) {
+        InvocationHandler h = (proxy, method, args) -> {
+            switch (method.getName()) {
+                case "close":
+                    closed.set(true);
+                    if (throwOnClose) {
+                        throw new SQLException("simulated rs.close failure");
+                    }
+                    return null;
+                case "getStatement":
+                    if (throwOnGetStatement) {
+                        throw new SQLException("simulated rs.getStatement failure");
+                    }
+                    return parent;
+                case "isClosed":
+                    return closed.get();
+                case "equals":
+                    return proxy == args[0];
+                case "hashCode":
+                    return System.identityHashCode(proxy);
+                case "toString":
+                    return "StubResultSet";
+                default:
+                    return defaultReturn(method);
+            }
+        };
+        return (ResultSet)
+                Proxy.newProxyInstance(JdbcCleanupTest.class.getClassLoader(), new Class<?>[] {ResultSet.class}, h);
+    }
+
+    private static Statement stubStatement(AtomicBoolean closed, boolean throwOnClose) {
+        InvocationHandler h = (proxy, method, args) -> {
+            switch (method.getName()) {
+                case "close":
+                    closed.set(true);
+                    if (throwOnClose) {
+                        throw new SQLException("simulated stmt.close failure");
+                    }
+                    return null;
+                case "isClosed":
+                    return closed.get();
+                case "equals":
+                    return proxy == args[0];
+                case "hashCode":
+                    return System.identityHashCode(proxy);
+                case "toString":
+                    return "StubStatement";
+                default:
+                    return defaultReturn(method);
+            }
+        };
+        return (Statement)
+                Proxy.newProxyInstance(JdbcCleanupTest.class.getClassLoader(), new Class<?>[] {Statement.class}, h);
+    }
+
+    private static Object defaultReturn(Method method) {
+        Class<?> rt = method.getReturnType();
+        if (rt == boolean.class) return false;
+        if (rt == byte.class || rt == short.class || rt == int.class || rt == long.class) return 0;
+        if (rt == float.class || rt == double.class) return 0d;
+        if (rt == char.class) return '\0';
+        return null;
+    }
+}

--- a/saiku-launcher/src/main/java/org/saiku/launcher/SaikuLauncher.java
+++ b/saiku-launcher/src/main/java/org/saiku/launcher/SaikuLauncher.java
@@ -144,8 +144,38 @@ public class SaikuLauncher implements Callable<Integer> {
             System.out.println("  Workspace : " + base + "ui/");
             System.out.println("  Admin     : " + base + "ui/admin");
             System.out.println("  REST API  : " + base + "rest/saiku/");
+            printDefaultCredentialWarning();
             server.join();
             return 0;
+        }
+
+        /**
+         * The bundled WAR ships with the in-memory Spring Security config
+         * (applicationContext-spring-security-memory.xml) backed by an
+         * admin/admin seed entry in users.properties. Suitable for a
+         * single-host demo, not for any deployment exposed to the network.
+         *
+         * <p>Emit a loud, ASCII-bordered warning every launch so it's visible
+         * in log aggregation and screen sessions. Suppressable for CI / demo
+         * by setting {@code -Dsaiku.security.acknowledged=true} — at which
+         * point you take responsibility for whatever auth posture you've put
+         * in front of Saiku (reverse proxy, SSO, replaced security XML, etc.).
+         */
+        private void printDefaultCredentialWarning() {
+            if (Boolean.parseBoolean(System.getProperty("saiku.security.acknowledged", "false"))) {
+                return;
+            }
+            String bar = "============================================================";
+            System.out.println();
+            System.out.println(bar);
+            System.out.println("  SECURITY: default credentials (admin/admin) are active.");
+            System.out.println("  Change them in saiku-webapp's users.properties before");
+            System.out.println("  exposing this instance, or replace the in-memory auth");
+            System.out.println("  config (applicationContext-spring-security-memory.xml)");
+            System.out.println("  with LDAP / OAuth / SAML.");
+            System.out.println("  Suppress this warning with -Dsaiku.security.acknowledged=true");
+            System.out.println(bar);
+            System.out.println();
         }
 
         private void stageSeedAssets(Path dataDir) throws Exception {


### PR DESCRIPTION
## Summary

Ten follow-on findings from the post-SAIKU-780 code review, addressed as a single PR. 31 files changed, 15 new tests, all behavioural changes covered by Red→Green TDD where the change had assertable behaviour.

Net diff: **+809 / -145**. `mvn verify` passes (including spotless) across saiku-service, saiku-web, and saiku-launcher.

## Security

| # | Fix | File |
|---|-----|------|
| 1 | **Path traversal** — `getFile/getInternalFile/getBinaryInternalFile/getNode/delete` resolve through a `resolveWithinDatadir()` helper that normalises and refuses paths escaping the data root. | `FilesystemRepositoryManager.java` |
| 4 | **XXE** — new `SecureXml` helper (DOCTYPE disallowed, external entities off, `FEATURE_SECURE_PROCESSING` on) wired into JAXB `.sds` unmarshal + `DocumentBuilder` in PdfReport. | `SecureXml.java`, `FilesystemRepositoryManager.java`, `PdfReport.java` |
| 7 | **Default-creds warning** — `SaikuLauncher` prints an ASCII banner on every start; suppress with `-Dsaiku.security.acknowledged=true`. | `SaikuLauncher.java` |
| 9 | **@RolesAllowed defence-in-depth** — `RolesAllowedDynamicFeature` registered; `@RolesAllowed("ROLE_ADMIN")` on `AdminResource` (class-level) and `DataSourceResource` mutation methods. | `SaikuJerseyApplication.java`, `AdminResource.java`, `DataSourceResource.java` |

## Concurrency

| # | Fix |
|---|-----|
| 3 | `HashMap` → `ConcurrentHashMap` in five singletons mutated by request threads: `OlapQueryService.queries`, `OlapUtil.cellSetMap`, `CasAuthenticationProvider.userCache`, `SessionService.sessionHolder`, `RepositoryDatasourceManager.datasources` (was `Collections.synchronizedMap`). |

## Performance

| # | Fix |
|---|-----|
| 5 | AI schema build skips redundant Mondrian round-trips: when `populateSampleMembers` fetches ≥1 member, `AiSchema.Level.queryableProven` is set and `pruneUnqueryable` skips its limit=1 probe. Halves the per-level fetch count on cold cube load. |
| 6 | `SaikuQueryCache.evictIfOverBudget` runs on a single-thread daemon executor instead of inside `put()`'s writeLock. New `flushEvictions()` for tests; `submitEvictionTask()` lets tests park the executor to assert `put()` doesn't block. |
| 10 | `Query2Resource`: 3× per-request `new ObjectMapper()` collapsed to one `static final MAPPER` (mirrors `AiQueryResource`). |

## Bug fix

| # | Fix |
|---|-----|
| 2 | Drillthrough `ResultSet/Statement` lifecycle — new `JdbcCleanup.closeQuietly` helper replaces the nested-`finally` pattern in `Query2Resource` that rethrew `SaikuServiceException` from cleanup, suppressing the real query exception and leaking the statement. |

## Hygiene

| # | Fix |
|---|-----|
| 8 | 18× `e.printStackTrace()` replaced with slf4j `log.error` across `FilesystemRepositoryManager`, `RepositoryDatasourceManager`, `Database`, `MdxQuery`, `Fat`, both XMLA servlets, `JdbcUserDAO`, `AbstractConnectionManager`. Four files gained loggers. |

## Test plan

- [x] `mvn -pl saiku-core/saiku-service -am test` — **301/301 pass** (includes 11 new tests: path-traversal repro × 3, XXE × 2, AI schema N+1 × 1, cache eviction off-write-path × 1, plus existing tests still green)
- [x] `mvn -pl saiku-core/saiku-web -am test` — **58/58 pass** (includes 4 new `JdbcCleanupTest` tests)
- [x] `mvn -pl saiku-launcher -am package` — builds the fat-JAR
- [x] `mvn spotless:check` passes across all touched modules
- [ ] Smoke-test the launcher banner appears on startup
- [ ] Smoke-test `BasicRepositoryResource2` still works end-to-end — `getNode()` now throws `SaikuServiceException` on traversal where it previously silently returned an out-of-tree `File`; existing callers may have relied on silent behaviour
- [ ] Verify no AdminResource endpoint was being legitimately used by `ROLE_USER` (URL filter already required `isFullyAuthenticated()`, so most likely safe)

## Notes

- Cache eviction is now eventually-consistent (background thread) rather than synchronous. Under sustained write pressure the disk can briefly exceed `maxSizeBytes`; if that matters in a deployment, expose tighter scheduling.
- I deliberately did **not** create a `DEPLOYMENT-SECURITY.md` doc for item #7 — CLAUDE.md forbids new docs without explicit ask. The startup banner stands alone; happy to append guidance to README/CONTRIBUTING if preferred.
- The original `MdxParameterSubstitutor` work (the actual SAIKU-780 ticket) is **not** part of this PR — it was merged separately in PR #831.