### PR TITLE
fix: saveBinaryInternalFile + repo-relative path regression in PR #851

### DIFF
--- a/saiku-core/saiku-service/src/main/java/org/saiku/repository/FilesystemRepositoryManager.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/repository/FilesystemRepositoryManager.java
@@ -364,51 +364,33 @@ public class FilesystemRepositoryManager implements IRepositoryManager {
 
     public Object saveBinaryInternalFile(InputStream file, String path, String type) throws RepositoryException {
         if (file == null) {
-            // Create new folder
-            String parent = path.substring(0, path.lastIndexOf(sep));
-
-            int pos = path.lastIndexOf(sep);
-            String filename = "." + sep + path.substring(pos + 1, path.length());
-            return this.createNode(filename);
-
-        } else {
-            int pos = path.lastIndexOf(sep);
-            String filename = "." + sep + path.substring(pos + 1, path.length());
-
-            log.debug("Saving:" + filename);
-            File check = this.getNode(filename);
-            if (check.exists()) {
-                check.delete();
-            }
-
-            File resNode = this.createNode(filename);
-
-            FileOutputStream outputStream = null;
-            try {
-                outputStream = new FileOutputStream(new File(filename));
-            } catch (FileNotFoundException e) {
-                log.error("Cannot open output stream for {}", filename, e);
-            }
-
-            int read;
-            byte[] bytes = new byte[1024];
-
-            try {
-                while ((read = file.read(bytes)) != -1) {
-                    try {
-                        if (outputStream != null) {
-                            outputStream.write(bytes, 0, read);
-                        }
-                    } catch (IOException e) {
-                        log.error("Failed to write byte block to {}", filename, e);
-                    }
-                }
-            } catch (IOException e) {
-                log.error("Failed reading input stream while saving {}", filename, e);
-            }
-
-            return resNode;
+            // No content: create the directory node at the user-supplied path
+            // (createNode resolves the path inside the datadir for us).
+            return this.createNode(path);
         }
+        // Resolve the target inside the repo *first* and write to it. The legacy
+        // code used `"./" + basename` and `new FileOutputStream(filename)` which
+        // wrote the bytes to the JVM working directory and silently lost the
+        // intended directory structure (saiku#780 follow-up MEDIUM-1).
+        File resNode = this.createNode(path);
+        if (resNode.getParentFile() != null && !resNode.getParentFile().exists()) {
+            resNode.getParentFile().mkdirs();
+        }
+        if (resNode.exists()) {
+            resNode.delete();
+        }
+        log.debug("Saving binary file to {}", resNode);
+
+        byte[] bytes = new byte[1024];
+        try (FileOutputStream outputStream = new FileOutputStream(resNode)) {
+            int read;
+            while ((read = file.read(bytes)) != -1) {
+                outputStream.write(bytes, 0, read);
+            }
+        } catch (IOException e) {
+            log.error("Failed to write binary file to {}", resNode, e);
+        }
+        return resNode;
     }
 
     public String getFile(String s, String username, List<String> roles) throws RepositoryException {
@@ -911,9 +893,22 @@ public class FilesystemRepositoryManager implements IRepositoryManager {
         }
         Path base = Paths.get(getDatadir()).toAbsolutePath().normalize();
         Path candidate = Paths.get(userPath);
-        Path resolved = candidate.isAbsolute()
-                ? candidate.normalize()
-                : base.resolve(userPath).normalize();
+        Path resolved;
+        if (candidate.isAbsolute() && userPath.startsWith(getDatadir())) {
+            // Truly filesystem-absolute path already inside the datadir — keep as-is.
+            resolved = candidate.normalize();
+        } else {
+            // Saiku treats leading-{slash} paths like {@code "/etc/foo"} as REPO-relative
+            // (i.e. {@code <datadir>/etc/foo}), not as filesystem-absolute. The legacy
+            // implementation got this for free via string concat ({@code datadir + path});
+            // we have to strip the leading separator so {@link Path#resolve} keeps the
+            // segment relative on Unix.
+            String stripped = userPath;
+            while (stripped.startsWith("/") || stripped.startsWith("\\")) {
+                stripped = stripped.substring(1);
+            }
+            resolved = base.resolve(stripped).normalize();
+        }
         if (!resolved.startsWith(base)) {
             throw new RepositoryException("Path traversal attempt rejected: " + userPath);
         }

--- a/saiku-core/saiku-service/src/test/java/org/saiku/repository/FilesystemRepositoryManagerPathTraversalTest.java
+++ b/saiku-core/saiku-service/src/test/java/org/saiku/repository/FilesystemRepositoryManagerPathTraversalTest.java
@@ -108,6 +108,41 @@ public class FilesystemRepositoryManagerPathTraversalTest {
     }
 
     @Test
+    public void saveBinaryInternalFile_writes_inside_datadir_not_jvm_cwd() throws Exception {
+        // Pre-fix bug: saveBinaryInternalFile used `new FileOutputStream(new File("./" + basename))`,
+        // landing the bytes in the JVM's working directory instead of the repo root. The intended
+        // target (resNode from createNode()) was constructed but never written to.
+        byte[] payload = "hello".getBytes(StandardCharsets.UTF_8);
+        String repoPath = "/etc/test-binary-write.bin";
+
+        manager.saveBinaryInternalFile(new java.io.ByteArrayInputStream(payload), repoPath, "application/octet-stream");
+
+        // Expected: file lands at <datadir>/unknown/etc/test-binary-write.bin (getDatadir() resolves
+        // to <datadir>/unknown/ when there's no workspace session).
+        File expected = new File(datadir, "unknown/etc/test-binary-write.bin");
+        if (!expected.exists()) {
+            fail("saveBinaryInternalFile must write inside the repo. Expected at "
+                    + expected.getAbsolutePath()
+                    + " but the file is missing.");
+        }
+        byte[] readBack = Files.readAllBytes(expected.toPath());
+        if (!new String(readBack, StandardCharsets.UTF_8).equals("hello")) {
+            fail("saveBinaryInternalFile wrote unexpected bytes to " + expected.getAbsolutePath());
+        }
+
+        // Also assert the bug-vector file does NOT exist at CWD.
+        File cwdLeak = new File("test-binary-write.bin");
+        if (cwdLeak.exists()) {
+            try {
+                cwdLeak.delete();
+            } catch (Exception ignored) {
+            }
+            fail("saveBinaryInternalFile leaked bytes into the JVM working directory (" + cwdLeak.getAbsolutePath()
+                    + ")");
+        }
+    }
+
+    @Test
     public void getInternalFile_absolute_path_outside_datadir_is_rejected() throws Exception {
         // An absolute path that doesn't start with the datadir must not be readable either.
         String absoluteOutside = outsideSecret.getAbsolutePath();


### PR DESCRIPTION
## Summary

Stacked on top of PR #851. Two follow-ups to that branch's `FilesystemRepositoryManager` hardening, plus verification that the long-standing drillthrough classloader bug is now resolved.

### 1. `saveBinaryInternalFile` was writing to JVM CWD, not the repo

The legacy code constructed `resNode` via `createNode(filename)` (correct path under the datadir) but then wrote with `new FileOutputStream(new File("./" + basename))` — landing the bytes in the JVM working directory and never touching `resNode`. Binary uploads were effectively black-holed. Now:
- `resNode` is created via `createNode(path)` (which goes through `resolveWithinDatadir`)
- bytes are streamed into `resNode` via try-with-resources
- new test asserts the file lands at `<datadir>/unknown/etc/<name>` and that the JVM CWD has no leak

### 2. Legitimate Saiku repo-relative paths starting with `/` were being rejected

The `resolveWithinDatadir` helper introduced in PR #851 treated **any** absolute-looking path as filesystem-absolute. Saiku has historically used leading-`/` paths like `/etc/.repo_version` as **repo-relative**, not filesystem-absolute. This caused launcher startup to die:

```
Caused by: org.saiku.repository.RepositoryException:
  Path traversal attempt rejected: /etc/.repo_version
    at FilesystemRepositoryManager.resolveWithinDatadir
    at FilesystemRepositoryManager.saveInternalFile
    at RepositoryDatasourceManager.load
```

Fix: only treat absolute paths as filesystem-absolute when they actually start with the datadir. Otherwise strip leading separators and resolve against the base. The traversal containment check still rejects `../`-style escapes — the existing path-traversal tests all still pass.

### 3. Drillthrough classloader bug verified resolved

While the launcher was up, I ran the full `saiku-launcher/test-ai-live.sh` regression suite plus the specific repro pattern from the project memory note:

| Path | Result |
|---|---|
| `GET /rest/saiku/api/query/{id}/drillthrough?maxrows=5` | 200 |
| `GET /rest/saiku/api/query/{id}/drillthrough?returns=[Customer],[Measures].[Unit Sales]` (exact memory repro) | 200 |
| `GET /rest/saiku/api/query/{id}/drillthrough/export/csv?maxrows=5` | 200 |
| `GET /rest/saiku/api/ai/query/{id}/drillthrough?maxrows=5` | 200 |
| `test-ai-live.sh` | 143/146 pass — all 7 drillthrough scenarios green |

Likely cause of the resolution: the `JdbcCleanup.closeQuietly` refactor in PR #851 replaced the old nested-`finally` block that called `rs.getStatement()` and re-threw as `SaikuServiceException` — that pattern was the suspected surfacing path for the classloader error. Memory note updated to RESOLVED.

(The 3 `test-ai-live.sh` failures are unrelated MDX same-hier 2-level edge cases not on this PR's surface.)

## Test plan

- [x] `mvn -pl saiku-core/saiku-service,saiku-core/saiku-web -am test` — 306 + 58 pass
- [x] `mvn -pl saiku-launcher -am package` — fat-JAR builds
- [x] Launcher starts cleanly (Spring context loads; was failing on `/etc/.repo_version` before this PR)
- [x] `test-ai-live.sh` runs against the launcher, 143/146 pass
- [x] Spotless clean