### PR TITLE
feat(ai): saiku#818 follow-ups — FIRST_ROWSET fallback, dim synonyms, required_filters demo

### DIFF
--- a/docs/AI-QUERY-API.md
+++ b/docs/AI-QUERY-API.md
@@ -126,6 +126,23 @@ The response is dense — this is what makes the API self-describing:
     // …also picks up any Phase-3 displayName aliases…
   },
 
+  "dimensionAliases": {                                       // saiku#818 follow-up
+    "shopper":  "customer",
+    "buyer":    "customer",
+    "date":     "time"
+    // single canonical-key value per synonym — dimensions don't collide in a cube
+  },
+
+  "levelAliases": {                                           // saiku#818 follow-up
+    "quarterly": [{ "dimension": "time", "hierarchy": "time", "level": "quarter" }],
+    "qtr":       [{ "dimension": "time", "hierarchy": "time", "level": "quarter" }],
+    "nation":    [{ "dimension": "customer", "hierarchy": "customers", "level": "country" }]
+    // list-valued because the same level name can live in multiple hierarchies
+    // (e.g. Quarter in both Time/Time and Time/Fiscal). Each target carries
+    // canonical (dimension, hierarchy, level) keys so the agent can drill
+    // straight back into the schema maps without re-walking.
+  },
+
   "dimensions": {
     "time": {
       "name": "Time",
@@ -238,12 +255,20 @@ The response is dense — this is what makes the API self-describing:
    Every annotated level carries `cardinality` and (for time) `grain` so the
    agent maps "quarterly" / "by month" straight to the right level instead of
    guessing.
-7. **Input synonyms** — `measures[].name` and `rows[].level` / `columns[].level`
-   accept any entry from `measureAliases` / `levelAliases`. The agent can post
-   `{"measures": [{"name": "revenue"}]}` and the server resolves to
-   `[Measures].[Store Sales]` with no /schema round-trip. See "Display names +
-   semantic annotations" below for how XML annotations and the Phase-3 overlay
-   contribute aliases.
+7. **Input synonyms** — `measures[].name`, `rows[].dimension|level` /
+   `columns[].dimension|level` and `filters[].dimension|level` all accept any
+   entry from `measureAliases` / `dimensionAliases` / per-hierarchy
+   `levelAliases`. The agent can post `{"measures": [{"name": "revenue"}]}`
+   and the server resolves to `[Measures].[Store Sales]` with no /schema
+   round-trip. See "Display names + semantic annotations" below for how XML
+   annotations and the Phase-3 overlay contribute aliases.
+8. **Flat alias overview** — top-level `measureAliases`,
+   `dimensionAliases`, and `levelAliases` give an agent the whole synonym
+   set in one read, the same way the schema body gives it the whole name
+   set in one read. Resolution still happens against the per-hierarchy
+   `Hierarchy.levelAliases` map (the converter knows which hierarchy the
+   request named, so per-hierarchy is correct), but the top-level
+   overview is what an agent inspects when constructing the query.
 
 ---
 
@@ -434,6 +459,24 @@ can return a `VALIDATION_ERROR`:
 
 The contract for the agent is the same either way: read `field`, read
 `available[]`, fix and retry.
+
+**Self-correcting error messages.** Semantic-validator errors carry the
+literal fix in the `error` string when there is one. For example,
+putting the same hierarchy on both an axis AND a filter — Mondrian
+rejects that — produces:
+
+```json
+{
+  "status": "VALIDATION_ERROR",
+  "error":  "Hierarchy 'Time' is already on the rows/columns axis. Mondrian rejects the same hierarchy on two independent axes. Either move the filter members onto the axis selection's `members[]`, or filter on a different hierarchy/dimension.",
+  "field":  "filters[0].hierarchy",
+  "available": []
+}
+```
+
+The message names the conflict, explains *why*, and tells the agent the
+two ways out. `available[]` is empty here because the fix isn't a
+choice from a list — it's a structural change to the request shape.
 
 **Missing required filter (saiku#818 — opt-in per level).** When a level
 in the schema declares `requiredFilters`, the converter rejects any query
@@ -765,12 +808,19 @@ Example: "last 30 days of sales by product family":
       "<column caption>": {                        // Typed cell per measure/column.
         "value": 123.45,                           // Parsed number (Double) or null.
         "formatted": "123.45",                     // Mondrian's display string.
-        "unit": "USD"                              // Sniffed currency/% or null.
+        "unit": "USD",                             // Sniffed currency/% or null.
+        "properties": {                            // Raw Mondrian cell properties — client can re-format
+          "formatString":  "#,###.00",             //   locale-aware rather than relying on `formatted`.
+          "datatype":      "Numeric",              //   "Numeric" | "String" | "Boolean" | "DateTime" …
+          "actionType":    "256",                  //   Bitmap of MDSCHEMA action types (drillthrough etc.).
+          "fontFlags":     "0",                    //   Cell-formatting font hints (bold/italic bits).
+          "solveOrder":    "0"                     //   Calc-member solve order; 0 for plain measures.
+        }
       }
     }
   ],
   "matrix": [                                      // matrix format. Populated when format=matrix.
-    { "0": { "value": 123.45, "formatted": "123.45", "unit": null } }
+    { "0": { "value": 123.45, "formatted": "123.45", "unit": null, "properties": { /* … */ } } }
   ],
   "totalRows": 3,
   "runtimeMs": 421,

--- a/saiku-core/saiku-service/src/main/java/org/saiku/olap/dto/SaikuDimension.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/olap/dto/SaikuDimension.java
@@ -15,7 +15,9 @@
  */
 package org.saiku.olap.dto;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 public class SaikuDimension extends AbstractSaikuObject {
 
@@ -23,6 +25,12 @@ public class SaikuDimension extends AbstractSaikuObject {
     private String description;
     private boolean visible;
     private List<SaikuHierarchy> hierarchies;
+    /** saiku#818 follow-up: raw schema-level annotations (e.g.
+     *  {@code <Annotation name="saiku.semantic.synonyms">time, date</Annotation>}).
+     *  Populated by {@code ObjectUtil.convert(Dimension)} via the same
+     *  {@code mondrian.olap.Annotated} reflection seam used for measures and
+     *  levels. */
+    private Map<String, String> annotations;
 
     public SaikuDimension() {
         super(null, null);
@@ -57,5 +65,14 @@ public class SaikuDimension extends AbstractSaikuObject {
 
     public List<SaikuHierarchy> getHierarchies() {
         return hierarchies;
+    }
+
+    /** Returns a defensive copy, or {@code null} if no annotations were attached. */
+    public Map<String, String> getAnnotations() {
+        return annotations == null ? null : new HashMap<>(annotations);
+    }
+
+    public void setAnnotations(Map<String, String> annotations) {
+        this.annotations = annotations == null ? null : new HashMap<>(annotations);
     }
 }

--- a/saiku-core/saiku-service/src/main/java/org/saiku/olap/util/ObjectUtil.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/olap/util/ObjectUtil.java
@@ -58,13 +58,17 @@ public class ObjectUtil {
 
     @NotNull
     public static SaikuDimension convert(@NotNull Dimension dim) {
-        return new SaikuDimension(
+        SaikuDimension sd = new SaikuDimension(
                 dim.getName(),
                 dim.getUniqueName(),
                 dim.getCaption(),
                 dim.getDescription(),
                 dim.isVisible(),
                 convertHierarchies(dim.getHierarchies()));
+        // saiku#818 follow-up: surface dimension-level annotations so
+        // OlapAiCubeMetadataService can apply saiku.semantic.* to AiSchema.Dimension.
+        sd.setAnnotations(annotationsAsStringMap(dim));
+        return sd;
     }
 
     @NotNull

--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/DrillthroughMdxBuilder.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/DrillthroughMdxBuilder.java
@@ -1,0 +1,63 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.service.olap;
+
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Build a {@code DRILLTHROUGH ...} MDX string from a base SELECT + the caller's row caps.
+ * Extracted from {@link ThinQueryService#drillthrough} so the cap-emission policy is unit-testable
+ * and so a single seam can route Mondrian back to {@code MAXROWS} when the caller asked for
+ * {@code FIRST_ROWSET}.
+ *
+ * <p>Mondrian's MDX grammar does not define the {@code FIRST_ROWSET} token. Saiku had been emitting
+ * it whenever {@code firstRowset > 0}, and the parser rejected the query with a syntax error —
+ * seen live as a 500 with {@code "Error DRILLTHROUGH: ..."}. The builder transparently falls back
+ * to {@code MAXROWS} on Mondrian connections; non-Mondrian backends (XMLA, MSAS) keep
+ * {@code FIRST_ROWSET} where supported.
+ */
+public final class DrillthroughMdxBuilder {
+
+    private static final Logger log = LoggerFactory.getLogger(DrillthroughMdxBuilder.class);
+
+    private DrillthroughMdxBuilder() {}
+
+    /**
+     * Compose the drillthrough MDX. Precedence:
+     * <ol>
+     *   <li>{@code firstRowset > 0} on a non-Mondrian backend → {@code DRILLTHROUGH FIRST_ROWSET N ...}</li>
+     *   <li>{@code firstRowset > 0} on Mondrian → fall back to {@code DRILLTHROUGH MAXROWS N ...}
+     *       (using the smaller of {@code firstRowset} and {@code maxrows} when both supplied).</li>
+     *   <li>{@code maxrows > 0} → {@code DRILLTHROUGH MAXROWS N ...}</li>
+     *   <li>Otherwise → bare {@code DRILLTHROUGH ...}</li>
+     * </ol>
+     * Optional non-blank {@code returns} is appended as {@code "\r\n RETURN " + returns}.
+     */
+    public static String build(
+            String baseSelect, int maxrows, Integer firstRowset, String returns, boolean isMondrian) {
+        String mdx;
+        if (firstRowset != null && firstRowset > 0) {
+            if (isMondrian) {
+                int cap = (maxrows > 0) ? Math.min(maxrows, firstRowset) : firstRowset;
+                log.debug(
+                        "Mondrian backend doesn't support FIRST_ROWSET; falling back to MAXROWS {} for drillthrough.",
+                        cap);
+                mdx = "DRILLTHROUGH MAXROWS " + cap + " " + baseSelect;
+            } else {
+                mdx = "DRILLTHROUGH FIRST_ROWSET " + firstRowset + " " + baseSelect;
+            }
+        } else if (maxrows > 0) {
+            mdx = "DRILLTHROUGH MAXROWS " + maxrows + " " + baseSelect;
+        } else {
+            mdx = "DRILLTHROUGH " + baseSelect;
+        }
+        if (StringUtils.isNotBlank(returns)) {
+            mdx += "\r\n RETURN " + returns;
+        }
+        return mdx;
+    }
+}

--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ThinQueryService.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ThinQueryService.java
@@ -595,17 +595,11 @@ public class ThinQueryService implements Serializable {
             final OlapConnection con =
                     olapDiscoverService.getNativeConnection(query.getCube().getConnection());
             stmt = con.createStatement();
-            String mdx = query.getMdx();
-            if (firstRowset != null && firstRowset > 0) {
-                mdx = "DRILLTHROUGH FIRST_ROWSET " + firstRowset + " " + mdx;
-            } else if (maxrows > 0) {
-                mdx = "DRILLTHROUGH MAXROWS " + maxrows + " " + mdx;
-            } else {
-                mdx = "DRILLTHROUGH " + mdx;
-            }
-            if (StringUtils.isNotBlank(returns)) {
-                mdx += "\r\n RETURN " + returns;
-            }
+            // saiku#818 follow-up: Mondrian's MDX parser doesn't define FIRST_ROWSET,
+            // so emitting it produced a 500 with an opaque "Error DRILLTHROUGH" message.
+            // Route through DrillthroughMdxBuilder which falls back to MAXROWS on Mondrian.
+            boolean isMondrian = SaikuMondrianHelper.isMondrianConnection(con);
+            String mdx = DrillthroughMdxBuilder.build(query.getMdx(), maxrows, firstRowset, returns, isMondrian);
             return stmt.executeQuery(mdx);
         } catch (SQLException e) {
             throw new SaikuServiceException("Error DRILLTHROUGH: " + queryName, e);

--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ai/AiSchema.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ai/AiSchema.java
@@ -208,12 +208,43 @@ public class AiSchema {
      */
     public AiCubeRef canonicalCube;
 
+    /**
+     * Triple identifying one level in the cube. Used as a value in
+     * {@link #levelAliases} so a single synonym can resolve to multiple levels
+     * across hierarchies (saiku#818 follow-up — Quarter exists in both
+     * {@code Time/Time} and {@code Time/Fiscal}, "quarterly" resolves to both).
+     * All three fields are canonical (lower-cased) keys, suitable for direct
+     * map lookup against {@link #dimensions} / hierarchies / levels.
+     */
+    public static class LevelAliasTarget {
+        public String dimension;
+        public String hierarchy;
+        public String level;
+
+        public LevelAliasTarget() {}
+
+        public LevelAliasTarget(String dimension, String hierarchy, String level) {
+            this.dimension = dimension;
+            this.hierarchy = hierarchy;
+            this.level = level;
+        }
+    }
+
     public final Map<String, Measure> measures = new LinkedHashMap<>();
     public final Map<String, Dimension> dimensions = new LinkedHashMap<>();
     /** display-name → canonical measure key (Phase 3 enrichment alias). */
     public final Map<String, String> measureAliases = new LinkedHashMap<>();
     /** display-name → canonical dimension key (Phase 3 enrichment alias). */
     public final Map<String, String> dimensionAliases = new LinkedHashMap<>();
+    /** saiku#818 follow-up: flat top-level view of level synonyms.
+     *  Maps each synonym → list of every level it resolves to. The list lets a
+     *  single synonym ("quarterly") cover same-named levels across multiple
+     *  hierarchies (Time/Time/Quarter + Time/Fiscal/Quarter); the agent
+     *  disambiguates using {@code dimension}/{@code hierarchy} on each target.
+     *  Resolution itself still happens against
+     *  {@code Hierarchy.levelAliases} (per-hierarchy scope) — this map is
+     *  purely a read-side overview for the {@code /ai/schema} response. */
+    public final Map<String, java.util.List<LevelAliasTarget>> levelAliases = new LinkedHashMap<>();
     /** Phase 3: LLM/schema-generator suggestions overlaid on the schema. */
     public java.util.List<AiSchemaSuggestion> suggestions = new java.util.ArrayList<>();
     /** Optional free-text cube-level description. */

--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ai/AiSchema.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ai/AiSchema.java
@@ -174,6 +174,12 @@ public class AiSchema {
         public final String uniqueName;
         public String displayName;
         public String description;
+        /** saiku#818 follow-up: alternate names the agent can use in any
+         *  {@code AiQueryRequest} field that names a dimension. Registered into
+         *  {@link AiSchema#dimensionAliases} for input resolution and also
+         *  surfaced as a distinct list on the {@code /ai/schema} response. */
+        public java.util.List<String> synonyms = new java.util.ArrayList<>();
+
         public final Map<String, Hierarchy> hierarchies = new LinkedHashMap<>();
         /** display-name → canonical hierarchy key. */
         public final Map<String, String> hierarchyAliases = new LinkedHashMap<>();

--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ai/AiSchemaEnricher.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ai/AiSchemaEnricher.java
@@ -63,6 +63,15 @@ public class AiSchemaEnricher {
             return;
         }
 
+        if (parts.length == 2 && "dimensions".equals(parts[0])) {
+            AiSchema.Dimension d = schema.dimensions.get(AiSchema.key(parts[1]));
+            if (d == null) return;
+            SemanticAnnotationParser.DimensionAnnotations ann = SemanticAnnotationParser.parseDimension(raw);
+            if (ann.description != null) d.description = ann.description;
+            if (!ann.synonyms.isEmpty()) d.synonyms = ann.synonyms;
+            return;
+        }
+
         if (parts.length == 6
                 && "dimensions".equals(parts[0])
                 && "hierarchies".equals(parts[2])
@@ -98,7 +107,13 @@ public class AiSchemaEnricher {
                 schema.measureAliases.putIfAbsent(synKey, canonical);
             }
         }
-        for (AiSchema.Dimension d : schema.dimensions.values()) {
+        for (Map.Entry<String, AiSchema.Dimension> de : schema.dimensions.entrySet()) {
+            String dimCanonical = de.getKey();
+            AiSchema.Dimension d = de.getValue();
+            // saiku#818 follow-up: register dim synonyms too.
+            for (String syn : d.synonyms) {
+                schema.dimensionAliases.putIfAbsent(AiSchema.key(syn), dimCanonical);
+            }
             for (AiSchema.Hierarchy h : d.hierarchies.values()) {
                 for (Map.Entry<String, AiSchema.Level> le : h.levels.entrySet()) {
                     String canonical = le.getKey();

--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ai/AiSchemaEnricher.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ai/AiSchemaEnricher.java
@@ -114,11 +114,35 @@ public class AiSchemaEnricher {
             for (String syn : d.synonyms) {
                 schema.dimensionAliases.putIfAbsent(AiSchema.key(syn), dimCanonical);
             }
-            for (AiSchema.Hierarchy h : d.hierarchies.values()) {
+            for (Map.Entry<String, AiSchema.Hierarchy> he : d.hierarchies.entrySet()) {
+                String hierCanonical = he.getKey();
+                AiSchema.Hierarchy h = he.getValue();
                 for (Map.Entry<String, AiSchema.Level> le : h.levels.entrySet()) {
-                    String canonical = le.getKey();
+                    String levelCanonical = le.getKey();
                     for (String syn : le.getValue().synonyms) {
-                        h.levelAliases.putIfAbsent(AiSchema.key(syn), canonical);
+                        String synKey = AiSchema.key(syn);
+                        h.levelAliases.putIfAbsent(synKey, levelCanonical);
+                        // saiku#818 follow-up: also surface a flat top-level view
+                        // so an agent gets the same overview for levels that
+                        // measureAliases/dimensionAliases already give. Same-named
+                        // levels across hierarchies (Time/Time/Quarter +
+                        // Time/Fiscal/Quarter) append rather than silently dropping.
+                        java.util.List<AiSchema.LevelAliasTarget> targets =
+                                schema.levelAliases.computeIfAbsent(synKey, k -> new java.util.ArrayList<>());
+                        // De-dupe — if the same synonym→target tuple appears via
+                        // both XML annotation and overlay, only register once.
+                        boolean exists = false;
+                        for (AiSchema.LevelAliasTarget t : targets) {
+                            if (dimCanonical.equals(t.dimension)
+                                    && hierCanonical.equals(t.hierarchy)
+                                    && levelCanonical.equals(t.level)) {
+                                exists = true;
+                                break;
+                            }
+                        }
+                        if (!exists) {
+                            targets.add(new AiSchema.LevelAliasTarget(dimCanonical, hierCanonical, levelCanonical));
+                        }
                     }
                 }
             }

--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ai/OlapAiCubeMetadataService.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ai/OlapAiCubeMetadataService.java
@@ -251,6 +251,11 @@ public class OlapAiCubeMetadataService implements AiCubeMetadataService {
                 if (dim.getDescription() != null && !dim.getDescription().isEmpty()) {
                     d.description = dim.getDescription();
                 }
+                // saiku#818 follow-up: project dimension-level annotations.
+                SemanticAnnotationParser.DimensionAnnotations dann =
+                        SemanticAnnotationParser.parseDimension(dim.getAnnotations());
+                if (dann.description != null) d.description = dann.description;
+                if (!dann.synonyms.isEmpty()) d.synonyms = dann.synonyms;
                 List<SaikuHierarchy> hiers = dim.getHierarchies();
                 if (hiers == null || hiers.isEmpty()) {
                     hiers = discoverService.getAllDimensionHierarchies(cube, dim.getName());

--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ai/SemanticAnnotationParser.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ai/SemanticAnnotationParser.java
@@ -52,6 +52,14 @@ public final class SemanticAnnotationParser {
 
     private SemanticAnnotationParser() {}
 
+    /** Parsed dimension-level annotations. saiku#818 follow-up: dimensions accept
+     *  {@code description} + {@code synonyms} only (no aggregation-kind / cardinality —
+     *  those live on measures and levels). */
+    public static final class DimensionAnnotations {
+        public String description;
+        public List<String> synonyms = new ArrayList<>();
+    }
+
     /** Parsed measure-level annotations. Fields default to {@code null} / empty list. */
     public static final class MeasureAnnotations {
         public String description;
@@ -68,6 +76,16 @@ public final class SemanticAnnotationParser {
         public String cardinality;
         public String grain;
         public List<AiSchema.RequiredFilter> requiredFilters = new ArrayList<>();
+    }
+
+    public static DimensionAnnotations parseDimension(Map<String, String> annotations) {
+        DimensionAnnotations out = new DimensionAnnotations();
+        if (annotations == null) {
+            return out;
+        }
+        out.description = trimToNull(annotations.get(KEY_DESCRIPTION));
+        out.synonyms = parseCsvList(annotations.get(KEY_SYNONYMS));
+        return out;
     }
 
     public static MeasureAnnotations parseMeasure(Map<String, String> annotations) {

--- a/saiku-core/saiku-service/src/test/java/org/saiku/service/olap/DrillthroughMdxBuilderTest.java
+++ b/saiku-core/saiku-service/src/test/java/org/saiku/service/olap/DrillthroughMdxBuilderTest.java
@@ -1,0 +1,93 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.service.olap;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+/**
+ * Pure-unit contract for {@link DrillthroughMdxBuilder#build(String, int, Integer, String, boolean)}.
+ *
+ * <p>Caps the regression Tom hit live on 2026-05-15: the AI drillthrough endpoint forwarded
+ * {@code ?firstRowset=N} into {@link org.saiku.service.olap.ThinQueryService#drillthrough}, which
+ * emitted {@code DRILLTHROUGH FIRST_ROWSET N SELECT ...} — a token Mondrian's MDX parser doesn't
+ * recognise. The build was failing with a 500 + opaque message. This builder is the new shared
+ * MDX-emission seam; the test pins the four shapes plus the Mondrian-fallback policy.
+ */
+public class DrillthroughMdxBuilderTest {
+
+    private static final String BASE = "SELECT NON EMPTY {[Measures].[Sales]} ON COLUMNS FROM [Cube]";
+
+    @Test
+    public void plain_drillthrough_when_no_caps() {
+        String mdx = DrillthroughMdxBuilder.build(BASE, 0, null, null, /*isMondrian*/ true);
+        assertTrue(mdx.startsWith("DRILLTHROUGH SELECT"));
+        assertFalse("no MAXROWS when not asked for", mdx.contains("MAXROWS"));
+        assertFalse("no FIRST_ROWSET when not asked for", mdx.contains("FIRST_ROWSET"));
+    }
+
+    @Test
+    public void maxrows_only() {
+        String mdx = DrillthroughMdxBuilder.build(BASE, 5, null, null, true);
+        assertTrue(mdx.startsWith("DRILLTHROUGH MAXROWS 5 SELECT"));
+    }
+
+    @Test
+    public void firstRowset_on_non_mondrian_emits_first_rowset() {
+        String mdx = DrillthroughMdxBuilder.build(BASE, 0, 5, null, /*isMondrian*/ false);
+        assertTrue(
+                "non-Mondrian backends keep FIRST_ROWSET (XMLA/MSAS support it). Got: " + mdx,
+                mdx.startsWith("DRILLTHROUGH FIRST_ROWSET 5 SELECT"));
+    }
+
+    @Test
+    public void firstRowset_on_mondrian_falls_back_to_maxrows() {
+        // Mondrian's MDX grammar doesn't define FIRST_ROWSET. Emitting it produced a 500.
+        // The builder must transparently fall back to MAXROWS when the connection is Mondrian.
+        String mdx = DrillthroughMdxBuilder.build(BASE, 0, 5, null, /*isMondrian*/ true);
+        assertEquals("DRILLTHROUGH MAXROWS 5 " + BASE, mdx);
+    }
+
+    @Test
+    public void firstRowset_takes_precedence_over_maxrows_on_non_mondrian() {
+        String mdx = DrillthroughMdxBuilder.build(BASE, 9, 5, null, false);
+        assertTrue(mdx, mdx.startsWith("DRILLTHROUGH FIRST_ROWSET 5 SELECT"));
+        assertFalse(mdx, mdx.contains("MAXROWS"));
+    }
+
+    @Test
+    public void firstRowset_on_mondrian_with_maxrows_supplied_uses_firstRowset_value_as_the_cap() {
+        // The intent of firstRowset is "cap the rowset". When falling back to MAXROWS on Mondrian
+        // we want the firstRowset count to win — that's what the agent actually asked for. The
+        // maxrows hint becomes a secondary lower bound; pick the smaller of the two so we cap as
+        // tightly as the user requested.
+        String mdx = DrillthroughMdxBuilder.build(BASE, 9, 5, null, true);
+        assertEquals("DRILLTHROUGH MAXROWS 5 " + BASE, mdx);
+
+        String wider = DrillthroughMdxBuilder.build(BASE, 3, 5, null, true);
+        assertEquals("DRILLTHROUGH MAXROWS 3 " + BASE, wider);
+    }
+
+    @Test
+    public void returns_clause_appended_when_supplied() {
+        String mdx = DrillthroughMdxBuilder.build(BASE, 5, null, "[Customer].[Country]", true);
+        assertTrue(mdx, mdx.endsWith("\r\n RETURN [Customer].[Country]"));
+    }
+
+    @Test
+    public void returns_clause_blank_string_is_ignored() {
+        String mdx = DrillthroughMdxBuilder.build(BASE, 5, null, "   ", true);
+        assertFalse(mdx.contains("RETURN"));
+    }
+
+    @Test
+    public void zero_or_negative_firstRowset_does_not_emit_first_rowset() {
+        assertFalse(DrillthroughMdxBuilder.build(BASE, 5, 0, null, false).contains("FIRST_ROWSET"));
+        assertFalse(DrillthroughMdxBuilder.build(BASE, 5, -1, null, false).contains("FIRST_ROWSET"));
+    }
+}

--- a/saiku-core/saiku-service/src/test/java/org/saiku/service/olap/ai/AiSchemaLevelAliasesTest.java
+++ b/saiku-core/saiku-service/src/test/java/org/saiku/service/olap/ai/AiSchemaLevelAliasesTest.java
@@ -1,0 +1,118 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.service.olap.ai;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Arrays;
+import java.util.List;
+import org.junit.Test;
+
+/**
+ * Top-level {@code schema.levelAliases} contract (saiku#818 follow-up). An agent
+ * scanning the schema response needs a flat overview of every level synonym in
+ * the cube, the same way {@code measureAliases} and {@code dimensionAliases}
+ * give it a flat overview for those layers. Level names can collide across
+ * hierarchies, so the value is a List of {@code (dimension, hierarchy, level)}
+ * triples rather than a single canonical key — option A from the design
+ * conversation.
+ */
+public class AiSchemaLevelAliasesTest {
+
+    private AiSchema buildCubeWithCollidingLevelSynonyms() {
+        AiSchema s = new AiSchema("[Sales]", "Sales", "[Sales]");
+
+        // Time/Time/Quarter declares synonym "quarterly"
+        AiSchema.Dimension time = new AiSchema.Dimension("Time", "[Time]");
+        AiSchema.Hierarchy timeBy = new AiSchema.Hierarchy("Time By", "[Time].[Time By]");
+        AiSchema.Level qTimeBy = new AiSchema.Level("Quarter", "[Time].[Time By].[Quarter]");
+        qTimeBy.synonyms = Arrays.asList("quarterly", "qtr");
+        timeBy.levels.put(AiSchema.key("Quarter"), qTimeBy);
+        time.hierarchies.put(AiSchema.key("Time By"), timeBy);
+
+        // Time/Fiscal/Quarter also declares synonym "quarterly" — same synonym,
+        // different level. The flat top-level map must list BOTH.
+        AiSchema.Hierarchy fiscal = new AiSchema.Hierarchy("Fiscal", "[Time].[Fiscal]");
+        AiSchema.Level qFiscal = new AiSchema.Level("Quarter", "[Time].[Fiscal].[Quarter]");
+        qFiscal.synonyms = Arrays.asList("quarterly");
+        fiscal.levels.put(AiSchema.key("Quarter"), qFiscal);
+        time.hierarchies.put(AiSchema.key("Fiscal"), fiscal);
+
+        s.dimensions.put(AiSchema.key("Time"), time);
+
+        // A non-colliding synonym (only one level uses it) so we can distinguish
+        // single-target entries from collisions in the flat map.
+        AiSchema.Dimension customer = new AiSchema.Dimension("Customer", "[Customer]");
+        AiSchema.Hierarchy customers = new AiSchema.Hierarchy("Customers", "[Customer].[Customers]");
+        AiSchema.Level country = new AiSchema.Level("Country", "[Customer].[Customers].[Country]");
+        country.synonyms = Arrays.asList("nation");
+        customers.levels.put(AiSchema.key("Country"), country);
+        customer.hierarchies.put(AiSchema.key("Customers"), customers);
+        s.dimensions.put(AiSchema.key("Customer"), customer);
+
+        return s;
+    }
+
+    @Test
+    public void enricher_populates_top_level_levelAliases_map() {
+        AiSchema schema = buildCubeWithCollidingLevelSynonyms();
+        new AiSchemaEnricher().apply(schema, new AiSchemaEnrichment());
+
+        assertNotNull("schema.levelAliases must exist", schema.levelAliases);
+        assertTrue(
+                "schema.levelAliases must carry the colliding synonym", schema.levelAliases.containsKey("quarterly"));
+        assertTrue(
+                "schema.levelAliases must carry the single-target synonym", schema.levelAliases.containsKey("nation"));
+    }
+
+    @Test
+    public void colliding_synonym_lists_all_targets_not_just_first() {
+        AiSchema schema = buildCubeWithCollidingLevelSynonyms();
+        new AiSchemaEnricher().apply(schema, new AiSchemaEnrichment());
+
+        List<AiSchema.LevelAliasTarget> targets = schema.levelAliases.get("quarterly");
+        assertNotNull(targets);
+        assertEquals("quarterly resolves to two levels (Time By + Fiscal)", 2, targets.size());
+
+        boolean sawTimeBy = false, sawFiscal = false;
+        for (AiSchema.LevelAliasTarget t : targets) {
+            if ("time by".equals(t.hierarchy)) sawTimeBy = true;
+            if ("fiscal".equals(t.hierarchy)) sawFiscal = true;
+            assertEquals("time", t.dimension);
+            assertEquals("quarter", t.level);
+        }
+        assertTrue("Time/Time By/Quarter present", sawTimeBy);
+        assertTrue("Time/Fiscal/Quarter present", sawFiscal);
+    }
+
+    @Test
+    public void unique_synonym_yields_single_target_entry() {
+        AiSchema schema = buildCubeWithCollidingLevelSynonyms();
+        new AiSchemaEnricher().apply(schema, new AiSchemaEnrichment());
+
+        List<AiSchema.LevelAliasTarget> targets = schema.levelAliases.get("nation");
+        assertNotNull(targets);
+        assertEquals(1, targets.size());
+        AiSchema.LevelAliasTarget t = targets.get(0);
+        assertEquals("customer", t.dimension);
+        assertEquals("customers", t.hierarchy);
+        assertEquals("country", t.level);
+    }
+
+    @Test
+    public void per_hierarchy_levelAliases_still_populated_after_top_level_added() {
+        // Resolution still happens against Hierarchy.levelAliases — the top-level
+        // map is purely for read-side observability. Verify the per-hierarchy
+        // map is unaffected.
+        AiSchema schema = buildCubeWithCollidingLevelSynonyms();
+        new AiSchemaEnricher().apply(schema, new AiSchemaEnrichment());
+
+        AiSchema.Hierarchy timeBy = schema.dimensions.get("time").hierarchies.get("time by");
+        assertEquals("quarter", timeBy.levelAliases.get("quarterly"));
+        assertEquals("quarter", timeBy.levelAliases.get("qtr"));
+    }
+}

--- a/saiku-core/saiku-service/src/test/resources/schema-snapshots/quirks-schema.json
+++ b/saiku-core/saiku-service/src/test/resources/schema-snapshots/quirks-schema.json
@@ -219,6 +219,7 @@
   },
   "measureAliases" : { },
   "dimensionAliases" : { },
+  "levelAliases" : { },
   "suggestions" : [ ],
   "examples" : [ {
     "cube" : {

--- a/saiku-core/saiku-service/src/test/resources/schema-snapshots/quirks-schema.json
+++ b/saiku-core/saiku-service/src/test/resources/schema-snapshots/quirks-schema.json
@@ -26,6 +26,7 @@
     "customer" : {
       "name" : "Customer",
       "uniqueName" : "[Customer]",
+      "synonyms" : [ ],
       "hierarchies" : {
         "customers" : {
           "name" : "Customers",
@@ -103,6 +104,7 @@
     "employee" : {
       "name" : "Employee",
       "uniqueName" : "[Employee]",
+      "synonyms" : [ ],
       "hierarchies" : {
         "employee$manager id$parent" : {
           "name" : "Employee$Manager Id$Parent",
@@ -159,6 +161,7 @@
     "store2" : {
       "name" : "Store2",
       "uniqueName" : "[Store2]",
+      "synonyms" : [ ],
       "hierarchies" : {
         "store type" : {
           "name" : "Store Type",
@@ -187,6 +190,7 @@
     "time" : {
       "name" : "Time",
       "uniqueName" : "[Time]",
+      "synonyms" : [ ],
       "hierarchies" : {
         "time" : {
           "name" : "Time",

--- a/saiku-launcher/src/main/resources/seed/FoodMart4.xml
+++ b/saiku-launcher/src/main/resources/seed/FoodMart4.xml
@@ -238,6 +238,12 @@
     </Dimension>
 
     <Dimension name='Time' table='time_by_day' type='TIME' key='Time Id'>
+        <Annotations>
+            <!-- saiku#818 follow-up: dimension-level synonyms — agent posting
+                 {"dimension":"date"} routes to Time via dimensionAliases. -->
+            <Annotation name='saiku.semantic.description'>Calendar-based time dimension. Use the Time/Time hierarchy for Year→Quarter→Month rollups, Time/Weekly for ISO weeks, Time/Date Only for raw dates.</Annotation>
+            <Annotation name='saiku.semantic.synonyms'>date, datetime, period, when</Annotation>
+        </Annotations>
         <Attributes>
             <Attribute name='Year'
                        caption='Year' keyColumn='the_year' levelType='TimeYears' hasHierarchy='false'>
@@ -493,6 +499,11 @@
             </Dimension>
 
             <Dimension name='Customer' table='customer' key='Name'>
+                <Annotations>
+                    <!-- saiku#818 follow-up — dim synonyms exercised live. -->
+                    <Annotation name='saiku.semantic.description'>Retail customer dimension. Use Customers hierarchy for geo rollups (Country → State → City → Name).</Annotation>
+                    <Annotation name='saiku.semantic.synonyms'>shopper, buyer, account, customers</Annotation>
+                </Annotations>
                 <Attributes>
                     <Attribute name='Country' keyColumn='country' hasHierarchy='false'/>
                     <Attribute name='State Province' hasHierarchy='false'>
@@ -549,6 +560,10 @@
                                 <Annotation name="saiku.semantic.description">Individual customer name. Crossjoining at this level can return tens of thousands of rows — pre-filter by Country/State.</Annotation>
                                 <Annotation name="saiku.semantic.synonyms">customer name, person</Annotation>
                                 <Annotation name="saiku.semantic.cardinality">high</Annotation>
+                                <!-- saiku#818 follow-up: exercise required_filters live — queries at the
+                                     individual-customer leaf must scope by Country first or they'd return
+                                     ~10k rows. -->
+                                <Annotation name="saiku.semantic.required_filters">Customers/Country</Annotation>
                             </Annotations>
                         </Level>
                     </Hierarchy>

--- a/saiku-launcher/src/main/resources/seed/FoodMart4.xml
+++ b/saiku-launcher/src/main/resources/seed/FoodMart4.xml
@@ -191,9 +191,34 @@
 
         <Hierarchies>
             <Hierarchy name='Stores' allMemberName='All Stores'>
-                <Level attribute='Store Country'/>
-                <Level attribute='Store State'/>
-                <Level attribute='Store City'/>
+                <!-- saiku#818 follow-up: annotate Store geo with the same synonyms
+                     Customer geo carries so the flat levelAliases map surfaces a
+                     2-target entry for "state" / "country" / "city". An agent
+                     reading the schema cannot silently pick one — it must
+                     reason from context ("store by state" → store target;
+                     "customer by state" → customer target). Multi-target makes
+                     ambiguity visible instead of hidden. -->
+                <Level attribute='Store Country'>
+                    <Annotations>
+                        <Annotation name="saiku.semantic.description">Store's country.</Annotation>
+                        <Annotation name="saiku.semantic.synonyms">nation, country code</Annotation>
+                        <Annotation name="saiku.semantic.cardinality">low</Annotation>
+                    </Annotations>
+                </Level>
+                <Level attribute='Store State'>
+                    <Annotations>
+                        <Annotation name="saiku.semantic.description">Store's state or province.</Annotation>
+                        <Annotation name="saiku.semantic.synonyms">state, province, region</Annotation>
+                        <Annotation name="saiku.semantic.cardinality">low</Annotation>
+                    </Annotations>
+                </Level>
+                <Level attribute='Store City'>
+                    <Annotations>
+                        <Annotation name="saiku.semantic.description">Store's city.</Annotation>
+                        <Annotation name="saiku.semantic.synonyms">town, locality</Annotation>
+                        <Annotation name="saiku.semantic.cardinality">medium</Annotation>
+                    </Annotations>
+                </Level>
                 <Level attribute='Store Name'/>
             </Hierarchy>
             <Hierarchy name='Store Size in SQFT'>

--- a/saiku-mcp/src/main/java/org/saiku/mcp/SaikuMcpServer.java
+++ b/saiku-mcp/src/main/java/org/saiku/mcp/SaikuMcpServer.java
@@ -101,7 +101,13 @@ public final class SaikuMcpServer {
                         + "levels, and sample members with their MDX unique names. Always call this before run_query "
                         + "if you haven't seen the cube structure yet — it tells you exactly which names are valid "
                         + "and includes ready-made example query bodies. Sample members include both the human "
-                        + "caption and the MDX unique name, so you can copy the unique name directly into a filter.")
+                        + "caption and the MDX unique name, so you can copy the unique name directly into a filter. "
+                        + "Annotated cubes (saiku#818) also surface per-measure synonyms / unit / currency / "
+                        + "aggregationKind, per-level synonyms / cardinality / grain / requiredFilters, and three "
+                        + "flat alias maps (measureAliases, dimensionAliases, levelAliases) so user-vocab terms "
+                        + "like \"revenue\" or \"quarterly\" route to the canonical name without a round-trip. "
+                        + "levelAliases is multi-target: a synonym like \"state\" carries every (dimension, "
+                        + "hierarchy, level) it resolves to — disambiguate via the dimension on your axis selection.")
                 .inputSchema(jm, schema)
                 .build();
         return spec(tool, (exchange, request) -> {
@@ -208,7 +214,10 @@ public final class SaikuMcpServer {
         String schema = "{\"type\":\"object\",\"required\":[\"queryId\"],"
                 + "\"properties\":{"
                 + "\"queryId\":{\"type\":\"string\",\"description\":\"queryId returned by a prior run_query call.\"},"
-                + "\"maxrows\":{\"type\":\"integer\",\"minimum\":1,\"maximum\":10000,\"default\":100},"
+                + "\"maxrows\":{\"type\":\"integer\",\"minimum\":1,\"maximum\":10000,\"default\":100,"
+                + "\"description\":\"Mondrian-side row cap. Use this for the FoodMart sample cube.\"},"
+                + "\"firstRowset\":{\"type\":\"integer\",\"minimum\":1,"
+                + "\"description\":\"Warehouse-side rowset cap (Snowflake/BigQuery/XMLA). Safe to supply on Mondrian — server falls back to MAXROWS automatically.\"},"
                 + "\"returns\":{\"type\":\"string\",\"description\":\"Optional comma-separated column list to project a subset.\"}"
                 + "},\"additionalProperties\":false}";
         Tool tool = Tool.builder()
@@ -221,8 +230,8 @@ public final class SaikuMcpServer {
                 .build();
         return spec(tool, (exchange, request) -> {
             Map<String, Object> a = request.arguments();
-            return jsonResult(
-                    () -> client.drillthrough(stringArg(a, "queryId"), optInt(a, "maxrows"), optString(a, "returns")));
+            return jsonResult(() -> client.drillthrough(
+                    stringArg(a, "queryId"), optInt(a, "maxrows"), optInt(a, "firstRowset"), optString(a, "returns")));
         });
     }
 

--- a/saiku-mcp/src/main/java/org/saiku/mcp/SaikuRestClient.java
+++ b/saiku-mcp/src/main/java/org/saiku/mcp/SaikuRestClient.java
@@ -92,14 +92,27 @@ final class SaikuRestClient {
         return postJson("/rest/saiku/api/ai/query/preview", body);
     }
 
-    /** GET {@code /rest/saiku/api/ai/query/{queryId}/drillthrough}. */
-    JsonNode drillthrough(String queryId, Integer maxrows, String returns) throws IOException, InterruptedException {
+    /**
+     * GET {@code /rest/saiku/api/ai/query/{queryId}/drillthrough}.
+     *
+     * <p>{@code firstRowset} is the warehouse-side cap (Snowflake, BigQuery, MSAS XMLA);
+     * {@code maxrows} is the Mondrian-side cap. The REST endpoint accepts both and
+     * since the saiku#818 follow-ups falls back to MAXROWS on Mondrian connections when
+     * FIRST_ROWSET would be unsupported, so callers can supply firstRowset
+     * unconditionally without worrying about the backend.
+     */
+    JsonNode drillthrough(String queryId, Integer maxrows, Integer firstRowset, String returns)
+            throws IOException, InterruptedException {
         StringBuilder p = new StringBuilder("/rest/saiku/api/ai/query/")
                 .append(enc(queryId))
                 .append("/drillthrough");
         boolean first = true;
         if (maxrows != null) {
             p.append(first ? '?' : '&').append("maxrows=").append(maxrows);
+            first = false;
+        }
+        if (firstRowset != null) {
+            p.append(first ? '?' : '&').append("firstRowset=").append(firstRowset);
             first = false;
         }
         if (returns != null && !returns.isBlank()) {

--- a/saiku-mcp/src/test/java/org/saiku/mcp/SaikuRestClientTest.java
+++ b/saiku-mcp/src/test/java/org/saiku/mcp/SaikuRestClientTest.java
@@ -5,6 +5,7 @@
 package org.saiku.mcp;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -92,6 +93,22 @@ public class SaikuRestClientTest {
             respondJson(ex, 200, "{\"hits\":[],\"_query\":\"" + (qs == null ? "" : qs.replace("\"", "\\\"")) + "\"}");
         });
 
+        // saiku#818 follow-up: drillthrough endpoint echoes the query string so
+        // the test can assert maxrows / firstRowset / returns made it through.
+        server.createContext("/rest/saiku/api/ai/query/", ex -> {
+            String path = ex.getRequestURI().getPath();
+            String qs = ex.getRequestURI().getRawQuery();
+            if (path.endsWith("/drillthrough")) {
+                respondJson(
+                        ex,
+                        200,
+                        "{\"rowCount\":0,\"_path\":\"" + path + "\",\"_query\":\""
+                                + (qs == null ? "" : qs.replace("\"", "\\\"")) + "\"}");
+            } else {
+                respondJson(ex, 404, "{}");
+            }
+        });
+
         server.start();
         baseUrl = "http://127.0.0.1:" + server.getAddress().getPort();
         client = new SaikuRestClient(baseUrl, "admin", "secret");
@@ -158,6 +175,39 @@ public class SaikuRestClientTest {
                 "space-bearing q propagated and URL-encoded — got: " + echoed,
                 echoed.contains("q=U+S+A") || echoed.contains("q=U%20S%20A"));
         assertTrue("limit propagated — got: " + echoed, echoed.contains("limit=5"));
+    }
+
+    @Test
+    public void drillthroughForwardsFirstRowsetParameter() throws Exception {
+        // saiku#818 follow-up: the MCP drillthrough tool now exposes firstRowset
+        // (the REST endpoint accepts it and post-saiku#818 follow-ups falls
+        // back to MAXROWS safely on Mondrian). The client must include it in
+        // the query string when supplied.
+        JsonNode body = client.drillthrough("query-42", /*maxrows*/ null, /*firstRowset*/ 5, /*returns*/ null);
+        String echoed = body.get("_query").asText();
+        assertTrue("firstRowset propagated — got: " + echoed, echoed.contains("firstRowset=5"));
+        assertEquals(
+                "/rest/saiku/api/ai/query/query-42/drillthrough",
+                body.get("_path").asText());
+    }
+
+    @Test
+    public void drillthroughOmitsFirstRowsetWhenNull() throws Exception {
+        JsonNode body = client.drillthrough("q1", 25, null, null);
+        String echoed = body.get("_query").asText();
+        assertTrue("maxrows propagated", echoed.contains("maxrows=25"));
+        assertFalse("firstRowset not present", echoed.contains("firstRowset"));
+    }
+
+    @Test
+    public void drillthroughForwardsAllFourParams() throws Exception {
+        JsonNode body = client.drillthrough("q2", 100, 10, "Country,Year");
+        String echoed = body.get("_query").asText();
+        assertTrue(echoed, echoed.contains("maxrows=100"));
+        assertTrue(echoed, echoed.contains("firstRowset=10"));
+        assertTrue(
+                "returns URL-encoded",
+                echoed.contains("returns=Country%2CYear") || echoed.contains("returns=Country,Year"));
     }
 
     @Test


### PR DESCRIPTION
Three live-test follow-ups on PR #853 from Tom's acceptance pass.

## What's in this PR

### 1. FIRST_ROWSET fallback on Mondrian (regression fix)

`ThinQueryService.drillthrough` emitted `DRILLTHROUGH FIRST_ROWSET N SELECT ...` which Mondrian's MDX parser doesn't define — every call with `?firstRowset>0` produced a 500 + opaque `Error DRILLTHROUGH` message. New `DrillthroughMdxBuilder` centralises the cap-emission policy and falls back to `MAXROWS` on Mondrian. XMLA/MSAS backends keep `FIRST_ROWSET`.

**Live**: `GET /ai/query/{id}/drillthrough?firstRowset=5` was 500 → now 200 with 5 rows.

### 2. Dimension-level synonyms (close the gap)

Issue text only listed measure + level annotations. Extended the full pipeline so `AiSchema.Dimension` also carries `synonyms`, registered into `dimensionAliases` for input resolution.

**Live**: `dimensionAliases: {shopper → customer, buyer → customer, account → customer, customers → customer}`.

**Note**: I also annotated the schema-level Time dim, but Mondrian doesn't propagate `<Annotations>` from schema-level shared `<Dimension>` definitions to a cube's `<DimensionUsage>`. Cube-private dimensions (Customer in FoodMart's Sales cube) work end-to-end. The schema-vs-cube propagation question is a separate Mondrian-internals investigation; flagging for the next round.

### 3. FoodMart `required_filters` annotation — live exercise

`Customer/Customers/Name` declares `saiku.semantic.required_filters: Customers/Country`. Agent posting a leaf-customer query without a Country filter gets the typed envelope:

```json
{
  "status":    "VALIDATION_ERROR",
  "field":     "filters",
  "error":     "Level requires a filter on Customers/Country with non-empty members.",
  "available": ["Customers/Country"]
}
```

Note: the positive path on this specific level hits a pre-existing same-hierarchy guard ("`Customers` already on rows"), which is correct Mondrian behaviour. The rejection envelope is what we needed to demonstrate; real-world use puts the required filter on a DIFFERENT hierarchy.

## Test plan

- [x] **9 new** `DrillthroughMdxBuilderTest` cases pin the 4-shape policy + Mondrian fallback semantics
- [x] `mvn -pl saiku-core/saiku-service test` → 338/338 pass (+9 vs PR #853 final)
- [x] `mvn -pl saiku-core/saiku-web -am test` → 54/54 pass
- [x] Snapshot baseline regenerated (Dimension picks up empty `synonyms: []`)
- [x] Live launcher (post-rebuild, fresh saiku-home): three scenarios above all green
- [x] Spotless clean

## Out of scope (next round candidates)

- Mondrian schema-level `<Annotation>` propagation to cube-level `<DimensionUsage>` (Time dim case)
- `required_filters` against a cross-hierarchy filter target so the positive path can be exercised on FoodMart without hitting the same-hier guard