### PR TITLE
chore(deps): bump mondrian-saiku to 4.8.1.7

### DIFF
--- a/saiku-bom/pom.xml
+++ b/saiku-bom/pom.xml
@@ -346,7 +346,7 @@
             <dependency>
                 <groupId>pentaho</groupId>
                 <artifactId>mondrian</artifactId>
-                <version>4.8.1.6</version>
+                <version>4.8.1.7</version>
                 <!-- xerces 2.12.2 + xalan 2.7.2 are transitively pulled by
                      mondrian but hijack the JDK's built-in JAXP via
                      META-INF/services overrides. Spring 6.2's tightened


### PR DESCRIPTION
Picks up the just-published mondrian-saiku v4.8.1.7 (spiculedata/mondrian-saiku PR #14, tagged + published to GitHub Packages).

## What's in mondrian-saiku 4.8.1.7

23 commits since v4.8.1.6, all on the Calcite-backed query path:

* TopCount on calculated measures (binary arith)
* Parent-child level tuple-read (in-memory tree assembly)
* Const-vs-const filter folding + OrPredicate wildcard columns
* IsEmpty / IS_NULL, TopCount 2-arg, arithmetic measure, Descendants snowflake
* All-level skip + FilterConstraint lhs-literal swap
* SqlContextConstraint with real slicer
* Literal + CASE-shaped measure expressions
* (saiku#805) catch UnsupportedTranslation from fromSegmentLoad
* (saiku#809) TopCount probe fix

No public-API breakage — drop-in replacement for the prior 4.8.1.6 pin.

## Verified locally

\`mvn verify\` across the full reactor (saiku-service, saiku-web, saiku-launcher, saiku-mcp) — all green against 4.8.1.7.

## Why this PR

Needs to land on \`development\` before the v4.1.0 release tag so anyone rebuilding the release from source gets the matching mondrian bits. CI uses the GitHub Packages copy; this PR makes the build pin track the published artifact.