### PR TITLE
test: backfill unit tests + add integration test harness

### DIFF
--- a/saiku-core/saiku-semantic/src/test/java/org/saiku/semantic/SemanticLayerTest.java
+++ b/saiku-core/saiku-semantic/src/test/java/org/saiku/semantic/SemanticLayerTest.java
@@ -76,4 +76,171 @@ class SemanticLayerTest {
                 """;
         assertThrows(CubeYamlParser.SemanticValidationException.class, () -> new CubeYamlParser().parse(yaml));
     }
+
+    @Test
+    void rejectsBlankCubeName() {
+        String yaml =
+                """
+                name: ""
+                fact:
+                  table: t
+                measures:
+                  - name: a
+                    column: c
+                """;
+        assertThrows(CubeYamlParser.SemanticValidationException.class, () -> new CubeYamlParser().parse(yaml));
+    }
+
+    @Test
+    void rejectsMissingFactTable() {
+        String yaml =
+                """
+                name: Broken
+                fact:
+                  table: ""
+                measures:
+                  - name: a
+                    column: c
+                """;
+        assertThrows(CubeYamlParser.SemanticValidationException.class, () -> new CubeYamlParser().parse(yaml));
+    }
+
+    @Test
+    void rejectsDimensionWithoutLevels() {
+        String yaml =
+                """
+                name: Sales
+                fact:
+                  table: t
+                measures:
+                  - name: a
+                    column: c
+                dimensions:
+                  - name: Empty
+                """;
+        assertThrows(CubeYamlParser.SemanticValidationException.class, () -> new CubeYamlParser().parse(yaml));
+    }
+
+    @Test
+    void rejectsLevelMissingColumn() {
+        String yaml =
+                """
+                name: Sales
+                fact:
+                  table: t
+                measures:
+                  - name: a
+                    column: c
+                dimensions:
+                  - name: D
+                    levels:
+                      - name: L
+                """;
+        assertThrows(CubeYamlParser.SemanticValidationException.class, () -> new CubeYamlParser().parse(yaml));
+    }
+
+    @Test
+    void rejectsLevelMissingName() {
+        String yaml =
+                """
+                name: Sales
+                fact:
+                  table: t
+                measures:
+                  - name: a
+                    column: c
+                dimensions:
+                  - name: D
+                    levels:
+                      - column: lc
+                """;
+        assertThrows(CubeYamlParser.SemanticValidationException.class, () -> new CubeYamlParser().parse(yaml));
+    }
+
+    @Test
+    void compilerEmitsMultipleDimensionsInOrder() throws IOException {
+        String yaml =
+                """
+                name: Multi
+                fact:
+                  table: f
+                measures:
+                  - name: m1
+                    column: c1
+                dimensions:
+                  - name: Time
+                    levels: [{ name: Year, column: y }]
+                  - name: Geo
+                    levels: [{ name: Country, column: g }]
+                """;
+        CubeDefinition cube = new CubeYamlParser().parse(yaml);
+        String xml = new MondrianCompiler().compile(cube);
+        int timeAt = xml.indexOf("<Dimension name=\"Time\"");
+        int geoAt = xml.indexOf("<Dimension name=\"Geo\"");
+        assertTrue(timeAt > 0, "Time dim must be emitted");
+        assertTrue(geoAt > timeAt, "Geo dim must follow Time in declaration order, got " + xml);
+    }
+
+    @Test
+    void compilerEmitsFactSchemaAttributeWhenPresent() throws IOException {
+        String yaml =
+                """
+                name: WithSchema
+                fact:
+                  schema: analytics
+                  table: f
+                measures:
+                  - name: m
+                    column: c
+                """;
+        String xml = new MondrianCompiler().compile(new CubeYamlParser().parse(yaml));
+        assertTrue(xml.contains("schema=\"analytics\""), xml);
+    }
+
+    @Test
+    void compilerOmitsFactSchemaAttributeWhenBlank() throws IOException {
+        String yaml =
+                """
+                name: NoSchema
+                fact:
+                  schema: ""
+                  table: f
+                measures:
+                  - name: m
+                    column: c
+                """;
+        String xml = new MondrianCompiler().compile(new CubeYamlParser().parse(yaml));
+        assertTrue(!xml.contains("schema=\"\""), "blank schema must not be emitted, got: " + xml);
+    }
+
+    @Test
+    void compilerEmitsLevelTypeAndOptionalColumnsWhenPresent() throws IOException {
+        String yaml =
+                """
+                name: Sales
+                fact:
+                  table: f
+                measures:
+                  - name: m
+                    column: c
+                dimensions:
+                  - name: Geo
+                    foreignKey: geo_id
+                    primaryKey: id
+                    table: geo_dim
+                    levels:
+                      - name: Country
+                        column: country_id
+                        type: Numeric
+                        nameColumn: country_name
+                        ordinalColumn: country_ord
+                """;
+        String xml = new MondrianCompiler().compile(new CubeYamlParser().parse(yaml));
+        assertTrue(xml.contains("foreignKey=\"geo_id\""), xml);
+        assertTrue(xml.contains("primaryKey=\"id\""), xml);
+        assertTrue(xml.contains("<Table name=\"geo_dim\""), xml);
+        assertTrue(xml.contains("nameColumn=\"country_name\""), xml);
+        assertTrue(xml.contains("ordinalColumn=\"country_ord\""), xml);
+        assertTrue(xml.contains("type=\"Numeric\""), xml);
+    }
 }

--- a/saiku-core/saiku-service/src/test/java/org/saiku/service/async/AsyncQueryServiceTest.java
+++ b/saiku-core/saiku-service/src/test/java/org/saiku/service/async/AsyncQueryServiceTest.java
@@ -1,0 +1,405 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.service.async;
+
+import static org.junit.Assert.*;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Proxy;
+import java.sql.SQLException;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.After;
+import org.junit.Test;
+import org.olap4j.CellSet;
+import org.saiku.olap.query2.ThinQuery;
+import org.saiku.service.olap.ThinQueryService;
+import org.saiku.service.util.QueryContext;
+
+/**
+ * Unit tests for {@link AsyncQueryService}. Drives a synthetic {@link ThinQueryService}
+ * so the lifecycle is exercised without needing a live OLAP connection.
+ */
+public class AsyncQueryServiceTest {
+
+    private AsyncQueryService svc;
+
+    @After
+    public void tearDown() {
+        if (svc != null) {
+            svc.shutdown();
+        }
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void submit_throwsWhenThinQueryServiceUnwired() {
+        svc = new AsyncQueryService();
+        svc.submit(named("anything"));
+    }
+
+    @Test
+    public void submit_returnsHandleAndTransitionsToDone() throws Exception {
+        StubThinQueryService stub = new StubThinQueryService();
+        svc = new AsyncQueryService();
+        svc.setThinQueryService(stub);
+
+        AsyncQueryHandle h = svc.submit(named("q1"));
+        assertNotNull(h);
+        assertNotNull(h.getId());
+        // wait up to 2s for executor to drain.
+        awaitStatus(h, AsyncQueryHandle.Status.DONE, 2000);
+        assertEquals(AsyncQueryHandle.Status.DONE, h.getStatus());
+        assertEquals(1, stub.executeCount.get());
+    }
+
+    @Test
+    public void submit_recordsFailureWhenExecuteThrows() throws Exception {
+        StubThinQueryService stub = new StubThinQueryService();
+        stub.failure = new RuntimeException("boom");
+        svc = new AsyncQueryService();
+        svc.setThinQueryService(stub);
+
+        AsyncQueryHandle h = svc.submit(named("q2"));
+        awaitStatus(h, AsyncQueryHandle.Status.FAILED, 2000);
+        assertEquals(AsyncQueryHandle.Status.FAILED, h.getStatus());
+        assertEquals("boom", h.getErrorMessage());
+    }
+
+    @Test
+    public void submit_recordsFailureWithClassNameWhenMessageIsNull() throws Exception {
+        StubThinQueryService stub = new StubThinQueryService();
+        stub.failure = new NullPointerException();
+        svc = new AsyncQueryService();
+        svc.setThinQueryService(stub);
+
+        AsyncQueryHandle h = svc.submit(named("q-npe"));
+        awaitStatus(h, AsyncQueryHandle.Status.FAILED, 2000);
+        assertEquals("NullPointerException", h.getErrorMessage());
+    }
+
+    @Test
+    public void submit_propagatesRejectedExecutionAndRemovesHandle() {
+        // Single-slot, no-queue, abort-policy executor → first task occupies the
+        // worker slot, second submission is rejected.
+        ThreadPoolExecutor saturated = new ThreadPoolExecutor(
+                1, 1, 1L, TimeUnit.MINUTES, new java.util.concurrent.SynchronousQueue<>(), daemonFactory("test-rej"));
+        saturated.setRejectedExecutionHandler(new ThreadPoolExecutor.AbortPolicy());
+
+        StubThinQueryService stub = new StubThinQueryService();
+        stub.block = new CountDownLatch(1); // first submission parks the worker
+        svc = new AsyncQueryService(saturated);
+        svc.setThinQueryService(stub);
+
+        AsyncQueryHandle blocking = svc.submit(named("blocker"));
+        try {
+            svc.submit(named("rejected"));
+            fail("expected RejectedExecutionException");
+        } catch (java.util.concurrent.RejectedExecutionException expected) {
+            // rejected handle must NOT linger in the map.
+            assertEquals(1, svc.size());
+            assertEquals(blocking.getStatus(), svc.get(blocking.getId()).getStatus());
+        } finally {
+            stub.block.countDown();
+        }
+    }
+
+    @Test
+    public void get_returnsHandleAndTouches() throws Exception {
+        StubThinQueryService stub = new StubThinQueryService();
+        svc = new AsyncQueryService();
+        svc.setThinQueryService(stub);
+
+        AsyncQueryHandle h = svc.submit(named("q-get"));
+        awaitStatus(h, AsyncQueryHandle.Status.DONE, 2000);
+
+        long before = h.getLastAccessedAt();
+        Thread.sleep(5);
+        AsyncQueryHandle fetched = svc.get(h.getId());
+        assertSame(h, fetched);
+        assertTrue("touch should advance lastAccessedAt", fetched.getLastAccessedAt() >= before);
+    }
+
+    @Test
+    public void get_returnsNullForUnknownId() {
+        svc = new AsyncQueryService();
+        svc.setThinQueryService(new StubThinQueryService());
+        assertNull(svc.get("nope"));
+    }
+
+    @Test
+    public void register_storesExternalHandle() {
+        svc = new AsyncQueryService();
+        AsyncQueryHandle h = new AsyncQueryHandle("ext-1", named("x"));
+        svc.register(h);
+        assertSame(h, svc.get("ext-1"));
+        assertEquals(1, svc.size());
+    }
+
+    @Test
+    public void register_nullIsNoOp() {
+        svc = new AsyncQueryService();
+        svc.register(null);
+        assertEquals(0, svc.size());
+    }
+
+    @Test
+    public void result_nullUntilDoneThenReturnsCellSetAndMarksFetched() throws Exception {
+        StubThinQueryService stub = new StubThinQueryService();
+        stub.block = new CountDownLatch(1);
+        CellSet expected = newProxyCellSet(null);
+        stub.resultCellSet = expected;
+        svc = new AsyncQueryService();
+        svc.setThinQueryService(stub);
+
+        AsyncQueryHandle h = svc.submit(named("q-res"));
+        assertNull("result null while RUNNING/PENDING", svc.result(h.getId()));
+
+        stub.block.countDown();
+        awaitStatus(h, AsyncQueryHandle.Status.DONE, 2000);
+
+        CellSet got = svc.result(h.getId());
+        assertSame(expected, got);
+        assertTrue("markResultFetched should fire", h.isResultFetched());
+    }
+
+    @Test
+    public void result_returnsNullForUnknownId() {
+        svc = new AsyncQueryService();
+        svc.setThinQueryService(new StubThinQueryService());
+        assertNull(svc.result("nope"));
+    }
+
+    @Test
+    public void cancel_unknownIdReturnsFalse() {
+        svc = new AsyncQueryService();
+        svc.setThinQueryService(new StubThinQueryService());
+        assertFalse(svc.cancel("nope"));
+    }
+
+    @Test
+    public void cancel_flipsStatusAndCallsThinCancel() throws Exception {
+        StubThinQueryService stub = new StubThinQueryService();
+        stub.block = new CountDownLatch(1);
+        svc = new AsyncQueryService();
+        svc.setThinQueryService(stub);
+
+        AsyncQueryHandle h = svc.submit(named("q-cancel"));
+        assertTrue(svc.cancel(h.getId()));
+        assertEquals(AsyncQueryHandle.Status.CANCELLED, h.getStatus());
+
+        // cancelExecutor is async — give it time to dispatch.
+        stub.block.countDown();
+        long deadline = System.currentTimeMillis() + 2000;
+        while (stub.cancelCount.get() == 0 && System.currentTimeMillis() < deadline) {
+            Thread.sleep(10);
+        }
+        assertEquals("ThinQueryService.cancel should be invoked once", 1, stub.cancelCount.get());
+    }
+
+    @Test
+    public void cancel_swallowsSqlExceptionFromThinCancel() throws Exception {
+        StubThinQueryService stub = new StubThinQueryService();
+        stub.cancelFailure = new SQLException("statement gone");
+        svc = new AsyncQueryService();
+        svc.setThinQueryService(stub);
+
+        AsyncQueryHandle h = svc.submit(named("q-cancel-fail"));
+        awaitStatus(h, AsyncQueryHandle.Status.DONE, 2000);
+        assertTrue(svc.cancel(h.getId()));
+        // No exception bubbles. Status remains CANCELLED.
+        assertEquals(AsyncQueryHandle.Status.CANCELLED, h.getStatus());
+    }
+
+    @Test
+    public void sweep_evictsFetchedHandlesAfterIdleWindow() throws Exception {
+        StubThinQueryService stub = new StubThinQueryService();
+        stub.resultCellSet = newProxyCellSet(null);
+        svc = new AsyncQueryService();
+        svc.setThinQueryService(stub);
+
+        AsyncQueryHandle h = svc.submit(named("q-sweep"));
+        awaitStatus(h, AsyncQueryHandle.Status.DONE, 2000);
+        svc.result(h.getId()); // marks fetched
+        backdateLastAccessed(h, TimeUnit.MINUTES.toMillis(10));
+
+        svc.sweep();
+        assertEquals("fetched + idle > 5m must be evicted", 0, svc.size());
+    }
+
+    @Test
+    public void sweep_evictsTerminalHandlesAfterFailsafeWindow() throws Exception {
+        StubThinQueryService stub = new StubThinQueryService();
+        svc = new AsyncQueryService();
+        svc.setThinQueryService(stub);
+
+        AsyncQueryHandle h = svc.submit(named("q-failsafe"));
+        awaitStatus(h, AsyncQueryHandle.Status.DONE, 2000);
+        // not fetched — only the 30-min failsafe should reap.
+        backdateLastAccessed(h, TimeUnit.MINUTES.toMillis(45));
+
+        svc.sweep();
+        assertEquals(0, svc.size());
+    }
+
+    @Test
+    public void sweep_leavesNonTerminalHandlesAlone() throws Exception {
+        StubThinQueryService stub = new StubThinQueryService();
+        stub.block = new CountDownLatch(1);
+        svc = new AsyncQueryService();
+        svc.setThinQueryService(stub);
+
+        AsyncQueryHandle h = svc.submit(named("q-running"));
+        // Backdate the timestamp anyway — sweeper must skip non-terminal.
+        backdateLastAccessed(h, TimeUnit.MINUTES.toMillis(120));
+        svc.sweep();
+        assertEquals(1, svc.size());
+        stub.block.countDown();
+    }
+
+    @Test
+    public void sweep_leavesRecentTerminalHandles() throws Exception {
+        StubThinQueryService stub = new StubThinQueryService();
+        svc = new AsyncQueryService();
+        svc.setThinQueryService(stub);
+
+        AsyncQueryHandle h = svc.submit(named("q-recent"));
+        awaitStatus(h, AsyncQueryHandle.Status.DONE, 2000);
+        // No backdating — handle is fresh, idle ≈ 0.
+        svc.sweep();
+        assertEquals(1, svc.size());
+    }
+
+    @Test
+    public void size_reflectsHandleMap() {
+        svc = new AsyncQueryService();
+        svc.setThinQueryService(new StubThinQueryService());
+        assertEquals(0, svc.size());
+        svc.register(new AsyncQueryHandle("a", named("a")));
+        svc.register(new AsyncQueryHandle("b", named("b")));
+        assertEquals(2, svc.size());
+    }
+
+    @Test
+    public void shutdown_stopsExecutors() {
+        StubThinQueryService stub = new StubThinQueryService();
+        svc = new AsyncQueryService();
+        svc.setThinQueryService(stub);
+        svc.shutdown();
+        // After shutdown the work executor should reject new submissions.
+        try {
+            svc.submit(named("post-shutdown"));
+            fail("expected RejectedExecutionException after shutdown");
+        } catch (java.util.concurrent.RejectedExecutionException expected) {
+            // OK
+        }
+        svc = null; // prevent double-shutdown in @After
+    }
+
+    // ---------------------------------------------------------------- helpers
+
+    private static ThinQuery named(String name) {
+        ThinQuery q = new ThinQuery();
+        q.setName(name);
+        return q;
+    }
+
+    private static void awaitStatus(AsyncQueryHandle h, AsyncQueryHandle.Status want, long timeoutMs) throws Exception {
+        long deadline = System.currentTimeMillis() + timeoutMs;
+        while (h.getStatus() != want && System.currentTimeMillis() < deadline) {
+            Thread.sleep(10);
+        }
+        if (h.getStatus() != want) {
+            throw new AssertionError("timed out waiting for status " + want + ", saw " + h.getStatus());
+        }
+    }
+
+    private static void backdateLastAccessed(AsyncQueryHandle h, long deltaMs) throws Exception {
+        Field f = AsyncQueryHandle.class.getDeclaredField("lastAccessedAt");
+        f.setAccessible(true);
+        long current = f.getLong(h);
+        f.setLong(h, current - deltaMs);
+    }
+
+    private static ThreadFactory daemonFactory(String name) {
+        AtomicInteger i = new AtomicInteger();
+        return r -> {
+            Thread t = new Thread(r, name + "-" + i.incrementAndGet());
+            t.setDaemon(true);
+            return t;
+        };
+    }
+
+    /** A stub ThinQueryService that drives the async lifecycle without any OLAP. */
+    private static final class StubThinQueryService extends ThinQueryService {
+        final AtomicInteger executeCount = new AtomicInteger();
+        final AtomicInteger cancelCount = new AtomicInteger();
+        volatile RuntimeException failure;
+        volatile SQLException cancelFailure;
+        volatile CellSet resultCellSet;
+        volatile CountDownLatch block;
+
+        @Override
+        public org.saiku.olap.dto.resultset.CellDataSet execute(ThinQuery tq) {
+            executeCount.incrementAndGet();
+            if (block != null) {
+                try {
+                    block.await();
+                } catch (InterruptedException ie) {
+                    Thread.currentThread().interrupt();
+                    throw new RuntimeException("interrupted", ie);
+                }
+            }
+            if (failure != null) {
+                throw failure;
+            }
+            return null; // AsyncQueryService doesn't read this — it pulls from getContext().
+        }
+
+        @Override
+        public QueryContext getContext(String name) {
+            QueryContext ctx = new QueryContext(QueryContext.Type.OLAP, named(name));
+            if (resultCellSet != null) {
+                ctx.store(QueryContext.ObjectKey.RESULT, resultCellSet);
+            }
+            return ctx;
+        }
+
+        @Override
+        public void cancel(String name) throws SQLException {
+            cancelCount.incrementAndGet();
+            if (cancelFailure != null) {
+                throw cancelFailure;
+            }
+        }
+    }
+
+    /**
+     * Build a {@link CellSet} proxy. Returns sensible default values for
+     * primitive return types and {@code null} for everything else — sufficient
+     * for the AsyncQueryService surface, which never inspects the cellSet
+     * beyond {@code close()}.
+     */
+    private static CellSet newProxyCellSet(Object unusedCloseFlag) {
+        return (CellSet) Proxy.newProxyInstance(
+                CellSet.class.getClassLoader(), new Class<?>[] {CellSet.class}, (proxy, method, args) -> {
+                    if ("close".equals(method.getName())) {
+                        return null;
+                    }
+                    Class<?> rt = method.getReturnType();
+                    if (rt == boolean.class) return false;
+                    if (rt == int.class) return 0;
+                    if (rt == long.class) return 0L;
+                    if (rt == short.class) return (short) 0;
+                    if (rt == byte.class) return (byte) 0;
+                    if (rt == float.class) return 0f;
+                    if (rt == double.class) return 0d;
+                    if (rt == char.class) return '\0';
+                    return null;
+                });
+    }
+}

--- a/saiku-core/saiku-service/src/test/java/org/saiku/service/cache/SaikuQueryCacheTest.java
+++ b/saiku-core/saiku-service/src/test/java/org/saiku/service/cache/SaikuQueryCacheTest.java
@@ -209,4 +209,159 @@ public class SaikuQueryCacheTest {
         assertEquals(2, calls.get());
         assertFalse(r.cacheHit);
     }
+
+    @Test
+    public void invalidateAll_clearsIndexAndDeletesAllCacheFiles() throws IOException {
+        AtomicInteger calls = new AtomicInteger();
+        cache.get("k1", "v", supplierProducing("a".getBytes(), 1, 1, calls));
+        cache.get("k2", "v", supplierProducing("b".getBytes(), 1, 1, calls));
+
+        // Sanity: both keys on disk.
+        assertTrue(Files.exists(cacheDir.resolve("k1.arrow")));
+        assertTrue(Files.exists(cacheDir.resolve("k2.arrow")));
+
+        cache.invalidateAll();
+
+        assertFalse(Files.exists(cacheDir.resolve("k1.arrow")));
+        assertFalse(Files.exists(cacheDir.resolve("k1.meta.json")));
+        assertFalse(Files.exists(cacheDir.resolve("k2.arrow")));
+        assertFalse(Files.exists(cacheDir.resolve("k2.meta.json")));
+    }
+
+    @Test
+    public void invalidateAll_doesNotTouchUnrelatedFiles() throws IOException {
+        AtomicInteger calls = new AtomicInteger();
+        cache.get("k1", "v", supplierProducing("a".getBytes(), 1, 1, calls));
+        // Drop a stranger file alongside cache files.
+        Path stranger = cacheDir.resolve("README.txt");
+        Files.writeString(stranger, "do not delete me");
+
+        cache.invalidateAll();
+
+        assertTrue("non-saiku files must survive invalidateAll", Files.exists(stranger));
+    }
+
+    @Test
+    public void totalBytesOnDisk_sumsMetadataBytes() {
+        AtomicInteger calls = new AtomicInteger();
+        cache.get("k1", "v", supplierProducing(new byte[100], 1, 1, calls));
+        cache.get("k2", "v", supplierProducing(new byte[250], 1, 1, calls));
+
+        assertEquals(350L, cache.totalBytesOnDisk());
+    }
+
+    @Test
+    public void totalBytesOnDisk_zeroForEmptyCache() {
+        assertEquals(0L, cache.totalBytesOnDisk());
+    }
+
+    @Test
+    public void put_ignoresNullBytes() {
+        AtomicInteger calls = new AtomicInteger();
+        cache.get("k-null", "v", () -> {
+            calls.incrementAndGet();
+            return new CachedQueryResult(null, 1L, 1, false);
+        });
+        assertFalse(
+                "supplier with null bytes must not write a cache file", Files.exists(cacheDir.resolve("k-null.arrow")));
+        assertFalse(Files.exists(cacheDir.resolve("k-null.meta.json")));
+    }
+
+    @Test
+    public void put_ignoresNullResult() {
+        AtomicInteger calls = new AtomicInteger();
+        cache.get("k-null-result", "v", () -> {
+            calls.incrementAndGet();
+            return null;
+        });
+        assertFalse(Files.exists(cacheDir.resolve("k-null-result.arrow")));
+    }
+
+    @Test
+    public void reindex_warmsIndexFromExistingMetaFiles() throws Exception {
+        // Populate the first cache, then construct a fresh one over the same
+        // directory — its index should be warmed from the existing meta files.
+        AtomicInteger calls = new AtomicInteger();
+        cache.get("warmed", "v", supplierProducing("payload".getBytes(), 5, 2, calls));
+        cache.shutdown();
+
+        SaikuQueryCache reopened = new SaikuQueryCache(cacheDir, TimeUnit.MINUTES.toMillis(30), 268_435_456L, true);
+        try {
+            // A get with a brand-new supplier should hit on the reopened cache —
+            // proving the index was warmed from disk.
+            CachedQueryResult r = reopened.get("warmed", "v", supplierProducing("FRESH".getBytes(), 99, 99, calls));
+            assertTrue("reopened cache should serve warmed entry as a hit", r.cacheHit);
+            assertArrayEquals("payload".getBytes(), r.arrowBytes);
+        } finally {
+            reopened.shutdown();
+        }
+    }
+
+    @Test
+    public void reindex_deletesOrphanArrowFilesWithoutSidecar() throws Exception {
+        // Crash simulation: arrow file present but sidecar missing.
+        Files.createDirectories(cacheDir);
+        Path orphan = cacheDir.resolve("orphan.arrow");
+        Files.write(orphan, "leak".getBytes());
+
+        // New cache instance reindexes — orphan should be reaped.
+        SaikuQueryCache reopened = new SaikuQueryCache(cacheDir, TimeUnit.MINUTES.toMillis(30), 268_435_456L, true);
+        try {
+            assertFalse("orphan arrow file without sidecar must be deleted on reindex", Files.exists(orphan));
+        } finally {
+            reopened.shutdown();
+        }
+    }
+
+    @Test
+    public void getOnMissingArrowFile_invalidatesEntryAndRefetches() throws Exception {
+        AtomicInteger calls = new AtomicInteger();
+        cache.get("k-tampered", "v", supplierProducing("orig".getBytes(), 1, 1, calls));
+
+        // Out-of-band delete only the arrow file. Next get() should detect the
+        // miss, invalidate the index entry, and call the supplier again.
+        Files.delete(cacheDir.resolve("k-tampered.arrow"));
+
+        CachedQueryResult r = cache.get("k-tampered", "v", supplierProducing("refetched".getBytes(), 2, 2, calls));
+        assertEquals(2, calls.get());
+        assertFalse(r.cacheHit);
+        assertArrayEquals("refetched".getBytes(), r.arrowBytes);
+    }
+
+    @Test
+    public void isEnabledReportsConstructorFlag() {
+        SaikuQueryCache off = new SaikuQueryCache(cacheDir, 1L, 1L, false);
+        try {
+            assertFalse(off.isEnabled());
+            assertTrue(cache.isEnabled());
+        } finally {
+            off.shutdown();
+        }
+    }
+
+    @Test
+    public void getCacheDirReturnsConstructorPath() {
+        assertEquals(cacheDir, cache.getCacheDir());
+    }
+
+    @Test
+    public void shutdown_isIdempotent() {
+        // Two shutdowns in a row must not throw — sweeper / eviction executor
+        // both use shutdownNow() which tolerates already-terminated state.
+        cache.shutdown();
+        cache.shutdown();
+    }
+
+    @Test
+    public void lookupSkipsCubeVersionMismatchOnlyWhenBothNonNull() throws Exception {
+        // When the request's cubeVersion is null, an entry's stored cubeVersion
+        // does NOT cause a miss — the caller opted out of versioning.
+        AtomicInteger calls = new AtomicInteger();
+        cache.get("k-cv", "stored", supplierProducing("first".getBytes(), 1, 1, calls));
+
+        CachedQueryResult nullVer = cache.get("k-cv", null, supplierProducing("ignored".getBytes(), 9, 9, calls));
+        assertEquals(1, calls.get());
+        assertTrue("null cubeVersion should hit regardless of stored version", nullVer.cacheHit);
+        assertArrayEquals("first".getBytes(), nullVer.arrowBytes);
+    }
 }

--- a/saiku-core/saiku-service/src/test/java/org/saiku/service/datasource/DatasourceServiceTest.java
+++ b/saiku-core/saiku-service/src/test/java/org/saiku/service/datasource/DatasourceServiceTest.java
@@ -1,0 +1,528 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.service.datasource;
+
+import static org.junit.Assert.*;
+
+import java.io.InputStream;
+import java.util.*;
+import org.junit.Before;
+import org.junit.Test;
+import org.saiku.database.dto.MondrianSchema;
+import org.saiku.datasources.connection.IConnectionManager;
+import org.saiku.datasources.connection.ISaikuConnection;
+import org.saiku.datasources.connection.RepositoryFile;
+import org.saiku.datasources.datasource.SaikuDatasource;
+import org.saiku.olap.util.exception.SaikuOlapException;
+import org.saiku.repository.AclEntry;
+import org.saiku.repository.IRepositoryObject;
+import org.saiku.repository.RepositoryException;
+import org.saiku.service.importer.JujuSource;
+import org.saiku.service.user.UserService;
+import org.saiku.service.util.exception.SaikuDataSourceException;
+import org.saiku.service.util.exception.SaikuDataSourceNotFoundException;
+
+public class DatasourceServiceTest {
+
+    private DatasourceService svc;
+    private RecordingDatasourceManager manager;
+    private StubConnectionManager connManager;
+
+    @Before
+    public void setUp() {
+        manager = new RecordingDatasourceManager();
+        connManager = new StubConnectionManager(manager);
+        svc = new DatasourceService();
+        svc.setConnectionManager(connManager);
+    }
+
+    @Test
+    public void addDatasource_newName_invokesAddOnce() throws Exception {
+        SaikuDatasource fresh = ds("ds-new", "id-1");
+        svc.addDatasource(fresh, false, new String[] {"ROLE_ADMIN"});
+        assertEquals(1, manager.addCalls.size());
+        assertEquals("ds-new", manager.addCalls.get(0).getName());
+        assertEquals(0, manager.removeCalls.size());
+    }
+
+    @Test(expected = Exception.class)
+    public void addDatasource_existingName_withoutOverwrite_throws() throws Exception {
+        SaikuDatasource ds = ds("ds-existing", "id-1");
+        manager.seed(ds);
+        svc.addDatasource(ds("ds-existing", "id-2"), false, new String[0]);
+    }
+
+    @Test
+    public void addDatasource_existingName_withOverwrite_removesThenAdds() throws Exception {
+        SaikuDatasource original = ds("ds-replace", "id-orig");
+        manager.seed(original);
+        SaikuDatasource replacement = ds("ds-replace", "id-new");
+
+        svc.addDatasource(replacement, true, new String[0]);
+
+        assertEquals(1, manager.removeCalls.size());
+        assertEquals("id-orig", manager.removeCalls.get(0));
+        assertEquals(1, manager.addCalls.size());
+        assertEquals("id-new", manager.addCalls.get(0).getProperties().getProperty("id"));
+    }
+
+    @Test
+    public void fetchDataSourceById_returnsMatch() throws Exception {
+        manager.seed(ds("alpha", "id-aaa"));
+        manager.seed(ds("beta", "id-bbb"));
+        SaikuDatasource found = svc.fetchDataSourceById("id-bbb", new String[0]);
+        assertEquals("beta", found.getName());
+    }
+
+    @Test(expected = SaikuDataSourceException.class)
+    public void fetchDataSourceById_unknown_throws() throws SaikuDataSourceNotFoundException {
+        manager.seed(ds("alpha", "id-aaa"));
+        svc.fetchDataSourceById("does-not-exist", new String[0]);
+    }
+
+    @Test
+    public void setLocaleOfDataSource_swapsExistingLocale() throws SaikuDataSourceException {
+        SaikuDatasource d = ds("dl", "id-l");
+        d.getProperties()
+                .setProperty("location", "jdbc:mondrian:Jdbc=jdbc:h2:mem:foo;Catalog=x.xml;locale=en_GB;Foo=bar;");
+        svc.setLocaleOfDataSource(d, "fr_FR");
+        assertEquals(
+                "jdbc:mondrian:Jdbc=jdbc:h2:mem:foo;Catalog=x.xml;locale=fr_FR;Foo=bar;",
+                d.getProperties().getProperty("location"));
+    }
+
+    @Test(expected = SaikuDataSourceException.class)
+    public void setLocaleOfDataSource_missingLocale_throws() throws SaikuDataSourceException {
+        SaikuDatasource d = ds("dnl", "id-nl");
+        d.getProperties().setProperty("location", "jdbc:mondrian:Jdbc=jdbc:h2:mem:foo;Catalog=x.xml;");
+        svc.setLocaleOfDataSource(d, "fr_FR");
+    }
+
+    @Test
+    public void setLocaleOfDataSource_caseInsensitiveLocateButPreservesOriginalCase() throws SaikuDataSourceException {
+        SaikuDatasource d = ds("ci", "id-ci");
+        // Upper-case "Locale=" — locator is case-insensitive (toLowerCase).
+        d.getProperties().setProperty("location", "jdbc:mondrian:Locale=en_GB;Foo=bar;");
+        svc.setLocaleOfDataSource(d, "de_DE");
+        // The locale value got swapped but the original key casing comes through
+        // verbatim because String.replace works on the substring it located.
+        assertTrue(d.getProperties().getProperty("location").contains("de_DE"));
+    }
+
+    @Test
+    public void getInternalFileData_swallowsRepositoryException_returnsNull() {
+        manager.throwOnInternalFileRead = new RepositoryException("missing");
+        assertNull(svc.getInternalFileData("nope"));
+    }
+
+    @Test
+    public void getInternalFileData_passthroughOnSuccess() {
+        manager.internalFiles.put("/etc/x", "contents");
+        assertEquals("contents", svc.getInternalFileData("/etc/x"));
+    }
+
+    @Test
+    public void delegations_passThroughToManager() throws Exception {
+        // Spot-check the high-volume delegating surface.
+        SaikuDatasource d = ds("delegate", "id-d");
+        svc.setDatasource(d);
+        assertSame(d, manager.lastSet);
+
+        svc.removeDatasource("id-d");
+        assertEquals(Collections.singletonList("id-d"), manager.removeCalls);
+
+        manager.seed(d);
+        assertSame(d, svc.getDatasource("delegate"));
+        assertEquals(1, svc.getDatasources(new String[0]).size());
+
+        manager.schemas = List.of(new MondrianSchema());
+        assertEquals(1, svc.getAvailableSchema().size());
+
+        svc.addSchema("<schema/>", "/path", "name");
+        assertEquals("name", manager.addSchemaCalls.get(0).get("name"));
+
+        svc.saveInternalFile("/etc/k", "v", "nt:file");
+        assertEquals("v", manager.internalFiles.get("/etc/k"));
+
+        svc.saveFile("body", "/repo/file.saiku", "tom", List.of("R"));
+        assertEquals("body", manager.savedFiles.get("/repo/file.saiku"));
+
+        svc.removeFile("/repo/file.saiku", "tom", List.of("R"));
+        assertTrue(manager.removedFiles.contains("/repo/file.saiku"));
+
+        svc.moveFile("/a", "/b", "tom", List.of("R"));
+        assertEquals("/a -> /b", manager.movedFiles.get(0));
+
+        svc.removeSchema("schema-id");
+        assertEquals("schema-id", manager.lastRemovedSchema);
+
+        svc.exportRepository();
+        assertTrue(manager.exported);
+        svc.restoreRepository(new byte[] {1, 2, 3});
+        assertNotNull(manager.restored);
+        svc.restoreLegacyFiles(new byte[] {4});
+        assertNotNull(manager.legacyRestored);
+
+        assertFalse(svc.hasHomeDirectory("nobody"));
+        manager.homes.add("alice");
+        assertTrue(svc.hasHomeDirectory("alice"));
+
+        svc.createUserHome("alice");
+        assertEquals(Collections.singletonList("alice"), manager.createdUsers);
+    }
+
+    @Test
+    public void importLegacy_methodsAreNoOps_doNotThrow() {
+        svc.importLegacySchema();
+        svc.importLegacyDatasources();
+        svc.importLegacyUsers();
+    }
+
+    @Test
+    public void aclDelegations() {
+        svc.setResourceACL("/file", "ACL", "tom", List.of("R"));
+        assertEquals("ACL", manager.acls.get("/file"));
+
+        assertNull(svc.getResourceACL("/file", "tom", List.of("R")));
+    }
+
+    @Test
+    public void getConnectionManager_returnsWiredInstance() {
+        assertSame(connManager, svc.getConnectionManager());
+    }
+
+    // ---------------------------------------------------------------- helpers
+
+    private static SaikuDatasource ds(String name, String id) {
+        Properties p = new Properties();
+        p.setProperty("id", id);
+        return new SaikuDatasource(name, SaikuDatasource.Type.OLAP, p);
+    }
+
+    private static final class StubConnectionManager implements IConnectionManager {
+        private final IDatasourceManager dsm;
+
+        StubConnectionManager(IDatasourceManager dsm) {
+            this.dsm = dsm;
+        }
+
+        @Override
+        public void init() throws SaikuOlapException {}
+
+        @Override
+        public void setDataSourceManager(IDatasourceManager ds) {}
+
+        @Override
+        public IDatasourceManager getDataSourceManager() {
+            return dsm;
+        }
+
+        @Override
+        public void refreshConnection(String name) {}
+
+        @Override
+        public void refreshAllConnections() {}
+
+        @Override
+        public org.olap4j.OlapConnection getOlapConnection(String name) {
+            return null;
+        }
+
+        @Override
+        public Map<String, org.olap4j.OlapConnection> getAllOlapConnections() {
+            return Map.of();
+        }
+
+        @Override
+        public ISaikuConnection getConnection(String name) {
+            return null;
+        }
+
+        @Override
+        public Map<String, ISaikuConnection> getAllConnections() {
+            return Map.of();
+        }
+    }
+
+    private static final class RecordingDatasourceManager implements IDatasourceManager {
+        final Map<String, SaikuDatasource> store = new LinkedHashMap<>();
+        final List<SaikuDatasource> addCalls = new ArrayList<>();
+        final List<String> removeCalls = new ArrayList<>();
+        final Map<String, Object> internalFiles = new HashMap<>();
+        final Map<String, Object> savedFiles = new HashMap<>();
+        final Set<String> removedFiles = new HashSet<>();
+        final List<String> movedFiles = new ArrayList<>();
+        final List<Map<String, String>> addSchemaCalls = new ArrayList<>();
+        final List<String> createdUsers = new ArrayList<>();
+        final Set<String> homes = new HashSet<>();
+        final Map<String, String> acls = new HashMap<>();
+        List<MondrianSchema> schemas = List.of();
+        SaikuDatasource lastSet;
+        String lastRemovedSchema;
+        boolean exported;
+        byte[] restored;
+        byte[] legacyRestored;
+        RepositoryException throwOnInternalFileRead;
+
+        void seed(SaikuDatasource ds) {
+            store.put(ds.getName(), ds);
+        }
+
+        @Override
+        public void load() {}
+
+        @Override
+        public void unload() {}
+
+        @Override
+        public SaikuDatasource addDatasource(SaikuDatasource datasource) {
+            addCalls.add(datasource);
+            store.put(datasource.getName(), datasource);
+            return datasource;
+        }
+
+        @Override
+        public SaikuDatasource setDatasource(SaikuDatasource datasource) {
+            lastSet = datasource;
+            return datasource;
+        }
+
+        @Override
+        public List<SaikuDatasource> addDatasources(List<SaikuDatasource> datasources) {
+            return datasources;
+        }
+
+        @Override
+        public boolean removeDatasource(String datasourceName) {
+            removeCalls.add(datasourceName);
+            return true;
+        }
+
+        @Override
+        public boolean removeSchema(String schemaName) {
+            lastRemovedSchema = schemaName;
+            return true;
+        }
+
+        @Override
+        public Map<String, SaikuDatasource> getDatasources(String[] roles) {
+            return new LinkedHashMap<>(store);
+        }
+
+        @Override
+        public SaikuDatasource getDatasource(String datasourceName) {
+            return store.get(datasourceName);
+        }
+
+        @Override
+        public SaikuDatasource getDatasource(String datasourceName, boolean refresh) {
+            return store.get(datasourceName);
+        }
+
+        @Override
+        public void addSchema(String file, String path, String name) {
+            addSchemaCalls.add(Map.of("file", file, "path", path, "name", name));
+        }
+
+        @Override
+        public List<MondrianSchema> getMondrianSchema() {
+            return schemas;
+        }
+
+        @Override
+        public MondrianSchema getMondrianSchema(String catalog) {
+            return null;
+        }
+
+        @Override
+        public RepositoryFile getFile(String file) {
+            return null;
+        }
+
+        @Override
+        public String getFileData(String file, String username, List<String> roles) {
+            return (String) savedFiles.get(file);
+        }
+
+        @Override
+        public String getInternalFileData(String file) throws RepositoryException {
+            if (throwOnInternalFileRead != null) throw throwOnInternalFileRead;
+            return (String) internalFiles.get(file);
+        }
+
+        @Override
+        public InputStream getBinaryInternalFileData(String file) {
+            return null;
+        }
+
+        @Override
+        public String saveFile(String path, Object content, String user, List<String> roles) {
+            savedFiles.put(path, content);
+            return "ok";
+        }
+
+        @Override
+        public String removeFile(String path, String user, List<String> roles) {
+            removedFiles.add(path);
+            return "ok";
+        }
+
+        @Override
+        public String moveFile(String source, String target, String user, List<String> roles) {
+            movedFiles.add(source + " -> " + target);
+            return "ok";
+        }
+
+        @Override
+        public String saveInternalFile(String path, Object content, String type) {
+            internalFiles.put(path, content);
+            return "ok";
+        }
+
+        @Override
+        public String saveBinaryInternalFile(String path, InputStream content, String type) {
+            return "ok";
+        }
+
+        @Override
+        public void removeInternalFile(String filePath) {
+            internalFiles.remove(filePath);
+        }
+
+        @Override
+        public List<IRepositoryObject> getFiles(List<String> type, String username, List<String> roles) {
+            return List.of();
+        }
+
+        @Override
+        public List<IRepositoryObject> getFiles(List<String> type, String username, List<String> roles, String path) {
+            return List.of();
+        }
+
+        @Override
+        public void createUser(String user) {
+            createdUsers.add(user);
+        }
+
+        @Override
+        public void deleteFolder(String folder) {}
+
+        @Override
+        public AclEntry getACL(String object, String username, List<String> roles) {
+            return null;
+        }
+
+        @Override
+        public void setACL(String object, String acl, String username, List<String> roles) {
+            acls.put(object, acl);
+        }
+
+        @Override
+        public void setUserService(UserService userService) {}
+
+        @Override
+        public List<MondrianSchema> getInternalFilesOfFileType(String type) {
+            return List.of();
+        }
+
+        @Override
+        public void createFileMixin(String type) {}
+
+        @Override
+        public byte[] exportRepository() {
+            exported = true;
+            return new byte[0];
+        }
+
+        @Override
+        public void restoreRepository(byte[] data) {
+            restored = data;
+        }
+
+        @Override
+        public boolean hasHomeDirectory(String name) {
+            return homes.contains(name);
+        }
+
+        @Override
+        public void restoreLegacyFiles(byte[] data) {
+            legacyRestored = data;
+        }
+
+        @Override
+        public String getFoodmartschema() {
+            return null;
+        }
+
+        @Override
+        public void setFoodmartschema(String schema) {}
+
+        @Override
+        public void setFoodmartdir(String dir) {}
+
+        @Override
+        public String getFoodmartdir() {
+            return null;
+        }
+
+        @Override
+        public String getDatadir() {
+            return null;
+        }
+
+        @Override
+        public void setDatadir(String dir) {}
+
+        @Override
+        public void setFoodmarturl(String foodmarturl) {}
+
+        @Override
+        public String getFoodmarturl() {
+            return null;
+        }
+
+        @Override
+        public String getEarthquakeUrl() {
+            return null;
+        }
+
+        @Override
+        public String getEarthquakeDir() {
+            return null;
+        }
+
+        @Override
+        public String getEarthquakeSchema() {
+            return null;
+        }
+
+        @Override
+        public void setEarthquakeUrl(String earthquakeUrl) {}
+
+        @Override
+        public void setEarthquakeDir(String earthquakeDir) {}
+
+        @Override
+        public void setEarthquakeSchema(String earthquakeSchema) {}
+
+        @Override
+        public void setExternalPropertiesFile(String file) {}
+
+        @Override
+        public String[] getAvailablePropertiesKeys() {
+            return new String[0];
+        }
+
+        @Override
+        public List<JujuSource> getJujuDatasources() {
+            return List.of();
+        }
+
+        @Override
+        public String getType() {
+            return "stub";
+        }
+    }
+}

--- a/saiku-core/saiku-web/src/test/java/org/saiku/web/rest/resources/DataSourceResourceTest.java
+++ b/saiku-core/saiku-web/src/test/java/org/saiku/web/rest/resources/DataSourceResourceTest.java
@@ -1,0 +1,184 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.web.rest.resources;
+
+import static org.junit.Assert.*;
+
+import jakarta.ws.rs.core.Response;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Properties;
+import org.junit.Before;
+import org.junit.Test;
+import org.saiku.datasources.datasource.SaikuDatasource;
+import org.saiku.service.datasource.DatasourceService;
+import org.saiku.service.user.UserService;
+import org.saiku.service.util.exception.SaikuServiceException;
+
+/**
+ * Drives {@link DataSourceResource} against stubbed {@link DatasourceService}
+ * + {@link UserService} so the REST contract is exercised without a real
+ * datasource manager.
+ */
+public class DataSourceResourceTest {
+
+    private DataSourceResource resource;
+    private StubDatasourceService dsSvc;
+    private StubUserService users;
+
+    @Before
+    public void setUp() {
+        dsSvc = new StubDatasourceService();
+        users = new StubUserService();
+        resource = new DataSourceResource();
+        resource.setDatasourceService(dsSvc);
+        resource.setUserService(users);
+    }
+
+    @Test
+    public void getDatasources_returnsAllDatasources() {
+        dsSvc.store.put("alpha", ds("alpha", "id-a"));
+        dsSvc.store.put("beta", ds("beta", "id-b"));
+        assertEquals(2, resource.getDatasources().size());
+    }
+
+    @Test
+    public void getDatasources_swallowsSaikuServiceException_returnsEmpty() {
+        dsSvc.throwOnList = new SaikuServiceException("backend down");
+        assertTrue(resource.getDatasources().isEmpty());
+    }
+
+    @Test
+    public void deleteDatasource_returnsGoneStatus_andDelegates() {
+        Response.Status s = resource.deleteDatasource("ds-name");
+        assertEquals(Response.Status.GONE, s);
+        assertEquals(1, dsSvc.removeCount);
+        assertEquals("ds-name", dsSvc.lastRemovedName);
+    }
+
+    @Test
+    public void getDatasourceById_returnsMatchingDatasourceWrapped() {
+        dsSvc.store.put("beta", dsForMapper("beta", "id-b"));
+        Response resp = resource.getDatasourceById("id-b");
+        assertEquals(200, resp.getStatus());
+        // body is a DataSourceMapper around the matching SaikuDatasource.
+        assertNotNull(resp.getEntity());
+    }
+
+    @Test
+    public void getDatasourceById_unknownId_returns500FromMapperNpe() {
+        // When no datasource matches, the resource still tries to construct a
+        // DataSourceMapper(null) which NPEs on ds.getProperties() — caught by
+        // the catch block and surfaced as 500. Pinning current behavior so a
+        // future fix that returns 404/200 is a deliberate change, not a silent
+        // regression.
+        dsSvc.store.put("alpha", dsForMapper("alpha", "id-a"));
+        Response resp = resource.getDatasourceById("missing-id");
+        assertEquals(500, resp.getStatus());
+    }
+
+    @Test
+    public void getDatasourceById_underlyingException_returns500() {
+        dsSvc.throwOnList = new RuntimeException("kaboom");
+        Response resp = resource.getDatasourceById("id-b");
+        assertEquals(500, resp.getStatus());
+        assertEquals("kaboom", resp.getEntity());
+    }
+
+    @Test
+    public void updateDatasourceLocale_swapsLocale_andSavesOverwrite() {
+        SaikuDatasource d = ds("with-locale", "id-locale");
+        d.getProperties().setProperty("location", "jdbc:mondrian:Jdbc=foo;Catalog=x;locale=en_GB;");
+        dsSvc.store.put("with-locale", d);
+
+        Response resp = resource.updateDatasourceLocale("fr_FR", "id-locale");
+        assertEquals(200, resp.getStatus());
+        assertEquals(1, dsSvc.addCount);
+        assertTrue(dsSvc.lastAddOverwrite);
+        assertTrue(d.getProperties().getProperty("location").contains("locale=fr_FR;"));
+    }
+
+    @Test
+    public void updateDatasourceLocale_unknownId_doesNothing_butStillReturns200() {
+        Response resp = resource.updateDatasourceLocale("fr_FR", "no-such-id");
+        assertEquals(200, resp.getStatus());
+        assertEquals(0, dsSvc.addCount);
+    }
+
+    @Test
+    public void updateDatasourceLocale_addThrows_returns500() {
+        SaikuDatasource d = ds("with-locale", "id-locale");
+        d.getProperties().setProperty("location", "jdbc:mondrian:Jdbc=foo;locale=en_GB;");
+        dsSvc.store.put("with-locale", d);
+        dsSvc.throwOnAdd = new RuntimeException("disk full");
+
+        Response resp = resource.updateDatasourceLocale("fr_FR", "id-locale");
+        assertEquals(500, resp.getStatus());
+        assertEquals("disk full", resp.getEntity());
+    }
+
+    @Test
+    public void getUserService_returnsWiredInstance() {
+        assertSame(users, resource.getUserService());
+    }
+
+    // ---------------------------------------------------------------- helpers
+
+    private static SaikuDatasource ds(String name, String id) {
+        Properties p = new Properties();
+        p.setProperty("id", id);
+        return new SaikuDatasource(name, SaikuDatasource.Type.OLAP, p);
+    }
+
+    /**
+     * Build a SaikuDatasource with the minimum set of properties that
+     * DataSourceMapper needs to construct without throwing.
+     */
+    private static SaikuDatasource dsForMapper(String name, String id) {
+        Properties p = new Properties();
+        p.setProperty("id", id);
+        p.setProperty("driver", "mondrian.olap4j.MondrianOlap4jDriver");
+        p.setProperty("location", "jdbc:mondrian:Jdbc=jdbc:h2:mem:foo;Catalog=x.xml;JdbcDrivers=org.h2.Driver");
+        p.setProperty("connectiontype", "OLAP");
+        p.setProperty("advanced", "false");
+        return new SaikuDatasource(name, SaikuDatasource.Type.OLAP, p);
+    }
+
+    private static final class StubDatasourceService extends DatasourceService {
+        final Map<String, SaikuDatasource> store = new LinkedHashMap<>();
+        RuntimeException throwOnList;
+        Exception throwOnAdd;
+        int removeCount;
+        int addCount;
+        String lastRemovedName;
+        boolean lastAddOverwrite;
+
+        @Override
+        public Map<String, SaikuDatasource> getDatasources(String[] roles) {
+            if (throwOnList != null) throw throwOnList;
+            return store;
+        }
+
+        @Override
+        public void removeDatasource(String datasourceId) {
+            removeCount++;
+            lastRemovedName = datasourceId;
+        }
+
+        @Override
+        public void addDatasource(SaikuDatasource ds, boolean overwrite, String[] roles) throws Exception {
+            if (throwOnAdd != null) throw throwOnAdd;
+            addCount++;
+            lastAddOverwrite = overwrite;
+        }
+    }
+
+    private static final class StubUserService extends UserService {
+        @Override
+        public String[] getCurrentUserRoles() {
+            return new String[] {"ROLE_USER"};
+        }
+    }
+}

--- a/saiku-core/saiku-web/src/test/java/org/saiku/web/rest/resources/InfoResourceTest.java
+++ b/saiku-core/saiku-web/src/test/java/org/saiku/web/rest/resources/InfoResourceTest.java
@@ -1,0 +1,58 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.web.rest.resources;
+
+import static org.junit.Assert.*;
+
+import jakarta.ws.rs.core.Response;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.Test;
+import org.saiku.service.PlatformUtilsService;
+import org.saiku.service.util.dto.Plugin;
+
+public class InfoResourceTest {
+
+    @Test
+    public void getAvailablePlugins_returns200WithPluginList() {
+        PlatformUtilsService stub = new PlatformUtilsService() {
+            @Override
+            public ArrayList<Plugin> getAvailablePlugins() {
+                ArrayList<Plugin> out = new ArrayList<>();
+                out.add(new Plugin("alpha", "", "js/saiku/plugins/alpha/plugin.js"));
+                return out;
+            }
+        };
+        InfoResource r = new InfoResource();
+        r.setPlatformUtilsService(stub);
+
+        Response resp = r.getAvailablePlugins();
+        assertEquals(200, resp.getStatus());
+        // Response.ok(GenericEntity) unwraps the generic, so the entity is the
+        // raw List. The GenericEntity wrapper is only used to carry the type.
+        @SuppressWarnings("unchecked")
+        List<Plugin> body = (List<Plugin>) resp.getEntity();
+        assertEquals(1, body.size());
+        assertEquals("alpha", body.get(0).getName());
+    }
+
+    @Test
+    public void getAvailablePlugins_emptyListStillReturns200() {
+        PlatformUtilsService stub = new PlatformUtilsService() {
+            @Override
+            public ArrayList<Plugin> getAvailablePlugins() {
+                return new ArrayList<>();
+            }
+        };
+        InfoResource r = new InfoResource();
+        r.setPlatformUtilsService(stub);
+
+        Response resp = r.getAvailablePlugins();
+        assertEquals(200, resp.getStatus());
+        @SuppressWarnings("unchecked")
+        List<Plugin> body = (List<Plugin>) resp.getEntity();
+        assertTrue(body.isEmpty());
+    }
+}

--- a/saiku-core/saiku-web/src/test/java/org/saiku/web/rest/resources/SessionResourceTest.java
+++ b/saiku-core/saiku-web/src/test/java/org/saiku/web/rest/resources/SessionResourceTest.java
@@ -1,0 +1,242 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.web.rest.resources;
+
+import static org.junit.Assert.*;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.ws.rs.core.Response;
+import java.lang.reflect.Proxy;
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+import org.junit.Before;
+import org.junit.Test;
+import org.saiku.service.ISessionService;
+import org.saiku.service.user.UserService;
+import org.saiku.web.security.ratelimit.LoginRateLimiter;
+
+/**
+ * Exercise the SessionResource HTTP contract without spinning up Jersey. We
+ * drive the resource with hand-built stubs for {@link ISessionService},
+ * {@link UserService} and {@link HttpServletRequest} (via a dynamic proxy) so
+ * the test stays in-process and fast.
+ */
+public class SessionResourceTest {
+
+    private SessionResource resource;
+    private RecordingSessionService session;
+    private RecordingUserService users;
+    private LoginRateLimiter rateLimiter;
+    private HttpServletRequest req;
+
+    @Before
+    public void setUp() {
+        session = new RecordingSessionService();
+        users = new RecordingUserService();
+        // Generous limits so the happy paths don't trip the limiter.
+        rateLimiter = new LoginRateLimiter(50, 60_000L, false);
+        req = newRequest("203.0.113.10", new Locale("en"));
+
+        resource = new SessionResource();
+        resource.setSessionService(session);
+        resource.setUserService(users);
+        resource.setRateLimiter(rateLimiter);
+    }
+
+    @Test
+    public void login_validCredentials_returns200() {
+        Response resp = resource.login(req, "admin", "secret");
+        assertEquals(200, resp.getStatus());
+        assertEquals(1, session.loginCalls);
+    }
+
+    @Test
+    public void login_invalidCredentials_returns401() {
+        session.loginException = new RuntimeException("bad creds");
+        Response resp = resource.login(req, "admin", "wrong");
+        assertEquals(401, resp.getStatus());
+        assertEquals("Authentication failed", resp.getEntity());
+    }
+
+    @Test
+    public void login_blockedByRateLimiter_returns429WithRetryAfter() {
+        // Tiny window so we can quickly exhaust the bucket from the test side.
+        LoginRateLimiter strict = new LoginRateLimiter(1, 600_000L, false);
+        resource.setRateLimiter(strict);
+        session.loginException = new RuntimeException("bad creds");
+
+        // First failure counts; second attempt is blocked.
+        resource.login(req, "admin", "wrong");
+        Response resp = resource.login(req, "admin", "wrong");
+
+        assertEquals(429, resp.getStatus());
+        assertNotNull("Retry-After header must be set", resp.getHeaderString("Retry-After"));
+        assertEquals(String.valueOf(strict.getWindowMs() / 1000), resp.getHeaderString("Retry-After"));
+    }
+
+    @Test
+    public void login_nullRateLimiter_setterDoesNotOverwrite() {
+        // setRateLimiter(null) is documented as a no-op — the existing limiter
+        // must still apply. Pass a real null and verify the resource still
+        // accepts a normal login.
+        resource.setRateLimiter(null);
+        Response resp = resource.login(req, "admin", "secret");
+        assertEquals(200, resp.getStatus());
+    }
+
+    @Test
+    public void getSession_returns200WithSessionAndLanguageAndIsAdmin() {
+        session.sessionMap = new HashMap<>();
+        session.sessionMap.put("username", "tom");
+        users.isAdmin = true;
+
+        Response resp = resource.getSession(req);
+        assertEquals(200, resp.getStatus());
+        @SuppressWarnings("unchecked")
+        Map<String, Object> body = (Map<String, Object>) resp.getEntity();
+        assertEquals("tom", body.get("username"));
+        assertEquals("en", body.get("language"));
+        assertEquals(Boolean.TRUE, body.get("isadmin"));
+        assertTrue("checkFolders must be called once per session probe", users.checkFoldersCalls >= 1);
+    }
+
+    @Test
+    public void getSession_sessionServiceFailure_returns500() {
+        session.getSessionException = new RuntimeException("backend down");
+        Response resp = resource.getSession(req);
+        assertEquals(500, resp.getStatus());
+        assertEquals("backend down", resp.getEntity());
+    }
+
+    @Test
+    public void getSession_isAdminThrows_doesNotPropagate() {
+        session.sessionMap = new HashMap<>();
+        users.isAdminException = new RuntimeException("acl backend missing");
+        Response resp = resource.getSession(req);
+        assertEquals(200, resp.getStatus());
+        @SuppressWarnings("unchecked")
+        Map<String, Object> body = (Map<String, Object>) resp.getEntity();
+        // No isadmin key on swallowed exception.
+        assertFalse(body.containsKey("isadmin"));
+    }
+
+    @Test
+    public void logout_returns200_andCallsLogout() {
+        session.sessionMap = new HashMap<>();
+        session.sessionMap.put("username", "tom");
+        Response resp = resource.logout(req);
+        assertEquals(200, resp.getStatus());
+        assertEquals(1, session.logoutCalls);
+    }
+
+    @Test
+    public void logout_withoutActiveSession_stillReturns200() {
+        session.getSessionException = new RuntimeException("no session");
+        Response resp = resource.logout(req);
+        assertEquals(200, resp.getStatus());
+        assertEquals(1, session.logoutCalls);
+    }
+
+    @Test
+    public void clearSession_success_returns200() {
+        Response resp = resource.clearSession(req, "admin", "secret");
+        assertEquals(200, resp.getStatus());
+        assertEquals("Session cleared", resp.getEntity());
+        assertEquals(1, session.clearCalls);
+    }
+
+    @Test
+    public void clearSession_failure_returns500WithMessage() {
+        session.clearException = new RuntimeException("forbidden");
+        Response resp = resource.clearSession(req, "admin", "secret");
+        assertEquals(500, resp.getStatus());
+        assertEquals("forbidden", resp.getEntity());
+    }
+
+    @Test
+    public void getSessionService_returnsWiredInstance() {
+        assertSame(session, resource.getSessionService());
+    }
+
+    // ---------------------------------------------------------------- helpers
+
+    private static HttpServletRequest newRequest(String remoteAddr, Locale locale) {
+        return (HttpServletRequest) Proxy.newProxyInstance(
+                HttpServletRequest.class.getClassLoader(),
+                new Class<?>[] {HttpServletRequest.class},
+                (proxy, method, args) -> {
+                    String n = method.getName();
+                    if ("getRemoteAddr".equals(n)) return remoteAddr;
+                    if ("getLocale".equals(n)) return locale;
+                    if ("getHeader".equals(n)) return null;
+                    if ("getSession".equals(n)) return null;
+                    Class<?> rt = method.getReturnType();
+                    if (rt == boolean.class) return false;
+                    if (rt == int.class) return 0;
+                    if (rt == long.class) return 0L;
+                    return null;
+                });
+    }
+
+    private static final class RecordingSessionService implements ISessionService {
+        Map<String, Object> sessionMap = new HashMap<>();
+        RuntimeException loginException;
+        RuntimeException getSessionException;
+        RuntimeException clearException;
+        int loginCalls;
+        int logoutCalls;
+        int clearCalls;
+
+        @Override
+        public Map<String, Object> login(HttpServletRequest req, String username, String password) {
+            loginCalls++;
+            if (loginException != null) throw loginException;
+            return sessionMap;
+        }
+
+        @Override
+        public void logout(HttpServletRequest req) {
+            logoutCalls++;
+        }
+
+        @Override
+        public void authenticate(HttpServletRequest req, String username, String password) {}
+
+        @Override
+        public Map<String, Object> getSession() {
+            if (getSessionException != null) throw getSessionException;
+            return sessionMap;
+        }
+
+        @Override
+        public Map<String, Object> getAllSessionObjects() {
+            return Map.of();
+        }
+
+        @Override
+        public void clearSessions(HttpServletRequest req, String username, String password) {
+            clearCalls++;
+            if (clearException != null) throw clearException;
+        }
+    }
+
+    private static final class RecordingUserService extends UserService {
+        boolean isAdmin;
+        RuntimeException isAdminException;
+        int checkFoldersCalls;
+
+        @Override
+        public boolean isAdmin() {
+            if (isAdminException != null) throw isAdminException;
+            return isAdmin;
+        }
+
+        @Override
+        public void checkFolders() {
+            checkFoldersCalls++;
+        }
+    }
+}

--- a/saiku-core/saiku-web/src/test/java/org/saiku/web/rest/resources/StatisticsResourceTest.java
+++ b/saiku-core/saiku-web/src/test/java/org/saiku/web/rest/resources/StatisticsResourceTest.java
@@ -1,0 +1,40 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.web.rest.resources;
+
+import static org.junit.Assert.*;
+
+import mondrian.olap.MondrianServer;
+import mondrian.olap.MondrianServer.MondrianVersion;
+import org.junit.Test;
+
+/**
+ * {@link MondrianServer#forId(String)} returns a process-singleton default
+ * server, so the stats endpoints always have a server to talk to even in
+ * unit-test JVMs. Verify the resource surfaces a sensible body that wraps
+ * the default server's monitor data.
+ */
+public class StatisticsResourceTest {
+
+    private final StatisticsResource resource = new StatisticsResource();
+
+    @Test
+    public void getMondrianStats_returnsNonNullBodyAgainstDefaultServer() {
+        MondrianStats stats = resource.getMondrianStats();
+        assertNotNull(stats);
+    }
+
+    @Test
+    public void getMondrianServer_returnsServerInfoFromDefaultServer() {
+        assertNotNull(resource.getMondrianServer());
+    }
+
+    @Test
+    public void getMondrianServerVersion_returnsRunningMondrianVersion() {
+        MondrianVersion v = resource.getMondrianServerVersion();
+        assertNotNull(v);
+        assertNotNull("MondrianVersion.getVersionString must be non-null", v.getVersionString());
+    }
+}

--- a/saiku-launcher/pom.xml
+++ b/saiku-launcher/pom.xml
@@ -56,6 +56,21 @@
             <version>1.7.36</version>
             <scope>runtime</scope>
         </dependency>
+
+        <!-- Integration test dependencies. JUnit + Jackson for JSON shape
+             assertions. JDK's java.net.http handles the wire calls. -->
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.13.2</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>2.18.6</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>
@@ -93,6 +108,38 @@
                         </configuration>
                     </execution>
                 </executions>
+            </plugin>
+            <!--
+              Integration tests boot the launcher's Jetty in-process via
+              SaikuLauncher.ServeCommand.bootServer(...). Bound to the
+              integration-test phase so they run AFTER prepare-package
+              stages target/classes/webapp/saiku.war via the copy-war
+              execution below. Gated by the {@code integration} profile
+              (see below) so `mvn verify` keeps the inner dev loop fast.
+            -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <version>3.5.2</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>integration-test</goal>
+                            <goal>verify</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <includes>
+                        <include>**/*IT.java</include>
+                    </includes>
+                    <!-- Real OLAP queries are heavyweight; ITs run serially. -->
+                    <forkCount>1</forkCount>
+                    <reuseForks>true</reuseForks>
+                    <argLine>--add-opens=java.base/java.nio=ALL-UNNAMED</argLine>
+                    <!-- Default skip; the {@code integration} profile flips this on. -->
+                    <skipITs>true</skipITs>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -170,4 +217,24 @@
             </plugin>
         </plugins>
     </build>
+
+    <profiles>
+        <!-- Activate with `mvn verify -P integration` to actually run the
+             whole-API integration tests. The default reactor (CI's
+             `mvn verify`) leaves them skipped so day-to-day builds stay fast. -->
+        <profile>
+            <id>integration</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-failsafe-plugin</artifactId>
+                        <configuration>
+                            <skipITs>false</skipITs>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>

--- a/saiku-launcher/src/main/java/org/saiku/launcher/SaikuLauncher.java
+++ b/saiku-launcher/src/main/java/org/saiku/launcher/SaikuLauncher.java
@@ -68,6 +68,30 @@ public class SaikuLauncher implements Callable<Integer> {
 
         @Override
         public Integer call() throws Exception {
+            Server server = bootServer(port, host, contextPath, home);
+            int actualPort = ((ServerConnector) server.getConnectors()[0]).getLocalPort();
+            String base = "http://" + host + ":" + actualPort + contextPath;
+            if (!base.endsWith("/")) base = base + "/";
+            System.out.println("Saiku ready:");
+            System.out.println("  Workspace : " + base + "ui/");
+            System.out.println("  Admin     : " + base + "ui/admin");
+            System.out.println("  REST API  : " + base + "rest/saiku/");
+            printDefaultCredentialWarning();
+            server.join();
+            return 0;
+        }
+
+        /**
+         * Boot the embedded Jetty server with a fully wired Saiku WAR. Returns
+         * the running {@link Server} so callers can introspect the bound port
+         * via {@code server.getConnectors()[0].getLocalPort()} and orchestrate
+         * shutdown. Used by the integration test harness so it can hit a real
+         * webapp without spawning a separate JVM.
+         *
+         * <p>The supplied port may be {@code 0} for an OS-assigned ephemeral
+         * port — discoverable post-start via the connector.
+         */
+        public static Server bootServer(int port, String host, String contextPath, Path home) throws Exception {
             Path saikuHome = (home != null ? home : Paths.get("saiku-home")).toAbsolutePath();
             Path dataDir = saikuHome.resolve("data");
             Path brandingDir = saikuHome.resolve("branding");
@@ -138,15 +162,7 @@ public class SaikuLauncher implements Callable<Integer> {
             }));
 
             server.start();
-            String base = "http://" + host + ":" + port + contextPath;
-            if (!base.endsWith("/")) base = base + "/";
-            System.out.println("Saiku ready:");
-            System.out.println("  Workspace : " + base + "ui/");
-            System.out.println("  Admin     : " + base + "ui/admin");
-            System.out.println("  REST API  : " + base + "rest/saiku/");
-            printDefaultCredentialWarning();
-            server.join();
-            return 0;
+            return server;
         }
 
         /**
@@ -178,7 +194,7 @@ public class SaikuLauncher implements Callable<Integer> {
             System.out.println();
         }
 
-        private void stageSeedAssets(Path dataDir) throws Exception {
+        private static void stageSeedAssets(Path dataDir) throws Exception {
             Path schema = dataDir.resolve("FoodMart4.xml");
             if (!Files.exists(schema)) {
                 try (InputStream in = SaikuLauncher.class.getResourceAsStream("/seed/FoodMart4.xml")) {
@@ -214,7 +230,7 @@ public class SaikuLauncher implements Callable<Integer> {
          * the JDBC URL is portable across machines. Skipped if the file already
          * exists — preserves user customisations on re-launch.
          */
-        private void stageDefaultDatasource(Path saikuHome) throws Exception {
+        private static void stageDefaultDatasource(Path saikuHome) throws Exception {
             Path dsDir = saikuHome
                     .resolve("repository")
                     .resolve("data")
@@ -236,7 +252,7 @@ public class SaikuLauncher implements Callable<Integer> {
             }
         }
 
-        private void stageBrandingSample(Path brandingDir) throws Exception {
+        private static void stageBrandingSample(Path brandingDir) throws Exception {
             Path sample = brandingDir.resolve("brand.css.sample");
             if (!Files.exists(sample)) {
                 try (InputStream in = SaikuLauncher.class.getResourceAsStream("/seed/brand.css.sample")) {
@@ -248,7 +264,7 @@ public class SaikuLauncher implements Callable<Integer> {
             }
         }
 
-        private Path extractWar() throws Exception {
+        private static Path extractWar() throws Exception {
             Path tmp = Files.createTempFile("saiku-", ".war");
             tmp.toFile().deleteOnExit();
             try (InputStream in = SaikuLauncher.class.getResourceAsStream("/webapp/saiku.war")) {

--- a/saiku-launcher/src/test/java/org/saiku/launcher/it/AiQueryIT.java
+++ b/saiku-launcher/src/test/java/org/saiku/launcher/it/AiQueryIT.java
@@ -1,0 +1,220 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.launcher.it;
+
+import static org.junit.Assert.*;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import java.net.http.HttpResponse;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ * End-to-end integration tests for the AI Query API surface ({@code
+ * /rest/saiku/api/ai/*}). Mirrors a meaningful subset of
+ * {@code saiku-launcher/test-ai-live.sh} as JUnit assertions, so the contract
+ * is enforced by {@code mvn verify -P integration} rather than only by an
+ * out-of-band shell script.
+ *
+ * <p>Boots once via {@link SaikuItHarness}; assumes the seeded FoodMart H2
+ * datasource that the launcher ships.
+ */
+public class AiQueryIT {
+
+    private static final String CUBE = "unknown_foodmart/FoodMart/FoodMart/Sales";
+    private static SaikuItHarness harness;
+
+    @BeforeClass
+    public static void boot() throws Exception {
+        harness = SaikuItHarness.shared();
+    }
+
+    // ---------------------------------------------------------------- discovery
+
+    @Test
+    public void cubes_listIncludesSales() throws Exception {
+        HttpResponse<String> resp = harness.getAuth("/rest/saiku/api/ai/cubes");
+        assertEquals(200, resp.statusCode());
+        JsonNode body = harness.parse(resp);
+        assertTrue("response must be a JSON array", body.isArray());
+
+        boolean foundSales = false;
+        for (JsonNode c : body) {
+            if ("Sales".equals(c.path("cubeName").asText())) {
+                foundSales = true;
+                break;
+            }
+        }
+        assertTrue("Sales cube must be present in /ai/cubes — body: " + resp.body(), foundSales);
+    }
+
+    @Test
+    public void schema_SalesCubeHasProductAndStoreSales() throws Exception {
+        HttpResponse<String> resp = harness.getAuth("/rest/saiku/api/ai/schema/" + CUBE);
+        assertEquals(200, resp.statusCode());
+        JsonNode body = harness.parse(resp);
+        assertTrue(
+                "schema must include 'product' dimension",
+                body.path("dimensions").has("product"));
+        assertTrue(
+                "schema must include 'store sales' measure",
+                body.path("measures").has("store sales"));
+    }
+
+    @Test
+    public void schema_threeSegmentCubeId_returns400WithCubeIdField() throws Exception {
+        HttpResponse<String> resp = harness.getAuth("/rest/saiku/api/ai/schema/foo/bar/baz");
+        assertEquals(400, resp.statusCode());
+        JsonNode body = harness.parse(resp);
+        assertEquals("VALIDATION_ERROR", body.path("status").asText());
+        assertEquals("cubeId", body.path("field").asText());
+    }
+
+    @Test
+    public void schema_unknownCubeName_returnsAvailableList() throws Exception {
+        HttpResponse<String> resp =
+                harness.getAuth("/rest/saiku/api/ai/schema/unknown_foodmart/FoodMart/FoodMart/Nonsense");
+        assertEquals(400, resp.statusCode());
+        JsonNode body = harness.parse(resp);
+        assertEquals("VALIDATION_ERROR", body.path("status").asText());
+        assertEquals("cube", body.path("field").asText());
+
+        boolean salesIsAnAvailableOption = false;
+        for (JsonNode candidate : body.path("available")) {
+            if ("Sales".equals(candidate.asText())) {
+                salesIsAnAvailableOption = true;
+                break;
+            }
+        }
+        assertTrue("Sales must be listed in the 'available' candidates", salesIsAnAvailableOption);
+    }
+
+    // ---------------------------------------------------------------- happy paths
+
+    @Test
+    public void query_simpleMeasureByProductFamily_returns3Rows() throws Exception {
+        String body =
+                """
+                {
+                  "cube": "%s",
+                  "measures": [{"name": "Store Sales"}],
+                  "rows": [{"dimension": "Product", "hierarchy": "Products", "level": "Product Family"}]
+                }
+                """
+                        .formatted(CUBE);
+        HttpResponse<String> resp = harness.postAuthJson("/rest/saiku/api/ai/query", body);
+        assertEquals("expected 200, got " + resp.statusCode() + " body=" + resp.body(), 200, resp.statusCode());
+        JsonNode r = harness.parse(resp);
+        assertEquals("SUCCESS", r.path("status").asText());
+        assertEquals(3, r.path("totalRows").asInt());
+        double firstValue =
+                r.path("data").get(0).path("Store Sales").path("value").asDouble();
+        assertTrue("first row Store Sales must be > 0, got " + firstValue, firstValue > 0);
+    }
+
+    @Test
+    public void query_orderAndLimit_emitsTopCountAndReturnsLimitedRows() throws Exception {
+        String body =
+                """
+                {
+                  "cube": "%s",
+                  "measures": [{"name": "Store Sales"}],
+                  "rows": [{"dimension": "Product", "hierarchy": "Products", "level": "Product Family"}],
+                  "order": [{"by": "Store Sales", "direction": "desc"}],
+                  "limit": 2
+                }
+                """
+                        .formatted(CUBE);
+        HttpResponse<String> resp = harness.postAuthJson("/rest/saiku/api/ai/query", body);
+        assertEquals(200, resp.statusCode());
+        JsonNode r = harness.parse(resp);
+        assertEquals("SUCCESS", r.path("status").asText());
+        assertEquals(2, r.path("totalRows").asInt());
+        assertTrue(
+                "generatedMdx should use TopCount: "
+                        + r.path("metadata").path("generatedMdx").asText(),
+                r.path("metadata").path("generatedMdx").asText().contains("TopCount"));
+    }
+
+    @Test
+    public void query_filterIn_singleYearFilter_returnsAllProductFamilies() throws Exception {
+        String body =
+                """
+                {
+                  "cube": "%s",
+                  "measures": [{"name": "Store Sales"}],
+                  "rows": [{"dimension": "Product", "hierarchy": "Products", "level": "Product Family"}],
+                  "filters": [{
+                    "dimension": "Time",
+                    "hierarchy": "Time",
+                    "level": "Year",
+                    "members": ["[Time].[Time].[1997]"]
+                  }]
+                }
+                """
+                        .formatted(CUBE);
+        HttpResponse<String> resp = harness.postAuthJson("/rest/saiku/api/ai/query", body);
+        assertEquals(200, resp.statusCode());
+        JsonNode r = harness.parse(resp);
+        assertEquals("SUCCESS", r.path("status").asText());
+        assertEquals(3, r.path("totalRows").asInt());
+    }
+
+    // ---------------------------------------------------------------- validation
+
+    @Test
+    public void query_unknownMeasure_returnsValidationErrorWithAvailable() throws Exception {
+        String body =
+                """
+                {
+                  "cube": "%s",
+                  "measures": [{"name": "Made Up Measure"}],
+                  "rows": []
+                }
+                """
+                        .formatted(CUBE);
+        HttpResponse<String> resp = harness.postAuthJson("/rest/saiku/api/ai/query", body);
+        assertEquals(400, resp.statusCode());
+        JsonNode r = harness.parse(resp);
+        assertEquals("VALIDATION_ERROR", r.path("status").asText());
+        assertEquals("measures[].name", r.path("field").asText());
+
+        boolean storeSalesListed = false;
+        for (JsonNode candidate : r.path("available")) {
+            if ("Store Sales".equals(candidate.asText())) {
+                storeSalesListed = true;
+                break;
+            }
+        }
+        assertTrue("'Store Sales' must be in 'available' for self-correction", storeSalesListed);
+    }
+
+    @Test
+    public void query_mdxInjectionInMembers_rejectedWithEmbeddedMdxMessage() throws Exception {
+        String body =
+                """
+                {
+                  "cube": "%s",
+                  "measures": [{"name": "Store Sales"}],
+                  "rows": [{
+                    "dimension": "Product",
+                    "hierarchy": "Products",
+                    "level": "Product Family",
+                    "members": ["[Product].[Products].[Drink], Crossjoin([Time].[1997])"]
+                  }]
+                }
+                """
+                        .formatted(CUBE);
+        HttpResponse<String> resp = harness.postAuthJson("/rest/saiku/api/ai/query", body);
+        assertEquals(400, resp.statusCode());
+        JsonNode r = harness.parse(resp);
+        assertEquals("VALIDATION_ERROR", r.path("status").asText());
+        assertEquals("rows[0].members[0]", r.path("field").asText());
+        assertTrue(
+                "error message must mention 'Embedded MDX' — got: "
+                        + r.path("error").asText(),
+                r.path("error").asText().contains("Embedded MDX"));
+    }
+}

--- a/saiku-launcher/src/test/java/org/saiku/launcher/it/InfoEndpointIT.java
+++ b/saiku-launcher/src/test/java/org/saiku/launcher/it/InfoEndpointIT.java
@@ -1,0 +1,45 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.launcher.it;
+
+import static org.junit.Assert.*;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import java.net.http.HttpResponse;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ * Smoke test: the launcher comes up, the {@code /rest/saiku/info} endpoint
+ * answers, and the response body is a JSON list. This is the gating IT — if
+ * this is red, the rest of the IT surface is meaningless.
+ */
+public class InfoEndpointIT {
+
+    private static SaikuItHarness harness;
+
+    @BeforeClass
+    public static void boot() throws Exception {
+        harness = SaikuItHarness.shared();
+    }
+
+    @Test
+    public void info_returns200WithJsonArray() throws Exception {
+        HttpResponse<String> resp = harness.getAuth("/rest/saiku/info");
+        assertEquals("info should be 200, body was: " + resp.body(), 200, resp.statusCode());
+        JsonNode body = harness.parse(resp);
+        assertTrue("info body must be a JSON array (plugin list), got: " + resp.body(), body.isArray());
+    }
+
+    @Test
+    public void info_unauthenticatedAlsoAllowed() throws Exception {
+        // The /info endpoint is configured anonymous-allowed in the shipped
+        // applicationContext-spring-security-memory.xml — the SPA fetches it
+        // pre-login to render the plugin list. Lock that contract here so a
+        // tightening change is an explicit decision, not a silent regression.
+        HttpResponse<String> resp = harness.getAnon("/rest/saiku/info");
+        assertEquals(200, resp.statusCode());
+    }
+}

--- a/saiku-launcher/src/test/java/org/saiku/launcher/it/SaikuItHarness.java
+++ b/saiku-launcher/src/test/java/org/saiku/launcher/it/SaikuItHarness.java
@@ -1,0 +1,160 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.launcher.it;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.Base64;
+import java.util.concurrent.atomic.AtomicReference;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.ServerConnector;
+import org.saiku.launcher.SaikuLauncher;
+
+/**
+ * One-shot bootstrap for the saiku-launcher Jetty + WAR stack against an
+ * ephemeral port and a temp saiku-home. Used by every {@code *IT} as a static
+ * fixture: boot once per IT suite, share across tests, tear down at the end.
+ *
+ * <p>The harness keeps the boot logic out of individual test classes so the
+ * test bodies focus on REST contract assertions. It also centralises the
+ * helper methods for issuing HTTP requests with Basic auth and parsing JSON
+ * responses.
+ *
+ * <p>Auth defaults to {@code admin/admin} — the in-memory seed user that
+ * Saiku ships with. Tests can override per-call.
+ */
+public final class SaikuItHarness {
+
+    private static final AtomicReference<SaikuItHarness> SINGLETON = new AtomicReference<>();
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+    private static final Duration HTTP_TIMEOUT = Duration.ofSeconds(60);
+
+    private final Server server;
+    private final Path home;
+    private final String baseUrl;
+    private final HttpClient http;
+    private final String adminBasicAuth;
+
+    private SaikuItHarness(Server server, Path home) {
+        this.server = server;
+        this.home = home;
+        int port = ((ServerConnector) server.getConnectors()[0]).getLocalPort();
+        this.baseUrl = "http://127.0.0.1:" + port;
+        this.http = HttpClient.newBuilder()
+                .connectTimeout(Duration.ofSeconds(5))
+                .followRedirects(HttpClient.Redirect.NORMAL)
+                .build();
+        this.adminBasicAuth =
+                "Basic " + Base64.getEncoder().encodeToString("admin:admin".getBytes(StandardCharsets.UTF_8));
+    }
+
+    /**
+     * Boot the harness if it isn't already running, returning the singleton.
+     * Concurrent callers race-safely — only one actual boot occurs.
+     */
+    public static synchronized SaikuItHarness shared() throws Exception {
+        SaikuItHarness existing = SINGLETON.get();
+        if (existing != null) {
+            return existing;
+        }
+        Path home = Files.createTempDirectory("saiku-it-");
+        // Boot port=0 → OS picks an ephemeral port. Host 127.0.0.1 to avoid
+        // firewall prompts on macOS CI runners.
+        Server server = SaikuLauncher.ServeCommand.bootServer(0, "127.0.0.1", "/", home);
+        SaikuItHarness h = new SaikuItHarness(server, home);
+        // Block until the webapp finishes its Spring init. Without this, the
+        // first test races against Spring's bean wiring and gets a 503.
+        h.waitForReady();
+        SINGLETON.set(h);
+        // Shut down at JVM exit (failsafe forks a reusable JVM per test class).
+        Runtime.getRuntime().addShutdownHook(new Thread(h::stopQuietly));
+        return h;
+    }
+
+    private void waitForReady() throws Exception {
+        long deadline = System.currentTimeMillis() + Duration.ofMinutes(2).toMillis();
+        Exception last = null;
+        while (System.currentTimeMillis() < deadline) {
+            try {
+                HttpResponse<String> resp = http.send(
+                        HttpRequest.newBuilder(URI.create(baseUrl + "/rest/saiku/info"))
+                                .timeout(Duration.ofSeconds(5))
+                                .GET()
+                                .build(),
+                        HttpResponse.BodyHandlers.ofString());
+                if (resp.statusCode() < 500) {
+                    return; // Spring has finished wiring beans.
+                }
+            } catch (Exception e) {
+                last = e;
+            }
+            Thread.sleep(500);
+        }
+        throw new IllegalStateException("Saiku failed to become ready within 2 minutes", last);
+    }
+
+    public String baseUrl() {
+        return baseUrl;
+    }
+
+    public Path home() {
+        return home;
+    }
+
+    /** Issue a GET against {@code path} with admin Basic auth. */
+    public HttpResponse<String> getAuth(String path) throws Exception {
+        return http.send(
+                HttpRequest.newBuilder(URI.create(baseUrl + path))
+                        .timeout(HTTP_TIMEOUT)
+                        .header("Authorization", adminBasicAuth)
+                        .header("Accept", "application/json")
+                        .GET()
+                        .build(),
+                HttpResponse.BodyHandlers.ofString());
+    }
+
+    /** Issue a POST against {@code path} with admin Basic auth + JSON body. */
+    public HttpResponse<String> postAuthJson(String path, String body) throws Exception {
+        return http.send(
+                HttpRequest.newBuilder(URI.create(baseUrl + path))
+                        .timeout(HTTP_TIMEOUT)
+                        .header("Authorization", adminBasicAuth)
+                        .header("Accept", "application/json")
+                        .header("Content-Type", "application/json")
+                        .POST(HttpRequest.BodyPublishers.ofString(body, StandardCharsets.UTF_8))
+                        .build(),
+                HttpResponse.BodyHandlers.ofString());
+    }
+
+    /** Issue a GET against {@code path} without auth — used for testing the 401 path. */
+    public HttpResponse<String> getAnon(String path) throws Exception {
+        return http.send(
+                HttpRequest.newBuilder(URI.create(baseUrl + path))
+                        .timeout(HTTP_TIMEOUT)
+                        .header("Accept", "application/json")
+                        .GET()
+                        .build(),
+                HttpResponse.BodyHandlers.ofString());
+    }
+
+    public JsonNode parse(HttpResponse<String> resp) throws Exception {
+        return MAPPER.readTree(resp.body());
+    }
+
+    private void stopQuietly() {
+        try {
+            server.stop();
+        } catch (Exception ignored) {
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Two-track test coverage push:

**1. Unit-test backfill (94 new tests across 7 files)**

| Area | File | New tests | Notes |
|---|---|---|---|
| saiku-service | `AsyncQueryServiceTest` | 20 | Lifecycle, RejectedExecutionException cleanup, sweep eviction windows, shutdown idempotency |
| saiku-service | `SaikuQueryCacheTest` | +12 | invalidateAll, reindex warming + orphan-arrow cleanup, totalBytesOnDisk, null-bytes guards, missing-arrow refetch, cubeVersion-null hit |
| saiku-service | `DatasourceServiceTest` | 14 | add/overwrite, fetchById, locale string surgery, RepositoryException swallow, delegation passthroughs |
| saiku-semantic | `SemanticLayerTest` | +9 | Missing-field validation, MondrianCompiler ordering + optional attrs |
| saiku-web | `InfoResourceTest` | 2 | Plugin enumeration |
| saiku-web | `SessionResourceTest` | 12 | Login happy/unauth/rate-limited, getSession (language+isAdmin+checkFolders), logout, clearSession |
| saiku-web | `DataSourceResourceTest` | 10 | List/delete/getById/locale update + 500-on-mapper-NPE behavior |
| saiku-web | `StatisticsResourceTest` | 3 | Mondrian default-server contract |

All stubs are hand-rolled (no Mockito dependency); `HttpServletRequest` and `CellSet` use dynamic Proxy. saiku-web went from 13 → 17 test files; saiku-service core engine + cache + datasource now have characterisation coverage.

**2. Integration test harness for whole API (saiku-launcher, 11 ITs)**

New module structure under `saiku-launcher/src/test/`:
- `SaikuItHarness` — shared singleton that boots Jetty + WAR in-process against an ephemeral port with admin/admin Basic auth.
- `InfoEndpointIT` (2) — smoke test that the launcher comes up and answers.
- `AiQueryIT` (9) — `/api/ai/cubes`, `/api/ai/schema` (validation envelopes), `/api/ai/query` (happy paths: simple measure, TopCount via order+limit, filter-in; validation: unknown measure with available list, MDX injection rejection).

The shell-based `saiku-launcher/test-ai-live.sh` remains the broader sweep — the IT subset turns its most load-bearing assertions into JUnit so CI can gate on them.

**Runtime gating:**
- `mvn verify` keeps the inner dev loop fast — ITs are **skipped by default** via maven-failsafe-plugin's `skipITs=true`.
- `mvn verify -P integration` runs the full suite — boot is paid once (~16s), tests run in ~18s total.

**Refactor:**
`SaikuLauncher.ServeCommand.call()` extracts boot into a public static `bootServer(port, host, contextPath, home)` returning the running `Server`. `call()` now reads the actual bound port off the connector so port=0 (ephemeral) works. Seed/WAR helpers become static. Minimal, no behaviour change.

## Test plan

- [x] `mvn verify` clean (ITs skipped)
- [x] `mvn verify -P integration` green (11 ITs against real Jetty + FoodMart H2)
- [x] Spotless clean across the touched modules
- [ ] CI green on the PR