### PR TITLE
release: 4.2.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <groupId>org.saikuanalytics</groupId>
     <artifactId>saiku</artifactId>
     <packaging>pom</packaging>
-    <version>4.0.1</version>
+    <version>4.2.0</version>
     <name>Saiku Module Project</name>
     <scm>
         <developerConnection>

--- a/saiku-bom/pom.xml
+++ b/saiku-bom/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.saikuanalytics</groupId>
     <artifactId>saiku-bom</artifactId>
-    <version>4.0.1</version>
+    <version>4.2.0</version>
     <packaging>pom</packaging>
     <name>Saiku BOM</name>
     <description>Central dependency-version catalogue for Saiku modules.</description>

--- a/saiku-core/pom.xml
+++ b/saiku-core/pom.xml
@@ -2,14 +2,14 @@
     <parent>
         <artifactId>saiku</artifactId>
         <groupId>org.saikuanalytics</groupId>
-        <version>4.0.1</version>
+        <version>4.2.0</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>
     <artifactId>saiku-core</artifactId>
     <packaging>pom</packaging>
     <name>saiku - core libraries</name>
-    <version>4.0.1</version>
+    <version>4.2.0</version>
 
     <modules>
         <module>saiku-olap-util</module>

--- a/saiku-core/saiku-olap-util/pom.xml
+++ b/saiku-core/saiku-olap-util/pom.xml
@@ -3,11 +3,11 @@
     <parent>
         <artifactId>saiku-core</artifactId>
         <groupId>org.saikuanalytics</groupId>
-        <version>4.0.1</version>
+        <version>4.2.0</version>
     </parent>
 	<artifactId>saiku-olap-util</artifactId>
 	<packaging>jar</packaging>
-	<version>4.0.1</version>
+	<version>4.2.0</version>
 	<name>saiku olap util</name>
 	<properties>
 		<maven.compiler.source>1.8</maven.compiler.source>

--- a/saiku-core/saiku-semantic/pom.xml
+++ b/saiku-core/saiku-semantic/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <artifactId>saiku-core</artifactId>
         <groupId>org.saikuanalytics</groupId>
-        <version>4.0.1</version>
+        <version>4.2.0</version>
     </parent>
 
     <artifactId>saiku-semantic</artifactId>

--- a/saiku-core/saiku-semantic/src/test/java/org/saiku/semantic/SemanticLayerTest.java
+++ b/saiku-core/saiku-semantic/src/test/java/org/saiku/semantic/SemanticLayerTest.java
@@ -76,4 +76,171 @@ class SemanticLayerTest {
                 """;
         assertThrows(CubeYamlParser.SemanticValidationException.class, () -> new CubeYamlParser().parse(yaml));
     }
+
+    @Test
+    void rejectsBlankCubeName() {
+        String yaml =
+                """
+                name: ""
+                fact:
+                  table: t
+                measures:
+                  - name: a
+                    column: c
+                """;
+        assertThrows(CubeYamlParser.SemanticValidationException.class, () -> new CubeYamlParser().parse(yaml));
+    }
+
+    @Test
+    void rejectsMissingFactTable() {
+        String yaml =
+                """
+                name: Broken
+                fact:
+                  table: ""
+                measures:
+                  - name: a
+                    column: c
+                """;
+        assertThrows(CubeYamlParser.SemanticValidationException.class, () -> new CubeYamlParser().parse(yaml));
+    }
+
+    @Test
+    void rejectsDimensionWithoutLevels() {
+        String yaml =
+                """
+                name: Sales
+                fact:
+                  table: t
+                measures:
+                  - name: a
+                    column: c
+                dimensions:
+                  - name: Empty
+                """;
+        assertThrows(CubeYamlParser.SemanticValidationException.class, () -> new CubeYamlParser().parse(yaml));
+    }
+
+    @Test
+    void rejectsLevelMissingColumn() {
+        String yaml =
+                """
+                name: Sales
+                fact:
+                  table: t
+                measures:
+                  - name: a
+                    column: c
+                dimensions:
+                  - name: D
+                    levels:
+                      - name: L
+                """;
+        assertThrows(CubeYamlParser.SemanticValidationException.class, () -> new CubeYamlParser().parse(yaml));
+    }
+
+    @Test
+    void rejectsLevelMissingName() {
+        String yaml =
+                """
+                name: Sales
+                fact:
+                  table: t
+                measures:
+                  - name: a
+                    column: c
+                dimensions:
+                  - name: D
+                    levels:
+                      - column: lc
+                """;
+        assertThrows(CubeYamlParser.SemanticValidationException.class, () -> new CubeYamlParser().parse(yaml));
+    }
+
+    @Test
+    void compilerEmitsMultipleDimensionsInOrder() throws IOException {
+        String yaml =
+                """
+                name: Multi
+                fact:
+                  table: f
+                measures:
+                  - name: m1
+                    column: c1
+                dimensions:
+                  - name: Time
+                    levels: [{ name: Year, column: y }]
+                  - name: Geo
+                    levels: [{ name: Country, column: g }]
+                """;
+        CubeDefinition cube = new CubeYamlParser().parse(yaml);
+        String xml = new MondrianCompiler().compile(cube);
+        int timeAt = xml.indexOf("<Dimension name=\"Time\"");
+        int geoAt = xml.indexOf("<Dimension name=\"Geo\"");
+        assertTrue(timeAt > 0, "Time dim must be emitted");
+        assertTrue(geoAt > timeAt, "Geo dim must follow Time in declaration order, got " + xml);
+    }
+
+    @Test
+    void compilerEmitsFactSchemaAttributeWhenPresent() throws IOException {
+        String yaml =
+                """
+                name: WithSchema
+                fact:
+                  schema: analytics
+                  table: f
+                measures:
+                  - name: m
+                    column: c
+                """;
+        String xml = new MondrianCompiler().compile(new CubeYamlParser().parse(yaml));
+        assertTrue(xml.contains("schema=\"analytics\""), xml);
+    }
+
+    @Test
+    void compilerOmitsFactSchemaAttributeWhenBlank() throws IOException {
+        String yaml =
+                """
+                name: NoSchema
+                fact:
+                  schema: ""
+                  table: f
+                measures:
+                  - name: m
+                    column: c
+                """;
+        String xml = new MondrianCompiler().compile(new CubeYamlParser().parse(yaml));
+        assertTrue(!xml.contains("schema=\"\""), "blank schema must not be emitted, got: " + xml);
+    }
+
+    @Test
+    void compilerEmitsLevelTypeAndOptionalColumnsWhenPresent() throws IOException {
+        String yaml =
+                """
+                name: Sales
+                fact:
+                  table: f
+                measures:
+                  - name: m
+                    column: c
+                dimensions:
+                  - name: Geo
+                    foreignKey: geo_id
+                    primaryKey: id
+                    table: geo_dim
+                    levels:
+                      - name: Country
+                        column: country_id
+                        type: Numeric
+                        nameColumn: country_name
+                        ordinalColumn: country_ord
+                """;
+        String xml = new MondrianCompiler().compile(new CubeYamlParser().parse(yaml));
+        assertTrue(xml.contains("foreignKey=\"geo_id\""), xml);
+        assertTrue(xml.contains("primaryKey=\"id\""), xml);
+        assertTrue(xml.contains("<Table name=\"geo_dim\""), xml);
+        assertTrue(xml.contains("nameColumn=\"country_name\""), xml);
+        assertTrue(xml.contains("ordinalColumn=\"country_ord\""), xml);
+        assertTrue(xml.contains("type=\"Numeric\""), xml);
+    }
 }

--- a/saiku-core/saiku-service/pom.xml
+++ b/saiku-core/saiku-service/pom.xml
@@ -2,12 +2,12 @@
     <parent>
         <artifactId>saiku-core</artifactId>
         <groupId>org.saikuanalytics</groupId>
-        <version>4.0.1</version>
+        <version>4.2.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>jar</packaging>
     <artifactId>saiku-service</artifactId>
-    <version>4.0.1</version>
+    <version>4.2.0</version>
     <name>saiku - services</name>
     <build>
         <plugins>

--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ThinQueryService.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ThinQueryService.java
@@ -236,6 +236,32 @@ public class ThinQueryService implements Serializable {
         return this.context.get(name);
     }
 
+    /**
+     * saiku#862: import an externally-built ThinQuery + CellSet into this
+     * session's context. Lets the AI Query API's async-drillthrough path
+     * re-attach a previously-executed async query to the current request
+     * session so {@link #drillthrough(String, java.util.List, Integer, String)}
+     * can resolve the QueryContext by name.
+     *
+     * <p>Without this hook, a drillthrough request that lands on a different
+     * session than the one that submitted the async query hits an empty
+     * context map and the resource layer surfaces a "Unknown queryId" 404
+     * even though the underlying AsyncQueryHandle still has the cellset
+     * loaded.
+     */
+    public void registerExternalContext(ThinQuery query, CellSet cellSet) {
+        if (query == null || query.getName() == null) return;
+        QueryContext qc = context.get(query.getName());
+        if (qc == null) {
+            qc = new QueryContext(Type.OLAP, query);
+            context.put(query.getName(), qc);
+        }
+        qc.store(ObjectKey.QUERY, query);
+        if (cellSet != null) {
+            qc.store(ObjectKey.RESULT, cellSet);
+        }
+    }
+
     @Deprecated
     public ThinQuery createEmpty(String name, SaikuCube cube) {
         try {
@@ -658,10 +684,20 @@ public class ThinQueryService implements Serializable {
 
     public boolean isMdxDrillthrough(ThinQuery query) {
         try {
-            if (ThinQuery.Type.MDX.equals(query.getType())) {
+            // saiku#861: detect DRILLTHROUGH MDX even when ThinQuery.type is
+            // null (the JSON body /api/query/execute often omits it, and the
+            // default constructor leaves the field null). Without this guard
+            // the falls-through path hits Mondrian's
+            // MondrianOlap4jStatement.parseQuery() which casts to (Query) →
+            // ClassCastException because DRILLTHROUGH parses to a different
+            // class.
+            String mdx = query.getMdx();
+            boolean isMdxMode = ThinQuery.Type.MDX.equals(query.getType())
+                    || (query.getType() == null && mdx != null && !mdx.isBlank());
+            if (isMdxMode) {
                 SaikuCube cube = query.getCube();
                 final OlapConnection con = olapDiscoverService.getNativeConnection(cube.getConnection());
-                return SaikuMondrianHelper.isMondrianDrillthrough(con, query.getMdx());
+                return SaikuMondrianHelper.isMondrianDrillthrough(con, mdx);
             }
         } catch (Exception | Error e) {
             log.warn("Error checking for DRILLTHROUGH: " + query.getName() + " DRILLTHROUGH MDX:" + query.getMdx(), e);

--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ai/AiRequestJsonSchema.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ai/AiRequestJsonSchema.java
@@ -54,7 +54,9 @@ public final class AiRequestJsonSchema {
                 "limit",
                 intField(
                         0,
-                        "Optional row cap. With order, emits TopCount/BottomCount; without order, emits HEAD(rows, N). 0 or absent = no cap."));
+                        "Optional row cap. With order, emits TopCount/BottomCount; without order, emits HEAD(rows, N). "
+                                + "0 or absent = no cap. Must be >= 0 and <= 10000 — larger values are rejected with "
+                                + "VALIDATION_ERROR. Page client-side for larger result sets."));
         properties.put(
                 "visualTotals",
                 boolField(

--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ai/AiSchemaConverter.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ai/AiSchemaConverter.java
@@ -23,6 +23,14 @@ import org.saiku.olap.query2.ThinQuery;
 public class AiSchemaConverter {
 
     /**
+     * Upper bound for {@link AiQueryRequest#getLimit()}. Anything above this
+     * is rejected with a {@code VALIDATION_ERROR} envelope so a bad agent
+     * request can't HEAD() a 100M-row set out of Mondrian. 10k matches the
+     * SPA's pager default; tune via patch if the deployment needs more.
+     */
+    public static final int AI_QUERY_LIMIT_MAX = 10_000;
+
+    /**
      * Convert + validate.
      *
      * @throws AiValidationException with field/available populated if any
@@ -48,6 +56,27 @@ public class AiSchemaConverter {
         }
         if (req.getMeasures() == null || req.getMeasures().isEmpty()) {
             throw new AiValidationException("measures", "At least one measure required", null);
+        }
+        // saiku#864: reject negative limit and clamp the upper bound. Limit
+        // semantics are "0 or absent = no cap" by design (documented in the
+        // schema field description), so 0 is fine — but a negative value
+        // silently routed to the no-cap path before this guard, and a
+        // 99,999,999-row HEAD() against a large cube is a memory bomb.
+        int limit = req.getLimit();
+        if (limit < 0) {
+            throw new AiValidationException(
+                    "limit",
+                    "limit must be >= 0. Use 0 (or omit) for no cap, or a positive integer up to " + AI_QUERY_LIMIT_MAX
+                            + ". Got " + limit + ".",
+                    null);
+        }
+        if (limit > AI_QUERY_LIMIT_MAX) {
+            throw new AiValidationException(
+                    "limit",
+                    "limit must be <= " + AI_QUERY_LIMIT_MAX
+                            + " to prevent unbounded result-set generation. Got " + limit
+                            + ". For larger result sets, page client-side or refine the query.",
+                    null);
         }
         // Reject duplicate measures up-front. Without this guard the records
         // renderer silently drops the duplicate's cell (same map-key collision

--- a/saiku-core/saiku-service/src/test/java/org/saiku/service/async/AsyncQueryServiceTest.java
+++ b/saiku-core/saiku-service/src/test/java/org/saiku/service/async/AsyncQueryServiceTest.java
@@ -1,0 +1,405 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.service.async;
+
+import static org.junit.Assert.*;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Proxy;
+import java.sql.SQLException;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.After;
+import org.junit.Test;
+import org.olap4j.CellSet;
+import org.saiku.olap.query2.ThinQuery;
+import org.saiku.service.olap.ThinQueryService;
+import org.saiku.service.util.QueryContext;
+
+/**
+ * Unit tests for {@link AsyncQueryService}. Drives a synthetic {@link ThinQueryService}
+ * so the lifecycle is exercised without needing a live OLAP connection.
+ */
+public class AsyncQueryServiceTest {
+
+    private AsyncQueryService svc;
+
+    @After
+    public void tearDown() {
+        if (svc != null) {
+            svc.shutdown();
+        }
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void submit_throwsWhenThinQueryServiceUnwired() {
+        svc = new AsyncQueryService();
+        svc.submit(named("anything"));
+    }
+
+    @Test
+    public void submit_returnsHandleAndTransitionsToDone() throws Exception {
+        StubThinQueryService stub = new StubThinQueryService();
+        svc = new AsyncQueryService();
+        svc.setThinQueryService(stub);
+
+        AsyncQueryHandle h = svc.submit(named("q1"));
+        assertNotNull(h);
+        assertNotNull(h.getId());
+        // wait up to 2s for executor to drain.
+        awaitStatus(h, AsyncQueryHandle.Status.DONE, 2000);
+        assertEquals(AsyncQueryHandle.Status.DONE, h.getStatus());
+        assertEquals(1, stub.executeCount.get());
+    }
+
+    @Test
+    public void submit_recordsFailureWhenExecuteThrows() throws Exception {
+        StubThinQueryService stub = new StubThinQueryService();
+        stub.failure = new RuntimeException("boom");
+        svc = new AsyncQueryService();
+        svc.setThinQueryService(stub);
+
+        AsyncQueryHandle h = svc.submit(named("q2"));
+        awaitStatus(h, AsyncQueryHandle.Status.FAILED, 2000);
+        assertEquals(AsyncQueryHandle.Status.FAILED, h.getStatus());
+        assertEquals("boom", h.getErrorMessage());
+    }
+
+    @Test
+    public void submit_recordsFailureWithClassNameWhenMessageIsNull() throws Exception {
+        StubThinQueryService stub = new StubThinQueryService();
+        stub.failure = new NullPointerException();
+        svc = new AsyncQueryService();
+        svc.setThinQueryService(stub);
+
+        AsyncQueryHandle h = svc.submit(named("q-npe"));
+        awaitStatus(h, AsyncQueryHandle.Status.FAILED, 2000);
+        assertEquals("NullPointerException", h.getErrorMessage());
+    }
+
+    @Test
+    public void submit_propagatesRejectedExecutionAndRemovesHandle() {
+        // Single-slot, no-queue, abort-policy executor → first task occupies the
+        // worker slot, second submission is rejected.
+        ThreadPoolExecutor saturated = new ThreadPoolExecutor(
+                1, 1, 1L, TimeUnit.MINUTES, new java.util.concurrent.SynchronousQueue<>(), daemonFactory("test-rej"));
+        saturated.setRejectedExecutionHandler(new ThreadPoolExecutor.AbortPolicy());
+
+        StubThinQueryService stub = new StubThinQueryService();
+        stub.block = new CountDownLatch(1); // first submission parks the worker
+        svc = new AsyncQueryService(saturated);
+        svc.setThinQueryService(stub);
+
+        AsyncQueryHandle blocking = svc.submit(named("blocker"));
+        try {
+            svc.submit(named("rejected"));
+            fail("expected RejectedExecutionException");
+        } catch (java.util.concurrent.RejectedExecutionException expected) {
+            // rejected handle must NOT linger in the map.
+            assertEquals(1, svc.size());
+            assertEquals(blocking.getStatus(), svc.get(blocking.getId()).getStatus());
+        } finally {
+            stub.block.countDown();
+        }
+    }
+
+    @Test
+    public void get_returnsHandleAndTouches() throws Exception {
+        StubThinQueryService stub = new StubThinQueryService();
+        svc = new AsyncQueryService();
+        svc.setThinQueryService(stub);
+
+        AsyncQueryHandle h = svc.submit(named("q-get"));
+        awaitStatus(h, AsyncQueryHandle.Status.DONE, 2000);
+
+        long before = h.getLastAccessedAt();
+        Thread.sleep(5);
+        AsyncQueryHandle fetched = svc.get(h.getId());
+        assertSame(h, fetched);
+        assertTrue("touch should advance lastAccessedAt", fetched.getLastAccessedAt() >= before);
+    }
+
+    @Test
+    public void get_returnsNullForUnknownId() {
+        svc = new AsyncQueryService();
+        svc.setThinQueryService(new StubThinQueryService());
+        assertNull(svc.get("nope"));
+    }
+
+    @Test
+    public void register_storesExternalHandle() {
+        svc = new AsyncQueryService();
+        AsyncQueryHandle h = new AsyncQueryHandle("ext-1", named("x"));
+        svc.register(h);
+        assertSame(h, svc.get("ext-1"));
+        assertEquals(1, svc.size());
+    }
+
+    @Test
+    public void register_nullIsNoOp() {
+        svc = new AsyncQueryService();
+        svc.register(null);
+        assertEquals(0, svc.size());
+    }
+
+    @Test
+    public void result_nullUntilDoneThenReturnsCellSetAndMarksFetched() throws Exception {
+        StubThinQueryService stub = new StubThinQueryService();
+        stub.block = new CountDownLatch(1);
+        CellSet expected = newProxyCellSet(null);
+        stub.resultCellSet = expected;
+        svc = new AsyncQueryService();
+        svc.setThinQueryService(stub);
+
+        AsyncQueryHandle h = svc.submit(named("q-res"));
+        assertNull("result null while RUNNING/PENDING", svc.result(h.getId()));
+
+        stub.block.countDown();
+        awaitStatus(h, AsyncQueryHandle.Status.DONE, 2000);
+
+        CellSet got = svc.result(h.getId());
+        assertSame(expected, got);
+        assertTrue("markResultFetched should fire", h.isResultFetched());
+    }
+
+    @Test
+    public void result_returnsNullForUnknownId() {
+        svc = new AsyncQueryService();
+        svc.setThinQueryService(new StubThinQueryService());
+        assertNull(svc.result("nope"));
+    }
+
+    @Test
+    public void cancel_unknownIdReturnsFalse() {
+        svc = new AsyncQueryService();
+        svc.setThinQueryService(new StubThinQueryService());
+        assertFalse(svc.cancel("nope"));
+    }
+
+    @Test
+    public void cancel_flipsStatusAndCallsThinCancel() throws Exception {
+        StubThinQueryService stub = new StubThinQueryService();
+        stub.block = new CountDownLatch(1);
+        svc = new AsyncQueryService();
+        svc.setThinQueryService(stub);
+
+        AsyncQueryHandle h = svc.submit(named("q-cancel"));
+        assertTrue(svc.cancel(h.getId()));
+        assertEquals(AsyncQueryHandle.Status.CANCELLED, h.getStatus());
+
+        // cancelExecutor is async — give it time to dispatch.
+        stub.block.countDown();
+        long deadline = System.currentTimeMillis() + 2000;
+        while (stub.cancelCount.get() == 0 && System.currentTimeMillis() < deadline) {
+            Thread.sleep(10);
+        }
+        assertEquals("ThinQueryService.cancel should be invoked once", 1, stub.cancelCount.get());
+    }
+
+    @Test
+    public void cancel_swallowsSqlExceptionFromThinCancel() throws Exception {
+        StubThinQueryService stub = new StubThinQueryService();
+        stub.cancelFailure = new SQLException("statement gone");
+        svc = new AsyncQueryService();
+        svc.setThinQueryService(stub);
+
+        AsyncQueryHandle h = svc.submit(named("q-cancel-fail"));
+        awaitStatus(h, AsyncQueryHandle.Status.DONE, 2000);
+        assertTrue(svc.cancel(h.getId()));
+        // No exception bubbles. Status remains CANCELLED.
+        assertEquals(AsyncQueryHandle.Status.CANCELLED, h.getStatus());
+    }
+
+    @Test
+    public void sweep_evictsFetchedHandlesAfterIdleWindow() throws Exception {
+        StubThinQueryService stub = new StubThinQueryService();
+        stub.resultCellSet = newProxyCellSet(null);
+        svc = new AsyncQueryService();
+        svc.setThinQueryService(stub);
+
+        AsyncQueryHandle h = svc.submit(named("q-sweep"));
+        awaitStatus(h, AsyncQueryHandle.Status.DONE, 2000);
+        svc.result(h.getId()); // marks fetched
+        backdateLastAccessed(h, TimeUnit.MINUTES.toMillis(10));
+
+        svc.sweep();
+        assertEquals("fetched + idle > 5m must be evicted", 0, svc.size());
+    }
+
+    @Test
+    public void sweep_evictsTerminalHandlesAfterFailsafeWindow() throws Exception {
+        StubThinQueryService stub = new StubThinQueryService();
+        svc = new AsyncQueryService();
+        svc.setThinQueryService(stub);
+
+        AsyncQueryHandle h = svc.submit(named("q-failsafe"));
+        awaitStatus(h, AsyncQueryHandle.Status.DONE, 2000);
+        // not fetched — only the 30-min failsafe should reap.
+        backdateLastAccessed(h, TimeUnit.MINUTES.toMillis(45));
+
+        svc.sweep();
+        assertEquals(0, svc.size());
+    }
+
+    @Test
+    public void sweep_leavesNonTerminalHandlesAlone() throws Exception {
+        StubThinQueryService stub = new StubThinQueryService();
+        stub.block = new CountDownLatch(1);
+        svc = new AsyncQueryService();
+        svc.setThinQueryService(stub);
+
+        AsyncQueryHandle h = svc.submit(named("q-running"));
+        // Backdate the timestamp anyway — sweeper must skip non-terminal.
+        backdateLastAccessed(h, TimeUnit.MINUTES.toMillis(120));
+        svc.sweep();
+        assertEquals(1, svc.size());
+        stub.block.countDown();
+    }
+
+    @Test
+    public void sweep_leavesRecentTerminalHandles() throws Exception {
+        StubThinQueryService stub = new StubThinQueryService();
+        svc = new AsyncQueryService();
+        svc.setThinQueryService(stub);
+
+        AsyncQueryHandle h = svc.submit(named("q-recent"));
+        awaitStatus(h, AsyncQueryHandle.Status.DONE, 2000);
+        // No backdating — handle is fresh, idle ≈ 0.
+        svc.sweep();
+        assertEquals(1, svc.size());
+    }
+
+    @Test
+    public void size_reflectsHandleMap() {
+        svc = new AsyncQueryService();
+        svc.setThinQueryService(new StubThinQueryService());
+        assertEquals(0, svc.size());
+        svc.register(new AsyncQueryHandle("a", named("a")));
+        svc.register(new AsyncQueryHandle("b", named("b")));
+        assertEquals(2, svc.size());
+    }
+
+    @Test
+    public void shutdown_stopsExecutors() {
+        StubThinQueryService stub = new StubThinQueryService();
+        svc = new AsyncQueryService();
+        svc.setThinQueryService(stub);
+        svc.shutdown();
+        // After shutdown the work executor should reject new submissions.
+        try {
+            svc.submit(named("post-shutdown"));
+            fail("expected RejectedExecutionException after shutdown");
+        } catch (java.util.concurrent.RejectedExecutionException expected) {
+            // OK
+        }
+        svc = null; // prevent double-shutdown in @After
+    }
+
+    // ---------------------------------------------------------------- helpers
+
+    private static ThinQuery named(String name) {
+        ThinQuery q = new ThinQuery();
+        q.setName(name);
+        return q;
+    }
+
+    private static void awaitStatus(AsyncQueryHandle h, AsyncQueryHandle.Status want, long timeoutMs) throws Exception {
+        long deadline = System.currentTimeMillis() + timeoutMs;
+        while (h.getStatus() != want && System.currentTimeMillis() < deadline) {
+            Thread.sleep(10);
+        }
+        if (h.getStatus() != want) {
+            throw new AssertionError("timed out waiting for status " + want + ", saw " + h.getStatus());
+        }
+    }
+
+    private static void backdateLastAccessed(AsyncQueryHandle h, long deltaMs) throws Exception {
+        Field f = AsyncQueryHandle.class.getDeclaredField("lastAccessedAt");
+        f.setAccessible(true);
+        long current = f.getLong(h);
+        f.setLong(h, current - deltaMs);
+    }
+
+    private static ThreadFactory daemonFactory(String name) {
+        AtomicInteger i = new AtomicInteger();
+        return r -> {
+            Thread t = new Thread(r, name + "-" + i.incrementAndGet());
+            t.setDaemon(true);
+            return t;
+        };
+    }
+
+    /** A stub ThinQueryService that drives the async lifecycle without any OLAP. */
+    private static final class StubThinQueryService extends ThinQueryService {
+        final AtomicInteger executeCount = new AtomicInteger();
+        final AtomicInteger cancelCount = new AtomicInteger();
+        volatile RuntimeException failure;
+        volatile SQLException cancelFailure;
+        volatile CellSet resultCellSet;
+        volatile CountDownLatch block;
+
+        @Override
+        public org.saiku.olap.dto.resultset.CellDataSet execute(ThinQuery tq) {
+            executeCount.incrementAndGet();
+            if (block != null) {
+                try {
+                    block.await();
+                } catch (InterruptedException ie) {
+                    Thread.currentThread().interrupt();
+                    throw new RuntimeException("interrupted", ie);
+                }
+            }
+            if (failure != null) {
+                throw failure;
+            }
+            return null; // AsyncQueryService doesn't read this — it pulls from getContext().
+        }
+
+        @Override
+        public QueryContext getContext(String name) {
+            QueryContext ctx = new QueryContext(QueryContext.Type.OLAP, named(name));
+            if (resultCellSet != null) {
+                ctx.store(QueryContext.ObjectKey.RESULT, resultCellSet);
+            }
+            return ctx;
+        }
+
+        @Override
+        public void cancel(String name) throws SQLException {
+            cancelCount.incrementAndGet();
+            if (cancelFailure != null) {
+                throw cancelFailure;
+            }
+        }
+    }
+
+    /**
+     * Build a {@link CellSet} proxy. Returns sensible default values for
+     * primitive return types and {@code null} for everything else — sufficient
+     * for the AsyncQueryService surface, which never inspects the cellSet
+     * beyond {@code close()}.
+     */
+    private static CellSet newProxyCellSet(Object unusedCloseFlag) {
+        return (CellSet) Proxy.newProxyInstance(
+                CellSet.class.getClassLoader(), new Class<?>[] {CellSet.class}, (proxy, method, args) -> {
+                    if ("close".equals(method.getName())) {
+                        return null;
+                    }
+                    Class<?> rt = method.getReturnType();
+                    if (rt == boolean.class) return false;
+                    if (rt == int.class) return 0;
+                    if (rt == long.class) return 0L;
+                    if (rt == short.class) return (short) 0;
+                    if (rt == byte.class) return (byte) 0;
+                    if (rt == float.class) return 0f;
+                    if (rt == double.class) return 0d;
+                    if (rt == char.class) return '\0';
+                    return null;
+                });
+    }
+}

--- a/saiku-core/saiku-service/src/test/java/org/saiku/service/cache/SaikuQueryCacheTest.java
+++ b/saiku-core/saiku-service/src/test/java/org/saiku/service/cache/SaikuQueryCacheTest.java
@@ -209,4 +209,159 @@ public class SaikuQueryCacheTest {
         assertEquals(2, calls.get());
         assertFalse(r.cacheHit);
     }
+
+    @Test
+    public void invalidateAll_clearsIndexAndDeletesAllCacheFiles() throws IOException {
+        AtomicInteger calls = new AtomicInteger();
+        cache.get("k1", "v", supplierProducing("a".getBytes(), 1, 1, calls));
+        cache.get("k2", "v", supplierProducing("b".getBytes(), 1, 1, calls));
+
+        // Sanity: both keys on disk.
+        assertTrue(Files.exists(cacheDir.resolve("k1.arrow")));
+        assertTrue(Files.exists(cacheDir.resolve("k2.arrow")));
+
+        cache.invalidateAll();
+
+        assertFalse(Files.exists(cacheDir.resolve("k1.arrow")));
+        assertFalse(Files.exists(cacheDir.resolve("k1.meta.json")));
+        assertFalse(Files.exists(cacheDir.resolve("k2.arrow")));
+        assertFalse(Files.exists(cacheDir.resolve("k2.meta.json")));
+    }
+
+    @Test
+    public void invalidateAll_doesNotTouchUnrelatedFiles() throws IOException {
+        AtomicInteger calls = new AtomicInteger();
+        cache.get("k1", "v", supplierProducing("a".getBytes(), 1, 1, calls));
+        // Drop a stranger file alongside cache files.
+        Path stranger = cacheDir.resolve("README.txt");
+        Files.writeString(stranger, "do not delete me");
+
+        cache.invalidateAll();
+
+        assertTrue("non-saiku files must survive invalidateAll", Files.exists(stranger));
+    }
+
+    @Test
+    public void totalBytesOnDisk_sumsMetadataBytes() {
+        AtomicInteger calls = new AtomicInteger();
+        cache.get("k1", "v", supplierProducing(new byte[100], 1, 1, calls));
+        cache.get("k2", "v", supplierProducing(new byte[250], 1, 1, calls));
+
+        assertEquals(350L, cache.totalBytesOnDisk());
+    }
+
+    @Test
+    public void totalBytesOnDisk_zeroForEmptyCache() {
+        assertEquals(0L, cache.totalBytesOnDisk());
+    }
+
+    @Test
+    public void put_ignoresNullBytes() {
+        AtomicInteger calls = new AtomicInteger();
+        cache.get("k-null", "v", () -> {
+            calls.incrementAndGet();
+            return new CachedQueryResult(null, 1L, 1, false);
+        });
+        assertFalse(
+                "supplier with null bytes must not write a cache file", Files.exists(cacheDir.resolve("k-null.arrow")));
+        assertFalse(Files.exists(cacheDir.resolve("k-null.meta.json")));
+    }
+
+    @Test
+    public void put_ignoresNullResult() {
+        AtomicInteger calls = new AtomicInteger();
+        cache.get("k-null-result", "v", () -> {
+            calls.incrementAndGet();
+            return null;
+        });
+        assertFalse(Files.exists(cacheDir.resolve("k-null-result.arrow")));
+    }
+
+    @Test
+    public void reindex_warmsIndexFromExistingMetaFiles() throws Exception {
+        // Populate the first cache, then construct a fresh one over the same
+        // directory — its index should be warmed from the existing meta files.
+        AtomicInteger calls = new AtomicInteger();
+        cache.get("warmed", "v", supplierProducing("payload".getBytes(), 5, 2, calls));
+        cache.shutdown();
+
+        SaikuQueryCache reopened = new SaikuQueryCache(cacheDir, TimeUnit.MINUTES.toMillis(30), 268_435_456L, true);
+        try {
+            // A get with a brand-new supplier should hit on the reopened cache —
+            // proving the index was warmed from disk.
+            CachedQueryResult r = reopened.get("warmed", "v", supplierProducing("FRESH".getBytes(), 99, 99, calls));
+            assertTrue("reopened cache should serve warmed entry as a hit", r.cacheHit);
+            assertArrayEquals("payload".getBytes(), r.arrowBytes);
+        } finally {
+            reopened.shutdown();
+        }
+    }
+
+    @Test
+    public void reindex_deletesOrphanArrowFilesWithoutSidecar() throws Exception {
+        // Crash simulation: arrow file present but sidecar missing.
+        Files.createDirectories(cacheDir);
+        Path orphan = cacheDir.resolve("orphan.arrow");
+        Files.write(orphan, "leak".getBytes());
+
+        // New cache instance reindexes — orphan should be reaped.
+        SaikuQueryCache reopened = new SaikuQueryCache(cacheDir, TimeUnit.MINUTES.toMillis(30), 268_435_456L, true);
+        try {
+            assertFalse("orphan arrow file without sidecar must be deleted on reindex", Files.exists(orphan));
+        } finally {
+            reopened.shutdown();
+        }
+    }
+
+    @Test
+    public void getOnMissingArrowFile_invalidatesEntryAndRefetches() throws Exception {
+        AtomicInteger calls = new AtomicInteger();
+        cache.get("k-tampered", "v", supplierProducing("orig".getBytes(), 1, 1, calls));
+
+        // Out-of-band delete only the arrow file. Next get() should detect the
+        // miss, invalidate the index entry, and call the supplier again.
+        Files.delete(cacheDir.resolve("k-tampered.arrow"));
+
+        CachedQueryResult r = cache.get("k-tampered", "v", supplierProducing("refetched".getBytes(), 2, 2, calls));
+        assertEquals(2, calls.get());
+        assertFalse(r.cacheHit);
+        assertArrayEquals("refetched".getBytes(), r.arrowBytes);
+    }
+
+    @Test
+    public void isEnabledReportsConstructorFlag() {
+        SaikuQueryCache off = new SaikuQueryCache(cacheDir, 1L, 1L, false);
+        try {
+            assertFalse(off.isEnabled());
+            assertTrue(cache.isEnabled());
+        } finally {
+            off.shutdown();
+        }
+    }
+
+    @Test
+    public void getCacheDirReturnsConstructorPath() {
+        assertEquals(cacheDir, cache.getCacheDir());
+    }
+
+    @Test
+    public void shutdown_isIdempotent() {
+        // Two shutdowns in a row must not throw — sweeper / eviction executor
+        // both use shutdownNow() which tolerates already-terminated state.
+        cache.shutdown();
+        cache.shutdown();
+    }
+
+    @Test
+    public void lookupSkipsCubeVersionMismatchOnlyWhenBothNonNull() throws Exception {
+        // When the request's cubeVersion is null, an entry's stored cubeVersion
+        // does NOT cause a miss — the caller opted out of versioning.
+        AtomicInteger calls = new AtomicInteger();
+        cache.get("k-cv", "stored", supplierProducing("first".getBytes(), 1, 1, calls));
+
+        CachedQueryResult nullVer = cache.get("k-cv", null, supplierProducing("ignored".getBytes(), 9, 9, calls));
+        assertEquals(1, calls.get());
+        assertTrue("null cubeVersion should hit regardless of stored version", nullVer.cacheHit);
+        assertArrayEquals("first".getBytes(), nullVer.arrowBytes);
+    }
 }

--- a/saiku-core/saiku-service/src/test/java/org/saiku/service/datasource/DatasourceServiceTest.java
+++ b/saiku-core/saiku-service/src/test/java/org/saiku/service/datasource/DatasourceServiceTest.java
@@ -1,0 +1,528 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.service.datasource;
+
+import static org.junit.Assert.*;
+
+import java.io.InputStream;
+import java.util.*;
+import org.junit.Before;
+import org.junit.Test;
+import org.saiku.database.dto.MondrianSchema;
+import org.saiku.datasources.connection.IConnectionManager;
+import org.saiku.datasources.connection.ISaikuConnection;
+import org.saiku.datasources.connection.RepositoryFile;
+import org.saiku.datasources.datasource.SaikuDatasource;
+import org.saiku.olap.util.exception.SaikuOlapException;
+import org.saiku.repository.AclEntry;
+import org.saiku.repository.IRepositoryObject;
+import org.saiku.repository.RepositoryException;
+import org.saiku.service.importer.JujuSource;
+import org.saiku.service.user.UserService;
+import org.saiku.service.util.exception.SaikuDataSourceException;
+import org.saiku.service.util.exception.SaikuDataSourceNotFoundException;
+
+public class DatasourceServiceTest {
+
+    private DatasourceService svc;
+    private RecordingDatasourceManager manager;
+    private StubConnectionManager connManager;
+
+    @Before
+    public void setUp() {
+        manager = new RecordingDatasourceManager();
+        connManager = new StubConnectionManager(manager);
+        svc = new DatasourceService();
+        svc.setConnectionManager(connManager);
+    }
+
+    @Test
+    public void addDatasource_newName_invokesAddOnce() throws Exception {
+        SaikuDatasource fresh = ds("ds-new", "id-1");
+        svc.addDatasource(fresh, false, new String[] {"ROLE_ADMIN"});
+        assertEquals(1, manager.addCalls.size());
+        assertEquals("ds-new", manager.addCalls.get(0).getName());
+        assertEquals(0, manager.removeCalls.size());
+    }
+
+    @Test(expected = Exception.class)
+    public void addDatasource_existingName_withoutOverwrite_throws() throws Exception {
+        SaikuDatasource ds = ds("ds-existing", "id-1");
+        manager.seed(ds);
+        svc.addDatasource(ds("ds-existing", "id-2"), false, new String[0]);
+    }
+
+    @Test
+    public void addDatasource_existingName_withOverwrite_removesThenAdds() throws Exception {
+        SaikuDatasource original = ds("ds-replace", "id-orig");
+        manager.seed(original);
+        SaikuDatasource replacement = ds("ds-replace", "id-new");
+
+        svc.addDatasource(replacement, true, new String[0]);
+
+        assertEquals(1, manager.removeCalls.size());
+        assertEquals("id-orig", manager.removeCalls.get(0));
+        assertEquals(1, manager.addCalls.size());
+        assertEquals("id-new", manager.addCalls.get(0).getProperties().getProperty("id"));
+    }
+
+    @Test
+    public void fetchDataSourceById_returnsMatch() throws Exception {
+        manager.seed(ds("alpha", "id-aaa"));
+        manager.seed(ds("beta", "id-bbb"));
+        SaikuDatasource found = svc.fetchDataSourceById("id-bbb", new String[0]);
+        assertEquals("beta", found.getName());
+    }
+
+    @Test(expected = SaikuDataSourceException.class)
+    public void fetchDataSourceById_unknown_throws() throws SaikuDataSourceNotFoundException {
+        manager.seed(ds("alpha", "id-aaa"));
+        svc.fetchDataSourceById("does-not-exist", new String[0]);
+    }
+
+    @Test
+    public void setLocaleOfDataSource_swapsExistingLocale() throws SaikuDataSourceException {
+        SaikuDatasource d = ds("dl", "id-l");
+        d.getProperties()
+                .setProperty("location", "jdbc:mondrian:Jdbc=jdbc:h2:mem:foo;Catalog=x.xml;locale=en_GB;Foo=bar;");
+        svc.setLocaleOfDataSource(d, "fr_FR");
+        assertEquals(
+                "jdbc:mondrian:Jdbc=jdbc:h2:mem:foo;Catalog=x.xml;locale=fr_FR;Foo=bar;",
+                d.getProperties().getProperty("location"));
+    }
+
+    @Test(expected = SaikuDataSourceException.class)
+    public void setLocaleOfDataSource_missingLocale_throws() throws SaikuDataSourceException {
+        SaikuDatasource d = ds("dnl", "id-nl");
+        d.getProperties().setProperty("location", "jdbc:mondrian:Jdbc=jdbc:h2:mem:foo;Catalog=x.xml;");
+        svc.setLocaleOfDataSource(d, "fr_FR");
+    }
+
+    @Test
+    public void setLocaleOfDataSource_caseInsensitiveLocateButPreservesOriginalCase() throws SaikuDataSourceException {
+        SaikuDatasource d = ds("ci", "id-ci");
+        // Upper-case "Locale=" — locator is case-insensitive (toLowerCase).
+        d.getProperties().setProperty("location", "jdbc:mondrian:Locale=en_GB;Foo=bar;");
+        svc.setLocaleOfDataSource(d, "de_DE");
+        // The locale value got swapped but the original key casing comes through
+        // verbatim because String.replace works on the substring it located.
+        assertTrue(d.getProperties().getProperty("location").contains("de_DE"));
+    }
+
+    @Test
+    public void getInternalFileData_swallowsRepositoryException_returnsNull() {
+        manager.throwOnInternalFileRead = new RepositoryException("missing");
+        assertNull(svc.getInternalFileData("nope"));
+    }
+
+    @Test
+    public void getInternalFileData_passthroughOnSuccess() {
+        manager.internalFiles.put("/etc/x", "contents");
+        assertEquals("contents", svc.getInternalFileData("/etc/x"));
+    }
+
+    @Test
+    public void delegations_passThroughToManager() throws Exception {
+        // Spot-check the high-volume delegating surface.
+        SaikuDatasource d = ds("delegate", "id-d");
+        svc.setDatasource(d);
+        assertSame(d, manager.lastSet);
+
+        svc.removeDatasource("id-d");
+        assertEquals(Collections.singletonList("id-d"), manager.removeCalls);
+
+        manager.seed(d);
+        assertSame(d, svc.getDatasource("delegate"));
+        assertEquals(1, svc.getDatasources(new String[0]).size());
+
+        manager.schemas = List.of(new MondrianSchema());
+        assertEquals(1, svc.getAvailableSchema().size());
+
+        svc.addSchema("<schema/>", "/path", "name");
+        assertEquals("name", manager.addSchemaCalls.get(0).get("name"));
+
+        svc.saveInternalFile("/etc/k", "v", "nt:file");
+        assertEquals("v", manager.internalFiles.get("/etc/k"));
+
+        svc.saveFile("body", "/repo/file.saiku", "tom", List.of("R"));
+        assertEquals("body", manager.savedFiles.get("/repo/file.saiku"));
+
+        svc.removeFile("/repo/file.saiku", "tom", List.of("R"));
+        assertTrue(manager.removedFiles.contains("/repo/file.saiku"));
+
+        svc.moveFile("/a", "/b", "tom", List.of("R"));
+        assertEquals("/a -> /b", manager.movedFiles.get(0));
+
+        svc.removeSchema("schema-id");
+        assertEquals("schema-id", manager.lastRemovedSchema);
+
+        svc.exportRepository();
+        assertTrue(manager.exported);
+        svc.restoreRepository(new byte[] {1, 2, 3});
+        assertNotNull(manager.restored);
+        svc.restoreLegacyFiles(new byte[] {4});
+        assertNotNull(manager.legacyRestored);
+
+        assertFalse(svc.hasHomeDirectory("nobody"));
+        manager.homes.add("alice");
+        assertTrue(svc.hasHomeDirectory("alice"));
+
+        svc.createUserHome("alice");
+        assertEquals(Collections.singletonList("alice"), manager.createdUsers);
+    }
+
+    @Test
+    public void importLegacy_methodsAreNoOps_doNotThrow() {
+        svc.importLegacySchema();
+        svc.importLegacyDatasources();
+        svc.importLegacyUsers();
+    }
+
+    @Test
+    public void aclDelegations() {
+        svc.setResourceACL("/file", "ACL", "tom", List.of("R"));
+        assertEquals("ACL", manager.acls.get("/file"));
+
+        assertNull(svc.getResourceACL("/file", "tom", List.of("R")));
+    }
+
+    @Test
+    public void getConnectionManager_returnsWiredInstance() {
+        assertSame(connManager, svc.getConnectionManager());
+    }
+
+    // ---------------------------------------------------------------- helpers
+
+    private static SaikuDatasource ds(String name, String id) {
+        Properties p = new Properties();
+        p.setProperty("id", id);
+        return new SaikuDatasource(name, SaikuDatasource.Type.OLAP, p);
+    }
+
+    private static final class StubConnectionManager implements IConnectionManager {
+        private final IDatasourceManager dsm;
+
+        StubConnectionManager(IDatasourceManager dsm) {
+            this.dsm = dsm;
+        }
+
+        @Override
+        public void init() throws SaikuOlapException {}
+
+        @Override
+        public void setDataSourceManager(IDatasourceManager ds) {}
+
+        @Override
+        public IDatasourceManager getDataSourceManager() {
+            return dsm;
+        }
+
+        @Override
+        public void refreshConnection(String name) {}
+
+        @Override
+        public void refreshAllConnections() {}
+
+        @Override
+        public org.olap4j.OlapConnection getOlapConnection(String name) {
+            return null;
+        }
+
+        @Override
+        public Map<String, org.olap4j.OlapConnection> getAllOlapConnections() {
+            return Map.of();
+        }
+
+        @Override
+        public ISaikuConnection getConnection(String name) {
+            return null;
+        }
+
+        @Override
+        public Map<String, ISaikuConnection> getAllConnections() {
+            return Map.of();
+        }
+    }
+
+    private static final class RecordingDatasourceManager implements IDatasourceManager {
+        final Map<String, SaikuDatasource> store = new LinkedHashMap<>();
+        final List<SaikuDatasource> addCalls = new ArrayList<>();
+        final List<String> removeCalls = new ArrayList<>();
+        final Map<String, Object> internalFiles = new HashMap<>();
+        final Map<String, Object> savedFiles = new HashMap<>();
+        final Set<String> removedFiles = new HashSet<>();
+        final List<String> movedFiles = new ArrayList<>();
+        final List<Map<String, String>> addSchemaCalls = new ArrayList<>();
+        final List<String> createdUsers = new ArrayList<>();
+        final Set<String> homes = new HashSet<>();
+        final Map<String, String> acls = new HashMap<>();
+        List<MondrianSchema> schemas = List.of();
+        SaikuDatasource lastSet;
+        String lastRemovedSchema;
+        boolean exported;
+        byte[] restored;
+        byte[] legacyRestored;
+        RepositoryException throwOnInternalFileRead;
+
+        void seed(SaikuDatasource ds) {
+            store.put(ds.getName(), ds);
+        }
+
+        @Override
+        public void load() {}
+
+        @Override
+        public void unload() {}
+
+        @Override
+        public SaikuDatasource addDatasource(SaikuDatasource datasource) {
+            addCalls.add(datasource);
+            store.put(datasource.getName(), datasource);
+            return datasource;
+        }
+
+        @Override
+        public SaikuDatasource setDatasource(SaikuDatasource datasource) {
+            lastSet = datasource;
+            return datasource;
+        }
+
+        @Override
+        public List<SaikuDatasource> addDatasources(List<SaikuDatasource> datasources) {
+            return datasources;
+        }
+
+        @Override
+        public boolean removeDatasource(String datasourceName) {
+            removeCalls.add(datasourceName);
+            return true;
+        }
+
+        @Override
+        public boolean removeSchema(String schemaName) {
+            lastRemovedSchema = schemaName;
+            return true;
+        }
+
+        @Override
+        public Map<String, SaikuDatasource> getDatasources(String[] roles) {
+            return new LinkedHashMap<>(store);
+        }
+
+        @Override
+        public SaikuDatasource getDatasource(String datasourceName) {
+            return store.get(datasourceName);
+        }
+
+        @Override
+        public SaikuDatasource getDatasource(String datasourceName, boolean refresh) {
+            return store.get(datasourceName);
+        }
+
+        @Override
+        public void addSchema(String file, String path, String name) {
+            addSchemaCalls.add(Map.of("file", file, "path", path, "name", name));
+        }
+
+        @Override
+        public List<MondrianSchema> getMondrianSchema() {
+            return schemas;
+        }
+
+        @Override
+        public MondrianSchema getMondrianSchema(String catalog) {
+            return null;
+        }
+
+        @Override
+        public RepositoryFile getFile(String file) {
+            return null;
+        }
+
+        @Override
+        public String getFileData(String file, String username, List<String> roles) {
+            return (String) savedFiles.get(file);
+        }
+
+        @Override
+        public String getInternalFileData(String file) throws RepositoryException {
+            if (throwOnInternalFileRead != null) throw throwOnInternalFileRead;
+            return (String) internalFiles.get(file);
+        }
+
+        @Override
+        public InputStream getBinaryInternalFileData(String file) {
+            return null;
+        }
+
+        @Override
+        public String saveFile(String path, Object content, String user, List<String> roles) {
+            savedFiles.put(path, content);
+            return "ok";
+        }
+
+        @Override
+        public String removeFile(String path, String user, List<String> roles) {
+            removedFiles.add(path);
+            return "ok";
+        }
+
+        @Override
+        public String moveFile(String source, String target, String user, List<String> roles) {
+            movedFiles.add(source + " -> " + target);
+            return "ok";
+        }
+
+        @Override
+        public String saveInternalFile(String path, Object content, String type) {
+            internalFiles.put(path, content);
+            return "ok";
+        }
+
+        @Override
+        public String saveBinaryInternalFile(String path, InputStream content, String type) {
+            return "ok";
+        }
+
+        @Override
+        public void removeInternalFile(String filePath) {
+            internalFiles.remove(filePath);
+        }
+
+        @Override
+        public List<IRepositoryObject> getFiles(List<String> type, String username, List<String> roles) {
+            return List.of();
+        }
+
+        @Override
+        public List<IRepositoryObject> getFiles(List<String> type, String username, List<String> roles, String path) {
+            return List.of();
+        }
+
+        @Override
+        public void createUser(String user) {
+            createdUsers.add(user);
+        }
+
+        @Override
+        public void deleteFolder(String folder) {}
+
+        @Override
+        public AclEntry getACL(String object, String username, List<String> roles) {
+            return null;
+        }
+
+        @Override
+        public void setACL(String object, String acl, String username, List<String> roles) {
+            acls.put(object, acl);
+        }
+
+        @Override
+        public void setUserService(UserService userService) {}
+
+        @Override
+        public List<MondrianSchema> getInternalFilesOfFileType(String type) {
+            return List.of();
+        }
+
+        @Override
+        public void createFileMixin(String type) {}
+
+        @Override
+        public byte[] exportRepository() {
+            exported = true;
+            return new byte[0];
+        }
+
+        @Override
+        public void restoreRepository(byte[] data) {
+            restored = data;
+        }
+
+        @Override
+        public boolean hasHomeDirectory(String name) {
+            return homes.contains(name);
+        }
+
+        @Override
+        public void restoreLegacyFiles(byte[] data) {
+            legacyRestored = data;
+        }
+
+        @Override
+        public String getFoodmartschema() {
+            return null;
+        }
+
+        @Override
+        public void setFoodmartschema(String schema) {}
+
+        @Override
+        public void setFoodmartdir(String dir) {}
+
+        @Override
+        public String getFoodmartdir() {
+            return null;
+        }
+
+        @Override
+        public String getDatadir() {
+            return null;
+        }
+
+        @Override
+        public void setDatadir(String dir) {}
+
+        @Override
+        public void setFoodmarturl(String foodmarturl) {}
+
+        @Override
+        public String getFoodmarturl() {
+            return null;
+        }
+
+        @Override
+        public String getEarthquakeUrl() {
+            return null;
+        }
+
+        @Override
+        public String getEarthquakeDir() {
+            return null;
+        }
+
+        @Override
+        public String getEarthquakeSchema() {
+            return null;
+        }
+
+        @Override
+        public void setEarthquakeUrl(String earthquakeUrl) {}
+
+        @Override
+        public void setEarthquakeDir(String earthquakeDir) {}
+
+        @Override
+        public void setEarthquakeSchema(String earthquakeSchema) {}
+
+        @Override
+        public void setExternalPropertiesFile(String file) {}
+
+        @Override
+        public String[] getAvailablePropertiesKeys() {
+            return new String[0];
+        }
+
+        @Override
+        public List<JujuSource> getJujuDatasources() {
+            return List.of();
+        }
+
+        @Override
+        public String getType() {
+            return "stub";
+        }
+    }
+}

--- a/saiku-core/saiku-service/src/test/java/org/saiku/service/olap/ai/AiSchemaConverterTest.java
+++ b/saiku-core/saiku-service/src/test/java/org/saiku/service/olap/ai/AiSchemaConverterTest.java
@@ -868,6 +868,64 @@ public class AiSchemaConverterTest {
         }
     }
 
+    /* ------------------------ saiku#864 limit guards ------------------------ */
+
+    @Test
+    public void negativeLimitRejected() {
+        AiQueryRequest req = baseReq();
+        req.setRows(Collections.singletonList(new AiAxisSelection("Time", "Time By", "Year")));
+        req.setLimit(-5);
+        try {
+            converter.convert(req, schema);
+            fail("expected validation error for negative limit");
+        } catch (AiValidationException e) {
+            assertEquals("limit", e.getField());
+            assertTrue(
+                    "error must mention >= 0: " + e.getMessage(), e.getMessage().contains(">= 0"));
+        }
+    }
+
+    @Test
+    public void limitAboveCeilingRejected() {
+        AiQueryRequest req = baseReq();
+        req.setRows(Collections.singletonList(new AiAxisSelection("Time", "Time By", "Year")));
+        req.setLimit(AiSchemaConverter.AI_QUERY_LIMIT_MAX + 1);
+        try {
+            converter.convert(req, schema);
+            fail("expected validation error for limit > max");
+        } catch (AiValidationException e) {
+            assertEquals("limit", e.getField());
+            assertTrue(
+                    "error must cite the maximum: " + e.getMessage(),
+                    e.getMessage().contains(String.valueOf(AiSchemaConverter.AI_QUERY_LIMIT_MAX)));
+        }
+    }
+
+    @Test
+    public void limitAtCeilingAccepted() {
+        AiQueryRequest req = baseReq();
+        req.setRows(Collections.singletonList(new AiAxisSelection("Time", "Time By", "Year")));
+        req.setLimit(AiSchemaConverter.AI_QUERY_LIMIT_MAX);
+        ThinQuery tq = converter.convert(req, schema);
+        assertTrue(
+                "limit at ceiling must emit HEAD(..., N)",
+                tq.getMdx().contains("HEAD(")
+                        && tq.getMdx().contains(String.valueOf(AiSchemaConverter.AI_QUERY_LIMIT_MAX)));
+    }
+
+    @Test
+    public void limitZeroAccepted_asDocumentedNoCap() {
+        // The schema description documents "0 or absent = no cap." Pin that
+        // 0 is accepted and the MDX has no HEAD wrapper.
+        AiQueryRequest req = baseReq();
+        req.setRows(Collections.singletonList(new AiAxisSelection("Time", "Time By", "Year")));
+        req.setLimit(0);
+        ThinQuery tq = converter.convert(req, schema);
+        assertTrue(
+                "limit=0 must not emit a HEAD wrapper: " + tq.getMdx(),
+                !tq.getMdx().contains("HEAD("));
+    }
+
     private static int countOccurrences(String s, String token) {
         int n = 0;
         int from = 0;

--- a/saiku-core/saiku-service/src/test/resources/schema-snapshots/quirks-schema.json
+++ b/saiku-core/saiku-service/src/test/resources/schema-snapshots/quirks-schema.json
@@ -419,7 +419,7 @@
       },
       "limit" : {
         "default" : 0,
-        "description" : "Optional row cap. With order, emits TopCount/BottomCount; without order, emits HEAD(rows, N). 0 or absent = no cap.",
+        "description" : "Optional row cap. With order, emits TopCount/BottomCount; without order, emits HEAD(rows, N). 0 or absent = no cap. Must be >= 0 and <= 10000 — larger values are rejected with VALIDATION_ERROR. Page client-side for larger result sets.",
         "type" : "integer"
       },
       "measures" : {

--- a/saiku-core/saiku-web/pom.xml
+++ b/saiku-core/saiku-web/pom.xml
@@ -2,11 +2,11 @@
     <parent>
         <artifactId>saiku-core</artifactId>
         <groupId>org.saikuanalytics</groupId>
-        <version>4.0.1</version>
+        <version>4.2.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>saiku-web</artifactId>
-    <version>4.0.1</version>
+    <version>4.2.0</version>
     <name>saiku - web</name>
     <packaging>jar</packaging>
 

--- a/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/SaikuJerseyApplication.java
+++ b/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/SaikuJerseyApplication.java
@@ -31,6 +31,11 @@ public class SaikuJerseyApplication extends ResourceConfig {
         // typed AiQueryResponse 400 envelope instead of the raw text/plain
         // Jackson message that leaked class names and source location.
         register(org.saiku.web.rest.exception.JacksonValidationExceptionMapper.class);
+        // saiku#865: catch-all mapper that prevents Jetty's HTML error page
+        // (with its `Powered by Jetty:// 12.0.32` server banner) from ever
+        // reaching a JSON client. Turns unguarded NPEs / missing-param
+        // failures into a typed JSON envelope.
+        register(org.saiku.web.rest.exception.GenericFailureExceptionMapper.class);
 
         ApplicationContext ctx = WebApplicationContextUtils.getRequiredWebApplicationContext(servletContext);
         for (String name : ctx.getBeanNamesForAnnotation(Path.class)) {

--- a/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/exception/GenericFailureExceptionMapper.java
+++ b/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/exception/GenericFailureExceptionMapper.java
@@ -1,0 +1,94 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.web.rest.exception;
+
+import com.fasterxml.jackson.databind.JsonMappingException;
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.ext.ExceptionMapper;
+import jakarta.ws.rs.ext.Provider;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * saiku#865 — catch any otherwise-unhandled {@link Throwable} that propagates
+ * out of a JAX-RS resource method and emit a JSON envelope instead of letting
+ * Jersey hand it back to Jetty's default {@code ErrorHandler} (which renders
+ * an HTML page complete with a {@code Powered by Jetty:// 12.0.32} banner —
+ * a free server-fingerprint for attackers and a useless body for JSON
+ * clients).
+ *
+ * <p>Specifically targets {@code BasicRepositoryResource2}'s missing-param
+ * NPEs and any other resource that throws an unexpected runtime exception.
+ * Domain errors with their own typed envelopes
+ * ({@code AiValidationException}, {@link WebApplicationException}) bypass
+ * this mapper — the {@code WebApplicationException} check below preserves
+ * the typed responses they emit (e.g.,
+ * {@link org.saiku.web.rest.resources.OlapDiscoverResource}'s 404s).
+ *
+ * <p>The {@code JsonMappingException} check defers to the more-specific
+ * {@link JacksonValidationExceptionMapper} (saiku#791).
+ */
+@Provider
+public class GenericFailureExceptionMapper implements ExceptionMapper<Throwable> {
+
+    private static final Logger log = LoggerFactory.getLogger(GenericFailureExceptionMapper.class);
+
+    @Override
+    public Response toResponse(Throwable t) {
+        // Preserve the typed envelopes resources already build.
+        if (t instanceof WebApplicationException wae) {
+            return wae.getResponse();
+        }
+        // Defer to the more-specific Jackson mapper.
+        if (t instanceof JsonMappingException) {
+            // The JacksonValidationExceptionMapper is registered first and
+            // ranks more-specific, so JAX-RS should pick it before this one.
+            // If we still see one here, treat it the same as a 400.
+            return jsonEnvelope(
+                    Response.Status.BAD_REQUEST, "BAD_REQUEST", "request", "Malformed request body", safeMessage(t));
+        }
+        // NullPointerException is the dominant case for missing form/query
+        // params on BasicRepositoryResource2. Surface as 400, not 500 — a
+        // missing required field is a client error.
+        if (t instanceof NullPointerException) {
+            log.debug("Resource NPE, likely missing param", t);
+            return jsonEnvelope(
+                    Response.Status.BAD_REQUEST, "BAD_REQUEST", "request", "Required parameter missing or null", null);
+        }
+        // Anything else: log the stack server-side, return a clean 500
+        // envelope. Never include the stack trace in the response body.
+        log.error("Unhandled resource exception", t);
+        return jsonEnvelope(
+                Response.Status.INTERNAL_SERVER_ERROR,
+                "INTERNAL_ERROR",
+                null,
+                "Request failed: " + t.getClass().getSimpleName(),
+                safeMessage(t));
+    }
+
+    private static Response jsonEnvelope(
+            Response.Status status, String tag, String field, String message, String detail) {
+        Map<String, Object> body = new LinkedHashMap<>();
+        body.put("status", tag);
+        if (field != null) body.put("field", field);
+        body.put("error", message);
+        if (detail != null) body.put("detail", detail);
+        return Response.status(status)
+                .type(MediaType.APPLICATION_JSON)
+                .entity(body)
+                .build();
+    }
+
+    /** Strip nothing — but cap length so we don't echo a megabyte stack message back. */
+    private static String safeMessage(Throwable t) {
+        String m = t.getMessage();
+        if (m == null) return null;
+        return m.length() > 500 ? m.substring(0, 500) + "…" : m;
+    }
+}

--- a/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/AiQueryResource.java
+++ b/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/AiQueryResource.java
@@ -517,7 +517,20 @@ public class AiQueryResource {
         String name = queryId;
         if (asyncQueryService != null) {
             AsyncQueryHandle h = asyncQueryService.get(queryId);
-            if (h != null) name = h.getQuery().getName();
+            if (h != null) {
+                name = h.getQuery().getName();
+                // saiku#862: re-attach the async query's ThinQuery + CellSet
+                // to THIS request's session-scoped ThinQueryService context.
+                // Without this, a drillthrough request that lands on a
+                // different session than the async submit (e.g. Basic-auth
+                // clients without a shared cookie jar; some load-balanced
+                // setups) hits an empty context map and the NPE-catch path
+                // surfaces "Unknown queryId" even though the handle is live.
+                if (thinQueryService.getContext(name) == null) {
+                    org.olap4j.CellSet cs = asyncQueryService.result(queryId);
+                    thinQueryService.registerExternalContext(h.getQuery(), cs);
+                }
+            }
         }
         // saiku#782: agents only have bare captions (the keys of each row in
         // a drillthrough response) — accept those and rewrite to the fully
@@ -662,7 +675,16 @@ public class AiQueryResource {
         String name = queryId;
         if (asyncQueryService != null) {
             AsyncQueryHandle h = asyncQueryService.get(queryId);
-            if (h != null) name = h.getQuery().getName();
+            if (h != null) {
+                name = h.getQuery().getName();
+                // saiku#862: re-attach the async result's cellset to this
+                // request's session-scoped ThinQueryService context so
+                // column discovery can resolve. See drillthrough() above.
+                if (thinQueryService.getContext(name) == null) {
+                    org.olap4j.CellSet cs = asyncQueryService.result(queryId);
+                    thinQueryService.registerExternalContext(h.getQuery(), cs);
+                }
+            }
         }
         try {
             List<Map<String, String>> cols = thinQueryService.drillthroughColumns(name);

--- a/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/InfoResource.java
+++ b/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/InfoResource.java
@@ -17,6 +17,7 @@ package org.saiku.web.rest.resources;
 
 import com.qmino.miredot.annotations.ReturnType;
 import jakarta.ws.rs.GET;
+import jakarta.ws.rs.HEAD;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.GenericEntity;
@@ -57,5 +58,21 @@ public class InfoResource {
 
         GenericEntity<List<Plugin>> entity = new GenericEntity<List<Plugin>>(platformService.getAvailablePlugins()) {};
         return Response.ok(entity).build();
+    }
+
+    /**
+     * Cheap HEAD for monitors / health checks.
+     *
+     * <p>saiku#866: without this, Jersey's auto-HEAD handler runs the
+     * full GET (including the plugin directory walk in
+     * {@link org.saiku.service.PlatformUtilsService#getAvailablePlugins()}),
+     * then tries to strip the body. On the launcher the plugin dir is
+     * often unset and {@code File.list} returns null, leaving the
+     * response writer stalled on a Content-Length that never matches.
+     * HEAD callers see a 30-second hang followed by a connection reset.
+     */
+    @HEAD
+    public Response head() {
+        return Response.ok().build();
     }
 }

--- a/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/OlapDiscoverResource.java
+++ b/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/OlapDiscoverResource.java
@@ -21,8 +21,12 @@ import jakarta.ws.rs.Path;
 import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
 import java.io.Serializable;
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import org.saiku.olap.dto.*;
@@ -71,10 +75,21 @@ public class OlapDiscoverResource implements Serializable {
     @Path("/{connection}")
     public List<SaikuConnection> getConnections(@PathParam("connection") String connectionName) {
         try {
-            return olapDiscoverService.getConnection(connectionName);
+            List<SaikuConnection> conns = olapDiscoverService.getConnection(connectionName);
+            // saiku#867: empty result here means the underlying service
+            // swallowed a SaikuOlapException ("Cannot find connection: ...")
+            // — the SPA / agents can't tell "no connection by this name"
+            // from "connection has no schemas" when both return []. Surface
+            // the missing-name case as a typed 404 envelope.
+            if (conns == null || conns.isEmpty()) {
+                throw notFound("connection", connectionName, "Cannot find connection: '" + connectionName + "'", null);
+            }
+            return conns;
+        } catch (WebApplicationException pass) {
+            throw pass;
         } catch (Exception e) {
             log.error(this.getClass().getName(), e);
-            return new ArrayList<>();
+            throw notFound("connection", connectionName, "Cannot find connection: '" + connectionName + "'", e);
         }
     }
 
@@ -139,11 +154,43 @@ public class OlapDiscoverResource implements Serializable {
             List<SaikuDimension> dimensions = olapDiscoverService.getAllDimensions(cube);
             List<SaikuMember> measures = olapDiscoverService.getMeasures(cube);
             Map<String, Object> properties = olapDiscoverService.getProperties(cube);
+            // saiku#867: empty dimensions+measures indicates the cube isn't
+            // resolvable (the service swallows the lookup and returns []s).
+            // Surface as 404 rather than {dimensions:null, measures:null}.
+            if ((dimensions == null || dimensions.isEmpty()) && (measures == null || measures.isEmpty())) {
+                throw notFound(
+                        "cube",
+                        cubeName,
+                        "Cube '" + cubeName + "' not found in " + connectionName + "/" + catalogName + "/" + schemaName,
+                        null);
+            }
             return new SaikuCubeMetadata(dimensions, measures, properties);
+        } catch (WebApplicationException pass) {
+            throw pass;
         } catch (Exception e) {
             log.error(this.getClass().getName(), e);
+            throw notFound("cube", cubeName, "Cube metadata lookup failed: " + e.getMessage(), e);
         }
-        return new SaikuCubeMetadata(null, null, null);
+    }
+
+    /**
+     * Build a {@link WebApplicationException} carrying the standard JSON
+     * not-found envelope: {@code {error,field,available}}. saiku#867: replaces
+     * silent 200-with-null-body / 204 No Content returns so clients can
+     * distinguish "doesn't exist" from "exists but empty".
+     */
+    private static WebApplicationException notFound(String field, String value, String message, Throwable cause) {
+        Map<String, Object> body = new LinkedHashMap<>();
+        body.put("status", "NOT_FOUND");
+        body.put("field", field);
+        body.put("value", value);
+        body.put("error", message);
+        return new WebApplicationException(
+                cause,
+                Response.status(Response.Status.NOT_FOUND)
+                        .type(MediaType.APPLICATION_JSON)
+                        .entity(body)
+                        .build());
     }
 
     /**
@@ -199,11 +246,24 @@ public class OlapDiscoverResource implements Serializable {
         }
         SaikuCube cube = new SaikuCube(connectionName, cubeName, cubeName, cubeName, catalogName, schemaName);
         try {
-            return olapDiscoverService.getDimension(cube, dimensionName);
+            SaikuDimension dim = olapDiscoverService.getDimension(cube, dimensionName);
+            // saiku#867: null return from the service means the dimension
+            // isn't on the cube. Surface as 404 rather than the 204 the
+            // JAX-RS null-mapper otherwise emits.
+            if (dim == null) {
+                throw notFound(
+                        "dimension",
+                        dimensionName,
+                        "Dimension '" + dimensionName + "' not found on cube '" + cubeName + "'",
+                        null);
+            }
+            return dim;
+        } catch (WebApplicationException pass) {
+            throw pass;
         } catch (Exception e) {
             log.error(this.getClass().getName(), e);
+            throw notFound("dimension", dimensionName, "Dimension lookup failed: " + e.getMessage(), e);
         }
-        return null;
     }
 
     /**

--- a/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/Query2Resource.java
+++ b/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/Query2Resource.java
@@ -201,6 +201,20 @@ public class Query2Resource {
     @Path("/execute")
     public Response execute(ThinQuery tq, @Context HttpHeaders headers) {
         try {
+            // saiku#861: default ThinQuery.type when the client posts a body
+            // with mdx but no explicit type field. The Jackson-deserialized
+            // ThinQuery() default ctor leaves type=null; ThinQueryService
+            // helpers gate on Type.MDX.equals(type) which silently falls
+            // through to the QUERYMODEL path (or worse, the Mondrian
+            // executeOlapQuery cast-to-Query that ClassCastExceptions on
+            // DRILLTHROUGH).
+            if (tq != null && tq.getType() == null) {
+                if (tq.getMdx() != null && !tq.getMdx().isBlank()) {
+                    tq.setType(ThinQuery.Type.MDX);
+                } else if (tq.getQueryModel() != null) {
+                    tq.setType(ThinQuery.Type.QUERYMODEL);
+                }
+            }
             if (thinQueryService.isMdxDrillthrough(tq)) {
                 Long start = (new Date()).getTime();
                 ResultSet rs = thinQueryService.drillthrough(tq);
@@ -466,7 +480,7 @@ public class Query2Resource {
     @GET
     @Produces({"application/json"})
     @Path("/{queryname}/result/metadata/hierarchies/{hierarchy}/levels/{level}")
-    public List<SimpleCubeElement> getLevelMembers(
+    public Response getLevelMembers(
             @PathParam("queryname") String queryName,
             @PathParam("hierarchy") String hierarchyName,
             @PathParam("level") String levelName,
@@ -479,8 +493,29 @@ public class Query2Resource {
                     + "/hierarchies/" + hierarchyName + "/levels/" + levelName + "\tGET");
         }
         try {
-            return thinQueryService.getResultMetadataMembers(
+            List<SimpleCubeElement> members = thinQueryService.getResultMetadataMembers(
                     queryName, result, hierarchyName, levelName, searchString, searchLimit);
+            // saiku#863: null means the query name isn't in this session's
+            // per-user ThinQueryService context — either no /execute happened
+            // for this query yet, or the request lost session continuity
+            // (e.g. Basic auth with no shared cookie jar). Surface a typed
+            // 404 envelope rather than the JAX-RS default 204 No Content
+            // (which the SPA can't distinguish from "level has no members").
+            if (members == null) {
+                Map<String, Object> body = new java.util.LinkedHashMap<>();
+                body.put("status", "NOT_FOUND");
+                body.put("field", "queryname");
+                body.put("value", queryName);
+                body.put(
+                        "error",
+                        "No live query named '" + queryName
+                                + "' in this session. Re-issue POST /api/query/execute with this name to seed the per-session context, or check the session cookie is being sent.");
+                return Response.status(Response.Status.NOT_FOUND)
+                        .type(MediaType.APPLICATION_JSON)
+                        .entity(body)
+                        .build();
+            }
+            return Response.ok(members).type(MediaType.APPLICATION_JSON).build();
         } catch (Exception e) {
             log.error("Cannot execute query (" + queryName + ")", e);
             String error = ExceptionUtils.getRootCauseMessage(e);

--- a/saiku-core/saiku-web/src/test/java/org/saiku/web/rest/resources/DataSourceResourceTest.java
+++ b/saiku-core/saiku-web/src/test/java/org/saiku/web/rest/resources/DataSourceResourceTest.java
@@ -1,0 +1,184 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.web.rest.resources;
+
+import static org.junit.Assert.*;
+
+import jakarta.ws.rs.core.Response;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Properties;
+import org.junit.Before;
+import org.junit.Test;
+import org.saiku.datasources.datasource.SaikuDatasource;
+import org.saiku.service.datasource.DatasourceService;
+import org.saiku.service.user.UserService;
+import org.saiku.service.util.exception.SaikuServiceException;
+
+/**
+ * Drives {@link DataSourceResource} against stubbed {@link DatasourceService}
+ * + {@link UserService} so the REST contract is exercised without a real
+ * datasource manager.
+ */
+public class DataSourceResourceTest {
+
+    private DataSourceResource resource;
+    private StubDatasourceService dsSvc;
+    private StubUserService users;
+
+    @Before
+    public void setUp() {
+        dsSvc = new StubDatasourceService();
+        users = new StubUserService();
+        resource = new DataSourceResource();
+        resource.setDatasourceService(dsSvc);
+        resource.setUserService(users);
+    }
+
+    @Test
+    public void getDatasources_returnsAllDatasources() {
+        dsSvc.store.put("alpha", ds("alpha", "id-a"));
+        dsSvc.store.put("beta", ds("beta", "id-b"));
+        assertEquals(2, resource.getDatasources().size());
+    }
+
+    @Test
+    public void getDatasources_swallowsSaikuServiceException_returnsEmpty() {
+        dsSvc.throwOnList = new SaikuServiceException("backend down");
+        assertTrue(resource.getDatasources().isEmpty());
+    }
+
+    @Test
+    public void deleteDatasource_returnsGoneStatus_andDelegates() {
+        Response.Status s = resource.deleteDatasource("ds-name");
+        assertEquals(Response.Status.GONE, s);
+        assertEquals(1, dsSvc.removeCount);
+        assertEquals("ds-name", dsSvc.lastRemovedName);
+    }
+
+    @Test
+    public void getDatasourceById_returnsMatchingDatasourceWrapped() {
+        dsSvc.store.put("beta", dsForMapper("beta", "id-b"));
+        Response resp = resource.getDatasourceById("id-b");
+        assertEquals(200, resp.getStatus());
+        // body is a DataSourceMapper around the matching SaikuDatasource.
+        assertNotNull(resp.getEntity());
+    }
+
+    @Test
+    public void getDatasourceById_unknownId_returns500FromMapperNpe() {
+        // When no datasource matches, the resource still tries to construct a
+        // DataSourceMapper(null) which NPEs on ds.getProperties() — caught by
+        // the catch block and surfaced as 500. Pinning current behavior so a
+        // future fix that returns 404/200 is a deliberate change, not a silent
+        // regression.
+        dsSvc.store.put("alpha", dsForMapper("alpha", "id-a"));
+        Response resp = resource.getDatasourceById("missing-id");
+        assertEquals(500, resp.getStatus());
+    }
+
+    @Test
+    public void getDatasourceById_underlyingException_returns500() {
+        dsSvc.throwOnList = new RuntimeException("kaboom");
+        Response resp = resource.getDatasourceById("id-b");
+        assertEquals(500, resp.getStatus());
+        assertEquals("kaboom", resp.getEntity());
+    }
+
+    @Test
+    public void updateDatasourceLocale_swapsLocale_andSavesOverwrite() {
+        SaikuDatasource d = ds("with-locale", "id-locale");
+        d.getProperties().setProperty("location", "jdbc:mondrian:Jdbc=foo;Catalog=x;locale=en_GB;");
+        dsSvc.store.put("with-locale", d);
+
+        Response resp = resource.updateDatasourceLocale("fr_FR", "id-locale");
+        assertEquals(200, resp.getStatus());
+        assertEquals(1, dsSvc.addCount);
+        assertTrue(dsSvc.lastAddOverwrite);
+        assertTrue(d.getProperties().getProperty("location").contains("locale=fr_FR;"));
+    }
+
+    @Test
+    public void updateDatasourceLocale_unknownId_doesNothing_butStillReturns200() {
+        Response resp = resource.updateDatasourceLocale("fr_FR", "no-such-id");
+        assertEquals(200, resp.getStatus());
+        assertEquals(0, dsSvc.addCount);
+    }
+
+    @Test
+    public void updateDatasourceLocale_addThrows_returns500() {
+        SaikuDatasource d = ds("with-locale", "id-locale");
+        d.getProperties().setProperty("location", "jdbc:mondrian:Jdbc=foo;locale=en_GB;");
+        dsSvc.store.put("with-locale", d);
+        dsSvc.throwOnAdd = new RuntimeException("disk full");
+
+        Response resp = resource.updateDatasourceLocale("fr_FR", "id-locale");
+        assertEquals(500, resp.getStatus());
+        assertEquals("disk full", resp.getEntity());
+    }
+
+    @Test
+    public void getUserService_returnsWiredInstance() {
+        assertSame(users, resource.getUserService());
+    }
+
+    // ---------------------------------------------------------------- helpers
+
+    private static SaikuDatasource ds(String name, String id) {
+        Properties p = new Properties();
+        p.setProperty("id", id);
+        return new SaikuDatasource(name, SaikuDatasource.Type.OLAP, p);
+    }
+
+    /**
+     * Build a SaikuDatasource with the minimum set of properties that
+     * DataSourceMapper needs to construct without throwing.
+     */
+    private static SaikuDatasource dsForMapper(String name, String id) {
+        Properties p = new Properties();
+        p.setProperty("id", id);
+        p.setProperty("driver", "mondrian.olap4j.MondrianOlap4jDriver");
+        p.setProperty("location", "jdbc:mondrian:Jdbc=jdbc:h2:mem:foo;Catalog=x.xml;JdbcDrivers=org.h2.Driver");
+        p.setProperty("connectiontype", "OLAP");
+        p.setProperty("advanced", "false");
+        return new SaikuDatasource(name, SaikuDatasource.Type.OLAP, p);
+    }
+
+    private static final class StubDatasourceService extends DatasourceService {
+        final Map<String, SaikuDatasource> store = new LinkedHashMap<>();
+        RuntimeException throwOnList;
+        Exception throwOnAdd;
+        int removeCount;
+        int addCount;
+        String lastRemovedName;
+        boolean lastAddOverwrite;
+
+        @Override
+        public Map<String, SaikuDatasource> getDatasources(String[] roles) {
+            if (throwOnList != null) throw throwOnList;
+            return store;
+        }
+
+        @Override
+        public void removeDatasource(String datasourceId) {
+            removeCount++;
+            lastRemovedName = datasourceId;
+        }
+
+        @Override
+        public void addDatasource(SaikuDatasource ds, boolean overwrite, String[] roles) throws Exception {
+            if (throwOnAdd != null) throw throwOnAdd;
+            addCount++;
+            lastAddOverwrite = overwrite;
+        }
+    }
+
+    private static final class StubUserService extends UserService {
+        @Override
+        public String[] getCurrentUserRoles() {
+            return new String[] {"ROLE_USER"};
+        }
+    }
+}

--- a/saiku-core/saiku-web/src/test/java/org/saiku/web/rest/resources/InfoResourceTest.java
+++ b/saiku-core/saiku-web/src/test/java/org/saiku/web/rest/resources/InfoResourceTest.java
@@ -1,0 +1,58 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.web.rest.resources;
+
+import static org.junit.Assert.*;
+
+import jakarta.ws.rs.core.Response;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.Test;
+import org.saiku.service.PlatformUtilsService;
+import org.saiku.service.util.dto.Plugin;
+
+public class InfoResourceTest {
+
+    @Test
+    public void getAvailablePlugins_returns200WithPluginList() {
+        PlatformUtilsService stub = new PlatformUtilsService() {
+            @Override
+            public ArrayList<Plugin> getAvailablePlugins() {
+                ArrayList<Plugin> out = new ArrayList<>();
+                out.add(new Plugin("alpha", "", "js/saiku/plugins/alpha/plugin.js"));
+                return out;
+            }
+        };
+        InfoResource r = new InfoResource();
+        r.setPlatformUtilsService(stub);
+
+        Response resp = r.getAvailablePlugins();
+        assertEquals(200, resp.getStatus());
+        // Response.ok(GenericEntity) unwraps the generic, so the entity is the
+        // raw List. The GenericEntity wrapper is only used to carry the type.
+        @SuppressWarnings("unchecked")
+        List<Plugin> body = (List<Plugin>) resp.getEntity();
+        assertEquals(1, body.size());
+        assertEquals("alpha", body.get(0).getName());
+    }
+
+    @Test
+    public void getAvailablePlugins_emptyListStillReturns200() {
+        PlatformUtilsService stub = new PlatformUtilsService() {
+            @Override
+            public ArrayList<Plugin> getAvailablePlugins() {
+                return new ArrayList<>();
+            }
+        };
+        InfoResource r = new InfoResource();
+        r.setPlatformUtilsService(stub);
+
+        Response resp = r.getAvailablePlugins();
+        assertEquals(200, resp.getStatus());
+        @SuppressWarnings("unchecked")
+        List<Plugin> body = (List<Plugin>) resp.getEntity();
+        assertTrue(body.isEmpty());
+    }
+}

--- a/saiku-core/saiku-web/src/test/java/org/saiku/web/rest/resources/SessionResourceTest.java
+++ b/saiku-core/saiku-web/src/test/java/org/saiku/web/rest/resources/SessionResourceTest.java
@@ -1,0 +1,242 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.web.rest.resources;
+
+import static org.junit.Assert.*;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.ws.rs.core.Response;
+import java.lang.reflect.Proxy;
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+import org.junit.Before;
+import org.junit.Test;
+import org.saiku.service.ISessionService;
+import org.saiku.service.user.UserService;
+import org.saiku.web.security.ratelimit.LoginRateLimiter;
+
+/**
+ * Exercise the SessionResource HTTP contract without spinning up Jersey. We
+ * drive the resource with hand-built stubs for {@link ISessionService},
+ * {@link UserService} and {@link HttpServletRequest} (via a dynamic proxy) so
+ * the test stays in-process and fast.
+ */
+public class SessionResourceTest {
+
+    private SessionResource resource;
+    private RecordingSessionService session;
+    private RecordingUserService users;
+    private LoginRateLimiter rateLimiter;
+    private HttpServletRequest req;
+
+    @Before
+    public void setUp() {
+        session = new RecordingSessionService();
+        users = new RecordingUserService();
+        // Generous limits so the happy paths don't trip the limiter.
+        rateLimiter = new LoginRateLimiter(50, 60_000L, false);
+        req = newRequest("203.0.113.10", new Locale("en"));
+
+        resource = new SessionResource();
+        resource.setSessionService(session);
+        resource.setUserService(users);
+        resource.setRateLimiter(rateLimiter);
+    }
+
+    @Test
+    public void login_validCredentials_returns200() {
+        Response resp = resource.login(req, "admin", "secret");
+        assertEquals(200, resp.getStatus());
+        assertEquals(1, session.loginCalls);
+    }
+
+    @Test
+    public void login_invalidCredentials_returns401() {
+        session.loginException = new RuntimeException("bad creds");
+        Response resp = resource.login(req, "admin", "wrong");
+        assertEquals(401, resp.getStatus());
+        assertEquals("Authentication failed", resp.getEntity());
+    }
+
+    @Test
+    public void login_blockedByRateLimiter_returns429WithRetryAfter() {
+        // Tiny window so we can quickly exhaust the bucket from the test side.
+        LoginRateLimiter strict = new LoginRateLimiter(1, 600_000L, false);
+        resource.setRateLimiter(strict);
+        session.loginException = new RuntimeException("bad creds");
+
+        // First failure counts; second attempt is blocked.
+        resource.login(req, "admin", "wrong");
+        Response resp = resource.login(req, "admin", "wrong");
+
+        assertEquals(429, resp.getStatus());
+        assertNotNull("Retry-After header must be set", resp.getHeaderString("Retry-After"));
+        assertEquals(String.valueOf(strict.getWindowMs() / 1000), resp.getHeaderString("Retry-After"));
+    }
+
+    @Test
+    public void login_nullRateLimiter_setterDoesNotOverwrite() {
+        // setRateLimiter(null) is documented as a no-op — the existing limiter
+        // must still apply. Pass a real null and verify the resource still
+        // accepts a normal login.
+        resource.setRateLimiter(null);
+        Response resp = resource.login(req, "admin", "secret");
+        assertEquals(200, resp.getStatus());
+    }
+
+    @Test
+    public void getSession_returns200WithSessionAndLanguageAndIsAdmin() {
+        session.sessionMap = new HashMap<>();
+        session.sessionMap.put("username", "tom");
+        users.isAdmin = true;
+
+        Response resp = resource.getSession(req);
+        assertEquals(200, resp.getStatus());
+        @SuppressWarnings("unchecked")
+        Map<String, Object> body = (Map<String, Object>) resp.getEntity();
+        assertEquals("tom", body.get("username"));
+        assertEquals("en", body.get("language"));
+        assertEquals(Boolean.TRUE, body.get("isadmin"));
+        assertTrue("checkFolders must be called once per session probe", users.checkFoldersCalls >= 1);
+    }
+
+    @Test
+    public void getSession_sessionServiceFailure_returns500() {
+        session.getSessionException = new RuntimeException("backend down");
+        Response resp = resource.getSession(req);
+        assertEquals(500, resp.getStatus());
+        assertEquals("backend down", resp.getEntity());
+    }
+
+    @Test
+    public void getSession_isAdminThrows_doesNotPropagate() {
+        session.sessionMap = new HashMap<>();
+        users.isAdminException = new RuntimeException("acl backend missing");
+        Response resp = resource.getSession(req);
+        assertEquals(200, resp.getStatus());
+        @SuppressWarnings("unchecked")
+        Map<String, Object> body = (Map<String, Object>) resp.getEntity();
+        // No isadmin key on swallowed exception.
+        assertFalse(body.containsKey("isadmin"));
+    }
+
+    @Test
+    public void logout_returns200_andCallsLogout() {
+        session.sessionMap = new HashMap<>();
+        session.sessionMap.put("username", "tom");
+        Response resp = resource.logout(req);
+        assertEquals(200, resp.getStatus());
+        assertEquals(1, session.logoutCalls);
+    }
+
+    @Test
+    public void logout_withoutActiveSession_stillReturns200() {
+        session.getSessionException = new RuntimeException("no session");
+        Response resp = resource.logout(req);
+        assertEquals(200, resp.getStatus());
+        assertEquals(1, session.logoutCalls);
+    }
+
+    @Test
+    public void clearSession_success_returns200() {
+        Response resp = resource.clearSession(req, "admin", "secret");
+        assertEquals(200, resp.getStatus());
+        assertEquals("Session cleared", resp.getEntity());
+        assertEquals(1, session.clearCalls);
+    }
+
+    @Test
+    public void clearSession_failure_returns500WithMessage() {
+        session.clearException = new RuntimeException("forbidden");
+        Response resp = resource.clearSession(req, "admin", "secret");
+        assertEquals(500, resp.getStatus());
+        assertEquals("forbidden", resp.getEntity());
+    }
+
+    @Test
+    public void getSessionService_returnsWiredInstance() {
+        assertSame(session, resource.getSessionService());
+    }
+
+    // ---------------------------------------------------------------- helpers
+
+    private static HttpServletRequest newRequest(String remoteAddr, Locale locale) {
+        return (HttpServletRequest) Proxy.newProxyInstance(
+                HttpServletRequest.class.getClassLoader(),
+                new Class<?>[] {HttpServletRequest.class},
+                (proxy, method, args) -> {
+                    String n = method.getName();
+                    if ("getRemoteAddr".equals(n)) return remoteAddr;
+                    if ("getLocale".equals(n)) return locale;
+                    if ("getHeader".equals(n)) return null;
+                    if ("getSession".equals(n)) return null;
+                    Class<?> rt = method.getReturnType();
+                    if (rt == boolean.class) return false;
+                    if (rt == int.class) return 0;
+                    if (rt == long.class) return 0L;
+                    return null;
+                });
+    }
+
+    private static final class RecordingSessionService implements ISessionService {
+        Map<String, Object> sessionMap = new HashMap<>();
+        RuntimeException loginException;
+        RuntimeException getSessionException;
+        RuntimeException clearException;
+        int loginCalls;
+        int logoutCalls;
+        int clearCalls;
+
+        @Override
+        public Map<String, Object> login(HttpServletRequest req, String username, String password) {
+            loginCalls++;
+            if (loginException != null) throw loginException;
+            return sessionMap;
+        }
+
+        @Override
+        public void logout(HttpServletRequest req) {
+            logoutCalls++;
+        }
+
+        @Override
+        public void authenticate(HttpServletRequest req, String username, String password) {}
+
+        @Override
+        public Map<String, Object> getSession() {
+            if (getSessionException != null) throw getSessionException;
+            return sessionMap;
+        }
+
+        @Override
+        public Map<String, Object> getAllSessionObjects() {
+            return Map.of();
+        }
+
+        @Override
+        public void clearSessions(HttpServletRequest req, String username, String password) {
+            clearCalls++;
+            if (clearException != null) throw clearException;
+        }
+    }
+
+    private static final class RecordingUserService extends UserService {
+        boolean isAdmin;
+        RuntimeException isAdminException;
+        int checkFoldersCalls;
+
+        @Override
+        public boolean isAdmin() {
+            if (isAdminException != null) throw isAdminException;
+            return isAdmin;
+        }
+
+        @Override
+        public void checkFolders() {
+            checkFoldersCalls++;
+        }
+    }
+}

--- a/saiku-core/saiku-web/src/test/java/org/saiku/web/rest/resources/StatisticsResourceTest.java
+++ b/saiku-core/saiku-web/src/test/java/org/saiku/web/rest/resources/StatisticsResourceTest.java
@@ -1,0 +1,40 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.web.rest.resources;
+
+import static org.junit.Assert.*;
+
+import mondrian.olap.MondrianServer;
+import mondrian.olap.MondrianServer.MondrianVersion;
+import org.junit.Test;
+
+/**
+ * {@link MondrianServer#forId(String)} returns a process-singleton default
+ * server, so the stats endpoints always have a server to talk to even in
+ * unit-test JVMs. Verify the resource surfaces a sensible body that wraps
+ * the default server's monitor data.
+ */
+public class StatisticsResourceTest {
+
+    private final StatisticsResource resource = new StatisticsResource();
+
+    @Test
+    public void getMondrianStats_returnsNonNullBodyAgainstDefaultServer() {
+        MondrianStats stats = resource.getMondrianStats();
+        assertNotNull(stats);
+    }
+
+    @Test
+    public void getMondrianServer_returnsServerInfoFromDefaultServer() {
+        assertNotNull(resource.getMondrianServer());
+    }
+
+    @Test
+    public void getMondrianServerVersion_returnsRunningMondrianVersion() {
+        MondrianVersion v = resource.getMondrianServerVersion();
+        assertNotNull(v);
+        assertNotNull("MondrianVersion.getVersionString must be non-null", v.getVersionString());
+    }
+}

--- a/saiku-launcher/pom.xml
+++ b/saiku-launcher/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.saikuanalytics</groupId>
         <artifactId>saiku</artifactId>
-        <version>4.0.1</version>
+        <version>4.2.0</version>
     </parent>
 
     <artifactId>saiku-launcher</artifactId>

--- a/saiku-launcher/pom.xml
+++ b/saiku-launcher/pom.xml
@@ -56,6 +56,21 @@
             <version>1.7.36</version>
             <scope>runtime</scope>
         </dependency>
+
+        <!-- Integration test dependencies. JUnit + Jackson for JSON shape
+             assertions. JDK's java.net.http handles the wire calls. -->
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.13.2</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>2.18.6</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>
@@ -93,6 +108,38 @@
                         </configuration>
                     </execution>
                 </executions>
+            </plugin>
+            <!--
+              Integration tests boot the launcher's Jetty in-process via
+              SaikuLauncher.ServeCommand.bootServer(...). Bound to the
+              integration-test phase so they run AFTER prepare-package
+              stages target/classes/webapp/saiku.war via the copy-war
+              execution below. Gated by the {@code integration} profile
+              (see below) so `mvn verify` keeps the inner dev loop fast.
+            -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <version>3.5.2</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>integration-test</goal>
+                            <goal>verify</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <includes>
+                        <include>**/*IT.java</include>
+                    </includes>
+                    <!-- Real OLAP queries are heavyweight; ITs run serially. -->
+                    <forkCount>1</forkCount>
+                    <reuseForks>true</reuseForks>
+                    <argLine>--add-opens=java.base/java.nio=ALL-UNNAMED</argLine>
+                    <!-- Default skip; the {@code integration} profile flips this on. -->
+                    <skipITs>true</skipITs>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -170,4 +217,24 @@
             </plugin>
         </plugins>
     </build>
+
+    <profiles>
+        <!-- Activate with `mvn verify -P integration` to actually run the
+             whole-API integration tests. The default reactor (CI's
+             `mvn verify`) leaves them skipped so day-to-day builds stay fast. -->
+        <profile>
+            <id>integration</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-failsafe-plugin</artifactId>
+                        <configuration>
+                            <skipITs>false</skipITs>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>

--- a/saiku-launcher/src/main/java/org/saiku/launcher/SaikuLauncher.java
+++ b/saiku-launcher/src/main/java/org/saiku/launcher/SaikuLauncher.java
@@ -68,6 +68,30 @@ public class SaikuLauncher implements Callable<Integer> {
 
         @Override
         public Integer call() throws Exception {
+            Server server = bootServer(port, host, contextPath, home);
+            int actualPort = ((ServerConnector) server.getConnectors()[0]).getLocalPort();
+            String base = "http://" + host + ":" + actualPort + contextPath;
+            if (!base.endsWith("/")) base = base + "/";
+            System.out.println("Saiku ready:");
+            System.out.println("  Workspace : " + base + "ui/");
+            System.out.println("  Admin     : " + base + "ui/admin");
+            System.out.println("  REST API  : " + base + "rest/saiku/");
+            printDefaultCredentialWarning();
+            server.join();
+            return 0;
+        }
+
+        /**
+         * Boot the embedded Jetty server with a fully wired Saiku WAR. Returns
+         * the running {@link Server} so callers can introspect the bound port
+         * via {@code server.getConnectors()[0].getLocalPort()} and orchestrate
+         * shutdown. Used by the integration test harness so it can hit a real
+         * webapp without spawning a separate JVM.
+         *
+         * <p>The supplied port may be {@code 0} for an OS-assigned ephemeral
+         * port — discoverable post-start via the connector.
+         */
+        public static Server bootServer(int port, String host, String contextPath, Path home) throws Exception {
             Path saikuHome = (home != null ? home : Paths.get("saiku-home")).toAbsolutePath();
             Path dataDir = saikuHome.resolve("data");
             Path brandingDir = saikuHome.resolve("branding");
@@ -138,15 +162,7 @@ public class SaikuLauncher implements Callable<Integer> {
             }));
 
             server.start();
-            String base = "http://" + host + ":" + port + contextPath;
-            if (!base.endsWith("/")) base = base + "/";
-            System.out.println("Saiku ready:");
-            System.out.println("  Workspace : " + base + "ui/");
-            System.out.println("  Admin     : " + base + "ui/admin");
-            System.out.println("  REST API  : " + base + "rest/saiku/");
-            printDefaultCredentialWarning();
-            server.join();
-            return 0;
+            return server;
         }
 
         /**
@@ -178,7 +194,7 @@ public class SaikuLauncher implements Callable<Integer> {
             System.out.println();
         }
 
-        private void stageSeedAssets(Path dataDir) throws Exception {
+        private static void stageSeedAssets(Path dataDir) throws Exception {
             Path schema = dataDir.resolve("FoodMart4.xml");
             if (!Files.exists(schema)) {
                 try (InputStream in = SaikuLauncher.class.getResourceAsStream("/seed/FoodMart4.xml")) {
@@ -214,7 +230,7 @@ public class SaikuLauncher implements Callable<Integer> {
          * the JDBC URL is portable across machines. Skipped if the file already
          * exists — preserves user customisations on re-launch.
          */
-        private void stageDefaultDatasource(Path saikuHome) throws Exception {
+        private static void stageDefaultDatasource(Path saikuHome) throws Exception {
             Path dsDir = saikuHome
                     .resolve("repository")
                     .resolve("data")
@@ -236,7 +252,7 @@ public class SaikuLauncher implements Callable<Integer> {
             }
         }
 
-        private void stageBrandingSample(Path brandingDir) throws Exception {
+        private static void stageBrandingSample(Path brandingDir) throws Exception {
             Path sample = brandingDir.resolve("brand.css.sample");
             if (!Files.exists(sample)) {
                 try (InputStream in = SaikuLauncher.class.getResourceAsStream("/seed/brand.css.sample")) {
@@ -248,7 +264,7 @@ public class SaikuLauncher implements Callable<Integer> {
             }
         }
 
-        private Path extractWar() throws Exception {
+        private static Path extractWar() throws Exception {
             Path tmp = Files.createTempFile("saiku-", ".war");
             tmp.toFile().deleteOnExit();
             try (InputStream in = SaikuLauncher.class.getResourceAsStream("/webapp/saiku.war")) {

--- a/saiku-launcher/src/test/java/org/saiku/launcher/it/AdminIT.java
+++ b/saiku-launcher/src/test/java/org/saiku/launcher/it/AdminIT.java
@@ -1,0 +1,66 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.launcher.it;
+
+import static org.junit.Assert.*;
+
+import java.net.http.HttpResponse;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ * Coverage for {@code /rest/saiku/admin/*} — admin-console endpoints managing
+ * datasources, schemas and users. All methods are guarded by both Spring
+ * security and the JAX-RS {@code @RolesAllowed("ROLE_ADMIN")} annotation
+ * (saiku#780 hardening), so the harness's admin Basic-auth credential is
+ * exactly the right access level to exercise them.
+ */
+public class AdminIT {
+
+    private static SaikuItHarness harness;
+    private static final String BASE = "/rest/saiku/admin";
+
+    @BeforeClass
+    public static void boot() throws Exception {
+        harness = SaikuItHarness.shared();
+    }
+
+    @Test
+    public void getDatasources_authPassesEvenIfJaxRsRoleCheckBlocks() throws Exception {
+        // FINDING (pinned, not a happy-path assertion): with Basic auth the
+        // JAX-RS SecurityContext doesn't pick up ROLE_ADMIN from Spring
+        // Security's principal, so AdminResource's @RolesAllowed("ROLE_ADMIN")
+        // gate returns 403 even though the user is provisioned as admin in
+        // users.properties. The Spring URL filter chain accepts the request
+        // (no 401), so auth itself succeeds — the gap is in the JAX-RS layer.
+        // This test pins current observed behaviour so a fix is a deliberate,
+        // testable change. Untested: form-login session path, which would
+        // populate the SecurityContext via the cookie-bound auth.
+        HttpResponse<String> resp = harness.getAuth(BASE + "/datasources");
+        assertNotEquals("auth must reach the endpoint (no 401)", 401, resp.statusCode());
+        assertEquals("current observed status — 403 due to JAX-RS @RolesAllowed gap", 403, resp.statusCode());
+    }
+
+    @Test
+    public void getSchemas_currentlyForbidden_pinned() throws Exception {
+        HttpResponse<String> resp = harness.getAuth(BASE + "/schema");
+        assertNotEquals(401, resp.statusCode());
+        assertEquals(403, resp.statusCode());
+    }
+
+    @Test
+    public void getUsers_currentlyForbidden_pinned() throws Exception {
+        HttpResponse<String> resp = harness.getAuth(BASE + "/users");
+        assertNotEquals(401, resp.statusCode());
+        assertEquals(403, resp.statusCode());
+    }
+
+    @Test
+    public void refreshDatasource_unknownId_currentlyForbidden_pinned() throws Exception {
+        HttpResponse<String> resp = harness.getAuth(BASE + "/datasources/no-such-id/refresh");
+        assertNotEquals(401, resp.statusCode());
+        assertEquals(403, resp.statusCode());
+    }
+}

--- a/saiku-launcher/src/test/java/org/saiku/launcher/it/AdvancedAiQueryIT.java
+++ b/saiku-launcher/src/test/java/org/saiku/launcher/it/AdvancedAiQueryIT.java
@@ -1,0 +1,434 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.launcher.it;
+
+import static org.junit.Assert.*;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import java.net.http.HttpResponse;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ * Coverage for the AI Query API's advanced features — visual totals,
+ * Hierarchize-merged same-hierarchy rows, CROSSJOIN cross-axis, explicit
+ * member sets, exclusion filters, descendants-of, relative time filters,
+ * multi-measure × dim crossjoin cell preservation, and parent-member /
+ * cross-level rows. These are the surfaces real Saiku users hit the most
+ * but that the simple-happy-path test in {@link AiQueryIT} doesn't exercise.
+ */
+public class AdvancedAiQueryIT {
+
+    private static SaikuItHarness harness;
+    private static final String CUBE = "unknown_foodmart/FoodMart/FoodMart/Sales";
+    private static final String QUERY = "/rest/saiku/api/ai/query";
+
+    @BeforeClass
+    public static void boot() throws Exception {
+        harness = SaikuItHarness.shared();
+    }
+
+    @Test
+    public void visualTotalsTrue_emitsVisualtotalsInGeneratedMdx() throws Exception {
+        String body =
+                """
+                {
+                  "cube": "%s",
+                  "measures": [{"name": "Store Sales"}],
+                  "rows": [{"dimension": "Product", "hierarchy": "Products", "level": "Product Category"}],
+                  "visualTotals": true,
+                  "limit": 3
+                }
+                """
+                        .formatted(CUBE);
+        HttpResponse<String> resp = harness.postAuthJson(QUERY, body);
+        assertEquals("expected 200, got " + resp.statusCode() + " body=" + resp.body(), 200, resp.statusCode());
+        JsonNode r = harness.parse(resp);
+        assertEquals("SUCCESS", r.path("status").asText());
+        String mdx = r.path("metadata").path("generatedMdx").asText();
+        assertTrue("generated MDX must use VISUALTOTALS, got: " + mdx, mdx.contains("VISUALTOTALS"));
+    }
+
+    @Test
+    public void sameHierarchyMultiLevelRows_emitsHierarchizeNotCrossjoin() throws Exception {
+        // Store State + Store Name share the Stores hierarchy → Hierarchize merge,
+        // NOT CROSSJOIN which would multiply rows.
+        String body =
+                """
+                {
+                  "cube": "%s",
+                  "measures": [{"name": "Store Sales"}],
+                  "rows": [
+                    {"dimension": "Store", "hierarchy": "Stores", "level": "Store State"},
+                    {"dimension": "Store", "hierarchy": "Stores", "level": "Store Name"}
+                  ],
+                  "limit": 4,
+                  "nonEmpty": false
+                }
+                """
+                        .formatted(CUBE);
+        HttpResponse<String> resp = harness.postAuthJson(QUERY, body);
+        assertEquals("expected 200, got " + resp.statusCode() + " body=" + resp.body(), 200, resp.statusCode());
+        JsonNode r = harness.parse(resp);
+        assertEquals("SUCCESS", r.path("status").asText());
+        String mdx = r.path("metadata").path("generatedMdx").asText();
+        assertTrue("same-hierarchy multi-level rows must emit Hierarchize, got: " + mdx, mdx.contains("Hierarchize"));
+        assertFalse(
+                "same-hierarchy rows must NOT emit CROSSJOIN — that would multiply unrelated rows, got: " + mdx,
+                mdx.contains("CROSSJOIN"));
+    }
+
+    @Test
+    public void distinctHierarchyRows_emitsCrossjoin() throws Exception {
+        // Time × Product → distinct hierarchies, CROSSJOIN required.
+        String body =
+                """
+                {
+                  "cube": "%s",
+                  "measures": [{"name": "Store Sales"}],
+                  "rows": [
+                    {"dimension": "Time", "hierarchy": "Time", "level": "Year"},
+                    {"dimension": "Product", "hierarchy": "Products", "level": "Product Family"}
+                  ],
+                  "limit": 6
+                }
+                """
+                        .formatted(CUBE);
+        HttpResponse<String> resp = harness.postAuthJson(QUERY, body);
+        assertEquals(200, resp.statusCode());
+        JsonNode r = harness.parse(resp);
+        assertEquals("SUCCESS", r.path("status").asText());
+        String mdx = r.path("metadata").path("generatedMdx").asText();
+        assertTrue("distinct-hierarchy rows must emit CROSSJOIN, got: " + mdx, mdx.contains("CROSSJOIN"));
+    }
+
+    @Test
+    public void multiMeasureCrossDim_preservesAllCells_saiku789() throws Exception {
+        // Regression for saiku#789: 2 measures × Quarter must yield 8
+        // distinct columns and the value cells must differ across measures.
+        String body =
+                """
+                {
+                  "cube": "%s",
+                  "measures": [{"name": "Store Sales"}, {"name": "Unit Sales"}],
+                  "rows": [{"dimension": "Product", "hierarchy": "Products", "level": "Product Family"}],
+                  "columns": [{"dimension": "Time", "hierarchy": "Time", "level": "Quarter"}]
+                }
+                """
+                        .formatted(CUBE);
+        HttpResponse<String> resp = harness.postAuthJson(QUERY, body);
+        assertEquals(200, resp.statusCode());
+        JsonNode r = harness.parse(resp);
+        assertEquals("SUCCESS", r.path("status").asText());
+        assertEquals(
+                "2 measures × 4 quarters must yield exactly 8 columns",
+                8,
+                r.path("metadata").path("columns").size());
+        // Values for the same row/quarter must differ across measures —
+        // otherwise the cross-join collapsed measures into one cell.
+        double storeSalesQ1 =
+                r.path("data").get(0).path("Store Sales | Q1").path("value").asDouble();
+        double unitSalesQ1 =
+                r.path("data").get(0).path("Unit Sales | Q1").path("value").asDouble();
+        assertNotEquals("Store Sales Q1 and Unit Sales Q1 must be distinct values", storeSalesQ1, unitSalesQ1, 1e-6);
+    }
+
+    @Test
+    public void explicitMembersOnRows_returnsOnlyRequestedMembers() throws Exception {
+        String body =
+                """
+                {
+                  "cube": "%s",
+                  "measures": [{"name": "Store Sales"}],
+                  "rows": [{
+                    "dimension": "Product",
+                    "hierarchy": "Products",
+                    "level": "Product Family",
+                    "members": ["[Product].[Products].[Drink]", "[Product].[Products].[Food]"]
+                  }]
+                }
+                """
+                        .formatted(CUBE);
+        HttpResponse<String> resp = harness.postAuthJson(QUERY, body);
+        assertEquals(200, resp.statusCode());
+        JsonNode r = harness.parse(resp);
+        assertEquals("SUCCESS", r.path("status").asText());
+        assertEquals(
+                "explicit two-member set must return exactly 2 rows",
+                2,
+                r.path("totalRows").asInt());
+    }
+
+    @Test
+    public void filterNotIn_excludesNamedMember() throws Exception {
+        String body =
+                """
+                {
+                  "cube": "%s",
+                  "measures": [{"name": "Store Sales"}],
+                  "rows": [{"dimension": "Product", "hierarchy": "Products", "level": "Product Family"}],
+                  "filters": [{
+                    "dimension": "Store",
+                    "hierarchy": "Stores",
+                    "level": "Store Country",
+                    "op": "not_in",
+                    "members": ["[Store].[Stores].[Canada]"]
+                  }]
+                }
+                """
+                        .formatted(CUBE);
+        HttpResponse<String> resp = harness.postAuthJson(QUERY, body);
+        assertEquals(200, resp.statusCode());
+        JsonNode r = harness.parse(resp);
+        assertEquals("SUCCESS", r.path("status").asText());
+        // FoodMart has no data for Canada, so the result count is the same as
+        // the full set, but the MDX should encode the exclusion.
+        String mdx = r.path("metadata").path("generatedMdx").asText();
+        assertTrue(
+                "not_in must encode an Except/exclude semantics, got: " + mdx,
+                mdx.contains("Except") || mdx.contains("EXCEPT"));
+    }
+
+    @Test
+    public void filterDescendantsOf_resolvesToDescendantsCall() throws Exception {
+        String body =
+                """
+                {
+                  "cube": "%s",
+                  "measures": [{"name": "Store Sales"}],
+                  "rows": [{"dimension": "Product", "hierarchy": "Products", "level": "Product Family"}],
+                  "filters": [{
+                    "dimension": "Store",
+                    "hierarchy": "Stores",
+                    "level": "Store Country",
+                    "op": "descendants_of",
+                    "members": ["[Store].[Stores].[USA]"]
+                  }]
+                }
+                """
+                        .formatted(CUBE);
+        HttpResponse<String> resp = harness.postAuthJson(QUERY, body);
+        assertEquals(200, resp.statusCode());
+        JsonNode r = harness.parse(resp);
+        assertEquals("SUCCESS", r.path("status").asText());
+        assertEquals(
+                "descendants_of must still return all 3 product families",
+                3,
+                r.path("totalRows").asInt());
+    }
+
+    @Test
+    public void filterBetween_year1997to1998_returnsAllProductFamilies() throws Exception {
+        String body =
+                """
+                {
+                  "cube": "%s",
+                  "measures": [{"name": "Unit Sales"}],
+                  "rows": [{"dimension": "Product", "hierarchy": "Products", "level": "Product Family"}],
+                  "filters": [{
+                    "dimension": "Time",
+                    "hierarchy": "Time",
+                    "level": "Year",
+                    "op": "between",
+                    "members": ["[Time].[Time].[1997]", "[Time].[Time].[1998]"]
+                  }],
+                  "nonEmpty": false
+                }
+                """
+                        .formatted(CUBE);
+        HttpResponse<String> resp = harness.postAuthJson(QUERY, body);
+        assertEquals(200, resp.statusCode());
+        JsonNode r = harness.parse(resp);
+        assertEquals("SUCCESS", r.path("status").asText());
+        assertEquals(3, r.path("totalRows").asInt());
+    }
+
+    @Test
+    public void filterRelativeLastNQuarters_emitsTailInMdx() throws Exception {
+        String body =
+                """
+                {
+                  "cube": "%s",
+                  "measures": [{"name": "Store Sales"}],
+                  "rows": [{"dimension": "Product", "hierarchy": "Products", "level": "Product Family"}],
+                  "filters": [{
+                    "dimension": "Time",
+                    "hierarchy": "Time",
+                    "level": "Quarter",
+                    "op": "relative",
+                    "value": "last_n_quarters",
+                    "n": 2
+                  }]
+                }
+                """
+                        .formatted(CUBE);
+        HttpResponse<String> resp = harness.postAuthJson(QUERY, body);
+        assertEquals(200, resp.statusCode());
+        JsonNode r = harness.parse(resp);
+        assertEquals("SUCCESS", r.path("status").asText());
+        String mdx = r.path("metadata").path("generatedMdx").asText();
+        assertTrue("relative last_n_quarters must emit Tail(...), got: " + mdx, mdx.contains("Tail"));
+    }
+
+    @Test
+    public void multipleFiltersOnSameHierarchy_rejectedAsValidationError() throws Exception {
+        // Two filters on the Time hierarchy at different levels must be
+        // rejected — Mondrian can't combine them into a coherent slicer set.
+        String body =
+                """
+                {
+                  "cube": "%s",
+                  "measures": [{"name": "Store Sales"}],
+                  "rows": [{"dimension": "Product", "hierarchy": "Products", "level": "Product Family"}],
+                  "filters": [
+                    {"dimension": "Time", "hierarchy": "Time", "level": "Year", "members": ["[Time].[Time].[1997]"]},
+                    {"dimension": "Time", "hierarchy": "Time", "level": "Quarter", "members": ["[Time].[Time].[1997].[Q1]"]}
+                  ]
+                }
+                """
+                        .formatted(CUBE);
+        HttpResponse<String> resp = harness.postAuthJson(QUERY, body);
+        assertEquals(400, resp.statusCode());
+        JsonNode r = harness.parse(resp);
+        assertEquals("VALIDATION_ERROR", r.path("status").asText());
+        assertTrue(
+                "error message should call out the hierarchy collision, got: "
+                        + r.path("error").asText(),
+                r.path("error").asText().contains("Multiple filters")
+                        || r.path("error").asText().contains("hierarchy"));
+    }
+
+    @Test
+    public void axisHierarchyReusedInFilter_rejectedSaiku784() throws Exception {
+        // Regression for saiku#784: if a hierarchy is already on rows/columns,
+        // also using it in a filter is rejected.
+        String body =
+                """
+                {
+                  "cube": "%s",
+                  "measures": [{"name": "Unit Sales"}],
+                  "rows": [{"dimension": "Customer", "hierarchy": "Customers", "level": "City"}],
+                  "filters": [{
+                    "dimension": "Customer",
+                    "hierarchy": "Customers",
+                    "level": "State Province",
+                    "op": "descendants_of",
+                    "members": ["[Customer].[Customers].[USA].[CA]"]
+                  }]
+                }
+                """
+                        .formatted(CUBE);
+        HttpResponse<String> resp = harness.postAuthJson(QUERY, body);
+        assertEquals(400, resp.statusCode());
+        JsonNode r = harness.parse(resp);
+        assertEquals("VALIDATION_ERROR", r.path("status").asText());
+        assertTrue(
+                "error must mention axis-reuse, got: " + r.path("error").asText(),
+                r.path("error").asText().contains("already on the rows/columns axis"));
+    }
+
+    @Test
+    public void memberAtWrongLevel_rejectedSaiku790() throws Exception {
+        // Regression for saiku#790: claiming a Product Department member at
+        // the Product Family level must be flagged with the correct level
+        // name in the error.
+        String body =
+                """
+                {
+                  "cube": "%s",
+                  "measures": [{"name": "Store Sales"}],
+                  "rows": [{
+                    "dimension": "Product",
+                    "hierarchy": "Products",
+                    "level": "Product Family",
+                    "members": ["[Product].[Products].[Drink].[Beverages]"]
+                  }]
+                }
+                """
+                        .formatted(CUBE);
+        HttpResponse<String> resp = harness.postAuthJson(QUERY, body);
+        assertEquals(400, resp.statusCode());
+        JsonNode r = harness.parse(resp);
+        assertEquals("VALIDATION_ERROR", r.path("status").asText());
+        String err = r.path("error").asText();
+        assertTrue(
+                "error must mention both Product Department (actual) and Product Family (requested), got: " + err,
+                err.contains("Product Department") && err.contains("Product Family"));
+    }
+
+    @Test
+    public void duplicateMeasures_rejectedSaiku796() throws Exception {
+        String body =
+                """
+                {
+                  "cube": "%s",
+                  "measures": [{"name": "Store Sales"}, {"name": "Store Sales"}, {"name": "Unit Sales"}],
+                  "rows": [{"dimension": "Product", "hierarchy": "Products", "level": "Product Family"}]
+                }
+                """
+                        .formatted(CUBE);
+        HttpResponse<String> resp = harness.postAuthJson(QUERY, body);
+        assertEquals(400, resp.statusCode());
+        JsonNode r = harness.parse(resp);
+        assertEquals("VALIDATION_ERROR", r.path("status").asText());
+        assertEquals("measures", r.path("field").asText());
+    }
+
+    @Test
+    public void invalidOrderDirection_rejectedWithAvailable() throws Exception {
+        String body =
+                """
+                {
+                  "cube": "%s",
+                  "measures": [{"name": "Store Sales"}],
+                  "rows": [{"dimension": "Product", "hierarchy": "Products", "level": "Product Family"}],
+                  "order": [{"by": "Store Sales", "direction": "sideways"}],
+                  "limit": 2
+                }
+                """
+                        .formatted(CUBE);
+        HttpResponse<String> resp = harness.postAuthJson(QUERY, body);
+        assertEquals(400, resp.statusCode());
+        JsonNode r = harness.parse(resp);
+        assertEquals("VALIDATION_ERROR", r.path("status").asText());
+        assertEquals("order[0].direction", r.path("field").asText());
+        // 'available' should list only asc/desc.
+        boolean hasAsc = false;
+        boolean hasDesc = false;
+        for (JsonNode v : r.path("available")) {
+            if ("asc".equals(v.asText())) hasAsc = true;
+            if ("desc".equals(v.asText())) hasDesc = true;
+        }
+        assertTrue("available must list asc + desc", hasAsc && hasDesc);
+    }
+
+    @Test
+    public void nonexistentMember_returnsValidationErrorNotMondrianException() throws Exception {
+        // A made-up member name must be caught client-side and surfaced as
+        // a typed 400 envelope, not a Mondrian 500 stack trace.
+        String body =
+                """
+                {
+                  "cube": "%s",
+                  "measures": [{"name": "Store Sales"}],
+                  "rows": [{
+                    "dimension": "Product",
+                    "hierarchy": "Products",
+                    "level": "Product Family",
+                    "members": ["[Product].[Products].[Drink]", "[Product].[Products].[Pizza]"]
+                  }]
+                }
+                """
+                        .formatted(CUBE);
+        HttpResponse<String> resp = harness.postAuthJson(QUERY, body);
+        assertEquals(400, resp.statusCode());
+        JsonNode r = harness.parse(resp);
+        assertEquals("VALIDATION_ERROR", r.path("status").asText());
+        assertEquals("members", r.path("field").asText());
+        assertTrue(
+                "error must name the offending member, got: " + r.path("error").asText(),
+                r.path("error").asText().contains("Pizza"));
+    }
+}

--- a/saiku-launcher/src/test/java/org/saiku/launcher/it/AiQueryAsyncIT.java
+++ b/saiku-launcher/src/test/java/org/saiku/launcher/it/AiQueryAsyncIT.java
@@ -1,0 +1,107 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.launcher.it;
+
+import static org.junit.Assert.*;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ * Coverage for the AI Query API's fire-and-poll async endpoints
+ * ({@code /rest/saiku/api/ai/query/execute-async}, status, result, cancel,
+ * drillthrough columns).
+ */
+public class AiQueryAsyncIT {
+
+    private static SaikuItHarness harness;
+    private static final String CUBE = "unknown_foodmart/FoodMart/FoodMart/Sales";
+    private static final String BASE = "/rest/saiku/api/ai";
+
+    @BeforeClass
+    public static void boot() throws Exception {
+        harness = SaikuItHarness.shared();
+    }
+
+    @Test
+    public void asyncQueryRoundTrip_submitPollResult() throws Exception {
+        String body =
+                """
+                {
+                  "cube": "%s",
+                  "measures": [{"name": "Store Sales"}],
+                  "rows": [{"dimension": "Product", "hierarchy": "Products", "level": "Product Family"}]
+                }
+                """
+                        .formatted(CUBE);
+        HttpResponse<String> submit = harness.postAuthJson(BASE + "/query/execute-async", body);
+        assertEquals(
+                "submit should be 202/200, got " + submit.statusCode() + " body=" + submit.body(),
+                202,
+                submit.statusCode());
+        JsonNode submitBody = harness.parse(submit);
+        String queryId = submitBody.path("queryId").asText();
+        assertFalse("queryId must be present on submit", queryId.isBlank());
+
+        // Poll until DONE.
+        long deadline = System.currentTimeMillis() + Duration.ofSeconds(30).toMillis();
+        String lastStatus = null;
+        while (System.currentTimeMillis() < deadline) {
+            HttpResponse<String> status = harness.getAuth(BASE + "/query/status/" + queryId);
+            assertEquals(200, status.statusCode());
+            lastStatus = harness.parse(status).path("status").asText();
+            if ("DONE".equals(lastStatus) || "FAILED".equals(lastStatus) || "CANCELLED".equals(lastStatus)) {
+                break;
+            }
+            Thread.sleep(100);
+        }
+        assertEquals("query should complete with DONE, last status was " + lastStatus, "DONE", lastStatus);
+
+        // Fetch result.
+        HttpResponse<String> result = harness.getAuth(BASE + "/query/result/" + queryId);
+        assertEquals(200, result.statusCode());
+        JsonNode r = harness.parse(result);
+        assertEquals("SUCCESS", r.path("status").asText());
+        assertEquals(3, r.path("totalRows").asInt());
+    }
+
+    @Test
+    public void asyncQuery_cancelSucceedsImmediately() throws Exception {
+        String body =
+                """
+                {
+                  "cube": "%s",
+                  "measures": [{"name": "Store Sales"}],
+                  "rows": [{"dimension": "Product", "hierarchy": "Products", "level": "Product Family"}]
+                }
+                """
+                        .formatted(CUBE);
+        HttpResponse<String> submit = harness.postAuthJson(BASE + "/query/execute-async", body);
+        assertEquals(202, submit.statusCode());
+        String queryId = harness.parse(submit).path("queryId").asText();
+
+        HttpResponse<String> cancel = harness.deleteAuth(BASE + "/query/" + queryId);
+        // 200 OK regardless of whether the underlying task had already completed.
+        assertEquals(
+                "cancel should be 200, got " + cancel.statusCode() + " body=" + cancel.body(),
+                200,
+                cancel.statusCode());
+    }
+
+    @Test
+    public void asyncStatus_unknownId_returns404() throws Exception {
+        HttpResponse<String> resp = harness.getAuth(BASE + "/query/status/no-such-id");
+        assertEquals(404, resp.statusCode());
+    }
+
+    @Test
+    public void asyncResult_unknownId_returns404() throws Exception {
+        HttpResponse<String> resp = harness.getAuth(BASE + "/query/result/no-such-id");
+        assertEquals(404, resp.statusCode());
+    }
+}

--- a/saiku-launcher/src/test/java/org/saiku/launcher/it/AiQueryExtrasIT.java
+++ b/saiku-launcher/src/test/java/org/saiku/launcher/it/AiQueryExtrasIT.java
@@ -1,0 +1,92 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.launcher.it;
+
+import static org.junit.Assert.*;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import java.net.URLEncoder;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ * Coverage for the remaining AI Query API endpoints not exercised by
+ * {@link AiQueryIT} or {@link AiQueryAsyncIT}: {@code /query/preview} and
+ * {@code /members/search}.
+ */
+public class AiQueryExtrasIT {
+
+    private static SaikuItHarness harness;
+    private static final String CUBE = "unknown_foodmart/FoodMart/FoodMart/Sales";
+    private static final String BASE = "/rest/saiku/api/ai";
+
+    @BeforeClass
+    public static void boot() throws Exception {
+        harness = SaikuItHarness.shared();
+    }
+
+    @Test
+    public void preview_returnsGeneratedMdxWithoutExecuting() throws Exception {
+        String body =
+                """
+                {
+                  "cube": "%s",
+                  "measures": [{"name": "Store Sales"}],
+                  "rows": [{"dimension": "Product", "hierarchy": "Products", "level": "Product Family"}]
+                }
+                """
+                        .formatted(CUBE);
+        HttpResponse<String> resp = harness.postAuthJson(BASE + "/query/preview", body);
+        assertEquals(
+                "preview should be 200, got " + resp.statusCode() + " body=" + resp.body(), 200, resp.statusCode());
+        JsonNode r = harness.parse(resp);
+        // Preview returns the generated MDX + metadata but no data array.
+        assertTrue(
+                "preview body should expose generatedMdx",
+                r.has("generatedMdx") || r.path("metadata").has("generatedMdx"));
+    }
+
+    @Test
+    public void preview_unknownMeasure_returns400WithValidationError() throws Exception {
+        String body =
+                """
+                {
+                  "cube": "%s",
+                  "measures": [{"name": "Made Up Measure"}],
+                  "rows": []
+                }
+                """
+                        .formatted(CUBE);
+        HttpResponse<String> resp = harness.postAuthJson(BASE + "/query/preview", body);
+        assertEquals(400, resp.statusCode());
+        JsonNode r = harness.parse(resp);
+        assertEquals("VALIDATION_ERROR", r.path("status").asText());
+    }
+
+    @Test
+    public void searchMembers_productFamily_returnsMatches() throws Exception {
+        String url = BASE + "/members/search?"
+                + "cubeId=" + URLEncoder.encode(CUBE, StandardCharsets.UTF_8)
+                + "&dimension=Product"
+                + "&hierarchy=Products"
+                + "&level=Product+Family"
+                + "&q=Dri"
+                + "&limit=5";
+        HttpResponse<String> resp = harness.getAuth(url);
+        assertEquals("search should be 200, got " + resp.statusCode() + " body=" + resp.body(), 200, resp.statusCode());
+        JsonNode r = harness.parse(resp);
+        // Either returns an array of matches or a structured envelope; either way it must be non-null JSON.
+        assertNotNull(r);
+    }
+
+    @Test
+    public void searchMembers_invalidCubeId_returns400() throws Exception {
+        String url = BASE + "/members/search?cubeId=foo&dimension=x&hierarchy=y&level=z&q=test";
+        HttpResponse<String> resp = harness.getAuth(url);
+        assertEquals(400, resp.statusCode());
+    }
+}

--- a/saiku-launcher/src/test/java/org/saiku/launcher/it/AiQueryIT.java
+++ b/saiku-launcher/src/test/java/org/saiku/launcher/it/AiQueryIT.java
@@ -1,0 +1,220 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.launcher.it;
+
+import static org.junit.Assert.*;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import java.net.http.HttpResponse;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ * End-to-end integration tests for the AI Query API surface ({@code
+ * /rest/saiku/api/ai/*}). Mirrors a meaningful subset of
+ * {@code saiku-launcher/test-ai-live.sh} as JUnit assertions, so the contract
+ * is enforced by {@code mvn verify -P integration} rather than only by an
+ * out-of-band shell script.
+ *
+ * <p>Boots once via {@link SaikuItHarness}; assumes the seeded FoodMart H2
+ * datasource that the launcher ships.
+ */
+public class AiQueryIT {
+
+    private static final String CUBE = "unknown_foodmart/FoodMart/FoodMart/Sales";
+    private static SaikuItHarness harness;
+
+    @BeforeClass
+    public static void boot() throws Exception {
+        harness = SaikuItHarness.shared();
+    }
+
+    // ---------------------------------------------------------------- discovery
+
+    @Test
+    public void cubes_listIncludesSales() throws Exception {
+        HttpResponse<String> resp = harness.getAuth("/rest/saiku/api/ai/cubes");
+        assertEquals(200, resp.statusCode());
+        JsonNode body = harness.parse(resp);
+        assertTrue("response must be a JSON array", body.isArray());
+
+        boolean foundSales = false;
+        for (JsonNode c : body) {
+            if ("Sales".equals(c.path("cubeName").asText())) {
+                foundSales = true;
+                break;
+            }
+        }
+        assertTrue("Sales cube must be present in /ai/cubes — body: " + resp.body(), foundSales);
+    }
+
+    @Test
+    public void schema_SalesCubeHasProductAndStoreSales() throws Exception {
+        HttpResponse<String> resp = harness.getAuth("/rest/saiku/api/ai/schema/" + CUBE);
+        assertEquals(200, resp.statusCode());
+        JsonNode body = harness.parse(resp);
+        assertTrue(
+                "schema must include 'product' dimension",
+                body.path("dimensions").has("product"));
+        assertTrue(
+                "schema must include 'store sales' measure",
+                body.path("measures").has("store sales"));
+    }
+
+    @Test
+    public void schema_threeSegmentCubeId_returns400WithCubeIdField() throws Exception {
+        HttpResponse<String> resp = harness.getAuth("/rest/saiku/api/ai/schema/foo/bar/baz");
+        assertEquals(400, resp.statusCode());
+        JsonNode body = harness.parse(resp);
+        assertEquals("VALIDATION_ERROR", body.path("status").asText());
+        assertEquals("cubeId", body.path("field").asText());
+    }
+
+    @Test
+    public void schema_unknownCubeName_returnsAvailableList() throws Exception {
+        HttpResponse<String> resp =
+                harness.getAuth("/rest/saiku/api/ai/schema/unknown_foodmart/FoodMart/FoodMart/Nonsense");
+        assertEquals(400, resp.statusCode());
+        JsonNode body = harness.parse(resp);
+        assertEquals("VALIDATION_ERROR", body.path("status").asText());
+        assertEquals("cube", body.path("field").asText());
+
+        boolean salesIsAnAvailableOption = false;
+        for (JsonNode candidate : body.path("available")) {
+            if ("Sales".equals(candidate.asText())) {
+                salesIsAnAvailableOption = true;
+                break;
+            }
+        }
+        assertTrue("Sales must be listed in the 'available' candidates", salesIsAnAvailableOption);
+    }
+
+    // ---------------------------------------------------------------- happy paths
+
+    @Test
+    public void query_simpleMeasureByProductFamily_returns3Rows() throws Exception {
+        String body =
+                """
+                {
+                  "cube": "%s",
+                  "measures": [{"name": "Store Sales"}],
+                  "rows": [{"dimension": "Product", "hierarchy": "Products", "level": "Product Family"}]
+                }
+                """
+                        .formatted(CUBE);
+        HttpResponse<String> resp = harness.postAuthJson("/rest/saiku/api/ai/query", body);
+        assertEquals("expected 200, got " + resp.statusCode() + " body=" + resp.body(), 200, resp.statusCode());
+        JsonNode r = harness.parse(resp);
+        assertEquals("SUCCESS", r.path("status").asText());
+        assertEquals(3, r.path("totalRows").asInt());
+        double firstValue =
+                r.path("data").get(0).path("Store Sales").path("value").asDouble();
+        assertTrue("first row Store Sales must be > 0, got " + firstValue, firstValue > 0);
+    }
+
+    @Test
+    public void query_orderAndLimit_emitsTopCountAndReturnsLimitedRows() throws Exception {
+        String body =
+                """
+                {
+                  "cube": "%s",
+                  "measures": [{"name": "Store Sales"}],
+                  "rows": [{"dimension": "Product", "hierarchy": "Products", "level": "Product Family"}],
+                  "order": [{"by": "Store Sales", "direction": "desc"}],
+                  "limit": 2
+                }
+                """
+                        .formatted(CUBE);
+        HttpResponse<String> resp = harness.postAuthJson("/rest/saiku/api/ai/query", body);
+        assertEquals(200, resp.statusCode());
+        JsonNode r = harness.parse(resp);
+        assertEquals("SUCCESS", r.path("status").asText());
+        assertEquals(2, r.path("totalRows").asInt());
+        assertTrue(
+                "generatedMdx should use TopCount: "
+                        + r.path("metadata").path("generatedMdx").asText(),
+                r.path("metadata").path("generatedMdx").asText().contains("TopCount"));
+    }
+
+    @Test
+    public void query_filterIn_singleYearFilter_returnsAllProductFamilies() throws Exception {
+        String body =
+                """
+                {
+                  "cube": "%s",
+                  "measures": [{"name": "Store Sales"}],
+                  "rows": [{"dimension": "Product", "hierarchy": "Products", "level": "Product Family"}],
+                  "filters": [{
+                    "dimension": "Time",
+                    "hierarchy": "Time",
+                    "level": "Year",
+                    "members": ["[Time].[Time].[1997]"]
+                  }]
+                }
+                """
+                        .formatted(CUBE);
+        HttpResponse<String> resp = harness.postAuthJson("/rest/saiku/api/ai/query", body);
+        assertEquals(200, resp.statusCode());
+        JsonNode r = harness.parse(resp);
+        assertEquals("SUCCESS", r.path("status").asText());
+        assertEquals(3, r.path("totalRows").asInt());
+    }
+
+    // ---------------------------------------------------------------- validation
+
+    @Test
+    public void query_unknownMeasure_returnsValidationErrorWithAvailable() throws Exception {
+        String body =
+                """
+                {
+                  "cube": "%s",
+                  "measures": [{"name": "Made Up Measure"}],
+                  "rows": []
+                }
+                """
+                        .formatted(CUBE);
+        HttpResponse<String> resp = harness.postAuthJson("/rest/saiku/api/ai/query", body);
+        assertEquals(400, resp.statusCode());
+        JsonNode r = harness.parse(resp);
+        assertEquals("VALIDATION_ERROR", r.path("status").asText());
+        assertEquals("measures[].name", r.path("field").asText());
+
+        boolean storeSalesListed = false;
+        for (JsonNode candidate : r.path("available")) {
+            if ("Store Sales".equals(candidate.asText())) {
+                storeSalesListed = true;
+                break;
+            }
+        }
+        assertTrue("'Store Sales' must be in 'available' for self-correction", storeSalesListed);
+    }
+
+    @Test
+    public void query_mdxInjectionInMembers_rejectedWithEmbeddedMdxMessage() throws Exception {
+        String body =
+                """
+                {
+                  "cube": "%s",
+                  "measures": [{"name": "Store Sales"}],
+                  "rows": [{
+                    "dimension": "Product",
+                    "hierarchy": "Products",
+                    "level": "Product Family",
+                    "members": ["[Product].[Products].[Drink], Crossjoin([Time].[1997])"]
+                  }]
+                }
+                """
+                        .formatted(CUBE);
+        HttpResponse<String> resp = harness.postAuthJson("/rest/saiku/api/ai/query", body);
+        assertEquals(400, resp.statusCode());
+        JsonNode r = harness.parse(resp);
+        assertEquals("VALIDATION_ERROR", r.path("status").asText());
+        assertEquals("rows[0].members[0]", r.path("field").asText());
+        assertTrue(
+                "error message must mention 'Embedded MDX' — got: "
+                        + r.path("error").asText(),
+                r.path("error").asText().contains("Embedded MDX"));
+    }
+}

--- a/saiku-launcher/src/test/java/org/saiku/launcher/it/DataSourceIT.java
+++ b/saiku-launcher/src/test/java/org/saiku/launcher/it/DataSourceIT.java
@@ -1,0 +1,48 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.launcher.it;
+
+import static org.junit.Assert.*;
+
+import java.net.http.HttpResponse;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ * Coverage for the per-user datasource discovery endpoint
+ * ({@code /rest/saiku/{username}/org.saiku.datasources}). Strictly read-only
+ * tests against the seeded {@code unknown_foodmart} datasource — DELETE/PUT
+ * paths are covered by AdminIT against the admin surface.
+ */
+public class DataSourceIT {
+
+    private static SaikuItHarness harness;
+    private static final String BASE = "/rest/saiku/admin/org.saiku.datasources";
+
+    @BeforeClass
+    public static void boot() throws Exception {
+        harness = SaikuItHarness.shared();
+    }
+
+    @Test
+    public void listDatasources_route_returns404_pinningCurrentBehavior() throws Exception {
+        // FINDING (pinned): `/rest/saiku/{username}/org.saiku.datasources`
+        // returns 404 against this embedded launcher build — the JAX-RS
+        // route registers but Spring Security or Jersey path-matching is
+        // rejecting it before the resource method runs. Likely a dotted-
+        // path issue with the {username} variable. The admin console uses
+        // `/rest/saiku/admin/datasources` (see AdminIT) which is the
+        // canonical path; this older user-scoped endpoint is unused by
+        // the SPA. Pin so a future fix is testable.
+        HttpResponse<String> resp = harness.getAuth(BASE);
+        assertEquals(404, resp.statusCode());
+    }
+
+    @Test
+    public void getDatasourceById_route_returns404_pinningCurrentBehavior() throws Exception {
+        HttpResponse<String> resp = harness.getAuth(BASE + "/any-id");
+        assertEquals(404, resp.statusCode());
+    }
+}

--- a/saiku-launcher/src/test/java/org/saiku/launcher/it/DrillthroughIT.java
+++ b/saiku-launcher/src/test/java/org/saiku/launcher/it/DrillthroughIT.java
@@ -31,16 +31,12 @@ public class DrillthroughIT {
     }
 
     @Test
-    public void mdxDrillthrough_classCastException_pinnedBug() throws Exception {
-        // FINDING (real bug, pinned): Submitting raw DRILLTHROUGH MDX to
-        // /api/query/execute throws
-        //   ClassCastException: mondrian.olap.DrillThrough cannot be cast to mondrian.olap.Query
-        // The endpoint's isMdxDrillthrough() branch is supposed to route
-        // around this with thinQueryService.drillthrough(ThinQuery), but
-        // some path still hits a Query-typed cast on the underlying
-        // QueryPart. Pinned so a fix in ThinQueryService.execute/drillthrough
-        // is a deliberate testable change. SPA users of the drillthrough
-        // MDX path will see an inline error envelope until this is fixed.
+    public void mdxDrillthrough_returnsCellSetWithoutClassCastException() throws Exception {
+        // saiku#861 fix: raw DRILLTHROUGH MDX now routes through
+        // thinQueryService.drillthrough(ThinQuery) — the type-defaulting
+        // guard in Query2Resource.execute lets isMdxDrillthrough() detect
+        // the statement even when the JSON body omits the explicit
+        // {"type": "MDX"} field.
         String body =
                 """
                 {
@@ -59,21 +55,21 @@ public class DrillthroughIT {
         assertEquals(200, resp.statusCode());
         JsonNode r = harness.parse(resp);
         assertTrue(
-                "error envelope must carry the ClassCastException — pinning until fix",
-                r.path("error").asText().contains("ClassCastException")
-                        && r.path("error").asText().contains("DrillThrough"));
+                "drillthrough body must NOT carry an error: "
+                        + resp.body().substring(0, Math.min(300, resp.body().length())),
+                r.path("error").isMissingNode() || r.path("error").isNull());
+        // The cellset surface for drillthrough carries the row tuples.
+        assertTrue("drillthrough body should include a cellset/runtime field", r.has("cellset") || r.has("runtime"));
     }
 
     @Test
-    public void asyncDrillthrough_currentlyRejectsAsyncQueryIds_pinned() throws Exception {
-        // FINDING (pinned, not asserted as desired): AI Query drillthrough
-        // doesn't accept queryIds from /execute-async. The underlying handle
-        // resolves to a ThinQuery name that ThinQueryService no longer has
-        // a live context for, so the resource returns 404 with an
-        // "Unknown queryId" envelope. The SPA workflow expects to drillthrough
-        // INTO an async result — this gap means a chart-cell drill on a
-        // long-running query falls through to a re-execute. Pinned so a fix
-        // is testable.
+    public void asyncDrillthrough_resolvesAcrossSessions_saiku862() throws Exception {
+        // saiku#862 fix: drillthrough on an async queryId now re-attaches
+        // the handle's ThinQuery + CellSet to the current session's
+        // ThinQueryService context before invoking drillthrough(name, …).
+        // Previously a cross-session call (e.g. Basic auth without a shared
+        // cookie jar) returned 404 "Unknown queryId" even though the handle
+        // was live.
         String body =
                 """
                 {
@@ -93,14 +89,15 @@ public class DrillthroughIT {
             Thread.sleep(100);
         }
         HttpResponse<String> drill = harness.getAuth(AI + "/query/" + queryId + "/drillthrough?maxrows=5");
-        assertEquals("current observed status — drillthrough rejects async queryIds", 404, drill.statusCode());
-        JsonNode body2 = harness.parse(drill);
-        assertEquals("VALIDATION_ERROR", body2.path("status").asText());
-        assertEquals("queryId", body2.path("field").asText());
+        assertEquals(
+                "drillthrough should succeed after re-attachment, got " + drill.statusCode() + " body=" + drill.body(),
+                200,
+                drill.statusCode());
     }
 
     @Test
-    public void asyncDrillthroughColumns_alsoRejects_pinned() throws Exception {
+    public void asyncDrillthroughColumns_resolvesAcrossSessions() throws Exception {
+        // Same saiku#862 fix applied to the columns-discovery endpoint.
         String body =
                 """
                 {
@@ -120,8 +117,11 @@ public class DrillthroughIT {
             Thread.sleep(100);
         }
         HttpResponse<String> cols = harness.getAuth(AI + "/query/" + queryId + "/drillthrough/columns");
-        // Same root cause; pin the observed behaviour.
-        assertNotEquals("auth reaches the endpoint (no 401)", 401, cols.statusCode());
+        assertEquals(
+                "drillthrough columns should be 200 after re-attachment, got " + cols.statusCode() + " body="
+                        + cols.body(),
+                200,
+                cols.statusCode());
     }
 
     @Test

--- a/saiku-launcher/src/test/java/org/saiku/launcher/it/DrillthroughIT.java
+++ b/saiku-launcher/src/test/java/org/saiku/launcher/it/DrillthroughIT.java
@@ -1,0 +1,135 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.launcher.it;
+
+import static org.junit.Assert.*;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ * Drill-through is the single feature users ask Saiku to do most often —
+ * pull the raw fact rows behind a measure cell. Both the legacy
+ * {@code Query2Resource.execute} (DRILLTHROUGH MDX → SQL) and the new
+ * AI-Query async drill-through path go through {@code ThinQueryService}, so
+ * regressions are very easy to miss without an end-to-end IT.
+ */
+public class DrillthroughIT {
+
+    private static SaikuItHarness harness;
+    private static final String CUBE = "unknown_foodmart/FoodMart/FoodMart/Sales";
+    private static final String AI = "/rest/saiku/api/ai";
+
+    @BeforeClass
+    public static void boot() throws Exception {
+        harness = SaikuItHarness.shared();
+    }
+
+    @Test
+    public void mdxDrillthrough_classCastException_pinnedBug() throws Exception {
+        // FINDING (real bug, pinned): Submitting raw DRILLTHROUGH MDX to
+        // /api/query/execute throws
+        //   ClassCastException: mondrian.olap.DrillThrough cannot be cast to mondrian.olap.Query
+        // The endpoint's isMdxDrillthrough() branch is supposed to route
+        // around this with thinQueryService.drillthrough(ThinQuery), but
+        // some path still hits a Query-typed cast on the underlying
+        // QueryPart. Pinned so a fix in ThinQueryService.execute/drillthrough
+        // is a deliberate testable change. SPA users of the drillthrough
+        // MDX path will see an inline error envelope until this is fixed.
+        String body =
+                """
+                {
+                  "name": "drill-it-1",
+                  "cube": {
+                    "connection": "unknown_foodmart",
+                    "catalog": "FoodMart",
+                    "schema": "FoodMart",
+                    "name": "Sales",
+                    "uniqueName": "[Sales]"
+                  },
+                  "mdx": "DRILLTHROUGH MAXROWS 5 SELECT FROM [Sales] WHERE ([Measures].[Store Sales], [Product].[Products].[Drink])"
+                }
+                """;
+        HttpResponse<String> resp = harness.postAuthJson("/rest/saiku/api/query/execute", body);
+        assertEquals(200, resp.statusCode());
+        JsonNode r = harness.parse(resp);
+        assertTrue(
+                "error envelope must carry the ClassCastException — pinning until fix",
+                r.path("error").asText().contains("ClassCastException")
+                        && r.path("error").asText().contains("DrillThrough"));
+    }
+
+    @Test
+    public void asyncDrillthrough_currentlyRejectsAsyncQueryIds_pinned() throws Exception {
+        // FINDING (pinned, not asserted as desired): AI Query drillthrough
+        // doesn't accept queryIds from /execute-async. The underlying handle
+        // resolves to a ThinQuery name that ThinQueryService no longer has
+        // a live context for, so the resource returns 404 with an
+        // "Unknown queryId" envelope. The SPA workflow expects to drillthrough
+        // INTO an async result — this gap means a chart-cell drill on a
+        // long-running query falls through to a re-execute. Pinned so a fix
+        // is testable.
+        String body =
+                """
+                {
+                  "cube": "%s",
+                  "measures": [{"name": "Store Sales"}],
+                  "rows": [{"dimension": "Product", "hierarchy": "Products", "level": "Product Family"}]
+                }
+                """
+                        .formatted(CUBE);
+        HttpResponse<String> submit = harness.postAuthJson(AI + "/query/execute-async", body);
+        assertEquals(202, submit.statusCode());
+        String queryId = harness.parse(submit).path("queryId").asText();
+        long deadline = System.currentTimeMillis() + Duration.ofSeconds(30).toMillis();
+        while (System.currentTimeMillis() < deadline) {
+            HttpResponse<String> status = harness.getAuth(AI + "/query/status/" + queryId);
+            if ("DONE".equals(harness.parse(status).path("status").asText())) break;
+            Thread.sleep(100);
+        }
+        HttpResponse<String> drill = harness.getAuth(AI + "/query/" + queryId + "/drillthrough?maxrows=5");
+        assertEquals("current observed status — drillthrough rejects async queryIds", 404, drill.statusCode());
+        JsonNode body2 = harness.parse(drill);
+        assertEquals("VALIDATION_ERROR", body2.path("status").asText());
+        assertEquals("queryId", body2.path("field").asText());
+    }
+
+    @Test
+    public void asyncDrillthroughColumns_alsoRejects_pinned() throws Exception {
+        String body =
+                """
+                {
+                  "cube": "%s",
+                  "measures": [{"name": "Store Sales"}],
+                  "rows": [{"dimension": "Product", "hierarchy": "Products", "level": "Product Family"}]
+                }
+                """
+                        .formatted(CUBE);
+        HttpResponse<String> submit = harness.postAuthJson(AI + "/query/execute-async", body);
+        assertEquals(202, submit.statusCode());
+        String queryId = harness.parse(submit).path("queryId").asText();
+        long deadline = System.currentTimeMillis() + Duration.ofSeconds(30).toMillis();
+        while (System.currentTimeMillis() < deadline) {
+            HttpResponse<String> status = harness.getAuth(AI + "/query/status/" + queryId);
+            if ("DONE".equals(harness.parse(status).path("status").asText())) break;
+            Thread.sleep(100);
+        }
+        HttpResponse<String> cols = harness.getAuth(AI + "/query/" + queryId + "/drillthrough/columns");
+        // Same root cause; pin the observed behaviour.
+        assertNotEquals("auth reaches the endpoint (no 401)", 401, cols.statusCode());
+    }
+
+    @Test
+    public void drillthroughOnUnknownQueryId_returns4xx() throws Exception {
+        HttpResponse<String> resp = harness.getAuth(AI + "/query/no-such-id/drillthrough");
+        // Could be 400/404/500 depending on the not-found path; assert it
+        // isn't 200 and doesn't 401 (auth works).
+        assertTrue("drillthrough on unknown id should not 200, got " + resp.statusCode(), resp.statusCode() >= 400);
+        assertNotEquals(401, resp.statusCode());
+    }
+}

--- a/saiku-launcher/src/test/java/org/saiku/launcher/it/ExporterIT.java
+++ b/saiku-launcher/src/test/java/org/saiku/launcher/it/ExporterIT.java
@@ -1,0 +1,58 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.launcher.it;
+
+import static org.junit.Assert.*;
+
+import java.net.http.HttpResponse;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ * Smoke coverage for {@code /rest/saiku/{user}/export/*}. The export
+ * endpoints depend on a saved query file in the repository, which is a
+ * heavier setup the SPA assembles client-side. Here we exercise the route
+ * surface to confirm Spring + Jersey wiring resolves, and that missing
+ * params surface as a clean error rather than a 500 with stack trace.
+ */
+public class ExporterIT {
+
+    private static SaikuItHarness harness;
+    private static final String BASE = "/rest/saiku/admin/export/saiku";
+
+    @BeforeClass
+    public static void boot() throws Exception {
+        harness = SaikuItHarness.shared();
+    }
+
+    @Test
+    public void exportXls_withoutFileParam_returnsServerError() throws Exception {
+        // The endpoint loads the named file from the repository; without one
+        // it surfaces the underlying NPE as a 500. Pin the contract so a
+        // future hardening to 400 is a deliberate change.
+        HttpResponse<String> resp = harness.getAuth(BASE + "/xls");
+        assertTrue(
+                "no-file export should be a 4xx/5xx — got " + resp.statusCode() + " body=" + resp.body(),
+                resp.statusCode() >= 400);
+    }
+
+    @Test
+    public void exportCsv_withoutFileParam_returnsServerError() throws Exception {
+        HttpResponse<String> resp = harness.getAuth(BASE + "/csv");
+        assertTrue(resp.statusCode() >= 400);
+    }
+
+    @Test
+    public void exportJson_withoutFileParam_returnsServerError() throws Exception {
+        HttpResponse<String> resp = harness.getAuth(BASE + "/json");
+        assertTrue(resp.statusCode() >= 400);
+    }
+
+    @Test
+    public void exportHtml_withoutFileParam_returnsServerError() throws Exception {
+        HttpResponse<String> resp = harness.getAuth(BASE + "/html");
+        assertTrue(resp.statusCode() >= 400);
+    }
+}

--- a/saiku-launcher/src/test/java/org/saiku/launcher/it/InfoEndpointIT.java
+++ b/saiku-launcher/src/test/java/org/saiku/launcher/it/InfoEndpointIT.java
@@ -1,0 +1,45 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.launcher.it;
+
+import static org.junit.Assert.*;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import java.net.http.HttpResponse;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ * Smoke test: the launcher comes up, the {@code /rest/saiku/info} endpoint
+ * answers, and the response body is a JSON list. This is the gating IT — if
+ * this is red, the rest of the IT surface is meaningless.
+ */
+public class InfoEndpointIT {
+
+    private static SaikuItHarness harness;
+
+    @BeforeClass
+    public static void boot() throws Exception {
+        harness = SaikuItHarness.shared();
+    }
+
+    @Test
+    public void info_returns200WithJsonArray() throws Exception {
+        HttpResponse<String> resp = harness.getAuth("/rest/saiku/info");
+        assertEquals("info should be 200, body was: " + resp.body(), 200, resp.statusCode());
+        JsonNode body = harness.parse(resp);
+        assertTrue("info body must be a JSON array (plugin list), got: " + resp.body(), body.isArray());
+    }
+
+    @Test
+    public void info_unauthenticatedAlsoAllowed() throws Exception {
+        // The /info endpoint is configured anonymous-allowed in the shipped
+        // applicationContext-spring-security-memory.xml — the SPA fetches it
+        // pre-login to render the plugin list. Lock that contract here so a
+        // tightening change is an explicit decision, not a silent regression.
+        HttpResponse<String> resp = harness.getAnon("/rest/saiku/info");
+        assertEquals(200, resp.statusCode());
+    }
+}

--- a/saiku-launcher/src/test/java/org/saiku/launcher/it/OlapDiscoverIT.java
+++ b/saiku-launcher/src/test/java/org/saiku/launcher/it/OlapDiscoverIT.java
@@ -148,13 +148,16 @@ public class OlapDiscoverIT {
     }
 
     @Test
-    public void unknownConnection_returnsEmptyArray() throws Exception {
-        // OlapDiscoverResource swallows lookup exceptions and returns []
-        // rather than 404 — that's the documented contract.
+    public void unknownConnection_returns404WithTypedEnvelope() throws Exception {
+        // saiku#867 fix: unknown connection now surfaces as 404 with
+        // {status,field,value,error} envelope rather than a silent empty
+        // array — clients can tell "no connection by this name" apart
+        // from "connection has no schemas".
         HttpResponse<String> resp = harness.getAuth(BASE + "/no-such-conn");
-        assertEquals(200, resp.statusCode());
+        assertEquals(404, resp.statusCode());
         JsonNode body = harness.parse(resp);
-        assertTrue(body.isArray());
-        assertEquals(0, body.size());
+        assertEquals("NOT_FOUND", body.path("status").asText());
+        assertEquals("connection", body.path("field").asText());
+        assertEquals("no-such-conn", body.path("value").asText());
     }
 }

--- a/saiku-launcher/src/test/java/org/saiku/launcher/it/OlapDiscoverIT.java
+++ b/saiku-launcher/src/test/java/org/saiku/launcher/it/OlapDiscoverIT.java
@@ -1,0 +1,160 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.launcher.it;
+
+import static org.junit.Assert.*;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import java.net.http.HttpResponse;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ * Coverage for the legacy discovery surface ({@code /rest/saiku/{user}/discover/*}),
+ * which the SPA uses to populate the cube tree, dimensions, hierarchies, levels
+ * and member lists. All endpoints are read-only GETs against the seeded
+ * FoodMart datasource.
+ */
+public class OlapDiscoverIT {
+
+    private static SaikuItHarness harness;
+    private static final String BASE = "/rest/saiku/admin/discover";
+    private static final String FOODMART_CUBE_PATH = "/unknown_foodmart/FoodMart/FoodMart/Sales";
+
+    @BeforeClass
+    public static void boot() throws Exception {
+        harness = SaikuItHarness.shared();
+    }
+
+    @Test
+    public void listAllConnections_returnsArrayWithFoodmart() throws Exception {
+        HttpResponse<String> resp = harness.getAuth(BASE);
+        assertEquals(200, resp.statusCode());
+        JsonNode body = harness.parse(resp);
+        assertTrue("connections must be a JSON array", body.isArray());
+        boolean foodmartFound = false;
+        for (JsonNode c : body) {
+            if ("unknown_foodmart".equals(c.path("name").asText())) {
+                foodmartFound = true;
+                break;
+            }
+        }
+        assertTrue("unknown_foodmart connection must be present, body=" + resp.body(), foodmartFound);
+    }
+
+    @Test
+    public void listSingleConnection_returnsSpecifiedConnection() throws Exception {
+        HttpResponse<String> resp = harness.getAuth(BASE + "/unknown_foodmart");
+        assertEquals(200, resp.statusCode());
+        JsonNode body = harness.parse(resp);
+        assertTrue("response must be a single-element array", body.isArray());
+        assertEquals(1, body.size());
+        assertEquals("unknown_foodmart", body.get(0).path("name").asText());
+    }
+
+    @Test
+    public void refreshAllConnections_returnsArray() throws Exception {
+        HttpResponse<String> resp = harness.getAuth(BASE + "/refresh");
+        assertEquals(200, resp.statusCode());
+        JsonNode body = harness.parse(resp);
+        assertTrue("refresh response must be an array", body.isArray());
+    }
+
+    @Test
+    public void refreshSingleConnection_returnsArrayContainingIt() throws Exception {
+        HttpResponse<String> resp = harness.getAuth(BASE + "/unknown_foodmart/refresh");
+        assertEquals(200, resp.statusCode());
+        JsonNode body = harness.parse(resp);
+        assertTrue(body.isArray());
+        boolean foodmartFound = false;
+        for (JsonNode c : body) {
+            if ("unknown_foodmart".equals(c.path("name").asText())) {
+                foodmartFound = true;
+                break;
+            }
+        }
+        assertTrue("unknown_foodmart must still be in the connection list after refresh", foodmartFound);
+    }
+
+    @Test
+    public void cubeMetadata_returnsDimensionsAndMeasures() throws Exception {
+        HttpResponse<String> resp = harness.getAuth(BASE + FOODMART_CUBE_PATH + "/metadata");
+        assertEquals(200, resp.statusCode());
+        JsonNode body = harness.parse(resp);
+        // /metadata returns a CubeMetadata wrapper with dimensions + measures.
+        assertTrue("metadata body must include dimensions key", body.has("dimensions"));
+        assertTrue("metadata body must include measures key", body.has("measures"));
+    }
+
+    @Test
+    public void cubeDimensions_includesProductTimeStoreCustomer() throws Exception {
+        HttpResponse<String> resp = harness.getAuth(BASE + FOODMART_CUBE_PATH + "/dimensions");
+        assertEquals(200, resp.statusCode());
+        JsonNode body = harness.parse(resp);
+        assertTrue("dimensions must be a JSON array", body.isArray());
+
+        boolean foundProduct = false;
+        boolean foundTime = false;
+        for (JsonNode d : body) {
+            String name = d.path("name").asText();
+            if ("Product".equals(name)) foundProduct = true;
+            if ("Time".equals(name)) foundTime = true;
+        }
+        assertTrue("Product dim must be present", foundProduct);
+        assertTrue("Time dim must be present", foundTime);
+    }
+
+    @Test
+    public void dimensionDetail_productReturnsSchemaWithHierarchies() throws Exception {
+        HttpResponse<String> resp = harness.getAuth(BASE + FOODMART_CUBE_PATH + "/dimensions/Product");
+        assertEquals(200, resp.statusCode());
+        JsonNode body = harness.parse(resp);
+        assertEquals("Product", body.path("name").asText());
+    }
+
+    @Test
+    public void hierarchiesForDimension_productHasProductsHierarchy() throws Exception {
+        HttpResponse<String> resp = harness.getAuth(BASE + FOODMART_CUBE_PATH + "/dimensions/Product/hierarchies");
+        assertEquals(200, resp.statusCode());
+        JsonNode body = harness.parse(resp);
+        assertTrue(body.isArray());
+        boolean productsFound = false;
+        for (JsonNode h : body) {
+            if ("Products".equals(h.path("name").asText())) {
+                productsFound = true;
+                break;
+            }
+        }
+        assertTrue("Products hierarchy must be present, body=" + resp.body(), productsFound);
+    }
+
+    @Test
+    public void levelsForHierarchy_productsHasProductFamilyLevel() throws Exception {
+        HttpResponse<String> resp =
+                harness.getAuth(BASE + FOODMART_CUBE_PATH + "/dimensions/Product/hierarchies/Products/levels");
+        assertEquals(200, resp.statusCode());
+        JsonNode body = harness.parse(resp);
+        assertTrue(body.isArray());
+        boolean familyFound = false;
+        for (JsonNode l : body) {
+            if ("Product Family".equals(l.path("name").asText())) {
+                familyFound = true;
+                break;
+            }
+        }
+        assertTrue("Product Family level must be present", familyFound);
+    }
+
+    @Test
+    public void unknownConnection_returnsEmptyArray() throws Exception {
+        // OlapDiscoverResource swallows lookup exceptions and returns []
+        // rather than 404 — that's the documented contract.
+        HttpResponse<String> resp = harness.getAuth(BASE + "/no-such-conn");
+        assertEquals(200, resp.statusCode());
+        JsonNode body = harness.parse(resp);
+        assertTrue(body.isArray());
+        assertEquals(0, body.size());
+    }
+}

--- a/saiku-launcher/src/test/java/org/saiku/launcher/it/Query2AdvancedIT.java
+++ b/saiku-launcher/src/test/java/org/saiku/launcher/it/Query2AdvancedIT.java
@@ -38,13 +38,18 @@ public class Query2AdvancedIT {
     }
 
     @Test
-    public void levelMembers_resolveRoute_pinned204() throws Exception {
-        // FINDING (pinned): the level-members metadata route resolves but
-        // returns 204 (No Content) instead of the expected JSON array. The
-        // SPA relies on this for the slicer dropdown — a 204 means the
-        // dropdown stays empty. Likely a name-encoding mismatch between the
-        // path param shape and ThinQueryService.getResultMetadataMembers.
-        // Pinned so a fix is testable.
+    public void levelMembers_returns404WithTypedEnvelopeWhenSessionDiscontinuous() throws Exception {
+        // saiku#863 fix: the level-members metadata endpoint now returns
+        // a typed 404 envelope when the query name isn't in the current
+        // session's ThinQueryService context, instead of the previous
+        // silent 204 No Content. The 204 was indistinguishable from
+        // "level has no members" — the typed envelope tells clients
+        // exactly what went wrong and how to recover.
+        //
+        // Under Basic auth with no shared cookie jar (this harness's
+        // setup), every request creates a new session, so the query
+        // posted in the helper above isn't in *this* request's context.
+        // The 404 envelope is the documented correct response.
         String name = "q2-meta-" + System.nanoTime();
         executeProductFamilyQuery(name);
 
@@ -54,7 +59,11 @@ public class Query2AdvancedIT {
                 + "/levels/"
                 + URLEncoder.encode("[Product].[Products].[Product Family]", StandardCharsets.UTF_8);
         HttpResponse<String> resp = harness.getAuth(url);
-        assertEquals("current observed: 204 No Content", 204, resp.statusCode());
+        assertEquals(404, resp.statusCode());
+        JsonNode body = harness.parse(resp);
+        assertEquals("NOT_FOUND", body.path("status").asText());
+        assertEquals("queryname", body.path("field").asText());
+        assertEquals(name, body.path("value").asText());
     }
 
     @Test

--- a/saiku-launcher/src/test/java/org/saiku/launcher/it/Query2AdvancedIT.java
+++ b/saiku-launcher/src/test/java/org/saiku/launcher/it/Query2AdvancedIT.java
@@ -1,0 +1,164 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.launcher.it;
+
+import static org.junit.Assert.*;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import java.net.URLEncoder;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ * Advanced Saiku query features users hit but unit tests rarely exercise:
+ * <ul>
+ *   <li>Zoom-in (drilling down a member by cell position)</li>
+ *   <li>Drill-across (re-running the slicer through another cube context)</li>
+ *   <li>Result-metadata level members (slicer member lookup)</li>
+ *   <li>Query enrich (axis re-projection)</li>
+ *   <li>MDX → cellset → metadata round trip</li>
+ * </ul>
+ * All tests use the legacy Query2Resource because that's where these features
+ * live; the AI-Query API doesn't expose drill-across or zoom semantics.
+ *
+ * <p>Each test first executes a named MDX query so subsequent calls can look
+ * it up by name in the per-session ThinQuery cache.
+ */
+public class Query2AdvancedIT {
+
+    private static SaikuItHarness harness;
+
+    @BeforeClass
+    public static void boot() throws Exception {
+        harness = SaikuItHarness.shared();
+    }
+
+    @Test
+    public void levelMembers_resolveRoute_pinned204() throws Exception {
+        // FINDING (pinned): the level-members metadata route resolves but
+        // returns 204 (No Content) instead of the expected JSON array. The
+        // SPA relies on this for the slicer dropdown — a 204 means the
+        // dropdown stays empty. Likely a name-encoding mismatch between the
+        // path param shape and ThinQueryService.getResultMetadataMembers.
+        // Pinned so a fix is testable.
+        String name = "q2-meta-" + System.nanoTime();
+        executeProductFamilyQuery(name);
+
+        String url = "/rest/saiku/api/query/"
+                + name + "/result/metadata/hierarchies/"
+                + URLEncoder.encode("[Product].[Products]", StandardCharsets.UTF_8)
+                + "/levels/"
+                + URLEncoder.encode("[Product].[Products].[Product Family]", StandardCharsets.UTF_8);
+        HttpResponse<String> resp = harness.getAuth(url);
+        assertEquals("current observed: 204 No Content", 204, resp.statusCode());
+    }
+
+    @Test
+    public void executeQueryThenEnrich_returnsAxisProjection() throws Exception {
+        String name = "q2-enrich-" + System.nanoTime();
+        executeProductFamilyQuery(name);
+
+        // /enrich projects the query's axes for the UI.
+        String enrichBody =
+                """
+                {
+                  "name": "%s",
+                  "cube": {
+                    "connection": "unknown_foodmart",
+                    "catalog": "FoodMart",
+                    "schema": "FoodMart",
+                    "name": "Sales",
+                    "uniqueName": "[Sales]"
+                  },
+                  "mdx": "SELECT NON EMPTY {[Measures].[Store Sales]} ON COLUMNS, NON EMPTY {[Product].[Products].[Product Family].Members} ON ROWS FROM [Sales]"
+                }
+                """
+                        .formatted(name);
+        HttpResponse<String> resp = harness.postAuthJson("/rest/saiku/api/query/enrich", enrichBody);
+        assertEquals("enrich should be 200, got " + resp.statusCode() + " body=" + resp.body(), 200, resp.statusCode());
+        JsonNode body = harness.parse(resp);
+        // Enrich returns a ThinQuery with queryModel populated.
+        assertEquals(name, body.path("name").asText());
+    }
+
+    @Test
+    public void zoomIn_byCellPosition_returnsRefinedQuery() throws Exception {
+        String name = "q2-zoom-" + System.nanoTime();
+        executeProductFamilyQuery(name);
+
+        // zoomIn takes a selections form-param of "row:col" position pairs
+        // encoded as a JSON array string. Position [0,0] is the first data row.
+        String form = "selections=" + URLEncoder.encode("[\"0:0\"]", StandardCharsets.UTF_8);
+        HttpResponse<String> resp = harness.postAuthForm("/rest/saiku/api/query/" + name + "/zoomin", form);
+        // 200 or 5xx are both pinnable; we just want to verify the route
+        // resolves and Saiku attempts the operation rather than 404ing.
+        assertNotEquals("zoomin route must resolve (no 404)", 404, resp.statusCode());
+        assertNotEquals("zoomin auth must pass (no 401)", 401, resp.statusCode());
+    }
+
+    @Test
+    public void drillacross_byCellPosition_routeResolves() throws Exception {
+        String name = "q2-across-" + System.nanoTime();
+        executeProductFamilyQuery(name);
+
+        // drillacross POST form with `position` + `drill`. Position points
+        // at a row/col tuple; drill is a hierarchy spec.
+        String form = "position="
+                + URLEncoder.encode("0:0", StandardCharsets.UTF_8)
+                + "&drill="
+                + URLEncoder.encode("[Time].[Time].[Quarter]", StandardCharsets.UTF_8);
+        HttpResponse<String> resp = harness.postAuthForm("/rest/saiku/api/query/" + name + "/drillacross", form);
+        assertNotEquals("drillacross route must resolve (no 404)", 404, resp.statusCode());
+        assertNotEquals("drillacross auth must pass (no 401)", 401, resp.statusCode());
+    }
+
+    @Test
+    public void deleteQueryByName_returnsGoneOrOk() throws Exception {
+        String name = "q2-delete-" + System.nanoTime();
+        executeProductFamilyQuery(name);
+
+        HttpResponse<String> resp = harness.deleteAuth("/rest/saiku/api/query/" + name);
+        // Status.GONE = 410 in JAX-RS; some setups return 200 as a wrapper.
+        assertTrue(
+                "delete should be 200/204/410, got " + resp.statusCode(),
+                resp.statusCode() == 200 || resp.statusCode() == 204 || resp.statusCode() == 410);
+    }
+
+    @Test
+    public void cancelExistingQuery_succeeds() throws Exception {
+        String name = "q2-cancel-" + System.nanoTime();
+        executeProductFamilyQuery(name);
+
+        HttpResponse<String> resp = harness.deleteAuth("/rest/saiku/api/query/" + name + "/cancel");
+        assertEquals(200, resp.statusCode());
+    }
+
+    // ---------------------------------------------------------------- helpers
+
+    private void executeProductFamilyQuery(String name) throws Exception {
+        String body =
+                """
+                {
+                  "name": "%s",
+                  "cube": {
+                    "connection": "unknown_foodmart",
+                    "catalog": "FoodMart",
+                    "schema": "FoodMart",
+                    "name": "Sales",
+                    "uniqueName": "[Sales]"
+                  },
+                  "mdx": "SELECT NON EMPTY {[Measures].[Store Sales]} ON COLUMNS, NON EMPTY {[Product].[Products].[Product Family].Members} ON ROWS FROM [Sales]"
+                }
+                """
+                        .formatted(name);
+        HttpResponse<String> exec = harness.postAuthJson("/rest/saiku/api/query/execute", body);
+        assertEquals(
+                "setup execute should succeed, got " + exec.statusCode() + " body=" + exec.body(),
+                200,
+                exec.statusCode());
+    }
+}

--- a/saiku-launcher/src/test/java/org/saiku/launcher/it/Query2ResourceIT.java
+++ b/saiku-launcher/src/test/java/org/saiku/launcher/it/Query2ResourceIT.java
@@ -1,0 +1,96 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.launcher.it;
+
+import static org.junit.Assert.*;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import java.net.http.HttpResponse;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ * Coverage for the legacy MDX query surface ({@code /rest/saiku/api/query/*}).
+ * The SPA uses {@code /execute} to run raw MDX strings and {@code /enrich}
+ * to project a query model onto axes for visualisation.
+ *
+ * <p>FoodMart Sales cube is the workhorse — every query body references it
+ * via the seed datasource catalog.
+ */
+public class Query2ResourceIT {
+
+    private static SaikuItHarness harness;
+
+    @BeforeClass
+    public static void boot() throws Exception {
+        harness = SaikuItHarness.shared();
+    }
+
+    @Test
+    public void executeMdx_returnsCellSetWithMetadata() throws Exception {
+        String body =
+                """
+                {
+                  "name": "it-execute-1",
+                  "cube": {
+                    "connection": "unknown_foodmart",
+                    "catalog": "FoodMart",
+                    "schema": "FoodMart",
+                    "name": "Sales",
+                    "uniqueName": "[Sales]"
+                  },
+                  "mdx": "SELECT NON EMPTY {[Measures].[Store Sales]} ON COLUMNS, NON EMPTY {[Product].[Products].[Product Family].Members} ON ROWS FROM [Sales]"
+                }
+                """;
+        HttpResponse<String> resp = harness.postAuthJson("/rest/saiku/api/query/execute", body);
+        assertEquals("expected 200, got " + resp.statusCode() + " body=" + resp.body(), 200, resp.statusCode());
+        JsonNode r = harness.parse(resp);
+        // Returned QueryResult has cellset + query metadata.
+        assertTrue("response should have a cellset field", r.has("cellset"));
+        assertTrue("cellset must be a JSON array", r.path("cellset").isArray());
+        assertTrue(
+                "cellset must contain at least header + 3 product families",
+                r.path("cellset").size() >= 4);
+    }
+
+    @Test
+    public void executeMdx_unknownMeasure_returnsQueryResultWithErrorField() throws Exception {
+        // Query2Resource.execute catches Mondrian exceptions and returns
+        // 200 with a QueryResult body whose 'error' field carries the
+        // underlying message. SPA renders this as an inline error.
+        String body =
+                """
+                {
+                  "name": "it-execute-bad",
+                  "cube": {
+                    "connection": "unknown_foodmart",
+                    "catalog": "FoodMart",
+                    "schema": "FoodMart",
+                    "name": "Sales",
+                    "uniqueName": "[Sales]"
+                  },
+                  "mdx": "SELECT {[Measures].[Made Up Measure]} ON COLUMNS FROM [Sales]"
+                }
+                """;
+        HttpResponse<String> resp = harness.postAuthJson("/rest/saiku/api/query/execute", body);
+        assertEquals(200, resp.statusCode());
+        JsonNode r = harness.parse(resp);
+        assertFalse(
+                "response should carry an 'error' field for bad MDX",
+                r.path("error").isMissingNode());
+        assertTrue(
+                "error must mention the bad measure name",
+                r.path("error").asText().contains("Made Up Measure"));
+    }
+
+    @Test
+    public void cancelNonexistentQuery_is200_idempotent() throws Exception {
+        // Cancel is idempotent at the service layer — cancelling a name with
+        // no live cellset is a no-op rather than an error. Pin that contract
+        // so an accidental tighten-to-404 is caught.
+        HttpResponse<String> resp = harness.deleteAuth("/rest/saiku/api/query/no-such-query/cancel");
+        assertEquals(200, resp.statusCode());
+    }
+}

--- a/saiku-launcher/src/test/java/org/saiku/launcher/it/RepositoryIT.java
+++ b/saiku-launcher/src/test/java/org/saiku/launcher/it/RepositoryIT.java
@@ -1,0 +1,77 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.launcher.it;
+
+import static org.junit.Assert.*;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import java.net.URLEncoder;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ * Coverage for {@code /rest/saiku/api/repository/*} — file storage surface
+ * the SPA uses for saved queries and dashboards.
+ *
+ * <p>The repository endpoints depend on a Spring Security session. With Basic
+ * auth, Spring populates the SecurityContext per-request, which Saiku's
+ * ISessionService projects into the {@code username} / {@code roles} keys
+ * that BasicRepositoryResource2 relies on.
+ */
+public class RepositoryIT {
+
+    private static SaikuItHarness harness;
+    private static final String BASE = "/rest/saiku/api/repository";
+
+    @BeforeClass
+    public static void boot() throws Exception {
+        harness = SaikuItHarness.shared();
+    }
+
+    @Test
+    public void getRepositoryRoot_returns200() throws Exception {
+        HttpResponse<String> resp = harness.getAuth(BASE);
+        assertEquals("repository root must return 200, got " + resp.statusCode(), 200, resp.statusCode());
+        JsonNode body = harness.parse(resp);
+        assertTrue("repository root must be a JSON array", body.isArray());
+    }
+
+    @Test
+    public void saveAndReadAndDeleteResource_endToEnd() throws Exception {
+        String name = "/homes/home:admin/it-test-resource-" + System.nanoTime() + ".saiku";
+        String content = "{\"it-marker\":\"hello-world\"}";
+
+        // Save
+        String form = "file="
+                + URLEncoder.encode(name, StandardCharsets.UTF_8)
+                + "&content="
+                + URLEncoder.encode(content, StandardCharsets.UTF_8);
+        HttpResponse<String> save = harness.postAuthForm(BASE + "/resource", form);
+        // 200 on success; if the in-memory session shape doesn't expose
+        // username/roles the endpoint NPEs with 500 — pin both cases.
+        assertTrue(
+                "save should be 200 or 500 (session-dependent), got " + save.statusCode() + " body=" + save.body(),
+                save.statusCode() == 200 || save.statusCode() == 500);
+
+        if (save.statusCode() != 200) {
+            // Session-bound endpoint can't run under stateless Basic auth in
+            // every config; skip the rest rather than fail noisily.
+            return;
+        }
+
+        // Read
+        HttpResponse<String> read =
+                harness.getAuth(BASE + "/resource?file=" + URLEncoder.encode(name, StandardCharsets.UTF_8));
+        assertEquals(200, read.statusCode());
+        assertEquals(content, read.body());
+
+        // Delete
+        HttpResponse<String> del =
+                harness.deleteAuth(BASE + "/resource?file=" + URLEncoder.encode(name, StandardCharsets.UTF_8));
+        assertEquals(200, del.statusCode());
+    }
+}

--- a/saiku-launcher/src/test/java/org/saiku/launcher/it/RepositoryIT.java
+++ b/saiku-launcher/src/test/java/org/saiku/launcher/it/RepositoryIT.java
@@ -51,11 +51,15 @@ public class RepositoryIT {
                 + "&content="
                 + URLEncoder.encode(content, StandardCharsets.UTF_8);
         HttpResponse<String> save = harness.postAuthForm(BASE + "/resource", form);
-        // 200 on success; if the in-memory session shape doesn't expose
-        // username/roles the endpoint NPEs with 500 — pin both cases.
+        // 200 on success; under stateless Basic auth the in-memory session
+        // shape doesn't expose username/roles and the endpoint NPEs.
+        // saiku#865 fix: the NPE is now translated by the
+        // GenericFailureExceptionMapper into a 400 BAD_REQUEST envelope
+        // ("Required parameter missing or null") instead of a 500 HTML
+        // page. Pin both the happy 200 and the 400-envelope cases.
         assertTrue(
-                "save should be 200 or 500 (session-dependent), got " + save.statusCode() + " body=" + save.body(),
-                save.statusCode() == 200 || save.statusCode() == 500);
+                "save should be 200 or 400 (session-dependent), got " + save.statusCode() + " body=" + save.body(),
+                save.statusCode() == 200 || save.statusCode() == 400);
 
         if (save.statusCode() != 200) {
             // Session-bound endpoint can't run under stateless Basic auth in

--- a/saiku-launcher/src/test/java/org/saiku/launcher/it/SaikuItHarness.java
+++ b/saiku-launcher/src/test/java/org/saiku/launcher/it/SaikuItHarness.java
@@ -147,8 +147,53 @@ public final class SaikuItHarness {
                 HttpResponse.BodyHandlers.ofString());
     }
 
+    /** Issue a DELETE against {@code path} with admin Basic auth. */
+    public HttpResponse<String> deleteAuth(String path) throws Exception {
+        return http.send(
+                HttpRequest.newBuilder(URI.create(baseUrl + path))
+                        .timeout(HTTP_TIMEOUT)
+                        .header("Authorization", adminBasicAuth)
+                        .DELETE()
+                        .build(),
+                HttpResponse.BodyHandlers.ofString());
+    }
+
+    /** Issue a PUT against {@code path} with admin Basic auth + JSON body. */
+    public HttpResponse<String> putAuthJson(String path, String body) throws Exception {
+        return http.send(
+                HttpRequest.newBuilder(URI.create(baseUrl + path))
+                        .timeout(HTTP_TIMEOUT)
+                        .header("Authorization", adminBasicAuth)
+                        .header("Accept", "application/json")
+                        .header("Content-Type", "application/json")
+                        .PUT(HttpRequest.BodyPublishers.ofString(body, StandardCharsets.UTF_8))
+                        .build(),
+                HttpResponse.BodyHandlers.ofString());
+    }
+
+    /** Issue a POST against {@code path} with admin Basic auth + form-encoded body. */
+    public HttpResponse<String> postAuthForm(String path, String formBody) throws Exception {
+        return http.send(
+                HttpRequest.newBuilder(URI.create(baseUrl + path))
+                        .timeout(HTTP_TIMEOUT)
+                        .header("Authorization", adminBasicAuth)
+                        .header("Content-Type", "application/x-www-form-urlencoded")
+                        .POST(HttpRequest.BodyPublishers.ofString(formBody, StandardCharsets.UTF_8))
+                        .build(),
+                HttpResponse.BodyHandlers.ofString());
+    }
+
+    /** Generic send escape hatch — for tests that need to roll their own request. */
+    public HttpResponse<String> send(HttpRequest req) throws Exception {
+        return http.send(req, HttpResponse.BodyHandlers.ofString());
+    }
+
     public JsonNode parse(HttpResponse<String> resp) throws Exception {
         return MAPPER.readTree(resp.body());
+    }
+
+    public String adminBasicAuth() {
+        return adminBasicAuth;
     }
 
     private void stopQuietly() {

--- a/saiku-launcher/src/test/java/org/saiku/launcher/it/SaikuItHarness.java
+++ b/saiku-launcher/src/test/java/org/saiku/launcher/it/SaikuItHarness.java
@@ -123,17 +123,24 @@ public final class SaikuItHarness {
                 HttpResponse.BodyHandlers.ofString());
     }
 
-    /** Issue a POST against {@code path} with admin Basic auth + JSON body. */
+    /** Issue a POST against {@code path} with admin Basic auth + JSON body.
+     *  Retries once on the JDK HttpClient's transient
+     *  "HTTP/1.1 header parser received no bytes" — observed sporadically
+     *  when many tests share the same client across a short window. */
     public HttpResponse<String> postAuthJson(String path, String body) throws Exception {
-        return http.send(
-                HttpRequest.newBuilder(URI.create(baseUrl + path))
-                        .timeout(HTTP_TIMEOUT)
-                        .header("Authorization", adminBasicAuth)
-                        .header("Accept", "application/json")
-                        .header("Content-Type", "application/json")
-                        .POST(HttpRequest.BodyPublishers.ofString(body, StandardCharsets.UTF_8))
-                        .build(),
-                HttpResponse.BodyHandlers.ofString());
+        HttpRequest req = HttpRequest.newBuilder(URI.create(baseUrl + path))
+                .timeout(HTTP_TIMEOUT)
+                .header("Authorization", adminBasicAuth)
+                .header("Accept", "application/json")
+                .header("Content-Type", "application/json")
+                .POST(HttpRequest.BodyPublishers.ofString(body, StandardCharsets.UTF_8))
+                .build();
+        try {
+            return http.send(req, HttpResponse.BodyHandlers.ofString());
+        } catch (java.io.IOException ioe) {
+            Thread.sleep(100);
+            return http.send(req, HttpResponse.BodyHandlers.ofString());
+        }
     }
 
     /** Issue a GET against {@code path} without auth — used for testing the 401 path. */

--- a/saiku-launcher/src/test/java/org/saiku/launcher/it/SaikuItHarness.java
+++ b/saiku-launcher/src/test/java/org/saiku/launcher/it/SaikuItHarness.java
@@ -1,0 +1,160 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.launcher.it;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.Base64;
+import java.util.concurrent.atomic.AtomicReference;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.ServerConnector;
+import org.saiku.launcher.SaikuLauncher;
+
+/**
+ * One-shot bootstrap for the saiku-launcher Jetty + WAR stack against an
+ * ephemeral port and a temp saiku-home. Used by every {@code *IT} as a static
+ * fixture: boot once per IT suite, share across tests, tear down at the end.
+ *
+ * <p>The harness keeps the boot logic out of individual test classes so the
+ * test bodies focus on REST contract assertions. It also centralises the
+ * helper methods for issuing HTTP requests with Basic auth and parsing JSON
+ * responses.
+ *
+ * <p>Auth defaults to {@code admin/admin} — the in-memory seed user that
+ * Saiku ships with. Tests can override per-call.
+ */
+public final class SaikuItHarness {
+
+    private static final AtomicReference<SaikuItHarness> SINGLETON = new AtomicReference<>();
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+    private static final Duration HTTP_TIMEOUT = Duration.ofSeconds(60);
+
+    private final Server server;
+    private final Path home;
+    private final String baseUrl;
+    private final HttpClient http;
+    private final String adminBasicAuth;
+
+    private SaikuItHarness(Server server, Path home) {
+        this.server = server;
+        this.home = home;
+        int port = ((ServerConnector) server.getConnectors()[0]).getLocalPort();
+        this.baseUrl = "http://127.0.0.1:" + port;
+        this.http = HttpClient.newBuilder()
+                .connectTimeout(Duration.ofSeconds(5))
+                .followRedirects(HttpClient.Redirect.NORMAL)
+                .build();
+        this.adminBasicAuth =
+                "Basic " + Base64.getEncoder().encodeToString("admin:admin".getBytes(StandardCharsets.UTF_8));
+    }
+
+    /**
+     * Boot the harness if it isn't already running, returning the singleton.
+     * Concurrent callers race-safely — only one actual boot occurs.
+     */
+    public static synchronized SaikuItHarness shared() throws Exception {
+        SaikuItHarness existing = SINGLETON.get();
+        if (existing != null) {
+            return existing;
+        }
+        Path home = Files.createTempDirectory("saiku-it-");
+        // Boot port=0 → OS picks an ephemeral port. Host 127.0.0.1 to avoid
+        // firewall prompts on macOS CI runners.
+        Server server = SaikuLauncher.ServeCommand.bootServer(0, "127.0.0.1", "/", home);
+        SaikuItHarness h = new SaikuItHarness(server, home);
+        // Block until the webapp finishes its Spring init. Without this, the
+        // first test races against Spring's bean wiring and gets a 503.
+        h.waitForReady();
+        SINGLETON.set(h);
+        // Shut down at JVM exit (failsafe forks a reusable JVM per test class).
+        Runtime.getRuntime().addShutdownHook(new Thread(h::stopQuietly));
+        return h;
+    }
+
+    private void waitForReady() throws Exception {
+        long deadline = System.currentTimeMillis() + Duration.ofMinutes(2).toMillis();
+        Exception last = null;
+        while (System.currentTimeMillis() < deadline) {
+            try {
+                HttpResponse<String> resp = http.send(
+                        HttpRequest.newBuilder(URI.create(baseUrl + "/rest/saiku/info"))
+                                .timeout(Duration.ofSeconds(5))
+                                .GET()
+                                .build(),
+                        HttpResponse.BodyHandlers.ofString());
+                if (resp.statusCode() < 500) {
+                    return; // Spring has finished wiring beans.
+                }
+            } catch (Exception e) {
+                last = e;
+            }
+            Thread.sleep(500);
+        }
+        throw new IllegalStateException("Saiku failed to become ready within 2 minutes", last);
+    }
+
+    public String baseUrl() {
+        return baseUrl;
+    }
+
+    public Path home() {
+        return home;
+    }
+
+    /** Issue a GET against {@code path} with admin Basic auth. */
+    public HttpResponse<String> getAuth(String path) throws Exception {
+        return http.send(
+                HttpRequest.newBuilder(URI.create(baseUrl + path))
+                        .timeout(HTTP_TIMEOUT)
+                        .header("Authorization", adminBasicAuth)
+                        .header("Accept", "application/json")
+                        .GET()
+                        .build(),
+                HttpResponse.BodyHandlers.ofString());
+    }
+
+    /** Issue a POST against {@code path} with admin Basic auth + JSON body. */
+    public HttpResponse<String> postAuthJson(String path, String body) throws Exception {
+        return http.send(
+                HttpRequest.newBuilder(URI.create(baseUrl + path))
+                        .timeout(HTTP_TIMEOUT)
+                        .header("Authorization", adminBasicAuth)
+                        .header("Accept", "application/json")
+                        .header("Content-Type", "application/json")
+                        .POST(HttpRequest.BodyPublishers.ofString(body, StandardCharsets.UTF_8))
+                        .build(),
+                HttpResponse.BodyHandlers.ofString());
+    }
+
+    /** Issue a GET against {@code path} without auth — used for testing the 401 path. */
+    public HttpResponse<String> getAnon(String path) throws Exception {
+        return http.send(
+                HttpRequest.newBuilder(URI.create(baseUrl + path))
+                        .timeout(HTTP_TIMEOUT)
+                        .header("Accept", "application/json")
+                        .GET()
+                        .build(),
+                HttpResponse.BodyHandlers.ofString());
+    }
+
+    public JsonNode parse(HttpResponse<String> resp) throws Exception {
+        return MAPPER.readTree(resp.body());
+    }
+
+    private void stopQuietly() {
+        try {
+            server.stop();
+        } catch (Exception ignored) {
+        }
+    }
+}

--- a/saiku-launcher/src/test/java/org/saiku/launcher/it/SessionIT.java
+++ b/saiku-launcher/src/test/java/org/saiku/launcher/it/SessionIT.java
@@ -1,0 +1,84 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.launcher.it;
+
+import static org.junit.Assert.*;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import java.net.URI;
+import java.net.URLEncoder;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ * Coverage for {@code /rest/saiku/session/*} — the REST-form-encoded session
+ * surface that the SPA uses for login/logout.
+ *
+ * <p>Form-login goes through Spring Security's filter chain which also
+ * accepts Basic auth, so the REST {@code /session} endpoint just verifies the
+ * already-authenticated context (or returns 401 if anon).
+ */
+public class SessionIT {
+
+    private static SaikuItHarness harness;
+
+    @BeforeClass
+    public static void boot() throws Exception {
+        harness = SaikuItHarness.shared();
+    }
+
+    @Test
+    public void getSession_withBasicAuth_returns200WithJsonBody() throws Exception {
+        // Basic auth doesn't establish an HTTP session; the SessionService's
+        // session-objects map is empty for stateless requests so the body
+        // surfaces just the language injected by the resource. Pin that 200
+        // is still returned so the SPA's pre-login probe doesn't break.
+        HttpResponse<String> resp = harness.getAuth("/rest/saiku/session");
+        assertEquals(200, resp.statusCode());
+        JsonNode body = harness.parse(resp);
+        assertNotNull("session body must be JSON, got: " + resp.body(), body);
+        // Resource attempts to inject language; for stateless calls
+        // it lands on the empty map and is still returned as a JSON object.
+        assertTrue("response must be a JSON object", body.isObject());
+    }
+
+    @Test
+    public void postLogin_validCredentials_returns200() throws Exception {
+        HttpResponse<String> resp = formLogin("admin", "admin");
+        assertEquals(200, resp.statusCode());
+    }
+
+    @Test
+    public void postLogin_invalidCredentials_returns401() throws Exception {
+        HttpResponse<String> resp = formLogin("admin", "wrongpass");
+        assertEquals(401, resp.statusCode());
+        assertTrue(
+                "401 body should mention authentication: " + resp.body(),
+                resp.body().toLowerCase().contains("authentication"));
+    }
+
+    @Test
+    public void logout_withAuth_returns200() throws Exception {
+        HttpResponse<String> resp = harness.deleteAuth("/rest/saiku/session");
+        assertEquals(200, resp.statusCode());
+    }
+
+    private static HttpResponse<String> formLogin(String user, String pass) throws Exception {
+        String form = "username="
+                + URLEncoder.encode(user, StandardCharsets.UTF_8)
+                + "&password="
+                + URLEncoder.encode(pass, StandardCharsets.UTF_8);
+        HttpRequest req = HttpRequest.newBuilder(URI.create(harness.baseUrl() + "/rest/saiku/session"))
+                .timeout(Duration.ofSeconds(30))
+                .header("Content-Type", "application/x-www-form-urlencoded")
+                .POST(HttpRequest.BodyPublishers.ofString(form, StandardCharsets.UTF_8))
+                .build();
+        return harness.send(req);
+    }
+}

--- a/saiku-launcher/src/test/java/org/saiku/launcher/it/StatisticsIT.java
+++ b/saiku-launcher/src/test/java/org/saiku/launcher/it/StatisticsIT.java
@@ -1,0 +1,52 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.launcher.it;
+
+import static org.junit.Assert.*;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import java.net.http.HttpResponse;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ * Coverage for {@code /rest/saiku/statistics/mondrian/*} — Mondrian-server
+ * introspection used by the admin console / Grafana scrape targets.
+ */
+public class StatisticsIT {
+
+    private static SaikuItHarness harness;
+    private static final String BASE = "/rest/saiku/statistics/mondrian";
+
+    @BeforeClass
+    public static void boot() throws Exception {
+        harness = SaikuItHarness.shared();
+    }
+
+    @Test
+    public void getMondrianStats_returns200WithMondrianBody() throws Exception {
+        HttpResponse<String> resp = harness.getAuth(BASE);
+        assertEquals(200, resp.statusCode());
+        // Body shape is MondrianStats; just confirm we got JSON.
+        JsonNode body = harness.parse(resp);
+        assertNotNull(body);
+    }
+
+    @Test
+    public void getMondrianServer_returns200() throws Exception {
+        HttpResponse<String> resp = harness.getAuth(BASE + "/server");
+        assertEquals(200, resp.statusCode());
+        assertNotNull(harness.parse(resp));
+    }
+
+    @Test
+    public void getMondrianServerVersion_returns200WithVersionString() throws Exception {
+        HttpResponse<String> resp = harness.getAuth(BASE + "/server/version");
+        assertEquals(200, resp.statusCode());
+        JsonNode body = harness.parse(resp);
+        // MondrianVersion has versionString, productName, etc.
+        assertTrue("version body must expose versionString", body.has("versionString"));
+    }
+}

--- a/saiku-launcher/src/test/java/org/saiku/launcher/it/UserWorkflowIT.java
+++ b/saiku-launcher/src/test/java/org/saiku/launcher/it/UserWorkflowIT.java
@@ -1,0 +1,119 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.launcher.it;
+
+import static org.junit.Assert.*;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import java.net.http.HttpResponse;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ * End-to-end Saiku user workflow ITs. Where the per-resource ITs each pin a
+ * specific contract, this class threads several endpoints together the way the
+ * SPA actually uses them — so coupling bugs (e.g., schema → query → cellset
+ * mismatch) surface even when the individual endpoints look fine in isolation.
+ */
+public class UserWorkflowIT {
+
+    private static SaikuItHarness harness;
+    private static final String CUBE = "unknown_foodmart/FoodMart/FoodMart/Sales";
+
+    @BeforeClass
+    public static void boot() throws Exception {
+        harness = SaikuItHarness.shared();
+    }
+
+    @Test
+    public void discoverThenAiQuery_endToEnd() throws Exception {
+        // Step 1: enumerate cubes via /api/ai/cubes
+        HttpResponse<String> cubes = harness.getAuth("/rest/saiku/api/ai/cubes");
+        assertEquals(200, cubes.statusCode());
+        boolean salesPresent = false;
+        for (JsonNode c : harness.parse(cubes)) {
+            if ("Sales".equals(c.path("cubeName").asText())) {
+                salesPresent = true;
+                break;
+            }
+        }
+        assertTrue("Sales cube must be discoverable", salesPresent);
+
+        // Step 2: fetch the cube schema
+        HttpResponse<String> schema = harness.getAuth("/rest/saiku/api/ai/schema/" + CUBE);
+        assertEquals(200, schema.statusCode());
+        JsonNode schemaBody = harness.parse(schema);
+        // Read a measure name from the live schema and use it in step 3 to
+        // prove the discover → query coupling holds end-to-end.
+        JsonNode measures = schemaBody.path("measures");
+        assertTrue("schema must expose at least one measure", measures.fields().hasNext());
+        String firstMeasureName =
+                measures.fields().next().getValue().path("name").asText();
+        assertFalse("measure name must be non-blank", firstMeasureName.isBlank());
+
+        // Step 3: query that measure
+        String body =
+                """
+                {
+                  "cube": "%s",
+                  "measures": [{"name": "%s"}],
+                  "rows": [{"dimension": "Product", "hierarchy": "Products", "level": "Product Family"}]
+                }
+                """
+                        .formatted(CUBE, firstMeasureName);
+        HttpResponse<String> query = harness.postAuthJson("/rest/saiku/api/ai/query", body);
+        assertEquals(200, query.statusCode());
+        JsonNode queryBody = harness.parse(query);
+        assertEquals("SUCCESS", queryBody.path("status").asText());
+        assertEquals(
+                "schema-derived query must return all 3 product families",
+                3,
+                queryBody.path("totalRows").asInt());
+    }
+
+    @Test
+    public void legacyDiscoverThenLegacyExecute_endToEnd() throws Exception {
+        // Walk the older OlapDiscoverResource → Query2Resource path that
+        // pre-AiQueryResource clients use.
+        HttpResponse<String> conns = harness.getAuth("/rest/saiku/admin/discover");
+        assertEquals(200, conns.statusCode());
+        boolean foundFoodmart = false;
+        for (JsonNode c : harness.parse(conns)) {
+            if ("unknown_foodmart".equals(c.path("name").asText())) {
+                foundFoodmart = true;
+                break;
+            }
+        }
+        assertTrue(foundFoodmart);
+
+        // The discover route resolves to a CubeMetadata; we don't read it
+        // here. Jump straight to executing a vanilla MDX statement via the
+        // /api/query/execute endpoint.
+        String mdx =
+                """
+                {
+                  "name": "workflow-it",
+                  "cube": {
+                    "connection": "unknown_foodmart",
+                    "catalog": "FoodMart",
+                    "schema": "FoodMart",
+                    "name": "Sales",
+                    "uniqueName": "[Sales]"
+                  },
+                  "mdx": "SELECT NON EMPTY {[Measures].[Store Sales]} ON COLUMNS, NON EMPTY {[Product].[Products].[Product Family].Members} ON ROWS FROM [Sales]"
+                }
+                """;
+        HttpResponse<String> exec = harness.postAuthJson("/rest/saiku/api/query/execute", mdx);
+        assertEquals(200, exec.statusCode());
+        JsonNode r = harness.parse(exec);
+        assertTrue("cellset shape present", r.has("cellset"));
+        assertTrue(r.path("cellset").isArray());
+        // header row + 3 product families = 4 rows minimum
+        assertTrue(
+                "cellset must contain at least header + 3 product families, got "
+                        + r.path("cellset").size(),
+                r.path("cellset").size() >= 4);
+    }
+}

--- a/saiku-mcp/pom.xml
+++ b/saiku-mcp/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.saikuanalytics</groupId>
         <artifactId>saiku</artifactId>
-        <version>4.0.1</version>
+        <version>4.2.0</version>
     </parent>
 
     <artifactId>saiku-mcp</artifactId>

--- a/saiku-webapp/pom.xml
+++ b/saiku-webapp/pom.xml
@@ -2,11 +2,11 @@
     <parent>
         <artifactId>saiku</artifactId>
         <groupId>org.saikuanalytics</groupId>
-        <version>4.0.1</version>
+        <version>4.2.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>saiku-webapp</artifactId>
-    <version>4.0.1</version>
+    <version>4.2.0</version>
     <name>saiku - webapp</name>
     <packaging>war</packaging>
     <build>


### PR DESCRIPTION
## Summary

Saiku 4.2.0 — first release after the IT harness + 7-issue fix pass.

### Tests + harness
- 94 new unit tests across `saiku-service`, `saiku-web`, `saiku-semantic`
- New `SaikuItHarness` boots Jetty + WAR in-process for whole-API ITs
- 78 integration tests covering every REST resource against the seeded FoodMart H2
- Opt-in gate: `mvn verify -P integration`
- Default `mvn verify` keeps the inner dev loop fast (ITs skipped)

### Fixes (#861–#867)
| # | Fix |
|---|---|
| #861 | DRILLTHROUGH MDX no longer ClassCastExceptions when JSON body omits `type` |
| #862 | AI drillthrough resolves async queryIds across sessions |
| #863 | Level-members metadata returns typed 404 envelope (was 204 No Content) |
| #864 | AI Query API rejects `limit < 0` and `limit > 10000` with VALIDATION_ERROR |
| #865 | New `GenericFailureExceptionMapper` redacts Jetty's HTML 500 page + version banner |
| #866 | `HEAD /rest/saiku/info` no longer hangs 30 seconds — health checks fixed |
| #867 | OlapDiscover surfaces unknown cube/dimension/connection as typed 404 |

### After merge
- Tag `v4.2.0` on `main` → triggers `release.yml` (saiku-launcher fat-JAR + saiku-mcp fat-JAR + multi-arch Docker image to `ghcr.io/spiculedata/saiku` + GitHub Release).

## Test plan

- [x] `mvn verify` clean
- [x] `mvn verify -P integration` → 78/78 ITs green
- [x] Spotless clean
- [ ] CI green on this PR