### PR TITLE
feat: connection-info panel for AI API + MCP (demo-mode aware)

### DIFF
--- a/docker/saiku-entrypoint
+++ b/docker/saiku-entrypoint
@@ -18,7 +18,19 @@ set -euo pipefail
 case "${1:-serve}" in
   serve)
     shift || true
-    exec java -jar /app/saiku.jar serve \
+    # Capability props surfaced by GET /rest/saiku/info/capabilities so
+    # the SPA's admin panel + (when on) demo-mode login screen can show
+    # accurate connection instructions. Empty values are passed through
+    # as empty strings so the resource code's blank-check treats them
+    # as "not configured".
+    JAVA_OPTS=()
+    if [[ -n "${SAIKU_DEMO:-}" ]]; then
+      JAVA_OPTS+=("-Dsaiku.demo=${SAIKU_DEMO}")
+    fi
+    if [[ -n "${SAIKU_MCP_URL:-}" ]]; then
+      JAVA_OPTS+=("-Dsaiku.mcp.url=${SAIKU_MCP_URL}")
+    fi
+    exec java "${JAVA_OPTS[@]}" -jar /app/saiku.jar serve \
       --host 0.0.0.0 \
       --port 8080 \
       --home "${SAIKU_HOME:-/app/saiku-home}" \

--- a/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/InfoResource.java
+++ b/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/InfoResource.java
@@ -24,7 +24,9 @@ import jakarta.ws.rs.core.GenericEntity;
 import jakarta.ws.rs.core.Response;
 import jakarta.xml.bind.annotation.XmlAccessType;
 import jakarta.xml.bind.annotation.XmlAccessorType;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import org.saiku.service.PlatformUtilsService;
 import org.saiku.service.util.dto.Plugin;
 import org.slf4j.Logger;
@@ -74,5 +76,59 @@ public class InfoResource {
     @HEAD
     public Response head() {
         return Response.ok().build();
+    }
+
+    /**
+     * Connection-info surface for the admin console + (when demo mode is on)
+     * the login page. Reports which agent-facing APIs are reachable on this
+     * deployment so the UI can render copy-pasteable connection snippets
+     * without each page having to probe the endpoints itself.
+     *
+     * <p>Driven by system properties so a launcher operator can toggle the
+     * panel without rebuilding:
+     * <ul>
+     *   <li>{@code saiku.demo=true} — flips the {@code demoMode} flag on,
+     *       which the SPA reads to expose the same info on the login page.</li>
+     *   <li>{@code saiku.mcp.url=https://.../mcp} — public URL of the MCP
+     *       endpoint (StreamableHTTP). Absent / blank means MCP is not
+     *       exposed (default for vanilla launcher deployments). The
+     *       container ships {@code saiku-mcp} but it's stdio-only by
+     *       default; setting this property tells the UI an HTTP front-end
+     *       is in place (e.g. demo.saiku.bi runs mcp-proxy in front).</li>
+     * </ul>
+     *
+     * <p>The AI Query API is always present in the codebase, so
+     * {@code ai.enabled} is always true — the UI still benefits from a
+     * machine-readable URL + sample bodies.
+     */
+    @GET
+    @Path("/capabilities")
+    @Produces({"application/json"})
+    public Response getCapabilities() {
+        Map<String, Object> ai = new LinkedHashMap<>();
+        ai.put("enabled", true);
+        ai.put("basePath", "/rest/saiku/api/ai");
+        ai.put(
+                "endpoints",
+                Map.of(
+                        "cubes", "/rest/saiku/api/ai/cubes",
+                        "schema", "/rest/saiku/api/ai/schema/{connection}/{catalog}/{schema}/{cube}",
+                        "query", "/rest/saiku/api/ai/query"));
+
+        Map<String, Object> mcp = new LinkedHashMap<>();
+        String mcpUrl = System.getProperty("saiku.mcp.url", "");
+        if (mcpUrl != null && !mcpUrl.isBlank()) {
+            mcp.put("enabled", true);
+            mcp.put("url", mcpUrl);
+            mcp.put("transport", "streamable-http");
+        } else {
+            mcp.put("enabled", false);
+        }
+
+        Map<String, Object> body = new LinkedHashMap<>();
+        body.put("ai", ai);
+        body.put("mcp", mcp);
+        body.put("demoMode", Boolean.parseBoolean(System.getProperty("saiku.demo", "false")));
+        return Response.ok(body).build();
     }
 }

--- a/saiku-core/saiku-web/src/test/java/org/saiku/web/rest/resources/InfoResourceTest.java
+++ b/saiku-core/saiku-web/src/test/java/org/saiku/web/rest/resources/InfoResourceTest.java
@@ -9,6 +9,8 @@ import static org.junit.Assert.*;
 import jakarta.ws.rs.core.Response;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+import org.junit.After;
 import org.junit.Test;
 import org.saiku.service.PlatformUtilsService;
 import org.saiku.service.util.dto.Plugin;
@@ -36,6 +38,54 @@ public class InfoResourceTest {
         List<Plugin> body = (List<Plugin>) resp.getEntity();
         assertEquals(1, body.size());
         assertEquals("alpha", body.get(0).getName());
+    }
+
+    @After
+    public void clearCapabilityProps() {
+        System.clearProperty("saiku.demo");
+        System.clearProperty("saiku.mcp.url");
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void capabilities_defaultDeployment_mcpDisabledDemoOff() {
+        Response resp = new InfoResource().getCapabilities();
+        assertEquals(200, resp.getStatus());
+        Map<String, Object> body = (Map<String, Object>) resp.getEntity();
+        Map<String, Object> ai = (Map<String, Object>) body.get("ai");
+        assertEquals(Boolean.TRUE, ai.get("enabled"));
+        assertEquals("/rest/saiku/api/ai", ai.get("basePath"));
+        Map<String, Object> mcp = (Map<String, Object>) body.get("mcp");
+        assertEquals(Boolean.FALSE, mcp.get("enabled"));
+        assertEquals(Boolean.FALSE, body.get("demoMode"));
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void capabilities_demoModeAndMcpUrl_surfaceCorrectly() {
+        System.setProperty("saiku.demo", "true");
+        System.setProperty("saiku.mcp.url", "https://demo.saiku.bi/mcp");
+
+        Response resp = new InfoResource().getCapabilities();
+        assertEquals(200, resp.getStatus());
+        Map<String, Object> body = (Map<String, Object>) resp.getEntity();
+        assertEquals(Boolean.TRUE, body.get("demoMode"));
+        Map<String, Object> mcp = (Map<String, Object>) body.get("mcp");
+        assertEquals(Boolean.TRUE, mcp.get("enabled"));
+        assertEquals("https://demo.saiku.bi/mcp", mcp.get("url"));
+        assertEquals("streamable-http", mcp.get("transport"));
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void capabilities_blankMcpUrl_treatedAsDisabled() {
+        System.setProperty("saiku.mcp.url", "   ");
+        Response resp = new InfoResource().getCapabilities();
+        assertEquals(200, resp.getStatus());
+        Map<String, Object> body = (Map<String, Object>) resp.getEntity();
+        Map<String, Object> mcp = (Map<String, Object>) body.get("mcp");
+        assertEquals(Boolean.FALSE, mcp.get("enabled"));
+        assertFalse("blank URL must not surface a url field", mcp.containsKey("url"));
     }
 
     @Test

--- a/saiku-ui/src/lib/stores/platform.svelte.ts
+++ b/saiku-ui/src/lib/stores/platform.svelte.ts
@@ -1,10 +1,29 @@
 import { browser } from "$app/environment";
 
+/** Shape returned by GET /rest/saiku/info/capabilities. */
+export interface PlatformCapabilities {
+  ai: {
+    enabled: boolean;
+    basePath: string;
+    endpoints: Record<string, string>;
+  };
+  mcp: {
+    enabled: boolean;
+    url?: string;
+    transport?: string;
+  };
+  /** True when the launcher was started with -Dsaiku.demo=true. */
+  demoMode: boolean;
+}
+
 class PlatformStore {
   fullscreen = $state<boolean>(false);
   /** Version info from /rest/saiku/info + /rest/saiku/admin/version. */
   version = $state<string | null>(null);
   newVersionAvailable = $state<boolean>(false);
+  /** Capabilities probe — populated lazily by loadCapabilities. Null
+   *  until the first successful fetch so callers can show a loading state. */
+  capabilities = $state<PlatformCapabilities | null>(null);
 
   constructor() {
     if (browser) {
@@ -29,6 +48,26 @@ class PlatformStore {
       if (res.ok) this.version = (await res.text()).trim() || null;
     } catch {
       // no-op
+    }
+  }
+
+  /**
+   * Probe /rest/saiku/info/capabilities so callers (admin info panel,
+   * conditional login-page demo banner) know whether AI/MCP are exposed
+   * and what URLs to surface. Anonymous-accessible, no auth required.
+   */
+  async loadCapabilities(): Promise<void> {
+    try {
+      const res = await fetch("/rest/saiku/info/capabilities", {
+        credentials: "include",
+        headers: { Accept: "application/json" },
+      });
+      if (res.ok) {
+        this.capabilities = (await res.json()) as PlatformCapabilities;
+      }
+    } catch {
+      // Capability probe failures are non-fatal — the rest of the UI
+      // continues without the connection-info panel.
     }
   }
 

--- a/saiku-ui/src/lib/views/LoginForm.svelte
+++ b/saiku-ui/src/lib/views/LoginForm.svelte
@@ -1,11 +1,27 @@
 <script lang="ts">
+  import { onMount } from "svelte";
   import { session } from "$lib/stores/session.svelte";
   import { i18n } from "$lib/stores/i18n.svelte";
+  import { platform } from "$lib/stores/platform.svelte";
+  import ApiAccessAdmin from "$lib/views/admin/ApiAccessAdmin.svelte";
 
   let username = $state("admin");
   let password = $state("");
   let error = $state<string | null>(null);
   let busy = $state(false);
+
+  // Anonymous-accessible probe — surfaces demoMode + AI/MCP URLs so the
+  // login screen of a demo deployment can show visitors how to drive the
+  // API or wire the MCP server before they ever sign in. On a normal
+  // (non-demo) deployment this panel stays hidden — Saiku admins see it
+  // only after auth via the /admin "API access" tab.
+  onMount(() => {
+    if (!platform.capabilities) {
+      platform.loadCapabilities();
+    }
+  });
+
+  const showDemoPanel = $derived(platform.capabilities?.demoMode === true);
 
   async function onSubmit(e: SubmitEvent) {
     e.preventDefault();
@@ -21,33 +37,55 @@
   }
 </script>
 
-<form class="login" onsubmit={onSubmit}>
-  <h1>{i18n.t("login.title")}</h1>
-  {#if error}
-    <p class="callout callout--danger" role="alert">{error}</p>
+<div class="login-stack">
+  <form class="login" onsubmit={onSubmit}>
+    <h1>{i18n.t("login.title")}</h1>
+    {#if showDemoPanel}
+      <p class="demo-creds">
+        Demo credentials: <code>admin</code> / <code>admin</code>. Data resets nightly.
+      </p>
+    {/if}
+    {#if error}
+      <p class="callout callout--danger" role="alert">{error}</p>
+    {/if}
+    <label class="field">
+      <span class="field__label">{i18n.t("login.username")}</span>
+      <input class="field__input" bind:value={username} autocomplete="username" required />
+    </label>
+    <label class="field">
+      <span class="field__label">{i18n.t("login.password")}</span>
+      <input
+        class="field__input"
+        type="password"
+        bind:value={password}
+        autocomplete="current-password"
+        required
+      />
+    </label>
+    <button type="submit" class="btn btn--primary btn--wide" disabled={busy}>
+      {busy ? i18n.t("login.submitting") : i18n.t("login.submit")}
+    </button>
+  </form>
+
+  {#if showDemoPanel}
+    <aside class="login-stack__demo">
+      <ApiAccessAdmin />
+    </aside>
   {/if}
-  <label class="field">
-    <span class="field__label">{i18n.t("login.username")}</span>
-    <input class="field__input" bind:value={username} autocomplete="username" required />
-  </label>
-  <label class="field">
-    <span class="field__label">{i18n.t("login.password")}</span>
-    <input
-      class="field__input"
-      type="password"
-      bind:value={password}
-      autocomplete="current-password"
-      required
-    />
-  </label>
-  <button type="submit" class="btn btn--primary btn--wide" disabled={busy}>
-    {busy ? i18n.t("login.submitting") : i18n.t("login.submit")}
-  </button>
-</form>
+</div>
 
 <style>
-  .login {
+  .login-stack {
     margin: auto;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: var(--space-5);
+    padding: var(--space-4);
+    width: 100%;
+    max-width: 80rem;
+  }
+  .login {
     padding: var(--space-6);
     max-width: 380px;
     width: 100%;
@@ -59,6 +97,21 @@
   .login h1 {
     margin: 0 0 var(--space-4);
     font-size: var(--fs-xl);
+  }
+  .demo-creds {
+    margin: 0 0 var(--space-3);
+    padding: var(--space-2) var(--space-3);
+    background: var(--accent-soft, #ecfdf5);
+    color: var(--accent-strong, #047857);
+    border-left: 3px solid var(--accent, #10b981);
+    font-size: 0.85rem;
+  }
+  .login-stack__demo {
+    width: 100%;
+    padding: var(--space-4);
+    background: var(--bg);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-lg);
   }
   .btn--wide {
     width: 100%;

--- a/saiku-ui/src/lib/views/admin/ApiAccessAdmin.svelte
+++ b/saiku-ui/src/lib/views/admin/ApiAccessAdmin.svelte
@@ -1,0 +1,219 @@
+<script lang="ts">
+  import { onMount } from "svelte";
+  import { platform } from "$lib/stores/platform.svelte";
+
+  onMount(() => {
+    if (!platform.capabilities) {
+      platform.loadCapabilities();
+    }
+  });
+
+  const baseUrl = $derived(typeof window === "undefined" ? "" : window.location.origin);
+
+  function copy(value: string): void {
+    if (typeof navigator !== "undefined" && navigator.clipboard) {
+      navigator.clipboard.writeText(value);
+    }
+  }
+
+  const sampleAiBody = JSON.stringify(
+    {
+      cube: "unknown_foodmart/FoodMart/FoodMart/Sales",
+      measures: [{ name: "Store Sales" }],
+      rows: [{ dimension: "Product", hierarchy: "Products", level: "Product Family" }],
+    },
+    null,
+    2,
+  );
+
+  const mcpClientConfig = $derived(
+    JSON.stringify(
+      {
+        mcpServers: {
+          saiku: {
+            transport: "streamable-http",
+            url: platform.capabilities?.mcp?.url ?? `${baseUrl}/mcp`,
+          },
+        },
+      },
+      null,
+      2,
+    ),
+  );
+</script>
+
+<div class="api-access">
+  <header>
+    <h2>Agent API access</h2>
+    <p class="muted">
+      Programmatic surfaces an LLM agent (or any HTTP client) can use against this Saiku.
+      All endpoints accept HTTP Basic auth with your Saiku credentials.
+    </p>
+  </header>
+
+  {#if !platform.capabilities}
+    <p class="muted">Probing capabilities…</p>
+  {:else}
+    <section class="card">
+      <h3>
+        AI Query API
+        <span class="badge badge--ok">enabled</span>
+      </h3>
+      <p class="muted">
+        Typed REST surface designed for agents. Hierarchies, levels and measures are
+        discoverable; a single <code>POST /ai/query</code> translates a JSON description
+        into validated MDX, runs it, and returns typed <code>{`{value, formatted, unit}`}</code> cells.
+        Validation failures carry a <code>{`{status, field, available}`}</code> envelope for self-correction.
+      </p>
+
+      <div class="kv">
+        <div class="kv__row">
+          <span class="kv__key">Base path</span>
+          <code class="kv__val">{baseUrl}{platform.capabilities.ai.basePath}</code>
+        </div>
+        {#each Object.entries(platform.capabilities.ai.endpoints) as [name, path] (name)}
+          <div class="kv__row">
+            <span class="kv__key">{name}</span>
+            <code class="kv__val">{baseUrl}{path}</code>
+          </div>
+        {/each}
+      </div>
+
+      <details class="recipe">
+        <summary>Example: list cubes</summary>
+        <pre><code>{`curl -u USERNAME:PASSWORD ${baseUrl}/rest/saiku/api/ai/cubes`}</code></pre>
+      </details>
+
+      <details class="recipe">
+        <summary>Example: run a query</summary>
+        <pre><code>{`curl -u USERNAME:PASSWORD \\
+  -H 'Content-Type: application/json' \\
+  -d '${sampleAiBody}' \\
+  ${baseUrl}/rest/saiku/api/ai/query`}</code></pre>
+      </details>
+
+      <p class="muted small">
+        Full reference: <code>docs/AI-QUERY-API.md</code> in the repo.
+      </p>
+    </section>
+
+    <section class="card">
+      <h3>
+        Model Context Protocol (MCP)
+        {#if platform.capabilities.mcp.enabled}
+          <span class="badge badge--ok">enabled</span>
+        {:else}
+          <span class="badge badge--off">not exposed</span>
+        {/if}
+      </h3>
+      <p class="muted">
+        <code>saiku-mcp</code> wraps the AI Query API as an MCP server so Claude Desktop,
+        Cursor, Cline and other agent hosts can wire to Saiku natively.
+      </p>
+
+      {#if platform.capabilities.mcp.enabled}
+        <div class="kv">
+          <div class="kv__row">
+            <span class="kv__key">URL</span>
+            <code class="kv__val">{platform.capabilities.mcp.url}</code>
+            <button class="copy" onclick={() => copy(platform.capabilities!.mcp.url!)}>Copy</button>
+          </div>
+          <div class="kv__row">
+            <span class="kv__key">Transport</span>
+            <code class="kv__val">{platform.capabilities.mcp.transport}</code>
+          </div>
+        </div>
+
+        <details class="recipe" open>
+          <summary>Client config (Claude Desktop, Cursor, Cline)</summary>
+          <pre><code>{mcpClientConfig}</code></pre>
+          <button class="copy" onclick={() => copy(mcpClientConfig)}>Copy</button>
+        </details>
+      {:else}
+        <p class="muted small">
+          The container ships <code>saiku-mcp</code> as a stdio binary at
+          <code>/usr/local/bin/saiku-mcp</code>. To expose it over HTTP, run a stdio↔HTTP
+          bridge (e.g. <a href="https://github.com/sparfenyuk/mcp-proxy">mcp-proxy</a>) in
+          front and start the launcher with
+          <code>-Dsaiku.mcp.url=https://your-host/mcp</code> so this panel surfaces the URL.
+        </p>
+      {/if}
+    </section>
+  {/if}
+</div>
+
+<style>
+  .api-access {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-5);
+    max-width: 60rem;
+  }
+  .muted { color: var(--fg-muted); }
+  .small { font-size: 0.85rem; }
+  .card {
+    background: var(--bg);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-md, 0.5rem);
+    padding: var(--space-4);
+  }
+  .card h3 {
+    margin: 0 0 var(--space-2);
+    display: flex;
+    align-items: center;
+    gap: var(--space-2);
+  }
+  .badge {
+    font-size: 0.7rem;
+    padding: 0.15rem 0.5rem;
+    border-radius: 999px;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+  }
+  .badge--ok {
+    background: var(--accent-soft, #d1fae5);
+    color: var(--accent-strong, #047857);
+  }
+  .badge--off {
+    background: var(--bg-muted);
+    color: var(--fg-muted);
+  }
+  .kv {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-1);
+    margin: var(--space-3) 0;
+  }
+  .kv__row {
+    display: grid;
+    grid-template-columns: 8rem 1fr auto;
+    align-items: baseline;
+    gap: var(--space-2);
+  }
+  .kv__key { color: var(--fg-muted); font-size: 0.85rem; }
+  .kv__val {
+    background: var(--bg-muted);
+    padding: 0.1rem 0.4rem;
+    border-radius: 0.25rem;
+    font-size: 0.85rem;
+    word-break: break-all;
+  }
+  .recipe { margin: var(--space-3) 0; }
+  .recipe summary { cursor: pointer; user-select: none; }
+  .recipe pre {
+    background: var(--bg-muted);
+    padding: var(--space-3);
+    border-radius: var(--radius-sm, 0.25rem);
+    overflow: auto;
+    font-size: 0.8rem;
+  }
+  .copy {
+    margin-left: var(--space-2);
+    font-size: 0.75rem;
+    padding: 0.15rem 0.5rem;
+    background: var(--bg-muted);
+    border: 1px solid var(--border);
+    border-radius: 0.25rem;
+    cursor: pointer;
+  }
+</style>

--- a/saiku-ui/src/routes/admin/+page.svelte
+++ b/saiku-ui/src/routes/admin/+page.svelte
@@ -6,9 +6,10 @@
   import SchemasAdmin from "$lib/views/admin/SchemasAdmin.svelte";
   import LogsAdmin from "$lib/views/admin/LogsAdmin.svelte";
   import StatsAdmin from "$lib/views/admin/StatsAdmin.svelte";
+  import ApiAccessAdmin from "$lib/views/admin/ApiAccessAdmin.svelte";
   import LoginForm from "$lib/views/LoginForm.svelte";
 
-  type Tab = "users" | "datasources" | "schemas" | "logs" | "stats";
+  type Tab = "users" | "datasources" | "schemas" | "logs" | "stats" | "api";
   let tab = $state<Tab>("users");
 </script>
 
@@ -29,6 +30,7 @@
       <button type="button" role="tab" class:active={tab === "schemas"} onclick={() => (tab = "schemas")}>{i18n.t("admin.tabs.schemas")}</button>
       <button type="button" role="tab" class:active={tab === "logs"} onclick={() => (tab = "logs")}>{i18n.t("admin.tabs.logs")}</button>
       <button type="button" role="tab" class:active={tab === "stats"} onclick={() => (tab = "stats")}>{i18n.t("admin.tabs.stats")}</button>
+      <button type="button" role="tab" class:active={tab === "api"} onclick={() => (tab = "api")}>API access</button>
     </nav>
     <section class="admin__body">
       {#if tab === "users"}
@@ -39,8 +41,10 @@
         <SchemasAdmin />
       {:else if tab === "logs"}
         <LogsAdmin />
-      {:else}
+      {:else if tab === "stats"}
         <StatsAdmin />
+      {:else}
+        <ApiAccessAdmin />
       {/if}
     </section>
   </div>


### PR DESCRIPTION
## Summary

Adds a copy-pasteable connection-info card for the AI Query API and MCP server, surfaced two ways:

1. **Admin only (default):** new **API access** tab in `/admin` shows AI/MCP endpoints, sample curl, and a Claude Desktop / Cursor / Cline client-config snippet. Always visible to authenticated admins.
2. **Demo mode (opt-in):** when the launcher is started with `-Dsaiku.demo=true`, the same panel renders on the login page alongside the sign-in form, plus an `admin/admin` callout. Non-demo deployments are unchanged.

## Backend

- `GET /rest/saiku/info/capabilities` returns
  `{ai: {enabled, basePath, endpoints}, mcp: {enabled, url?, transport?}, demoMode}`.
- Driven by:
  - `-Dsaiku.demo=true` → `demoMode: true`
  - `-Dsaiku.mcp.url=https://.../mcp` → MCP card surfaces the URL
- Blank/missing MCP URL → MCP card stays hidden (default for vanilla launchers — the container ships `saiku-mcp` as stdio only).
- 3 new unit tests in `InfoResourceTest` covering the matrix.

## UI

- `platform.svelte.ts` gains a `capabilities` field + lazy `loadCapabilities()`.
- New `ApiAccessAdmin.svelte` component renders the card.
- `/admin` gets the new tab.
- `LoginForm.svelte` conditionally renders the card on demo deployments.

## Container

`docker/saiku-entrypoint` now forwards `SAIKU_DEMO` and `SAIKU_MCP_URL` env vars into the matching `-D` properties. For `demo.saiku.bi`:

```
docker run -d -p 8080:8080 \
  -e SAIKU_DEMO=true \
  -e SAIKU_MCP_URL=https://demo.saiku.bi/mcp \
  ghcr.io/spiculedata/saiku
```

## Test plan

- [x] `mvn -pl saiku-core/saiku-web -am test -Dtest=InfoResourceTest` green
- [x] `npm run check` clean for the new/edited files (pre-existing ChartView errors untouched)
- [ ] CI green on this PR
- [ ] After merge: nightly reset on demo.saiku.bi picks up the new image; flip `SAIKU_DEMO=true` + `SAIKU_MCP_URL` on the VM