### PR TITLE
feat(mcp): runtime-generated .dxt download for Claude Desktop

### DIFF
--- a/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/InfoResource.java
+++ b/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/InfoResource.java
@@ -15,18 +15,25 @@
  */
 package org.saiku.web.rest.resources;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.qmino.miredot.annotations.ReturnType;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.HEAD;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.GenericEntity;
+import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 import jakarta.xml.bind.annotation.XmlAccessType;
 import jakarta.xml.bind.annotation.XmlAccessorType;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.net.URI;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
 import org.saiku.service.PlatformUtilsService;
 import org.saiku.service.util.dto.Plugin;
 import org.slf4j.Logger;
@@ -130,5 +137,119 @@ public class InfoResource {
         body.put("mcp", mcp);
         body.put("demoMode", Boolean.parseBoolean(System.getProperty("saiku.demo", "false")));
         return Response.ok(body).build();
+    }
+
+    /**
+     * Build and stream a Claude Desktop / Cursor DXT bundle for the running
+     * MCP endpoint so the SPA can offer a "Download .dxt" button on the
+     * connection-info panel. The bundle is generated on the fly so the
+     * embedded {@code url} matches whatever the operator configured via
+     * {@code -Dsaiku.mcp.url=...}; no static asset to keep in sync.
+     *
+     * <p>A DXT file is a ZIP archive with a {@code manifest.json} at the
+     * root describing how the agent host should connect. For a remote /
+     * streamable-http MCP server like Saiku's, the manifest carries the
+     * URL plus a small amount of human-readable metadata for the install
+     * dialog.
+     *
+     * <p>Returns 404 when MCP isn't enabled (i.e. {@code saiku.mcp.url}
+     * is unset or blank). Vanilla launcher deployments ship saiku-mcp
+     * as stdio only — no URL means no bundle to hand out.
+     */
+    @GET
+    @Path("/mcp.dxt")
+    @Produces("application/octet-stream")
+    public Response getMcpDxt() {
+        String mcpUrl = System.getProperty("saiku.mcp.url", "");
+        if (mcpUrl == null || mcpUrl.isBlank()) {
+            return Response.status(Response.Status.NOT_FOUND)
+                    .type(MediaType.APPLICATION_JSON)
+                    .entity(Map.of(
+                            "status",
+                            "NOT_FOUND",
+                            "error",
+                            "MCP server is not exposed over HTTP on this deployment. "
+                                    + "Set -Dsaiku.mcp.url to an HTTPS URL to enable the DXT download."))
+                    .build();
+        }
+
+        // Derive a friendly origin host for the display_name (e.g. "demo.saiku.bi")
+        // so the install dialog tells the user which Saiku they're wiring up.
+        String host = mcpUrl;
+        try {
+            host = URI.create(mcpUrl).getHost();
+            if (host == null || host.isBlank()) host = mcpUrl;
+        } catch (Exception ignored) {
+            // mcpUrl isn't a URI — fall through and let the raw string render.
+        }
+
+        Map<String, Object> manifest = buildDxtManifest(mcpUrl, host);
+        byte[] zipBytes;
+        try {
+            zipBytes = zipManifest(manifest);
+        } catch (IOException e) {
+            log.error("Failed to assemble MCP DXT bundle", e);
+            return Response.serverError()
+                    .type(MediaType.APPLICATION_JSON)
+                    .entity(Map.of("status", "ERROR", "error", "Failed to build DXT bundle"))
+                    .build();
+        }
+
+        return Response.ok(zipBytes)
+                .header("Content-Disposition", "attachment; filename=\"saiku.dxt\"")
+                .header("Content-Length", String.valueOf(zipBytes.length))
+                .type("application/octet-stream")
+                .build();
+    }
+
+    /** Build the DXT manifest payload. Package-visible for unit tests. */
+    Map<String, Object> buildDxtManifest(String mcpUrl, String host) {
+        Map<String, Object> manifest = new LinkedHashMap<>();
+        manifest.put("dxt_version", "0.1");
+        manifest.put("name", "saiku");
+        manifest.put("display_name", "Saiku OLAP — " + host);
+        manifest.put("version", saikuVersion());
+        manifest.put(
+                "description",
+                "Query Saiku OLAP cubes through MCP. Backed by the AI Query API at "
+                        + host
+                        + " — typed schema discovery, validated MDX generation, and structured cell results.");
+        manifest.put("author", Map.of("name", "Saiku Analytics", "url", "https://saiku.bi"));
+        manifest.put("homepage", "https://github.com/spiculedata/saiku");
+        manifest.put("license", "Apache-2.0");
+        Map<String, Object> server = new LinkedHashMap<>();
+        server.put("type", "remote");
+        Map<String, Object> transport = new LinkedHashMap<>();
+        transport.put("type", "streamable-http");
+        transport.put("url", mcpUrl);
+        server.put("transport", transport);
+        manifest.put("server", server);
+        return manifest;
+    }
+
+    /** Zip a manifest map into a single-entry {@code manifest.json} archive.
+     *  Package-visible for unit tests. */
+    static byte[] zipManifest(Map<String, Object> manifest) throws IOException {
+        byte[] json = new ObjectMapper().writerWithDefaultPrettyPrinter().writeValueAsBytes(manifest);
+        ByteArrayOutputStream buf = new ByteArrayOutputStream();
+        try (ZipOutputStream zip = new ZipOutputStream(buf)) {
+            ZipEntry entry = new ZipEntry("manifest.json");
+            zip.putNextEntry(entry);
+            zip.write(json);
+            zip.closeEntry();
+        }
+        return buf.toByteArray();
+    }
+
+    /**
+     * Best-effort Saiku version for the DXT manifest. Reads
+     * {@code -Dsaiku.version=...} (the launcher can set this from the
+     * shaded JAR's Implementation-Version) and falls back to {@code 0.0.0}
+     * so the manifest stays a valid semver string.
+     */
+    private static String saikuVersion() {
+        String v = System.getProperty("saiku.version", "");
+        if (v == null || v.isBlank()) return "0.0.0";
+        return v;
     }
 }

--- a/saiku-core/saiku-web/src/test/java/org/saiku/web/rest/resources/InfoResourceTest.java
+++ b/saiku-core/saiku-web/src/test/java/org/saiku/web/rest/resources/InfoResourceTest.java
@@ -6,10 +6,16 @@ package org.saiku.web.rest.resources;
 
 import static org.junit.Assert.*;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.ws.rs.core.Response;
+import java.io.ByteArrayInputStream;
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipInputStream;
 import org.junit.After;
 import org.junit.Test;
 import org.saiku.service.PlatformUtilsService;
@@ -44,6 +50,91 @@ public class InfoResourceTest {
     public void clearCapabilityProps() {
         System.clearProperty("saiku.demo");
         System.clearProperty("saiku.mcp.url");
+        System.clearProperty("saiku.version");
+    }
+
+    /* ------------------------------ DXT bundle ------------------------------ */
+
+    @Test
+    public void mcpDxt_returns404WhenMcpNotConfigured() {
+        Response resp = new InfoResource().getMcpDxt();
+        assertEquals(404, resp.getStatus());
+        @SuppressWarnings("unchecked")
+        Map<String, Object> body = (Map<String, Object>) resp.getEntity();
+        assertEquals("NOT_FOUND", body.get("status"));
+        assertTrue(((String) body.get("error")).contains("saiku.mcp.url"));
+    }
+
+    @Test
+    public void mcpDxt_returnsZipWithManifestJsonWhenMcpConfigured() throws Exception {
+        System.setProperty("saiku.mcp.url", "https://demo.saiku.bi/mcp");
+        System.setProperty("saiku.version", "4.2.0");
+
+        Response resp = new InfoResource().getMcpDxt();
+        assertEquals(200, resp.getStatus());
+        assertEquals("attachment; filename=\"saiku.dxt\"", resp.getHeaderString("Content-Disposition"));
+        byte[] zip = (byte[]) resp.getEntity();
+        assertTrue("zip body must be non-empty", zip.length > 0);
+
+        // The bundle must contain a single manifest.json entry.
+        try (ZipInputStream zin = new ZipInputStream(new ByteArrayInputStream(zip))) {
+            ZipEntry entry = zin.getNextEntry();
+            assertNotNull("zip must have at least one entry", entry);
+            assertEquals("manifest.json", entry.getName());
+
+            byte[] body = zin.readAllBytes();
+            JsonNode manifest = new ObjectMapper().readTree(body);
+
+            assertEquals("0.1", manifest.path("dxt_version").asText());
+            assertEquals("saiku", manifest.path("name").asText());
+            assertEquals("4.2.0", manifest.path("version").asText());
+            assertEquals(
+                    "https://demo.saiku.bi/mcp",
+                    manifest.path("server").path("transport").path("url").asText());
+            assertEquals(
+                    "streamable-http",
+                    manifest.path("server").path("transport").path("type").asText());
+
+            // No further entries — keep the bundle minimal.
+            assertNull("only one entry expected", zin.getNextEntry());
+        }
+    }
+
+    @Test
+    public void mcpDxt_includesHostnameInDisplayName() {
+        System.setProperty("saiku.mcp.url", "https://demo.saiku.bi/mcp");
+        InfoResource r = new InfoResource();
+        Map<String, Object> manifest = r.buildDxtManifest("https://demo.saiku.bi/mcp", "demo.saiku.bi");
+        assertTrue(
+                "display_name should mention the host so the install dialog is unambiguous",
+                manifest.get("display_name").toString().contains("demo.saiku.bi"));
+    }
+
+    @Test
+    public void zipManifest_isAValidZipArchive() throws Exception {
+        Map<String, Object> manifest = new LinkedHashMap<>();
+        manifest.put("dxt_version", "0.1");
+        manifest.put("name", "saiku");
+        byte[] zip = InfoResource.zipManifest(manifest);
+        try (ZipInputStream zin = new ZipInputStream(new ByteArrayInputStream(zip))) {
+            ZipEntry e = zin.getNextEntry();
+            assertNotNull(e);
+            JsonNode body = new ObjectMapper().readTree(zin.readAllBytes());
+            assertEquals("saiku", body.path("name").asText());
+        }
+    }
+
+    @Test
+    public void mcpDxt_versionFallsBackTo000WhenUnset() throws Exception {
+        System.setProperty("saiku.mcp.url", "https://demo.saiku.bi/mcp");
+        // Deliberately no saiku.version.
+        Response resp = new InfoResource().getMcpDxt();
+        byte[] zip = (byte[]) resp.getEntity();
+        try (ZipInputStream zin = new ZipInputStream(new ByteArrayInputStream(zip))) {
+            zin.getNextEntry();
+            JsonNode m = new ObjectMapper().readTree(zin.readAllBytes());
+            assertEquals("0.0.0", m.path("version").asText());
+        }
     }
 
     @Test

--- a/saiku-launcher/src/main/java/org/saiku/launcher/SaikuLauncher.java
+++ b/saiku-launcher/src/main/java/org/saiku/launcher/SaikuLauncher.java
@@ -101,6 +101,15 @@ public class SaikuLauncher implements Callable<Integer> {
             Files.createDirectories(saikuHome.resolve("plugins"));
             Files.createDirectories(brandingDir);
             System.setProperty("saiku.home", saikuHome.toString());
+            // Expose the running fat-JAR's version so InfoResource can stamp
+            // it into the DXT manifest + the eventual /info/version endpoint.
+            // Implementation-Version comes from the shade-plugin manifest
+            // transformer (see saiku-launcher/pom.xml). Null in IDE / unit
+            // runs — fine, the resource falls back to "0.0.0".
+            String pkgVersion = SaikuLauncher.class.getPackage().getImplementationVersion();
+            if (pkgVersion != null && !pkgVersion.isBlank()) {
+                System.setProperty("saiku.version", pkgVersion);
+            }
             System.out.println("Saiku home: " + saikuHome);
 
             stageSeedAssets(dataDir);

--- a/saiku-ui/src/lib/views/admin/ApiAccessAdmin.svelte
+++ b/saiku-ui/src/lib/views/admin/ApiAccessAdmin.svelte
@@ -216,4 +216,17 @@
     border-radius: 0.25rem;
     cursor: pointer;
   }
+  .install-row {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-2);
+    margin: var(--space-3) 0;
+    padding: var(--space-3);
+    background: var(--accent-soft, #ecfdf5);
+    border-radius: var(--radius-sm, 0.25rem);
+  }
+  .install-row .btn {
+    align-self: flex-start;
+    text-decoration: none;
+  }
 </style>


### PR DESCRIPTION
## Summary

Adds a **Download .dxt** button on the connection-info panel so users can install Saiku's MCP server into Claude Desktop / Cursor with one click. The bundle is built on the fly from this deployment's configured `saiku.mcp.url`, so the URL inside the manifest matches whatever host the operator is on — no static asset to maintain.

### Backend
- `GET /rest/saiku/info/mcp.dxt` returns a single-entry ZIP (`manifest.json`) following the DXT spec for remote / streamable-http servers.
- 404 with a typed envelope when MCP isn't exposed.
- `SaikuLauncher` now sets `-Dsaiku.version` from the JAR's `Implementation-Version` so the manifest stamps a real version instead of `0.0.0`.
- 5 new unit tests in `InfoResourceTest`.

### UI
- `ApiAccessAdmin.svelte` gets an install-row block with a direct download link styled in the same accent palette as the demo banner.
- The "client config" snippet for hand-pasted JSON drops to a collapsed disclosure.

### Demo
After merge: the nightly reset pulls the new `:development` image. The button surfaces immediately because `SAIKU_MCP_URL=https://demo.saiku.bi/mcp` is already set on the VM.

## Test plan
- [x] `mvn -pl saiku-core/saiku-web test -Dtest=InfoResourceTest` → 10/10 green
- [x] `npm run check` for the touched Svelte file (pre-existing warnings only)
- [ ] CI green
- [ ] After merge + reset: `curl -L -o /tmp/saiku.dxt https://demo.saiku.bi/rest/saiku/info/mcp.dxt && unzip -p /tmp/saiku.dxt manifest.json | jq .` returns the running manifest.