### PR TITLE
fix(mcp): drop WWW-Authenticate header + wrap array tool results (#878 follow-up)

### DIFF
--- a/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/mcp/McpResource.java
+++ b/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/mcp/McpResource.java
@@ -192,7 +192,12 @@ public class McpResource {
         }
         switch (name) {
             case "list_cubes": {
-                return unwrap(aiQueryResource.listCubes());
+                // saiku#878 follow-up: the MCP spec requires structuredContent
+                // to be a JSON object, not an array. AiQueryResource returns
+                // List<AiCubeSummary>; wrap under "cubes" so claude.ai's
+                // ClaudeAiToolResultRequest validator stops rejecting the
+                // result shape.
+                return wrapList("cubes", unwrap(aiQueryResource.listCubes()));
             }
             case "describe_cube": {
                 String cube = requiredString(args, "cube");
@@ -205,7 +210,11 @@ public class McpResource {
                 String level = requiredString(args, "level");
                 String q = optionalString(args, "q");
                 int limit = optionalInt(args, "limit", 20);
-                return unwrap(aiQueryResource.searchMembers(cube, dimension, hierarchy, level, q, limit));
+                // Same array-wrap as list_cubes — AiQueryResource returns a
+                // List<SimpleCubeElement>; MCP structuredContent must be an
+                // object so the host's validator accepts it.
+                return wrapList(
+                        "members", unwrap(aiQueryResource.searchMembers(cube, dimension, hierarchy, level, q, limit)));
             }
             case "run_query": {
                 String format = optionalString(args, "format");
@@ -226,6 +235,17 @@ public class McpResource {
             default:
                 throw new UnknownToolException("Unknown tool: " + name);
         }
+    }
+
+    /** Wrap a top-level array in a single-property object so the response
+     *  satisfies MCP's structuredContent contract (must be a JSON object).
+     *  No-op when the node is already an object — defensive in case the
+     *  underlying resource ever changes shape. */
+    private JsonNode wrapList(String key, JsonNode body) {
+        if (body == null || body.isObject()) return body == null ? MAPPER.createObjectNode() : body;
+        ObjectNode wrapped = MAPPER.createObjectNode();
+        wrapped.set(key, body);
+        return wrapped;
     }
 
     /** Read the JAX-RS Response entity as a JsonNode. AiQueryResource

--- a/saiku-core/saiku-web/src/test/java/org/saiku/web/rest/resources/mcp/McpResourceTest.java
+++ b/saiku-core/saiku-web/src/test/java/org/saiku/web/rest/resources/mcp/McpResourceTest.java
@@ -135,8 +135,13 @@ public class McpResourceTest {
         JsonNode body = MAPPER.valueToTree(resp.getEntity());
 
         JsonNode structured = body.path("result").path("structuredContent");
-        assertTrue("body should be the array AiQueryResource returned", structured.isArray());
-        assertEquals("Sales", structured.get(0).path("cubeCaption").asText());
+        // saiku#878 follow-up: MCP spec requires structuredContent to be a
+        // JSON object — list responses get wrapped under "cubes" so
+        // claude.ai's ClaudeAiToolResultRequest validator accepts them.
+        assertTrue("structuredContent must be a JSON object", structured.isObject());
+        JsonNode cubes = structured.path("cubes");
+        assertTrue("cubes[] survives the wrap", cubes.isArray());
+        assertEquals("Sales", cubes.get(0).path("cubeCaption").asText());
         assertEquals(false, body.path("result").path("isError").asBoolean());
     }
 

--- a/saiku-webapp/src/main/webapp/WEB-INF/applicationContext-saiku.xml
+++ b/saiku-webapp/src/main/webapp/WEB-INF/applicationContext-saiku.xml
@@ -92,8 +92,16 @@
            with Authorization: Basic. Coexists with the SPA form-login
            chain — Spring Security tries Basic first on requests carrying
            an Authorization header, falling through to the session cookie
-           otherwise. -->
-      <security:http-basic/>
+           otherwise.
+
+           entry-point-ref points at a no-challenge 401 entry point
+           (saiku#878 follow-up): the default BasicAuthenticationEntryPoint
+           stamps `WWW-Authenticate: Basic realm="..."` on every 401,
+           which makes the browser pop up a native auth dialog on the
+           SPA's XHR 401s. The SPA already has its own session-resume
+           modal — we never want the browser's default. The
+           HttpStatusEntryPoint just sets status 401 with no header. -->
+      <security:http-basic entry-point-ref="basicAuth401NoChallenge"/>
       <!-- Rate-limit auth attempts before BASIC_AUTH_FILTER so a blocked
            IP gets a clean 429 without ever waking the AuthenticationProvider.
            LoginRateLimiter is shared with SessionResource (form-login)

--- a/saiku-webapp/src/main/webapp/WEB-INF/saiku-beans.xml
+++ b/saiku-webapp/src/main/webapp/WEB-INF/saiku-beans.xml
@@ -251,6 +251,16 @@
          fronted by a proxy you control). -->
     <bean id="loginRateLimiter" class="org.saiku.web.security.ratelimit.LoginRateLimiter"/>
 
+    <!-- saiku#878 follow-up: replace BasicAuthenticationEntryPoint with
+         an entry point that returns 401 without WWW-Authenticate. The
+         SPA's XHRs hit 401s during normal "is the user signed in?"
+         probes; the default Basic challenge header was making the
+         browser pop up a native auth dialog over /ui/. -->
+    <bean id="basicAuth401NoChallenge"
+          class="org.springframework.security.web.authentication.HttpStatusEntryPoint">
+        <constructor-arg value="UNAUTHORIZED"/>
+    </bean>
+
     <!-- saiku#878: short-circuit Basic / form auth attempts from blocked IPs
          with a 429 before the AuthenticationProvider runs. Wired into the
          main Spring Security chain via <custom-filter> in


### PR DESCRIPTION
## Summary

Two regressions surfaced after PR #880 landed on demo.saiku.bi:

1. **Browser auth popup on /ui/** — SPA's XHR 401s carried `WWW-Authenticate: Basic realm=\"Realm\"`, triggering the browser's native auth dialog. Cause: `<security:http-basic/>` from #878 made `BasicAuthenticationEntryPoint` the chain's default, which stamps that header on every 401. The SPA already has its own session-resume modal.

   **Fix:** swap to `HttpStatusEntryPoint(UNAUTHORIZED)` via `entry-point-ref` on `<http-basic>`. The Basic credential check still runs — only the 401 challenge response changes (no header).

2. **claude.ai rejects MCP tool results for `list_cubes` / `search_members`** — `ClaudeAiToolResultRequest.structured_content: Input should be a valid dictionary`. Per the MCP spec, `structuredContent` must be a JSON **object**, not an array. AiQueryResource returns `List<AiCubeSummary>` / `List<SimpleCubeElement>` which were landing as top-level arrays.

   **Fix:** `wrapList()` in `McpResource.dispatchTool` wraps array responses under a property — `cubes` for `list_cubes`, `members` for `search_members`. Other tools (describe_cube, run_query, preview_query, drillthrough) already return objects and are unchanged.

## Demo VM status

- A Caddy hotfix (`header_down -Www-Authenticate`) was applied to demo.saiku.bi as an interim band-aid. Once this PR is deployed, that hotfix should be reverted so the header strip lives at the source. The MCP array bug is **not** mitigated by Caddy and remains live on demo until this lands.

## Test plan

- [x] `McpResourceTest` (12 cases) green — `list_cubes` assertion now reads `structuredContent.cubes[]` and confirms the top-level object shape.
- [x] `mvn -pl saiku-webapp -am package` green — XML wiring valid.
- [ ] Once deployed: verify no auth popup on `https://demo.saiku.bi/ui/` (XHR 401s no longer carry `WWW-Authenticate`).
- [ ] Once deployed: verify Claude Desktop / claude.ai `list_cubes` tool call returns `structuredContent: { \"cubes\": [...] }` and the validator accepts it.