### PR TITLE
chore: bump mondrian-saiku 4.8.1.10 → 4.8.1.11

### DIFF
--- a/saiku-bom/pom.xml
+++ b/saiku-bom/pom.xml
@@ -346,7 +346,7 @@
             <dependency>
                 <groupId>pentaho</groupId>
                 <artifactId>mondrian</artifactId>
-                <version>4.8.1.10</version>
+                <version>4.8.1.11</version>
                 <!-- xerces 2.12.2 + xalan 2.7.2 are transitively pulled by
                      mondrian but hijack the JDK's built-in JAXP via
                      META-INF/services overrides. Spring 6.2's tightened


### PR DESCRIPTION
4.8.1.11 closes the full #46 + #54 audit punchlist from today's multi-shape fuzz:

- **#56** — `SqlStatisticsProvider` catch + fallback for the multi-dim Calcite gap (closes [mondrian-saiku#46](https://github.com/spiculedata/mondrian-saiku/issues/46) follow-up)
- **#63** — legacy SQL alias collision for multi-shared-dim cubes (closes the [#51](https://github.com/spiculedata/mondrian-saiku/pull/51) follow-up I posted earlier)
- **#67** — `RolapNativeCrossJoin` guard for hanger-dim hierarchies with null `MemberBuilder` (closes [#54](https://github.com/spiculedata/mondrian-saiku/issues/54))

## Test plan

- [ ] CI green
- [ ] Docker workflow rebuilds `:development`
- [ ] Demo redeployed via `docker pull` + container restart
- [ ] Re-run `fuzz2-demo.py` against demo and confirm:
  - 54 CALCITE_FIELD_NOT_FOUND → 0
  - 5 ALIAS_COLLISION_SQL → 0
  - 2 MEMBER_BUILDER_NOT_FOUND → 0 (routed through `alertCrossJoinNonNative` per #67)

If any class still has failures, the result + repro will be posted back to whichever upstream ticket the residual shape maps to.