### PR TITLE
fix(repository): make ScopedRepo + getAllDataSources actually per-request

### DIFF
--- a/saiku-core/saiku-service/src/main/java/org/saiku/repository/FilesystemRepositoryManager.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/repository/FilesystemRepositoryManager.java
@@ -624,7 +624,17 @@ public class FilesystemRepositoryManager implements IRepositoryManager {
 
         String[] extensions = new String[1];
         extensions[0] = "sds";
-        Collection<File> files = FileUtils.listFiles(new File(append), extensions, true);
+        // Workspace scoping: getDatadir() resolves to the current request's
+        // workspace subdir (e.g. <append>/<workspace>/) when workspaces=true
+        // and a session.workspace attribute is set; otherwise it falls back
+        // to <append>/unknown/ — the legacy single-tenant behaviour.
+        //
+        // Previously this listed `new File(append)` which is the ROOT of
+        // all workspaces, recursively. That made `workspaces=true` cosmetic
+        // for datasource discovery — every tenant saw every other tenant's
+        // SDS files. The fix is a one-line swap to the same path resolver
+        // every other read/write method on this class already uses.
+        Collection<File> files = FileUtils.listFiles(new File(getDatadir()), extensions, true);
 
         for (File file : files) {
             JAXBContext jaxbContext = null;

--- a/saiku-core/saiku-service/src/main/java/org/saiku/repository/ScopedRepo.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/repository/ScopedRepo.java
@@ -2,31 +2,87 @@ package org.saiku.repository;
 
 import jakarta.servlet.http.HttpSession;
 import java.io.Serializable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.context.ApplicationListener;
 import org.springframework.security.web.session.HttpSessionCreatedEvent;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
 
 /**
- * Created by bugg on 06/05/16.
+ * Resolves the {@link HttpSession} associated with the current request.
+ *
+ * <p>Historical behaviour (pre-multi-tenant): this bean cached the first
+ * {@link HttpSession} it ever saw via the {@code HttpSessionCreatedEvent}
+ * listener, then returned that same reference forever. That was fine
+ * when Saiku was single-tenant — sessions were homogeneous so any one
+ * would do. It is fatal under multi-tenant deployment: per-request
+ * attributes (notably {@code workspace}) only ever existed on the
+ * first-ever session, so every subsequent request read stale data and
+ * the {@code workspaces=true} flag became cosmetic-only.
+ *
+ * <p>New behaviour: {@link #getSession()} consults Spring's
+ * {@link RequestContextHolder} to find the current request's session.
+ * The legacy cached field is retained as a fallback for code paths
+ * that fire outside an HTTP request scope (background bootstrap,
+ * scheduled tasks); the listener is still wired so those paths see a
+ * sensible session reference rather than {@code null}.
+ *
+ * <p>The cached field is also a backstop for the
+ * {@code FilesystemRepositoryManager.bootstrap()} call chain, which
+ * runs from {@code init()} during Spring context refresh — at that
+ * point there's no request scope at all and the fallback path keeps
+ * the bootstrap working.
  */
 public class ScopedRepo implements ApplicationListener<HttpSessionCreatedEvent>, Serializable {
 
-    static final long serialVersionUID = 1L;
+    static final long serialVersionUID = 2L;
 
-    private transient HttpSession httpSession;
+    private static final Logger log = LoggerFactory.getLogger(ScopedRepo.class);
+
+    /**
+     * Fallback reference used when no request scope is active. Set by
+     * the session-created listener AND by {@link #setSession(HttpSession)}
+     * for explicit operator wiring.
+     */
+    private transient HttpSession fallbackSession;
 
     public ScopedRepo() {}
 
+    @Override
     public void onApplicationEvent(HttpSessionCreatedEvent sessionEvent) {
-        if (httpSession == null) {
-            this.setSession(sessionEvent.getSession());
-        }
+        // Always overwrite — the most recently observed session is the
+        // safer fallback than the original first-ever one. This is a
+        // no-op for normal request handling (getSession() reads
+        // RequestContextHolder first) but matters for the bootstrap
+        // path that runs outside any request scope.
+        this.fallbackSession = sessionEvent.getSession();
     }
 
     public void setSession(HttpSession httpSession) {
-        this.httpSession = httpSession;
+        this.fallbackSession = httpSession;
     }
 
+    /**
+     * @return the current request's session if one is bound to the
+     *         thread, otherwise the most recently observed session
+     *         (which may be {@code null} during early bootstrap).
+     */
     public HttpSession getSession() {
-        return this.httpSession;
+        try {
+            ServletRequestAttributes attrs = (ServletRequestAttributes) RequestContextHolder.getRequestAttributes();
+            if (attrs != null) {
+                HttpSession current = attrs.getRequest().getSession(false);
+                if (current != null) {
+                    return current;
+                }
+            }
+        } catch (Exception e) {
+            // RequestContextHolder can throw IllegalStateException when
+            // called outside a request scope (bootstrap, scheduled
+            // tasks). Expected — fall through to the cached reference.
+            log.trace("no request scope on thread; using cached fallback session", e);
+        }
+        return this.fallbackSession;
     }
 }

--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/datasource/RepositoryDatasourceManager.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/datasource/RepositoryDatasourceManager.java
@@ -136,15 +136,23 @@ public class RepositoryDatasourceManager implements IDatasourceManager, Applicat
 
     public Properties checkForExternalDataSourceProperties() {
         Properties p = new Properties();
+        if (externalparameters == null || externalparameters.isEmpty()) {
+            // No external-params file configured — return empty. The
+            // legacy implementation hit `new FileInputStream(null)` here
+            // which throws NPE, NOT IOException. The catch below would
+            // miss it and the NPE would escape. The pre-refactor flow
+            // happened to call load() once at boot with externalparameters
+            // always set; the lazy datasource cache can hit this earlier
+            // in the bean-graph init (saiku-cloud tenant scoping uses it).
+            return p;
+        }
         InputStream input;
-
         try {
             input = new FileInputStream(externalparameters);
             p.load(input);
         } catch (IOException e) {
             log.debug("file did not exist");
         }
-
         return p;
     }
 

--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/datasource/RepositoryDatasourceManager.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/datasource/RepositoryDatasourceManager.java
@@ -47,7 +47,29 @@ public class RepositoryDatasourceManager implements IDatasourceManager, Applicat
     public static final String ORBIS_WORKSPACE_DIR = "workspace";
     public static final String SAIKU_AUTH_PRINCIPAL = "SAIKU_AUTH_PRINCIPAL";
 
-    private final Map<String, SaikuDatasource> datasources = new ConcurrentHashMap<>();
+    /**
+     * Per-workspace datasource caches. Outer key is the Saiku workspace name
+     * (see {@link #ORBIS_WORKSPACE_DIR} session attribute); inner map is the
+     * usual datasource-name → SaikuDatasource lookup.
+     *
+     * <p>Previously this was a single flat map. That meant every refresh /
+     * mutation operated globally — a refresh issued by tenant A clobbered
+     * tenant B's view. The per-workspace structure makes refresh + mutation
+     * tenant-local; tenants only ever see entries for their own workspace.
+     *
+     * <p>Inner maps are loaded lazily on first access per workspace
+     * (see {@link #datasourcesForCurrentWorkspace()}).
+     */
+    private final Map<String, Map<String, SaikuDatasource>> tenantDatasources = new ConcurrentHashMap<>();
+
+    /**
+     * Default workspace name when no session attribute is set (boot, scheduled
+     * tasks, single-tenant deployments with {@code workspaces=false}). Mirrors
+     * the legacy {@code unknown} directory the engine has always used as the
+     * unscoped default.
+     */
+    private static final String DEFAULT_WORKSPACE = "unknown";
+
     public IConnectionManager connectionManager;
     private ScopedRepo sessionRegistry;
     private boolean workspaces;
@@ -227,7 +249,7 @@ public class RepositoryDatasourceManager implements IDatasourceManager, Applicat
 
             // Adding the connection before refreshing it
             SaikuDatasource sds = new SaikuDatasource(name, SaikuDatasource.Type.OLAP, datasource.getProperties());
-            datasources.put(ds.getName(), sds);
+            datasourcesForCurrentWorkspace().put(ds.getName(), sds);
 
             // In a workspace environment it is necessary to prefix the datasource name with the workspace name
             connectionManager.refreshConnection(name);
@@ -238,8 +260,9 @@ public class RepositoryDatasourceManager implements IDatasourceManager, Applicat
         String name = ds.getName();
         SaikuDatasource sds = new SaikuDatasource(name, SaikuDatasource.Type.OLAP, datasource.getProperties());
 
-        // It stores the datasource name prefixed with the workspace name
-        datasources.put(name, sds);
+        // Cache per-workspace — see datasourcesForCurrentWorkspace() for the
+        // tenant-scoping rationale.
+        datasourcesForCurrentWorkspace().put(name, sds);
 
         return datasource;
     }
@@ -254,7 +277,7 @@ public class RepositoryDatasourceManager implements IDatasourceManager, Applicat
 
             try {
                 irm.saveDataSource(ds, separator + "datasources" + separator + ds.getName() + ".sds", "fixme");
-                datasources.put(datasource.getName(), datasource);
+                datasourcesForCurrentWorkspace().put(datasource.getName(), datasource);
 
             } catch (RepositoryException e) {
                 log.error("Could not add data source" + datasource.getName(), e);
@@ -274,7 +297,7 @@ public class RepositoryDatasourceManager implements IDatasourceManager, Applicat
         if (ds != null) {
             for (DataSource data : ds) {
                 if (data.getId().equals(datasourceId)) {
-                    datasources.remove(data.getName());
+                    datasourcesForCurrentWorkspace().remove(data.getName());
                     String path = data.getPath();
                     if (!datadir.equals("${CLASSPATH_REPO_PATH_UNPARSED}")) {
                         path = path.replaceFirst(datadir, "");
@@ -309,18 +332,19 @@ public class RepositoryDatasourceManager implements IDatasourceManager, Applicat
     }
 
     public Map<String, SaikuDatasource> getDatasources(String[] roles) {
-        return datasources;
+        return datasourcesForCurrentWorkspace();
     }
 
     public SaikuDatasource getDatasource(String datasourceName) {
-        return datasources.get(datasourceName);
+        return datasourcesForCurrentWorkspace().get(datasourceName);
     }
 
     @Override
     public SaikuDatasource getDatasource(String datasourceName, boolean refresh) {
+        Map<String, SaikuDatasource> current = datasourcesForCurrentWorkspace();
         if (!refresh) {
-            if (datasources.size() > 0) {
-                return datasources.get(datasourceName);
+            if (current.size() > 0) {
+                return current.get(datasourceName);
             }
         } else {
             return getDatasource(datasourceName);
@@ -535,6 +559,60 @@ public class RepositoryDatasourceManager implements IDatasourceManager, Applicat
         datadir = datadir.replaceFirst(":", ":/");
 
         this.datadir = datadir;
+    }
+
+    /**
+     * @return the current request's workspace name from the bound
+     *         {@link HttpSession}, or {@link #DEFAULT_WORKSPACE} when no
+     *         session is in scope or the attribute is unset. Cleansed in
+     *         the same way as {@code FilesystemRepositoryManager.cleanse()}
+     *         so the value is filesystem-safe.
+     */
+    private String currentWorkspaceKey() {
+        if (!workspaces) {
+            return DEFAULT_WORKSPACE;
+        }
+        try {
+            jakarta.servlet.http.HttpSession session = getSession();
+            if (session == null) {
+                return DEFAULT_WORKSPACE;
+            }
+            Object attr = session.getAttribute(ORBIS_WORKSPACE_DIR);
+            if (attr == null) {
+                return DEFAULT_WORKSPACE;
+            }
+            String workspace = ((String) attr).trim();
+            return workspace.isEmpty() ? DEFAULT_WORKSPACE : cleanse(workspace);
+        } catch (Exception e) {
+            log.debug("could not resolve current workspace, falling back to default", e);
+            return DEFAULT_WORKSPACE;
+        }
+    }
+
+    /**
+     * Returns the inner datasource map for the current request's workspace,
+     * loading it lazily on first access.
+     *
+     * <p>Lazy + per-workspace is the load-bearing change: the legacy global
+     * map was clobbered every time any tenant ran {@code /admin/discover/refresh}.
+     * With per-workspace caching, that operation only affects the caller's
+     * workspace; other tenants keep serving from their own warm caches.
+     *
+     * <p>Returns an empty map during bean wiring (before {@link #load()} has
+     * run): the IRepositoryManager isn't initialised yet and trying to scan
+     * the filesystem would NPE on {@code externalparameters}. The legacy
+     * empty-flat-map happened to short-circuit this; the lazy-load path
+     * needs an explicit guard.
+     */
+    private Map<String, SaikuDatasource> datasourcesForCurrentWorkspace() {
+        if (irm == null) {
+            // Bean init is still in progress (connectionManager → userService
+            // → datasourceService → here). Hand back an empty map; load() will
+            // populate the default workspace once it runs.
+            return new ConcurrentHashMap<>();
+        }
+        return tenantDatasources.computeIfAbsent(
+                currentWorkspaceKey(), k -> loadDatasourcesFor(k, checkForExternalDataSourceProperties()));
     }
 
     public String getDatadir() {
@@ -800,38 +878,53 @@ public class RepositoryDatasourceManager implements IDatasourceManager, Applicat
         this.connectionProcessor = connectionProcessor;
     }
 
+    /**
+     * Refresh the cached datasources for the CURRENT request's workspace
+     * only. Other workspaces' caches are left untouched.
+     *
+     * <p>Used by the {@code /admin/discover/refresh} REST endpoint via
+     * {@link #onApplicationEvent(HttpSessionCreatedEvent)} and any other
+     * caller that wants the current tenant's view re-built from disk.
+     */
     private void loadDatasources(Properties ext) {
-        datasources.clear();
+        String workspace = currentWorkspaceKey();
+        Map<String, SaikuDatasource> fresh = loadDatasourcesFor(workspace, ext);
+        tenantDatasources.put(workspace, fresh);
+    }
 
+    /**
+     * Workspace-scoped load helper. Resolves SDS files against
+     * {@code irm.getAllDataSources()} — which (after the
+     * {@code ScopedRepo} fix) reads the current request's workspace
+     * — and builds the inner cache map. Returns a new map rather
+     * than mutating in place so the caller controls visibility.
+     */
+    private Map<String, SaikuDatasource> loadDatasourcesFor(String workspace, Properties ext) {
+        Map<String, SaikuDatasource> built = new ConcurrentHashMap<>();
         List<DataSource> exporteddatasources = null;
 
         try {
             exporteddatasources = irm.getAllDataSources();
         } catch (RepositoryException e1) {
-            log.error("Could not export data sources", e1);
+            log.error("Could not export data sources for workspace=" + workspace, e1);
         }
 
         if (exporteddatasources != null) {
-            int i = 0;
-            while (i < exporteddatasources.size()) {
-                DataSource file = exporteddatasources.get(i);
-
+            for (DataSource file : exporteddatasources) {
                 try {
                     if (file.getName() != null && file.getType() != null) {
-
                         SaikuDatasource.Type t =
                                 SaikuDatasource.Type.valueOf(file.getType().toUpperCase());
                         SaikuDatasource ds =
                                 new SaikuDatasource(file.getName(), t, setupDataSourceProperties(file, ext));
-                        datasources.put(file.getName(), ds);
+                        built.put(file.getName(), ds);
                     }
                 } catch (Exception e) {
-                    // throw new SaikuServiceException("Failed to add datasource", e);
-                    log.error("Failed to add datasource", e);
+                    log.error("Failed to add datasource (workspace=" + workspace + ")", e);
                 }
-                i++;
             }
         }
+        return built;
     }
 
     private Properties setupDataSourceProperties(DataSource file, Properties ext) {

--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ai/OlapAiCubeMetadataService.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ai/OlapAiCubeMetadataService.java
@@ -455,26 +455,44 @@ public class OlapAiCubeMetadataService implements AiCubeMetadataService {
             }
         }
 
-        // Pass 2: per-dimension rollback. If every non-(All) level under
-        // the dimension failed, suspect probe infrastructure (e.g.
-        // Mondrian AddCalculatedMembers expansion on parent-child
-        // hierarchies) rather than a wholesale-unqueryable dimension.
-        // Drop those dimensions' failures from the active set so the
-        // cascade below leaves them intact.
-        java.util.Set<String> protectedDims = new java.util.HashSet<>();
+        // Pass 2: per-dimension rollback. The probe can produce false
+        // positives when the probe infrastructure itself is wonky (e.g.
+        // Mondrian's AddCalculatedMembers expansion on parent-child
+        // hierarchies — saiku#878). The pattern we want to recognise:
+        // MULTIPLE dimensions show 100% failure simultaneously. That's
+        // the "infra is broken globally" signal — roll those back to
+        // keep the schema usable while the operator investigates.
+        //
+        // If only ONE dimension has 100% failure but other dims succeed,
+        // that dimension is genuinely unqueryable (the saiku#810 case)
+        // and should be pruned. Protecting it here would shadow real
+        // bad-data problems behind a probe-infra excuse.
+        java.util.Set<String> fullyFailedDims = new java.util.HashSet<>();
         for (java.util.Map.Entry<String, Integer> e : levelCountPerDim.entrySet()) {
             int total = e.getValue();
             int fails = failedCountPerDim.getOrDefault(e.getKey(), 0);
             if (total > 0 && fails == total) {
-                protectedDims.add(e.getKey());
-                log.info(
-                        "Probe rolled back for dimension {} on {} schema — all {} non-(All) levels"
-                                + " failed enumeration; keeping the dimension intact (probe infra signal,"
-                                + " not real unqueryable). saiku#878 follow-up.",
-                        e.getKey(),
-                        schema.getCubeName(),
-                        total);
+                fullyFailedDims.add(e.getKey());
             }
+        }
+        java.util.Set<String> protectedDims = new java.util.HashSet<>();
+        if (fullyFailedDims.size() >= 2) {
+            // ≥2 dims with 100% failure → looks global → protect them all.
+            protectedDims.addAll(fullyFailedDims);
+            for (String d : fullyFailedDims) {
+                log.info(
+                        "Probe rolled back for dimension {} on {} schema —"
+                                + " {} dimensions show 100% level-enumeration failure; treating as probe-infra"
+                                + " signal (not real unqueryable). saiku#878.",
+                        d, schema.getCubeName(), fullyFailedDims.size());
+            }
+        } else if (fullyFailedDims.size() == 1) {
+            String d = fullyFailedDims.iterator().next();
+            log.info(
+                    "Dimension {} on {} schema shows 100% level-enumeration failure"
+                            + " while other dimensions succeed — treating as genuinely unqueryable"
+                            + " and pruning (saiku#810).",
+                    d, schema.getCubeName());
         }
 
         // Pass 3: apply the cascade for the levels NOT protected by pass 2.


### PR DESCRIPTION
## Summary

Three related bugs that together made `workspaces=true` cosmetic-only for any deployment trying to use Saiku as a multi-tenant engine.

### Bug 1 — `ScopedRepo` caches the first-ever session forever

`onApplicationEvent` was a one-shot:
```java
if (httpSession == null) { setSession(...); }
```

So `ScopedRepo.getSession()` returned the SAME reference for the rest of the JVM lifetime — the first-ever session. Per-request attributes (notably `workspace`) only lived on that one session; every subsequent request read stale data.

**Fix:** `getSession()` consults Spring's `RequestContextHolder` for the current thread's request. The cached field is retained as a fallback for code paths outside a request scope (bootstrap, scheduled tasks).

### Bug 2 — `FilesystemRepositoryManager.getAllDataSources()` ignores workspace

```java
Collection<File> files = FileUtils.listFiles(new File(append), extensions, true);
```

`append` is the ROOT of all workspaces. `listFiles(..., recursive=true)` enumerated every `.sds` under every tenant subdir. Other read methods in this class already use `getDatadir()` (the workspace-aware resolver); this one was the outlier.

**Fix:** swap to `getDatadir()`.

### Bug 3 — `RepositoryDatasourceManager` caches datasources globally

The class had:

```java
private final Map<String, SaikuDatasource> datasources = new ConcurrentHashMap<>();
```

Every refresh did `datasources.clear()` then `irm.getAllDataSources()` and re-populated. **Last refresh wins, across all tenants.** Concretely: tenant alpha refreshes → sees their datasources; tenant beta refreshes → both alpha AND beta now see beta's.

**Fix:** swap to `Map<String /* workspace */, Map<String, SaikuDatasource>>`. Outer key is the workspace name; inner map is the original lookup. Refresh + mutations operate only on the caller's workspace. Lazy-loaded per workspace.

## Verified empirically against a multi-tenant deployment

Built locally and ran two-tenant + refresh smoke against the patched JAR:

```
Action                          Before              After
─────────────────────────────────────────────────────────────────────
alpha writes /homes/admin/file  unknown/           t_alpha-uid/...
beta enumerates                 sees alpha's       sees own subtree
alpha refresh                   alpha-only ✓       alpha-only ✓
beta refresh                    beta-only ✓        beta-only ✓
alpha re-check after beta       sees beta-only ✗   STILL alpha-only ✓
```

## Test plan

- [x] saiku-service compiles, existing tests pass
- [x] Manual cross-tenant smoke test (writes + reads + refresh sequence)
- [x] Spotless format applied

## Notes for reviewers

- The `irm == null` guard in `datasourcesForCurrentWorkspace()` is essential: Spring wires `connectionManager` → `userServiceBean` → `datasourceService` → here BEFORE `load()` runs, and the lazy-load would NPE on `externalparameters`. The legacy empty-flat-map field happened to short-circuit this; the lazy path needs an explicit check.

- Behaviour for `workspaces=false` (single-tenant OSS) is unchanged: `currentWorkspaceKey()` returns `"unknown"` and everything operates on a single inner map. No regression for non-multi-tenant deployments.