### PR TITLE
chore: bump mondrian-saiku 4.8.1.11 → 4.8.1.12

### DIFF
--- a/saiku-bom/pom.xml
+++ b/saiku-bom/pom.xml
@@ -346,7 +346,7 @@
             <dependency>
                 <groupId>pentaho</groupId>
                 <artifactId>mondrian</artifactId>
-                <version>4.8.1.11</version>
+                <version>4.8.1.12</version>
                 <!-- xerces 2.12.2 + xalan 2.7.2 are transitively pulled by
                      mondrian but hijack the JDK's built-in JAXP via
                      META-INF/services overrides. Spring 6.2's tightened


### PR DESCRIPTION
Closes the audit thread:

- **#76** (closes [mondrian-saiku#74](https://github.com/spiculedata/mondrian-saiku/issues/74)) — attribute-scoped multi-shared-dim alias collision. The #63 fix keyed on `sharedDimension.table`, blind to the `<Attribute table='X'>` form (Store2 in FoodMart). Now resolves via attribute fallback.
- **#78** (closes [mondrian-saiku#77](https://github.com/spiculedata/mondrian-saiku/issues/77)) — null-`_def` synthetic-dim clone guard, surfaced by the widened clone path in #76.

## Test plan
- [ ] CI green
- [ ] Docker workflow → `:development`
- [ ] Demo redeployed
- [ ] Re-run fuzz against demo; expect ALIAS_COLLISION_SQL 8 → 0
