### PR TITLE
fix(security): repository ACL checks on saveFile + removeFile (closes #895, #896)

### DIFF
--- a/saiku-core/saiku-service/src/main/java/org/saiku/repository/FilesystemRepositoryManager.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/repository/FilesystemRepositoryManager.java
@@ -253,7 +253,12 @@ public class FilesystemRepositoryManager implements IRepositoryManager {
     public Object saveFile(Object file, String path, String user, String type, List<String> roles)
             throws RepositoryException {
         if (file == null) {
-            // Create new folder
+            // Create new folder. saiku#895 fix: the canWrite check below was
+            // previously INVERTED (`if (canWrite) throw`), denying writes to
+            // any user who actually had permission and permitting everyone
+            // else. Branch is dead code today (no REST caller reaches it
+            // with file == null), but left in place so a future folder-
+            // create caller doesn't trip the latent footgun.
             String parent;
             if (path.contains(sep)) {
                 parent = path.substring(0, path.lastIndexOf(sep));
@@ -263,8 +268,8 @@ public class FilesystemRepositoryManager implements IRepositoryManager {
             File node = getFolder(parent);
             Acl2 acl2 = new Acl2(node);
             acl2.setAdminRoles(userService.getAdminRoles());
-            if (acl2.canWrite(node, user, roles)) {
-                throw new SaikuServiceException("Can't write to file or folder");
+            if (!acl2.canWrite(node, user, roles)) {
+                throw new SaikuServiceException("You don't have permission to write to " + path);
             }
 
             int pos = path.lastIndexOf(sep);
@@ -273,11 +278,19 @@ public class FilesystemRepositoryManager implements IRepositoryManager {
             return null;
 
         } else {
+            // saiku#895: gate the actual file write on canWrite for the
+            // parent folder. The pre-fix code constructed the Acl2 but
+            // never consulted it, letting any authenticated user overwrite
+            // any path in the repository (including other users' homes
+            // and the shared /datasources tree).
             int pos = path.lastIndexOf(sep);
             String filename = "." + sep + path.substring(pos + 1, path.length());
             File n = getFolder(path.substring(0, pos));
             Acl2 acl2 = new Acl2(n);
             acl2.setAdminRoles(userService.getAdminRoles());
+            if (!acl2.canWrite(n, user, roles)) {
+                throw new SaikuServiceException("You don't have permission to write to " + path);
+            }
 
             File check = this.getNode(filename);
             if (check.exists()) {
@@ -307,12 +320,17 @@ public class FilesystemRepositoryManager implements IRepositoryManager {
     }
 
     public void removeFile(String path, String user, List<String> roles) throws RepositoryException {
+        // saiku#896: delete used to be gated on canRead — strictly weaker
+        // than the operation being performed. canRead is true for every
+        // authenticated user on un-ACL'd nodes (the default), which made
+        // delete a universal capability. canWrite is the correct minimum;
+        // an admin retains delete via the canWrite "admin-roles" override
+        // already baked into Acl2.
         File node = getFolder(path);
         Acl2 acl2 = new Acl2(node);
         acl2.setAdminRoles(userService.getAdminRoles());
-        if (!acl2.canRead(node, user, roles)) {
-            // TODO Throw exception
-            throw new RepositoryException();
+        if (!acl2.canWrite(node, user, roles)) {
+            throw new SaikuServiceException("You don't have permission to remove " + path);
         }
 
         this.getNode(path).delete();

--- a/saiku-core/saiku-service/src/test/java/org/saiku/repository/FilesystemRepositoryManagerAclTest.java
+++ b/saiku-core/saiku-service/src/test/java/org/saiku/repository/FilesystemRepositoryManagerAclTest.java
@@ -1,0 +1,176 @@
+package org.saiku.repository;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.io.File;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.saiku.service.user.UserService;
+
+/**
+ * Regression coverage for saiku#895 (saveFile missing canWrite check) and
+ * saiku#896 (removeFile checking canRead instead of canWrite).
+ *
+ * <p>Pre-fix: any authenticated user could overwrite or delete any file in
+ * the repository because {@link FilesystemRepositoryManager#saveFile} did
+ * not consult the {@link Acl2} it constructed, and
+ * {@link FilesystemRepositoryManager#removeFile} gated on the structurally-
+ * wrong {@code canRead} predicate (which is satisfied by every authenticated
+ * user on un-ACL'd nodes via the default {@code rootMethod=WRITE} trust
+ * posture).
+ *
+ * <p>Post-fix: both paths consult {@code canWrite}, which honours PRIVATE
+ * {@code acl.json} entries the owner has placed on a folder. Admin role
+ * short-circuits {@link Acl2#getMethods} (returns GRANT regardless of the
+ * entry) so admins retain delete capability even for owner-PRIVATE folders.
+ */
+public class FilesystemRepositoryManagerAclTest {
+
+    @Rule
+    public TemporaryFolder tmp = new TemporaryFolder();
+
+    private FilesystemRepositoryManager manager;
+    private File datadir;
+    private File adminHomeDir;
+    private File adminPrivateFile;
+
+    private static final List<String> ROLES_USER = Collections.singletonList("ROLE_USER");
+    private static final List<String> ROLES_ADMIN = Arrays.asList("ROLE_USER", "ROLE_ADMIN");
+
+    @Before
+    public void setUp() throws Exception {
+        resetSingleton();
+
+        datadir = tmp.newFolder("repo");
+        // <datadir>/unknown/etc bootstrap markers so getDatadir()'s lazy
+        // setup branch is skipped; same trick the path-traversal test uses.
+        File unknownEtc = new File(datadir, "unknown/etc");
+        if (!unknownEtc.mkdirs()) {
+            throw new IllegalStateException("Could not create " + unknownEtc);
+        }
+
+        // Build admin's home with a PRIVATE acl.json pinning ownership to admin.
+        adminHomeDir = new File(datadir, "unknown/homes/admin");
+        if (!adminHomeDir.mkdirs()) {
+            throw new IllegalStateException("Could not create " + adminHomeDir);
+        }
+        adminPrivateFile = new File(adminHomeDir, "private.saiku");
+        Files.write(adminPrivateFile.toPath(), "OWNED_BY_ADMIN".getBytes(StandardCharsets.UTF_8));
+
+        writeAclJson(adminHomeDir, adminHomeDir.getPath(), "PRIVATE", "admin");
+
+        manager = newManager(datadir.getAbsolutePath());
+        // saveFile/removeFile call userService.getAdminRoles(); wire a real
+        // UserService configured with ROLE_ADMIN so admin's role-based
+        // override fires correctly.
+        UserService us = new UserService();
+        us.setAdminRoles(Collections.singletonList("ROLE_ADMIN"));
+        injectUserService(manager, us);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        resetSingleton();
+    }
+
+    // ---- saiku#895: saveFile authorization ----------------------------
+
+    @Test
+    public void saveFile_nonOwner_nonAdmin_is_denied_on_PRIVATE_folder() throws Exception {
+        try {
+            manager.saveFile("HIJACKED", "/homes/admin/private.saiku", "bob", "nt:saikufiles", ROLES_USER);
+            fail("saveFile must reject a non-owner / non-admin write to a PRIVATE folder");
+        } catch (Exception expected) {
+            // SaikuServiceException is wrapped/rethrown — accept anything that aborts the write.
+        }
+        String preserved = new String(Files.readAllBytes(adminPrivateFile.toPath()), StandardCharsets.UTF_8);
+        assertEquals(
+                "file contents must not have been overwritten by an unauthorised caller", "OWNED_BY_ADMIN", preserved);
+    }
+
+    @Test
+    public void saveFile_admin_can_write_to_owner_PRIVATE_folder() throws Exception {
+        manager.saveFile("ADMIN_REWRITE", "/homes/admin/private.saiku", "admin", "nt:saikufiles", ROLES_ADMIN);
+        assertEquals(
+                "admin write must succeed (admin role overrides PRIVATE owner check)",
+                "ADMIN_REWRITE",
+                new String(Files.readAllBytes(adminPrivateFile.toPath()), StandardCharsets.UTF_8));
+    }
+
+    @Test
+    public void saveFile_owner_can_write_to_their_PRIVATE_folder() throws Exception {
+        manager.saveFile("OWNER_REWRITE", "/homes/admin/private.saiku", "admin", "nt:saikufiles", ROLES_USER);
+        assertEquals(
+                "owner write must succeed (PRIVATE entry grants the owner GRANT, which implies WRITE)",
+                "OWNER_REWRITE",
+                new String(Files.readAllBytes(adminPrivateFile.toPath()), StandardCharsets.UTF_8));
+    }
+
+    // ---- saiku#896: removeFile authorization --------------------------
+
+    @Test
+    public void removeFile_nonOwner_nonAdmin_is_denied_on_PRIVATE_folder() throws Exception {
+        try {
+            manager.removeFile("/homes/admin/private.saiku", "bob", ROLES_USER);
+            fail("removeFile must reject a non-owner / non-admin delete in a PRIVATE folder");
+        } catch (Exception expected) {
+            // Accept either SaikuServiceException or RepositoryException — both are
+            // valid "denied" signals depending on which catch block at the REST
+            // layer eats the throw.
+        }
+        assertTrue("PRIVATE file must not have been deleted by an unauthorised caller", adminPrivateFile.exists());
+    }
+
+    @Test
+    public void removeFile_admin_can_delete_owner_PRIVATE_file() throws Exception {
+        manager.removeFile("/homes/admin/private.saiku", "admin", ROLES_ADMIN);
+        assertTrue("admin must be able to delete a PRIVATE file (role override)", !adminPrivateFile.exists());
+    }
+
+    // ---- helpers ------------------------------------------------------
+
+    /**
+     * Write an {@code acl.json} into {@code dir} encoding a single PRIVATE
+     * entry keyed by {@code pathKey}. JSON shape matches what
+     * {@link Acl2#serialize(File)} produces via Jackson on an {@link AclEntry}.
+     */
+    private static void writeAclJson(File dir, String pathKey, String aclType, String owner) throws Exception {
+        // Escape the path for JSON (Windows backslashes / spaces). On unix
+        // there's nothing to escape, but keep it correct.
+        String escapedPath = pathKey.replace("\\", "\\\\").replace("\"", "\\\"");
+        String json = "{\"" + escapedPath + "\":{\"owner\":\"" + owner + "\",\"type\":\"" + aclType
+                + "\",\"roles\":null,\"users\":null}}";
+        Files.write(new File(dir, "acl.json").toPath(), json.getBytes(StandardCharsets.UTF_8));
+    }
+
+    private static FilesystemRepositoryManager newManager(String path) throws Exception {
+        Constructor<FilesystemRepositoryManager> ctor = FilesystemRepositoryManager.class.getDeclaredConstructor(
+                String.class, String.class, ScopedRepo.class, boolean.class);
+        ctor.setAccessible(true);
+        return ctor.newInstance(path, "ROLE_USER", new ScopedRepo(), false);
+    }
+
+    private static void injectUserService(FilesystemRepositoryManager mgr, UserService us) throws Exception {
+        Field f = FilesystemRepositoryManager.class.getDeclaredField("userService");
+        f.setAccessible(true);
+        f.set(mgr, us);
+    }
+
+    private static void resetSingleton() throws Exception {
+        Field ref = FilesystemRepositoryManager.class.getDeclaredField("ref");
+        ref.setAccessible(true);
+        ref.set(null, null);
+    }
+}


### PR DESCRIPTION
Two HIGH-severity authorization bypasses in `FilesystemRepositoryManager`, both reachable as any authenticated user with no ACL annotation required on the target.

## #895 — `saveFile` missed the `canWrite` check entirely

The `file != null` branch (the only one any REST caller reaches today) constructed an `Acl2` against the target's parent folder but never consulted it before writing. Any authenticated user could overwrite any path in the repository — other users' homes, the shared `/datasources` tree, dashboard files under `/dashboards/...`.

**Fix:** gate the write on `canWrite(parent, user, roles)`. Admin role short-circuits `Acl2.getMethods` so admins keep their global write capability; owners keep write on their own homes via the PRIVATE `acl.json` contract; everyone else is denied.

Also fixed a latent inverted check in the `file == null` (folder-create) branch: `if (canWrite) throw` was reversed. Currently dead code, but the inversion would flip the security posture the moment any future caller hit it.

## #896 — `removeFile` gated on the wrong predicate

Delete was protected by `canRead`, which is strictly weaker than the operation. Combined with `Acl2`'s default `rootMethod=WRITE` (granting READ to every authenticated user on un-ACL'd nodes), this meant any authenticated user could delete any file in the repository.

**Fix:** gate the delete on `canWrite`.

## Tests

`FilesystemRepositoryManagerAclTest` — 5 regression cases covering:

- ❌ non-owner / non-admin `saveFile` → denied + file contents preserved
- ✅ admin `saveFile` (role override) → allowed
- ✅ owner `saveFile` → allowed
- ❌ non-owner / non-admin `removeFile` → denied + file still exists
- ✅ admin `removeFile` (role override) → allowed

`mvn -pl saiku-core/saiku-service test` — **419/419** (1 pre-existing skip).

## Cross-issue note

These fixes don't address [#897](https://github.com/spiculedata/saiku/issues/897) (bundled `users.properties` ships 3 undocumented default accounts), which is the **how** an attacker authenticates in the first place. The combined chain is `bob/dylan (#897) + #895 or #896 = full repository takeover`, so #897 is still worth landing separately as the final piece of the audit.