### PR TITLE
fix(security): gate demo users behind 'demo' Spring profile (closes #897)

### DIFF
--- a/saiku-launcher/src/main/java/org/saiku/launcher/SaikuLauncher.java
+++ b/saiku-launcher/src/main/java/org/saiku/launcher/SaikuLauncher.java
@@ -110,6 +110,16 @@ public class SaikuLauncher implements Callable<Integer> {
             if (pkgVersion != null && !pkgVersion.isBlank()) {
                 System.setProperty("saiku.version", pkgVersion);
             }
+            // saiku#897: enable the "demo" Spring profile when the
+            // SAIKU_DEMO=true env var is set. The profile gates loading of
+            // users-demo.properties (bob / krishna / smith) — production
+            // deployments leave SAIKU_DEMO unset and only get admin/admin.
+            // An explicit -Dspring.profiles.active=demo also works for
+            // operators who don't want to rely on env vars; if BOTH are
+            // set, the explicit -D wins (don't clobber it here).
+            if (isDemoModeRequested() && System.getProperty("spring.profiles.active") == null) {
+                System.setProperty("spring.profiles.active", "demo");
+            }
             System.out.println("Saiku home: " + saikuHome);
 
             stageSeedAssets(dataDir);
@@ -193,14 +203,54 @@ public class SaikuLauncher implements Callable<Integer> {
             String bar = "============================================================";
             System.out.println();
             System.out.println(bar);
-            System.out.println("  SECURITY: default credentials (admin/admin) are active.");
-            System.out.println("  Change them in saiku-webapp's users.properties before");
+            if (isDemoModeActive()) {
+                System.out.println("  SECURITY: 4 default credentials are active (DEMO MODE):");
+                System.out.println("    admin/admin                (ROLE_USER, ROLE_ADMIN)");
+                System.out.println("    bob/dylan                  (ROLE_USER)");
+                System.out.println("    krishna/krish2341          (ROLE_USER)");
+                System.out.println("    smith/pravah@001           (ROLE_USER)");
+                System.out.println("  Demo accounts own pre-seeded saved queries in");
+                System.out.println("  /homes/<user>/ — useful for tutorials, NOT for production.");
+                System.out.println("  Drop demo mode by unsetting SAIKU_DEMO and removing");
+                System.out.println("  -Dspring.profiles.active=demo. See saiku#897.");
+            } else {
+                System.out.println("  SECURITY: default credentials (admin/admin) are active.");
+            }
+            System.out.println("  Rotate them in saiku-webapp's users.properties before");
             System.out.println("  exposing this instance, or replace the in-memory auth");
             System.out.println("  config (applicationContext-spring-security-memory.xml)");
             System.out.println("  with LDAP / OAuth / SAML.");
             System.out.println("  Suppress this warning with -Dsaiku.security.acknowledged=true");
             System.out.println(bar);
             System.out.println();
+        }
+
+        /**
+         * True when the operator asked for demo mode either by env var
+         * ({@code SAIKU_DEMO=true}) or explicit Spring profile activation
+         * ({@code -Dspring.profiles.active=demo}). The two are honoured
+         * symmetrically — the env var is the friendly switch the bundled
+         * Docker image already sets; the {@code -D} is the override path
+         * for operators who don't want the env-based affordance.
+         */
+        private static boolean isDemoModeRequested() {
+            String env = System.getenv("SAIKU_DEMO");
+            if (env != null && Boolean.parseBoolean(env.trim())) {
+                return true;
+            }
+            String profiles = System.getProperty("spring.profiles.active", "");
+            for (String p : profiles.split(",")) {
+                if ("demo".equalsIgnoreCase(p.trim())) return true;
+            }
+            return false;
+        }
+
+        /** True when demo mode is currently in effect (post-bootstrap), which
+         *  is equivalent to {@link #isDemoModeRequested()} once
+         *  {@code bootServer} has run. Kept as a separate method so the
+         *  intent at each call site is unambiguous. */
+        private static boolean isDemoModeActive() {
+            return isDemoModeRequested();
         }
 
         private static void stageSeedAssets(Path dataDir) throws Exception {

--- a/saiku-webapp/src/main/webapp/WEB-INF/applicationContext-spring-security-memory.xml
+++ b/saiku-webapp/src/main/webapp/WEB-INF/applicationContext-spring-security-memory.xml
@@ -6,18 +6,38 @@
        		   http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
 
 
-<!--+
-	| Application context containing "in memory" AuthenticationProvider
-	| implementation.
-	+-->
+  <!--+
+      | In-memory AuthenticationProvider for the bundled WAR.
+      |
+      | Production posture (default profile): only users.properties is
+      | loaded → ships with admin/admin which the launcher warns about
+      | and operators are expected to rotate or replace before exposure.
+      |
+      | Demo posture: when the "demo" Spring profile is active, the
+      | additional users-demo.properties file is also loaded, enabling
+      | the pre-seeded bob/krishna/smith accounts whose home folders
+      | contain example saved queries. The saiku-launcher activates
+      | this profile automatically when the SAIKU_DEMO=true env var is
+      | set (or via -Dspring.profiles.active=demo). See saiku#897.
+      +-->
 
-  	<security:authentication-manager alias="authenticationManager">
+  <beans profile="!demo">
+    <security:authentication-manager alias="authenticationManager">
+      <security:authentication-provider>
+        <security:user-service id="uds" properties="/WEB-INF/users.properties"/>
+      </security:authentication-provider>
+    </security:authentication-manager>
+  </beans>
 
-		<security:authentication-provider>
-			<security:user-service id="uds" properties="/WEB-INF/users.properties">
-
-			</security:user-service>
-		</security:authentication-provider>
-	</security:authentication-manager>
+  <beans profile="demo">
+    <security:authentication-manager alias="authenticationManager">
+      <security:authentication-provider>
+        <security:user-service id="uds" properties="/WEB-INF/users.properties"/>
+      </security:authentication-provider>
+      <security:authentication-provider>
+        <security:user-service id="udsDemo" properties="/WEB-INF/users-demo.properties"/>
+      </security:authentication-provider>
+    </security:authentication-manager>
+  </beans>
 
 </beans>

--- a/saiku-webapp/src/main/webapp/WEB-INF/users-demo.properties
+++ b/saiku-webapp/src/main/webapp/WEB-INF/users-demo.properties
@@ -1,0 +1,13 @@
+#Username,password,role
+#
+# Demo-only seed users. Loaded only when the "demo" Spring profile is
+# active (e.g. saiku-launcher sets spring.profiles.active=demo when the
+# SAIKU_DEMO=true env var is set). Production WARs do not load this file.
+#
+# These accounts own pre-seeded saved queries under /homes/<user>/ in
+# the bundled demo data — keeping them in a separate file lets a real
+# deployment ship without the publicly-knowable credentials being
+# active. See saiku#897.
+bob={noop}dylan,ROLE_USER
+krishna={noop}krish2341,ROLE_USER
+smith={noop}pravah@001,ROLE_USER

--- a/saiku-webapp/src/main/webapp/WEB-INF/users.properties
+++ b/saiku-webapp/src/main/webapp/WEB-INF/users.properties
@@ -1,5 +1,12 @@
 #Username,password,role
-bob={noop}dylan,ROLE_USER
-krishna={noop}krish2341,ROLE_USER
-smith={noop}pravah@001,ROLE_USER
+#
+# In-memory users for the bundled Spring Security config. Production
+# deployments should rotate admin/admin or replace this entirely with
+# an external auth provider (LDAP / OAuth / SAML) — see
+# applicationContext-spring-security-memory.xml.
+#
+# Additional demo accounts (bob / krishna / smith) live in
+# users-demo.properties and are loaded only when the "demo" Spring
+# profile is active (set spring.profiles.active=demo or, in the
+# launcher, the SAIKU_DEMO=true env var). See saiku#897.
 admin={noop}admin,ROLE_USER,ROLE_ADMIN


### PR DESCRIPTION
Closes #897. Option B from the audit thread — keep the demo affordance but require explicit opt-in.

## What changed

**Spring auth config now has two profiles**, gated by the standard `spring.profiles.active`:

| Profile | `users.properties` | `users-demo.properties` |
|---|:---:|:---:|
| default (`!demo`) | ✓ | — |
| `demo` | ✓ | ✓ |

- `users.properties` ships with only `admin/admin`
- `users-demo.properties` (new) ships with `bob/krishna/smith`
- `applicationContext-spring-security-memory.xml` — two profile-gated `<beans>` blocks; both define the same `authenticationManager` alias, so downstream filter chains are unaffected
- `SaikuLauncher.bootServer` — sets `spring.profiles.active=demo` when `SAIKU_DEMO=true` is in env (unless an explicit `-Dspring.profiles.active=…` overrides)
- `SaikuLauncher.printDefaultCredentialWarning` — in demo mode enumerates every active credential (not just `admin/admin`) and references #897 so the operator can find the switch

## Verified empirically

`mvn -pl saiku-launcher -am package -DskipTests` → fat-jar at `target/saiku-4.2.1.jar`. Launched twice:

**Production mode** (no `SAIKU_DEMO`):
```
POST /login admin/admin           → 302 to /             ✓ accepted
POST /login smith/pravah@001      → 302 to /login?error  ✓ rejected
```

**Demo mode** (`SAIKU_DEMO=true`):
```
POST /login admin/admin           → 302 to /             ✓
POST /login smith/pravah@001      → 302 to /             ✓
POST /login bob/dylan             → 302 to /             ✓
POST /login krishna/krish2341     → 302 to /             ✓
```

Banner output also confirmed in both modes (production banner unchanged; demo banner now lists all four accounts + the switch-off instructions).

## Demo deployment continuity

`demo.saiku.bi`'s docker container already sets `SAIKU_DEMO=true` (per the existing runbook). After this lands and CI rebuilds `:development`, the demo container redeploys and continues to authenticate `smith` for the seeded units.saiku / count.saiku workflows. Production downstream deployments (which don't set the env var) only get `admin/admin`.

## Tests

- `saiku-core/saiku-service` surefire: **414/414** (1 pre-existing skip — Anthropic provider env var).
- No new tests added — the regression surface is empirical launcher behaviour, covered by the smoke test above. If desired, an integration test on the `saiku-launcher` IT harness can lock in both profile paths in a follow-up.