### PR TITLE
chore(release): publish module jars to GitHub Packages on tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,6 +41,12 @@ jobs:
         env:
           GH_PACKAGES_USER: ${{ github.actor }}
           GH_PACKAGES_TOKEN: ${{ secrets.GH_PACKAGES_TOKEN }}
+          # GH_PACKAGES_TOKEN is a PAT scoped to read+write packages and
+          # used for resolving inbound deps (mondrian-saiku etc). For
+          # deploying THIS repo's own artifacts we use the workflow's
+          # ephemeral GITHUB_TOKEN under server id github-saiku-self —
+          # 'packages: write' is granted at the top of this workflow.
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           mkdir -p ~/.m2
           cat > ~/.m2/settings.xml <<EOF
@@ -50,6 +56,7 @@ jobs:
               <server><id>github-olap4j</id><username>${GH_PACKAGES_USER}</username><password>${GH_PACKAGES_TOKEN}</password></server>
               <server><id>github-olap4j-xmlaserver</id><username>${GH_PACKAGES_USER}</username><password>${GH_PACKAGES_TOKEN}</password></server>
               <server><id>github-saiku-query</id><username>${GH_PACKAGES_USER}</username><password>${GH_PACKAGES_TOKEN}</password></server>
+              <server><id>github-saiku-self</id><username>${GITHUB_ACTOR}</username><password>${GITHUB_TOKEN}</password></server>
             </servers>
           </settings>
           EOF
@@ -73,6 +80,22 @@ jobs:
         # saiku-mcp stdio binary is gone — MCP hosts now hit the launcher
         # directly with per-user Basic auth.
         run: mvn -B -ntp -DskipTests -pl saiku-launcher -am package
+
+      - name: mvn deploy (module jars to GH Packages)
+        # Publishes saiku-bom + saiku-core/* to maven.pkg.github.com/spiculedata/saiku
+        # so downstream consumers (saiku-cloud's IRepositoryManager
+        # adapter, embedders) can `<dependency>` saiku-service the
+        # normal way. saiku-launcher (fat jar) and saiku-webapp (raw
+        # war) opt out via maven-deploy-plugin <skip>true</skip> in
+        # their own poms — they ride to the GitHub Releases page only.
+        #
+        # `mvn deploy` from the reactor root walks every module in
+        # <modules>; the two opt-outs above keep GH Packages free of
+        # multi-hundred-meg blobs. Tests already ran in ci.yml on PR
+        # merge — re-running them here would be wasted runner minutes.
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: mvn -B -ntp -DskipTests deploy
 
       - name: Stage release assets
         env:

--- a/pom.xml
+++ b/pom.xml
@@ -104,6 +104,26 @@
             <snapshots><enabled>true</enabled></snapshots>
         </repository>
     </repositories>
+
+    <!-- Where mvn deploy publishes saiku's own module jars (saiku-bom,
+         saiku-core/*, saiku-webapp). The release workflow's settings.xml
+         supplies the GITHUB_TOKEN-backed credentials under server id
+         `github-saiku-self`. The fat-jar saiku-launcher and the raw war
+         saiku-webapp set <skip>true</skip> on maven-deploy-plugin in
+         their own poms — only sensibly-sized Maven-consumable artifacts
+         land in GH Packages. -->
+    <distributionManagement>
+        <repository>
+            <id>github-saiku-self</id>
+            <name>GitHub Packages - spiculedata/saiku</name>
+            <url>https://maven.pkg.github.com/spiculedata/saiku</url>
+        </repository>
+        <snapshotRepository>
+            <id>github-saiku-self</id>
+            <name>GitHub Packages - spiculedata/saiku (snapshots)</name>
+            <url>https://maven.pkg.github.com/spiculedata/saiku</url>
+        </snapshotRepository>
+    </distributionManagement>
     <build>
         <plugins>
             <plugin>

--- a/saiku-launcher/pom.xml
+++ b/saiku-launcher/pom.xml
@@ -76,6 +76,19 @@
     <build>
         <finalName>saiku-${project.version}</finalName>
         <plugins>
+            <!-- The launcher artifact is a ~360MB Spring Boot fat jar:
+                 a runnable thing, not a library. Nobody Maven-depends on
+                 a fat jar. Skip mvn deploy so it stays a GitHub release
+                 asset (downloadable from the Releases page) rather than
+                 also landing in GH Packages as a multi-hundred-meg blob. -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-deploy-plugin</artifactId>
+                <version>3.1.3</version>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.13.0</version>

--- a/saiku-webapp/pom.xml
+++ b/saiku-webapp/pom.xml
@@ -11,6 +11,20 @@
     <packaging>war</packaging>
     <build>
         <plugins>
+            <!-- The webapp's artifact is a ~100MB war that bundles every
+                 transitive dep. Nobody needs to <dependency> it from
+                 Maven — consumers either run the launcher fat-jar or
+                 build their own webapp. Skip mvn deploy so GH Packages
+                 doesn't fill up with multi-hundred-meg blobs per release.
+                 The saiku-core/* JARs are the actual consumable surface. -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-deploy-plugin</artifactId>
+                <version>3.1.3</version>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>


### PR DESCRIPTION
## Summary

The release workflow currently uploads the saiku-launcher fat jar and dist zip to the GitHub Releases page. Nothing consumable as a Maven dependency lands anywhere — downstream consumers (saiku-cloud's `IRepositoryManager` adapter is the immediate one, but also any embedders) can't `<dependency>` `saiku-service` the normal way.

Fix: have the release workflow run `mvn deploy` after `mvn package`, targeting `maven.pkg.github.com/spiculedata/saiku`. The workflow's ephemeral `GITHUB_TOKEN` (with `packages: write` already granted at the top of `release.yml`) authenticates the push.

## Module surface

| Module                           | Deployed? | Why                                                  |
|----------------------------------|-----------|------------------------------------------------------|
| `saiku` (root pom)               | yes       | needed as `<parent>` by every other module           |
| `saiku-bom`                      | yes       | consumers `import` this for dependency-management    |
| `saiku-core` (parent pom)        | yes       | needed as `<parent>` by saiku-core/*                 |
| `saiku-core/saiku-olap-util`     | yes       | transitive from saiku-service                        |
| `saiku-core/saiku-service`       | yes       | **the load-bearing consumer dep**                    |
| `saiku-core/saiku-web`           | yes       | useful for embedders wiring REST controllers         |
| `saiku-core/saiku-semantic`      | yes       | small, ships for completeness                        |
| `saiku-webapp`                   | **skip**  | ~100MB war; embedders build their own                |
| `saiku-launcher`                 | **skip**  | ~360MB runnable fat jar, not a library               |

Both opt out via `maven-deploy-plugin <skip>true</skip>` in their own poms so a future `mvn deploy` from anywhere stays correct.

The launcher fat jar and dist zip continue to land on the GitHub Releases page exactly as before — this PR is purely additive.

## Test plan

- [x] `mvn validate` from reactor root — passes
- [x] `mvn help:effective-pom -pl saiku-core/saiku-service` shows `distributionManagement` inheriting from root, no `<skip>` on the deploy plugin
- [x] `mvn help:effective-pom -pl saiku-launcher` shows `maven-deploy-plugin` with `<skip>true</skip>` in effect
- [x] `mvn help:effective-pom -pl saiku-webapp` ditto
- [ ] Tag-driven workflow run publishes saiku-service-X.X.X.jar to `https://maven.pkg.github.com/spiculedata/saiku` (verified post-merge by cutting a tag)

## After this lands

Cut v4.2.2 (or a release-candidate tag). Then saiku-cloud's `saiku-cloud-storage` module can add:

```xml
<repository>
  <id>github-saiku</id>
  <url>https://maven.pkg.github.com/spiculedata/saiku</url>
</repository>

<dependency>
  <groupId>org.saikuanalytics</groupId>
  <artifactId>saiku-service</artifactId>
  <version>4.2.2</version>
</dependency>
```

and the `SaikuCloudRepositoryManager implements IRepositoryManager` wiring PR unblocks.