### PR TITLE
feat(repo): protected createRepositoryManager() hook for downstream irm swap

### DIFF
--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/datasource/RepositoryDatasourceManager.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/datasource/RepositoryDatasourceManager.java
@@ -114,8 +114,7 @@ public class RepositoryDatasourceManager implements IDatasourceManager, Applicat
         // Phase 2: Jackrabbit content-repo backend deleted; only classpath remains.
         separator = "/";
         log.debug("init datadir= " + datadir);
-        irm = FilesystemRepositoryManager.getFilesystemRepositoryManager(
-                cleanse(datadir), defaultRole, sessionRegistry, workspaces);
+        irm = createRepositoryManager();
         log.debug("2nd init datadir= " + datadir);
 
         // Perform the repository manager startup routines
@@ -128,6 +127,27 @@ public class RepositoryDatasourceManager implements IDatasourceManager, Applicat
 
         // Load the datasources
         loadDatasources(ext);
+    }
+
+    /**
+     * Factory hook for the underlying {@link IRepositoryManager}. The default
+     * implementation returns a {@link FilesystemRepositoryManager} configured
+     * from this service's properties — the long-standing OSS behaviour.
+     *
+     * <p>Downstream distributions (e.g. Saiku Cloud) override this method to
+     * substitute a wrapping implementation that, say, routes specific path
+     * prefixes through a Postgres-backed store while leaving everything else
+     * on the filesystem. Subclasses typically call {@code super.createRepositoryManager()}
+     * to obtain the filesystem instance and wrap it.
+     *
+     * <p>Kept {@code protected} so the hook is invisible to bean consumers but
+     * available to subclasses; private state read here ({@code datadir},
+     * {@code defaultRole}, {@code sessionRegistry}, {@code workspaces}) stays
+     * encapsulated.
+     */
+    protected IRepositoryManager createRepositoryManager() {
+        return FilesystemRepositoryManager.getFilesystemRepositoryManager(
+                cleanse(datadir), defaultRole, sessionRegistry, workspaces);
     }
 
     public void setRepositoryManager(IRepositoryManager irm) {


### PR DESCRIPTION
## Summary

Extract the `FilesystemRepositoryManager` construction in `RepositoryDatasourceManager.load()` into a protected `createRepositoryManager()` hook. Pure refactor — default implementation returns the same filesystem irm as before. Behaviour unchanged for OSS.

## Why

Saiku Cloud's storage layer needs to substitute the `IRepositoryManager` instance that this service wires up internally — to route specific path prefixes (`/homes/**`, `/datasources/**`) through a Postgres-backed store while everything else stays on the filesystem.

Today the irm construction reads four private fields (`datadir`, `defaultRole`, `sessionRegistry`, `workspaces`) and is inlined in `load()`, so a downstream subclass can't override it without reflection or duplicating `load()`'s entire body. The hook lets Cloud's subclass override one method and call `super.createRepositoryManager()` to get the filesystem instance to wrap.

## Diff shape

```java
// Before
public void load() {
    ...
    irm = FilesystemRepositoryManager.getFilesystemRepositoryManager(
            cleanse(datadir), defaultRole, sessionRegistry, workspaces);
    ...
}

// After
public void load() {
    ...
    irm = createRepositoryManager();   // unchanged for OSS
    ...
}

protected IRepositoryManager createRepositoryManager() {
    return FilesystemRepositoryManager.getFilesystemRepositoryManager(
            cleanse(datadir), defaultRole, sessionRegistry, workspaces);
}
```

## Test plan

- [x] `mvn test -pl saiku-core/saiku-service` — 414 tests pass, 0 failures
- [ ] CI green