### PR TITLE
fix(repo): seed default ACLs on shared folders + fix latent createFolder bug (#948)

### DIFF
--- a/saiku-core/saiku-service/src/main/java/org/saiku/repository/FilesystemRepositoryManager.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/repository/FilesystemRepositoryManager.java
@@ -96,69 +96,87 @@ public class FilesystemRepositoryManager implements IRepositoryManager {
                 f.mkdir();
             }
 
-            File n = this.createFolder(sep + "homes");
-
-            HashMap<String, List<AclMethod>> m = new HashMap<>();
-            ArrayList<AclMethod> l = new ArrayList<>();
-            l.add(AclMethod.READ);
-            m.put(defaultRole, l);
-            AclEntry e = new AclEntry("admin", AclType.SECURED, m, null);
-
-            Acl2 acl2 = new Acl2(n);
-            acl2.addEntry(n.getPath(), e);
-            acl2.serialize(n);
-
-            this.createFolder(sep + "datasources");
-
-            m = new HashMap<>();
-            l = new ArrayList<>();
-            l.add(AclMethod.WRITE);
-            l.add(AclMethod.READ);
-            l.add(AclMethod.GRANT);
-            m.put("ROLE_ADMIN", l);
-            e = new AclEntry("admin", AclType.PUBLIC, m, null);
-
-            acl2 = new Acl2(n);
-            acl2.addEntry(n.getPath(), e);
-            acl2.serialize(n);
-
-            this.createFolder(sep + "legacyreports");
-
-            acl2 = new Acl2(n);
-            acl2.addEntry(n.getPath(), e);
-            acl2.serialize(n);
+            seedSkeleton();
 
             log.info("node added");
             this.session = "init";
         } else {
-            File n = this.createFolder(sep + "homes");
-
-            HashMap<String, List<AclMethod>> m = new HashMap<>();
-            ArrayList<AclMethod> l = new ArrayList<>();
-            l.add(AclMethod.READ);
-            m.put(defaultRole, l);
-            AclEntry e = new AclEntry("admin", AclType.SECURED, m, null);
-
-            Acl2 acl2 = new Acl2(n);
-            acl2.addEntry(n.getPath(), e);
-            acl2.serialize(n);
-
-            this.createFolder(sep + "datasources");
-
-            m = new HashMap<>();
-            l = new ArrayList<>();
-            l.add(AclMethod.WRITE);
-            l.add(AclMethod.READ);
-            l.add(AclMethod.GRANT);
-            m.put("ROLE_ADMIN", l);
-            e = new AclEntry("admin", AclType.PUBLIC, m, null);
-
-            acl2 = new Acl2(n);
-            acl2.addEntry(n.getPath(), e);
-            acl2.serialize(n);
+            seedSkeleton();
         }
 
         return true;
+    }
+
+    /**
+     * Seed the standard repository skeleton with sensible default ACLs.
+     *
+     * <p>Idempotent — re-running {@code start()} (e.g. on workspace bootstrap)
+     * re-applies these grants but does not destroy user content. Owner of every
+     * seeded ACL is {@code admin}.
+     *
+     * <ul>
+     *   <li><b>/homes/</b> — SECURED, defaultRole READ. Per-user PRIVATE folders
+     *       are added on first login via {@link #createUser(String)}.</li>
+     *   <li><b>/datasources/</b> — PUBLIC, ROLE_ADMIN WRITE/READ/GRANT. Authenticated
+     *       users can READ (rootMethod fallback); only admins mutate.</li>
+     *   <li><b>/dashboards/</b> — SECURED, ROLE_ADMIN WRITE/READ/GRANT. User-saved
+     *       dashboards live under {@code /homes/<user>/} where the home ACL applies;
+     *       the top-level folder is admin-only-write to prevent cross-user clobber
+     *       (closes saiku#948).</li>
+     *   <li><b>/queries/</b> — SECURED, ROLE_ADMIN WRITE/READ/GRANT. Same rationale
+     *       as {@code /dashboards/}.</li>
+     *   <li><b>/legacyreports/</b> — PUBLIC, ROLE_ADMIN WRITE/READ/GRANT. Mirrors
+     *       historical behaviour.</li>
+     * </ul>
+     *
+     * <p>Historical bug fixed inline: prior code captured one {@code File n} for
+     * {@code /homes/} and then re-serialised every subsequent folder's ACL onto
+     * that same reference — so the supposed {@code /datasources/} and
+     * {@code /legacyreports/} ACLs were silently overwriting {@code /homes/}'s
+     * {@code acl.json}. Each {@link #seedAcl} call now operates on its own folder.
+     */
+    private void seedSkeleton() throws RepositoryException {
+        seedAcl(this.createFolder(sep + "homes"), homesGrant());
+        seedAcl(this.createFolder(sep + "datasources"), publicAdminGrant());
+        seedAcl(this.createFolder(sep + "dashboards"), securedAdminGrant());
+        seedAcl(this.createFolder(sep + "queries"), securedAdminGrant());
+        seedAcl(this.createFolder(sep + "legacyreports"), publicAdminGrant());
+    }
+
+    /** Write an {@link AclEntry} to {@code folder/acl.json}. */
+    private void seedAcl(File folder, AclEntry entry) {
+        Acl2 acl2 = new Acl2(folder);
+        acl2.addEntry(folder.getPath(), entry);
+        acl2.serialize(folder);
+    }
+
+    /** {@code defaultRole} → READ; SECURED; admin owner. The {@code /homes/} default. */
+    private AclEntry homesGrant() {
+        HashMap<String, List<AclMethod>> roles = new HashMap<>();
+        ArrayList<AclMethod> grants = new ArrayList<>();
+        grants.add(AclMethod.READ);
+        roles.put(defaultRole, grants);
+        return new AclEntry("admin", AclType.SECURED, roles, null);
+    }
+
+    /** {@code ROLE_ADMIN} → WRITE/READ/GRANT; PUBLIC; admin owner. */
+    private AclEntry publicAdminGrant() {
+        return new AclEntry("admin", AclType.PUBLIC, adminGrants(), null);
+    }
+
+    /** {@code ROLE_ADMIN} → WRITE/READ/GRANT; SECURED; admin owner. */
+    private AclEntry securedAdminGrant() {
+        return new AclEntry("admin", AclType.SECURED, adminGrants(), null);
+    }
+
+    private Map<String, List<AclMethod>> adminGrants() {
+        HashMap<String, List<AclMethod>> roles = new HashMap<>();
+        ArrayList<AclMethod> grants = new ArrayList<>();
+        grants.add(AclMethod.WRITE);
+        grants.add(AclMethod.READ);
+        grants.add(AclMethod.GRANT);
+        roles.put("ROLE_ADMIN", grants);
+        return roles;
     }
 
     public void createUser(String u) throws RepositoryException {
@@ -794,13 +812,25 @@ public class FilesystemRepositoryManager implements IRepositoryManager {
         }
     }
 
+    /**
+     * Create {@code <datadir>/<path>} (mkdirs) and return the resolved
+     * filesystem {@link File} pointing at it.
+     *
+     * <p>Historically returned {@code new File(fixPath(path))} — i.e. the
+     * unresolved repo-relative path like {@code "/homes"} — which on Unix
+     * was interpreted as a filesystem-absolute path under the root
+     * directory. Downstream {@link Acl2#serialize} calls then tried to
+     * write {@code /homes/acl.json} (the OS root) and failed silently via
+     * Jackson's catch block, leaving the supposed default ACLs absent on
+     * disk. The new return value is the actual data-dir-relative File so
+     * ACLs land where the caller expects (closes the latent bug behind
+     * saiku#948).
+     */
     private File createFolder(String path) {
         String appended = fixPath(getDatadir() + path);
-        boolean success = (new File(appended)).mkdirs();
-        if (!success) {
-            // Directory creation failed
-        }
-        return new File(fixPath(path));
+        File resolved = new File(appended);
+        resolved.mkdirs();
+        return resolved;
     }
 
     private File[] getAllFoldersInCurrentDirectory(String path) {

--- a/saiku-core/saiku-service/src/test/java/org/saiku/repository/FilesystemRepositoryManagerSeedTest.java
+++ b/saiku-core/saiku-service/src/test/java/org/saiku/repository/FilesystemRepositoryManagerSeedTest.java
@@ -1,0 +1,132 @@
+package org.saiku.repository;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.File;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.util.Collections;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.saiku.service.user.UserService;
+
+/**
+ * Default-ACL coverage for saiku#948. Verifies that
+ * {@link FilesystemRepositoryManager#start} seeds explicit ACLs on every
+ * shared write surface — not just {@code /homes/} — and that each ACL lands
+ * on its own folder rather than overwriting {@code /homes/acl.json}
+ * repeatedly (the latent bug the seed refactor fixed).
+ */
+public class FilesystemRepositoryManagerSeedTest {
+
+    @Rule
+    public TemporaryFolder tmp = new TemporaryFolder();
+
+    private FilesystemRepositoryManager manager;
+    private File datadir;
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    @Before
+    public void setUp() throws Exception {
+        resetSingleton();
+
+        datadir = tmp.newFolder("repo");
+        manager = newManager(datadir.getAbsolutePath());
+
+        UserService us = new UserService();
+        us.setAdminRoles(Collections.singletonList("ROLE_ADMIN"));
+        injectUserService(manager, us);
+
+        // start() drives the seedSkeleton() helper.
+        manager.start(us);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        resetSingleton();
+    }
+
+    @Test
+    public void homes_seeded_with_SECURED_acl() throws Exception {
+        JsonNode entry = readEntry("homes");
+        assertEquals("SECURED", entry.get("type").asText());
+        assertEquals("admin", entry.get("owner").asText());
+    }
+
+    @Test
+    public void datasources_seeded_with_PUBLIC_admin_grant() throws Exception {
+        JsonNode entry = readEntry("datasources");
+        assertEquals("PUBLIC", entry.get("type").asText());
+        JsonNode roles = entry.get("roles");
+        assertTrue("ROLE_ADMIN grant must be present on /datasources/", roles.has("ROLE_ADMIN"));
+    }
+
+    @Test
+    public void dashboards_seeded_with_SECURED_admin_grant() throws Exception {
+        JsonNode entry = readEntry("dashboards");
+        assertEquals("SECURED", entry.get("type").asText());
+        JsonNode roles = entry.get("roles");
+        assertTrue("ROLE_ADMIN grant must be present on /dashboards/", roles.has("ROLE_ADMIN"));
+    }
+
+    @Test
+    public void queries_seeded_with_SECURED_admin_grant() throws Exception {
+        JsonNode entry = readEntry("queries");
+        assertEquals("SECURED", entry.get("type").asText());
+        JsonNode roles = entry.get("roles");
+        assertTrue("ROLE_ADMIN grant must be present on /queries/", roles.has("ROLE_ADMIN"));
+    }
+
+    /**
+     * Regression for the latent bug: prior code held one {@code File n} for
+     * {@code /homes/} and re-serialised every subsequent folder's ACL onto
+     * that same reference. After the fix each acl.json must live in its
+     * own folder, not all in /homes/.
+     */
+    @Test
+    public void each_seeded_folder_has_its_own_acl_json() {
+        File workspace = new File(datadir, "unknown");
+        assertTrue("/homes/acl.json missing", new File(workspace, "homes/acl.json").exists());
+        assertTrue(
+                "/datasources/acl.json missing — pre-fix this overwrote /homes/acl.json",
+                new File(workspace, "datasources/acl.json").exists());
+        assertTrue("/dashboards/acl.json missing", new File(workspace, "dashboards/acl.json").exists());
+        assertTrue("/queries/acl.json missing", new File(workspace, "queries/acl.json").exists());
+        assertTrue("/legacyreports/acl.json missing", new File(workspace, "legacyreports/acl.json").exists());
+    }
+
+    private JsonNode readEntry(String folder) throws Exception {
+        File aclJson = new File(datadir, "unknown/" + folder + "/acl.json");
+        assertTrue("acl.json missing for /" + folder + "/", aclJson.exists());
+        JsonNode root = mapper.readTree(aclJson);
+        // Acl2.serialize writes a single-key map keyed by the folder's absolute path.
+        JsonNode entry = root.elements().next();
+        assertTrue("acl.json for /" + folder + "/ has no entry payload", entry != null && !entry.isMissingNode());
+        return entry;
+    }
+
+    private static FilesystemRepositoryManager newManager(String path) throws Exception {
+        Constructor<FilesystemRepositoryManager> ctor = FilesystemRepositoryManager.class.getDeclaredConstructor(
+                String.class, String.class, ScopedRepo.class, boolean.class);
+        ctor.setAccessible(true);
+        return ctor.newInstance(path, "ROLE_USER", new ScopedRepo(), false);
+    }
+
+    private static void injectUserService(FilesystemRepositoryManager mgr, UserService us) throws Exception {
+        Field f = FilesystemRepositoryManager.class.getDeclaredField("userService");
+        f.setAccessible(true);
+        f.set(mgr, us);
+    }
+
+    private static void resetSingleton() throws Exception {
+        Field ref = FilesystemRepositoryManager.class.getDeclaredField("ref");
+        ref.setAccessible(true);
+        ref.set(null, null);
+    }
+}


### PR DESCRIPTION
## Summary

The audit prompted by saiku#895 / #896 surfaced **two real problems** with the bootstrap ACL seeding in \`FilesystemRepositoryManager.start()\`. Both go beyond the original ticket scope (which was just "add defaults for /dashboards/ and /queries/") because the existing seeding was structurally broken in ways that meant **no default ACLs have ever been written to disk in production**.

## The two compounding bugs

### Bug 1 — createFolder returned the wrong File

\`\`\`java
private File createFolder(String path) {
    String appended = fixPath(getDatadir() + path);
    boolean success = (new File(appended)).mkdirs();
    return new File(fixPath(path));  // <-- unresolved path, e.g. \"/homes\"
}
\`\`\`

The returned File represented an OS-absolute path like \`/homes\` (under root on Unix), not \`<datadir>/unknown/homes/\`. Subsequent \`Acl2.serialize\` calls failed silently — \`Jackson.writeValue\` hit IOException, caught and logged at debug level.

**Net effect**: every supposed default ACL the code claimed to seed has been silently failing to write for the entire life of this codebase.

### Bug 2 — shared File reference re-used across folders

\`\`\`java
File n = this.createFolder(\"/homes\");
// ... homes ACL setup ...
Acl2 acl2 = new Acl2(n);
acl2.serialize(n);  // would write /homes/acl.json

this.createFolder(\"/datasources\");  // <-- return ignored
acl2 = new Acl2(n);                  // <-- still 'n', still /homes/
acl2.serialize(n);                   // overwrites /homes/acl.json with /datasources/ entry
\`\`\`

Even if Bug 1 were fixed, /datasources/, /legacyreports/, /etc/theme/ would all be overwriting /homes/'s acl.json with whichever was applied last.

### Combined effect

Every deployment has been running with universal-write on every shared folder. The PRIVATE per-home ACLs added by \`createUser()\` are also affected (same broken createFolder).

## Fix

- **\`createFolder()\` returns the resolved File** under datadir. One-line semantic fix; downstream is unaffected because the only callers that USED the return value (\`start()\` and \`createUser()\`) needed the resolved path anyway.
- **Extracted helpers** \`seedSkeleton()\` + \`seedAcl(File, AclEntry)\` + grant-shape helpers (homesGrant, publicAdminGrant, securedAdminGrant, adminGrants) to replace the inline HashMap+ArrayList+AclEntry dance that was duplicated four times.
- **Added /dashboards/ and /queries/** to the skeleton with SECURED + ROLE_ADMIN WRITE/READ/GRANT. User-saved files live under \`/homes/<user>/\` where the home ACL applies; the top-level folder is admin-only-write to prevent cross-user clobber.

## Test surface

\`FilesystemRepositoryManagerSeedTest\` — 5 regression cases. Each verifies an acl.json lands in the right folder with the right type.

## Verified

\`saiku-core/saiku-service\` surefire: **424/424 passing** (1 pre-existing skip).

## Conflicts with PR #952

PR #952 (strip /etc/) touches the same start() block. The conflict is mechanical — when whichever lands second is rebased, the \`createFolder(\"/etc\")\` + license.lic block goes away cleanly.

## Test plan

- [ ] CI green (both OS, JDK 21)
- [ ] Fresh \`SAIKU_HOME\` bootstrap: \`<datadir>/unknown/{homes,datasources,dashboards,queries,legacyreports}/acl.json\` all exist with correct contents
- [ ] Non-admin user can save to \`/homes/<user>/\` (PRIVATE entry from createUser still grants owner WRITE)
- [ ] Non-admin user cannot save directly to \`/dashboards/foo.saikudash\` (admin-only-write at top level — has to go under their home)
- [ ] Existing deployments upgrading: \`acl.json\` files appear on next startup where they were always missing

## Pairs with

- #950 (strip /etc/) — separate PR #952
- #951 (rootMethod flip) — separate PR coming
- #949 (PermissionsModal UI) — separate PR #953, now actually usable since the defaults will be on-disk

Closes #948