### PR TITLE
feat(ui): design-token foundation — soft/strong colors, weight + icon scales, heading typography

### DIFF
--- a/saiku-ui/src/lib/components/ContextMenu.svelte
+++ b/saiku-ui/src/lib/components/ContextMenu.svelte
@@ -73,6 +73,6 @@
   }
   .ctx-menu__item:hover:not(:disabled) { background: var(--bg-subtle); }
   .ctx-menu__item:disabled { color: var(--fg-subtle); cursor: default; }
-  .ctx-menu__item.danger { color: #e06c75; }
+  .ctx-menu__item.danger { color: var(--danger); }
   .ctx-menu__sep { height: 1px; background: var(--border); margin: 3px 0; }
 </style>

--- a/saiku-ui/src/lib/components/Modal.svelte
+++ b/saiku-ui/src/lib/components/Modal.svelte
@@ -160,13 +160,13 @@
   .modal__title {
     margin: 0;
     font-size: var(--fs-lg);
-    font-weight: 600;
+    font-weight: var(--weight-semibold);
   }
   .modal__close {
     background: transparent;
     border: 0;
     color: var(--fg-muted);
-    font-size: 24px;
+    font-size: var(--fs-xl);
     line-height: 1;
     cursor: pointer;
     padding: 0 var(--space-1);

--- a/saiku-ui/src/lib/components/ToastStack.svelte
+++ b/saiku-ui/src/lib/components/ToastStack.svelte
@@ -66,7 +66,7 @@
     border: 0;
     color: var(--fg-muted);
     cursor: pointer;
-    font-size: 18px;
+    font-size: var(--fs-lg);
     line-height: 1;
   }
   .toast__close:hover { color: var(--fg); }

--- a/saiku-ui/src/lib/styles/app.css
+++ b/saiku-ui/src/lib/styles/app.css
@@ -15,8 +15,36 @@ body {
   color: var(--fg);
   font-family: var(--font-sans);
   font-size: var(--fs-md);
+  font-weight: var(--weight-normal);
   line-height: var(--lh-normal);
   -webkit-font-smoothing: antialiased;
+}
+
+/* Heading scale. Components should default to these and only override
+   when they have a deliberate type-treatment reason. Margins follow the
+   space token grid so heading-followed-by-body has consistent rhythm. */
+h1, h2, h3, h4, h5, h6 {
+  margin: 0 0 var(--space-3);
+  color: var(--fg);
+  font-weight: var(--weight-semibold);
+  line-height: var(--lh-tight);
+}
+
+h1 {
+  font-size: var(--fs-2xl);
+  font-weight: var(--weight-bold);
+}
+
+h2 {
+  font-size: var(--fs-xl);
+}
+
+h3 {
+  font-size: var(--fs-lg);
+}
+
+h4, h5, h6 {
+  font-size: var(--fs-md);
 }
 
 button {
@@ -73,7 +101,7 @@ a:hover {
   background: var(--accent);
   color: var(--accent-fg);
   border-color: var(--accent);
-  font-weight: 600;
+  font-weight: var(--weight-semibold);
 }
 
 .btn--primary:hover:not(:disabled) {

--- a/saiku-ui/src/lib/styles/tokens.css
+++ b/saiku-ui/src/lib/styles/tokens.css
@@ -27,6 +27,23 @@
   --lh-tight: 1.25;
   --lh-normal: 1.5;
 
+  /* Font weight scale. Keep usage to these four steps so weight choices
+     stay deliberate instead of drifting across components. */
+  --weight-normal: 400;
+  --weight-medium: 500;
+  --weight-semibold: 600;
+  --weight-bold: 700;
+
+  /* Icon sizes for lucide-svelte components. Keep usage to these four steps.
+     - xs (12px): tree twisties, inline cues
+     - sm (14px): list-row actions, form-field affordances
+     - md (16px): button content, modal close
+     - lg (20px): topbar primary actions, KPI accents */
+  --icon-xs: 12px;
+  --icon-sm: 14px;
+  --icon-md: 16px;
+  --icon-lg: 20px;
+
   --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.06);
   --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.08);
   --shadow-lg: 0 12px 32px rgba(0, 0, 0, 0.16);
@@ -49,9 +66,17 @@
   --accent: #4f46e5;
   --accent-hover: #4338ca;
   --accent-fg: #ffffff;
+  --accent-soft: #eef2ff;
+  --accent-strong: #3730a3;
   --danger: #dc2626;
+  --danger-soft: #fef2f2;
+  --danger-strong: #991b1b;
   --success: #16a34a;
+  --success-soft: #ecfdf5;
+  --success-strong: #047857;
   --warning: #d97706;
+  --warning-soft: #fffbeb;
+  --warning-strong: #b45309;
 
   --focus-ring: 0 0 0 2px var(--bg), 0 0 0 4px var(--accent);
 }
@@ -73,9 +98,17 @@
     --accent: #818cf8;
     --accent-hover: #a5b4fc;
     --accent-fg: #0b0d12;
+    --accent-soft: #1e1b4b;
+    --accent-strong: #c7d2fe;
     --danger: #ef4444;
+    --danger-soft: #2a1212;
+    --danger-strong: #fca5a5;
     --success: #22c55e;
+    --success-soft: #0d2a1a;
+    --success-strong: #86efac;
     --warning: #f59e0b;
+    --warning-soft: #2b1d09;
+    --warning-strong: #fcd34d;
 
     --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.5);
     --shadow-md: 0 4px 16px rgba(0, 0, 0, 0.6);
@@ -99,9 +132,17 @@
   --accent: #818cf8;
   --accent-hover: #a5b4fc;
   --accent-fg: #0b0d12;
+  --accent-soft: #1e1b4b;
+  --accent-strong: #c7d2fe;
   --danger: #ef4444;
+  --danger-soft: #2a1212;
+  --danger-strong: #fca5a5;
   --success: #22c55e;
+  --success-soft: #0d2a1a;
+  --success-strong: #86efac;
   --warning: #f59e0b;
+  --warning-soft: #2b1d09;
+  --warning-strong: #fcd34d;
 
   --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.5);
   --shadow-md: 0 4px 16px rgba(0, 0, 0, 0.6);
@@ -124,7 +165,15 @@
   --accent: #4f46e5;
   --accent-hover: #4338ca;
   --accent-fg: #ffffff;
+  --accent-soft: #eef2ff;
+  --accent-strong: #3730a3;
   --danger: #dc2626;
+  --danger-soft: #fef2f2;
+  --danger-strong: #991b1b;
   --success: #16a34a;
+  --success-soft: #ecfdf5;
+  --success-strong: #047857;
   --warning: #d97706;
+  --warning-soft: #fffbeb;
+  --warning-strong: #b45309;
 }

--- a/saiku-ui/src/lib/views/DimensionList.svelte
+++ b/saiku-ui/src/lib/views/DimensionList.svelte
@@ -557,16 +557,16 @@
     border-radius: var(--radius-sm);
   }
   .tree__row:hover { background: var(--bg-subtle); }
-  .tree__row--group { font-weight: 600; }
+  .tree__row--group { font-weight: var(--weight-semibold); }
   .tree__row--measure {
-    color: #e06c75;
+    color: var(--danger);
     cursor: grab;
   }
-  .tree__row--measure .tree__icon--measure { color: #e06c75; }
+  .tree__row--measure .tree__icon--measure { color: var(--danger); }
   .tree__row--dim { color: var(--fg); }
   .tree__row--level { color: var(--fg-muted); }
   .tree__row--level .tree__drag { cursor: grab; }
-  .tree__row--hier { color: #9aa8bc; }
+  .tree__row--hier { color: var(--fg-subtle); }
   .tree__twisty {
     display: inline-flex;
     align-items: center;

--- a/saiku-ui/src/lib/views/LoginForm.svelte
+++ b/saiku-ui/src/lib/views/LoginForm.svelte
@@ -108,10 +108,10 @@
   .demo-creds {
     margin: 0 0 var(--space-3);
     padding: var(--space-2) var(--space-3);
-    background: var(--accent-soft, #ecfdf5);
-    color: var(--accent-strong, #047857);
-    border-left: 3px solid var(--accent, #10b981);
-    font-size: 0.85rem;
+    background: var(--success-soft);
+    color: var(--success-strong);
+    border-left: 3px solid var(--success);
+    font-size: var(--fs-sm);
   }
   .login-stack__demo {
     width: 100%;

--- a/saiku-ui/src/lib/views/admin/ApiAccessAdmin.svelte
+++ b/saiku-ui/src/lib/views/admin/ApiAccessAdmin.svelte
@@ -210,8 +210,8 @@
     letter-spacing: 0.04em;
   }
   .badge--ok {
-    background: var(--accent-soft, #d1fae5);
-    color: var(--accent-strong, #047857);
+    background: var(--success-soft);
+    color: var(--success-strong);
   }
   .badge--off {
     background: var(--bg-muted);
@@ -261,8 +261,8 @@
     gap: var(--space-2);
     margin: var(--space-3) 0;
     padding: var(--space-3);
-    background: var(--accent-soft, #ecfdf5);
-    border-radius: var(--radius-sm, 0.25rem);
+    background: var(--accent-soft);
+    border-radius: var(--radius-sm);
   }
   .install-row .btn {
     align-self: flex-start;


### PR DESCRIPTION
## Summary

Foundation for the polish-ticket cluster (#957–#974). Extends \`tokens.css\` with the variables downstream tickets need, applies the heading scale, and replaces the most theme-breaking hardcoded values in the existing code.

## Scope

| Ticket | What | This PR |
|---|---|---|
| #957 | soft/strong color variants + font-weight tokens | ✅ tokens defined |
| #959 | icon-size token scale | ✅ tokens defined |
| #960 | heading scale (h1/h2/h3) | ✅ in app.css |
| #958 | audit hardcoded values, replace with tokens | partial — see below |

## Token additions (\`tokens.css\`)

- \`--accent-soft\` / \`--accent-strong\` / \`--danger-*\` / \`--success-*\` / \`--warning-*\` — both light and dark theme variants.
- \`--weight-normal\` (400) / \`--weight-medium\` (500) / \`--weight-semibold\` (600) / \`--weight-bold\` (700).
- \`--icon-xs\` (12) / \`--icon-sm\` (14) / \`--icon-md\` (16) / \`--icon-lg\` (20).

## Heading scale (\`app.css\`)

h1 = \`--fs-2xl\` / bold, h2 = \`--fs-xl\` / semibold, h3 = \`--fs-lg\` / semibold. Consistent \`margin-bottom: --space-3\` rhythm. Existing inline h1/h2 sizing in LoginForm and DashboardIndex becomes redundant (cleanup follows separately).

## Replacements in this PR (theme-breaking only)

- \`DimensionList\`: tree colors \`#e06c75\` (measure) → \`var(--danger)\`, \`#9aa8bc\` (hierarchy) → \`var(--fg-subtle)\`. Fixes dark-mode legibility.
- \`ContextMenu\`: danger items \`#e06c75\` → \`var(--danger)\`.
- \`LoginForm\` / \`ApiAccessAdmin\`: demo-creds and badges switched from placeholder \`--accent-soft\` (with hardcoded green fallback) to the new \`--success-soft\` / \`--success-strong\`. The original author meant green (per the fallback hex) — now semantically correct.
- \`Modal\` close button: \`font-size: 24px\` → \`var(--fs-xl)\` (20px).
- \`ToastStack\` close button: \`font-size: 18px\` → \`var(--fs-lg)\` (16px).

## Why not the full audit-and-replace

The remaining ~35 files have mechanical \`font-weight: 600\` / \`font-size: Npx\` swaps with no theme-breaking effect. They land as a follow-up sweep so reviewers can scan a single-purpose diff for the mechanical part.

## Verified

- \`npm run check\`: 0 new errors (6 pre-existing in ChartView.svelte unrelated)
- \`npm test\`: 170/170 passing