### PR TITLE
docs/ui: surface user-facing 'OLAP' as 'Semantic Layer' (#976)

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@
 <h1 align="center"><a href="https://saiku.bi">Saiku Analytics</a></h1>
 
 <p align="center">
-  Open-source OLAP analytics for cubes — drag-and-drop in the browser,
-  SQL through Mondrian + Calcite, and a typed REST surface so AI agents
-  can query without ever seeing MDX.
+  Open-source Semantic Layer analytics for cubes — drag-and-drop in the
+  browser, SQL through Mondrian + Calcite, and a typed REST surface so AI
+  agents can query without ever seeing MDX.
 </p>
 
 <p align="center">
@@ -33,7 +33,7 @@ nightly).
 ## What is Saiku
 
 Saiku started in 2010 as an open-source OLAP browser for Mondrian. In 2026
-it was rebuilt on top of:
+it was rebuilt as a modern Semantic Layer on top of:
 
 - **Mondrian 4.8.1.x (Spicule fork)** — with a Calcite-based SQL planner
   alongside the legacy `SqlQuery` builder. Calcite is the default; force
@@ -103,7 +103,7 @@ See [`CLAUDE.md`](CLAUDE.md) for the full layout, the dependency catalog
 saiku-bom/             # central dependency-version catalogue
 saiku-core/
   saiku-olap-util/     # olap4j helpers
-  saiku-service/       # OLAP service, AI Query, schema gen, async, cache
+  saiku-service/       # Semantic Layer service, AI Query, schema gen, async, cache
   saiku-semantic/      # YAML semantic layer
   saiku-web/           # JAX-RS REST resources
 saiku-webapp/          # Servlet webapp (Spring XML wiring)

--- a/docs/AI-QUERY-API.md
+++ b/docs/AI-QUERY-API.md
@@ -1,7 +1,7 @@
 # Saiku AI Query API — Usage Guide
 
 A typed REST surface at `/saiku/api/ai/*` for agents and LLMs to query
-Saiku OLAP cubes **without ever seeing MDX**. The agent fetches a typed
+Saiku Semantic Layer cubes **without ever seeing MDX**. The agent fetches a typed
 schema, fills in a JSON request against it, the server validates names
 against the live cube, builds MDX internally, and returns formatted
 results.

--- a/docs/MCP-SERVER-SPEC.md
+++ b/docs/MCP-SERVER-SPEC.md
@@ -36,8 +36,8 @@ The MCP wrapper closes that gap. With this spec implemented:
 
 - Agents discover Saiku cubes the same way they discover filesystem or git
   resources — via `tools/list`.
-- Tool descriptions are written as LLM-facing prose ("Run an OLAP analytical
-  query…"), not endpoint docs.
+- Tool descriptions are written as LLM-facing prose ("Run a Semantic Layer
+  analytical query…"), not endpoint docs.
 - Each tool ships a few-shot example tuned to the kind of natural-language
   question a user actually asks ("top 5 product families by sales last
   quarter") rather than the REST body.
@@ -91,7 +91,7 @@ use this" prose, optimised for tool-routing decisions.
 
 #### `list_cubes`
 
-> List every OLAP cube the current user can query. Use this first when you
+> List every Semantic Layer cube the current user can query. Use this first when you
 > don't know what data is available — the response includes a one-line
 > caption per cube and the default measure, which is usually enough to pick
 > the right one without describing each cube. Returns at most a few dozen
@@ -189,7 +189,7 @@ Maps to: `GET /saiku/api/ai/members/search`.
 
 #### `run_query`
 
-> Run an OLAP analytical query and get the results as records. This is
+> Run a Semantic Layer analytical query and get the results as records. This is
 > the primary tool — most user questions land here. Build the request
 > against the cube structure from describe_cube; the server validates
 > every name and returns a 400 with a list of valid alternatives if any

--- a/saiku-launcher/src/main/java/org/saiku/launcher/SaikuLauncher.java
+++ b/saiku-launcher/src/main/java/org/saiku/launcher/SaikuLauncher.java
@@ -23,7 +23,7 @@ import picocli.CommandLine.Option;
         name = "saiku",
         mixinStandardHelpOptions = true,
         version = "saiku 3.17",
-        description = "Saiku OLAP server.",
+        description = "Saiku Semantic Layer server.",
         subcommands = {SaikuLauncher.ServeCommand.class})
 public class SaikuLauncher implements Callable<Integer> {
 

--- a/saiku-ui/src/lib/modals/dateFilterMdx.ts
+++ b/saiku-ui/src/lib/modals/dateFilterMdx.ts
@@ -12,7 +12,7 @@
  * `<Level>.CurrentMember`. Absolute ranges use the `:` range operator so the
  * caller gets an inclusive set back from whatever pair of members we emit.
  *
- * TODO: `levelType` (from the OLAP metadata) would tell us unambiguously
+ * TODO: `levelType` (from the Semantic Layer metadata) would tell us unambiguously
  * whether a level is a Time-Day / Time-Month etc. Until `discover.ts` exposes
  * that, callers fall back to caption heuristics.
  */

--- a/saiku-ui/src/lib/views/admin/DatasourcesAdmin.svelte
+++ b/saiku-ui/src/lib/views/admin/DatasourcesAdmin.svelte
@@ -139,7 +139,7 @@
     <label class="field">
       <span class="field__label">Type</span>
       <select class="field__input" bind:value={editing.type}>
-        <option value="OLAP">OLAP (Mondrian)</option>
+        <option value="OLAP">Semantic Layer (Mondrian)</option>
         <option value="RELATIONAL">Relational</option>
       </select>
     </label>


### PR DESCRIPTION
## Summary

Surfaces the existing internal voice (\`saiku-semantic\` module, \`saiku.semantic.*\` annotation namespace) on the parts of the product an external user actually sees. Pure messaging change — no enum values, REST paths, or class names move.

## Touched (9 strings, 6 files)

- **README.md** — tagline, history rebuild description, module legend.
- **docs/AI-QUERY-API.md** — intro sentence.
- **docs/MCP-SERVER-SPEC.md** — \`run_query\` + \`list_cubes\` tool descriptions, plus the LLM-prose framing bullet.
- **saiku-launcher SaikuLauncher.java** — Picocli CLI \`description\`.
- **saiku-ui DatasourcesAdmin.svelte** — dropdown LABEL only (\"Semantic Layer (Mondrian)\"); enum VALUE stays \`\"OLAP\"\` for wire compatibility.
- **saiku-ui dateFilterMdx.ts** — TODO comment.

## What stays 'OLAP'

- Java package paths (\`org.saiku.olap.*\`, \`org.saiku.service.olap.*\`)
- Class names (\`OlapDiscoverService\`, \`OlapQueryService\`, etc.)
- REST endpoint path \`/saiku/{username}/discover\`
- Enum wire values (\`queryType: \"OLAP\"\`, datasource \`type: \"OLAP\"\`) — stored queries + REST integrations still work unchanged
- The \`olap4j\` library identifier — upstream contract
- Mondrian / MDX / cube vocabulary — not Saiku-owned terminology

## Verified

- \`npm run check\`: 0 new errors (6 pre-existing in ChartView.svelte unrelated)
- \`npm test\`: 170/170 passing
- Stored datasource records with \`type=\"OLAP\"\` keep working — only the dropdown LABEL shifted, not the wire value

## Test plan

- [ ] CI green
- [ ] Existing datasources with \`type=\"OLAP\"\` still load and edit correctly
- [ ] Admin dropdown reads \"Semantic Layer (Mondrian)\"
- [ ] CLI \`saiku --help\` shows \"Saiku Semantic Layer server\"

Closes #976