### PR TITLE
feat(ui): component polish — unified icon-btn, lucide modal close, chevron rotation, --bg-hover

### DIFF
--- a/saiku-ui/src/lib/components/Modal.svelte
+++ b/saiku-ui/src/lib/components/Modal.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import type { Snippet } from "svelte";
   import { tick } from "svelte";
+  import { X } from "lucide-svelte";
 
   interface Props {
     title: string;
@@ -102,7 +103,9 @@
     >
       <header class="modal__header">
         <h2 class="modal__title" id={titleId}>{title}</h2>
-        <button type="button" class="modal__close" aria-label="Close" onclick={onClose}>×</button>
+        <button type="button" class="icon-btn modal__close" aria-label="Close" onclick={onClose}>
+          <X size={16} />
+        </button>
       </header>
       <div class="modal__body">
         {@render children?.()}
@@ -162,16 +165,8 @@
     font-size: var(--fs-lg);
     font-weight: var(--weight-semibold);
   }
-  .modal__close {
-    background: transparent;
-    border: 0;
-    color: var(--fg-muted);
-    font-size: var(--fs-xl);
-    line-height: 1;
-    cursor: pointer;
-    padding: 0 var(--space-1);
-  }
-  .modal__close:hover { color: var(--fg); }
+  /* .modal__close inherits its shape from the global .icon-btn class;
+     this rule remains as a placeholder for modal-specific tweaks. */
   .modal__body {
     padding: var(--space-5);
     overflow: auto;

--- a/saiku-ui/src/lib/components/ToastStack.svelte
+++ b/saiku-ui/src/lib/components/ToastStack.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { toasts } from "$lib/stores/toasts.svelte";
+  import { X } from "lucide-svelte";
 </script>
 
 <div class="toast-stack" role="status" aria-live="polite">
@@ -15,10 +16,12 @@
       </div>
       <button
         type="button"
-        class="toast__close"
+        class="icon-btn toast__close"
         aria-label="Dismiss notification"
         onclick={() => toasts.dismiss(t.id)}
-      >×</button>
+      >
+        <X size={14} />
+      </button>
     </div>
   {/each}
 </div>
@@ -61,13 +64,5 @@
   }
   .toast__title { font-size: var(--fs-md); }
   .toast__text { color: var(--fg-muted); }
-  .toast__close {
-    background: transparent;
-    border: 0;
-    color: var(--fg-muted);
-    cursor: pointer;
-    font-size: var(--fs-lg);
-    line-height: 1;
-  }
-  .toast__close:hover { color: var(--fg); }
+  /* .toast__close inherits its shape from the global .icon-btn class. */
 </style>

--- a/saiku-ui/src/lib/modals/SavedQueriesModal.svelte
+++ b/saiku-ui/src/lib/modals/SavedQueriesModal.svelte
@@ -336,20 +336,7 @@
   .saved__name { font-weight: 500; }
   .saved__path { color: var(--fg-subtle); font-size: var(--fs-xs); }
   .saved__actions { display: flex; gap: 2px; }
-  .icon-btn {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    width: 28px;
-    height: 28px;
-    background: transparent;
-    border: 1px solid transparent;
-    border-radius: 4px;
-    color: var(--fg-muted);
-    cursor: pointer;
-  }
-  .icon-btn:hover { background: var(--bg); border-color: var(--border); color: var(--fg); }
-  .icon-btn--danger:hover { color: var(--danger); }
+  /* .icon-btn / .icon-btn--danger come from app.css */
   .saved__rename {
     display: flex;
     flex: 1;

--- a/saiku-ui/src/lib/styles/app.css
+++ b/saiku-ui/src/lib/styles/app.css
@@ -85,16 +85,60 @@ a:hover {
   border: 1px solid var(--border-strong);
   border-radius: var(--radius-sm);
   cursor: pointer;
-  transition: background var(--duration-fast);
+  transition:
+    background var(--duration-fast),
+    border-color var(--duration-fast),
+    color var(--duration-fast);
 }
 
 .btn:hover:not(:disabled) {
-  background: var(--bg-subtle);
+  background: var(--bg-hover);
 }
 
 .btn:disabled {
   opacity: 0.6;
   cursor: not-allowed;
+}
+
+/* ----------------------------------------------------------------- *
+ * Icon button — small square affordance for inline icon-only actions
+ * (list-row actions, toolbar quick-actions, modal close, etc).
+ *
+ * One canonical shape so SavedQueriesModal / Tile / Toast / Modal all
+ * render their X / pencil / trash icons the same way. Per-component
+ * .icon-btn declarations should be removed in favor of this class.
+ * ----------------------------------------------------------------- */
+.icon-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  padding: 0;
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: var(--radius-sm);
+  color: var(--fg-muted);
+  cursor: pointer;
+  transition:
+    background var(--duration-fast),
+    border-color var(--duration-fast),
+    color var(--duration-fast);
+}
+
+.icon-btn:hover:not(:disabled) {
+  background: var(--bg-hover);
+  border-color: var(--border);
+  color: var(--fg);
+}
+
+.icon-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.icon-btn--danger:hover:not(:disabled) {
+  color: var(--danger);
 }
 
 .btn--primary {

--- a/saiku-ui/src/lib/styles/tokens.css
+++ b/saiku-ui/src/lib/styles/tokens.css
@@ -56,6 +56,7 @@
   --bg: #ffffff;
   --bg-muted: #f6f7f9;
   --bg-subtle: #eef0f3;
+  --bg-hover: #e2e6ec;
   --bg-overlay: rgba(15, 23, 42, 0.32);
   --fg: #0f172a;
   --fg-muted: #475569;
@@ -88,6 +89,7 @@
     --bg: #0b0d12;
     --bg-muted: #11141b;
     --bg-subtle: #1a1e27;
+    --bg-hover: #242935;
     --bg-overlay: rgba(0, 0, 0, 0.6);
     --fg: #e6e8ec;
     --fg-muted: #a8aeba;
@@ -122,6 +124,7 @@
   --bg: #0b0d12;
   --bg-muted: #11141b;
   --bg-subtle: #1a1e27;
+  --bg-hover: #242935;
   --bg-overlay: rgba(0, 0, 0, 0.6);
   --fg: #e6e8ec;
   --fg-muted: #a8aeba;
@@ -155,6 +158,7 @@
   --bg: #ffffff;
   --bg-muted: #f6f7f9;
   --bg-subtle: #eef0f3;
+  --bg-hover: #e2e6ec;
   --bg-overlay: rgba(15, 23, 42, 0.32);
   --fg: #0f172a;
   --fg-muted: #475569;

--- a/saiku-ui/src/lib/views/DimensionList.svelte
+++ b/saiku-ui/src/lib/views/DimensionList.svelte
@@ -13,7 +13,6 @@
     Sigma,
     Folder,
     GitFork,
-    ChevronDown,
     ChevronRight,
     Settings2,
     Plus,
@@ -296,8 +295,8 @@
           {@const gid = `m:${group}`}
           <li class="tree__node">
             <button type="button" class="tree__row tree__row--group" onclick={() => toggle(gid)}>
-              <span class="tree__twisty">
-                {#if expanded[gid] === false}<ChevronRight size={12} />{:else}<ChevronDown size={12} />{/if}
+              <span class="tree__twisty" class:tree__twisty--open={expanded[gid] !== false}>
+                <ChevronRight size={12} />
               </span>
               <span class="tree__label">{group}</span>
               <span class="tree__count">{items.length}</span>
@@ -336,8 +335,8 @@
           {@const did = `d:${dim.uniqueName}`}
           <li class="tree__node">
             <button type="button" class="tree__row tree__row--dim" onclick={() => toggle(did)} title={dim.caption}>
-              <span class="tree__twisty">
-                {#if expanded[did] === false}<ChevronRight size={12} />{:else}<ChevronDown size={12} />{/if}
+              <span class="tree__twisty" class:tree__twisty--open={expanded[did] !== false}>
+                <ChevronRight size={12} />
               </span>
               <span class="tree__icon" aria-hidden="true"><Folder size={13} /></span>
               <span class="tree__label">{dim.caption || dim.name}</span>
@@ -375,8 +374,8 @@
                   {:else}
                     <li class="tree__node">
                       <button type="button" class="tree__row tree__row--hier" onclick={() => toggle(hid)}>
-                        <span class="tree__twisty">
-                          {#if expanded[hid] === false}<ChevronRight size={12} />{:else}<ChevronDown size={12} />{/if}
+                        <span class="tree__twisty" class:tree__twisty--open={expanded[hid] !== false}>
+                          <ChevronRight size={12} />
                         </span>
                         <span class="tree__icon" aria-hidden="true"><GitFork size={13} /></span>
                         <span class="tree__label">{hier.caption || hier.name}</span>
@@ -573,6 +572,12 @@
     justify-content: center;
     width: 14px;
     color: var(--fg-subtle);
+  }
+  .tree__twisty :global(svg) {
+    transition: transform var(--duration-fast) ease;
+  }
+  .tree__twisty--open :global(svg) {
+    transform: rotate(90deg);
   }
   .tree__icon {
     display: inline-flex;

--- a/saiku-ui/src/lib/views/dashboard/Tile.svelte
+++ b/saiku-ui/src/lib/views/dashboard/Tile.svelte
@@ -17,6 +17,7 @@
   import TextTile from "$lib/views/dashboard/tiles/TextTile.svelte";
   import FilterTile from "$lib/views/dashboard/tiles/FilterTile.svelte";
   import TileEditorModal from "$lib/views/dashboard/TileEditorModal.svelte";
+  import { Settings2, X } from "lucide-svelte";
 
   interface Props {
     tile: DashboardTile;
@@ -51,8 +52,12 @@
     <span class="title">{tile.title ?? defaultTitle(tile)}</span>
     {#if !readOnly}
       <div class="tile-actions">
-        <button type="button" class="icon-btn" aria-label="Edit tile" onclick={handleEdit}>⚙</button>
-        <button type="button" class="icon-btn" aria-label="Remove tile" onclick={handleRemove}>×</button>
+        <button type="button" class="icon-btn" aria-label="Edit tile" onclick={handleEdit}>
+          <Settings2 size={14} />
+        </button>
+        <button type="button" class="icon-btn icon-btn--danger" aria-label="Remove tile" onclick={handleRemove}>
+          <X size={14} />
+        </button>
       </div>
     {/if}
   </header>
@@ -125,14 +130,7 @@
     display: flex;
     gap: 0.25rem;
   }
-  .icon-btn {
-    border: none;
-    background: transparent;
-    cursor: pointer;
-    color: var(--fg-muted);
-    padding: 0 0.25rem;
-  }
-  .icon-btn:disabled { opacity: 0.4; cursor: not-allowed; }
+  /* .icon-btn / .icon-btn--danger inherit shape from app.css */
   .tile-body {
     flex: 1;
     min-height: 0;


### PR DESCRIPTION
## Summary

A cluster of small but visible component-level polish moves. Depends on the design-token foundation in #975 — merge that one first, then this rebases cleanly.

## What lands

### #963 — hover-state contrast
- Added \`--bg-hover\` token (light: \`#e2e6ec\`, dark: \`#242935\`).
- Previous \`.btn:hover\` shifted from \`--bg-muted\` to \`--bg-subtle\` — 1–2% lightness delta, barely visible. New value is ~8% shift, well past JND.
- Applied to \`.btn:hover\` and the new \`.icon-btn:hover\`.

### #962 — unified \`.icon-btn\`
- Promoted a single \`.icon-btn\` definition to \`app.css\` (plus \`.icon-btn--danger\`).
- Replaces three competing impls in SavedQueriesModal, Tile, ToastStack.
- 28×28 inline-flex, transparent → \`--bg-hover\` + subtle border on hover, focus-visible inherits global focus ring.

### #964 — modal × → lucide X
- \`Modal.svelte\` close: \`×\` glyph → \`<X size={16} />\` from lucide-svelte, wrapped in \`.icon-btn\`.
- Same treatment for \`Tile\` remove (X + \`.icon-btn--danger\`), \`Tile\` edit (Settings2), and \`ToastStack\` close.

### #961 — tree chevron rotation
- \`DimensionList.svelte\` previously swapped between \`ChevronRight\` and \`ChevronDown\` icons. Now uses a single ChevronRight rotated 90deg via CSS transform, transitioning with \`--duration-fast\`.
- \`ChevronDown\` import removed.
- The ContextMenu separator part of the ticket turned out to already be styled — no change needed there.

## Verified

- \`npm run check\`: 0 new errors (6 pre-existing in ChartView.svelte unrelated)
- \`npm test\`: 170/170 passing

## Stacked on #975

This branch was branched off \`feature/design-tokens-foundation\` so it can use the \`--weight-*\` / \`--bg-hover\` / \`--icon-md\` tokens added there. Merging order:

1. Merge #975 first
2. Rebase + merge this one

Closes #961, #962, #963, #964