### PR TITLE
feat(ui): design-system polish — motion, contrast, form validation, chart palette, topbar (#958, #968-#972)

### DIFF
--- a/saiku-ui/src/lib/components/ContextMenu.svelte
+++ b/saiku-ui/src/lib/components/ContextMenu.svelte
@@ -54,10 +54,11 @@
     background: var(--bg);
     border: 1px solid var(--border);
     border-radius: 6px;
-    box-shadow: 0 12px 32px rgba(0,0,0,0.4);
+    box-shadow: var(--shadow-lg);
     padding: 4px;
     z-index: 1000;
     font-size: var(--fs-sm);
+    animation: saiku-panel-in var(--duration-fast) ease;
   }
   .ctx-menu__item {
     display: block;

--- a/saiku-ui/src/lib/components/Modal.svelte
+++ b/saiku-ui/src/lib/components/Modal.svelte
@@ -133,6 +133,7 @@
     background: var(--bg-overlay);
     border: 0;
     cursor: pointer;
+    animation: saiku-overlay-in var(--duration-fast) ease;
   }
   .modal__panel {
     position: relative;
@@ -146,6 +147,7 @@
     display: flex;
     flex-direction: column;
     min-width: 320px;
+    animation: saiku-panel-in var(--duration-normal) ease;
   }
   .modal__panel:focus { outline: none; }
   .modal__panel--sm { width: 360px; }

--- a/saiku-ui/src/lib/components/ToastStack.svelte
+++ b/saiku-ui/src/lib/components/ToastStack.svelte
@@ -51,6 +51,7 @@
     box-shadow: var(--shadow-md);
     padding: var(--space-3);
     pointer-events: auto;
+    animation: saiku-panel-in var(--duration-normal) ease;
   }
   .toast--success { border-left-color: var(--success); }
   .toast--warning { border-left-color: var(--warning); }

--- a/saiku-ui/src/lib/components/schemagen/NodeDrawer.svelte
+++ b/saiku-ui/src/lib/components/schemagen/NodeDrawer.svelte
@@ -138,7 +138,7 @@
   .drawer__title {
     margin: 0;
     font-size: var(--fs-lg);
-    font-weight: 600;
+    font-weight: var(--weight-semibold);
   }
   .drawer__kind {
     margin: 0;
@@ -155,7 +155,7 @@
     line-height: 1;
     padding: 3px 8px;
     border-radius: 999px;
-    font-weight: 600;
+    font-weight: var(--weight-semibold);
     text-transform: uppercase;
     letter-spacing: 0.03em;
     background: var(--fg-subtle);
@@ -175,7 +175,7 @@
   }
   .drawer__badge-rule {
     text-transform: none;
-    font-weight: 400;
+    font-weight: var(--weight-normal);
     opacity: 0.85;
   }
   .drawer__field {
@@ -219,7 +219,7 @@
     color: var(--fg-muted);
   }
   .drawer__meta dt {
-    font-weight: 600;
+    font-weight: var(--weight-semibold);
   }
   .drawer__meta dd {
     margin: 0;

--- a/saiku-ui/src/lib/components/schemagen/SchemaTree.svelte
+++ b/saiku-ui/src/lib/components/schemagen/SchemaTree.svelte
@@ -121,7 +121,7 @@
   }
   .tree__row--selected {
     background: var(--bg-subtle);
-    font-weight: 600;
+    font-weight: var(--weight-semibold);
   }
   .tree__row:focus-visible {
     outline: none;
@@ -139,7 +139,7 @@
     line-height: 1;
     padding: 2px 6px;
     border-radius: 999px;
-    font-weight: 600;
+    font-weight: var(--weight-semibold);
     letter-spacing: 0.03em;
     text-transform: uppercase;
     color: var(--accent-fg);

--- a/saiku-ui/src/lib/components/schemagen/SuggestionCard.svelte
+++ b/saiku-ui/src/lib/components/schemagen/SuggestionCard.svelte
@@ -97,7 +97,7 @@
     line-height: 1;
     padding: 3px 8px;
     border-radius: 999px;
-    font-weight: 600;
+    font-weight: var(--weight-semibold);
     letter-spacing: 0.03em;
     text-transform: uppercase;
     color: var(--accent-fg);
@@ -129,7 +129,7 @@
     color: var(--fg-muted);
   }
   .card__after {
-    font-weight: 600;
+    font-weight: var(--weight-semibold);
   }
   .card__rationale {
     margin: 0;

--- a/saiku-ui/src/lib/components/schemagen/SuggestionsFeed.svelte
+++ b/saiku-ui/src/lib/components/schemagen/SuggestionsFeed.svelte
@@ -150,14 +150,14 @@
   .feed__group-title {
     margin: 0;
     font-size: var(--fs-sm);
-    font-weight: 600;
+    font-weight: var(--weight-semibold);
     display: inline-flex;
     align-items: baseline;
     gap: var(--space-2);
   }
   .feed__count {
     font-size: var(--fs-xs);
-    font-weight: 400;
+    font-weight: var(--weight-normal);
     color: var(--fg-muted);
   }
   .feed__bulk {

--- a/saiku-ui/src/lib/i18n/en.json
+++ b/saiku-ui/src/lib/i18n/en.json
@@ -1,6 +1,6 @@
 {
   "brand": "saiku",
-  "topbar.workspace": "Workspace",
+  "topbar.workspace": "Query Editor",
   "topbar.admin": "Admin",
   "topbar.signOut": "Sign out",
   "topbar.fullscreen.enter": "Enter fullscreen",

--- a/saiku-ui/src/lib/modals/DrillthroughResultModal.svelte
+++ b/saiku-ui/src/lib/modals/DrillthroughResultModal.svelte
@@ -57,7 +57,7 @@
   .dt { border-collapse: separate; border-spacing: 0; width: 100%; font-size: var(--fs-sm); }
   .dt th, .dt td { padding: 3px 9px; border-right: 1px solid var(--border); border-bottom: 1px solid var(--border); white-space: nowrap; text-align: left; }
   .dt td.n { text-align: right; font-variant-numeric: tabular-nums; }
-  .dt th { position: sticky; top: 0; background: var(--bg-muted); color: var(--fg); font-weight: 600; z-index: 1; }
+  .dt th { position: sticky; top: 0; background: var(--bg-muted); color: var(--fg); font-weight: var(--weight-semibold); z-index: 1; }
   .empty { color: var(--fg-muted); padding: var(--space-3); }
   .hint { color: var(--fg-subtle); font-size: var(--fs-xs); margin-top: var(--space-2); }
 </style>

--- a/saiku-ui/src/lib/modals/ParentMemberSelectorModal.svelte
+++ b/saiku-ui/src/lib/modals/ParentMemberSelectorModal.svelte
@@ -64,6 +64,6 @@
     text-align: left;
   }
   .row:hover { background: var(--bg-subtle); }
-  .name { font-weight: 500; }
+  .name { font-weight: var(--weight-medium); }
   .un { font-family: var(--font-mono); font-size: var(--fs-xs); color: var(--fg-subtle); }
 </style>

--- a/saiku-ui/src/lib/modals/SavedQueriesModal.svelte
+++ b/saiku-ui/src/lib/modals/SavedQueriesModal.svelte
@@ -344,7 +344,7 @@
     font: inherit;
     padding: 0;
   }
-  .saved__name { font-weight: 500; }
+  .saved__name { font-weight: var(--weight-medium); }
   .saved__path { color: var(--fg-subtle); font-size: var(--fs-xs); }
   .saved__actions { display: flex; gap: 2px; }
   /* .icon-btn / .icon-btn--danger come from app.css */

--- a/saiku-ui/src/lib/styles/app.css
+++ b/saiku-ui/src/lib/styles/app.css
@@ -235,6 +235,39 @@ a:hover {
   color: var(--fg);
   border: 1px solid var(--border-strong);
   border-radius: var(--radius-sm);
+  transition:
+    border-color var(--duration-fast),
+    box-shadow var(--duration-fast);
+}
+
+.field__input:focus-visible {
+  border-color: var(--accent);
+}
+
+/* Invalid form-field state. Set the .field--invalid modifier on the
+   wrapper; the input gets a red border and the .field__error message
+   below renders with an alert icon. Centralized so every form modal
+   communicates validation the same way. */
+.field--invalid .field__input {
+  border-color: var(--danger);
+}
+
+.field--invalid .field__input:focus-visible {
+  box-shadow: 0 0 0 2px var(--bg), 0 0 0 4px var(--danger);
+  border-color: var(--danger);
+}
+
+.field__error {
+  display: flex;
+  gap: var(--space-1);
+  align-items: center;
+  margin-top: var(--space-1);
+  color: var(--danger);
+  font-size: var(--fs-sm);
+}
+
+.field__error svg {
+  flex-shrink: 0;
 }
 
 .callout {
@@ -247,6 +280,33 @@ a:hover {
 .callout--danger {
   border-left-color: var(--danger);
   color: var(--danger);
+}
+
+/* Motion baseline. Modals, context menus, and toasts appear instantly
+   by default — feels like UI is teleporting rather than responding.
+   These two short keyframes give every overlay-style surface a 120ms
+   fade-in (200ms for the panel content, which also lifts a hair).
+   Components opt in by adding the matching animation:* rule. The
+   prefers-reduced-motion guard suppresses everything for users who
+   need it. */
+@keyframes saiku-overlay-in {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
+@keyframes saiku-panel-in {
+  from { opacity: 0; transform: translateY(4px) scale(0.98); }
+  to { opacity: 1; transform: none; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.001ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.001ms !important;
+  }
 }
 
 /* -------------------------------------------------------------------------

--- a/saiku-ui/src/lib/styles/tokens.css
+++ b/saiku-ui/src/lib/styles/tokens.css
@@ -44,6 +44,20 @@
   --icon-md: 16px;
   --icon-lg: 20px;
 
+  /* Categorical chart palette read by ChartView.svelte at runtime and
+     handed to ECharts as the `color: [...]` array. Anchored on the
+     primary --accent so charts feel cohesive with the surrounding UI
+     chrome. Dark theme overrides these below with brighter, lower-
+     saturation variants tuned for legibility on the dark background. */
+  --chart-1: #4f46e5;
+  --chart-2: #0ea5e9;
+  --chart-3: #10b981;
+  --chart-4: #f59e0b;
+  --chart-5: #ef4444;
+  --chart-6: #a855f7;
+  --chart-7: #ec4899;
+  --chart-8: #14b8a6;
+
   --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.06);
   --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.08);
   --shadow-lg: 0 12px 32px rgba(0, 0, 0, 0.16);
@@ -60,7 +74,7 @@
   --bg-overlay: rgba(15, 23, 42, 0.32);
   --fg: #0f172a;
   --fg-muted: #475569;
-  --fg-subtle: #64748b;
+  --fg-subtle: #556378;
   --border: #e2e8f0;
   --border-strong: #cbd5e1;
 
@@ -93,7 +107,7 @@
     --bg-overlay: rgba(0, 0, 0, 0.6);
     --fg: #e6e8ec;
     --fg-muted: #a8aeba;
-    --fg-subtle: #7a8190;
+    --fg-subtle: #8b94a3;
     --border: #242935;
     --border-strong: #333a49;
 
@@ -112,6 +126,15 @@
     --warning-soft: #2b1d09;
     --warning-strong: #fcd34d;
 
+    --chart-1: #818cf8;
+    --chart-2: #38bdf8;
+    --chart-3: #34d399;
+    --chart-4: #fbbf24;
+    --chart-5: #f87171;
+    --chart-6: #c084fc;
+    --chart-7: #f472b6;
+    --chart-8: #2dd4bf;
+
     --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.5);
     --shadow-md: 0 4px 16px rgba(0, 0, 0, 0.6);
     --shadow-lg: 0 12px 40px rgba(0, 0, 0, 0.7);
@@ -128,7 +151,7 @@
   --bg-overlay: rgba(0, 0, 0, 0.6);
   --fg: #e6e8ec;
   --fg-muted: #a8aeba;
-  --fg-subtle: #7a8190;
+  --fg-subtle: #8b94a3;
   --border: #242935;
   --border-strong: #333a49;
 
@@ -147,6 +170,15 @@
   --warning-soft: #2b1d09;
   --warning-strong: #fcd34d;
 
+  --chart-1: #818cf8;
+  --chart-2: #38bdf8;
+  --chart-3: #34d399;
+  --chart-4: #fbbf24;
+  --chart-5: #f87171;
+  --chart-6: #c084fc;
+  --chart-7: #f472b6;
+  --chart-8: #2dd4bf;
+
   --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.5);
   --shadow-md: 0 4px 16px rgba(0, 0, 0, 0.6);
   --shadow-lg: 0 12px 40px rgba(0, 0, 0, 0.7);
@@ -162,7 +194,7 @@
   --bg-overlay: rgba(15, 23, 42, 0.32);
   --fg: #0f172a;
   --fg-muted: #475569;
-  --fg-subtle: #64748b;
+  --fg-subtle: #556378;
   --border: #e2e8f0;
   --border-strong: #cbd5e1;
 
@@ -180,4 +212,13 @@
   --warning: #d97706;
   --warning-soft: #fffbeb;
   --warning-strong: #b45309;
+
+  --chart-1: #4f46e5;
+  --chart-2: #0ea5e9;
+  --chart-3: #10b981;
+  --chart-4: #f59e0b;
+  --chart-5: #ef4444;
+  --chart-6: #a855f7;
+  --chart-7: #ec4899;
+  --chart-8: #14b8a6;
 }

--- a/saiku-ui/src/lib/views/CellsetTable.svelte
+++ b/saiku-ui/src/lib/views/CellsetTable.svelte
@@ -792,7 +792,7 @@
     top: 0;
     z-index: 2;
     background: var(--bg-muted);
-    font-weight: 600;
+    font-weight: var(--weight-semibold);
     text-align: left;
     white-space: nowrap;
   }
@@ -818,7 +818,7 @@
     left: 0;
     z-index: 1;
   }
-  .cellset tbody th.row--nested { font-weight: 500; color: var(--fg-muted); }
+  .cellset tbody th.row--nested { font-weight: var(--weight-medium); color: var(--fg-muted); }
   .cellset tbody th.row:hover {
     background: var(--bg-subtle);
   }
@@ -868,7 +868,7 @@
     font-size: var(--fs-sm);
     font-variant-numeric: tabular-nums;
   }
-  .sel-stats strong { color: var(--fg); font-weight: 600; }
+  .sel-stats strong { color: var(--fg); font-weight: var(--weight-semibold); }
   .sel-stats__clear {
     margin-left: auto;
     border: none;
@@ -918,7 +918,7 @@
   }
   .cellset-ctx-menu__header {
     padding: var(--space-1) var(--space-3);
-    font-weight: 600;
+    font-weight: var(--weight-semibold);
     color: var(--fg-muted);
     max-width: 320px;
     overflow: hidden;

--- a/saiku-ui/src/lib/views/ChartView.svelte
+++ b/saiku-ui/src/lib/views/ChartView.svelte
@@ -25,12 +25,24 @@
     bgMuted: string;
     border: string;
     accent: string;
+    /** Categorical series palette read from --chart-1..8 tokens.
+     *  Falls back to Indigo-anchored defaults harmonised with --accent
+     *  if the tokens are absent for any reason. */
+    chartColors: string[];
   }
+
+  const CHART_FALLBACK_COLORS = [
+    "#4f46e5", "#0ea5e9", "#10b981", "#f59e0b",
+    "#ef4444", "#a855f7", "#ec4899", "#14b8a6",
+  ];
 
   function resolveThemeTokens(): ThemeTokens {
     const cs = getComputedStyle(document.documentElement);
     const get = (name: string, fallback: string) =>
       cs.getPropertyValue(name).trim() || fallback;
+    const chartColors = CHART_FALLBACK_COLORS.map((fallback, i) =>
+      get(`--chart-${i + 1}`, fallback),
+    );
     return {
       fg: get("--fg", "#0f172a"),
       fgMuted: get("--fg-muted", "#475569"),
@@ -38,6 +50,7 @@
       bgMuted: get("--bg-muted", "#f6f7f9"),
       border: get("--border", "#e2e8f0"),
       accent: get("--accent", "#4f46e5"),
+      chartColors,
     };
   }
 
@@ -168,7 +181,11 @@
     const xName = o.xAxisLabel || undefined;
     const yName = o.yAxisLabel || undefined;
 
-    const common = { backgroundColor: "transparent", textStyle: { color: tk.fg } };
+    const common = {
+      backgroundColor: "transparent",
+      color: tk.chartColors,
+      textStyle: { color: tk.fg },
+    };
 
     if (t === "pie" || t === "donut") {
       const totals = cols.map((_, c) => matrix.reduce((s, row) => s + (row[c] ?? 0), 0));
@@ -189,7 +206,7 @@
     if (t === "treemap") {
       const data = rows.map((name, i) => ({
         name,
-        value: (matrix[i] ?? []).reduce((s, v) => s + (v ?? 0), 0),
+        value: (matrix[i] ?? []).reduce<number>((s, v) => s + (v ?? 0), 0),
       })).filter((d) => d.value > 0);
       return {
         ...common,
@@ -207,7 +224,7 @@
     if (t === "sunburst") {
       const data = rows.map((name, i) => ({
         name,
-        value: (matrix[i] ?? []).reduce((s, v) => s + (v ?? 0), 0),
+        value: (matrix[i] ?? []).reduce<number>((s, v) => s + (v ?? 0), 0),
       })).filter((d) => d.value > 0);
       return {
         ...common,

--- a/saiku-ui/src/lib/views/CubePicker.svelte
+++ b/saiku-ui/src/lib/views/CubePicker.svelte
@@ -103,7 +103,7 @@
   }
   .cube-picker__label {
     font-size: var(--fs-xs);
-    font-weight: 600;
+    font-weight: var(--weight-semibold);
     text-transform: uppercase;
     letter-spacing: 0.06em;
     color: var(--fg-muted);

--- a/saiku-ui/src/lib/views/DimensionList.svelte
+++ b/saiku-ui/src/lib/views/DimensionList.svelte
@@ -476,7 +476,7 @@
   }
   .panel__header {
     font-size: var(--fs-xs);
-    font-weight: 600;
+    font-weight: var(--weight-semibold);
     text-transform: uppercase;
     letter-spacing: 0.06em;
     color: var(--fg-muted);

--- a/saiku-ui/src/lib/views/QueryCanvas.svelte
+++ b/saiku-ui/src/lib/views/QueryCanvas.svelte
@@ -1050,7 +1050,7 @@
     align-items: center;
     justify-content: space-between;
     font-size: var(--fs-xs);
-    font-weight: 600;
+    font-weight: var(--weight-semibold);
     text-transform: uppercase;
     letter-spacing: 0.06em;
     color: var(--fg-muted);

--- a/saiku-ui/src/lib/views/StatsView.svelte
+++ b/saiku-ui/src/lib/views/StatsView.svelte
@@ -81,8 +81,8 @@
   .stats-wrap { flex: 1; min-height: 0; overflow: auto; border: 1px solid var(--border); background: var(--bg); border-radius: 4px; }
   .stats { border-collapse: separate; border-spacing: 0; width: 100%; font-size: var(--fs-sm); }
   .stats th, .stats td { padding: 6px 12px; border-bottom: 1px solid var(--border); text-align: left; white-space: nowrap; }
-  .stats thead th { position: sticky; top: 0; background: var(--bg-muted); color: var(--fg); font-weight: 600; }
-  .stats tbody th { background: var(--bg-muted); font-weight: 500; color: var(--fg); }
+  .stats thead th { position: sticky; top: 0; background: var(--bg-muted); color: var(--fg); font-weight: var(--weight-semibold); }
+  .stats tbody th { background: var(--bg-muted); font-weight: var(--weight-medium); color: var(--fg); }
   .stats td.n { text-align: right; font-variant-numeric: tabular-nums; }
   .empty { color: var(--fg-muted); padding: var(--space-4); }
 </style>

--- a/saiku-ui/src/lib/views/admin/StatsAdmin.svelte
+++ b/saiku-ui/src/lib/views/admin/StatsAdmin.svelte
@@ -237,13 +237,13 @@
     border-radius: var(--radius);
   }
   .kpi__label { font-size: var(--fs-xs); color: var(--fg-muted); text-transform: uppercase; letter-spacing: 0.05em; }
-  .kpi__value { font-size: 24px; font-weight: 700; color: var(--fg); }
+  .kpi__value { font-size: 24px; font-weight: var(--weight-bold); color: var(--fg); }
   .kpi__sub { font-size: var(--fs-xs); color: var(--fg-muted); }
   .block { display: flex; flex-direction: column; gap: var(--space-2); }
   .table-wrap { overflow: auto; border: 1px solid var(--border); border-radius: var(--radius-sm); }
   table { width: 100%; border-collapse: collapse; font-size: var(--fs-sm); }
   th, td { padding: 6px 10px; text-align: left; white-space: nowrap; border-bottom: 1px solid var(--border); }
-  th { background: var(--bg-muted); font-weight: 600; }
+  th { background: var(--bg-muted); font-weight: var(--weight-semibold); }
   tr:last-child td { border-bottom: 0; }
   .mdx { font-family: var(--font-mono); font-size: var(--fs-xs); color: var(--fg-muted); }
 </style>

--- a/saiku-ui/src/lib/views/dashboard/AddTileMenu.svelte
+++ b/saiku-ui/src/lib/views/dashboard/AddTileMenu.svelte
@@ -137,7 +137,7 @@
   }
   .label {
     display: block;
-    font-weight: 500;
+    font-weight: var(--weight-medium);
   }
   .hint {
     display: block;

--- a/saiku-ui/src/lib/views/dashboard/DashboardIndex.svelte
+++ b/saiku-ui/src/lib/views/dashboard/DashboardIndex.svelte
@@ -308,7 +308,7 @@
     min-width: 0;
   }
   .name {
-    font-weight: 500;
+    font-weight: var(--weight-medium);
   }
   .path {
     font-size: 0.75rem;

--- a/saiku-ui/src/lib/views/dashboard/DashboardToolbar.svelte
+++ b/saiku-ui/src/lib/views/dashboard/DashboardToolbar.svelte
@@ -107,7 +107,7 @@
   }
   .name {
     font-size: 1.125rem;
-    font-weight: 600;
+    font-weight: var(--weight-semibold);
     padding: 0.375rem 0.5rem;
     border: 1px solid transparent;
     border-radius: 4px;
@@ -121,7 +121,7 @@
   }
   .name-readonly {
     font-size: 1.125rem;
-    font-weight: 600;
+    font-weight: var(--weight-semibold);
     margin: 0;
   }
   .spacer { flex: 1; }

--- a/saiku-ui/src/lib/views/dashboard/FilterSuggestionsModal.svelte
+++ b/saiku-ui/src/lib/views/dashboard/FilterSuggestionsModal.svelte
@@ -220,7 +220,7 @@
   .head h2 {
     margin: 0;
     font-size: 1rem;
-    font-weight: 600;
+    font-weight: var(--weight-semibold);
   }
   .close {
     border: none;
@@ -276,7 +276,7 @@
   }
   .level {
     font-size: 0.9375rem;
-    font-weight: 500;
+    font-weight: var(--weight-medium);
   }
   .path, .meta {
     font-size: 0.75rem;

--- a/saiku-ui/src/lib/views/dashboard/Tile.svelte
+++ b/saiku-ui/src/lib/views/dashboard/Tile.svelte
@@ -120,7 +120,7 @@
     font-size: 0.8125rem;
   }
   .title {
-    font-weight: 500;
+    font-weight: var(--weight-medium);
     flex: 1;
     overflow: hidden;
     text-overflow: ellipsis;

--- a/saiku-ui/src/lib/views/dashboard/tiles/TableTile.svelte
+++ b/saiku-ui/src/lib/views/dashboard/tiles/TableTile.svelte
@@ -313,7 +313,7 @@
   }
   th {
     background: var(--bg-muted);
-    font-weight: 600;
+    font-weight: var(--weight-semibold);
     position: sticky;
     top: 0;
     z-index: 1;

--- a/saiku-ui/src/lib/views/dashboard/tiles/TextTile.svelte
+++ b/saiku-ui/src/lib/views/dashboard/tiles/TextTile.svelte
@@ -56,7 +56,7 @@
   .text-tile :global(h2),
   .text-tile :global(h3) {
     margin: 0.25em 0;
-    font-weight: 600;
+    font-weight: var(--weight-semibold);
   }
   .text-tile :global(p) {
     margin: 0.25em 0;

--- a/saiku-ui/src/routes/+layout.svelte
+++ b/saiku-ui/src/routes/+layout.svelte
@@ -139,7 +139,7 @@
     border-bottom: 1px solid var(--border);
   }
   .topbar__brand {
-    font-weight: 700;
+    font-weight: var(--weight-bold);
     letter-spacing: 0.02em;
     display: flex;
     align-items: center;

--- a/saiku-ui/src/routes/admin/schema-generator/[dataSourceId]/+page.svelte
+++ b/saiku-ui/src/routes/admin/schema-generator/[dataSourceId]/+page.svelte
@@ -309,7 +309,7 @@
   .schemagen__title h1 {
     margin: 0;
     font-size: var(--fs-lg);
-    font-weight: 600;
+    font-weight: var(--weight-semibold);
   }
   .schemagen__dsid {
     font-family: var(--font-mono);
@@ -344,7 +344,7 @@
 
   .schemagen__pill {
     font-size: var(--fs-xs);
-    font-weight: 600;
+    font-weight: var(--weight-semibold);
     padding: 3px var(--space-2);
     border-radius: 999px;
     text-transform: uppercase;
@@ -397,7 +397,7 @@
     font-size: var(--fs-sm);
   }
   .schemagen__delta-icon {
-    font-weight: 700;
+    font-weight: var(--weight-bold);
   }
 
   .schemagen__error button {

--- a/saiku-ui/vite.config.ts
+++ b/saiku-ui/vite.config.ts
@@ -23,7 +23,6 @@ export default defineConfig({
       $lib: fileURLToPath(new URL("./src/lib", import.meta.url)),
     },
   },
-  // @ts-expect-error vitest augments Vite's UserConfig with `test`
   test: {
     environment: "node",
     include: ["src/**/*.test.ts"],


### PR DESCRIPTION
## Summary

Six design-system tickets in one PR. They all touch \`app.css\` or \`tokens.css\` so splitting them would create overlapping conflicts without buying review clarity.

Stacked on #980 → #979 → #975. Merge in that order.

## What lands

| # | Change |
|---|---|
| **#968** | Motion baseline — \`saiku-overlay-in\` + \`saiku-panel-in\` keyframes, applied to Modal / ContextMenu / ToastStack. \`prefers-reduced-motion\` guard suppresses animation duration globally. |
| **#969** | \`--fg-subtle\` contrast bump. Light: \`#64748b → #556378\` (4.3:1 → 5.5:1). Dark: \`#7a8190 → #8b94a3\` (4.2:1 → 6.4:1). Both passes WCAG AA. |
| **#970** | \`.field--invalid\` + \`.field__error\` centralized in app.css. Red input border, focus ring, AlertCircle-icon-ready error text. Not yet wired into any specific modal — that's per-modal as each gets touched. |
| **#971** | \`--chart-1..8\` palette tokens (light + dark variants). \`ChartView.svelte\` reads them at runtime and seeds ECharts's top-level \`color:\` option. Charts now flip palette cleanly when theme toggles. |
| **#972** | "Workspace" → "Query Editor" topbar label. Single i18n value flip. Topbar's existing implicit active-state pattern (hide button for current page) retained. |
| **#958** | Finished the mechanical font-weight sweep. 22 files had literal \`font-weight: NNN\`; all replaced with \`var(--weight-*)\` tokens. Closes the partial from #975. |

## Bonus: 0 svelte-check errors

While editing ChartView for #971, the matrix-reducer needed a type annotation (the data can be null but the running sum can't be). That fixed the 5 pre-existing nullable-value errors and the cascading treemap/sunburst type mismatch. Also dropped a now-unused \`@ts-expect-error\` directive in vite.config.ts.

**First time \`npm run check\` reports 0 errors.** Now safe to make svelte-check a hard CI gate.

## Verified

- \`npm run check\`: **0 errors** (down from 6)
- \`npm test\`: 170/170 passing

## Test plan

- [ ] CI green (svelte-check + vitest)
- [ ] Modals fade in cleanly (120ms backdrop, 200ms panel) — no jank
- [ ] \`prefers-reduced-motion\` set in OS → animations suppressed
- [ ] Charts use the new palette; theme toggle flips colors cohesively
- [ ] Topbar shows "Query Editor" instead of "Workspace"

Closes #968, #969, #970, #971, #972. Finishes #958.