### PR TITLE
feat(ui): topbar + workspace polish-on-polish

### DIFF
--- a/saiku-ui/src/lib/components/ContextMenu.svelte
+++ b/saiku-ui/src/lib/components/ContextMenu.svelte
@@ -54,10 +54,11 @@
     background: var(--bg);
     border: 1px solid var(--border);
     border-radius: 6px;
-    box-shadow: 0 12px 32px rgba(0,0,0,0.4);
+    box-shadow: var(--shadow-lg);
     padding: 4px;
     z-index: 1000;
     font-size: var(--fs-sm);
+    animation: saiku-panel-in var(--duration-fast) ease;
   }
   .ctx-menu__item {
     display: block;

--- a/saiku-ui/src/lib/components/Modal.svelte
+++ b/saiku-ui/src/lib/components/Modal.svelte
@@ -133,6 +133,7 @@
     background: var(--bg-overlay);
     border: 0;
     cursor: pointer;
+    animation: saiku-overlay-in var(--duration-fast) ease;
   }
   .modal__panel {
     position: relative;
@@ -146,6 +147,7 @@
     display: flex;
     flex-direction: column;
     min-width: 320px;
+    animation: saiku-panel-in var(--duration-normal) ease;
   }
   .modal__panel:focus { outline: none; }
   .modal__panel--sm { width: 360px; }

--- a/saiku-ui/src/lib/components/ToastStack.svelte
+++ b/saiku-ui/src/lib/components/ToastStack.svelte
@@ -51,6 +51,7 @@
     box-shadow: var(--shadow-md);
     padding: var(--space-3);
     pointer-events: auto;
+    animation: saiku-panel-in var(--duration-normal) ease;
   }
   .toast--success { border-left-color: var(--success); }
   .toast--warning { border-left-color: var(--warning); }

--- a/saiku-ui/src/lib/components/schemagen/NodeDrawer.svelte
+++ b/saiku-ui/src/lib/components/schemagen/NodeDrawer.svelte
@@ -138,7 +138,7 @@
   .drawer__title {
     margin: 0;
     font-size: var(--fs-lg);
-    font-weight: 600;
+    font-weight: var(--weight-semibold);
   }
   .drawer__kind {
     margin: 0;
@@ -155,7 +155,7 @@
     line-height: 1;
     padding: 3px 8px;
     border-radius: 999px;
-    font-weight: 600;
+    font-weight: var(--weight-semibold);
     text-transform: uppercase;
     letter-spacing: 0.03em;
     background: var(--fg-subtle);
@@ -175,7 +175,7 @@
   }
   .drawer__badge-rule {
     text-transform: none;
-    font-weight: 400;
+    font-weight: var(--weight-normal);
     opacity: 0.85;
   }
   .drawer__field {
@@ -219,7 +219,7 @@
     color: var(--fg-muted);
   }
   .drawer__meta dt {
-    font-weight: 600;
+    font-weight: var(--weight-semibold);
   }
   .drawer__meta dd {
     margin: 0;

--- a/saiku-ui/src/lib/components/schemagen/SchemaTree.svelte
+++ b/saiku-ui/src/lib/components/schemagen/SchemaTree.svelte
@@ -121,7 +121,7 @@
   }
   .tree__row--selected {
     background: var(--bg-subtle);
-    font-weight: 600;
+    font-weight: var(--weight-semibold);
   }
   .tree__row:focus-visible {
     outline: none;
@@ -139,7 +139,7 @@
     line-height: 1;
     padding: 2px 6px;
     border-radius: 999px;
-    font-weight: 600;
+    font-weight: var(--weight-semibold);
     letter-spacing: 0.03em;
     text-transform: uppercase;
     color: var(--accent-fg);

--- a/saiku-ui/src/lib/components/schemagen/SuggestionCard.svelte
+++ b/saiku-ui/src/lib/components/schemagen/SuggestionCard.svelte
@@ -97,7 +97,7 @@
     line-height: 1;
     padding: 3px 8px;
     border-radius: 999px;
-    font-weight: 600;
+    font-weight: var(--weight-semibold);
     letter-spacing: 0.03em;
     text-transform: uppercase;
     color: var(--accent-fg);
@@ -129,7 +129,7 @@
     color: var(--fg-muted);
   }
   .card__after {
-    font-weight: 600;
+    font-weight: var(--weight-semibold);
   }
   .card__rationale {
     margin: 0;

--- a/saiku-ui/src/lib/components/schemagen/SuggestionsFeed.svelte
+++ b/saiku-ui/src/lib/components/schemagen/SuggestionsFeed.svelte
@@ -150,14 +150,14 @@
   .feed__group-title {
     margin: 0;
     font-size: var(--fs-sm);
-    font-weight: 600;
+    font-weight: var(--weight-semibold);
     display: inline-flex;
     align-items: baseline;
     gap: var(--space-2);
   }
   .feed__count {
     font-size: var(--fs-xs);
-    font-weight: 400;
+    font-weight: var(--weight-normal);
     color: var(--fg-muted);
   }
   .feed__bulk {

--- a/saiku-ui/src/lib/i18n/en.json
+++ b/saiku-ui/src/lib/i18n/en.json
@@ -1,6 +1,6 @@
 {
   "brand": "saiku",
-  "topbar.workspace": "Workspace",
+  "topbar.workspace": "Query Editor",
   "topbar.admin": "Admin",
   "topbar.signOut": "Sign out",
   "topbar.fullscreen.enter": "Enter fullscreen",

--- a/saiku-ui/src/lib/modals/DrillthroughResultModal.svelte
+++ b/saiku-ui/src/lib/modals/DrillthroughResultModal.svelte
@@ -57,7 +57,7 @@
   .dt { border-collapse: separate; border-spacing: 0; width: 100%; font-size: var(--fs-sm); }
   .dt th, .dt td { padding: 3px 9px; border-right: 1px solid var(--border); border-bottom: 1px solid var(--border); white-space: nowrap; text-align: left; }
   .dt td.n { text-align: right; font-variant-numeric: tabular-nums; }
-  .dt th { position: sticky; top: 0; background: var(--bg-muted); color: var(--fg); font-weight: 600; z-index: 1; }
+  .dt th { position: sticky; top: 0; background: var(--bg-muted); color: var(--fg); font-weight: var(--weight-semibold); z-index: 1; }
   .empty { color: var(--fg-muted); padding: var(--space-3); }
   .hint { color: var(--fg-subtle); font-size: var(--fs-xs); margin-top: var(--space-2); }
 </style>

--- a/saiku-ui/src/lib/modals/ParentMemberSelectorModal.svelte
+++ b/saiku-ui/src/lib/modals/ParentMemberSelectorModal.svelte
@@ -64,6 +64,6 @@
     text-align: left;
   }
   .row:hover { background: var(--bg-subtle); }
-  .name { font-weight: 500; }
+  .name { font-weight: var(--weight-medium); }
   .un { font-family: var(--font-mono); font-size: var(--fs-xs); color: var(--fg-subtle); }
 </style>

--- a/saiku-ui/src/lib/modals/SavedQueriesModal.svelte
+++ b/saiku-ui/src/lib/modals/SavedQueriesModal.svelte
@@ -344,7 +344,7 @@
     font: inherit;
     padding: 0;
   }
-  .saved__name { font-weight: 500; }
+  .saved__name { font-weight: var(--weight-medium); }
   .saved__path { color: var(--fg-subtle); font-size: var(--fs-xs); }
   .saved__actions { display: flex; gap: 2px; }
   /* .icon-btn / .icon-btn--danger come from app.css */

--- a/saiku-ui/src/lib/styles/app.css
+++ b/saiku-ui/src/lib/styles/app.css
@@ -235,6 +235,39 @@ a:hover {
   color: var(--fg);
   border: 1px solid var(--border-strong);
   border-radius: var(--radius-sm);
+  transition:
+    border-color var(--duration-fast),
+    box-shadow var(--duration-fast);
+}
+
+.field__input:focus-visible {
+  border-color: var(--accent);
+}
+
+/* Invalid form-field state. Set the .field--invalid modifier on the
+   wrapper; the input gets a red border and the .field__error message
+   below renders with an alert icon. Centralized so every form modal
+   communicates validation the same way. */
+.field--invalid .field__input {
+  border-color: var(--danger);
+}
+
+.field--invalid .field__input:focus-visible {
+  box-shadow: 0 0 0 2px var(--bg), 0 0 0 4px var(--danger);
+  border-color: var(--danger);
+}
+
+.field__error {
+  display: flex;
+  gap: var(--space-1);
+  align-items: center;
+  margin-top: var(--space-1);
+  color: var(--danger);
+  font-size: var(--fs-sm);
+}
+
+.field__error svg {
+  flex-shrink: 0;
 }
 
 .callout {
@@ -247,6 +280,33 @@ a:hover {
 .callout--danger {
   border-left-color: var(--danger);
   color: var(--danger);
+}
+
+/* Motion baseline. Modals, context menus, and toasts appear instantly
+   by default — feels like UI is teleporting rather than responding.
+   These two short keyframes give every overlay-style surface a 120ms
+   fade-in (200ms for the panel content, which also lifts a hair).
+   Components opt in by adding the matching animation:* rule. The
+   prefers-reduced-motion guard suppresses everything for users who
+   need it. */
+@keyframes saiku-overlay-in {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
+@keyframes saiku-panel-in {
+  from { opacity: 0; transform: translateY(4px) scale(0.98); }
+  to { opacity: 1; transform: none; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.001ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.001ms !important;
+  }
 }
 
 /* -------------------------------------------------------------------------

--- a/saiku-ui/src/lib/styles/tokens.css
+++ b/saiku-ui/src/lib/styles/tokens.css
@@ -44,6 +44,20 @@
   --icon-md: 16px;
   --icon-lg: 20px;
 
+  /* Categorical chart palette read by ChartView.svelte at runtime and
+     handed to ECharts as the `color: [...]` array. Anchored on the
+     primary --accent so charts feel cohesive with the surrounding UI
+     chrome. Dark theme overrides these below with brighter, lower-
+     saturation variants tuned for legibility on the dark background. */
+  --chart-1: #4f46e5;
+  --chart-2: #0ea5e9;
+  --chart-3: #10b981;
+  --chart-4: #f59e0b;
+  --chart-5: #ef4444;
+  --chart-6: #a855f7;
+  --chart-7: #ec4899;
+  --chart-8: #14b8a6;
+
   --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.06);
   --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.08);
   --shadow-lg: 0 12px 32px rgba(0, 0, 0, 0.16);
@@ -60,7 +74,7 @@
   --bg-overlay: rgba(15, 23, 42, 0.32);
   --fg: #0f172a;
   --fg-muted: #475569;
-  --fg-subtle: #64748b;
+  --fg-subtle: #556378;
   --border: #e2e8f0;
   --border-strong: #cbd5e1;
 
@@ -93,7 +107,7 @@
     --bg-overlay: rgba(0, 0, 0, 0.6);
     --fg: #e6e8ec;
     --fg-muted: #a8aeba;
-    --fg-subtle: #7a8190;
+    --fg-subtle: #8b94a3;
     --border: #242935;
     --border-strong: #333a49;
 
@@ -112,6 +126,15 @@
     --warning-soft: #2b1d09;
     --warning-strong: #fcd34d;
 
+    --chart-1: #818cf8;
+    --chart-2: #38bdf8;
+    --chart-3: #34d399;
+    --chart-4: #fbbf24;
+    --chart-5: #f87171;
+    --chart-6: #c084fc;
+    --chart-7: #f472b6;
+    --chart-8: #2dd4bf;
+
     --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.5);
     --shadow-md: 0 4px 16px rgba(0, 0, 0, 0.6);
     --shadow-lg: 0 12px 40px rgba(0, 0, 0, 0.7);
@@ -128,7 +151,7 @@
   --bg-overlay: rgba(0, 0, 0, 0.6);
   --fg: #e6e8ec;
   --fg-muted: #a8aeba;
-  --fg-subtle: #7a8190;
+  --fg-subtle: #8b94a3;
   --border: #242935;
   --border-strong: #333a49;
 
@@ -147,6 +170,15 @@
   --warning-soft: #2b1d09;
   --warning-strong: #fcd34d;
 
+  --chart-1: #818cf8;
+  --chart-2: #38bdf8;
+  --chart-3: #34d399;
+  --chart-4: #fbbf24;
+  --chart-5: #f87171;
+  --chart-6: #c084fc;
+  --chart-7: #f472b6;
+  --chart-8: #2dd4bf;
+
   --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.5);
   --shadow-md: 0 4px 16px rgba(0, 0, 0, 0.6);
   --shadow-lg: 0 12px 40px rgba(0, 0, 0, 0.7);
@@ -162,7 +194,7 @@
   --bg-overlay: rgba(15, 23, 42, 0.32);
   --fg: #0f172a;
   --fg-muted: #475569;
-  --fg-subtle: #64748b;
+  --fg-subtle: #556378;
   --border: #e2e8f0;
   --border-strong: #cbd5e1;
 
@@ -180,4 +212,13 @@
   --warning: #d97706;
   --warning-soft: #fffbeb;
   --warning-strong: #b45309;
+
+  --chart-1: #4f46e5;
+  --chart-2: #0ea5e9;
+  --chart-3: #10b981;
+  --chart-4: #f59e0b;
+  --chart-5: #ef4444;
+  --chart-6: #a855f7;
+  --chart-7: #ec4899;
+  --chart-8: #14b8a6;
 }

--- a/saiku-ui/src/lib/views/CellsetTable.svelte
+++ b/saiku-ui/src/lib/views/CellsetTable.svelte
@@ -792,7 +792,7 @@
     top: 0;
     z-index: 2;
     background: var(--bg-muted);
-    font-weight: 600;
+    font-weight: var(--weight-semibold);
     text-align: left;
     white-space: nowrap;
   }
@@ -818,7 +818,7 @@
     left: 0;
     z-index: 1;
   }
-  .cellset tbody th.row--nested { font-weight: 500; color: var(--fg-muted); }
+  .cellset tbody th.row--nested { font-weight: var(--weight-medium); color: var(--fg-muted); }
   .cellset tbody th.row:hover {
     background: var(--bg-subtle);
   }
@@ -868,7 +868,7 @@
     font-size: var(--fs-sm);
     font-variant-numeric: tabular-nums;
   }
-  .sel-stats strong { color: var(--fg); font-weight: 600; }
+  .sel-stats strong { color: var(--fg); font-weight: var(--weight-semibold); }
   .sel-stats__clear {
     margin-left: auto;
     border: none;
@@ -918,7 +918,7 @@
   }
   .cellset-ctx-menu__header {
     padding: var(--space-1) var(--space-3);
-    font-weight: 600;
+    font-weight: var(--weight-semibold);
     color: var(--fg-muted);
     max-width: 320px;
     overflow: hidden;

--- a/saiku-ui/src/lib/views/ChartView.svelte
+++ b/saiku-ui/src/lib/views/ChartView.svelte
@@ -25,12 +25,24 @@
     bgMuted: string;
     border: string;
     accent: string;
+    /** Categorical series palette read from --chart-1..8 tokens.
+     *  Falls back to Indigo-anchored defaults harmonised with --accent
+     *  if the tokens are absent for any reason. */
+    chartColors: string[];
   }
+
+  const CHART_FALLBACK_COLORS = [
+    "#4f46e5", "#0ea5e9", "#10b981", "#f59e0b",
+    "#ef4444", "#a855f7", "#ec4899", "#14b8a6",
+  ];
 
   function resolveThemeTokens(): ThemeTokens {
     const cs = getComputedStyle(document.documentElement);
     const get = (name: string, fallback: string) =>
       cs.getPropertyValue(name).trim() || fallback;
+    const chartColors = CHART_FALLBACK_COLORS.map((fallback, i) =>
+      get(`--chart-${i + 1}`, fallback),
+    );
     return {
       fg: get("--fg", "#0f172a"),
       fgMuted: get("--fg-muted", "#475569"),
@@ -38,6 +50,7 @@
       bgMuted: get("--bg-muted", "#f6f7f9"),
       border: get("--border", "#e2e8f0"),
       accent: get("--accent", "#4f46e5"),
+      chartColors,
     };
   }
 
@@ -168,7 +181,11 @@
     const xName = o.xAxisLabel || undefined;
     const yName = o.yAxisLabel || undefined;
 
-    const common = { backgroundColor: "transparent", textStyle: { color: tk.fg } };
+    const common = {
+      backgroundColor: "transparent",
+      color: tk.chartColors,
+      textStyle: { color: tk.fg },
+    };
 
     if (t === "pie" || t === "donut") {
       const totals = cols.map((_, c) => matrix.reduce((s, row) => s + (row[c] ?? 0), 0));
@@ -189,7 +206,7 @@
     if (t === "treemap") {
       const data = rows.map((name, i) => ({
         name,
-        value: (matrix[i] ?? []).reduce((s, v) => s + (v ?? 0), 0),
+        value: (matrix[i] ?? []).reduce<number>((s, v) => s + (v ?? 0), 0),
       })).filter((d) => d.value > 0);
       return {
         ...common,
@@ -207,7 +224,7 @@
     if (t === "sunburst") {
       const data = rows.map((name, i) => ({
         name,
-        value: (matrix[i] ?? []).reduce((s, v) => s + (v ?? 0), 0),
+        value: (matrix[i] ?? []).reduce<number>((s, v) => s + (v ?? 0), 0),
       })).filter((d) => d.value > 0);
       return {
         ...common,

--- a/saiku-ui/src/lib/views/CubePicker.svelte
+++ b/saiku-ui/src/lib/views/CubePicker.svelte
@@ -103,7 +103,7 @@
   }
   .cube-picker__label {
     font-size: var(--fs-xs);
-    font-weight: 600;
+    font-weight: var(--weight-semibold);
     text-transform: uppercase;
     letter-spacing: 0.06em;
     color: var(--fg-muted);

--- a/saiku-ui/src/lib/views/CubePicker.svelte
+++ b/saiku-ui/src/lib/views/CubePicker.svelte
@@ -5,6 +5,7 @@
   import type { SaikuCube } from "$lib/api/discover";
   import { cubeKey } from "$lib/stores/datasources.svelte";
   import { i18n } from "$lib/stores/i18n.svelte";
+  import { RotateCw } from "lucide-svelte";
 
   interface Props {
     username: string;
@@ -82,10 +83,14 @@
     </select>
     <button
       type="button"
-      class="btn cube-picker__refresh"
+      class="icon-btn cube-picker__refresh"
       onclick={onRefresh}
+      title={i18n.t("cubes.refresh")}
       aria-label={i18n.t("cubes.refresh")}
-    >⟳</button>
+      disabled={datasources.loading}
+    >
+      <RotateCw size={14} class={datasources.loading ? "spin" : ""} />
+    </button>
   </div>
   {#if datasources.error}
     <p class="callout callout--danger">{datasources.error}</p>
@@ -122,7 +127,15 @@
     font-size: var(--fs-sm);
   }
   .cube-picker__refresh {
-    padding: var(--space-2);
+    /* match the select's vertical footprint so they line up at the same height */
+    width: 36px;
+    height: 36px;
+  }
+  .cube-picker__refresh :global(.spin) {
+    animation: cube-picker-spin 900ms linear infinite;
+  }
+  @keyframes cube-picker-spin {
+    to { transform: rotate(360deg); }
   }
   .cube-picker__empty {
     margin: 0;

--- a/saiku-ui/src/lib/views/DimensionList.svelte
+++ b/saiku-ui/src/lib/views/DimensionList.svelte
@@ -534,7 +534,12 @@
     padding-left: 0;
   }
   .tree .tree {
-    padding-left: var(--space-4);
+    /* Tighter per-level indent + a vertical guide line, file-browser
+       style. Helps deep cubes (Stores → Country → State → City → ...)
+       stay readable without consuming the whole sidebar width. */
+    padding-left: var(--space-3);
+    margin-left: var(--space-2);
+    border-left: 1px solid var(--border);
   }
   .tree__empty {
     color: var(--fg-subtle);

--- a/saiku-ui/src/lib/views/DimensionList.svelte
+++ b/saiku-ui/src/lib/views/DimensionList.svelte
@@ -476,7 +476,7 @@
   }
   .panel__header {
     font-size: var(--fs-xs);
-    font-weight: 600;
+    font-weight: var(--weight-semibold);
     text-transform: uppercase;
     letter-spacing: 0.06em;
     color: var(--fg-muted);

--- a/saiku-ui/src/lib/views/DimensionList.svelte
+++ b/saiku-ui/src/lib/views/DimensionList.svelte
@@ -558,10 +558,10 @@
   .tree__row:hover { background: var(--bg-subtle); }
   .tree__row--group { font-weight: var(--weight-semibold); }
   .tree__row--measure {
-    color: var(--danger);
+    color: var(--accent);
     cursor: grab;
   }
-  .tree__row--measure .tree__icon--measure { color: var(--danger); }
+  .tree__row--measure .tree__icon--measure { color: var(--accent); }
   .tree__row--dim { color: var(--fg); }
   .tree__row--level { color: var(--fg-muted); }
   .tree__row--level .tree__drag { cursor: grab; }

--- a/saiku-ui/src/lib/views/LoginForm.svelte
+++ b/saiku-ui/src/lib/views/LoginForm.svelte
@@ -4,6 +4,7 @@
   import { i18n } from "$lib/stores/i18n.svelte";
   import { platform } from "$lib/stores/platform.svelte";
   import ApiAccessAdmin from "$lib/views/admin/ApiAccessAdmin.svelte";
+  import { Info } from "lucide-svelte";
 
   let username = $state("admin");
   let password = $state("");
@@ -35,15 +36,37 @@
       busy = false;
     }
   }
+
+  async function loginAsDemo() {
+    username = "admin";
+    password = "admin";
+    error = null;
+    busy = true;
+    try {
+      await session.login("admin", "admin");
+    } catch (err) {
+      error = err instanceof Error ? err.message : i18n.t("login.failed");
+    } finally {
+      busy = false;
+    }
+  }
 </script>
 
 <div class="login-stack">
   <form class="login" onsubmit={onSubmit}>
     <h1>{i18n.t("login.title")}</h1>
+    <p class="login__tagline">Semantic Layer analytics for cubes — drag, drop, drill.</p>
     {#if showDemoPanel}
-      <p class="demo-creds">
-        Demo credentials: <code>admin</code> / <code>admin</code>. Data resets nightly.
-      </p>
+      <div class="demo-creds">
+        <Info size={16} class="demo-creds__icon" />
+        <div class="demo-creds__body">
+          <strong>Try the demo</strong>
+          <span>
+            Sign in with <code>admin</code> / <code>admin</code>, or use the
+            shortcut below. Data resets nightly.
+          </span>
+        </div>
+      </div>
     {/if}
     {#if error}
       <p class="callout callout--danger" role="alert">{error}</p>
@@ -65,6 +88,16 @@
     <button type="submit" class="btn btn--primary btn--wide" disabled={busy}>
       {busy ? i18n.t("login.submitting") : i18n.t("login.submit")}
     </button>
+    {#if showDemoPanel}
+      <button
+        type="button"
+        class="btn btn--wide login__demo-button"
+        onclick={loginAsDemo}
+        disabled={busy}
+      >
+        Sign in as demo user
+      </button>
+    {/if}
   </form>
 
   {#if showDemoPanel}
@@ -102,16 +135,39 @@
     box-shadow: var(--shadow-md);
   }
   .login h1 {
-    margin: 0 0 var(--space-4);
+    margin: 0 0 var(--space-1);
     font-size: var(--fs-xl);
   }
+  .login__tagline {
+    margin: 0 0 var(--space-4);
+    color: var(--fg-muted);
+    font-size: var(--fs-sm);
+    line-height: var(--lh-normal);
+  }
   .demo-creds {
+    display: flex;
+    gap: var(--space-2);
+    align-items: flex-start;
     margin: 0 0 var(--space-3);
-    padding: var(--space-2) var(--space-3);
+    padding: var(--space-3);
     background: var(--success-soft);
     color: var(--success-strong);
     border-left: 3px solid var(--success);
+    border-radius: var(--radius-sm);
     font-size: var(--fs-sm);
+    line-height: var(--lh-normal);
+  }
+  .demo-creds__body {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+  }
+  .demo-creds :global(.demo-creds__icon) {
+    flex-shrink: 0;
+    margin-top: 2px;
+  }
+  .login__demo-button {
+    margin-top: var(--space-2);
   }
   .login-stack__demo {
     width: 100%;

--- a/saiku-ui/src/lib/views/QueryCanvas.svelte
+++ b/saiku-ui/src/lib/views/QueryCanvas.svelte
@@ -20,7 +20,8 @@
   import { looksLikeTimeHierarchy } from "$lib/modals/dateFilterMdx";
   import ContextMenu from "$lib/components/ContextMenu.svelte";
   type ContextMenuItem = { id: string; label: string; disabled?: boolean; danger?: boolean; sep?: boolean };
-  import { MoreHorizontal, Loader2, XCircle, ChevronDown, Settings } from "lucide-svelte";
+  import { MoreHorizontal, Loader2, XCircle, ChevronDown, Settings, Sparkles } from "lucide-svelte";
+  import EmptyState from "$lib/components/EmptyState.svelte";
   import { listLevelMembers, listRootMembers, type SaikuMember } from "$lib/api/discover";
   import { datasources } from "$lib/stores/datasources.svelte";
   import { drillthrough as fetchDrillthrough, type QueryResult } from "$lib/api/query";
@@ -868,7 +869,11 @@
           <CellsetTable result={query.result} />
         {/if}
       {:else}
-        <p class="canvas__hint">{i18n.t("canvas.buildPrompt")}</p>
+        <EmptyState
+          icon={Sparkles}
+          title="Build a query"
+          description={i18n.t("canvas.buildPrompt")}
+        />
       {/if}
     </div>
     </div>

--- a/saiku-ui/src/lib/views/QueryCanvas.svelte
+++ b/saiku-ui/src/lib/views/QueryCanvas.svelte
@@ -1050,7 +1050,7 @@
     align-items: center;
     justify-content: space-between;
     font-size: var(--fs-xs);
-    font-weight: 600;
+    font-weight: var(--weight-semibold);
     text-transform: uppercase;
     letter-spacing: 0.06em;
     color: var(--fg-muted);

--- a/saiku-ui/src/lib/views/QueryCanvas.svelte
+++ b/saiku-ui/src/lib/views/QueryCanvas.svelte
@@ -1075,7 +1075,15 @@
     flex-wrap: wrap;
     gap: var(--space-1);
   }
-  .chips__empty { color: var(--fg-subtle); font-size: var(--fs-sm); }
+  .chips__empty {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    min-height: 32px;
+    color: var(--fg-subtle);
+    font-size: var(--fs-sm);
+    font-style: italic;
+  }
   .chip {
     display: inline-flex;
     align-items: center;

--- a/saiku-ui/src/lib/views/StatsView.svelte
+++ b/saiku-ui/src/lib/views/StatsView.svelte
@@ -81,8 +81,8 @@
   .stats-wrap { flex: 1; min-height: 0; overflow: auto; border: 1px solid var(--border); background: var(--bg); border-radius: 4px; }
   .stats { border-collapse: separate; border-spacing: 0; width: 100%; font-size: var(--fs-sm); }
   .stats th, .stats td { padding: 6px 12px; border-bottom: 1px solid var(--border); text-align: left; white-space: nowrap; }
-  .stats thead th { position: sticky; top: 0; background: var(--bg-muted); color: var(--fg); font-weight: 600; }
-  .stats tbody th { background: var(--bg-muted); font-weight: 500; color: var(--fg); }
+  .stats thead th { position: sticky; top: 0; background: var(--bg-muted); color: var(--fg); font-weight: var(--weight-semibold); }
+  .stats tbody th { background: var(--bg-muted); font-weight: var(--weight-medium); color: var(--fg); }
   .stats td.n { text-align: right; font-variant-numeric: tabular-nums; }
   .empty { color: var(--fg-muted); padding: var(--space-4); }
 </style>

--- a/saiku-ui/src/lib/views/Workspace.svelte
+++ b/saiku-ui/src/lib/views/Workspace.svelte
@@ -259,8 +259,8 @@
   }
   .workspace__sidebar-footer {
     padding: var(--space-3) var(--space-4);
-    border-top: 1px solid var(--border);
-    background: var(--bg-muted);
+    border-top: 1px solid var(--border-strong);
+    background: var(--bg-subtle);
     display: flex;
     align-items: center;
     gap: var(--space-2);

--- a/saiku-ui/src/lib/views/Workspace.svelte
+++ b/saiku-ui/src/lib/views/Workspace.svelte
@@ -280,7 +280,7 @@
     display: inline-flex;
     align-items: center;
     gap: var(--space-2);
-    padding: var(--space-3) var(--space-3) var(--space-3) var(--space-4);
+    padding: var(--space-2) var(--space-3);
     color: var(--fg-muted);
     border-bottom: 2px solid transparent;
     background: transparent;
@@ -288,6 +288,7 @@
     border-left: 0;
     border-right: 0;
     font: inherit;
+    font-size: var(--fs-sm);
     cursor: pointer;
     max-width: 18rem;
   }

--- a/saiku-ui/src/lib/views/WorkspaceToolbar.svelte
+++ b/saiku-ui/src/lib/views/WorkspaceToolbar.svelte
@@ -504,7 +504,7 @@
     font: inherit;
     cursor: pointer;
   }
-  .toolbar__item:hover { background: var(--bg-subtle); }
+  .toolbar__item:hover { background: var(--bg-hover); }
   .toolbar__sep {
     width: 1px;
     height: 22px;
@@ -538,7 +538,8 @@
     cursor: pointer;
     font: inherit;
   }
-  .tb-btn:hover { background: var(--bg-subtle); color: var(--fg); }
+  .tb-btn { transition: background var(--duration-fast), color var(--duration-fast); }
+  .tb-btn:hover { background: var(--bg-hover); color: var(--fg); }
   .tb-btn:active { transform: translateY(1px); }
   .tb-btn__label { font-size: var(--fs-sm); }
   .tb-btn--primary {

--- a/saiku-ui/src/lib/views/admin/StatsAdmin.svelte
+++ b/saiku-ui/src/lib/views/admin/StatsAdmin.svelte
@@ -237,13 +237,13 @@
     border-radius: var(--radius);
   }
   .kpi__label { font-size: var(--fs-xs); color: var(--fg-muted); text-transform: uppercase; letter-spacing: 0.05em; }
-  .kpi__value { font-size: 24px; font-weight: 700; color: var(--fg); }
+  .kpi__value { font-size: 24px; font-weight: var(--weight-bold); color: var(--fg); }
   .kpi__sub { font-size: var(--fs-xs); color: var(--fg-muted); }
   .block { display: flex; flex-direction: column; gap: var(--space-2); }
   .table-wrap { overflow: auto; border: 1px solid var(--border); border-radius: var(--radius-sm); }
   table { width: 100%; border-collapse: collapse; font-size: var(--fs-sm); }
   th, td { padding: 6px 10px; text-align: left; white-space: nowrap; border-bottom: 1px solid var(--border); }
-  th { background: var(--bg-muted); font-weight: 600; }
+  th { background: var(--bg-muted); font-weight: var(--weight-semibold); }
   tr:last-child td { border-bottom: 0; }
   .mdx { font-family: var(--font-mono); font-size: var(--fs-xs); color: var(--fg-muted); }
 </style>

--- a/saiku-ui/src/lib/views/dashboard/AddTileMenu.svelte
+++ b/saiku-ui/src/lib/views/dashboard/AddTileMenu.svelte
@@ -137,7 +137,7 @@
   }
   .label {
     display: block;
-    font-weight: 500;
+    font-weight: var(--weight-medium);
   }
   .hint {
     display: block;

--- a/saiku-ui/src/lib/views/dashboard/DashboardIndex.svelte
+++ b/saiku-ui/src/lib/views/dashboard/DashboardIndex.svelte
@@ -308,7 +308,7 @@
     min-width: 0;
   }
   .name {
-    font-weight: 500;
+    font-weight: var(--weight-medium);
   }
   .path {
     font-size: 0.75rem;

--- a/saiku-ui/src/lib/views/dashboard/DashboardToolbar.svelte
+++ b/saiku-ui/src/lib/views/dashboard/DashboardToolbar.svelte
@@ -107,7 +107,7 @@
   }
   .name {
     font-size: 1.125rem;
-    font-weight: 600;
+    font-weight: var(--weight-semibold);
     padding: 0.375rem 0.5rem;
     border: 1px solid transparent;
     border-radius: 4px;
@@ -121,7 +121,7 @@
   }
   .name-readonly {
     font-size: 1.125rem;
-    font-weight: 600;
+    font-weight: var(--weight-semibold);
     margin: 0;
   }
   .spacer { flex: 1; }

--- a/saiku-ui/src/lib/views/dashboard/FilterSuggestionsModal.svelte
+++ b/saiku-ui/src/lib/views/dashboard/FilterSuggestionsModal.svelte
@@ -220,7 +220,7 @@
   .head h2 {
     margin: 0;
     font-size: 1rem;
-    font-weight: 600;
+    font-weight: var(--weight-semibold);
   }
   .close {
     border: none;
@@ -276,7 +276,7 @@
   }
   .level {
     font-size: 0.9375rem;
-    font-weight: 500;
+    font-weight: var(--weight-medium);
   }
   .path, .meta {
     font-size: 0.75rem;

--- a/saiku-ui/src/lib/views/dashboard/Tile.svelte
+++ b/saiku-ui/src/lib/views/dashboard/Tile.svelte
@@ -120,7 +120,7 @@
     font-size: 0.8125rem;
   }
   .title {
-    font-weight: 500;
+    font-weight: var(--weight-medium);
     flex: 1;
     overflow: hidden;
     text-overflow: ellipsis;

--- a/saiku-ui/src/lib/views/dashboard/tiles/TableTile.svelte
+++ b/saiku-ui/src/lib/views/dashboard/tiles/TableTile.svelte
@@ -313,7 +313,7 @@
   }
   th {
     background: var(--bg-muted);
-    font-weight: 600;
+    font-weight: var(--weight-semibold);
     position: sticky;
     top: 0;
     z-index: 1;

--- a/saiku-ui/src/lib/views/dashboard/tiles/TextTile.svelte
+++ b/saiku-ui/src/lib/views/dashboard/tiles/TextTile.svelte
@@ -56,7 +56,7 @@
   .text-tile :global(h2),
   .text-tile :global(h3) {
     margin: 0.25em 0;
-    font-weight: 600;
+    font-weight: var(--weight-semibold);
   }
   .text-tile :global(p) {
     margin: 0.25em 0;

--- a/saiku-ui/src/routes/+layout.svelte
+++ b/saiku-ui/src/routes/+layout.svelte
@@ -8,7 +8,7 @@
   import { embed } from "$lib/stores/embed.svelte";
   import ToastStack from "$lib/components/ToastStack.svelte";
   import UpgradeBanner from "$lib/components/UpgradeBanner.svelte";
-  import { LogOut, Shield, Home, LayoutDashboard } from "lucide-svelte";
+  import { LogOut, Shield, Home, LayoutDashboard, UserRound } from "lucide-svelte";
   import Tour from "$lib/components/Tour.svelte";
   import SessionErrorModal from "$lib/modals/SessionErrorModal.svelte";
   import { i18n } from "$lib/stores/i18n.svelte";
@@ -86,7 +86,10 @@
     </a>
     <div class="topbar__actions">
       {#if session.current}
-        <span class="topbar__user">{session.current.username}</span>
+        <span class="topbar__user" title="Signed in as {session.current.username}">
+          <UserRound size={14} />
+          {session.current.username}
+        </span>
         {#if !page.url.pathname.startsWith(`${base}/dashboards`) && !page.url.pathname.startsWith(`${base}/admin`)}
           <a class="btn" href="{base}/dashboards"><LayoutDashboard size={14} /><span>Dashboards</span></a>
         {/if}
@@ -147,9 +150,11 @@
   }
   .topbar__brand:hover { text-decoration: none; }
   .topbar__brand-logo {
-    height: var(--brand-logo-height, 24px);
+    height: 28px;
+    max-height: 28px;
     width: auto;
     display: block;
+    object-fit: contain;
   }
   /* Wordmark — typeset Saiku next to the symbol. Falls back to text-only
      brand when no logo file ships with the deployment. Hidden on narrow
@@ -182,9 +187,17 @@
     padding-bottom: 0;
   }
   .topbar__user {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--space-1);
+    padding: 4px var(--space-2);
+    background: var(--bg-subtle);
+    border: 1px solid var(--border);
+    border-radius: 999px;
     color: var(--fg-muted);
     font-size: var(--fs-sm);
   }
+  .topbar__user :global(svg) { color: var(--fg-subtle); }
   .app__main {
     flex: 1;
     min-height: 0;

--- a/saiku-ui/src/routes/+layout.svelte
+++ b/saiku-ui/src/routes/+layout.svelte
@@ -77,11 +77,12 @@
         <img
           class="topbar__brand-logo"
           src={brandLogo}
-          alt=""
+          alt={i18n.t("brand")}
           onerror={onBrandLogoError}
         />
+      {:else}
+        <span class="topbar__brand-wordmark">{i18n.t("brand")}</span>
       {/if}
-      <span class="topbar__brand-wordmark">{i18n.t("brand")}</span>
     </a>
     <div class="topbar__actions">
       {#if session.current}

--- a/saiku-ui/src/routes/+layout.svelte
+++ b/saiku-ui/src/routes/+layout.svelte
@@ -72,18 +72,17 @@
   {/if}
   {#if !embed.active}
   <header class="topbar">
-    <div class="topbar__brand">
+    <a class="topbar__brand" href="{base}/" aria-label={i18n.t("brand")}>
       {#if brandLogo}
         <img
           class="topbar__brand-logo"
           src={brandLogo}
-          alt={i18n.t("brand")}
+          alt=""
           onerror={onBrandLogoError}
         />
-      {:else}
-        {i18n.t("brand")}
       {/if}
-    </div>
+      <span class="topbar__brand-wordmark">{i18n.t("brand")}</span>
+    </a>
     <div class="topbar__actions">
       {#if session.current}
         <span class="topbar__user">{session.current.username}</span>
@@ -139,15 +138,29 @@
     border-bottom: 1px solid var(--border);
   }
   .topbar__brand {
-    font-weight: var(--weight-bold);
-    letter-spacing: 0.02em;
     display: flex;
     align-items: center;
+    gap: var(--space-2);
+    color: var(--fg);
+    text-decoration: none;
   }
+  .topbar__brand:hover { text-decoration: none; }
   .topbar__brand-logo {
     height: var(--brand-logo-height, 24px);
     width: auto;
     display: block;
+  }
+  /* Wordmark — typeset Saiku next to the symbol. Falls back to text-only
+     brand when no logo file ships with the deployment. Hidden on narrow
+     viewports so the topbar doesn't crowd on mobile. */
+  .topbar__brand-wordmark {
+    font-weight: var(--weight-bold);
+    font-size: var(--fs-lg);
+    letter-spacing: -0.01em;
+    line-height: 1;
+  }
+  @media (max-width: 640px) {
+    .topbar__brand-wordmark { display: none; }
   }
   .topbar__actions {
     display: flex;

--- a/saiku-ui/src/routes/+layout.svelte
+++ b/saiku-ui/src/routes/+layout.svelte
@@ -139,7 +139,7 @@
     border-bottom: 1px solid var(--border);
   }
   .topbar__brand {
-    font-weight: 700;
+    font-weight: var(--weight-bold);
     letter-spacing: 0.02em;
     display: flex;
     align-items: center;

--- a/saiku-ui/src/routes/admin/schema-generator/[dataSourceId]/+page.svelte
+++ b/saiku-ui/src/routes/admin/schema-generator/[dataSourceId]/+page.svelte
@@ -309,7 +309,7 @@
   .schemagen__title h1 {
     margin: 0;
     font-size: var(--fs-lg);
-    font-weight: 600;
+    font-weight: var(--weight-semibold);
   }
   .schemagen__dsid {
     font-family: var(--font-mono);
@@ -344,7 +344,7 @@
 
   .schemagen__pill {
     font-size: var(--fs-xs);
-    font-weight: 600;
+    font-weight: var(--weight-semibold);
     padding: 3px var(--space-2);
     border-radius: 999px;
     text-transform: uppercase;
@@ -397,7 +397,7 @@
     font-size: var(--fs-sm);
   }
   .schemagen__delta-icon {
-    font-weight: 700;
+    font-weight: var(--weight-bold);
   }
 
   .schemagen__error button {

--- a/saiku-ui/vite.config.ts
+++ b/saiku-ui/vite.config.ts
@@ -23,7 +23,6 @@ export default defineConfig({
       $lib: fileURLToPath(new URL("./src/lib", import.meta.url)),
     },
   },
-  // @ts-expect-error vitest augments Vite's UserConfig with `test`
   test: {
     environment: "node",
     include: ["src/**/*.test.ts"],


### PR DESCRIPTION
## Summary

Six small workspace-view improvements Tom spotted in a quick look-around after #982. Each 1-5 lines; together they push the post-polish screen from 'feels MVP' to 'feels designed'.

Stacked on #982.

## What lands

1. **Topbar logo constrained to 28px** — \`max-height\` + \`object-fit: contain\` so the SVG can't render larger than chrome size on retina.
2. **Measure color** — \`var(--danger)\` → \`var(--accent)\`. Red carries error semantics; measures are just numbers. The Σ icon already signals 'measure'; color reinforces category, not severity.
3. **Username pill** — \`.topbar__user\` now flex with UserRound icon, \`--bg-subtle\` background, fully-rounded border. Reads as an identity affordance rather than floating text.
4. **Sidebar footer separation** — dark-mode contrast between \`--bg\` (sidebar) and \`--bg-muted\` (footer) was ~1%; bumped to \`--bg-subtle\` + \`--border-strong\`.
5. **Toolbar hover contrast** — \`.tb-btn\` / \`.toolbar__item\` were still hovering to \`--bg-subtle\` (the same 1-2% delta #963 called out for \`.btn\`). Now \`--bg-hover\` with transition.
6. **Empty dropzones** — \`.chips__empty\` placeholder flex-centers + italic. Reads as instructional cue rather than static label.

## What did NOT need changing

- Toolbar icon \`title=\`+ \`aria-label=\` — already in place (I assumed they weren't from screenshot alone).
- Dropzone dashed border + \`--bg-muted\` background — already in place; only the inner empty-state text needed refinement.

## Verified

- \`npm run check\`: 0 errors
- \`npm test\`: 170/170 passing