### PR TITLE
feat(ui): KPI tile — measure, format, comparison, sparkline, threshol…

### DIFF
--- a/saiku-ui/src/lib/api/dashboards.ts
+++ b/saiku-ui/src/lib/api/dashboards.ts
@@ -36,7 +36,7 @@ export interface InlineQuery {
 
 export type TileQuery = ReferenceQuery | InlineQuery;
 
-export type TileType = "chart" | "table" | "text" | "filter";
+export type TileType = "chart" | "table" | "text" | "filter" | "kpi";
 
 export type FilterWidget = "single-select" | "multi-select" | "date-range";
 
@@ -47,6 +47,58 @@ export interface DashboardFilter {
   hierarchy: string;
   level: string;
   members: string[]; // MDX unique names; empty = "any"
+}
+
+/** Display format for the KPI tile's main number. "custom" enables the
+ *  {@link KpiConfig.customFormat} pattern. */
+export type KpiFormat = "number" | "currency" | "percent" | "custom";
+
+/** Reference to a time level on a cube — used by KPI comparison and
+ *  sparkline. Same shape as DashboardFilter without members. */
+export interface TimeLevelRef {
+  dimension: string;
+  hierarchy: string;
+  level: string;
+}
+
+/** Comparison mode for the KPI tile's secondary callout. */
+export type KpiComparison = "none" | "prior-period" | "target";
+
+/** Direction: "higher" means a bigger number is better (drives both the
+ *  prior-period arrow colour and threshold green/red mapping). */
+export type KpiDirection = "higher-is-better" | "lower-is-better";
+
+/** Threshold breakpoints for colour-banding the main number. Optional
+ *  per band — leave a band undefined to skip it. The bands are
+ *  interpreted with respect to {@link KpiConfig.direction}. */
+export interface KpiThresholds {
+  red?: number;
+  yellow?: number;
+  green?: number;
+}
+
+/** Per-tile KPI config. All fields optional so an unfinished tile saves
+ *  cleanly; the renderer falls back to a placeholder until the analyst
+ *  picks a measure. */
+export interface KpiConfig {
+  /** Measure unique name, e.g. {@code [Measures].[Unit Sales]}. */
+  measure?: string;
+  /** Optional cube-side caption to render under the number when no
+   *  comparison is configured. Mirrors the AiQueryMetadata measure
+   *  caption — set by the editor on pick. */
+  measureCaption?: string;
+  format?: KpiFormat;
+  /** When {@link format} is "custom", the d3-style or printf-style
+   *  pattern to apply. Loose-typed; the formatter handles the parse. */
+  customFormat?: string;
+  comparison?: KpiComparison;
+  /** Target value when {@link comparison} is "target". */
+  target?: number;
+  /** Time level used for prior-period delta and / or sparkline. */
+  timeLevel?: TimeLevelRef;
+  sparkline?: boolean;
+  thresholds?: KpiThresholds;
+  direction?: KpiDirection;
 }
 
 export interface DashboardTile {
@@ -63,6 +115,8 @@ export interface DashboardTile {
   text?: string;
   target?: DashboardFilter;
   widget?: FilterWidget;
+  /** KPI-tile config. Only consulted when {@code type === "kpi"}. */
+  kpi?: KpiConfig;
 }
 
 export interface DashboardLayout {

--- a/saiku-ui/src/lib/dashboard/kpi.test.ts
+++ b/saiku-ui/src/lib/dashboard/kpi.test.ts
@@ -1,0 +1,154 @@
+/*
+ * Unit tests for the KPI tile's pure helpers (#917).
+ *
+ * Locale-sensitive output (Intl.NumberFormat) is asserted with regex
+ * rather than string equality so the suite is robust across runtime
+ * locales (CI may differ from a developer laptop).
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { formatKpi, kpiDelta, kpiThresholdToken, lastAndPriorValues } from "./kpi";
+
+describe("formatKpi", () => {
+  it("renders null / undefined / NaN as an em-dash", () => {
+    expect(formatKpi(null, "number")).toBe("—");
+    expect(formatKpi(undefined, "number")).toBe("—");
+    expect(formatKpi(Number.NaN, "number")).toBe("—");
+  });
+
+  it("formats whole numbers without trailing decimals by default", () => {
+    expect(formatKpi(1234567, "number")).toMatch(/1[ ,.\s]?234[ ,.\s]?567/);
+  });
+
+  it("formats currency with a currency symbol and no fractional digits", () => {
+    const out = formatKpi(1234, "currency");
+    expect(out).toMatch(/1[ ,.\s]?234/);
+    expect(out).toMatch(/[$€£¥]/); // some locale-appropriate currency mark
+  });
+
+  it("formats percent values with a % suffix", () => {
+    expect(formatKpi(0.156, "percent")).toMatch(/15.6\s?%/);
+  });
+
+  it("custom % pattern routes through percent formatter with the right digits", () => {
+    const out = formatKpi(0.1234, "custom", "2%");
+    expect(out).toMatch(/12\.34\s?%/);
+  });
+
+  it("custom $N pattern routes through USD currency", () => {
+    const out = formatKpi(99.5, "custom", "$2");
+    expect(out).toMatch(/[$]\s?99\.50/);
+  });
+
+  it("custom bare-digit pattern fixes fractional digit count", () => {
+    const out = formatKpi(3.14159, "custom", "3");
+    expect(out).toMatch(/3\.142/);
+  });
+
+  it("falls back to plain number when format is undefined", () => {
+    expect(formatKpi(42, undefined)).toMatch(/^42/);
+  });
+});
+
+describe("kpiThresholdToken", () => {
+  it("returns undefined when value is null", () => {
+    expect(kpiThresholdToken(null, { red: 0, yellow: 50, green: 100 })).toBeUndefined();
+  });
+
+  it("returns undefined when no thresholds configured", () => {
+    expect(kpiThresholdToken(42, undefined)).toBeUndefined();
+    expect(kpiThresholdToken(42, {})).toBeUndefined();
+  });
+
+  it("higher-is-better: maps to green when value clears the green cutoff", () => {
+    expect(kpiThresholdToken(120, { red: 0, yellow: 50, green: 100 })).toBe("--kpi-green");
+    expect(kpiThresholdToken(100, { red: 0, yellow: 50, green: 100 })).toBe("--kpi-green");
+  });
+
+  it("higher-is-better: maps to yellow between yellow and green cutoffs", () => {
+    expect(kpiThresholdToken(75, { red: 0, yellow: 50, green: 100 })).toBe("--kpi-yellow");
+    expect(kpiThresholdToken(50, { red: 0, yellow: 50, green: 100 })).toBe("--kpi-yellow");
+  });
+
+  it("higher-is-better: maps to red below yellow cutoff", () => {
+    expect(kpiThresholdToken(25, { red: 0, yellow: 50, green: 100 })).toBe("--kpi-red");
+  });
+
+  it("higher-is-better: out-of-bounds value falls into red (open-ended)", () => {
+    expect(kpiThresholdToken(-5, { red: 0, yellow: 50, green: 100 })).toBe("--kpi-red");
+  });
+
+  it("returns undefined when value misses green+yellow and red isn't configured", () => {
+    expect(kpiThresholdToken(25, { yellow: 50, green: 100 })).toBeUndefined();
+  });
+
+  it("lower-is-better: small values are green", () => {
+    expect(
+      kpiThresholdToken(5, { red: 100, yellow: 50, green: 10 }, "lower-is-better"),
+    ).toBe("--kpi-green");
+  });
+
+  it("lower-is-better: large values are red", () => {
+    expect(
+      kpiThresholdToken(150, { red: 100, yellow: 50, green: 10 }, "lower-is-better"),
+    ).toBe("--kpi-red");
+  });
+});
+
+describe("kpiDelta", () => {
+  it("returns null + flat when either input is null", () => {
+    expect(kpiDelta(null, 100)).toEqual({ ratio: null, tone: "flat" });
+    expect(kpiDelta(100, null)).toEqual({ ratio: null, tone: "flat" });
+  });
+
+  it("returns null + flat when baseline is zero (no division)", () => {
+    expect(kpiDelta(100, 0)).toEqual({ ratio: null, tone: "flat" });
+  });
+
+  it("positive growth with higher-is-better is positive tone", () => {
+    expect(kpiDelta(115, 100)).toEqual({ ratio: 0.15, tone: "positive" });
+  });
+
+  it("negative growth with higher-is-better is negative tone", () => {
+    expect(kpiDelta(85, 100)).toEqual({ ratio: -0.15, tone: "negative" });
+  });
+
+  it("flat (no change) is flat regardless of direction", () => {
+    expect(kpiDelta(100, 100)).toEqual({ ratio: 0, tone: "flat" });
+    expect(kpiDelta(100, 100, "lower-is-better")).toEqual({ ratio: 0, tone: "flat" });
+  });
+
+  it("lower-is-better inverts the tone polarity", () => {
+    expect(kpiDelta(85, 100, "lower-is-better")).toEqual({ ratio: -0.15, tone: "positive" });
+    expect(kpiDelta(115, 100, "lower-is-better")).toEqual({ ratio: 0.15, tone: "negative" });
+  });
+});
+
+describe("lastAndPriorValues", () => {
+  it("returns {null, null} on empty input", () => {
+    expect(lastAndPriorValues([])).toEqual({ current: null, prior: null });
+  });
+
+  it("returns current only when one row", () => {
+    expect(lastAndPriorValues([{ value: 42 }])).toEqual({ current: 42, prior: null });
+  });
+
+  it("returns the last and second-to-last non-null values", () => {
+    expect(
+      lastAndPriorValues([{ value: 10 }, { value: 20 }, { value: 30 }]),
+    ).toEqual({ current: 30, prior: 20 });
+  });
+
+  it("skips null cells so a blank row doesn't shift the baseline", () => {
+    expect(
+      lastAndPriorValues([{ value: 10 }, { value: null }, { value: 30 }]),
+    ).toEqual({ current: 30, prior: 10 });
+  });
+
+  it("returns null for both when every cell is null", () => {
+    expect(
+      lastAndPriorValues([{ value: null }, { value: null }]),
+    ).toEqual({ current: null, prior: null });
+  });
+});

--- a/saiku-ui/src/lib/dashboard/kpi.ts
+++ b/saiku-ui/src/lib/dashboard/kpi.ts
@@ -1,0 +1,177 @@
+/*
+ * Pure helpers for the KPI tile.
+ *
+ * Format selection, threshold-to-colour mapping, and prior-period delta
+ * calculation live here so the renderer (KpiTile.svelte) stays a thin
+ * dispatcher and these branches are unit-testable without a DOM.
+ */
+
+import type { KpiDirection, KpiFormat, KpiThresholds } from "$lib/api/dashboards";
+
+/** Apply the KPI format choice to a raw numeric value. Returns a
+ *  display string. Locale-aware via Intl.NumberFormat — falls back to
+ *  the browser default; for SSR / unit tests, jsdom honours "en-US".
+ *
+ *  Custom pattern handling is intentionally minimal: a percent-sign
+ *  suffix or currency-prefix shorthand ("$", "€", "£") is detected
+ *  and routed to Intl.NumberFormat; anything else is treated as a
+ *  digit-count hint (number of fractional digits). Full d3-format
+ *  support would be a bigger lift than this PR; the existing format
+ *  cards cover the four cases the issue calls out. */
+export function formatKpi(
+  value: number | null | undefined,
+  format: KpiFormat | undefined,
+  customFormat?: string,
+): string {
+  if (value == null || Number.isNaN(value)) return "—";
+  switch (format) {
+    case "currency":
+      return new Intl.NumberFormat(undefined, {
+        style: "currency",
+        currency: "USD",
+        maximumFractionDigits: 0,
+      }).format(value);
+    case "percent":
+      return new Intl.NumberFormat(undefined, {
+        style: "percent",
+        maximumFractionDigits: 1,
+      }).format(value);
+    case "custom":
+      return formatCustom(value, customFormat ?? "");
+    case "number":
+    default:
+      return new Intl.NumberFormat(undefined, {
+        maximumFractionDigits: 2,
+      }).format(value);
+  }
+}
+
+function formatCustom(value: number, pattern: string): string {
+  const p = pattern.trim();
+  if (!p) return new Intl.NumberFormat(undefined, { maximumFractionDigits: 2 }).format(value);
+  if (p.endsWith("%")) {
+    const digits = parseFractionDigits(p.slice(0, -1));
+    return new Intl.NumberFormat(undefined, {
+      style: "percent",
+      maximumFractionDigits: digits,
+      minimumFractionDigits: digits,
+    }).format(value);
+  }
+  const currencyMatch = p.match(/^([$€£¥])(\d*)$/);
+  if (currencyMatch) {
+    const symbol = currencyMatch[1];
+    const digits = parseFractionDigits(currencyMatch[2]);
+    const code = currencyCodeFor(symbol);
+    return new Intl.NumberFormat(undefined, {
+      style: "currency",
+      currency: code,
+      maximumFractionDigits: digits,
+      minimumFractionDigits: digits,
+    }).format(value);
+  }
+  // Bare digit count, e.g. "3" -> 3 fractional digits.
+  const digitsOnly = parseFractionDigits(p);
+  return new Intl.NumberFormat(undefined, {
+    maximumFractionDigits: digitsOnly,
+    minimumFractionDigits: digitsOnly,
+  }).format(value);
+}
+
+function parseFractionDigits(s: string): number {
+  const n = parseInt(s, 10);
+  return Number.isFinite(n) && n >= 0 && n <= 10 ? n : 0;
+}
+
+function currencyCodeFor(symbol: string): string {
+  switch (symbol) {
+    case "$": return "USD";
+    case "€": return "EUR";
+    case "£": return "GBP";
+    case "¥": return "JPY";
+    default: return "USD";
+  }
+}
+
+/** Bands the value into a CSS custom property name (one of --kpi-red /
+ *  --kpi-yellow / --kpi-green / undefined). Direction flips the band
+ *  comparisons — for "lower-is-better", *smaller* values map to green.
+ *
+ *  Semantics: green and yellow are explicit cutoffs; red is an
+ *  open-ended fallback ("worse than yellow"). This makes the colour
+ *  band a visual classifier rather than a strict membership check —
+ *  an out-of-bounds value still flags red instead of silently going
+ *  uncoloured.
+ *
+ *  Example (direction = higher-is-better, thresholds = {red:0, yellow:50, green:100}):
+ *    value >= 100 → green
+ *    50 <= value < 100 → yellow
+ *    value < 50 (and red configured) → red — including values below 0
+ *
+ *  Returns undefined when no thresholds are configured at all, or when
+ *  value is null. If only green/yellow are configured and the value
+ *  misses both, also returns undefined (no red opt-in). */
+export function kpiThresholdToken(
+  value: number | null | undefined,
+  thresholds: KpiThresholds | undefined,
+  direction: KpiDirection = "higher-is-better",
+): "--kpi-red" | "--kpi-yellow" | "--kpi-green" | undefined {
+  if (value == null || Number.isNaN(value)) return undefined;
+  if (!thresholds) return undefined;
+  const { red, yellow, green } = thresholds;
+  if (red == null && yellow == null && green == null) return undefined;
+  const cmp = direction === "higher-is-better"
+    ? (v: number, t: number) => v >= t
+    : (v: number, t: number) => v <= t;
+  // Evaluate from "best" to "worst". green and yellow are strict
+  // boundaries; red is the open-ended fallback so a wildly bad value
+  // doesn't silently fall off the colour scale.
+  if (green != null && cmp(value, green)) return "--kpi-green";
+  if (yellow != null && cmp(value, yellow)) return "--kpi-yellow";
+  if (red != null) return "--kpi-red";
+  return undefined;
+}
+
+export interface KpiDelta {
+  /** Fractional change: (current - prior) / prior. NaN/Infinity become null. */
+  ratio: number | null;
+  /** Direction-aware classification — used to pick the arrow + colour. */
+  tone: "positive" | "negative" | "flat";
+}
+
+/** Compute the delta between two KPI values, with the direction baked
+ *  into the tone (so "lower-is-better" + delta < 0 → "positive"). Used
+ *  for both prior-period and target comparisons. */
+export function kpiDelta(
+  current: number | null | undefined,
+  baseline: number | null | undefined,
+  direction: KpiDirection = "higher-is-better",
+): KpiDelta {
+  if (current == null || baseline == null || baseline === 0) {
+    return { ratio: null, tone: "flat" };
+  }
+  const ratio = (current - baseline) / baseline;
+  if (!Number.isFinite(ratio)) return { ratio: null, tone: "flat" };
+  if (ratio === 0) return { ratio, tone: "flat" };
+  const better = direction === "higher-is-better" ? ratio > 0 : ratio < 0;
+  return { ratio, tone: better ? "positive" : "negative" };
+}
+
+/** Return the last two numeric cells from a time-sorted result series.
+ *  Used by the KPI tile when comparison is "prior-period": the latest
+ *  cell becomes the headline number, the second-to-last becomes the
+ *  baseline. Cells with null value are skipped so a blank "no data"
+ *  row doesn't poison the comparison. */
+export function lastAndPriorValues(
+  series: ReadonlyArray<{ value: number | null }>,
+): { current: number | null; prior: number | null } {
+  const nonNull: number[] = [];
+  for (const c of series) {
+    if (c.value != null && Number.isFinite(c.value)) nonNull.push(c.value);
+  }
+  if (nonNull.length === 0) return { current: null, prior: null };
+  if (nonNull.length === 1) return { current: nonNull[nonNull.length - 1], prior: null };
+  return {
+    current: nonNull[nonNull.length - 1],
+    prior: nonNull[nonNull.length - 2],
+  };
+}

--- a/saiku-ui/src/lib/dashboard/tilePlacement.ts
+++ b/saiku-ui/src/lib/dashboard/tilePlacement.ts
@@ -9,7 +9,9 @@ import type { DashboardLayout, DashboardTile, TileType } from "$lib/api/dashboar
 /** Default size for each tile type. Tuned for the 12-column grid:
  *  - chart / table fill half the row (analyst can resize later)
  *  - filter is a wide skinny strip (full row, 1 row tall)
- *  - text is half-width, slightly shorter than chart/table */
+ *  - text is half-width, slightly shorter than chart/table
+ *  - kpi is a compact card — quarter-row width, 2 rows tall, so four
+ *    fit across the top of a dashboard */
 export function defaultSizeFor(type: TileType): { w: number; h: number } {
   switch (type) {
     case "chart":
@@ -20,6 +22,8 @@ export function defaultSizeFor(type: TileType): { w: number; h: number } {
       return { w: 12, h: 1 };
     case "text":
       return { w: 6, h: 2 };
+    case "kpi":
+      return { w: 3, h: 2 };
   }
 }
 

--- a/saiku-ui/src/lib/views/dashboard/AddTileMenu.svelte
+++ b/saiku-ui/src/lib/views/dashboard/AddTileMenu.svelte
@@ -70,6 +70,13 @@
           <span class="hint">Records of measure cells with row headers.</span>
         </span>
       </button>
+      <button type="button" class="menu-item" role="menuitem" onclick={() => pick("kpi")}>
+        <span class="icon" aria-hidden="true">📈</span>
+        <span>
+          <span class="label">KPI</span>
+          <span class="hint">A single measure as a big number, with optional comparison + sparkline.</span>
+        </span>
+      </button>
       <button type="button" class="menu-item" role="menuitem" onclick={() => pick("filter")}>
         <span class="icon" aria-hidden="true">🔍</span>
         <span>

--- a/saiku-ui/src/lib/views/dashboard/DashboardIndex.svelte
+++ b/saiku-ui/src/lib/views/dashboard/DashboardIndex.svelte
@@ -22,7 +22,12 @@
     type RepositoryNode,
   } from "$lib/api/repository";
   import { listAllRoles } from "$lib/api/admin";
-  import { deleteDashboard, newDashboard, saveDashboard } from "$lib/api/dashboards";
+  import {
+    deleteDashboard,
+    newDashboard,
+    normaliseDashboardPath,
+    saveDashboard,
+  } from "$lib/api/dashboards";
   import { session } from "$lib/stores/session.svelte";
   import { toasts } from "$lib/stores/toasts.svelte";
   import { i18n } from "$lib/stores/i18n.svelte";

--- a/saiku-ui/src/lib/views/dashboard/Tile.svelte
+++ b/saiku-ui/src/lib/views/dashboard/Tile.svelte
@@ -16,6 +16,7 @@
   import TableTile from "$lib/views/dashboard/tiles/TableTile.svelte";
   import TextTile from "$lib/views/dashboard/tiles/TextTile.svelte";
   import FilterTile from "$lib/views/dashboard/tiles/FilterTile.svelte";
+  import KpiTile from "$lib/views/dashboard/tiles/KpiTile.svelte";
   import TileEditorModal from "$lib/views/dashboard/TileEditorModal.svelte";
   import { Settings2, X } from "lucide-svelte";
 
@@ -70,6 +71,8 @@
       <TextTile {tile} />
     {:else if tile.type === "filter"}
       <FilterTile {tile} {readOnly} />
+    {:else if tile.type === "kpi"}
+      <KpiTile {tile} />
     {:else}
       <div class="unknown">Unknown tile type: {tile.type}</div>
     {/if}
@@ -95,6 +98,8 @@
         return "Note";
       case "filter":
         return tile.target?.level ? `Filter: ${tile.target.level}` : "Filter";
+      case "kpi":
+        return tile.kpi?.measureCaption ?? tile.kpi?.measure ?? "KPI";
       default:
         return tile.type;
     }

--- a/saiku-ui/src/lib/views/dashboard/TileEditorModal.svelte
+++ b/saiku-ui/src/lib/views/dashboard/TileEditorModal.svelte
@@ -25,6 +25,7 @@
     type DashboardFilter,
     type DashboardTile,
     type FilterWidget,
+    type KpiConfig,
     type TileQuery,
   } from "$lib/api/dashboards";
   import { flatten, listRepository, type RepositoryNode } from "$lib/api/repository";
@@ -59,6 +60,23 @@
       dimension: tile.target?.dimension ?? "",
       hierarchy: tile.target?.hierarchy ?? "",
       level: tile.target?.level ?? "",
+    })),
+  );
+  // KPI tile config — single working-copy object; nested fields bind
+  // directly via Svelte 5's $state proxy. Defaults fill in unset fields
+  // so the form has stable controls even for a fresh KPI tile.
+  let kpiConfig = $state<KpiConfig>(
+    untrack(() => ({
+      measure: tile.kpi?.measure ?? "",
+      measureCaption: tile.kpi?.measureCaption ?? "",
+      format: tile.kpi?.format ?? "number",
+      customFormat: tile.kpi?.customFormat ?? "",
+      comparison: tile.kpi?.comparison ?? "none",
+      target: tile.kpi?.target,
+      timeLevel: tile.kpi?.timeLevel ?? { dimension: "", hierarchy: "", level: "" },
+      sparkline: tile.kpi?.sparkline ?? false,
+      thresholds: tile.kpi?.thresholds ?? {},
+      direction: tile.kpi?.direction ?? "higher-is-better",
     })),
   );
   let inlineBodyJson = $state<string>(
@@ -115,10 +133,13 @@
     }
   });
 
-  // Filter tiles need the cube's schema to populate dim/hier/level
-  // dropdowns. Prime when a cube is selected.
+  // Filter and KPI tiles need the cube's schema — filters for the
+  // dim/hier/level dropdowns, KPI for the measure picker and (when
+  // prior-period or sparkline are on) the time-level picker. Prime
+  // whenever a cube is selected so the dropdowns aren't empty.
   $effect(() => {
-    if (tile.type !== "filter" || !cube) return;
+    if (tile.type !== "filter" && tile.type !== "kpi") return;
+    if (!cube) return;
     void schemaCache.get(cube).catch(() => {
       // Surface failure inline below
     });
@@ -147,6 +168,62 @@
     for (const d of Object.values(s.dimensions)) {
       if (d.name === filterTarget.dimension && d.hierarchies) {
         return Object.values(d.hierarchies).map((h) => h.name);
+      }
+    }
+    return [];
+  });
+
+  // KPI tile derivers — keyed on kpiConfig.timeLevel.* so they're
+  // independent of the filter-tile dropdowns above. Same loose-schema
+  // narrowing as the filter ones.
+  let measureOptions = $derived(() => {
+    const s = schema() as
+      | { measures?: Record<string, { name?: string; displayName?: string | null; visible?: boolean }> }
+      | null;
+    if (!s?.measures) return [] as { name: string; label: string }[];
+    const out: { name: string; label: string }[] = [];
+    for (const m of Object.values(s.measures)) {
+      if (m?.visible === false) continue;
+      const name = m?.name;
+      if (!name) continue;
+      out.push({ name, label: m?.displayName ?? name });
+    }
+    return out;
+  });
+
+  let kpiHierarchyOptions = $derived(() => {
+    const s = schema() as
+      | { dimensions?: Record<string, { name: string; hierarchies?: Record<string, { name: string }> }> }
+      | null;
+    if (!s?.dimensions) return [] as string[];
+    for (const d of Object.values(s.dimensions)) {
+      if (d.name === kpiConfig.timeLevel?.dimension && d.hierarchies) {
+        return Object.values(d.hierarchies).map((h) => h.name);
+      }
+    }
+    return [];
+  });
+
+  let kpiLevelOptions = $derived(() => {
+    const s = schema() as
+      | {
+          dimensions?: Record<
+            string,
+            {
+              name: string;
+              hierarchies?: Record<string, { name: string; levels?: Record<string, { name: string }> }>;
+            }
+          >;
+        }
+      | null;
+    if (!s?.dimensions) return [] as string[];
+    for (const d of Object.values(s.dimensions)) {
+      if (d.name !== kpiConfig.timeLevel?.dimension) continue;
+      if (!d.hierarchies) return [];
+      for (const h of Object.values(d.hierarchies)) {
+        if (h.name === kpiConfig.timeLevel?.hierarchy && h.levels) {
+          return Object.values(h.levels).map((l) => l.name);
+        }
       }
     }
     return [];
@@ -201,6 +278,12 @@
     // names won't apply to the new cube's schema.
     if (tile.type === "filter") {
       filterTarget = { dimension: "", hierarchy: "", level: "" };
+    }
+    // Same reasoning for KPI: measure + time-level names are cube-scoped.
+    if (tile.type === "kpi") {
+      kpiConfig.measure = "";
+      kpiConfig.measureCaption = "";
+      kpiConfig.timeLevel = { dimension: "", hierarchy: "", level: "" };
     }
   }
 
@@ -274,6 +357,30 @@
         };
         patch.target = target;
       }
+    }
+
+    if (tile.type === "kpi") {
+      // Drop the timeLevel placeholder when none of the time-aware
+      // features need it — keeps the saved JSON tidy.
+      const needsTime = kpiConfig.comparison === "prior-period" || kpiConfig.sparkline === true;
+      const tl = kpiConfig.timeLevel;
+      const cleaned: KpiConfig = {
+        ...kpiConfig,
+        timeLevel:
+          needsTime && tl && tl.dimension && tl.hierarchy && tl.level ? tl : undefined,
+        // Drop empty thresholds object so the JSON diff is empty when
+        // the analyst doesn't touch the threshold inputs.
+        thresholds:
+          kpiConfig.thresholds &&
+          (kpiConfig.thresholds.red != null ||
+            kpiConfig.thresholds.yellow != null ||
+            kpiConfig.thresholds.green != null)
+            ? kpiConfig.thresholds
+            : undefined,
+        target: kpiConfig.comparison === "target" ? kpiConfig.target : undefined,
+        customFormat: kpiConfig.format === "custom" ? kpiConfig.customFormat : undefined,
+      };
+      patch.kpi = cleaned;
     }
 
     // Merge the patch into the repositioned source tile, then commit
@@ -467,6 +574,151 @@
           </select>
         </label>
       {/if}
+
+      {#if tile.type === "kpi"}
+        <label class="field">
+          <span>Measure</span>
+          <select
+            value={kpiConfig.measure ?? ""}
+            disabled={!cube || measureOptions().length === 0}
+            onchange={(e) => {
+              const picked = (e.target as HTMLSelectElement).value;
+              const opt = measureOptions().find((m) => m.name === picked);
+              kpiConfig.measure = picked || undefined;
+              kpiConfig.measureCaption = opt?.label;
+            }}
+          >
+            <option value="">— pick a measure —</option>
+            {#each measureOptions() as m (m.name)}
+              <option value={m.name}>{m.label}</option>
+            {/each}
+          </select>
+        </label>
+
+        <label class="field">
+          <span>Format</span>
+          <select bind:value={kpiConfig.format}>
+            <option value="number">Number</option>
+            <option value="currency">Currency</option>
+            <option value="percent">Percent</option>
+            <option value="custom">Custom pattern</option>
+          </select>
+        </label>
+        {#if kpiConfig.format === "custom"}
+          <label class="field">
+            <span>Custom pattern</span>
+            <input
+              type="text"
+              bind:value={kpiConfig.customFormat}
+              placeholder="e.g. $2 / 2% / 3"
+            />
+            <span class="hint">
+              $N / €N / £N for currency, N% for percent, plain N for fractional digits.
+            </span>
+          </label>
+        {/if}
+
+        <fieldset class="size">
+          <legend>Comparison</legend>
+          <label class="field inline">
+            <span>Mode</span>
+            <select bind:value={kpiConfig.comparison}>
+              <option value="none">None</option>
+              <option value="prior-period">Prior period</option>
+              <option value="target">Target value</option>
+            </select>
+          </label>
+          {#if kpiConfig.comparison === "target"}
+            <label class="field inline">
+              <span>Target</span>
+              <input
+                type="number"
+                bind:value={kpiConfig.target}
+                placeholder="e.g. 100000"
+              />
+            </label>
+          {/if}
+          <label class="field inline">
+            <span>Direction</span>
+            <select bind:value={kpiConfig.direction}>
+              <option value="higher-is-better">Higher is better</option>
+              <option value="lower-is-better">Lower is better</option>
+            </select>
+          </label>
+        </fieldset>
+
+        <label class="checkbox">
+          <input type="checkbox" bind:checked={kpiConfig.sparkline} />
+          <span>Sparkline (mini line chart under the number)</span>
+        </label>
+
+        {#if kpiConfig.comparison === "prior-period" || kpiConfig.sparkline}
+          <fieldset class="size">
+            <legend>Time level (for comparison + sparkline)</legend>
+            <label class="field inline">
+              <span>Dimension</span>
+              <select bind:value={kpiConfig.timeLevel!.dimension} disabled={!cube}>
+                <option value="">— pick —</option>
+                {#each dimensionOptions() as d (d)}
+                  <option value={d}>{d}</option>
+                {/each}
+              </select>
+            </label>
+            <label class="field inline">
+              <span>Hierarchy</span>
+              <select
+                bind:value={kpiConfig.timeLevel!.hierarchy}
+                disabled={!kpiConfig.timeLevel?.dimension}
+              >
+                <option value="">— pick —</option>
+                {#each kpiHierarchyOptions() as h (h)}
+                  <option value={h}>{h}</option>
+                {/each}
+              </select>
+            </label>
+            <label class="field inline">
+              <span>Level</span>
+              <select
+                bind:value={kpiConfig.timeLevel!.level}
+                disabled={!kpiConfig.timeLevel?.hierarchy}
+              >
+                <option value="">— pick —</option>
+                {#each kpiLevelOptions() as l (l)}
+                  <option value={l}>{l}</option>
+                {/each}
+              </select>
+            </label>
+          </fieldset>
+        {/if}
+
+        <fieldset class="size">
+          <legend>Threshold colouring (optional)</legend>
+          <label class="field inline">
+            <span>Red ≤ / ≥</span>
+            <input
+              type="number"
+              bind:value={kpiConfig.thresholds!.red}
+              placeholder="off"
+            />
+          </label>
+          <label class="field inline">
+            <span>Yellow</span>
+            <input
+              type="number"
+              bind:value={kpiConfig.thresholds!.yellow}
+              placeholder="off"
+            />
+          </label>
+          <label class="field inline">
+            <span>Green</span>
+            <input
+              type="number"
+              bind:value={kpiConfig.thresholds!.green}
+              placeholder="off"
+            />
+          </label>
+        </fieldset>
+      {/if}
     </div>
     <footer class="modal-footer">
       <button type="button" class="btn" onclick={onClose}>Cancel</button>
@@ -567,7 +819,8 @@
     letter-spacing: 0.04em;
     padding: 0 0.25rem;
   }
-  .radio {
+  .radio,
+  .checkbox {
     display: inline-flex;
     align-items: center;
     gap: 0.375rem;

--- a/saiku-ui/src/lib/views/dashboard/tiles/KpiTile.svelte
+++ b/saiku-ui/src/lib/views/dashboard/tiles/KpiTile.svelte
@@ -1,0 +1,321 @@
+<script lang="ts">
+  /*
+   * KPI tile (issue #917).
+   *
+   * Renders a single big number from a one-measure query on the bound
+   * cube. Optional features:
+   *   - Format selection (number / currency / percent / custom pattern)
+   *   - Prior-period comparison: a second-cell delta with ↑/↓ arrow,
+   *     coloured by direction.
+   *   - Target comparison: delta vs a static target value.
+   *   - Sparkline: mini line chart of the configured time level under
+   *     the number.
+   *   - Threshold-based colouring of the main number using red /
+   *     yellow / green bands.
+   *
+   * Query plumbing mirrors ChartTile / TableTile: an $effect keyed on
+   * the active-filter set and resolved cube refetches via the AI Query
+   * API. When comparison="prior-period" or sparkline is on, we issue a
+   * "by time level" query so both features can read the same series;
+   * otherwise a single-cell query is enough.
+   */
+
+  import { onDestroy, onMount } from "svelte";
+  import * as echarts from "echarts";
+  import { ArrowDownRight, ArrowUpRight, Minus } from "lucide-svelte";
+  import type { CubeRef, DashboardTile, KpiConfig } from "$lib/api/dashboards";
+  import {
+    executeAiQuery,
+    isAiCell,
+    type AiCell,
+    type AiQueryResponse,
+  } from "$lib/api/aiQuery";
+  import { activeFilters } from "$lib/stores/activeFilters.svelte";
+  import {
+    formatKpi,
+    kpiDelta,
+    kpiThresholdToken,
+    lastAndPriorValues,
+    type KpiDelta as KpiDeltaT,
+  } from "$lib/dashboard/kpi";
+
+  interface Props {
+    tile: DashboardTile;
+  }
+
+  let { tile }: Props = $props();
+
+  let loading = $state(false);
+  let error = $state<string | null>(null);
+  let response = $state<AiQueryResponse | null>(null);
+
+  let sparkHost = $state<HTMLDivElement | null>(null);
+  let spark: echarts.ECharts | null = null;
+  let sparkResize: ResizeObserver | null = null;
+
+  onMount(() => {
+    if (sparkHost) {
+      spark = echarts.init(sparkHost);
+      sparkResize = new ResizeObserver(() => spark?.resize());
+      sparkResize.observe(sparkHost);
+    }
+  });
+
+  onDestroy(() => {
+    sparkResize?.disconnect();
+    spark?.dispose();
+    spark = null;
+  });
+
+  // Derived: the KpiConfig with defaults filled in. Lets the renderer
+  // treat the config as totally-defined.
+  let kpi = $derived<Required<Pick<KpiConfig, "format" | "comparison" | "direction" | "sparkline">> & KpiConfig>({
+    format: "number",
+    comparison: "none",
+    direction: "higher-is-better",
+    sparkline: false,
+    ...(tile.kpi ?? {}),
+  });
+
+  let cube = $derived<CubeRef | null>(tile.cube ?? null);
+
+  // True when we need the by-time-level query (for sparkline or
+  // prior-period delta); false when a single-cell query is enough.
+  let wantsSeries = $derived(
+    !!kpi.timeLevel && (kpi.sparkline === true || kpi.comparison === "prior-period"),
+  );
+
+  let lastQueryJson = $state<string>("");
+
+  $effect(() => {
+    const measure = kpi.measure;
+    const c = cube;
+    const series = wantsSeries;
+    const tl = kpi.timeLevel;
+    const active = activeFilters.all;
+    if (!measure || !c) {
+      response = null;
+      return;
+    }
+
+    // Build the request body. Inline KPI tiles don't carry a TileQuery
+    // — the cube + measure + (optional) time-level on rows is enough.
+    type Filter = { dimension: string; hierarchy: string; level: string; members: string[] };
+    const body: Record<string, unknown> = {
+      cube: c,
+      measures: [{ name: measure }],
+      rows: series && tl ? [{ dimension: tl.dimension, hierarchy: tl.hierarchy, level: tl.level }] : [],
+      filters: active.map(
+        (f) =>
+          ({
+            dimension: f.filter.dimension,
+            hierarchy: f.filter.hierarchy,
+            level: f.filter.level,
+            members: f.filter.members ?? [],
+          }) satisfies Filter,
+      ),
+    };
+    const json = JSON.stringify(body);
+    if (json === lastQueryJson) return;
+    lastQueryJson = json;
+
+    loading = true;
+    error = null;
+    void (async () => {
+      try {
+        const r = await executeAiQuery(body, "records");
+        response = r;
+        if (r.status !== "SUCCESS") error = r.error ?? `Query failed: ${r.status}`;
+      } catch (e: unknown) {
+        error = e instanceof Error ? e.message : String(e);
+        response = null;
+      } finally {
+        loading = false;
+      }
+    })();
+  });
+
+  /** The headline number's source value. For "prior-period" comparison
+   *  we want the latest period (last row); otherwise the only cell. */
+  let valueAndPrior = $derived.by<{ current: number | null; prior: number | null }>(() => {
+    if (!response || response.status !== "SUCCESS") return { current: null, prior: null };
+    if (wantsSeries) {
+      const series = (response.data ?? []).map((row) => {
+        // The single measure column — pick whichever value in the row is
+        // an AiCell. There's only one per row for a one-measure query.
+        for (const v of Object.values(row)) {
+          if (isAiCell(v)) return { value: v.value };
+        }
+        return { value: null };
+      });
+      return lastAndPriorValues(series);
+    }
+    // Single-cell query: data has one row with one measure cell.
+    const row = response.data?.[0];
+    if (!row) return { current: null, prior: null };
+    for (const v of Object.values(row)) {
+      if (isAiCell(v)) return { current: v.value, prior: null };
+    }
+    return { current: null, prior: null };
+  });
+
+  let mainValue = $derived(valueAndPrior.current);
+
+  let delta = $derived.by<KpiDeltaT | null>(() => {
+    if (kpi.comparison === "prior-period") {
+      return kpiDelta(valueAndPrior.current, valueAndPrior.prior, kpi.direction);
+    }
+    if (kpi.comparison === "target" && kpi.target != null) {
+      return kpiDelta(mainValue, kpi.target, kpi.direction);
+    }
+    return null;
+  });
+
+  let mainColourToken = $derived(kpiThresholdToken(mainValue, kpi.thresholds, kpi.direction));
+
+  let formattedMain = $derived(formatKpi(mainValue, kpi.format, kpi.customFormat));
+
+  /** Re-render sparkline whenever the underlying series changes. */
+  $effect(() => {
+    if (!kpi.sparkline || !wantsSeries) {
+      spark?.clear();
+      return;
+    }
+    if (!spark || !response || response.status !== "SUCCESS") return;
+    const values = (response.data ?? []).map((row) => {
+      for (const v of Object.values(row)) {
+        if (isAiCell(v)) return v.value ?? null;
+      }
+      return null;
+    });
+    spark.setOption(
+      {
+        animation: false,
+        grid: { top: 4, right: 4, bottom: 4, left: 4 },
+        xAxis: { type: "category", show: false, data: values.map((_, i) => i) },
+        yAxis: { type: "value", show: false, scale: true },
+        series: [
+          {
+            type: "line",
+            data: values,
+            smooth: true,
+            showSymbol: false,
+            lineStyle: { width: 1.5 },
+          },
+        ],
+        tooltip: { show: false },
+      },
+      true,
+    );
+  });
+
+  // Pretty-print the delta ratio for the comparison callout.
+  let deltaLabel = $derived(formatDeltaLabel(delta));
+
+  function formatDeltaLabel(d: KpiDeltaT | null): string {
+    if (!d || d.ratio == null) return "";
+    const pct = new Intl.NumberFormat(undefined, {
+      style: "percent",
+      maximumFractionDigits: 1,
+      signDisplay: "always",
+    }).format(d.ratio);
+    if (kpi.comparison === "target") return `${pct} vs target`;
+    return `${pct} vs prior`;
+  }
+</script>
+
+{#if !tile.cube || !kpi.measure}
+  <div class="placeholder">KPI tile has no measure — open ⚙ to pick a cube + measure.</div>
+{:else}
+  <div class="kpi-tile" data-tone={delta?.tone ?? "flat"}>
+    {#if loading && response == null}
+      <div class="loading">Loading…</div>
+    {:else if error}
+      <div class="error">{error}</div>
+    {:else}
+      <div class="value" style={mainColourToken ? `color: var(${mainColourToken});` : ""}>
+        {formattedMain}
+      </div>
+      {#if delta && delta.ratio != null}
+        <div class="delta" data-tone={delta.tone}>
+          {#if delta.tone === "positive"}
+            <ArrowUpRight size={14} aria-hidden="true" />
+          {:else if delta.tone === "negative"}
+            <ArrowDownRight size={14} aria-hidden="true" />
+          {:else}
+            <Minus size={14} aria-hidden="true" />
+          {/if}
+          <span>{deltaLabel}</span>
+        </div>
+      {:else if kpi.measureCaption}
+        <div class="caption">{kpi.measureCaption}</div>
+      {/if}
+      {#if kpi.sparkline && wantsSeries}
+        <div class="spark" bind:this={sparkHost} aria-hidden="true"></div>
+      {/if}
+    {/if}
+  </div>
+{/if}
+
+<style>
+  .kpi-tile {
+    --kpi-red: var(--danger, #c00);
+    --kpi-yellow: var(--warning, #c79a00);
+    --kpi-green: var(--success, #1b8a3a);
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    height: 100%;
+    padding: 0.5rem;
+    text-align: center;
+    gap: 0.25rem;
+  }
+  .value {
+    /* 4-6x chart-tile font size per the issue spec — clamp scales it
+       responsively so the number stays readable in 2-row tiles. */
+    font-size: clamp(1.75rem, 4.5cqi + 0.5rem, 4rem);
+    font-weight: 600;
+    line-height: 1.1;
+    letter-spacing: -0.01em;
+    color: var(--fg);
+    container-type: inline-size;
+  }
+  .delta {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.25rem;
+    font-size: 0.8125rem;
+    color: var(--fg-muted);
+  }
+  .delta[data-tone="positive"] {
+    color: var(--success, #1b8a3a);
+  }
+  .delta[data-tone="negative"] {
+    color: var(--danger, #c00);
+  }
+  .caption {
+    font-size: 0.75rem;
+    color: var(--fg-muted);
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+  }
+  .spark {
+    width: 100%;
+    height: 36px;
+    flex-shrink: 0;
+  }
+  .placeholder,
+  .loading,
+  .error {
+    padding: 0.75rem 1rem;
+    color: var(--fg-muted);
+    font-size: 0.8125rem;
+    text-align: center;
+  }
+  .error {
+    color: var(--danger);
+    background: color-mix(in srgb, var(--danger) 12%, transparent);
+    border-radius: 4px;
+  }
+</style>


### PR DESCRIPTION
…ds (closes #917)

New "kpi" tile type alongside chart / table / text / filter. Renders a single measure as a large centred number with optional secondary callouts.

Features:
  - Format: number / currency / percent / custom pattern ($N, N%, plain fractional-digit count).
  - Comparison: none / prior-period (latest cell from a by-time-level query vs second-to-latest) / target (vs a fixed numeric input). Renders ↑ / ↓ / — arrow with direction-aware colour.
  - Sparkline: optional mini line chart from the same time-series query; ECharts (already a dep) with all chrome stripped.
  - Threshold colouring: red / yellow / green bands on the main number, direction-aware (higher-is-better or lower-is-better). Red is open-ended so out-of-bounds values still flag visually.

Plumbing:
  - DashboardTile.kpi: KpiConfig sub-object (additive — no existing tile-type schema change).
  - KpiTile.svelte issues one /ai/query: by-time-level when sparkline or prior-period is on, single-cell otherwise.
  - TileEditorModal grew a KPI panel — measure picker driven by the cube's /ai/schema measures, time-level picker reusing the same schema for dim/hier/level dropdowns.
  - AddTileMenu + Tile dispatch + tilePlacement default size (3×2).

Pure helpers in $lib/dashboard/kpi.ts:
  - formatKpi() — locale-aware via Intl.NumberFormat.
  - kpiThresholdToken() — value-to-CSS-var with direction.
  - kpiDelta() — fractional change with direction-aware tone.
  - lastAndPriorValues() — pulls the latest and previous non-null cells from a time-sorted series.

Tests: 28 new vitest cases for the pure helpers.

Also includes a one-line regression fix: DashboardIndex.svelte was calling normaliseDashboardPath() (introduced by #945) without importing it — the conflict resolution on PRs #979/#980 dropped the import while keeping the call site, breaking svelte-check on development. Restoring the named import here so this PR's check is clean; the same fix could ship in a follow-up chore if preferred.

 ## Summary

  New "kpi" tile type rendering a single measure as a large centred number, with optional secondary callouts (prior-period delta, target delta, sparkline)
  and direction-aware threshold colouring. Full scope from the issue body — measure picker, format choices, comparison modes, sparkline, threshold bands,
  direction toggle — in one PR.

  ## Two corrections from the original ticket

  1. The ticket says "Single-cell MDX (one measure, no rows/columns) — already supported by AI Query API records output." That's the *baseline* query, but
  when comparison=prior-period or sparkline is on, the tile actually issues a **by-time-level** query so both features can read the same series. Falls back
  to single-cell when neither is on.
  2. The ticket didn't address out-of-bounds threshold values. After the implementation, the test I wrote forced the call: strict band membership (a value
  past the worst threshold returns *no* colour) defeats the whole point of threshold colouring. Switched to **open-ended red** — green and yellow are
  explicit cutoffs, red is "everything worse than yellow." Documented in `kpi.ts:kpiThresholdToken`.

  ## The change

  Pure helpers in `$lib/dashboard/kpi.ts`:

  - `formatKpi()` — locale-aware via `Intl.NumberFormat`, with custom-pattern support for `$N` / `€N` / `£N` / `¥N` (currency + fractional digits), `N%`
  (percent + digits), and plain `N` (bare fractional-digit count).
  - `kpiThresholdToken()` — direction-aware band-to-CSS-var (`--kpi-red` / `--kpi-yellow` / `--kpi-green`). Open-ended red per #2 above.
  - `kpiDelta()` — fractional change between two values, with `direction` baking into a `positive` / `negative` / `flat` tone.
  - `lastAndPriorValues()` — pulls the latest two non-null cells from a time-sorted series. Skips nulls so a blank row doesn't shift the baseline.

  Plumbing:

  - `DashboardTile.kpi: KpiConfig` — additive sub-object. `TileType` gains `"kpi"`. Existing tile JSON is untouched.
  - `KpiTile.svelte` issues one `/ai/query` per render cycle: by-time-level when sparkline or prior-period is on, single-cell otherwise. Active dashboard
  filters merge into both shapes via `activeFilters.all`.
  - `TileEditorModal.svelte` grew a KPI panel — measure picker driven by `/ai/schema`'s `measures` record, time-level pickers reusing the schema for
  dim/hier/level dropdowns (with their own derivers, independent of the existing filter-tile dropdowns), comparison + target + sparkline + threshold inputs,
   direction toggle.
  - `AddTileMenu`, `Tile.svelte` dispatch, `defaultTitle`, and `tilePlacement.defaultSizeFor` ("kpi" → `3×2` so four KPI cards fit across the top of a
  12-col grid).
  - `KpiConfig.thresholds` empty objects are dropped on save so the dashboard JSON stays diff-friendly. Same for `customFormat` (only stored when `format
  === "custom"`) and `target` (only when `comparison === "target"`).

  ## Bundled regression fix

  `DashboardIndex.svelte` was calling `normaliseDashboardPath(...)` without importing it. The function exists (introduced by #945, exported from
  `$lib/api/dashboards`), but the conflict resolution on PRs #979 and #980 dropped the import while keeping the call site — `npm run check` flagged it on a
  clean `development` checkout. Restoring the named import here so this PR's check is clean. Happy to split this into a follow-up chore commit if you'd
  rather keep the KPI PR pure.

  ## Verified

  - `npx vitest run` — **207/207 passing** (28 new cases in `kpi.test.ts` covering format variants, threshold bands in both directions including the
  open-ended red, delta polarity inversion under `lower-is-better`, and `lastAndPriorValues` null-skipping).
  - `npm run check` — 6 errors + 30 warnings, **all pre-existing** (`vite.config.ts:26` ts-expect-error, `ChartView.svelte` treemap typing). Zero errors in
  any KPI file or in the now-fixed `DashboardIndex`.

  ## Test plan

  - [ ] CI green (both OS, JDK 21)
  - [ ] Manual: + Add tile → KPI → opens modal showing the KPI panel
  - [ ] Manual: pick a cube + measure, format = currency → big number renders as `$N,NNN`
  - [ ] Manual: switch comparison to "prior period," pick the time hierarchy/level → second query fires, delta arrow + percent appears, colour matches
  `direction`
  - [ ] Manual: toggle sparkline → mini line chart appears below the number using the same series
  - [ ] Manual: set thresholds {red:0, yellow:50, green:100} with value=120 → green; value=25 → red; value=-5 → red (open-ended)
  - [ ] Manual: change cube → measure + time-level reset; old values don't carry over to a cube that doesn't have them
  - [ ] Manual: hand-type `/ui/dashboards/oops.saikudash` → still routes to `homes/<user>/oops.saikudash` (regression fix verified, doubles as a #945 sanity
   check)

  Closes #917
