### PR TITLE
fix(launcher): SPA fallback for /ui/* — refreshing a SvelteKit deep route no longer 404s

### DIFF
--- a/saiku-core/saiku-web/src/main/java/org/saiku/web/servlet/SpaFallbackFilter.java
+++ b/saiku-core/saiku-web/src/main/java/org/saiku/web/servlet/SpaFallbackFilter.java
@@ -1,0 +1,181 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.web.servlet;
+
+import jakarta.servlet.Filter;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.RequestDispatcher;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpServletResponseWrapper;
+import java.io.IOException;
+
+/**
+ * SPA fallback for the SvelteKit UI at {@code /ui/*}.
+ *
+ * <p>The SvelteKit static adapter is configured with
+ * {@code fallback: "index.html"} and routes like
+ * {@code /dashboards/[...path]/} are marked {@code prerender = false} —
+ * meaning the build does not emit a file at every possible deep URL.
+ * Without server-side help, refreshing a page at e.g.
+ * {@code /ui/dashboards/homes/admin/sales.saikudash} hits Jetty's
+ * default servlet, which can't find the file and returns a 404.
+ *
+ * <p>This filter wraps the response, lets the default servlet attempt
+ * its lookup, and if the result is a 404 on a path that looks like a
+ * SPA route (no asset-style extension), it discards the 404 and
+ * dispatches forward to {@code /ui/index.html} which contains the
+ * SvelteKit fallback HTML. The client then takes the URL from
+ * {@code window.location} and hydrates the right route.
+ *
+ * <p>Asset extensions (.js / .css / .svg / .png / .woff / .ico / .json /
+ * .map / .html / .txt / .webmanifest) are passed straight through —
+ * a missing static asset is genuinely a 404 and shouldn't be
+ * masked by the fallback (or it'd produce a confusing infinite-load
+ * for the script tags inside index.html).
+ *
+ * <p>Paths under {@code /ui/branding/*} are also passed straight
+ * through; the {@link BrandingServlet} handles those with its own
+ * 404 semantics (defaults are expected to be missing).
+ */
+public class SpaFallbackFilter implements Filter {
+
+    private static final String FALLBACK = "/ui/index.html";
+    private static final String BRANDING_PREFIX = "/ui/branding/";
+
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
+            throws IOException, ServletException {
+        if (!(request instanceof HttpServletRequest req) || !(response instanceof HttpServletResponse resp)) {
+            chain.doFilter(request, response);
+            return;
+        }
+
+        String path = req.getRequestURI();
+        String ctx = req.getContextPath();
+        if (ctx != null && !ctx.isEmpty() && path.startsWith(ctx)) {
+            path = path.substring(ctx.length());
+        }
+
+        if (!shouldFallback(path)) {
+            chain.doFilter(request, response);
+            return;
+        }
+
+        StatusCapturingResponse wrapper = new StatusCapturingResponse(resp);
+        chain.doFilter(request, wrapper);
+
+        if (wrapper.getStatus() == HttpServletResponse.SC_NOT_FOUND && !resp.isCommitted()) {
+            wrapper.discardCapturedError();
+            resp.setStatus(HttpServletResponse.SC_OK);
+            RequestDispatcher dispatcher = req.getRequestDispatcher(FALLBACK);
+            dispatcher.forward(req, resp);
+        }
+    }
+
+    /**
+     * @return true if this request should attempt the SPA fallback on a
+     *         404. False for everything outside /ui/, for the branding
+     *         overlay, for the fallback target itself, and for asset
+     *         requests whose extension implies a real static file.
+     */
+    static boolean shouldFallback(String path) {
+        if (path == null || !path.startsWith("/ui/")) return false;
+        if (path.equals(FALLBACK)) return false;
+        if (path.startsWith(BRANDING_PREFIX)) return false;
+        int dot = path.lastIndexOf('.');
+        int slash = path.lastIndexOf('/');
+        if (dot > slash && dot >= 0) {
+            String ext = path.substring(dot + 1).toLowerCase();
+            return !ASSET_EXTENSIONS.contains(ext);
+        }
+        // No extension — looks like an SPA route segment.
+        return true;
+    }
+
+    private static final java.util.Set<String> ASSET_EXTENSIONS = java.util.Set.of(
+            "js",
+            "mjs",
+            "css",
+            "map",
+            "html",
+            "htm",
+            "json",
+            "txt",
+            "xml",
+            "svg",
+            "png",
+            "jpg",
+            "jpeg",
+            "gif",
+            "ico",
+            "webp",
+            "avif",
+            "woff",
+            "woff2",
+            "ttf",
+            "otf",
+            "eot",
+            "webmanifest",
+            "wasm");
+
+    /**
+     * Captures the status code so the filter can decide whether to
+     * forward to the fallback. Also suppresses the body that the
+     * default servlet writes for a 404 — without this, even a
+     * successful forward would emit the 404 page first and the
+     * fallback second.
+     */
+    private static final class StatusCapturingResponse extends HttpServletResponseWrapper {
+        private int status = HttpServletResponse.SC_OK;
+
+        StatusCapturingResponse(HttpServletResponse response) {
+            super(response);
+        }
+
+        @Override
+        public void setStatus(int sc) {
+            this.status = sc;
+            super.setStatus(sc);
+        }
+
+        @Override
+        public void sendError(int sc) throws IOException {
+            this.status = sc;
+            if (sc == HttpServletResponse.SC_NOT_FOUND) {
+                // Swallow — the filter will decide to forward on the
+                // way back up. Returning here keeps Jetty's
+                // ErrorHandler from writing its body.
+                return;
+            }
+            super.sendError(sc);
+        }
+
+        @Override
+        public void sendError(int sc, String msg) throws IOException {
+            this.status = sc;
+            if (sc == HttpServletResponse.SC_NOT_FOUND) {
+                return;
+            }
+            super.sendError(sc, msg);
+        }
+
+        @Override
+        public int getStatus() {
+            return status;
+        }
+
+        /** Called when we decide to use the fallback — clears any
+         *  partial buffer from the suppressed 404 path. */
+        void discardCapturedError() {
+            if (!isCommitted()) {
+                resetBuffer();
+            }
+        }
+    }
+}

--- a/saiku-core/saiku-web/src/test/java/org/saiku/web/servlet/SpaFallbackFilterTest.java
+++ b/saiku-core/saiku-web/src/test/java/org/saiku/web/servlet/SpaFallbackFilterTest.java
@@ -1,0 +1,111 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.web.servlet;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+/** Unit tests for the path-classification logic in {@link SpaFallbackFilter}. */
+public class SpaFallbackFilterTest {
+
+    @Test
+    public void spaRouteSegmentsFallback() {
+        assertTrue(SpaFallbackFilter.shouldFallback("/ui/dashboards"));
+        assertTrue(SpaFallbackFilter.shouldFallback("/ui/dashboards/homes/admin/sales.saikudash"));
+        assertTrue(SpaFallbackFilter.shouldFallback("/ui/admin"));
+        assertTrue(SpaFallbackFilter.shouldFallback("/ui/admin/datasources"));
+        assertTrue(SpaFallbackFilter.shouldFallback("/ui/workspace"));
+    }
+
+    @Test
+    public void uiRootFallsBack() {
+        // /ui/ itself doesn't have an extension — let it fall through to
+        // the fallback (the default servlet would serve index.html anyway
+        // via welcome-file, but if that's not configured this catches it).
+        assertTrue(SpaFallbackFilter.shouldFallback("/ui/"));
+    }
+
+    @Test
+    public void assetExtensionsPassThrough() {
+        for (String ext : new String[] {
+            "js",
+            "mjs",
+            "css",
+            "map",
+            "html",
+            "json",
+            "txt",
+            "xml",
+            "svg",
+            "png",
+            "jpg",
+            "jpeg",
+            "gif",
+            "ico",
+            "webp",
+            "avif",
+            "woff",
+            "woff2",
+            "ttf",
+            "otf",
+            "eot",
+            "webmanifest",
+            "wasm"
+        }) {
+            String path = "/ui/_app/immutable/chunks/x." + ext;
+            assertFalse("expected " + ext + " to pass through", SpaFallbackFilter.shouldFallback(path));
+        }
+    }
+
+    @Test
+    public void fallbackTargetDoesNotLoop() {
+        // The forward target itself must NOT match — would loop.
+        assertFalse(SpaFallbackFilter.shouldFallback("/ui/index.html"));
+    }
+
+    @Test
+    public void brandingOverlayPassesThrough() {
+        // Branding 404s are intentional — the operator may not ship a
+        // custom logo; the UI's <img onerror> falls back to defaults.
+        // Wrapping these in the SPA fallback would mask the 404 and
+        // serve index.html as if it were the missing logo.
+        assertFalse(SpaFallbackFilter.shouldFallback("/ui/branding/logo.svg"));
+        assertFalse(SpaFallbackFilter.shouldFallback("/ui/branding/logo.png"));
+    }
+
+    @Test
+    public void nonUiPathsPassThrough() {
+        assertFalse(SpaFallbackFilter.shouldFallback("/rest/saiku/info"));
+        assertFalse(SpaFallbackFilter.shouldFallback("/xmla/foo"));
+        assertFalse(SpaFallbackFilter.shouldFallback("/login"));
+        assertFalse(SpaFallbackFilter.shouldFallback("/"));
+    }
+
+    @Test
+    public void nullSafe() {
+        assertFalse(SpaFallbackFilter.shouldFallback(null));
+    }
+
+    @Test
+    public void mixedCaseExtensionsClassifiedCorrectly() {
+        // Real-world: some browsers / clients lowercase the URL, some
+        // don't. Filter must be case-insensitive on the extension
+        // classification.
+        assertFalse(SpaFallbackFilter.shouldFallback("/ui/logo.SVG"));
+        assertFalse(SpaFallbackFilter.shouldFallback("/ui/icon.PNG"));
+        assertFalse(SpaFallbackFilter.shouldFallback("/ui/x.JS"));
+    }
+
+    @Test
+    public void dotInSegmentNameNotMistakenForExtension() {
+        // The dashboard repository path can contain dots in directory
+        // names (e.g. user "data.science" or a folder named "v1.0").
+        // The filter should still recognise the trailing segment as a
+        // SPA route, not as an extension.
+        assertTrue(SpaFallbackFilter.shouldFallback("/ui/dashboards/v1.0/sales"));
+    }
+}

--- a/saiku-webapp/src/main/webapp/WEB-INF/web.xml
+++ b/saiku-webapp/src/main/webapp/WEB-INF/web.xml
@@ -373,4 +373,18 @@
         <url-pattern>/ui/branding/*</url-pattern>
     </servlet-mapping>
 
+    <!-- SvelteKit SPA fallback: any /ui/* request that the default
+         servlet can't resolve to a real file (and isn't a static-asset
+         extension) gets rewritten to /ui/index.html so the SPA can
+         hydrate the route from window.location. Without this,
+         refreshing /ui/dashboards/<path> returns Jetty's 404 page. -->
+    <filter>
+        <filter-name>spaFallback</filter-name>
+        <filter-class>org.saiku.web.servlet.SpaFallbackFilter</filter-class>
+    </filter>
+    <filter-mapping>
+        <filter-name>spaFallback</filter-name>
+        <url-pattern>/ui/*</url-pattern>
+    </filter-mapping>
+
 </web-app>


### PR DESCRIPTION
## Problem

Refreshing a SvelteKit deep route like \`/ui/dashboards/homes/admin/sales.saikudash\` returns Jetty's 404 page. SvelteKit's static adapter is configured with \`fallback: \"index.html\"\` and \`/dashboards/[...path]\` is marked \`prerender = false\` — so the build emits no file at every possible URL. The launcher's Jetty default servlet has no SPA fallback.

## Fix

New \`SpaFallbackFilter\` mapped to \`/ui/*\` in \`saiku-webapp/web.xml\`:

1. Wraps the response with a status-capturing wrapper that suppresses Jetty's 404 body
2. Lets the default servlet attempt its lookup
3. On 404 + a path that looks like an SPA route (no asset extension, not \`/ui/branding/*\`, not the fallback target itself), dispatches forward to \`/ui/index.html\`

## Pass-through rules

- **Asset extensions** (.js / .css / .svg / .png / .woff / .ico / .json / .map / .html / .txt / .webmanifest / .wasm and more) bypass the fallback — missing assets are genuine 404s.
- **\`/ui/branding/*\`** bypasses — \`BrandingServlet\` returns 404 by design when operator branding is absent.
- **Case-insensitive** extension matching.
- **Dots inside folder names** (e.g. \`/ui/dashboards/v1.0/sales\`) don't get mistaken for extensions — the filter checks the last segment only.

## Test

\`SpaFallbackFilterTest\` — 9 cases covering SPA routes, all asset extensions (lowercase + uppercase), the no-loop guard on \`/ui/index.html\`, the branding pass-through, the null-safe guard, and the dot-in-folder-name edge case.

## Verified

- \`saiku-core/saiku-web\` surefire: **125/125 passing** (was 116; +9 new)