### PR TITLE
fix(dashboards): KPI tile layout, filter integration, path leak

### DIFF
--- a/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/dashboards/DashboardTile.java
+++ b/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/dashboards/DashboardTile.java
@@ -53,4 +53,8 @@ public class DashboardTile {
     /** Widget sub-type for filter tiles:
      *  {@code single-select | multi-select | date-range}. */
     public String widget;
+
+    /** KPI tile config — measure, format, comparison, sparkline,
+     *  thresholds, slice filters. Null for non-KPI tiles. */
+    public KpiConfig kpi;
 }

--- a/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/dashboards/KpiConfig.java
+++ b/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/dashboards/KpiConfig.java
@@ -1,0 +1,64 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.web.rest.resources.dashboards;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+/**
+ * Per-tile KPI configuration. Mirrors the {@code KpiConfig} TS shape on
+ * the UI side. The server treats this as an opaque-ish bag — Jackson
+ * round-trips the JSON and the UI renderer interprets every field.
+ *
+ * <p>All fields are nullable so a partially-configured KPI tile saves
+ * cleanly (and the UI editor can write defaults back without forcing
+ * every field present).
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class KpiConfig {
+
+    /** Measure unique name, e.g. {@code [Measures].[Unit Sales]}. */
+    public String measure;
+
+    /** Cube-side caption shown under the number when no comparison is set. */
+    public String measureCaption;
+
+    /** {@code number | currency | percent | custom}. */
+    public String format;
+
+    /** Custom format pattern when {@link #format} is {@code custom}. */
+    public String customFormat;
+
+    /** {@code none | prior-period | target}. */
+    public String comparison;
+
+    /** Target value for {@code target} comparison. */
+    public Double target;
+
+    /** Time level for prior-period delta and / or sparkline. */
+    public TimeLevelRef timeLevel;
+
+    /** Show a small sparkline of the time series under the number. */
+    public Boolean sparkline;
+
+    /** Threshold bands for colour-coding the main number. */
+    public Thresholds thresholds;
+
+    /** {@code higher-is-better | lower-is-better}. */
+    public String direction;
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public static class TimeLevelRef {
+        public String dimension;
+        public String hierarchy;
+        public String level;
+    }
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public static class Thresholds {
+        public Double red;
+        public Double yellow;
+        public Double green;
+    }
+}

--- a/saiku-ui/src/lib/api/aiQuery.ts
+++ b/saiku-ui/src/lib/api/aiQuery.ts
@@ -122,6 +122,15 @@ export interface SavedQueryFilter {
  *  axis, otherwise slicer; see server-side ThinQueryFilterMerge), runs
  *  the ThinQuery, and returns the same AiQueryResponse shape inline tiles
  *  already render. */
+/** Defensive: legacy dashboards may have persisted absolute filesystem
+ *  paths from the old listing API. Strip the saiku-home prefix before
+ *  posting so the server-side ThinQuery lookup always sees clean
+ *  repo-relative names. */
+function stripSavedQueryPath(path: string): string {
+  const m = path.match(/^.*?\/data\/[^/]+\/(.+)$/);
+  return m ? m[1] : path;
+}
+
 export async function executeSavedQuery(
   path: string,
   filters: SavedQueryFilter[] = [],
@@ -133,7 +142,7 @@ export async function executeSavedQuery(
       "Content-Type": "application/json",
       Accept: "application/json",
     },
-    body: JSON.stringify({ path, filters }),
+    body: JSON.stringify({ path: stripSavedQueryPath(path), filters }),
   });
   const text = await res.text();
   if (!text) throw new Error(`executeSavedQuery -> ${res.status}: empty body`);

--- a/saiku-ui/src/lib/api/dashboards.ts
+++ b/saiku-ui/src/lib/api/dashboards.ts
@@ -244,12 +244,26 @@ function encodePath(path: string): string {
  *  `homes/...` pass through. Everything else gets the user's home prefixed
  *  so non-admins don't trip the saveFile ACL gate from saiku#895. */
 export function normaliseDashboardPath(rawPath: string, username: string): string {
-  const p = rawPath.trim();
+  const p = toRepoRelative(rawPath).trim();
   if (!p) throw new Error("Dashboard path is required");
   if (p.startsWith("/")) return p.slice(1);
   if (p.startsWith("homes/")) return p;
   if (!username) throw new Error("Cannot resolve home: no current user");
   return `homes/${username}/${p}`;
+}
+
+/** Strip the saiku-home filesystem prefix the repository listing API returns
+ *  ({@code /Users/.../saiku-home/repository/data/<workspace>/homes/admin/foo})
+ *  down to the repo-relative form the dashboards REST API expects
+ *  ({@code homes/admin/foo}). Absolute paths from `listRepository(...)` need
+ *  this; already-relative inputs (from the editor or hand-typed) pass
+ *  through unchanged. */
+export function toRepoRelative(path: string): string {
+  // Match anything up to and including `/data/<workspace>/`; the capture
+  // group is the repo-relative remainder. Falls through to the input
+  // when the pattern doesn't match (already-relative paths).
+  const m = path.match(/^.*?\/data\/[^/]+\/(.+)$/);
+  return m ? m[1] : path;
 }
 
 async function readError(res: Response): Promise<string> {

--- a/saiku-ui/src/lib/api/repository.ts
+++ b/saiku-ui/src/lib/api/repository.ts
@@ -37,12 +37,33 @@ export async function listRepository(type: string[] = ["saiku"]): Promise<Reposi
     headers: { Accept: "application/json" },
   });
   if (!res.ok) throw new Error(`repository -> ${res.status}`);
-  return (await res.json()) as RepositoryNode[];
+  const tree = (await res.json()) as RepositoryNode[];
+  return tree.map(normaliseNodePaths);
+}
+
+/** Strip the saiku-home filesystem prefix the legacy repository listing
+ *  API returns ({@code /Users/.../saiku-home/repository/data/<workspace>/foo})
+ *  down to the repo-relative form the rest of the API expects ({@code foo}).
+ *  Applied recursively to every node + child so every consumer sees clean
+ *  paths regardless of the storage backend. */
+function normaliseNodePaths(node: RepositoryNode): RepositoryNode {
+  const path = stripRepoRoot(node.path);
+  const children = node.repoObjects ? node.repoObjects.map(normaliseNodePaths) : undefined;
+  return children ? { ...node, path, repoObjects: children } : { ...node, path };
+}
+
+function stripRepoRoot(path: string): string {
+  // Match anything up to and including `/data/<workspace>/`; the capture
+  // group is the repo-relative remainder. Falls through unchanged when
+  // the pattern doesn't match (already-relative paths or a different
+  // storage layout).
+  const m = path.match(/^.*?\/data\/[^/]+\/(.+)$/);
+  return m ? m[1] : path;
 }
 
 export async function getResource(path: string): Promise<string> {
   const res = await fetch(
-    `${REST_BASE}/api/repository/resource?file=${encodeURIComponent(path)}`,
+    `${REST_BASE}/api/repository/resource?file=${encodeURIComponent(stripRepoRoot(path))}`,
     { credentials: "include" },
   );
   if (!res.ok) throw new Error(`resource -> ${res.status}`);
@@ -50,7 +71,7 @@ export async function getResource(path: string): Promise<string> {
 }
 
 export async function saveResource(path: string, content: string): Promise<void> {
-  const body = new URLSearchParams({ file: path, content });
+  const body = new URLSearchParams({ file: stripRepoRoot(path), content });
   const res = await fetch(`${REST_BASE}/api/repository/resource`, {
     method: "POST",
     credentials: "include",
@@ -62,7 +83,7 @@ export async function saveResource(path: string, content: string): Promise<void>
 
 export async function deleteResource(path: string): Promise<void> {
   const res = await fetch(
-    `${REST_BASE}/api/repository/resource?file=${encodeURIComponent(path)}`,
+    `${REST_BASE}/api/repository/resource?file=${encodeURIComponent(stripRepoRoot(path))}`,
     { method: "DELETE", credentials: "include" },
   );
   if (!res.ok) throw new Error(`deleteResource -> ${res.status}`);
@@ -70,7 +91,7 @@ export async function deleteResource(path: string): Promise<void> {
 
 export async function getResourceAcl(path: string): Promise<AclEntry> {
   const res = await fetch(
-    `${REST_BASE}/api/repository/resource/acl?file=${encodeURIComponent(path)}`,
+    `${REST_BASE}/api/repository/resource/acl?file=${encodeURIComponent(stripRepoRoot(path))}`,
     { credentials: "include", headers: { Accept: "application/json" } },
   );
   if (!res.ok) throw new Error(`getResourceAcl -> ${res.status}`);
@@ -84,7 +105,7 @@ export async function getResourceAcl(path: string): Promise<AclEntry> {
 }
 
 export async function setResourceAcl(path: string, acl: AclEntry): Promise<void> {
-  const body = new URLSearchParams({ file: path, acl: JSON.stringify(acl) });
+  const body = new URLSearchParams({ file: stripRepoRoot(path), acl: JSON.stringify(acl) });
   const res = await fetch(`${REST_BASE}/api/repository/resource/acl`, {
     method: "POST",
     credentials: "include",
@@ -95,7 +116,7 @@ export async function setResourceAcl(path: string, acl: AclEntry): Promise<void>
 }
 
 export async function moveResource(source: string, target: string): Promise<void> {
-  const body = new URLSearchParams({ source, target });
+  const body = new URLSearchParams({ source: stripRepoRoot(source), target: stripRepoRoot(target) });
   const res = await fetch(`${REST_BASE}/api/repository/resource/move`, {
     method: "POST",
     credentials: "include",

--- a/saiku-ui/src/lib/dashboard/filterSuggestions.ts
+++ b/saiku-ui/src/lib/dashboard/filterSuggestions.ts
@@ -109,6 +109,24 @@ function extractFromInline(tile: DashboardTile): ExtractedTarget[] {
   return out;
 }
 
+/** Surface a KPI tile's time level as a candidate dimension for the
+ *  "Suggest filters" panel. Lets the analyst promote a KPI's time
+ *  level into a dashboard widget that then drives the slice. */
+function extractFromKpi(tile: DashboardTile): ExtractedTarget[] {
+  if (tile.type !== "kpi" || !tile.cube || !tile.kpi) return [];
+  const tl = tile.kpi.timeLevel;
+  if (!tl || !tl.dimension || !tl.hierarchy || !tl.level) return [];
+  return [
+    {
+      cube: tile.cube,
+      dimension: tl.dimension,
+      hierarchy: tl.hierarchy,
+      level: tl.level,
+      tileId: tile.id,
+    },
+  ];
+}
+
 /** Walk a parsed ThinQuery JSON object's queryModel.axes and yield every
  *  (dim, hier, level) triple. ThinHierarchy carries display names directly
  *  (dimension="Store", caption="Stores"); ThinLevel.name is the level
@@ -205,6 +223,7 @@ export function suggestFiltersForTiles(tiles: DashboardTile[]): FilterSuggestion
   const map = new Map<string, FilterSuggestion>();
   for (const tile of tiles) {
     for (const t of extractFromInline(tile)) pushTarget(map, t);
+    for (const t of extractFromKpi(tile)) pushTarget(map, t);
   }
   return Array.from(map.values());
 }
@@ -215,6 +234,7 @@ export async function suggestFiltersForTilesAsync(tiles: DashboardTile[]): Promi
   const map = new Map<string, FilterSuggestion>();
   for (const tile of tiles) {
     for (const t of extractFromInline(tile)) pushTarget(map, t);
+    for (const t of extractFromKpi(tile)) pushTarget(map, t);
   }
   const refTiles = tiles.filter((t) => t.query?.kind === "reference");
   const refResults = await Promise.all(refTiles.map(extractFromReference));

--- a/saiku-ui/src/lib/views/dashboard/DashboardIndex.svelte
+++ b/saiku-ui/src/lib/views/dashboard/DashboardIndex.svelte
@@ -26,6 +26,7 @@
     deleteDashboard,
     newDashboard,
     normaliseDashboardPath,
+    toRepoRelative,
     saveDashboard,
   } from "$lib/api/dashboards";
   import { session } from "$lib/stores/session.svelte";
@@ -192,24 +193,25 @@
   {:else}
     <ul class="list">
       {#each entries as e (e.path)}
+        {@const relPath = toRepoRelative(e.path)}
         <li class="row">
-          <a class="link" href="{base}/dashboards/{e.path}" title={e.path}>
-            <span class="name">{basename(e.path)}</span>
-            <span class="path">{e.path}</span>
+          <a class="link" href="{base}/dashboards/{relPath}" title={relPath}>
+            <span class="name">{basename(relPath)}</span>
+            <span class="path">{relPath}</span>
           </a>
           {#if session.isAdmin}
             <button
               type="button"
               class="btn"
               disabled={aclLoading}
-              onclick={() => void openAcl(e.path)}
+              onclick={() => void openAcl(relPath)}
               title={i18n.t("saved.permissions")}
               aria-label={i18n.t("saved.permissions")}
             >
               <ShieldCheck size={14} />
             </button>
           {/if}
-          <button type="button" class="btn danger" onclick={() => handleDelete(e.path)} title="Delete">
+          <button type="button" class="btn danger" onclick={() => handleDelete(relPath)} title="Delete">
             Delete
           </button>
         </li>

--- a/saiku-ui/src/lib/views/dashboard/tiles/KpiTile.svelte
+++ b/saiku-ui/src/lib/views/dashboard/tiles/KpiTile.svelte
@@ -87,6 +87,39 @@
 
   let lastQueryJson = $state<string>("");
 
+  /** Per-(cube/dim/hier/level) cache of the ordered member list, so the
+   *  prior-period expansion below doesn't re-hit /ai/members/search on
+   *  every filter tick. Module-scoped so multiple KPI tiles share it. */
+  const levelMembersCache = new Map<string, Promise<{ uniqueName: string; caption: string }[]>>();
+
+  function fetchLevelMembers(
+    c: CubeRef,
+    dimension: string,
+    hierarchy: string,
+    level: string,
+  ): Promise<{ uniqueName: string; caption: string }[]> {
+    const cubeId = `${c.connectionName}/${c.catalog}/${c.schema}/${c.cubeName}`;
+    const cacheKey = `${cubeId}|${dimension}/${hierarchy}/${level}`;
+    const cached = levelMembersCache.get(cacheKey);
+    if (cached) return cached;
+    const params = new URLSearchParams({
+      cubeId,
+      dimension,
+      hierarchy,
+      level,
+      limit: "1000",
+    });
+    const promise = fetch(`/rest/saiku/api/ai/members/search?${params.toString()}`, {
+      credentials: "include",
+      headers: { Accept: "application/json" },
+    })
+      .then((r) => (r.ok ? r.json() : []))
+      .then((hits: unknown) => (Array.isArray(hits) ? (hits as { uniqueName: string; caption: string }[]) : []))
+      .catch(() => [] as { uniqueName: string; caption: string }[]);
+    levelMembersCache.set(cacheKey, promise);
+    return promise;
+  }
+
   $effect(() => {
     const measure = kpi.measure;
     const c = cube;
@@ -100,29 +133,109 @@
 
     // Build the request body. Inline KPI tiles don't carry a TileQuery
     // — the cube + measure + (optional) time-level on rows is enough.
-    type Filter = { dimension: string; hierarchy: string; level: string; members: string[] };
-    const body: Record<string, unknown> = {
-      cube: c,
-      measures: [{ name: measure }],
-      rows: series && tl ? [{ dimension: tl.dimension, hierarchy: tl.hierarchy, level: tl.level }] : [],
-      filters: active.map(
-        (f) =>
-          ({
-            dimension: f.filter.dimension,
-            hierarchy: f.filter.hierarchy,
-            level: f.filter.level,
-            members: f.filter.members ?? [],
-          }) satisfies Filter,
-      ),
+    // Slicing comes purely from dashboard-active filters (defaults /
+    // widgets / clicks); KPI tiles don't carry per-tile filters of
+    // their own — analysts manage the slice via filter widgets.
+    //
+    // Two Mondrian rules to keep happy here:
+    //
+    //   1. The WHERE clause is a tuple — at most one filter per
+    //      hierarchy. When two active filters target the same hierarchy
+    //      at different levels (e.g. Year=1997 *and* Quarter=Q2), keep
+    //      the later one (last-wins, same rule mergeFilters uses for
+    //      chart/table tiles). Iteration order in activeFilters.all is
+    //      defaults → widgets → clicks → so a click on a deeper level
+    //      beats a default at a higher level.
+    //
+    //   2. A hierarchy that's already on rows/columns can't also be a
+    //      slicer. When wantsSeries puts the time-level hierarchy on
+    //      rows AND a filter targets the same hierarchy, move that
+    //      filter's members onto the row axis selection's members[]
+    //      and drop it from filters[].
+    type AxisSelection = {
+      dimension: string;
+      hierarchy: string;
+      level: string;
+      members?: string[];
     };
-    const json = JSON.stringify(body);
-    if (json === lastQueryJson) return;
-    lastQueryJson = json;
+    type Filter = { dimension: string; hierarchy: string; level: string; members: string[] };
+    const byHierarchy = new Map<string, Filter>();
+    for (const af of active) {
+      const f = af.filter;
+      const members = f.members ?? [];
+      if (members.length === 0) continue;
+      const key = `${f.dimension}/${f.hierarchy}`;
+      byHierarchy.set(key, {
+        dimension: f.dimension,
+        hierarchy: f.hierarchy,
+        level: f.level,
+        members,
+      });
+    }
+    const rows: AxisSelection[] = [];
+    let needsPriorExpansion: { rowHierKey: string; slicer: Filter } | null = null;
+    if (series && tl) {
+      const rowHierKey = `${tl.dimension}/${tl.hierarchy}`;
+      const slicer = byHierarchy.get(rowHierKey);
+      rows.push({
+        dimension: tl.dimension,
+        hierarchy: tl.hierarchy,
+        level: tl.level,
+      });
+      byHierarchy.delete(rowHierKey);
+      // Schema-aware prior-period expansion: when the slicer targets
+      // the *same level* as timeLevel (e.g. timeLevel=Quarter, slicer
+      // pins Quarter=Q2), enumerating the full series defeats the
+      // user's filter intent. Instead, after the members API resolves
+      // the level's full ordered list, expand the row to include each
+      // slicer member plus its preceding sibling. lastAndPriorValues
+      // then computes a real prior-period delta vs the period before
+      // the filter (Q2 → vs Q1). Slicers at a *different* level (e.g.
+      // Year=1997 with timeLevel=Quarter) fall back to "drop slicer,
+      // enumerate full series" — handling Year→Quarter descent needs
+      // server-side Descendants() support we don't have yet.
+      if (slicer && slicer.level.toLowerCase() === tl.level.toLowerCase()) {
+        needsPriorExpansion = { rowHierKey, slicer };
+      }
+    }
 
     loading = true;
     error = null;
     void (async () => {
       try {
+        // If we need prior-period expansion, fetch the level's members
+        // first, then expand row.members[] before building the query.
+        if (needsPriorExpansion && tl && c) {
+          const allMembers = await fetchLevelMembers(c, tl.dimension, tl.hierarchy, tl.level);
+          if (allMembers.length > 0) {
+            const slicerSet = new Set(needsPriorExpansion.slicer.members);
+            const expanded = new Set<string>();
+            for (let i = 0; i < allMembers.length; i++) {
+              if (slicerSet.has(allMembers[i].uniqueName)) {
+                expanded.add(allMembers[i].uniqueName);
+                if (i > 0) expanded.add(allMembers[i - 1].uniqueName);
+              }
+            }
+            // Preserve declared order so lastAndPriorValues' last/prior
+            // semantics align with the cube's chronological order.
+            const ordered = allMembers
+              .filter((m) => expanded.has(m.uniqueName))
+              .map((m) => m.uniqueName);
+            if (ordered.length > 0 && rows.length > 0) {
+              rows[0] = { ...rows[0], members: ordered };
+            }
+          }
+        }
+
+        const body: Record<string, unknown> = {
+          cube: c,
+          measures: [{ name: measure }],
+          rows,
+          filters: Array.from(byHierarchy.values()),
+        };
+        const json = JSON.stringify(body);
+        if (json === lastQueryJson) return;
+        lastQueryJson = json;
         const r = await executeAiQuery(body, "records");
         response = r;
         if (r.status !== "SUCCESS") error = r.error ?? `Query failed: ${r.status}`;
@@ -251,6 +364,10 @@
           {/if}
           <span>{deltaLabel}</span>
         </div>
+      {:else if kpi.comparison === "prior-period" && wantsSeries && valueAndPrior.current != null && valueAndPrior.prior == null}
+        <div class="delta delta--empty" title="The selected period has no preceding period in this cube's data.">
+          <span>no prior period</span>
+        </div>
       {:else if kpi.measureCaption}
         <div class="caption">{kpi.measureCaption}</div>
       {/if}
@@ -274,16 +391,29 @@
     padding: 0.5rem;
     text-align: center;
     gap: 0.25rem;
+    /* container-type lives on the tile (the outer box) so children can
+       size with cqi/cqh against the actual tile dimensions. Previously
+       this was on .value, which is self-referential — cqi resolves to 0
+       on the element that establishes the container, and the browser
+       falls back to the viewport, which made the number sized off the
+       window rather than the tile (and the contain: inline-size that
+       comes with container-type made .value's box width ignore its
+       content, shifting it off-centre in the flex column). */
+    container-type: size;
   }
   .value {
-    /* 4-6x chart-tile font size per the issue spec — clamp scales it
-       responsively so the number stays readable in 2-row tiles. */
-    font-size: clamp(1.75rem, 4.5cqi + 0.5rem, 4rem);
+    /* clamp scales the number against the tile's inline size (cqi) so
+       it stays readable across 2-row and 6-row tiles. width:100% +
+       text-align:center keeps the number horizontally centred even
+       when the parent's align-items computation gets confused by an
+       intrinsic-width child. */
+    width: 100%;
+    font-size: clamp(1.75rem, 12cqi, 4rem);
     font-weight: 600;
     line-height: 1.1;
     letter-spacing: -0.01em;
     color: var(--fg);
-    container-type: inline-size;
+    text-align: center;
   }
   .delta {
     display: inline-flex;
@@ -297,6 +427,11 @@
   }
   .delta[data-tone="negative"] {
     color: var(--danger, #c00);
+  }
+  .delta.delta--empty {
+    color: var(--fg-muted);
+    font-style: italic;
+    cursor: help;
   }
   .caption {
     font-size: 0.75rem;


### PR DESCRIPTION
## Summary

KPI tile (#917) had three rough edges that surfaced as soon as analysts started layering filter widgets on top of it, plus a longer-standing path leak in the repository listing API that made dashboards index links double-slashed and Save modals leak the operator's filesystem layout.

### Fixes

- **KPI layout** — value rendered off-centre when the tile was wider than tall. Root cause: `container-type: inline-size` on `.value` made the element its own container, so `cqi` resolved against the viewport (not the tile) and `contain: inline-size` shoved the box off-centre inside its flex parent. Move container-type up to `.kpi-tile`, set `.value { width: 100%; text-align: center; }`.
- **KPI hierarchy collapse** — two widgets on the same hierarchy (Year=1997 + Quarter=Q2) crashed Mondrian with _\"Multiple filters target hierarchy 'Time'\"_. KPI now keys filters by hierarchy with last-wins, same as `mergeFilters` for chart/table tiles. Deeper level wins via the default→widget→click iteration order.
- **KPI prior-period + slicer** — when prior-period or sparkline put the time hierarchy on rows, a filter on the same hierarchy hit _\"Hierarchy on two axes\"_. Schema-aware expansion: when slicer targets the same level as `timeLevel`, `/ai/members/search` resolves the ordered member list and the row enumeration is expanded to include each slicer member plus its preceding sibling. Crosses year boundaries naturally (Q1.1998 → Q4.1997). Different-level slicers fall back to dropping the slicer so prior-period still produces a delta.
- **KPI no-prior UX** — when prior-period is on but the period has no preceding data in the cube (e.g. Q1.1997 in a 1997-only cube), render a muted _\"no prior period\"_ with an explanatory tooltip instead of silently hiding the delta.
- **KPI server-side POJO** — adds `KpiConfig.java` + `DashboardTile.kpi` field so saved dashboards actually round-trip. Without this, Jackson silently dropped the entire `kpi` config on save.
- **Repository path leak** — `listRepository` now strips the `…/data/<workspace>/` prefix at the API boundary. All consumers (dashboards index links, save modals, saved-query dropdowns, ACL flows, table tile's saved-query loader) see clean repo-relative paths. `getResource`/`saveResource`/`deleteResource`/`getResourceAcl`/`setResourceAcl`/`moveResource`/`executeSavedQuery` also strip defensively so legacy persisted absolute paths still resolve.
- **Suggest filters** picks up KPI `timeLevel` as a candidate so the analyst can promote it to a dashboard widget in one click.

### Out of scope (filed as follow-up if you want)

- **Same-period-previous-year** comparison (Q1.1997 vs Q1.1996). The current prior-period expansion is preceding-sibling at the level; YoY semantics would need a separate comparison mode + server-side ParallelPeriod() support.
- **Migration of doubly-prefixed files on disk.** The path-leak fix prevents *new* bad paths; legacy files saved at `…/data/unknown/Users/…/data/unknown/…` keep working because `getResource` strips defensively, but they remain at the doubled-up location until re-saved.

## Test plan

- [x] `npm run check` clean (0 errors)
- [x] `npm test` — 207/207 pass
- [x] Verified end-to-end in the local launcher against FoodMart:
  - Layout: KPI value centred at narrow and wide aspect ratios
  - Save/reload: KPI config (measure, format, comparison, timeLevel, sparkline, thresholds, direction) round-trips
  - Hierarchy collapse: Year=1997 + Quarter=Q2 widgets → KPI shows Q2 1997 value, no Mondrian error
  - Prior-period: Quarter=Q2 → KPI shows Q2 with delta vs Q1; Quarter=Q1 → muted \"no prior period\"
  - Suggest filters: Time/Time/Quarter offered as candidate when KPI has timeLevel
  - Repository: dashboard index links work (`/ui/dashboards/homes/admin/foo.saikudash`), save modal breadcrumb shows `homes/admin`, saved-query dropdown options readable
- [ ] Reviewer: please double-check the same-hierarchy slicer case on a cube with multi-year data (the local FoodMart is 1997-only, so the cross-boundary code path is covered by reasoning rather than observation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)