### PR TITLE
fix(ui): demo-mode login prefills the admin password

### DIFF
--- a/saiku-ui/src/lib/views/LoginForm.svelte
+++ b/saiku-ui/src/lib/views/LoginForm.svelte
@@ -16,9 +16,17 @@
   // API or wire the MCP server before they ever sign in. On a normal
   // (non-demo) deployment this panel stays hidden — Saiku admins see it
   // only after auth via the /admin "API access" tab.
-  onMount(() => {
+  onMount(async () => {
     if (!platform.capabilities) {
-      platform.loadCapabilities();
+      await platform.loadCapabilities();
+    }
+    // Prefill the demo password the moment the capabilities probe confirms
+    // demo mode. Username already defaults to "admin"; pre-filling the
+    // password lets a visitor click Sign in without first having to dig
+    // the credentials out of the connection-info panel. On a real
+    // deployment demoMode is false and this stays a no-op.
+    if (platform.capabilities?.demoMode && !password) {
+      password = "admin";
     }
   });
 


### PR DESCRIPTION
## Summary

Cherry-picks the still-useful half of the abandoned `fix/login-ui-polish` branch: in demo mode, the LoginForm now prefills the password with `admin` once the capabilities probe confirms `demoMode`, matching the already-prefilled username. Visitors landing on demo.saiku.bi can click **Sign in** immediately instead of digging the credential out of the connection-info panel.

On any non-demo deployment, `demoMode` is false and the prefill is a no-op — the password field stays blank.

The companion accordion connection-info card change from the original branch was superseded by the connection-info panel feature already in development (#871), so only the LoginForm change carries forward here.

## Test plan

- [x] `npm run check` clean
- [ ] Reviewer: confirm the prefill only fires when `platform.capabilities.demoMode === true` (default in this codebase is the live demo flag — non-demo runs leave `password` blank).

🤖 Generated with [Claude Code](https://claude.com/claude-code)