### PR TITLE
feat(dashboards): click-to-filter on reference tiles

### DIFF
--- a/saiku-ui/src/lib/dashboard/filterSuggestions.ts
+++ b/saiku-ui/src/lib/dashboard/filterSuggestions.ts
@@ -183,6 +183,68 @@ function extractFromThinQuery(thinQueryJson: unknown): Omit<ExtractedTarget, "ti
   return out;
 }
 
+/** Row-axis (dim, hier, level) triple from a saved query, used by the
+ *  reference-tile click-to-filter capture. Charts read the first entry;
+ *  tables match clicked column captions against the level field. */
+export interface RowAxisRef {
+  dimension: string;
+  hierarchy: string;
+  level: string;
+}
+
+/** Fetch + parse a saved-query reference and return the ROW-axis
+ *  (dim, hier, level) triples in declared order. Empty on any failure
+ *  or when the query has no row axis (column-only or measure-only
+ *  reports). Used by ChartTile / TableTile click-to-filter when the
+ *  tile is bound to a saved query — inline tiles read the same shape
+ *  directly off `tile.query.body.rows`. */
+export async function inferRowAxesFromReference(path: string): Promise<RowAxisRef[]> {
+  try {
+    const raw = await getResource(path);
+    const parsed = JSON.parse(raw) as unknown;
+    return extractAxisRefs(parsed, "ROWS");
+  } catch {
+    return [];
+  }
+}
+
+function extractAxisRefs(thinQueryJson: unknown, axisName: string): RowAxisRef[] {
+  if (!thinQueryJson || typeof thinQueryJson !== "object") return [];
+  const tq = thinQueryJson as Record<string, unknown>;
+  const queryModel = tq.queryModel as Record<string, unknown> | undefined;
+  if (!queryModel) return [];
+  const axes = queryModel.axes as Record<string, unknown> | undefined;
+  if (!axes) return [];
+  const axis = axes[axisName] as Record<string, unknown> | undefined;
+  if (!axis) return [];
+  const hierarchies = axis.hierarchies;
+  if (!Array.isArray(hierarchies)) return [];
+
+  const out: RowAxisRef[] = [];
+  for (const h of hierarchies) {
+    if (!h || typeof h !== "object") continue;
+    const hier = h as Record<string, unknown>;
+    const dim = asString(hier.dimension);
+    let hierName = asString(hier.caption);
+    if (!hierName) {
+      const raw = asString(hier.name);
+      if (raw) {
+        const m = raw.match(/\[([^\]]+)\]\s*$/);
+        hierName = m ? m[1] : raw;
+      }
+    }
+    const levels = hier.levels as Record<string, unknown> | undefined;
+    if (!dim || !hierName || !levels || typeof levels !== "object") continue;
+    for (const levelKey of Object.keys(levels)) {
+      const level = levels[levelKey] as Record<string, unknown> | undefined;
+      const levelName = asString(level?.name) ?? levelKey;
+      if (!levelName) continue;
+      out.push({ dimension: dim, hierarchy: hierName, level: levelName });
+    }
+  }
+  return out;
+}
+
 /** Fetch + parse a saved-query reference into ExtractedTargets. Returns
  *  [] on any failure (missing file, unparseable JSON, missing cube) so
  *  the suggestion panel degrades gracefully. */

--- a/saiku-ui/src/lib/views/dashboard/tiles/ChartTile.svelte
+++ b/saiku-ui/src/lib/views/dashboard/tiles/ChartTile.svelte
@@ -26,7 +26,11 @@
     applicableSavedFilters,
     type SchemaLike,
   } from "$lib/dashboard/effectiveQuery";
-  import { inferCubeFromReference } from "$lib/dashboard/filterSuggestions";
+  import {
+    inferCubeFromReference,
+    inferRowAxesFromReference,
+    type RowAxisRef,
+  } from "$lib/dashboard/filterSuggestions";
   import { buildChartOption, isSupportedChartKind } from "$lib/dashboard/chartOptions";
   import type { CubeRef } from "$lib/api/dashboards";
 
@@ -72,10 +76,19 @@
   // the schema lookup + filter applicability check still works.
   let resolvedCube = $state<CubeRef | null>(null);
   let inferenceAttempted = $state(false);
+  // Row axes from the saved ThinQuery for reference tiles. Click-to-
+  // filter uses the first entry as the dim/hier/level the clicked
+  // category corresponds to — inline tiles read the same shape directly
+  // off `tile.query.body.rows`. Null until inference completes; click
+  // handler short-circuits while we wait.
+  let referenceRowAxes = $state<RowAxisRef[] | null>(null);
 
   $effect(() => {
     if (tile.cube) {
       resolvedCube = tile.cube;
+      // Inline tiles never need row-axis inference (the handler reads
+      // tile.query.body.rows directly), but leave the state null so
+      // the reference branch in handleEChartsClick stays opt-in.
       return;
     }
     if (tile.query?.kind !== "reference" || inferenceAttempted) return;
@@ -83,6 +96,9 @@
     const refPath = tile.query.path;
     void inferCubeFromReference(refPath).then((inferred) => {
       if (inferred) resolvedCube = inferred;
+    });
+    void inferRowAxesFromReference(refPath).then((axes) => {
+      referenceRowAxes = axes;
     });
   });
 
@@ -195,11 +211,22 @@
 
   function handleEChartsClick(params: echarts.ECElementEvent): void {
     if (!onClickFilter) return;
-    if (!tile.query || tile.query.kind !== "inline") return;
-    const body = tile.query.body as {
-      rows?: Array<{ dimension: string; hierarchy: string; level: string }>;
-    };
-    const rowAxis = body.rows?.[0];
+    if (!tile.query) return;
+
+    // Resolve the row axis the clicked category maps to. Inline tiles
+    // carry it directly on the request body; reference tiles need the
+    // axes inferred lazily from the saved ThinQuery (handled in the
+    // mount-time effect above). If inference hasn't completed yet, the
+    // click is a no-op rather than building a malformed filter.
+    let rowAxis: { dimension: string; hierarchy: string; level: string } | undefined;
+    if (tile.query.kind === "inline") {
+      const body = tile.query.body as {
+        rows?: Array<{ dimension: string; hierarchy: string; level: string }>;
+      };
+      rowAxis = body.rows?.[0];
+    } else if (tile.query.kind === "reference") {
+      rowAxis = referenceRowAxes?.[0];
+    }
     if (!rowAxis) return;
 
     // ECharts click events carry different shapes per series type. For

--- a/saiku-ui/src/lib/views/dashboard/tiles/TableTile.svelte
+++ b/saiku-ui/src/lib/views/dashboard/tiles/TableTile.svelte
@@ -32,7 +32,11 @@
     applicableSavedFilters,
     type SchemaLike,
   } from "$lib/dashboard/effectiveQuery";
-  import { inferCubeFromReference } from "$lib/dashboard/filterSuggestions";
+  import {
+    inferCubeFromReference,
+    inferRowAxesFromReference,
+    type RowAxisRef,
+  } from "$lib/dashboard/filterSuggestions";
   import type { CubeRef } from "$lib/api/dashboards";
 
   interface Props {
@@ -56,6 +60,9 @@
   // works on existing dashboards.
   let resolvedCube = $state<CubeRef | null>(null);
   let inferenceAttempted = $state(false);
+  // Row axes lazy-inferred from the saved ThinQuery on reference tiles.
+  // clickFilterForCell uses them in place of `tile.query.body.rows`.
+  let referenceRowAxes = $state<RowAxisRef[] | null>(null);
 
   $effect(() => {
     if (tile.cube) {
@@ -67,6 +74,9 @@
     const refPath = tile.query.path;
     void inferCubeFromReference(refPath).then((inferred) => {
       if (inferred) resolvedCube = inferred;
+    });
+    void inferRowAxesFromReference(refPath).then((axes) => {
+      referenceRowAxes = axes;
     });
   });
 
@@ -190,11 +200,21 @@
     // click capture (cross-join measures × time) will be served when
     // task #14's live test pins the contract. For row-axis levels the
     // header caption equals the level caption.
-    if (!tile.query || tile.query.kind !== "inline") return null;
-    const body = tile.query.body as {
-      rows?: Array<{ dimension: string; hierarchy: string; level: string }>;
-    };
-    const match = (body.rows ?? []).find((ax) => ax.level === column);
+    if (!tile.query) return null;
+    // Pick the row-axis set off the inline body or the lazy-inferred
+    // axes from the saved ThinQuery for reference tiles. If inference
+    // hasn't completed yet, the click is a no-op.
+    let rows: Array<{ dimension: string; hierarchy: string; level: string }> | null = null;
+    if (tile.query.kind === "inline") {
+      const body = tile.query.body as {
+        rows?: Array<{ dimension: string; hierarchy: string; level: string }>;
+      };
+      rows = body.rows ?? null;
+    } else if (tile.query.kind === "reference") {
+      rows = referenceRowAxes;
+    }
+    if (!rows) return null;
+    const match = rows.find((ax) => ax.level === column);
     if (!match) return null;
     // The cell value is the formatted caption — we don't have the MDX
     // unique name here. The server's filter applicability check will


### PR DESCRIPTION
## Summary

Closes #923.

Click-to-filter already worked on **inline-query** chart/table tiles — the click handler reads the row-axis `(dim, hier, level)` directly off `tile.query.body.rows`. **Reference tiles** (saved `.saiku` files) silently no-op'd because the handler short-circuited with `if (tile.query.kind !== \"inline\") return`. The row-axis info lives inside the saved ThinQuery, not on the tile.

### Approach

- Add `inferRowAxesFromReference(path)` alongside the existing `inferCubeFromReference` in `filterSuggestions.ts`. Fetches and parses the saved `.saiku` ThinQuery, walks `queryModel.axes.ROWS.hierarchies[].levels`, returns the ordered `(dim, hier, level)` triples.
- ChartTile + TableTile fire it lazily from their existing mount-time effect, same pattern that already populates `resolvedCube` for legacy reference tiles.
- ChartTile click handler uses the first row axis (chart x-axis is one dim).
- TableTile click handler matches the clicked column caption against the level field — keeps hierarchical drilldown (Year → Quarter → Month all on rows) attributing clicks to the right level.
- While inference is in flight the click is a no-op rather than shipping a malformed filter.

### Test plan

- [x] `npm run check` clean
- [x] `npm test` — 207/207
- [ ] Reviewer: clicking a bar in a reference chart should add a filter chip and refilter sibling tiles bound to the same cube. Same for cells in a row-header column of a reference table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)