### PR TITLE
feat(dashboards): date-range filter widget

### DIFF
--- a/saiku-ui/src/lib/dashboard/dateRange.test.ts
+++ b/saiku-ui/src/lib/dashboard/dateRange.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, test } from "vitest";
+
+import {
+  expandDateRange,
+  fromDateInputValue,
+  parseMemberDateRange,
+  toDateInputValue,
+} from "./dateRange";
+
+describe("parseMemberDateRange", () => {
+  test("year-only member spans the calendar year", () => {
+    const r = parseMemberDateRange("[Time].[Time].[1997]");
+    expect(r).not.toBeNull();
+    expect(r!.start).toEqual(new Date(1997, 0, 1));
+    expect(r!.end.getFullYear()).toBe(1997);
+    expect(r!.end.getMonth()).toBe(11);
+    expect(r!.end.getDate()).toBe(31);
+  });
+
+  test("quarter narrows to three months", () => {
+    const r = parseMemberDateRange("[Time].[Time].[1997].[Q2]");
+    expect(r!.start).toEqual(new Date(1997, 3, 1)); // April 1
+    expect(r!.end.getMonth()).toBe(5); // June
+    expect(r!.end.getDate()).toBe(30);
+  });
+
+  test("numeric month under quarter", () => {
+    const r = parseMemberDateRange("[Time].[Time].[1997].[Q1].[2]");
+    expect(r!.start).toEqual(new Date(1997, 1, 1));
+    expect(r!.end.getMonth()).toBe(1);
+    expect(r!.end.getDate()).toBe(28); // 1997 not leap
+  });
+
+  test("English month name", () => {
+    const r = parseMemberDateRange("[Time].[Time].[1997].[April]");
+    expect(r!.start).toEqual(new Date(1997, 3, 1));
+    expect(r!.end.getMonth()).toBe(3);
+    expect(r!.end.getDate()).toBe(30);
+  });
+
+  test("short month name", () => {
+    const r = parseMemberDateRange("[Time].[Time].[2000].[Feb]");
+    expect(r!.start).toEqual(new Date(2000, 1, 1));
+    expect(r!.end.getDate()).toBe(29); // 2000 leap
+  });
+
+  test("year + month + day", () => {
+    const r = parseMemberDateRange("[Time].[Time].[1997].[Q1].[3].[15]");
+    expect(r!.start).toEqual(new Date(1997, 2, 15));
+    expect(r!.end.getMonth()).toBe(2);
+    expect(r!.end.getDate()).toBe(15);
+  });
+
+  test("returns null when no year segment present", () => {
+    expect(parseMemberDateRange("[Customer].[Country].[USA]")).toBeNull();
+  });
+
+  test("returns null for unparseable input", () => {
+    expect(parseMemberDateRange("not-an-mdx-name")).toBeNull();
+  });
+});
+
+describe("expandDateRange", () => {
+  const QUARTERS = [
+    { uniqueName: "[Time].[Time].[1997].[Q1]", caption: "Q1" },
+    { uniqueName: "[Time].[Time].[1997].[Q2]", caption: "Q2" },
+    { uniqueName: "[Time].[Time].[1997].[Q3]", caption: "Q3" },
+    { uniqueName: "[Time].[Time].[1997].[Q4]", caption: "Q4" },
+    { uniqueName: "[Time].[Time].[1998].[Q1]", caption: "Q1" },
+  ];
+
+  test("returns empty when either bound is null", () => {
+    expect(expandDateRange(null, new Date(1997, 0, 1), QUARTERS)).toEqual([]);
+    expect(expandDateRange(new Date(1997, 0, 1), null, QUARTERS)).toEqual([]);
+  });
+
+  test("intersects: window inside one quarter", () => {
+    // Feb 15 1997 → falls in Q1 1997 only.
+    const out = expandDateRange(new Date(1997, 1, 15), new Date(1997, 1, 15), QUARTERS);
+    expect(out).toEqual(["[Time].[Time].[1997].[Q1]"]);
+  });
+
+  test("intersects: window covers multiple quarters", () => {
+    // Feb 1997 → May 1997 → Q1 (overlaps Feb-Mar) + Q2 (overlaps Apr-May).
+    const out = expandDateRange(new Date(1997, 1, 1), new Date(1997, 4, 31), QUARTERS);
+    expect(out).toEqual(["[Time].[Time].[1997].[Q1]", "[Time].[Time].[1997].[Q2]"]);
+  });
+
+  test("intersects: window straddles year boundary", () => {
+    // Dec 1997 → Feb 1998 → Q4 1997 + Q1 1998.
+    const out = expandDateRange(new Date(1997, 11, 1), new Date(1998, 1, 28), QUARTERS);
+    expect(out).toEqual(["[Time].[Time].[1997].[Q4]", "[Time].[Time].[1998].[Q1]"]);
+  });
+
+  test("skips members the parser can't place", () => {
+    const mixed = [
+      ...QUARTERS,
+      { uniqueName: "[Customer].[Country].[USA]", caption: "USA" },
+    ];
+    const out = expandDateRange(new Date(1997, 0, 1), new Date(1997, 11, 31), mixed);
+    expect(out).not.toContain("[Customer].[Country].[USA]");
+    expect(out).toHaveLength(4);
+  });
+});
+
+describe("toDateInputValue / fromDateInputValue", () => {
+  test("round-trips through YYYY-MM-DD", () => {
+    const d = new Date(1997, 1, 15);
+    const s = toDateInputValue(d);
+    expect(s).toBe("1997-02-15");
+    const parsed = fromDateInputValue(s);
+    expect(parsed?.getFullYear()).toBe(1997);
+    expect(parsed?.getMonth()).toBe(1);
+    expect(parsed?.getDate()).toBe(15);
+  });
+
+  test("null / empty inputs", () => {
+    expect(toDateInputValue(null)).toBe("");
+    expect(fromDateInputValue("")).toBeNull();
+    expect(fromDateInputValue("garbage")).toBeNull();
+    expect(fromDateInputValue("1997-13-01")).toBeNull(); // bad month
+  });
+});

--- a/saiku-ui/src/lib/dashboard/dateRange.ts
+++ b/saiku-ui/src/lib/dashboard/dateRange.ts
@@ -1,0 +1,181 @@
+/*
+ * Date-range filter expansion (saiku#925).
+ *
+ * A `date-range` widget on the filter panel surfaces two HTML date
+ * inputs (from, to) but the underlying cube doesn't speak dates — it
+ * speaks members at some time level (Year, Quarter, Month, Day). This
+ * module parses each candidate member's MDX unique name into a
+ * concrete `[start, end]` calendar range and returns the subset whose
+ * range intersects the user's chosen window.
+ *
+ * Heuristics — works for the common Mondrian time hierarchies
+ * (Year → Quarter → Month → Day or Year → Month → Day), tolerates
+ * both numeric ("1") and English-named ("January") month captions,
+ * and gracefully returns no expansion for members the parser can't
+ * place on the calendar (cube-specific weird hierarchies, fiscal
+ * calendars with non-standard captions).
+ *
+ * The output is the list of MDX unique names to feed into the panel
+ * filter's `members[]` — the rest of the query pipeline already
+ * accepts a flat list at the configured level, so the slicer fires
+ * with no further server changes.
+ */
+
+const MONTHS_FULL = [
+  "january",
+  "february",
+  "march",
+  "april",
+  "may",
+  "june",
+  "july",
+  "august",
+  "september",
+  "october",
+  "november",
+  "december",
+];
+
+const MONTHS_SHORT = ["jan", "feb", "mar", "apr", "may", "jun", "jul", "aug", "sep", "oct", "nov", "dec"];
+
+export interface MemberRange {
+  start: Date;
+  end: Date;
+}
+
+/** Parse a Mondrian unique name like `[Time].[Time].[1997].[Q1]` into
+ *  the calendar range the member covers. Returns null when the parser
+ *  can't place the member confidently (no recognisable year segment,
+ *  unknown captions). */
+export function parseMemberDateRange(uniqueName: string): MemberRange | null {
+  const segs = uniqueName.match(/\[[^\]]+\]/g);
+  if (!segs) return null;
+  // Skip the [Dim].[Hier] prefix segments; the rest are level values
+  // in declaration order (root-most first).
+  const levelSegs = segs.slice(2).map((s) => s.slice(1, -1));
+  if (levelSegs.length === 0) return null;
+
+  let year: number | null = null;
+  let monthStart = 0; // 0-indexed (January = 0)
+  let monthEnd = 11;
+  let dayStart = 1;
+  let dayEnd: number | null = null; // null = clamp to end of month
+
+  let haveQuarter = false;
+  let haveMonth = false;
+
+  for (const raw of levelSegs) {
+    const v = raw.trim();
+    // Year — 4 digit number.
+    if (year == null && /^\d{4}$/.test(v)) {
+      year = parseInt(v, 10);
+      continue;
+    }
+    // Quarter — "Q1" .. "Q4" (case-insensitive).
+    const qm = v.match(/^Q([1-4])$/i);
+    if (qm) {
+      const q = parseInt(qm[1], 10);
+      monthStart = (q - 1) * 3;
+      monthEnd = (q - 1) * 3 + 2;
+      haveQuarter = true;
+      continue;
+    }
+    // Month — numeric 1-12 OR English name.
+    if (!haveMonth) {
+      const n = parseInt(v, 10);
+      if (!isNaN(n) && n >= 1 && n <= 12 && /^\d{1,2}$/.test(v)) {
+        monthStart = n - 1;
+        monthEnd = n - 1;
+        haveMonth = true;
+        continue;
+      }
+      const lower = v.toLowerCase();
+      const fi = MONTHS_FULL.indexOf(lower);
+      if (fi >= 0) {
+        monthStart = fi;
+        monthEnd = fi;
+        haveMonth = true;
+        continue;
+      }
+      const si = MONTHS_SHORT.indexOf(lower);
+      if (si >= 0) {
+        monthStart = si;
+        monthEnd = si;
+        haveMonth = true;
+        continue;
+      }
+    }
+    // Day — numeric 1-31, only meaningful after a month is known.
+    if (haveMonth && /^\d{1,2}$/.test(v)) {
+      const d = parseInt(v, 10);
+      if (d >= 1 && d <= 31) {
+        dayStart = d;
+        dayEnd = d;
+      }
+    }
+  }
+
+  // Need at least the year to place the member on the calendar.
+  if (year == null) return null;
+
+  // Quarter parsed but no narrower month → start/end span the quarter;
+  // year-only members span the whole year (monthStart/monthEnd already 0/11).
+  void haveQuarter;
+  const start = new Date(year, monthStart, dayStart);
+  const endMonth = monthEnd;
+  const endDay = dayEnd ?? lastDayOfMonth(year, endMonth);
+  const end = new Date(year, endMonth, endDay, 23, 59, 59, 999);
+  return { start, end };
+}
+
+function lastDayOfMonth(year: number, monthZeroIndexed: number): number {
+  // Day 0 of the next month is the last day of the current month.
+  return new Date(year, monthZeroIndexed + 1, 0).getDate();
+}
+
+/** Given a date-range picker's [from, to] window and the catalogue of
+ *  members at the filter's level, return the unique names whose
+ *  calendar range intersects the window. Members that can't be parsed
+ *  are silently skipped. Empty from / to → empty result. */
+export function expandDateRange(
+  from: Date | null,
+  to: Date | null,
+  members: { uniqueName: string; caption: string }[],
+): string[] {
+  if (!from || !to) return [];
+  // Normalise to inclusive day bounds.
+  const winStart = new Date(from.getFullYear(), from.getMonth(), from.getDate(), 0, 0, 0, 0);
+  const winEnd = new Date(to.getFullYear(), to.getMonth(), to.getDate(), 23, 59, 59, 999);
+  const out: string[] = [];
+  for (const m of members) {
+    const range = parseMemberDateRange(m.uniqueName);
+    if (!range) continue;
+    if (range.start <= winEnd && range.end >= winStart) {
+      out.push(m.uniqueName);
+    }
+  }
+  return out;
+}
+
+/** Format a Date as `YYYY-MM-DD` for binding to `<input type="date">`.
+ *  Returns "" for null so the input renders empty. */
+export function toDateInputValue(d: Date | null): string {
+  if (!d) return "";
+  const yyyy = d.getFullYear().toString().padStart(4, "0");
+  const mm = (d.getMonth() + 1).toString().padStart(2, "0");
+  const dd = d.getDate().toString().padStart(2, "0");
+  return `${yyyy}-${mm}-${dd}`;
+}
+
+/** Parse `YYYY-MM-DD` (as emitted by `<input type="date">`) into a
+ *  local-time Date at midnight. Returns null for empty strings or
+ *  malformed input so callers can short-circuit cleanly. */
+export function fromDateInputValue(s: string): Date | null {
+  const m = s.match(/^(\d{4})-(\d{2})-(\d{2})$/);
+  if (!m) return null;
+  const y = parseInt(m[1], 10);
+  const mo = parseInt(m[2], 10);
+  const d = parseInt(m[3], 10);
+  if (mo < 1 || mo > 12 || d < 1 || d > 31) return null;
+  return new Date(y, mo - 1, d);
+}

--- a/saiku-ui/src/lib/views/dashboard/DashboardFilterPanel.svelte
+++ b/saiku-ui/src/lib/views/dashboard/DashboardFilterPanel.svelte
@@ -27,6 +27,11 @@
     memberDescendsFromAny,
   } from "$lib/dashboard/cascadingFilters";
   import {
+    expandDateRange,
+    fromDateInputValue,
+    toDateInputValue,
+  } from "$lib/dashboard/dateRange";
+  import {
     listAiCubes,
     type AiCubeSummary,
     type CubeRef,
@@ -350,7 +355,38 @@
 
   function handleMemberChange(filterId: string, e: Event): void {
     const v = (e.target as HTMLSelectElement).value;
-    dashboardStore.updatePanelFilter(filterId, { members: v ? [v] : [] });
+    commitPanelMembers(filterId, v ? [v] : []);
+  }
+
+  /** Date-range pickers carry two HTML date inputs — local UI state
+   *  keyed by panel filter id. Persisted member expansion happens via
+   *  expandDateRange + commitPanelMembers; the raw date strings stay
+   *  client-side so we don't pollute the saved JSON with a UX-only
+   *  artefact. */
+  let dateRangeState = $state<Record<string, { from: string; to: string }>>({});
+
+  function dateRangeFor(filterId: string): { from: string; to: string } {
+    return dateRangeState[filterId] ?? { from: "", to: "" };
+  }
+
+  function setDateRange(filterId: string, from: string, to: string): void {
+    dateRangeState = { ...dateRangeState, [filterId]: { from, to } };
+    const f = dashboardStore.current?.filterPanel?.filters.find((p) => p.id === filterId);
+    if (!f) return;
+    const cat = memberCatalogues[filterId];
+    if (!cat?.members) {
+      // Members not loaded yet; bail and let the load $effect re-run
+      // with the new state when ready (next dateRange change retries).
+      return;
+    }
+    const fromDate = fromDateInputValue(from);
+    const toDate = fromDateInputValue(to);
+    const members = expandDateRange(fromDate, toDate, cat.members);
+    commitPanelMembers(filterId, members);
+  }
+
+  function commitPanelMembers(filterId: string, members: string[]): void {
+    dashboardStore.updatePanelFilter(filterId, { members });
     // An explicit panel pick replaces any transient click on the same
     // target — otherwise the click would keep overriding the user's
     // intentional choice and the chip strip would still show the click.
@@ -489,25 +525,48 @@
                 </span>
               {/if}
               <span class="picker-label">{f.level}</span>
-              <select
-                class="picker-select"
-                value={selected}
-                disabled={readOnly}
-                onchange={(e) => handleMemberChange(f.id, e)}
-              >
-                <option value="">— any —</option>
-                {#if displayOptions}
-                  {#each displayOptions as m (m.uniqueName)}
-                    <option value={m.uniqueName}>{m.caption}</option>
-                  {/each}
-                {:else if !f.cube}
-                  <option value="" disabled>(no cube on filter)</option>
-                {:else if cat?.loading}
-                  <option value="" disabled>Loading…</option>
-                {:else if cat?.error}
-                  <option value="" disabled>Error: {cat.error}</option>
-                {/if}
-              </select>
+              {#if f.widget === "date-range"}
+                {@const dr = dateRangeFor(f.id)}
+                <span class="date-range">
+                  <input
+                    type="date"
+                    class="picker-date"
+                    value={dr.from}
+                    disabled={readOnly}
+                    aria-label="From"
+                    onchange={(e) => setDateRange(f.id, (e.target as HTMLInputElement).value, dr.to)}
+                  />
+                  <span class="date-sep" aria-hidden="true">→</span>
+                  <input
+                    type="date"
+                    class="picker-date"
+                    value={dr.to}
+                    disabled={readOnly}
+                    aria-label="To"
+                    onchange={(e) => setDateRange(f.id, dr.from, (e.target as HTMLInputElement).value)}
+                  />
+                </span>
+              {:else}
+                <select
+                  class="picker-select"
+                  value={selected}
+                  disabled={readOnly}
+                  onchange={(e) => handleMemberChange(f.id, e)}
+                >
+                  <option value="">— any —</option>
+                  {#if displayOptions}
+                    {#each displayOptions as m (m.uniqueName)}
+                      <option value={m.uniqueName}>{m.caption}</option>
+                    {/each}
+                  {:else if !f.cube}
+                    <option value="" disabled>(no cube on filter)</option>
+                  {:else if cat?.loading}
+                    <option value="" disabled>Loading…</option>
+                  {:else if cat?.error}
+                    <option value="" disabled>Error: {cat.error}</option>
+                  {/if}
+                </select>
+              {/if}
               {#if !readOnly}
                 <button
                   type="button"
@@ -686,6 +745,23 @@
     background: var(--bg);
     font-size: 0.8125rem;
     max-width: 200px;
+  }
+  .date-range {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.25rem;
+  }
+  .picker-date {
+    padding: 0.125rem 0.25rem;
+    border: 1px solid var(--border-strong, var(--border));
+    border-radius: 4px;
+    background: var(--bg);
+    font-size: 0.8125rem;
+    font-family: inherit;
+  }
+  .date-sep {
+    color: var(--fg-muted);
+    font-size: 0.75rem;
   }
   .picker-remove {
     background: transparent;


### PR DESCRIPTION
## Summary

Closes #925.

Completes the third panel-filter widget mode. The picker for any panel filter with \`widget=\"date-range\"\` now renders two HTML \`<input type=\"date\">\` controls; on change, the from/to dates are mapped to the cube's actual time members at the configured level and the result is persisted as the filter's \`members[]\`.

### How it works

Pure helper \`expandDateRange(from, to, members)\` lives in \`\$lib/dashboard/dateRange.ts\`. \`parseMemberDateRange\` reads each candidate member's MDX unique name segments and infers a calendar range:

- **Year-only** members span the calendar year
- **Quarter** members narrow to three months (Q1 = Jan-Mar, etc.)
- **Month** members (numeric \`1\`–\`12\` or English names — full and short forms both accepted)
- **Day** members tail onto a known month

Members the parser can't place are silently skipped, so cube-specific weird hierarchies (fiscal calendars, non-English captions) degrade gracefully rather than crashing the picker.

Local component state holds the picker's two date strings (one entry per panel filter id). Raw date strings are **not** persisted to the dashboard — only the materialised member list is — so the saved JSON stays a proper Mondrian slicer with no UX-only artefacts.

### Test plan

- [x] \`npm run check\` clean
- [x] 15 new unit tests covering parser (year, quarter, named/numeric month, day, unparseable input) + intersect logic (single quarter, window covering multiple quarters, year boundary, mixed-cube member lists). 228/228 total.
- [ ] Reviewer: \"+ Add filter\" → cube, dim/hier/level, widget=date-range, Add → two date inputs render. Pick 1997-02-01 → 1997-05-31 → KPI/table refresh against Q1+Q2 1997.

### Out of scope (future iterations)

- Loading pre-existing saved date-range filters back into the date inputs on dashboard open. Members[] persists fine; the date input fields start empty on load and the analyst re-picks. Cheap to add later if asked.
- Fiscal-calendar cube support (custom captions that don't follow Q[1-4] / month-name conventions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)