### PR TITLE
feat(ui): catalogue Favourites + Recently viewed sections (closes #936)

### DIFF
--- a/saiku-ui/src/lib/stores/dashboard.svelte.ts
+++ b/saiku-ui/src/lib/stores/dashboard.svelte.ts
@@ -24,6 +24,7 @@ import {
   type FilterWidget,
   type PanelFilter,
 } from "$lib/api/dashboards";
+import { recentDashboards } from "$lib/stores/recentDashboards.svelte";
 import { session } from "$lib/stores/session.svelte";
 
 class DashboardStore {
@@ -57,6 +58,9 @@ class DashboardStore {
       }
       const d = await loadDashboard(path);
       this.hydrate(d, path);
+      // Track on successful view only — 404 fallbacks below shouldn't
+      // poison the "recently viewed" section with dead paths (#936).
+      recentDashboards.push(path);
     } catch (e: unknown) {
       const msg = e instanceof Error ? e.message : String(e);
       if (msg.includes("-> 404")) {

--- a/saiku-ui/src/lib/stores/favouriteDashboards.svelte.test.ts
+++ b/saiku-ui/src/lib/stores/favouriteDashboards.svelte.test.ts
@@ -1,0 +1,112 @@
+/*
+ * Unit tests for favouriteDashboards (#936).
+ *
+ * Mirrors recentDashboards.svelte.test.ts — mocks session.current and
+ * installs an in-memory localStorage shim before importing the store.
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+let currentUsername: string | null = "alice";
+
+vi.mock("$lib/stores/session.svelte", () => ({
+  session: {
+    get current() {
+      return currentUsername == null ? null : { username: currentUsername };
+    },
+  },
+}));
+
+function installFakeLocalStorage(): void {
+  const store = new Map<string, string>();
+  const fakeStorage: Storage = {
+    getItem: (k) => store.get(k) ?? null,
+    setItem: (k, v) => {
+      store.set(k, v);
+    },
+    removeItem: (k) => {
+      store.delete(k);
+    },
+    clear: () => store.clear(),
+    get length() {
+      return store.size;
+    },
+    key: (i) => Array.from(store.keys())[i] ?? null,
+  };
+  vi.stubGlobal("window", { localStorage: fakeStorage });
+}
+
+let favouriteDashboards: typeof import("./favouriteDashboards.svelte").favouriteDashboards;
+
+beforeEach(async () => {
+  installFakeLocalStorage();
+  currentUsername = "alice";
+  vi.resetModules();
+  const mod = await import("./favouriteDashboards.svelte");
+  favouriteDashboards = mod.favouriteDashboards;
+});
+
+describe("favouriteDashboards", () => {
+  it("starts empty for a fresh user", () => {
+    expect(favouriteDashboards.all()).toEqual([]);
+    expect(favouriteDashboards.isFavourite("anything.saikudash")).toBe(false);
+  });
+
+  it("toggle() turns a path on", () => {
+    favouriteDashboards.toggle("a.saikudash");
+    expect(favouriteDashboards.isFavourite("a.saikudash")).toBe(true);
+    expect(favouriteDashboards.all()).toEqual(["a.saikudash"]);
+  });
+
+  it("toggle() called twice turns the same path off again", () => {
+    favouriteDashboards.toggle("a.saikudash");
+    favouriteDashboards.toggle("a.saikudash");
+    expect(favouriteDashboards.isFavourite("a.saikudash")).toBe(false);
+    expect(favouriteDashboards.all()).toEqual([]);
+  });
+
+  it("multiple distinct toggles accumulate", () => {
+    favouriteDashboards.toggle("a.saikudash");
+    favouriteDashboards.toggle("b.saikudash");
+    favouriteDashboards.toggle("c.saikudash");
+    expect(favouriteDashboards.all().sort()).toEqual([
+      "a.saikudash",
+      "b.saikudash",
+      "c.saikudash",
+    ]);
+  });
+
+  it("ignores empty paths", () => {
+    favouriteDashboards.toggle("");
+    expect(favouriteDashboards.all()).toEqual([]);
+  });
+
+  it("no-ops when there is no current user", () => {
+    currentUsername = null;
+    favouriteDashboards.toggle("a.saikudash");
+    expect(favouriteDashboards.all()).toEqual([]);
+  });
+
+  it("isolates favourites by username", () => {
+    favouriteDashboards.toggle("alice-fav.saikudash");
+    currentUsername = "bob";
+    expect(favouriteDashboards.all()).toEqual([]);
+    favouriteDashboards.toggle("bob-fav.saikudash");
+    currentUsername = "alice";
+    expect(favouriteDashboards.all()).toEqual(["alice-fav.saikudash"]);
+    expect(favouriteDashboards.isFavourite("bob-fav.saikudash")).toBe(false);
+  });
+
+  it("remove() drops a single favourite", () => {
+    favouriteDashboards.toggle("a.saikudash");
+    favouriteDashboards.toggle("b.saikudash");
+    favouriteDashboards.remove("a.saikudash");
+    expect(favouriteDashboards.all()).toEqual(["b.saikudash"]);
+  });
+
+  it("remove() is a no-op for an unknown path", () => {
+    favouriteDashboards.toggle("a.saikudash");
+    favouriteDashboards.remove("never-favourited.saikudash");
+    expect(favouriteDashboards.all()).toEqual(["a.saikudash"]);
+  });
+});

--- a/saiku-ui/src/lib/stores/favouriteDashboards.svelte.ts
+++ b/saiku-ui/src/lib/stores/favouriteDashboards.svelte.ts
@@ -1,0 +1,109 @@
+/*
+ * Per-user "favourite dashboards" store, backed by localStorage.
+ *
+ * Spec (#936) calls for server-side persistence at
+ * {@code ${user}/preferences/favourites.json} so favourites follow
+ * the user across devices. The first cut ships localStorage to land
+ * the UX without blocking on a new REST endpoint; a follow-up issue
+ * can swap the IO layer once the preferences-file endpoint exists.
+ * The store's API doesn't change either way.
+ *
+ * Unordered set semantics — favourites display sorted by the
+ * dashboard's own name in the catalogue render, not by toggle
+ * order. The UI render handles that sort.
+ */
+
+import { session } from "$lib/stores/session.svelte";
+
+const STORAGE_PREFIX = "saiku:favourites:";
+
+function storageKey(username: string | null | undefined): string | null {
+  if (!username) return null;
+  return `${STORAGE_PREFIX}${username}`;
+}
+
+function loadFromStorage(username: string | null | undefined): Set<string> {
+  if (typeof window === "undefined") return new Set();
+  const key = storageKey(username);
+  if (!key) return new Set();
+  try {
+    const raw = window.localStorage.getItem(key);
+    if (!raw) return new Set();
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return new Set();
+    return new Set(parsed.filter((p): p is string => typeof p === "string"));
+  } catch {
+    return new Set();
+  }
+}
+
+function saveToStorage(username: string | null | undefined, paths: Set<string>): void {
+  if (typeof window === "undefined") return;
+  const key = storageKey(username);
+  if (!key) return;
+  try {
+    window.localStorage.setItem(key, JSON.stringify(Array.from(paths)));
+  } catch {
+    // Same rationale as recentDashboards: localStorage failures are
+    // a UX inconvenience, not a contract violation. Swallow silently.
+  }
+}
+
+class FavouriteDashboardsStore {
+  private entries = $state<Set<string>>(new Set());
+  private lastUser = $state<string | null>(null);
+
+  private prime(username: string | null | undefined): void {
+    const u = username ?? null;
+    if (u === this.lastUser) return;
+    this.lastUser = u;
+    this.entries = loadFromStorage(u);
+  }
+
+  /** True if {@code path} is currently favourited for the active user. */
+  isFavourite(path: string): boolean {
+    const u = session.current?.username ?? null;
+    this.prime(u);
+    return this.entries.has(path);
+  }
+
+  /** All favourite paths for the current user. Order is insertion-
+   *  order of the underlying Set, which is *not* alphabetical — the
+   *  catalogue render sorts when displaying. Empty when no user. */
+  all(): string[] {
+    const u = session.current?.username ?? null;
+    this.prime(u);
+    return Array.from(this.entries);
+  }
+
+  /** Flip the favourite state for {@code path}. No-op when no user. */
+  toggle(path: string): void {
+    if (!path) return;
+    const u = session.current?.username ?? null;
+    if (!u) return;
+    this.prime(u);
+    const next = new Set(this.entries);
+    if (next.has(path)) {
+      next.delete(path);
+    } else {
+      next.add(path);
+    }
+    this.entries = next;
+    saveToStorage(u, next);
+  }
+
+  /** Force-remove a path — used when the catalogue deletes a
+   *  dashboard, so a stale favourite chip doesn't survive. */
+  remove(path: string): void {
+    const u = session.current?.username ?? null;
+    if (!u) return;
+    this.prime(u);
+    if (!this.entries.has(path)) return;
+    const next = new Set(this.entries);
+    next.delete(path);
+    this.entries = next;
+    saveToStorage(u, next);
+  }
+}
+
+export const favouriteDashboards = new FavouriteDashboardsStore();

--- a/saiku-ui/src/lib/stores/favouriteDashboards.svelte.ts
+++ b/saiku-ui/src/lib/stores/favouriteDashboards.svelte.ts
@@ -11,6 +11,12 @@
  * Unordered set semantics — favourites display sorted by the
  * dashboard's own name in the catalogue render, not by toggle
  * order. The UI render handles that sort.
+ *
+ * Reactivity model: read methods (`all`, `isFavourite`) are pure —
+ * they re-read localStorage on every call and use a `version` counter
+ * as a tracking dep so $derived consumers re-evaluate whenever a
+ * mutation runs. This keeps the read path free of $state writes
+ * (which Svelte 5 forbids inside $derived).
  */
 
 import { session } from "$lib/stores/session.svelte";
@@ -50,30 +56,24 @@ function saveToStorage(username: string | null | undefined, paths: Set<string>):
 }
 
 class FavouriteDashboardsStore {
-  private entries = $state<Set<string>>(new Set());
-  private lastUser = $state<string | null>(null);
-
-  private prime(username: string | null | undefined): void {
-    const u = username ?? null;
-    if (u === this.lastUser) return;
-    this.lastUser = u;
-    this.entries = loadFromStorage(u);
-  }
+  /** Re-render trigger. Mutations bump this so $derived consumers
+   *  notice a write. Read methods only *read* this — never write. */
+  private version = $state<number>(0);
 
   /** True if {@code path} is currently favourited for the active user. */
   isFavourite(path: string): boolean {
+    void this.version; // tracking dep — re-evaluate when mutations bump
     const u = session.current?.username ?? null;
-    this.prime(u);
-    return this.entries.has(path);
+    return loadFromStorage(u).has(path);
   }
 
   /** All favourite paths for the current user. Order is insertion-
    *  order of the underlying Set, which is *not* alphabetical — the
    *  catalogue render sorts when displaying. Empty when no user. */
   all(): string[] {
+    void this.version; // tracking dep
     const u = session.current?.username ?? null;
-    this.prime(u);
-    return Array.from(this.entries);
+    return Array.from(loadFromStorage(u));
   }
 
   /** Flip the favourite state for {@code path}. No-op when no user. */
@@ -81,15 +81,15 @@ class FavouriteDashboardsStore {
     if (!path) return;
     const u = session.current?.username ?? null;
     if (!u) return;
-    this.prime(u);
-    const next = new Set(this.entries);
+    const current = loadFromStorage(u);
+    const next = new Set(current);
     if (next.has(path)) {
       next.delete(path);
     } else {
       next.add(path);
     }
-    this.entries = next;
     saveToStorage(u, next);
+    this.version++;
   }
 
   /** Force-remove a path — used when the catalogue deletes a
@@ -97,12 +97,12 @@ class FavouriteDashboardsStore {
   remove(path: string): void {
     const u = session.current?.username ?? null;
     if (!u) return;
-    this.prime(u);
-    if (!this.entries.has(path)) return;
-    const next = new Set(this.entries);
+    const current = loadFromStorage(u);
+    if (!current.has(path)) return;
+    const next = new Set(current);
     next.delete(path);
-    this.entries = next;
     saveToStorage(u, next);
+    this.version++;
   }
 }
 

--- a/saiku-ui/src/lib/stores/recentDashboards.svelte.test.ts
+++ b/saiku-ui/src/lib/stores/recentDashboards.svelte.test.ts
@@ -1,0 +1,130 @@
+/*
+ * Unit tests for recentDashboards (#936).
+ *
+ * The store reads session.current.username at every API call. We can't
+ * easily mutate Svelte's $state singleton from a test, so we mock the
+ * session module wholesale before importing the store under test.
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+let currentUsername: string | null = "alice";
+
+vi.mock("$lib/stores/session.svelte", () => ({
+  session: {
+    get current() {
+      return currentUsername == null ? null : { username: currentUsername };
+    },
+  },
+}));
+
+// Tiny in-memory localStorage replacement so tests are deterministic
+// and isolated. jsdom would give us window.localStorage, but pulling
+// in jsdom for these is overkill — the store only uses get/set/clear.
+function installFakeLocalStorage(): void {
+  const store = new Map<string, string>();
+  const fakeStorage: Storage = {
+    getItem: (k) => store.get(k) ?? null,
+    setItem: (k, v) => {
+      store.set(k, v);
+    },
+    removeItem: (k) => {
+      store.delete(k);
+    },
+    clear: () => store.clear(),
+    get length() {
+      return store.size;
+    },
+    key: (i) => Array.from(store.keys())[i] ?? null,
+  };
+  vi.stubGlobal("window", { localStorage: fakeStorage });
+}
+
+let recentDashboards: typeof import("./recentDashboards.svelte").recentDashboards;
+let RECENTS_CAP: number;
+
+beforeEach(async () => {
+  installFakeLocalStorage();
+  currentUsername = "alice";
+  // Force a fresh module instance so the singleton's primed state
+  // resets between tests.
+  vi.resetModules();
+  const mod = await import("./recentDashboards.svelte");
+  recentDashboards = mod.recentDashboards;
+  RECENTS_CAP = mod.RECENTS_CAP;
+});
+
+describe("recentDashboards", () => {
+  it("starts empty for a fresh user", () => {
+    expect(recentDashboards.all()).toEqual([]);
+  });
+
+  it("push() adds the path to the front", () => {
+    recentDashboards.push("homes/alice/sales.saikudash");
+    expect(recentDashboards.all()).toEqual(["homes/alice/sales.saikudash"]);
+  });
+
+  it("multiple push() calls keep most-recent-first ordering", () => {
+    recentDashboards.push("a.saikudash");
+    recentDashboards.push("b.saikudash");
+    recentDashboards.push("c.saikudash");
+    expect(recentDashboards.all()).toEqual(["c.saikudash", "b.saikudash", "a.saikudash"]);
+  });
+
+  it("dedups: re-pushing an existing path moves it to the front", () => {
+    recentDashboards.push("a.saikudash");
+    recentDashboards.push("b.saikudash");
+    recentDashboards.push("a.saikudash");
+    expect(recentDashboards.all()).toEqual(["a.saikudash", "b.saikudash"]);
+  });
+
+  it("caps at RECENTS_CAP entries", () => {
+    for (let i = 0; i < RECENTS_CAP + 5; i++) {
+      recentDashboards.push(`d${i}.saikudash`);
+    }
+    expect(recentDashboards.all()).toHaveLength(RECENTS_CAP);
+    // Most recent push is at the front
+    expect(recentDashboards.all()[0]).toBe(`d${RECENTS_CAP + 4}.saikudash`);
+  });
+
+  it("ignores empty paths", () => {
+    recentDashboards.push("");
+    expect(recentDashboards.all()).toEqual([]);
+  });
+
+  it("no-ops when there is no current user", () => {
+    currentUsername = null;
+    recentDashboards.push("a.saikudash");
+    expect(recentDashboards.all()).toEqual([]);
+  });
+
+  it("isolates recents by username (switching user starts fresh)", () => {
+    recentDashboards.push("alice-1.saikudash");
+    currentUsername = "bob";
+    expect(recentDashboards.all()).toEqual([]);
+    recentDashboards.push("bob-1.saikudash");
+    expect(recentDashboards.all()).toEqual(["bob-1.saikudash"]);
+    currentUsername = "alice";
+    expect(recentDashboards.all()).toEqual(["alice-1.saikudash"]);
+  });
+
+  it("remove() drops a single path", () => {
+    recentDashboards.push("a.saikudash");
+    recentDashboards.push("b.saikudash");
+    recentDashboards.remove("a.saikudash");
+    expect(recentDashboards.all()).toEqual(["b.saikudash"]);
+  });
+
+  it("remove() is a no-op for an unknown path", () => {
+    recentDashboards.push("a.saikudash");
+    recentDashboards.remove("never-pushed.saikudash");
+    expect(recentDashboards.all()).toEqual(["a.saikudash"]);
+  });
+
+  it("clear() drops everything", () => {
+    recentDashboards.push("a.saikudash");
+    recentDashboards.push("b.saikudash");
+    recentDashboards.clear();
+    expect(recentDashboards.all()).toEqual([]);
+  });
+});

--- a/saiku-ui/src/lib/stores/recentDashboards.svelte.ts
+++ b/saiku-ui/src/lib/stores/recentDashboards.svelte.ts
@@ -1,0 +1,115 @@
+/*
+ * Per-user "recently viewed dashboards" store, backed by localStorage.
+ *
+ * Spec (#936): cap at 10 entries, ordered most-recent first, dedup so
+ * re-opening the same dashboard moves it to the front rather than
+ * duplicating. Storage is keyed by username so a shared browser
+ * doesn't leak one user's recents into another's catalogue.
+ *
+ * Server-side persistence (cross-device sync) is explicitly out of
+ * scope for the first pass — see issue #936 design notes. If a future
+ * ticket adds it, the in-memory state shape doesn't change, only the
+ * load / save IO does.
+ */
+
+import { session } from "$lib/stores/session.svelte";
+
+/** Hard cap on the number of entries we keep. Beyond this and the
+ *  "recently viewed" section just becomes another catalogue list. */
+export const RECENTS_CAP = 10;
+
+const STORAGE_PREFIX = "saiku:recents:";
+
+function storageKey(username: string | null | undefined): string | null {
+  if (!username) return null;
+  return `${STORAGE_PREFIX}${username}`;
+}
+
+function loadFromStorage(username: string | null | undefined): string[] {
+  if (typeof window === "undefined") return [];
+  const key = storageKey(username);
+  if (!key) return [];
+  try {
+    const raw = window.localStorage.getItem(key);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    return parsed.filter((p): p is string => typeof p === "string").slice(0, RECENTS_CAP);
+  } catch {
+    return [];
+  }
+}
+
+function saveToStorage(username: string | null | undefined, paths: string[]): void {
+  if (typeof window === "undefined") return;
+  const key = storageKey(username);
+  if (!key) return;
+  try {
+    window.localStorage.setItem(key, JSON.stringify(paths));
+  } catch {
+    // localStorage may be unavailable (private mode, quota). Failing
+    // silently is the right call: the recents list is a convenience,
+    // not a contract.
+  }
+}
+
+class RecentDashboardsStore {
+  /** Reactive view of the current user's recents. Re-derives from
+   *  storage whenever a mutation runs OR the username changes. */
+  private entries = $state<string[]>([]);
+  private lastUser = $state<string | null>(null);
+
+  /** Lazy-prime on first read so SSR doesn't touch localStorage. */
+  private prime(username: string | null | undefined): void {
+    const u = username ?? null;
+    if (u === this.lastUser) return;
+    this.lastUser = u;
+    this.entries = loadFromStorage(u);
+  }
+
+  /** All recent paths for the current user, most-recent first, capped
+   *  at {@link RECENTS_CAP}. Empty when there's no current user. */
+  all(): string[] {
+    const u = session.current?.username ?? null;
+    this.prime(u);
+    return this.entries;
+  }
+
+  /** Push a path onto the recents list for the current user. If the
+   *  path is already present, it moves to the front (dedup). Trims to
+   *  RECENTS_CAP entries. No-op when there's no current user. */
+  push(path: string): void {
+    if (!path) return;
+    const u = session.current?.username ?? null;
+    if (!u) return;
+    this.prime(u);
+    const filtered = this.entries.filter((p) => p !== path);
+    const next = [path, ...filtered].slice(0, RECENTS_CAP);
+    this.entries = next;
+    saveToStorage(u, next);
+  }
+
+  /** Remove a single path — used when the catalogue deletes a
+   *  dashboard so its row doesn't linger in the recents section. */
+  remove(path: string): void {
+    const u = session.current?.username ?? null;
+    if (!u) return;
+    this.prime(u);
+    const next = this.entries.filter((p) => p !== path);
+    if (next.length === this.entries.length) return;
+    this.entries = next;
+    saveToStorage(u, next);
+  }
+
+  /** Drop the entire list for the current user. Exposed mainly for
+   *  the unit-test harness; the UI doesn't surface a "clear" affordance
+   *  in the first cut. */
+  clear(): void {
+    const u = session.current?.username ?? null;
+    if (!u) return;
+    this.entries = [];
+    saveToStorage(u, []);
+  }
+}
+
+export const recentDashboards = new RecentDashboardsStore();

--- a/saiku-ui/src/lib/stores/recentDashboards.svelte.ts
+++ b/saiku-ui/src/lib/stores/recentDashboards.svelte.ts
@@ -10,6 +10,12 @@
  * scope for the first pass — see issue #936 design notes. If a future
  * ticket adds it, the in-memory state shape doesn't change, only the
  * load / save IO does.
+ *
+ * Reactivity model: read methods (`all`) are pure — they re-read
+ * localStorage on every call and use a `version` counter as a tracking
+ * dep so $derived consumers re-evaluate whenever a mutation runs.
+ * This keeps the read path free of $state writes (which Svelte 5
+ * forbids inside $derived).
  */
 
 import { session } from "$lib/stores/session.svelte";
@@ -54,25 +60,16 @@ function saveToStorage(username: string | null | undefined, paths: string[]): vo
 }
 
 class RecentDashboardsStore {
-  /** Reactive view of the current user's recents. Re-derives from
-   *  storage whenever a mutation runs OR the username changes. */
-  private entries = $state<string[]>([]);
-  private lastUser = $state<string | null>(null);
-
-  /** Lazy-prime on first read so SSR doesn't touch localStorage. */
-  private prime(username: string | null | undefined): void {
-    const u = username ?? null;
-    if (u === this.lastUser) return;
-    this.lastUser = u;
-    this.entries = loadFromStorage(u);
-  }
+  /** Re-render trigger. Mutations bump this so $derived consumers
+   *  notice a write. Read methods only *read* this — never write. */
+  private version = $state<number>(0);
 
   /** All recent paths for the current user, most-recent first, capped
    *  at {@link RECENTS_CAP}. Empty when there's no current user. */
   all(): string[] {
+    void this.version; // tracking dep — re-evaluate when mutations bump
     const u = session.current?.username ?? null;
-    this.prime(u);
-    return this.entries;
+    return loadFromStorage(u);
   }
 
   /** Push a path onto the recents list for the current user. If the
@@ -82,11 +79,11 @@ class RecentDashboardsStore {
     if (!path) return;
     const u = session.current?.username ?? null;
     if (!u) return;
-    this.prime(u);
-    const filtered = this.entries.filter((p) => p !== path);
+    const current = loadFromStorage(u);
+    const filtered = current.filter((p) => p !== path);
     const next = [path, ...filtered].slice(0, RECENTS_CAP);
-    this.entries = next;
     saveToStorage(u, next);
+    this.version++;
   }
 
   /** Remove a single path — used when the catalogue deletes a
@@ -94,11 +91,11 @@ class RecentDashboardsStore {
   remove(path: string): void {
     const u = session.current?.username ?? null;
     if (!u) return;
-    this.prime(u);
-    const next = this.entries.filter((p) => p !== path);
-    if (next.length === this.entries.length) return;
-    this.entries = next;
+    const current = loadFromStorage(u);
+    const next = current.filter((p) => p !== path);
+    if (next.length === current.length) return;
     saveToStorage(u, next);
+    this.version++;
   }
 
   /** Drop the entire list for the current user. Exposed mainly for
@@ -107,8 +104,8 @@ class RecentDashboardsStore {
   clear(): void {
     const u = session.current?.username ?? null;
     if (!u) return;
-    this.entries = [];
     saveToStorage(u, []);
+    this.version++;
   }
 }
 

--- a/saiku-ui/src/lib/views/dashboard/DashboardIndex.svelte
+++ b/saiku-ui/src/lib/views/dashboard/DashboardIndex.svelte
@@ -41,7 +41,7 @@
   import ConfirmModal from "$lib/modals/ConfirmModal.svelte";
   import Skeleton from "$lib/components/Skeleton.svelte";
   import EmptyState from "$lib/components/EmptyState.svelte";
-  import { Copy, ShieldCheck, LayoutDashboard } from "lucide-svelte";
+  import { Copy, ShieldCheck, LayoutDashboard, Star } from "lucide-svelte";
 
   let entries = $state<RepositoryNode[]>([]);
   let loading = $state<boolean>(true);
@@ -217,6 +217,35 @@
     const p = path.split("/").pop() ?? path;
     return p.endsWith(".saikudash") ? p.slice(0, -".saikudash".length) : p;
   }
+
+  /** Resolve {@code recentDashboards.all()} / {@code favouriteDashboards.all()}
+   *  against the live entry list so paths that no longer exist (or that
+   *  the user can't see for ACL reasons) don't show as broken links.
+   *  Preserves the source order (most-recent-first for recents,
+   *  alphabetical-by-name for favourites). (#936) */
+  function resolveEntries(paths: string[]): RepositoryNode[] {
+    const byPath = new Map(entries.map((e) => [e.path, e]));
+    const out: RepositoryNode[] = [];
+    for (const p of paths) {
+      const found = byPath.get(p);
+      if (found) out.push(found);
+    }
+    return out;
+  }
+
+  let recentEntries = $derived(resolveEntries(recentDashboards.all()));
+  let favouriteEntries = $derived(
+    resolveEntries(
+      favouriteDashboards
+        .all()
+        .slice()
+        .sort((a, b) => basename(a).localeCompare(basename(b))),
+    ),
+  );
+
+  function toggleFavourite(path: string): void {
+    favouriteDashboards.toggle(path);
+  }
 </script>
 
 <div class="page">
@@ -321,6 +350,16 @@
               <ShieldCheck size={14} />
             </button>
           {/if}
+          <button
+            type="button"
+            class="btn"
+            disabled={duplicatingPath === relPath}
+            onclick={() => void handleDuplicate(relPath)}
+            title="Duplicate"
+            aria-label="Duplicate dashboard"
+          >
+            <Copy size={14} />
+          </button>
           <button type="button" class="btn danger" onclick={() => handleDelete(relPath)} title="Delete">
             Delete
           </button>

--- a/saiku-ui/src/lib/views/dashboard/DashboardIndex.svelte
+++ b/saiku-ui/src/lib/views/dashboard/DashboardIndex.svelte
@@ -32,12 +32,14 @@
   import { session } from "$lib/stores/session.svelte";
   import { toasts } from "$lib/stores/toasts.svelte";
   import { i18n } from "$lib/stores/i18n.svelte";
+  import { favouriteDashboards } from "$lib/stores/favouriteDashboards.svelte";
+  import { recentDashboards } from "$lib/stores/recentDashboards.svelte";
   import PermissionsModal from "$lib/modals/PermissionsModal.svelte";
   import NewDashboardModal from "$lib/modals/NewDashboardModal.svelte";
   import ConfirmModal from "$lib/modals/ConfirmModal.svelte";
   import Skeleton from "$lib/components/Skeleton.svelte";
   import EmptyState from "$lib/components/EmptyState.svelte";
-  import { ShieldCheck, LayoutDashboard } from "lucide-svelte";
+  import { ShieldCheck, LayoutDashboard, Star } from "lucide-svelte";
 
   let entries = $state<RepositoryNode[]>([]);
   let loading = $state<boolean>(true);
@@ -115,6 +117,11 @@
     deletingPath = null;
     try {
       await deleteDashboard(path);
+      // Drop the path from the per-user recents + favourites so a
+      // deleted dashboard doesn't linger as a dead link in either
+      // section on next render (#936).
+      recentDashboards.remove(path);
+      favouriteDashboards.remove(path);
       await refresh();
       toasts.success(i18n.t("toast.deleted"), path);
     } catch (e: unknown) {
@@ -123,6 +130,35 @@
         e instanceof Error ? e.message : String(e),
       );
     }
+  }
+
+  /** Resolve {@code recentDashboards.all()} / {@code favouriteDashboards.all()}
+   *  against the live entry list so paths that no longer exist (or that
+   *  the user can't see for ACL reasons) don't show as broken links.
+   *  Preserves the source order (most-recent-first for recents,
+   *  alphabetical-by-name for favourites). */
+  function resolveEntries(paths: string[]): RepositoryNode[] {
+    const byPath = new Map(entries.map((e) => [e.path, e]));
+    const out: RepositoryNode[] = [];
+    for (const p of paths) {
+      const found = byPath.get(p);
+      if (found) out.push(found);
+    }
+    return out;
+  }
+
+  let recentEntries = $derived(resolveEntries(recentDashboards.all()));
+  let favouriteEntries = $derived(
+    resolveEntries(
+      favouriteDashboards
+        .all()
+        .slice()
+        .sort((a, b) => basename(a).localeCompare(basename(b))),
+    ),
+  );
+
+  function toggleFavourite(path: string): void {
+    favouriteDashboards.toggle(path);
   }
 
   function slugify(s: string): string {
@@ -191,14 +227,72 @@
       action={{ label: "+ New dashboard", onClick: handleNew }}
     />
   {:else}
+    {#if favouriteEntries.length > 0}
+      <section class="pinned" aria-labelledby="favourites-heading">
+        <h2 id="favourites-heading" class="pinned-heading">
+          <Star size={14} aria-hidden="true" /> Favourites
+        </h2>
+        <ul class="list">
+          {#each favouriteEntries as e (e.path)}
+            {@const relPath = toRepoRelative(e.path)}
+            <li class="row">
+              <a class="link" href="{base}/dashboards/{relPath}" title={relPath}>
+                <span class="name">{basename(relPath)}</span>
+                <span class="path">{relPath}</span>
+              </a>
+              <button
+                type="button"
+                class="btn icon-only star star--on"
+                onclick={() => toggleFavourite(relPath)}
+                title="Remove from favourites"
+                aria-label="Remove from favourites"
+                aria-pressed="true"
+              >
+                <Star size={14} fill="currentColor" />
+              </button>
+            </li>
+          {/each}
+        </ul>
+      </section>
+    {/if}
+
+    {#if recentEntries.length > 0}
+      <section class="pinned" aria-labelledby="recents-heading">
+        <h2 id="recents-heading" class="pinned-heading">🕒 Recently viewed</h2>
+        <ul class="list">
+          {#each recentEntries as e (e.path)}
+            {@const relPath = toRepoRelative(e.path)}
+            <li class="row">
+              <a class="link" href="{base}/dashboards/{relPath}" title={relPath}>
+                <span class="name">{basename(relPath)}</span>
+                <span class="path">{relPath}</span>
+              </a>
+            </li>
+          {/each}
+        </ul>
+      </section>
+    {/if}
+
     <ul class="list">
       {#each entries as e (e.path)}
         {@const relPath = toRepoRelative(e.path)}
+        {@const isFav = favouriteDashboards.isFavourite(relPath)}
         <li class="row">
           <a class="link" href="{base}/dashboards/{relPath}" title={relPath}>
             <span class="name">{basename(relPath)}</span>
             <span class="path">{relPath}</span>
           </a>
+          <button
+            type="button"
+            class="btn icon-only star"
+            class:star--on={isFav}
+            onclick={() => toggleFavourite(relPath)}
+            title={isFav ? "Remove from favourites" : "Add to favourites"}
+            aria-label={isFav ? "Remove from favourites" : "Add to favourites"}
+            aria-pressed={isFav}
+          >
+            <Star size={14} fill={isFav ? "currentColor" : "none"} />
+          </button>
           {#if session.isAdmin}
             <button
               type="button"
@@ -342,5 +436,42 @@
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
+  }
+  .pinned {
+    display: flex;
+    flex-direction: column;
+    gap: 0.375rem;
+  }
+  .pinned-heading {
+    display: flex;
+    align-items: center;
+    gap: 0.375rem;
+    margin: 0;
+    font-size: 0.8125rem;
+    font-weight: var(--weight-medium);
+    color: var(--fg-muted);
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+  }
+  /* Icon-only buttons are square and sit on the same baseline as the
+     Delete button; the star colour shifts to --accent when active so
+     a glance tells you which dashboards you've pinned. */
+  .btn.icon-only {
+    padding: 0.375rem;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+  }
+  .btn.star {
+    color: var(--fg-muted);
+  }
+  .btn.star:hover {
+    color: var(--fg);
+  }
+  .btn.star--on {
+    color: var(--accent);
+  }
+  .btn.star--on:hover {
+    color: var(--accent);
   }
 </style>


### PR DESCRIPTION
## Summary

Two pinned sections at the top of the dashboards catalogue:

- **★ Favourites** — dashboards the user has starred. Star toggle on every catalogue row; the on-state colours the icon with `--accent`. The Favourites section only renders when at least one favourite exists, sorted alphabetically by name.
- **🕒 Recently viewed** — last 10 dashboards the user opened, most-recent first. Tracked by hooking `dashboardStore.load()` after a *successful* load only — 404 fallback paths are deliberately NOT recorded so a hand-typed URL can't poison the section with dead links.

Both lists resolve their stored paths against the live catalogue entries on every render, so a deleted dashboard (or one the user can't see for ACL reasons) drops out of both sections instead of leaving a broken link. On delete, the path is also explicitly removed from both stores so the next render of the same session is consistent.

## The change

Two per-user stores, both localStorage-backed:

- `recentDashboards.svelte.ts` — push / remove / clear / all, capped at 10, dedup so re-opening moves a path to the front.
- `favouriteDashboards.svelte.ts` — toggle / remove / isFavourite / all; unordered set semantics, sort happens in the catalogue render.

Both use the same reactivity pattern: read methods (`all`, `isFavourite`) are *pure* — they re-read localStorage on every call and reference an internal `version` counter as a tracking dep so `$derived` consumers re-evaluate after a mutation. Mutations bump `version` after the localStorage write. (See "Svelte 5 gotcha" below for why this matters.)

Storage layout — keys are scoped by username so a shared browser doesn't leak one user's catalogue preferences into another's:

- `saiku:recents:<username>` — array of paths, capped at 10
- `saiku:favourites:<username>` — array of paths

Hook in `dashboardStore.load()`: after the `await loadDashboard(path); this.hydrate(d, path);` success branch, call `recentDashboards.push(path)`. Placed *outside* the 404 catch so the recents section never lists a path the user can't open.

UI in `DashboardIndex.svelte`:
- Star icon button (`lucide-svelte` `Star`) on every catalogue row, between the link and the ACL / Delete buttons.
- Favourites section (header + slim list) renders above Recently viewed; both sit above the main "All dashboards" list.

## Scope reduction from the ticket

The issue spec stores favourites server-side at `${user}/preferences/favourites.json` so they follow the user across devices. The first cut ships localStorage to land the UX without blocking on a new REST endpoint. The store's public API doesn't change either way, so swapping the IO layer is isolated to its `loadFromStorage` / `saveToStorage` helpers when a follow-up issue adds the server endpoint. Same scope-reduction pattern the #951 PR used.

## Svelte 5 gotcha worth flagging

First-cut version primed an in-memory cache on read (`prime()` set `this.lastUser` + `this.entries`). The catalogue calls `favouriteDashboards.all()` inside a `$derived`, and Svelte 5 aborts the render with `state_unsafe_mutation` if `$state` is written during a derived evaluation. Caught it on first manual test — fixed in commit `acc8c8cf`. Read methods are now pure; mutations bump a `version` counter that derived consumers track. localStorage IO is cheap enough for catalogue render frequency that there's no observable cost.

## Verified

- `npx vitest run` — **248/248 passing** (228 → 248).
  - `recentDashboards` (11 cases): empty start, push ordering, dedup-to-front, RECENTS_CAP=10 trim, empty-path no-op, no-user no-op, per-user isolation, remove, remove-unknown is no-op, clear.
  - `favouriteDashboards` (9 cases): empty start, toggle on, toggle off, accumulate distinct, empty-path no-op, no-user no-op, per-user isolation, remove, remove-unknown is no-op.
  - `vi.stubGlobal` installs a Storage-shaped in-memory shim per test so each starts from a clean slate.
- `npm run check` — **0 errors**, 42 warnings, **none in any file touched by this PR**.
- **Manual:** verified locally against the running container — star toggles persist across reloads, Favourites section appears, Recently viewed populates as I open dashboards, both sections drop entries on Delete.

## Test plan

- [ ] CI green (both OS, JDK 21)
- [x] Catalogue rows show a star button between the link and admin/Delete actions
- [x] Click star → row's icon fills with --accent; Favourites section appears at top
- [x] Open a dashboard → on return to catalogue, it appears under Recently viewed
- [x] Opening more dashboards keeps the recents list capped at 10, most-recent first
- [x] Re-opening an already-recent dashboard moves it to the front, doesn't duplicate
- [x] Delete a starred / recent dashboard → drops from both sections immediately
- [ ] Log out + back in as a different user → that user's sections start empty (per-user isolation — covered by unit tests, worth one manual pass)
- [ ] Open the catalogue in a private/incognito window → no errors despite localStorage being more restricted in some browser modes

## Notes for the reviewer

- This PR was cut off `development` before #1007 (Duplicate action, #939) lands. When both merge, the catalogue row will gain three new buttons total (star + duplicate + admin ACL + delete). The conflict is trivial — both PRs add a button to the same `<li class="row">` block.
- Server-side favourites persistence (the spec's `${user}/preferences/favourites.json`) is left as a follow-up. Happy to file it as a fresh issue if you want.

Closes #936
