### PR TITLE
feat(ui): catalogue search + tag filter + owner filter + modified sort (closes #935)

### DIFF
--- a/saiku-core/saiku-service/src/main/java/org/saiku/repository/Acl2.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/repository/Acl2.java
@@ -164,6 +164,43 @@ class Acl2 {
         return acls.contains(AclMethod.READ);
     }
 
+    /**
+     * Best-effort owner lookup for a path. Walks the same {@code acl.json}
+     * chain that {@link #getMethods} consults; returns the {@code owner}
+     * field from the file's own ACL entry, or the closest parent's, or
+     * {@code null} when no ACL entry is found before the root.
+     *
+     * <p>Surfaced for the catalogue's #935 owner filter — needed at
+     * listing time without forcing a separate {@code getResourceAcl}
+     * round-trip per file. Best-effort only: a missing or malformed
+     * {@code acl.json} yields {@code null} (the catalogue then renders
+     * the file under an "unknown owner" bucket rather than failing the
+     * listing).
+     */
+    @Nullable
+    public String getOwner(@NotNull File file) {
+        try {
+            ObjectMapper mapper = new ObjectMapper();
+            TypeReference<Map<String, AclEntry>> ref = new TypeReference<Map<String, AclEntry>>() {};
+            try {
+                Map<String, AclEntry> aclData = mapper.readValue(new File(file, "acl.json"), ref);
+                AclEntry entry = aclData.get(file.getPath());
+                if (entry != null && StringUtils.isNotBlank(entry.getOwner())) {
+                    return entry.getOwner();
+                }
+            } catch (Exception ignored) {
+                // No acl.json at this level — fall through and walk up.
+            }
+            if (file.getParentFile() != null) {
+                return getOwner(file.getParentFile());
+            }
+            return null;
+        } catch (Exception e) {
+            LOG.debug("Owner lookup failed for {}", file.getPath(), e);
+            return null;
+        }
+    }
+
     @NotNull
     public List<AclMethod> getMethods(@NotNull File file, String username, @NotNull List<String> roles) {
         try {

--- a/saiku-core/saiku-service/src/main/java/org/saiku/repository/FilesystemRepositoryManager.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/repository/FilesystemRepositoryManager.java
@@ -763,8 +763,16 @@ public class FilesystemRepositoryManager implements IRepositoryManager {
                                     }
 
                                     String extension = FilenameUtils.getExtension(file.getPath());
+                                    String owner = acl.getOwner(new File(relativePath));
+                                    long modified = file.lastModified();
                                     repoObjects.add(new RepositoryFileObject(
-                                            filename, "#" + relativePath, extension, relativePath, acls));
+                                            filename,
+                                            "#" + relativePath,
+                                            extension,
+                                            relativePath,
+                                            acls,
+                                            owner,
+                                            modified));
                                 }
                             }
                         }

--- a/saiku-core/saiku-service/src/main/java/org/saiku/repository/RepositoryFileObject.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/repository/RepositoryFileObject.java
@@ -10,14 +10,37 @@ public class RepositoryFileObject implements IRepositoryObject {
     private final String filetype;
     private final String path;
     private final List<AclMethod> acl;
+    /** Optional ACL owner — populated when {@link Acl2#getOwner} finds one,
+     *  null otherwise. Used by the catalogue's #935 owner filter. */
+    private final String owner;
+    /** Filesystem last-modified time in millis since epoch. Used by the
+     *  catalogue's #935 modified-sort. {@code 0} when the underlying
+     *  storage doesn't expose mtime. */
+    private final long modified;
 
+    /** Legacy constructor preserved for any external callers; new ones
+     *  should use {@link #RepositoryFileObject(String, String, String, String, List, String, long)}
+     *  so the {@code owner} + {@code modified} catalogue fields aren't lost. */
     public RepositoryFileObject(String filename, String id, String filetype, String path, List<AclMethod> acl) {
+        this(filename, id, filetype, path, acl, null, 0L);
+    }
+
+    public RepositoryFileObject(
+            String filename,
+            String id,
+            String filetype,
+            String path,
+            List<AclMethod> acl,
+            String owner,
+            long modified) {
         this.type = Type.FILE;
         this.name = filename;
         this.id = id;
         this.filetype = filetype;
         this.path = path;
         this.acl = acl;
+        this.owner = owner;
+        this.modified = modified;
     }
 
     public Type getType() {
@@ -42,5 +65,13 @@ public class RepositoryFileObject implements IRepositoryObject {
 
     public List<AclMethod> getAcl() {
         return acl;
+    }
+
+    public String getOwner() {
+        return owner;
+    }
+
+    public long getModified() {
+        return modified;
     }
 }

--- a/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/dashboards/Dashboard.java
+++ b/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/dashboards/Dashboard.java
@@ -40,4 +40,9 @@ public class Dashboard {
      *  the client populates it on first load by promoting any
      *  {@code type:"filter"} tiles. */
     public DashboardFilterPanel filterPanel;
+
+    /** Free-text labels for catalogue grouping + filtering (#935).
+     *  Optional — older dashboards round-trip through {@code null} and
+     *  the catalogue simply doesn't surface them in the tag dropdown. */
+    public List<String> tags;
 }

--- a/saiku-ui/src/lib/api/dashboards.ts
+++ b/saiku-ui/src/lib/api/dashboards.ts
@@ -157,6 +157,8 @@ export interface Dashboard {
   layout: DashboardLayout;
   filters: DashboardFilter[];
   filterPanel?: DashboardFilterPanel;
+  /** Free-text labels for catalogue grouping + filtering (#935). */
+  tags?: string[];
 }
 
 export interface DashboardSaveResponse {

--- a/saiku-ui/src/lib/api/repository.ts
+++ b/saiku-ui/src/lib/api/repository.ts
@@ -9,6 +9,13 @@ export interface RepositoryNode {
   fileType?: string | null;
   acl?: string | null;
   repoObjects?: RepositoryNode[];
+  /** ACL owner of the file, when the server can resolve one from the
+   *  closest {@code acl.json}. Used by the catalogue's #935 owner filter. */
+  owner?: string | null;
+  /** Last-modified time in millis since epoch. Used by the catalogue's
+   *  #935 modified-sort. {@code 0} when the storage layer doesn't
+   *  expose mtime. */
+  modified?: number;
 }
 
 export type AclType = "PRIVATE" | "SECURED" | "PUBLIC";

--- a/saiku-ui/src/lib/dashboard/catalogueFilter.test.ts
+++ b/saiku-ui/src/lib/dashboard/catalogueFilter.test.ts
@@ -1,0 +1,195 @@
+/*
+ * Unit tests for catalogue filter / sort helpers (#935).
+ */
+
+import { describe, expect, it } from "vitest";
+
+import {
+  UNKNOWN_OWNER,
+  applyCatalogueFilters,
+  collectOwners,
+  collectTags,
+  ownerPredicate,
+  searchPredicate,
+  sortComparator,
+  tagPredicate,
+  type CatalogueEntry,
+} from "./catalogueFilter";
+
+function entry(partial: Partial<CatalogueEntry> & { path: string }): CatalogueEntry {
+  return {
+    title: null,
+    tags: [],
+    owner: null,
+    modified: 0,
+    basename: partial.basename ?? partial.path.split("/").pop()!.replace(/\.saikudash$/, ""),
+    ...partial,
+  };
+}
+
+describe("searchPredicate", () => {
+  it("matches everything when query is blank or whitespace", () => {
+    const p = searchPredicate("   ");
+    expect(p(entry({ path: "anything.saikudash" }))).toBe(true);
+  });
+
+  it("matches the title case-insensitively", () => {
+    const p = searchPredicate("SALES");
+    expect(p(entry({ path: "x.saikudash", title: "Quarterly Sales" }))).toBe(true);
+  });
+
+  it("falls back to basename when title is null", () => {
+    const p = searchPredicate("sales");
+    expect(p(entry({ path: "homes/a/sales.saikudash", title: null }))).toBe(true);
+  });
+
+  it("matches the path", () => {
+    const p = searchPredicate("marketing");
+    expect(p(entry({ path: "homes/a/marketing/x.saikudash" }))).toBe(true);
+  });
+
+  it("returns false when no field contains the query", () => {
+    const p = searchPredicate("zzz");
+    expect(p(entry({ path: "homes/a/sales.saikudash", title: "Sales" }))).toBe(false);
+  });
+});
+
+describe("tagPredicate", () => {
+  it("matches everything when selection is empty", () => {
+    const p = tagPredicate([]);
+    expect(p(entry({ path: "x.saikudash", tags: [] }))).toBe(true);
+  });
+
+  it("requires all selected tags to be present (AND)", () => {
+    const p = tagPredicate(["exec", "finance"]);
+    expect(p(entry({ path: "a", tags: ["exec", "finance"] }))).toBe(true);
+    expect(p(entry({ path: "b", tags: ["exec"] }))).toBe(false);
+    expect(p(entry({ path: "c", tags: ["exec", "finance", "extra"] }))).toBe(true);
+    expect(p(entry({ path: "d", tags: [] }))).toBe(false);
+  });
+});
+
+describe("ownerPredicate", () => {
+  it("matches everything when selection is empty", () => {
+    const p = ownerPredicate([]);
+    expect(p(entry({ path: "x", owner: "alice" }))).toBe(true);
+    expect(p(entry({ path: "y", owner: null }))).toBe(true);
+  });
+
+  it("matches OR-semantics on selected owners", () => {
+    const p = ownerPredicate(["alice", "bob"]);
+    expect(p(entry({ path: "a", owner: "alice" }))).toBe(true);
+    expect(p(entry({ path: "b", owner: "bob" }))).toBe(true);
+    expect(p(entry({ path: "c", owner: "carol" }))).toBe(false);
+  });
+
+  it("excludes null-owner entries unless UNKNOWN_OWNER is selected", () => {
+    const p = ownerPredicate(["alice"]);
+    expect(p(entry({ path: "a", owner: null }))).toBe(false);
+    const q = ownerPredicate(["alice", UNKNOWN_OWNER]);
+    expect(q(entry({ path: "b", owner: null }))).toBe(true);
+    expect(q(entry({ path: "c", owner: "alice" }))).toBe(true);
+    expect(q(entry({ path: "d", owner: "bob" }))).toBe(false);
+  });
+});
+
+describe("sortComparator", () => {
+  const a = entry({ path: "a.saikudash", title: "Apple", modified: 100 });
+  const b = entry({ path: "b.saikudash", title: "Banana", modified: 300 });
+  const c = entry({ path: "c.saikudash", title: "Cherry", modified: 200 });
+
+  it("name (default) is case-insensitive alphabetical on title/basename", () => {
+    const sorted = [c, a, b].sort(sortComparator("name"));
+    expect(sorted.map((e) => e.title)).toEqual(["Apple", "Banana", "Cherry"]);
+  });
+
+  it("modified-desc puts most-recent first", () => {
+    const sorted = [a, b, c].sort(sortComparator("modified-desc"));
+    expect(sorted.map((e) => e.title)).toEqual(["Banana", "Cherry", "Apple"]);
+  });
+
+  it("modified-asc puts oldest first", () => {
+    const sorted = [a, b, c].sort(sortComparator("modified-asc"));
+    expect(sorted.map((e) => e.title)).toEqual(["Apple", "Cherry", "Banana"]);
+  });
+
+  it("name is the tiebreaker when modified ties", () => {
+    const x = entry({ path: "x.saikudash", title: "Xenon", modified: 100 });
+    const y = entry({ path: "y.saikudash", title: "Argon", modified: 100 });
+    const sorted = [x, y].sort(sortComparator("modified-desc"));
+    expect(sorted.map((e) => e.title)).toEqual(["Argon", "Xenon"]);
+  });
+});
+
+describe("applyCatalogueFilters", () => {
+  const entries: CatalogueEntry[] = [
+    entry({
+      path: "homes/alice/sales.saikudash",
+      title: "Sales Q4",
+      tags: ["exec", "finance"],
+      owner: "alice",
+      modified: 300,
+    }),
+    entry({
+      path: "homes/bob/ops.saikudash",
+      title: "Ops dashboard",
+      tags: ["ops"],
+      owner: "bob",
+      modified: 100,
+    }),
+    entry({
+      path: "homes/alice/marketing.saikudash",
+      title: "Marketing",
+      tags: ["marketing", "exec"],
+      owner: "alice",
+      modified: 200,
+    }),
+  ];
+
+  it("returns everything sorted by name when no filters apply", () => {
+    const out = applyCatalogueFilters(entries, {});
+    expect(out.map((e) => e.title)).toEqual(["Marketing", "Ops dashboard", "Sales Q4"]);
+  });
+
+  it("combines search + tag + owner + sort", () => {
+    const out = applyCatalogueFilters(entries, {
+      search: "marketing",
+      tags: ["exec"],
+      owners: ["alice"],
+      sort: "modified-desc",
+    });
+    expect(out.map((e) => e.title)).toEqual(["Marketing"]);
+  });
+
+  it("does not mutate the input array", () => {
+    const snapshot = entries.slice();
+    applyCatalogueFilters(entries, { sort: "modified-desc" });
+    expect(entries).toEqual(snapshot);
+  });
+});
+
+describe("collectTags / collectOwners", () => {
+  const entries: CatalogueEntry[] = [
+    entry({ path: "a", tags: ["exec", "finance"], owner: "alice" }),
+    entry({ path: "b", tags: ["ops"], owner: "bob" }),
+    entry({ path: "c", tags: ["exec"], owner: null }),
+  ];
+
+  it("collectTags returns the union alphabetised", () => {
+    expect(collectTags(entries)).toEqual(["exec", "finance", "ops"]);
+  });
+
+  it("collectTags skips empty / falsy tag values", () => {
+    const noisy = [entry({ path: "x", tags: ["", "real"] })];
+    expect(collectTags(noisy)).toEqual(["real"]);
+  });
+
+  it("collectOwners returns the union, with UNKNOWN_OWNER appended when any are null", () => {
+    expect(collectOwners(entries)).toEqual(["alice", "bob", UNKNOWN_OWNER]);
+  });
+
+  it("collectOwners omits UNKNOWN_OWNER when all entries have a real owner", () => {
+    const onlyOwners = entries.filter((e) => e.owner != null);
+    expect(collectOwners(onlyOwners)).toEqual(["alice", "bob"]);
+  });
+});

--- a/saiku-ui/src/lib/dashboard/catalogueFilter.ts
+++ b/saiku-ui/src/lib/dashboard/catalogueFilter.ts
@@ -1,0 +1,151 @@
+/*
+ * Pure helpers for the dashboard catalogue's search + filter + sort UX
+ * (#935). Filters are *additive* — the catalogue applies all configured
+ * predicates in sequence, then sorts the result.
+ *
+ * Each predicate factory returns a function on an enriched catalogue
+ * entry (RepositoryNode + the dashboard's own name/tags loaded
+ * separately). Keeping the predicate factories pure makes the
+ * compound filter easy to unit-test without spinning up a Svelte
+ * harness.
+ */
+
+/** Minimal shape the catalogue keeps in memory per entry. The
+ *  repository listing supplies most of this; `title` and `tags` come
+ *  from the dashboard JSON loaded lazily on catalogue mount. */
+export interface CatalogueEntry {
+  path: string;
+  /** Filename without the `.saikudash` extension. */
+  basename: string;
+  /** Human-readable dashboard name from the JSON, or `null` while the
+   *  JSON is still loading / failed to load. Search falls back to
+   *  `basename` when this is null. */
+  title: string | null;
+  /** Tags from the dashboard JSON, empty when none / still loading. */
+  tags: string[];
+  /** ACL owner, when known. `null` when the server didn't resolve one. */
+  owner: string | null;
+  /** Last-modified millis since epoch, `0` when unknown. */
+  modified: number;
+}
+
+/** Build a case-insensitive substring predicate for the search box.
+ *  Matches on title (when available) and basename + path. Empty / blank
+ *  query matches everything. */
+export function searchPredicate(query: string): (e: CatalogueEntry) => boolean {
+  const q = query.trim().toLowerCase();
+  if (!q) return () => true;
+  return (e) => {
+    if (e.title && e.title.toLowerCase().includes(q)) return true;
+    if (e.basename.toLowerCase().includes(q)) return true;
+    if (e.path.toLowerCase().includes(q)) return true;
+    return false;
+  };
+}
+
+/** Build a tag-membership predicate. AND semantics — all selected tags
+ *  must appear on the entry. Empty selection matches everything. */
+export function tagPredicate(selected: ReadonlyArray<string>): (e: CatalogueEntry) => boolean {
+  if (selected.length === 0) return () => true;
+  const wanted = new Set(selected);
+  return (e) => {
+    if (e.tags.length === 0) return false;
+    const have = new Set(e.tags);
+    for (const t of wanted) {
+      if (!have.has(t)) return false;
+    }
+    return true;
+  };
+}
+
+/** Build an owner-membership predicate. OR semantics — any selected
+ *  owner matches. Empty selection matches everything. Entries with
+ *  `owner === null` only match when the special sentinel "(unknown)"
+ *  is selected, so an admin can deliberately surface ACL-leaks. */
+export const UNKNOWN_OWNER = "(unknown)";
+
+export function ownerPredicate(selected: ReadonlyArray<string>): (e: CatalogueEntry) => boolean {
+  if (selected.length === 0) return () => true;
+  const wanted = new Set(selected);
+  return (e) => {
+    if (e.owner == null) return wanted.has(UNKNOWN_OWNER);
+    return wanted.has(e.owner);
+  };
+}
+
+/** Sort options surfaced by the catalogue toolbar's sort-by dropdown. */
+export type SortKey = "name" | "modified-desc" | "modified-asc";
+
+/** Build a comparator for the given sort key. Stable ordering is
+ *  achieved by name as the tiebreaker when sorting by modified. */
+export function sortComparator(key: SortKey): (a: CatalogueEntry, b: CatalogueEntry) => number {
+  const byName = (a: CatalogueEntry, b: CatalogueEntry): number => {
+    const ax = (a.title ?? a.basename).toLowerCase();
+    const bx = (b.title ?? b.basename).toLowerCase();
+    return ax.localeCompare(bx);
+  };
+  switch (key) {
+    case "modified-desc":
+      return (a, b) => {
+        if (b.modified !== a.modified) return b.modified - a.modified;
+        return byName(a, b);
+      };
+    case "modified-asc":
+      return (a, b) => {
+        if (a.modified !== b.modified) return a.modified - b.modified;
+        return byName(a, b);
+      };
+    case "name":
+    default:
+      return byName;
+  }
+}
+
+/** Apply search + tag + owner predicates in series, then sort by the
+ *  given key. Returns a new array — does not mutate {@code entries}. */
+export function applyCatalogueFilters(
+  entries: ReadonlyArray<CatalogueEntry>,
+  opts: {
+    search?: string;
+    tags?: ReadonlyArray<string>;
+    owners?: ReadonlyArray<string>;
+    sort?: SortKey;
+  },
+): CatalogueEntry[] {
+  const s = searchPredicate(opts.search ?? "");
+  const t = tagPredicate(opts.tags ?? []);
+  const o = ownerPredicate(opts.owners ?? []);
+  const out = entries.filter((e) => s(e) && t(e) && o(e));
+  out.sort(sortComparator(opts.sort ?? "name"));
+  return out;
+}
+
+/** Collect the union of all tags across the supplied entries, sorted
+ *  alphabetically. Used to populate the tag-filter dropdown. */
+export function collectTags(entries: ReadonlyArray<CatalogueEntry>): string[] {
+  const set = new Set<string>();
+  for (const e of entries) {
+    for (const t of e.tags) {
+      if (t) set.add(t);
+    }
+  }
+  return Array.from(set).sort((a, b) => a.localeCompare(b));
+}
+
+/** Collect the union of owners across the supplied entries, sorted
+ *  alphabetically. Entries with `owner === null` contribute the
+ *  {@link UNKNOWN_OWNER} sentinel. */
+export function collectOwners(entries: ReadonlyArray<CatalogueEntry>): string[] {
+  const set = new Set<string>();
+  let hasUnknown = false;
+  for (const e of entries) {
+    if (e.owner == null) {
+      hasUnknown = true;
+    } else if (e.owner) {
+      set.add(e.owner);
+    }
+  }
+  const sorted = Array.from(set).sort((a, b) => a.localeCompare(b));
+  if (hasUnknown) sorted.push(UNKNOWN_OWNER);
+  return sorted;
+}

--- a/saiku-ui/src/lib/stores/dashboard.svelte.ts
+++ b/saiku-ui/src/lib/stores/dashboard.svelte.ts
@@ -150,6 +150,22 @@ class DashboardStore {
     this.markDirty();
   }
 
+  /** Replace the dashboard's tag list. Deduped + trimmed; empty list
+   *  collapses to undefined so the persisted JSON stays clean. (#935) */
+  updateTags(tags: string[]): void {
+    if (!this.current) return;
+    const cleaned = Array.from(
+      new Set(tags.map((t) => t.trim()).filter((t) => t.length > 0)),
+    );
+    const next = cleaned.length === 0 ? undefined : cleaned;
+    const same =
+      (this.current.tags ?? []).length === (next ?? []).length &&
+      (this.current.tags ?? []).every((t, i) => t === (next ?? [])[i]);
+    if (same) return;
+    this.current = { ...this.current, tags: next };
+    this.markDirty();
+  }
+
   /** Replace the entire tiles array. Used by repositionTile callers
    *  (the edit modal) that need to commit a tile move AND any cascaded
    *  shifts on neighbours in a single dirty bump. */

--- a/saiku-ui/src/lib/views/dashboard/DashboardEditor.svelte
+++ b/saiku-ui/src/lib/views/dashboard/DashboardEditor.svelte
@@ -91,6 +91,10 @@
     dashboardStore.updateName(name);
   }
 
+  function handleTagsChange(tags: string[]): void {
+    dashboardStore.updateTags(tags);
+  }
+
   function handleAddTile(type: TileType): void {
     const layout = dashboardStore.current?.layout;
     if (!layout) return;
@@ -106,6 +110,8 @@
     <DashboardToolbar
       name={dashboardStore.current.name}
       onNameChange={handleNameChange}
+      tags={dashboardStore.current.tags ?? []}
+      onTagsChange={handleTagsChange}
       {readOnly}
       saving={dashboardStore.saving}
       dirty={dashboardStore.dirty}

--- a/saiku-ui/src/lib/views/dashboard/DashboardIndex.svelte
+++ b/saiku-ui/src/lib/views/dashboard/DashboardIndex.svelte
@@ -42,6 +42,13 @@
   import Skeleton from "$lib/components/Skeleton.svelte";
   import EmptyState from "$lib/components/EmptyState.svelte";
   import { Copy, ShieldCheck, LayoutDashboard, Star } from "lucide-svelte";
+  import {
+    applyCatalogueFilters,
+    collectOwners,
+    collectTags,
+    type CatalogueEntry,
+    type SortKey,
+  } from "$lib/dashboard/catalogueFilter";
 
   let entries = $state<RepositoryNode[]>([]);
   let loading = $state<boolean>(true);
@@ -60,6 +67,16 @@
   let newModalOpen = $state<boolean>(false);
   let deletingPath = $state<string | null>(null);
 
+  /** Title + tags pulled out of each dashboard's JSON. Populated by
+   *  {@link enrichEntries} after the listing arrives so the catalogue
+   *  can show real names (not filename slugs) and filter on tags. (#935) */
+  let catalogueMeta = $state<Map<string, { title: string | null; tags: string[] }>>(new Map());
+
+  let searchQuery = $state<string>("");
+  let selectedTags = $state<string[]>([]);
+  let selectedOwners = $state<string[]>([]);
+  let sortKey = $state<SortKey>("name");
+
   async function refresh(): Promise<void> {
     loading = true;
     loadError = null;
@@ -69,11 +86,37 @@
       entries = flat.filter(
         (n) => n.type === "FILE" && (n.fileType === "saikudash" || n.path.endsWith(".saikudash")),
       );
+      // Kick off the metadata enrichment — the catalogue renders
+      // immediately with basename-only labels and lights up real names
+      // + tags as each fetch resolves. Doesn't block the UI thread
+      // and tolerates per-entry failures (one bad dashboard doesn't
+      // poison the whole catalogue). (#935)
+      void enrichEntries(entries);
     } catch (e: unknown) {
       loadError = e instanceof Error ? e.message : String(e);
     } finally {
       loading = false;
     }
+  }
+
+  /** Load each dashboard's JSON in parallel and stash the title + tags
+   *  in {@link catalogueMeta}. Per-entry errors are swallowed — a
+   *  dashboard with a malformed body just stays "title:null, tags:[]"
+   *  and falls back to its basename in the UI. */
+  async function enrichEntries(items: ReadonlyArray<RepositoryNode>): Promise<void> {
+    const fresh = new Map<string, { title: string | null; tags: string[] }>();
+    await Promise.all(
+      items.map(async (n) => {
+        const relPath = toRepoRelative(n.path);
+        try {
+          const d = await loadDashboard(relPath);
+          fresh.set(n.path, { title: d.name ?? null, tags: d.tags ?? [] });
+        } catch {
+          fresh.set(n.path, { title: null, tags: [] });
+        }
+      }),
+    );
+    catalogueMeta = fresh;
   }
 
   onMount(() => {
@@ -246,6 +289,46 @@
   function toggleFavourite(path: string): void {
     favouriteDashboards.toggle(path);
   }
+
+  /** Project the raw repo listing into the enriched CatalogueEntry shape
+   *  the filter helpers expect. Title/tags come from {@link catalogueMeta}
+   *  when the per-dashboard fetch has landed; otherwise nulls/empties.
+   *  Owner + modified pass straight through from the listing response. */
+  let catalogueEntries = $derived<CatalogueEntry[]>(
+    entries.map((n) => {
+      const meta = catalogueMeta.get(n.path);
+      return {
+        path: n.path,
+        basename: basename(toRepoRelative(n.path)),
+        title: meta?.title ?? null,
+        tags: meta?.tags ?? [],
+        owner: n.owner ?? null,
+        modified: n.modified ?? 0,
+      };
+    }),
+  );
+
+  let filteredEntries = $derived(
+    applyCatalogueFilters(catalogueEntries, {
+      search: searchQuery,
+      tags: selectedTags,
+      owners: selectedOwners,
+      sort: sortKey,
+    }),
+  );
+
+  let availableTags = $derived(collectTags(catalogueEntries));
+  let availableOwners = $derived(collectOwners(catalogueEntries));
+
+  function toggleSelected(list: string[], value: string): string[] {
+    return list.includes(value) ? list.filter((x) => x !== value) : [...list, value];
+  }
+
+  function clearFilters(): void {
+    searchQuery = "";
+    selectedTags = [];
+    selectedOwners = [];
+  }
 </script>
 
 <div class="page">
@@ -318,13 +401,75 @@
       </section>
     {/if}
 
+    <section class="catalogue-filters" aria-label="Catalogue filters">
+      <input
+        type="search"
+        class="search"
+        placeholder="Search dashboards by name or path…"
+        bind:value={searchQuery}
+        aria-label="Search dashboards"
+      />
+      <label class="sort">
+        <span>Sort:</span>
+        <select bind:value={sortKey} aria-label="Sort dashboards">
+          <option value="name">Name</option>
+          <option value="modified-desc">Last modified ↓</option>
+          <option value="modified-asc">Last modified ↑</option>
+        </select>
+      </label>
+      {#if searchQuery || selectedTags.length > 0 || selectedOwners.length > 0}
+        <button type="button" class="btn btn--ghost" onclick={clearFilters}>
+          Clear filters
+        </button>
+      {/if}
+    </section>
+
+    {#if availableTags.length > 0 || availableOwners.length > 0}
+      <section class="filter-chips" aria-label="Tag and owner filters">
+        {#if availableTags.length > 0}
+          <div class="chip-group" aria-label="Filter by tag">
+            <span class="chip-group-label">Tags</span>
+            {#each availableTags as t (t)}
+              {@const selected = selectedTags.includes(t)}
+              <button
+                type="button"
+                class="chip"
+                class:chip--on={selected}
+                aria-pressed={selected}
+                onclick={() => (selectedTags = toggleSelected(selectedTags, t))}
+              >
+                {t}
+              </button>
+            {/each}
+          </div>
+        {/if}
+        {#if availableOwners.length > 0}
+          <div class="chip-group" aria-label="Filter by owner">
+            <span class="chip-group-label">Owners</span>
+            {#each availableOwners as o (o)}
+              {@const selected = selectedOwners.includes(o)}
+              <button
+                type="button"
+                class="chip"
+                class:chip--on={selected}
+                aria-pressed={selected}
+                onclick={() => (selectedOwners = toggleSelected(selectedOwners, o))}
+              >
+                {o}
+              </button>
+            {/each}
+          </div>
+        {/if}
+      </section>
+    {/if}
+
     <ul class="list">
-      {#each entries as e (e.path)}
+      {#each filteredEntries as e (e.path)}
         {@const relPath = toRepoRelative(e.path)}
         {@const isFav = favouriteDashboards.isFavourite(relPath)}
         <li class="row">
           <a class="link" href="{base}/dashboards/{relPath}" title={relPath}>
-            <span class="name">{basename(relPath)}</span>
+            <span class="name">{e.title ?? e.basename}</span>
             <span class="path">{relPath}</span>
           </a>
           <button
@@ -528,5 +673,79 @@
   }
   .btn.star--on:hover {
     color: var(--accent);
+  }
+  .catalogue-filters {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    flex-wrap: wrap;
+  }
+  .catalogue-filters .search {
+    flex: 1;
+    min-width: 12rem;
+    padding: 0.5rem 0.75rem;
+    border: 1px solid var(--border-strong);
+    border-radius: 4px;
+    background: var(--bg);
+    font-size: 0.875rem;
+  }
+  .catalogue-filters .sort {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.375rem;
+    font-size: 0.8125rem;
+    color: var(--fg-muted);
+  }
+  .catalogue-filters select {
+    padding: 0.375rem 0.5rem;
+    border: 1px solid var(--border-strong);
+    border-radius: 4px;
+    background: var(--bg);
+    font-size: 0.8125rem;
+  }
+  .btn--ghost {
+    background: transparent;
+    border-color: var(--border);
+    color: var(--fg-muted);
+    font-size: 0.8125rem;
+  }
+  .filter-chips {
+    display: flex;
+    flex-direction: column;
+    gap: 0.375rem;
+  }
+  .chip-group {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 0.375rem;
+  }
+  .chip-group-label {
+    font-size: 0.6875rem;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    color: var(--fg-muted);
+    font-weight: var(--weight-medium);
+    margin-right: 0.25rem;
+  }
+  .chip {
+    padding: 0.25rem 0.625rem;
+    border: 1px solid var(--border);
+    border-radius: 999px;
+    background: var(--bg);
+    cursor: pointer;
+    font-size: 0.75rem;
+    color: var(--fg);
+  }
+  .chip:hover {
+    background: var(--bg-subtle);
+  }
+  .chip--on {
+    background: var(--accent);
+    color: white;
+    border-color: var(--accent);
+  }
+  .chip--on:hover {
+    background: var(--accent);
   }
 </style>

--- a/saiku-ui/src/lib/views/dashboard/DashboardIndex.svelte
+++ b/saiku-ui/src/lib/views/dashboard/DashboardIndex.svelte
@@ -355,6 +355,29 @@
       action={{ label: "+ New dashboard", onClick: handleNew }}
     />
   {:else}
+    <section class="catalogue-filters" aria-label="Catalogue filters">
+      <input
+        type="search"
+        class="search"
+        placeholder="Search dashboards by name or path…"
+        bind:value={searchQuery}
+        aria-label="Search dashboards"
+      />
+      <label class="sort">
+        <span>Sort:</span>
+        <select bind:value={sortKey} aria-label="Sort dashboards">
+          <option value="name">Name</option>
+          <option value="modified-desc">Last modified ↓</option>
+          <option value="modified-asc">Last modified ↑</option>
+        </select>
+      </label>
+      {#if searchQuery || selectedTags.length > 0 || selectedOwners.length > 0}
+        <button type="button" class="btn btn--ghost" onclick={clearFilters}>
+          Clear filters
+        </button>
+      {/if}
+    </section>
+
     {#if favouriteEntries.length > 0}
       <section class="pinned" aria-labelledby="favourites-heading">
         <h2 id="favourites-heading" class="pinned-heading">
@@ -400,29 +423,6 @@
         </ul>
       </section>
     {/if}
-
-    <section class="catalogue-filters" aria-label="Catalogue filters">
-      <input
-        type="search"
-        class="search"
-        placeholder="Search dashboards by name or path…"
-        bind:value={searchQuery}
-        aria-label="Search dashboards"
-      />
-      <label class="sort">
-        <span>Sort:</span>
-        <select bind:value={sortKey} aria-label="Sort dashboards">
-          <option value="name">Name</option>
-          <option value="modified-desc">Last modified ↓</option>
-          <option value="modified-asc">Last modified ↑</option>
-        </select>
-      </label>
-      {#if searchQuery || selectedTags.length > 0 || selectedOwners.length > 0}
-        <button type="button" class="btn btn--ghost" onclick={clearFilters}>
-          Clear filters
-        </button>
-      {/if}
-    </section>
 
     {#if availableTags.length > 0 || availableOwners.length > 0}
       <section class="filter-chips" aria-label="Tag and owner filters">

--- a/saiku-ui/src/lib/views/dashboard/DashboardToolbar.svelte
+++ b/saiku-ui/src/lib/views/dashboard/DashboardToolbar.svelte
@@ -15,10 +15,13 @@
   import AddTileMenu from "$lib/views/dashboard/AddTileMenu.svelte";
   import FilterSuggestionsModal from "$lib/views/dashboard/FilterSuggestionsModal.svelte";
   import type { TileType } from "$lib/api/dashboards";
+  import { X } from "lucide-svelte";
 
   interface Props {
     name: string;
     onNameChange?: (next: string) => void;
+    tags?: string[];
+    onTagsChange?: (next: string[]) => void;
     readOnly?: boolean;
     saving?: boolean;
     dirty?: boolean;
@@ -29,6 +32,8 @@
   let {
     name,
     onNameChange,
+    tags = [],
+    onTagsChange,
     readOnly = false,
     saving = false,
     dirty = false,
@@ -37,6 +42,7 @@
   }: Props = $props();
 
   let suggestOpen = $state(false);
+  let newTagInput = $state<string>("");
 
   // The input is controlled by the `name` prop directly — the store is
   // the source of truth. onNameChange propagates user edits upstream and
@@ -44,21 +50,93 @@
   function handleNameInput(e: Event): void {
     onNameChange?.((e.target as HTMLInputElement).value);
   }
+
+  /** Commit the new-tag input. Trims whitespace; ignores empty / dupes
+   *  (the store de-dupes too, this is just to keep the chip rendering
+   *  intuitive). Splits on comma so users can paste "a, b, c". */
+  function commitNewTag(): void {
+    const raw = newTagInput.trim();
+    if (!raw) return;
+    const incoming = raw
+      .split(",")
+      .map((s) => s.trim())
+      .filter((s) => s.length > 0 && !tags.includes(s));
+    if (incoming.length === 0) {
+      newTagInput = "";
+      return;
+    }
+    onTagsChange?.([...tags, ...incoming]);
+    newTagInput = "";
+  }
+
+  function removeTag(t: string): void {
+    onTagsChange?.(tags.filter((x) => x !== t));
+  }
+
+  function handleTagInputKeydown(e: KeyboardEvent): void {
+    if (e.key === "Enter") {
+      e.preventDefault();
+      commitNewTag();
+    } else if (e.key === "Backspace" && newTagInput === "" && tags.length > 0) {
+      // Backspace on empty input removes the last chip — standard chip-
+      // picker UX.
+      e.preventDefault();
+      removeTag(tags[tags.length - 1]);
+    }
+  }
 </script>
 
 <header class="toolbar" role="toolbar" aria-label="Dashboard toolbar">
-  {#if readOnly}
-    <h1 class="name-readonly">{name}</h1>
-  {:else}
-    <input
-      class="name"
-      type="text"
-      value={name}
-      oninput={handleNameInput}
-      placeholder="Untitled dashboard"
-      aria-label="Dashboard name"
-    />
-  {/if}
+  <div class="title-block">
+    {#if readOnly}
+      <h1 class="name-readonly">{name}</h1>
+    {:else}
+      <input
+        class="name"
+        type="text"
+        value={name}
+        oninput={handleNameInput}
+        placeholder="Untitled dashboard"
+        aria-label="Dashboard name"
+      />
+    {/if}
+
+    {#if readOnly}
+      {#if tags.length > 0}
+        <div class="tags" aria-label="Dashboard tags">
+          {#each tags as t (t)}
+            <span class="tag-chip">{t}</span>
+          {/each}
+        </div>
+      {/if}
+    {:else}
+      <div class="tags" aria-label="Dashboard tags">
+        {#each tags as t (t)}
+          <span class="tag-chip">
+            {t}
+            <button
+              type="button"
+              class="tag-remove"
+              onclick={() => removeTag(t)}
+              aria-label="Remove tag {t}"
+              title="Remove tag"
+            >
+              <X size={10} />
+            </button>
+          </span>
+        {/each}
+        <input
+          class="tag-input"
+          type="text"
+          bind:value={newTagInput}
+          onkeydown={handleTagInputKeydown}
+          onblur={commitNewTag}
+          placeholder={tags.length === 0 ? "Add tags…" : "Add tag"}
+          aria-label="Add tag"
+        />
+      </div>
+    {/if}
+  </div>
 
   <div class="spacer"></div>
 
@@ -100,10 +178,16 @@
 <style>
   .toolbar {
     display: flex;
-    align-items: center;
+    align-items: flex-start;
     gap: 0.75rem;
     padding: 0.5rem 0.25rem;
     border-bottom: 1px solid var(--border);
+  }
+  .title-block {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+    min-width: 0;
   }
   .name {
     font-size: 1.125rem;
@@ -123,6 +207,48 @@
     font-size: 1.125rem;
     font-weight: var(--weight-semibold);
     margin: 0;
+  }
+  .tags {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.25rem;
+    align-items: center;
+    padding-left: 0.5rem;
+  }
+  .tag-chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.25rem;
+    padding: 0.125rem 0.5rem;
+    border-radius: 999px;
+    background: var(--bg-subtle);
+    color: var(--fg);
+    font-size: 0.6875rem;
+    line-height: 1.4;
+  }
+  .tag-remove {
+    background: none;
+    border: none;
+    padding: 0;
+    color: var(--fg-muted);
+    cursor: pointer;
+    display: inline-flex;
+    align-items: center;
+  }
+  .tag-remove:hover {
+    color: var(--danger);
+  }
+  .tag-input {
+    border: 1px dashed transparent;
+    background: transparent;
+    padding: 0.125rem 0.375rem;
+    font-size: 0.6875rem;
+    min-width: 6rem;
+    color: var(--fg);
+  }
+  .tag-input:hover, .tag-input:focus {
+    border-color: var(--border-strong);
+    outline: none;
   }
   .spacer { flex: 1; }
   .actions {


### PR DESCRIPTION
## Summary

Full scope of the ticket — search, tag filter, owner filter, and last-modified sort all in one PR. Surfaces a catalogue toolbar (search box, sort dropdown, clear-filters button) plus two chip rows (tags + owners) above the main "All dashboards" list, and a tag chip editor under the dashboard name in the editor toolbar.

## The change

**UI — `DashboardIndex.svelte`:**
- Case-insensitive search across title, basename, and path
- Tag chips with AND semantics (all selected tags must match) — drawn from the union of all dashboards' tags
- Owner chips with OR semantics — drawn from the union of entry owners, with an `(unknown)` sentinel for files where the server couldn't resolve an ACL owner
- Sort dropdown: **Name** (default), **Last modified ↓**, **Last modified ↑**; name acts as the stable tiebreaker for modified ties
- "Clear filters" button appears when any of the three filters is active
- Pinned Favourites + Recently-viewed sections stay above the filters and are intentionally NOT filtered — those are short curated lists with their own ordering

**UI — `DashboardToolbar.svelte`:**
- Tag chip editor under the dashboard name. Existing chips with × to remove, comma-or-Enter to add, Backspace on empty input removes the last chip. Hidden in read-only mode.

**Backend — Java DTOs:**
- `Dashboard.tags: List<String>` — additive, optional. Existing dashboards round-trip through `null`.
- `RepositoryFileObject.owner` (String, from ACL) + `modified` (long, from `file.lastModified()`)
- `Acl2.getOwner(File)` — best-effort owner lookup that walks the same parent chain as `getMethods`. Returns null when no `acl.json` is reachable; the catalogue renders those entries under `(unknown)`.
- `FilesystemRepositoryManager` populates the two new fields when it constructs each `RepositoryFileObject` so the catalogue doesn't need a per-row ACL round-trip.

**Frontend plumbing:**
- `Dashboard.tags?: string[]` on the TS side, `RepositoryNode.owner?` + `.modified?` on the listing interface
- `dashboardStore.updateTags()` — dedups + trims input, collapses empty list to `undefined` so persisted JSON stays clean
- Per-dashboard metadata enrichment: catalogue fires `Promise.all(entries.map(loadDashboard))` after the initial listing, populating a `Map<path, {title, tags}>` as each fetch resolves. Per-entry errors are swallowed — one malformed dashboard stays `title:null, tags:[]` and falls back to its basename rather than poisoning the whole catalogue.

**Pure helpers — `$lib/dashboard/catalogueFilter.ts`:**
- `searchPredicate`, `tagPredicate`, `ownerPredicate`, `sortComparator`, `applyCatalogueFilters`
- `collectTags(entries)`, `collectOwners(entries)` — alphabetical, with `UNKNOWN_OWNER` appended only when any entry has null owner

## Verified

- `npx vitest run` — **276/276 passing** (255 → 276). 21 new cases in `catalogueFilter.test.ts` covering search (blank, title match, basename fallback, path match, no match), tag predicate (empty selection, AND semantics, partial match, empty entry tags), owner predicate (empty, OR semantics, null-owner handling with the UNKNOWN_OWNER sentinel), sort comparator (name, modified-desc, modified-asc, name-as-tiebreaker), combined apply, input immutability, and `collectTags` / `collectOwners`.
- `npm run check` — **0 errors**, 42 warnings, none in any file touched by this PR.
- Java changes not built locally — gated on GH Packages auth on this machine — but follow existing patterns: small DTO additions, one new helper method, one extra ctor on `RepositoryFileObject` with a deprecation-grade fallback for any external caller. CI's `build` job exercises `mvn verify` on JDK 21 across both OSes.

## Test plan

- [ ] CI green (both OS, JDK 21) including the Java side
- [ ] Manual: catalogue page renders search box + sort dropdown above the main list
- [ ] Manual: typing in search filters the visible list in real time (case-insensitive substring on title / basename / path)
- [ ] Manual: with dashboards that have tags set, Tags chip row appears and clicking a chip filters to that tag (AND semantics — clicking a second chip narrows further)
- [ ] Manual: Owners row appears with the union of owners + `(unknown)` when applicable; clicking owners filters OR-semantics
- [ ] Manual: Sort dropdown reorders the list; switching to modified-desc puts the most-recently-edited dashboards on top
- [ ] Manual: editor toolbar shows a tag chip editor under the name; adding a tag persists across save + reload
- [ ] Manual: removing a tag via × marks the dashboard dirty so the Save button reactivates
- [ ] Manual: backspace in empty tag input removes the last tag chip

## Notes for the reviewer

- Eager `Promise.all` enrichment is fine at small scale (tens of dashboards). For deployments with hundreds of dashboards this should become a server-side tag index — happy to file as a follow-up if you want.
- `Acl2.getOwner` walks the same parent chain as `getMethods`; the recursion bottoms out at a null parent. The known dead-code case from #951 (`getName().equals("/")` never matching) doesn't affect this helper because it doesn't consult `rootMethod`.
- The Java `RepositoryFileObject` change keeps the old constructor as a delegation shim so any external caller compiles unchanged; new callers use the 7-arg ctor that supplies owner + modified.

Closes #935
