### PR TITLE
#1010 - starter-cube URL bootstrap so embedders can pre-populate the workbench

### DIFF
--- a/saiku-ui/src/lib/api/starterCube.test.ts
+++ b/saiku-ui/src/lib/api/starterCube.test.ts
@@ -1,0 +1,303 @@
+import { describe, expect, it } from "vitest";
+import {
+  findCubeByRef,
+  parseStarterCubeRef,
+  pickStarterLevelDrop,
+  pickStarterMeasure,
+  pickStarterMeasureAndLevel,
+} from "./starterCube";
+import type {
+  SaikuConnection,
+  SaikuDimension,
+  SaikuLevel,
+  SaikuMeasure,
+} from "./discover";
+
+describe("parseStarterCubeRef()", () => {
+  it("returns null when no params present", () => {
+    const params = new URLSearchParams();
+    expect(parseStarterCubeRef(params)).toBeNull();
+  });
+
+  it("returns null when any of the 4 fields is missing", () => {
+    const p = new URLSearchParams();
+    p.set("starterCubeConnection", "conn");
+    p.set("starterCubeCatalog", "cat");
+    p.set("starterCubeSchema", "sch");
+    // starterCubeName missing
+    expect(parseStarterCubeRef(p)).toBeNull();
+  });
+
+  it("returns null when a field is blank/whitespace", () => {
+    const p = new URLSearchParams();
+    p.set("starterCubeConnection", "  ");
+    p.set("starterCubeCatalog", "cat");
+    p.set("starterCubeSchema", "sch");
+    p.set("starterCubeName", "Sales");
+    expect(parseStarterCubeRef(p)).toBeNull();
+  });
+
+  it("parses all 4 fields when present", () => {
+    const p = new URLSearchParams();
+    p.set("starterCubeConnection", "my-conn");
+    p.set("starterCubeCatalog", "FoodMart");
+    p.set("starterCubeSchema", "FoodMart");
+    p.set("starterCubeName", "Sales");
+    expect(parseStarterCubeRef(p)).toEqual({
+      connection: "my-conn",
+      catalog: "FoodMart",
+      schema: "FoodMart",
+      name: "Sales",
+    });
+  });
+
+  it("trims surrounding whitespace", () => {
+    const p = new URLSearchParams();
+    p.set("starterCubeConnection", "  my-conn  ");
+    p.set("starterCubeCatalog", " FoodMart");
+    p.set("starterCubeSchema", "FoodMart ");
+    p.set("starterCubeName", " Sales ");
+    expect(parseStarterCubeRef(p)).toEqual({
+      connection: "my-conn",
+      catalog: "FoodMart",
+      schema: "FoodMart",
+      name: "Sales",
+    });
+  });
+});
+
+describe("findCubeByRef()", () => {
+  const connections: SaikuConnection[] = [
+    {
+      name: "conn-a",
+      catalogs: [
+        {
+          name: "cat",
+          schemas: [
+            {
+              name: "sch",
+              cubes: [
+                cube("Sales", "conn-a"),
+                cube("Inventory", "conn-a"),
+              ],
+            },
+          ],
+        },
+      ],
+    },
+    {
+      name: "conn-b",
+      catalogs: [
+        {
+          name: "cat",
+          schemas: [
+            {
+              name: "sch",
+              cubes: [cube("Sales", "conn-b")], // same cube name, different connection
+            },
+          ],
+        },
+      ],
+    },
+  ];
+
+  it("finds a cube by exact 4-tuple match", () => {
+    const found = findCubeByRef(connections, {
+      connection: "conn-a",
+      catalog: "cat",
+      schema: "sch",
+      name: "Inventory",
+    });
+    expect(found?.name).toBe("Inventory");
+    expect(found?.connection).toBe("conn-a");
+  });
+
+  it("disambiguates same cube name across connections", () => {
+    const found = findCubeByRef(connections, {
+      connection: "conn-b",
+      catalog: "cat",
+      schema: "sch",
+      name: "Sales",
+    });
+    expect(found?.connection).toBe("conn-b");
+  });
+
+  it("returns null when no cube matches", () => {
+    expect(
+      findCubeByRef(connections, {
+        connection: "missing",
+        catalog: "cat",
+        schema: "sch",
+        name: "Sales",
+      }),
+    ).toBeNull();
+  });
+});
+
+describe("pickStarterMeasure()", () => {
+  it("returns null on empty list", () => {
+    expect(pickStarterMeasure([])).toBeNull();
+  });
+
+  it("prefers a non-calculated measure over a calculated one", () => {
+    const measures: SaikuMeasure[] = [
+      { name: "Revenue per Order", caption: "Revenue/Order", uniqueName: "[Measures].[RPO]", calculated: true },
+      { name: "Revenue", caption: "Revenue", uniqueName: "[Measures].[Revenue]" },
+    ];
+    const picked = pickStarterMeasure(measures);
+    expect(picked?.name).toBe("Revenue");
+    expect(picked?.type).toBe("EXACT");
+  });
+
+  it("falls back to the first measure when all are calculated and tags type", () => {
+    const measures: SaikuMeasure[] = [
+      { name: "RPO", caption: "RPO", uniqueName: "[Measures].[RPO]", calculated: true },
+      { name: "Margin", caption: "Margin", uniqueName: "[Measures].[Margin]", calculated: true },
+    ];
+    const picked = pickStarterMeasure(measures);
+    expect(picked?.name).toBe("RPO");
+    expect(picked?.type).toBe("CALCULATED");
+  });
+
+  it("returns a ThinMeasure shape ready for query.addMeasure", () => {
+    const picked = pickStarterMeasure([
+      { name: "Revenue", caption: "", uniqueName: "[Measures].[Revenue]" },
+    ]);
+    expect(picked).toEqual({
+      name: "Revenue",
+      uniqueName: "[Measures].[Revenue]",
+      caption: "Revenue", // empty caption falls back to name
+      type: "EXACT",
+    });
+  });
+});
+
+describe("pickStarterLevelDrop()", () => {
+  it("returns null when no dimensions", () => {
+    expect(pickStarterLevelDrop([])).toBeNull();
+  });
+
+  it("prefers a time-named level (e.g. Year) over a String dim", () => {
+    const dims: SaikuDimension[] = [
+      dimension("Region", [hierarchy("Region", [level("Region")])]),
+      dimension("Time", [hierarchy("Time", [level("Year"), level("Month")])]),
+    ];
+    const drop = pickStarterLevelDrop(dims);
+    expect(drop?.dimensionName).toBe("Time");
+    expect(drop?.levelName).toBe("Year");
+  });
+
+  it("recognises a time-named DIMENSION when its levels are non-obvious", () => {
+    const dims: SaikuDimension[] = [
+      dimension("Region", [hierarchy("Region", [level("Region")])]),
+      dimension("Date", [hierarchy("Date", [level("All Members")])]),
+    ];
+    const drop = pickStarterLevelDrop(dims);
+    expect(drop?.dimensionName).toBe("Date");
+  });
+
+  it("falls back to first dim's first level when nothing is time-like", () => {
+    const dims: SaikuDimension[] = [
+      dimension("Product", [hierarchy("Product", [level("Category"), level("SKU")])]),
+      dimension("Region", [hierarchy("Region", [level("Region")])]),
+    ];
+    const drop = pickStarterLevelDrop(dims);
+    expect(drop?.dimensionName).toBe("Product");
+    expect(drop?.levelName).toBe("Category");
+  });
+
+  it("skips a dimension whose hierarchy has no levels", () => {
+    const dims: SaikuDimension[] = [
+      dimension("EmptyDim", [hierarchy("EmptyHier", [])]),
+      dimension("Region", [hierarchy("Region", [level("Region")])]),
+    ];
+    const drop = pickStarterLevelDrop(dims);
+    expect(drop?.dimensionName).toBe("Region");
+  });
+
+  it("returns a LevelDrop with all 7 chip fields populated", () => {
+    const dims: SaikuDimension[] = [
+      dimension("Region", [hierarchy("Region", [level("Region")])]),
+    ];
+    const drop = pickStarterLevelDrop(dims);
+    expect(drop).toEqual({
+      dimensionName: "Region",
+      dimensionUniqueName: "[Region]",
+      hierarchyName: "Region",
+      hierarchyUniqueName: "[Region.Region]",
+      hierarchyCaption: "Region",
+      levelName: "Region",
+      levelCaption: "Region",
+    });
+  });
+});
+
+describe("pickStarterMeasureAndLevel()", () => {
+  it("returns null when measures are empty", () => {
+    expect(
+      pickStarterMeasureAndLevel(
+        [],
+        [dimension("Region", [hierarchy("Region", [level("Region")])])],
+      ),
+    ).toBeNull();
+  });
+
+  it("returns null when dimensions are empty", () => {
+    expect(
+      pickStarterMeasureAndLevel(
+        [measure("Revenue")],
+        [],
+      ),
+    ).toBeNull();
+  });
+
+  it("returns both picks together when both axes have viable candidates", () => {
+    const r = pickStarterMeasureAndLevel(
+      [measure("Revenue")],
+      [dimension("Time", [hierarchy("Time", [level("Year")])])],
+    );
+    expect(r?.measure.name).toBe("Revenue");
+    expect(r?.drop.dimensionName).toBe("Time");
+    expect(r?.drop.levelName).toBe("Year");
+  });
+});
+
+// ----- helpers ------------------------------------------------------
+
+function cube(name: string, connection = "conn-a") {
+  return {
+    connection,
+    catalog: "cat",
+    schema: "sch",
+    name,
+    caption: name,
+    uniqueName: `[${name}]`,
+    visible: true,
+  };
+}
+
+function level(name: string): SaikuLevel {
+  return { name, caption: name, uniqueName: `[${name}]` };
+}
+
+function hierarchy(name: string, levels: SaikuLevel[]) {
+  return {
+    name,
+    caption: name,
+    uniqueName: `[${name}.${name}]`,
+    levels,
+  };
+}
+
+function dimension(name: string, hierarchies: ReturnType<typeof hierarchy>[]): SaikuDimension {
+  return {
+    name,
+    caption: name,
+    uniqueName: `[${name}]`,
+    hierarchies,
+  };
+}
+
+function measure(name: string): SaikuMeasure {
+  return { name, caption: name, uniqueName: `[Measures].[${name}]` };
+}

--- a/saiku-ui/src/lib/api/starterCube.ts
+++ b/saiku-ui/src/lib/api/starterCube.ts
@@ -1,0 +1,210 @@
+/**
+ * Starter-cube URL bootstrap (saiku-cloud#450 / saiku-ui contract).
+ *
+ * <p>When Saiku Studio is launched with the URL params:
+ * <pre>
+ *   ?starterCubeConnection=&lt;c&gt;
+ *   &amp;starterCubeCatalog=&lt;cat&gt;
+ *   &amp;starterCubeSchema=&lt;s&gt;
+ *   &amp;starterCubeName=&lt;n&gt;
+ * </pre>
+ * the {@link Workspace} mount hook resolves the cube via the
+ * existing discover endpoint, picks the first measure + first
+ * dimension level (preferring a time-typed hierarchy if any), and
+ * hydrates the workbench so the customer sees a populated query
+ * model immediately.
+ *
+ * <p>Critically: the workbench loads a <strong>query model</strong>,
+ * not a flat MDX result. Customer can drag a different measure,
+ * drill on the dim, or add filters — Studio re-fires the query on
+ * every interaction. Pre-baked MDX (which Studio can't round-trip
+ * into draggable chips because there's no MDX → model inverse
+ * parser) would freeze the workbench on the starter output.
+ *
+ * <p>The dashboard's Saiku Cloud `/saiku/launch?cube=&lt;id&gt;` is
+ * the typical caller; this contract is generic enough that any
+ * embedder can use it.
+ */
+
+import type {
+  SaikuConnection,
+  SaikuCube,
+  SaikuDimension,
+  SaikuLevel,
+  SaikuMeasure,
+} from "$lib/api/discover";
+import type { ThinMeasure } from "$lib/api/query";
+import type { LevelDrop } from "$lib/stores/query.svelte";
+
+/** Inputs the URL handler extracts from `?starterCube*=...` params. */
+export interface StarterCubeRef {
+  connection: string;
+  catalog: string;
+  schema: string;
+  name: string;
+}
+
+/**
+ * Parse the 4 `starterCube*` URL params from a {@link URLSearchParams}.
+ * Returns null when any required field is missing — leaving the
+ * Workspace bootstrap to fall through to the empty-workbench default.
+ */
+export function parseStarterCubeRef(params: URLSearchParams): StarterCubeRef | null {
+  const connection = params.get("starterCubeConnection")?.trim();
+  const catalog = params.get("starterCubeCatalog")?.trim();
+  const schema = params.get("starterCubeSchema")?.trim();
+  const name = params.get("starterCubeName")?.trim();
+  if (!connection || !catalog || !schema || !name) return null;
+  return { connection, catalog, schema, name };
+}
+
+/**
+ * Walk the loaded connection tree to find the cube matching the ref.
+ * Returns null when no cube matches — the caller falls through to
+ * the empty-workbench default. We match on all 4 fields because a
+ * fresh tenant can have multiple connections with overlapping cube
+ * names (e.g. two FoodMart instances; or a customer testing two
+ * versions of the same warehouse).
+ */
+export function findCubeByRef(
+  connections: SaikuConnection[],
+  ref: StarterCubeRef,
+): SaikuCube | null {
+  for (const conn of connections) {
+    if (conn.name !== ref.connection) continue;
+    for (const cat of conn.catalogs) {
+      if (cat.name !== ref.catalog) continue;
+      for (const sch of cat.schemas) {
+        if (sch.name !== ref.schema) continue;
+        for (const cube of sch.cubes) {
+          if (cube.name === ref.name) return cube;
+        }
+      }
+    }
+  }
+  return null;
+}
+
+/**
+ * Pick the first measure + first dimension level to seed the starter
+ * query. Heuristic priority for the dimension (most-informative-first):
+ *
+ * <ol>
+ *   <li>A hierarchy with a level whose caption / name signals time
+ *       (Year / Month / Day / Date / Time substring). Date hierarchies
+ *       are the highest-information default for a single-axis query.</li>
+ *   <li>A hierarchy whose dimension's caption signals time (e.g. a
+ *       dim named "Date" with a single level "Date").</li>
+ *   <li>The first dimension's first hierarchy's first level — pure
+ *       fallback so we always land somewhere if the cube has any
+ *       dimension at all.</li>
+ * </ol>
+ *
+ * <p>Returns null when the cube has no measures (defensive — Mondrian
+ * requires ≥1 measure per cube but the contract permits the call) or
+ * no dimensions at all. The caller falls through to the empty-workbench
+ * default rather than render an obviously-broken starter.
+ */
+export interface StarterPick {
+  measure: ThinMeasure;
+  drop: LevelDrop;
+}
+
+export function pickStarterMeasureAndLevel(
+  measures: SaikuMeasure[],
+  dimensions: SaikuDimension[],
+): StarterPick | null {
+  const measure = pickStarterMeasure(measures);
+  if (!measure) return null;
+  const drop = pickStarterLevelDrop(dimensions);
+  if (!drop) return null;
+  return { measure, drop };
+}
+
+/**
+ * First non-calculated measure when one exists; first measure
+ * regardless otherwise. Returns a {@link ThinMeasure} ready to pass
+ * to {@code query.addMeasure}. Saiku Studio renders calculated
+ * measures identically, but for a starter query a base measure is
+ * the less-surprising default ("revenue" beats "revenue per order").
+ */
+export function pickStarterMeasure(measures: SaikuMeasure[]): ThinMeasure | null {
+  if (measures.length === 0) return null;
+  const base = measures.find((m) => !m.calculated);
+  const picked = base ?? measures[0];
+  return {
+    name: picked.name,
+    uniqueName: picked.uniqueName,
+    caption: picked.caption || picked.name,
+    type: picked.calculated ? "CALCULATED" : "EXACT",
+  };
+}
+
+/**
+ * Find a usable level + the hierarchy + dimension it sits inside,
+ * wrap as a {@link LevelDrop} the {@link query.svelte.ts} store can
+ * splice onto an axis directly via {@code includeLevel}.
+ */
+export function pickStarterLevelDrop(dimensions: SaikuDimension[]): LevelDrop | null {
+  // Pass 1: any hierarchy whose first level has a time-signalling name.
+  for (const dim of dimensions) {
+    for (const hier of dim.hierarchies ?? []) {
+      const levels = hier.levels ?? [];
+      for (const lvl of levels) {
+        if (isTimeLikeLevel(lvl)) {
+          return makeLevelDrop(dim, hier, lvl);
+        }
+      }
+    }
+  }
+  // Pass 2: any dimension whose caption / name signals time.
+  for (const dim of dimensions) {
+    if (isTimeLikeDimensionName(dim.caption || dim.name)) {
+      const hier = (dim.hierarchies ?? [])[0];
+      const lvl = hier?.levels?.[0];
+      if (hier && lvl) return makeLevelDrop(dim, hier, lvl);
+    }
+  }
+  // Pass 3: first dim, first hier, first level.
+  for (const dim of dimensions) {
+    const hier = (dim.hierarchies ?? [])[0];
+    const lvl = hier?.levels?.[0];
+    if (hier && lvl) return makeLevelDrop(dim, hier, lvl);
+  }
+  return null;
+}
+
+/**
+ * Build a {@link LevelDrop} from a discovered triple. Pulled out
+ * for symmetry with the existing chip-drop flow in
+ * {@link DimensionList} — keep the shape identical so the store's
+ * {@code includeLevel} can't tell the difference between this and
+ * a real drag.
+ */
+function makeLevelDrop(
+  dim: { name: string; caption: string; uniqueName: string },
+  hier: { name: string; caption: string; uniqueName: string },
+  lvl: SaikuLevel,
+): LevelDrop {
+  return {
+    dimensionName: dim.name,
+    dimensionUniqueName: dim.uniqueName,
+    hierarchyName: hier.name,
+    hierarchyUniqueName: hier.uniqueName,
+    hierarchyCaption: hier.caption,
+    levelName: lvl.name,
+    levelCaption: lvl.caption,
+  };
+}
+
+const TIME_NAME_REGEX = /\b(year|quarter|month|week|day|date|time)\b/i;
+
+function isTimeLikeLevel(level: SaikuLevel): boolean {
+  const caption = level.caption ?? "";
+  const name = level.name ?? "";
+  return TIME_NAME_REGEX.test(caption) || TIME_NAME_REGEX.test(name);
+}
+
+function isTimeLikeDimensionName(name: string): boolean {
+  return TIME_NAME_REGEX.test(name);
+}

--- a/saiku-ui/src/lib/views/Workspace.svelte
+++ b/saiku-ui/src/lib/views/Workspace.svelte
@@ -17,6 +17,12 @@
     serializeQueryToHash,
     type ThinQuery,
   } from "$lib/api/query";
+  import { datasources } from "$lib/stores/datasources.svelte";
+  import {
+    findCubeByRef,
+    parseStarterCubeRef,
+    pickStarterMeasureAndLevel,
+  } from "$lib/api/starterCube";
   import type { ChartType, ChartOptions } from "$lib/views/chartTypes";
   import { DEFAULT_CHART_OPTIONS } from "$lib/views/chartTypes";
 
@@ -107,9 +113,63 @@
         query.chartOptions = (decoded.view.chartOptions as ChartOptions) ?? { ...DEFAULT_CHART_OPTIONS };
         if (query.hasRunnableShape()) void query.run();
       }
+      hydrated = true;
+      return;
     }
+
+    // saiku-cloud#450 — starter-cube bootstrap. When the launch URL
+    // carries the four starterCube* params, resolve the cube via the
+    // discover endpoint, pick first measure + first dim level
+    // (preferring a time-typed hierarchy), and hydrate the workbench
+    // with a fully-formed query model. Customer can immediately drag
+    // a different measure / drill / filter — Studio re-fires the query
+    // on every interaction. No flat MDX preload — that would freeze
+    // the workbench because there's no MDX → model inverse parser.
+    const ref = parseStarterCubeRef(params);
+    if (ref) {
+      void hydrateStarterCube(ref).finally(() => {
+        hydrated = true;
+      });
+      return;
+    }
+
     hydrated = true;
   });
+
+  /** Resolve starter-cube ref → SaikuCube → metadata → query.hydrate.
+   *  Every failure falls through silently: a malformed or missing cube
+   *  must not show an error toast, just leave the empty workbench
+   *  rendered as if the URL params were absent. */
+  async function hydrateStarterCube(ref: ReturnType<typeof parseStarterCubeRef>): Promise<void> {
+    if (!ref) return;
+    try {
+      // Ensure the connection tree is loaded. The session+CubePicker
+      // mount sequence usually does this, but the timing is racey and
+      // we don't want to depend on it.
+      if (!datasources.loaded) {
+        await datasources.load(session.username);
+      }
+      const cube = findCubeByRef(datasources.connections, ref);
+      if (!cube) return;
+      // Fetch dimensions + measures (cached after first call).
+      const metadata = await datasources.metadata(session.username, cube);
+      const pick = pickStarterMeasureAndLevel(metadata.measures, metadata.dimensions);
+      if (!pick) return;
+
+      // Hydrate the query model the same way a manual chip-drop would:
+      // initFor(cube) → addMeasure → includeLevel(ROWS, drop). Studio
+      // sees an ordinary user-built query, so drag/drill/filter all
+      // work natively from this starting point.
+      selection.select(cube);
+      query.initFor(cube);
+      query.addMeasure(pick.measure);
+      query.includeLevel("ROWS", pick.drop);
+      if (query.hasRunnableShape()) void query.run();
+    } catch (err) {
+      // eslint-disable-next-line no-console
+      console.warn("saiku: starter-cube hydrate failed, falling back to empty workbench", err);
+    }
+  }
 
   /** Debounced write-back. history.replaceState — not pushState — so the
    *  back button doesn't step through every chip drop. */


### PR DESCRIPTION
## Summary

Closes #1010. Adds a small URL bootstrap to Saiku Studio so an embedder (Saiku Cloud's \`/saiku/launch?cube=<id>\` SSO flow being the immediate customer — see \`spiculedata/saiku-cloud#450\`) can pre-populate the workbench with a fully-formed query model. Customer lands on actual numbers immediately and can then drag a different measure, drill on the dim, or add filters — Studio re-fires the query on every interaction.

## URL contract

\`\`\`
?starterCubeConnection=<connection-name>
&starterCubeCatalog=<catalog-name>
&starterCubeSchema=<schema-name>
&starterCubeName=<cube-name>
\`\`\`

All 4 required. \`?q=\` (existing deep-link) wins if both present.

## Why a query model, NOT pre-baked MDX

Studio's UX is interactive drag/drop on the query model. MDX is generated from the model on every interaction, but Studio has no inverse parser (MDX → model). Pre-baked MDX would execute and render numbers but leave the chips empty — the customer would be frozen on the starter output, unable to drag anything. Strictly worse than the empty-workbench baseline. So the contract pre-populates the **query model**, not the MDX.

## Bootstrap flow (\`Workspace.svelte\` onMount, after the existing \`?q=\` check)

1. \`parseStarterCubeRef\` extracts the 4 URL fields
2. Ensure \`datasources.connections\` is loaded
3. \`findCubeByRef\` walks the connection tree for an exact 4-tuple match
4. \`datasources.metadata\` fetches dims + measures (cached after first call)
5. \`pickStarterMeasureAndLevel\` picks first measure + first dim level using a 3-pass heuristic:
   - Pass 1: hierarchy with a time-named level (Year/Month/Date/...)
   - Pass 2: time-named dimension
   - Pass 3: first dim's first hierarchy's first level
6. \`query.initFor(cube)\` + \`query.addMeasure\` + \`query.includeLevel("ROWS", drop)\` — same surface the chip drop flow uses, so the resulting workbench state is indistinguishable from a manually-built starter
7. \`query.run()\` if runnable

## Failure paths

Every failure path falls through silently to the empty workbench:
- Missing / malformed URL params
- No matching cube in the connection tree
- Cube has no measures or no dimensions
- All hierarchies have empty level lists

No error toast — SSO entry points must not surface internal errors to first-time customers.

## Test plan

- [x] 21 new vitest cases in \`starterCube.test.ts\` covering:
  - URL parser (4 missing-field permutations, whitespace trim, happy path)
  - 4-tuple cube finder (exact match, disambiguation across same-named cubes in different connections, no-match returns null)
  - Heuristic order (Time-level wins over String dim, Time-named dim wins over non-Time levels, fallback to first dim, ThinMeasure type tagging)
  - Empty-input fallbacks (no measures → null, no dims → null, hierarchy without levels skipped)
- [x] Full saiku-ui suite: **297/297** pass
- [x] svelte-check: **0 errors** (42 pre-existing warnings on other files unchanged)

## What's NOT in scope

- Persisting the starter as a saved query — just renders; doesn't write to repo.
- Custom heuristics per embedder — first measure + first dim, time-first priority. Smarter starters are a follow-up.
- Multi-level axes (Year + Month on rows). Single level is enough for v1.

## Cross-references

- \`spiculedata/saiku-cloud#450\` — the embedder-side issue that motivates this. Cloud-side PR depends on this landing + a saiku release + the engine Dockerfile bump.