### PR TITLE
feat(ui): VISUALTOTALS checkbox in workspace toolbar (closes #830)

### DIFF
--- a/saiku-ui/src/lib/i18n/de.json
+++ b/saiku-ui/src/lib/i18n/de.json
@@ -32,6 +32,7 @@
   "toolbar.run": "▶ Ausführen",
   "toolbar.autorun": "Autom. Ausführung",
   "toolbar.nonEmpty": "Nicht leer",
+  "toolbar.visualTotals": "Sichtbare Summen neu berechnen",
   "toolbar.async": "Asynchron",
   "toolbar.swap": "⇄ Tauschen",
   "toolbar.mdx": "MDX",

--- a/saiku-ui/src/lib/i18n/en.json
+++ b/saiku-ui/src/lib/i18n/en.json
@@ -44,6 +44,8 @@
   "toolbar.autorun.hint": "Automatically run queries after each edit",
   "toolbar.nonEmpty": "Non-empty",
   "toolbar.nonEmpty.hint": "Hide empty rows and columns",
+  "toolbar.visualTotals": "Recalculate totals for visible",
+  "toolbar.visualTotals.hint": "Recompute parent totals from only the visible members (VISUALTOTALS)",
   "toolbar.async": "Async",
   "toolbar.async.hint": "Submit queries asynchronously with progress + cancel",
   "toolbar.swap": "Swap axes",

--- a/saiku-ui/src/lib/i18n/es.json
+++ b/saiku-ui/src/lib/i18n/es.json
@@ -32,6 +32,7 @@
   "toolbar.run": "▶ Ejecutar",
   "toolbar.autorun": "Ejecución automática",
   "toolbar.nonEmpty": "No vacío",
+  "toolbar.visualTotals": "Recalcular totales para visibles",
   "toolbar.async": "Asíncrono",
   "toolbar.swap": "⇄ Intercambiar",
   "toolbar.mdx": "MDX",

--- a/saiku-ui/src/lib/i18n/fr.json
+++ b/saiku-ui/src/lib/i18n/fr.json
@@ -32,6 +32,7 @@
   "toolbar.run": "▶ Exécuter",
   "toolbar.autorun": "Exécution auto",
   "toolbar.nonEmpty": "Non vide",
+  "toolbar.visualTotals": "Recalculer les totaux pour les visibles",
   "toolbar.async": "Asynchrone",
   "toolbar.swap": "⇄ Échanger",
   "toolbar.mdx": "MDX",

--- a/saiku-ui/src/lib/views/WorkspaceToolbar.svelte
+++ b/saiku-ui/src/lib/views/WorkspaceToolbar.svelte
@@ -39,11 +39,18 @@
   import { platform } from "$lib/stores/platform.svelte";
 
   let nonEmpty = $state(true);
+  let visualTotals = $state(false);
 
   $effect(() => {
     if (query.current?.queryModel) {
       query.current.queryModel.axes.ROWS.nonEmpty = nonEmpty;
       query.current.queryModel.axes.COLUMNS.nonEmpty = nonEmpty;
+    }
+  });
+
+  $effect(() => {
+    if (query.current?.queryModel) {
+      query.current.queryModel.visualTotals = visualTotals;
     }
   });
 
@@ -338,6 +345,10 @@
         <label class="toolbar__check" title={i18n.t("toolbar.nonEmpty.hint")}>
           <input type="checkbox" bind:checked={nonEmpty} />
           <span>{i18n.t("toolbar.nonEmpty")}</span>
+        </label>
+        <label class="toolbar__check" title={i18n.t("toolbar.visualTotals.hint")}>
+          <input type="checkbox" bind:checked={visualTotals} />
+          <span>{i18n.t("toolbar.visualTotals")}</span>
         </label>
         <label class="toolbar__check" title={i18n.t("toolbar.async.hint")}>
           <input type="checkbox" bind:checked={query.async} />


### PR DESCRIPTION
## Summary

Closes #830. Adds the missing UI toggle so analysts can flip `VISUALTOTALS` without editing the JSON request body. The backend wiring already exists end-to-end on both REST surfaces (`AiQueryRequest.visualTotals` → `AiSchemaConverter` and `ThinQueryModel.visualTotals` → `Fat.convert` → saiku-query `Query.setVisualTotals(true)`) — PR #829 / #777. This PR just surfaces the flag in the workspace toolbar.

## The change

**UI — `WorkspaceToolbar.svelte`:**
- New local `visualTotals` `$state(false)` next to the existing `nonEmpty` state.
- New `$effect` that syncs `visualTotals` → `query.current.queryModel.visualTotals`. One-way write, same shape as the `nonEmpty` effect right above it.
- New checkbox in the Run-options dropdown (between Non-empty and Async), `bind:checked={visualTotals}`, title pulls from `toolbar.visualTotals.hint`.
- No backend changes; no API changes; `visualTotalsPattern` (the optional advanced regex from the issue) deliberately left out of scope — see "Not in scope" below.

**i18n — `en.json` / `de.json` / `es.json` / `fr.json`:**
- `toolbar.visualTotals` translated in all four locales (`Recalculate totals for visible` / `Sichtbare Summen neu berechnen` / `Recalcular totales para visibles` / `Recalculer les totaux pour les visibles`).
- `toolbar.visualTotals.hint` in `en.json` only. Non-English locales fall back to the English string via `I18nStore.t()`'s existing fallback path — same convention currently used for `toolbar.autorun.hint`, `toolbar.nonEmpty.hint`, and `toolbar.async.hint` (which also live in `en.json` only).

## Verified

- [x] `npm run check` — **0 errors**, 42 warnings unchanged from baseline (all pre-existing in other files; nothing new in `WorkspaceToolbar.svelte` or the four i18n bundles).
- [x] `npm test` (vitest) — **297/297 passing**, no new tests added (pure-UI toggle with no logic worth covering in isolation; the toggle's effect is two lines of state assignment that exercise the same pattern as `nonEmpty` which also has no dedicated tests).

## Test plan

- [ ] Manual: open a cube in the workspace, click the Run-options caret → dropdown shows four checkboxes: **Autorun**, **Non-empty**, **Recalculate totals for visible** (new), **Async**.
- [ ] Manual: with a query that has dimension members filtered/excluded on ROWS, toggle the new checkbox and re-run. With it OFF, parent member totals reflect the full dimension. With it ON, parent totals reflect only the visible (included) members.
- [ ] Manual: hover the new checkbox label — tooltip reads "Recompute parent totals from only the visible members (VISUALTOTALS)".
- [ ] Manual: switch UI locale to de/es/fr — the label translates; the hint tooltip falls back to English text (expected, matches `nonEmpty`/`async` behaviour).
- [ ] Manual: open browser devtools network tab on Run — confirm the request body now carries `"visualTotals": true` under `queryModel` when the box is ticked.
- [ ] Reviewer sanity: regression-check the existing `nonEmpty` and `async` toggles still behave (the new `$effect` was added alongside, not replacing).

## What's NOT in scope

- `visualTotalsPattern` (the Mondrian regex that scopes which members the wrap applies to) — issue calls this out as an "optional advanced field". Defer until there's a concrete need; surfacing a regex input in the toolbar dropdown would unbalance the menu and the unscoped flag already covers the common case.
- Persisting `visualTotals` into the deep-link `?q=` payload or saved query JSON state — it already round-trips via `queryModel.visualTotals` (which `serializeQueryToHash` includes wholesale), so this is a no-op rather than an omission, but worth a reviewer eyeball.
- Tests for the toggle — matches the existing pattern (`nonEmpty`/`async` toggles have no dedicated unit tests either; the two-line `$effect` is exercised end-to-end by the existing query-execution suite via `queryModel.visualTotals`).

## Cross-references

- #777 — original spec where the checkbox label wording originates.
- #829 — backend wiring (already merged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
