### PR TITLE
feat(ui): link Slack community from About modal

### DIFF
--- a/saiku-ui/src/lib/i18n/de.json
+++ b/saiku-ui/src/lib/i18n/de.json
@@ -57,6 +57,7 @@
   "modal.delete": "Löschen",
   "modal.about.title": "Über Saiku",
   "modal.about.tagline": "Saiku — modernisierter Stack.",
+  "modal.about.community": "Tritt der Community auf Slack bei",
   "modal.save.title": "Abfrage speichern",
   "modal.save.folder": "Ordner",
   "modal.save.name": "Name",

--- a/saiku-ui/src/lib/i18n/en.json
+++ b/saiku-ui/src/lib/i18n/en.json
@@ -127,6 +127,7 @@
   "modal.delete.confirm": "Permanently delete {kind} \"{path}\"? This cannot be undone.",
   "modal.about.title": "About Saiku",
   "modal.about.tagline": "Saiku — modernised stack.",
+  "modal.about.community": "Join the community on Slack",
   "modal.save.title": "Save query",
   "modal.save.folder": "Folder",
   "modal.save.folderHint": "Pick an existing folder or type a new path. Missing parent folders are created automatically.",

--- a/saiku-ui/src/lib/i18n/es.json
+++ b/saiku-ui/src/lib/i18n/es.json
@@ -57,6 +57,7 @@
   "modal.delete": "Eliminar",
   "modal.about.title": "Acerca de Saiku",
   "modal.about.tagline": "Saiku — pila modernizada.",
+  "modal.about.community": "Únete a la comunidad en Slack",
   "modal.save.title": "Guardar consulta",
   "modal.save.folder": "Carpeta",
   "modal.save.name": "Nombre",

--- a/saiku-ui/src/lib/i18n/fr.json
+++ b/saiku-ui/src/lib/i18n/fr.json
@@ -57,6 +57,7 @@
   "modal.delete": "Supprimer",
   "modal.about.title": "À propos de Saiku",
   "modal.about.tagline": "Saiku — pile modernisée.",
+  "modal.about.community": "Rejoindre la communauté sur Slack",
   "modal.save.title": "Enregistrer la requête",
   "modal.save.folder": "Dossier",
   "modal.save.name": "Nom",

--- a/saiku-ui/src/lib/views/Workspace.svelte
+++ b/saiku-ui/src/lib/views/Workspace.svelte
@@ -278,6 +278,12 @@
   <p>
     <strong>{session.username}</strong> · {session.roles.join(", ")}
   </p>
+  <p>
+    <a
+      href="https://join.slack.com/t/saikucloud/shared_invite/zt-3yor7kgiv-YUPhqK0pvd4WljctIQVOTA"
+      target="_blank"
+      rel="noopener noreferrer">{i18n.t("modal.about.community")}</a>
+  </p>
   {#snippet footer()}
     <button class="btn btn--primary" onclick={() => (aboutOpen = false)}>{i18n.t("modal.close")}</button>
   {/snippet}


### PR DESCRIPTION
## Summary
- Adds a "Join the community on Slack" link in the About modal (`Workspace.svelte`).
- New i18n key `modal.about.community` with translations for en/es/de/fr.
- Slack invite: https://join.slack.com/t/saikucloud/shared_invite/zt-3yor7kgiv-YUPhqK0pvd4WljctIQVOTA

## Test plan
- [ ] Open the workbench, click "About Saiku" in the sidebar footer.
- [ ] Verify the Slack link renders below the username/roles line and opens in a new tab.
- [ ] Toggle locale and verify each translation reads naturally.