### PR TITLE
fix(ai): sync executeAi registers handle for cross-session drillthrough

### DIFF
--- a/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/AiQueryResource.java
+++ b/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/AiQueryResource.java
@@ -247,6 +247,40 @@ public class AiQueryResource {
             return error("execute failed: " + describeDeepestCause(e));
         }
 
+        // saiku#915 / saiku-cloud MCP smoke-test 2026-05-23: a follow-up
+        // drillthrough call lands on a different session than this sync
+        // execute (very common via MCP, which gets a fresh JSESSIONID per
+        // request when the client doesn't keep a cookie jar). The
+        // session-scoped ThinQueryService context that holds the
+        // (ThinQuery, CellSet) pair is empty on the new session and
+        // drillthrough's resolver path surfaces "Unknown queryId" even
+        // though the result is still hot.
+        //
+        // Mirror the async submission path: register a pre-completed
+        // AsyncQueryHandle keyed on the ThinQuery name. The drillthrough
+        // resource's existing fallback already calls
+        // asyncQueryService.get(queryId) and re-attaches via
+        // ThinQueryService.registerExternalContext — so sync queries get
+        // the same cross-session reachability for free.
+        if (asyncQueryService != null && tq.getName() != null) {
+            try {
+                org.olap4j.CellSet cellSet = thinQueryService.getContext(tq.getName()).getOlapResult();
+                org.saiku.service.async.AsyncQueryHandle handle =
+                        new org.saiku.service.async.AsyncQueryHandle(tq.getName(), tq);
+                handle.setFuture(java.util.concurrent.CompletableFuture.completedFuture(cellSet));
+                handle.compareAndSetStatus(
+                        org.saiku.service.async.AsyncQueryHandle.Status.PENDING,
+                        org.saiku.service.async.AsyncQueryHandle.Status.DONE);
+                asyncQueryService.register(handle);
+            } catch (RuntimeException registerErr) {
+                // Never fail the query response over the registration —
+                // drillthrough simply won't be reachable from a different
+                // session, which is the pre-fix behaviour.
+                log.debug("AI sync handle registration failed for {}: {}",
+                        tq.getName(), registerErr.toString());
+            }
+        }
+
         AiQueryResponse resp = buildResponse(tq, cds, start, format);
         return Response.ok(resp).type(MediaType.APPLICATION_JSON).build();
     }

--- a/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/AiQueryResource.java
+++ b/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/AiQueryResource.java
@@ -264,7 +264,8 @@ public class AiQueryResource {
         // the same cross-session reachability for free.
         if (asyncQueryService != null && tq.getName() != null) {
             try {
-                org.olap4j.CellSet cellSet = thinQueryService.getContext(tq.getName()).getOlapResult();
+                org.olap4j.CellSet cellSet =
+                        thinQueryService.getContext(tq.getName()).getOlapResult();
                 org.saiku.service.async.AsyncQueryHandle handle =
                         new org.saiku.service.async.AsyncQueryHandle(tq.getName(), tq);
                 handle.setFuture(java.util.concurrent.CompletableFuture.completedFuture(cellSet));
@@ -276,8 +277,7 @@ public class AiQueryResource {
                 // Never fail the query response over the registration —
                 // drillthrough simply won't be reachable from a different
                 // session, which is the pre-fix behaviour.
-                log.debug("AI sync handle registration failed for {}: {}",
-                        tq.getName(), registerErr.toString());
+                log.debug("AI sync handle registration failed for {}: {}", tq.getName(), registerErr.toString());
             }
         }
 

--- a/saiku-core/saiku-web/src/test/java/org/saiku/web/rest/resources/AiQueryResourceTest.java
+++ b/saiku-core/saiku-web/src/test/java/org/saiku/web/rest/resources/AiQueryResourceTest.java
@@ -248,6 +248,68 @@ public class AiQueryResourceTest {
         assertEquals("Sales", body.get(0).getCubeName());
     }
 
+    /* --- saiku#915 / MCP drillthrough cross-session re-attach ---------- */
+
+    @Test
+    public void syncExecuteRegistersHandleForCrossSessionDrillthrough() {
+        // MCP smoke 2026-05-23: a follow-up drillthrough call lands on a
+        // different session than the sync run_query (JSESSIONID per
+        // request). Without the cross-session re-attach, drillthrough's
+        // resolver sees an empty per-session context and surfaces
+        // "Unknown queryId" even though the result is hot.
+        //
+        // Fix: executeAi mirrors the async-submission path — register a
+        // pre-completed AsyncQueryHandle in the cross-session
+        // AsyncQueryService so drillthrough's existing handle-fallback
+        // path can re-attach. Test pins that the handle ends up in the
+        // expected DONE state with the executed ThinQuery.
+        org.saiku.service.async.AsyncQueryService async =
+                new org.saiku.service.async.AsyncQueryService();
+        resource.setAsyncQueryService(async);
+        // Custom stub that populates the QueryContext getOlapResult so the
+        // re-attach branch can read the CellSet. Default StubThinQueryService
+        // returns null context; this one stores a no-op CellSet via the
+        // registerExternalContext seam the production code uses too.
+        resource.setThinQueryService(new StubThinQueryService() {
+            @Override
+            public CellDataSet execute(ThinQuery tq) {
+                registerExternalContext(tq, null);
+                return buildStubCellDataSet();
+            }
+        });
+
+        Response resp = resource.executeAi(baseRequest(), "records");
+        assertEquals(200, resp.getStatus());
+
+        AiQueryResponse body = (AiQueryResponse) resp.getEntity();
+        String queryId = body.getQueryId();
+        assertNotNull("sync executeAi returns a queryId", queryId);
+
+        org.saiku.service.async.AsyncQueryHandle handle = async.get(queryId);
+        assertNotNull(
+                "sync executeAi should register a pre-completed handle for cross-session drillthrough",
+                handle);
+        assertEquals(
+                "registered handle reports DONE so resource-layer drillthrough resolves it",
+                org.saiku.service.async.AsyncQueryHandle.Status.DONE,
+                handle.getStatus());
+        assertEquals(
+                "handle carries the executed ThinQuery so registerExternalContext re-attaches the right query",
+                queryId,
+                handle.getQuery().getName());
+    }
+
+    @Test
+    public void syncExecuteSucceedsEvenIfAsyncQueryServiceUnwired() {
+        // Back-compat: callers that don't wire asyncQueryService (older
+        // webapp configs, the JSP-only flow, tests) must still get a
+        // clean 200. The re-attach is an opt-in cross-session
+        // enhancement, not a required pre-condition.
+        resource.setAsyncQueryService(null);
+        Response resp = resource.executeAi(baseRequest(), "records");
+        assertEquals(200, resp.getStatus());
+    }
+
     /* ----------------------- Phase 4: async ---------------------------------- */
 
     @Test

--- a/saiku-core/saiku-web/src/test/java/org/saiku/web/rest/resources/AiQueryResourceTest.java
+++ b/saiku-core/saiku-web/src/test/java/org/saiku/web/rest/resources/AiQueryResourceTest.java
@@ -263,8 +263,7 @@ public class AiQueryResourceTest {
         // AsyncQueryService so drillthrough's existing handle-fallback
         // path can re-attach. Test pins that the handle ends up in the
         // expected DONE state with the executed ThinQuery.
-        org.saiku.service.async.AsyncQueryService async =
-                new org.saiku.service.async.AsyncQueryService();
+        org.saiku.service.async.AsyncQueryService async = new org.saiku.service.async.AsyncQueryService();
         resource.setAsyncQueryService(async);
         // Custom stub that populates the QueryContext getOlapResult so the
         // re-attach branch can read the CellSet. Default StubThinQueryService
@@ -286,9 +285,7 @@ public class AiQueryResourceTest {
         assertNotNull("sync executeAi returns a queryId", queryId);
 
         org.saiku.service.async.AsyncQueryHandle handle = async.get(queryId);
-        assertNotNull(
-                "sync executeAi should register a pre-completed handle for cross-session drillthrough",
-                handle);
+        assertNotNull("sync executeAi should register a pre-completed handle for cross-session drillthrough", handle);
         assertEquals(
                 "registered handle reports DONE so resource-layer drillthrough resolves it",
                 org.saiku.service.async.AsyncQueryHandle.Status.DONE,


### PR DESCRIPTION
## Summary

A follow-up drillthrough call against a queryId from a prior sync `run_query` returns "Unknown queryId" even though the result is still hot in the cache. Caught by the saiku-cloud MCP smoke test 2026-05-23.

**Root cause:** `thinQueryService` is a session-scoped Spring bean. The sync `executeAi` path stores the `(ThinQuery, CellSet)` pair in that session's `QueryContext`, so a drillthrough request that lands on a **different** session (very common via MCP — JSESSIONID per request when the client doesn't keep a cookie jar) hits an empty context map and the resolver surfaces "Unknown queryId".

The async path already solved this in saiku#862 via `ThinQueryService.registerExternalContext` + `asyncQueryService.get` fallback. The drillthrough resource walks both paths already; **only the sync executeAi path was missing the cross-session registration.**

## Fix

After a successful sync execute, register a pre-completed `AsyncQueryHandle` in the (singleton) `AsyncQueryService` keyed on the ThinQuery name. The drillthrough resource's existing `asyncQueryService.get(queryId)` fallback then resolves the handle and re-attaches the `(query, cellSet)` pair via `ThinQueryService.registerExternalContext` for **this** request's session — same shape as the async path.

Wrapped in try/catch so a registration failure never poisons the sync query response (back-compat: pre-fix behaviour kept).

## Tests

Two new in `AiQueryResourceTest`:

- `syncExecuteRegistersHandleForCrossSessionDrillthrough` — asserts the handle lands in `AsyncQueryService` in `DONE` state with the executed `ThinQuery`.
- `syncExecuteSucceedsEvenIfAsyncQueryServiceUnwired` — pins back-compat for setups that don't wire `asyncQueryService` at all.

30/30 in `AiQueryResourceTest` (was 28).

🤖 Generated with [Claude Code](https://claude.com/claude-code)