### PR TITLE
feat(ui): Duplicate action on dashboard tiles (closes #913)

### DIFF
--- a/saiku-ui/src/lib/api/dashboards.test.ts
+++ b/saiku-ui/src/lib/api/dashboards.test.ts
@@ -11,8 +11,10 @@ import { describe, expect, it } from "vitest";
 
 import {
   cloneDashboardWithFreshIds,
+  cloneTileWithFreshId,
   normaliseDashboardPath,
   type Dashboard,
+  type DashboardTile,
 } from "./dashboards";
 
 describe("normaliseDashboardPath", () => {
@@ -157,6 +159,81 @@ describe("cloneDashboardWithFreshIds", () => {
     const src = makeSource();
     const snapshot = JSON.parse(JSON.stringify(src));
     cloneDashboardWithFreshIds(src);
+    expect(src).toEqual(snapshot);
+  });
+});
+
+describe("cloneTileWithFreshId", () => {
+  function makeChartTile(): DashboardTile {
+    return {
+      id: "src-tile",
+      x: 2,
+      y: 3,
+      w: 6,
+      h: 4,
+      type: "chart",
+      title: "Sales by region",
+      chartType: "bar",
+      cube: { connectionName: "c", catalog: "C", schema: "S", cubeName: "Sales" },
+      query: { kind: "inline", body: { measures: [{ name: "Store Sales" }] } },
+    };
+  }
+
+  function makeUntitledKpiTile(): DashboardTile {
+    return {
+      id: "src-kpi",
+      x: 0,
+      y: 0,
+      w: 3,
+      h: 2,
+      type: "kpi",
+      kpi: { measure: "[Measures].[Store Sales]", format: "currency" },
+    };
+  }
+
+  it("mints a fresh tile id by default", () => {
+    const src = makeChartTile();
+    const copy = cloneTileWithFreshId(src);
+    expect(copy.id).not.toBe(src.id);
+    expect(copy.id.length).toBeGreaterThan(0);
+  });
+
+  it("honours an explicit newId override", () => {
+    const copy = cloneTileWithFreshId(makeChartTile(), { newId: "my-fixed-id" });
+    expect(copy.id).toBe("my-fixed-id");
+  });
+
+  it("appends ' (copy)' to a titled tile's title by default", () => {
+    const copy = cloneTileWithFreshId(makeChartTile());
+    expect(copy.title).toBe("Sales by region (copy)");
+  });
+
+  it("leaves an untitled tile's title undefined so the defaultTitle fallback still applies", () => {
+    const copy = cloneTileWithFreshId(makeUntitledKpiTile());
+    expect(copy.title).toBeUndefined();
+  });
+
+  it("honours an explicit titleSuffix override", () => {
+    const copy = cloneTileWithFreshId(makeChartTile(), { titleSuffix: " — duplicate" });
+    expect(copy.title).toBe("Sales by region — duplicate");
+  });
+
+  it("preserves every non-id field on the source tile", () => {
+    const src = makeChartTile();
+    const copy = cloneTileWithFreshId(src, { newId: "new" });
+    const { id: _aId, title: _aTitle, ...aRest } = src;
+    const { id: _bId, title: _bTitle, ...bRest } = copy;
+    void _aId;
+    void _bId;
+    void _aTitle;
+    void _bTitle;
+    expect(bRest).toEqual(aRest);
+  });
+
+  it("does not mutate the source tile", () => {
+    const src = makeChartTile();
+    const snapshot = JSON.parse(JSON.stringify(src));
+    cloneTileWithFreshId(src);
     expect(src).toEqual(snapshot);
   });
 });

--- a/saiku-ui/src/lib/api/dashboards.ts
+++ b/saiku-ui/src/lib/api/dashboards.ts
@@ -280,6 +280,35 @@ export function cloneDashboardWithFreshIds(source: Dashboard, newName?: string):
   };
 }
 
+/** Pure: clone a single tile with a fresh id and an optional title
+ *  suffix. Position / size / type / cube / query / kpi / target /
+ *  widget / chartType / text are preserved verbatim; only id (and
+ *  optionally title) change.
+ *
+ *  Title rules:
+ *   - When {@code source.title} is set, the clone's title becomes
+ *     {@code `${source.title}${titleSuffix ?? " (copy)"}`}.
+ *   - When {@code source.title} is missing (the tile relies on the
+ *     `defaultTitle` fallback in Tile.svelte), the clone's title is
+ *     left undefined too — the fallback continues to apply.
+ *
+ *  Pure / immutable: the source is not mutated. Caller must pick the
+ *  layout slot separately (see {@code firstFreeSlot} in
+ *  $lib/dashboard/tilePlacement) and merge x/y after the clone.
+ *  Issue #913. */
+export function cloneTileWithFreshId(
+  source: DashboardTile,
+  opts?: { newId?: string; titleSuffix?: string },
+): DashboardTile {
+  const suffix = opts?.titleSuffix ?? " (copy)";
+  const title = source.title ? `${source.title}${suffix}` : source.title;
+  return {
+    ...source,
+    id: opts?.newId ?? cryptoUuid(),
+    title,
+  };
+}
+
 /** Glue: load a dashboard at {@code srcPath}, clone it with fresh ids,
  *  save the clone at {@code destPath}, and return the new dashboard.
  *  The caller is responsible for picking a non-colliding destPath —

--- a/saiku-ui/src/lib/stores/dashboard.svelte.ts
+++ b/saiku-ui/src/lib/stores/dashboard.svelte.ts
@@ -13,6 +13,7 @@
  */
 
 import {
+  cloneTileWithFreshId,
   loadDashboard,
   newDashboard,
   normaliseDashboardPath,
@@ -24,6 +25,7 @@ import {
   type FilterWidget,
   type PanelFilter,
 } from "$lib/api/dashboards";
+import { firstFreeSlot } from "$lib/dashboard/tilePlacement";
 import { recentDashboards } from "$lib/stores/recentDashboards.svelte";
 import { session } from "$lib/stores/session.svelte";
 
@@ -43,6 +45,12 @@ class DashboardStore {
 
   dirty = $state<boolean>(false);
   dirtyCount = $state<number>(0);
+
+  /** Signal that the next Tile to render with this id should auto-open
+   *  its editor modal — used by {@link duplicateTile} so the freshly
+   *  cloned tile lands in immediate-edit mode (issue #913). Consumed
+   *  exactly once via {@link consumeEditSignal}; left unset otherwise. */
+  pendingEditTileId = $state<string | null>(null);
 
   /* ----------------------------- lifecycle ----------------------------- */
 
@@ -190,6 +198,44 @@ class DashboardStore {
       },
     };
     this.markDirty();
+  }
+
+  /** Duplicate a tile: mint a fresh id, suffix the title with " (copy)",
+   *  drop it at the next free slot (same w×h as the source), and signal
+   *  the new tile to auto-open its editor. Returns the new tile id, or
+   *  null when the source isn't in the current layout. Issue #913. */
+  duplicateTile(id: string): string | null {
+    if (!this.current) return null;
+    const source = this.current.layout.tiles.find((t) => t.id === id);
+    if (!source) return null;
+    const slot = firstFreeSlot(this.current.layout, source.w, source.h);
+    const cloned: DashboardTile = {
+      ...cloneTileWithFreshId(source),
+      x: slot.x,
+      y: slot.y,
+    };
+    this.current = {
+      ...this.current,
+      layout: {
+        ...this.current.layout,
+        tiles: [...this.current.layout.tiles, cloned],
+      },
+    };
+    this.pendingEditTileId = cloned.id;
+    this.markDirty();
+    return cloned.id;
+  }
+
+  /** Returns true (and clears the signal) iff this tile id matches the
+   *  pending edit signal. Tile.svelte calls this on mount to decide
+   *  whether to open its editor modal automatically. Idempotent: a
+   *  second call returns false. */
+  consumeEditSignal(id: string): boolean {
+    if (this.pendingEditTileId === id) {
+      this.pendingEditTileId = null;
+      return true;
+    }
+    return false;
   }
 
   removeTile(id: string): void {

--- a/saiku-ui/src/lib/views/dashboard/Tile.svelte
+++ b/saiku-ui/src/lib/views/dashboard/Tile.svelte
@@ -7,6 +7,10 @@
    * them for free. The edit modal is co-located here — keeping the
    * open/closed state per-tile-instance avoids prop-drilling up to the
    * grid and back.
+   *
+   * Secondary actions (Duplicate, future cut/paste/lock) live in a
+   * shared overflow menu that opens from either the ⋮ kebab button on
+   * the header OR a right-click anywhere on the tile (issue #913).
    */
 
   import { dashboardStore } from "$lib/stores/dashboard.svelte";
@@ -17,7 +21,7 @@
   import TextTile from "$lib/views/dashboard/tiles/TextTile.svelte";
   import KpiTile from "$lib/views/dashboard/tiles/KpiTile.svelte";
   import TileEditorModal from "$lib/views/dashboard/TileEditorModal.svelte";
-  import { Copy, Settings2, X } from "lucide-svelte";
+  import { Copy, MoreVertical, Settings2, X } from "lucide-svelte";
 
   interface Props {
     tile: DashboardTile;
@@ -28,6 +32,15 @@
 
   let editorOpen = $state(false);
 
+  // Overflow menu: opened from the kebab button or right-click. Coords
+  // are viewport-relative (position: fixed) so the same menu element
+  // covers both the kebab-anchored open and the cursor-anchored open
+  // without a second DOM node.
+  let menuOpen = $state(false);
+  let menuX = $state(0);
+  let menuY = $state(0);
+  let menuEl = $state<HTMLDivElement | null>(null);
+
   // Freshly-duplicated tiles arrive with their id stamped on the
   // store's pendingEditTileId signal — open the editor immediately so
   // the analyst can rename / re-bind without a second click (issue #913).
@@ -35,6 +48,26 @@
     if (!readOnly && dashboardStore.consumeEditSignal(tile.id)) {
       editorOpen = true;
     }
+  });
+
+  // Close on outside click / Escape while the menu is open.
+  $effect(() => {
+    if (!menuOpen) return;
+    function onDocClick(e: MouseEvent): void {
+      const target = e.target as Node | null;
+      if (target && !menuEl?.contains(target)) {
+        menuOpen = false;
+      }
+    }
+    function onKey(e: KeyboardEvent): void {
+      if (e.key === "Escape") menuOpen = false;
+    }
+    document.addEventListener("mousedown", onDocClick);
+    document.addEventListener("keydown", onKey);
+    return () => {
+      document.removeEventListener("mousedown", onDocClick);
+      document.removeEventListener("keydown", onKey);
+    };
   });
 
   function handleEdit(): void {
@@ -52,6 +85,37 @@
     dashboardStore.removeTile(tile.id);
   }
 
+  /** Open the overflow menu anchored to the kebab button — pinned to
+   *  the button's bottom-right corner so the menu hangs below + left,
+   *  keeping it inside the tile chrome rather than overflowing right. */
+  function openKebabMenu(e: MouseEvent): void {
+    if (readOnly) return;
+    e.stopPropagation();
+    const btn = e.currentTarget as HTMLElement;
+    const rect = btn.getBoundingClientRect();
+    menuX = rect.right - 160; // 160px ≈ menu width; align right edge
+    menuY = rect.bottom + 4;
+    menuOpen = true;
+  }
+
+  /** Right-click on the tile → open the overflow menu at the cursor.
+   *  Suppresses the browser's native context menu only when we have
+   *  something to offer (skip in readOnly so the analyst still gets
+   *  Inspect / Save Image etc. on read-only dashboards). */
+  function openContextMenu(e: MouseEvent): void {
+    if (readOnly) return;
+    e.preventDefault();
+    e.stopPropagation();
+    menuX = e.clientX;
+    menuY = e.clientY;
+    menuOpen = true;
+  }
+
+  function duplicateFromMenu(): void {
+    menuOpen = false;
+    handleDuplicate();
+  }
+
   /** Click-filter capture from chart / table sub-tiles. Push onto the
    *  active-filter set tagged with this tile's id; the chip bar shows
    *  the new filter and every compatible tile recomputes its effective
@@ -61,7 +125,12 @@
   }
 </script>
 
-<div class="tile" data-tile-type={tile.type}>
+<!-- svelte-ignore a11y_no_static_element_interactions
+     Right-click is a power-user shortcut for the overflow menu. The
+     kebab button (⋮) in the header is the keyboard-accessible
+     equivalent — same menu, same actions — so no a11y regression
+     from suppressing the contextmenu-handler-needs-a-role rule. -->
+<div class="tile" data-tile-type={tile.type} oncontextmenu={openContextMenu}>
   <header
     class="tile-header"
     class:tile-header--draggable={!readOnly}
@@ -73,8 +142,15 @@
         <button type="button" class="icon-btn" aria-label="Edit tile" onclick={handleEdit}>
           <Settings2 size={14} />
         </button>
-        <button type="button" class="icon-btn" aria-label="Duplicate tile" onclick={handleDuplicate}>
-          <Copy size={14} />
+        <button
+          type="button"
+          class="icon-btn"
+          aria-label="Tile actions"
+          aria-haspopup="menu"
+          aria-expanded={menuOpen}
+          onclick={openKebabMenu}
+        >
+          <MoreVertical size={14} />
         </button>
         <button type="button" class="icon-btn icon-btn--danger" aria-label="Remove tile" onclick={handleRemove}>
           <X size={14} />
@@ -96,6 +172,20 @@
     {/if}
   </div>
 </div>
+
+{#if menuOpen}
+  <div
+    class="tile-menu"
+    role="menu"
+    bind:this={menuEl}
+    style="left: {menuX}px; top: {menuY}px;"
+  >
+    <button type="button" class="tile-menu__item" role="menuitem" onclick={duplicateFromMenu}>
+      <Copy size={14} aria-hidden="true" />
+      <span>Duplicate</span>
+    </button>
+  </div>
+{/if}
 
 {#if editorOpen}
   <TileEditorModal {tile} onClose={() => (editorOpen = false)} />
@@ -172,5 +262,38 @@
     padding: 0.5rem;
     color: var(--danger);
     font-size: 0.8125rem;
+  }
+
+  /* Overflow menu — positioned: fixed so both kebab + right-click
+     callers can drive (left, top) directly from viewport coords. */
+  .tile-menu {
+    position: fixed;
+    min-width: 10rem;
+    background: var(--bg);
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.18);
+    padding: 0.25rem;
+    z-index: 50;
+  }
+  .tile-menu__item {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    width: 100%;
+    padding: 0.5rem 0.625rem;
+    border: 0;
+    background: transparent;
+    text-align: left;
+    cursor: pointer;
+    border-radius: 4px;
+    color: var(--fg);
+    font: inherit;
+    font-size: 0.8125rem;
+  }
+  .tile-menu__item:hover,
+  .tile-menu__item:focus {
+    background: var(--bg-subtle);
+    outline: none;
   }
 </style>

--- a/saiku-ui/src/lib/views/dashboard/Tile.svelte
+++ b/saiku-ui/src/lib/views/dashboard/Tile.svelte
@@ -17,7 +17,7 @@
   import TextTile from "$lib/views/dashboard/tiles/TextTile.svelte";
   import KpiTile from "$lib/views/dashboard/tiles/KpiTile.svelte";
   import TileEditorModal from "$lib/views/dashboard/TileEditorModal.svelte";
-  import { Settings2, X } from "lucide-svelte";
+  import { Copy, Settings2, X } from "lucide-svelte";
 
   interface Props {
     tile: DashboardTile;
@@ -28,9 +28,23 @@
 
   let editorOpen = $state(false);
 
+  // Freshly-duplicated tiles arrive with their id stamped on the
+  // store's pendingEditTileId signal — open the editor immediately so
+  // the analyst can rename / re-bind without a second click (issue #913).
+  $effect(() => {
+    if (!readOnly && dashboardStore.consumeEditSignal(tile.id)) {
+      editorOpen = true;
+    }
+  });
+
   function handleEdit(): void {
     if (readOnly) return;
     editorOpen = true;
+  }
+
+  function handleDuplicate(): void {
+    if (readOnly) return;
+    dashboardStore.duplicateTile(tile.id);
   }
 
   function handleRemove(): void {
@@ -58,6 +72,9 @@
       <div class="tile-actions">
         <button type="button" class="icon-btn" aria-label="Edit tile" onclick={handleEdit}>
           <Settings2 size={14} />
+        </button>
+        <button type="button" class="icon-btn" aria-label="Duplicate tile" onclick={handleDuplicate}>
+          <Copy size={14} />
         </button>
         <button type="button" class="icon-btn icon-btn--danger" aria-label="Remove tile" onclick={handleRemove}>
           <X size={14} />


### PR DESCRIPTION
## Summary

Closes #913. Adds a **Duplicate** action to every dashboard tile so analysts building variations on a theme (same query, different chart type; same chart, different filter) can clone-then-edit instead of building from scratch. Mirrors PR #1007 (catalogue Duplicate action for dashboards) one level down for the pure / store layers; the trigger UI is the kebab + right-click pattern the issue asked for.

## The change

**Pure helper — `$lib/api/dashboards.ts`:**
- `cloneTileWithFreshId(source, opts?)` — returns a copy with a fresh tile id and `<original title> (copy)` suffix; everything else (position, size, type, cube binding, query body, KPI / filter / chart config) preserved verbatim. Lives next to `cloneDashboardWithFreshIds` for direct symmetry with #1007. Same source-immutable contract.
- **Title rules:** titled source → `"<title> (copy)"`. Untitled source → title stays `undefined` so the `defaultTitle` fallback in `Tile.svelte` continues to apply (avoids materialising a stale `"bar chart (copy)"` when the analyst hadn't named the original). Explicit `opts.titleSuffix` overrides for callers that want a different separator.

**Store glue — `$lib/stores/dashboard.svelte.ts`:**
- `duplicateTile(id): string | null` — finds the source tile, clones it, picks `{x, y}` via `firstFreeSlot(layout, source.w, source.h)` (matching the `addTile` flow), appends to the layout immutably, signals the new tile to auto-open its editor, marks the dashboard dirty, returns the new id. Returns `null` if the source id isn't in the current layout.
- `pendingEditTileId` + `consumeEditSignal(id)` — one-shot signal so a freshly cloned tile lands in immediate-edit mode. The Tile reads + clears the signal in a `$effect` on mount; a re-render does not re-trigger because consumption clears the flag.

**Tile UI — `$lib/views/dashboard/Tile.svelte`:**
- **Kebab button** (⋮ via `MoreVertical` from lucide-svelte) in the tile header, between Edit and Remove. `aria-haspopup="menu"`, `aria-expanded={menuOpen}`, `aria-label="Tile actions"`.
- **Right-click handler** on the whole tile div. Opens the same overflow menu at the cursor; falls through to the browser's native menu in `readOnly` mode (so analysts still get Inspect / Save Image on read-only dashboards).
- **Overflow menu** is one `<div role="menu">` with `position: fixed` so both invocation paths drive `(left, top)` directly from viewport coords — no second DOM node, no duplicate close logic.
  - Closes on outside-click (document `mousedown` listener) and Escape.
  - Currently contains one `role="menuitem"`: Duplicate. Designed to grow when future actions land (cut/paste, lock, lock-aspect-ratio).
- A11y carve-out: the right-click trigger on the tile `<div>` would normally trip `a11y_no_static_element_interactions`. Suppressed via `<!-- svelte-ignore -->` with a justification comment — the kebab button is the keyboard-accessible equivalent (same menu, same actions), so there's no regression for non-mouse users.

**Tests — `$lib/api/dashboards.test.ts`:**
- 7 new `cloneTileWithFreshId` cases: fresh id, explicit `newId` override, `(copy)` suffix on titled source, `undefined` preserved on untitled source, explicit `titleSuffix` override, full field preservation (position / size / cube / query / kpi / chartType / etc.), source immutability.

## Verified

- [x] `npm run check` — **0 errors**, 42 warnings (baseline unchanged — no new warnings on any touched file).
- [x] `npm test` — **304/304 passing** (was 297; +7 from the new `cloneTileWithFreshId` suite).

## Test plan

- [x] Manual: open a dashboard with a chart tile. Click the **⋮ kebab** in the header → overflow menu opens below + left of the button containing "Duplicate". Click Duplicate → a copy appears at the next free grid slot, the editor modal opens immediately on the new tile, the title field is pre-filled `<original> (copy)`.
- [x] Manual: **right-click** anywhere on a tile → same overflow menu opens at the cursor. Same Duplicate action available. Browser's native context menu is suppressed.
- [ ] Manual: duplicate a tile whose original had no title set. The new tile renders with the `defaultTitle` fallback (e.g. `"bar chart"`, `"KPI"`), not a literal `"undefined (copy)"` string.
- [ ] Manual: duplicate a KPI tile (different defaults: `w: 3`, `h: 2`). The duplicate respects the source's w×h, not the chart defaults.
- [x] Manual: open menu → click outside the menu → menu closes (no action).
- [x] Manual: open menu → press Escape → menu closes (no action).
- [ ] Manual: read-only dashboard (e.g. visiting via shareable read-only link, once #941 lands) — the kebab button does NOT render, and right-click falls through to the browser's native menu (Inspect / Save Image / etc.). Verify on a chart tile to confirm the browser menu is reachable.
- [x] Manual: rapid double-click on Duplicate. Two duplicates land in two different free slots, both open their editors in sequence (the second wins the `pendingEditTileId` race). Acceptable — neither is silently dropped.
- [x] Reviewer sanity: dim/hier/level click-to-filter on the duplicated chart still respects the source's `target` binding (no broken filter id references — `consumeEditSignal` is the only place id-keyed cleanup matters, and `removeTile` already handles late deletions).

## Notes for the reviewer

- **Why a store signal for auto-open editor:** `Tile.svelte` owns its `editorOpen` state locally, so cross-component dispatch goes through the dashboard store (closer fit than a window event, which is reserved for cross-store dispatches like `saiku-open-drillthrough`). One-shot semantics via `consumeEditSignal` so re-renders don't re-open.
- **Why one menu element, not separate "kebab dropdown" + "context menu":** both invocation paths boil down to "open this overflow menu at (x, y)". Position: fixed plus viewport coords lets the same `<div>` handle both, halves the close logic, and keeps the menu a single source of truth for future items.
- **Why suppress the svelte-check warning instead of restructuring:** the rule fires on any non-interactive element with an event handler. Right-click on a card / tile container is a recognized pattern (GitHub, Google Drive, file managers). The keyboard-accessible equivalent is the kebab button — same menu, same items — so the a11y goal is met. Adding a fake `role="..."` to silence the rule would mislead screen-reader users about the element's semantics; the targeted `svelte-ignore` with justification is cleaner.

## What's NOT in scope

- **Compactify after duplicate.** `compactUpward` in `tilePlacement.ts` runs only after resize-shrink (per its docstring); a duplicate that lands far down because the upper rows are dense will not pull up. Matches the existing "drag drop is an explicit placement" rule.
- **Cube ref sanitisation on clone.** The cloned tile inherits any bloated `cube` properties (cubeCaption, defaultMeasure, measureCount) the source carried from legacy saves — `sanitiseForSave` already strips these at save time, so no on-disk impact.
- **Keyboard shortcut for the kebab menu** (Shift+F10 / Menu key). The kebab button itself is keyboard-reachable via Tab; opening with Enter / Space is standard browser button behaviour. A dedicated shortcut can land when a hotkey scheme arrives more broadly.

## Cross-references

- #1007 — direct pattern source for the pure / store layer (catalogue Duplicate action for dashboards, closes #939).
- `$lib/dashboard/tilePlacement.ts` — `firstFreeSlot` is reused as-is; no changes there.
- `$lib/views/dashboard/AddTileMenu.svelte` — pattern source for the kebab dropdown's open-and-outside-click-close logic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
