### PR TITLE
feat(dashboards): Reset filters button on the dashboard toolbar (closes #927)

### DIFF
--- a/saiku-ui/src/lib/dashboard/filterDefaults.test.ts
+++ b/saiku-ui/src/lib/dashboard/filterDefaults.test.ts
@@ -1,0 +1,153 @@
+/*
+ * Unit tests for the pure half of the reset-filters flow (issue #927).
+ *
+ * Covers: snapshot capture, diff detection, restore semantics for both
+ * saved widgets and in-session-added widgets, and referential identity
+ * preservation when nothing would change.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import type { PanelFilter } from "$lib/api/dashboards";
+import {
+  panelDiffersFromDefaults,
+  restoreMembersToDefaults,
+  snapshotPanelDefaults,
+  type SavedDefaultMembers,
+} from "./filterDefaults";
+
+/** Compact constructor — most tests vary only id + members. */
+function w(id: string, members: string[]): PanelFilter {
+  return {
+    id,
+    widget: "single-select",
+    dimension: "Time",
+    hierarchy: "Time",
+    level: "Year",
+    members,
+  };
+}
+
+describe("snapshotPanelDefaults", () => {
+  it("returns an empty index for an undefined panel", () => {
+    expect(snapshotPanelDefaults(undefined)).toEqual({});
+  });
+
+  it("returns an empty index for an empty panel", () => {
+    expect(snapshotPanelDefaults([])).toEqual({});
+  });
+
+  it("captures members[] keyed by widget id", () => {
+    const snap = snapshotPanelDefaults([w("year", ["[Time].[2024]"]), w("region", [])]);
+    expect(snap).toEqual({ year: ["[Time].[2024]"], region: [] });
+  });
+
+  it("deep-clones members[] so later mutations on the source don't leak in", () => {
+    const original = ["[Time].[2024]"];
+    const snap = snapshotPanelDefaults([w("year", original)]);
+    original.push("[Time].[2025]");
+    expect(snap.year).toEqual(["[Time].[2024]"]);
+  });
+
+  it("treats a widget with undefined members[] as the empty default", () => {
+    // PanelFilter.members is typed as required string[] but the migration
+    // path can leave it undefined briefly; snapshot must coerce.
+    const widget = { ...w("year", []), members: undefined as unknown as string[] };
+    const snap = snapshotPanelDefaults([widget]);
+    expect(snap.year).toEqual([]);
+  });
+});
+
+describe("panelDiffersFromDefaults", () => {
+  it("returns false for an undefined or empty panel", () => {
+    expect(panelDiffersFromDefaults(undefined, {})).toBe(false);
+    expect(panelDiffersFromDefaults([], {})).toBe(false);
+  });
+
+  it("returns false when every widget matches its saved default", () => {
+    const defaults: SavedDefaultMembers = { year: ["[Time].[2024]"], region: [] };
+    const cur = [w("year", ["[Time].[2024]"]), w("region", [])];
+    expect(panelDiffersFromDefaults(cur, defaults)).toBe(false);
+  });
+
+  it("returns true when a widget's members differ from its default", () => {
+    const defaults: SavedDefaultMembers = { year: ["[Time].[2024]"] };
+    const cur = [w("year", ["[Time].[2025]"])];
+    expect(panelDiffersFromDefaults(cur, defaults)).toBe(true);
+  });
+
+  it("returns true for an in-session widget (not in snapshot) carrying members", () => {
+    const cur = [w("new", ["[Region].[EU]"])];
+    expect(panelDiffersFromDefaults(cur, {})).toBe(true);
+  });
+
+  it("returns false for an in-session widget with empty members (already at default)", () => {
+    const cur = [w("new", [])];
+    expect(panelDiffersFromDefaults(cur, {})).toBe(false);
+  });
+
+  it("treats member order as significant — [A,B] differs from [B,A]", () => {
+    const defaults: SavedDefaultMembers = { x: ["a", "b"] };
+    const cur = [w("x", ["b", "a"])];
+    expect(panelDiffersFromDefaults(cur, defaults)).toBe(true);
+  });
+});
+
+describe("restoreMembersToDefaults", () => {
+  it("returns the same array reference when nothing would change", () => {
+    const defaults: SavedDefaultMembers = { year: ["[Time].[2024]"] };
+    const panel = [w("year", ["[Time].[2024]"])];
+    expect(restoreMembersToDefaults(panel, defaults)).toBe(panel);
+  });
+
+  it("restores a widget's members[] to its saved default", () => {
+    const defaults: SavedDefaultMembers = { year: ["[Time].[2024]"] };
+    const panel = [w("year", ["[Time].[2025]"])];
+    const next = restoreMembersToDefaults(panel, defaults);
+    expect(next[0].members).toEqual(["[Time].[2024]"]);
+  });
+
+  it("clears in-session widgets (not in snapshot) to empty members[]", () => {
+    const panel = [w("new", ["[Region].[EU]"])];
+    const next = restoreMembersToDefaults(panel, {});
+    expect(next[0].members).toEqual([]);
+  });
+
+  it("preserves widget identity on restore (id, widget type, cube, dim/hier/level)", () => {
+    const defaults: SavedDefaultMembers = { x: [] };
+    const panel: PanelFilter[] = [
+      {
+        id: "x",
+        widget: "multi-select",
+        cube: { connectionName: "c", catalog: "C", schema: "S", cubeName: "Sales" },
+        dimension: "Region",
+        hierarchy: "Geo",
+        level: "Country",
+        members: ["[Region].[EU]"],
+      },
+    ];
+    const next = restoreMembersToDefaults(panel, defaults);
+    expect(next[0].id).toBe("x");
+    expect(next[0].widget).toBe("multi-select");
+    expect(next[0].cube).toEqual({ connectionName: "c", catalog: "C", schema: "S", cubeName: "Sales" });
+    expect(next[0].dimension).toBe("Region");
+    expect(next[0].hierarchy).toBe("Geo");
+    expect(next[0].level).toBe("Country");
+  });
+
+  it("returns a new array (not mutated) when any widget changes; source untouched", () => {
+    const defaults: SavedDefaultMembers = { x: ["a"] };
+    const panel = [w("x", ["b"])];
+    const next = restoreMembersToDefaults(panel, defaults);
+    expect(next).not.toBe(panel);
+    expect(panel[0].members).toEqual(["b"]);
+  });
+
+  it("deep-clones restored members[] so post-restore mutations don't leak into the snapshot", () => {
+    const defaults: SavedDefaultMembers = { x: ["a"] };
+    const panel = [w("x", ["b"])];
+    const next = restoreMembersToDefaults(panel, defaults);
+    next[0].members.push("c");
+    expect(defaults.x).toEqual(["a"]);
+  });
+});

--- a/saiku-ui/src/lib/dashboard/filterDefaults.ts
+++ b/saiku-ui/src/lib/dashboard/filterDefaults.ts
@@ -1,0 +1,84 @@
+/*
+ * Saved-default tracking for dashboard panel filters (issue #927).
+ *
+ * Pure helpers: capture the per-widget members[] of a dashboard at
+ * load time, detect when the in-memory panel diverges from those
+ * defaults, and restore-to-defaults without losing widget identity.
+ *
+ * Lives separately from $lib/api/dashboards (DTO + REST surface) and
+ * from $lib/stores/dashboard (singleton store) so the diff/restore
+ * logic stays unit-testable without DOM or fetch mocks.
+ */
+
+import type { PanelFilter } from "$lib/api/dashboards";
+
+/** Map of {@code PanelFilter.id} → the members[] those widgets had on
+ *  the saved-to-disk dashboard. Captured at {@link snapshotPanelDefaults}
+ *  / dashboardStore.hydrate time so callers can compare or restore
+ *  without a network round-trip.
+ *
+ *  Widgets added in-session (after hydrate) are intentionally absent —
+ *  see {@link restoreMembersToDefaults} for the new-widget semantics. */
+export type SavedDefaultMembers = Record<string, string[]>;
+
+/** Build a {@link SavedDefaultMembers} index from the panel filters of
+ *  a freshly-loaded dashboard. Deep-clones each members[] so subsequent
+ *  in-memory mutations on the live panel can't leak back into the
+ *  snapshot. */
+export function snapshotPanelDefaults(filters: PanelFilter[] | undefined): SavedDefaultMembers {
+  const out: SavedDefaultMembers = {};
+  if (!filters) return out;
+  for (const f of filters) {
+    out[f.id] = [...(f.members ?? [])];
+  }
+  return out;
+}
+
+/** True iff any panel widget's members[] differs from its saved
+ *  default. New widgets (id not present in {@code defaults}) are
+ *  considered non-default when they carry any members; empty-member
+ *  new widgets count as default (nothing to reset). */
+export function panelDiffersFromDefaults(
+  filters: PanelFilter[] | undefined,
+  defaults: SavedDefaultMembers,
+): boolean {
+  if (!filters || filters.length === 0) return false;
+  for (const f of filters) {
+    const cur = f.members ?? [];
+    const saved = defaults[f.id] ?? [];
+    if (!arraysEqual(cur, saved)) return true;
+  }
+  return false;
+}
+
+/** Return a new filters array where each widget's members[] is restored
+ *  to its saved default — or to empty[] for widgets added in-session
+ *  (the "default" for a freshly-created widget is no slicing). Widget
+ *  definitions themselves (id, widget type, cube, dim/hier/level) are
+ *  preserved.
+ *
+ *  Returns the SAME array reference when nothing would change so callers
+ *  can use referential identity to short-circuit a markDirty() / no-op
+ *  store update. */
+export function restoreMembersToDefaults(
+  filters: PanelFilter[],
+  defaults: SavedDefaultMembers,
+): PanelFilter[] {
+  let changed = false;
+  const next = filters.map((f) => {
+    const saved = defaults[f.id] ?? [];
+    const cur = f.members ?? [];
+    if (arraysEqual(cur, saved)) return f;
+    changed = true;
+    return { ...f, members: [...saved] };
+  });
+  return changed ? next : filters;
+}
+
+function arraysEqual(a: string[], b: string[]): boolean {
+  if (a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i++) {
+    if (a[i] !== b[i]) return false;
+  }
+  return true;
+}

--- a/saiku-ui/src/lib/stores/dashboard.svelte.ts
+++ b/saiku-ui/src/lib/stores/dashboard.svelte.ts
@@ -25,6 +25,11 @@ import {
   type FilterWidget,
   type PanelFilter,
 } from "$lib/api/dashboards";
+import {
+  restoreMembersToDefaults,
+  snapshotPanelDefaults,
+  type SavedDefaultMembers,
+} from "$lib/dashboard/filterDefaults";
 import { firstFreeSlot } from "$lib/dashboard/tilePlacement";
 import { recentDashboards } from "$lib/stores/recentDashboards.svelte";
 import { session } from "$lib/stores/session.svelte";
@@ -51,6 +56,12 @@ class DashboardStore {
    *  cloned tile lands in immediate-edit mode (issue #913). Consumed
    *  exactly once via {@link consumeEditSignal}; left unset otherwise. */
   pendingEditTileId = $state<string | null>(null);
+
+  /** Per-panel-widget snapshot of members[] as they were on the
+   *  saved-to-disk dashboard. Re-captured on every {@link hydrate} so
+   *  {@link resetPanelFiltersToSaved} and the toolbar's "can reset?"
+   *  check can compare without a network round-trip. (Issue #927.) */
+  savedDefaultMembers = $state<SavedDefaultMembers>({});
 
   /* ----------------------------- lifecycle ----------------------------- */
 
@@ -99,6 +110,10 @@ class DashboardStore {
     this.dirty = changed;
     this.dirtyCount = changed ? 1 : 0;
     this.saveError = null;
+    // Snapshot AFTER migration — analysts who reset want to land on
+    // the migrated baseline, not on the pre-migration shape that no
+    // longer exists in-memory. (Issue #927.)
+    this.savedDefaultMembers = snapshotPanelDefaults(migrated.filterPanel?.filters);
   }
 
   /** Persist via DashboardResource. Returns true on success. */
@@ -148,6 +163,23 @@ class DashboardStore {
     this.dirtyCount = 0;
     this.loadError = null;
     this.saveError = null;
+    this.savedDefaultMembers = {};
+  }
+
+  /** Restore every panel widget's members[] to its saved-default
+   *  state (empty[] for in-session-added widgets). No-op when nothing
+   *  would change — the {@link restoreMembersToDefaults} helper
+   *  short-circuits via referential identity. Issue #927. */
+  resetPanelFiltersToSaved(): void {
+    if (!this.current?.filterPanel) return;
+    const current = this.current.filterPanel.filters;
+    const next = restoreMembersToDefaults(current, this.savedDefaultMembers);
+    if (next === current) return;
+    this.current = {
+      ...this.current,
+      filterPanel: { ...this.current.filterPanel, filters: next },
+    };
+    this.markDirty();
   }
 
   /* ----------------------------- mutations ----------------------------- */

--- a/saiku-ui/src/lib/views/dashboard/DashboardEditor.svelte
+++ b/saiku-ui/src/lib/views/dashboard/DashboardEditor.svelte
@@ -13,6 +13,7 @@
   import { dashboardStore } from "$lib/stores/dashboard.svelte";
   import { activeFilters } from "$lib/stores/activeFilters.svelte";
   import { newTileId, type TileType } from "$lib/api/dashboards";
+  import { panelDiffersFromDefaults } from "$lib/dashboard/filterDefaults";
   import { buildTile } from "$lib/dashboard/tilePlacement";
   import { decodeFilterParams, encodeActiveFilters } from "$lib/dashboard/urlFilterState";
   import DashboardToolbar from "$lib/views/dashboard/DashboardToolbar.svelte";
@@ -101,6 +102,24 @@
     const tile = buildTile(layout, type, newTileId());
     dashboardStore.addTile(tile);
   }
+
+  // Issue #927: Reset filters button enable-state. True when there are
+  // any click-captured filters OR any panel widget whose members[]
+  // differs from its saved default. The URL deep-link state mirrors
+  // activeFilters.all via the existing $effect above, so resetting
+  // clicks here propagates to the URL automatically.
+  let canResetFilters = $derived(
+    activeFilters.clicks.length > 0 ||
+      panelDiffersFromDefaults(
+        dashboardStore.current?.filterPanel?.filters,
+        dashboardStore.savedDefaultMembers,
+      ),
+  );
+
+  function handleResetFilters(): void {
+    activeFilters.resetTransient();
+    dashboardStore.resetPanelFiltersToSaved();
+  }
 </script>
 
 <div class="dashboard-editor">
@@ -117,6 +136,8 @@
       dirty={dashboardStore.dirty}
       onSave={handleSave}
       onAddTile={readOnly ? undefined : handleAddTile}
+      {canResetFilters}
+      onResetFilters={readOnly ? undefined : handleResetFilters}
     />
     {#if dashboardStore.loadError}
       <div class="notice">{dashboardStore.loadError}</div>

--- a/saiku-ui/src/lib/views/dashboard/DashboardToolbar.svelte
+++ b/saiku-ui/src/lib/views/dashboard/DashboardToolbar.svelte
@@ -15,7 +15,7 @@
   import AddTileMenu from "$lib/views/dashboard/AddTileMenu.svelte";
   import FilterSuggestionsModal from "$lib/views/dashboard/FilterSuggestionsModal.svelte";
   import type { TileType } from "$lib/api/dashboards";
-  import { X } from "lucide-svelte";
+  import { RotateCcw, X } from "lucide-svelte";
 
   interface Props {
     name: string;
@@ -27,6 +27,11 @@
     dirty?: boolean;
     onSave?: () => void;
     onAddTile?: (type: TileType) => void;
+    /** Issue #927 — true iff any click-filter exists OR any panel
+     *  widget's members[] differs from its saved default. Drives the
+     *  Reset filters button's disabled state. */
+    canResetFilters?: boolean;
+    onResetFilters?: () => void;
   }
 
   let {
@@ -39,6 +44,8 @@
     dirty = false,
     onSave,
     onAddTile,
+    canResetFilters = false,
+    onResetFilters,
   }: Props = $props();
 
   let suggestOpen = $state(false);
@@ -152,6 +159,20 @@
         🔍 Suggest filters
       </button>
 
+      <button
+        type="button"
+        class="btn"
+        onclick={() => onResetFilters?.()}
+        disabled={!canResetFilters || !onResetFilters}
+        aria-disabled={!canResetFilters || !onResetFilters}
+        title={canResetFilters
+          ? "Clear all click-filters and restore panel filters to their saved defaults"
+          : "No active filters to reset"}
+      >
+        <RotateCcw size={14} aria-hidden="true" />
+        <span>Reset filters</span>
+      </button>
+
       <AddTileMenu onPick={(t) => onAddTile?.(t)} disabled={!onAddTile} />
 
       <button
@@ -257,6 +278,9 @@
     align-items: center;
   }
   .btn {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.375rem;
     padding: 0.375rem 0.75rem;
     border: 1px solid var(--border-strong);
     background: var(--bg);


### PR DESCRIPTION
## Summary

Closes #927. Adds a **Reset filters** button to the dashboard toolbar that clears every active filter (click-captured + panel widget member selections) back to the saved-default state in one click. Replaces the per-chip clear loop after a chain of click-to-filter actions. The URL deep-link state resets too via the existing `activeFilters` → URL `$effect` — no extra plumbing.

## The change

**Pure helpers — new `$lib/dashboard/filterDefaults.ts`:**
- `snapshotPanelDefaults(filters)` — captures `{ widgetId → members[] }` from a freshly-loaded dashboard. Deep-clones each `members[]` so subsequent in-memory mutations can't leak back into the snapshot.
- `panelDiffersFromDefaults(filters, defaults)` — drives the button's enable-state. Returns true iff any widget's `members[]` differs from its saved default, including in-session-added widgets that carry any members.
- `restoreMembersToDefaults(filters, defaults)` — returns a new filters array with each widget's `members[]` restored to its saved default (empty[] for in-session widgets, since the "default" for a freshly-created widget is no slicing). **Returns the same array reference when nothing would change** so the store can short-circuit `markDirty()` on a no-op reset.

**Store glue — `$lib/stores/dashboard.svelte.ts`:**
- New `savedDefaultMembers: SavedDefaultMembers` `$state` field; captured in `hydrate()` **after `migrateLegacyFilters` runs**, so analysts who reset land on the migrated baseline rather than on a pre-migration shape that no longer exists in memory.
- New `resetPanelFiltersToSaved()` method that delegates to `restoreMembersToDefaults` and only mutates `current` + `markDirty()` when something actually changed.
- `reset()` now clears `savedDefaultMembers` too, alongside the other lifecycle state.

**Editor wiring — `$lib/views/dashboard/DashboardEditor.svelte`:**
- New `$derived` `canResetFilters` = `activeFilters.clicks.length > 0 || panelDiffersFromDefaults(...)`.
- New `handleResetFilters()` calls `activeFilters.resetTransient()` then `dashboardStore.resetPanelFiltersToSaved()`. The URL mirror `$effect` re-encodes from `activeFilters.all` on the next tick — no manual `replaceState` here.
- Both pass through to the toolbar as props; `onResetFilters` is `undefined` in `readOnly` mode (button disables / hides via the existing pattern).

**Toolbar UI — `$lib/views/dashboard/DashboardToolbar.svelte`:**
- New button between **Suggest filters** and **Add tile**. `<RotateCcw size={14}>` icon + "Reset filters" label.
- `disabled` when `!canResetFilters || !onResetFilters`, `aria-disabled` mirrors.
- Tooltip swaps based on state: `"Clear all click-filters and restore panel filters to their saved defaults"` when enabled, `"No active filters to reset"` when disabled.
- `.btn` rule promoted to `display: inline-flex` with a small `gap` so the icon + label sit cleanly. Existing text-only buttons (Suggest filters, Save) unaffected (single text node, no gap rendered).

**Tests — new `$lib/dashboard/filterDefaults.test.ts`:**
- 17 cases covering: snapshot capture (empty / populated / deep-clone / undefined-members coercion); diff detection (empty panel, all-default, modified member, in-session widget with vs without members, member-order significance); restore semantics (referential identity on no-op, restoration to saved, in-session clear to empty, full identity preservation across `widget`/`cube`/`dim`/`hier`/`level`, source immutability, clone independence).

## Verified

- [x] `npm run check` — **0 errors**, 42 warnings (baseline unchanged — no new warnings on any touched file).
- [x] `npm test` — **321/321 passing** (was 304; +17 from the new `filterDefaults` suite). Test file count 24.

## Test plan

- [ ] Manual: open a dashboard with at least one panel filter widget. Initial state — **Reset filters** button is disabled.
- [ ] Manual: click on a chart cell to capture a click-filter. Button enables. Click it → click-filter clears, chip disappears, URL `?f=...` strips that target.
- [ ] Manual: change a panel filter widget's member selection (e.g. Year: 2024 → 2025). Button enables. Click it → member selection restores to the saved 2024.
- [ ] Manual: do both — change a panel filter AND add a click-filter — then click Reset. Both clear in one action, URL resets to the no-filter form, dashboard re-renders unfiltered.
- [ ] Manual: open a dashboard, click Reset (panel at defaults, no clicks) → no-op visible behaviour (button shouldn't have been clickable, but if it were, store change-detection short-circuits and dirty doesn't increment).
- [ ] Manual: add a new panel filter widget mid-session, pick a member, click Reset → the widget's `members[]` clears to empty (widget remains in the panel; only slicing is reset).
- [ ] Manual: read-only view of a dashboard (when shareable read-only links land in #941) — the Reset filters button does not render.
- [ ] Reviewer sanity: open devtools network tab; clicking Reset should NOT trigger a load/save round-trip. Reset is in-memory only; user still needs to hit Save if they want to persist the cleared state.

## What's NOT in scope

- **No i18n keys.** `DashboardToolbar.svelte` currently hardcodes all button labels in English ("🔍 Suggest filters", "Save", "Saved", "Saving…", "+ Add tile"). Adding i18n for one new button would create inconsistency; the right move is a separate sweep that i18ns the whole component at once. Filed mentally as a chore follow-up.
- **No confirmation dialog.** Per the issue: "Confirmation? — no; the filter state is shown above the dashboard so it's reversible visually." Click-filters re-fire on a single chart click; panel filter changes are restoring to saved state, not destroying user work.
- **No undo.** Reset mutates `dashboardStore.current` in place; there's no per-mutation undo stack. If we add undo/redo (issue #914 — Dashboard A4) it should cover this same surface.

## Notes for the reviewer

- **Why "saved-default" semantics for panel widgets rather than wipe-to-empty:** the issue wording ("back to the saved default state") is explicit. A dashboard saved with `Year=2024` as the default should keep that default after Reset, not wipe to `any`. Wipe-to-empty would also clobber an analyst's intentional panel configuration, which feels destructive for a button labelled Reset.
- **Why snapshot AFTER `migrateLegacyFilters`:** that migration runs on every `hydrate` for legacy dashboards (saiku#996 — promotes `type:"filter"` tiles + `dashboard.filters[]` defaults into the unified filter panel). Snapshotting before would mean Reset tries to restore widgets that don't exist in the in-memory model, which would either error or no-op confusingly. Snapshotting after means Reset's "default state" is the migrated baseline — the same thing the user sees on first load.
- **Why `restoreMembersToDefaults` returns the same array reference on no-op:** lets the store gate `markDirty()` on actual change. Prevents a dashboard that's already at defaults from going dirty (and the Save button reactivating) when the user incidentally clicks Reset.
- **The `.btn` CSS change** (`inline-block` → `inline-flex` + `gap`) is benign for the existing text-only buttons (single text node, no gap rendered) but lets the new button align its icon and label cleanly without an extra wrapper element. If reviewer prefers, I can pin the change to a new `.btn--with-icon` modifier instead.

## Cross-references

- `$lib/stores/activeFilters.svelte.ts` — `resetTransient()` reused as-is (already cleared on dashboard swap; we're just calling it explicitly on user request).
- `$lib/dashboard/urlFilterState.ts` — no changes; the URL mirror $effect in `DashboardEditor` runs on every `activeFilters.all` change, so reset propagates to the URL for free.
- #941 (shareable read-only link) — `onResetFilters` is `undefined` in `readOnly`, so the button will degrade cleanly when that lands.
- #914 (undo/redo) — Reset is one of the operations that should be undoable when that work happens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
