### PR TITLE
feat(dashboards): empty-state guidance on new dashboards (closes #916)

### DIFF
--- a/saiku-ui/src/lib/views/dashboard/DashboardEditor.svelte
+++ b/saiku-ui/src/lib/views/dashboard/DashboardEditor.svelte
@@ -20,6 +20,7 @@
   import DashboardFilterBar from "$lib/views/dashboard/DashboardFilterBar.svelte";
   import DashboardFilterPanel from "$lib/views/dashboard/DashboardFilterPanel.svelte";
   import DashboardGrid from "$lib/views/dashboard/DashboardGrid.svelte";
+  import EmptyDashboardGuidance from "$lib/views/dashboard/EmptyDashboardGuidance.svelte";
 
   interface Props {
     dashboardPath: string;
@@ -120,6 +121,13 @@
     activeFilters.resetTransient();
     dashboardStore.resetPanelFiltersToSaved();
   }
+
+  // Issue #916: surface the empty-state guidance when an editable
+  // dashboard has zero tiles. Viewer mode (readOnly) keeps the blank
+  // canvas — a published-but-empty dashboard isn't an authoring moment.
+  let showEmptyGuidance = $derived(
+    !readOnly && (dashboardStore.current?.layout?.tiles?.length ?? 0) === 0,
+  );
 </script>
 
 <div class="dashboard-editor">
@@ -147,7 +155,11 @@
     {/if}
     <DashboardFilterPanel {readOnly} />
     <DashboardFilterBar {readOnly} />
-    <DashboardGrid {readOnly} />
+    {#if showEmptyGuidance}
+      <EmptyDashboardGuidance onAddTile={handleAddTile} />
+    {:else}
+      <DashboardGrid {readOnly} />
+    {/if}
   {:else}
     <div class="error">{dashboardStore.loadError ?? "Unable to load dashboard."}</div>
   {/if}

--- a/saiku-ui/src/lib/views/dashboard/EmptyDashboardGuidance.svelte
+++ b/saiku-ui/src/lib/views/dashboard/EmptyDashboardGuidance.svelte
@@ -1,0 +1,185 @@
+<script lang="ts">
+  /*
+   * Empty-state guidance shown when an editable dashboard has zero tiles
+   * (issue #916). Replaces the blank canvas with a single visible call-
+   * to-action: "Add your first tile" plus three primary buttons that
+   * each pre-pick a tile type (Chart, Table, KPI) and hand it off to
+   * the parent's existing handleAddTile() path.
+   *
+   * A secondary "More tile types" affordance points users at the
+   * toolbar's existing Add tile dropdown — we deliberately do NOT
+   * duplicate the dropdown itself here. One source of truth for the
+   * full tile menu, an obvious starter set for first-time users.
+   *
+   * Render contract: parent decides when to show this (tiles.length === 0
+   * AND !readOnly). The component is purely presentational; no store
+   * subscriptions, no lifecycle.
+   */
+
+  import type { TileType } from "$lib/api/dashboards";
+  import { BarChart3, Gauge, Table2 } from "lucide-svelte";
+
+  interface Props {
+    /** Invoked with the selected tile type. Parent owns placement +
+     *  dashboardStore.addTile() (already implemented as handleAddTile()
+     *  in DashboardEditor — same callback wired to AddTileMenu). */
+    onAddTile: (type: TileType) => void;
+  }
+
+  let { onAddTile }: Props = $props();
+</script>
+
+<div class="empty-state" role="region" aria-label="Add your first tile">
+  <div class="card">
+    <h2 class="title">Add your first tile</h2>
+    <p class="subtitle">
+      Pick a tile type to start building this dashboard. You can configure data,
+      filters, and layout after the tile is dropped.
+    </p>
+
+    <div class="cta-row">
+      <button
+        type="button"
+        class="cta"
+        onclick={() => onAddTile("chart")}
+        aria-label="Add a chart tile"
+      >
+        <span class="cta-icon" aria-hidden="true">
+          <BarChart3 size={28} strokeWidth={1.75} />
+        </span>
+        <span class="cta-label">Chart</span>
+        <span class="cta-hint">Bar, line, pie or area visualisations of your measures.</span>
+      </button>
+
+      <button
+        type="button"
+        class="cta"
+        onclick={() => onAddTile("table")}
+        aria-label="Add a table tile"
+      >
+        <span class="cta-icon" aria-hidden="true">
+          <Table2 size={28} strokeWidth={1.75} />
+        </span>
+        <span class="cta-label">Table</span>
+        <span class="cta-hint">Tabular cells with row and column headers.</span>
+      </button>
+
+      <button
+        type="button"
+        class="cta"
+        onclick={() => onAddTile("kpi")}
+        aria-label="Add a KPI tile"
+      >
+        <span class="cta-icon" aria-hidden="true">
+          <Gauge size={28} strokeWidth={1.75} />
+        </span>
+        <span class="cta-label">KPI</span>
+        <span class="cta-hint">A single measure as a big number with optional comparison.</span>
+      </button>
+    </div>
+
+    <p class="more">
+      Need a text note or filter widget? Use
+      <strong>+ Add tile</strong> in the toolbar above for the full list.
+    </p>
+  </div>
+</div>
+
+<style>
+  .empty-state {
+    display: flex;
+    align-items: flex-start;
+    justify-content: center;
+    padding: 2.5rem 1rem;
+    flex: 1;
+    min-height: 0;
+  }
+  .card {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 1rem;
+    max-width: 56rem;
+    width: 100%;
+    padding: 2rem 1.5rem;
+    border: 1px dashed var(--border-strong);
+    border-radius: 8px;
+    background: var(--bg-subtle);
+    text-align: center;
+  }
+  .title {
+    margin: 0;
+    font-size: 1.25rem;
+    font-weight: var(--weight-semibold);
+    color: var(--fg);
+  }
+  .subtitle {
+    margin: 0;
+    max-width: 36rem;
+    color: var(--fg-muted);
+    font-size: 0.875rem;
+    line-height: 1.5;
+  }
+  .cta-row {
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: 0.75rem;
+    width: 100%;
+    margin-top: 0.5rem;
+  }
+  @media (max-width: 640px) {
+    .cta-row {
+      grid-template-columns: 1fr;
+    }
+  }
+  .cta {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 0.375rem;
+    padding: 1.25rem 1rem;
+    background: var(--bg);
+    border: 1px solid var(--border-strong);
+    border-radius: 6px;
+    cursor: pointer;
+    color: var(--fg);
+    font-family: inherit;
+    transition: border-color 120ms ease, background 120ms ease, transform 120ms ease;
+  }
+  .cta:hover {
+    border-color: var(--accent);
+    background: color-mix(in srgb, var(--accent) 6%, var(--bg));
+  }
+  .cta:focus-visible {
+    outline: 2px solid var(--accent);
+    outline-offset: 2px;
+  }
+  .cta:active {
+    transform: translateY(1px);
+  }
+  .cta-icon {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    color: var(--accent);
+    margin-bottom: 0.25rem;
+  }
+  .cta-label {
+    font-weight: var(--weight-semibold);
+    font-size: 1rem;
+  }
+  .cta-hint {
+    font-size: 0.75rem;
+    color: var(--fg-muted);
+    line-height: 1.4;
+  }
+  .more {
+    margin: 0.25rem 0 0;
+    color: var(--fg-muted);
+    font-size: 0.8125rem;
+  }
+  .more strong {
+    font-weight: var(--weight-medium);
+    color: var(--fg);
+  }
+</style>


### PR DESCRIPTION
## Summary
Issue #916. A brand-new dashboard currently opens to a fully blank canvas — first-time authors have to discover the `+ Add tile` dropdown on their own. This PR replaces that blank canvas with a guided empty state: a dashed card titled "Add your first tile" with three primary CTAs (Chart, Table, KPI) plus a hint pointing at the toolbar dropdown for the rest. The card disappears the moment the first tile lands.

## The change
**UI — `EmptyDashboardGuidance.svelte` (new):** purely presentational Svelte 5 component. Three `<button>` CTAs each call the parent's `onAddTile(type)` prop with `"chart"`, `"table"`, or `"kpi"` respectively. Lucide icons (`BarChart3`, `Table2`, `Gauge`) reused from the existing lucide-svelte dep — no new packages. Each button has an explicit `aria-label`; the card wraps in `role="region"` with an `aria-label` so screen readers announce the section.

**UI — `DashboardEditor.svelte`:** added an `EmptyDashboardGuidance` import and a `$derived` flag `showEmptyGuidance = !readOnly && (current?.layout?.tiles?.length ?? 0) === 0`. When true the guidance renders in place of `<DashboardGrid />`; the grid still mounts as soon as a tile is added. Viewer mode (`readOnly`) intentionally keeps the blank canvas — a published-but-empty dashboard isn't an authoring moment.

## Verified
- [x] `npm run check` — 0 errors, 42 warnings (baseline unchanged; +1 file processed, 4680 → 4681)
- [x] `npm test` — 321/321 passing across 24 files (no regressions, no new tests needed — pure UI composition)

## Test plan
- [ ] Open a freshly-created (zero-tile) dashboard in edit mode → empty-state card appears between the filter bar and where the grid would be.
- [ ] Click each of the three CTAs (Chart, Table, KPI) → a tile of that type is added and the empty-state card disappears immediately.
- [ ] Delete every tile from a dashboard → the empty-state card reappears.
- [ ] Open the same dashboard in viewer mode (`readOnly`, e.g. the public dashboard view) → no card, blank canvas as before.
- [ ] Tab through the card with the keyboard → all three CTAs are focusable and trigger on Enter / Space.
- [ ] Inspect the toolbar's existing `+ Add tile` dropdown → still works, still the source of truth for text + filter tile types.

## Notes for the reviewer
- The card is purposely just three buttons, not a re-implementation of `AddTileMenu`. Keeping one source of truth for the full menu avoids drift; the secondary "More tile types" hint lines up users with the toolbar dropdown that already lists text + filter.
- Visual language matches the existing dashboard surfaces: `var(--bg-subtle)` card with a dashed border, `var(--accent)` for icon colour and hover/focus rings, `var(--weight-semibold)` for the title.
- Mobile fallback: the three-column CTA grid collapses to a single column under 640px via a single `@media` rule.

## What's NOT in scope
- The optional "Show again next time" toggle is deferred per the issue notes — the persistence story isn't worth the v1 complexity, and the card already disappears as soon as the user adds a tile.
- No i18n keys added: dashboard components in this codebase currently hardcode English strings (e.g. `DashboardToolbar.svelte`); matched that convention rather than introducing keys for one component.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
