### PR TITLE
feat(workspace): per-level removal from hierarchy chip right-click menu

### DIFF
--- a/saiku-ui/src/lib/stores/query.svelte.ts
+++ b/saiku-ui/src/lib/stores/query.svelte.ts
@@ -321,6 +321,25 @@ class QueryStore {
     this.markDirty();
   }
 
+  /** Remove a single level from a hierarchy chip. If it was the only
+   *  level, the hierarchy itself is dropped. Mirrors what the cellset
+   *  header's "Remove Level" right-click does, so both entry points
+   *  agree on what "remove" means. */
+  removeLevel(hierarchyName: string, levelName: string): void {
+    if (!this.current?.queryModel) return;
+    const loc = this.findAxisForHierarchy(hierarchyName);
+    if (!loc) return;
+    const hier = this.current.queryModel.axes[loc].hierarchies.find((h) => h.name === hierarchyName);
+    if (!hier) return;
+    if (!(levelName in hier.levels)) return;
+    delete hier.levels[levelName];
+    if (Object.keys(hier.levels).length === 0) {
+      this.removeHierarchy(hierarchyName);
+      return;
+    }
+    this.markDirty();
+  }
+
   addMeasure(m: ThinMeasure): void {
     if (!this.current?.queryModel) return;
     const list = this.current.queryModel.details.measures;

--- a/saiku-ui/src/lib/views/QueryCanvas.svelte
+++ b/saiku-ui/src/lib/views/QueryCanvas.svelte
@@ -126,16 +126,32 @@
   function openHierMenu(e: MouseEvent, axis: AxisLocation, h: ThinHierarchy) {
     e.preventDefault();
     e.stopPropagation();
+    // When the chip carries more than one level, surface a per-level
+    // removal item so users can drop "Quarter" without losing "Year".
+    // The flat-menu approach (vs a submenu) keeps ContextMenu.svelte
+    // simple; a hierarchy with >5 levels would benefit from a submenu,
+    // but those are rare enough that this trade-off is fine for now.
+    const levelNames = Object.keys(h.levels);
+    const items: ContextMenuItem[] = [
+      { id: "selections", label: i18n.t("canvas.menu.editSelections") },
+      { id: "_sep1", sep: true, label: "" },
+    ];
+    if (levelNames.length > 1) {
+      for (const levelName of levelNames) {
+        items.push({
+          id: `removeLevel:${levelName}`,
+          label: `${i18n.t("canvas.menu.removeLevel")}: ${levelName}`,
+        });
+      }
+      items.push({ id: "_sep2", sep: true, label: "" });
+    }
+    items.push({ id: "remove", label: i18n.t("canvas.menu.removeHierarchy"), danger: true });
     menu = {
       open: true,
       x: e.clientX, y: e.clientY,
       kind: "hierarchy",
       axis, measure: null, hierarchy: h,
-      items: [
-        { id: "selections", label: i18n.t("canvas.menu.editSelections") },
-        { id: "_sep", sep: true, label: "" },
-        { id: "remove", label: i18n.t("canvas.menu.removeHierarchy"), danger: true },
-      ],
+      items,
     };
   }
 
@@ -179,6 +195,11 @@
     if (m.kind === "hierarchy" && m.axis && m.hierarchy) {
       if (id === "selections") openSelections(m.axis, m.hierarchy);
       else if (id === "remove") query.removeHierarchy(m.hierarchy.name);
+      else if (id.startsWith("removeLevel:")) {
+        const levelName = id.substring("removeLevel:".length);
+        query.removeLevel(m.hierarchy.name, levelName);
+        if (query.hasRunnableShape()) void query.run();
+      }
       return;
     }
     if (m.kind === "axis" && m.axis) {


### PR DESCRIPTION
## Summary
- A multi-level chip like 'Time (2 levels)' had no way to drop just Quarter and keep Year — the chip × removed the whole hierarchy. Per-level removal lived only on the cellset header right-click, a long trip from the chip the user is reading.
- Chip right-click menu now lists 'Remove Level: <name>' per level when the hierarchy carries more than one. Flat menu (no submenu — ContextMenu doesn't nest yet; the >5-level case is rare enough to accept this).
- Shared `query.removeLevel(hierarchyName, levelName)` store method so the chip menu and the cellset header agree on what 'remove' means; if it was the last level, the hierarchy is dropped.

## Test plan
- [ ] Add Year + Quarter to Time on Columns → chip shows 'Time (2 levels)'
- [ ] Right-click chip → 'Remove Level: Quarter' present
- [ ] Click it → chip becomes 'Time › Year', query reruns
- [ ] Remove the last remaining level → hierarchy chip disappears
- [ ] Single-level chip still shows only Edit selections / Remove hierarchy