### PR TITLE
fix(workspace): missing canvas.menu.removeLevel i18n key

### DIFF
--- a/saiku-ui/src/lib/i18n/en.json
+++ b/saiku-ui/src/lib/i18n/en.json
@@ -97,6 +97,7 @@
   "canvas.menu.removeMeasure": "Remove measure",
   "canvas.menu.editSelections": "Edit selections…",
   "canvas.menu.removeHierarchy": "Remove hierarchy",
+  "canvas.menu.removeLevel": "Remove level",
   "canvas.menu.orderMdx": "Order…",
   "canvas.menu.filterMdx": "Filter (MDX)…",
   "canvas.menu.topCount": "Top count…",


### PR DESCRIPTION
Tail of #1023: the menu entries rendered the literal key 'canvas.menu.removeLevel: Year' because the key wasn't in the en bundle (only cellset.menu.removeLevel existed). One-line add.