### PR TITLE
fix(query): Profit (schema calc member) NPE on execute

### DIFF
--- a/saiku-core/saiku-service/src/main/java/org/saiku/olap/query2/util/Fat.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/olap/query2/util/Fat.java
@@ -180,11 +180,28 @@ public class Fat {
         if (details.getMeasures().size() > 0) {
             for (ThinMeasure m : details.getMeasures()) {
                 if (Type.CALCULATED.equals(m.getType())) {
+                    // query.getCalculatedMeasure() only returns
+                    // USER-created Saiku calc measures. Schema-defined
+                    // calc members (e.g. FoodMart Profit) were tagged
+                    // CALCULATED by older UI builds (saiku#1019) — fall
+                    // back to the regular cube-measure lookup so legacy
+                    // saved queries don't NPE on roundtrip.
                     Measure measure = query.getCalculatedMeasure(m.getName());
-                    query.getDetails().add(measure);
+                    if (measure == null) {
+                        measure = query.getMeasure(m.getName());
+                    }
+                    if (measure != null) {
+                        query.getDetails().add(measure);
+                    }
                 } else if (Type.EXACT.equals(m.getType())) {
-                    Measure measure = new MeasureAdapter(query.getMeasure(m.getName()), m);
-                    query.getDetails().add(measure);
+                    Measure inner = query.getMeasure(m.getName());
+                    // Skip rather than wrap null — MeasureAdapter
+                    // delegates getName/getUniqueName to the inner
+                    // Measure, and a null inner trips an NPE on the
+                    // first Thin.convert roundtrip.
+                    if (inner != null) {
+                        query.getDetails().add(new MeasureAdapter(inner, m));
+                    }
                 }
             }
         }

--- a/saiku-ui/src/lib/views/DimensionList.svelte
+++ b/saiku-ui/src/lib/views/DimensionList.svelte
@@ -53,7 +53,17 @@
       name: m.name,
       uniqueName: m.uniqueName,
       caption: m.caption || m.name,
-      type: m.calculated ? "CALCULATED" : "EXACT",
+      // saiku#1019: schema-defined calc members (e.g. FoodMart Profit)
+      // show as calculated:true in /discover, but Fat.convertDetails'
+      // CALCULATED branch looks them up via query.getCalculatedMeasure()
+      // — a map that only holds USER-added Saiku calc measures, so the
+      // schema one returns null, gets added to details, and trips a
+      // NullPointerException on the next m.getName() roundtrip. Schema
+      // calc members live in cube.getMeasures() like any normal measure,
+      // so the EXACT path (query.getMeasure → cube.getMeasures lookup)
+      // resolves them correctly. The CALCULATED tag stays reserved for
+      // the modal-created measures in QueryCanvas.svelte.
+      type: "EXACT",
     };
     e.dataTransfer?.setData("application/x-saiku-measure", JSON.stringify(thin));
     if (e.dataTransfer) e.dataTransfer.effectAllowed = "move";
@@ -66,7 +76,17 @@
       name: m.name,
       uniqueName: m.uniqueName,
       caption: m.caption || m.name,
-      type: m.calculated ? "CALCULATED" : "EXACT",
+      // saiku#1019: schema-defined calc members (e.g. FoodMart Profit)
+      // show as calculated:true in /discover, but Fat.convertDetails'
+      // CALCULATED branch looks them up via query.getCalculatedMeasure()
+      // — a map that only holds USER-added Saiku calc measures, so the
+      // schema one returns null, gets added to details, and trips a
+      // NullPointerException on the next m.getName() roundtrip. Schema
+      // calc members live in cube.getMeasures() like any normal measure,
+      // so the EXACT path (query.getMeasure → cube.getMeasures lookup)
+      // resolves them correctly. The CALCULATED tag stays reserved for
+      // the modal-created measures in QueryCanvas.svelte.
+      type: "EXACT",
     });
   }
 
@@ -145,7 +165,17 @@
         name: m.name,
         uniqueName: m.uniqueName,
         caption: m.caption || m.name,
-        type: m.calculated ? "CALCULATED" : "EXACT",
+        // saiku#1019: schema-defined calc members (e.g. FoodMart Profit)
+      // show as calculated:true in /discover, but Fat.convertDetails'
+      // CALCULATED branch looks them up via query.getCalculatedMeasure()
+      // — a map that only holds USER-added Saiku calc measures, so the
+      // schema one returns null, gets added to details, and trips a
+      // NullPointerException on the next m.getName() roundtrip. Schema
+      // calc members live in cube.getMeasures() like any normal measure,
+      // so the EXACT path (query.getMeasure → cube.getMeasures lookup)
+      // resolves them correctly. The CALCULATED tag stays reserved for
+      // the modal-created measures in QueryCanvas.svelte.
+      type: "EXACT",
       });
     }
     query.setMeasures(next);


### PR DESCRIPTION
Two-layer fix for the NPE Tom hit dropping FoodMart Profit onto a query.

**Cause**: schema-defined calc members come back from /discover with calculated:true; the UI was tagging them ThinMeasure type=CALCULATED; Fat.convertDetails' CALCULATED branch looked them up via query.getCalculatedMeasure() (user-defined calcs only) → null → wrapped/added to details → NPE on roundtrip.

**Fix**:
- UI: sidebar measures always tag type=EXACT. CALCULATED stays reserved for the modal-created user calc measures.
- Java: defensive fallbacks in Fat.convertDetails so legacy saved queries with the bad tag don't keep NPE'ing (CALCULATED falls through to getMeasure on null; EXACT skips on null instead of wrapping in MeasureAdapter).