### PR TITLE
fix(cellset): parse Mondrian style-markers in formatted values

### DIFF
--- a/saiku-ui/src/lib/cellset/cellFormat.test.ts
+++ b/saiku-ui/src/lib/cellset/cellFormat.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, test } from "vitest";
+import { parseFormattedCell } from "./cellFormat";
+
+describe("parseFormattedCell", () => {
+  test("returns raw string when no marker", () => {
+    expect(parseFormattedCell("2,096")).toEqual({ display: "2,096" });
+    expect(parseFormattedCell("$4,250.51")).toEqual({ display: "$4,250.51" });
+  });
+
+  test("extracts inner value + colour for the Mondrian marker", () => {
+    expect(parseFormattedCell("|($2,561.57)|style=red")).toEqual({
+      display: "($2,561.57)",
+      color: "red",
+    });
+  });
+
+  test("handles localised currency inside the marker", () => {
+    expect(parseFormattedCell("|(2,561.57 €)|style=red")).toEqual({
+      display: "(2,561.57 €)",
+      color: "red",
+    });
+  });
+
+  test("handles hex colours", () => {
+    expect(parseFormattedCell("|42|style=#ff8800")).toEqual({
+      display: "42",
+      color: "#ff8800",
+    });
+    expect(parseFormattedCell("|42|style=#fff")).toEqual({
+      display: "42",
+      color: "#fff",
+    });
+  });
+
+  test("returns raw when the marker is malformed", () => {
+    expect(parseFormattedCell("|value|noStyle")).toEqual({ display: "|value|noStyle" });
+    expect(parseFormattedCell("|value|style=")).toEqual({ display: "|value|style=" });
+    expect(parseFormattedCell("|value|style=rgba(255,0,0,0.5)")).toEqual({
+      display: "|value|style=rgba(255,0,0,0.5)",
+    });
+  });
+
+  test("handles null/empty input", () => {
+    expect(parseFormattedCell(null)).toEqual({ display: "" });
+    expect(parseFormattedCell(undefined)).toEqual({ display: "" });
+    expect(parseFormattedCell("")).toEqual({ display: "" });
+  });
+});

--- a/saiku-ui/src/lib/cellset/cellFormat.ts
+++ b/saiku-ui/src/lib/cellset/cellFormat.ts
@@ -1,0 +1,39 @@
+/*
+ * Parse Mondrian's inline cell-formatting markers.
+ *
+ * Mondrian renders conditional-format hints by wrapping the formatted
+ * value in pipe characters with a trailing `style=<css>` token, e.g.
+ *
+ *   |($2,561.57)|style=red
+ *
+ * Schema-defined calculated members (FoodMart Profit being the canonical
+ * example) emit this whenever their format string carries a coloured
+ * negative branch. The legacy Saiku UI rendered the inner value in the
+ * declared colour; the rewrite was passing the whole string through
+ * verbatim, so cells looked like literal markup.
+ *
+ * Conservative parser: only matches the canonical
+ *   ^\|(.*)\|style=<colour>$
+ * shape. Anything else returns { display: raw } so non-conforming text
+ * (or future Mondrian markers we don't yet know about) renders as-is.
+ */
+
+/** Hex (#fff, #ffffff) or CSS colour keyword. Mondrian only ever
+ *  emits one of these — no rgba()/hsl() in the wild. Keep the regex
+ *  conservative so we don't accidentally swallow ordinary pipe-bracketed
+ *  text. */
+const MARKER_RE = /^\|(.*)\|style=(#[0-9a-fA-F]{3,8}|[a-zA-Z]+)$/;
+
+export interface ParsedCell {
+  /** What to render in the cell. */
+  display: string;
+  /** Inline CSS colour to apply, if the marker carried one. */
+  color?: string;
+}
+
+export function parseFormattedCell(raw: string | null | undefined): ParsedCell {
+  if (raw == null) return { display: "" };
+  const m = MARKER_RE.exec(raw);
+  if (!m) return { display: raw };
+  return { display: m[1], color: m[2] };
+}

--- a/saiku-ui/src/lib/views/CellsetTable.svelte
+++ b/saiku-ui/src/lib/views/CellsetTable.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import type { CellEntry, QueryResult } from "$lib/api/query";
   import { parseCellset, rowHeaderDisplay } from "$lib/views/cellsetUtils";
+  import { parseFormattedCell } from "$lib/cellset/cellFormat";
   import { query as queryStore } from "$lib/stores/query.svelte";
   import { datasources } from "$lib/stores/datasources.svelte";
   import { selection } from "$lib/stores/selection.svelte";
@@ -35,7 +36,8 @@
     let min = Infinity, max = -Infinity;
     for (const row of parsed.dataRows) {
       for (const cell of row) {
-        const n = Number(String(cell.value ?? "").replace(/[, ]/g, ""));
+        const display = parseFormattedCell(cell.value).display;
+        const n = Number(String(display ?? "").replace(/[, ]/g, ""));
         if (Number.isFinite(n)) {
           if (n < min) min = n;
           if (n > max) max = n;
@@ -523,7 +525,11 @@
   function toNumber(cell: CellEntry | undefined): number | null {
     if (!cell) return null;
     const raw = cell.properties?.raw;
-    const src = raw ?? cell.value;
+    // Strip Mondrian style-markers from the formatted fallback so
+    // values like "|($2,561.57)|style=red" parse as -2561.57 rather
+    // than NaN. properties.raw (when present) is the unformatted
+    // numeric and bypasses the marker entirely.
+    const src = raw ?? parseFormattedCell(cell.value).display;
     if (src == null || src === "") return null;
     const n = Number(String(src).replace(/[, ]/g, ""));
     return Number.isFinite(n) ? n : null;
@@ -650,7 +656,8 @@
               {/if}
             {/each}
             {#each parsed.dataRows[r] as dc, cIdx}
-              {@const num = isNumeric(dc.value)}
+              {@const fmt = parseFormattedCell(dc.value)}
+              {@const num = isNumeric(fmt.display)}
               {@const selected = isSelected(r, cIdx)}
               {@const hasFocus = isFocused(r, cIdx)}
               <td
@@ -662,10 +669,11 @@
                 aria-selected={selected ? "true" : undefined}
                 data-r={r}
                 data-c={cIdx}
+                style={fmt.color ? `color: ${fmt.color}` : undefined}
                 onmousedown={(e) => onCellMouseDown(e, r, cIdx)}
                 onmouseenter={() => onCellMouseEnter(r, cIdx)}
                 oncontextmenu={(e) => onDataCellContextMenu(e, r, cIdx)}
-              >{dc.value}</td>
+              >{fmt.display}</td>
             {/each}
             {#if spark !== "none"}
               {@const range = sparkRange()}

--- a/saiku-ui/src/lib/views/dashboard/tiles/TableTile.svelte
+++ b/saiku-ui/src/lib/views/dashboard/tiles/TableTile.svelte
@@ -38,6 +38,7 @@
     type RowAxisRef,
   } from "$lib/dashboard/filterSuggestions";
   import type { CubeRef } from "$lib/api/dashboards";
+  import { parseFormattedCell } from "$lib/cellset/cellFormat";
 
   interface Props {
     tile: DashboardTile;
@@ -296,20 +297,22 @@
               <tr>
                 {#each columns as col (col.caption)}
                   {@const v = row[col.caption]}
+                  {@const fmt = parseFormattedCell(renderCell(v))}
                   <td
                     class:row-header={col.isRowHeader}
                     class:clickable={col.isRowHeader}
-                    onclick={() => handleCellClick(col.caption, renderCell(v), col.isRowHeader, row)}
+                    style={fmt.color ? `color: ${fmt.color}` : undefined}
+                    onclick={() => handleCellClick(col.caption, fmt.display, col.isRowHeader, row)}
                     role={col.isRowHeader ? "button" : undefined}
                     tabindex={col.isRowHeader ? 0 : undefined}
                     onkeydown={(e) => {
                       if (col.isRowHeader && (e.key === "Enter" || e.key === " ")) {
                         e.preventDefault();
-                        handleCellClick(col.caption, renderCell(v), col.isRowHeader, row);
+                        handleCellClick(col.caption, fmt.display, col.isRowHeader, row);
                       }
                     }}
                   >
-                    {renderCell(v)}
+                    {fmt.display}
                   </td>
                 {/each}
               </tr>


### PR DESCRIPTION
Cells showed the literal Mondrian conditional-format markup ('|(2,561.57 €)|style=red') instead of the inner value rendered in the declared colour.

New parser $lib/cellset/cellFormat with 6 unit tests for the canonical shape, hex colours, malformed input, and null/empty. Applied in CellsetTable + TableTile so the inner value + CSS color make it through, and the marker is stripped before selection stats / sparkline scaling / click-to-filter so those derivations don't see the markup.