### PR TITLE
feat(dashboards): cascading single-select filter widget (closes #922)

### DIFF
--- a/saiku-ui/src/lib/api/dashboards.ts
+++ b/saiku-ui/src/lib/api/dashboards.ts
@@ -38,7 +38,35 @@ export type TileQuery = ReferenceQuery | InlineQuery;
 
 export type TileType = "chart" | "table" | "text" | "filter" | "kpi";
 
-export type FilterWidget = "single-select" | "multi-select" | "date-range";
+export type FilterWidget = "single-select" | "multi-select" | "date-range" | "cascading-select";
+
+/* --- issue #922: cascading single-select filter widget -------------------
+ * Self-contained additions for the "cascading-select" FilterWidget variant.
+ * Kept in one clearly-delimited block (appended, nothing reordered) so the
+ * parallel #919 conditional-formatting work rebases cleanly. The variant
+ * walks a single hierarchy level-by-level: pick a parent member, the next
+ * dropdown shows only that parent's children, and so on. The deepest
+ * concrete selection is emitted as the filter member. Pure cascade state
+ * logic lives in $lib/dashboard/cascadingFilter; this is just the config
+ * DTO carried on the panel filter / tile.
+ */
+
+/** Per-widget config for the {@code "cascading-select"} variant. The
+ *  cascade walks the levels of {@link DashboardFilter.hierarchy} starting
+ *  at {@code startLevel} (which defaults to the filter's own
+ *  {@code level}) and descends at most {@code depth} dropdowns. No new
+ *  backend surface — each dropdown reuses the existing member-search
+ *  fetch, scoped to the parent member chosen above it. */
+export interface CascadingSelectConfig {
+  /** Root-most cascade level (caption). When omitted the renderer falls
+   *  back to the panel filter's {@link DashboardFilter.level}. */
+  startLevel?: string;
+  /** How many dropdowns deep the cascade may walk (clamped 1..6 and
+   *  further bounded by the levels actually present below startLevel).
+   *  Defaults to 3 when unset. */
+  depth?: number;
+}
+/* --- end issue #922 block ------------------------------------------------- */
 
 /** A dim/hier/level filter — used as both a dashboard-level default and
  *  as the {@code target} of a filter-widget tile. */
@@ -115,6 +143,9 @@ export interface DashboardTile {
   text?: string;
   target?: DashboardFilter;
   widget?: FilterWidget;
+  /** Cascading-select config (issue #922). Only consulted when
+   *  {@code widget === "cascading-select"}. */
+  cascading?: CascadingSelectConfig;
   /** KPI-tile config. Only consulted when {@code type === "kpi"}. */
   kpi?: KpiConfig;
   /** Per-column conditional formatting rules. Only consulted when
@@ -192,6 +223,9 @@ export interface PanelFilter extends DashboardFilter {
   id: string;
   widget: FilterWidget;
   cube?: CubeRef;
+  /** Config for {@code widget === "cascading-select"} (issue #922).
+   *  Ignored by the other variants. */
+  cascading?: CascadingSelectConfig;
 }
 
 /** Unified filter panel: docks at the top of the dashboard editor as

--- a/saiku-ui/src/lib/dashboard/cascadingFilter.test.ts
+++ b/saiku-ui/src/lib/dashboard/cascadingFilter.test.ts
@@ -1,0 +1,221 @@
+/*
+ * Unit tests for the pure cascading single-select filter logic
+ * (issue #922).
+ *
+ * Covers: depth bounds (clampDepth / effectiveDepth); which dropdowns
+ * are visible given selections at levels [0..k]; selecting "All" at
+ * level k truncating deeper selections; computing the emitted leaf
+ * member (deepest non-"All", or none); the parent that feeds the next
+ * dropdown; and idempotent re-selection.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import {
+  applySelection,
+  clampDepth,
+  effectiveDepth,
+  emittedLeafMember,
+  emittedMembers,
+  parentForLevel,
+  selectionsEqual,
+  visibleDropdownCount,
+  type CascadeSelections,
+} from "./cascadingFilter";
+
+// Realistic Mondrian-style member unique names for a Geography walk:
+// Region -> Country -> State -> City.
+const USA = "[Geo].[Geography].[USA]";
+const OR = "[Geo].[Geography].[USA].[OR]";
+const PORTLAND = "[Geo].[Geography].[USA].[OR].[Portland]";
+const MEXICO = "[Geo].[Geography].[Mexico]";
+
+describe("clampDepth", () => {
+  it("defaults a nullish / NaN depth to 1", () => {
+    expect(clampDepth(undefined)).toBe(1);
+    expect(clampDepth(NaN)).toBe(1);
+  });
+
+  it("floors a fractional depth", () => {
+    expect(clampDepth(3.9)).toBe(3);
+  });
+
+  it("never returns below 1", () => {
+    expect(clampDepth(0)).toBe(1);
+    expect(clampDepth(-5)).toBe(1);
+  });
+
+  it("caps at the default max of 6", () => {
+    expect(clampDepth(99)).toBe(6);
+  });
+
+  it("respects a custom max", () => {
+    expect(clampDepth(10, 3)).toBe(3);
+  });
+});
+
+describe("effectiveDepth", () => {
+  it("is 0 when no levels are available", () => {
+    expect(effectiveDepth(4, 0)).toBe(0);
+    expect(effectiveDepth(4, -1)).toBe(0);
+  });
+
+  it("never exceeds the available level count", () => {
+    expect(effectiveDepth(4, 2)).toBe(2);
+  });
+
+  it("uses the configured depth when levels are plentiful", () => {
+    expect(effectiveDepth(3, 5)).toBe(3);
+  });
+
+  it("clamps the configured depth before bounding by levels", () => {
+    expect(effectiveDepth(99, 4)).toBe(4); // clamp -> 6, then min(6,4)
+    expect(effectiveDepth(0, 4)).toBe(1); // clamp -> 1, then min(1,4)
+  });
+});
+
+describe("visibleDropdownCount", () => {
+  it("is 0 for a zero-depth cascade", () => {
+    expect(visibleDropdownCount([], 0)).toBe(0);
+  });
+
+  it("shows just the first dropdown when nothing is selected", () => {
+    expect(visibleDropdownCount([], 4)).toBe(1);
+    expect(visibleDropdownCount([null], 4)).toBe(1);
+  });
+
+  it("reveals the next dropdown once a parent is concretely chosen", () => {
+    expect(visibleDropdownCount([USA], 4)).toBe(2);
+  });
+
+  it("reveals one dropdown per concrete selection, in order", () => {
+    expect(visibleDropdownCount([USA, OR], 4)).toBe(3);
+    expect(visibleDropdownCount([USA, OR, PORTLAND], 4)).toBe(4);
+  });
+
+  it("hides deeper dropdowns when an intermediate level is 'All'", () => {
+    // dropdown 0 = USA, dropdown 1 = All -> dropdown 2+ hidden.
+    expect(visibleDropdownCount([USA, null], 4)).toBe(2);
+  });
+
+  it("never exceeds the configured depth even with deeper selections", () => {
+    expect(visibleDropdownCount([USA, OR, PORTLAND], 2)).toBe(2);
+  });
+});
+
+describe("applySelection", () => {
+  it("sets a concrete member at the root level", () => {
+    expect(applySelection([], 0, USA)).toEqual([USA]);
+  });
+
+  it("appends a child selection below a chosen parent", () => {
+    expect(applySelection([USA], 1, OR)).toEqual([USA, OR]);
+  });
+
+  it("truncates deeper selections when re-choosing a shallower level", () => {
+    // user had USA/OR/Portland, then changes the country dropdown.
+    expect(applySelection([USA, OR, PORTLAND], 0, MEXICO)).toEqual([MEXICO]);
+  });
+
+  it("selecting 'All' (null) at level k truncates to length k", () => {
+    expect(applySelection([USA, OR, PORTLAND], 1, null)).toEqual([USA]);
+  });
+
+  it("selecting 'All' at the root clears everything", () => {
+    expect(applySelection([USA, OR], 0, null)).toEqual([]);
+  });
+
+  it("pads sparse upstream gaps with explicit nulls", () => {
+    // choosing a value at level 2 with nothing above keeps the indices dense.
+    expect(applySelection([], 2, PORTLAND)).toEqual([null, null, PORTLAND]);
+  });
+
+  it("does not mutate the input array", () => {
+    const src: CascadeSelections = [USA, OR];
+    const out = applySelection(src, 1, null);
+    expect(src).toEqual([USA, OR]);
+    expect(out).not.toBe(src);
+  });
+
+  it("is a no-op-equivalent on idempotent re-selection of the same value", () => {
+    const src: CascadeSelections = [USA, OR];
+    const out = applySelection(src, 1, OR);
+    expect(selectionsEqual(src, out)).toBe(true);
+  });
+
+  it("ignores a negative level (defensive clone)", () => {
+    const src: CascadeSelections = [USA];
+    const out = applySelection(src, -1, OR);
+    expect(out).toEqual([USA]);
+    expect(out).not.toBe(src);
+  });
+});
+
+describe("emittedLeafMember", () => {
+  it("returns null when every level is 'All'", () => {
+    expect(emittedLeafMember([])).toBeNull();
+    expect(emittedLeafMember([null, null])).toBeNull();
+  });
+
+  it("returns the only concrete selection", () => {
+    expect(emittedLeafMember([USA])).toBe(USA);
+  });
+
+  it("returns the deepest concrete selection", () => {
+    expect(emittedLeafMember([USA, OR, PORTLAND])).toBe(PORTLAND);
+  });
+
+  it("ignores trailing 'All' levels", () => {
+    expect(emittedLeafMember([USA, OR, null])).toBe(OR);
+  });
+
+  it("returns the deepest concrete even with an intermediate 'All'", () => {
+    // pathological but well-defined: deepest non-null wins.
+    expect(emittedLeafMember([USA, null, PORTLAND])).toBe(PORTLAND);
+  });
+});
+
+describe("emittedMembers", () => {
+  it("is an empty array when nothing concrete is selected", () => {
+    expect(emittedMembers([null])).toEqual([]);
+  });
+
+  it("wraps the leaf member in a single-element array", () => {
+    expect(emittedMembers([USA, OR])).toEqual([OR]);
+  });
+});
+
+describe("parentForLevel", () => {
+  it("returns the concrete member at the requested level", () => {
+    expect(parentForLevel([USA, OR], 0)).toBe(USA);
+    expect(parentForLevel([USA, OR], 1)).toBe(OR);
+  });
+
+  it("returns null for an 'All' level", () => {
+    expect(parentForLevel([USA, null], 1)).toBeNull();
+  });
+
+  it("returns null out of range", () => {
+    expect(parentForLevel([USA], 5)).toBeNull();
+    expect(parentForLevel([USA], -1)).toBeNull();
+  });
+});
+
+describe("selectionsEqual", () => {
+  it("treats trailing nulls as absence", () => {
+    expect(selectionsEqual([USA], [USA, null, null])).toBe(true);
+    expect(selectionsEqual([], [null, null])).toBe(true);
+  });
+
+  it("distinguishes different concrete selections", () => {
+    expect(selectionsEqual([USA], [MEXICO])).toBe(false);
+  });
+
+  it("distinguishes different depths of concrete selection", () => {
+    expect(selectionsEqual([USA], [USA, OR])).toBe(false);
+  });
+
+  it("distinguishes an intermediate 'All' from a concrete member", () => {
+    expect(selectionsEqual([USA, null, PORTLAND], [USA, OR, PORTLAND])).toBe(false);
+  });
+});

--- a/saiku-ui/src/lib/dashboard/cascadingFilter.ts
+++ b/saiku-ui/src/lib/dashboard/cascadingFilter.ts
@@ -1,0 +1,155 @@
+/*
+ * Pure state logic for the cascading single-select filter widget
+ * (issue #922).
+ *
+ * A cascading-select filter walks a single hierarchy level-by-level:
+ * the analyst picks a parent member, the next dropdown reveals only that
+ * parent's children, and so on (e.g. Region -> Country -> State -> City).
+ * The deepest *concrete* selection is the member the widget emits as the
+ * active filter. An "All" choice at any level resets every level below
+ * it.
+ *
+ * This module owns ALL of the cascade branching so the Svelte component
+ * stays thin — it only does the async member fetch + binding and hands
+ * raw selections in / reads derived state out. Nothing here touches the
+ * DOM, fetch, or the dashboard store, which keeps it trivially testable.
+ *
+ * Naming note: lives alongside the older $lib/dashboard/cascadingFilters
+ * (plural) module, which solves a *different* problem — ancestor-prefix
+ * restriction across two independent panel widgets. This one (singular)
+ * is the self-contained N-dropdown walk of a single widget. They do not
+ * share code.
+ */
+
+/** "All" / no-selection sentinel for a cascade level. Modelled as null
+ *  so a selections array is `(string | null)[]` indexed by depth. */
+export type CascadeSelection = string | null;
+
+/** Per-level selections, index 0 = root-most cascade level. A `null`
+ *  entry means "All" (no member chosen at that level). The array may be
+ *  shorter than the configured depth — missing trailing entries are
+ *  treated as "All". */
+export type CascadeSelections = CascadeSelection[];
+
+/** Clamp a requested cascade depth to a sane range. A cascade needs at
+ *  least one dropdown; we cap at {@code maxDepth} (default 6) so a
+ *  mis-configured tile can't spawn an unbounded column of selects. The
+ *  effective depth is additionally bounded by how many levels actually
+ *  remain in the hierarchy below the start level — see
+ *  {@link effectiveDepth}. */
+export function clampDepth(depth: number | undefined, maxDepth = 6): number {
+  if (depth == null || Number.isNaN(depth)) return 1;
+  const floored = Math.floor(depth);
+  if (floored < 1) return 1;
+  if (floored > maxDepth) return maxDepth;
+  return floored;
+}
+
+/** The number of cascade dropdowns this widget can show, given the
+ *  configured depth and the number of hierarchy levels available at or
+ *  below the start level. Never exceeds {@code availableLevels} (you
+ *  can't walk past the leaf) and never drops below 1 when at least one
+ *  level exists. Returns 0 when there are no available levels. */
+export function effectiveDepth(configuredDepth: number | undefined, availableLevels: number): number {
+  if (availableLevels <= 0) return 0;
+  const want = clampDepth(configuredDepth);
+  return Math.min(want, availableLevels);
+}
+
+/** How many dropdowns are currently *visible*, given the selections so
+ *  far. The first dropdown is always visible. Each subsequent dropdown
+ *  appears only once its parent has a concrete (non-"All") selection —
+ *  there's nothing to fetch children for until the parent is chosen. The
+ *  count is capped at {@code depth}.
+ *
+ *  Example (depth 4): with selections [USA, null] the visible count is 2
+ *  — dropdown 0 (USA chosen) and dropdown 1 (its children, currently
+ *  "All"); dropdowns 2+ stay hidden because dropdown 1 is still "All". */
+export function visibleDropdownCount(selections: CascadeSelections, depth: number): number {
+  if (depth <= 0) return 0;
+  let visible = 1;
+  for (let i = 0; i < depth - 1; i++) {
+    const sel = selections[i] ?? null;
+    if (sel == null) break; // parent is "All" — deeper dropdowns hidden
+    visible = i + 2;
+  }
+  return Math.min(visible, depth);
+}
+
+/** Apply a selection at level {@code level}, returning a NEW selections
+ *  array. Selecting "All" (value null) at level k truncates the array to
+ *  length k — every deeper selection is discarded because its parent no
+ *  longer pins a member. Selecting a concrete member at level k sets that
+ *  slot and likewise drops any now-stale deeper selections (the children
+ *  shown below must be re-derived from the new parent).
+ *
+ *  Pure: the input array is never mutated. Re-selecting the same value
+ *  that's already at that level (with the same tail) returns a value that
+ *  is deep-equal to the input — see {@link selectionsEqual} for the
+ *  idempotence check callers can use to short-circuit. */
+export function applySelection(
+  selections: CascadeSelections,
+  level: number,
+  value: CascadeSelection,
+): CascadeSelections {
+  if (level < 0) return [...selections];
+  // Keep everything strictly above the changed level untouched; the
+  // changed level takes the new value; everything below is dropped.
+  const head = selections.slice(0, level);
+  // Pad any gap (sparse upstream "All"s) with explicit nulls so indexing
+  // stays dense and predictable for the component's #each.
+  while (head.length < level) head.push(null);
+  if (value == null) {
+    // "All" at this level: truncate here, no slot retained.
+    return head;
+  }
+  return [...head, value];
+}
+
+/** The deepest concrete (non-"All") selection — the member the widget
+ *  emits as its filter. Returns null when every level is "All" (the
+ *  widget contributes no slicing). Trailing "All"s are ignored. */
+export function emittedLeafMember(selections: CascadeSelections): string | null {
+  for (let i = selections.length - 1; i >= 0; i--) {
+    const sel = selections[i];
+    if (sel != null) return sel;
+  }
+  return null;
+}
+
+/** Emit the leaf as the members[] array the rest of the dashboard filter
+ *  machinery expects (single-element, or empty for "All at every
+ *  level"). Mirrors how the other widget variants push an ActiveFilter
+ *  member list. */
+export function emittedMembers(selections: CascadeSelections): string[] {
+  const leaf = emittedLeafMember(selections);
+  return leaf == null ? [] : [leaf];
+}
+
+/** The concrete member selected at level {@code level} whose children
+ *  should populate dropdown {@code level + 1}. Returns null when that
+ *  level is "All" (or out of range) — i.e. there is no parent to fetch
+ *  children for, so the next dropdown stays hidden. */
+export function parentForLevel(selections: CascadeSelections, level: number): string | null {
+  if (level < 0 || level >= selections.length) return null;
+  return selections[level] ?? null;
+}
+
+/** Structural equality of two selections arrays, treating a trailing
+ *  run of nulls as equivalent to absence. Lets callers detect a no-op
+ *  re-selection and skip a store write / re-render. */
+export function selectionsEqual(a: CascadeSelections, b: CascadeSelections): boolean {
+  const an = trimTrailingNulls(a);
+  const bn = trimTrailingNulls(b);
+  if (an.length !== bn.length) return false;
+  for (let i = 0; i < an.length; i++) {
+    if (an[i] !== bn[i]) return false;
+  }
+  return true;
+}
+
+function trimTrailingNulls(s: CascadeSelections): CascadeSelections {
+  let end = s.length;
+  while (end > 0 && (s[end - 1] ?? null) == null) end--;
+  return s.slice(0, end);
+}

--- a/saiku-ui/src/lib/views/dashboard/DashboardFilterPanel.svelte
+++ b/saiku-ui/src/lib/views/dashboard/DashboardFilterPanel.svelte
@@ -26,6 +26,16 @@
     ancestorSelections,
     memberDescendsFromAny,
   } from "$lib/dashboard/cascadingFilters";
+  // issue #922: pure cascade state logic for the cascading-select variant.
+  import {
+    applySelection,
+    effectiveDepth,
+    emittedMembers,
+    parentForLevel,
+    selectionsEqual,
+    visibleDropdownCount,
+    type CascadeSelections,
+  } from "$lib/dashboard/cascadingFilter";
   import {
     expandDateRange,
     fromDateInputValue,
@@ -100,6 +110,12 @@
       hierarchy: addHierarchy,
       level: addLevel,
       members: [],
+      // issue #922: a cascading-select needs a config; default to walking
+      // from the chosen level down 3 dropdowns. Editable later via the tile
+      // editor / future panel-row config.
+      ...(addWidget === "cascading-select"
+        ? { cascading: { startLevel: addLevel, depth: 3 } }
+        : {}),
     };
     dashboardStore.addPanelFilter(filter);
     closeAdd();
@@ -192,6 +208,9 @@
     const filters = panel?.filters ?? [];
     for (const f of filters) {
       if (!f.cube) continue;
+      // issue #922: cascading-select runs its own per-level fetch effect
+      // below; the flat single-level catalogue isn't used for it.
+      if (f.widget === "cascading-select") continue;
       // Prime the schema cache so ancestor-cascade resolution
       // (selectedForPicker below) can compute level depths without
       // hitting /ai/schema synchronously inside the template.
@@ -397,6 +416,146 @@
     if (stale) activeFilters.clearChip(stale.id);
   }
 
+  /* ===================== issue #922: cascading-select ====================
+   * The cascading-select variant walks ONE hierarchy level-by-level:
+   * dropdown 0 lists members at the start level; picking one reveals
+   * dropdown 1 with only that member's children; and so on. The deepest
+   * concrete pick is emitted via commitPanelMembers (the SAME merge path
+   * the other variants use). All branching (visibility, "All" truncation,
+   * leaf computation) lives in $lib/dashboard/cascadingFilter; this block
+   * owns only the async per-level member fetch + binding.
+   *
+   * Each dropdown reuses the EXISTING /ai/members/search endpoint, scoped
+   * to the parent member by client-side prefix filtering (member unique
+   * names embed the parent path), so there is no new backend surface.
+   * ====================================================================== */
+
+  // Per-widget cascade selections (index 0 = start level). Keyed by filter id.
+  let cascadeState = $state<Record<string, CascadeSelections>>({});
+  // Fetched member catalogues per (filter, level) — keyed so a parent
+  // change re-fetches. Reuses the same MemberRowState shape as the flat
+  // catalogue above.
+  let cascadeMembers = $state<Record<string, MemberRowState>>({});
+
+  function cascadeSelections(filterId: string): CascadeSelections {
+    return cascadeState[filterId] ?? [];
+  }
+
+  /** Ordered cascade level names (captions), root-most first, starting at
+   *  the configured start level (or the filter's own level) and running
+   *  down the hierarchy. Empty when the schema isn't loaded yet. */
+  function cascadeLevels(f: PanelFilter): string[] {
+    if (!f.cube) return [];
+    void schemaCache.version;
+    const schema = schemaCache.peek(f.cube) as SchemaLike | null;
+    if (!schema?.dimensions) return [];
+    const d = schema.dimensions[f.dimension.toLowerCase()];
+    const h = d?.hierarchies?.[f.hierarchy.toLowerCase()];
+    if (!h?.levels) return [];
+    const allLevels = Object.values(h.levels).map((l) => l.name);
+    const start = f.cascading?.startLevel || f.level;
+    const startIdx = allLevels.findIndex((n) => n.toLowerCase() === start.toLowerCase());
+    if (startIdx < 0) return [];
+    return allLevels.slice(startIdx);
+  }
+
+  /** Effective number of cascade dropdowns for this widget — configured
+   *  depth, bounded by the levels actually available below the start. */
+  function cascadeDepth(f: PanelFilter): number {
+    return effectiveDepth(f.cascading?.depth, cascadeLevels(f).length);
+  }
+
+  function cascadeKey(f: PanelFilter, levelIdx: number, parent: string | null): string {
+    return `${f.id}|${levelIdx}|${parent ?? ""}`;
+  }
+
+  /** Prime / refresh the member catalogue for every currently-visible
+   *  cascade dropdown of every cascading widget. Runs whenever the panel,
+   *  the schema, or the cascade selections change. */
+  $effect(() => {
+    const filters = panel?.filters ?? [];
+    for (const f of filters) {
+      if (f.widget !== "cascading-select" || !f.cube) continue;
+      void schemaCache.get(f.cube).catch(() => {});
+      const levels = cascadeLevels(f);
+      const depth = cascadeDepth(f);
+      if (depth <= 0) continue;
+      const sels = cascadeSelections(f.id);
+      const visible = visibleDropdownCount(sels, depth);
+      for (let i = 0; i < visible; i++) {
+        const parent = i === 0 ? null : parentForLevel(sels, i - 1);
+        if (i > 0 && parent == null) continue; // parent is "All" — nothing to fetch
+        const key = cascadeKey(f, i, parent);
+        const existing = cascadeMembers[key];
+        if (existing && existing.key === key) continue;
+        void loadCascadeMembers(f, levels[i], i, parent, key);
+      }
+    }
+  });
+
+  async function loadCascadeMembers(
+    f: PanelFilter,
+    levelName: string,
+    levelIdx: number,
+    parent: string | null,
+    key: string,
+  ): Promise<void> {
+    if (!f.cube) return;
+    cascadeMembers = {
+      ...cascadeMembers,
+      [key]: { loading: true, error: null, members: null, key },
+    };
+    try {
+      const params = new URLSearchParams({
+        cubeId: cubeKey(f.cube),
+        dimension: f.dimension,
+        hierarchy: f.hierarchy,
+        level: levelName,
+        limit: "500",
+      });
+      const res = await fetch(`/rest/saiku/api/ai/members/search?${params.toString()}`, {
+        credentials: "include",
+        headers: { Accept: "application/json" },
+      });
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      let hits = (await res.json()) as { uniqueName: string; caption: string }[];
+      // Scope to the parent member's children via the embedded-path prefix.
+      if (parent) hits = hits.filter((m) => memberDescendsFromAny(m.uniqueName, [parent]));
+      cascadeMembers = {
+        ...cascadeMembers,
+        [key]: { loading: false, error: null, members: hits, key },
+      };
+    } catch (e: unknown) {
+      const msg = e instanceof Error ? e.message : String(e);
+      cascadeMembers = {
+        ...cascadeMembers,
+        [key]: { loading: false, error: msg, members: [], key },
+      };
+    }
+  }
+
+  function cascadeMembersFor(
+    f: PanelFilter,
+    levelIdx: number,
+  ): MemberRowState | undefined {
+    const sels = cascadeSelections(f.id);
+    const parent = levelIdx === 0 ? null : parentForLevel(sels, levelIdx - 1);
+    return cascadeMembers[cascadeKey(f, levelIdx, parent)];
+  }
+
+  function handleCascadeChange(filterId: string, levelIdx: number, e: Event): void {
+    const raw = (e.target as HTMLSelectElement).value;
+    const value = raw === "" ? null : raw; // "" option = "All"
+    const cur = cascadeSelections(filterId);
+    const next = applySelection(cur, levelIdx, value);
+    if (selectionsEqual(cur, next)) return; // idempotent re-selection — no-op
+    cascadeState = { ...cascadeState, [filterId]: next };
+    // Emit the deepest concrete pick through the same merge path the
+    // other variants use (single-element member list, or empty for "All").
+    commitPanelMembers(filterId, emittedMembers(next));
+  }
+  /* ===================== end issue #922 ================================= */
+
   function handleRemove(id: string): void {
     dashboardStore.removePanelFilter(id);
   }
@@ -525,7 +684,36 @@
                 </span>
               {/if}
               <span class="picker-label">{f.level}</span>
-              {#if f.widget === "date-range"}
+              {#if f.widget === "cascading-select"}
+                <!-- issue #922: N stacked dropdowns walking the hierarchy. -->
+                {@const levels = cascadeLevels(f)}
+                {@const depth = cascadeDepth(f)}
+                {@const sels = cascadeSelections(f.id)}
+                {@const visible = visibleDropdownCount(sels, depth)}
+                <span class="cascade">
+                  {#each Array(visible) as _, i (i)}
+                    {@const lvlCat = cascadeMembersFor(f, i)}
+                    <select
+                      class="picker-select"
+                      value={sels[i] ?? ""}
+                      disabled={readOnly}
+                      aria-label={levels[i] ?? `Level ${i + 1}`}
+                      onchange={(e) => handleCascadeChange(f.id, i, e)}
+                    >
+                      <option value="">— all {levels[i] ?? ""} —</option>
+                      {#if lvlCat?.members}
+                        {#each lvlCat.members as m (m.uniqueName)}
+                          <option value={m.uniqueName}>{m.caption}</option>
+                        {/each}
+                      {:else if lvlCat?.loading}
+                        <option value="" disabled>Loading…</option>
+                      {:else if lvlCat?.error}
+                        <option value="" disabled>Error: {lvlCat.error}</option>
+                      {/if}
+                    </select>
+                  {/each}
+                </span>
+              {:else if f.widget === "date-range"}
                 {@const dr = dateRangeFor(f.id)}
                 <span class="date-range">
                   <input
@@ -632,6 +820,7 @@
               <option value="single-select">single-select</option>
               <option value="multi-select">multi-select</option>
               <option value="date-range">date-range</option>
+              <option value="cascading-select">cascading-select</option>
             </select>
           </label>
           {#if addError}
@@ -748,6 +937,14 @@
   }
   .date-range {
     display: inline-flex;
+    align-items: center;
+    gap: 0.25rem;
+  }
+  /* issue #922: stacked cascade dropdowns. Wrap so a deep walk doesn't
+     blow out the picker row horizontally. */
+  .cascade {
+    display: inline-flex;
+    flex-wrap: wrap;
     align-items: center;
     gap: 0.25rem;
   }

--- a/saiku-ui/src/lib/views/dashboard/TileEditorModal.svelte
+++ b/saiku-ui/src/lib/views/dashboard/TileEditorModal.svelte
@@ -59,6 +59,12 @@
   let tileW = $state<number>(untrack(() => tile.w));
   let tileH = $state<number>(untrack(() => tile.h));
   let widget = $state<FilterWidget>(untrack(() => tile.widget ?? "single-select"));
+  // --- issue #922: cascading-select config (start level + depth). Held in
+  // a self-contained working copy so the rebase against #919 stays clean;
+  // only consulted when widget === "cascading-select". ---
+  let cascadeStartLevel = $state<string>(untrack(() => tile.cascading?.startLevel ?? ""));
+  let cascadeDepth = $state<number>(untrack(() => tile.cascading?.depth ?? 3));
+  // --- end issue #922 ---
   let filterTarget = $state<{ dimension: string; hierarchy: string; level: string }>(
     untrack(() => ({
       dimension: tile.target?.dimension ?? "",
@@ -406,6 +412,15 @@
         };
         patch.target = target;
       }
+      // issue #922: persist cascade config only for the cascading variant;
+      // clear it otherwise so the saved JSON stays tidy across widget swaps.
+      patch.cascading =
+        widget === "cascading-select"
+          ? {
+              startLevel: cascadeStartLevel || undefined,
+              depth: cascadeDepth,
+            }
+          : undefined;
     }
 
     if (tile.type === "kpi") {
@@ -619,6 +634,7 @@
             <option value="single-select">single-select</option>
             <option value="multi-select">multi-select</option>
             <option value="date-range">date-range</option>
+            <option value="cascading-select">cascading-select</option>
           </select>
         </label>
         <label class="field">
@@ -648,6 +664,31 @@
             {/each}
           </select>
         </label>
+        <!-- issue #922: cascading-select config. Self-contained block,
+             guarded by the widget check so the #919 rebase is clean. -->
+        {#if widget === "cascading-select"}
+          <fieldset class="size">
+            <legend>Cascade (walk the hierarchy level-by-level)</legend>
+            <label class="field inline">
+              <span>Start level</span>
+              <select bind:value={cascadeStartLevel} disabled={!filterTarget.hierarchy}>
+                <option value="">— use level above —</option>
+                {#each levelOptions() as l (l)}
+                  <option value={l}>{l}</option>
+                {/each}
+              </select>
+            </label>
+            <label class="field inline">
+              <span>Depth</span>
+              <input type="number" min="1" max="6" bind:value={cascadeDepth} />
+            </label>
+          </fieldset>
+          <span class="hint">
+            Renders one dropdown per level from the start level down. Picking a
+            parent reveals its children; choosing “All” resets the levels below.
+          </span>
+        {/if}
+        <!-- end issue #922 -->
       {/if}
 
       {#if tile.type === "kpi"}


### PR DESCRIPTION
## Summary

Closes #922. Adds a **cascading single-select** dashboard filter widget that walks one hierarchy level-by-level: pick a parent member, the next dropdown reveals only that parent's children, and so on (Region → Country → State → City). The deepest concrete selection is emitted as the active filter; choosing **All** at any level resets the levels below it. No backend changes — each dropdown reuses the existing member-search fetch.

## The change

**Pure helper — cascadingFilter.ts:**
New `$lib/dashboard/cascadingFilter.ts` owns all cascade branching so the component stays thin: `clampDepth` / `effectiveDepth` (depth bounds), `visibleDropdownCount` (which dropdowns show given selections at levels [0..k]), `applySelection` ("All" at level k truncates deeper selections; concrete pick drops stale children), `emittedLeafMember` / `emittedMembers` (deepest non-"All" selection, or none), `parentForLevel` (the member whose children feed the next dropdown), and `selectionsEqual` (idempotent re-selection short-circuit). Lives alongside the existing plural `cascadingFilters.ts` (a different concept — cross-widget ancestor-prefix restriction) and shares no code with it.

**UI — DashboardFilterPanel.svelte:**
The unified filter panel is the live filter renderer in the current architecture (the old per-tile `FilterTile.svelte` is gone). Added a `cascading-select` branch that renders N stacked dropdowns. The component owns only the async per-level member fetch + binding; each dropdown reuses the **same** `/ai/members/search` endpoint the other variants use, scoped to the parent member by client-side prefix filtering (Mondrian unique names embed the parent path). Selecting a value emits via the existing `commitPanelMembers` merge path (single-element member list, or empty for "All"). The inline "+ Add filter" form gains the variant with a sensible default config.

**UI — TileEditorModal.svelte:**
Added the `cascading-select` widget option plus a self-contained, widget-guarded config block (start level + depth) within the `filter` tile path, mirroring the existing field/fieldset styling. Persisted in `handleSave`; cleared when the widget is switched away.

**Types — dashboards.ts:**
`FilterWidget` gains `"cascading-select"`; new `CascadingSelectConfig` (`startLevel?`, `depth?`); optional `cascading?` field on `PanelFilter` and `DashboardTile`. All additions are in a clearly-delimited, appended block — nothing reordered.

## Verified

- [x] npx vitest run — 375/375 (38 new in cascadingFilter.test.ts)
- [x] npm run check — 0 errors (42 baseline a11y warnings; none added in changed files)

## Test plan

1. Open a dashboard, add a filter (panel "+ Add filter" or a filter tile in the editor).
2. Set **widget = cascading-select** on a multi-level hierarchy (e.g. Geography: Region → Country → State → City); set a start level and depth.
3. Confirm only the first dropdown shows initially; picking a parent populates the next dropdown with **only that parent's children**.
4. Confirm choosing **All** at an intermediate level resets/hides the deeper dropdowns.
5. Confirm the deepest concrete selection filters the other tiles (emitted as the active filter member); "All everywhere" contributes no slicing.

## Notes for the reviewer

- Shared-file overlap with #919 (conditional formatting): both touch `dashboards.ts` and `TileEditorModal.svelte`. My additions in both are isolated in clearly-commented, appended blocks (no reordering/reformatting) so the rebase is trivial — see the `--- issue #922 ---` delimiters.
- No backend changes: the cascade reuses the existing `/ai/members/search` fetch; child scoping is pure client-side prefix matching on member unique names.
- The issue text references the pre-#996 filter-tile model (`FilterTile.svelte`); that file no longer exists. The variant is implemented in the current unified-panel renderer (`DashboardFilterPanel.svelte`) plus the still-present `filter` tile path in `TileEditorModal.svelte`. Helper named `cascadingFilter.ts` (singular) to avoid clobbering the unrelated existing `cascadingFilters.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
