### PR TITLE
feat(dashboards): conditional formatting on table tiles (closes #919)

### DIFF
--- a/saiku-ui/src/lib/api/dashboards.ts
+++ b/saiku-ui/src/lib/api/dashboards.ts
@@ -117,6 +117,59 @@ export interface DashboardTile {
   widget?: FilterWidget;
   /** KPI-tile config. Only consulted when {@code type === "kpi"}. */
   kpi?: KpiConfig;
+  /** Per-column conditional formatting rules. Only consulted when
+   *  {@code type === "table"}. See the issue-#919 block below. */
+  conditionalFormat?: ConditionalFormatRule[];
+}
+
+/* ====================================================================
+ * Issue #919 — conditional formatting on table tiles.
+ *
+ * Self-contained block, appended so a rebase against the parallel #922
+ * (cascading-filter) branch is trivial. The only edit above is the
+ * `conditionalFormat?` field on DashboardTile.
+ * ==================================================================== */
+
+/** How a table cell is decorated by its rule. Display-only.
+ *   - "background": cell background colour by threshold band.
+ *   - "bar":        horizontal mini data-bar, width ∝ value.
+ *   - "font":       font colour by sign or by threshold band.
+ *   - "icon":       ↑ ↓ → glyph by threshold band (or by sign). */
+export type ConditionalFormatType = "background" | "bar" | "font" | "icon";
+
+/** Whether thresholds are read as percentiles of the column's own values
+ *  ("relative", 0–100) or as fixed numeric values ("absolute"). */
+export type ConditionalThresholdMode = "relative" | "absolute";
+
+/** Per-band colour overrides for background / font / icon rules. Omit a
+ *  band to fall back to the helper's default palette. */
+export interface ConditionalBandColors {
+  low?: string;
+  mid?: string;
+  high?: string;
+}
+
+/** A single per-column conditional-formatting rule on a table tile. The
+ *  evaluation logic lives in $lib/dashboard/conditionalFormat.ts; this
+ *  type is just the serialisable config persisted on the dashboard. */
+export interface ConditionalFormatRule {
+  /** Column caption this rule targets — matches the table header text. */
+  column: string;
+  type: ConditionalFormatType;
+  /** Threshold interpretation. Ignored by "bar" (always min/max scaled)
+   *  and by "font"/"icon" when both thresholds are unset (sign mode). */
+  thresholdMode: ConditionalThresholdMode;
+  /** Lower cut: percentile (0–100) when relative, raw value when
+   *  absolute. Leave unset (with {@link highThreshold}) on font/icon to
+   *  get sign-based colouring. */
+  lowThreshold?: number;
+  /** Upper cut: percentile (0–100) when relative, raw value when
+   *  absolute. */
+  highThreshold?: number;
+  /** Per-band colour overrides for background / font / icon. */
+  colors?: ConditionalBandColors;
+  /** Fill colour for "bar" rules. */
+  barColor?: string;
 }
 
 export interface DashboardLayout {

--- a/saiku-ui/src/lib/dashboard/conditionalFormat.test.ts
+++ b/saiku-ui/src/lib/dashboard/conditionalFormat.test.ts
@@ -1,0 +1,292 @@
+/*
+ * Unit tests for the pure conditional-formatting engine (issue #919).
+ *
+ * Covers: numeric coercion, percentile maths, relative + absolute band
+ * classification, bar-width clamping, font/icon by sign and by threshold,
+ * empty / NaN / null cell handling, the no-rules pass-through, and the
+ * style-string serialiser.
+ */
+
+import { describe, expect, test } from "vitest";
+
+import type { ConditionalFormatRule } from "$lib/api/dashboards";
+import {
+  barWidthPct,
+  bandColor,
+  cellFormatToStyle,
+  classifyByCuts,
+  DEFAULT_BAND_COLORS,
+  evaluateCell,
+  formatCell,
+  numericValues,
+  percentile,
+  resolveCuts,
+  ruleForColumn,
+  toNumber,
+} from "./conditionalFormat";
+
+/** Compact rule constructor. */
+function rule(over: Partial<ConditionalFormatRule>): ConditionalFormatRule {
+  return {
+    column: "Sales",
+    type: "background",
+    thresholdMode: "absolute",
+    ...over,
+  };
+}
+
+describe("toNumber", () => {
+  test("passes finite numbers through", () => {
+    expect(toNumber(42)).toBe(42);
+    expect(toNumber(-3.5)).toBe(-3.5);
+    expect(toNumber(0)).toBe(0);
+  });
+  test("parses numeric strings, stripping commas/spaces", () => {
+    expect(toNumber("1,234.5")).toBe(1234.5);
+    expect(toNumber(" 99 ")).toBe(99);
+    expect(toNumber("-7")).toBe(-7);
+  });
+  test("returns null for null/undefined/NaN/empty/non-numeric", () => {
+    expect(toNumber(null)).toBeNull();
+    expect(toNumber(undefined)).toBeNull();
+    expect(toNumber(NaN)).toBeNull();
+    expect(toNumber(Infinity)).toBeNull();
+    expect(toNumber("")).toBeNull();
+    expect(toNumber("   ")).toBeNull();
+    expect(toNumber("abc")).toBeNull();
+    expect(toNumber({})).toBeNull();
+  });
+});
+
+describe("numericValues", () => {
+  test("filters to the finite numeric subset, preserving order", () => {
+    expect(numericValues([3, "x", "2", null, 1, NaN])).toEqual([3, 2, 1]);
+  });
+  test("returns empty for an all-non-numeric column", () => {
+    expect(numericValues([null, "x", undefined])).toEqual([]);
+  });
+});
+
+describe("percentile", () => {
+  test("null on empty input", () => {
+    expect(percentile([], 50)).toBeNull();
+  });
+  test("single element returns that element for any p", () => {
+    expect(percentile([7], 0)).toBe(7);
+    expect(percentile([7], 100)).toBe(7);
+  });
+  test("p=0 is min, p=100 is max", () => {
+    expect(percentile([10, 20, 30, 40], 0)).toBe(10);
+    expect(percentile([10, 20, 30, 40], 100)).toBe(40);
+  });
+  test("p=50 is the median (linear interpolation)", () => {
+    expect(percentile([1, 2, 3, 4], 50)).toBeCloseTo(2.5, 6);
+    expect(percentile([1, 2, 3], 50)).toBe(2);
+  });
+  test("interpolates between ranks", () => {
+    // 4 elements, p=25 → rank = 0.75 → 10 + 0.75*(20-10) = 17.5
+    expect(percentile([10, 20, 30, 40], 25)).toBeCloseTo(17.5, 6);
+  });
+  test("sorts unsorted input first", () => {
+    expect(percentile([40, 10, 30, 20], 0)).toBe(10);
+  });
+  test("clamps out-of-range p", () => {
+    expect(percentile([1, 2, 3], -10)).toBe(1);
+    expect(percentile([1, 2, 3], 999)).toBe(3);
+  });
+});
+
+describe("classifyByCuts", () => {
+  test("low / mid / high boundaries (upper-exclusive on lower band)", () => {
+    expect(classifyByCuts(5, 10, 20)).toBe("low");
+    expect(classifyByCuts(10, 10, 20)).toBe("mid"); // inclusive lower edge of mid
+    expect(classifyByCuts(15, 10, 20)).toBe("mid");
+    expect(classifyByCuts(20, 10, 20)).toBe("high"); // inclusive lower edge of high
+    expect(classifyByCuts(25, 10, 20)).toBe("high");
+  });
+  test("normalises inverted cuts", () => {
+    expect(classifyByCuts(5, 20, 10)).toBe("low");
+    expect(classifyByCuts(25, 20, 10)).toBe("high");
+  });
+  test("none for null value or null cut", () => {
+    expect(classifyByCuts(null, 10, 20)).toBe("none");
+    expect(classifyByCuts(5, null, 20)).toBe("none");
+    expect(classifyByCuts(5, 10, null)).toBe("none");
+  });
+});
+
+describe("resolveCuts", () => {
+  test("absolute mode returns thresholds verbatim", () => {
+    const r = rule({ thresholdMode: "absolute", lowThreshold: 100, highThreshold: 500 });
+    expect(resolveCuts(r, [1, 2, 3])).toEqual({ lowCut: 100, highCut: 500 });
+  });
+  test("relative mode maps thresholds through column percentiles", () => {
+    const r = rule({ thresholdMode: "relative", lowThreshold: 0, highThreshold: 100 });
+    expect(resolveCuts(r, [10, 20, 30, 40])).toEqual({ lowCut: 10, highCut: 40 });
+  });
+  test("null cuts when thresholds are missing", () => {
+    expect(resolveCuts(rule({ lowThreshold: undefined }), [1, 2])).toEqual({
+      lowCut: null,
+      highCut: null,
+    });
+  });
+});
+
+describe("bandColor", () => {
+  test("defaults from the palette", () => {
+    const r = rule({});
+    expect(bandColor("low", r)).toBe(DEFAULT_BAND_COLORS.low);
+    expect(bandColor("high", r)).toBe(DEFAULT_BAND_COLORS.high);
+  });
+  test("per-rule overrides win", () => {
+    const r = rule({ colors: { low: "#000", high: "#fff" } });
+    expect(bandColor("low", r)).toBe("#000");
+    expect(bandColor("high", r)).toBe("#fff");
+    expect(bandColor("mid", r)).toBe(DEFAULT_BAND_COLORS.mid); // not overridden
+  });
+  test("none → undefined", () => {
+    expect(bandColor("none", rule({}))).toBeUndefined();
+  });
+});
+
+describe("barWidthPct", () => {
+  test("scales between column min (0%) and max (100%)", () => {
+    expect(barWidthPct(10, [10, 20, 30])).toBe(0);
+    expect(barWidthPct(20, [10, 20, 30])).toBe(50);
+    expect(barWidthPct(30, [10, 20, 30])).toBe(100);
+  });
+  test("all-equal column → full bar for any finite value", () => {
+    expect(barWidthPct(5, [5, 5, 5])).toBe(100);
+  });
+  test("clamps values outside the column range to 0–100", () => {
+    expect(barWidthPct(0, [10, 20, 30])).toBe(0);
+    expect(barWidthPct(40, [10, 20, 30])).toBe(100);
+  });
+  test("null for non-finite value or empty column", () => {
+    expect(barWidthPct(null, [1, 2, 3])).toBeNull();
+    expect(barWidthPct(10, [])).toBeNull();
+  });
+  test("handles negative ranges", () => {
+    expect(barWidthPct(-50, [-100, 0])).toBe(50);
+  });
+});
+
+describe("evaluateCell — bar", () => {
+  test("emits clamped barWidthPct + a bar colour", () => {
+    const fmt = evaluateCell(rule({ type: "bar" }), 20, [10, 20, 30]);
+    expect(fmt.barWidthPct).toBe(50);
+    expect(fmt.barColor).toBeTruthy();
+  });
+  test("honours a custom bar colour", () => {
+    const fmt = evaluateCell(rule({ type: "bar", barColor: "#abc" }), 30, [10, 30]);
+    expect(fmt.barColor).toBe("#abc");
+  });
+  test("empty object for a non-numeric cell", () => {
+    expect(evaluateCell(rule({ type: "bar" }), "n/a", [10, 20])).toEqual({});
+    expect(evaluateCell(rule({ type: "bar" }), null, [10, 20])).toEqual({});
+  });
+});
+
+describe("evaluateCell — background", () => {
+  const r = rule({ type: "background", thresholdMode: "absolute", lowThreshold: 100, highThreshold: 500 });
+  test("bands by absolute thresholds", () => {
+    expect(evaluateCell(r, 50, []).backgroundColor).toBe(DEFAULT_BAND_COLORS.low);
+    expect(evaluateCell(r, 300, []).backgroundColor).toBe(DEFAULT_BAND_COLORS.mid);
+    expect(evaluateCell(r, 900, []).backgroundColor).toBe(DEFAULT_BAND_COLORS.high);
+  });
+  test("bands by relative (percentile) thresholds against the column", () => {
+    const rel = rule({
+      type: "background",
+      thresholdMode: "relative",
+      lowThreshold: 33,
+      highThreshold: 66,
+    });
+    const col = [0, 50, 100];
+    // cuts: p33 ≈ 33, p66 ≈ 66 → 10 low, 60 mid, 100 high
+    expect(evaluateCell(rel, 10, col).backgroundColor).toBe(DEFAULT_BAND_COLORS.low);
+    expect(evaluateCell(rel, 60, col).backgroundColor).toBe(DEFAULT_BAND_COLORS.mid);
+    expect(evaluateCell(rel, 100, col).backgroundColor).toBe(DEFAULT_BAND_COLORS.high);
+  });
+  test("empty object when thresholds are unset", () => {
+    expect(evaluateCell(rule({ type: "background" }), 50, [])).toEqual({});
+  });
+  test("empty object for a null cell", () => {
+    expect(evaluateCell(r, null, [])).toEqual({});
+  });
+});
+
+describe("evaluateCell — font", () => {
+  test("sign mode (no thresholds): positive green, negative red, zero none", () => {
+    const r = rule({ type: "font" });
+    expect(evaluateCell(r, 5, []).color).toBe(DEFAULT_BAND_COLORS.high);
+    expect(evaluateCell(r, -5, []).color).toBe(DEFAULT_BAND_COLORS.low);
+    expect(evaluateCell(r, 0, [])).toEqual({});
+  });
+  test("threshold mode colours by band", () => {
+    const r = rule({ type: "font", thresholdMode: "absolute", lowThreshold: 10, highThreshold: 20 });
+    expect(evaluateCell(r, 5, []).color).toBe(DEFAULT_BAND_COLORS.low);
+    expect(evaluateCell(r, 25, []).color).toBe(DEFAULT_BAND_COLORS.high);
+  });
+  test("empty for a non-numeric cell", () => {
+    expect(evaluateCell(rule({ type: "font" }), "x", [])).toEqual({});
+  });
+});
+
+describe("evaluateCell — icon", () => {
+  test("sign mode glyphs", () => {
+    const r = rule({ type: "icon" });
+    expect(evaluateCell(r, 5, []).icon).toBe("↑");
+    expect(evaluateCell(r, -5, []).icon).toBe("↓");
+    expect(evaluateCell(r, 0, []).icon).toBe("→");
+  });
+  test("threshold mode glyphs", () => {
+    const r = rule({ type: "icon", thresholdMode: "absolute", lowThreshold: 10, highThreshold: 20 });
+    expect(evaluateCell(r, 5, []).icon).toBe("↓");
+    expect(evaluateCell(r, 15, []).icon).toBe("→");
+    expect(evaluateCell(r, 25, []).icon).toBe("↑");
+  });
+  test("empty for a non-numeric cell", () => {
+    expect(evaluateCell(rule({ type: "icon" }), null, [])).toEqual({});
+  });
+});
+
+describe("ruleForColumn / formatCell — no-rules pass-through", () => {
+  test("ruleForColumn returns undefined for empty/undefined rules", () => {
+    expect(ruleForColumn(undefined, "Sales")).toBeUndefined();
+    expect(ruleForColumn([], "Sales")).toBeUndefined();
+  });
+  test("ruleForColumn matches by column caption", () => {
+    const rules = [rule({ column: "Sales" }), rule({ column: "Cost", type: "bar" })];
+    expect(ruleForColumn(rules, "Cost")?.type).toBe("bar");
+    expect(ruleForColumn(rules, "Profit")).toBeUndefined();
+  });
+  test("formatCell returns {} when no rule targets the column", () => {
+    expect(formatCell(undefined, "Sales", 5, [1, 2, 3])).toEqual({});
+    expect(formatCell([rule({ column: "Other" })], "Sales", 5, [1, 2, 3])).toEqual({});
+  });
+  test("formatCell delegates to evaluateCell for a matching rule", () => {
+    const rules = [rule({ column: "Sales", type: "bar" })];
+    expect(formatCell(rules, "Sales", 20, [10, 20, 30]).barWidthPct).toBe(50);
+  });
+});
+
+describe("cellFormatToStyle", () => {
+  test("undefined for an empty format", () => {
+    expect(cellFormatToStyle({})).toBeUndefined();
+  });
+  test("serialises colour + background", () => {
+    const s = cellFormatToStyle({ color: "#111", backgroundColor: "#eee" });
+    expect(s).toContain("color: #111");
+    expect(s).toContain("background-color: #eee");
+  });
+  test("serialises a bar as a clamped linear-gradient", () => {
+    const s = cellFormatToStyle({ barWidthPct: 50, barColor: "#abc" })!;
+    expect(s).toContain("linear-gradient");
+    expect(s).toContain("#abc 50%");
+  });
+  test("clamps an out-of-range bar width", () => {
+    const s = cellFormatToStyle({ barWidthPct: 150 })!;
+    expect(s).toContain("100%");
+    expect(s).not.toContain("150%");
+  });
+});

--- a/saiku-ui/src/lib/dashboard/conditionalFormat.ts
+++ b/saiku-ui/src/lib/dashboard/conditionalFormat.ts
@@ -1,0 +1,277 @@
+/*
+ * Pure rule-evaluation engine for per-column conditional formatting on
+ * dashboard table tiles (issue #919). Display-only: the underlying data
+ * is never mutated — the helper only computes a style/class/icon for a
+ * single cell given the column's full value set and a rule.
+ *
+ * The Svelte components (TableTile.svelte, TileEditorModal.svelte) are
+ * intentionally thin: they collect the numeric values of a column, hand
+ * a (rule, value, columnValues) triple to {@link evaluateCell}, and apply
+ * the returned {@link CellFormat} verbatim. All the maths lives here so
+ * it can be unit-tested without a DOM.
+ *
+ * Threshold modes:
+ *   - "relative": thresholds are percentiles (0–100) of the column's
+ *     own non-null values. Used to band a column by its own distribution.
+ *   - "absolute": thresholds are fixed numeric values compared directly.
+ *
+ * Format types:
+ *   - "background": red/yellow/green cell background by band.
+ *   - "font":       font colour by band, or by sign when no thresholds.
+ *   - "icon":       ↑ ↓ → glyph by band.
+ *   - "bar":        horizontal data-bar width 0–100% of the column range.
+ */
+
+import type { ConditionalFormatRule } from "$lib/api/dashboards";
+
+/** The computed presentation for a single cell. All fields optional —
+ *  the renderer applies only what is set. {@code backgroundColor} /
+ *  {@code color} map to inline CSS; {@code icon} is a glyph to prepend;
+ *  {@code barWidthPct} (0–100) drives a mini data-bar overlay. */
+export interface CellFormat {
+  backgroundColor?: string;
+  color?: string;
+  icon?: string;
+  /** Bar width as a percentage of the cell, clamped to 0–100. Only set
+   *  for "bar" rules with a finite value. */
+  barWidthPct?: number;
+  barColor?: string;
+}
+
+/** The three threshold bands, low → high. {@code none} means the value
+ *  was not classifiable (null / NaN / no usable thresholds). */
+export type Band = "low" | "mid" | "high" | "none";
+
+/** Default band palette — picked to read as red (bad/low) → yellow
+ *  (mid) → green (good/high). Overridable per rule via
+ *  {@link ConditionalFormatRule.colors}. */
+export const DEFAULT_BAND_COLORS: Record<Exclude<Band, "none">, string> = {
+  low: "#e5534b", // red
+  mid: "#d9a420", // amber
+  high: "#3fa45b", // green
+};
+
+const DEFAULT_BAR_COLOR = "#4c8dff";
+
+/** Coerce an arbitrary cell value into a finite number, or null. Accepts
+ *  raw numbers and numeric strings (commas / spaces stripped); everything
+ *  else — null, undefined, NaN, non-numeric strings — yields null. */
+export function toNumber(value: unknown): number | null {
+  if (value == null) return null;
+  if (typeof value === "number") return Number.isFinite(value) ? value : null;
+  if (typeof value === "string") {
+    const cleaned = value.replace(/[\s,]/g, "").trim();
+    if (cleaned === "") return null;
+    const n = Number(cleaned);
+    return Number.isFinite(n) ? n : null;
+  }
+  return null;
+}
+
+/** Extract the finite numeric subset of a column's values, preserving
+ *  order. Used as the basis for percentile / min-max computations. */
+export function numericValues(values: readonly unknown[]): number[] {
+  const out: number[] = [];
+  for (const v of values) {
+    const n = toNumber(v);
+    if (n !== null) out.push(n);
+  }
+  return out;
+}
+
+/** Linear-interpolated percentile of a numeric array. {@code p} is in
+ *  0–100. Returns null for an empty array. Matches the common
+ *  "linear interpolation between closest ranks" definition so that
+ *  p=0 is the min, p=100 the max, p=50 the median. */
+export function percentile(values: readonly number[], p: number): number | null {
+  if (values.length === 0) return null;
+  const sorted = [...values].sort((a, b) => a - b);
+  if (sorted.length === 1) return sorted[0];
+  const clampedP = Math.min(100, Math.max(0, p));
+  const rank = (clampedP / 100) * (sorted.length - 1);
+  const lo = Math.floor(rank);
+  const hi = Math.ceil(rank);
+  if (lo === hi) return sorted[lo];
+  const frac = rank - lo;
+  return sorted[lo] + (sorted[hi] - sorted[lo]) * frac;
+}
+
+/** Classify {@code value} into a low/mid/high band given two cut points.
+ *  Boundaries are inclusive on the upper edge of each lower band:
+ *   value < lowCut          → "low"
+ *   lowCut <= value < highCut → "mid"
+ *   value >= highCut        → "high"
+ *  Returns "none" when either cut is null or the value isn't finite. */
+export function classifyByCuts(value: number | null, lowCut: number | null, highCut: number | null): Band {
+  if (value === null || lowCut === null || highCut === null) return "none";
+  // Guard against inverted cuts (analyst typed high < low): normalise.
+  const lo = Math.min(lowCut, highCut);
+  const hi = Math.max(lowCut, highCut);
+  if (value < lo) return "low";
+  if (value < hi) return "mid";
+  return "high";
+}
+
+/** Resolve the (lowCut, highCut) pair a rule implies, given the column's
+ *  numeric values. For "relative" rules the thresholds are percentiles
+ *  evaluated against {@code columnNumbers}; for "absolute" they are used
+ *  directly. Returns nulls when the rule lacks usable thresholds. */
+export function resolveCuts(
+  rule: ConditionalFormatRule,
+  columnNumbers: readonly number[],
+): { lowCut: number | null; highCut: number | null } {
+  const lowT = rule.lowThreshold;
+  const highT = rule.highThreshold;
+  if (lowT == null || highT == null) return { lowCut: null, highCut: null };
+  if (rule.thresholdMode === "relative") {
+    return {
+      lowCut: percentile(columnNumbers, lowT),
+      highCut: percentile(columnNumbers, highT),
+    };
+  }
+  // absolute
+  return { lowCut: lowT, highCut: highT };
+}
+
+/** Band → colour, honouring per-rule overrides then the default palette. */
+export function bandColor(band: Band, rule: ConditionalFormatRule): string | undefined {
+  if (band === "none") return undefined;
+  const override = rule.colors?.[band];
+  return override ?? DEFAULT_BAND_COLORS[band];
+}
+
+/** Compute the data-bar width (0–100%) for {@code value} relative to the
+ *  column's min/max. The bar fills proportionally between min (0%) and
+ *  max (100%). When all values are equal the bar is full (100%) for any
+ *  finite value. Returns null for non-finite values or an empty column. */
+export function barWidthPct(value: number | null, columnNumbers: readonly number[]): number | null {
+  if (value === null || columnNumbers.length === 0) return null;
+  let min = columnNumbers[0];
+  let max = columnNumbers[0];
+  for (const n of columnNumbers) {
+    if (n < min) min = n;
+    if (n > max) max = n;
+  }
+  if (max === min) return 100;
+  const pct = ((value - min) / (max - min)) * 100;
+  return Math.min(100, Math.max(0, pct));
+}
+
+/** Icon glyphs by band for the "icon" format. Up for high, down for low,
+ *  flat for mid. */
+const BAND_ICON: Record<Exclude<Band, "none">, string> = {
+  low: "↓", // ↓
+  mid: "→", // →
+  high: "↑", // ↑
+};
+
+/** Sign-based icon: positive ↑, negative ↓, zero →. */
+function signIcon(value: number): string {
+  if (value > 0) return BAND_ICON.high;
+  if (value < 0) return BAND_ICON.low;
+  return BAND_ICON.mid;
+}
+
+/** Sign-based colour: positive → high colour, negative → low colour,
+ *  zero → undefined (no emphasis). Honours per-rule overrides. */
+function signColor(value: number, rule: ConditionalFormatRule): string | undefined {
+  if (value > 0) return bandColor("high", rule);
+  if (value < 0) return bandColor("low", rule);
+  return undefined;
+}
+
+/** Core: evaluate a single cell against one rule, given the full set of
+ *  the column's (raw) values. Returns an empty object when the rule
+ *  doesn't apply (non-numeric cell, missing thresholds where required).
+ *  Pure — no mutation of inputs. */
+export function evaluateCell(
+  rule: ConditionalFormatRule,
+  cellValue: unknown,
+  columnValues: readonly unknown[],
+): CellFormat {
+  const value = toNumber(cellValue);
+  const columnNumbers = numericValues(columnValues);
+
+  switch (rule.type) {
+    case "bar": {
+      const width = barWidthPct(value, columnNumbers);
+      if (width === null) return {};
+      return { barWidthPct: width, barColor: rule.barColor ?? DEFAULT_BAR_COLOR };
+    }
+    case "background": {
+      const { lowCut, highCut } = resolveCuts(rule, columnNumbers);
+      const band = classifyByCuts(value, lowCut, highCut);
+      const bg = bandColor(band, rule);
+      return bg ? { backgroundColor: bg } : {};
+    }
+    case "font": {
+      if (value === null) return {};
+      // No thresholds → colour by sign. With thresholds → colour by band.
+      if (rule.lowThreshold == null || rule.highThreshold == null) {
+        const c = signColor(value, rule);
+        return c ? { color: c } : {};
+      }
+      const { lowCut, highCut } = resolveCuts(rule, columnNumbers);
+      const band = classifyByCuts(value, lowCut, highCut);
+      const c = bandColor(band, rule);
+      return c ? { color: c } : {};
+    }
+    case "icon": {
+      if (value === null) return {};
+      if (rule.lowThreshold == null || rule.highThreshold == null) {
+        return { icon: signIcon(value) };
+      }
+      const { lowCut, highCut } = resolveCuts(rule, columnNumbers);
+      const band = classifyByCuts(value, lowCut, highCut);
+      if (band === "none") return {};
+      return { icon: BAND_ICON[band] };
+    }
+    default:
+      return {};
+  }
+}
+
+/** Find the rule (if any) that targets {@code columnCaption}. Rules are
+ *  keyed by the column caption shown in the table header. Returns the
+ *  first match — the editor enforces one rule per column, but a defensive
+ *  first-match keeps a malformed config from throwing. */
+export function ruleForColumn(
+  rules: readonly ConditionalFormatRule[] | undefined,
+  columnCaption: string,
+): ConditionalFormatRule | undefined {
+  if (!rules || rules.length === 0) return undefined;
+  return rules.find((r) => r.column === columnCaption);
+}
+
+/** Convenience: resolve + evaluate in one call for a given column. When
+ *  no rule targets the column (or rules is empty/undefined) returns an
+ *  empty CellFormat — the no-rules pass-through. */
+export function formatCell(
+  rules: readonly ConditionalFormatRule[] | undefined,
+  columnCaption: string,
+  cellValue: unknown,
+  columnValues: readonly unknown[],
+): CellFormat {
+  const rule = ruleForColumn(rules, columnCaption);
+  if (!rule) return {};
+  return evaluateCell(rule, cellValue, columnValues);
+}
+
+/** Build an inline-style string from a {@link CellFormat}. Returns
+ *  undefined when nothing would be applied so callers can pass it
+ *  straight to a Svelte {@code style={...}} attribute. The data-bar is
+ *  rendered as a left-anchored linear-gradient so it needs no extra DOM. */
+export function cellFormatToStyle(fmt: CellFormat): string | undefined {
+  const parts: string[] = [];
+  if (fmt.color) parts.push(`color: ${fmt.color}`);
+  if (fmt.backgroundColor) parts.push(`background-color: ${fmt.backgroundColor}`);
+  if (fmt.barWidthPct != null) {
+    const color = fmt.barColor ?? DEFAULT_BAR_COLOR;
+    const w = Math.min(100, Math.max(0, fmt.barWidthPct));
+    // Tinted fill from the left edge to w%, transparent beyond.
+    parts.push(
+      `background-image: linear-gradient(to right, ${color} 0%, ${color} ${w}%, transparent ${w}%, transparent 100%)`,
+    );
+  }
+  return parts.length > 0 ? parts.join("; ") : undefined;
+}

--- a/saiku-ui/src/lib/views/dashboard/TileEditorModal.svelte
+++ b/saiku-ui/src/lib/views/dashboard/TileEditorModal.svelte
@@ -27,6 +27,10 @@
     type FilterWidget,
     type KpiConfig,
     type TileQuery,
+    // Issue #919 — conditional formatting on table tiles.
+    type ConditionalFormatRule,
+    type ConditionalFormatType,
+    type ConditionalThresholdMode,
   } from "$lib/api/dashboards";
   import { flatten, listRepository, type RepositoryNode } from "$lib/api/repository";
   import { repositionTile } from "$lib/dashboard/tilePlacement";
@@ -83,6 +87,18 @@
     untrack(() => (tile.query?.kind === "inline" ? JSON.stringify(tile.query.body, null, 2) : "")),
   );
   let bodyError = $state<string | null>(null);
+  // ── Issue #919: per-column conditional-formatting rules (table only) ──
+  // Self-contained working copy, deep-cloned from the source so edits are
+  // discardable on Cancel. Persisted in handleSave under a table-guarded
+  // block. Isolated here so the parallel #922 edit rebases cleanly.
+  let conditionalFormat = $state<ConditionalFormatRule[]>(
+    untrack(() =>
+      (tile.conditionalFormat ?? []).map((r) => ({
+        ...r,
+        colors: r.colors ? { ...r.colors } : undefined,
+      })),
+    ),
+  );
   // Query source — "reference" picks a saved .saiku from the repo,
   // "inline" pastes an AiQueryRequest body. Default to "reference" so
   // non-technical authors aren't dropped into a JSON textarea on a
@@ -289,6 +305,39 @@
 
   let positionError = $state<string | null>(null);
 
+  // ── Issue #919: rule-editor helpers (table only) ──
+  /** Append a fresh rule with sensible defaults. */
+  function addConditionalRule(): void {
+    conditionalFormat = [
+      ...conditionalFormat,
+      {
+        column: "",
+        type: "background",
+        thresholdMode: "relative",
+        lowThreshold: 25,
+        highThreshold: 75,
+      },
+    ];
+  }
+  function removeConditionalRule(index: number): void {
+    conditionalFormat = conditionalFormat.filter((_, i) => i !== index);
+  }
+  /** A rule needs explicit thresholds for background; font/icon may run in
+   *  sign mode (no thresholds). bar never uses thresholds. */
+  function ruleUsesThresholds(r: ConditionalFormatRule): boolean {
+    return r.type === "background" || r.type === "font" || r.type === "icon";
+  }
+  const CONDITIONAL_TYPES: { id: ConditionalFormatType; label: string }[] = [
+    { id: "background", label: "Background colour" },
+    { id: "bar", label: "Data bar" },
+    { id: "font", label: "Font colour" },
+    { id: "icon", label: "Icon (↑ ↓ →)" },
+  ];
+  const CONDITIONAL_MODES: { id: ConditionalThresholdMode; label: string }[] = [
+    { id: "relative", label: "Relative (percentile)" },
+    { id: "absolute", label: "Absolute (fixed value)" },
+  ];
+
   function handleSave(): void {
     bodyError = null;
     positionError = null;
@@ -381,6 +430,32 @@
         customFormat: kpiConfig.format === "custom" ? kpiConfig.customFormat : undefined,
       };
       patch.kpi = cleaned;
+    }
+
+    // ── Issue #919: persist conditional-formatting rules (table only) ──
+    // Drop incomplete rules (no column) and normalise the threshold
+    // fields away for sign-mode font/icon and for bar. Persist undefined
+    // when no usable rule remains so the saved JSON stays tidy.
+    if (tile.type === "table") {
+      const cleaned = conditionalFormat
+        .filter((r) => r.column.trim() !== "")
+        .map((r) => {
+          const out: ConditionalFormatRule = {
+            column: r.column.trim(),
+            type: r.type,
+            thresholdMode: r.thresholdMode,
+          };
+          if (ruleUsesThresholds(r)) {
+            if (r.lowThreshold != null) out.lowThreshold = r.lowThreshold;
+            if (r.highThreshold != null) out.highThreshold = r.highThreshold;
+          }
+          if (r.colors && (r.colors.low || r.colors.mid || r.colors.high)) {
+            out.colors = { ...r.colors };
+          }
+          if (r.type === "bar" && r.barColor) out.barColor = r.barColor;
+          return out;
+        });
+      patch.conditionalFormat = cleaned.length > 0 ? cleaned : undefined;
     }
 
     // Merge the patch into the repositioned source tile, then commit
@@ -719,6 +794,143 @@
           </label>
         </fieldset>
       {/if}
+
+      <!-- ════════════════════════════════════════════════════════════
+           Issue #919 — Conditional formatting (TABLE tiles only).
+           Self-contained block guarded by tile.type === "table" so the
+           parallel #922 (cascading filter) edit rebases cleanly. All
+           rule maths lives in $lib/dashboard/conditionalFormat.ts; this
+           is config capture only.
+           ════════════════════════════════════════════════════════════ -->
+      {#if tile.type === "table"}
+        <fieldset class="cf-section">
+          <legend>Conditional formatting (per column)</legend>
+          <span class="hint">
+            Display-only — the underlying data is unchanged. Match a rule to a
+            column by its header caption.
+          </span>
+
+          {#if conditionalFormat.length === 0}
+            <span class="hint">No rules yet.</span>
+          {/if}
+
+          {#each conditionalFormat as cfRule, i (i)}
+            <div class="cf-rule">
+              <div class="cf-rule-head">
+                <span class="cf-rule-label">Rule {i + 1}</span>
+                <button
+                  type="button"
+                  class="cf-remove"
+                  aria-label="Remove rule"
+                  onclick={() => removeConditionalRule(i)}>×</button
+                >
+              </div>
+
+              <label class="field">
+                <span>Column (header caption)</span>
+                <input type="text" bind:value={cfRule.column} placeholder="e.g. Unit Sales" />
+              </label>
+
+              <div class="cf-row">
+                <label class="field inline">
+                  <span>Format</span>
+                  <select bind:value={cfRule.type}>
+                    {#each CONDITIONAL_TYPES as t (t.id)}
+                      <option value={t.id}>{t.label}</option>
+                    {/each}
+                  </select>
+                </label>
+
+                {#if ruleUsesThresholds(cfRule)}
+                  <label class="field inline">
+                    <span>Threshold mode</span>
+                    <select bind:value={cfRule.thresholdMode}>
+                      {#each CONDITIONAL_MODES as m (m.id)}
+                        <option value={m.id}>{m.label}</option>
+                      {/each}
+                    </select>
+                  </label>
+                {/if}
+              </div>
+
+              {#if ruleUsesThresholds(cfRule)}
+                <div class="cf-row">
+                  <label class="field inline">
+                    <span>
+                      Low {cfRule.thresholdMode === "relative" ? "(percentile)" : "(value)"}
+                    </span>
+                    <input type="number" bind:value={cfRule.lowThreshold} placeholder="off" />
+                  </label>
+                  <label class="field inline">
+                    <span>
+                      High {cfRule.thresholdMode === "relative" ? "(percentile)" : "(value)"}
+                    </span>
+                    <input type="number" bind:value={cfRule.highThreshold} placeholder="off" />
+                  </label>
+                </div>
+                {#if cfRule.type === "font" || cfRule.type === "icon"}
+                  <span class="hint">
+                    Leave both thresholds empty to colour / point by sign
+                    (negative = red / ↓, positive = green / ↑).
+                  </span>
+                {/if}
+              {/if}
+
+              {#if cfRule.type === "bar"}
+                <label class="field">
+                  <span>Bar colour</span>
+                  <input type="text" bind:value={cfRule.barColor} placeholder="#4c8dff" />
+                </label>
+              {/if}
+
+              {#if cfRule.type === "background" || cfRule.type === "font" || cfRule.type === "icon"}
+                <div class="cf-row">
+                  <label class="field inline">
+                    <span>Low colour</span>
+                    <input
+                      type="text"
+                      value={cfRule.colors?.low ?? ""}
+                      placeholder="default red"
+                      oninput={(e) => {
+                        const v = (e.target as HTMLInputElement).value;
+                        cfRule.colors = { ...cfRule.colors, low: v || undefined };
+                      }}
+                    />
+                  </label>
+                  <label class="field inline">
+                    <span>Mid colour</span>
+                    <input
+                      type="text"
+                      value={cfRule.colors?.mid ?? ""}
+                      placeholder="default amber"
+                      oninput={(e) => {
+                        const v = (e.target as HTMLInputElement).value;
+                        cfRule.colors = { ...cfRule.colors, mid: v || undefined };
+                      }}
+                    />
+                  </label>
+                  <label class="field inline">
+                    <span>High colour</span>
+                    <input
+                      type="text"
+                      value={cfRule.colors?.high ?? ""}
+                      placeholder="default green"
+                      oninput={(e) => {
+                        const v = (e.target as HTMLInputElement).value;
+                        cfRule.colors = { ...cfRule.colors, high: v || undefined };
+                      }}
+                    />
+                  </label>
+                </div>
+              {/if}
+            </div>
+          {/each}
+
+          <button type="button" class="btn cf-add" onclick={addConditionalRule}>
+            + Add column rule
+          </button>
+        </fieldset>
+      {/if}
     </div>
     <footer class="modal-footer">
       <button type="button" class="btn" onclick={onClose}>Cancel</button>
@@ -873,5 +1085,58 @@
     background: var(--accent);
     color: white;
     border-color: var(--accent);
+  }
+  /* ── Issue #919: conditional-formatting rule editor (table only) ── */
+  .cf-section {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    border: 1px solid var(--border);
+    border-radius: 4px;
+    padding: 0.5rem 0.75rem;
+    margin: 0;
+  }
+  .cf-section legend {
+    font-size: 0.75rem;
+    color: var(--fg-muted);
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    padding: 0 0.25rem;
+  }
+  .cf-rule {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    border: 1px solid var(--border);
+    border-radius: 4px;
+    padding: 0.5rem 0.625rem;
+    background: var(--bg-subtle);
+  }
+  .cf-rule-head {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+  }
+  .cf-rule-label {
+    font-size: 0.75rem;
+    color: var(--fg-muted);
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+  }
+  .cf-remove {
+    border: none;
+    background: transparent;
+    font-size: 1.125rem;
+    line-height: 1;
+    cursor: pointer;
+    color: var(--fg-muted);
+  }
+  .cf-row {
+    display: flex;
+    gap: 0.5rem;
+    align-items: flex-end;
+  }
+  .cf-add {
+    align-self: flex-start;
   }
 </style>

--- a/saiku-ui/src/lib/views/dashboard/tiles/TableTile.svelte
+++ b/saiku-ui/src/lib/views/dashboard/tiles/TableTile.svelte
@@ -39,6 +39,12 @@
   } from "$lib/dashboard/filterSuggestions";
   import type { CubeRef } from "$lib/api/dashboards";
   import { parseFormattedCell } from "$lib/cellset/cellFormat";
+  // Issue #919 — per-column conditional formatting (display-only).
+  import {
+    formatCell,
+    cellFormatToStyle,
+    type CellFormat,
+  } from "$lib/dashboard/conditionalFormat";
 
   interface Props {
     tile: DashboardTile;
@@ -194,6 +200,43 @@
     return [...rowHeader, ...measures];
   })());
 
+  // Issue #919 — conditional formatting. Per-column the rule engine needs
+  // the column's full set of raw numeric values to compute percentile
+  // bands and bar widths. Build a caption → values[] index over the
+  // current response, using AiCell.value when present (the un-formatted
+  // number) and falling back to the plain string for row-header columns
+  // (which the engine then coerces / ignores). Recomputed whenever the
+  // response changes.
+  let columnValues = $derived<Record<string, unknown[]>>((() => {
+    const rules = tile.conditionalFormat;
+    if (!rules || rules.length === 0) return {};
+    const rows = response?.data ?? [];
+    const index: Record<string, unknown[]> = {};
+    for (const rule of rules) {
+      const vals: unknown[] = [];
+      for (const row of rows) {
+        const cell = row[rule.column];
+        vals.push(isAiCell(cell) ? cell.value : cell);
+      }
+      index[rule.column] = vals;
+    }
+    return index;
+  })());
+
+  /** The un-formatted numeric source for a cell — AiCell.value when the
+   *  cell is a measure, else the raw string (engine coerces / ignores). */
+  function cellNumericSource(v: AiCell | string | undefined): unknown {
+    return isAiCell(v) ? v.value : v;
+  }
+
+  /** Compute the conditional-format result for one cell. Returns an empty
+   *  CellFormat when no rule targets the column (the common path). */
+  function cellFormatFor(column: string, v: AiCell | string | undefined): CellFormat {
+    const rules = tile.conditionalFormat;
+    if (!rules || rules.length === 0) return {};
+    return formatCell(rules, column, cellNumericSource(v), columnValues[column] ?? []);
+  }
+
   /** Build the click-filter context for a row-header cell. The dashboard
    *  level for the click is inferred from the tile's base query — we
    *  match the column caption against the row-axis level captions —
@@ -298,10 +341,14 @@
                 {#each columns as col (col.caption)}
                   {@const v = row[col.caption]}
                   {@const fmt = parseFormattedCell(renderCell(v))}
+                  {@const cf = cellFormatFor(col.caption, v)}
+                  {@const cfStyle = cellFormatToStyle(cf)}
                   <td
                     class:row-header={col.isRowHeader}
                     class:clickable={col.isRowHeader}
-                    style={fmt.color ? `color: ${fmt.color}` : undefined}
+                    style={[fmt.color && !cf.color ? `color: ${fmt.color}` : undefined, cfStyle]
+                      .filter(Boolean)
+                      .join("; ") || undefined}
                     onclick={() => handleCellClick(col.caption, fmt.display, col.isRowHeader, row)}
                     role={col.isRowHeader ? "button" : undefined}
                     tabindex={col.isRowHeader ? 0 : undefined}
@@ -312,7 +359,7 @@
                       }
                     }}
                   >
-                    {fmt.display}
+                    {#if cf.icon}<span class="cf-icon" aria-hidden="true">{cf.icon}</span>{/if}{fmt.display}
                   </td>
                 {/each}
               </tr>
@@ -377,5 +424,11 @@
   td.clickable:focus {
     outline: 2px solid var(--accent);
     outline-offset: -2px;
+  }
+  /* Issue #919 — conditional-format icon glyph prepended to a cell. */
+  .cf-icon {
+    display: inline-block;
+    margin-right: 0.25rem;
+    font-weight: var(--weight-semibold);
   }
 </style>


### PR DESCRIPTION
## Summary

Closes #919. Adds per-column, display-only conditional formatting to dashboard table tiles. Four format types — **background** (cell colour by threshold band), **bar** (horizontal mini data-bar, width ∝ value), **font** (colour by sign or threshold), and **icon** (↑ ↓ → by sign or threshold) — each driven by **relative** (percentile of the column's own values) or **absolute** (fixed numeric) thresholds. The underlying query data is never mutated; formatting is purely presentational.

## The change

**Pure helper — conditionalFormat.ts:**
New `src/lib/dashboard/conditionalFormat.ts` holds all rule-evaluation maths: numeric coercion (`toNumber`/`numericValues`), `percentile` (linear-interpolated), `classifyByCuts` (low/mid/high banding with inverted-cut normalisation), `resolveCuts` (relative→percentile vs absolute pass-through), `barWidthPct` (min/max scaled, clamped 0–100, full bar for an all-equal column), and `evaluateCell` which dispatches per format type — including sign-mode font/icon when thresholds are omitted. `formatCell` / `ruleForColumn` give the no-rules pass-through, and `cellFormatToStyle` serialises a `CellFormat` to an inline style string (the data-bar renders as a left-anchored `linear-gradient`, no extra DOM). Companion `conditionalFormat.test.ts` — 47 vitest cases mirroring the density of `chartOptions.test.ts` / `filterDefaults.test.ts`.

**UI — TableTile.svelte:**
Builds a per-column `caption → values[]` index (using `AiCell.value`, falling back to the raw cell) only when rules exist, calls `formatCell` per cell, and applies the result: inline style merged with the existing Mondrian style-marker colour (conditional `color` wins), plus an optional prepended icon glyph. Thin — no maths in the component.

**UI — TileEditorModal.svelte:**
Adds a table-only rule editor (guarded by `tile.type === 'table'`): add/remove column rules, pick format type, threshold mode (relative/absolute), low/high thresholds, per-band colour overrides, and bar colour. Working copy is deep-cloned from the tile and persisted in `handleSave` under a table-guarded block that drops incomplete rules and normalises away unused threshold/colour fields.

**Types — dashboards.ts:**
Adds `ConditionalFormatRule`, `ConditionalFormatType`, `ConditionalThresholdMode`, `ConditionalBandColors`, and a `conditionalFormat?: ConditionalFormatRule[]` field on `DashboardTile`.

## Verified

- [x] npx vitest run — 384/384 (47 new in conditionalFormat.test.ts)
- [x] npm run check — 0 errors (42 baseline a11y warnings, none in the changed files)

## Test plan

1. Open a dashboard, add a **table** tile, bind it to a query that returns at least one measure column.
2. Open the tile editor (⚙). Scroll to **Conditional formatting**.
3. Add a **background** rule targeting a measure column's header caption; set mode **Relative**, low 25 / high 75. Save → confirm cells render red/amber/green bands by their value distribution.
4. Re-open, switch the rule to **Absolute** with fixed low/high values → confirm bands now follow the fixed cut points.
5. Add a **bar** rule on another column → confirm a proportional left-anchored data bar appears, widest at the column max.
6. Add a **font** rule and a **icon** rule with thresholds cleared → confirm sign-mode (negative red / ↓, positive green / ↑).
7. Confirm the displayed numbers themselves are unchanged (formatting is display-only).

## Notes for the reviewer

This branch touches two files also edited by **#922 (cascading filter)**: `dashboards.ts` and `TileEditorModal.svelte`. To keep a rebase trivial, all #919 additions are isolated:
- `dashboards.ts` — only the one `conditionalFormat?` field is added inside `DashboardTile`; every new type lives in a clearly-commented `Issue #919` block appended after the interface.
- `TileEditorModal.svelte` — the new state, helpers, save block, markup section, and styles are each in self-contained, `tile.type === 'table'`-guarded, comment-delimited blocks. No existing content was reordered or reformatted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
