### PR TITLE
feat(ui): truncate long chart axis labels with hover tooltip (closes #934)

### DIFF
--- a/saiku-ui/src/lib/dashboard/chartOptions.ts
+++ b/saiku-ui/src/lib/dashboard/chartOptions.ts
@@ -12,6 +12,17 @@
  */
 
 import type { AiCell, AiQueryResponse } from "$lib/api/aiQuery";
+import { axisLabelConfig } from "$lib/views/chartAxisLabel";
+
+/**
+ * Truncating axisLabel for a dashboard tile's category axis. Tiles are small,
+ * so a fixed cap keeps deep member captions from overflowing; ECharts shows
+ * the full label in the axis-pointer tooltip on hover. `rotate` is preserved
+ * for callers that crowd many categories. Width default suits a tile.
+ */
+function categoryAxisLabel(rotate = 0): Record<string, unknown> {
+  return { rotate, ...axisLabelConfig(100) };
+}
 
 /** All chart kinds the workspace exposes — matches chartTypes.ts. */
 export type ChartKind =
@@ -162,7 +173,7 @@ export function buildChartOption(response: AiQueryResponse, kind: string): Recor
     return {
       tooltip: {},
       grid: { left: 120, top: 24, right: 16, bottom: 64 },
-      xAxis: { type: "category", data: cols },
+      xAxis: { type: "category", data: cols, axisLabel: categoryAxisLabel() },
       yAxis: { type: "category", data: rows, inverse: true },
       visualMap: { min, max, calculable: true, orient: "horizontal", left: "center", bottom: 8 },
       series: [{ type: "heatmap", data, label: { show: false } }],
@@ -189,7 +200,7 @@ export function buildChartOption(response: AiQueryResponse, kind: string): Recor
     return {
       tooltip: {},
       legend: { type: "scroll", bottom: 0 },
-      xAxis: { type: "category", data: cols },
+      xAxis: { type: "category", data: cols, axisLabel: categoryAxisLabel() },
       yAxis: { type: "value" },
       series: rows.map((name, i) => ({
         type: "scatter",
@@ -228,7 +239,7 @@ export function buildChartOption(response: AiQueryResponse, kind: string): Recor
       tooltip: { trigger: "axis" },
       legend: { type: "scroll", bottom: 0 },
       grid: { top: 24, left: 48, right: 16, bottom: 36 },
-      xAxis: { type: "category", data: rows },
+      xAxis: { type: "category", data: rows, axisLabel: categoryAxisLabel() },
       yAxis: { type: "value" },
       series: [
         {
@@ -266,7 +277,7 @@ export function buildChartOption(response: AiQueryResponse, kind: string): Recor
     tooltip: { trigger: "axis" },
     legend: { type: "scroll", bottom: 0 },
     grid: { top: 24, left: 48, right: 16, bottom: 36 },
-    xAxis: { type: "category", data: rows, axisLabel: { rotate: rows.length > 8 ? 30 : 0 } },
+    xAxis: { type: "category", data: rows, axisLabel: categoryAxisLabel(rows.length > 8 ? 30 : 0) },
     yAxis: { type: "value" },
     series: cols.map((name, c) => ({
       name,

--- a/saiku-ui/src/lib/views/ChartView.svelte
+++ b/saiku-ui/src/lib/views/ChartView.svelte
@@ -5,6 +5,7 @@
   import { parseCellset, toNumber } from "$lib/views/cellsetUtils";
   import type { ChartType, ChartOptions } from "$lib/views/chartTypes";
   import { DEFAULT_CHART_OPTIONS } from "$lib/views/chartTypes";
+  import { axisLabelConfig, deriveAxisLabelWidth } from "$lib/views/chartAxisLabel";
   import { theme } from "$lib/stores/theme.svelte";
 
   interface Props {
@@ -157,9 +158,25 @@
     const splitLine = { lineStyle: { color: tk.border, opacity: 0.5 } };
     const nameTextStyle = { color: tk.fg };
 
+    // Truncate long category labels (e.g. deep member captions) so they don't
+    // overflow the plot and break the layout. ECharts shows the full,
+    // untruncated label in the axis-pointer tooltip on hover. Width is derived
+    // from the available chart width divided by the number of categories.
+    const chartWidth = host?.clientWidth ?? 0;
+    const catCount = Math.max(rows.length, cols.length, 1);
+    const truncLabel = {
+      color: tk.fgMuted,
+      ...axisLabelConfig(deriveAxisLabelWidth(chartWidth, catCount)),
+    };
+
     const baseAxis = {
       type: "category" as const,
       axisLabel, axisLine, axisTick, splitLine, nameTextStyle,
+    };
+    // Bottom category axis that truncates long labels with an ellipsis.
+    const categoryAxis = {
+      ...baseAxis,
+      axisLabel: truncLabel,
     };
     const valueAxis = {
       type: "value" as const,
@@ -249,7 +266,7 @@
         title,
         tooltip: itemTooltip,
         grid: { left: 120, top: 40, right: 40, bottom: 80 },
-        xAxis: { ...baseAxis, data: cols, name: xName },
+        xAxis: { ...categoryAxis, data: cols, name: xName },
         yAxis: { ...baseAxis, data: rows, inverse: true, name: yName },
         visualMap: {
           min, max, calculable: true, orient: "horizontal",
@@ -284,7 +301,7 @@
         title,
         tooltip: itemTooltip,
         legend,
-        xAxis: { ...baseAxis, data: cols, name: xName },
+        xAxis: { ...categoryAxis, data: cols, name: xName },
         yAxis: { ...valueAxis, name: yName },
         series: rows.map((name, i) => ({
           type: "scatter",
@@ -325,7 +342,7 @@
         tooltip,
         legend,
         grid: { left: 60, top: title ? 50 : 30, right: 40, bottom: 60 },
-        xAxis: { ...baseAxis, data: rows, name: xName },
+        xAxis: { ...categoryAxis, data: rows, name: xName },
         yAxis: { ...valueAxis, name: yName },
         series: [
           { type: "bar", name: "", stack: "waterfall", itemStyle: { borderColor: "transparent", color: "transparent" }, data: spacers, emphasis: { itemStyle: { borderColor: "transparent", color: "transparent" } } },
@@ -359,7 +376,7 @@
       ...common,
       title, tooltip, legend,
       grid: { left: 60, top: title ? 50 : 40, right: 40, bottom: 60 },
-      xAxis: { ...baseAxis, data: rows, name: xName },
+      xAxis: { ...categoryAxis, data: rows, name: xName },
       yAxis: { ...valueAxis, name: yName },
       series: [...base, ...trend],
     };

--- a/saiku-ui/src/lib/views/chartAxisLabel.test.ts
+++ b/saiku-ui/src/lib/views/chartAxisLabel.test.ts
@@ -1,0 +1,90 @@
+/*
+ * Unit tests for the shared chart axis-label truncation helpers used by both
+ * the workspace ChartView and the dashboard chartOptions builder.
+ */
+
+import { describe, test, expect } from "vitest";
+import {
+  ELLIPSIS,
+  DEFAULT_AXIS_LABEL_WIDTH,
+  MIN_AXIS_LABEL_WIDTH,
+  MAX_AXIS_LABEL_WIDTH,
+  truncateAxisLabel,
+  deriveAxisLabelWidth,
+  axisLabelConfig,
+} from "$lib/views/chartAxisLabel";
+
+describe("truncateAxisLabel", () => {
+  test("leaves short labels unchanged", () => {
+    expect(truncateAxisLabel("Q3 2026", 20)).toBe("Q3 2026");
+  });
+
+  test("returns the label unchanged when it exactly fits", () => {
+    expect(truncateAxisLabel("abcde", 5)).toBe("abcde");
+  });
+
+  test("truncates long labels and appends a single ellipsis", () => {
+    const long = "Quarter 3 Fiscal Year 2026 - Europe Region - Premium Tier";
+    const out = truncateAxisLabel(long, 12);
+    expect(out.length).toBe(12);
+    expect(out.endsWith(ELLIPSIS)).toBe(true);
+    expect(out).toBe("Quarter 3 F" + ELLIPSIS);
+  });
+
+  test("max <= 0 disables truncation", () => {
+    const long = "a very long label indeed";
+    expect(truncateAxisLabel(long, 0)).toBe(long);
+    expect(truncateAxisLabel(long, -5)).toBe(long);
+  });
+
+  test("max smaller than the ellipsis collapses to the ellipsis", () => {
+    expect(truncateAxisLabel("abcdef", 1)).toBe(ELLIPSIS);
+  });
+});
+
+describe("deriveAxisLabelWidth", () => {
+  test("falls back to default when geometry is unknown", () => {
+    expect(deriveAxisLabelWidth(0, 5)).toBe(DEFAULT_AXIS_LABEL_WIDTH);
+    expect(deriveAxisLabelWidth(600, 0)).toBe(DEFAULT_AXIS_LABEL_WIDTH);
+    expect(deriveAxisLabelWidth(-1, -1)).toBe(DEFAULT_AXIS_LABEL_WIDTH);
+  });
+
+  test("divides available width across categories", () => {
+    // 600 / 6 = 100, within [MIN, MAX]
+    expect(deriveAxisLabelWidth(600, 6)).toBe(100);
+  });
+
+  test("clamps to the maximum when few wide categories", () => {
+    // 2000 / 2 = 1000 -> clamped to MAX
+    expect(deriveAxisLabelWidth(2000, 2)).toBe(MAX_AXIS_LABEL_WIDTH);
+  });
+
+  test("clamps to the minimum when many crowded categories", () => {
+    // 300 / 100 = 3 -> clamped to MIN
+    expect(deriveAxisLabelWidth(300, 100)).toBe(MIN_AXIS_LABEL_WIDTH);
+  });
+});
+
+describe("axisLabelConfig", () => {
+  test("produces an ECharts truncate fragment with the default width", () => {
+    const cfg = axisLabelConfig();
+    expect(cfg.overflow).toBe("truncate");
+    expect(cfg.hideOverlap).toBe(true);
+    expect(cfg.ellipsis).toBe(ELLIPSIS);
+    expect(cfg.width).toBe(DEFAULT_AXIS_LABEL_WIDTH);
+  });
+
+  test("honours an explicit width within range", () => {
+    expect(axisLabelConfig(90).width).toBe(90);
+  });
+
+  test("clamps out-of-range widths", () => {
+    expect(axisLabelConfig(5).width).toBe(MIN_AXIS_LABEL_WIDTH);
+    expect(axisLabelConfig(9999).width).toBe(MAX_AXIS_LABEL_WIDTH);
+  });
+
+  test("falls back to default for invalid widths", () => {
+    expect(axisLabelConfig(0).width).toBe(DEFAULT_AXIS_LABEL_WIDTH);
+    expect(axisLabelConfig(Number.NaN).width).toBe(DEFAULT_AXIS_LABEL_WIDTH);
+  });
+});

--- a/saiku-ui/src/lib/views/chartAxisLabel.ts
+++ b/saiku-ui/src/lib/views/chartAxisLabel.ts
@@ -1,0 +1,75 @@
+/*
+ * Shared axis-label truncation helpers for chart category axes.
+ *
+ * Long member captions (e.g. "Quarter 3 Fiscal Year 2026 - Europe Region -
+ * Premium Tier") overflow the chart area and break the layout. Both the
+ * workspace chart (ChartView.svelte) and the dashboard chart tiles
+ * (chartOptions.ts) feed their category axis through axisLabelConfig() so the
+ * truncation behaviour is identical and unit-tested in one place.
+ *
+ * ECharts handles the actual rendering truncation via `overflow: 'truncate'`
+ * + a pixel `width`; it shows the full untruncated label in the axis-pointer
+ * tooltip on hover by default. truncateAxisLabel() is a pure character-based
+ * fallback used by tests (and available for any non-ECharts consumer) that
+ * mirrors the intent: cut to `max` characters and append an ellipsis.
+ *
+ * Pure: no DOM, no fetches.
+ */
+
+/** Single-character ellipsis (U+2026) appended to truncated labels. */
+export const ELLIPSIS = "…";
+
+/** Default per-label width cap (px) when no width can be derived. */
+export const DEFAULT_AXIS_LABEL_WIDTH = 120;
+
+/** Lower / upper bounds for a width derived from chart geometry. */
+export const MIN_AXIS_LABEL_WIDTH = 40;
+export const MAX_AXIS_LABEL_WIDTH = 160;
+
+/**
+ * Truncate `label` to at most `max` characters, appending an ellipsis when
+ * the label is longer. Pure string helper — `max` is a character count, not
+ * pixels. Returns the original label unchanged when it already fits or when
+ * `max` is non-positive (treated as "no truncation").
+ */
+export function truncateAxisLabel(label: string, max: number): string {
+  if (max <= 0) return label;
+  if (label.length <= max) return label;
+  if (max <= ELLIPSIS.length) return ELLIPSIS;
+  return label.slice(0, max - ELLIPSIS.length) + ELLIPSIS;
+}
+
+/**
+ * Derive a sensible per-label pixel width from the available axis width and
+ * the number of categories, clamped to [MIN, MAX]. More categories → less
+ * room per label. Falls back to DEFAULT_AXIS_LABEL_WIDTH when geometry isn't
+ * known (chartWidth <= 0 or categoryCount <= 0).
+ */
+export function deriveAxisLabelWidth(chartWidth: number, categoryCount: number): number {
+  if (chartWidth <= 0 || categoryCount <= 0) return DEFAULT_AXIS_LABEL_WIDTH;
+  const per = Math.floor(chartWidth / categoryCount);
+  return Math.max(MIN_AXIS_LABEL_WIDTH, Math.min(MAX_AXIS_LABEL_WIDTH, per));
+}
+
+/** ECharts axisLabel fragment that truncates long labels with an ellipsis. */
+export interface AxisLabelTruncation {
+  overflow: "truncate";
+  width: number;
+  hideOverlap: true;
+  ellipsis: string;
+}
+
+/**
+ * Build the ECharts `axisLabel` truncation fragment for a category axis.
+ * Spread this into an existing axisLabel object (e.g. `{ color, ...config }`).
+ * `width` defaults to DEFAULT_AXIS_LABEL_WIDTH and is clamped to a sane range.
+ */
+export function axisLabelConfig(width: number = DEFAULT_AXIS_LABEL_WIDTH): AxisLabelTruncation {
+  const w = Number.isFinite(width) && width > 0 ? Math.round(width) : DEFAULT_AXIS_LABEL_WIDTH;
+  return {
+    overflow: "truncate",
+    width: Math.max(MIN_AXIS_LABEL_WIDTH, Math.min(MAX_AXIS_LABEL_WIDTH, w)),
+    hideOverlap: true,
+    ellipsis: ELLIPSIS,
+  };
+}


### PR DESCRIPTION
## Summary

Closes #934. Long category-axis labels (e.g. deep member captions like `Quarter 3 Fiscal Year 2026 - Europe Region - Premium Tier`) overflowed the plot area and broke the chart layout. ECharts supports label truncation — it just wasn't configured. This wires truncation into **both** chart surfaces (the workspace chart renderer and the dashboard chart tiles) through one shared, unit-tested helper, so labels render with an ellipsis and the full text shows on hover via the axis-pointer tooltip.

## The change

**New helper `src/lib/views/chartAxisLabel.ts`**
Pure module (no DOM, no fetches) exposing:
- `axisLabelConfig(width)` — emits the ECharts `axisLabel` truncation fragment: `overflow: 'truncate'`, a pixel `width` (clamped to `[40, 160]`), `hideOverlap: true`, and an ellipsis. Spread into an existing `axisLabel`.
- `deriveAxisLabelWidth(chartWidth, categoryCount)` — derives a per-label width from available geometry (`chartWidth / categoryCount`), clamped, falling back to `120px` when geometry is unknown.
- `truncateAxisLabel(label, max)` — pure character-based fallback that mirrors the intent (cut + ellipsis), used by tests and any non-ECharts consumer.

**`src/lib/views/ChartView.svelte`** (workspace chart)
Replaces the bare `axisLabel = { color: tk.fgMuted }` on category axes with a truncating variant whose width is derived from `host.clientWidth` and the category count. Applied to every bottom category axis — `bar`/`line`/`area`, `scatter`/`bubble`, `waterfall`, and the `heatmap` x-axis. The `valueAxis`, the heatmap y-axis (which keeps its wide `120px` left grid), and existing rotation/theming behaviour are untouched.

**`src/lib/dashboard/chartOptions.ts`** (dashboard chart tiles)
Adds a small `categoryAxisLabel(rotate)` helper that merges the shared `axisLabelConfig(100)` with the existing `rotate`, applied to each tile's category axis (`bar`/`line` group, `scatter`/`bubble`, `waterfall`, `heatmap` x). The prior `rotate: rows.length > 8 ? 30 : 0` crowding behaviour is preserved.

**`src/lib/views/chartAxisLabel.test.ts`**
13 vitest cases covering truncation (short/exact/long/disabled/ellipsis-collapse), width derivation and clamping, and config generation.

## Verified

- [x] `npx vitest run` — 350/350 passing (13 new in `chartAxisLabel.test.ts`)
- [x] `npm run check` — 0 errors, warnings unchanged (42 pre-existing a11y baseline; none in touched files)

## Test plan

1. Open a workspace chart (bar/line) on a query whose row members have long captions (e.g. a crossjoin producing `Quarter 3 Fiscal Year 2026 - Europe Region - Premium Tier`).
2. Confirm the X-axis labels truncate with an ellipsis instead of overflowing the plot, and that hovering a category shows the full untruncated label in the axis-pointer tooltip.
3. Add a dashboard chart tile bound to the same query; confirm the tile's category axis truncates identically and the tile layout no longer breaks.
4. Resize the workspace chart wider/narrower; confirm the truncation width adapts (more room per label when wider / fewer categories).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
