### PR TITLE
feat(observability): opt-in OpenTelemetry via side-loaded Java agent (Tier 1)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,11 +11,23 @@
 #      avoids needing GH Packages auth inside the container.
 FROM eclipse-temurin:21-jre-noble
 ARG JAR_PATH=build-context/saiku.jar
+ARG OTEL_AGENT_VERSION=2.28.1
+ARG OTEL_AGENT_SHA256=faa89bdeebf9b1f52be4a4374689176717b02a59df2d8f8b6eb9aa39f9292589
 WORKDIR /app
 
 COPY ${JAR_PATH} /app/saiku.jar
 COPY docker/saiku-entrypoint /usr/local/bin/saiku-entrypoint
 RUN chmod +x /usr/local/bin/saiku-entrypoint
+
+# OpenTelemetry Java agent — side-loaded, only attached at runtime when
+# OTEL_EXPORTER_OTLP_ENDPOINT is set (see saiku-entrypoint). Pinned by
+# checksum so a tampered Maven Central response can't slip in a different
+# binary. See docs/observability.md for the runtime activation contract.
+RUN set -eux; \
+    mkdir -p /opt/saiku/otel; \
+    curl -fsSL -o /opt/saiku/otel/opentelemetry-javaagent.jar \
+      "https://repo1.maven.org/maven2/io/opentelemetry/javaagent/opentelemetry-javaagent/${OTEL_AGENT_VERSION}/opentelemetry-javaagent-${OTEL_AGENT_VERSION}.jar"; \
+    echo "${OTEL_AGENT_SHA256}  /opt/saiku/otel/opentelemetry-javaagent.jar" | sha256sum -c -
 
 ENV SAIKU_HOME=/app/saiku-home
 

--- a/dist/README.md
+++ b/dist/README.md
@@ -62,6 +62,35 @@ saiku-home/
   branding/        Brand customisation samples.
 ```
 
+## OpenTelemetry (optional)
+
+The `run.sh` / `run.bat` wrappers will attach the OpenTelemetry Java
+agent automatically when **both** conditions are true:
+
+1. `opentelemetry-javaagent.jar` is present next to the wrapper script.
+2. `OTEL_EXPORTER_OTLP_ENDPOINT` is set in the environment.
+
+Download the agent (this distribution doesn't ship it to avoid
+inflating the zip with a ~22 MB jar that most users won't use):
+
+```bash
+curl -fsSLO https://repo1.maven.org/maven2/io/opentelemetry/javaagent/opentelemetry-javaagent/2.28.1/opentelemetry-javaagent-2.28.1.jar
+mv opentelemetry-javaagent-2.28.1.jar opentelemetry-javaagent.jar
+```
+
+Then point it at your collector:
+
+```bash
+export OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318
+./run.sh
+```
+
+When `OTEL_EXPORTER_OTLP_ENDPOINT` is unset, the agent is never loaded
+— zero overhead, zero observability. See
+[docs/observability.md](../docs/observability.md) for the full
+configuration reference, what gets auto-instrumented, and sampling
+guidance.
+
 ## Calcite vs legacy Mondrian backend
 
 The bundled Mondrian fork (`pentaho:mondrian:4.8.1.2`) ships a Calcite-based

--- a/dist/run.bat
+++ b/dist/run.bat
@@ -18,5 +18,17 @@ if not defined JAR (
     exit /b 1
 )
 
-java -jar "%JAR%" serve --home "%SCRIPT_DIR%saiku-home" %*
+rem Optional OpenTelemetry: drop opentelemetry-javaagent.jar next to this
+rem script and set OTEL_EXPORTER_OTLP_ENDPOINT to enable. See
+rem docs\observability.md for the download command and config reference.
+set "JAVA_OPTS="
+set "OTEL_AGENT_JAR=%SCRIPT_DIR%opentelemetry-javaagent.jar"
+if defined OTEL_EXPORTER_OTLP_ENDPOINT (
+    if exist "%OTEL_AGENT_JAR%" (
+        set "JAVA_OPTS=-javaagent:%OTEL_AGENT_JAR%"
+        if not defined OTEL_SERVICE_NAME set "OTEL_SERVICE_NAME=saiku"
+    )
+)
+
+java %JAVA_OPTS% -jar "%JAR%" serve --home "%SCRIPT_DIR%saiku-home" %*
 endlocal

--- a/dist/run.sh
+++ b/dist/run.sh
@@ -15,5 +15,15 @@ if [[ -z "$JAR" ]]; then
   exit 1
 fi
 
+# Optional OpenTelemetry: drop opentelemetry-javaagent.jar next to this
+# script and set OTEL_EXPORTER_OTLP_ENDPOINT to enable. See
+# docs/observability.md for the download command and config reference.
+JAVA_OPTS=()
+OTEL_AGENT_JAR="$SCRIPT_DIR/opentelemetry-javaagent.jar"
+if [[ -n "${OTEL_EXPORTER_OTLP_ENDPOINT:-}" && -f "$OTEL_AGENT_JAR" ]]; then
+  JAVA_OPTS+=("-javaagent:$OTEL_AGENT_JAR")
+  export OTEL_SERVICE_NAME="${OTEL_SERVICE_NAME:-saiku}"
+fi
+
 # Default to a saiku-home that lives next to the JAR (not the user's CWD).
-exec java -jar "$JAR" serve --home "$SCRIPT_DIR/saiku-home" "$@"
+exec java "${JAVA_OPTS[@]}" -jar "$JAR" serve --home "$SCRIPT_DIR/saiku-home" "$@"

--- a/docker/saiku-entrypoint
+++ b/docker/saiku-entrypoint
@@ -30,6 +30,18 @@ case "${1:-serve}" in
     if [[ -n "${SAIKU_MCP_URL:-}" ]]; then
       JAVA_OPTS+=("-Dsaiku.mcp.url=${SAIKU_MCP_URL}")
     fi
+    # OpenTelemetry: attach the side-loaded Java agent only when an OTLP
+    # endpoint is configured. With no endpoint, the agent jar is never
+    # loaded — zero startup cost, zero runtime overhead. OTEL_SERVICE_NAME
+    # defaults to "saiku" so traces are attributed correctly without
+    # forcing every deployer to set it. All other OTEL_* env vars
+    # (sampler, headers, resource attrs) pass through to the agent
+    # untouched — see docs/observability.md.
+    OTEL_AGENT_JAR=/opt/saiku/otel/opentelemetry-javaagent.jar
+    if [[ -n "${OTEL_EXPORTER_OTLP_ENDPOINT:-}" && -f "$OTEL_AGENT_JAR" ]]; then
+      JAVA_OPTS+=("-javaagent:${OTEL_AGENT_JAR}")
+      export OTEL_SERVICE_NAME="${OTEL_SERVICE_NAME:-saiku}"
+    fi
     exec java "${JAVA_OPTS[@]}" -jar /app/saiku.jar serve \
       --host 0.0.0.0 \
       --port 8080 \

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -1,0 +1,142 @@
+# Observability
+
+Saiku ships with **opt-in OpenTelemetry instrumentation** via the
+[OpenTelemetry Java agent](https://github.com/open-telemetry/opentelemetry-java-instrumentation).
+The agent is side-loaded — it is only attached at JVM start when an
+OTLP endpoint is configured, so deployments that don't want
+observability pay no cost (no agent loaded, no startup delay, no
+runtime overhead).
+
+This is **Tier 1**: zero-code instrumentation. Custom spans for
+`ThinQueryService`, AI Query API, and cellset cache (Tier 2) layer on
+top of the same SDK once we know what's worth tracing — tracked under
+a follow-up issue.
+
+## What gets instrumented automatically
+
+The agent's bytecode-injected instrumentation covers everything Saiku
+runs on:
+
+| Component | What you get |
+|---|---|
+| **Jetty 12 (EE10)** | Server span per HTTP request, populated with `http.method`, `http.route`, `http.status_code`, `url.path`. |
+| **Jersey 3.1** | Resource method attribution on the request span (`code.namespace`, `code.function`). |
+| **JDBC** | A child span per SQL statement Mondrian emits, with `db.system` and `db.statement`. This is the big win: every slow MDX query is decomposed into the SQL it generated. |
+| **java.net.http.HttpClient** | Outbound calls to AI providers (Anthropic, OpenAI, etc.) and any other downstream HTTP service appear as child spans. |
+| **Log4j 2** | Trace context (`trace_id`, `span_id`) injected into MDC. The Saiku log4j pattern renders these as `[trace_id=… span_id=…]` when present and elides the bracket entirely when absent. Logs can also be exported as OTLP log records. |
+| **JVM** | Process metrics: heap usage, GC pause duration, thread count, class loading. |
+| **DBCP2** | Connection pool metrics (active, idle, waits). |
+
+## Enabling it
+
+### Docker
+
+The published `ghcr.io/spiculedata/saiku` image bakes the agent into
+`/opt/saiku/otel/opentelemetry-javaagent.jar`. The entrypoint attaches
+it only when `OTEL_EXPORTER_OTLP_ENDPOINT` is set:
+
+```bash
+docker run -d \
+  --name saiku \
+  -p 8080:8080 \
+  -e OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector:4318 \
+  -e OTEL_SERVICE_NAME=saiku-prod \
+  -e OTEL_RESOURCE_ATTRIBUTES=deployment.environment=production \
+  ghcr.io/spiculedata/saiku:latest
+```
+
+### Standalone distribution
+
+Download the agent jar manually and drop it next to `run.sh` /
+`run.bat`:
+
+```bash
+curl -fsSLO https://repo1.maven.org/maven2/io/opentelemetry/javaagent/opentelemetry-javaagent/2.28.1/opentelemetry-javaagent-2.28.1.jar
+mv opentelemetry-javaagent-2.28.1.jar opentelemetry-javaagent.jar
+export OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318
+./run.sh
+```
+
+The wrapper attaches the agent only when both the jar AND the endpoint
+env var are present.
+
+### Hand-rolled (bare `java -jar`)
+
+```bash
+java -javaagent:/path/to/opentelemetry-javaagent.jar \
+  -jar saiku-<version>.jar serve
+```
+
+## Configuration reference
+
+All settings are standard OpenTelemetry SDK environment variables —
+Saiku passes them straight through to the agent. The full list is in
+the [OTel SDK env-var spec](https://opentelemetry.io/docs/specs/otel/configuration/sdk-environment-variables/);
+the ones you'll actually want:
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | _unset_ | OTLP collector URL. **Setting this is what activates the agent.** Supports both gRPC (`:4317`) and HTTP/protobuf (`:4318`). |
+| `OTEL_EXPORTER_OTLP_PROTOCOL` | `grpc` | `grpc` or `http/protobuf`. Pick whichever your collector speaks. |
+| `OTEL_SERVICE_NAME` | `saiku` | Service identifier in your tracing UI. Saiku sets this default when the agent activates; override per environment. |
+| `OTEL_RESOURCE_ATTRIBUTES` | _unset_ | Comma-separated `key=value` pairs. Typical: `deployment.environment=demo,service.version=4.3.4`. |
+| `OTEL_TRACES_EXPORTER` | `otlp` | `otlp` / `none`. |
+| `OTEL_METRICS_EXPORTER` | `otlp` | `otlp` / `prometheus` / `none`. |
+| `OTEL_LOGS_EXPORTER` | `otlp` | `otlp` / `none`. |
+| `OTEL_TRACES_SAMPLER` | `parentbased_always_on` | Sampling strategy. See sampling below. |
+| `OTEL_TRACES_SAMPLER_ARG` | _unset_ | Sampler argument (e.g. ratio for `traceidratio`). |
+| `OTEL_EXPORTER_OTLP_HEADERS` | _unset_ | For SaaS providers needing auth: `api-key=…`. |
+
+## Sampling
+
+The default `parentbased_always_on` sampler captures every trace —
+fine for development and the demo, **not** what you want under
+production load. For a real deployment:
+
+```bash
+# Capture 5% of root traces; child spans follow the root's decision.
+export OTEL_TRACES_SAMPLER=parentbased_traceidratio
+export OTEL_TRACES_SAMPLER_ARG=0.05
+```
+
+If you ingest into a SaaS provider with usage-based billing, lean
+toward 1–5%. Self-hosted (Tempo, Jaeger) can comfortably handle 25–100%
+on Saiku's typical query volume.
+
+## Verifying it works
+
+Spin up a quick collector via Docker to sanity-check end-to-end:
+
+```bash
+docker run --rm -p 4318:4318 \
+  otel/opentelemetry-collector:latest \
+  --config=/etc/otelcol/config.yaml
+```
+
+Default collector config logs received spans to stdout. Send a query
+to Saiku and you should see spans named `GET /rest/saiku/info`,
+`POST /rest/saiku/api/query/execute`, and JDBC child spans for the
+Mondrian-generated SQL.
+
+Log lines for the same request will now include the trace ID so you
+can correlate logs ↔ traces:
+
+```
+2026-06-03T12:34:56.789 INFO  [ThinQueryService] [trace_id=4bf92f3577b34da6a3ce929d0e0e4736 span_id=00f067aa0ba902b7] Executing MDX …
+```
+
+## What this doesn't cover
+
+Tier 1 stops at framework-level auto-instrumentation. The following
+require custom spans (Tier 2):
+
+- Per-MDX-query attribution (cube name, axis structure, cell count)
+- AI Query API request metadata (model, provider, token usage)
+- Cellset cache hit/miss attribution
+- Mondrian Calcite-vs-legacy backend selection events
+- Schema discovery vs query-execute attribution beyond the HTTP route
+
+These ship in a follow-up. Tier 1 gives us the request/SQL/JVM
+visibility that 80% of operational questions need; Tier 2 fills in the
+domain-specific gaps once we know which gaps actually matter in
+production.

--- a/saiku-webapp/src/main/webapp/WEB-INF/classes/log4j2.xml
+++ b/saiku-webapp/src/main/webapp/WEB-INF/classes/log4j2.xml
@@ -16,7 +16,14 @@
 <Configuration status="WARN" name="saiku">
   <Properties>
     <Property name="saikuHome">${sys:saiku.home:-saiku-home}</Property>
-    <Property name="pattern">%d{ISO8601} %-5p [%c{1}] %m%n</Property>
+    <!--
+      Pattern includes OpenTelemetry trace context when the agent is
+      attached. The agent's log4j2-appender instrumentation populates
+      MDC with trace_id/span_id automatically; %notEmpty hides the
+      bracket entirely when the keys are unset, so logs stay clean
+      when OTEL_EXPORTER_OTLP_ENDPOINT isn't configured.
+    -->
+    <Property name="pattern">%d{ISO8601} %-5p [%c{1}] %notEmpty{[trace_id=%X{trace_id} span_id=%X{span_id}] }%m%n</Property>
   </Properties>
 
   <Appenders>


### PR DESCRIPTION
Closes part of #1033 (Tier 1; Tier 2 follow-up stays open).

## Summary

Adds opt-in OpenTelemetry instrumentation to Saiku via the OTel Java agent — **zero code changes**, conditional attach, zero overhead when disabled. Setting `OTEL_EXPORTER_OTLP_ENDPOINT` activates the agent at JVM start; leaving it unset means the agent jar is never loaded.

What you get for free once enabled:
- Jetty 12 server spans (route, method, status)
- Jersey 3.1 resource method attribution
- JDBC child spans for every Mondrian-generated SQL statement
- `java.net.http.HttpClient` outbound calls (AI providers, future WorkOS calls from #1029)
- Log4j 2 trace context in MDC (rendered in the Saiku log pattern via `%notEmpty` so the brackets vanish when the agent is off)
- JVM + DBCP2 connection pool metrics

## Changes

- **`Dockerfile`** — fetches `opentelemetry-javaagent.jar` `2.28.1` from Maven Central into `/opt/saiku/otel/`, SHA256-verified. Pinned via `ARG OTEL_AGENT_VERSION` so version bumps are a one-line PR.
- **`docker/saiku-entrypoint`** — conditionally appends `-javaagent:...` to `JAVA_OPTS` only when both the jar exists AND `OTEL_EXPORTER_OTLP_ENDPOINT` is set. Defaults `OTEL_SERVICE_NAME=saiku`.
- **`dist/run.sh` + `dist/run.bat`** — same conditional logic for the standalone distribution. Doesn't bundle the agent (would add ~22 MB to the zip for users who don't need it); operators download it once and drop it next to the wrapper.
- **`saiku-webapp/.../log4j2.xml`** — pattern includes `%notEmpty{[trace_id=%X{trace_id} span_id=%X{span_id}] }` so trace context appears when the agent populates MDC and disappears cleanly when it doesn't.
- **`docs/observability.md`** (new) — env-var matrix, what's auto-instrumented, sampling guidance, local-collector sanity-check command, and an explicit list of what Tier 1 does **not** cover (custom MDX-query spans etc. — Tier 2 follow-up).
- **`dist/README.md`** — opt-in section pointing at `docs/observability.md` with the one-line agent download command.

Zero new Maven dependencies. The agent is side-loaded, not embedded.

## Test plan

- [x] `mvn -pl saiku-webapp -am compile` clean
- [x] `bash -n` clean on `docker/saiku-entrypoint` and `dist/run.sh`
- [ ] Manual: build the Docker image, run with no `OTEL_*` env vars → boots normally, no agent in process listing
- [ ] Manual: run with `OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318` against a local `otel/opentelemetry-collector` → traces appear for `/rest/saiku/info` and JDBC child spans visible for an MDX query
- [ ] Manual: confirm log lines include `[trace_id=… span_id=…]` only when the agent is attached
- [ ] Manual (Windows): smoke-test `run.bat` with the env var set

## Out of scope (Tier 2 — separate ticket once this lands)

- Custom `@WithSpan` on `ThinQueryService.execute` (cube/connection/cell-count tags)
- AI Query API custom metrics (model, provider, token usage)
- Cellset cache hit/miss attribution
- Mondrian Calcite-vs-legacy backend selection events

Filed once Tier 1 is producing data that tells us which custom spans are actually worth the maintenance cost.