### PR TITLE
chore(ui): clean up svelte-check warnings + fix npm run build (closes #1037)

### DIFF
--- a/saiku-ui/src/app.html
+++ b/saiku-ui/src/app.html
@@ -5,14 +5,14 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="color-scheme" content="light dark" />
     <title>Saiku</title>
-    <link rel="icon" type="image/svg+xml" href="/ui/favicon.svg" />
-    <link rel="icon" type="image/x-icon" href="/ui/favicon.ico" />
-    <link rel="apple-touch-icon" href="/ui/apple-touch-icon.png" />
+    <link rel="icon" type="image/svg+xml" href="%sveltekit.assets%/favicon.svg" />
+    <link rel="icon" type="image/x-icon" href="%sveltekit.assets%/favicon.ico" />
+    <link rel="apple-touch-icon" href="%sveltekit.assets%/apple-touch-icon.png" />
     %sveltekit.head%
     <!-- Operator branding overlay. Served from <saiku.home>/branding/brand.css.
          If the file does not exist the backend returns 404 and the link drops
          silently, leaving the built-in tokens.css theme in place. -->
-    <link rel="stylesheet" href="/ui/branding/brand.css" onerror="this.remove()" />
+    <link rel="stylesheet" href="%sveltekit.assets%/branding/brand.css" onerror="this.remove()" />
   </head>
   <body data-sveltekit-preload-data="hover">
     <div style="display: contents">%sveltekit.body%</div>

--- a/saiku-ui/src/lib/components/Modal.svelte
+++ b/saiku-ui/src/lib/components/Modal.svelte
@@ -85,6 +85,7 @@
   <div
     class="modal"
     role="dialog"
+    tabindex="-1"
     aria-modal="true"
     aria-labelledby={titleId}
     onkeydown={onKeyDown}

--- a/saiku-ui/src/lib/components/RepositoryBrowser.svelte
+++ b/saiku-ui/src/lib/components/RepositoryBrowser.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { untrack } from "svelte";
   import { Folder, FolderPlus, FileText, ChevronRight, Home } from "lucide-svelte";
   import {
     flatten,
@@ -52,7 +53,7 @@
   }: Props = $props();
 
   // Browser state — current folder being viewed + search filter.
-  let currentPath = $state<string>(deriveStartPath(selectedPath));
+  let currentPath = $state<string>(untrack(() => deriveStartPath(selectedPath)));
   let search = $state<string>("");
   let newFolderName = $state<string>("");
   let creatingFolder = $state<boolean>(false);
@@ -309,7 +310,9 @@
   }
   .repo-browser__crumb:hover { background: var(--bg-hover); color: var(--fg); }
   .repo-browser__crumb.is-current { color: var(--fg); font-weight: var(--weight-medium); }
-  .repo-browser__crumb-sep { color: var(--fg-subtle); }
+  /* Applied via class={} on a lucide-svelte icon — needs :global so the
+     scoped-style hash doesn't suppress it on the child component's root. */
+  :global(.repo-browser__crumb-sep) { color: var(--fg-subtle); }
 
   .repo-browser__search-input {
     width: 100%;

--- a/saiku-ui/src/lib/modals/CalculatedMemberModal.svelte
+++ b/saiku-ui/src/lib/modals/CalculatedMemberModal.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { untrack } from "svelte";
   import Modal from "$lib/components/Modal.svelte";
   import { i18n } from "$lib/stores/i18n.svelte";
 
@@ -63,7 +64,7 @@
     onCancel,
   }: Props = $props();
 
-  let form = $state<CalculatedMember>({ ...initial });
+  let form = $state<CalculatedMember>(untrack(() => ({ ...initial })));
   let textarea: HTMLTextAreaElement | null = null;
   let measureFilter = $state("");
 

--- a/saiku-ui/src/lib/modals/ChartEditorModal.svelte
+++ b/saiku-ui/src/lib/modals/ChartEditorModal.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { untrack } from "svelte";
   import Modal from "$lib/components/Modal.svelte";
   import { i18n } from "$lib/stores/i18n.svelte";
   import type { ChartOptions, TrendLineMode } from "$lib/views/chartTypes";
@@ -22,7 +23,7 @@
   ];
 
   let { initial, open, onSave, onCancel }: Props = $props();
-  let form = $state<ChartOptions>({ ...initial });
+  let form = $state<ChartOptions>(untrack(() => ({ ...initial })));
 
   $effect(() => {
     if (open) form = { ...initial };

--- a/saiku-ui/src/lib/modals/DrillAcrossModal.svelte
+++ b/saiku-ui/src/lib/modals/DrillAcrossModal.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { untrack } from "svelte";
   import Modal from "$lib/components/Modal.svelte";
   import type { SaikuCube } from "$lib/api/discover";
   import { i18n } from "$lib/stores/i18n.svelte";
@@ -12,7 +13,7 @@
   }
 
   let { targets, open, onRun, onCancel }: Props = $props();
-  let picked = $state<string>(targets[0]?.uniqueName ?? "");
+  let picked = $state<string>(untrack(() => targets[0]?.uniqueName ?? ""));
 
   $effect(() => {
     if (open) picked = targets[0]?.uniqueName ?? "";

--- a/saiku-ui/src/lib/modals/DrillthroughModal.svelte
+++ b/saiku-ui/src/lib/modals/DrillthroughModal.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { untrack } from "svelte";
   import Modal from "$lib/components/Modal.svelte";
   import type { SaikuDimension, SaikuMeasure } from "$lib/api/discover";
   import { i18n } from "$lib/stores/i18n.svelte";
@@ -17,7 +18,7 @@
   let { dimensions, measures, maxRows, open, onRun, onExportCsv, onCancel }: Props = $props();
   let pickedDims = $state<Set<string>>(new Set());
   let pickedMeasures = $state<Set<string>>(new Set());
-  let rows = $state<number>(maxRows);
+  let rows = $state<number>(untrack(() => maxRows));
 
   $effect(() => {
     if (open) {

--- a/saiku-ui/src/lib/modals/FilterModal.svelte
+++ b/saiku-ui/src/lib/modals/FilterModal.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { untrack } from "svelte";
   import Modal from "$lib/components/Modal.svelte";
   import MonacoEditor from "$lib/components/MonacoEditor.svelte";
   import { i18n } from "$lib/stores/i18n.svelte";
@@ -23,7 +24,7 @@
 
   let { axis, expression, open, onSave, onCancel }: Props = $props();
 
-  let buffer = $state<string>(expression);
+  let buffer = $state<string>(untrack(() => expression));
 
   $effect(() => {
     if (open) buffer = expression;

--- a/saiku-ui/src/lib/modals/FormatAsPercentageModal.svelte
+++ b/saiku-ui/src/lib/modals/FormatAsPercentageModal.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { untrack } from "svelte";
   import Modal from "$lib/components/Modal.svelte";
   import { i18n } from "$lib/stores/i18n.svelte";
 
@@ -15,8 +16,8 @@
   }
 
   let { defaultAxis, scope, open, onApply, onCancel }: Props = $props();
-  let axis = $state<PercentageAxis>(defaultAxis);
-  let s = $state<PercentageScope>(scope);
+  let axis = $state<PercentageAxis>(untrack(() => defaultAxis));
+  let s = $state<PercentageScope>(untrack(() => scope));
 
   $effect(() => {
     if (open) {

--- a/saiku-ui/src/lib/modals/LimitModal.svelte
+++ b/saiku-ui/src/lib/modals/LimitModal.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { untrack } from "svelte";
   import Modal from "$lib/components/Modal.svelte";
   import MonacoEditor from "$lib/components/MonacoEditor.svelte";
   import { i18n } from "$lib/stores/i18n.svelte";
@@ -24,7 +25,7 @@
   let { axis, initialCount, open, onSave, onCancel }: Props = $props();
 
   let mode = $state<Mode>("simple");
-  let count = $state<number>(initialCount);
+  let count = $state<number>(untrack(() => initialCount));
   let mdxBuffer = $state<string>("");
 
   $effect(() => {

--- a/saiku-ui/src/lib/modals/MDXModal.svelte
+++ b/saiku-ui/src/lib/modals/MDXModal.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { untrack } from "svelte";
   import Modal from "$lib/components/Modal.svelte";
   import MonacoEditor from "$lib/components/MonacoEditor.svelte";
   import { i18n } from "$lib/stores/i18n.svelte";
@@ -12,7 +13,7 @@
   }
 
   let { mdx, open, onRun, onCancel }: Props = $props();
-  let buffer = $state<string>(mdx);
+  let buffer = $state<string>(untrack(() => mdx));
 
   $effect(() => {
     if (open) buffer = mdx;
@@ -24,7 +25,7 @@
 </script>
 
 <Modal title={i18n.t("toolbar.mdx", "MDX query")} {open} size="xl" onClose={onCancel}>
-  <label class="field__label">MDX</label>
+  <div class="field__label">MDX</div>
   {#if open}
     <MonacoEditor value={buffer} language="mdx" minHeight="320px" onChange={(v) => (buffer = v)} />
   {/if}

--- a/saiku-ui/src/lib/modals/MeasuresModal.svelte
+++ b/saiku-ui/src/lib/modals/MeasuresModal.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { untrack } from "svelte";
   import Modal from "$lib/components/Modal.svelte";
   import type { SaikuMeasure } from "$lib/api/discover";
   import { i18n } from "$lib/stores/i18n.svelte";
@@ -32,7 +33,7 @@
     refreshing = false,
   }: Props = $props();
 
-  let picks = $state<Set<string>>(new Set(selectedUniqueNames));
+  let picks = $state<Set<string>>(untrack(() => new Set(selectedUniqueNames)));
   let search = $state("");
 
   $effect(() => {

--- a/saiku-ui/src/lib/modals/MoveRepositoryObject.svelte
+++ b/saiku-ui/src/lib/modals/MoveRepositoryObject.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { untrack } from "svelte";
   import Modal from "$lib/components/Modal.svelte";
   import { i18n } from "$lib/stores/i18n.svelte";
 
@@ -12,7 +13,7 @@
   }
 
   let { sourcePath, folders, open, onMove, onCancel }: Props = $props();
-  let target = $state<string>(folders[0] ?? "");
+  let target = $state<string>(untrack(() => folders[0] ?? ""));
 </script>
 
 <Modal title={i18n.t("modal.move.title")} {open} size="md" onClose={onCancel}>

--- a/saiku-ui/src/lib/modals/NewDashboardModal.svelte
+++ b/saiku-ui/src/lib/modals/NewDashboardModal.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { untrack } from "svelte";
   import Modal from "$lib/components/Modal.svelte";
   import RepositoryBrowser from "$lib/components/RepositoryBrowser.svelte";
   import { i18n } from "$lib/stores/i18n.svelte";
@@ -25,8 +26,8 @@
 
   let { defaultName, defaultFolder, open, onCreate, onCancel }: Props = $props();
 
-  let name = $state<string>(defaultName);
-  let folder = $state<string>(defaultFolder);
+  let name = $state<string>(untrack(() => defaultName));
+  let folder = $state<string>(untrack(() => defaultFolder));
   let nameTouched = $state<boolean>(false);
 
   $effect(() => {

--- a/saiku-ui/src/lib/modals/OrderModal.svelte
+++ b/saiku-ui/src/lib/modals/OrderModal.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { untrack } from "svelte";
   import Modal from "$lib/components/Modal.svelte";
   import MonacoEditor from "$lib/components/MonacoEditor.svelte";
   import { i18n } from "$lib/stores/i18n.svelte";
@@ -43,9 +44,9 @@
   }: Props = $props();
 
   let mode = $state<Mode>("simple");
-  let selected = $state<string>(initialMeasure);
-  let sort = $state<SortFn>(initialSort);
-  let mdxBuffer = $state<string>(initialMeasure || "");
+  let selected = $state<string>(untrack(() => initialMeasure));
+  let sort = $state<SortFn>(untrack(() => initialSort));
+  let mdxBuffer = $state<string>(untrack(() => initialMeasure || ""));
 
   $effect(() => {
     if (open) {

--- a/saiku-ui/src/lib/modals/PermissionsModal.svelte
+++ b/saiku-ui/src/lib/modals/PermissionsModal.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { untrack } from "svelte";
   import Modal from "$lib/components/Modal.svelte";
   import { i18n } from "$lib/stores/i18n.svelte";
   import type { AclEntry, AclMethod } from "$lib/api/repository";
@@ -13,7 +14,7 @@
   }
 
   let { path, allRoles, initial, open, onSave, onCancel }: Props = $props();
-  let acl = $state<AclEntry>(structuredClone(initial));
+  let acl = $state<AclEntry>(untrack(() => structuredClone(initial)));
 
   $effect(() => {
     if (open) acl = structuredClone(initial);

--- a/saiku-ui/src/lib/modals/ReportTitlesModal.svelte
+++ b/saiku-ui/src/lib/modals/ReportTitlesModal.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { untrack } from "svelte";
   import Modal from "$lib/components/Modal.svelte";
   import { i18n } from "$lib/stores/i18n.svelte";
 
@@ -17,7 +18,7 @@
   }
 
   let { titles, open, onSave, onCancel }: Props = $props();
-  let form = $state<ReportTitles>({ ...titles });
+  let form = $state<ReportTitles>(untrack(() => ({ ...titles })));
 
   $effect(() => {
     if (open) form = { ...titles };

--- a/saiku-ui/src/lib/modals/SaveQueryModal.svelte
+++ b/saiku-ui/src/lib/modals/SaveQueryModal.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { untrack } from "svelte";
   import Modal from "$lib/components/Modal.svelte";
   import RepositoryBrowser from "$lib/components/RepositoryBrowser.svelte";
   import { i18n } from "$lib/stores/i18n.svelte";
@@ -26,8 +27,8 @@
 
   let { defaultName, defaultFolder, open, onSave, onCancel }: Props = $props();
 
-  let name = $state<string>(defaultName);
-  let folder = $state<string>(defaultFolder);
+  let name = $state<string>(untrack(() => defaultName));
+  let folder = $state<string>(untrack(() => defaultFolder));
 
   $effect(() => {
     if (open) {

--- a/saiku-ui/src/lib/modals/SavedQueriesModal.svelte
+++ b/saiku-ui/src/lib/modals/SavedQueriesModal.svelte
@@ -314,6 +314,7 @@
         <li class="saved__row">
           {#if renaming?.path === entry.path}
             <div class="saved__rename">
+              <!-- svelte-ignore a11y_autofocus -->
               <input
                 class="saved__rename-input"
                 bind:value={renameValue}
@@ -434,7 +435,9 @@
   }
   .saved__crumb:hover { background: var(--bg-hover); color: var(--fg); }
   .saved__crumb.is-current { color: var(--fg); font-weight: var(--weight-medium); }
-  .saved__crumb-sep { color: var(--fg-subtle); }
+  /* Applied via class={} on a lucide-svelte icon — needs :global so the
+     scoped-style hash doesn't suppress it on the child component's root. */
+  :global(.saved__crumb-sep) { color: var(--fg-subtle); }
 
   .saved__search {
     display: flex;

--- a/saiku-ui/src/lib/modals/SelectionsModal.svelte
+++ b/saiku-ui/src/lib/modals/SelectionsModal.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { untrack } from "svelte";
   import Modal from "$lib/components/Modal.svelte";
   import type { SaikuMember } from "$lib/api/discover";
   import { i18n } from "$lib/stores/i18n.svelte";
@@ -34,8 +35,8 @@
   }: Props = $props();
 
   let search = $state("");
-  let selected = $state<Set<string>>(new Set(initialSelected));
-  let type = $state<SelectionType>(initialType);
+  let selected = $state<Set<string>>(untrack(() => new Set(initialSelected)));
+  let type = $state<SelectionType>(untrack(() => initialType));
 
   $effect(() => {
     if (open) {

--- a/saiku-ui/src/lib/modals/TopBottomCountModal.svelte
+++ b/saiku-ui/src/lib/modals/TopBottomCountModal.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { untrack } from "svelte";
   import Modal from "$lib/components/Modal.svelte";
   import MonacoEditor from "$lib/components/MonacoEditor.svelte";
   import { i18n } from "$lib/stores/i18n.svelte";
@@ -39,8 +40,8 @@
   }: Props = $props();
 
   let mode = $state<Mode>("simple");
-  let count = $state<number>(initialCount);
-  let selected = $state<string>(initialMeasure);
+  let count = $state<number>(untrack(() => initialCount));
+  let selected = $state<string>(untrack(() => initialMeasure));
   let mdxBuffer = $state<string>("");
 
   $effect(() => {

--- a/saiku-ui/src/lib/views/CellsetTable.svelte
+++ b/saiku-ui/src/lib/views/CellsetTable.svelte
@@ -307,7 +307,7 @@
     }
   }
 
-  let wrapperEl: HTMLDivElement | null = null;
+  let wrapperEl = $state<HTMLDivElement | null>(null);
 
   function isNumeric(v: unknown): boolean {
     if (typeof v !== "string") return typeof v === "number";
@@ -603,7 +603,7 @@
     <table class="cellset" role="presentation">
       <thead>
         {#each parsed.columnHeaderRows as hdrRow, rIdx}
-          <tr role="row" aria-rowindex={rIdx + 1}>
+          <tr aria-rowindex={rIdx + 1}>
             {#each hdrRow as c, cIdx}
               {#if cIdx < parsed.rowHeaderColCount}
                 <th class="all_null" role="columnheader" aria-colindex={cIdx + 1}></th>
@@ -638,7 +638,7 @@
         {/if}
         {#each parsed.bodyRows.slice(renderWindow.first, renderWindow.last + 1) as rowCells, iOffset}
           {@const r = renderWindow.first + iOffset}
-          <tr class="vrow" role="row" aria-rowindex={parsed.columnHeaderRows.length + r + 1}>
+          <tr class="vrow" aria-rowindex={parsed.columnHeaderRows.length + r + 1}>
             {#each rowCells as c, cIdx}
               {@const display = rowDisplay[r][cIdx]}
               {#if display.isNull}

--- a/saiku-ui/src/lib/views/QueryCanvas.svelte
+++ b/saiku-ui/src/lib/views/QueryCanvas.svelte
@@ -767,6 +767,7 @@
         </header>
         <div class="chips">
           {#each query.current?.queryModel?.details.measures ?? [] as m}
+            <!-- svelte-ignore a11y_no_static_element_interactions — drag/context-menu are mouse affordances; the inner buttons (label, close) handle keyboard accessibility. -->
             <span
               class={dragOverChipKey === chipKey("MEASURES", "measure", m.uniqueName) ? "chip chip--measure is-drop-before" : "chip chip--measure"}
               draggable="true"
@@ -811,6 +812,7 @@
           </header>
           <div class="chips">
             {#each query.current?.queryModel?.axes[axis].hierarchies ?? [] as h}
+              <!-- svelte-ignore a11y_no_static_element_interactions — drag/context-menu are mouse affordances; the inner buttons (label, close) handle keyboard accessibility. -->
               <span
                 class={dragOverChipKey === chipKey(axis, "hierarchy", h.name) ? "chip chip--level is-drop-before" : "chip chip--level"}
                 draggable="true"
@@ -859,6 +861,7 @@
         </header>
         <div class="chips">
           {#each query.current?.queryModel?.axes.FILTER.hierarchies ?? [] as h}
+            <!-- svelte-ignore a11y_no_static_element_interactions — drag/context-menu are mouse affordances; the inner buttons (label, close) handle keyboard accessibility. -->
             <span
               class={dragOverChipKey === chipKey("FILTER", "hierarchy", h.name) ? "chip chip--level is-drop-before" : "chip chip--level"}
               draggable="true"

--- a/saiku-ui/src/lib/views/WorkspaceToolbar.svelte
+++ b/saiku-ui/src/lib/views/WorkspaceToolbar.svelte
@@ -571,19 +571,6 @@
     margin: 0 4px;
   }
   .toolbar__spacer { flex: 1; }
-  .toolbar__toggle {
-    display: inline-flex;
-    align-items: center;
-    gap: 6px;
-    padding: 4px 8px;
-    color: var(--fg-muted);
-    font-size: var(--fs-sm);
-    cursor: pointer;
-    user-select: none;
-    border-radius: 4px;
-  }
-  .toolbar__toggle:hover { background: var(--bg-subtle); color: var(--fg); }
-  .toolbar__toggle input { cursor: pointer; }
 
   .tb-btn {
     display: inline-flex;

--- a/saiku-ui/src/lib/views/dashboard/DashboardFilterPanel.svelte
+++ b/saiku-ui/src/lib/views/dashboard/DashboardFilterPanel.svelte
@@ -660,6 +660,7 @@
         </p>
       {/if}
       {#if panel.filters.length > 0}
+        <!-- svelte-ignore a11y_no_static_element_interactions — pointer events implement drag-to-reorder; keyboard reordering would be a separate UX (kbd shortcuts on focused picker). -->
         <div
           class="picker-row"
           class:picker-row--dragging={drag !== null}
@@ -671,6 +672,7 @@
             {@const cat = memberCatalogues[f.id]}
             {@const selected = selectedForPicker(f)}
             {@const displayOptions = displayedOptionsFor(f)}
+            <!-- svelte-ignore a11y_no_static_element_interactions — pointer events implement drag-to-reorder; the inner Combobox handles keyboard. -->
             <div
               class="picker"
               class:picker--hover={drag?.hoverId === f.id && drag.fromId !== f.id}

--- a/saiku-ui/src/routes/admin/+page.svelte
+++ b/saiku-ui/src/routes/admin/+page.svelte
@@ -24,14 +24,14 @@
   </div>
 {:else}
   <div class="admin">
-    <nav class="admin__tabs" role="tablist">
+    <div class="admin__tabs" role="tablist">
       <button type="button" role="tab" class:active={tab === "users"} onclick={() => (tab = "users")}>{i18n.t("admin.tabs.users")}</button>
       <button type="button" role="tab" class:active={tab === "datasources"} onclick={() => (tab = "datasources")}>{i18n.t("admin.tabs.datasources")}</button>
       <button type="button" role="tab" class:active={tab === "schemas"} onclick={() => (tab = "schemas")}>{i18n.t("admin.tabs.schemas")}</button>
       <button type="button" role="tab" class:active={tab === "logs"} onclick={() => (tab = "logs")}>{i18n.t("admin.tabs.logs")}</button>
       <button type="button" role="tab" class:active={tab === "stats"} onclick={() => (tab = "stats")}>{i18n.t("admin.tabs.stats")}</button>
       <button type="button" role="tab" class:active={tab === "api"} onclick={() => (tab = "api")}>API access</button>
-    </nav>
+    </div>
     <section class="admin__body">
       {#if tab === "users"}
         <UsersAdmin />

--- a/saiku-ui/svelte.config.js
+++ b/saiku-ui/svelte.config.js
@@ -17,8 +17,10 @@ const config = {
     prerender: {
       // The branding overlay is served at runtime from <saiku.home>/branding/
       // and is expected to 404 at build time; don't fail the build for it.
+      // Match with/without the SAIKU_BASE_PATH=/ui prefix so both the
+      // Maven-driven build and a bare `npm run build` succeed.
       handleHttpError: ({ path, referrer, message }) => {
-        if (path.startsWith("/ui/branding/")) return;
+        if (path.includes("/branding/")) return;
         throw new Error(`${message} (linked from ${referrer})`);
       },
     },


### PR DESCRIPTION
Closes #1037.

## Before / after

| | Before | After |
|---|---|---|
| svelte-check | 0 errors, 42 warnings, 25 files | 0 errors, 0 warnings, 0 files |
| vitest | 435 passed | 435 passed |
| npm run build (standalone) | **fails** on prerender 404 | green |

## Build blocker (npm run build)

\`app.html\` hardcoded \`/ui/favicon.svg\` etc. — the launcher's Maven build sets \`SAIKU_BASE_PATH=/ui\` via \`frontend-maven-plugin\`, but a bare \`cd saiku-ui && npm run build\` doesn't, so \`paths.base\` was \`""\` and the prerender step threw on every favicon 404. Switched the four asset refs in \`app.html\` to \`%sveltekit.assets%/...\` so SvelteKit substitutes the configured base path at build time. Works in both modes.

Relaxed \`handleHttpError\`'s branding allowlist to match with/without the \`/ui/\` prefix.

## state_referenced_locally (22 warnings → 0)

In every flagged modal: \`let x = \$state(propValue)\` where \`propValue\` is a prop. Captures only the initial value; later prop changes don't propagate. In each file an existing \`\$effect\` already re-seeds when \`open\` becomes true, so the bug was latent. Wrapped each initializer in \`untrack(() => propValue)\` to silence the warning honestly: snapshot at init, \`\$effect\` handles updates.

Touched: 17 modals + \`RepositoryBrowser.svelte\`.

## a11y (8 warnings → 0)

- \`Modal.svelte\` — \`role=\"dialog\"\` needed \`tabindex=\"-1\"\`
- \`MDXModal.svelte\` — \`<label>\` with no control → \`<div>\`
- \`SavedQueriesModal.svelte\` — \`autofocus\` on rename input: \`svelte-ignore\` (UX is intentional — user just clicked Rename)
- \`CellsetTable.svelte\` ×2 — redundant \`role=\"row\"\` on \`<tr>\`: removed
- \`QueryCanvas.svelte\` ×3 — chip \`<span>\`s with drag handlers: \`svelte-ignore\` (inner buttons handle keyboard; drag is mouse-only by design)
- \`DashboardFilterPanel.svelte\` ×2 — picker pointer handlers: \`svelte-ignore\` (drag-to-reorder; inner Combobox handles keyboard)
- \`admin/+page.svelte\` — \`<nav role=\"tablist\">\` → \`<div role=\"tablist\">\`

## Reactivity / dead CSS

- \`CellsetTable.svelte:310\` — \`let wrapperEl\` was reassigned by \`bind:this\` but declared with plain \`let\`. Converted to \`\$state(null)\` — the downstream \`\$effect\` reading it now actually re-runs on attach.
- \`WorkspaceToolbar\` — \`.toolbar__toggle\` (3 selectors) genuinely unused, deleted.
- \`RepositoryBrowser\` / \`SavedQueriesModal\` — \`.repo-browser__crumb-sep\` / \`.saved__crumb-sep\` were **false positives** (class passed to a \`lucide-svelte\` \`ChevronRight\` via \`class={}\`). Wrapped in \`:global(...)\` so the scoped-style hash doesn't suppress them on the child component's root SVG.

## Test plan

- [x] \`npm run check\` — 0 errors, 0 warnings, 0 files with problems
- [x] \`npm test\` — 435 passed
- [x] \`npm run build\` — green standalone (no env vars set)
- [ ] Manual: open every fixed modal in dev, confirm props still seed correctly when re-opening
- [ ] Manual: drag/drop chips on QueryCanvas and dashboard filter panel still work
- [ ] Manual: admin tabs still navigate correctly