### PR TITLE
feat(query): surface Mondrian engine failures with a contact-support callout

### DIFF
--- a/saiku-ui/src/lib/i18n/en.json
+++ b/saiku-ui/src/lib/i18n/en.json
@@ -87,6 +87,7 @@
   "canvas.buildPrompt": "Drop levels onto Rows/Columns and measures onto Columns, then hit Run.",
   "canvas.running": "Running query…",
   "canvas.running.short": "Running…",
+  "canvas.error.showDetails": "Show details",
   "canvas.loadingMembers": "Loading members…",
   "canvas.cancelQuery": "Cancel query",
   "canvas.columns": "Columns",

--- a/saiku-ui/src/lib/stores/query.svelte.ts
+++ b/saiku-ui/src/lib/stores/query.svelte.ts
@@ -94,6 +94,10 @@ class QueryStore {
   result = $state<QueryResult | null>(null);
   running = $state<boolean>(false);
   error = $state<string | null>(null);
+  /** Optional raw engine message for the error callout's "Show details"
+   *  panel. Operators copy-paste this into a support ticket — users see
+   *  the friendly text in {@link error}. */
+  errorDetail = $state<string | null>(null);
   dirty = $state<boolean>(false);
   dirtyCount = $state<number>(0);
   savedPath = $state<string | null>(null);
@@ -129,6 +133,7 @@ class QueryStore {
     this.current = newQuery(cube);
     this.result = null;
     this.error = null;
+    this.errorDetail = null;
     this.dirty = false;
     this.dirtyCount = 0;
     this.savedPath = null;
@@ -139,6 +144,7 @@ class QueryStore {
     this.current = withSafeName(parsed);
     this.result = null;
     this.error = null;
+    this.errorDetail = null;
     this.dirty = false;
     this.dirtyCount = 0;
     this.savedPath = path;
@@ -150,6 +156,7 @@ class QueryStore {
     this.current = withSafeName(q);
     this.result = null;
     this.error = null;
+    this.errorDetail = null;
     this.dirty = false;
     this.dirtyCount = 0;
     this.savedPath = savedPath;
@@ -170,6 +177,7 @@ class QueryStore {
     this.current = null;
     this.result = null;
     this.error = null;
+    this.errorDetail = null;
     this.dirty = false;
     this.dirtyCount = 0;
     this.savedPath = null;
@@ -464,6 +472,7 @@ class QueryStore {
     }
     this.running = true;
     this.error = null;
+    this.errorDetail = null;
     this.runningQueryId = null;
     this.runningElapsedMs = 0;
     const startedAt = Date.now();
@@ -490,6 +499,16 @@ class QueryStore {
         }
       } else {
         this.result = await executeQuery(this.current);
+      }
+      // The backend always returns HTTP 200; engine failures (Mondrian /
+      // Calcite UnsupportedTranslation, MDX parse, datasource down, etc.)
+      // ride along in QueryResult.error with a null cellset. Surface them
+      // as a callout instead of rendering an empty grid.
+      const embedded = this.result?.error;
+      if (embedded) {
+        this.error = friendlyExecuteError(embedded);
+        this.errorDetail = embedded;
+        this.result = null;
       }
     } catch (err) {
       this.error = err instanceof Error ? err.message : String(err);
@@ -537,6 +556,32 @@ class QueryStore {
  *  shapes thrown by the query API when credentials lapse. */
 function isAuthError(message: string): boolean {
   return /\b(?:execute|execute-async|status|result)\s+40[13]\b/.test(message);
+}
+
+/** True when the engine error message names a backend translation /
+ *  internal failure that the user can't fix themselves (Mondrian
+ *  UnsupportedTranslation when Calcite refuses the SQL emission,
+ *  Calcite SqlValidatorException, RolapEvaluatorException, etc.). For
+ *  these, we hide the cryptic detail behind "Show details" and lead
+ *  with a contact-support callout. Other errors (MDX parse, bad cube
+ *  name, datasource down) get the raw message — they're usually
+ *  self-explanatory or fixable. */
+function isInternalEngineError(message: string): boolean {
+  if (!message) return false;
+  return /UnsupportedTranslation|SqlValidatorException|RolapEvaluatorException|InternalError|NullPointerException|CalciteContextException|AssertionError/i.test(
+    message,
+  );
+}
+
+/** Choose the user-facing message for an engine error coming back in
+ *  {@link QueryResult.error}. Internal/translation failures get a
+ *  contact-support callout; ordinary errors (parse, bad name) keep the
+ *  raw message so the user can fix them. */
+export function friendlyExecuteError(raw: string): string {
+  if (isInternalEngineError(raw)) {
+    return "Query failed to run. Please contact support.";
+  }
+  return raw;
 }
 
 export const query = new QueryStore();

--- a/saiku-ui/src/lib/stores/queryErrors.test.ts
+++ b/saiku-ui/src/lib/stores/queryErrors.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import { friendlyExecuteError } from "./query.svelte";
+
+describe("friendlyExecuteError", () => {
+  it("returns a contact-support message for Mondrian UnsupportedTranslation", () => {
+    const raw =
+      "mondrian.calcite.UnsupportedTranslation: cannot translate operator TIMESTAMP_TRUNC to dialect H2";
+    expect(friendlyExecuteError(raw)).toBe(
+      "Query failed to run. Please contact support.",
+    );
+  });
+
+  it("returns the raw message for ordinary MDX parse errors", () => {
+    const raw = "MDX syntax error at line 1: unexpected token 'WITHH'";
+    expect(friendlyExecuteError(raw)).toBe(raw);
+  });
+
+  it("matches case-insensitively across the engine error family", () => {
+    expect(friendlyExecuteError("Caused by NullPointerException at row 4")).toBe(
+      "Query failed to run. Please contact support.",
+    );
+    expect(
+      friendlyExecuteError("CalciteContextException at line 3: parse error"),
+    ).toBe("Query failed to run. Please contact support.");
+    expect(friendlyExecuteError("RolapEvaluatorException: internal state")).toBe(
+      "Query failed to run. Please contact support.",
+    );
+  });
+
+  it("passes through messages that don't name an internal exception", () => {
+    expect(friendlyExecuteError("Datasource not found: foodmart-postgres")).toBe(
+      "Datasource not found: foodmart-postgres",
+    );
+  });
+});

--- a/saiku-ui/src/lib/styles/app.css
+++ b/saiku-ui/src/lib/styles/app.css
@@ -282,6 +282,35 @@ a:hover {
   color: var(--danger);
 }
 
+.callout__text {
+  margin: 0;
+  font-weight: var(--weight-medium);
+}
+
+.callout__details {
+  margin-top: var(--space-2);
+  color: var(--fg-muted);
+  font-weight: var(--weight-normal);
+}
+
+.callout__details summary {
+  cursor: pointer;
+  font-size: var(--fs-sm);
+  user-select: none;
+}
+
+.callout__detail-text {
+  margin: var(--space-2) 0 0;
+  padding: var(--space-2);
+  background: var(--bg-muted);
+  border-radius: var(--radius-sm);
+  font-family: var(--font-mono, ui-monospace, monospace);
+  font-size: var(--fs-xs);
+  white-space: pre-wrap;
+  word-break: break-word;
+  color: var(--fg);
+}
+
 /* Motion baseline. Modals, context menus, and toasts appear instantly
    by default — feels like UI is teleporting rather than responding.
    These two short keyframes give every overlay-style surface a 120ms

--- a/saiku-ui/src/lib/views/QueryCanvas.svelte
+++ b/saiku-ui/src/lib/views/QueryCanvas.svelte
@@ -959,7 +959,15 @@
       {#if query.running && !query.result}
         <p class="canvas__hint">{i18n.t("canvas.running")}</p>
       {:else if query.error}
-        <p class="callout callout--danger">{query.error}</p>
+        <div class="callout callout--danger" role="alert">
+          <p class="callout__text">{query.error}</p>
+          {#if query.errorDetail}
+            <details class="callout__details">
+              <summary>{i18n.t("canvas.error.showDetails")}</summary>
+              <pre class="callout__detail-text">{query.errorDetail}</pre>
+            </details>
+          {/if}
+        </div>
       {:else if query.result}
         {#if query.viewMode === "chart"}
           <ChartView result={query.result} type={query.chartType} options={query.chartOptions} />


### PR DESCRIPTION
## Why

The \`/execute\` endpoint always returns HTTP 200; engine failures (Mondrian / Calcite \`UnsupportedTranslation\`, \`SqlValidatorException\`, \`NullPointerException\`, etc.) ride along in \`QueryResult.error\` with a null cellset. The frontend ignored that field, so a Mondrian translation failure showed up as a silently-blank grid with no indication anything was wrong. Tom asked for a user-visible warning that the query failed and to suggest contacting support.

## What

\`QueryStore.run\` now inspects \`result.error\` after a successful HTTP round-trip and:

- Routes the message through \`friendlyExecuteError()\`. Translation / internal failures (\`UnsupportedTranslation\`, \`SqlValidatorException\`, \`RolapEvaluatorException\`, \`NullPointerException\`, \`CalciteContextException\`, \`InternalError\`, \`AssertionError\`) collapse to **\"Query failed to run. Please contact support.\"**
- Preserves the raw engine message in a new \`errorDetail\` field so operators can copy-paste it into a support ticket via a **\"Show details\"** disclosure on the existing canvas callout.
- Clears \`result\` so the chart/grid panes don't render against a null cellset.

Ordinary engine errors (MDX parse errors, missing datasource, bad cube name) pass through unchanged — those are usually self-explanatory or fixable by the user, and hiding them behind a generic message would just make debugging harder.

## Test plan

- [x] 4 vitest cases in \`queryErrors.test.ts\` cover \`UnsupportedTranslation\`, MDX parse, case-insensitive family, datasource-not-found
- [x] \`npm test\` — 449 passing
- [x] \`npm run check\` — 0 errors, 0 warnings
- [x] \`npm run build\` — green
- [ ] Manual: open the demo cube whose query previously surfaced an \`UnsupportedTranslation\` error → click Run → confirm the callout reads \"Query failed to run. Please contact support.\" with a working \"Show details\" disclosure
- [ ] Manual: write a deliberately-broken MDX query → confirm the raw parse error still surfaces (the friendly substitution only fires on the internal-error allowlist)

## Out of scope

- Backend changes to \`Query2Resource\`. The current \`getRootCauseMessage\` envelope is fine; this PR just makes the UI honour it.
- Async / arrow paths: \`executeQueryAsync\` and \`executeArrow\` go through the same store path so they get the same treatment, but the async error-mapping logic in \`async/{id}/status\` already throws on failure — those cases land in the outer \`catch\`. This PR fixes the synchronous JSON path where the error is embedded in the body.