### PR TITLE
fix(chart): detect rollup rows via uniquename depth, not column count

### DIFF
--- a/saiku-ui/src/lib/views/ChartView.svelte
+++ b/saiku-ui/src/lib/views/ChartView.svelte
@@ -155,9 +155,11 @@
     // The grid view is untouched.
     let rows = parsed.rowCategories;
     let matrix: (number | null)[][] = parsed.dataRows.map((row) => row.map(toNumber));
-    if (o.hideRollupRows && parsed.rowHeaderColCount > 1) {
+    if (o.hideRollupRows) {
+      // deriveLeafRows is a no-op for single-level rowsets (all rows at the
+      // same depth) and for empty results, so no extra guard is needed here.
       const leaf = deriveLeafRows(parsed);
-      if (leaf.indices.length > 0) {
+      if (leaf.indices.length > 0 && leaf.indices.length < matrix.length) {
         rows = leaf.labels;
         matrix = leaf.indices.map((i) => matrix[i]);
       }

--- a/saiku-ui/src/lib/views/cellsetUtils.test.ts
+++ b/saiku-ui/src/lib/views/cellsetUtils.test.ts
@@ -5,8 +5,10 @@ import type { CellEntry, QueryResult } from "$lib/api/query";
 function header(value: string): CellEntry {
   return { type: "COLUMN_HEADER", value };
 }
-function rowHeader(value: string): CellEntry {
-  return { type: "ROW_HEADER", value };
+function rowHeader(value: string, uniquename?: string): CellEntry {
+  const cell: CellEntry = { type: "ROW_HEADER", value };
+  if (uniquename) cell.properties = { uniquename };
+  return cell;
 }
 function dataCell(value: string): CellEntry {
   return { type: "DATA_CELL", value, properties: { raw: value } };
@@ -72,8 +74,10 @@ describe("deriveLeafRows", () => {
     expect(leaf.labels).toEqual(["2024 / Q1", "2024 / Q2"]);
   });
 
-  it("returns empty arrays when there are no leaf rows", () => {
-    // Pathological case: only rollup rows, no quarter detail.
+  it("keeps every row when they all sit at the same depth (no rollups present)", () => {
+    // No quarter detail — just two year rows. Treating these as "all
+    // rollups so drop them all" would produce an empty chart, which is
+    // strictly worse UX than just charting the two year totals.
     const result = buildResult([
       [emptyHeader(), emptyHeader(), header("Sales")],
       [rowHeader("2024"), rowHeader(""), dataCell("99")],
@@ -81,7 +85,46 @@ describe("deriveLeafRows", () => {
     ]);
     const parsed = parseCellset(result);
     const leaf = deriveLeafRows(parsed);
-    expect(leaf.indices).toEqual([]);
-    expect(leaf.labels).toEqual([]);
+    expect(leaf.indices).toEqual([0, 1]);
+    expect(leaf.labels).toEqual(["2024", "2025"]);
+  });
+
+  it("detects rollup rows by uniquename depth when the hierarchy uses one row-header column", () => {
+    // The Time(2 levels) shape from Mondrian — Year and Month flattened
+    // into a single row-header column, distinguished by uniquename depth.
+    const result = buildResult([
+      [emptyHeader(), header("Store Cost")],
+      [rowHeader("1997", "[Time].[Time].[1997]"), dataCell("225627")],
+      [rowHeader("1", "[Time].[Time].[1997].[1]"), dataCell("18000")],
+      [rowHeader("2", "[Time].[Time].[1997].[2]"), dataCell("17500")],
+      [rowHeader("3", "[Time].[Time].[1997].[3]"), dataCell("19500")],
+    ]);
+    const parsed = parseCellset(result);
+    const leaf = deriveLeafRows(parsed);
+    // The 1997 rollup at body row 0 must drop; the three months survive
+    // with parent context restored.
+    expect(leaf.indices).toEqual([1, 2, 3]);
+    expect(leaf.labels).toEqual(["1997 / 1", "1997 / 2", "1997 / 3"]);
+  });
+
+  it("handles single-col cellsets across multiple parents", () => {
+    const result = buildResult([
+      [emptyHeader(), header("Sales")],
+      [rowHeader("1997", "[Time].[Time].[1997]"), dataCell("100")],
+      [rowHeader("Q1", "[Time].[Time].[1997].[Q1]"), dataCell("40")],
+      [rowHeader("Q2", "[Time].[Time].[1997].[Q2]"), dataCell("60")],
+      [rowHeader("1998", "[Time].[Time].[1998]"), dataCell("120")],
+      [rowHeader("Q1", "[Time].[Time].[1998].[Q1]"), dataCell("50")],
+      [rowHeader("Q2", "[Time].[Time].[1998].[Q2]"), dataCell("70")],
+    ]);
+    const parsed = parseCellset(result);
+    const leaf = deriveLeafRows(parsed);
+    expect(leaf.indices).toEqual([1, 2, 4, 5]);
+    expect(leaf.labels).toEqual([
+      "1997 / Q1",
+      "1997 / Q2",
+      "1998 / Q1",
+      "1998 / Q2",
+    ]);
   });
 });

--- a/saiku-ui/src/lib/views/cellsetUtils.ts
+++ b/saiku-ui/src/lib/views/cellsetUtils.ts
@@ -128,42 +128,101 @@ export interface LeafRows {
 }
 
 /**
- * Returns the indices of rows whose deepest row-header column carries a
- * value — i.e. leaf rows in the multi-level hierarchy on ROWS — together
- * with their parent-prefixed labels.
+ * Returns the indices of rows whose row-header sits at the deepest level
+ * of the hierarchy on ROWS — i.e. leaf rows — together with their
+ * parent-prefixed labels.
  *
  * Charts call this with `hideRollupRows = true` to drop the year/quarter-
  * style rollup rows that otherwise dominate the bar heights and make the
- * leaf detail unreadable (saiku#TBD). The grid keeps showing all rows.
+ * leaf detail unreadable. The grid keeps showing all rows.
  *
- * If the rowset has only one level (rowHeaderColCount <= 1) every row is
- * a leaf and the result mirrors `parsed.rowCategories`.
+ * Row "depth" is determined from the Mondrian uniquename on the deepest
+ * row-header cell — segment count in
+ *  `[Time].[Time].[1997]` (3) vs `[Time].[Time].[1997].[1]` (4). This
+ * works whether the cellset packs the hierarchy into a single row-header
+ * column (a single Time hierarchy spanning Year+Month — every row has
+ * one cell, but Year cells are shallower) or into multiple columns
+ * (legacy Year/Quarter shape — multi-col with the deeper column empty
+ * on rollup rows). If no uniquename is present, falls back to "deepest
+ * non-empty column index" — accurate for the multi-col case and a
+ * graceful no-op when there's no hierarchy at all.
  */
 export function deriveLeafRows(parsed: ParsedCellset): LeafRows {
-  if (parsed.rowHeaderColCount <= 1) {
+  const n = parsed.bodyRows.length;
+  if (n === 0 || parsed.rowHeaderColCount === 0) {
+    return { indices: [], labels: [] };
+  }
+
+  // Walk forward once to compute every row's depth + its leaf-level
+  // segment text. The segment is the cell value at the deepest level,
+  // NOT the joined rowCategories label — joining would double-count
+  // parents when Mondrian repeats them on every row instead of deduping.
+  const depths: number[] = new Array(n);
+  const ownSegments: string[] = new Array(n);
+  for (let r = 0; r < n; r++) {
+    const info = depthOfRow(parsed.bodyRows[r]);
+    depths[r] = info.depth;
+    ownSegments[r] = info.segment;
+  }
+  const maxDepth = Math.max(...depths);
+
+  // No hierarchy — every row is at the same level. Keep them all so the
+  // chart matches the grid for the trivial single-level case.
+  if (depths.every((d) => d === maxDepth)) {
     return {
       indices: parsed.bodyRows.map((_, i) => i),
       labels: parsed.rowCategories.slice(),
     };
   }
-  const lastCol = parsed.rowHeaderColCount - 1;
+
+  // For each leaf row, build "parent / .../ leaf" from the most recent
+  // segment seen at each level walked so far.
+  const lastSegByDepth = new Map<number, string>();
   const indices: number[] = [];
   const labels: string[] = [];
-  // Most recent non-empty value seen for each row-header column, so we
-  // can reconstruct the parent context for leaf rows where Mondrian has
-  // elided the repeated parent (the common dedup pattern).
-  const lastSeen: string[] = new Array(parsed.rowHeaderColCount).fill("");
-  for (let r = 0; r < parsed.bodyRows.length; r++) {
-    const row = parsed.bodyRows[r];
-    for (let c = 0; c < row.length; c++) {
-      const v = row[c]?.value ?? "";
-      if (v) lastSeen[c] = v;
-    }
-    const leafCell = row[lastCol];
-    if (leafCell?.value) {
+  for (let r = 0; r < n; r++) {
+    const d = depths[r];
+    const seg = ownSegments[r];
+    if (seg) lastSegByDepth.set(d, seg);
+    if (d === maxDepth) {
       indices.push(r);
-      labels.push(lastSeen.slice(0, lastCol + 1).filter(Boolean).join(" / "));
+      const parts: string[] = [];
+      for (let dd = 1; dd <= maxDepth; dd++) {
+        const v = lastSegByDepth.get(dd);
+        if (v) parts.push(v);
+      }
+      labels.push(parts.length ? parts.join(" / ") : seg);
     }
   }
   return { indices, labels };
+}
+
+interface RowDepth {
+  /** 1-based depth in the hierarchy on rows. */
+  depth: number;
+  /** The cell value at that depth — used as the leaf segment when
+   *  reconstructing parent / leaf labels. */
+  segment: string;
+}
+
+/** Depth + segment of the deepest cell in a row's row-header section.
+ *  Uses the uniquename when available (count of bracketed segments),
+ *  otherwise falls back to the deepest non-empty column index. */
+function depthOfRow(row: CellEntry[]): RowDepth {
+  for (let c = row.length - 1; c >= 0; c--) {
+    const cell = row[c];
+    const un = cell?.properties?.uniquename;
+    if (un) {
+      // `[Time].[Time].[1997].[1]` → 4 segments.
+      const matches = un.match(/\.\[/g);
+      return {
+        depth: (matches?.length ?? 0) + 1,
+        segment: cell?.value ?? "",
+      };
+    }
+    if (cell?.value) {
+      return { depth: c + 1, segment: cell.value };
+    }
+  }
+  return { depth: 0, segment: "" };
 }


### PR DESCRIPTION
Follow-up to #1040.

## What was broken

The first cut of \`hideRollupRows\` guarded on \`rowHeaderColCount > 1\`, so it worked for the legacy multi-column layout (Year + Quarter as two row-header columns) but missed the single-column case Mondrian actually emits for \`Time(2 levels)\` on Foodmart: every row has one row-header cell — \`1997\` for the year, \`1\`..\`12\` for the months — and the hierarchy lives in \`properties.uniquename\`:

| value | uniquename | depth |
|---|---|---|
| \`1997\` | \`[Time].[Time].[1997]\` | 3 |
| \`1\` | \`[Time].[Time].[1997].[1]\` | 4 |

The 1997 rollup bar dwarfed the twelve monthly bars even with \"Hide rollup rows\" ticked — exactly the symptom #1040 was supposed to cure.

## Fix

\`deriveLeafRows\` now:

- Computes each row's depth from the deepest row-header cell's \`uniquename\` when available, falling back to \"deepest non-empty column index\" so legacy multi-column shapes still work.
- Captures the cell's leaf-level **value** (not the joined \`rowCategories\` label) so reconstructing parent / leaf doesn't double-count when Mondrian repeats the parent on every row instead of deduping.

\`ChartView\` drops the \`rowHeaderColCount > 1\` guard so single-col payloads flow through too.

## Test plan

- [x] Two new vitest cases for the single-col Foodmart-style shape (one year with three months, two years with two quarters each)
- [x] Existing \"returns empty arrays when there are no leaf rows\" was asserting strictly worse UX — when every row is at the same depth the chart now keeps them all instead of clearing the canvas. Test renamed and updated to match.
- [x] \`npm run check\` — 0 errors, 0 warnings
- [x] \`npm test\` — 451 passing
- [x] \`npm run build\` — green
- [ ] Manual on demo: load Store Cost / Time(2 levels), chart view → confirm only 12 month bars show, labels read \`1997 / 1\`, \`1997 / 2\`, …