### PR TITLE
fix(ui): unblock Top N / Order modal inputs + lift the silent 2-tab cap

### DIFF
--- a/saiku-ui/src/lib/modals/OrderModal.svelte
+++ b/saiku-ui/src/lib/modals/OrderModal.svelte
@@ -50,10 +50,14 @@
 
   $effect(() => {
     if (open) {
+      // Don't read `selected` here — reading it inside the same effect
+      // that wrote it makes the dropdown's bind:value-driven change re-fire
+      // this effect and reset the user's pick. Use the source.
+      const seedMeasure = initialMeasure || measures[0]?.uniqueName || "";
       mode = "simple";
-      selected = initialMeasure || measures[0]?.uniqueName || "";
+      selected = seedMeasure;
       sort = initialSort;
-      mdxBuffer = selected;
+      mdxBuffer = seedMeasure;
     }
   });
 

--- a/saiku-ui/src/lib/modals/TopBottomCountModal.svelte
+++ b/saiku-ui/src/lib/modals/TopBottomCountModal.svelte
@@ -46,10 +46,16 @@
 
   $effect(() => {
     if (open) {
+      // Don't read `count` / `selected` here — they were just written, and
+      // reading state inside the same effect that wrote it turns the user's
+      // keystrokes into a dep that re-fires this effect and resets the
+      // value back to the prop. Use the source values instead.
+      const seedCount = initialCount || 10;
+      const seedMeasure = initialMeasure || measures[0]?.uniqueName || "";
       mode = "simple";
-      count = initialCount || 10;
-      selected = initialMeasure || measures[0]?.uniqueName || "";
-      mdxBuffer = `${Math.floor(count)}, ${selected}`;
+      count = seedCount;
+      selected = seedMeasure;
+      mdxBuffer = `${Math.floor(seedCount)}, ${seedMeasure}`;
     }
   });
 

--- a/saiku-ui/src/lib/views/Workspace.svelte
+++ b/saiku-ui/src/lib/views/Workspace.svelte
@@ -335,6 +335,15 @@
     padding: 0 var(--space-2);
     border-bottom: 1px solid var(--border);
     background: var(--bg-muted);
+    /* .workspace__main has overflow:hidden; without horizontal scroll
+       here a third (or further) tab gets clipped past the right edge
+       and the "+" button becomes unreachable, which presents to the
+       user as "can't open more than 2 tabs". Allow the strip to scroll
+       and make each tab non-shrinking so the labels don't compact
+       into an unreadable column either. */
+    overflow-x: auto;
+    overflow-y: hidden;
+    scrollbar-width: thin;
   }
   .tab {
     display: inline-flex;
@@ -351,6 +360,7 @@
     font-size: var(--fs-sm);
     cursor: pointer;
     max-width: 18rem;
+    flex-shrink: 0;
   }
   .tab:hover:not(.tab--active) {
     color: var(--fg);


### PR DESCRIPTION
Three regressions from #1038 (svelte-check cleanup), fixed in one PR.

## 1. Top N / Bottom N modal — count and measure both locked

\`\`\`ts
\$effect(() => {
  if (open) {
    count = initialCount || 10;
    selected = initialMeasure || measures[0]?.uniqueName || \"\";
    mdxBuffer = \`\${Math.floor(count)}, \${selected}\`;  // ← bug
  }
});
\`\`\`

That trailing read of \`count\` / \`selected\` makes them tracked deps of the same effect that writes them. Typing into the count input → \`count\` changes → effect re-fires → \`count = initialCount || 10\` resets it. User sees a dead input.

Fix: capture seed values into locals before writing state, then build \`mdxBuffer\` from the locals so no state read happens inside the effect.

## 2. Order modal — measure dropdown stuck on the first item

Same shape: \`mdxBuffer = selected\` after \`selected = initialMeasure || …\`. Picking a new measure re-fires the effect and resets it.

## 3. Workspace tab strip — silently capped at 2 visible tabs

\`.workspace__main\` is \`overflow: hidden\`. \`.tabset\` had plain \`display: flex\` with no overflow handling, so a third tab pushed past the right edge and got clipped. Eventually the \`+\` button itself was clipped — presenting as \"can't open more than 2 tabs\".

Fix: \`overflow-x: auto\` on the strip + \`flex-shrink: 0\` on each tab.

## Audit

I checked every other modal \$effect after fixing TopBottom and Order — only these two had the read-write loop. Everything else either writes pure prop values or writes literals.

## Test plan

- [x] \`npm run check\` — 0 errors, 0 warnings
- [x] \`npm test\` — 451 passing
- [x] \`npm run build\` — green
- [ ] Manual on demo: open Top N modal → confirm count input is typeable and measure dropdown changes
- [ ] Manual: open Order modal → confirm measure dropdown selects through every option
- [ ] Manual: click \"+\" 4–5 times → confirm all tabs render and the strip scrolls