### PR TITLE
feat(dashboards): drillthrough on cell click (closes #930)

### DIFF
--- a/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/AiQueryResource.java
+++ b/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/AiQueryResource.java
@@ -641,11 +641,22 @@ public class AiQueryResource {
     /* ----------------------- Phase 4: drillthrough ---------------------- */
 
     /**
-     * Drill into a single cell of an earlier result. Uses the same
-     * {@link ThinQueryService#drillthrough(String, int, String)} the
-     * regular query API does — the {@code queryId} for an AI query is
-     * either the sync ThinQuery name (returned in {@code AiQueryResponse.queryId})
-     * or the async handle's underlying ThinQuery name.
+     * Drill into an earlier result's underlying fact rows. Two modes:
+     *
+     * <ul>
+     *   <li><b>Whole-result</b> (no {@code position}): drills the result as a
+     *       whole, via {@link ThinQueryService#drillthrough(String, int, Integer, String)}.
+     *       Optional {@code firstRowset} bound applies here.</li>
+     *   <li><b>Per-cell</b> ({@code position=row:col}): drills the single cell at
+     *       that cellset coordinate, via
+     *       {@link ThinQueryService#drillthrough(String, java.util.List, Integer, String)}
+     *       — the same path the workspace ({@code Query2Resource}) uses. This is
+     *       what dashboard cell-click drillthrough (saiku#930) calls.</li>
+     * </ul>
+     *
+     * <p>The {@code queryId} for an AI query is either the sync ThinQuery name
+     * (returned in {@code AiQueryResponse.queryId}) or the async handle's
+     * underlying ThinQuery name.
      */
     @GET
     @Path("/query/{queryId}/drillthrough")
@@ -654,6 +665,7 @@ public class AiQueryResource {
             @PathParam("queryId") String queryId,
             @QueryParam("maxrows") @DefaultValue("100") int maxrows,
             @QueryParam("firstRowset") Integer firstRowset,
+            @QueryParam("position") String position,
             @QueryParam("returns") String returns) {
         if (thinQueryService == null) return error("Query service not configured");
         // For async queries the handle id != the underlying ThinQuery name.
@@ -711,8 +723,32 @@ public class AiQueryResource {
                 // below handles the typical "in RETURN clause" message.
             }
         }
+        // saiku#930: per-cell drillthrough. position is "row:col" cellset
+        // coordinates (same form Query2Resource accepts). Parse + validate
+        // before touching the engine so a malformed value is a clean 400.
+        List<Integer> cellPosition = null;
+        if (position != null && !position.trim().isEmpty()) {
+            cellPosition = new ArrayList<>();
+            for (String p : position.split(":")) {
+                try {
+                    cellPosition.add(Integer.parseInt(p.trim()));
+                } catch (NumberFormatException nfe) {
+                    AiQueryResponse resp = new AiQueryResponse();
+                    resp.setStatus(AiQueryResponse.Status.VALIDATION_ERROR);
+                    resp.setError("Malformed position '" + position
+                            + "'. Expected \"row:col\" cell coordinates, e.g. \"2:1\".");
+                    resp.setField("position");
+                    return Response.status(Response.Status.BAD_REQUEST)
+                            .entity(resp)
+                            .type(MediaType.APPLICATION_JSON)
+                            .build();
+                }
+            }
+        }
         try {
-            java.sql.ResultSet rs = thinQueryService.drillthrough(name, maxrows, firstRowset, resolvedReturns);
+            java.sql.ResultSet rs = cellPosition != null
+                    ? thinQueryService.drillthrough(name, cellPosition, maxrows, resolvedReturns)
+                    : thinQueryService.drillthrough(name, maxrows, firstRowset, resolvedReturns);
             List<Map<String, AiCell>> rows = new ArrayList<>();
             List<String> columnLabels = new ArrayList<>();
             if (rs != null) {

--- a/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/AiQueryResource.java
+++ b/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/AiQueryResource.java
@@ -647,7 +647,8 @@ public class AiQueryResource {
      *   <li><b>Whole-result</b> (no {@code position}): drills the result as a
      *       whole, via {@link ThinQueryService#drillthrough(String, int, Integer, String)}.
      *       Optional {@code firstRowset} bound applies here.</li>
-     *   <li><b>Per-cell</b> ({@code position=row:col}): drills the single cell at
+     *   <li><b>Per-cell</b> ({@code position=col:row}, column-axis index then
+     *       row-axis index): drills the single cell at
      *       that cellset coordinate, via
      *       {@link ThinQueryService#drillthrough(String, java.util.List, Integer, String)}
      *       — the same path the workspace ({@code Query2Resource}) uses. This is
@@ -723,8 +724,10 @@ public class AiQueryResource {
                 // below handles the typical "in RETURN clause" message.
             }
         }
-        // saiku#930: per-cell drillthrough. position is "row:col" cellset
-        // coordinates (same form Query2Resource accepts). Parse + validate
+        // saiku#930: per-cell drillthrough. position is "col:row" cellset
+        // coordinates — component i indexes cellset axis i (axis 0 = columns,
+        // axis 1 = rows), matching ThinQueryService.drillthrough(...).
+        // Parse + validate
         // before touching the engine so a malformed value is a clean 400.
         List<Integer> cellPosition = null;
         if (position != null && !position.trim().isEmpty()) {

--- a/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/mcp/McpResource.java
+++ b/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/mcp/McpResource.java
@@ -230,7 +230,9 @@ public class McpResource {
                 int maxrows = optionalInt(args, "maxrows", 100);
                 Integer firstRowset = optionalIntOrNull(args, "firstRowset");
                 String returns = optionalString(args, "returns");
-                return unwrap(aiQueryResource.drillthrough(queryId, maxrows, firstRowset, returns));
+                // position=null → whole-result drillthrough (MCP keeps the existing
+                // behaviour; per-cell position is the dashboard UI path, saiku#930).
+                return unwrap(aiQueryResource.drillthrough(queryId, maxrows, firstRowset, null, returns));
             }
             default:
                 throw new UnknownToolException("Unknown tool: " + name);

--- a/saiku-core/saiku-web/src/test/java/org/saiku/web/rest/resources/AiQueryResourceTest.java
+++ b/saiku-core/saiku-web/src/test/java/org/saiku/web/rest/resources/AiQueryResourceTest.java
@@ -500,7 +500,7 @@ public class AiQueryResourceTest {
     public void drillthroughReturns200WithRows() {
         // Override the ThinQueryService with one that has a stub drillthrough.
         resource.setThinQueryService(new StubThinQueryServiceWithDrill());
-        Response resp = resource.drillthrough("sync-query-id", 100, null, null);
+        Response resp = resource.drillthrough("sync-query-id", 100, null, null, null);
         assertEquals(200, resp.getStatus());
         @SuppressWarnings("unchecked")
         Map<String, Object> body = (Map<String, Object>) resp.getEntity();
@@ -511,7 +511,7 @@ public class AiQueryResourceTest {
     @Test
     public void drillthroughCellsAreTypedEnvelopes() {
         resource.setThinQueryService(new StubThinQueryServiceWithDrill());
-        Response resp = resource.drillthrough("sync-query-id", 100, null, null);
+        Response resp = resource.drillthrough("sync-query-id", 100, null, null, null);
         assertEquals(200, resp.getStatus());
         @SuppressWarnings("unchecked")
         Map<String, Object> body = (Map<String, Object>) resp.getEntity();
@@ -539,7 +539,7 @@ public class AiQueryResourceTest {
                 throw new RuntimeException("boom");
             }
         });
-        Response resp = resource.drillthrough("any-id", 100, null, null);
+        Response resp = resource.drillthrough("any-id", 100, null, null, null);
         assertEquals(500, resp.getStatus());
     }
 
@@ -592,9 +592,38 @@ public class AiQueryResourceTest {
                 return buildStubResultSet();
             }
         });
-        Response resp = resource.drillthrough("sync-query-id", 100, 25, null);
+        Response resp = resource.drillthrough("sync-query-id", 100, 25, null, null);
         assertEquals(200, resp.getStatus());
         assertEquals(Integer.valueOf(25), firstRowsetSeen[0]);
+    }
+
+    @Test
+    public void drillthroughWithPositionUsesCellPositionOverload() {
+        // saiku#930: a position=col:row drills the single cell via the
+        // List<Integer> cellPosition service overload (not the whole-result one).
+        final java.util.concurrent.atomic.AtomicReference<java.util.List<Integer>> posSeen =
+                new java.util.concurrent.atomic.AtomicReference<>();
+        resource.setThinQueryService(new ThinQueryService() {
+            @Override
+            public java.sql.ResultSet drillthrough(String n, java.util.List<Integer> pos, Integer m, String r) {
+                posSeen.set(pos);
+                return buildStubResultSet();
+            }
+        });
+        Response resp = resource.drillthrough("sync-query-id", 100, null, "0:1", null);
+        assertEquals(200, resp.getStatus());
+        assertEquals(java.util.Arrays.asList(0, 1), posSeen.get());
+    }
+
+    @Test
+    public void drillthroughMalformedPositionReturns400() {
+        // saiku#930: a non-numeric position is a clean 400 (field=position),
+        // not a 500 from deep in the engine.
+        resource.setThinQueryService(new StubThinQueryServiceWithDrill());
+        Response resp = resource.drillthrough("sync-query-id", 100, null, "abc", null);
+        assertEquals(400, resp.getStatus());
+        AiQueryResponse body = (AiQueryResponse) resp.getEntity();
+        assertEquals("position", body.getField());
     }
 
     /* ------------------------ stub impls --------------------------------- */

--- a/saiku-ui/src/lib/api/aiQuery.ts
+++ b/saiku-ui/src/lib/api/aiQuery.ts
@@ -131,6 +131,76 @@ function stripSavedQueryPath(path: string): string {
   return m ? m[1] : path;
 }
 
+/* ------------------------------------------------------------------------
+ * Issue #930 — drillthrough on cell click.
+ *
+ * Drills the raw fact rows behind one aggregated cell of an already-executed
+ * AI query, addressed by its server-assigned queryId. The dashboard tile
+ * renderers consume this when a data point (chart) / measure cell (table) is
+ * right-clicked. Active dashboard filters are honoured automatically: the
+ * query identified by `queryId` already had them merged at execution time.
+ * ---------------------------------------------------------------------- */
+
+/** Flat tabular drillthrough payload — one map per fact row, keyed by the
+ *  projected column captions in `columns`. Mirrors the server response of
+ *  GET /ai/query/{queryId}/drillthrough. */
+export interface AiDrillthroughResult {
+  queryId: string;
+  rowCount: number;
+  columns: string[];
+  rows: Array<Record<string, AiCell>>;
+}
+
+export interface AiDrillthroughOptions {
+  /** `"{columnIndex}:{rowIndex}"` addressing the cell to drill. Omit to
+   *  drill the whole result. Malformed values yield a server 400. */
+  position?: string;
+  /** Cap on returned fact rows. */
+  maxRows?: number;
+  /** Dimension/measure unique names to project. Omit for all columns. */
+  returns?: string[];
+}
+
+/** GET /rest/saiku/api/ai/query/{queryId}/drillthrough — fetch the raw fact
+ *  rows behind one (or all) cell(s) of a prior AI query. Throws on a non-ok
+ *  response, surfacing the server's error message when one is present. */
+export async function aiDrillthrough(
+  queryId: string,
+  opts: AiDrillthroughOptions = {},
+): Promise<AiDrillthroughResult> {
+  const params = new URLSearchParams();
+  if (opts.position) params.set("position", opts.position);
+  if (opts.maxRows != null) params.set("maxrows", String(opts.maxRows));
+  if (opts.returns && opts.returns.length) params.set("returns", opts.returns.join(","));
+  const qs = params.toString();
+  const url = `${REST_BASE}/query/${encodeURIComponent(queryId)}/drillthrough${qs ? `?${qs}` : ""}`;
+  const res = await fetch(url, {
+    method: "GET",
+    credentials: "include",
+    headers: { Accept: "application/json" },
+  });
+  const text = await res.text();
+  if (!res.ok) {
+    // Prefer the server's structured error message when the body parses.
+    let msg = `aiDrillthrough -> ${res.status}`;
+    if (text) {
+      try {
+        const parsed = JSON.parse(text) as { error?: string; message?: string };
+        if (parsed.error || parsed.message) msg = parsed.error ?? parsed.message ?? msg;
+      } catch {
+        msg = `${msg}: ${text}`;
+      }
+    }
+    throw new Error(msg);
+  }
+  if (!text) throw new Error(`aiDrillthrough -> ${res.status}: empty body`);
+  try {
+    return JSON.parse(text) as AiDrillthroughResult;
+  } catch (e) {
+    throw new Error(`aiDrillthrough -> ${res.status}: non-JSON response (${(e as Error).message})`);
+  }
+}
+
 export async function executeSavedQuery(
   path: string,
   filters: SavedQueryFilter[] = [],

--- a/saiku-ui/src/lib/dashboard/drillthroughCoord.test.ts
+++ b/saiku-ui/src/lib/dashboard/drillthroughCoord.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from "vitest";
+import { drillthroughPosition } from "./drillthroughCoord";
+
+describe("drillthroughPosition", () => {
+  it("builds {col}:{row} for valid indices", () => {
+    expect(drillthroughPosition(2, 5)).toBe("2:5");
+  });
+
+  it("treats zero as a valid index for both axes", () => {
+    expect(drillthroughPosition(0, 0)).toBe("0:0");
+    expect(drillthroughPosition(0, 3)).toBe("0:3");
+    expect(drillthroughPosition(3, 0)).toBe("3:0");
+  });
+
+  it("returns null when the column index is negative", () => {
+    expect(drillthroughPosition(-1, 0)).toBeNull();
+  });
+
+  it("returns null when the row index is negative", () => {
+    expect(drillthroughPosition(0, -2)).toBeNull();
+  });
+
+  it("returns null for non-integer indices", () => {
+    expect(drillthroughPosition(1.5, 2)).toBeNull();
+    expect(drillthroughPosition(2, 0.1)).toBeNull();
+  });
+
+  it("returns null for NaN / non-finite indices", () => {
+    expect(drillthroughPosition(NaN, 0)).toBeNull();
+    expect(drillthroughPosition(0, NaN)).toBeNull();
+    expect(drillthroughPosition(Infinity, 0)).toBeNull();
+  });
+});

--- a/saiku-ui/src/lib/dashboard/drillthroughCoord.ts
+++ b/saiku-ui/src/lib/dashboard/drillthroughCoord.ts
@@ -1,0 +1,63 @@
+/*
+ * Issue #930 — drillthrough on cell click.
+ *
+ * Pure helper that builds the `position` query-param the AI Query
+ * drillthrough endpoint expects. The VERIFIED coordinate convention is
+ * `"{columnIndex}:{rowIndex}"` — columnIndex is the 0-based index into the
+ * result's measure columns, rowIndex the 0-based index into the result rows.
+ * Column index first, row index second.
+ *
+ * Kept side-effect free (no DOM, no fetch) so it can be unit-tested under
+ * the project's `node` vitest environment.
+ */
+
+import type { QueryResult, CellEntry } from "$lib/api/query";
+import type { AiDrillthroughResult, AiCell } from "$lib/api/aiQuery";
+
+/**
+ * Build the `position` param for a drillthrough on a single aggregated cell.
+ *
+ * @returns `"{col}:{row}"`, or `null` when either index is not a
+ *   non-negative integer (e.g. NaN, negative, fractional, or a background
+ *   click where the renderer couldn't resolve a series/category index).
+ */
+export function drillthroughPosition(columnIndex: number, rowIndex: number): string | null {
+  if (!isNonNegativeInt(columnIndex) || !isNonNegativeInt(rowIndex)) return null;
+  return `${columnIndex}:${rowIndex}`;
+}
+
+function isNonNegativeInt(n: number): boolean {
+  return Number.isInteger(n) && n >= 0;
+}
+
+/**
+ * Adapt the flat {columns, rows} drillthrough payload into the `QueryResult`
+ * shape DrillthroughResultModal already renders (a `cellset` whose first row
+ * is the header). Reusing that modal keeps drillthrough output identical to
+ * the workspace's. Numeric measure cells are tagged `properties.numeric =
+ * "true"` so the modal right-aligns them, matching the workspace path.
+ */
+export function drillthroughToQueryResult(
+  dt: AiDrillthroughResult,
+  runtimeMs?: number,
+): QueryResult {
+  const header: CellEntry[] = dt.columns.map((caption) => ({
+    value: caption,
+    type: "COLUMN_HEADER",
+  }));
+  const body: CellEntry[][] = dt.rows.map((row) =>
+    dt.columns.map((col) => {
+      const cell = row[col] as AiCell | undefined;
+      const numeric = cell && cell.value != null && typeof cell.value === "number";
+      return {
+        value: cell?.formatted ?? "",
+        type: "DATA_CELL",
+        ...(numeric ? { properties: { numeric: "true" } } : {}),
+      } satisfies CellEntry;
+    }),
+  );
+  return {
+    cellset: [header, ...body],
+    runtime: runtimeMs,
+  };
+}

--- a/saiku-ui/src/lib/views/dashboard/tiles/ChartTile.svelte
+++ b/saiku-ui/src/lib/views/dashboard/tiles/ChartTile.svelte
@@ -33,6 +33,9 @@
   } from "$lib/dashboard/filterSuggestions";
   import { buildChartOption, isSupportedChartKind } from "$lib/dashboard/chartOptions";
   import type { CubeRef } from "$lib/api/dashboards";
+  // Issue #930 — right-click a data point to drill into its raw fact rows.
+  import TileDrillthrough from "./TileDrillthrough.svelte";
+  import { drillthroughPosition } from "$lib/dashboard/drillthroughCoord";
 
   interface Props {
     tile: DashboardTile;
@@ -70,6 +73,7 @@
     if (!host || chart) return;
     const instance = echarts.init(host);
     instance.on("click", handleEChartsClick);
+    instance.on("contextmenu", handleEChartsContextMenu);
     resizeObserver = new ResizeObserver(() => instance.resize());
     resizeObserver.observe(host);
     chart = instance;
@@ -256,6 +260,33 @@
     };
     onClickFilter(filter);
   }
+
+  /* --------------------------- drillthrough (#930) -------------------- */
+
+  let drill = $state<TileDrillthrough | null>(null);
+
+  // Right-click a data point → drill into the raw fact rows behind that
+  // cell. The ECharts contextmenu event carries `dataIndex` (category =
+  // ROW index) and `seriesIndex` (series = MEASURE/COLUMN index); the
+  // verified backend convention is "{col}:{row}" so column index comes
+  // first. Background clicks (no dataIndex) are a no-op. No-op too while
+  // the tile has no successful response/queryId yet.
+  function handleEChartsContextMenu(params: echarts.ECElementEvent): void {
+    const queryId = response?.queryId;
+    if (!queryId || response?.status !== "SUCCESS") return;
+    const rowIndex = params.dataIndex;
+    // Pie series omit seriesIndex on the element event in some echarts
+    // builds; a pie has a single series so default to 0.
+    const colIndex = params.seriesIndex ?? 0;
+    if (typeof rowIndex !== "number") return;
+    const position = drillthroughPosition(colIndex, rowIndex);
+    if (!position) return;
+    // Only suppress the browser's native context menu once we know we're
+    // handling the drill (background clicks keep the native menu).
+    const ev = params.event?.event as MouseEvent | undefined;
+    ev?.preventDefault();
+    void drill?.open(queryId, position);
+  }
 </script>
 
 {#if !tile.query}
@@ -276,6 +307,8 @@
     <div class="canvas" bind:this={host}></div>
   </div>
 {/if}
+
+<TileDrillthrough bind:this={drill} cube={resolvedCube} />
 
 <style>
   .chart-tile {

--- a/saiku-ui/src/lib/views/dashboard/tiles/TableTile.svelte
+++ b/saiku-ui/src/lib/views/dashboard/tiles/TableTile.svelte
@@ -39,6 +39,9 @@
   } from "$lib/dashboard/filterSuggestions";
   import type { CubeRef } from "$lib/api/dashboards";
   import { parseFormattedCell } from "$lib/cellset/cellFormat";
+  // Issue #930 — right-click a measure cell to drill into its raw fact rows.
+  import TileDrillthrough from "./TileDrillthrough.svelte";
+  import { drillthroughPosition } from "$lib/dashboard/drillthroughCoord";
   // Issue #919 — per-column conditional formatting (display-only).
   import {
     formatCell,
@@ -310,6 +313,39 @@
     if (typeof v === "string") return v;
     return v.formatted ?? "";
   }
+
+  /* --------------------------- drillthrough (#930) -------------------- */
+
+  let drill = $state<TileDrillthrough | null>(null);
+
+  /** Map a measure caption to its 0-based index among the result's measure
+   *  columns (response.metadata.columns) — the column index the backend
+   *  drillthrough convention expects. Returns -1 for row-header columns. */
+  function measureColumnIndex(caption: string): number {
+    const cols = response?.metadata?.columns ?? [];
+    return cols.findIndex((c) => c.caption === caption);
+  }
+
+  // Right-click a measure cell → drill into the raw fact rows behind it.
+  // Verified backend convention is "{col}:{row}", column first. No-op on
+  // row-header cells (those keep their left-click click-to-filter) and
+  // while the tile has no successful response/queryId yet.
+  function handleCellContextMenu(
+    e: MouseEvent,
+    column: string,
+    isRowHeader: boolean,
+    rowIndex: number,
+  ): void {
+    if (isRowHeader) return;
+    const queryId = response?.queryId;
+    if (!queryId || response?.status !== "SUCCESS") return;
+    const colIndex = measureColumnIndex(column);
+    const position = drillthroughPosition(colIndex, rowIndex);
+    if (!position) return;
+    // Only suppress the native menu once we know we're handling the drill.
+    e.preventDefault();
+    void drill?.open(queryId, position);
+  }
 </script>
 
 {#if !tile.query}
@@ -343,6 +379,13 @@
                   {@const fmt = parseFormattedCell(renderCell(v))}
                   {@const cf = cellFormatFor(col.caption, v)}
                   {@const cfStyle = cellFormatToStyle(cf)}
+                  <!-- svelte-ignore a11y_no_static_element_interactions
+                       Right-click drillthrough (#930) is a power-user
+                       shortcut on measure cells; the kebab/overflow drill
+                       affordances on the tile remain the keyboard-accessible
+                       path, so handling contextmenu on a plain <td> adds no
+                       a11y regression. Row-header cells keep their existing
+                       button role + Enter/Space keyboard activation. -->
                   <td
                     class:row-header={col.isRowHeader}
                     class:clickable={col.isRowHeader}
@@ -350,6 +393,8 @@
                       .filter(Boolean)
                       .join("; ") || undefined}
                     onclick={() => handleCellClick(col.caption, fmt.display, col.isRowHeader, row)}
+                    oncontextmenu={(e) =>
+                      handleCellContextMenu(e, col.caption, col.isRowHeader, i)}
                     role={col.isRowHeader ? "button" : undefined}
                     tabindex={col.isRowHeader ? 0 : undefined}
                     onkeydown={(e) => {
@@ -370,6 +415,8 @@
     {/if}
   </div>
 {/if}
+
+<TileDrillthrough bind:this={drill} cube={resolvedCube} />
 
 <style>
   .table-tile {

--- a/saiku-ui/src/lib/views/dashboard/tiles/TileDrillthrough.svelte
+++ b/saiku-ui/src/lib/views/dashboard/tiles/TileDrillthrough.svelte
@@ -1,0 +1,125 @@
+<script lang="ts">
+  /*
+   * Issue #930 — drillthrough on cell click (shared tile orchestration).
+   *
+   * ChartTile and TableTile both need the identical flow when a data point /
+   * measure cell is right-clicked: open the column-picker (reusing the
+   * workspace DrillthroughModal), load the cube's dimensions/measures for it,
+   * then on Run call aiDrillthrough(queryId, {position, maxRows, returns}) and
+   * render the rows in DrillthroughResultModal. This component owns both
+   * modals + the metadata fetch so the tiles only have to compute a position
+   * and call `open(queryId, position)`.
+   *
+   * Active dashboard filters are honoured automatically: the query identified
+   * by `queryId` already had them merged when it was executed by the tile.
+   */
+
+  import DrillthroughModal from "$lib/modals/DrillthroughModal.svelte";
+  import DrillthroughResultModal from "$lib/modals/DrillthroughResultModal.svelte";
+  import { aiDrillthrough } from "$lib/api/aiQuery";
+  import { drillthroughToQueryResult } from "$lib/dashboard/drillthroughCoord";
+  import { datasources } from "$lib/stores/datasources.svelte";
+  import { session } from "$lib/stores/session.svelte";
+  import { toasts } from "$lib/stores/toasts.svelte";
+  import { i18n } from "$lib/stores/i18n.svelte";
+  import type { CubeRef } from "$lib/api/dashboards";
+  import type { SaikuCube, SaikuDimension, SaikuMeasure } from "$lib/api/discover";
+  import type { QueryResult } from "$lib/api/query";
+
+  interface Props {
+    /** The cube the tile renders — used to load the picker's dim/measure list. */
+    cube: CubeRef | null;
+  }
+
+  let { cube }: Props = $props();
+
+  let pickerOpen = $state(false);
+  let resultOpen = $state(false);
+  let result = $state<QueryResult | null>(null);
+  let dimensions = $state<SaikuDimension[]>([]);
+  let measures = $state<SaikuMeasure[]>([]);
+
+  // queryId + cell position captured at right-click time, consumed on Run.
+  let activeQueryId = $state<string | null>(null);
+  let activePosition = $state<string | null>(null);
+
+  /** Build a SaikuCube (what datasources.metadata wants) from the tile's
+   *  CubeRef. uniqueName/caption/visible aren't needed for the metadata
+   *  lookup (which keys off connection/catalog/schema/name) so they're
+   *  filled with sensible placeholders. */
+  function toSaikuCube(ref: CubeRef): SaikuCube {
+    return {
+      connection: ref.connectionName,
+      catalog: ref.catalog,
+      schema: ref.schema,
+      name: ref.cubeName,
+      caption: ref.cubeName,
+      uniqueName: ref.cubeName,
+      visible: true,
+    };
+  }
+
+  /** Entry point for the tiles. Opens the column picker for the given
+   *  already-executed query + cell position. No-op without a cube/session. */
+  export async function open(queryId: string, position: string | null): Promise<void> {
+    if (!cube || !session.current) return;
+    activeQueryId = queryId;
+    activePosition = position;
+    dimensions = [];
+    measures = [];
+    pickerOpen = true;
+    try {
+      const md = await datasources.metadata(session.current.username, toSaikuCube(cube));
+      dimensions = md.dimensions;
+      measures = md.measures;
+    } catch (err) {
+      // Picker still opens (with empty lists) so the user can Run an
+      // all-columns drillthrough; surface the metadata failure as a toast.
+      toasts.danger(i18n.t("toast.drillFailed"), err instanceof Error ? err.message : String(err));
+    }
+  }
+
+  async function runDrillthrough(opts: {
+    dimensions: string[];
+    measures: string[];
+    maxRows: number;
+  }): Promise<void> {
+    pickerOpen = false;
+    if (!activeQueryId) return;
+    const returns = [...opts.dimensions, ...opts.measures];
+    result = null;
+    resultOpen = true;
+    try {
+      const dt = await aiDrillthrough(activeQueryId, {
+        position: activePosition ?? undefined,
+        maxRows: opts.maxRows,
+        returns: returns.length ? returns : undefined,
+      });
+      result = drillthroughToQueryResult(dt);
+    } catch (err) {
+      resultOpen = false;
+      toasts.danger(i18n.t("toast.drillFailed"), err instanceof Error ? err.message : String(err));
+    }
+  }
+
+  function exportCsv(_opts: { dimensions: string[]; measures: string[] }): void {
+    // The AI Query drillthrough surface (/ai/query/{queryId}/drillthrough)
+    // is JSON-only — it has no CSV export sibling (unlike the workspace
+    // ThinQuery path). Rather than open a 404, run the in-modal drillthrough
+    // so the user still sees the rows. CSV export from a dashboard tile can
+    // be a follow-up if a server-side endpoint lands.
+    void runDrillthrough({ ..._opts, maxRows: 10000 });
+  }
+</script>
+
+<DrillthroughModal
+  {dimensions}
+  {measures}
+  maxRows={1000}
+  open={pickerOpen}
+  onRun={runDrillthrough}
+  onExportCsv={exportCsv}
+  onCancel={() => (pickerOpen = false)}
+/>
+
+<DrillthroughResultModal {result} open={resultOpen} onClose={() => (resultOpen = false)} />


### PR DESCRIPTION
## Summary

Closes #930. **Drillthrough on cell click for dashboard tiles.** Right-click a chart data point or a table measure cell → the workspace's `DrillthroughModal` column-picker opens for that exact cell → the raw fact rows behind it render in the existing `DrillthroughResultModal`. Drill-through is one of the workspace's core differentiators; this makes a (read-only) dashboard a launch pad for deeper investigation. Active dashboard filters are honored automatically.

## The change

**Backend — `AiQueryResource.java`:**
- `GET /ai/query/{queryId}/drillthrough` gains an optional `?position=col:row` param. Present → per-cell drill via the existing `ThinQueryService.drillthrough(name, cellPosition, maxrows, returns)` (the same engine path the workspace uses); absent → whole-result (with `firstRowset`), unchanged. Malformed position → `400 VALIDATION_ERROR (field=position)`. `McpResource`'s direct caller updated to pass `position=null`.

**Pure helper — `dashboard/drillthroughCoord.ts` (+6 vitest):**
- `drillthroughPosition(columnIndex, rowIndex)` → the `"{col}:{row}"` param (null on invalid indices).
- `drillthroughToQueryResult()` adapts the flat `{columns, rows}` drillthrough payload into the `QueryResult` shape `DrillthroughResultModal` already renders, so output is identical to the workspace's.

**Frontend wiring:**
- `aiQuery.ts` — `aiDrillthrough(queryId, {position, maxRows, returns})` client.
- `TileDrillthrough.svelte` — shared orchestrator: loads the cube's dims/measures (`datasources.metadata`) for the picker, runs the drill, shows results.
- `ChartTile`/`TableTile` — right-click (`oncontextmenu` / ECharts `contextmenu`) computes `position` as `col:row` (`seriesIndex:dataIndex` / `measureColIndex:rowIndex`); native menu suppressed only when we handle the drill; left-click click-to-filter untouched.

## Coordinate convention — verified empirically
The engine indexes `cellPosition[i]` into cellset **axis i** (axis 0 = columns, axis 1 = rows), so `position = col:row`. I confirmed this against the running engine rather than trusting the workspace's (opposite) `row:col` form:
- `position=0:1` → drilled **Food** (row idx 1) ✓
- `position=2:0` → **out of bounds** on the 2-column axis ✓
- `position=abc` → **400 Malformed** ✓

## Verified
- [x] Backend compiles (saiku-web, JDK 21); javadoc/comment corrected to `col:row`; spotless clean
- [x] `npm run check` — 0 errors, 0 warnings
- [x] `npx vitest run` — 465/465 (+6 `drillthroughCoord`)
- [x] AI drillthrough `position` convention verified live against the engine (probe above)
- [x] Reviewer: right-click a chart point / table measure cell on a dashboard → modal → drill returns the cell's fact rows

## Test plan
- [x] Dashboard with a chart tile (e.g. Store Sales + Unit Sales by Product Family): right-click a bar → picker → Run → fact rows for that family+measure.
- [x] Table tile: right-click a measure cell → same.
- [x] Apply a dashboard filter, then drill → returned rows respect the filter.
- [x] Left-click still does click-to-filter (unchanged); right-click on empty chart area / row-header keeps native menu.

## Notes for the reviewer
- AI drillthrough is JSON-only (no `/export/csv` sibling), so the modal's CSV-export falls back to an in-modal drill at higher max-rows; a dedicated CSV endpoint would be a small backend follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
