### PR TITLE
feat(dashboards): theme + language control in dashboard toolbar (#1050)

### DIFF
--- a/saiku-ui/src/lib/components/PrefsMenu.svelte
+++ b/saiku-ui/src/lib/components/PrefsMenu.svelte
@@ -4,6 +4,14 @@
   import { i18n } from "$lib/stores/i18n.svelte";
   import LocalePicker from "$lib/components/LocalePicker.svelte";
 
+  interface Props {
+    /** Panel open direction. "up" (default) suits a bottom-anchored host like
+     *  the workspace sidebar footer; "down" suits a top toolbar (saiku#1050,
+     *  the dashboard toolbar) so the panel doesn't open off the top of screen. */
+    placement?: "up" | "down";
+  }
+  let { placement = "up" }: Props = $props();
+
   let open = $state(false);
 
   function onDocumentClick(e: MouseEvent) {
@@ -30,7 +38,7 @@
     <Settings size={14} />
   </button>
   {#if open}
-    <div class="prefs-menu__panel" role="menu">
+    <div class="prefs-menu__panel" class:prefs-menu__panel--down={placement === "down"} role="menu">
       <div class="prefs-menu__row">
         <span class="prefs-menu__label">{i18n.t("topbar.theme")}</span>
         <button
@@ -72,6 +80,14 @@
     display: flex;
     flex-direction: column;
     gap: var(--space-2);
+  }
+  /* Top-toolbar placement (saiku#1050): open downward, aligned to the
+     button's right edge so the panel stays on-screen in the dashboard toolbar. */
+  .prefs-menu__panel--down {
+    bottom: auto;
+    top: calc(100% + 6px);
+    left: auto;
+    right: 0;
   }
   .prefs-menu__row {
     display: flex;

--- a/saiku-ui/src/lib/views/dashboard/DashboardToolbar.svelte
+++ b/saiku-ui/src/lib/views/dashboard/DashboardToolbar.svelte
@@ -14,6 +14,7 @@
 
   import AddTileMenu from "$lib/views/dashboard/AddTileMenu.svelte";
   import FilterSuggestionsModal from "$lib/views/dashboard/FilterSuggestionsModal.svelte";
+  import PrefsMenu from "$lib/components/PrefsMenu.svelte";
   import type { TileType } from "$lib/api/dashboards";
   import { Monitor, RotateCcw, X } from "lucide-svelte";
 
@@ -208,6 +209,11 @@
         {/if}
       </button>
     {/if}
+
+    <!-- saiku#1050: theme (dark/light/system) + language control, parity with
+         the workspace. Shown in both editor and viewer; the whole toolbar is
+         hidden in presentation mode (#928), so it disappears on TV walls. -->
+    <PrefsMenu placement="down" />
   </div>
 </header>
 


### PR DESCRIPTION
## Summary

Brings the **theme (dark/light/system) + language control** into the **dashboard view** so dashboards have parity with the workspace (#1050). It previously lived only in the workspace sidebar footer (`PrefsMenu` in `Workspace.svelte`), so on the dashboard / viewer / admin routes there was no way to switch theme.

## The change

**`PrefsMenu.svelte`** — new `placement?: "up" | "down"` prop:
- `"up"` (default) keeps the existing bottom-anchored behaviour for the workspace sidebar footer — unchanged.
- `"down"` opens the panel below and right-aligned, for a top toolbar.

**`DashboardToolbar.svelte`** — mounts `<PrefsMenu placement="down" />` in the actions area, shown in **both editor and viewer** modes. Because the whole toolbar is hidden in presentation/fullscreen mode (#928), the control correctly disappears on TV-wall displays.

The dashboard chrome already re-themes live via the global `data-theme` CSS, so flipping theme is immediate for everything except ECharts canvases (see scope note).

## Verified
- [x] `npm run check` — 0 errors, 0 warnings
- [x] `npx vitest run` — 473/473
- [ ] Reviewer: on a dashboard (editor + read-only viewer), the ⚙ prefs button switches light/dark/system and language; the panel opens downward and stays on-screen; in presentation mode (F) the toolbar + control hide.

## Scope / coordination
- The "**chart tiles repaint against new theme tokens on flip**" part of #1050 touches `ChartTile.svelte` / `chartOptions.ts`, which **AGENT OG's #1053 (PR #1054, in review) is actively rewriting**. Per the collab board we agreed I **hold** that bit — it lands as a small follow-up rebased onto `development` after #1054 merges. **So this PR does not fully close #1050**; it ships the control. No chart files are touched here (zero overlap with #1054).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
