### PR TITLE
feat(dashboards): theme-aware chart tiles — repaint on light/dark/system flip (closes #1056)

### DIFF
--- a/saiku-ui/src/lib/dashboard/chartOptions.test.ts
+++ b/saiku-ui/src/lib/dashboard/chartOptions.test.ts
@@ -189,6 +189,59 @@ describe("buildChartOption — extended types", () => {
   });
 });
 
+describe("buildChartOption — theme tokens (#1050 repaint)", () => {
+  const darkTokens = {
+    fg: "#e5e7eb",
+    fgMuted: "#9ca3af",
+    bg: "#0b1220",
+    bgMuted: "#111827",
+    border: "#334155",
+    accent: "#818cf8",
+    chartColors: ["#aaa111", "#bbb222"],
+  };
+
+  test("bar threads the categorical palette + text/axis colours from tk", () => {
+    const opt = buildChartOption(sampleResponse(), "bar", 1, darkTokens) as Record<string, unknown>;
+    // common: transparent canvas + palette + default text fg.
+    expect(opt.backgroundColor).toBe("transparent");
+    expect(opt.color).toEqual(darkTokens.chartColors);
+    expect((opt.textStyle as { color: string }).color).toBe("#e5e7eb");
+    // axis labels follow fgMuted; gridlines follow border.
+    const xAxis = opt.xAxis as { axisLabel: { color: string }; axisLine: { lineStyle: { color: string } } };
+    expect(xAxis.axisLabel.color).toBe("#9ca3af");
+    expect(xAxis.axisLine.lineStyle.color).toBe("#334155");
+    // tooltip surface follows bg/border/fg.
+    const tooltip = opt.tooltip as { backgroundColor: string; textStyle: { color: string } };
+    expect(tooltip.backgroundColor).toBe("#0b1220");
+    expect(tooltip.textStyle.color).toBe("#e5e7eb");
+  });
+
+  test("pie slice labels follow fg (single chart) and titles follow fg", () => {
+    const single: AiQueryResponse = {
+      ...sampleResponse(),
+      data: [
+        { Year: "1997", "Store Sales": { value: 1, formatted: "1" } },
+        { Year: "1998", "Store Sales": { value: 2, formatted: "2" } },
+      ],
+    };
+    const opt = buildChartOption(single, "pie", 1, darkTokens) as Record<string, unknown>;
+    const series = opt.series as Array<{ label: { position: string; color: string } }>;
+    // M=1 → single chart → labels drawn outside in fg (not the inside "#fff").
+    expect(series[0].label.position).toBe("outside");
+    expect(series[0].label.color).toBe("#e5e7eb");
+    const titles = opt.title as Array<{ textStyle: { color: string } }>;
+    expect(titles[0].textStyle.color).toBe("#e5e7eb");
+  });
+
+  test("defaults to the light fallback palette when tk is omitted", () => {
+    const opt = buildChartOption(sampleResponse(), "bar") as Record<string, unknown>;
+    // Light default fg (#0f172a) — proves the pure callers still get a complete,
+    // deterministic token set with no DOM.
+    expect((opt.textStyle as { color: string }).color).toBe("#0f172a");
+    expect(opt.backgroundColor).toBe("transparent");
+  });
+});
+
 describe("buildChartOption — rejection", () => {
   test("returns null for unknown chart kinds", () => {
     expect(buildChartOption(sampleResponse(), "made-up-kind")).toBeNull();

--- a/saiku-ui/src/lib/dashboard/chartOptions.ts
+++ b/saiku-ui/src/lib/dashboard/chartOptions.ts
@@ -14,6 +14,7 @@
 import type { AiCell, AiQueryResponse } from "$lib/api/aiQuery";
 import { axisLabelConfig } from "$lib/views/chartAxisLabel";
 import { cellRadiusPct, gridCells, MAX_LABELLED_SLICES } from "$lib/dashboard/smallMultiples";
+import { type ThemeTokens, DEFAULT_THEME_TOKENS } from "$lib/views/chartTheme";
 
 /**
  * Truncating axisLabel for a dashboard tile's category axis. Tiles are small,
@@ -111,11 +112,17 @@ function projectFromAiQueryResponse(response: AiQueryResponse): ChartProjection 
 
 /** Build an ECharts option object for the given chart kind, projected
  *  from an AiQueryResponse. Returns null when the response has no rows
- *  or the kind isn't recognised. */
+ *  or the kind isn't recognised.
+ *
+ *  `tk` carries the active theme tokens (see chartTheme.ts) so the chart
+ *  text/axes/palette repaint on a light/dark/system flip. It's optional and
+ *  defaults to the light fallback so the pure callers (tests) stay DOM-free
+ *  and structurally unchanged; ChartTile passes the live resolved tokens. */
 export function buildChartOption(
   response: AiQueryResponse,
   kind: string,
   aspect = 1,
+  tk: ThemeTokens = DEFAULT_THEME_TOKENS,
 ): Record<string, unknown> | null {
   if (!isSupportedChartKind(kind)) return null;
   const p = projectFromAiQueryResponse(response);
@@ -125,6 +132,24 @@ export function buildChartOption(
   const rows = p.rowCategories;
   const cols = p.columnCategories;
   const matrix = p.matrix;
+
+  // Theme-aware shared config — mirrors ChartView.buildOption so dashboard
+  // tiles and the workspace chart colour identically. `common` themes the
+  // canvas (transparent so the tile bg shows through), the categorical
+  // palette, and default text; the axis/legend/tooltip helpers carry the
+  // fg/border tokens into each branch.
+  const common = {
+    backgroundColor: "transparent",
+    color: tk.chartColors,
+    textStyle: { color: tk.fg },
+  };
+  const axisLabel = { color: tk.fgMuted };
+  const axisLine = { lineStyle: { color: tk.border } };
+  const axisTick = { lineStyle: { color: tk.border } };
+  const splitLine = { lineStyle: { color: tk.border, opacity: 0.5 } };
+  const nameTextStyle = { color: tk.fg };
+  const legendStyle = { textStyle: { color: tk.fg } };
+  const tooltipStyle = { backgroundColor: tk.bg, borderColor: tk.border, textStyle: { color: tk.fg } };
 
   // Pie / donut / treemap / sunburst encode a SINGLE measure. With M measures
   // we fan out into M small-multiple charts — one per measure — laid out in a
@@ -137,7 +162,7 @@ export function buildChartOption(
     left: cell.centerXPct + "%",
     top: cell.topPct + "%",
     textAlign: "center",
-    textStyle: { fontSize: 12 },
+    textStyle: { color: tk.fg, fontSize: 12 },
   }));
   // Category identification: a shared category legend collides with the
   // per-measure titles and bloats off-screen once there are many categories.
@@ -150,7 +175,8 @@ export function buildChartOption(
 
   if (t === "pie" || t === "donut") {
     return {
-      tooltip: { trigger: "item" },
+      ...common,
+      tooltip: { trigger: "item", ...tooltipStyle },
       title: titles,
       series: cells.map((cell, m) => {
         const outer = cellRadiusPct(cell, aspect);
@@ -163,6 +189,7 @@ export function buildChartOption(
             show: showSliceLabels,
             position: sliceLabelInside ? "inside" : "outside",
             formatter: "{b}",
+            color: sliceLabelInside ? "#fff" : tk.fg,
           },
           labelLine: { show: showSliceLabels && !sliceLabelInside },
           data: rows.map((name, i) => ({ name, value: matrix[i][m] ?? 0 })),
@@ -173,7 +200,8 @@ export function buildChartOption(
 
   if (t === "treemap") {
     return {
-      tooltip: {},
+      ...common,
+      tooltip: tooltipStyle,
       title: titles,
       series: cells.map((cell, m) => ({
         type: "treemap",
@@ -182,6 +210,7 @@ export function buildChartOption(
         top: cell.topPct + cell.heightPct * 0.18 + "%",
         width: cell.widthPct + "%",
         height: cell.heightPct * 0.82 + "%",
+        label: { color: "#fff" },
         breadcrumb: { show: false },
         data: rows.map((name, i) => ({ name, value: matrix[i][m] ?? 0 })).filter((d) => d.value > 0),
       })),
@@ -190,14 +219,15 @@ export function buildChartOption(
 
   if (t === "sunburst") {
     return {
-      tooltip: {},
+      ...common,
+      tooltip: tooltipStyle,
       title: titles,
       series: cells.map((cell, m) => ({
         type: "sunburst",
         name: cols[m],
         center: [cell.centerXPct + "%", cell.centerYPct + "%"],
         radius: [0, cellRadiusPct(cell, aspect) + "%"],
-        label: { show: showSliceLabels },
+        label: { show: showSliceLabels, color: "#fff" },
         data: rows.map((name, i) => ({ name, value: matrix[i][m] ?? 0 })).filter((d) => d.value > 0),
       })),
     };
@@ -214,11 +244,26 @@ export function buildChartOption(
     const min = values.length ? Math.min(...values) : 0;
     const max = values.length ? Math.max(...values) : 1;
     return {
-      tooltip: {},
+      ...common,
+      tooltip: tooltipStyle,
       grid: { left: 120, top: 24, right: 16, bottom: 64 },
-      xAxis: { type: "category", data: cols, axisLabel: categoryAxisLabel() },
-      yAxis: { type: "category", data: rows, inverse: true },
-      visualMap: { min, max, calculable: true, orient: "horizontal", left: "center", bottom: 8 },
+      xAxis: {
+        type: "category",
+        data: cols,
+        axisLabel: { ...categoryAxisLabel(), color: tk.fgMuted },
+        axisLine,
+        axisTick,
+      },
+      yAxis: { type: "category", data: rows, inverse: true, axisLabel, axisLine, axisTick },
+      visualMap: {
+        min,
+        max,
+        calculable: true,
+        orient: "horizontal",
+        left: "center",
+        bottom: 8,
+        textStyle: { color: tk.fgMuted },
+      },
       series: [{ type: "heatmap", data, label: { show: false } }],
     };
   }
@@ -226,9 +271,16 @@ export function buildChartOption(
   if (t === "radar") {
     const max = Math.max(0, ...matrix.flatMap((r) => r.map((v) => Math.abs(v ?? 0))));
     return {
-      tooltip: {},
-      legend: { type: "scroll", bottom: 0 },
-      radar: { indicator: cols.map((c) => ({ name: c, max: max || 1 })) },
+      ...common,
+      tooltip: tooltipStyle,
+      legend: { type: "scroll", bottom: 0, ...legendStyle },
+      radar: {
+        indicator: cols.map((c) => ({ name: c, max: max || 1 })),
+        axisName: { color: tk.fgMuted },
+        axisLine: { lineStyle: { color: tk.border } },
+        splitLine: { lineStyle: { color: tk.border, opacity: 0.5 } },
+        splitArea: { areaStyle: { color: [tk.bg, tk.bgMuted], opacity: 0.3 } },
+      },
       series: [
         {
           type: "radar",
@@ -241,10 +293,19 @@ export function buildChartOption(
   if (t === "scatter" || t === "bubble") {
     const max = Math.max(1, ...matrix.flatMap((r) => r.map((v) => Math.abs(v ?? 0))));
     return {
-      tooltip: {},
-      legend: { type: "scroll", bottom: 0 },
-      xAxis: { type: "category", data: cols, axisLabel: categoryAxisLabel() },
-      yAxis: { type: "value" },
+      ...common,
+      tooltip: tooltipStyle,
+      legend: { type: "scroll", bottom: 0, ...legendStyle },
+      xAxis: {
+        type: "category",
+        data: cols,
+        axisLabel: { ...categoryAxisLabel(), color: tk.fgMuted },
+        axisLine,
+        axisTick,
+        splitLine,
+        nameTextStyle,
+      },
+      yAxis: { type: "value", axisLabel, axisLine, axisTick, splitLine, nameTextStyle },
       series: rows.map((name, i) => ({
         type: "scatter",
         name,
@@ -279,11 +340,20 @@ export function buildChartOption(
       running += v;
     }
     return {
-      tooltip: { trigger: "axis" },
-      legend: { type: "scroll", bottom: 0 },
+      ...common,
+      tooltip: { trigger: "axis", ...tooltipStyle },
+      legend: { type: "scroll", bottom: 0, ...legendStyle },
       grid: { top: 24, left: 48, right: 16, bottom: 36 },
-      xAxis: { type: "category", data: rows, axisLabel: categoryAxisLabel() },
-      yAxis: { type: "value" },
+      xAxis: {
+        type: "category",
+        data: rows,
+        axisLabel: { ...categoryAxisLabel(), color: tk.fgMuted },
+        axisLine,
+        axisTick,
+        splitLine,
+        nameTextStyle,
+      },
+      yAxis: { type: "value", axisLabel, axisLine, axisTick, splitLine, nameTextStyle },
       series: [
         {
           type: "bar",
@@ -317,11 +387,20 @@ export function buildChartOption(
   const kindBase: "bar" | "line" = lower.includes("bar") ? "bar" : "line";
   const areaStyle = t === "area" || t === "stackedArea" ? {} : undefined;
   return {
-    tooltip: { trigger: "axis" },
-    legend: { type: "scroll", bottom: 0 },
+    ...common,
+    tooltip: { trigger: "axis", ...tooltipStyle },
+    legend: { type: "scroll", bottom: 0, ...legendStyle },
     grid: { top: 24, left: 48, right: 16, bottom: 36 },
-    xAxis: { type: "category", data: rows, axisLabel: categoryAxisLabel(rows.length > 8 ? 30 : 0) },
-    yAxis: { type: "value" },
+    xAxis: {
+      type: "category",
+      data: rows,
+      axisLabel: { ...categoryAxisLabel(rows.length > 8 ? 30 : 0), color: tk.fgMuted },
+      axisLine,
+      axisTick,
+      splitLine,
+      nameTextStyle,
+    },
+    yAxis: { type: "value", axisLabel, axisLine, axisTick, splitLine, nameTextStyle },
     series: cols.map((name, c) => ({
       name,
       type: kindBase,

--- a/saiku-ui/src/lib/views/ChartView.svelte
+++ b/saiku-ui/src/lib/views/ChartView.svelte
@@ -14,6 +14,7 @@
     smallMultipleRowCount,
   } from "$lib/dashboard/smallMultiples";
   import { theme } from "$lib/stores/theme.svelte";
+  import { type ThemeTokens, resolveThemeTokens } from "$lib/views/chartTheme";
 
   interface Props {
     result: QueryResult;
@@ -33,42 +34,6 @@
     const measureCount = parseCellset(result).columnCategories.length;
     return isSingleMeasureKind(type) && measureCount > 1 ? smallMultipleRowCount(measureCount) : 1;
   });
-
-  interface ThemeTokens {
-    fg: string;
-    fgMuted: string;
-    bg: string;
-    bgMuted: string;
-    border: string;
-    accent: string;
-    /** Categorical series palette read from --chart-1..8 tokens.
-     *  Falls back to Indigo-anchored defaults harmonised with --accent
-     *  if the tokens are absent for any reason. */
-    chartColors: string[];
-  }
-
-  const CHART_FALLBACK_COLORS = [
-    "#4f46e5", "#0ea5e9", "#10b981", "#f59e0b",
-    "#ef4444", "#a855f7", "#ec4899", "#14b8a6",
-  ];
-
-  function resolveThemeTokens(): ThemeTokens {
-    const cs = getComputedStyle(document.documentElement);
-    const get = (name: string, fallback: string) =>
-      cs.getPropertyValue(name).trim() || fallback;
-    const chartColors = CHART_FALLBACK_COLORS.map((fallback, i) =>
-      get(`--chart-${i + 1}`, fallback),
-    );
-    return {
-      fg: get("--fg", "#0f172a"),
-      fgMuted: get("--fg-muted", "#475569"),
-      bg: get("--bg", "#ffffff"),
-      bgMuted: get("--bg-muted", "#f6f7f9"),
-      border: get("--border", "#e2e8f0"),
-      accent: get("--accent", "#4f46e5"),
-      chartColors,
-    };
-  }
 
   function legendConfig(o: ChartOptions, tk: ThemeTokens) {
     if (!o.showLegend) return { show: false };

--- a/saiku-ui/src/lib/views/chartTheme.ts
+++ b/saiku-ui/src/lib/views/chartTheme.ts
@@ -1,0 +1,64 @@
+/*
+ * Shared ECharts theme tokens.
+ *
+ * The workspace chart (ChartView.svelte) and the dashboard chart tiles
+ * (chartOptions.ts / ChartTile.svelte) both colour their charts from the
+ * same CSS custom properties so a theme flip (light/dark/system) repaints
+ * both identically. This module is the single source of those tokens —
+ * extracted from ChartView so the dashboard builder stays in sync rather
+ * than re-deriving its own palette.
+ *
+ * resolveThemeTokens() reads the live computed style off :root, so it must
+ * run client-side. DEFAULT_THEME_TOKENS is the pure (DOM-free) light
+ * fallback used both as a per-token backstop and by callers (tests, the
+ * pure builder) that have no document to read from.
+ */
+
+export interface ThemeTokens {
+  fg: string;
+  fgMuted: string;
+  bg: string;
+  bgMuted: string;
+  border: string;
+  accent: string;
+  /** Categorical series palette read from --chart-1..8 tokens.
+   *  Falls back to Indigo-anchored defaults harmonised with --accent
+   *  if the tokens are absent for any reason. */
+  chartColors: string[];
+}
+
+export const CHART_FALLBACK_COLORS = [
+  "#4f46e5", "#0ea5e9", "#10b981", "#f59e0b",
+  "#ef4444", "#a855f7", "#ec4899", "#14b8a6",
+];
+
+/** Light-theme defaults — mirror the :root token values in app.css. Used as
+ *  the per-token fallback and whenever there's no DOM to read (SSR/tests). */
+export const DEFAULT_THEME_TOKENS: ThemeTokens = {
+  fg: "#0f172a",
+  fgMuted: "#475569",
+  bg: "#ffffff",
+  bgMuted: "#f6f7f9",
+  border: "#e2e8f0",
+  accent: "#4f46e5",
+  chartColors: CHART_FALLBACK_COLORS,
+};
+
+/** Resolve the active theme tokens from :root's computed style. Falls back
+ *  to DEFAULT_THEME_TOKENS per-token (and wholesale when there's no document,
+ *  e.g. during SSR), so callers always get a complete token set. */
+export function resolveThemeTokens(): ThemeTokens {
+  if (typeof document === "undefined") return DEFAULT_THEME_TOKENS;
+  const cs = getComputedStyle(document.documentElement);
+  const get = (name: string, fallback: string) => cs.getPropertyValue(name).trim() || fallback;
+  const chartColors = CHART_FALLBACK_COLORS.map((fallback, i) => get(`--chart-${i + 1}`, fallback));
+  return {
+    fg: get("--fg", DEFAULT_THEME_TOKENS.fg),
+    fgMuted: get("--fg-muted", DEFAULT_THEME_TOKENS.fgMuted),
+    bg: get("--bg", DEFAULT_THEME_TOKENS.bg),
+    bgMuted: get("--bg-muted", DEFAULT_THEME_TOKENS.bgMuted),
+    border: get("--border", DEFAULT_THEME_TOKENS.border),
+    accent: get("--accent", DEFAULT_THEME_TOKENS.accent),
+    chartColors,
+  };
+}

--- a/saiku-ui/src/lib/views/dashboard/tiles/ChartTile.svelte
+++ b/saiku-ui/src/lib/views/dashboard/tiles/ChartTile.svelte
@@ -33,6 +33,8 @@
   } from "$lib/dashboard/filterSuggestions";
   import { buildChartOption, isSupportedChartKind } from "$lib/dashboard/chartOptions";
   import { isSingleMeasureKind, smallMultipleRowCount } from "$lib/dashboard/smallMultiples";
+  import { theme } from "$lib/stores/theme.svelte";
+  import { resolveThemeTokens } from "$lib/views/chartTheme";
   import type { CubeRef } from "$lib/api/dashboards";
   // Issue #930 — right-click a data point to drill into its raw fact rows.
   import TileDrillthrough from "./TileDrillthrough.svelte";
@@ -260,6 +262,10 @@
     // current aspect ratio (#1053).
     void resizeTick;
     void smallMultipleRows;
+    // Re-theme when the effective theme flips (light/dark/system) so chart
+    // text/axes/palette repaint — resolveThemeTokens() reads the now-current
+    // :root tokens (#1050).
+    void theme.effective;
     if (!chart) return;
     unsupported = !isSupportedChartKind(kind);
     if (!r || r.status !== "SUCCESS") {
@@ -271,7 +277,7 @@
       return;
     }
     const aspect = host && host.clientHeight > 0 ? host.clientWidth / host.clientHeight : 1;
-    const option = buildChartOption(r, kind, aspect);
+    const option = buildChartOption(r, kind, aspect, resolveThemeTokens());
     if (option) {
       // notMerge=true so axis category changes don't leave stale ticks.
       chart.setOption(option, true);


### PR DESCRIPTION
## Summary
Follow-up to #1050 (theme selector). Dashboard **chart tiles** render through ECharts (canvas), which ignores the global `data-theme` CSS the theme selector toggles — so tile text used ECharts' default dark-grey (invisible on a dark dashboard) and never repainted on a theme flip. This brings dashboard chart tiles to parity with the workspace chart's existing theming. Closes #1056.

## The change
- **New `saiku-ui/src/lib/views/chartTheme.ts`** — the theme-token resolver extracted out of `ChartView.svelte` (`ThemeTokens`, `CHART_FALLBACK_COLORS`, `DEFAULT_THEME_TOKENS`, `resolveThemeTokens()`), so the workspace chart and the dashboard builder colour from one source.
- **`chartOptions.ts`** — `buildChartOption` gains an optional `tk` param (defaults to the light fallback so the pure/test callers stay DOM-free and structurally unchanged) and threads `fg`/`fgMuted`/`border`/`bg` + the categorical palette into **every** branch: axes, legend, tooltip, titles, and pie/treemap/sunburst slice labels.
- **`ChartTile.svelte`** — resolves live tokens, passes them to `buildChartOption`, and reads `theme.effective` in the render effect so tiles repaint on a light/dark/system flip.
- **`ChartView.svelte`** — refactored to import the shared module (no behaviour change; removes the now-duplicated local copies).

## Verified
- `npm run check` → 0 errors / 0 warnings
- `npm test` → **490/490** (+3 new tests in `chartOptions.test.ts` covering token threading, pie slice/title colours, and the light-fallback default)

## Test plan
1. Open a dashboard with a chart tile; flip theme (light → dark → system) via the toolbar control.
2. Axis labels, legend, titles, and pie/sunburst slice labels stay legible in both themes and **repaint immediately** on flip (no reload).
3. Workspace chart (`ChartView`) unchanged.

## Notes
- ⚠️ **Coordination:** this touches chart-tile internals (`chartOptions.ts`/`ChartTile.svelte`/`ChartView.svelte`) that overlap @AGENT-OG's in-flight #933 / #920. Built + greened on a direct user instruction this session; opening the PR per the user's call. **Merge ordering is OG's** (owns merges) — happy to rebase onto OG's chart PRs once they land if there's conflict.
- #1050 itself is already closed; this is filed under the fresh follow-up #1056.

🤖 Generated with [Claude Code](https://claude.com/claude-code)