### PR TITLE
feat(dashboards): per-tile loading / error / empty states (closes #933)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,11 @@ saiku-core/saiku-service/repository.xml
 saiku-ui/target/
 osgitests/
 
+# Launcher runtime home — materialised next to the fat-JAR on first `serve`
+# (data, repository, sessions, logs, plugins, FoodMart H2 seed). Pure runtime
+# state; never commit it. Created wherever --home points (repo root in local dev).
+saiku-home/
+
 # Created by https://www.gitignore.io/api/vim,git,node,java,linux,macos,maven,windows,webstorm,jetbrains,sublimetext,jetbrains+all,visualstudiocode,eclipse,netbeans
 
 ### Git ###

--- a/saiku-ui/src/lib/i18n/de.json
+++ b/saiku-ui/src/lib/i18n/de.json
@@ -123,5 +123,10 @@
   "modal.addFolder.title": "Neuer Ordner",
   "modal.warning.title": "Warnung",
   "modal.session.title": "Sitzung beendet",
-  "modal.session.reload": "Neu laden"
+  "modal.session.reload": "Neu laden",
+  "tile.error": "Beim Laden dieser Kachel ist ein Fehler aufgetreten.",
+  "tile.retry": "Erneut versuchen",
+  "tile.empty": "Keine Daten.",
+  "tile.empty.filtered": "Keine Daten entsprechen den aktuellen Filtern.",
+  "tile.resetFilters": "Filter zurücksetzen"
 }

--- a/saiku-ui/src/lib/i18n/en.json
+++ b/saiku-ui/src/lib/i18n/en.json
@@ -493,5 +493,10 @@
   "a11y.viewOptions": "View options",
   "a11y.axisOptions": "Axis options",
   "a11y.editChartOptions": "Edit chart options",
-  "a11y.cellsetGrid": "Query result grid"
+  "a11y.cellsetGrid": "Query result grid",
+  "tile.error": "Something went wrong loading this tile.",
+  "tile.retry": "Retry",
+  "tile.empty": "No data.",
+  "tile.empty.filtered": "No data matches the current filters.",
+  "tile.resetFilters": "Reset filters"
 }

--- a/saiku-ui/src/lib/i18n/es.json
+++ b/saiku-ui/src/lib/i18n/es.json
@@ -123,5 +123,10 @@
   "modal.addFolder.title": "Nueva carpeta",
   "modal.warning.title": "Advertencia",
   "modal.session.title": "Sesión terminada",
-  "modal.session.reload": "Recargar"
+  "modal.session.reload": "Recargar",
+  "tile.error": "Se produjo un error al cargar este panel.",
+  "tile.retry": "Reintentar",
+  "tile.empty": "Sin datos.",
+  "tile.empty.filtered": "Ningún dato coincide con los filtros actuales.",
+  "tile.resetFilters": "Restablecer filtros"
 }

--- a/saiku-ui/src/lib/i18n/fr.json
+++ b/saiku-ui/src/lib/i18n/fr.json
@@ -123,5 +123,10 @@
   "modal.addFolder.title": "Nouveau dossier",
   "modal.warning.title": "Avertissement",
   "modal.session.title": "Session terminée",
-  "modal.session.reload": "Recharger"
+  "modal.session.reload": "Recharger",
+  "tile.error": "Une erreur s'est produite lors du chargement de cette tuile.",
+  "tile.retry": "Réessayer",
+  "tile.empty": "Aucune donnée.",
+  "tile.empty.filtered": "Aucune donnée ne correspond aux filtres actuels.",
+  "tile.resetFilters": "Réinitialiser les filtres"
 }

--- a/saiku-ui/src/lib/views/dashboard/tiles/ChartTile.svelte
+++ b/saiku-ui/src/lib/views/dashboard/tiles/ChartTile.svelte
@@ -37,6 +37,11 @@
   // Issue #930 — right-click a data point to drill into its raw fact rows.
   import TileDrillthrough from "./TileDrillthrough.svelte";
   import { drillthroughPosition } from "$lib/dashboard/drillthroughCoord";
+  // Issue #933 — shared loading / error / empty states.
+  import TileLoading from "./TileLoading.svelte";
+  import TileError from "./TileError.svelte";
+  import TileEmpty from "./TileEmpty.svelte";
+  import { dashboardStore } from "$lib/stores/dashboard.svelte";
 
   interface Props {
     tile: DashboardTile;
@@ -64,6 +69,26 @@
   let response = $state<AiQueryResponse | null>(null);
   let schema = $state<SchemaLike | null>(null);
   let unsupported = $state(false);
+
+  // Issue #933 — retry re-runs the deduped fetch effect by clearing its
+  // last-query cache and bumping a tick the effect reads. Empty = a
+  // successful query with zero rows; hasEffectiveFilters gates the
+  // empty-state "Reset filters" affordance.
+  let retryTick = $state(0);
+  let isEmpty = $derived(
+    !!response && response.status === "SUCCESS" && (response.data?.length ?? 0) === 0,
+  );
+  let hasEffectiveFilters = $derived(
+    activeFilters.all.some((f) => (f.filter.members?.length ?? 0) > 0),
+  );
+  function retry(): void {
+    lastQueryJson = "";
+    retryTick++;
+  }
+  function resetFilters(): void {
+    activeFilters.resetTransient();
+    dashboardStore.resetPanelFiltersToSaved();
+  }
 
   // Issue #1053: single-measure kinds (pie/donut/treemap/sunburst) with >1
   // measure render as small multiples — 2 per row (see gridCells). The canvas
@@ -162,6 +187,8 @@
     const active = activeFilters.all;
     const s = schema;
     void s;
+    // #933 — retry() bumps this to force a refetch with unchanged inputs.
+    void retryTick;
     if (!tileQuery) return;
 
     if (tileQuery.kind === "reference") {
@@ -317,18 +344,20 @@
   <div class="placeholder">Tile has no query binding — open ⚙ to set one.</div>
 {:else}
   <div class="chart-tile">
+    <div class="canvas" bind:this={host} style="height: {smallMultipleRows * 100}%"></div>
     {#if loading && !response}
-      <div class="overlay">Loading…</div>
-    {/if}
-    {#if error}
-      <div class="overlay error">{error}</div>
-    {/if}
-    {#if unsupported}
+      <div class="overlay solid"><TileLoading variant="chart" /></div>
+    {:else if error}
+      <div class="overlay solid"><TileError message={error} onRetry={retry} /></div>
+    {:else if unsupported}
       <div class="overlay">
         Chart type <code>{tile.chartType}</code> not yet supported in dashboards.
       </div>
+    {:else if isEmpty}
+      <div class="overlay solid">
+        <TileEmpty filtered={hasEffectiveFilters} onReset={resetFilters} />
+      </div>
     {/if}
-    <div class="canvas" bind:this={host} style="height: {smallMultipleRows * 100}%"></div>
   </div>
 {/if}
 
@@ -362,9 +391,12 @@
     text-align: center;
     padding: 0.5rem;
   }
-  .overlay.error {
-    color: var(--danger);
-    background: color-mix(in srgb, var(--danger) 18%, var(--bg));
+  /* Opaque, interactive overlay for the loading skeleton / error / empty
+     states (which carry Retry / Reset buttons). #933 */
+  .overlay.solid {
+    background: var(--bg);
+    pointer-events: auto;
+    padding: 0;
   }
   .placeholder {
     padding: 1rem;

--- a/saiku-ui/src/lib/views/dashboard/tiles/ChartTile.svelte
+++ b/saiku-ui/src/lib/views/dashboard/tiles/ChartTile.svelte
@@ -89,6 +89,11 @@
     activeFilters.resetTransient();
     dashboardStore.resetPanelFiltersToSaved();
   }
+  // Radial charts get a ring-shaped loading skeleton; everything else bars.
+  const RADIAL_KINDS = new Set(["pie", "donut", "sunburst"]);
+  let loadingVariant: "chart" | "radial" = $derived(
+    RADIAL_KINDS.has(tile.chartType ?? "") ? "radial" : "chart",
+  );
 
   // Issue #1053: single-measure kinds (pie/donut/treemap/sunburst) with >1
   // measure render as small multiples — 2 per row (see gridCells). The canvas
@@ -346,7 +351,7 @@
   <div class="chart-tile">
     <div class="canvas" bind:this={host} style="height: {smallMultipleRows * 100}%"></div>
     {#if loading && !response}
-      <div class="overlay solid"><TileLoading variant="chart" /></div>
+      <div class="overlay solid"><TileLoading variant={loadingVariant} /></div>
     {:else if error}
       <div class="overlay solid"><TileError message={error} onRetry={retry} /></div>
     {:else if unsupported}

--- a/saiku-ui/src/lib/views/dashboard/tiles/KpiTile.svelte
+++ b/saiku-ui/src/lib/views/dashboard/tiles/KpiTile.svelte
@@ -38,6 +38,11 @@
     lastAndPriorValues,
     type KpiDelta as KpiDeltaT,
   } from "$lib/dashboard/kpi";
+  // Issue #933 — shared loading / error / empty states.
+  import TileLoading from "./TileLoading.svelte";
+  import TileError from "./TileError.svelte";
+  import TileEmpty from "./TileEmpty.svelte";
+  import { dashboardStore } from "$lib/stores/dashboard.svelte";
 
   interface Props {
     tile: DashboardTile;
@@ -48,6 +53,24 @@
   let loading = $state(false);
   let error = $state<string | null>(null);
   let response = $state<AiQueryResponse | null>(null);
+
+  // Issue #933 — retry re-fires the deduped fetch effect; empty = a
+  // successful query with no rows; hasEffectiveFilters gates the reset.
+  let retryTick = $state(0);
+  let isEmpty = $derived(
+    !!response && response.status === "SUCCESS" && (response.data?.length ?? 0) === 0,
+  );
+  let hasEffectiveFilters = $derived(
+    activeFilters.all.some((f) => (f.filter.members?.length ?? 0) > 0),
+  );
+  function retry(): void {
+    lastQueryJson = "";
+    retryTick++;
+  }
+  function resetFilters(): void {
+    activeFilters.resetTransient();
+    dashboardStore.resetPanelFiltersToSaved();
+  }
 
   let sparkHost = $state<HTMLDivElement | null>(null);
   let spark: echarts.ECharts | null = null;
@@ -126,6 +149,8 @@
     const series = wantsSeries;
     const tl = kpi.timeLevel;
     const active = activeFilters.all;
+    // #933 — retry() bumps this to force a refetch with unchanged inputs.
+    void retryTick;
     if (!measure || !c) {
       response = null;
       return;
@@ -346,9 +371,11 @@
 {:else}
   <div class="kpi-tile" data-tone={delta?.tone ?? "flat"}>
     {#if loading && response == null}
-      <div class="loading">Loading…</div>
+      <TileLoading variant="kpi" />
     {:else if error}
-      <div class="error">{error}</div>
+      <TileError message={error} onRetry={retry} />
+    {:else if isEmpty}
+      <TileEmpty filtered={hasEffectiveFilters} onReset={resetFilters} />
     {:else}
       <div class="value" style={mainColourToken ? `color: var(${mainColourToken});` : ""}>
         {formattedMain}
@@ -444,9 +471,7 @@
     height: 36px;
     flex-shrink: 0;
   }
-  .placeholder,
-  .loading,
-  .error {
+  .placeholder {
     padding: 0.75rem 1rem;
     color: var(--fg-muted);
     font-size: 0.8125rem;
@@ -456,10 +481,5 @@
     display: inline-block;
     vertical-align: -2px;
     color: var(--fg-subtle);
-  }
-  .error {
-    color: var(--danger);
-    background: color-mix(in srgb, var(--danger) 12%, transparent);
-    border-radius: 4px;
   }
 </style>

--- a/saiku-ui/src/lib/views/dashboard/tiles/TableTile.svelte
+++ b/saiku-ui/src/lib/views/dashboard/tiles/TableTile.svelte
@@ -48,6 +48,11 @@
     cellFormatToStyle,
     type CellFormat,
   } from "$lib/dashboard/conditionalFormat";
+  // Issue #933 — shared loading / error / empty states.
+  import TileLoading from "./TileLoading.svelte";
+  import TileError from "./TileError.svelte";
+  import TileEmpty from "./TileEmpty.svelte";
+  import { dashboardStore } from "$lib/stores/dashboard.svelte";
 
   interface Props {
     tile: DashboardTile;
@@ -63,6 +68,21 @@
   let error = $state<string | null>(null);
   let response = $state<AiQueryResponse | null>(null);
   let schema = $state<SchemaLike | null>(null);
+
+  // Issue #933 — retry re-fires the deduped fetch effect; hasEffectiveFilters
+  // gates the empty-state "Reset filters" affordance.
+  let retryTick = $state(0);
+  let hasEffectiveFilters = $derived(
+    activeFilters.all.some((f) => (f.filter.members?.length ?? 0) > 0),
+  );
+  function retry(): void {
+    lastQueryJson = "";
+    retryTick++;
+  }
+  function resetFilters(): void {
+    activeFilters.resetTransient();
+    dashboardStore.resetPanelFiltersToSaved();
+  }
 
   // Resolved cube — usually tile.cube directly, but reference tiles
   // authored before saiku#878 left tile.cube undefined. Lazy-infer from
@@ -117,6 +137,8 @@
     const active = activeFilters.all;
     const s = schema;
     void s;
+    // #933 — retry() bumps this to force a refetch with unchanged inputs.
+    void retryTick;
     if (!tileQuery) return;
 
     if (tileQuery.kind === "reference") {
@@ -353,15 +375,13 @@
 {:else}
   <div class="table-tile" role="region" aria-label="Table tile">
     {#if loading && !response}
-      <div class="state">Loading…</div>
-    {/if}
-    {#if error}
-      <div class="state error">{error}</div>
-    {/if}
-    {#if response && response.status === "SUCCESS"}
+      <TileLoading variant="table" />
+    {:else if error}
+      <TileError message={error} onRetry={retry} />
+    {:else if response && response.status === "SUCCESS"}
       {@const rows = response.data ?? []}
       {#if rows.length === 0}
-        <div class="state empty">No rows.</div>
+        <TileEmpty filtered={hasEffectiveFilters} onReset={resetFilters} />
       {:else}
         <table>
           <thead>
@@ -428,19 +448,6 @@
     padding: 1rem;
     color: var(--fg-muted);
     font-size: 0.8125rem;
-  }
-  .state {
-    padding: 0.5rem;
-    color: var(--fg-muted);
-    font-size: 0.875rem;
-  }
-  .state.error {
-    background: color-mix(in srgb, var(--danger) 10%, transparent);
-    color: var(--danger);
-    border-radius: 4px;
-  }
-  .state.empty {
-    text-align: center;
   }
   table {
     width: 100%;

--- a/saiku-ui/src/lib/views/dashboard/tiles/TileEmpty.svelte
+++ b/saiku-ui/src/lib/views/dashboard/tiles/TileEmpty.svelte
@@ -1,0 +1,78 @@
+<script lang="ts">
+  /*
+   * Issue #933 — per-tile empty state.
+   *
+   * Shown when a tile's query succeeds but returns no rows. When the empty
+   * result is caused by active dashboard filters, we say so and offer a
+   * "Reset filters" button (clears click filters + restores panel defaults,
+   * matching the toolbar's reset). With no active filters it's a plain
+   * "no data" — nothing to reset.
+   */
+  import { Inbox, FilterX } from "lucide-svelte";
+  import { i18n } from "$lib/stores/i18n.svelte";
+
+  interface Props {
+    message?: string | null;
+    /** True when dashboard filters are narrowing this tile (enables reset). */
+    filtered?: boolean;
+    onReset?: () => void;
+  }
+  let { message = null, filtered = false, onReset }: Props = $props();
+</script>
+
+<div class="tile-empty">
+  <Inbox size={22} aria-hidden="true" />
+  <p class="msg">
+    {message ??
+      (filtered
+        ? i18n.t("tile.empty.filtered", "No data matches the current filters.")
+        : i18n.t("tile.empty", "No data."))}
+  </p>
+  {#if filtered && onReset}
+    <button type="button" class="reset" onclick={onReset}>
+      <FilterX size={14} aria-hidden="true" />
+      {i18n.t("tile.resetFilters", "Reset filters")}
+    </button>
+  {/if}
+</div>
+
+<style>
+  .tile-empty {
+    height: 100%;
+    width: 100%;
+    box-sizing: border-box;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 0.5rem;
+    padding: 0.75rem;
+    text-align: center;
+    color: var(--fg-muted);
+  }
+  .msg {
+    margin: 0;
+    font-size: 0.8125rem;
+    max-width: 100%;
+    overflow-wrap: anywhere;
+  }
+  .reset {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    padding: 0.25rem 0.6rem;
+    font-size: 0.8125rem;
+    color: var(--fg);
+    background: var(--bg-subtle);
+    border: 1px solid var(--border);
+    border-radius: 4px;
+    cursor: pointer;
+  }
+  .reset:hover {
+    background: var(--bg-muted);
+  }
+  .reset:focus-visible {
+    outline: 2px solid var(--accent);
+    outline-offset: 1px;
+  }
+</style>

--- a/saiku-ui/src/lib/views/dashboard/tiles/TileError.svelte
+++ b/saiku-ui/src/lib/views/dashboard/tiles/TileError.svelte
@@ -1,0 +1,72 @@
+<script lang="ts">
+  /*
+   * Issue #933 — per-tile error state.
+   *
+   * Replaces the old raw red error text with an icon + message + a Retry
+   * button that re-runs the owning tile's query. The tile passes the error
+   * message and an `onRetry` callback (which clears its fetch-dedupe cache
+   * and re-fires the query effect).
+   */
+  import { TriangleAlert, RotateCw } from "lucide-svelte";
+  import { i18n } from "$lib/stores/i18n.svelte";
+
+  interface Props {
+    message?: string | null;
+    onRetry?: () => void;
+  }
+  let { message = null, onRetry }: Props = $props();
+</script>
+
+<div class="tile-error" role="alert">
+  <TriangleAlert size={22} aria-hidden="true" />
+  <p class="msg">{message ?? i18n.t("tile.error", "Something went wrong loading this tile.")}</p>
+  {#if onRetry}
+    <button type="button" class="retry" onclick={onRetry}>
+      <RotateCw size={14} aria-hidden="true" />
+      {i18n.t("tile.retry", "Retry")}
+    </button>
+  {/if}
+</div>
+
+<style>
+  .tile-error {
+    height: 100%;
+    width: 100%;
+    box-sizing: border-box;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 0.5rem;
+    padding: 0.75rem;
+    text-align: center;
+    color: var(--danger);
+  }
+  .msg {
+    margin: 0;
+    font-size: 0.8125rem;
+    /* Long backend errors shouldn't blow out the tile. */
+    max-width: 100%;
+    overflow-wrap: anywhere;
+    color: var(--danger);
+  }
+  .retry {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    padding: 0.25rem 0.6rem;
+    font-size: 0.8125rem;
+    color: var(--fg);
+    background: var(--bg-subtle);
+    border: 1px solid var(--border);
+    border-radius: 4px;
+    cursor: pointer;
+  }
+  .retry:hover {
+    background: var(--bg-muted);
+  }
+  .retry:focus-visible {
+    outline: 2px solid var(--accent);
+    outline-offset: 1px;
+  }
+</style>

--- a/saiku-ui/src/lib/views/dashboard/tiles/TileLoading.svelte
+++ b/saiku-ui/src/lib/views/dashboard/tiles/TileLoading.svelte
@@ -8,8 +8,9 @@
    * the owning tile decides when to show it (first load, before any response).
    */
   interface Props {
-    /** Skeleton silhouette to draw. */
-    variant?: "chart" | "table" | "kpi";
+    /** Skeleton silhouette to draw. `radial` = a shimmer ring for
+     *  pie/donut/sunburst; `chart` = rising bars for everything else. */
+    variant?: "chart" | "radial" | "table" | "kpi";
   }
   let { variant = "chart" }: Props = $props();
 
@@ -34,6 +35,10 @@
     <div class="sk-kpi">
       <div class="sk sk-number"></div>
       <div class="sk sk-label"></div>
+    </div>
+  {:else if variant === "radial"}
+    <div class="sk-radial">
+      <div class="sk sk-ring"></div>
     </div>
   {:else}
     <div class="sk-chart">
@@ -95,6 +100,23 @@
   .sk-bar {
     flex: 1;
     min-width: 0;
+  }
+
+  /* Radial: a shimmer ring (pie / donut / sunburst). The mask punches a
+     hole in the centre so the disc reads as a ring. */
+  .sk-radial {
+    flex: 1;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+  .sk-ring {
+    height: 85%;
+    max-width: 85%;
+    aspect-ratio: 1;
+    border-radius: 50%;
+    -webkit-mask: radial-gradient(circle, transparent 38%, #000 39%);
+    mask: radial-gradient(circle, transparent 38%, #000 39%);
   }
 
   /* Table: header strip + body rows of equal cells. */

--- a/saiku-ui/src/lib/views/dashboard/tiles/TileLoading.svelte
+++ b/saiku-ui/src/lib/views/dashboard/tiles/TileLoading.svelte
@@ -1,0 +1,137 @@
+<script lang="ts">
+  /*
+   * Issue #933 — per-tile loading skeleton.
+   *
+   * A shimmering placeholder shaped to the tile type so the tile reads as
+   * "waiting on data" rather than "broken": bar shapes for charts, a header
+   * + grid for tables, a big-number outline for KPIs. Purely presentational;
+   * the owning tile decides when to show it (first load, before any response).
+   */
+  interface Props {
+    /** Skeleton silhouette to draw. */
+    variant?: "chart" | "table" | "kpi";
+  }
+  let { variant = "chart" }: Props = $props();
+
+  // Fixed, deterministic bar heights so the skeleton doesn't reflow between
+  // renders (Math.random is also unavailable in some of our tooling).
+  const BAR_HEIGHTS = [55, 80, 42, 95, 64, 78, 50];
+</script>
+
+<div class="tile-loading" role="status" aria-busy="true" aria-label="Loading">
+  {#if variant === "table"}
+    <div class="sk-table">
+      <div class="sk-row sk-row--head">
+        {#each [0, 1, 2, 3] as c (c)}<div class="sk skeleton-cell"></div>{/each}
+      </div>
+      {#each [0, 1, 2, 3, 4] as r (r)}
+        <div class="sk-row">
+          {#each [0, 1, 2, 3] as c (c)}<div class="sk skeleton-cell"></div>{/each}
+        </div>
+      {/each}
+    </div>
+  {:else if variant === "kpi"}
+    <div class="sk-kpi">
+      <div class="sk sk-number"></div>
+      <div class="sk sk-label"></div>
+    </div>
+  {:else}
+    <div class="sk-chart">
+      {#each BAR_HEIGHTS as h, i (i)}
+        <div class="sk sk-bar" style="height: {h}%"></div>
+      {/each}
+    </div>
+  {/if}
+</div>
+
+<style>
+  .tile-loading {
+    height: 100%;
+    width: 100%;
+    padding: 0.75rem;
+    box-sizing: border-box;
+    display: flex;
+  }
+
+  /* Shared shimmer fill. */
+  .sk {
+    background: var(--bg-subtle);
+    border-radius: 4px;
+    position: relative;
+    overflow: hidden;
+  }
+  .sk::after {
+    content: "";
+    position: absolute;
+    inset: 0;
+    background: linear-gradient(
+      90deg,
+      transparent 0%,
+      color-mix(in srgb, var(--fg) 8%, transparent) 50%,
+      transparent 100%
+    );
+    transform: translateX(-100%);
+    animation: tile-shimmer 1.3s ease-in-out infinite;
+  }
+  @keyframes tile-shimmer {
+    100% {
+      transform: translateX(100%);
+    }
+  }
+  @media (prefers-reduced-motion: reduce) {
+    .sk::after {
+      animation: none;
+    }
+  }
+
+  /* Chart: bars rising from a shared baseline. */
+  .sk-chart {
+    flex: 1;
+    display: flex;
+    align-items: flex-end;
+    justify-content: space-around;
+    gap: 0.5rem;
+  }
+  .sk-bar {
+    flex: 1;
+    min-width: 0;
+  }
+
+  /* Table: header strip + body rows of equal cells. */
+  .sk-table {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    gap: 0.4rem;
+  }
+  .sk-row {
+    display: flex;
+    gap: 0.5rem;
+  }
+  .skeleton-cell {
+    flex: 1;
+    height: 0.85rem;
+  }
+  .sk-row--head .skeleton-cell {
+    height: 1.05rem;
+    background: var(--bg-muted);
+  }
+
+  /* KPI: a big number block + a small caption block. */
+  .sk-kpi {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 0.6rem;
+  }
+  .sk-number {
+    width: 55%;
+    height: 2.5rem;
+  }
+  .sk-label {
+    width: 32%;
+    height: 0.75rem;
+  }
+</style>


### PR DESCRIPTION
## Summary
Distinct, polished per-tile **loading / error / empty** states across chart, table and KPI tiles (closes #933). Today every tile shows the same bare "Loading…" / raw error text / "No rows." — this makes it obvious when a tile is waiting on data vs broken vs filtered-to-empty.

## The change
Three shared components in `views/dashboard/tiles/`:
- **TileLoading** — shimmer skeleton shaped to the tile type: rising bars (chart), header + grid (table), big-number + caption (KPI). Respects `prefers-reduced-motion`.
- **TileError** — alert icon + message + **Retry** (re-runs the tile's query).
- **TileEmpty** — "No data matches the current filters." + **Reset filters** (clears click filters + restores panel defaults, same as the toolbar reset); plain "No data." when nothing is filtering.

Wired into `ChartTile`, `TableTile`, `KpiTile`:
- `retryTick` re-fires each tile's deduped fetch `$effect` with unchanged inputs (Retry).
- `isEmpty` = SUCCESS response with zero rows; `hasEffectiveFilters` gates the Reset affordance.
- Removed the old inline `.overlay.error` / `.state` / `.loading`/`.error` markup + CSS.
- New i18n keys (`tile.*`) in en/de/es/fr.

## Verified
- `npm run check` → 0 errors / 0 warnings
- `vitest` → 487/487

## Test plan
- Open a dashboard with chart/table/KPI tiles → first load shows the shaped skeleton.
- Kill the backend / force a bad query → error state with a working **Retry**.
- Apply a filter that excludes all data → empty state with **Reset filters** that restores data.

## Notes
- Presentational components (no pure logic) → no new unit tests, consistent with the repo's vitest-helpers-only convention.
- Touches all data tiles — AGENT 1's tile-touching work (and #1057) should rebase onto this once merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
