### PR TITLE
fix(repository): per-dashboard ACLs actually persist and enforce (closes #940)

### DIFF
--- a/saiku-core/saiku-service/src/main/java/org/saiku/repository/Acl2.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/repository/Acl2.java
@@ -65,7 +65,52 @@ class Acl2 {
     @NotNull
     private final Map<String, AclEntry> acl = new TreeMap<>();
 
-    public Acl2(File n) {}
+    @Nullable
+    private final File node;
+
+    public Acl2(File n) {
+        this.node = n;
+        loadAclHome();
+    }
+
+    /**
+     * The directory whose {@code acl.json} holds {@code f}'s entry: the folder
+     * itself for a directory, otherwise its parent. A node's ACL lives in the
+     * acl.json of its own folder (folders) or its parent folder (files) —
+     * keyed by the node's absolute path. This is what lets a single file
+     * (e.g. a {@code .saikudash} dashboard) carry its own ACL alongside its
+     * siblings instead of being limited to whole-folder granularity (#940).
+     */
+    @Nullable
+    private static File aclHome(@Nullable File f) {
+        if (f == null) {
+            return null;
+        }
+        return f.isDirectory() ? f : f.getParentFile();
+    }
+
+    /**
+     * Best-effort load of the node's acl-home {@code acl.json} into
+     * {@link #acl} so {@link #getEntry} sees persisted entries and
+     * {@link #serialize} merges rather than overwrites siblings. A missing
+     * file (fresh folder) just leaves the map empty.
+     */
+    private void loadAclHome() {
+        File home = aclHome(node);
+        if (home == null) {
+            return;
+        }
+        try {
+            ObjectMapper mapper = new ObjectMapper();
+            TypeReference<Map<String, AclEntry>> ref = new TypeReference<Map<String, AclEntry>>() {};
+            Map<String, AclEntry> data = mapper.readValue(new File(home, "acl.json"), ref);
+            if (data != null) {
+                acl.putAll(data);
+            }
+        } catch (Exception ignored) {
+            // No acl.json at this level yet — start from an empty map.
+        }
+    }
 
     public void setAdminRoles(List<String> adminRoles) {
         this.adminRoles = adminRoles;
@@ -124,7 +169,11 @@ class Acl2 {
 
     public void serialize(File n) {
         try {
-            File f = new File(n, "acl.json");
+            File home = aclHome(n);
+            if (home == null) {
+                home = n;
+            }
+            File f = new File(home, "acl.json");
             ObjectMapper mapper = new ObjectMapper();
             mapper.writeValue(f, acl);
         } catch (Exception e) {
@@ -183,7 +232,8 @@ class Acl2 {
             ObjectMapper mapper = new ObjectMapper();
             TypeReference<Map<String, AclEntry>> ref = new TypeReference<Map<String, AclEntry>>() {};
             try {
-                Map<String, AclEntry> aclData = mapper.readValue(new File(file, "acl.json"), ref);
+                File home = aclHome(file);
+                Map<String, AclEntry> aclData = mapper.readValue(new File(home, "acl.json"), ref);
                 AclEntry entry = aclData.get(file.getPath());
                 if (entry != null && StringUtils.isNotBlank(entry.getOwner())) {
                     return entry.getOwner();
@@ -210,7 +260,12 @@ class Acl2 {
 
             try {
                 TypeReference<Map<String, AclEntry>> ref = new TypeReference<Map<String, AclEntry>>() {};
-                aclData = mapper.readValue(new File(file, "acl.json"), ref);
+                // Read the node's acl-home: a folder's own acl.json, or — for a
+                // file — its parent's, where the file's per-resource entry lives
+                // keyed by absolute path. A null/absent entry then falls through
+                // to the parent-chain walk below (inheritance), unchanged (#940).
+                File home = aclHome(file);
+                aclData = mapper.readValue(new File(home, "acl.json"), ref);
                 entry = aclData.get(file.getPath());
             } catch (Exception e) {
                 LOG.debug("Exception: " + file.getPath(), e.getCause());

--- a/saiku-core/saiku-service/src/main/java/org/saiku/repository/FilesystemRepositoryManager.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/repository/FilesystemRepositoryManager.java
@@ -268,10 +268,17 @@ public class FilesystemRepositoryManager implements IRepositoryManager {
             // and the shared /datasources tree).
             int pos = path.lastIndexOf(sep);
             String filename = "." + sep + path.substring(pos + 1, path.length());
-            File n = getFolder(path.substring(0, pos));
-            Acl2 acl2 = new Acl2(n);
+            File parent = getFolder(path.substring(0, pos));
+            // saiku#895: gate the write on canWrite. #940: when OVERWRITING an
+            // existing file, check that file's own ACL (which inherits the
+            // parent folder when it has no per-file entry) so a per-dashboard
+            // edit/PRIVATE setting is honoured; for a NEW file, fall back to
+            // the parent folder (you need folder-write to create a child).
+            File target = getNode(path);
+            File aclNode = target.exists() ? target : parent;
+            Acl2 acl2 = new Acl2(aclNode);
             acl2.setAdminRoles(userService.getAdminRoles());
-            if (!acl2.canWrite(n, user, roles)) {
+            if (!acl2.canWrite(aclNode, user, roles)) {
                 throw new SaikuServiceException("You don't have permission to write to " + path);
             }
 
@@ -521,13 +528,18 @@ public class FilesystemRepositoryManager implements IRepositoryManager {
     private AclEntry getAclObj(String path) {
         File node = null;
         try {
-            node = (File) getFolderNode(path);
+            // getFolder → resolveWithinDatadir → the real File (the broken
+            // getFolderNode/getAllFoldersInCurrentDirectory stub returned null,
+            // so every ACL read silently produced a default entry). Key the
+            // lookup by the node's absolute path to match how entries are
+            // persisted by setACL/seedAcl and read by Acl2.getMethods (#940).
+            node = getFolder(path);
         } catch (RepositoryException e) {
             log.error("Could not get file", e);
         }
         Acl2 acl2 = new Acl2(node);
         acl2.setAdminRoles(userService.getAdminRoles());
-        AclEntry entry = acl2.getEntry(path);
+        AclEntry entry = node != null ? acl2.getEntry(node.getPath()) : null;
         if (entry == null) entry = new AclEntry();
         return entry;
     }
@@ -535,7 +547,7 @@ public class FilesystemRepositoryManager implements IRepositoryManager {
     public AclEntry getACL(String object, String username, List<String> roles) {
         File node = null;
         try {
-            node = (File) getFolderNode(object);
+            node = getFolder(object);
         } catch (RepositoryException e) {
             log.error("Could not get file/folder", e);
         }
@@ -562,7 +574,7 @@ public class FilesystemRepositoryManager implements IRepositoryManager {
 
         File node = null;
         try {
-            node = (File) getFolderNode(object);
+            node = getFolder(object);
         } catch (RepositoryException e) {
             log.error("Could not get file/folder " + object, e);
         }
@@ -572,7 +584,13 @@ public class FilesystemRepositoryManager implements IRepositoryManager {
 
         if (acl2.canGrant(node, username, roles)) {
             if (node != null) {
-                acl2.addEntry(object, ae);
+                // Key by absolute path (was the relative `object`, which never
+                // matched getMethods' file.getPath() lookup) and let serialize
+                // write to the node's acl-home — its parent folder's acl.json
+                // for a file — so a per-dashboard ACL actually persists and is
+                // enforced. The constructor pre-loaded sibling entries, so this
+                // merges instead of clobbering them (#940).
+                acl2.addEntry(node.getPath(), ae);
                 acl2.serialize(node);
             }
         }

--- a/saiku-core/saiku-service/src/test/java/org/saiku/repository/FilesystemRepositoryManagerFileAclTest.java
+++ b/saiku-core/saiku-service/src/test/java/org/saiku/repository/FilesystemRepositoryManagerFileAclTest.java
@@ -1,0 +1,199 @@
+package org.saiku.repository;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.io.File;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.saiku.service.user.UserService;
+
+/**
+ * Regression coverage for saiku#940 — per-resource (per-dashboard) ACLs.
+ *
+ * <p>Pre-fix the ACL get/set REST surface operated on {@code null} (it used
+ * {@code getFolderNode → getAllFoldersInCurrentDirectory}, an unimplemented
+ * stub returning {@code null}) and the ACL store was directory-granular:
+ * {@link Acl2#serialize} wrote {@code new File(node,"acl.json")} and
+ * {@link Acl2#getMethods} read it back the same way, so a regular file's ACL
+ * could never be stored, read, or enforced. Setting a per-dashboard ACL was a
+ * silent no-op (the REST call returned 200 but persisted nothing).
+ *
+ * <p>Post-fix a file's ACL lives in its parent folder's {@code acl.json}
+ * keyed by the file's absolute path; {@code getMethods} consults it (falling
+ * back to folder inheritance), and read/edit/delete enforcement honour it.
+ */
+public class FilesystemRepositoryManagerFileAclTest {
+
+    @Rule
+    public TemporaryFolder tmp = new TemporaryFolder();
+
+    private FilesystemRepositoryManager manager;
+    private File datadir;
+    private File adminHomeDir;
+
+    private static final List<String> ROLES_USER = Collections.singletonList("ROLE_USER");
+    private static final List<String> ROLES_ADMIN = Arrays.asList("ROLE_USER", "ROLE_ADMIN");
+
+    // A bare AclEntry JSON (NOT the {path: entry} map shape) — this is what
+    // the REST layer feeds setACL, deserialised via mapper.readValue(.., AclEntry).
+    private static final String SECURED_ROLE_USER_READ =
+            "{\"owner\":\"admin\",\"type\":\"SECURED\",\"roles\":{\"ROLE_USER\":[\"READ\"]},\"users\":null}";
+
+    @Before
+    public void setUp() throws Exception {
+        resetSingleton();
+
+        datadir = tmp.newFolder("repo");
+        File unknownEtc = new File(datadir, "unknown/etc");
+        if (!unknownEtc.mkdirs()) {
+            throw new IllegalStateException("Could not create " + unknownEtc);
+        }
+
+        // admin's home is PRIVATE (owner=admin) — a non-owner/non-admin would
+        // be denied everything inside it by folder inheritance. The per-file
+        // ACL tests below open up a single file within it.
+        adminHomeDir = new File(datadir, "unknown/homes/admin");
+        if (!adminHomeDir.mkdirs()) {
+            throw new IllegalStateException("Could not create " + adminHomeDir);
+        }
+        writeFolderAclJson(adminHomeDir, "PRIVATE", "admin");
+
+        manager = newManager(datadir.getAbsolutePath());
+        UserService us = new UserService();
+        us.setAdminRoles(Collections.singletonList("ROLE_ADMIN"));
+        injectUserService(manager, us);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        resetSingleton();
+    }
+
+    @Test
+    public void setACL_then_getACL_roundtrips_a_per_file_acl() throws Exception {
+        File f = new File(adminHomeDir, "shared.saikudash");
+        Files.write(f.toPath(), "DASH".getBytes(StandardCharsets.UTF_8));
+
+        manager.setACL("/homes/admin/shared.saikudash", SECURED_ROLE_USER_READ, "admin", ROLES_ADMIN);
+
+        AclEntry got = manager.getACL("/homes/admin/shared.saikudash", "admin", ROLES_ADMIN);
+        assertNotNull("getACL must read back the per-file ACL that setACL persisted", got);
+        assertEquals(AclType.SECURED, got.getType());
+        assertNotNull("roles must round-trip", got.getRoles());
+        assertTrue(
+                "ROLE_USER must have READ on the file",
+                got.getRoles()
+                        .getOrDefault("ROLE_USER", Collections.emptyList())
+                        .contains(AclMethod.READ));
+    }
+
+    @Test
+    public void per_file_acl_grants_read_where_the_PRIVATE_folder_would_deny() throws Exception {
+        File f = new File(adminHomeDir, "report.saikudash");
+        Files.write(f.toPath(), "REPORT_DATA".getBytes(StandardCharsets.UTF_8));
+
+        // bob is denied by the PRIVATE folder before any per-file ACL exists.
+        try {
+            manager.getFile("/homes/admin/report.saikudash", "bob", ROLES_USER);
+            fail("bob must be denied read while only the PRIVATE folder ACL applies");
+        } catch (Exception expectedDenied) {
+            // expected — folder inheritance denies a non-owner
+        }
+
+        manager.setACL("/homes/admin/report.saikudash", SECURED_ROLE_USER_READ, "admin", ROLES_ADMIN);
+
+        // …now the per-file SECURED ROLE_USER:READ entry lets bob read it.
+        String body = manager.getFile("/homes/admin/report.saikudash", "bob", ROLES_USER);
+        assertEquals("bob must read the file once the per-file ACL grants ROLE_USER READ", "REPORT_DATA", body);
+    }
+
+    @Test
+    public void per_file_read_only_acl_still_denies_write_and_delete() throws Exception {
+        File f = new File(adminHomeDir, "locked.saikudash");
+        Files.write(f.toPath(), "ORIGINAL".getBytes(StandardCharsets.UTF_8));
+        manager.setACL("/homes/admin/locked.saikudash", SECURED_ROLE_USER_READ, "admin", ROLES_ADMIN);
+
+        try {
+            manager.saveFile("HACK", "/homes/admin/locked.saikudash", "bob", "nt:saikufiles", ROLES_USER);
+            fail("bob has only READ on the file — write must be denied");
+        } catch (Exception expected) {
+            // expected
+        }
+        assertEquals(
+                "file must be untouched after a denied write",
+                "ORIGINAL",
+                new String(Files.readAllBytes(f.toPath()), StandardCharsets.UTF_8));
+
+        try {
+            manager.removeFile("/homes/admin/locked.saikudash", "bob", ROLES_USER);
+            fail("bob has only READ on the file — delete must be denied");
+        } catch (Exception expected) {
+            // expected
+        }
+        assertTrue("file must survive a denied delete", f.exists());
+    }
+
+    @Test
+    public void setACL_merges_and_does_not_clobber_the_folder_entry() throws Exception {
+        File f = new File(adminHomeDir, "merged.saikudash");
+        Files.write(f.toPath(), "X".getBytes(StandardCharsets.UTF_8));
+
+        manager.setACL("/homes/admin/merged.saikudash", SECURED_ROLE_USER_READ, "admin", ROLES_ADMIN);
+
+        // The folder's own PRIVATE entry must still be intact alongside the
+        // new per-file entry (serialize merges, it does not overwrite).
+        AclEntry folder = manager.getACL("/homes/admin", "admin", ROLES_ADMIN);
+        assertNotNull(folder);
+        assertEquals("folder ACL must be preserved", AclType.PRIVATE, folder.getType());
+        assertEquals("admin", folder.getOwner());
+
+        AclEntry file = manager.getACL("/homes/admin/merged.saikudash", "admin", ROLES_ADMIN);
+        assertNotNull(file);
+        assertEquals(AclType.SECURED, file.getType());
+        assertFalse(
+                "the two entries are distinct keys in the same acl.json",
+                folder.getType().equals(file.getType()));
+    }
+
+    // ---- helpers ------------------------------------------------------
+
+    private static void writeFolderAclJson(File dir, String aclType, String owner) throws Exception {
+        String escapedPath = dir.getPath().replace("\\", "\\\\").replace("\"", "\\\"");
+        String json = "{\"" + escapedPath + "\":{\"owner\":\"" + owner + "\",\"type\":\"" + aclType
+                + "\",\"roles\":null,\"users\":null}}";
+        Files.write(new File(dir, "acl.json").toPath(), json.getBytes(StandardCharsets.UTF_8));
+    }
+
+    private static FilesystemRepositoryManager newManager(String path) throws Exception {
+        Constructor<FilesystemRepositoryManager> ctor = FilesystemRepositoryManager.class.getDeclaredConstructor(
+                String.class, String.class, ScopedRepo.class, boolean.class);
+        ctor.setAccessible(true);
+        return ctor.newInstance(path, "ROLE_USER", new ScopedRepo(), false);
+    }
+
+    private static void injectUserService(FilesystemRepositoryManager mgr, UserService us) throws Exception {
+        Field f = FilesystemRepositoryManager.class.getDeclaredField("userService");
+        f.setAccessible(true);
+        f.set(mgr, us);
+    }
+
+    private static void resetSingleton() throws Exception {
+        Field ref = FilesystemRepositoryManager.class.getDeclaredField("ref");
+        ref.setAccessible(true);
+        ref.set(null, null);
+    }
+}


### PR DESCRIPTION
## Summary
Per-dashboard **view/edit/own** ACLs were a **silent no-op**. #948/#949 shipped the UI (ShieldCheck → PermissionsModal) + seeded folder defaults, but setting an ACL on an individual `.saikudash` returned `200` while persisting **nothing** — `getResourceAcl` read back empty and a non-owner stayed denied even after the dashboard was set `PUBLIC`. Found via live verification (8/10). Closes #940. **Security-sensitive — @AGENT-OG please run the pre-merge security gate.**

## Root causes (3)
1. **ACL get/set operated on `null`.** `getAclObj`/`getACL`/`setACL` resolved the node via `getFolderNode → getAllFoldersInCurrentDirectory`, an unimplemented stub that returns `null` (a Phase-2 FS-port regression). So they silently did nothing. → switched to `getFolder` (→ `resolveWithinDatadir`, real File, **path-traversal guard intact**) — the same resolver the working save/read path already uses.
2. **Directory-granular store.** `Acl2.serialize` wrote `new File(node,"acl.json")` and `getMethods` read it back the same way — a regular file's ACL could never be written (a file isn't a directory) or matched. `Acl2` now resolves a node's **acl-home** (its own folder for a directory, its **parent** folder for a file), so a file's entry lives in the parent's `acl.json` keyed by absolute path. `getMethods`/`getOwner` read from there, **falling back to the parent-chain walk (inheritance)** when absent; `serialize` writes there.
3. **Key mismatch.** `setACL` keyed `addEntry` by the *relative* `object` while `getMethods` looked up `file.getPath()` (*absolute*) — a permanent miss. Both now use the absolute path (matching `seedAcl`). The `Acl2` constructor pre-loads the acl-home so `serialize` **merges** rather than overwrites siblings (also fixes a latent **re-seed data-loss** bug that would wipe file ACLs on bootstrap).

Also: `saveFile` now checks an existing file's **own** ACL on overwrite (still the parent folder for new-file creation, since you need folder-write to create a child), so *edit* is per-dashboard too. `removeFile`/`getFile` already resolve the file node, so *delete* + *view* became per-file once `Acl2` was fixed.

## The change
- `Acl2.java` — `aclHome()` helper; constructor pre-loads the acl-home `acl.json`; `serialize`/`getMethods`/`getOwner` read & write the acl-home.
- `FilesystemRepositoryManager.java` — `getAclObj`/`getACL`/`setACL` use `getFolder` + key by absolute path; `saveFile` checks an existing file's own ACL.

## Verified
- `mvn -pl saiku-core/saiku-service -am test` → **25/25 pass**, incl. new `FilesystemRepositoryManagerFileAclTest` (round-trip; per-file grant overriding a denying PRIVATE folder; read-only denies write+delete; merge-not-clobber) **and** the existing #895/#896 folder-ACL regression tests (unchanged).
- **Live** against a launcher (admin + bob, `SAIKU_DEMO=true`): the REST scenario that was 8/10 is now **10/10** — bob views a `PUBLIC` dashboard, reads a `SECURED ROLE_USER:READ` one, and is denied **write** and **delete**.
- `spotless:apply` clean.

## Test plan
1. As admin, create a dashboard; open ShieldCheck → set it `PUBLIC` (or grant a role READ).
2. As a non-admin in that role, confirm the dashboard is now viewable; confirm a `SECURED`/read-only grant still blocks save + delete; confirm `PRIVATE` hides it from others.
3. Confirm folder-level defaults (seeded `/dashboards/`, `/homes/`) still gate as before.

## Notes
- Backend-only; no REST contract or UI change — the existing `/resource/acl` endpoints + `PermissionsModal` now actually work.
- Unblocks #941 (share link) and OG's #943 (subscriptions), which depend on #940.

🤖 Generated with [Claude Code](https://claude.com/claude-code)