### PR TITLE
feat(comments): per-tile dashboard comments — backend (issue #942, PR1)

### DIFF
--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/comments/Comment.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/comments/Comment.java
@@ -1,0 +1,44 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.service.comments;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * One comment on a dashboard tile (issue #942). Persisted as a single JSON
+ * line in a per-dashboard {@code .comments.jsonl} file (see
+ * {@link CommentService}); {@link #tileId} scopes it to a tile within that
+ * dashboard. Deletion is soft ({@link #deleted}) so the append-only thread
+ * keeps its order.
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class Comment {
+
+    /** Stable id (UUID). */
+    public String id;
+
+    /** The tile this comment is attached to. */
+    public String tileId;
+
+    /** Username of the author (server-assigned from the session — never trusted from the client). */
+    public String author;
+
+    /** Free-text body. */
+    public String body;
+
+    /** Usernames @-mentioned in {@link #body}, parsed server-side. Delivery of
+     *  notifications is deferred (#942 has no notification layer yet). */
+    public List<String> mentions = new ArrayList<>();
+
+    /** Epoch millis. */
+    public long createdAt;
+
+    /** Soft-delete marker. */
+    public boolean deleted;
+
+    public Comment() {}
+}

--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/comments/CommentService.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/comments/CommentService.java
@@ -1,0 +1,169 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.service.comments;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.saiku.service.datasource.DatasourceService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Per-tile dashboard comments (issue #942), persisted as one JSONL file per
+ * dashboard under an internal {@code comments/} area.
+ *
+ * <p>Mechanics only — read / append / soft-delete + @-mention parsing. The
+ * REST layer ({@code CommentResource}) owns identity + authorisation: it calls
+ * {@link #canReadDashboard} to gate every operation on the caller's ability to
+ * READ the dashboard (reusing the #940 ACL), and checks author/admin before
+ * {@link #softDelete}. Storage uses the internal-file API (no ACL of its own),
+ * so access is governed solely by that dashboard check — not by where the
+ * comments file happens to sit.
+ *
+ * <p>Writes are full-file read-modify-write (no append primitive exists); this
+ * is single-node-safe but not concurrency-guarded — see the PR note.
+ */
+public class CommentService {
+
+    private static final Logger log = LoggerFactory.getLogger(CommentService.class);
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+    private static final Pattern MENTION = Pattern.compile("@([A-Za-z0-9._-]+)");
+
+    private DatasourceService datasourceService;
+
+    public void setDatasourceService(DatasourceService s) {
+        this.datasourceService = s;
+    }
+
+    /** True if {@code user} can READ {@code dashboardPath} — the gate for every
+     *  comment operation. Uses a successful dashboard read as the canRead proxy
+     *  (getResourceACL can't be used: it returns null unless canGrant). */
+    public boolean canReadDashboard(String dashboardPath, String user, List<String> roles) {
+        if (dashboardPath == null || !dashboardPath.endsWith(".saikudash")) {
+            return false;
+        }
+        try {
+            String d = datasourceService.getFileData(dashboardPath, user, roles);
+            return d != null && !d.isEmpty();
+        } catch (RuntimeException e) {
+            return false;
+        }
+    }
+
+    /** Live (non-deleted) comments for one tile, in insertion order. */
+    public List<Comment> list(String dashboardPath, String tileId) {
+        List<Comment> out = new ArrayList<>();
+        for (Comment c : readAll(dashboardPath)) {
+            if (!c.deleted && tileId != null && tileId.equals(c.tileId)) {
+                out.add(c);
+            }
+        }
+        return out;
+    }
+
+    /** Append a comment authored by {@code author}; @-mentions parsed from body. */
+    public Comment add(String dashboardPath, String tileId, String author, String body) {
+        Comment c = new Comment();
+        c.id = UUID.randomUUID().toString();
+        c.tileId = tileId;
+        c.author = author;
+        c.body = body;
+        c.mentions = parseMentions(body);
+        c.createdAt = System.currentTimeMillis();
+        c.deleted = false;
+
+        List<Comment> all = readAll(dashboardPath);
+        all.add(c);
+        writeAll(dashboardPath, all);
+        return c;
+    }
+
+    /** Find a comment by id (incl. soft-deleted), or null. */
+    public Comment findById(String dashboardPath, String commentId) {
+        for (Comment c : readAll(dashboardPath)) {
+            if (c.id != null && c.id.equals(commentId)) {
+                return c;
+            }
+        }
+        return null;
+    }
+
+    /** Soft-delete a comment. Returns false if not found. */
+    public boolean softDelete(String dashboardPath, String commentId) {
+        List<Comment> all = readAll(dashboardPath);
+        boolean found = false;
+        for (Comment c : all) {
+            if (c.id != null && c.id.equals(commentId) && !c.deleted) {
+                c.deleted = true;
+                found = true;
+            }
+        }
+        if (found) {
+            writeAll(dashboardPath, all);
+        }
+        return found;
+    }
+
+    /* --------------------------- internals --------------------------- */
+
+    static List<String> parseMentions(String body) {
+        Set<String> out = new LinkedHashSet<>();
+        if (body != null) {
+            Matcher m = MENTION.matcher(body);
+            while (m.find()) {
+                out.add(m.group(1));
+            }
+        }
+        return new ArrayList<>(out);
+    }
+
+    /** Internal storage path for a dashboard's comments — a flat, sanitised
+     *  name under {@code comments/}. The repository layer additionally guards
+     *  this with resolveWithinDatadir, so a crafted dashboard path can't escape. */
+    static String commentsPath(String dashboardPath) {
+        String flat = dashboardPath == null ? "null" : dashboardPath.replaceAll("[^A-Za-z0-9._-]", "_");
+        // Separators are already gone (so no traversal); also collapse any ".."
+        // run as belt-and-braces. resolveWithinDatadir guards the final path too.
+        flat = flat.replace("..", "_");
+        return "comments/" + flat + ".jsonl";
+    }
+
+    private List<Comment> readAll(String dashboardPath) {
+        List<Comment> out = new ArrayList<>();
+        String raw = datasourceService.getInternalFileData(commentsPath(dashboardPath));
+        if (raw == null || raw.isBlank()) {
+            return out;
+        }
+        for (String line : raw.split("\n")) {
+            if (line.isBlank()) {
+                continue;
+            }
+            try {
+                out.add(MAPPER.readValue(line, Comment.class));
+            } catch (Exception e) {
+                log.warn("Skipping unparseable comment line in {}", commentsPath(dashboardPath), e);
+            }
+        }
+        return out;
+    }
+
+    private void writeAll(String dashboardPath, List<Comment> comments) {
+        StringBuilder sb = new StringBuilder();
+        for (Comment c : comments) {
+            try {
+                sb.append(MAPPER.writeValueAsString(c)).append('\n');
+            } catch (Exception e) {
+                log.error("Failed to serialise comment {}", c.id, e);
+            }
+        }
+        datasourceService.saveInternalFile(commentsPath(dashboardPath), sb.toString(), null);
+    }
+}

--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/comments/CommentService.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/comments/CommentService.java
@@ -125,15 +125,15 @@ public class CommentService {
         return new ArrayList<>(out);
     }
 
-    /** Internal storage path for a dashboard's comments — a flat, sanitised
-     *  name under {@code comments/}. The repository layer additionally guards
-     *  this with resolveWithinDatadir, so a crafted dashboard path can't escape. */
+    /** Internal storage path for a dashboard's comments — a single flat,
+     *  sanitised file at the datadir root (the internal-file writer does NOT
+     *  create parent dirs, so a subfolder would silently fail; the root always
+     *  exists). Separators collapse to {@code _} (no traversal) and {@code ..}
+     *  is neutralised; resolveWithinDatadir guards the final path too. */
     static String commentsPath(String dashboardPath) {
         String flat = dashboardPath == null ? "null" : dashboardPath.replaceAll("[^A-Za-z0-9._-]", "_");
-        // Separators are already gone (so no traversal); also collapse any ".."
-        // run as belt-and-braces. resolveWithinDatadir guards the final path too.
         flat = flat.replace("..", "_");
-        return "comments/" + flat + ".jsonl";
+        return "saiku-comments-" + flat + ".jsonl";
     }
 
     private List<Comment> readAll(String dashboardPath) {

--- a/saiku-core/saiku-service/src/test/java/org/saiku/service/comments/CommentServiceTest.java
+++ b/saiku-core/saiku-service/src/test/java/org/saiku/service/comments/CommentServiceTest.java
@@ -1,0 +1,119 @@
+package org.saiku.service.comments;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.Before;
+import org.junit.Test;
+import org.saiku.service.datasource.DatasourceService;
+
+/**
+ * Unit coverage for {@link CommentService} (issue #942) — append/list/soft-delete
+ * mechanics, per-tile scoping, @-mention parsing, the canRead gate, and the
+ * traversal-flattened storage path. Uses an in-memory {@link DatasourceService}
+ * stub so no repository/filesystem is needed.
+ */
+public class CommentServiceTest {
+
+    /** In-memory internal-file store; getFileData controls the canRead gate. */
+    private static class FakeDs extends DatasourceService {
+        final Map<String, String> internal = new HashMap<>();
+        boolean dashboardReadable = true;
+
+        @Override
+        public String saveInternalFile(String path, String content, String type) {
+            internal.put(path, content);
+            return "Save Okay";
+        }
+
+        @Override
+        public String getInternalFileData(String path) {
+            return internal.get(path);
+        }
+
+        @Override
+        public String getFileData(String path, String username, List<String> roles) {
+            return dashboardReadable ? "{\"id\":\"x\"}" : null;
+        }
+    }
+
+    private FakeDs ds;
+    private CommentService svc;
+
+    private static final String DASH = "dashboards/foo.saikudash";
+
+    @Before
+    public void setUp() {
+        ds = new FakeDs();
+        svc = new CommentService();
+        svc.setDatasourceService(ds);
+    }
+
+    @Test
+    public void add_then_list_scoped_by_tile() {
+        svc.add(DASH, "t1", "admin", "hello on tile one");
+        svc.add(DASH, "t2", "bob", "different tile");
+        svc.add(DASH, "t1", "admin", "second on t1");
+
+        List<Comment> t1 = svc.list(DASH, "t1");
+        assertEquals(2, t1.size());
+        assertEquals("hello on tile one", t1.get(0).body);
+        assertEquals("second on t1", t1.get(1).body); // insertion order preserved
+        assertEquals(1, svc.list(DASH, "t2").size());
+        assertEquals(0, svc.list(DASH, "tX").size());
+    }
+
+    @Test
+    public void soft_delete_hides_from_list_but_keeps_order() {
+        Comment a = svc.add(DASH, "t1", "admin", "first");
+        svc.add(DASH, "t1", "admin", "second");
+        assertTrue(svc.softDelete(DASH, a.id));
+
+        List<Comment> live = svc.list(DASH, "t1");
+        assertEquals("deleted one is hidden", 1, live.size());
+        assertEquals("second", live.get(0).body);
+        // The deleted row is still on disk (findById sees it) so order is kept.
+        assertTrue(svc.findById(DASH, a.id).deleted);
+        assertFalse("deleting unknown id is false", svc.softDelete(DASH, "nope"));
+    }
+
+    @Test
+    public void mentions_are_parsed_from_body() {
+        Comment c = svc.add(DASH, "t1", "admin", "ping @bob and @krishna, also @bob again");
+        assertEquals(List.of("bob", "krishna"), c.mentions); // de-duped, in order
+        assertEquals(List.of(), CommentService.parseMentions("no mentions here"));
+        assertEquals(List.of("a.b-c_d"), CommentService.parseMentions("hi @a.b-c_d!"));
+    }
+
+    @Test
+    public void missing_file_is_empty_thread() {
+        assertEquals(0, svc.list("dashboards/never.saikudash", "t1").size());
+        assertNull(svc.findById("dashboards/never.saikudash", "anything"));
+    }
+
+    @Test
+    public void canRead_gate() {
+        ds.dashboardReadable = true;
+        assertTrue(svc.canReadDashboard(DASH, "admin", List.of("ROLE_ADMIN")));
+        ds.dashboardReadable = false;
+        assertFalse(svc.canReadDashboard(DASH, "bob", List.of("ROLE_USER")));
+        // Non-dashboard paths are rejected outright.
+        assertFalse(svc.canReadDashboard("dashboards/foo.saiku", "admin", List.of("ROLE_ADMIN")));
+        assertFalse(svc.canReadDashboard(null, "admin", List.of("ROLE_ADMIN")));
+    }
+
+    @Test
+    public void comments_path_is_flattened_and_namespaced() {
+        // Separators / traversal chars collapse to underscores under comments/.
+        assertEquals("comments/dashboards_foo.saikudash.jsonl", CommentService.commentsPath("dashboards/foo.saikudash"));
+        String evil = CommentService.commentsPath("../../etc/passwd");
+        assertTrue(evil.startsWith("comments/"));
+        assertFalse("no parent-dir hops survive", evil.contains(".."));
+        assertFalse(evil.contains("/etc/"));
+    }
+}

--- a/saiku-core/saiku-service/src/test/java/org/saiku/service/comments/CommentServiceTest.java
+++ b/saiku-core/saiku-service/src/test/java/org/saiku/service/comments/CommentServiceTest.java
@@ -109,11 +109,14 @@ public class CommentServiceTest {
 
     @Test
     public void comments_path_is_flattened_and_namespaced() {
-        // Separators / traversal chars collapse to underscores under comments/.
-        assertEquals("comments/dashboards_foo.saikudash.jsonl", CommentService.commentsPath("dashboards/foo.saikudash"));
+        // A single flat file at the datadir root; separators / traversal chars
+        // collapse to underscores (the internal writer won't mkdir a subdir).
+        assertEquals(
+                "saiku-comments-dashboards_foo.saikudash.jsonl",
+                CommentService.commentsPath("dashboards/foo.saikudash"));
         String evil = CommentService.commentsPath("../../etc/passwd");
-        assertTrue(evil.startsWith("comments/"));
+        assertTrue(evil.startsWith("saiku-comments-"));
         assertFalse("no parent-dir hops survive", evil.contains(".."));
-        assertFalse(evil.contains("/etc/"));
+        assertFalse("no separators survive", evil.contains("/") || evil.contains("\\"));
     }
 }

--- a/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/comments/CommentResource.java
+++ b/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/comments/CommentResource.java
@@ -1,0 +1,164 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.web.rest.resources.comments;
+
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.DELETE;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import java.util.List;
+import java.util.Map;
+import org.saiku.service.comments.Comment;
+import org.saiku.service.comments.CommentService;
+import org.saiku.service.user.UserService;
+import org.saiku.web.service.SessionService;
+
+/**
+ * Per-tile dashboard comments (issue #942), under {@code /saiku/api/dashboards/comments}.
+ * Sits on {@code /rest/**} = {@code isFullyAuthenticated()}, so a #941 share-link
+ * guest ({@code ROLE_SHARE_GUEST}, which only unlocks {@code /share/view/**})
+ * cannot reach it. Every operation is gated on the caller's ability to READ the
+ * dashboard (the #940 ACL); deleting a comment additionally requires being its
+ * author or an admin.
+ */
+@Path("/saiku/api/dashboards/comments")
+public class CommentResource {
+
+    private CommentService commentService;
+    private SessionService sessionService;
+    private UserService userService;
+
+    public void setCommentService(CommentService s) {
+        this.commentService = s;
+    }
+
+    public void setSessionService(SessionService s) {
+        this.sessionService = s;
+    }
+
+    public void setUserService(UserService s) {
+        this.userService = s;
+    }
+
+    public static class CommentRequest {
+        public String dashboard;
+        public String tile;
+        public String body;
+    }
+
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response list(@QueryParam("dashboard") String dashboard, @QueryParam("tile") String tile) {
+        if (dashboard == null || tile == null) {
+            return badRequest("dashboard+tile required");
+        }
+        if (!commentService.canReadDashboard(dashboard, currentUsername(), currentRoles())) {
+            return forbidden();
+        }
+        return Response.ok(commentService.list(dashboard, tile))
+                .type(MediaType.APPLICATION_JSON)
+                .build();
+    }
+
+    @POST
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response add(CommentRequest req) {
+        if (req == null || req.dashboard == null || req.tile == null || req.body == null || req.body.isBlank()) {
+            return badRequest("dashboard, tile and non-empty body required");
+        }
+        String username = currentUsername();
+        if (!commentService.canReadDashboard(req.dashboard, username, currentRoles())) {
+            return forbidden();
+        }
+        Comment c = commentService.add(req.dashboard, req.tile, username, req.body);
+        return Response.ok(c).type(MediaType.APPLICATION_JSON).build();
+    }
+
+    @DELETE
+    @Path("/{commentId}")
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response delete(
+            @PathParam("commentId") String commentId, @QueryParam("dashboard") String dashboard) {
+        if (dashboard == null) {
+            return badRequest("dashboard required");
+        }
+        String username = currentUsername();
+        if (!commentService.canReadDashboard(dashboard, username, currentRoles())) {
+            return forbidden();
+        }
+        Comment c = commentService.findById(dashboard, commentId);
+        if (c == null) {
+            return Response.status(Response.Status.NOT_FOUND)
+                    .entity(Map.of("status", "NOT_FOUND", "error", "Unknown comment"))
+                    .type(MediaType.APPLICATION_JSON)
+                    .build();
+        }
+        boolean canDelete = (username != null && username.equals(c.author)) || isAdmin(currentRoles());
+        if (!canDelete) {
+            return forbidden();
+        }
+        commentService.softDelete(dashboard, commentId);
+        return Response.ok(Map.of("status", "OK")).type(MediaType.APPLICATION_JSON).build();
+    }
+
+    /* --------------------------- helpers ---------------------------- */
+
+    private boolean isAdmin(List<String> roles) {
+        if (roles == null || userService == null) {
+            return false;
+        }
+        List<String> admin = userService.getAdminRoles();
+        if (admin == null) {
+            return false;
+        }
+        for (String r : roles) {
+            if (admin.contains(r)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private String currentUsername() {
+        if (sessionService == null) {
+            return null;
+        }
+        Object u = sessionService.getAllSessionObjects().get("username");
+        return u == null ? null : u.toString();
+    }
+
+    @SuppressWarnings("unchecked")
+    private List<String> currentRoles() {
+        if (sessionService == null) {
+            return List.of();
+        }
+        Object r = sessionService.getAllSessionObjects().get("roles");
+        if (r instanceof List<?>) {
+            return (List<String>) r;
+        }
+        return List.of();
+    }
+
+    private static Response badRequest(String message) {
+        return Response.status(Response.Status.BAD_REQUEST)
+                .entity(Map.of("status", "VALIDATION_ERROR", "error", message))
+                .type(MediaType.APPLICATION_JSON)
+                .build();
+    }
+
+    private static Response forbidden() {
+        return Response.status(Response.Status.FORBIDDEN)
+                .entity(Map.of("status", "FORBIDDEN", "error", "You don't have access to this dashboard"))
+                .type(MediaType.APPLICATION_JSON)
+                .build();
+    }
+}

--- a/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/comments/CommentResource.java
+++ b/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/comments/CommentResource.java
@@ -86,8 +86,7 @@ public class CommentResource {
     @DELETE
     @Path("/{commentId}")
     @Produces(MediaType.APPLICATION_JSON)
-    public Response delete(
-            @PathParam("commentId") String commentId, @QueryParam("dashboard") String dashboard) {
+    public Response delete(@PathParam("commentId") String commentId, @QueryParam("dashboard") String dashboard) {
         if (dashboard == null) {
             return badRequest("dashboard required");
         }
@@ -107,7 +106,9 @@ public class CommentResource {
             return forbidden();
         }
         commentService.softDelete(dashboard, commentId);
-        return Response.ok(Map.of("status", "OK")).type(MediaType.APPLICATION_JSON).build();
+        return Response.ok(Map.of("status", "OK"))
+                .type(MediaType.APPLICATION_JSON)
+                .build();
     }
 
     /* --------------------------- helpers ---------------------------- */

--- a/saiku-launcher/test-comments-live.sh
+++ b/saiku-launcher/test-comments-live.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# Live verification for #942 — per-tile dashboard comments.
+# Proves: author CRUD; @-mention captured; access gated on dashboard canRead
+# (a non-reader and an anonymous client are denied); delete is author/admin-only.
+# Usage: launcher on :8087 (SAIKU_DEMO=true), then ./test-comments-live.sh
+set -u
+URL="${SAIKU_URL:-http://localhost:8087}"
+A=$(mktemp); B=$(mktemp); trap 'rm -f "$A" "$B"' EXIT   # admin, bob cookie jars
+PASS=0; FAIL=0
+ok(){ echo "  PASS: $1"; PASS=$((PASS+1)); }
+no(){ echo "  FAIL: $1 | code=$2 body=${3:0:180}"; FAIL=$((FAIL+1)); }
+login(){ curl -s -b "$1" -c "$1" -X POST "$URL/rest/saiku/session" --data "username=$2&password=$3" -o /dev/null -w '%{http_code}'; }
+# req: jar method path [body]  (jar="-" => no cookie / anonymous). sets RC/RB
+req(){ local jar="$1" m="$2" p="$3" body="${4:-}"; local out cj; out=$(mktemp)
+  if [ "$jar" = "-" ]; then cj=""; else cj="-b $jar"; fi
+  if [ "$m" = GET ]; then RC=$(curl -s $cj "$URL$p" -o "$out" -w '%{http_code}')
+  elif [ "$m" = DELETE ]; then RC=$(curl -s $cj -X DELETE "$URL$p" -o "$out" -w '%{http_code}')
+  else RC=$(curl -s $cj -X "$m" "$URL$p" -H 'Content-Type: application/json' --data "$body" -o "$out" -w '%{http_code}'); fi
+  RB=$(cat "$out"); rm -f "$out"; }
+denied(){ case "$1" in 401|403) return 0;; *) return 1;; esac; }
+
+C="/rest/saiku/api/dashboards/comments"
+DASH="dashboards/commenttest942.saikudash"
+DBODY='{"id":"c942","name":"Comment Test","version":1,"layout":{"cols":12,"tiles":[{"id":"t1","x":0,"y":0,"w":6,"h":4,"type":"text","text":"hi"}]}}'
+
+echo "== setup =="
+[ "$(login "$A" admin admin)" = 200 ] && ok "admin login" || no "admin login" "?" ""
+[ "$(login "$B" bob dylan)" = 200 ] && ok "bob login" || no "bob login" "?" ""
+req "$A" POST "/rest/saiku/api/dashboards/$DASH" "$DBODY"; echo "$RB" | grep -q '"status":"OK"' && ok "admin saved dashboard (SECURED /dashboards)" || no "save" "$RC" "$RB"
+
+echo "== author CRUD + @-mention =="
+req "$A" POST "$C" "{\"dashboard\":\"$DASH\",\"tile\":\"t1\",\"body\":\"hello @bob please review\"}"
+CID=$(echo "$RB" | sed -n 's/.*"id":"\([^"]*\)".*/\1/p')
+{ [ "$RC" = 200 ] && echo "$RB" | grep -q '"bob"'; } && ok "admin posts comment + @bob mention captured" || no "post" "$RC" "$RB"
+req "$A" GET "$C?dashboard=$DASH&tile=t1"; { [ "$RC" = 200 ] && echo "$RB" | grep -q 'hello @bob'; } && ok "admin lists the comment" || no "list" "$RC" "$RB"
+req "$A" GET "$C?dashboard=$DASH&tile=t2"; { [ "$RC" = 200 ] && [ "$RB" = "[]" ]; } && ok "other tile is empty (per-tile scope)" || no "tile scope" "$RC" "$RB"
+
+echo "== access gating: non-reader + anonymous denied =="
+req "$B" GET "$C?dashboard=$DASH&tile=t1"; denied "$RC" && ok "bob (can't read dashboard) list denied ($RC)" || no "bob list not denied" "$RC" "$RB"
+req "$B" POST "$C" "{\"dashboard\":\"$DASH\",\"tile\":\"t1\",\"body\":\"sneak\"}"; denied "$RC" && ok "bob post denied ($RC)" || no "bob post not denied" "$RC" "$RB"
+req "-" GET "$C?dashboard=$DASH&tile=t1"; denied "$RC" && ok "anonymous denied ($RC)" || no "anon not denied" "$RC" "$RB"
+
+echo "== delete is author/admin only =="
+# Open the dashboard to everyone so bob CAN read but still can't delete admin's comment.
+req "$A" POST "/rest/saiku/api/repository/resource/acl" "" >/dev/null 2>&1
+curl -s -b "$A" -X POST "$URL/rest/saiku/api/repository/resource/acl" --data "file=$DASH" --data-urlencode 'acl={"owner":"admin","type":"PUBLIC","roles":{},"users":{}}' -o /dev/null
+req "$B" GET "$C?dashboard=$DASH&tile=t1"; [ "$RC" = 200 ] && ok "bob can read after dashboard set PUBLIC" || no "bob read after public" "$RC" "$RB"
+req "$B" DELETE "$C/$CID?dashboard=$DASH"; denied "$RC" && ok "bob cannot delete admin's comment ($RC)" || no "bob delete not denied" "$RC" "$RB"
+req "$A" DELETE "$C/$CID?dashboard=$DASH"; echo "$RB" | grep -q '"status":"OK"' && ok "admin (author) deletes own comment" || no "admin delete" "$RC" "$RB"
+req "$A" GET "$C?dashboard=$DASH&tile=t1"; { [ "$RC" = 200 ] && [ "$RB" = "[]" ]; } && ok "soft-deleted comment hidden from list" || no "soft-delete hidden" "$RC" "$RB"
+
+echo "== cleanup =="
+req "$A" DELETE "/rest/saiku/api/dashboards/$DASH" >/dev/null 2>&1
+echo ""; echo "RESULT: $PASS passed, $FAIL failed"; exit $FAIL

--- a/saiku-webapp/src/main/webapp/WEB-INF/saiku-beans.xml
+++ b/saiku-webapp/src/main/webapp/WEB-INF/saiku-beans.xml
@@ -355,6 +355,22 @@
         <property name="aiQueryResource" ref="aiQueryResource"/>
     </bean>
 
+    <!-- Per-tile dashboard comments (issue #942). commentService stores a
+         per-dashboard .jsonl via the internal-file API; commentResource
+         (@ /saiku/api/dashboards/comments) gates every op on the caller's
+         ability to READ the dashboard (#940 ACL) + author/admin to delete.
+         Sits on /rest/** = isFullyAuthenticated() so share-link guests
+         (#941 ROLE_SHARE_GUEST) can't reach it. -->
+    <bean id="commentService" class="org.saiku.service.comments.CommentService">
+        <property name="datasourceService" ref="datasourceServiceBean"/>
+    </bean>
+
+    <bean id="commentResource"
+          class="org.saiku.web.rest.resources.comments.CommentResource">
+        <property name="commentService" ref="commentService"/>
+        <property name="sessionService" ref="sessionService"/>
+        <property name="userService" ref="userServiceBean"/>
+    </bean>
 
     <bean id="filterRepositoryBean" scope="session"
           class="org.saiku.web.rest.resources.FilterRepositoryResource">


### PR DESCRIPTION
## Summary
Backend for **#942 — comments / annotations on dashboard tiles**: a per-tile comment thread so the conversation lives with the dashboard. This is the backend (REST + storage + ACL gating + tests); a follow-up **PR2** adds the UI (comment-count badge on the `Tile.svelte` wrapper + a side-panel thread + @-mention autocomplete).

> 🔗 **Stacked on #1059 (#940 ACL fix)** — comment access is gated on the dashboard's per-dashboard ACL, so this branch is based on #1059 and its diff currently includes #940. **Merge #1059 first**, then I'll rebase to the #942-only delta. (Independent of #1060/#941.)

## Design
- **Storage:** one flat `saiku-comments-<sanitised-dashboardPath>.jsonl` at the datadir root via the internal-file API (`DatasourceService.saveInternalFile/getInternalFileData`). One JSON line per comment `{id,tileId,author,body,mentions[],createdAt,deleted}`; read-modify-write (no append primitive exists); delete is soft so the thread keeps order. Flat path because the internal writer doesn't create parent dirs — caught by the live test.
- **Access (reuses #940):** every op is gated on the caller's ability to **READ the dashboard** (`canReadDashboard` = a successful `getFileData`; `getResourceACL` can't be used — it's canGrant-only). Delete additionally requires **author or admin**.
- **Identity:** the `DashboardResource` pattern (`sessionService.getAllSessionObjects()`).
- **Auth:** under `/rest/**` = `isFullyAuthenticated()`, so a #941 share-link **guest cannot reach comments** (verified: anonymous → 401).
- **@-mentions:** `@name` parsed + stored in `mentions[]`. **Delivery is deferred** — there is *no* notification infrastructure in the codebase yet (no email/in-app/push), and #943 has no code. Mentions are captured for the UI/future notifier.

## New files
- `saiku-service`: `comments/Comment.java`, `comments/CommentService.java` (+ `CommentServiceTest`)
- `saiku-web`: `rest/resources/comments/CommentResource.java` (`@Path /saiku/api/dashboards/comments` — GET list, POST add, DELETE)
- `saiku-beans.xml`: `commentService` + `commentResource` beans
- `saiku-launcher/test-comments-live.sh`

## Verified
- `CommentServiceTest` → **6/6** (append/list/per-tile scope, soft-delete order, @-mention parse incl. de-dupe, canRead gate, traversal-flattened path).
- **Live REST** `test-comments-live.sh` → **13/13** (author CRUD + @bob captured; non-reader `bob` and anonymous denied 403/401; bob can read once dashboard is PUBLIC but still can't delete admin's comment; soft-deleted hidden). **User-verified locally.**
- No #940-test regression; reactor compiles; spotless clean. (The same 10 pre-existing Windows-CRLF golden failures in mdx/cache/schema are unrelated — green on Linux CI.)

## Out of scope / deferred (→ PR2 / future)
- UI: `Tile.svelte` badge + `CommentsPanel` drawer + @-mention autocomplete (touches the wrapper only, not OG's tile internals); a non-admin users-list endpoint for autocomplete.
- @-mention **delivery** (in-app unread / email) — until a notification layer exists (overlaps OG's future #943).
- Markdown, threaded replies, real-time refresh, moderation.

## Test plan
With a launcher on :8087 (`SAIKU_DEMO=true`): `bash saiku-launcher/test-comments-live.sh` → expect 13/13. Manual: `POST /rest/saiku/api/dashboards/comments {dashboard,tile,body}`; `GET ...?dashboard=&tile=`; confirm a non-reader gets 403 and anonymous 401.

## Note
Read-modify-write has no concurrency guard (two simultaneous comments on one dashboard could race) — acceptable single-node; revisit (advisory lock / DB) if it matters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)