### PR TITLE
feat(history): dashboard versioning / history — backend (issue #947, PR1)

### DIFF
--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/history/DashboardHistoryService.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/history/DashboardHistoryService.java
@@ -1,0 +1,123 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.service.history;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
+import org.saiku.service.datasource.DatasourceService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Dashboard version history (issue #947). Each save archives the replaced
+ * state here; users can list, preview, and restore prior versions.
+ *
+ * <p>Stored as one flat {@code saiku-history-<sanitised-dashboardPath>.jsonl}
+ * at the datadir root via the internal-file API (the internal writer doesn't
+ * create subdirs). One version per line, chronological; the most recent
+ * {@link #RETENTION} are kept (prune-on-append). Mechanics only — the REST
+ * layer owns identity + the dashboard canRead/canWrite gate.
+ *
+ * <p>Read-modify-write (no append primitive); single-node-safe, not
+ * concurrency-guarded — see the PR note.
+ */
+public class DashboardHistoryService {
+
+    private static final Logger log = LoggerFactory.getLogger(DashboardHistoryService.class);
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    /** Versions retained per dashboard. */
+    static final int RETENTION = 50;
+
+    private DatasourceService datasourceService;
+
+    public void setDatasourceService(DatasourceService s) {
+        this.datasourceService = s;
+    }
+
+    /** Archive {@code dashboardJson} as the latest version, pruning to the most
+     *  recent {@link #RETENTION}. No-op for null/blank content. */
+    public DashboardVersion archive(String dashboardPath, String dashboardJson, String author) {
+        if (dashboardJson == null || dashboardJson.isBlank()) {
+            return null;
+        }
+        DashboardVersion v = new DashboardVersion();
+        v.version = UUID.randomUUID().toString();
+        v.createdAt = System.currentTimeMillis();
+        v.author = author;
+        v.dashboard = dashboardJson;
+
+        List<DashboardVersion> all = readAll(dashboardPath);
+        all.add(v);
+        // Keep the most recent RETENTION (drop oldest from the front).
+        while (all.size() > RETENTION) {
+            all.remove(0);
+        }
+        writeAll(dashboardPath, all);
+        return v;
+    }
+
+    /** Versions newest-first (full snapshots; the resource trims for listing). */
+    public List<DashboardVersion> list(String dashboardPath) {
+        List<DashboardVersion> all = readAll(dashboardPath);
+        Collections.reverse(all);
+        return all;
+    }
+
+    /** One version by id, or null. */
+    public DashboardVersion getVersion(String dashboardPath, String versionId) {
+        for (DashboardVersion v : readAll(dashboardPath)) {
+            if (v.version != null && v.version.equals(versionId)) {
+                return v;
+            }
+        }
+        return null;
+    }
+
+    /* --------------------------- internals --------------------------- */
+
+    /** Flat, sanitised internal path at the datadir root (no subdir — the
+     *  internal writer won't mkdir one). Separators collapse to {@code _} and
+     *  {@code ..} is neutralised; resolveWithinDatadir guards the final path. */
+    static String historyPath(String dashboardPath) {
+        String flat = dashboardPath == null ? "null" : dashboardPath.replaceAll("[^A-Za-z0-9._-]", "_");
+        flat = flat.replace("..", "_");
+        return "saiku-history-" + flat + ".jsonl";
+    }
+
+    private List<DashboardVersion> readAll(String dashboardPath) {
+        List<DashboardVersion> out = new ArrayList<>();
+        String raw = datasourceService.getInternalFileData(historyPath(dashboardPath));
+        if (raw == null || raw.isBlank()) {
+            return out;
+        }
+        for (String line : raw.split("\n")) {
+            if (line.isBlank()) {
+                continue;
+            }
+            try {
+                out.add(MAPPER.readValue(line, DashboardVersion.class));
+            } catch (Exception e) {
+                log.warn("Skipping unparseable history line in {}", historyPath(dashboardPath), e);
+            }
+        }
+        return out;
+    }
+
+    private void writeAll(String dashboardPath, List<DashboardVersion> versions) {
+        StringBuilder sb = new StringBuilder();
+        for (DashboardVersion v : versions) {
+            try {
+                sb.append(MAPPER.writeValueAsString(v)).append('\n');
+            } catch (Exception e) {
+                log.error("Failed to serialise dashboard version {}", v.version, e);
+            }
+        }
+        datasourceService.saveInternalFile(historyPath(dashboardPath), sb.toString(), null);
+    }
+}

--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/history/DashboardVersion.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/history/DashboardVersion.java
@@ -1,0 +1,31 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.service.history;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+/**
+ * One archived dashboard version (issue #947). Stored as a single JSON line in
+ * a per-dashboard {@code saiku-history-*.jsonl} file (see
+ * {@link DashboardHistoryService}). {@link #dashboard} holds the full
+ * {@code .saikudash} JSON of that version; list responses omit it.
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class DashboardVersion {
+
+    /** Stable id (UUID). */
+    public String version;
+
+    /** Epoch millis the version was archived. */
+    public long createdAt;
+
+    /** Username whose save replaced this state (the prior author of record). */
+    public String author;
+
+    /** The full dashboard JSON snapshot. */
+    public String dashboard;
+
+    public DashboardVersion() {}
+}

--- a/saiku-core/saiku-service/src/test/java/org/saiku/service/history/DashboardHistoryServiceTest.java
+++ b/saiku-core/saiku-service/src/test/java/org/saiku/service/history/DashboardHistoryServiceTest.java
@@ -1,0 +1,99 @@
+package org.saiku.service.history;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.Before;
+import org.junit.Test;
+import org.saiku.service.datasource.DatasourceService;
+
+/**
+ * Unit coverage for {@link DashboardHistoryService} (issue #947): archive →
+ * list (newest-first), exact-snapshot retrieval, retain-{@value
+ * DashboardHistoryService#RETENTION} pruning, empty/missing handling, and the
+ * traversal-flattened storage path. In-memory {@link DatasourceService} stub.
+ */
+public class DashboardHistoryServiceTest {
+
+    private static class FakeDs extends DatasourceService {
+        final Map<String, String> internal = new HashMap<>();
+
+        @Override
+        public String saveInternalFile(String path, String content, String type) {
+            internal.put(path, content);
+            return "Save Okay";
+        }
+
+        @Override
+        public String getInternalFileData(String path) {
+            return internal.get(path);
+        }
+    }
+
+    private FakeDs ds;
+    private DashboardHistoryService svc;
+    private static final String DASH = "dashboards/foo.saikudash";
+
+    @Before
+    public void setUp() {
+        ds = new FakeDs();
+        svc = new DashboardHistoryService();
+        svc.setDatasourceService(ds);
+    }
+
+    @Test
+    public void archive_then_list_newest_first() {
+        svc.archive(DASH, "{\"v\":1}", "admin");
+        svc.archive(DASH, "{\"v\":2}", "bob");
+        List<DashboardVersion> list = svc.list(DASH);
+        assertEquals(2, list.size());
+        assertEquals("newest first", "{\"v\":2}", list.get(0).dashboard);
+        assertEquals("bob", list.get(0).author);
+        assertEquals("{\"v\":1}", list.get(1).dashboard);
+    }
+
+    @Test
+    public void getVersion_returns_exact_snapshot() {
+        DashboardVersion v = svc.archive(DASH, "{\"layout\":{\"tiles\":[]}}", "admin");
+        assertNotNull(v.version);
+        DashboardVersion got = svc.getVersion(DASH, v.version);
+        assertNotNull(got);
+        assertEquals("{\"layout\":{\"tiles\":[]}}", got.dashboard);
+        assertNull("unknown version id", svc.getVersion(DASH, "nope"));
+    }
+
+    @Test
+    public void retention_prunes_oldest_beyond_50() {
+        for (int i = 1; i <= 55; i++) {
+            svc.archive(DASH, "{\"v\":" + i + "}", "admin");
+        }
+        List<DashboardVersion> list = svc.list(DASH);
+        assertEquals(DashboardHistoryService.RETENTION, list.size());
+        assertEquals("newest kept", "{\"v\":55}", list.get(0).dashboard);
+        assertEquals("oldest kept is v6 (v1-5 pruned)", "{\"v\":6}", list.get(list.size() - 1).dashboard);
+    }
+
+    @Test
+    public void blank_and_missing_are_safe() {
+        assertNull("blank content is a no-op", svc.archive(DASH, "  ", "admin"));
+        assertEquals(0, svc.list("dashboards/never.saikudash").size());
+        assertNull(svc.getVersion("dashboards/never.saikudash", "x"));
+    }
+
+    @Test
+    public void history_path_is_flattened_and_namespaced() {
+        assertEquals(
+                "saiku-history-dashboards_foo.saikudash.jsonl",
+                DashboardHistoryService.historyPath("dashboards/foo.saikudash"));
+        String evil = DashboardHistoryService.historyPath("../../etc/passwd");
+        assertTrue(evil.startsWith("saiku-history-"));
+        assertFalse(evil.contains(".."));
+        assertFalse(evil.contains("/") || evil.contains("\\"));
+    }
+}

--- a/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/dashboards/DashboardResource.java
+++ b/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/dashboards/DashboardResource.java
@@ -50,6 +50,7 @@ public class DashboardResource {
 
     private DatasourceService datasourceService;
     private SessionService sessionService;
+    private org.saiku.service.history.DashboardHistoryService historyService;
 
     public void setDatasourceService(DatasourceService s) {
         this.datasourceService = s;
@@ -57,6 +58,11 @@ public class DashboardResource {
 
     public void setSessionService(SessionService s) {
         this.sessionService = s;
+    }
+
+    /** Optional (#947): archives the replaced version on each successful save. */
+    public void setHistoryService(org.saiku.service.history.DashboardHistoryService s) {
+        this.historyService = s;
     }
 
     /**
@@ -123,8 +129,25 @@ public class DashboardResource {
                     .type(MediaType.APPLICATION_JSON)
                     .build();
         }
+        // #947: capture the state being replaced so we can archive it after a
+        // successful write. Best-effort read (a brand-new dashboard has none).
+        String previous = null;
+        try {
+            previous = datasourceService.getFileData(path, username, roles);
+        } catch (RuntimeException ignored) {
+            // no prior version / not readable — nothing to archive
+        }
         String resp = datasourceService.saveFile(body, path, username, roles);
         if (SAVE_OK.equals(resp)) {
+            // Archive AFTER the write succeeds, and never let a history failure
+            // affect the save result (#947).
+            if (historyService != null && previous != null && !previous.isEmpty()) {
+                try {
+                    historyService.archive(path, previous, username);
+                } catch (RuntimeException e) {
+                    log.warn("dashboard history archive failed for {} (save still succeeded)", path, e);
+                }
+            }
             return Response.ok(Map.of("status", "OK", "path", path))
                     .type(MediaType.APPLICATION_JSON)
                     .build();

--- a/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/history/DashboardHistoryResource.java
+++ b/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/history/DashboardHistoryResource.java
@@ -1,0 +1,190 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.web.rest.resources.history;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import org.saiku.service.datasource.DatasourceService;
+import org.saiku.service.history.DashboardHistoryService;
+import org.saiku.service.history.DashboardVersion;
+import org.saiku.web.service.SessionService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Dashboard version history (issue #947), under
+ * {@code /saiku/api/dashboards/history}. List + preview are gated on the
+ * caller's ability to READ the dashboard (#940 ACL); restore goes through
+ * {@code saveFile}, which enforces {@code canWrite}. Under {@code /rest/**}
+ * ({@code isFullyAuthenticated()}) so #941 share guests can't reach it.
+ */
+@Path("/saiku/api/dashboards/history")
+public class DashboardHistoryResource {
+
+    private static final Logger log = LoggerFactory.getLogger(DashboardHistoryResource.class);
+    private static final String SAVE_OK = "Save Okay";
+
+    private DashboardHistoryService historyService;
+    private DatasourceService datasourceService;
+    private SessionService sessionService;
+
+    public void setHistoryService(DashboardHistoryService s) {
+        this.historyService = s;
+    }
+
+    public void setDatasourceService(DatasourceService s) {
+        this.datasourceService = s;
+    }
+
+    public void setSessionService(SessionService s) {
+        this.sessionService = s;
+    }
+
+    /** Version metadata (no full snapshots), newest-first. */
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response list(@QueryParam("dashboard") String dashboard) {
+        if (dashboard == null) {
+            return badRequest("dashboard required");
+        }
+        if (!canRead(dashboard)) {
+            return forbidden();
+        }
+        List<Map<String, Object>> out = new ArrayList<>();
+        for (DashboardVersion v : historyService.list(dashboard)) {
+            out.add(Map.of("version", v.version, "createdAt", v.createdAt, "author", v.author == null ? "" : v.author));
+        }
+        return Response.ok(out).type(MediaType.APPLICATION_JSON).build();
+    }
+
+    /** The full dashboard JSON of one archived version (preview). */
+    @GET
+    @Path("/version")
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response version(@QueryParam("dashboard") String dashboard, @QueryParam("version") String version) {
+        if (dashboard == null || version == null) {
+            return badRequest("dashboard+version required");
+        }
+        if (!canRead(dashboard)) {
+            return forbidden();
+        }
+        DashboardVersion v = historyService.getVersion(dashboard, version);
+        if (v == null) {
+            return notFound();
+        }
+        // v.dashboard is already a JSON document — return it verbatim.
+        return Response.ok(v.dashboard).type(MediaType.APPLICATION_JSON).build();
+    }
+
+    /** Overwrite the live dashboard with an archived version; the pre-restore
+     *  state is itself archived so a restore is reversible. */
+    @POST
+    @Path("/restore")
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response restore(@QueryParam("dashboard") String dashboard, @QueryParam("version") String version) {
+        if (dashboard == null || version == null) {
+            return badRequest("dashboard+version required");
+        }
+        String username = currentUsername();
+        List<String> roles = currentRoles();
+        if (!canRead(dashboard)) {
+            return forbidden();
+        }
+        DashboardVersion v = historyService.getVersion(dashboard, version);
+        if (v == null) {
+            return notFound();
+        }
+        // Snapshot the current state before overwriting (so restore is undoable).
+        String current;
+        try {
+            current = datasourceService.getFileData(dashboard, username, roles);
+        } catch (RuntimeException e) {
+            current = null;
+        }
+        // saveFile enforces canWrite (#940) — a non-writer is rejected here.
+        String resp;
+        try {
+            resp = datasourceService.saveFile(v.dashboard, dashboard, username, roles);
+        } catch (RuntimeException e) {
+            return forbidden();
+        }
+        if (!SAVE_OK.equals(resp)) {
+            return forbidden();
+        }
+        try {
+            historyService.archive(dashboard, current, username);
+        } catch (RuntimeException e) {
+            log.warn("history archive after restore failed for {}", dashboard, e);
+        }
+        log.info("dashboard {} restored to version {} by {}", dashboard, version, username);
+        return Response.ok(Map.of("status", "OK", "restored", version))
+                .type(MediaType.APPLICATION_JSON)
+                .build();
+    }
+
+    /* --------------------------- helpers ---------------------------- */
+
+    /** canRead proxy: a successful dashboard read (getResourceACL is canGrant-only). */
+    private boolean canRead(String dashboard) {
+        if (dashboard == null || !dashboard.endsWith(".saikudash")) {
+            return false;
+        }
+        try {
+            String d = datasourceService.getFileData(dashboard, currentUsername(), currentRoles());
+            return d != null && !d.isEmpty();
+        } catch (RuntimeException e) {
+            return false;
+        }
+    }
+
+    private String currentUsername() {
+        if (sessionService == null) {
+            return null;
+        }
+        Object u = sessionService.getAllSessionObjects().get("username");
+        return u == null ? null : u.toString();
+    }
+
+    @SuppressWarnings("unchecked")
+    private List<String> currentRoles() {
+        if (sessionService == null) {
+            return List.of();
+        }
+        Object r = sessionService.getAllSessionObjects().get("roles");
+        if (r instanceof List<?>) {
+            return (List<String>) r;
+        }
+        return List.of();
+    }
+
+    private static Response badRequest(String message) {
+        return Response.status(Response.Status.BAD_REQUEST)
+                .entity(Map.of("status", "VALIDATION_ERROR", "error", message))
+                .type(MediaType.APPLICATION_JSON)
+                .build();
+    }
+
+    private static Response forbidden() {
+        return Response.status(Response.Status.FORBIDDEN)
+                .entity(Map.of("status", "FORBIDDEN", "error", "You don't have access to this dashboard"))
+                .type(MediaType.APPLICATION_JSON)
+                .build();
+    }
+
+    private static Response notFound() {
+        return Response.status(Response.Status.NOT_FOUND)
+                .entity(Map.of("status", "NOT_FOUND", "error", "Unknown version"))
+                .type(MediaType.APPLICATION_JSON)
+                .build();
+    }
+}

--- a/saiku-launcher/test-history-live.sh
+++ b/saiku-launcher/test-history-live.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# Live verification for #947 — dashboard versioning / history.
+# Proves: each save archives the replaced version; list/preview/restore work;
+# restore is reversible (pre-restore state archived); access gated on dashboard
+# canRead (non-reader + anonymous denied).
+# Usage: launcher on :8087 (SAIKU_DEMO=true), then ./test-history-live.sh
+set -u
+URL="${SAIKU_URL:-http://localhost:8087}"
+A=$(mktemp); B=$(mktemp); trap 'rm -f "$A" "$B"' EXIT
+PASS=0; FAIL=0
+ok(){ echo "  PASS: $1"; PASS=$((PASS+1)); }
+no(){ echo "  FAIL: $1 | code=$2 body=${3:0:180}"; FAIL=$((FAIL+1)); }
+login(){ curl -s -b "$1" -c "$1" -X POST "$URL/rest/saiku/session" --data "username=$2&password=$3" -o /dev/null -w '%{http_code}'; }
+req(){ local jar="$1" m="$2" p="$3" body="${4:-}"; local out cj; out=$(mktemp)
+  if [ "$jar" = "-" ]; then cj=""; else cj="-b $jar"; fi
+  if [ "$m" = GET ]; then RC=$(curl -s $cj "$URL$p" -o "$out" -w '%{http_code}')
+  else RC=$(curl -s $cj -X "$m" "$URL$p" -H 'Content-Type: application/json' --data "$body" -o "$out" -w '%{http_code}'); fi
+  RB=$(cat "$out"); rm -f "$out"; }
+denied(){ case "$1" in 401|403) return 0;; *) return 1;; esac; }
+
+H="/rest/saiku/api/dashboards/history"
+DASH="dashboards/histtest947.saikudash"
+DGET="/rest/saiku/api/dashboards/$DASH"
+V1='{"id":"h1","name":"V1","version":1,"layout":{"cols":12,"tiles":[]}}'
+V2='{"id":"h1","name":"V2","version":1,"layout":{"cols":12,"tiles":[]}}'
+
+echo "== setup: save v1 then v2 (v2 save archives v1) =="
+[ "$(login "$A" admin admin)" = 200 ] && ok "admin login" || no "admin login" "?" ""
+[ "$(login "$B" bob dylan)" = 200 ] && ok "bob login" || no "bob login" "?" ""
+req "$A" POST "$DGET" "$V1"; echo "$RB" | grep -q '"status":"OK"' && ok "save v1" || no "save v1" "$RC" "$RB"
+req "$A" POST "$DGET" "$V2"; echo "$RB" | grep -q '"status":"OK"' && ok "save v2" || no "save v2" "$RC" "$RB"
+
+echo "== history lists the archived v1 =="
+req "$A" GET "$H?dashboard=$DASH"
+VID=$(echo "$RB" | sed -n 's/.*"version":"\([^"]*\)".*/\1/p' | head -1)
+{ [ "$RC" = 200 ] && [ -n "$VID" ] && echo "$RB" | grep -q '"author":"admin"'; } && ok "history shows 1 archived version (v1, author admin)" || no "history list" "$RC" "$RB"
+# Preview returns the stored dashboard JSON (pretty-printed), so match name tolerantly.
+req "$A" GET "$H/version?dashboard=$DASH&version=$VID"; echo "$RB" | grep -Eq '"name" *: *"V1"' && ok "preview returns the v1 snapshot" || no "preview" "$RC" "$RB"
+
+echo "== restore v1 (reversible) =="
+req "$A" POST "$H/restore?dashboard=$DASH&version=$VID"; echo "$RB" | grep -q '"status":"OK"' && ok "restore v1" || no "restore" "$RC" "$RB"
+req "$A" GET "$DGET"; echo "$RB" | grep -q '"name":"V1"' && ok "live dashboard is now V1" || no "restored content" "$RC" "$RB"
+req "$A" GET "$H?dashboard=$DASH"
+# >= 2 (v1 + the pre-restore V2). >= rather than == so the script is re-runnable:
+# the saiku-history-*.jsonl persists across runs (not removed on dashboard delete).
+CNT=$(echo "$RB" | grep -o '"version":"' | wc -l | tr -d ' ')
+[ "$CNT" -ge 2 ] && ok "history grew to $CNT (v1 + pre-restore V2 archived → restore is reversible)" || no "history count after restore ($CNT)" "$RC" "$RB"
+
+echo "== access gating =="
+req "$B" GET "$H?dashboard=$DASH"; denied "$RC" && ok "bob (non-reader) history denied ($RC)" || no "bob history not denied" "$RC" "$RB"
+req "$B" POST "$H/restore?dashboard=$DASH&version=$VID"; denied "$RC" && ok "bob restore denied ($RC)" || no "bob restore not denied" "$RC" "$RB"
+req "-" GET "$H?dashboard=$DASH"; denied "$RC" && ok "anonymous denied ($RC)" || no "anon not denied" "$RC" "$RB"
+
+echo "== cleanup =="
+req "$A" DELETE "$DGET" >/dev/null 2>&1
+echo ""; echo "RESULT: $PASS passed, $FAIL failed"; exit $FAIL

--- a/saiku-webapp/src/main/webapp/WEB-INF/saiku-beans.xml
+++ b/saiku-webapp/src/main/webapp/WEB-INF/saiku-beans.xml
@@ -319,6 +319,24 @@
           class="org.saiku.web.rest.resources.dashboards.DashboardResource">
         <property name="datasourceService" ref="datasourceServiceBean"/>
         <property name="sessionService" ref="sessionService"/>
+        <property name="historyService" ref="dashboardHistoryService"/>
+    </bean>
+
+    <!-- Dashboard versioning / history (issue #947). dashboardHistoryService
+         archives the replaced version on each save (flat saiku-history-*.jsonl,
+         retain 50); dashboardHistoryResource (@ /saiku/api/dashboards/history)
+         lists/previews/restores, gated on dashboard canRead (#940) for view and
+         canWrite (via saveFile) for restore. Under /rest/** so #941 guests
+         can't reach it. -->
+    <bean id="dashboardHistoryService" class="org.saiku.service.history.DashboardHistoryService">
+        <property name="datasourceService" ref="datasourceServiceBean"/>
+    </bean>
+
+    <bean id="dashboardHistoryResource"
+          class="org.saiku.web.rest.resources.history.DashboardHistoryResource">
+        <property name="historyService" ref="dashboardHistoryService"/>
+        <property name="datasourceService" ref="datasourceServiceBean"/>
+        <property name="sessionService" ref="sessionService"/>
     </bean>
 
     <!-- ====================================================================


### PR DESCRIPTION
## Summary
Backend for **#947 — dashboard versioning / history**: every save archives the previous version so a botched edit is recoverable. Users can list versions (timestamp + author), preview a prior version, and restore it (restore is itself reversible). This is the backend (hook + REST + storage + tests); a follow-up **PR2** adds the toolbar "Version history" side panel.

> 🔗 **Stacked on #1059 (#940 ACL fix)** — restore goes through `saveFile` (file-level `canWrite`) and history viewing is gated on dashboard `canRead`, so this is based on #1059 and its diff currently includes #940. **Merge #1059 first**, then I'll rebase to the #947-only delta. (Independent of #1060/#1061.)

## Design
- **Archive-on-save hook** in `DashboardResource.save`: capture the current file *before* writing; `saveFile` (enforces #940 `canWrite`); only on `SAVE_OK` + a non-empty previous body, `historyService.archive(...)`. Strictly **additive and after a successful write**, wrapped so a history failure can never block/corrupt a save.
- **Storage:** one flat `saiku-history-<sanitised-dashboardPath>.jsonl` at the datadir root via the internal-file API (same pattern + constraints as #942 comments). One version per line `{version(UUID), createdAt, author, dashboard(raw JSON)}`; **retain the most recent 50** (prune-on-append; satisfies "never delete if < 5").
- **REST** `DashboardHistoryResource` (`/saiku/api/dashboards/history`): `GET ?dashboard=` (list metadata, newest-first), `GET /version?dashboard=&version=` (preview full snapshot), `POST /restore?dashboard=&version=` (overwrite live + archive the pre-restore state). List/preview gated on dashboard **canRead**; restore on **canWrite** (via `saveFile`). Under `/rest/**` so #941 share guests can't reach it.

## New / changed files
- `saiku-service`: `history/DashboardVersion.java`, `history/DashboardHistoryService.java` (+ `DashboardHistoryServiceTest`)
- `saiku-web`: `rest/resources/history/DashboardHistoryResource.java`; **edit** `dashboards/DashboardResource.java` (archive hook + setter)
- `saiku-beans.xml`: `dashboardHistoryService` + `dashboardHistoryResource` beans, inject history into `dashboardResource`
- `saiku-launcher/test-history-live.sh`

## Verified
- `DashboardHistoryServiceTest` → **5/5** (archive→list newest-first; exact-snapshot retrieval; retain-50 pruning; blank/missing safe; traversal-flattened path).
- **Live REST** `test-history-live.sh` → **12/12** (save v1→v2 archives v1; list/preview; restore reverts the live dashboard; restore archives the pre-restore state → reversible; non-reader + anonymous denied 403/401). **User-verified locally.**
- No #940-test regression; reactor compiles; spotless clean. (Same 10 pre-existing Windows-CRLF golden failures in mdx/cache/schema are unrelated — green on Linux CI.)

## Out of scope / deferred (→ PR2 / future)
- UI: toolbar "Version history" panel + read-only preview render + Restore button.
- Configurable retention (hard-coded 50); diffing; named snapshots.
- **Orphaned history on dashboard delete** — deleting a dashboard currently leaves its `saiku-history-*.jsonl`; a small follow-up should clean it up.

## Test plan
Launcher on :8087 (`SAIKU_DEMO=true`): `bash saiku-launcher/test-history-live.sh` → 12/12. Manual: save a dashboard twice (different names); `GET /rest/saiku/api/dashboards/history?dashboard=...`; copy a `version`; `POST .../history/restore?dashboard=...&version=...`; confirm the live dashboard reverted.

## Note
Read-modify-write history file is single-node-safe, not concurrency-guarded (note for future; same as #942).

🤖 Generated with [Claude Code](https://claude.com/claude-code)