### PR TITLE
feat(dashboard): PR2 UIs — share viewer + version history + comments (#941 #942 #947)

### DIFF
--- a/saiku-ui/src/lib/api/aiQuery.ts
+++ b/saiku-ui/src/lib/api/aiQuery.ts
@@ -105,6 +105,37 @@ export function isAiCell(v: unknown): v is AiCell {
   return typeof v === "object" && v !== null && "formatted" in (v as object);
 }
 
+/* ------------------------- share view (#941 PR2) ------------------------- */
+
+/** Base for the account-free guest view surface. The token is carried in the
+ *  `X-Saiku-Share-Token` header (NOT a cookie / query param) — see the
+ *  hardened backend. */
+const SHARE_VIEW_BASE = "/rest/saiku/share/view";
+
+/** Run one tile's authored query under the share owner's scope (#941). The
+ *  guest supplies no query body — only the tile id, validated server-side
+ *  against the token-pinned dashboard. */
+export async function runSharedTileQuery(
+  token: string,
+  tileId: string,
+  format: "records" | "matrix" = "records",
+): Promise<AiQueryResponse> {
+  const url = `${SHARE_VIEW_BASE}/tile/${encodeURIComponent(tileId)}/query?format=${encodeURIComponent(format)}`;
+  const res = await fetch(url, {
+    method: "POST",
+    headers: { "X-Saiku-Share-Token": token, Accept: "application/json" },
+  });
+  const text = await res.text();
+  if (!text) {
+    throw new Error(`runSharedTileQuery -> ${res.status}: empty body`);
+  }
+  try {
+    return JSON.parse(text) as AiQueryResponse;
+  } catch (e) {
+    throw new Error(`runSharedTileQuery -> ${res.status}: non-JSON response (${(e as Error).message})`);
+  }
+}
+
 /** Slicer-style filter shape that /ai/query/saved accepts to merge
  *  dashboard-level filters onto the loaded ThinQuery. Mirrors the
  *  server-side AiFilterSelection: dim/hier/level + canonical MDX member

--- a/saiku-ui/src/lib/api/dashboards.ts
+++ b/saiku-ui/src/lib/api/dashboards.ts
@@ -527,3 +527,176 @@ function cryptoUuid(): string {
 // Kept for forward compatibility — the inline TileQuery body uses the same
 // shape ThinQuery already round-trips through the AI API.
 export type { ThinQuery };
+
+/* =========================================================================
+ * PR2 clients for the merged governance/sharing backends.
+ * ========================================================================= */
+
+const SHARE_BASE = "/rest/saiku/share";
+
+/** Load a dashboard via the account-free guest share surface (#941). Token in
+ *  the `X-Saiku-Share-Token` header — no cookie. */
+export async function loadSharedDashboard(token: string): Promise<Dashboard> {
+  const res = await fetch(`${SHARE_BASE}/view/dashboard`, {
+    headers: { "X-Saiku-Share-Token": token, Accept: "application/json" },
+  });
+  if (!res.ok) {
+    throw new Error(`loadSharedDashboard -> ${res.status}`);
+  }
+  return (await res.json()) as Dashboard;
+}
+
+/* --------------------------- comments (#942) --------------------------- */
+
+export interface DashboardComment {
+  id: string;
+  tileId: string;
+  author: string;
+  body: string;
+  mentions: string[];
+  createdAt: number;
+  deleted: boolean;
+}
+
+export async function getComments(dashboardPath: string, tileId: string): Promise<DashboardComment[]> {
+  const params = new URLSearchParams({ dashboard: dashboardPath, tile: tileId });
+  const res = await fetch(`${REST_BASE}/comments?${params}`, {
+    credentials: "include",
+    headers: { Accept: "application/json" },
+  });
+  if (!res.ok) {
+    throw new Error(`getComments -> ${res.status}`);
+  }
+  return (await res.json()) as DashboardComment[];
+}
+
+export async function postComment(
+  dashboardPath: string,
+  tileId: string,
+  body: string,
+): Promise<DashboardComment> {
+  const res = await fetch(`${REST_BASE}/comments`, {
+    method: "POST",
+    credentials: "include",
+    headers: { "Content-Type": "application/json", Accept: "application/json" },
+    body: JSON.stringify({ dashboard: dashboardPath, tile: tileId, body }),
+  });
+  if (!res.ok) {
+    throw new Error(`postComment -> ${res.status}: ${await readError(res)}`);
+  }
+  return (await res.json()) as DashboardComment;
+}
+
+export async function deleteComment(dashboardPath: string, commentId: string): Promise<void> {
+  const params = new URLSearchParams({ dashboard: dashboardPath });
+  const res = await fetch(`${REST_BASE}/comments/${encodeURIComponent(commentId)}?${params}`, {
+    method: "DELETE",
+    credentials: "include",
+    headers: { Accept: "application/json" },
+  });
+  if (!res.ok) {
+    throw new Error(`deleteComment -> ${res.status}`);
+  }
+}
+
+/* --------------------------- history (#947) ---------------------------- */
+
+export interface DashboardHistoryEntry {
+  version: string;
+  createdAt: number;
+  author: string;
+}
+
+export async function getHistory(dashboardPath: string): Promise<DashboardHistoryEntry[]> {
+  const res = await fetch(`${REST_BASE}/history?dashboard=${encodeURIComponent(dashboardPath)}`, {
+    credentials: "include",
+    headers: { Accept: "application/json" },
+  });
+  if (!res.ok) {
+    throw new Error(`getHistory -> ${res.status}`);
+  }
+  return (await res.json()) as DashboardHistoryEntry[];
+}
+
+export async function getHistoryVersion(dashboardPath: string, version: string): Promise<Dashboard> {
+  const params = new URLSearchParams({ dashboard: dashboardPath, version });
+  const res = await fetch(`${REST_BASE}/history/version?${params}`, {
+    credentials: "include",
+    headers: { Accept: "application/json" },
+  });
+  if (!res.ok) {
+    throw new Error(`getHistoryVersion -> ${res.status}`);
+  }
+  return (await res.json()) as Dashboard;
+}
+
+export async function restoreHistory(dashboardPath: string, version: string): Promise<void> {
+  const params = new URLSearchParams({ dashboard: dashboardPath, version });
+  const res = await fetch(`${REST_BASE}/history/restore?${params}`, {
+    method: "POST",
+    credentials: "include",
+    headers: { Accept: "application/json" },
+  });
+  if (!res.ok) {
+    throw new Error(`restoreHistory -> ${res.status}`);
+  }
+}
+
+/* ---------------------------- share mint (#941) ------------------------ */
+
+export interface ShareMintResult {
+  status: string;
+  token: string;
+  url: string;
+  expiresAt: number;
+}
+
+export interface ShareTokenInfo {
+  token: string;
+  dashboardPath: string;
+  createdBy: string;
+  createdAt: number;
+  expiresAt: number;
+  revoked: boolean;
+  label: string;
+  active: boolean;
+}
+
+export async function mintShare(
+  dashboardPath: string,
+  ttlHours?: number,
+  label?: string,
+): Promise<ShareMintResult> {
+  const res = await fetch(`${SHARE_BASE}/mint`, {
+    method: "POST",
+    credentials: "include",
+    headers: { "Content-Type": "application/json", Accept: "application/json" },
+    body: JSON.stringify({ dashboardPath, ttlHours, label }),
+  });
+  if (!res.ok) {
+    throw new Error(`mintShare -> ${res.status}: ${await readError(res)}`);
+  }
+  return (await res.json()) as ShareMintResult;
+}
+
+export async function listShareTokens(): Promise<ShareTokenInfo[]> {
+  const res = await fetch(`${SHARE_BASE}/tokens`, {
+    credentials: "include",
+    headers: { Accept: "application/json" },
+  });
+  if (!res.ok) {
+    throw new Error(`listShareTokens -> ${res.status}`);
+  }
+  return (await res.json()) as ShareTokenInfo[];
+}
+
+export async function revokeShareToken(token: string): Promise<void> {
+  const res = await fetch(`${SHARE_BASE}/tokens/${encodeURIComponent(token)}`, {
+    method: "DELETE",
+    credentials: "include",
+    headers: { Accept: "application/json" },
+  });
+  if (!res.ok) {
+    throw new Error(`revokeShareToken -> ${res.status}`);
+  }
+}

--- a/saiku-ui/src/lib/dashboard/shareUrl.test.ts
+++ b/saiku-ui/src/lib/dashboard/shareUrl.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import { buildShareUrl, parseShareToken } from "./shareUrl";
+
+describe("buildShareUrl", () => {
+  it("puts the token in the fragment, root-relative by default", () => {
+    expect(buildShareUrl("abc123")).toBe("/share#abc123");
+  });
+
+  it("includes origin + base when provided", () => {
+    expect(buildShareUrl("abc123", { origin: "https://demo.saiku.bi", base: "/ui" })).toBe(
+      "https://demo.saiku.bi/ui/share#abc123",
+    );
+  });
+
+  it("url-encodes the token", () => {
+    expect(buildShareUrl("a b/c")).toBe("/share#a%20b%2Fc");
+  });
+});
+
+describe("parseShareToken", () => {
+  it("reads the token with or without a leading #", () => {
+    expect(parseShareToken("#mytoken")).toBe("mytoken");
+    expect(parseShareToken("mytoken")).toBe("mytoken");
+  });
+
+  it("round-trips an encoded token", () => {
+    expect(parseShareToken("#a%20b%2Fc")).toBe("a b/c");
+  });
+
+  it("returns null for an empty fragment", () => {
+    expect(parseShareToken("")).toBeNull();
+    expect(parseShareToken("#")).toBeNull();
+  });
+});

--- a/saiku-ui/src/lib/dashboard/shareUrl.ts
+++ b/saiku-ui/src/lib/dashboard/shareUrl.ts
@@ -1,0 +1,26 @@
+/*
+ * Share-link URL helpers (#941 PR2). The share token is carried in the URL
+ * FRAGMENT (after `#`), never a path or query param — the fragment is not sent
+ * to the server in the Referer header or access logs, which is why the backend
+ * was hardened to read the token from the `X-Saiku-Share-Token` header that the
+ * viewer page echoes from `window.location.hash`.
+ *
+ * Pure (no DOM / SvelteKit imports) so it unit-tests cleanly; callers pass the
+ * current origin + SvelteKit base in.
+ */
+
+/** Build a shareable link for `token`, e.g.
+ *  `https://host/ui/share#<token>`. `origin` + `base` are passed in so this
+ *  stays pure; omit them for a root-relative `/share#<token>`. */
+export function buildShareUrl(token: string, opts?: { origin?: string; base?: string }): string {
+  const origin = opts?.origin ?? "";
+  const base = opts?.base ?? "";
+  return `${origin}${base}/share#${encodeURIComponent(token)}`;
+}
+
+/** Extract the token from a URL fragment (`window.location.hash`), accepting
+ *  it with or without the leading `#`. Returns null when absent. */
+export function parseShareToken(hash: string): string | null {
+  const h = (hash ?? "").replace(/^#/, "");
+  return h.length > 0 ? decodeURIComponent(h) : null;
+}

--- a/saiku-ui/src/lib/dashboard/shareViewContext.ts
+++ b/saiku-ui/src/lib/dashboard/shareViewContext.ts
@@ -1,0 +1,29 @@
+/*
+ * Share-view response injection (#941 PR2). The public /share viewer prefetches
+ * each tile's data via the guest endpoint and stashes it in a per-tile map set
+ * as a Svelte context. Data tiles (ChartTile/TableTile/KpiTile) look up their
+ * own response here at init and, if present, render from it instead of running
+ * the normal live fetch — so the same tile components serve the read-only guest
+ * view without a Saiku session or access to /ai/query.
+ *
+ * Outside the share viewer the context is absent, so getShareViewResponse()
+ * returns undefined and tiles fetch as usual — zero impact on normal mode.
+ */
+import { getContext, setContext } from "svelte";
+import type { AiQueryResponse } from "$lib/api/aiQuery";
+
+const SHARE_VIEW_KEY = Symbol("saiku.shareViewResponses");
+
+/** Provide the prefetched per-tile responses to descendant tiles. Call once in
+ *  the share viewer page before rendering the dashboard. */
+export function setShareViewResponses(responses: Map<string, AiQueryResponse>): void {
+  setContext(SHARE_VIEW_KEY, responses);
+}
+
+/** The prefetched response for `tileId`, or undefined when not in a share view
+ *  (normal dashboard mode — the tile then fetches live). Must be called during
+ *  component init (getContext requirement). */
+export function getShareViewResponse(tileId: string): AiQueryResponse | undefined {
+  const responses = getContext<Map<string, AiQueryResponse> | undefined>(SHARE_VIEW_KEY);
+  return responses?.get(tileId);
+}

--- a/saiku-ui/src/lib/views/dashboard/CommentsPanel.svelte
+++ b/saiku-ui/src/lib/views/dashboard/CommentsPanel.svelte
@@ -1,0 +1,211 @@
+<script lang="ts">
+  /*
+   * #942 PR2 — per-tile comments thread. Lists comments for one tile, lets the
+   * user post (plain @username typing — mentions are parsed server-side;
+   * autocomplete deferred until a non-admin users-list endpoint exists), and
+   * delete their own (admins delete any).
+   */
+  import Modal from "$lib/components/Modal.svelte";
+  import { Trash2, Send } from "lucide-svelte";
+  import { session } from "$lib/stores/session.svelte";
+  import { getComments, postComment, deleteComment, type DashboardComment } from "$lib/api/dashboards";
+
+  interface Props {
+    dashboardPath: string;
+    tileId: string;
+    tileTitle?: string;
+    open: boolean;
+    onClose: () => void;
+    /** Bubble the live comment count up so the tile badge stays in sync. */
+    onCountChange?: (count: number) => void;
+  }
+
+  let { dashboardPath, tileId, tileTitle, open, onClose, onCountChange }: Props = $props();
+
+  let comments = $state<DashboardComment[]>([]);
+  let loading = $state(false);
+  let error = $state<string | null>(null);
+  let body = $state("");
+  let posting = $state(false);
+
+  $effect(() => {
+    if (open) {
+      void load();
+    }
+  });
+
+  async function load(): Promise<void> {
+    loading = true;
+    error = null;
+    try {
+      comments = await getComments(dashboardPath, tileId);
+      onCountChange?.(comments.length);
+    } catch (e) {
+      error = e instanceof Error ? e.message : "Failed to load comments";
+    } finally {
+      loading = false;
+    }
+  }
+
+  async function post(): Promise<void> {
+    const text = body.trim();
+    if (!text) return;
+    posting = true;
+    error = null;
+    try {
+      await postComment(dashboardPath, tileId, text);
+      body = "";
+      await load();
+    } catch (e) {
+      error = e instanceof Error ? e.message : "Failed to post";
+    } finally {
+      posting = false;
+    }
+  }
+
+  async function remove(id: string): Promise<void> {
+    try {
+      await deleteComment(dashboardPath, id);
+      await load();
+    } catch (e) {
+      error = e instanceof Error ? e.message : "Failed to delete";
+    }
+  }
+
+  function canDelete(c: DashboardComment): boolean {
+    return session.current?.username === c.author || session.isAdmin;
+  }
+
+  function fmtDate(ms: number): string {
+    try {
+      return new Date(ms).toLocaleString();
+    } catch {
+      return String(ms);
+    }
+  }
+
+  function onKeydown(e: KeyboardEvent): void {
+    // Ctrl/Cmd+Enter posts.
+    if ((e.ctrlKey || e.metaKey) && e.key === "Enter") {
+      e.preventDefault();
+      void post();
+    }
+  }
+</script>
+
+<Modal title={tileTitle ? `Comments — ${tileTitle}` : "Comments"} {open} size="md" {onClose}>
+  <div class="cmts">
+    {#if loading}
+      <p class="cmts__state">Loading…</p>
+    {:else if error}
+      <p class="cmts__state cmts__state--error">{error}</p>
+    {:else if comments.length === 0}
+      <p class="cmts__state">No comments yet. Start the conversation about this tile.</p>
+    {:else}
+      <ul class="cmts__list">
+        {#each comments as c (c.id)}
+          <li class="cmts__item">
+            <div class="cmts__head">
+              <span class="cmts__author">{c.author}</span>
+              <span class="cmts__date">{fmtDate(c.createdAt)}</span>
+              {#if canDelete(c)}
+                <button type="button" class="cmts__del" onclick={() => remove(c.id)} title="Delete comment">
+                  <Trash2 size={13} />
+                </button>
+              {/if}
+            </div>
+            <p class="cmts__body">{c.body}</p>
+          </li>
+        {/each}
+      </ul>
+    {/if}
+
+    <div class="cmts__compose">
+      <textarea
+        class="cmts__input"
+        bind:value={body}
+        placeholder="Add a comment… use @name to mention someone (Ctrl/Cmd+Enter to post)"
+        rows="2"
+        onkeydown={onKeydown}
+      ></textarea>
+      <button type="button" class="btn primary" onclick={post} disabled={posting || !body.trim()}>
+        <Send size={14} /><span>{posting ? "Posting…" : "Post"}</span>
+      </button>
+    </div>
+  </div>
+</Modal>
+
+<style>
+  .cmts {
+    min-width: 24rem;
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-3);
+  }
+  .cmts__state {
+    color: var(--fg-muted);
+    font-size: var(--fs-sm);
+    padding: var(--space-2) 0;
+  }
+  .cmts__state--error {
+    color: var(--danger);
+  }
+  .cmts__list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-2);
+    max-height: 40vh;
+    overflow: auto;
+  }
+  .cmts__item {
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+    padding: var(--space-2);
+    background: var(--bg-subtle);
+  }
+  .cmts__head {
+    display: flex;
+    align-items: center;
+    gap: var(--space-2);
+  }
+  .cmts__author {
+    font-weight: var(--weight-bold);
+    font-size: var(--fs-sm);
+  }
+  .cmts__date {
+    font-size: var(--fs-xs, 0.75rem);
+    color: var(--fg-muted);
+  }
+  .cmts__del {
+    margin-left: auto;
+    background: none;
+    border: none;
+    color: var(--fg-muted);
+    cursor: pointer;
+    padding: 2px;
+  }
+  .cmts__del:hover {
+    color: var(--danger);
+  }
+  .cmts__body {
+    margin: var(--space-1) 0 0;
+    font-size: var(--fs-sm);
+    white-space: pre-wrap;
+    word-break: break-word;
+  }
+  .cmts__compose {
+    display: flex;
+    gap: var(--space-2);
+    align-items: flex-end;
+    border-top: 1px solid var(--border);
+    padding-top: var(--space-2);
+  }
+  .cmts__input {
+    flex: 1;
+    resize: vertical;
+    font: inherit;
+  }
+</style>

--- a/saiku-ui/src/lib/views/dashboard/DashboardShareModal.svelte
+++ b/saiku-ui/src/lib/views/dashboard/DashboardShareModal.svelte
@@ -1,0 +1,215 @@
+<script lang="ts">
+  /*
+   * #941 PR2 — owner-facing "Share" dialog. Mints a time-bounded, account-free
+   * read-only link (POST /share/mint), shows the copyable /ui/share#<token> URL
+   * (token in the fragment), and lists / revokes this dashboard's active links.
+   */
+  import { base } from "$app/paths";
+  import Modal from "$lib/components/Modal.svelte";
+  import { Copy, Check, Trash2 } from "lucide-svelte";
+  import {
+    mintShare,
+    listShareTokens,
+    revokeShareToken,
+    type ShareTokenInfo,
+  } from "$lib/api/dashboards";
+  import { buildShareUrl } from "$lib/dashboard/shareUrl";
+
+  interface Props {
+    dashboardPath: string;
+    open: boolean;
+    onClose: () => void;
+  }
+
+  let { dashboardPath, open, onClose }: Props = $props();
+
+  let ttlHours = $state(72);
+  let busy = $state(false);
+  let error = $state<string | null>(null);
+  let mintedUrl = $state<string | null>(null);
+  let copied = $state(false);
+  let tokens = $state<ShareTokenInfo[]>([]);
+
+  function fullUrl(token: string): string {
+    const origin = typeof window !== "undefined" ? window.location.origin : "";
+    return buildShareUrl(token, { origin, base });
+  }
+
+  async function refresh(): Promise<void> {
+    try {
+      const all = await listShareTokens();
+      tokens = all.filter((t) => t.dashboardPath === dashboardPath && t.active);
+    } catch {
+      // listing is best-effort; minting still works
+    }
+  }
+
+  // Reload the active-link list whenever the dialog opens.
+  $effect(() => {
+    if (open) {
+      mintedUrl = null;
+      error = null;
+      copied = false;
+      void refresh();
+    }
+  });
+
+  async function create(): Promise<void> {
+    busy = true;
+    error = null;
+    copied = false;
+    try {
+      const res = await mintShare(dashboardPath, ttlHours);
+      mintedUrl = fullUrl(res.token);
+      await refresh();
+    } catch (e) {
+      error = e instanceof Error ? e.message : "Failed to create share link";
+    } finally {
+      busy = false;
+    }
+  }
+
+  async function copy(): Promise<void> {
+    if (!mintedUrl) return;
+    try {
+      await navigator.clipboard.writeText(mintedUrl);
+      copied = true;
+      setTimeout(() => (copied = false), 1500);
+    } catch {
+      error = "Could not copy — select the link and copy manually.";
+    }
+  }
+
+  async function revoke(token: string): Promise<void> {
+    try {
+      await revokeShareToken(token);
+      await refresh();
+    } catch (e) {
+      error = e instanceof Error ? e.message : "Failed to revoke";
+    }
+  }
+
+  function fmtDate(ms: number): string {
+    try {
+      return new Date(ms).toLocaleString();
+    } catch {
+      return String(ms);
+    }
+  }
+</script>
+
+<Modal title="Share dashboard" {open} size="md" {onClose}>
+  <div class="share">
+    <p class="share__hint">
+      Anyone with the link can <strong>view</strong> this dashboard read-only — no Saiku
+      account needed. Links expire and can be revoked.
+    </p>
+
+    <div class="share__create">
+      <label class="share__ttl">
+        <span>Expires in (hours)</span>
+        <input type="number" min="1" max="720" bind:value={ttlHours} />
+      </label>
+      <button type="button" class="btn primary" onclick={create} disabled={busy || !dashboardPath}>
+        {busy ? "Creating…" : "Create link"}
+      </button>
+    </div>
+
+    {#if error}<p class="share__error">{error}</p>{/if}
+
+    {#if mintedUrl}
+      <div class="share__result">
+        <input class="share__url" readonly value={mintedUrl} aria-label="Share link" />
+        <button type="button" class="btn" onclick={copy} title="Copy link">
+          {#if copied}<Check size={14} />{:else}<Copy size={14} />{/if}
+          <span>{copied ? "Copied" : "Copy"}</span>
+        </button>
+      </div>
+    {/if}
+
+    {#if tokens.length > 0}
+      <div class="share__list">
+        <span class="share__list-title">Active links</span>
+        {#each tokens as t (t.token)}
+          <div class="share__row">
+            <span class="share__row-meta">expires {fmtDate(t.expiresAt)}</span>
+            <button
+              type="button"
+              class="btn btn--sm danger"
+              onclick={() => revoke(t.token)}
+              title="Revoke this link"
+            >
+              <Trash2 size={13} /><span>Revoke</span>
+            </button>
+          </div>
+        {/each}
+      </div>
+    {/if}
+  </div>
+</Modal>
+
+<style>
+  .share {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-3);
+    min-width: 22rem;
+  }
+  .share__hint {
+    color: var(--fg-muted);
+    font-size: var(--fs-sm);
+    margin: 0;
+  }
+  .share__create {
+    display: flex;
+    align-items: flex-end;
+    gap: var(--space-3);
+  }
+  .share__ttl {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-1);
+    font-size: var(--fs-sm);
+    color: var(--fg-muted);
+  }
+  .share__ttl input {
+    width: 6rem;
+  }
+  .share__result {
+    display: flex;
+    gap: var(--space-2);
+    align-items: center;
+  }
+  .share__url {
+    flex: 1;
+    font-family: var(--font-mono, monospace);
+    font-size: var(--fs-sm);
+  }
+  .share__error {
+    color: var(--danger);
+    font-size: var(--fs-sm);
+    margin: 0;
+  }
+  .share__list {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-2);
+    border-top: 1px solid var(--border);
+    padding-top: var(--space-2);
+  }
+  .share__list-title {
+    font-size: var(--fs-sm);
+    color: var(--fg-muted);
+    font-weight: var(--weight-bold);
+  }
+  .share__row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--space-2);
+  }
+  .share__row-meta {
+    font-size: var(--fs-sm);
+    color: var(--fg-muted);
+  }
+</style>

--- a/saiku-ui/src/lib/views/dashboard/DashboardToolbar.svelte
+++ b/saiku-ui/src/lib/views/dashboard/DashboardToolbar.svelte
@@ -16,7 +16,11 @@
   import FilterSuggestionsModal from "$lib/views/dashboard/FilterSuggestionsModal.svelte";
   import PrefsMenu from "$lib/components/PrefsMenu.svelte";
   import type { TileType } from "$lib/api/dashboards";
-  import { Monitor, RotateCcw, X } from "lucide-svelte";
+  import { Monitor, RotateCcw, X, Share2, History } from "lucide-svelte";
+  // #941 + #947 PR2 — share-link + version-history entry points.
+  import { dashboardStore } from "$lib/stores/dashboard.svelte";
+  import DashboardShareModal from "$lib/views/dashboard/DashboardShareModal.svelte";
+  import HistoryPanel from "$lib/views/dashboard/HistoryPanel.svelte";
 
   interface Props {
     name: string;
@@ -52,6 +56,12 @@
     onResetFilters,
     onPresent,
   }: Props = $props();
+
+  // #941/#947: share + history act on the SAVED dashboard, so the buttons only
+  // appear once it has a repository path (not for an unsaved draft).
+  const savedPath = $derived(dashboardStore.savedPath);
+  let shareOpen = $state(false);
+  let historyOpen = $state(false);
 
   let suggestOpen = $state(false);
   let newTagInput = $state<string>("");
@@ -210,12 +220,45 @@
       </button>
     {/if}
 
+    {#if savedPath}
+      <button
+        type="button"
+        class="btn"
+        onclick={() => (historyOpen = true)}
+        title="Version history — preview and restore earlier saves"
+        aria-haspopup="dialog"
+      >
+        <History size={14} aria-hidden="true" />
+        <span>History</span>
+      </button>
+      <button
+        type="button"
+        class="btn"
+        onclick={() => (shareOpen = true)}
+        title="Share a read-only link to this dashboard"
+        aria-haspopup="dialog"
+      >
+        <Share2 size={14} aria-hidden="true" />
+        <span>Share</span>
+      </button>
+    {/if}
+
     <!-- saiku#1050: theme (dark/light/system) + language control, parity with
          the workspace. Shown in both editor and viewer; the whole toolbar is
          hidden in presentation mode (#928), so it disappears on TV walls. -->
     <PrefsMenu placement="down" />
   </div>
 </header>
+
+{#if savedPath}
+  <DashboardShareModal dashboardPath={savedPath} open={shareOpen} onClose={() => (shareOpen = false)} />
+  <HistoryPanel
+    dashboardPath={savedPath}
+    open={historyOpen}
+    onClose={() => (historyOpen = false)}
+    onRestored={() => void dashboardStore.load(savedPath)}
+  />
+{/if}
 
 <FilterSuggestionsModal open={suggestOpen} onClose={() => (suggestOpen = false)} />
 

--- a/saiku-ui/src/lib/views/dashboard/HistoryPanel.svelte
+++ b/saiku-ui/src/lib/views/dashboard/HistoryPanel.svelte
@@ -1,0 +1,185 @@
+<script lang="ts">
+  /*
+   * #947 PR2 — dashboard version history. Lists archived versions (newest
+   * first), previews a version's summary, and restores one (which itself
+   * archives the current state, so restore is reversible).
+   */
+  import Modal from "$lib/components/Modal.svelte";
+  import { RotateCcw, Eye } from "lucide-svelte";
+  import {
+    getHistory,
+    getHistoryVersion,
+    restoreHistory,
+    type DashboardHistoryEntry,
+  } from "$lib/api/dashboards";
+
+  interface Props {
+    dashboardPath: string;
+    open: boolean;
+    onClose: () => void;
+    /** Called after a successful restore so the parent can reload the dashboard. */
+    onRestored?: () => void;
+  }
+
+  let { dashboardPath, open, onClose, onRestored }: Props = $props();
+
+  let versions = $state<DashboardHistoryEntry[]>([]);
+  let loading = $state(false);
+  let error = $state<string | null>(null);
+  let busyVersion = $state<string | null>(null);
+  let preview = $state<{ version: string; name: string; tiles: number } | null>(null);
+
+  $effect(() => {
+    if (open) {
+      preview = null;
+      void load();
+    }
+  });
+
+  async function load(): Promise<void> {
+    loading = true;
+    error = null;
+    try {
+      versions = await getHistory(dashboardPath);
+    } catch (e) {
+      error = e instanceof Error ? e.message : "Failed to load history";
+    } finally {
+      loading = false;
+    }
+  }
+
+  async function showPreview(version: string): Promise<void> {
+    busyVersion = version;
+    try {
+      const d = await getHistoryVersion(dashboardPath, version);
+      preview = { version, name: d.name ?? "(untitled)", tiles: d.layout?.tiles?.length ?? 0 };
+    } catch (e) {
+      error = e instanceof Error ? e.message : "Failed to load version";
+    } finally {
+      busyVersion = null;
+    }
+  }
+
+  async function restore(version: string): Promise<void> {
+    if (!confirm("Restore this version? The current state is archived first, so this is reversible.")) {
+      return;
+    }
+    busyVersion = version;
+    error = null;
+    try {
+      await restoreHistory(dashboardPath, version);
+      onRestored?.();
+      onClose();
+    } catch (e) {
+      error = e instanceof Error ? e.message : "Failed to restore";
+    } finally {
+      busyVersion = null;
+    }
+  }
+
+  function fmtDate(ms: number): string {
+    try {
+      return new Date(ms).toLocaleString();
+    } catch {
+      return String(ms);
+    }
+  }
+</script>
+
+<Modal title="Version history" {open} size="md" {onClose}>
+  <div class="hist">
+    {#if loading}
+      <p class="hist__state">Loading…</p>
+    {:else if error}
+      <p class="hist__state hist__state--error">{error}</p>
+    {:else if versions.length === 0}
+      <p class="hist__state">No earlier versions yet. A version is archived each time you save.</p>
+    {:else}
+      <ul class="hist__list">
+        {#each versions as v (v.version)}
+          <li class="hist__row">
+            <div class="hist__meta">
+              <span class="hist__date">{fmtDate(v.createdAt)}</span>
+              <span class="hist__author">by {v.author || "unknown"}</span>
+              {#if preview && preview.version === v.version}
+                <span class="hist__preview">“{preview.name}” · {preview.tiles} tile(s)</span>
+              {/if}
+            </div>
+            <div class="hist__actions">
+              <button
+                type="button"
+                class="btn btn--sm"
+                onclick={() => showPreview(v.version)}
+                disabled={busyVersion === v.version}
+                title="Preview this version"
+              >
+                <Eye size={13} /><span>Preview</span>
+              </button>
+              <button
+                type="button"
+                class="btn btn--sm primary"
+                onclick={() => restore(v.version)}
+                disabled={busyVersion === v.version}
+                title="Restore this version"
+              >
+                <RotateCcw size={13} /><span>Restore</span>
+              </button>
+            </div>
+          </li>
+        {/each}
+      </ul>
+    {/if}
+  </div>
+</Modal>
+
+<style>
+  .hist {
+    min-width: 24rem;
+    display: flex;
+    flex-direction: column;
+  }
+  .hist__state {
+    color: var(--fg-muted);
+    font-size: var(--fs-sm);
+    padding: var(--space-3) 0;
+  }
+  .hist__state--error {
+    color: var(--danger);
+  }
+  .hist__list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+  }
+  .hist__row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--space-3);
+    padding: var(--space-2) 0;
+    border-bottom: 1px solid var(--border);
+  }
+  .hist__meta {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+  }
+  .hist__date {
+    font-size: var(--fs-sm);
+    color: var(--fg);
+  }
+  .hist__author {
+    font-size: var(--fs-xs, 0.75rem);
+    color: var(--fg-muted);
+  }
+  .hist__preview {
+    font-size: var(--fs-xs, 0.75rem);
+    color: var(--accent);
+  }
+  .hist__actions {
+    display: flex;
+    gap: var(--space-2);
+  }
+</style>

--- a/saiku-ui/src/lib/views/dashboard/Tile.svelte
+++ b/saiku-ui/src/lib/views/dashboard/Tile.svelte
@@ -22,7 +22,10 @@
   import KpiTile from "$lib/views/dashboard/tiles/KpiTile.svelte";
   import ImageTile from "$lib/views/dashboard/tiles/ImageTile.svelte";
   import TileEditorModal from "$lib/views/dashboard/TileEditorModal.svelte";
-  import { Copy, MoreVertical, Settings2, X } from "lucide-svelte";
+  import { Copy, MoreVertical, Settings2, X, MessageCircle } from "lucide-svelte";
+  // #942 PR2 — per-tile comments.
+  import CommentsPanel from "$lib/views/dashboard/CommentsPanel.svelte";
+  import { getComments } from "$lib/api/dashboards";
 
   interface Props {
     tile: DashboardTile;
@@ -32,6 +35,22 @@
   let { tile, readOnly = false }: Props = $props();
 
   let editorOpen = $state(false);
+
+  // #942: comments act on the SAVED dashboard. savedPath is empty for an
+  // unsaved draft AND for the public share viewer (hydrated with ""), so the
+  // badge naturally hides in both — guests can't comment.
+  const commentsPath = $derived(dashboardStore.savedPath);
+  let commentsOpen = $state(false);
+  let commentCount = $state(0);
+  let countLoaded = $state(false);
+  $effect(() => {
+    const path = commentsPath;
+    if (!path || countLoaded) return;
+    countLoaded = true;
+    void getComments(path, tile.id)
+      .then((cs) => (commentCount = cs.length))
+      .catch(() => {});
+  });
 
   // Overflow menu: opened from the kebab button or right-click. Coords
   // are viewport-relative (position: fixed) so the same menu element
@@ -138,6 +157,20 @@
     data-drag-handle={readOnly ? undefined : tile.id}
   >
     <span class="title">{tile.title ?? defaultTitle(tile)}</span>
+    <!-- #942: comment badge — shown for a saved dashboard in both edit + viewer
+         (hidden in the share view, where savedPath is empty). -->
+    {#if commentsPath}
+      <button
+        type="button"
+        class="icon-btn tile-comment-badge"
+        aria-label="Comments"
+        title="Comments"
+        onclick={() => (commentsOpen = true)}
+      >
+        <MessageCircle size={14} />
+        {#if commentCount > 0}<span class="tile-comment-count">{commentCount}</span>{/if}
+      </button>
+    {/if}
     {#if !readOnly}
       <div class="tile-actions">
         <button type="button" class="icon-btn" aria-label="Edit tile" onclick={handleEdit}>
@@ -194,6 +227,17 @@
   <TileEditorModal {tile} onClose={() => (editorOpen = false)} />
 {/if}
 
+{#if commentsPath}
+  <CommentsPanel
+    dashboardPath={commentsPath}
+    tileId={tile.id}
+    tileTitle={tile.title ?? defaultTitle(tile)}
+    open={commentsOpen}
+    onClose={() => (commentsOpen = false)}
+    onCountChange={(n) => (commentCount = n)}
+  />
+{/if}
+
 <script module lang="ts">
   import type { DashboardTile as DT } from "$lib/api/dashboards";
 
@@ -228,6 +272,29 @@
     border-radius: 6px;
     background: var(--bg);
     overflow: hidden;
+  }
+  /* #942: comment badge sits between the title and the edit actions. */
+  .tile-comment-badge {
+    position: relative;
+    margin-left: auto;
+  }
+  .tile-comment-badge ~ :global(.tile-actions) {
+    margin-left: 0;
+  }
+  .tile-comment-count {
+    position: absolute;
+    top: -3px;
+    right: -3px;
+    min-width: 14px;
+    height: 14px;
+    padding: 0 3px;
+    border-radius: 999px;
+    background: var(--accent);
+    color: #fff;
+    font-size: 0.625rem;
+    line-height: 14px;
+    text-align: center;
+    box-sizing: border-box;
   }
   .tile-header {
     display: flex;

--- a/saiku-ui/src/lib/views/dashboard/tiles/ChartTile.svelte
+++ b/saiku-ui/src/lib/views/dashboard/tiles/ChartTile.svelte
@@ -44,6 +44,9 @@
   import TileError from "./TileError.svelte";
   import TileEmpty from "./TileEmpty.svelte";
   import { dashboardStore } from "$lib/stores/dashboard.svelte";
+  // #941 share viewer (PR2): in the public /share view a prefetched response is
+  // injected via context; tiles render from it instead of fetching live.
+  import { getShareViewResponse } from "$lib/dashboard/shareViewContext";
 
   interface Props {
     tile: DashboardTile;
@@ -51,6 +54,12 @@
   }
 
   let { tile, onClickFilter }: Props = $props();
+
+  // Non-null only inside the share viewer (getContext at init); see fetch effect.
+  // tile.id is stable for a tile instance and getContext must run at init, so the
+  // one-time read is intentional.
+  // svelte-ignore state_referenced_locally
+  const sharedResponse = getShareViewResponse(tile.id);
 
   let host = $state<HTMLDivElement | null>(null);
   // `$state.raw` so the ECharts instance is reactive on *reassignment*
@@ -190,6 +199,14 @@
   let lastQueryJson = $state<string>("");
 
   $effect(() => {
+    // #941 share viewer: render the prefetched guest response; never fetch live
+    // (a share guest has no session / no /ai/query access).
+    if (sharedResponse) {
+      response = sharedResponse;
+      loading = false;
+      error = null;
+      return;
+    }
     const tileQuery = tile.query;
     const active = activeFilters.all;
     const s = schema;

--- a/saiku-ui/src/lib/views/dashboard/tiles/KpiTile.svelte
+++ b/saiku-ui/src/lib/views/dashboard/tiles/KpiTile.svelte
@@ -43,12 +43,18 @@
   import TileError from "./TileError.svelte";
   import TileEmpty from "./TileEmpty.svelte";
   import { dashboardStore } from "$lib/stores/dashboard.svelte";
+  // #941 share viewer (PR2): render from a prefetched guest response when present.
+  import { getShareViewResponse } from "$lib/dashboard/shareViewContext";
 
   interface Props {
     tile: DashboardTile;
   }
 
   let { tile }: Props = $props();
+
+  // Non-null only inside the share viewer (getContext at init); see fetch effect.
+  // svelte-ignore state_referenced_locally
+  const sharedResponse = getShareViewResponse(tile.id);
 
   let loading = $state(false);
   let error = $state<string | null>(null);
@@ -144,6 +150,13 @@
   }
 
   $effect(() => {
+    // #941 share viewer: render the prefetched guest response; never fetch live.
+    if (sharedResponse) {
+      response = sharedResponse;
+      loading = false;
+      error = null;
+      return;
+    }
     const measure = kpi.measure;
     const c = cube;
     const series = wantsSeries;

--- a/saiku-ui/src/lib/views/dashboard/tiles/TableTile.svelte
+++ b/saiku-ui/src/lib/views/dashboard/tiles/TableTile.svelte
@@ -53,6 +53,8 @@
   import TileError from "./TileError.svelte";
   import TileEmpty from "./TileEmpty.svelte";
   import { dashboardStore } from "$lib/stores/dashboard.svelte";
+  // #941 share viewer (PR2): render from a prefetched guest response when present.
+  import { getShareViewResponse } from "$lib/dashboard/shareViewContext";
 
   interface Props {
     tile: DashboardTile;
@@ -63,6 +65,10 @@
   }
 
   let { tile, onClickFilter }: Props = $props();
+
+  // Non-null only inside the share viewer (getContext at init); see fetch effect.
+  // svelte-ignore state_referenced_locally
+  const sharedResponse = getShareViewResponse(tile.id);
 
   let loading = $state(false);
   let error = $state<string | null>(null);
@@ -133,6 +139,13 @@
   let lastQueryJson = $state<string>("");
 
   $effect(() => {
+    // #941 share viewer: render the prefetched guest response; never fetch live.
+    if (sharedResponse) {
+      response = sharedResponse;
+      loading = false;
+      error = null;
+      return;
+    }
     const tileQuery = tile.query;
     const active = activeFilters.all;
     const s = schema;

--- a/saiku-ui/src/routes/+layout.svelte
+++ b/saiku-ui/src/routes/+layout.svelte
@@ -19,6 +19,10 @@
 
   let { children } = $props();
 
+  // #941 share viewer: the public /share route renders a dashboard for an
+  // account-free guest — no app chrome (topbar / upgrade banner), no session.
+  const isShare = $derived(page.url.pathname.startsWith(`${base}/share`));
+
   // Non-modal session-expired banner state (issue #944). The previous
   // SessionErrorModal was a blocking modal in the middle of the screen,
   // which is jarring on long-running dashboard / TV-wall views. We now
@@ -74,10 +78,10 @@
 </script>
 
 <div class="app" class:app--cursor-hidden={presentation.active && presentation.cursorHidden}>
-  {#if !embed.active && !presentation.active}
+  {#if !embed.active && !presentation.active && !isShare}
     <UpgradeBanner />
   {/if}
-  {#if !embed.active && !presentation.active}
+  {#if !embed.active && !presentation.active && !isShare}
   <header class="topbar">
     <a class="topbar__brand" href="{base}/" aria-label={i18n.t("brand")}>
       {#if brandLogo}

--- a/saiku-ui/src/routes/share/+page.svelte
+++ b/saiku-ui/src/routes/share/+page.svelte
@@ -1,0 +1,121 @@
+<script lang="ts">
+  /*
+   * #941 share viewer — public, account-free, read-only dashboard page at
+   * /ui/share#<token>. The token lives in the URL fragment (never sent to the
+   * server); we read it from window.location.hash and echo it as the
+   * X-Saiku-Share-Token header to the guest endpoints. Each data tile's query
+   * is prefetched and injected via shareViewContext, so the normal tile
+   * components render read-only without a Saiku session or /ai/query access.
+   */
+  import { onMount } from "svelte";
+  import { parseShareToken } from "$lib/dashboard/shareUrl";
+  import { loadSharedDashboard } from "$lib/api/dashboards";
+  import { runSharedTileQuery, type AiQueryResponse } from "$lib/api/aiQuery";
+  import { setShareViewResponses } from "$lib/dashboard/shareViewContext";
+  import { dashboardStore } from "$lib/stores/dashboard.svelte";
+  import DashboardGrid from "$lib/views/dashboard/DashboardGrid.svelte";
+
+  // Same Map reference is mutated in onMount, then read by tiles once `ready`.
+  const responses = new Map<string, AiQueryResponse>();
+  setShareViewResponses(responses);
+
+  let loading = $state(true);
+  let error = $state<string | null>(null);
+  let name = $state("");
+  let ready = $state(false);
+
+  onMount(async () => {
+    const token = parseShareToken(window.location.hash);
+    if (!token) {
+      error = "This share link is missing its access token.";
+      loading = false;
+      return;
+    }
+    try {
+      const dash = await loadSharedDashboard(token);
+      name = dash.name ?? "Shared dashboard";
+      for (const tile of dash.layout?.tiles ?? []) {
+        if (tile.type === "chart" || tile.type === "table" || tile.type === "kpi") {
+          try {
+            responses.set(tile.id, await runSharedTileQuery(token, tile.id));
+          } catch {
+            // leave it unset — the tile shows its own error frame
+          }
+        }
+      }
+      dashboardStore.hydrate(dash, "");
+      ready = true;
+    } catch {
+      error = "This share link is invalid or has expired.";
+    } finally {
+      loading = false;
+    }
+  });
+</script>
+
+<svelte:head><title>{name || "Shared dashboard"} — Saiku</title></svelte:head>
+
+<div class="share-view">
+  {#if loading}
+    <div class="share-view__state">Loading shared dashboard…</div>
+  {:else if error}
+    <div class="share-view__state share-view__state--error">{error}</div>
+  {:else if ready}
+    <header class="share-view__header">
+      <span class="share-view__title">{name}</span>
+      <span class="share-view__badge">Read-only shared view</span>
+    </header>
+    <div class="share-view__grid">
+      <DashboardGrid readOnly={true} />
+    </div>
+  {/if}
+</div>
+
+<style>
+  .share-view {
+    flex: 1;
+    min-height: 0;
+    display: flex;
+    flex-direction: column;
+    background: var(--bg);
+  }
+  .share-view__header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--space-3);
+    padding: var(--space-3) var(--space-5);
+    border-bottom: 1px solid var(--border);
+    background: var(--bg-muted);
+  }
+  .share-view__title {
+    font-weight: var(--weight-bold);
+    font-size: var(--fs-lg);
+    color: var(--fg);
+  }
+  .share-view__badge {
+    font-size: var(--fs-sm);
+    color: var(--fg-muted);
+    padding: 2px var(--space-2);
+    border: 1px solid var(--border);
+    border-radius: 999px;
+    background: var(--bg-subtle);
+  }
+  .share-view__grid {
+    flex: 1;
+    min-height: 0;
+    overflow: auto;
+    padding: var(--space-4);
+  }
+  .share-view__state {
+    flex: 1;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: var(--fg-muted);
+    font-size: var(--fs-md);
+  }
+  .share-view__state--error {
+    color: var(--danger);
+  }
+</style>

--- a/saiku-ui/src/routes/share/+page.ts
+++ b/saiku-ui/src/routes/share/+page.ts
@@ -1,0 +1,4 @@
+// #941 share viewer — client-only (reads the token from window.location.hash;
+// not prerendered, no SSR).
+export const ssr = false;
+export const prerender = false;


### PR DESCRIPTION
## Summary
The #941/#942/#947 backends merged but had **no UI**. This adds all three front-ends in one PR (user-requested), reusing the merged REST endpoints. Frontend-only (`saiku-ui`); **user-verified locally** end-to-end.

## What's in it
**#941 — shareable read-only link**
- New **public route `/ui/share#<token>`** (`src/routes/share/+page.svelte`): reads the token from the URL **fragment**, echoes it as the `X-Saiku-Share-Token` header, prefetches each data tile via the guest endpoint, and renders `DashboardGrid` **read-only** — no Saiku session, no topbar (hidden on `/share` in `+layout.svelte`).
- **Share modal** (`DashboardShareModal.svelte`) from a toolbar **Share** button: mint a link, copy the `/ui/share#<token>` URL, list + revoke active links.
- `shareViewContext.ts` + `shareUrl.ts` (pure, unit-tested).

**#947 — version history**
- Toolbar **History** button → `HistoryPanel.svelte`: list versions (time + author), preview, restore (reversible).

**#942 — comments**
- Comment-count **badge on each tile** (`Tile.svelte` wrapper) → `CommentsPanel.svelte`: thread, post (plain `@name` typing), author/admin delete. Badge hidden in the share view (savedPath empty) so guests can't comment.

- API clients added to `dashboards.ts` / `aiQuery.ts`; icons from `lucide-svelte`.

## ⚠️ For reviewers (security + coordination)
- **Touches OG-owned tile internals** (`ChartTile/TableTile/KpiTile.svelte`): a tiny, clearly-commented **share-mode guard** — `if (sharedResponse) { render it; return; }` at the top of each fetch effect — so they render the prefetched guest response instead of fetching live. This is the one place a non-OG change reaches those files; please eyeball it.
- **`Tile.svelte` overlaps OG's #918 (image tile)** in the header region. My insertion is a single delimited comment-badge node. **Sequence: merge #918 first, then I rebase this** (ping me) — no merge-order risk.
- The guest route renders with **no session**; the token is fragment-only + header-only (matches the hardened backend).

## Verified
- `npm run check` → **0 errors / 0 warnings**; `npm test` → **496/496** (+6 new `shareUrl.test.ts`); `npm run build` → OK.
- **Live (launcher :8087, user-verified):** mint a link → open `/ui/share#token` in a fresh tab → dashboard renders read-only with data; revoke → link dead. Save twice → History → preview + restore reverts. Tile comment badge → post `@admin` → appears → delete.

## Deferred (noted)
@-mention autocomplete (needs a non-admin users-list endpoint); full read-only history *preview* render (currently a summary); comment notifications/unread; orphaned `saiku-comments-*`/`saiku-history-*` cleanup on dashboard delete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)