### PR TITLE
feat(dashboards): image tile — URL or uploaded image (closes #918)

### DIFF
--- a/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/dashboards/DashboardImageResource.java
+++ b/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/dashboards/DashboardImageResource.java
@@ -1,0 +1,276 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.web.rest.resources.dashboards;
+
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import java.io.ByteArrayOutputStream;
+import java.io.InputStream;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.List;
+import java.util.Map;
+import org.glassfish.jersey.media.multipart.FormDataParam;
+import org.saiku.service.datasource.DatasourceService;
+import org.saiku.web.service.SessionService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Upload + serve image assets for dashboard image tiles (issue #918).
+ *
+ * <p>Storage rides the same ACL-checked text-file primitives the dashboards
+ * themselves use ({@link DatasourceService#saveFile}/{@code getFileData}),
+ * with the image bytes Base64-encoded into a file stored <em>in the uploader's
+ * home folder</em> ({@code homes/<user>/<tileId>.<ext>}). That gives us, for
+ * free: the repository's path-traversal defence ({@code resolveWithinDatadir}),
+ * ACL-enforced reads (a viewer who can read the path sees the image, others
+ * get a 404), and no new binary storage path to secure separately.
+ *
+ * <p>Hardening: session auth required; the uploaded bytes are sniffed by
+ * magic number and only PNG/JPEG/GIF/WebP are accepted (SVG and everything
+ * else are rejected — SVG can carry script); a {@value #MAX_BYTES}-byte cap
+ * applies; {@code tileId} is restricted to a safe charset; and the download
+ * is served with a fixed image content-type plus {@code nosniff} + a
+ * locked-down CSP so the endpoint can't be coerced into serving active
+ * content.
+ */
+@Path("/saiku/api/dashboards/image")
+public class DashboardImageResource {
+
+    private static final Logger log = LoggerFactory.getLogger(DashboardImageResource.class);
+    private static final String SAVE_OK = "Save Okay";
+    /** 2 MiB raw-byte cap (≈2.7 MB Base64 on disk). */
+    private static final int MAX_BYTES = 2 * 1024 * 1024;
+    /** tileId path-segment allowlist — mirrors the client's newTileId() shape. */
+    private static final java.util.regex.Pattern TILE_ID = java.util.regex.Pattern.compile("^[A-Za-z0-9_-]{1,64}$");
+
+    private DatasourceService datasourceService;
+    private SessionService sessionService;
+
+    public void setDatasourceService(DatasourceService s) {
+        this.datasourceService = s;
+    }
+
+    public void setSessionService(SessionService s) {
+        this.sessionService = s;
+    }
+
+    /** Store an uploaded image beside its dashboard and return its download src. */
+    @POST
+    @Path("/upload")
+    @Consumes(MediaType.MULTIPART_FORM_DATA)
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response upload(@FormDataParam("file") InputStream fileStream, @FormDataParam("tileId") String tileId) {
+        String username = currentUsername();
+        if (username == null) {
+            return error(Response.Status.UNAUTHORIZED, "auth", "Not authenticated");
+        }
+        // Defence in depth — the session username is trusted, but it becomes a
+        // path segment, so reject anything that could escape the home folder.
+        if (username.contains("/") || username.contains("\\") || username.contains("..")) {
+            return error(Response.Status.BAD_REQUEST, "auth", "Invalid username");
+        }
+        if (fileStream == null) {
+            return error(Response.Status.BAD_REQUEST, "file", "file required");
+        }
+        if (tileId == null || !TILE_ID.matcher(tileId).matches()) {
+            return error(Response.Status.BAD_REQUEST, "tileId", "invalid tileId");
+        }
+
+        byte[] bytes;
+        try {
+            bytes = readCapped(fileStream, MAX_BYTES);
+        } catch (TooLargeException e) {
+            return error(Response.Status.REQUEST_ENTITY_TOO_LARGE, "file", "Image exceeds 2 MB limit");
+        } catch (Exception e) {
+            log.warn("image upload read failed (user={}, tile={})", username, tileId, e);
+            return error(Response.Status.BAD_REQUEST, "file", "Could not read upload");
+        }
+        if (bytes.length == 0) {
+            return error(Response.Status.BAD_REQUEST, "file", "Empty upload");
+        }
+
+        String ext = sniffImageExt(bytes);
+        if (ext == null) {
+            return error(
+                    Response.Status.BAD_REQUEST,
+                    "file",
+                    "Unsupported image type — only PNG, JPEG, GIF and WebP are allowed");
+        }
+
+        // Store in the uploader's home folder (always present + writable for the
+        // owner — no fragile dashboard-path parsing). The download is ACL-checked,
+        // so a viewer who can read this path sees the image and others don't.
+        String assetPath = "homes/" + username + "/" + tileId + "." + ext;
+
+        String base64 = Base64.getEncoder().encodeToString(bytes);
+        String resp;
+        try {
+            resp = datasourceService.saveFile(base64, assetPath, username, currentRoles());
+        } catch (RuntimeException e) {
+            log.warn("image save rejected (user={}, path={})", username, assetPath, e);
+            return error(Response.Status.FORBIDDEN, "file", "Not permitted to store here");
+        }
+        if (!SAVE_OK.equals(resp)) {
+            return error(Response.Status.INTERNAL_SERVER_ERROR, "file", "Save rejected: " + resp);
+        }
+        return Response.ok(Map.of("src", downloadSrc(assetPath)))
+                .type(MediaType.APPLICATION_JSON)
+                .build();
+    }
+
+    /** Serve a stored image asset, ACL-checked, with hardened headers. */
+    @GET
+    @Path("/get/{path:.+}")
+    public Response get(@PathParam("path") String path) {
+        String username = currentUsername();
+        if (username == null) {
+            return Response.status(Response.Status.UNAUTHORIZED).build();
+        }
+        String ext = extensionOf(path);
+        String contentType = contentTypeFor(ext);
+        if (contentType == null) {
+            // Only ever serve known image extensions from this endpoint, so it
+            // can't be coerced into streaming arbitrary repo files.
+            return Response.status(Response.Status.NOT_FOUND).build();
+        }
+        String base64;
+        try {
+            base64 = datasourceService.getFileData(path, username, currentRoles());
+        } catch (RuntimeException e) {
+            return Response.status(Response.Status.NOT_FOUND).build();
+        }
+        if (base64 == null || base64.isEmpty()) {
+            return Response.status(Response.Status.NOT_FOUND).build();
+        }
+        byte[] bytes;
+        try {
+            bytes = Base64.getDecoder().decode(base64.trim());
+        } catch (IllegalArgumentException e) {
+            return Response.status(Response.Status.NOT_FOUND).build();
+        }
+        return Response.ok(bytes)
+                .type(contentType)
+                .header("X-Content-Type-Options", "nosniff")
+                .header("Content-Security-Policy", "default-src 'none'; sandbox")
+                .header("Content-Disposition", "inline")
+                .header("Cache-Control", "private, max-age=300")
+                .build();
+    }
+
+    /* --------------------------- helpers ---------------------------- */
+
+    /** Read at most {@code max} bytes; throw if the stream has more. */
+    private static byte[] readCapped(InputStream in, int max) throws Exception {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        byte[] buf = new byte[8192];
+        int total = 0;
+        int read;
+        while ((read = in.read(buf)) != -1) {
+            total += read;
+            if (total > max) throw new TooLargeException();
+            out.write(buf, 0, read);
+        }
+        return out.toByteArray();
+    }
+
+    private static final class TooLargeException extends Exception {}
+
+    /** Identify the image type by magic number; null = unsupported (incl. SVG).
+     *  Package-private for unit testing the allowlist / SVG-block. */
+    static String sniffImageExt(byte[] b) {
+        if (b.length >= 8
+                && (b[0] & 0xFF) == 0x89
+                && b[1] == 0x50
+                && b[2] == 0x4E
+                && b[3] == 0x47
+                && b[4] == 0x0D
+                && b[5] == 0x0A
+                && b[6] == 0x1A
+                && b[7] == 0x0A) {
+            return "png";
+        }
+        if (b.length >= 3 && (b[0] & 0xFF) == 0xFF && (b[1] & 0xFF) == 0xD8 && (b[2] & 0xFF) == 0xFF) {
+            return "jpg";
+        }
+        if (b.length >= 6
+                && b[0] == 'G'
+                && b[1] == 'I'
+                && b[2] == 'F'
+                && b[3] == '8'
+                && (b[4] == '7' || b[4] == '9')
+                && b[5] == 'a') {
+            return "gif";
+        }
+        if (b.length >= 12
+                && b[0] == 'R'
+                && b[1] == 'I'
+                && b[2] == 'F'
+                && b[3] == 'F'
+                && b[8] == 'W'
+                && b[9] == 'E'
+                && b[10] == 'B'
+                && b[11] == 'P') {
+            return "webp";
+        }
+        return null;
+    }
+
+    static String extensionOf(String path) {
+        int dot = path.lastIndexOf('.');
+        return dot < 0 ? "" : path.substring(dot + 1).toLowerCase(java.util.Locale.ROOT);
+    }
+
+    static String contentTypeFor(String ext) {
+        return switch (ext) {
+            case "png" -> "image/png";
+            case "jpg", "jpeg" -> "image/jpeg";
+            case "gif" -> "image/gif";
+            case "webp" -> "image/webp";
+            default -> null;
+        };
+    }
+
+    /** Build the same-origin download path, URL-encoding each segment but
+     *  preserving the slashes that map to the {path:.+} matcher. */
+    private static String downloadSrc(String assetPath) {
+        String[] parts = assetPath.split("/");
+        StringBuilder sb = new StringBuilder("/rest/saiku/api/dashboards/image/get/");
+        for (int i = 0; i < parts.length; i++) {
+            if (i > 0) sb.append('/');
+            sb.append(URLEncoder.encode(parts[i], StandardCharsets.UTF_8).replace("+", "%20"));
+        }
+        return sb.toString();
+    }
+
+    private String currentUsername() {
+        if (sessionService == null) return null;
+        Object u = sessionService.getAllSessionObjects().get("username");
+        return u == null ? null : u.toString();
+    }
+
+    @SuppressWarnings("unchecked")
+    private List<String> currentRoles() {
+        if (sessionService == null) return List.of();
+        Object r = sessionService.getAllSessionObjects().get("roles");
+        if (r instanceof List<?>) return (List<String>) r;
+        return List.of();
+    }
+
+    private static Response error(Response.Status status, String field, String message) {
+        return Response.status(status)
+                .entity(Map.of("status", "ERROR", "field", field, "error", message))
+                .type(MediaType.APPLICATION_JSON)
+                .build();
+    }
+}

--- a/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/dashboards/DashboardTile.java
+++ b/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/dashboards/DashboardTile.java
@@ -57,4 +57,8 @@ public class DashboardTile {
     /** KPI tile config — measure, format, comparison, sparkline,
      *  thresholds, slice filters. Null for non-KPI tiles. */
     public KpiConfig kpi;
+
+    /** Image tile config — source (url/upload), src, fit, caption, alt.
+     *  Null for non-image tiles (issue #918). */
+    public ImageConfig image;
 }

--- a/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/dashboards/ImageConfig.java
+++ b/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/dashboards/ImageConfig.java
@@ -1,0 +1,36 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.web.rest.resources.dashboards;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+/**
+ * Per-tile image configuration (issue #918). Mirrors the {@code ImageConfig}
+ * TS shape on the UI side. The server treats it as an opaque bag — Jackson
+ * round-trips the JSON and the UI renderer interprets every field. Modelling
+ * it here (rather than ignoring unknowns) is what lets an image tile's config
+ * survive the load → edit → save round-trip.
+ *
+ * <p>All fields nullable so a partially-configured image tile saves cleanly.
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class ImageConfig {
+
+    /** {@code url | upload} — how {@link #src} is sourced. */
+    public String source;
+
+    /** External http(s) URL ("url" mode) or the repository asset download path
+     *  returned by the image upload endpoint ("upload" mode). */
+    public String src;
+
+    /** CSS object-fit: {@code contain | cover | fill | scale-down}. */
+    public String fit;
+
+    /** Optional caption rendered below the image. */
+    public String caption;
+
+    /** Alt text for accessibility. */
+    public String alt;
+}

--- a/saiku-core/saiku-web/src/test/java/org/saiku/web/rest/resources/dashboards/DashboardImageResourceTest.java
+++ b/saiku-core/saiku-web/src/test/java/org/saiku/web/rest/resources/dashboards/DashboardImageResourceTest.java
@@ -1,0 +1,90 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.web.rest.resources.dashboards;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import java.nio.charset.StandardCharsets;
+import org.junit.Test;
+
+/**
+ * Unit tests for the security-critical pure helpers of {@link DashboardImageResource}:
+ * the magic-byte image sniffer (allowlist + SVG/active-content block), the
+ * extension→content-type map, and the asset-path derivation.
+ */
+public class DashboardImageResourceTest {
+
+    private static byte[] bytes(int... ints) {
+        byte[] b = new byte[ints.length];
+        for (int i = 0; i < ints.length; i++) b[i] = (byte) ints[i];
+        return b;
+    }
+
+    @Test
+    public void sniffsPng() {
+        assertEquals(
+                "png",
+                DashboardImageResource.sniffImageExt(
+                        bytes(0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, 0x00, 0x01)));
+    }
+
+    @Test
+    public void sniffsJpeg() {
+        assertEquals("jpg", DashboardImageResource.sniffImageExt(bytes(0xFF, 0xD8, 0xFF, 0xE0, 0x00)));
+    }
+
+    @Test
+    public void sniffsGif() {
+        assertEquals("gif", DashboardImageResource.sniffImageExt("GIF89a----".getBytes(StandardCharsets.US_ASCII)));
+        assertEquals("gif", DashboardImageResource.sniffImageExt("GIF87a----".getBytes(StandardCharsets.US_ASCII)));
+    }
+
+    @Test
+    public void sniffsWebp() {
+        assertEquals(
+                "webp", DashboardImageResource.sniffImageExt("RIFF0000WEBPVP8 ".getBytes(StandardCharsets.US_ASCII)));
+    }
+
+    @Test
+    public void rejectsSvg() {
+        // SVG can carry script — must be rejected (not served same-origin).
+        assertNull(DashboardImageResource.sniffImageExt(
+                "<svg xmlns=\"http://www.w3.org/2000/svg\"><script>alert(1)</script></svg>"
+                        .getBytes(StandardCharsets.UTF_8)));
+        assertNull(
+                DashboardImageResource.sniffImageExt("<?xml version=\"1.0\"?><svg/>".getBytes(StandardCharsets.UTF_8)));
+    }
+
+    @Test
+    public void rejectsArbitraryAndShortInput() {
+        assertNull(DashboardImageResource.sniffImageExt("hello world not an image".getBytes(StandardCharsets.UTF_8)));
+        assertNull(DashboardImageResource.sniffImageExt(bytes(0x00)));
+        assertNull(DashboardImageResource.sniffImageExt(new byte[0]));
+        // HTML masquerading as an upload.
+        assertNull(DashboardImageResource.sniffImageExt("<html><body>x".getBytes(StandardCharsets.UTF_8)));
+    }
+
+    @Test
+    public void contentTypeMap() {
+        assertEquals("image/png", DashboardImageResource.contentTypeFor("png"));
+        assertEquals("image/jpeg", DashboardImageResource.contentTypeFor("jpg"));
+        assertEquals("image/jpeg", DashboardImageResource.contentTypeFor("jpeg"));
+        assertEquals("image/gif", DashboardImageResource.contentTypeFor("gif"));
+        assertEquals("image/webp", DashboardImageResource.contentTypeFor("webp"));
+        // Anything else → null → the GET endpoint 404s rather than serving it.
+        assertNull(DashboardImageResource.contentTypeFor("svg"));
+        assertNull(DashboardImageResource.contentTypeFor("html"));
+        assertNull(DashboardImageResource.contentTypeFor("saikudash"));
+        assertNull(DashboardImageResource.contentTypeFor(""));
+    }
+
+    @Test
+    public void extensionOf() {
+        assertEquals("png", DashboardImageResource.extensionOf("homes/a/t1.png"));
+        assertEquals("saikudash", DashboardImageResource.extensionOf("homes/a/x.saikudash"));
+        assertEquals("", DashboardImageResource.extensionOf("homes/a/noext"));
+    }
+}

--- a/saiku-ui/src/lib/api/dashboards.ts
+++ b/saiku-ui/src/lib/api/dashboards.ts
@@ -36,7 +36,7 @@ export interface InlineQuery {
 
 export type TileQuery = ReferenceQuery | InlineQuery;
 
-export type TileType = "chart" | "table" | "text" | "filter" | "kpi";
+export type TileType = "chart" | "table" | "text" | "filter" | "kpi" | "image";
 
 export type FilterWidget = "single-select" | "multi-select" | "date-range" | "cascading-select";
 
@@ -129,6 +129,36 @@ export interface KpiConfig {
   direction?: KpiDirection;
 }
 
+/* --- issue #918: image tile --------------------------------------------- */
+
+/** Where an image tile's bytes come from. {@code "url"} → {@link ImageConfig.src}
+ *  is an external http(s) URL the browser loads directly. {@code "upload"} →
+ *  src is the download path of an asset stored in the repository via the
+ *  image upload endpoint. */
+export type ImageSource = "url" | "upload";
+
+/** CSS object-fit for the image within its tile box. */
+export type ImageFit = "contain" | "cover" | "fill" | "scale-down";
+
+/** Per-tile image config (issue #918). Only consulted when
+ *  {@code type === "image"}. All fields optional so an unconfigured tile
+ *  saves cleanly; the renderer shows a placeholder until {@code src} is set. */
+export interface ImageConfig {
+  /** How {@link src} is sourced. Defaults to "url". */
+  source?: ImageSource;
+  /** The image to render: an external http(s) URL ("url" mode) or the
+   *  repository asset download path returned by the upload endpoint
+   *  ("upload" mode). */
+  src?: string;
+  /** CSS object-fit. Defaults to "contain". */
+  fit?: ImageFit;
+  /** Optional caption rendered below the image (plain text). */
+  caption?: string;
+  /** Alt text for accessibility / broken-image fallback. */
+  alt?: string;
+}
+/* --- end issue #918 block ------------------------------------------------ */
+
 export interface DashboardTile {
   id: string;
   x: number;
@@ -151,6 +181,9 @@ export interface DashboardTile {
   /** Per-column conditional formatting rules. Only consulted when
    *  {@code type === "table"}. See the issue-#919 block below. */
   conditionalFormat?: ConditionalFormatRule[];
+  /** Image-tile config (issue #918). Only consulted when
+   *  {@code type === "image"}. */
+  image?: ImageConfig;
 }
 
 /* ====================================================================
@@ -302,6 +335,30 @@ export async function deleteDashboard(path: string): Promise<void> {
     const err = await readError(res);
     throw new Error(`deleteDashboard(${path}) -> ${res.status}: ${err}`);
   }
+}
+
+/** Upload an image asset for an image tile (issue #918). POSTs the file as
+ *  multipart to the hardened upload endpoint (server enforces auth +
+ *  content-type allowlist + size cap + path-traversal-safe per-user storage)
+ *  and returns the same-origin download path to persist as the tile's
+ *  {@link ImageConfig.src}. */
+export async function uploadImageAsset(tileId: string, file: File): Promise<string> {
+  const form = new FormData();
+  form.append("file", file);
+  form.append("tileId", tileId);
+  const res = await fetch(`${REST_BASE}/image/upload`, {
+    method: "POST",
+    credentials: "include",
+    // No Content-Type header — the browser sets the multipart boundary.
+    body: form,
+  });
+  if (!res.ok) {
+    const err = await readError(res);
+    throw new Error(`uploadImageAsset -> ${res.status}: ${err}`);
+  }
+  const json = (await res.json()) as { src?: string };
+  if (!json.src) throw new Error("upload response missing src");
+  return json.src;
 }
 
 /** Build an empty Dashboard with a fresh id, ready to be populated by the

--- a/saiku-ui/src/lib/dashboard/imageSrc.test.ts
+++ b/saiku-ui/src/lib/dashboard/imageSrc.test.ts
@@ -1,0 +1,49 @@
+import { describe, test, expect } from "vitest";
+import { safeImageSrc, coerceImageFit } from "$lib/dashboard/imageSrc";
+
+describe("safeImageSrc", () => {
+  test("allows http/https absolute URLs (returned unchanged)", () => {
+    expect(safeImageSrc("https://cdn.example.com/logo.png")).toBe(
+      "https://cdn.example.com/logo.png",
+    );
+    expect(safeImageSrc("http://example.com/a.gif")).toBe("http://example.com/a.gif");
+  });
+
+  test("allows same-origin relative paths (e.g. the upload download path)", () => {
+    const p = "/rest/saiku/api/dashboards/image/get?tile=t1&name=a.png";
+    expect(safeImageSrc(p)).toBe(p);
+  });
+
+  test("rejects dangerous schemes", () => {
+    expect(safeImageSrc("javascript:alert(1)")).toBeNull();
+    expect(safeImageSrc("JavaScript:alert(1)")).toBeNull();
+    expect(safeImageSrc("data:image/svg+xml,<svg onload=alert(1)>")).toBeNull();
+    expect(safeImageSrc("vbscript:msgbox(1)")).toBeNull();
+    expect(safeImageSrc("file:///etc/passwd")).toBeNull();
+  });
+
+  test("rejects empty / whitespace / nullish", () => {
+    expect(safeImageSrc("")).toBeNull();
+    expect(safeImageSrc("   ")).toBeNull();
+    expect(safeImageSrc(null)).toBeNull();
+    expect(safeImageSrc(undefined)).toBeNull();
+  });
+
+  test("trims surrounding whitespace before validating", () => {
+    expect(safeImageSrc("  https://x.com/i.png  ")).toBe("https://x.com/i.png");
+  });
+});
+
+describe("coerceImageFit", () => {
+  test("passes through valid fits", () => {
+    for (const f of ["contain", "cover", "fill", "scale-down"]) {
+      expect(coerceImageFit(f)).toBe(f);
+    }
+  });
+  test("defaults invalid / nullish to contain", () => {
+    expect(coerceImageFit("bogus")).toBe("contain");
+    expect(coerceImageFit("")).toBe("contain");
+    expect(coerceImageFit(null)).toBe("contain");
+    expect(coerceImageFit(undefined)).toBe("contain");
+  });
+});

--- a/saiku-ui/src/lib/dashboard/imageSrc.ts
+++ b/saiku-ui/src/lib/dashboard/imageSrc.ts
@@ -1,0 +1,41 @@
+/*
+ * Image-tile src safety + fit coercion (issue #918).
+ *
+ * Pure (vitest env=node) — no DOM. The src guard is the client-side XSS
+ * defence for the image tile: only http(s) absolute URLs or same-origin
+ * relative paths (e.g. the upload endpoint's download path) are honoured;
+ * javascript:/data:/vbscript:/etc. are rejected. <img> never executes script
+ * from src and SVG loaded via <img> is non-scripting, so an http(s) allowlist
+ * is a sufficient client guard (the upload endpoint hardens the server side).
+ */
+
+export const IMAGE_FITS = ["contain", "cover", "fill", "scale-down"] as const;
+export type ImageFitValue = (typeof IMAGE_FITS)[number];
+
+/**
+ * Return `raw` unchanged when it's a safe image src, else null.
+ *
+ * Safe = resolves to an http: or https: URL. Parsing against a fixed base
+ * (no `window`, so it's SSR/test-safe) lets same-origin relative paths
+ * through (they resolve to http:) while rejecting javascript:/data:/etc.
+ * Returning the original string means the browser resolves a relative path
+ * against the real document origin at render time.
+ */
+export function safeImageSrc(raw: string | null | undefined): string | null {
+  const s = (raw ?? "").trim();
+  if (!s) return null;
+  try {
+    const u = new URL(s, "http://localhost/");
+    return u.protocol === "http:" || u.protocol === "https:" ? s : null;
+  } catch {
+    return null;
+  }
+}
+
+/** Clamp an arbitrary string to a valid CSS object-fit, defaulting to
+ *  "contain". */
+export function coerceImageFit(fit: string | null | undefined): ImageFitValue {
+  return (IMAGE_FITS as readonly string[]).includes(fit ?? "")
+    ? (fit as ImageFitValue)
+    : "contain";
+}

--- a/saiku-ui/src/lib/dashboard/tilePlacement.ts
+++ b/saiku-ui/src/lib/dashboard/tilePlacement.ts
@@ -24,6 +24,8 @@ export function defaultSizeFor(type: TileType): { w: number; h: number } {
       return { w: 6, h: 2 };
     case "kpi":
       return { w: 3, h: 2 };
+    case "image":
+      return { w: 4, h: 3 };
   }
 }
 

--- a/saiku-ui/src/lib/views/dashboard/AddTileMenu.svelte
+++ b/saiku-ui/src/lib/views/dashboard/AddTileMenu.svelte
@@ -84,6 +84,13 @@
           <span class="hint">Markdown annotation; no data.</span>
         </span>
       </button>
+      <button type="button" class="menu-item" role="menuitem" onclick={() => pick("image")}>
+        <span class="icon" aria-hidden="true">🖼️</span>
+        <span>
+          <span class="label">Image</span>
+          <span class="hint">A logo, diagram or screenshot from a URL or upload.</span>
+        </span>
+      </button>
     </div>
   {/if}
 </div>

--- a/saiku-ui/src/lib/views/dashboard/Tile.svelte
+++ b/saiku-ui/src/lib/views/dashboard/Tile.svelte
@@ -20,6 +20,7 @@
   import TableTile from "$lib/views/dashboard/tiles/TableTile.svelte";
   import TextTile from "$lib/views/dashboard/tiles/TextTile.svelte";
   import KpiTile from "$lib/views/dashboard/tiles/KpiTile.svelte";
+  import ImageTile from "$lib/views/dashboard/tiles/ImageTile.svelte";
   import TileEditorModal from "$lib/views/dashboard/TileEditorModal.svelte";
   import { Copy, MoreVertical, Settings2, X } from "lucide-svelte";
 
@@ -167,6 +168,8 @@
       <TextTile {tile} />
     {:else if tile.type === "kpi"}
       <KpiTile {tile} />
+    {:else if tile.type === "image"}
+      <ImageTile {tile} />
     {:else}
       <div class="unknown">Unknown tile type: {tile.type}</div>
     {/if}
@@ -208,6 +211,8 @@
         return tile.target?.level ? `Filter: ${tile.target.level}` : "Filter";
       case "kpi":
         return tile.kpi?.measureCaption ?? tile.kpi?.measure ?? "KPI";
+      case "image":
+        return "Image";
       default:
         return tile.type;
     }

--- a/saiku-ui/src/lib/views/dashboard/TileEditorModal.svelte
+++ b/saiku-ui/src/lib/views/dashboard/TileEditorModal.svelte
@@ -26,6 +26,9 @@
     type DashboardTile,
     type FilterWidget,
     type KpiConfig,
+    type ImageSource,
+    type ImageFit,
+    uploadImageAsset,
     type TileQuery,
     // Issue #919 — conditional formatting on table tiles.
     type ConditionalFormatRule,
@@ -89,6 +92,22 @@
       direction: tile.kpi?.direction ?? "higher-is-better",
     })),
   );
+  // ── Issue #918: image tile config (image only) ──
+  // mode "url" → imageUrl is an external http(s) URL; mode "upload" → a file
+  // is uploaded on save and its returned download path becomes the src
+  // (imageExistingSrc preserves the already-stored path when no new file is
+  // picked). Held as a self-contained working copy, persisted in handleSave.
+  let imageMode = $state<ImageSource>(untrack(() => tile.image?.source ?? "url"));
+  let imageUrl = $state<string>(
+    untrack(() => ((tile.image?.source ?? "url") === "url" ? (tile.image?.src ?? "") : "")),
+  );
+  let imageExistingSrc = $state<string>(untrack(() => tile.image?.src ?? ""));
+  let imageFit = $state<ImageFit>(untrack(() => tile.image?.fit ?? "contain"));
+  let imageCaption = $state<string>(untrack(() => tile.image?.caption ?? ""));
+  let imageAlt = $state<string>(untrack(() => tile.image?.alt ?? ""));
+  let imageFile = $state<File | null>(null);
+  let imageUploading = $state(false);
+  // ── end issue #918 ──
   let inlineBodyJson = $state<string>(
     untrack(() => (tile.query?.kind === "inline" ? JSON.stringify(tile.query.body, null, 2) : "")),
   );
@@ -344,7 +363,7 @@
     { id: "absolute", label: "Absolute (fixed value)" },
   ];
 
-  function handleSave(): void {
+  async function handleSave(): Promise<void> {
     bodyError = null;
     positionError = null;
 
@@ -473,6 +492,35 @@
       patch.conditionalFormat = cleaned.length > 0 ? cleaned : undefined;
     }
 
+    // ── Issue #918: image tile. URL mode persists the typed URL; upload mode
+    // POSTs the picked file to the (auth + content-type + size + path-traversal
+    // hardened) endpoint on save and persists the returned download path,
+    // keeping the existing path when no new file was picked. Upload failures
+    // surface in the modal and abort the save. ──
+    if (tile.type === "image") {
+      let src = imageExistingSrc;
+      if (imageMode === "url") {
+        src = imageUrl.trim();
+      } else if (imageFile) {
+        imageUploading = true;
+        try {
+          src = await uploadImageAsset(tile.id, imageFile);
+        } catch (e) {
+          bodyError = `Image upload failed: ${(e as Error).message}`;
+          imageUploading = false;
+          return;
+        }
+        imageUploading = false;
+      }
+      patch.image = {
+        source: imageMode,
+        src: src || undefined,
+        fit: imageFit,
+        caption: imageCaption.trim() || undefined,
+        alt: imageAlt.trim() || undefined,
+      };
+    }
+
     // Merge the patch into the repositioned source tile, then commit
     // the whole cascade in one go.
     const tiles = reposition.tiles!.map((t) => (t.id === tile.id ? { ...t, ...patch } : t));
@@ -532,7 +580,68 @@
         </label>
       {/if}
 
-      {#if tile.type !== "text"}
+      {#if tile.type === "image"}
+        <fieldset class="mode">
+          <legend>Image source</legend>
+          <label class="radio">
+            <input type="radio" bind:group={imageMode} value="url" />
+            <span>URL</span>
+          </label>
+          <label class="radio">
+            <input type="radio" bind:group={imageMode} value="upload" />
+            <span>Upload file</span>
+          </label>
+        </fieldset>
+
+        {#if imageMode === "url"}
+          <label class="field">
+            <span>Image URL (http/https)</span>
+            <input
+              type="url"
+              bind:value={imageUrl}
+              placeholder="https://example.com/logo.png"
+            />
+          </label>
+        {:else}
+          <label class="field">
+            <span>Upload image{imageExistingSrc ? " (replaces current)" : ""}</span>
+            <input
+              type="file"
+              accept="image/png,image/jpeg,image/gif,image/webp"
+              onchange={(e) => {
+                imageFile = (e.currentTarget as HTMLInputElement).files?.[0] ?? null;
+                bodyError = null;
+              }}
+            />
+            <span class="hint">
+              PNG, JPEG, GIF or WebP, up to 2&nbsp;MB. Stored privately in your
+              repository.{imageExistingSrc && !imageFile ? " An image is already set." : ""}
+            </span>
+          </label>
+        {/if}
+
+        <label class="field">
+          <span>Fit</span>
+          <select bind:value={imageFit}>
+            <option value="contain">Contain (whole image, letterboxed)</option>
+            <option value="cover">Cover (fill tile, crop edges)</option>
+            <option value="fill">Fill (stretch to tile)</option>
+            <option value="scale-down">Scale down (never upscale)</option>
+          </select>
+        </label>
+
+        <label class="field">
+          <span>Caption (optional)</span>
+          <input type="text" bind:value={imageCaption} placeholder="e.g. Q4 campaign" />
+        </label>
+
+        <label class="field">
+          <span>Alt text (accessibility)</span>
+          <input type="text" bind:value={imageAlt} placeholder="Describe the image" />
+        </label>
+      {/if}
+
+      {#if tile.type !== "text" && tile.type !== "image"}
         <label class="field">
           <span>Cube</span>
           {#if cubesLoading}
@@ -974,8 +1083,10 @@
       {/if}
     </div>
     <footer class="modal-footer">
-      <button type="button" class="btn" onclick={onClose}>Cancel</button>
-      <button type="button" class="btn primary" onclick={handleSave}>Save</button>
+      <button type="button" class="btn" onclick={onClose} disabled={imageUploading}>Cancel</button>
+      <button type="button" class="btn primary" onclick={handleSave} disabled={imageUploading}>
+        {imageUploading ? "Uploading…" : "Save"}
+      </button>
     </footer>
   </div>
 </div>

--- a/saiku-ui/src/lib/views/dashboard/tiles/ImageTile.svelte
+++ b/saiku-ui/src/lib/views/dashboard/tiles/ImageTile.svelte
@@ -1,0 +1,109 @@
+<script lang="ts">
+  /*
+   * Image tile (issue #918). Renders a static image — a company logo, a
+   * process diagram, a legend — from either an external URL or an asset
+   * uploaded into the repository. No query, no filters; purely declarative,
+   * like TextTile.
+   *
+   * Security: the src is only honoured if it resolves to an http(s) URL
+   * (absolute) or a same-origin relative path (e.g. the upload endpoint's
+   * download path). javascript:/data:/vbscript: and any other scheme are
+   * rejected → placeholder. <img> never executes script from src, and SVG
+   * loaded via <img> is non-scripting, so an http(s)-only allowlist is a
+   * sufficient client-side guard; the upload endpoint does its own
+   * content-type + path hardening server-side.
+   */
+  import { ImageOff, Image as ImageIcon, Settings2 } from "lucide-svelte";
+  import type { DashboardTile } from "$lib/api/dashboards";
+  import { safeImageSrc, coerceImageFit } from "$lib/dashboard/imageSrc";
+
+  interface Props {
+    tile: DashboardTile;
+  }
+  let { tile }: Props = $props();
+
+  let imgSrc = $derived(safeImageSrc(tile.image?.src));
+  let fit = $derived(coerceImageFit(tile.image?.fit));
+  let caption = $derived((tile.image?.caption ?? "").trim());
+  let alt = $derived(tile.image?.alt?.trim() || caption || tile.title || "Dashboard image");
+
+  // Reset the broken-image flag whenever the source changes.
+  let broken = $state(false);
+  $effect(() => {
+    void imgSrc;
+    broken = false;
+  });
+</script>
+
+{#if !imgSrc}
+  <div class="image-placeholder">
+    <ImageIcon size={22} aria-hidden="true" />
+    <span>
+      No image set — open
+      <Settings2 size={13} class="inline-gear" aria-label="tile settings" />
+      to add a URL or upload one.
+    </span>
+  </div>
+{:else if broken}
+  <div class="image-placeholder">
+    <ImageOff size={22} aria-hidden="true" />
+    <span>Couldn't load image.</span>
+  </div>
+{:else}
+  <figure class="image-tile">
+    <img
+      src={imgSrc}
+      {alt}
+      style="object-fit: {fit}"
+      onerror={() => (broken = true)}
+    />
+    {#if caption}<figcaption>{caption}</figcaption>{/if}
+  </figure>
+{/if}
+
+<style>
+  .image-tile {
+    margin: 0;
+    height: 100%;
+    width: 100%;
+    display: flex;
+    flex-direction: column;
+    min-height: 0;
+  }
+  .image-tile img {
+    flex: 1;
+    min-height: 0;
+    width: 100%;
+    /* object-fit is set inline (contain | cover | fill | scale-down). */
+    object-position: center;
+  }
+  .image-tile figcaption {
+    flex-shrink: 0;
+    padding: 0.25rem 0.5rem;
+    font-size: 0.75rem;
+    color: var(--fg-muted);
+    text-align: center;
+    overflow-wrap: anywhere;
+  }
+  .image-placeholder {
+    height: 100%;
+    width: 100%;
+    box-sizing: border-box;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 0.5rem;
+    padding: 0.75rem;
+    text-align: center;
+    color: var(--fg-muted);
+    font-size: 0.8125rem;
+  }
+  /* Render the real edit-button icon (lucide Settings2) inline so the
+     placeholder hint matches the tile's title-bar control exactly. */
+  .image-placeholder :global(.inline-gear) {
+    display: inline-block;
+    vertical-align: -2px;
+    color: var(--fg-subtle);
+  }
+</style>

--- a/saiku-webapp/src/main/webapp/WEB-INF/saiku-beans.xml
+++ b/saiku-webapp/src/main/webapp/WEB-INF/saiku-beans.xml
@@ -339,6 +339,17 @@
         <property name="sessionService" ref="sessionService"/>
     </bean>
 
+    <!-- Dashboard image-tile assets (issue #918) @ /saiku/api/dashboards/image.
+         Stores uploaded images Base64-encoded via the same ACL-checked file
+         primitives as the dashboards, in the uploader's home folder, so image
+         assets inherit the owner's permission model. Magic-byte sniffed
+         (PNG/JPEG/GIF/WebP only; SVG blocked), 2 MB cap, served nosniff. -->
+    <bean id="dashboardImageResource"
+          class="org.saiku.web.rest.resources.dashboards.DashboardImageResource">
+        <property name="datasourceService" ref="datasourceServiceBean"/>
+        <property name="sessionService" ref="sessionService"/>
+    </bean>
+
     <!-- ====================================================================
          Shareable read-only dashboard links (issue #941).
          - shareTokenStore: file-backed token store under ${saiku.home}/share-tokens.


### PR DESCRIPTION
## Summary
New **image** dashboard tile type (closes #918): render a logo / diagram / screenshot from an external **URL** or an **uploaded file**, with object-fit (contain/cover/fill/scale-down) and an optional caption — replacing the old "text tile with raw HTML" workaround.

## The change
**Frontend (saiku-ui)**
- `ImageConfig` + `"image"` `TileType`; `ImageTile.svelte` (renders `<img>` + caption, broken-image fallback, placeholder when unset).
- URL safety extracted to a pure, unit-tested helper `imageSrc.ts`: only `http(s)`/same-origin-relative srcs honoured; `javascript:`/`data:`/etc. rejected.
- Tile dispatcher + default title + `AddTileMenu` entry + default size.
- `TileEditorModal`: image sub-form (URL | upload, fit, caption, alt); upload posts on save and persists the returned download path.

**Backend (saiku-core)**
- `DashboardImageResource` @ `/saiku/api/dashboards/image` — upload + serve. Image bytes Base64-encoded via the ACL-checked file primitives, stored at `homes/<user>/<tileId>.<ext>`. Hardening: session auth required; **magic-byte sniff allowlist (PNG/JPEG/GIF/WebP; SVG blocked)**; 2 MB cap; `tileId` charset-restricted; download is ACL-gated + ext-allowlisted + served `nosniff` + locked-down CSP.
- `ImageConfig` + `image` field on the Java `DashboardTile` (so the tile round-trips through save); bean wired.

## Verified
- saiku-ui `check` 0/0, `vitest` 497/497 (+7 imageSrc tests)
- `DashboardImageResourceTest` 8/8
- Live: upload → download round-trip 200/200 (image bytes intact); `?token=`-style abuse N/A; user-verified in browser (URL + upload + persistence)
- **Security gate: clean** (file-upload allowlist/SVG-block/size/ACL; download ACL+nosniff/CSP; URL scheme-allowlist)

## Test plan
Dashboard → + Add tile → Image → ⚙ → set a URL **or** upload a PNG/JPG/GIF/WebP → Save → image renders; Save dashboard + reload → persists. SVG / >2 MB uploads are rejected.

## Notes
- Touches `Tile.svelte` (wrapper) — coordinated with AGENT 1's PR2 (#1063), which rebases onto this once merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
