### PR TITLE
chore(release): bump version 4.3.7 → 4.4.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <groupId>org.saikuanalytics</groupId>
     <artifactId>saiku</artifactId>
     <packaging>pom</packaging>
-    <version>4.3.7</version>
+    <version>4.4.0</version>
     <name>Saiku Module Project</name>
     <scm>
         <developerConnection>

--- a/saiku-bom/pom.xml
+++ b/saiku-bom/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.saikuanalytics</groupId>
     <artifactId>saiku-bom</artifactId>
-    <version>4.3.7</version>
+    <version>4.4.0</version>
     <packaging>pom</packaging>
     <name>Saiku BOM</name>
     <description>Central dependency-version catalogue for Saiku modules.</description>

--- a/saiku-core/pom.xml
+++ b/saiku-core/pom.xml
@@ -2,14 +2,14 @@
     <parent>
         <artifactId>saiku</artifactId>
         <groupId>org.saikuanalytics</groupId>
-        <version>4.3.7</version>
+        <version>4.4.0</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>
     <artifactId>saiku-core</artifactId>
     <packaging>pom</packaging>
     <name>saiku - core libraries</name>
-    <version>4.3.7</version>
+    <version>4.4.0</version>
 
     <modules>
         <module>saiku-olap-util</module>

--- a/saiku-core/saiku-olap-util/pom.xml
+++ b/saiku-core/saiku-olap-util/pom.xml
@@ -3,11 +3,11 @@
     <parent>
         <artifactId>saiku-core</artifactId>
         <groupId>org.saikuanalytics</groupId>
-        <version>4.3.7</version>
+        <version>4.4.0</version>
     </parent>
 	<artifactId>saiku-olap-util</artifactId>
 	<packaging>jar</packaging>
-	<version>4.3.7</version>
+	<version>4.4.0</version>
 	<name>saiku olap util</name>
 	<properties>
 		<maven.compiler.source>1.8</maven.compiler.source>

--- a/saiku-core/saiku-semantic/pom.xml
+++ b/saiku-core/saiku-semantic/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <artifactId>saiku-core</artifactId>
         <groupId>org.saikuanalytics</groupId>
-        <version>4.3.7</version>
+        <version>4.4.0</version>
     </parent>
 
     <artifactId>saiku-semantic</artifactId>

--- a/saiku-core/saiku-service/pom.xml
+++ b/saiku-core/saiku-service/pom.xml
@@ -2,12 +2,12 @@
     <parent>
         <artifactId>saiku-core</artifactId>
         <groupId>org.saikuanalytics</groupId>
-        <version>4.3.7</version>
+        <version>4.4.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>jar</packaging>
     <artifactId>saiku-service</artifactId>
-    <version>4.3.7</version>
+    <version>4.4.0</version>
     <name>saiku - services</name>
     <build>
         <plugins>

--- a/saiku-core/saiku-web/pom.xml
+++ b/saiku-core/saiku-web/pom.xml
@@ -2,11 +2,11 @@
     <parent>
         <artifactId>saiku-core</artifactId>
         <groupId>org.saikuanalytics</groupId>
-        <version>4.3.7</version>
+        <version>4.4.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>saiku-web</artifactId>
-    <version>4.3.7</version>
+    <version>4.4.0</version>
     <name>saiku - web</name>
     <packaging>jar</packaging>
 

--- a/saiku-launcher/pom.xml
+++ b/saiku-launcher/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.saikuanalytics</groupId>
         <artifactId>saiku</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.0</version>
     </parent>
 
     <artifactId>saiku-launcher</artifactId>

--- a/saiku-webapp/pom.xml
+++ b/saiku-webapp/pom.xml
@@ -2,11 +2,11 @@
     <parent>
         <artifactId>saiku</artifactId>
         <groupId>org.saikuanalytics</groupId>
-        <version>4.3.7</version>
+        <version>4.4.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>saiku-webapp</artifactId>
-    <version>4.3.7</version>
+    <version>4.4.0</version>
     <name>saiku - webapp</name>
     <packaging>war</packaging>
     <build>


### PR DESCRIPTION
## Summary
Version bump **4.3.7 → 4.4.0** to cut the **Saiku 4.4.0** release — the dashboard feature batch landed on `development` this cycle (small multiples, per-tile states, theme-aware charts, per-dashboard ACL, share links, comments, version history, image tile, + their UIs) warrants a minor bump.

## The change
`mvn versions:set -DnewVersion=4.4.0 -DprocessAllModules=true -DgenerateBackupPoms=false` — atomically updates all 9 reactor poms (root, `saiku-bom`, `saiku-core` + olap-util/semantic/service/web, `saiku-launcher`, `saiku-webapp`) including parent + bom-import refs. No `4.3.7` remains in any pom.

## Verified
- All 9 poms now `4.4.0`; no stale `4.3.7`; reactor refs consistent.
- Full build validated by CI (`mvn verify` on JDK 21 / ubuntu + macos).
- No code change — version strings only, so the pre-merge security gate is N/A (no attack surface).

## Test plan
CI `verify` is the gate. After merge: tag `v4.4.0` on `development` + push → `release.yml` builds the launcher fat-JAR, deploys module jars to GitHub Packages, pushes `ghcr.io/spiculedata/saiku:4.4.0`, and publishes the GitHub release.

## Notes
- Release tag goes on `development` (matches v4.3.x practice, #1003) — does **not** touch `main`.
- Downstream: once `ghcr.io/spiculedata/saiku:4.4.0` is published, bump `saiku_version` in `saiku-cloud` `group_vars/all.yml` (staging) → validate → then prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
