### PR TITLE
feat(dashboard): purge comment/history sidecars on delete + non-admin users endpoint (#942/#947 follow-ups)

### DIFF
--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/comments/CommentService.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/comments/CommentService.java
@@ -112,6 +112,16 @@ public class CommentService {
         return found;
     }
 
+    /** Delete this dashboard's entire comment file — called when the dashboard
+     *  itself is removed so the sidecar JSONL isn't orphaned (#942 cleanup). */
+    public void purge(String dashboardPath) {
+        try {
+            datasourceService.removeInternalFile(commentsPath(dashboardPath));
+        } catch (RuntimeException e) {
+            log.warn("could not purge comments for {}", dashboardPath, e);
+        }
+    }
+
     /* --------------------------- internals --------------------------- */
 
     static List<String> parseMentions(String body) {

--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/datasource/DatasourceService.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/datasource/DatasourceService.java
@@ -151,6 +151,15 @@ public class DatasourceService implements Serializable {
         }
     }
 
+    /**
+     * Delete an internal file (no ACL gate — internal files are server-managed).
+     * Best-effort: a missing file is a no-op. Used to purge a dashboard's
+     * sidecar comment / history JSONL when the dashboard itself is deleted.
+     */
+    public void removeInternalFile(String path) {
+        datasources.removeInternalFile(path);
+    }
+
     public String saveFile(String content, String path, String name, List<String> roles) {
         return datasources.saveFile(path, content, name, roles);
     }

--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/history/DashboardHistoryService.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/history/DashboardHistoryService.java
@@ -79,6 +79,16 @@ public class DashboardHistoryService {
         return null;
     }
 
+    /** Delete this dashboard's entire history file — called when the dashboard
+     *  itself is removed so the sidecar JSONL isn't orphaned (#947 cleanup). */
+    public void purge(String dashboardPath) {
+        try {
+            datasourceService.removeInternalFile(historyPath(dashboardPath));
+        } catch (RuntimeException e) {
+            log.warn("could not purge history for {}", dashboardPath, e);
+        }
+    }
+
     /* --------------------------- internals --------------------------- */
 
     /** Flat, sanitised internal path at the datadir root (no subdir — the

--- a/saiku-core/saiku-service/src/test/java/org/saiku/service/comments/CommentServiceTest.java
+++ b/saiku-core/saiku-service/src/test/java/org/saiku/service/comments/CommentServiceTest.java
@@ -40,6 +40,11 @@ public class CommentServiceTest {
         public String getFileData(String path, String username, List<String> roles) {
             return dashboardReadable ? "{\"id\":\"x\"}" : null;
         }
+
+        @Override
+        public void removeInternalFile(String path) {
+            internal.remove(path);
+        }
     }
 
     private FakeDs ds;
@@ -80,6 +85,14 @@ public class CommentServiceTest {
         // The deleted row is still on disk (findById sees it) so order is kept.
         assertTrue(svc.findById(DASH, a.id).deleted);
         assertFalse("deleting unknown id is false", svc.softDelete(DASH, "nope"));
+    }
+
+    @Test
+    public void purge_removes_the_comment_file() {
+        svc.add(DASH, "t1", "admin", "hi");
+        assertEquals(1, svc.list(DASH, "t1").size());
+        svc.purge(DASH);
+        assertEquals("purged thread is empty", 0, svc.list(DASH, "t1").size());
     }
 
     @Test

--- a/saiku-core/saiku-service/src/test/java/org/saiku/service/history/DashboardHistoryServiceTest.java
+++ b/saiku-core/saiku-service/src/test/java/org/saiku/service/history/DashboardHistoryServiceTest.java
@@ -34,6 +34,11 @@ public class DashboardHistoryServiceTest {
         public String getInternalFileData(String path) {
             return internal.get(path);
         }
+
+        @Override
+        public void removeInternalFile(String path) {
+            internal.remove(path);
+        }
     }
 
     private FakeDs ds;
@@ -77,6 +82,14 @@ public class DashboardHistoryServiceTest {
         assertEquals(DashboardHistoryService.RETENTION, list.size());
         assertEquals("newest kept", "{\"v\":55}", list.get(0).dashboard);
         assertEquals("oldest kept is v6 (v1-5 pruned)", "{\"v\":6}", list.get(list.size() - 1).dashboard);
+    }
+
+    @Test
+    public void purge_removes_the_history_file() {
+        svc.archive(DASH, "{\"v\":1}", "admin");
+        assertEquals(1, svc.list(DASH).size());
+        svc.purge(DASH);
+        assertEquals("purged history is empty", 0, svc.list(DASH).size());
     }
 
     @Test

--- a/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/UsersResource.java
+++ b/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/UsersResource.java
@@ -1,0 +1,50 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.web.rest.resources;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import org.saiku.database.dto.SaikuUser;
+import org.saiku.service.user.UserService;
+
+/**
+ * Minimal user directory for any authenticated user (issue #942 follow-up) —
+ * powers @-mention autocomplete in dashboard comments. Returns ONLY usernames
+ * (no email / roles / passwords); the admin user-management surface stays on
+ * {@code /saiku/admin/users} (ROLE_ADMIN). Sits on {@code /rest/**}
+ * ({@code isFullyAuthenticated()}), so guests / share links can't read it.
+ */
+@Path("/saiku/api/users")
+public class UsersResource {
+
+    private UserService userService;
+
+    public void setUserService(UserService s) {
+        this.userService = s;
+    }
+
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response list() {
+        List<Map<String, String>> out = new ArrayList<>();
+        if (userService != null) {
+            List<SaikuUser> users = userService.getUsers();
+            if (users != null) {
+                for (SaikuUser u : users) {
+                    if (u != null && u.getUsername() != null) {
+                        out.add(Map.of("username", u.getUsername()));
+                    }
+                }
+            }
+        }
+        return Response.ok(out).type(MediaType.APPLICATION_JSON).build();
+    }
+}

--- a/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/dashboards/DashboardResource.java
+++ b/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/dashboards/DashboardResource.java
@@ -51,6 +51,7 @@ public class DashboardResource {
     private DatasourceService datasourceService;
     private SessionService sessionService;
     private org.saiku.service.history.DashboardHistoryService historyService;
+    private org.saiku.service.comments.CommentService commentService;
 
     public void setDatasourceService(DatasourceService s) {
         this.datasourceService = s;
@@ -63,6 +64,11 @@ public class DashboardResource {
     /** Optional (#947): archives the replaced version on each successful save. */
     public void setHistoryService(org.saiku.service.history.DashboardHistoryService s) {
         this.historyService = s;
+    }
+
+    /** Optional (#942 cleanup): purges the comment sidecar on delete. */
+    public void setCommentService(org.saiku.service.comments.CommentService s) {
+        this.commentService = s;
     }
 
     /**
@@ -167,6 +173,23 @@ public class DashboardResource {
         List<String> roles = currentRoles();
         String resp = datasourceService.removeFile(path, username, roles);
         if (REMOVE_OK.equals(resp)) {
+            // Purge the dashboard's sidecar comment + history files so they
+            // aren't orphaned (#942/#947 cleanup). Best-effort — never fail the
+            // delete because a sidecar couldn't be removed.
+            if (historyService != null) {
+                try {
+                    historyService.purge(path);
+                } catch (RuntimeException ignored) {
+                    // logged at the service layer
+                }
+            }
+            if (commentService != null) {
+                try {
+                    commentService.purge(path);
+                } catch (RuntimeException ignored) {
+                    // logged at the service layer
+                }
+            }
             return Response.ok(Map.of("status", "OK", "path", path))
                     .type(MediaType.APPLICATION_JSON)
                     .build();

--- a/saiku-launcher/test-cleanup-live.sh
+++ b/saiku-launcher/test-cleanup-live.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# Live verification for the #942/#947 follow-ups:
+#  - deleting a dashboard PURGES its sidecar comment + history files (no orphans)
+#  - GET /rest/saiku/api/users returns a usernames list (for @-mention autocomplete)
+# Usage: launcher on :8087 (SAIKU_DEMO=true), then ./test-cleanup-live.sh
+set -u
+URL="${SAIKU_URL:-http://localhost:8087}"
+A=$(mktemp); trap 'rm -f "$A"' EXIT
+PASS=0; FAIL=0
+ok(){ echo "  PASS: $1"; PASS=$((PASS+1)); }
+no(){ echo "  FAIL: $1 | code=$2 body=${3:0:180}"; FAIL=$((FAIL+1)); }
+login(){ curl -s -b "$1" -c "$1" -X POST "$URL/rest/saiku/session" --data "username=$2&password=$3" -o /dev/null -w '%{http_code}'; }
+req(){ local m="$1" p="$2" body="${3:-}"; local out; out=$(mktemp)
+  if [ "$m" = GET ]; then RC=$(curl -s -b "$A" "$URL$p" -o "$out" -w '%{http_code}')
+  elif [ "$m" = DELETE ]; then RC=$(curl -s -b "$A" -X DELETE "$URL$p" -o "$out" -w '%{http_code}')
+  else RC=$(curl -s -b "$A" -X "$m" "$URL$p" -H 'Content-Type: application/json' --data "$body" -o "$out" -w '%{http_code}'); fi
+  RB=$(cat "$out"); rm -f "$out"; }
+
+DASH="dashboards/cleanup-demo.saikudash"
+DGET="/rest/saiku/api/dashboards/$DASH"
+C="/rest/saiku/api/dashboards/comments"
+H="/rest/saiku/api/dashboards/history"
+V1='{"id":"c","name":"V1","version":1,"layout":{"cols":12,"tiles":[{"id":"t1","x":0,"y":0,"w":4,"h":3,"type":"text","text":"hi"}]}}'
+V2='{"id":"c","name":"V2","version":1,"layout":{"cols":12,"tiles":[{"id":"t1","x":0,"y":0,"w":4,"h":3,"type":"text","text":"hi"}]}}'
+
+echo "== users directory (for @-mention) =="
+[ "$(login "$A" admin admin)" = 200 ] && ok "admin login" || no "admin login" "?" ""
+req GET "/rest/saiku/api/users"; { [ "$RC" = 200 ] && echo "$RB" | grep -q '"username":"admin"'; } && ok "GET /api/users lists usernames (incl admin)" || no "users list" "$RC" "$RB"
+
+echo "== seed: dashboard + comment + 2 saves (history) =="
+req POST "$DGET" "$V1"; echo "$RB" | grep -q '"status":"OK"' && ok "save v1" || no "save v1" "$RC" "$RB"
+req POST "$DGET" "$V2"; echo "$RB" | grep -q '"status":"OK"' && ok "save v2 (archives v1)" || no "save v2" "$RC" "$RB"
+req POST "$C" "{\"dashboard\":\"$DASH\",\"tile\":\"t1\",\"body\":\"a comment\"}"; echo "$RB" | grep -q 'a comment' && ok "post comment" || no "post comment" "$RC" "$RB"
+req GET "$C?dashboard=$DASH&tile=t1"; echo "$RB" | grep -q 'a comment' && ok "comment present" || no "comment present" "$RC" "$RB"
+req GET "$H?dashboard=$DASH"; echo "$RB" | grep -q '"version"' && ok "history present" || no "history present" "$RC" "$RB"
+
+echo "== delete the dashboard → sidecars must be purged =="
+req DELETE "$DGET"; echo "$RB" | grep -q '"status":"OK"' && ok "delete dashboard" || no "delete" "$RC" "$RB"
+# Re-create at the same path; the comment + history sidecars should be EMPTY now.
+req POST "$DGET" "$V1" >/dev/null
+req GET "$C?dashboard=$DASH&tile=t1"; { [ "$RC" = 200 ] && [ "$RB" = "[]" ]; } && ok "comments purged on delete (empty after recreate)" || no "comments not purged" "$RC" "$RB"
+req GET "$H?dashboard=$DASH"; { [ "$RC" = 200 ] && [ "$RB" = "[]" ]; } && ok "history purged on delete (empty after recreate)" || no "history not purged" "$RC" "$RB"
+
+echo "== cleanup =="
+req DELETE "$DGET" >/dev/null 2>&1
+echo ""; echo "RESULT: $PASS passed, $FAIL failed"; exit $FAIL

--- a/saiku-webapp/src/main/webapp/WEB-INF/saiku-beans.xml
+++ b/saiku-webapp/src/main/webapp/WEB-INF/saiku-beans.xml
@@ -320,6 +320,14 @@
         <property name="datasourceService" ref="datasourceServiceBean"/>
         <property name="sessionService" ref="sessionService"/>
         <property name="historyService" ref="dashboardHistoryService"/>
+        <!-- #942/#947 cleanup: purge sidecar comment + history files on delete. -->
+        <property name="commentService" ref="commentService"/>
+    </bean>
+
+    <!-- #942 follow-up: minimal authenticated user directory for @-mention
+         autocomplete (usernames only; admin user-mgmt stays on /saiku/admin). -->
+    <bean id="usersResource" class="org.saiku.web.rest.resources.UsersResource">
+        <property name="userService" ref="userServiceBean"/>
     </bean>
 
     <!-- Dashboard versioning / history (issue #947). dashboardHistoryService


### PR DESCRIPTION
## Summary
Two backend follow-ups to the merged comments (#942) + versioning (#947) features:
1. **Orphaned-file cleanup** — deleting a dashboard now also removes its sidecar `saiku-comments-<dash>.jsonl` and `saiku-history-<dash>.jsonl` files, so they're not left behind.
2. **Non-admin users endpoint** — `GET /rest/saiku/api/users` (authenticated, any user; usernames only) to power **@-mention autocomplete** in the comments UI (frontend lands in a follow-up PR).

## The change
- `DatasourceService.removeInternalFile(path)` — thin wrapper over the existing manager method (internal files have no ACL gate).
- `CommentService.purge(dashboardPath)` + `DashboardHistoryService.purge(dashboardPath)` — delete that dashboard's sidecar JSONL (best-effort, logged).
- `DashboardResource.delete` — after a successful `removeFile`, calls both purges; **never fails the delete** if a purge throws (try/catch, logged).
- **New `UsersResource`** (`@Path /saiku/api/users`): returns `[{username}]` from `userService.getUsers()` — **only usernames** (no email/roles/passwords). The admin user-management surface stays on `/saiku/admin/users` (ROLE_ADMIN). On `/rest/**` = `isFullyAuthenticated()`, so share-link guests can't read it.
- Beans: inject `commentService` into `dashboardResource`; add `usersResource`.

## Verified
- Unit: `CommentServiceTest` **7/7** + `DashboardHistoryServiceTest` **6/6** (new `purge_*` tests).
- **Live** `test-cleanup-live.sh` → **10/10** (user-verified): users endpoint lists usernames; seed comment + 2 saves (history) → delete dashboard → re-create at same path → comments + history come back **empty** (purged).
- Reactor compiles; spotless clean.

## Security note (for OG's gate)
The users endpoint exposes the **list of usernames** to any authenticated user — required for @-mention discovery, and strictly less than the admin endpoint (no email/roles). Flagging it for review.

## Test plan
Launcher on :8087 (`SAIKU_DEMO=true`): `bash saiku-launcher/test-cleanup-live.sh` → 10/10. Manual: `GET /rest/saiku/api/users`; create a dashboard with a comment + 2 saves, delete it, re-create → comments/history empty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)