### PR TITLE
feat(comments): @-mention autocomplete in the comments box (#942 follow-up)

### DIFF
--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/comments/CommentService.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/comments/CommentService.java
@@ -112,6 +112,16 @@ public class CommentService {
         return found;
     }
 
+    /** Delete this dashboard's entire comment file — called when the dashboard
+     *  itself is removed so the sidecar JSONL isn't orphaned (#942 cleanup). */
+    public void purge(String dashboardPath) {
+        try {
+            datasourceService.removeInternalFile(commentsPath(dashboardPath));
+        } catch (RuntimeException e) {
+            log.warn("could not purge comments for {}", dashboardPath, e);
+        }
+    }
+
     /* --------------------------- internals --------------------------- */
 
     static List<String> parseMentions(String body) {

--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/datasource/DatasourceService.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/datasource/DatasourceService.java
@@ -151,6 +151,15 @@ public class DatasourceService implements Serializable {
         }
     }
 
+    /**
+     * Delete an internal file (no ACL gate — internal files are server-managed).
+     * Best-effort: a missing file is a no-op. Used to purge a dashboard's
+     * sidecar comment / history JSONL when the dashboard itself is deleted.
+     */
+    public void removeInternalFile(String path) {
+        datasources.removeInternalFile(path);
+    }
+
     public String saveFile(String content, String path, String name, List<String> roles) {
         return datasources.saveFile(path, content, name, roles);
     }

--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/history/DashboardHistoryService.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/history/DashboardHistoryService.java
@@ -79,6 +79,16 @@ public class DashboardHistoryService {
         return null;
     }
 
+    /** Delete this dashboard's entire history file — called when the dashboard
+     *  itself is removed so the sidecar JSONL isn't orphaned (#947 cleanup). */
+    public void purge(String dashboardPath) {
+        try {
+            datasourceService.removeInternalFile(historyPath(dashboardPath));
+        } catch (RuntimeException e) {
+            log.warn("could not purge history for {}", dashboardPath, e);
+        }
+    }
+
     /* --------------------------- internals --------------------------- */
 
     /** Flat, sanitised internal path at the datadir root (no subdir — the

--- a/saiku-core/saiku-service/src/test/java/org/saiku/service/comments/CommentServiceTest.java
+++ b/saiku-core/saiku-service/src/test/java/org/saiku/service/comments/CommentServiceTest.java
@@ -40,6 +40,11 @@ public class CommentServiceTest {
         public String getFileData(String path, String username, List<String> roles) {
             return dashboardReadable ? "{\"id\":\"x\"}" : null;
         }
+
+        @Override
+        public void removeInternalFile(String path) {
+            internal.remove(path);
+        }
     }
 
     private FakeDs ds;
@@ -80,6 +85,14 @@ public class CommentServiceTest {
         // The deleted row is still on disk (findById sees it) so order is kept.
         assertTrue(svc.findById(DASH, a.id).deleted);
         assertFalse("deleting unknown id is false", svc.softDelete(DASH, "nope"));
+    }
+
+    @Test
+    public void purge_removes_the_comment_file() {
+        svc.add(DASH, "t1", "admin", "hi");
+        assertEquals(1, svc.list(DASH, "t1").size());
+        svc.purge(DASH);
+        assertEquals("purged thread is empty", 0, svc.list(DASH, "t1").size());
     }
 
     @Test

--- a/saiku-core/saiku-service/src/test/java/org/saiku/service/history/DashboardHistoryServiceTest.java
+++ b/saiku-core/saiku-service/src/test/java/org/saiku/service/history/DashboardHistoryServiceTest.java
@@ -34,6 +34,11 @@ public class DashboardHistoryServiceTest {
         public String getInternalFileData(String path) {
             return internal.get(path);
         }
+
+        @Override
+        public void removeInternalFile(String path) {
+            internal.remove(path);
+        }
     }
 
     private FakeDs ds;
@@ -77,6 +82,14 @@ public class DashboardHistoryServiceTest {
         assertEquals(DashboardHistoryService.RETENTION, list.size());
         assertEquals("newest kept", "{\"v\":55}", list.get(0).dashboard);
         assertEquals("oldest kept is v6 (v1-5 pruned)", "{\"v\":6}", list.get(list.size() - 1).dashboard);
+    }
+
+    @Test
+    public void purge_removes_the_history_file() {
+        svc.archive(DASH, "{\"v\":1}", "admin");
+        assertEquals(1, svc.list(DASH).size());
+        svc.purge(DASH);
+        assertEquals("purged history is empty", 0, svc.list(DASH).size());
     }
 
     @Test

--- a/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/UsersResource.java
+++ b/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/UsersResource.java
@@ -1,0 +1,50 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.web.rest.resources;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import org.saiku.database.dto.SaikuUser;
+import org.saiku.service.user.UserService;
+
+/**
+ * Minimal user directory for any authenticated user (issue #942 follow-up) —
+ * powers @-mention autocomplete in dashboard comments. Returns ONLY usernames
+ * (no email / roles / passwords); the admin user-management surface stays on
+ * {@code /saiku/admin/users} (ROLE_ADMIN). Sits on {@code /rest/**}
+ * ({@code isFullyAuthenticated()}), so guests / share links can't read it.
+ */
+@Path("/saiku/api/users")
+public class UsersResource {
+
+    private UserService userService;
+
+    public void setUserService(UserService s) {
+        this.userService = s;
+    }
+
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response list() {
+        List<Map<String, String>> out = new ArrayList<>();
+        if (userService != null) {
+            List<SaikuUser> users = userService.getUsers();
+            if (users != null) {
+                for (SaikuUser u : users) {
+                    if (u != null && u.getUsername() != null) {
+                        out.add(Map.of("username", u.getUsername()));
+                    }
+                }
+            }
+        }
+        return Response.ok(out).type(MediaType.APPLICATION_JSON).build();
+    }
+}

--- a/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/dashboards/DashboardResource.java
+++ b/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/dashboards/DashboardResource.java
@@ -51,6 +51,7 @@ public class DashboardResource {
     private DatasourceService datasourceService;
     private SessionService sessionService;
     private org.saiku.service.history.DashboardHistoryService historyService;
+    private org.saiku.service.comments.CommentService commentService;
 
     public void setDatasourceService(DatasourceService s) {
         this.datasourceService = s;
@@ -63,6 +64,11 @@ public class DashboardResource {
     /** Optional (#947): archives the replaced version on each successful save. */
     public void setHistoryService(org.saiku.service.history.DashboardHistoryService s) {
         this.historyService = s;
+    }
+
+    /** Optional (#942 cleanup): purges the comment sidecar on delete. */
+    public void setCommentService(org.saiku.service.comments.CommentService s) {
+        this.commentService = s;
     }
 
     /**
@@ -167,6 +173,23 @@ public class DashboardResource {
         List<String> roles = currentRoles();
         String resp = datasourceService.removeFile(path, username, roles);
         if (REMOVE_OK.equals(resp)) {
+            // Purge the dashboard's sidecar comment + history files so they
+            // aren't orphaned (#942/#947 cleanup). Best-effort — never fail the
+            // delete because a sidecar couldn't be removed.
+            if (historyService != null) {
+                try {
+                    historyService.purge(path);
+                } catch (RuntimeException ignored) {
+                    // logged at the service layer
+                }
+            }
+            if (commentService != null) {
+                try {
+                    commentService.purge(path);
+                } catch (RuntimeException ignored) {
+                    // logged at the service layer
+                }
+            }
             return Response.ok(Map.of("status", "OK", "path", path))
                     .type(MediaType.APPLICATION_JSON)
                     .build();

--- a/saiku-launcher/test-cleanup-live.sh
+++ b/saiku-launcher/test-cleanup-live.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# Live verification for the #942/#947 follow-ups:
+#  - deleting a dashboard PURGES its sidecar comment + history files (no orphans)
+#  - GET /rest/saiku/api/users returns a usernames list (for @-mention autocomplete)
+# Usage: launcher on :8087 (SAIKU_DEMO=true), then ./test-cleanup-live.sh
+set -u
+URL="${SAIKU_URL:-http://localhost:8087}"
+A=$(mktemp); trap 'rm -f "$A"' EXIT
+PASS=0; FAIL=0
+ok(){ echo "  PASS: $1"; PASS=$((PASS+1)); }
+no(){ echo "  FAIL: $1 | code=$2 body=${3:0:180}"; FAIL=$((FAIL+1)); }
+login(){ curl -s -b "$1" -c "$1" -X POST "$URL/rest/saiku/session" --data "username=$2&password=$3" -o /dev/null -w '%{http_code}'; }
+req(){ local m="$1" p="$2" body="${3:-}"; local out; out=$(mktemp)
+  if [ "$m" = GET ]; then RC=$(curl -s -b "$A" "$URL$p" -o "$out" -w '%{http_code}')
+  elif [ "$m" = DELETE ]; then RC=$(curl -s -b "$A" -X DELETE "$URL$p" -o "$out" -w '%{http_code}')
+  else RC=$(curl -s -b "$A" -X "$m" "$URL$p" -H 'Content-Type: application/json' --data "$body" -o "$out" -w '%{http_code}'); fi
+  RB=$(cat "$out"); rm -f "$out"; }
+
+DASH="dashboards/cleanup-demo.saikudash"
+DGET="/rest/saiku/api/dashboards/$DASH"
+C="/rest/saiku/api/dashboards/comments"
+H="/rest/saiku/api/dashboards/history"
+V1='{"id":"c","name":"V1","version":1,"layout":{"cols":12,"tiles":[{"id":"t1","x":0,"y":0,"w":4,"h":3,"type":"text","text":"hi"}]}}'
+V2='{"id":"c","name":"V2","version":1,"layout":{"cols":12,"tiles":[{"id":"t1","x":0,"y":0,"w":4,"h":3,"type":"text","text":"hi"}]}}'
+
+echo "== users directory (for @-mention) =="
+[ "$(login "$A" admin admin)" = 200 ] && ok "admin login" || no "admin login" "?" ""
+req GET "/rest/saiku/api/users"; { [ "$RC" = 200 ] && echo "$RB" | grep -q '"username":"admin"'; } && ok "GET /api/users lists usernames (incl admin)" || no "users list" "$RC" "$RB"
+
+echo "== seed: dashboard + comment + 2 saves (history) =="
+req POST "$DGET" "$V1"; echo "$RB" | grep -q '"status":"OK"' && ok "save v1" || no "save v1" "$RC" "$RB"
+req POST "$DGET" "$V2"; echo "$RB" | grep -q '"status":"OK"' && ok "save v2 (archives v1)" || no "save v2" "$RC" "$RB"
+req POST "$C" "{\"dashboard\":\"$DASH\",\"tile\":\"t1\",\"body\":\"a comment\"}"; echo "$RB" | grep -q 'a comment' && ok "post comment" || no "post comment" "$RC" "$RB"
+req GET "$C?dashboard=$DASH&tile=t1"; echo "$RB" | grep -q 'a comment' && ok "comment present" || no "comment present" "$RC" "$RB"
+req GET "$H?dashboard=$DASH"; echo "$RB" | grep -q '"version"' && ok "history present" || no "history present" "$RC" "$RB"
+
+echo "== delete the dashboard → sidecars must be purged =="
+req DELETE "$DGET"; echo "$RB" | grep -q '"status":"OK"' && ok "delete dashboard" || no "delete" "$RC" "$RB"
+# Re-create at the same path; the comment + history sidecars should be EMPTY now.
+req POST "$DGET" "$V1" >/dev/null
+req GET "$C?dashboard=$DASH&tile=t1"; { [ "$RC" = 200 ] && [ "$RB" = "[]" ]; } && ok "comments purged on delete (empty after recreate)" || no "comments not purged" "$RC" "$RB"
+req GET "$H?dashboard=$DASH"; { [ "$RC" = 200 ] && [ "$RB" = "[]" ]; } && ok "history purged on delete (empty after recreate)" || no "history not purged" "$RC" "$RB"
+
+echo "== cleanup =="
+req DELETE "$DGET" >/dev/null 2>&1
+echo ""; echo "RESULT: $PASS passed, $FAIL failed"; exit $FAIL

--- a/saiku-ui/src/lib/api/dashboards.ts
+++ b/saiku-ui/src/lib/api/dashboards.ts
@@ -700,3 +700,22 @@ export async function revokeShareToken(token: string): Promise<void> {
     throw new Error(`revokeShareToken -> ${res.status}`);
   }
 }
+
+/* ---------------------- user directory (#942 follow-up) ----------------- */
+
+export interface SaikuUserRef {
+  username: string;
+}
+
+/** Minimal authenticated user list (usernames only) — powers @-mention
+ *  autocomplete in comments. */
+export async function getUsers(): Promise<SaikuUserRef[]> {
+  const res = await fetch("/rest/saiku/api/users", {
+    credentials: "include",
+    headers: { Accept: "application/json" },
+  });
+  if (!res.ok) {
+    throw new Error(`getUsers -> ${res.status}`);
+  }
+  return (await res.json()) as SaikuUserRef[];
+}

--- a/saiku-ui/src/lib/dashboard/mentionAutocomplete.test.ts
+++ b/saiku-ui/src/lib/dashboard/mentionAutocomplete.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+import { applyMention, currentMentionToken, matchUsers } from "./mentionAutocomplete";
+
+describe("currentMentionToken", () => {
+  it("detects an @-mention in progress at the caret", () => {
+    const t = "hey @bo";
+    expect(currentMentionToken(t, t.length)).toEqual({ start: 4, query: "bo" });
+  });
+
+  it("detects an empty mention right after @", () => {
+    const t = "hi @";
+    expect(currentMentionToken(t, t.length)).toEqual({ start: 3, query: "" });
+  });
+
+  it("ignores a completed mention (whitespace after)", () => {
+    const t = "hi @bob ";
+    expect(currentMentionToken(t, t.length)).toBeNull();
+  });
+
+  it("ignores an email-style @ (mid-word)", () => {
+    const t = "mail me at user@exa";
+    expect(currentMentionToken(t, t.length)).toBeNull();
+  });
+
+  it("uses the caret, not the end of the string", () => {
+    const t = "@al and @bo";
+    expect(currentMentionToken(t, 3)).toEqual({ start: 0, query: "al" });
+  });
+});
+
+describe("applyMention", () => {
+  it("replaces the partial token with @username + trailing space", () => {
+    const t = "hey @bo";
+    const r = applyMention(t, t.length, "bob");
+    expect(r.text).toBe("hey @bob ");
+    expect(r.caret).toBe(r.text.length);
+  });
+
+  it("keeps text after the caret intact", () => {
+    const t = "hey @bo!";
+    const r = applyMention(t, 7, "bob"); // caret before "!"
+    expect(r.text).toBe("hey @bob !");
+  });
+
+  it("is a no-op outside a mention", () => {
+    const t = "no mention here";
+    expect(applyMention(t, t.length, "bob")).toEqual({ text: t, caret: t.length });
+  });
+});
+
+describe("matchUsers", () => {
+  it("filters case-insensitively and caps the count", () => {
+    const users = ["admin", "bob", "bobby", "krishna", "smith"];
+    expect(matchUsers(users, "bo")).toEqual(["bob", "bobby"]);
+    expect(matchUsers(users, "")).toHaveLength(5);
+    expect(matchUsers(users, "", 2)).toHaveLength(2);
+    expect(matchUsers(users, "ADMIN")).toEqual(["admin"]);
+  });
+});

--- a/saiku-ui/src/lib/dashboard/mentionAutocomplete.ts
+++ b/saiku-ui/src/lib/dashboard/mentionAutocomplete.ts
@@ -1,0 +1,61 @@
+/*
+ * @-mention autocomplete helpers for the comments box (#942 follow-up). Pure
+ * (no DOM) so they unit-test cleanly; the component supplies the textarea
+ * value + caret offset.
+ */
+
+export interface MentionToken {
+  /** Index of the triggering '@' in the text. */
+  start: number;
+  /** The partial username typed after '@' up to the caret (may be ""). */
+  query: string;
+}
+
+/**
+ * The @-mention currently being typed at {@code caret}, or null. A mention is
+ * an '@' that starts the text or follows whitespace, with no whitespace between
+ * it and the caret — so `user@example.com` (the '@' is mid-word) is NOT a
+ * mention, and a completed `@bob ` (trailing space) is no longer in-progress.
+ */
+export function currentMentionToken(text: string, caret: number): MentionToken | null {
+  if (caret < 0 || caret > text.length) {
+    return null;
+  }
+  const upto = text.slice(0, caret);
+  const at = upto.lastIndexOf("@");
+  if (at < 0) {
+    return null;
+  }
+  const between = upto.slice(at + 1);
+  if (/\s/.test(between)) {
+    return null;
+  }
+  const before = at === 0 ? "" : text[at - 1];
+  if (before && !/\s/.test(before)) {
+    return null; // '@' is mid-word (e.g. an email address) — not a mention
+  }
+  return { start: at, query: between };
+}
+
+/** Replace the in-progress mention at {@code caret} with `@username ` (trailing
+ *  space), returning the new text + caret offset. No-op if not in a mention. */
+export function applyMention(
+  text: string,
+  caret: number,
+  username: string,
+): { text: string; caret: number } {
+  const tok = currentMentionToken(text, caret);
+  if (!tok) {
+    return { text, caret };
+  }
+  const before = text.slice(0, tok.start);
+  const after = text.slice(caret);
+  const insert = `@${username} `;
+  return { text: before + insert + after, caret: before.length + insert.length };
+}
+
+/** Case-insensitive substring filter over usernames, capped at {@code limit}. */
+export function matchUsers(usernames: string[], query: string, limit = 6): string[] {
+  const q = query.toLowerCase();
+  return usernames.filter((u) => u.toLowerCase().includes(q)).slice(0, limit);
+}

--- a/saiku-ui/src/lib/views/dashboard/CommentsPanel.svelte
+++ b/saiku-ui/src/lib/views/dashboard/CommentsPanel.svelte
@@ -1,14 +1,21 @@
 <script lang="ts">
   /*
-   * #942 PR2 — per-tile comments thread. Lists comments for one tile, lets the
-   * user post (plain @username typing — mentions are parsed server-side;
-   * autocomplete deferred until a non-admin users-list endpoint exists), and
-   * delete their own (admins delete any).
+   * #942 — per-tile comments thread. Lists comments for one tile, lets the user
+   * post (with @-mention autocomplete from the user directory), and delete their
+   * own (admins delete any). Mentions are parsed + stored server-side.
    */
+  import { tick } from "svelte";
   import Modal from "$lib/components/Modal.svelte";
   import { Trash2, Send } from "lucide-svelte";
   import { session } from "$lib/stores/session.svelte";
-  import { getComments, postComment, deleteComment, type DashboardComment } from "$lib/api/dashboards";
+  import {
+    getComments,
+    postComment,
+    deleteComment,
+    getUsers,
+    type DashboardComment,
+  } from "$lib/api/dashboards";
+  import { applyMention, currentMentionToken, matchUsers } from "$lib/dashboard/mentionAutocomplete";
 
   interface Props {
     dashboardPath: string;
@@ -84,8 +91,73 @@
     }
   }
 
+  /* ----------------------- @-mention autocomplete ---------------------- */
+
+  let textareaEl = $state<HTMLTextAreaElement | null>(null);
+  let usernames = $state<string[]>([]);
+  let usersLoaded = false;
+  let suggestions = $state<string[]>([]);
+  let selectedIndex = $state(0);
+
+  async function ensureUsers(): Promise<void> {
+    if (usersLoaded) return;
+    usersLoaded = true;
+    try {
+      usernames = (await getUsers()).map((u) => u.username);
+    } catch {
+      usernames = [];
+    }
+  }
+
+  async function refreshSuggestions(): Promise<void> {
+    const caret = textareaEl?.selectionStart ?? body.length;
+    const tok = currentMentionToken(body, caret);
+    if (!tok) {
+      suggestions = [];
+      return;
+    }
+    await ensureUsers();
+    suggestions = matchUsers(usernames, tok.query);
+    selectedIndex = 0;
+  }
+
+  async function pickMention(username: string): Promise<void> {
+    const caret = textareaEl?.selectionStart ?? body.length;
+    const r = applyMention(body, caret, username);
+    body = r.text;
+    suggestions = [];
+    await tick();
+    if (textareaEl) {
+      textareaEl.focus();
+      textareaEl.setSelectionRange(r.caret, r.caret);
+    }
+  }
+
   function onKeydown(e: KeyboardEvent): void {
-    // Ctrl/Cmd+Enter posts.
+    if (suggestions.length > 0) {
+      // Navigate / accept the mention dropdown.
+      if (e.key === "ArrowDown") {
+        e.preventDefault();
+        selectedIndex = (selectedIndex + 1) % suggestions.length;
+        return;
+      }
+      if (e.key === "ArrowUp") {
+        e.preventDefault();
+        selectedIndex = (selectedIndex - 1 + suggestions.length) % suggestions.length;
+        return;
+      }
+      if (e.key === "Enter" || e.key === "Tab") {
+        e.preventDefault();
+        void pickMention(suggestions[selectedIndex]);
+        return;
+      }
+      if (e.key === "Escape") {
+        e.preventDefault();
+        suggestions = [];
+        return;
+      }
+    }
+    // Ctrl/Cmd+Enter posts (when not selecting a mention).
     if ((e.ctrlKey || e.metaKey) && e.key === "Enter") {
       e.preventDefault();
       void post();
@@ -121,13 +193,40 @@
     {/if}
 
     <div class="cmts__compose">
-      <textarea
-        class="cmts__input"
-        bind:value={body}
-        placeholder="Add a comment… use @name to mention someone (Ctrl/Cmd+Enter to post)"
-        rows="2"
-        onkeydown={onKeydown}
-      ></textarea>
+      <div class="cmts__field">
+        <textarea
+          class="cmts__input"
+          bind:this={textareaEl}
+          bind:value={body}
+          placeholder="Add a comment… type @ to mention someone (Ctrl/Cmd+Enter to post)"
+          rows="2"
+          onkeydown={onKeydown}
+          oninput={refreshSuggestions}
+          onclick={refreshSuggestions}
+          onkeyup={refreshSuggestions}
+        ></textarea>
+        {#if suggestions.length > 0}
+          <ul class="cmts__mentions" role="listbox">
+            {#each suggestions as u, i (u)}
+              <li>
+                <button
+                  type="button"
+                  class="cmts__mention"
+                  class:cmts__mention--active={i === selectedIndex}
+                  role="option"
+                  aria-selected={i === selectedIndex}
+                  onmousedown={(e) => {
+                    e.preventDefault();
+                    void pickMention(u);
+                  }}
+                >
+                  @{u}
+                </button>
+              </li>
+            {/each}
+          </ul>
+        {/if}
+      </div>
       <button type="button" class="btn primary" onclick={post} disabled={posting || !body.trim()}>
         <Send size={14} /><span>{posting ? "Posting…" : "Post"}</span>
       </button>
@@ -203,9 +302,47 @@
     border-top: 1px solid var(--border);
     padding-top: var(--space-2);
   }
-  .cmts__input {
+  .cmts__field {
+    position: relative;
     flex: 1;
+  }
+  .cmts__input {
+    width: 100%;
+    box-sizing: border-box;
     resize: vertical;
     font: inherit;
+  }
+  /* @-mention dropdown, floats above the textarea. */
+  .cmts__mentions {
+    position: absolute;
+    bottom: calc(100% + 2px);
+    left: 0;
+    right: 0;
+    margin: 0;
+    padding: 4px;
+    list-style: none;
+    background: var(--bg);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+    box-shadow: var(--shadow-md, 0 4px 12px rgba(0, 0, 0, 0.15));
+    max-height: 12rem;
+    overflow: auto;
+    z-index: 10;
+  }
+  .cmts__mention {
+    display: block;
+    width: 100%;
+    text-align: left;
+    padding: 4px var(--space-2);
+    border: none;
+    background: none;
+    border-radius: 4px;
+    cursor: pointer;
+    font: inherit;
+    color: var(--fg);
+  }
+  .cmts__mention:hover,
+  .cmts__mention--active {
+    background: var(--bg-subtle);
   }
 </style>

--- a/saiku-webapp/src/main/webapp/WEB-INF/saiku-beans.xml
+++ b/saiku-webapp/src/main/webapp/WEB-INF/saiku-beans.xml
@@ -320,6 +320,14 @@
         <property name="datasourceService" ref="datasourceServiceBean"/>
         <property name="sessionService" ref="sessionService"/>
         <property name="historyService" ref="dashboardHistoryService"/>
+        <!-- #942/#947 cleanup: purge sidecar comment + history files on delete. -->
+        <property name="commentService" ref="commentService"/>
+    </bean>
+
+    <!-- #942 follow-up: minimal authenticated user directory for @-mention
+         autocomplete (usernames only; admin user-mgmt stays on /saiku/admin). -->
+    <bean id="usersResource" class="org.saiku.web.rest.resources.UsersResource">
+        <property name="userService" ref="userServiceBean"/>
     </bean>
 
     <!-- Dashboard versioning / history (issue #947). dashboardHistoryService


### PR DESCRIPTION
## Summary
Adds **@-mention autocomplete** to the dashboard comments box — typing `@` shows a dropdown of matching usernames pulled from the new user directory, so mentions are real users rather than blind typing. Completes the comments UX from #942/#1063.

> 🔗 **Stacked on #1066 (PR A)** — uses the `GET /rest/saiku/api/users` endpoint that PR A adds. Its diff currently includes PR A's commit. **Merge #1066 first**, then I'll rebase this to the autocomplete-only delta.

## The change
- `src/lib/dashboard/mentionAutocomplete.ts` — pure, unit-tested helpers: `currentMentionToken` (the `@word` in progress at the caret; ignores email-style mid-word `@` and completed `@bob `), `applyMention` (replace the partial with `@username `), `matchUsers` (case-insensitive substring filter, capped).
- `dashboards.ts` — `getUsers()` client for `/rest/saiku/api/users`.
- `CommentsPanel.svelte` — on `@`, fetch users once, show a floating dropdown; **↑/↓** to navigate, **Enter/Tab/click** to insert, **Esc** to dismiss; `Ctrl/Cmd+Enter` still posts.

## Verified
- `npm run check` → **0/0**; `npm test` → **512/512** (+9 `mentionAutocomplete.test.ts`); `npm run build` → OK.
- **Live (launcher :8087, user-verified):** open a tile's comments → type `@` → dropdown of usernames (from `/api/users`) → filter by typing → arrow/Enter/click inserts `@name ` → post; mention stored.

## Deferred (still)
Full read-only **history version preview** (render the archived version live, not just its name + tile count) — needs an isolated render that doesn't clobber the current editing state; lower value, the summary preview works. Left for a later follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)