### PR TITLE
feat(history): full read-only version preview in a new tab (#947 follow-up)

### DIFF
--- a/saiku-ui/src/lib/dashboard/historyPreview.test.ts
+++ b/saiku-ui/src/lib/dashboard/historyPreview.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+import { buildHistoryPreviewUrl, parseHistoryPreviewParams } from "./historyPreview";
+
+describe("buildHistoryPreviewUrl", () => {
+  it("encodes dashboard + version into the query string", () => {
+    expect(buildHistoryPreviewUrl("dashboards/q.saikudash", "v-1", { base: "/ui" })).toBe(
+      "/ui/preview?dashboard=dashboards%2Fq.saikudash&version=v-1",
+    );
+  });
+
+  it("includes origin when provided, root-relative otherwise", () => {
+    expect(buildHistoryPreviewUrl("a.saikudash", "v1", { origin: "https://h", base: "/ui" })).toBe(
+      "https://h/ui/preview?dashboard=a.saikudash&version=v1",
+    );
+    expect(buildHistoryPreviewUrl("a.saikudash", "v1")).toBe("/preview?dashboard=a.saikudash&version=v1");
+  });
+});
+
+describe("parseHistoryPreviewParams", () => {
+  it("round-trips the built URL's query", () => {
+    const url = new URL("https://h/ui/preview?dashboard=dashboards%2Fq.saikudash&version=v-1");
+    expect(parseHistoryPreviewParams(url.searchParams)).toEqual({
+      dashboard: "dashboards/q.saikudash",
+      version: "v-1",
+    });
+  });
+
+  it("returns null when a param is missing", () => {
+    expect(parseHistoryPreviewParams("dashboard=a.saikudash")).toBeNull();
+    expect(parseHistoryPreviewParams("version=v1")).toBeNull();
+    expect(parseHistoryPreviewParams("")).toBeNull();
+  });
+});

--- a/saiku-ui/src/lib/dashboard/historyPreview.ts
+++ b/saiku-ui/src/lib/dashboard/historyPreview.ts
@@ -1,0 +1,34 @@
+/*
+ * Helpers for the read-only history version preview (#947 follow-up). The
+ * preview opens in a new tab at /ui/preview?dashboard=…&version=… so it renders
+ * in its own JS context — its own dashboardStore — and never clobbers the
+ * editing tab's state. Pure (no DOM) so it unit-tests cleanly.
+ */
+
+/** Build the preview URL for one archived version. `origin`+`base` are passed
+ *  in to stay pure; omit them for a root-relative URL. */
+export function buildHistoryPreviewUrl(
+  dashboardPath: string,
+  version: string,
+  opts?: { origin?: string; base?: string },
+): string {
+  const origin = opts?.origin ?? "";
+  const base = opts?.base ?? "";
+  const q = new URLSearchParams({ dashboard: dashboardPath, version });
+  return `${origin}${base}/preview?${q.toString()}`;
+}
+
+/** Extract `{dashboard, version}` from a preview URL's query string. Returns
+ *  null if either is missing. Accepts a URL or a raw search string. */
+export function parseHistoryPreviewParams(search: string | URLSearchParams): {
+  dashboard: string;
+  version: string;
+} | null {
+  const params = typeof search === "string" ? new URLSearchParams(search) : search;
+  const dashboard = params.get("dashboard");
+  const version = params.get("version");
+  if (!dashboard || !version) {
+    return null;
+  }
+  return { dashboard, version };
+}

--- a/saiku-ui/src/lib/views/dashboard/HistoryPanel.svelte
+++ b/saiku-ui/src/lib/views/dashboard/HistoryPanel.svelte
@@ -1,17 +1,15 @@
 <script lang="ts">
   /*
    * #947 PR2 — dashboard version history. Lists archived versions (newest
-   * first), previews a version's summary, and restores one (which itself
-   * archives the current state, so restore is reversible).
+   * first), opens a full read-only preview of one (in a new tab so it can't
+   * disturb the editing tab), and restores one (which itself archives the
+   * current state, so restore is reversible).
    */
+  import { base } from "$app/paths";
   import Modal from "$lib/components/Modal.svelte";
-  import { RotateCcw, Eye } from "lucide-svelte";
-  import {
-    getHistory,
-    getHistoryVersion,
-    restoreHistory,
-    type DashboardHistoryEntry,
-  } from "$lib/api/dashboards";
+  import { RotateCcw, ExternalLink } from "lucide-svelte";
+  import { getHistory, restoreHistory, type DashboardHistoryEntry } from "$lib/api/dashboards";
+  import { buildHistoryPreviewUrl } from "$lib/dashboard/historyPreview";
 
   interface Props {
     dashboardPath: string;
@@ -27,11 +25,9 @@
   let loading = $state(false);
   let error = $state<string | null>(null);
   let busyVersion = $state<string | null>(null);
-  let preview = $state<{ version: string; name: string; tiles: number } | null>(null);
 
   $effect(() => {
     if (open) {
-      preview = null;
       void load();
     }
   });
@@ -48,16 +44,11 @@
     }
   }
 
-  async function showPreview(version: string): Promise<void> {
-    busyVersion = version;
-    try {
-      const d = await getHistoryVersion(dashboardPath, version);
-      preview = { version, name: d.name ?? "(untitled)", tiles: d.layout?.tiles?.length ?? 0 };
-    } catch (e) {
-      error = e instanceof Error ? e.message : "Failed to load version";
-    } finally {
-      busyVersion = null;
-    }
+  /** Open a full read-only render of the version in a new tab (isolated store). */
+  function openPreview(version: string): void {
+    const origin = typeof window !== "undefined" ? window.location.origin : "";
+    const url = buildHistoryPreviewUrl(dashboardPath, version, { origin, base });
+    window.open(url, "_blank", "noopener");
   }
 
   async function restore(version: string): Promise<void> {
@@ -101,19 +92,15 @@
             <div class="hist__meta">
               <span class="hist__date">{fmtDate(v.createdAt)}</span>
               <span class="hist__author">by {v.author || "unknown"}</span>
-              {#if preview && preview.version === v.version}
-                <span class="hist__preview">“{preview.name}” · {preview.tiles} tile(s)</span>
-              {/if}
             </div>
             <div class="hist__actions">
               <button
                 type="button"
                 class="btn btn--sm"
-                onclick={() => showPreview(v.version)}
-                disabled={busyVersion === v.version}
-                title="Preview this version"
+                onclick={() => openPreview(v.version)}
+                title="Open a read-only preview in a new tab"
               >
-                <Eye size={13} /><span>Preview</span>
+                <ExternalLink size={13} /><span>Preview</span>
               </button>
               <button
                 type="button"
@@ -173,10 +160,6 @@
   .hist__author {
     font-size: var(--fs-xs, 0.75rem);
     color: var(--fg-muted);
-  }
-  .hist__preview {
-    font-size: var(--fs-xs, 0.75rem);
-    color: var(--accent);
   }
   .hist__actions {
     display: flex;

--- a/saiku-ui/src/routes/preview/+page.svelte
+++ b/saiku-ui/src/routes/preview/+page.svelte
@@ -1,0 +1,108 @@
+<script lang="ts">
+  /*
+   * #947 follow-up — read-only preview of an archived dashboard version at
+   * /ui/preview?dashboard=…&version=…. Opened in a NEW TAB from the History
+   * panel, so it renders in its own JS context (its own dashboardStore) and
+   * never disturbs the editing tab's state. Tiles fetch live (the user has a
+   * session); the version supplies the layout + tile config.
+   */
+  import { onMount } from "svelte";
+  import { page } from "$app/state";
+  import { parseHistoryPreviewParams } from "$lib/dashboard/historyPreview";
+  import { getHistoryVersion } from "$lib/api/dashboards";
+  import { dashboardStore } from "$lib/stores/dashboard.svelte";
+  import DashboardGrid from "$lib/views/dashboard/DashboardGrid.svelte";
+
+  let loading = $state(true);
+  let error = $state<string | null>(null);
+  let name = $state("");
+  let ready = $state(false);
+
+  onMount(async () => {
+    const params = parseHistoryPreviewParams(page.url.searchParams);
+    if (!params) {
+      error = "This preview link is missing its dashboard or version.";
+      loading = false;
+      return;
+    }
+    try {
+      const dash = await getHistoryVersion(params.dashboard, params.version);
+      name = dash.name ?? "Dashboard";
+      // Hydrate THIS tab's store with the archived version; savedPath "" marks
+      // it as a non-savable preview (also hides the comment badge on tiles).
+      dashboardStore.hydrate(dash, "");
+      ready = true;
+    } catch {
+      error = "Could not load this version — it may have been pruned or you no longer have access.";
+    } finally {
+      loading = false;
+    }
+  });
+</script>
+
+<svelte:head><title>Preview — {name || "version"} — Saiku</title></svelte:head>
+
+<div class="preview">
+  {#if loading}
+    <div class="preview__state">Loading version…</div>
+  {:else if error}
+    <div class="preview__state preview__state--error">{error}</div>
+  {:else if ready}
+    <header class="preview__header">
+      <span class="preview__title">{name}</span>
+      <span class="preview__badge">Read-only preview of an earlier version</span>
+    </header>
+    <div class="preview__grid">
+      <DashboardGrid readOnly={true} />
+    </div>
+  {/if}
+</div>
+
+<style>
+  .preview {
+    flex: 1;
+    min-height: 0;
+    display: flex;
+    flex-direction: column;
+    background: var(--bg);
+  }
+  .preview__header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--space-3);
+    padding: var(--space-3) var(--space-5);
+    border-bottom: 1px solid var(--border);
+    background: var(--bg-muted);
+  }
+  .preview__title {
+    font-weight: var(--weight-bold);
+    font-size: var(--fs-lg);
+    color: var(--fg);
+  }
+  .preview__badge {
+    font-size: var(--fs-sm);
+    color: var(--fg-muted);
+    padding: 2px var(--space-2);
+    border: 1px solid var(--border);
+    border-radius: 999px;
+    background: var(--bg-subtle);
+  }
+  .preview__grid {
+    flex: 1;
+    min-height: 0;
+    overflow: auto;
+    padding: var(--space-4);
+  }
+  .preview__state {
+    flex: 1;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: var(--fg-muted);
+    font-size: var(--fs-md);
+  }
+  .preview__state--error {
+    color: var(--danger);
+  }
+</style>

--- a/saiku-ui/src/routes/preview/+page.ts
+++ b/saiku-ui/src/routes/preview/+page.ts
@@ -1,0 +1,4 @@
+// #947 follow-up: read-only history version preview — client-only (reads
+// dashboard/version from query params; not prerendered, no SSR).
+export const ssr = false;
+export const prerender = false;


### PR DESCRIPTION
## Summary
Replaces the History panel's lightweight "name + tile-count" preview with a **full read-only render** of an archived version. Clicking **Preview** opens `/ui/preview?dashboard=…&version=…` in a **new tab** — a separate JS context with its own `dashboardStore`, so the version renders live (read-only) **without disturbing the editing tab's state**. Finishes the last deferred item from the comments/history follow-ups.

Frontend-only; reuses the already-merged `getHistoryVersion` endpoint — no backend change, independent of #1066/#1067.

## The change
- `src/lib/dashboard/historyPreview.ts` — pure, unit-tested `buildHistoryPreviewUrl` + `parseHistoryPreviewParams`.
- New route `src/routes/preview/+page.{ts,svelte}` (client-only): reads `dashboard`+`version` from the query, `getHistoryVersion`, `dashboardStore.hydrate(version, "")`, renders `DashboardGrid readOnly` + a "Read-only preview of an earlier version" banner. `savedPath=""` also keeps the comment badge hidden in the preview.
- `HistoryPanel.svelte` — **Preview** now `window.open(...)`s the new tab (↗ icon) instead of showing the inline summary; **Restore** unchanged.

## Why a new tab
`dashboardStore` is a module singleton shared across the SPA. An inline preview would have to hydrate it with the version, clobbering any unsaved edits in the current session (and restoring it reliably is fragile). A new tab is a fresh context with its own store — zero risk to the editing tab, same isolation principle as the share viewer.

## Verified
- `npm run check` → **0/0**; `npm test` → **507/507** (+4 `historyPreview.test.ts`); `npm run build` → OK.
- **Live (launcher :8087, user-verified):** save a dashboard twice (rename between saves) → History → Preview → new tab renders the older version read-only with live data + banner → the original editing tab is untouched → Restore still works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)