### PR TITLE
chore: bump mondrian-saiku 4.8.1.19 → 4.8.1.21

### DIFF
--- a/saiku-bom/pom.xml
+++ b/saiku-bom/pom.xml
@@ -346,7 +346,7 @@
             <dependency>
                 <groupId>pentaho</groupId>
                 <artifactId>mondrian</artifactId>
-                <version>4.8.1.19</version>
+                <version>4.8.1.21</version>
                 <!-- xerces 2.12.2 + xalan 2.7.2 are transitively pulled by
                      mondrian but hijack the JDK's built-in JAXP via
                      META-INF/services overrides. Spring 6.2's tightened


### PR DESCRIPTION
## Summary

Brings in two substantive Mondrian releases:

- **4.8.1.20** — native cross-measure-group UNION tuple reads (mondrian-saiku#89/#90), native unrelated-dimension + parent-child tuple reads (no fallback to legacy SQL).
- **4.8.1.21** — bridge dimensions (mondrian-saiku#107): many-to-many support via `<BridgeLink>` XOM element, both full-count and weighted allocation semantics; symmetric fan-out-safe aggregates (#103); calc-column measures.

## Test plan

- [ ] CI green on `mvn verify`
- [ ] Docker workflow on `development` succeeds
- [ ] Demo redeployed onto `:development` and `/saiku/api/info/version` reports the new mondrian build
- [ ] FoodMart cubes still load and respond to a basic MDX query