### PR TITLE
feat(demo): joint-accounts bridge datasource + mondrian 4.8.1.21

### DIFF
--- a/saiku-bom/pom.xml
+++ b/saiku-bom/pom.xml
@@ -346,7 +346,7 @@
             <dependency>
                 <groupId>pentaho</groupId>
                 <artifactId>mondrian</artifactId>
-                <version>4.8.1.19</version>
+                <version>4.8.1.21</version>
                 <!-- xerces 2.12.2 + xalan 2.7.2 are transitively pulled by
                      mondrian but hijack the JDK's built-in JAXP via
                      META-INF/services overrides. Spring 6.2's tightened

--- a/saiku-core/saiku-service/src/main/java/org/saiku/database/Database.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/database/Database.java
@@ -60,6 +60,11 @@ public class Database {
             log.warn("Foodmart sample data not loaded: {}", e.getMessage());
         }
         try {
+            loadBank();
+        } catch (Exception e) {
+            log.warn("Bank (bridge demo) sample data not loaded: {}", e.getMessage());
+        }
+        try {
             loadEarthquakes();
         } catch (Exception e) {
             log.warn("Earthquakes sample data not loaded: {}", e.getMessage());
@@ -173,6 +178,64 @@ public class Database {
 
                 statement.executeQuery("select 1");
             }
+        }
+    }
+
+    /**
+     * Bridge (many-to-many) demo: the joint-accounts "Bank" schema. Its mm_*
+     * tables live in the SAME H2 database as FoodMart (distinct names, no
+     * clash), so this reuses FoodMart's url + data dir — no extra config. On
+     * first run it RUNSCRIPTs bank.sql and registers the Bank datasource
+     * (two cubes: full-count + weighted). Requires the Calcite backend.
+     */
+    private void loadBank() throws SQLException {
+        String url = servletContext.getInitParameter("foodmart.url");
+        if (url == null || url.equals("${foodmart_url}")) {
+            return;
+        }
+        JdbcDataSource ds2 = new JdbcDataSource();
+        ds2.setURL(dsm.getFoodmarturl());
+        ds2.setUser("sa");
+        ds2.setPassword("");
+
+        Connection c = ds2.getConnection();
+        DatabaseMetaData dbm = c.getMetaData();
+        ResultSet tables = dbm.getTables(null, null, "mm_owner", null);
+        if (tables.next()) {
+            // Already loaded.
+            return;
+        }
+        Statement statement = c.createStatement();
+        statement.execute("RUNSCRIPT FROM '" + dsm.getFoodmartdir() + "/bank.sql'");
+        statement.executeQuery("select 1");
+
+        String schema = null;
+        try {
+            schema = readFile(dsm.getFoodmartdir() + "/Bank.xml", StandardCharsets.UTF_8);
+        } catch (IOException e) {
+            log.error("Can't read Bank schema file", e);
+        }
+        try {
+            dsm.addSchema(schema, "/datasources/bank.xml", null);
+        } catch (Exception e) {
+            log.error("Can't add Bank schema file to repo", e);
+        }
+        String catalogUri =
+                new java.io.File(dsm.getFoodmartdir() + "/Bank.xml").toURI().toString();
+        Properties p = new Properties();
+        p.setProperty("driver", "mondrian.olap4j.MondrianOlap4jDriver");
+        p.setProperty(
+                "location",
+                "jdbc:mondrian:Jdbc=jdbc:h2:" + dsm.getFoodmartdir() + "/foodmart;" + "Catalog=" + catalogUri
+                        + ";JdbcDrivers=org.h2.Driver");
+        p.setProperty("username", "sa");
+        p.setProperty("password", "");
+        p.setProperty("id", "4432dd20-fcae-11e3-a3ac-0800200c9a68");
+        SaikuDatasource ds = new SaikuDatasource("bank", SaikuDatasource.Type.OLAP, p);
+        try {
+            dsm.addDatasource(ds);
+        } catch (Exception e) {
+            log.error("Can't add Bank data source to repo", e);
         }
     }
 

--- a/saiku-launcher/src/main/java/org/saiku/launcher/SaikuLauncher.java
+++ b/saiku-launcher/src/main/java/org/saiku/launcher/SaikuLauncher.java
@@ -280,6 +280,26 @@ public class SaikuLauncher implements Callable<Integer> {
                     }
                 }
             }
+
+            // Bridge (many-to-many) demo: the Bank schema + its data load
+            // into the same H2 database as FoodMart (distinct mm_* tables).
+            // Database.loadBank() runs bank.sql and registers the datasource.
+            stageResource("/seed/Bank.xml", dataDir.resolve("Bank.xml"));
+            stageResource("/seed/bank.sql", dataDir.resolve("bank.sql"));
+        }
+
+        /** Copy a classpath seed resource to {@code target} if it is missing,
+         *  preserving any user edits on relaunch. */
+        private static void stageResource(String resource, Path target) throws Exception {
+            if (Files.exists(target)) {
+                return;
+            }
+            try (InputStream in = SaikuLauncher.class.getResourceAsStream(resource)) {
+                if (in != null) {
+                    Files.copy(in, target, StandardCopyOption.REPLACE_EXISTING);
+                    System.out.println("Seeded: " + target);
+                }
+            }
         }
 
         /**

--- a/saiku-launcher/src/main/resources/seed/Bank.xml
+++ b/saiku-launcher/src/main/resources/seed/Bank.xml
@@ -1,0 +1,131 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Saiku demo schema: joint bank accounts — a bridge (many-to-many) dimension.
+
+  One account has one balance but can be co-owned by several customers, so
+  the Customer dimension is linked through the account_owner bridge table
+  (mm_owner) with an ownership weight rather than a foreign key on the fact.
+
+  Two cubes over the SAME fact table show the two allocation styles:
+    - "Joint Accounts (Full Count)" — every owner sees the full balance;
+      totals de-duplicate on the account grain at every level (incl. the
+      Segment roll-up), so the grand total is the true 13000, not 21000.
+    - "Joint Accounts (Weighted)"   — each balance split by ownership weight,
+      reconciling to 13000.
+
+  Companion data: bank.sql (tables mm_*), loaded into the demo H2 database.
+  Requires the Calcite query backend (the Saiku default) — bridge queries
+  cannot be evaluated by the legacy SQL generator.
+-->
+<Schema name="Bank" metamodelVersion="4.0">
+
+  <PhysicalSchema>
+    <Table name="mm_fact">
+      <Key><Column name="account_id"/></Key>
+    </Table>
+    <Table name="mm_owner"/>
+    <Table name="mm_customer"/>
+    <Table name="mm_branch"/>
+    <Table name="mm_date"/>
+  </PhysicalSchema>
+
+  <!-- The many-to-many dimension. Customers roll up into segments; full-count
+       totals de-duplicate correctly at the Segment level too. -->
+  <Dimension name="Customer" table="mm_customer" key="Customer">
+    <Attributes>
+      <Attribute name="Segment"><Key><Column name="segment"/></Key></Attribute>
+      <Attribute name="Customer">
+        <Key><Column name="customer_id"/></Key>
+        <Name><Column name="customer_name"/></Name>
+      </Attribute>
+    </Attributes>
+    <Hierarchies>
+      <Hierarchy name="By Segment" allMemberName="All Customers">
+        <Level attribute="Segment"/>
+        <Level attribute="Customer"/>
+      </Hierarchy>
+    </Hierarchies>
+  </Dimension>
+
+  <Dimension name="Branch" table="mm_branch" key="Branch">
+    <Attributes>
+      <Attribute name="Branch">
+        <Key><Column name="branch_id"/></Key>
+        <Name><Column name="branch_name"/></Name>
+      </Attribute>
+    </Attributes>
+  </Dimension>
+
+  <Dimension name="Date" table="mm_date" key="Date Id" type="TIME">
+    <Attributes>
+      <Attribute name="Date Id" hasHierarchy="false">
+        <Key><Column name="date_key"/></Key>
+      </Attribute>
+      <Attribute name="Year" levelType="TimeYears" hasHierarchy="false">
+        <Key><Column name="yr"/></Key>
+      </Attribute>
+    </Attributes>
+    <Hierarchies>
+      <Hierarchy name="Calendar" allMemberName="All Years">
+        <Level attribute="Year"/>
+      </Hierarchy>
+    </Hierarchies>
+  </Dimension>
+
+  <Cube name="Joint Accounts (Full Count)">
+    <Dimensions>
+      <Dimension source="Customer"/>
+      <Dimension source="Branch"/>
+      <Dimension source="Date"/>
+    </Dimensions>
+    <MeasureGroups>
+      <MeasureGroup name="Balances" table="mm_fact">
+        <Measures>
+          <Measure name="Balance" column="balance" aggregator="sum"
+                   formatString="#,###"/>
+          <Measure name="Fees" column="fees" aggregator="sum"
+                   formatString="#,###"/>
+        </Measures>
+        <DimensionLinks>
+          <ForeignKeyLink dimension="Branch" foreignKeyColumn="branch_id"/>
+          <ForeignKeyLink dimension="Date" foreignKeyColumn="date_key"/>
+          <BridgeLink dimension="Customer"
+                      bridgeTable="mm_owner"
+                      factForeignKeyColumn="account_id"
+                      bridgeFactKeyColumn="account_id"
+                      bridgeDimensionKeyColumn="customer_id"/>
+        </DimensionLinks>
+      </MeasureGroup>
+    </MeasureGroups>
+  </Cube>
+
+  <Cube name="Joint Accounts (Weighted)">
+    <Dimensions>
+      <Dimension source="Customer"/>
+      <Dimension source="Branch"/>
+      <Dimension source="Date"/>
+    </Dimensions>
+    <MeasureGroups>
+      <MeasureGroup name="Balances" table="mm_fact">
+        <Measures>
+          <Measure name="Balance" column="balance" aggregator="sum"
+                   formatString="#,###"/>
+          <Measure name="Fees" column="fees" aggregator="sum"
+                   formatString="#,###"/>
+        </Measures>
+        <DimensionLinks>
+          <ForeignKeyLink dimension="Branch" foreignKeyColumn="branch_id"/>
+          <ForeignKeyLink dimension="Date" foreignKeyColumn="date_key"/>
+          <BridgeLink dimension="Customer"
+                      bridgeTable="mm_owner"
+                      factForeignKeyColumn="account_id"
+                      bridgeFactKeyColumn="account_id"
+                      bridgeDimensionKeyColumn="customer_id"
+                      aggregation="weighted"
+                      weightColumn="weight"/>
+        </DimensionLinks>
+      </MeasureGroup>
+    </MeasureGroups>
+  </Cube>
+
+</Schema>

--- a/saiku-launcher/src/main/resources/seed/bank.sql
+++ b/saiku-launcher/src/main/resources/seed/bank.sql
@@ -1,0 +1,88 @@
+-- Saiku demo: joint bank accounts — a bridge (many-to-many) dimension.
+--
+-- Loaded by Database.loadBank() via RUNSCRIPT into the SAME H2 database as
+-- FoodMart (distinct mm_* table names, no clash). Quoted-lowercase
+-- identifiers match how Mondrian references them, mirroring foodmart_h2.sql.
+--
+-- One account has one balance but can be co-owned by several customers, so
+-- the Customer dimension is linked through the account_owner bridge table
+-- (mm_owner) with an ownership weight. Two cubes (full-count and weighted)
+-- over the one fact demonstrate both allocation styles.
+--
+-- Deterministic and tiny so the numbers are verifiable by hand:
+--   total balance 13000, total fees 130.
+
+DROP TABLE IF EXISTS "mm_fact";
+DROP TABLE IF EXISTS "mm_owner";
+DROP TABLE IF EXISTS "mm_customer";
+DROP TABLE IF EXISTS "mm_branch";
+DROP TABLE IF EXISTS "mm_date";
+
+CREATE TABLE "mm_fact" (
+    "account_id" INTEGER,
+    "date_key"   INTEGER,
+    "branch_id"  VARCHAR(8),
+    "balance"    INTEGER,
+    "fees"       INTEGER
+);
+CREATE TABLE "mm_owner" (
+    "account_id"  INTEGER,
+    "customer_id" VARCHAR(16),
+    "weight"      DECIMAL(5,4)
+);
+CREATE TABLE "mm_customer" (
+    "customer_id"   VARCHAR(16),
+    "customer_name" VARCHAR(32),
+    "segment"       VARCHAR(16)
+);
+CREATE TABLE "mm_branch" (
+    "branch_id"   VARCHAR(8),
+    "branch_name" VARCHAR(32)
+);
+CREATE TABLE "mm_date" (
+    "date_key" INTEGER,
+    "yr"       INTEGER
+);
+
+INSERT INTO "mm_fact" ("account_id","date_key","branch_id","balance","fees") VALUES
+    (1, 2024, 'LON', 1000, 10),
+    (2, 2024, 'LON',  500,  5),
+    (3, 2025, 'LDS',  300,  3),
+    (4, 2024, 'LON', 2000, 20),
+    (5, 2024, 'LDS', 1500, 15),
+    (6, 2025, 'LDS',  700,  7),
+    (7, 2025, 'LON', 4000, 40),
+    (8, 2025, 'LDS', 3000, 30);
+
+INSERT INTO "mm_owner" ("account_id","customer_id","weight") VALUES
+    (1, 'alice', 0.50),
+    (1, 'bob',   0.50),
+    (2, 'bob',   1.00),
+    (3, 'alice', 0.25),
+    (3, 'carol', 0.75),
+    (4, 'erin',  0.50),
+    (4, 'frank', 0.50),
+    (5, 'frank', 1.00),
+    (6, 'grace', 0.40),
+    (6, 'heidi', 0.60),
+    (7, 'erin',  0.50),
+    (7, 'grace', 0.50),
+    (8, 'heidi', 1.00);
+
+INSERT INTO "mm_customer" ("customer_id","customer_name","segment") VALUES
+    ('alice', 'Alice', 'Premium'),
+    ('bob',   'Bob',   'Premium'),
+    ('carol', 'Carol', 'Standard'),
+    ('dave',  'Dave',  'Standard'),
+    ('erin',  'Erin',  'Premium'),
+    ('frank', 'Frank', 'Standard'),
+    ('grace', 'Grace', 'Premium'),
+    ('heidi', 'Heidi', 'Standard');
+
+INSERT INTO "mm_branch" ("branch_id","branch_name") VALUES
+    ('LON', 'London'),
+    ('LDS', 'Leeds');
+
+INSERT INTO "mm_date" ("date_key","yr") VALUES
+    (2024, 2024),
+    (2025, 2025);


### PR DESCRIPTION
## Summary

Ships a new default OLAP datasource — **Bank** — built around bridge (many-to-many) dimensions, so the new mondrian engine work is explorable out of the box alongside FoodMart.

- **seed/Bank.xml** — Mondrian 4 schema, two cubes (full-count + weighted) over one fact, Customer linked via a `<BridgeLink>`, with a Segment roll-up to show multi-level de-duplication.
- **seed/bank.sql** — `mm_*` tables + a deterministic 8-account dataset (total balance 13,000), quoted-lowercase identifiers like `foodmart_h2.sql`.
- **SaikuLauncher** — stages `Bank.xml` + `bank.sql` into `saiku-home/data` (new `stageResource` helper).
- **Database.loadBank()** — on first start, `RUNSCRIPT bank.sql` into the same H2 database as FoodMart (distinct `mm_*` tables) and register the Bank datasource. Mirrors `loadEarthquakes`, reuses FoodMart's url + dir so no new web.xml / beans / IDatasourceManager config is needed.
- **saiku-bom** — bumps mondrian to **4.8.1.21**: brings in bridge (#107) + symmetric fan-out-safe aggregates (#103) + native cross-measure-group UNION (#89/#90). Bridge queries require the Calcite backend, which is the Saiku default.

## Test plan

- [ ] `mvn verify` green
- [ ] Docker workflow on `development` succeeds
- [ ] Demo redeployed onto `:development`, `/saiku/api/info/version` reports the new mondrian build
- [ ] FoodMart cubes still load and respond to a basic MDX query (regression)
- [ ] Bank cubes appear in the cube list; a basic measure-by-Customer query returns the expected 13,000 total