### PR TITLE
feat(demo): Account Statistics cube on Bank schema

### DIFF
--- a/saiku-launcher/src/main/resources/seed/Bank.xml
+++ b/saiku-launcher/src/main/resources/seed/Bank.xml
@@ -6,12 +6,15 @@
   the Customer dimension is linked through the account_owner bridge table
   (mm_owner) with an ownership weight rather than a foreign key on the fact.
 
-  Two cubes over the SAME fact table show the two allocation styles:
+  Three cubes over the SAME fact table:
     - "Joint Accounts (Full Count)" — every owner sees the full balance;
       totals de-duplicate on the account grain at every level (incl. the
       Segment roll-up), so the grand total is the true 13000, not 21000.
     - "Joint Accounts (Weighted)"   — each balance split by ownership weight,
       reconciling to 13000.
+    - "Account Statistics"          — a plain star (no bridge) over the same
+      fact, exposing the non-additive median + percentile aggregators next to
+      the additive Total Balance for distributional comparison.
 
   Companion data: bank.sql (tables mm_*), loaded into the demo H2 database.
   Requires the Calcite query backend (the Saiku default) — bridge queries
@@ -123,6 +126,34 @@
                       bridgeDimensionKeyColumn="customer_id"
                       aggregation="weighted"
                       weightColumn="weight"/>
+        </DimensionLinks>
+      </MeasureGroup>
+    </MeasureGroups>
+  </Cube>
+
+  <!-- Plain star (no bridge) over the same fact. Shows the non-additive
+       median / percentile aggregators next to the additive Total Balance,
+       so the distributional shape of account balances is queryable
+       alongside the totals. Computed at the queried grain; not rolled up. -->
+  <Cube name="Account Statistics">
+    <Dimensions>
+      <Dimension source="Branch"/>
+      <Dimension source="Date"/>
+    </Dimensions>
+    <MeasureGroups>
+      <MeasureGroup name="Balances" table="mm_fact">
+        <Measures>
+          <Measure name="Total Balance" column="balance" aggregator="sum"
+                   formatString="#,###"/>
+          <Measure name="Median Balance" column="balance"
+                   aggregator="median" formatString="#,###"/>
+          <Measure name="P90 Balance" column="balance"
+                   aggregator="percentile" percentile="90"
+                   formatString="#,###"/>
+        </Measures>
+        <DimensionLinks>
+          <ForeignKeyLink dimension="Branch" foreignKeyColumn="branch_id"/>
+          <ForeignKeyLink dimension="Date" foreignKeyColumn="date_key"/>
         </DimensionLinks>
       </MeasureGroup>
     </MeasureGroups>


### PR DESCRIPTION
## Summary

Adds the third cube that the canonical many-to-many template ships but the embedded demo was missing.

- **Account Statistics** — plain star over the same `mm_fact` (Branch + Date), with **Total Balance** (sum), **Median Balance** (median), and **P90 Balance** (percentile, 90). Computed at the queried grain — not rolled up — so the distributional shape of account balances sits alongside the additive totals from the bridge cubes.

Bank schema now mirrors `saiku-cloud/cube-library/many-to-many/schema.xml`: two bridge cubes (Full Count + Weighted) + one plain-star statistics cube. Median + percentile aggregators rely on the Calcite backend (the Saiku default); H2 supports both via PERCENTILE_CONT.

## Test plan

- [ ] `mvn verify` green
- [ ] Docker workflow on `development` succeeds
- [ ] Demo redeployed; Bank datasource shows **three** cubes: Joint Accounts (Full Count), Joint Accounts (Weighted), Account Statistics
- [ ] Median + P90 queries succeed against the demo H2