### PR TITLE
chore: bump mondrian-saiku 4.8.1.21 → 4.8.1.22 + restore Account Statistics median/percentile

### DIFF
--- a/saiku-bom/pom.xml
+++ b/saiku-bom/pom.xml
@@ -346,7 +346,7 @@
             <dependency>
                 <groupId>pentaho</groupId>
                 <artifactId>mondrian</artifactId>
-                <version>4.8.1.21</version>
+                <version>4.8.1.22</version>
                 <!-- xerces 2.12.2 + xalan 2.7.2 are transitively pulled by
                      mondrian but hijack the JDK's built-in JAXP via
                      META-INF/services overrides. Spring 6.2's tightened

--- a/saiku-launcher/src/main/resources/seed/Bank.xml
+++ b/saiku-launcher/src/main/resources/seed/Bank.xml
@@ -131,13 +131,12 @@
     </MeasureGroups>
   </Cube>
 
-  <!-- Plain star (no bridge) over the same fact. Total + Avg + Min + Max
-       Balance plus an Account Count, so the distributional shape of account
-       balances is queryable alongside the totals. The mondrian-4.8.1.21
-       aggregator vocabulary is sum / count / min / max / avg /
-       distinct-count — non-additive median / percentile aggregators aren't
-       wired through the engine yet; if they land in a later mondrian release
-       they slot back in here. -->
+  <!-- Plain star (no bridge) over the same fact, exposing the non-additive
+       leaf aggregators median / percentile (mondrian-saiku #104) alongside
+       the additive total. Computed at the queried grain via
+       PERCENTILE_CONT(...) WITHIN GROUP (ORDER BY column); not rolled up.
+       Requires the Calcite backend (the Saiku default) on a database that
+       supports PERCENTILE_CONT — the demo's H2 datasource qualifies. -->
   <Cube name="Account Statistics">
     <Dimensions>
       <Dimension source="Branch"/>
@@ -148,14 +147,11 @@
         <Measures>
           <Measure name="Total Balance" column="balance" aggregator="sum"
                    formatString="#,###"/>
-          <Measure name="Avg Balance" column="balance" aggregator="avg"
+          <Measure name="Median Balance" column="balance"
+                   aggregator="median" formatString="#,###"/>
+          <Measure name="P90 Balance" column="balance"
+                   aggregator="percentile" percentile="90"
                    formatString="#,###"/>
-          <Measure name="Min Balance" column="balance" aggregator="min"
-                   formatString="#,###"/>
-          <Measure name="Max Balance" column="balance" aggregator="max"
-                   formatString="#,###"/>
-          <Measure name="Account Count" column="account_id"
-                   aggregator="distinct-count" formatString="#,###"/>
         </Measures>
         <DimensionLinks>
           <ForeignKeyLink dimension="Branch" foreignKeyColumn="branch_id"/>


### PR DESCRIPTION
## Summary

mondrian-saiku **4.8.1.22** wires non-additive leaf aggregators \`median\` + \`percentile\` through \`RolapSchemaLoader\` (mondrian-saiku#104), with an H2 dialect binding so the demo backend qualifies (\`PERCENTILE_CONT(...) WITHIN GROUP (ORDER BY column)\`).

#1073 had to swap the Account Statistics cube to \`sum/avg/min/max/distinct-count\` because 4.8.1.21's parser threw \`Unknown aggregator 'median'\` and failed the whole Bank schema. This:

1. Bumps \`saiku-bom\` mondrian \`4.8.1.21\` → \`4.8.1.22\`.
2. Restores **Total Balance / Median Balance / P90 Balance** on Account Statistics, matching the canonical \`demo/Bank.mondrian.xml\` shipped with v4.8.1.22.

## Test plan

- [ ] Docker build green on \`development\`
- [ ] Demo redeployed; Bank schema loads (no \`Unknown aggregator\` exception)
- [ ] **Three** Bank cubes visible
- [ ] MDX query over Account Statistics returns numeric Total / Median / P90 cells