### PR TITLE
fix(demo): bump H2 1.4.188 → 1.4.200 for PERCENTILE_CONT support

### DIFF
--- a/saiku-bom/pom.xml
+++ b/saiku-bom/pom.xml
@@ -590,7 +590,12 @@
             <dependency>
                 <groupId>com.h2database</groupId>
                 <artifactId>h2</artifactId>
-                <version>1.4.188</version>
+                <!-- 1.4.200 (last 1.4.x): adds PERCENTILE_CONT/MEDIAN ordered-set
+                     aggregates (since 1.4.198) needed by the Account Statistics
+                     demo cube; keeps the 1.x file format + SQL dialect so the
+                     foodmart/bank/earthquake seed scripts and any persisted
+                     data dir keep working (H2 2.x is a breaking jump). -->
+                <version>1.4.200</version>
             </dependency>
             <!-- httpclient + httpcore 4.x: 0 declarations across saiku modules
                  and 0 java imports. Removed from BOM. Transitive consumers


### PR DESCRIPTION
## Summary

The Account Statistics demo cube (Median / P90 Balance) emits \`PERCENTILE_CONT WITHIN GROUP (ORDER BY balance)\` via mondrian's Calcite backend. H2 \`1.4.188\` (what shipped in saiku-bom) predates ordered-set aggregates, so the query failed at runtime with:

\`\`\`
Function PERCENTILE_CONT not found [90022-188]
\`\`\`

\`1.4.200\` is the last 1.4.x release, adds the ordered-set aggregates (since 1.4.198), keeps the H2 1.x file format and SQL dialect, and is a drop-in for the foodmart/bank/earthquake seed scripts and any persisted data dir. H2 2.x would be a breaking jump in dialect + storage so it's not the right move here.

PR #1074 already shipped mondrian 4.8.1.22 + restored median/percentile aggregators on the Bank schema; without this H2 bump those cubes parse but their queries blow up at execution.

## Test plan

- [ ] Docker build green on \`development\`
- [ ] Demo redeployed; Median + P90 measures return numeric cells (not \`Function PERCENTILE_CONT not found\`)
- [ ] FoodMart still queries cleanly (regression)