### PR TITLE
fix(docker): preserve user-supplied JAVA_OPTS in container entrypoint

### DIFF
--- a/docker/saiku-entrypoint
+++ b/docker/saiku-entrypoint
@@ -18,6 +18,18 @@ set -euo pipefail
 case "${1:-serve}" in
   serve)
     shift || true
+    # Preserve any user-supplied JAVA_OPTS BEFORE we rebuild the array
+    # with the well-known capability props below. Without this, anything
+    # the operator passes via `-e JAVA_OPTS='-Dsaiku.ai.ask.provider=anthropic'`
+    # (or any other Spring placeholder override / JVM tuning flag) is
+    # silently dropped. word-splits the env var into an array so flags
+    # with spaces survive intact.
+    USER_JAVA_OPTS=()
+    if [[ -n "${JAVA_OPTS:-}" ]]; then
+      # shellcheck disable=SC2206  # intentional word-split
+      USER_JAVA_OPTS=( ${JAVA_OPTS} )
+    fi
+
     # Capability props surfaced by GET /rest/saiku/info/capabilities so
     # the SPA's admin panel + (when on) demo-mode login screen can show
     # accurate connection instructions. Empty values are passed through
@@ -41,6 +53,11 @@ case "${1:-serve}" in
     if [[ -n "${OTEL_EXPORTER_OTLP_ENDPOINT:-}" && -f "$OTEL_AGENT_JAR" ]]; then
       JAVA_OPTS+=("-javaagent:${OTEL_AGENT_JAR}")
       export OTEL_SERVICE_NAME="${OTEL_SERVICE_NAME:-saiku}"
+    fi
+    # Append user JAVA_OPTS last so they can override the built-ins
+    # (e.g. overriding -Dsaiku.demo from an env var stays possible).
+    if [[ ${#USER_JAVA_OPTS[@]} -gt 0 ]]; then
+      JAVA_OPTS+=( "${USER_JAVA_OPTS[@]}" )
     fi
     exec java "${JAVA_OPTS[@]}" -jar /app/saiku.jar serve \
       --host 0.0.0.0 \


### PR DESCRIPTION
## Why

\`docker/saiku-entrypoint\`'s \`serve\` branch unconditionally does \`JAVA_OPTS=()\` before building the array from the well-known env vars (\`SAIKU_DEMO\`, \`SAIKU_MCP_URL\`, \`OTEL_EXPORTER_OTLP_ENDPOINT\`), which silently discards any flags the operator passed via \`-e JAVA_OPTS=...\`. Caught while wiring the AI ask provider (#1093) on the demo: \`-Dsaiku.ai.ask.provider=anthropic\` never reached Spring, which fell back to the noop provider with no log trail, and the workspace drawer kept reporting "not configured."

The temporary workaround on the demo was to override the entrypoint and pass flags directly. This PR makes that unnecessary.

## What

- Capture \`JAVA_OPTS\` into a separate \`USER_JAVA_OPTS\` array **before** the reset.
- Word-split the env var so multi-flag strings (\`'-Dfoo=bar -Dbaz=qux'\`) survive intact.
- Append user flags **after** the built-ins so they can override them (e.g. \`-Dsaiku.demo=false\` from an env var stays possible).

## Test plan

- [ ] \`docker run -e JAVA_OPTS='-Dsaiku.ai.ask.provider=anthropic -Dfoo=bar' saiku serve\` → \`ps -ef\` shows the flags on the java cmdline
- [ ] \`docker run saiku serve\` (no JAVA_OPTS) still produces the existing cmdline shape — no regression
- [ ] The Anthropic provider boots on the demo container (\`AI ask provider: anthropic (model=claude-sonnet-4-6)\` in logs)