### PR TITLE
fix(workspace): AI Query drawer — Edit in canvas (#1125) + drawer a11y (#1126)

### DIFF
--- a/saiku-ui/src/lib/stores/query.svelte.ts
+++ b/saiku-ui/src/lib/stores/query.svelte.ts
@@ -450,9 +450,16 @@ class QueryStore {
   }
 
   hasRunnableShape(): boolean {
-    const q = this.current?.queryModel;
+    if (!this.current) return false;
+    // MDX-mode queries (raw expression set via MDXModal.onRun or the AI
+    // Query drawer's "Edit in canvas") bypass the queryModel surface — the
+    // server runs the raw mdx string and we just need it to be non-empty.
+    if (this.current.type === "MDX") {
+      return !!this.current.mdx && this.current.mdx.trim().length > 0;
+    }
+    const q = this.current.queryModel;
     if (!q) return false;
-    // A runnable shape needs at least one measure (on COLUMNS) AND at least
+    // QUERYMODEL-mode needs at least one measure (on COLUMNS) AND at least
     // one hierarchy on ROWS or COLUMNS. Running without either produces an
     // ugly server-side MDX error, so we silently short-circuit instead.
     const hasMeasure = q.details.measures.length > 0;

--- a/saiku-ui/src/lib/views/AiQueryDrawer.svelte
+++ b/saiku-ui/src/lib/views/AiQueryDrawer.svelte
@@ -257,7 +257,7 @@
   class="ai-drawer"
   class:ai-drawer--open={open}
   aria-labelledby="ai-drawer-title"
-  aria-hidden={!open}
+  inert={!open}
 >
   <header class="ai-drawer__header">
     <Sparkles size={18} aria-hidden="true" />


### PR DESCRIPTION
## Summary

Fixes the two bugs caught during Playwright smoke testing on demo.saiku.bi after the #1093 AI Query drawer landed.

### Closes #1125 — Edit in canvas no-ops

\`query.run()\` was short-circuited by \`hasRunnableShape()\` which checked \`queryModel.details.measures.length > 0\` unconditionally. MDX-mode queries don't use the queryModel surface — the server runs the raw \`mdx\` string — so the check only belongs on the QUERYMODEL branch.

The existing **Tools → MDX…** modal happened to work because users open it AFTER building a queryModel; \`details.measures\` was already populated by drag-and-drop. The AI drawer's first-question users hit this on a fresh cube.

Fix: branch on \`current.type === "MDX"\` first — a non-empty \`mdx\` string is runnable on its own. QUERYMODEL keeps its existing measure+hierarchy requirement.

### Closes #1126 — drawer aria-hidden a11y warning

\`AiQueryDrawer\` had \`aria-hidden={!open}\`, which conflicts with focus retained inside the drawer (e.g. the textarea after a successful ask). Browser warning:

\`\`\`
Blocked aria-hidden on an element because its descendant retained focus.
Consider using the inert attribute instead, which will also prevent focus.
\`\`\`

Fix: swap to the \`inert\` attribute, which both hides from a11y AND removes focusability so the conflict can't arise.

## Verified

- \`svelte-check\`: 0 errors / 0 warnings
- \`npm test\`: 523/523 passing
- Re-test on demo lands in the next deploy

## Test plan

- [ ] CI green
- [ ] Demo redeployed
- [ ] Playwright: pick Sales → open ⚡ drawer → ask "Top 5 product families by unit sales in 1997" → Edit in canvas → result table renders with 3 product family rows
- [ ] Console no longer warns about aria-hidden / focus