### PR TITLE
feat(dashboard): Top-N / Bottom-N filter widget (closes #921)

### DIFF
--- a/saiku-ui/src/lib/api/dashboards.ts
+++ b/saiku-ui/src/lib/api/dashboards.ts
@@ -38,7 +38,27 @@ export type TileQuery = ReferenceQuery | InlineQuery;
 
 export type TileType = "chart" | "table" | "text" | "filter" | "kpi" | "image";
 
-export type FilterWidget = "single-select" | "multi-select" | "date-range" | "cascading-select";
+export type FilterWidget = "single-select" | "multi-select" | "date-range" | "cascading-select" | "top-n";
+
+/* --- issue #921: Top-N / Bottom-N filter widget --------------------------
+ * A panel filter that ranks the members of its dimension/hierarchy/level by a
+ * chosen measure and narrows compatible tiles to the top (or bottom) N. It
+ * resolves at runtime to a member-unique-name list (run the ranking query →
+ * map the ranked captions to unique names via the level's member catalogue)
+ * which flows through the existing filter-merge unchanged — no backend or
+ * merge changes. Config lives in this block; pure resolution helpers are in
+ * $lib/dashboard/topN. */
+export interface TopNConfig {
+  /** Measure unique name to rank by, e.g. {@code [Measures].[Unit Sales]}. */
+  measure?: string;
+  /** Measure caption for display (mirrors the schema's measure caption). */
+  measureCaption?: string;
+  /** How many members to keep. Defaults to 10. */
+  n?: number;
+  /** {@code "top"} = highest-N (desc), {@code "bottom"} = lowest-N (asc). */
+  direction?: "top" | "bottom";
+}
+/* --- end issue #921 block ------------------------------------------------- */
 
 /* --- issue #922: cascading single-select filter widget -------------------
  * Self-contained additions for the "cascading-select" FilterWidget variant.
@@ -259,6 +279,8 @@ export interface PanelFilter extends DashboardFilter {
   /** Config for {@code widget === "cascading-select"} (issue #922).
    *  Ignored by the other variants. */
   cascading?: CascadingSelectConfig;
+  /** Config for {@code widget === "top-n"} (issue #921). Ignored by others. */
+  topN?: TopNConfig;
 }
 
 /** Unified filter panel: docks at the top of the dashboard editor as

--- a/saiku-ui/src/lib/dashboard/topN.test.ts
+++ b/saiku-ui/src/lib/dashboard/topN.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+import { buildTopNQuery, clampTopN, rankedCaptionsToUniqueNames } from "./topN";
+
+describe("buildTopNQuery", () => {
+  it("ranks descending for 'top' with order+limit", () => {
+    const q = buildTopNQuery("cube/id", "Customer", "Customers", "Name", "Store Sales", 5, "top");
+    expect(q).toEqual({
+      cube: "cube/id",
+      measures: [{ name: "Store Sales" }],
+      rows: [{ dimension: "Customer", hierarchy: "Customers", level: "Name" }],
+      order: [{ by: "Store Sales", direction: "desc" }],
+      limit: 5,
+    });
+  });
+
+  it("ranks ascending for 'bottom'", () => {
+    const q = buildTopNQuery("c", "D", "H", "L", "M", 3, "bottom") as { order: { direction: string }[] };
+    expect(q.order[0].direction).toBe("asc");
+  });
+
+  it("floors + min-clamps the limit", () => {
+    expect((buildTopNQuery("c", "D", "H", "L", "M", 2.9, "top") as { limit: number }).limit).toBe(2);
+    expect((buildTopNQuery("c", "D", "H", "L", "M", 0, "top") as { limit: number }).limit).toBe(1);
+  });
+});
+
+describe("rankedCaptionsToUniqueNames", () => {
+  const catalogue = [
+    { caption: "Food", uniqueName: "[Product].[Products].[Food]" },
+    { caption: "Drink", uniqueName: "[Product].[Products].[Drink]" },
+    { caption: "Non-Consumable", uniqueName: "[Product].[Products].[Non-Consumable]" },
+  ];
+
+  it("maps captions to unique names preserving the ranked order", () => {
+    expect(rankedCaptionsToUniqueNames(["Drink", "Food"], catalogue)).toEqual([
+      "[Product].[Products].[Drink]",
+      "[Product].[Products].[Food]",
+    ]);
+  });
+
+  it("drops captions with no catalogue match", () => {
+    expect(rankedCaptionsToUniqueNames(["Food", "Ghost"], catalogue)).toEqual(["[Product].[Products].[Food]"]);
+  });
+
+  it("is empty for an empty catalogue", () => {
+    expect(rankedCaptionsToUniqueNames(["Food"], [])).toEqual([]);
+  });
+});
+
+describe("clampTopN", () => {
+  it("defaults, floors, and clamps to 1..1000", () => {
+    expect(clampTopN(undefined)).toBe(10);
+    expect(clampTopN(0)).toBe(1);
+    expect(clampTopN(12.7)).toBe(12);
+    expect(clampTopN(5000)).toBe(1000);
+  });
+});

--- a/saiku-ui/src/lib/dashboard/topN.ts
+++ b/saiku-ui/src/lib/dashboard/topN.ts
@@ -1,0 +1,61 @@
+/*
+ * Top-N / Bottom-N filter resolution (#921). Pure (no DOM/fetch) so it
+ * unit-tests cleanly; the panel component supplies the cube id, the member
+ * catalogue (already fetched for the level), and runs the query.
+ *
+ * Strategy: run a ranking query (the AI Query API turns order+limit into
+ * TopCount/BottomCount), which returns the ranked member CAPTIONS in
+ * metadata.rows; map those captions back to their MDX unique names via the
+ * level's member catalogue (uniqueName+caption pairs) so the result flows
+ * through the existing filter-merge unchanged.
+ */
+
+/** The AI-query request body that ranks a level's members by `measure` and
+ *  keeps the top (desc) or bottom (asc) `n`. `measure` is the measure name the
+ *  AI API accepts (display or canonical). */
+export function buildTopNQuery(
+  cubeId: string,
+  dimension: string,
+  hierarchy: string,
+  level: string,
+  measure: string,
+  n: number,
+  direction: "top" | "bottom",
+): Record<string, unknown> {
+  return {
+    cube: cubeId,
+    measures: [{ name: measure }],
+    rows: [{ dimension, hierarchy, level }],
+    order: [{ by: measure, direction: direction === "bottom" ? "asc" : "desc" }],
+    limit: Math.max(1, Math.floor(n)),
+  };
+}
+
+/** Map ranked member captions to their MDX unique names via the level's
+ *  catalogue, preserving the ranked order and dropping any caption with no
+ *  catalogue match (so a stale/renamed member can't poison the filter). */
+export function rankedCaptionsToUniqueNames(
+  rankedCaptions: string[],
+  catalogue: ReadonlyArray<{ uniqueName: string; caption: string }>,
+): string[] {
+  const byCaption = new Map<string, string>();
+  for (const m of catalogue) {
+    if (!byCaption.has(m.caption)) {
+      byCaption.set(m.caption, m.uniqueName);
+    }
+  }
+  const out: string[] = [];
+  for (const caption of rankedCaptions) {
+    const unique = byCaption.get(caption);
+    if (unique) {
+      out.push(unique);
+    }
+  }
+  return out;
+}
+
+/** Clamp a user-entered N to a sane range (1..1000). */
+export function clampTopN(n: number | undefined | null): number {
+  if (n === undefined || n === null || !Number.isFinite(n)) return 10;
+  return Math.min(1000, Math.max(1, Math.floor(n)));
+}

--- a/saiku-ui/src/lib/views/dashboard/DashboardFilterPanel.svelte
+++ b/saiku-ui/src/lib/views/dashboard/DashboardFilterPanel.svelte
@@ -48,6 +48,11 @@
     type FilterWidget,
     type PanelFilter,
   } from "$lib/api/dashboards";
+  // issue #921: Top-N / Bottom-N widget — rank a level by a measure and keep
+  // the top/bottom N. Pure resolution in $lib/dashboard/topN; the query runs
+  // via the AI Query API (order+limit → TopCount/BottomCount).
+  import { executeAiQuery } from "$lib/api/aiQuery";
+  import { buildTopNQuery, clampTopN, rankedCaptionsToUniqueNames } from "$lib/dashboard/topN";
 
   interface Props {
     readOnly?: boolean;
@@ -116,6 +121,10 @@
       ...(addWidget === "cascading-select"
         ? { cascading: { startLevel: addLevel, depth: 3 } }
         : {}),
+      // issue #921: a top-n widget needs a config; default to Top 10, measure
+      // chosen on the row. It stays inert (selects no members) until a measure
+      // is picked.
+      ...(addWidget === "top-n" ? { topN: { n: 10, direction: "top" as const } } : {}),
     };
     dashboardStore.addPanelFilter(filter);
     closeAdd();
@@ -415,6 +424,83 @@
     const stale = activeFilters.clicks.find((c) => targetKey(c.filter) === tkey);
     if (stale) activeFilters.clearChip(stale.id);
   }
+
+  /* ===================== issue #921: top-n / bottom-n ====================
+   * Rank the level's members by a measure and keep the top/bottom N. The
+   * member catalogue (memberCatalogues[f.id]) is already loaded by the effect
+   * above; we run the ranking query (order+limit), map the ranked captions to
+   * their unique names via that catalogue, then commit them like any pick. */
+  interface TopNRowState {
+    loading: boolean;
+    error: string | null;
+    key: string;
+  }
+  let topNState = $state<Record<string, TopNRowState>>({});
+
+  function topNMeasureOptions(f: PanelFilter): string[] {
+    if (!f.cube) return [];
+    void schemaCache.version;
+    const s = schemaCache.peek(f.cube) as { measures?: Record<string, { name: string }> } | null;
+    if (!s?.measures) return [];
+    return Object.values(s.measures).map((m) => m.name);
+  }
+
+  function setTopN(
+    filterId: string,
+    partial: Partial<{ measure: string; n: number; direction: "top" | "bottom" }>,
+  ): void {
+    const f = panel?.filters.find((p) => p.id === filterId);
+    const next = { ...(f?.topN ?? {}), ...partial };
+    if (partial.n !== undefined) next.n = clampTopN(partial.n);
+    dashboardStore.updatePanelFilter(filterId, { topN: next });
+  }
+
+  async function resolveTopN(f: PanelFilter, key: string): Promise<void> {
+    topNState = { ...topNState, [f.id]: { loading: true, error: null, key } };
+    try {
+      const tn = f.topN;
+      if (!f.cube || !tn?.measure) return;
+      const body = buildTopNQuery(
+        cubeKey(f.cube),
+        f.dimension,
+        f.hierarchy,
+        f.level,
+        tn.measure,
+        clampTopN(tn.n),
+        tn.direction ?? "top",
+      );
+      const resp = await executeAiQuery(body, "records");
+      if (resp.status !== "SUCCESS" || !resp.metadata?.rows) {
+        throw new Error(resp.error ?? `query ${resp.status}`);
+      }
+      const captions = resp.metadata.rows.map((r) => r.name);
+      const cat = memberCatalogues[f.id];
+      const uniques = rankedCaptionsToUniqueNames(captions, cat?.members ?? []);
+      commitPanelMembers(f.id, uniques);
+      topNState = { ...topNState, [f.id]: { loading: false, error: null, key } };
+    } catch (e: unknown) {
+      topNState = {
+        ...topNState,
+        [f.id]: { loading: false, error: e instanceof Error ? e.message : String(e), key },
+      };
+    }
+  }
+
+  // Re-resolve a top-n filter when its config or member catalogue changes.
+  // Keyed so it runs once per distinct config (no re-fire loop on commit).
+  $effect(() => {
+    const filters = panel?.filters ?? [];
+    for (const f of filters) {
+      if (f.widget !== "top-n" || !f.cube) continue;
+      const tn = f.topN;
+      if (!tn?.measure) continue;
+      const cat = memberCatalogues[f.id];
+      if (!cat?.members) continue;
+      const key = `${cubeKey(f.cube)}|${f.dimension}/${f.hierarchy}/${f.level}|${tn.measure}|${clampTopN(tn.n)}|${tn.direction ?? "top"}|${cat.members.length}`;
+      if (topNState[f.id]?.key === key) continue;
+      void resolveTopN(f, key);
+    }
+  });
 
   /* ===================== issue #922: cascading-select ====================
    * The cascading-select variant walks ONE hierarchy level-by-level:
@@ -736,6 +822,55 @@
                     onchange={(e) => setDateRange(f.id, dr.from, (e.target as HTMLInputElement).value)}
                   />
                 </span>
+              {:else if f.widget === "top-n"}
+                <!-- issue #921: rank by a measure, keep top/bottom N. -->
+                {@const measures = topNMeasureOptions(f)}
+                {@const st = topNState[f.id]}
+                <span class="topn">
+                  <select
+                    class="picker-select"
+                    value={f.topN?.direction ?? "top"}
+                    disabled={readOnly}
+                    aria-label="Direction"
+                    onchange={(e) =>
+                      setTopN(f.id, { direction: (e.target as HTMLSelectElement).value as "top" | "bottom" })}
+                  >
+                    <option value="top">Top</option>
+                    <option value="bottom">Bottom</option>
+                  </select>
+                  <input
+                    type="number"
+                    class="picker-num"
+                    min="1"
+                    max="1000"
+                    value={f.topN?.n ?? 10}
+                    disabled={readOnly}
+                    aria-label="N"
+                    onchange={(e) => setTopN(f.id, { n: Number((e.target as HTMLInputElement).value) })}
+                  />
+                  <span class="topn-by">by</span>
+                  <select
+                    class="picker-select"
+                    value={f.topN?.measure ?? ""}
+                    disabled={readOnly}
+                    aria-label="Measure"
+                    onchange={(e) => setTopN(f.id, { measure: (e.target as HTMLSelectElement).value })}
+                  >
+                    <option value="">— measure —</option>
+                    {#each measures as m (m)}
+                      <option value={m}>{m}</option>
+                    {/each}
+                  </select>
+                  {#if st?.loading}
+                    <span class="topn-state">resolving…</span>
+                  {:else if st?.error}
+                    <span class="topn-state topn-state--error">{st.error}</span>
+                  {:else if (f.members?.length ?? 0) > 0}
+                    <span class="topn-state">{f.members.length} member(s)</span>
+                  {:else if f.topN?.measure}
+                    <span class="topn-state">no matches</span>
+                  {/if}
+                </span>
               {:else}
                 <select
                   class="picker-select"
@@ -823,6 +958,7 @@
               <option value="multi-select">multi-select</option>
               <option value="date-range">date-range</option>
               <option value="cascading-select">cascading-select</option>
+              <option value="top-n">top-n</option>
             </select>
           </label>
           {#if addError}
@@ -957,6 +1093,33 @@
     background: var(--bg);
     font-size: 0.8125rem;
     font-family: inherit;
+  }
+  /* issue #921: top-n / bottom-n inline config. */
+  .topn {
+    display: inline-flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 0.25rem;
+  }
+  .picker-num {
+    width: 3.5rem;
+    padding: 0.125rem 0.25rem;
+    border: 1px solid var(--border-strong, var(--border));
+    border-radius: 4px;
+    background: var(--bg);
+    font-size: 0.8125rem;
+    font-family: inherit;
+  }
+  .topn-by {
+    font-size: 0.75rem;
+    color: var(--fg-muted);
+  }
+  .topn-state {
+    font-size: 0.75rem;
+    color: var(--fg-muted);
+  }
+  .topn-state--error {
+    color: var(--danger);
   }
   .date-sep {
     color: var(--fg-muted);


### PR DESCRIPTION
## Summary
Adds a **Top-N / Bottom-N** filter widget to the dashboard filter panel (#921). An analyst can rank a level's members by a measure and keep only the top (or bottom) *N* — e.g. "top 10 Product Subcategories by Store Sales" — and every tile on the dashboard narrows to that ranked set via the existing filter-merge path. No new backend surface.

## The change
- **New widget type `top-n`** registered in `dashboards.ts` (`TopNConfig` on `PanelFilter`) and selectable in the panel's "➕ Add filter" form.
- **`$lib/dashboard/topN.ts`** (pure, unit-tested): `buildTopNQuery` (turns direction+N into an `order`+`limit` AI-query body → Mondrian TopCount/BottomCount), `rankedCaptionsToUniqueNames` (maps the ranked captions back to MDX unique names via the level's member catalogue, dropping unmatched so a stale/renamed member can't poison the filter), `clampTopN` (1..1000).
- **`DashboardFilterPanel.svelte`**: renders the row (`[Top/Bottom] [N] by [measure]`), runs the ranking query through the existing `executeAiQuery`, and commits the resolved members through the same `commitPanelMembers` path the other widgets use. Re-resolves reactively (keyed) when direction / N / measure / catalogue change — no re-fire loop on commit. Inert until a measure is picked.

## Verified
- `npm run check` → **0 errors / 0 warnings**.
- `npm test` (vitest) → **530 passed** (incl. 7 new `topN.test.ts`).
- Rebased clean onto current `origin/development` (was 24 behind; no conflicts).
- **User-verified locally** against a fresh `:8087` launcher (FoodMart, demo mode): added a `top-n` filter on Product → Product Subcategory, picked Store Sales → chart narrowed to the top 10; flipping Top→Bottom and N 10→5 re-resolved to the bottom 5. No console errors.

## Test plan
1. Run the launcher, open a dashboard with a chart tile over a many-membered level (FoodMart Sales, Store Sales, rows = Product → Product Subcategory).
2. Filter panel → ➕ Add filter → cube Sales, dim Product, hier Product, level Product Subcategory, Widget = **top-n** → Add.
3. Pick measure **Store Sales** → row shows *N member(s)* and the chart narrows to the top N.
4. Switch **Bottom** / change **N** → chart re-resolves.

## Notes
- Pure resolution lives in `topN.ts` (no DOM/fetch) so it unit-tests cleanly; the component supplies cube id + member catalogue + query runner.
- Reuses the AI Query API and the existing `/ai/members/search` catalogue — **no backend change**.
- Does **not** self-merge — for OG's security gate + merge to `development` (never `main`).

Closes #921

🤖 Generated with [Claude Code](https://claude.com/claude-code)
