### PR TITLE
refactor(viz): unify workspace + dashboard chart codepaths (closes #1076)

### DIFF
--- a/saiku-ui/src/lib/charts/__snapshots__/build.test.ts.snap
+++ b/saiku-ui/src/lib/charts/__snapshots__/build.test.ts.snap
@@ -1,0 +1,3571 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`buildChartOption — coverage of all 15 types > snapshot of every type's structure (compact / dashboard) 1`] = `
+{
+  "area": {
+    "backgroundColor": "transparent",
+    "color": [
+      "#4f46e5",
+      "#0ea5e9",
+      "#10b981",
+      "#f59e0b",
+      "#ef4444",
+      "#a855f7",
+      "#ec4899",
+      "#14b8a6",
+    ],
+    "grid": {
+      "bottom": 36,
+      "left": 48,
+      "right": 16,
+      "top": 24,
+    },
+    "legend": {
+      "bottom": 0,
+      "textStyle": {
+        "color": "#0f172a",
+      },
+      "type": "scroll",
+    },
+    "series": [
+      {
+        "areaStyle": {},
+        "data": [
+          565238.13,
+          612482.65,
+        ],
+        "name": "Store Sales",
+        "smooth": true,
+        "stack": undefined,
+        "type": "line",
+        "yAxisIndex": 0,
+      },
+      {
+        "areaStyle": {},
+        "data": [
+          266773,
+          282417,
+        ],
+        "name": "Unit Sales",
+        "smooth": true,
+        "stack": undefined,
+        "type": "line",
+        "yAxisIndex": 0,
+      },
+    ],
+    "textStyle": {
+      "color": "#0f172a",
+    },
+    "title": undefined,
+    "tooltip": {
+      "backgroundColor": "#ffffff",
+      "borderColor": "#e2e8f0",
+      "textStyle": {
+        "color": "#0f172a",
+      },
+      "trigger": "axis",
+    },
+    "xAxis": {
+      "axisLabel": {
+        "color": "#475569",
+        "ellipsis": "…",
+        "hideOverlap": true,
+        "overflow": "truncate",
+        "rotate": 0,
+        "width": 100,
+      },
+      "axisLine": {
+        "lineStyle": {
+          "color": "#e2e8f0",
+        },
+      },
+      "axisTick": {
+        "lineStyle": {
+          "color": "#e2e8f0",
+        },
+      },
+      "data": [
+        "1997",
+        "1998",
+      ],
+      "name": undefined,
+      "nameTextStyle": {
+        "color": "#0f172a",
+      },
+      "splitLine": {
+        "lineStyle": {
+          "color": "#e2e8f0",
+          "opacity": 0.5,
+        },
+      },
+      "type": "category",
+    },
+    "yAxis": {
+      "axisLabel": {
+        "color": "#475569",
+      },
+      "axisLine": {
+        "lineStyle": {
+          "color": "#e2e8f0",
+        },
+      },
+      "axisTick": {
+        "lineStyle": {
+          "color": "#e2e8f0",
+        },
+      },
+      "name": undefined,
+      "nameTextStyle": {
+        "color": "#0f172a",
+      },
+      "splitLine": {
+        "lineStyle": {
+          "color": "#e2e8f0",
+          "opacity": 0.5,
+        },
+      },
+      "type": "value",
+    },
+  },
+  "bar": {
+    "backgroundColor": "transparent",
+    "color": [
+      "#4f46e5",
+      "#0ea5e9",
+      "#10b981",
+      "#f59e0b",
+      "#ef4444",
+      "#a855f7",
+      "#ec4899",
+      "#14b8a6",
+    ],
+    "grid": {
+      "bottom": 36,
+      "left": 48,
+      "right": 16,
+      "top": 24,
+    },
+    "legend": {
+      "bottom": 0,
+      "textStyle": {
+        "color": "#0f172a",
+      },
+      "type": "scroll",
+    },
+    "series": [
+      {
+        "areaStyle": undefined,
+        "data": [
+          565238.13,
+          612482.65,
+        ],
+        "name": "Store Sales",
+        "smooth": false,
+        "stack": undefined,
+        "type": "bar",
+        "yAxisIndex": 0,
+      },
+      {
+        "areaStyle": undefined,
+        "data": [
+          266773,
+          282417,
+        ],
+        "name": "Unit Sales",
+        "smooth": false,
+        "stack": undefined,
+        "type": "bar",
+        "yAxisIndex": 0,
+      },
+    ],
+    "textStyle": {
+      "color": "#0f172a",
+    },
+    "title": undefined,
+    "tooltip": {
+      "backgroundColor": "#ffffff",
+      "borderColor": "#e2e8f0",
+      "textStyle": {
+        "color": "#0f172a",
+      },
+      "trigger": "axis",
+    },
+    "xAxis": {
+      "axisLabel": {
+        "color": "#475569",
+        "ellipsis": "…",
+        "hideOverlap": true,
+        "overflow": "truncate",
+        "rotate": 0,
+        "width": 100,
+      },
+      "axisLine": {
+        "lineStyle": {
+          "color": "#e2e8f0",
+        },
+      },
+      "axisTick": {
+        "lineStyle": {
+          "color": "#e2e8f0",
+        },
+      },
+      "data": [
+        "1997",
+        "1998",
+      ],
+      "name": undefined,
+      "nameTextStyle": {
+        "color": "#0f172a",
+      },
+      "splitLine": {
+        "lineStyle": {
+          "color": "#e2e8f0",
+          "opacity": 0.5,
+        },
+      },
+      "type": "category",
+    },
+    "yAxis": {
+      "axisLabel": {
+        "color": "#475569",
+      },
+      "axisLine": {
+        "lineStyle": {
+          "color": "#e2e8f0",
+        },
+      },
+      "axisTick": {
+        "lineStyle": {
+          "color": "#e2e8f0",
+        },
+      },
+      "name": undefined,
+      "nameTextStyle": {
+        "color": "#0f172a",
+      },
+      "splitLine": {
+        "lineStyle": {
+          "color": "#e2e8f0",
+          "opacity": 0.5,
+        },
+      },
+      "type": "value",
+    },
+  },
+  "bubble": {
+    "backgroundColor": "transparent",
+    "color": [
+      "#4f46e5",
+      "#0ea5e9",
+      "#10b981",
+      "#f59e0b",
+      "#ef4444",
+      "#a855f7",
+      "#ec4899",
+      "#14b8a6",
+    ],
+    "legend": {
+      "bottom": 0,
+      "textStyle": {
+        "color": "#0f172a",
+      },
+      "type": "scroll",
+    },
+    "series": [
+      {
+        "data": [
+          [
+            0,
+            565238.13,
+          ],
+          [
+            1,
+            266773,
+          ],
+        ],
+        "name": "1997",
+        "symbolSize": [Function],
+        "type": "scatter",
+      },
+      {
+        "data": [
+          [
+            0,
+            612482.65,
+          ],
+          [
+            1,
+            282417,
+          ],
+        ],
+        "name": "1998",
+        "symbolSize": [Function],
+        "type": "scatter",
+      },
+    ],
+    "textStyle": {
+      "color": "#0f172a",
+    },
+    "title": undefined,
+    "tooltip": {
+      "backgroundColor": "#ffffff",
+      "borderColor": "#e2e8f0",
+      "textStyle": {
+        "color": "#0f172a",
+      },
+    },
+    "xAxis": {
+      "axisLabel": {
+        "color": "#475569",
+        "ellipsis": "…",
+        "hideOverlap": true,
+        "overflow": "truncate",
+        "rotate": 0,
+        "width": 100,
+      },
+      "axisLine": {
+        "lineStyle": {
+          "color": "#e2e8f0",
+        },
+      },
+      "axisTick": {
+        "lineStyle": {
+          "color": "#e2e8f0",
+        },
+      },
+      "data": [
+        "Store Sales",
+        "Unit Sales",
+      ],
+      "name": undefined,
+      "nameTextStyle": {
+        "color": "#0f172a",
+      },
+      "splitLine": {
+        "lineStyle": {
+          "color": "#e2e8f0",
+          "opacity": 0.5,
+        },
+      },
+      "type": "category",
+    },
+    "yAxis": {
+      "axisLabel": {
+        "color": "#475569",
+      },
+      "axisLine": {
+        "lineStyle": {
+          "color": "#e2e8f0",
+        },
+      },
+      "axisTick": {
+        "lineStyle": {
+          "color": "#e2e8f0",
+        },
+      },
+      "name": undefined,
+      "nameTextStyle": {
+        "color": "#0f172a",
+      },
+      "splitLine": {
+        "lineStyle": {
+          "color": "#e2e8f0",
+          "opacity": 0.5,
+        },
+      },
+      "type": "value",
+    },
+  },
+  "donut": {
+    "backgroundColor": "transparent",
+    "color": [
+      "#4f46e5",
+      "#0ea5e9",
+      "#10b981",
+      "#f59e0b",
+      "#ef4444",
+      "#a855f7",
+      "#ec4899",
+      "#14b8a6",
+    ],
+    "series": [
+      {
+        "center": [
+          "25%",
+          "58.64%",
+        ],
+        "data": [
+          {
+            "name": "1997",
+            "value": 565238.13,
+          },
+          {
+            "name": "1998",
+            "value": 612482.65,
+          },
+        ],
+        "label": {
+          "color": "#fff",
+          "formatter": "{b}",
+          "position": "inside",
+          "show": true,
+        },
+        "labelLine": {
+          "show": false,
+        },
+        "name": "Store Sales",
+        "radius": [
+          "10.626000000000001%",
+          "19.32%",
+        ],
+        "type": "pie",
+      },
+      {
+        "center": [
+          "75%",
+          "58.64%",
+        ],
+        "data": [
+          {
+            "name": "1997",
+            "value": 266773,
+          },
+          {
+            "name": "1998",
+            "value": 282417,
+          },
+        ],
+        "label": {
+          "color": "#fff",
+          "formatter": "{b}",
+          "position": "inside",
+          "show": true,
+        },
+        "labelLine": {
+          "show": false,
+        },
+        "name": "Unit Sales",
+        "radius": [
+          "10.626000000000001%",
+          "19.32%",
+        ],
+        "type": "pie",
+      },
+    ],
+    "textStyle": {
+      "color": "#0f172a",
+    },
+    "title": [
+      {
+        "left": "25%",
+        "text": "Store Sales",
+        "textAlign": "center",
+        "textStyle": {
+          "color": "#0f172a",
+          "fontSize": 12,
+        },
+        "top": "2%",
+      },
+      {
+        "left": "75%",
+        "text": "Unit Sales",
+        "textAlign": "center",
+        "textStyle": {
+          "color": "#0f172a",
+          "fontSize": 12,
+        },
+        "top": "2%",
+      },
+    ],
+    "tooltip": {
+      "backgroundColor": "#ffffff",
+      "borderColor": "#e2e8f0",
+      "textStyle": {
+        "color": "#0f172a",
+      },
+      "trigger": "item",
+    },
+  },
+  "heatmap": {
+    "backgroundColor": "transparent",
+    "color": [
+      "#4f46e5",
+      "#0ea5e9",
+      "#10b981",
+      "#f59e0b",
+      "#ef4444",
+      "#a855f7",
+      "#ec4899",
+      "#14b8a6",
+    ],
+    "grid": {
+      "bottom": 64,
+      "left": 120,
+      "right": 16,
+      "top": 24,
+    },
+    "series": [
+      {
+        "data": [
+          [
+            0,
+            0,
+            565238.13,
+          ],
+          [
+            1,
+            0,
+            266773,
+          ],
+          [
+            0,
+            1,
+            612482.65,
+          ],
+          [
+            1,
+            1,
+            282417,
+          ],
+        ],
+        "emphasis": {
+          "itemStyle": {
+            "shadowBlur": 10,
+          },
+        },
+        "label": {
+          "show": false,
+        },
+        "type": "heatmap",
+      },
+    ],
+    "textStyle": {
+      "color": "#0f172a",
+    },
+    "title": undefined,
+    "tooltip": {
+      "backgroundColor": "#ffffff",
+      "borderColor": "#e2e8f0",
+      "textStyle": {
+        "color": "#0f172a",
+      },
+    },
+    "visualMap": {
+      "bottom": 8,
+      "calculable": true,
+      "left": "center",
+      "max": 612482.65,
+      "min": 266773,
+      "orient": "horizontal",
+      "textStyle": {
+        "color": "#475569",
+      },
+    },
+    "xAxis": {
+      "axisLabel": {
+        "color": "#475569",
+        "ellipsis": "…",
+        "hideOverlap": true,
+        "overflow": "truncate",
+        "rotate": 0,
+        "width": 100,
+      },
+      "axisLine": {
+        "lineStyle": {
+          "color": "#e2e8f0",
+        },
+      },
+      "axisTick": {
+        "lineStyle": {
+          "color": "#e2e8f0",
+        },
+      },
+      "data": [
+        "Store Sales",
+        "Unit Sales",
+      ],
+      "name": undefined,
+      "nameTextStyle": {
+        "color": "#0f172a",
+      },
+      "splitLine": {
+        "lineStyle": {
+          "color": "#e2e8f0",
+          "opacity": 0.5,
+        },
+      },
+      "type": "category",
+    },
+    "yAxis": {
+      "axisLabel": {
+        "color": "#475569",
+      },
+      "axisLine": {
+        "lineStyle": {
+          "color": "#e2e8f0",
+        },
+      },
+      "axisTick": {
+        "lineStyle": {
+          "color": "#e2e8f0",
+        },
+      },
+      "data": [
+        "1997",
+        "1998",
+      ],
+      "inverse": true,
+      "name": undefined,
+      "nameTextStyle": {
+        "color": "#0f172a",
+      },
+      "splitLine": {
+        "lineStyle": {
+          "color": "#e2e8f0",
+          "opacity": 0.5,
+        },
+      },
+      "type": "category",
+    },
+  },
+  "line": {
+    "backgroundColor": "transparent",
+    "color": [
+      "#4f46e5",
+      "#0ea5e9",
+      "#10b981",
+      "#f59e0b",
+      "#ef4444",
+      "#a855f7",
+      "#ec4899",
+      "#14b8a6",
+    ],
+    "grid": {
+      "bottom": 36,
+      "left": 48,
+      "right": 16,
+      "top": 24,
+    },
+    "legend": {
+      "bottom": 0,
+      "textStyle": {
+        "color": "#0f172a",
+      },
+      "type": "scroll",
+    },
+    "series": [
+      {
+        "areaStyle": undefined,
+        "data": [
+          565238.13,
+          612482.65,
+        ],
+        "name": "Store Sales",
+        "smooth": true,
+        "stack": undefined,
+        "type": "line",
+        "yAxisIndex": 0,
+      },
+      {
+        "areaStyle": undefined,
+        "data": [
+          266773,
+          282417,
+        ],
+        "name": "Unit Sales",
+        "smooth": true,
+        "stack": undefined,
+        "type": "line",
+        "yAxisIndex": 0,
+      },
+    ],
+    "textStyle": {
+      "color": "#0f172a",
+    },
+    "title": undefined,
+    "tooltip": {
+      "backgroundColor": "#ffffff",
+      "borderColor": "#e2e8f0",
+      "textStyle": {
+        "color": "#0f172a",
+      },
+      "trigger": "axis",
+    },
+    "xAxis": {
+      "axisLabel": {
+        "color": "#475569",
+        "ellipsis": "…",
+        "hideOverlap": true,
+        "overflow": "truncate",
+        "rotate": 0,
+        "width": 100,
+      },
+      "axisLine": {
+        "lineStyle": {
+          "color": "#e2e8f0",
+        },
+      },
+      "axisTick": {
+        "lineStyle": {
+          "color": "#e2e8f0",
+        },
+      },
+      "data": [
+        "1997",
+        "1998",
+      ],
+      "name": undefined,
+      "nameTextStyle": {
+        "color": "#0f172a",
+      },
+      "splitLine": {
+        "lineStyle": {
+          "color": "#e2e8f0",
+          "opacity": 0.5,
+        },
+      },
+      "type": "category",
+    },
+    "yAxis": {
+      "axisLabel": {
+        "color": "#475569",
+      },
+      "axisLine": {
+        "lineStyle": {
+          "color": "#e2e8f0",
+        },
+      },
+      "axisTick": {
+        "lineStyle": {
+          "color": "#e2e8f0",
+        },
+      },
+      "name": undefined,
+      "nameTextStyle": {
+        "color": "#0f172a",
+      },
+      "splitLine": {
+        "lineStyle": {
+          "color": "#e2e8f0",
+          "opacity": 0.5,
+        },
+      },
+      "type": "value",
+    },
+  },
+  "pie": {
+    "backgroundColor": "transparent",
+    "color": [
+      "#4f46e5",
+      "#0ea5e9",
+      "#10b981",
+      "#f59e0b",
+      "#ef4444",
+      "#a855f7",
+      "#ec4899",
+      "#14b8a6",
+    ],
+    "series": [
+      {
+        "center": [
+          "25%",
+          "58.64%",
+        ],
+        "data": [
+          {
+            "name": "1997",
+            "value": 565238.13,
+          },
+          {
+            "name": "1998",
+            "value": 612482.65,
+          },
+        ],
+        "label": {
+          "color": "#fff",
+          "formatter": "{b}",
+          "position": "inside",
+          "show": true,
+        },
+        "labelLine": {
+          "show": false,
+        },
+        "name": "Store Sales",
+        "radius": [
+          0,
+          "19.32%",
+        ],
+        "type": "pie",
+      },
+      {
+        "center": [
+          "75%",
+          "58.64%",
+        ],
+        "data": [
+          {
+            "name": "1997",
+            "value": 266773,
+          },
+          {
+            "name": "1998",
+            "value": 282417,
+          },
+        ],
+        "label": {
+          "color": "#fff",
+          "formatter": "{b}",
+          "position": "inside",
+          "show": true,
+        },
+        "labelLine": {
+          "show": false,
+        },
+        "name": "Unit Sales",
+        "radius": [
+          0,
+          "19.32%",
+        ],
+        "type": "pie",
+      },
+    ],
+    "textStyle": {
+      "color": "#0f172a",
+    },
+    "title": [
+      {
+        "left": "25%",
+        "text": "Store Sales",
+        "textAlign": "center",
+        "textStyle": {
+          "color": "#0f172a",
+          "fontSize": 12,
+        },
+        "top": "2%",
+      },
+      {
+        "left": "75%",
+        "text": "Unit Sales",
+        "textAlign": "center",
+        "textStyle": {
+          "color": "#0f172a",
+          "fontSize": 12,
+        },
+        "top": "2%",
+      },
+    ],
+    "tooltip": {
+      "backgroundColor": "#ffffff",
+      "borderColor": "#e2e8f0",
+      "textStyle": {
+        "color": "#0f172a",
+      },
+      "trigger": "item",
+    },
+  },
+  "radar": {
+    "backgroundColor": "transparent",
+    "color": [
+      "#4f46e5",
+      "#0ea5e9",
+      "#10b981",
+      "#f59e0b",
+      "#ef4444",
+      "#a855f7",
+      "#ec4899",
+      "#14b8a6",
+    ],
+    "legend": {
+      "bottom": 0,
+      "textStyle": {
+        "color": "#0f172a",
+      },
+      "type": "scroll",
+    },
+    "radar": {
+      "axisLine": {
+        "lineStyle": {
+          "color": "#e2e8f0",
+        },
+      },
+      "axisName": {
+        "color": "#475569",
+      },
+      "indicator": [
+        {
+          "max": 612482.65,
+          "name": "Store Sales",
+        },
+        {
+          "max": 612482.65,
+          "name": "Unit Sales",
+        },
+      ],
+      "splitArea": {
+        "areaStyle": {
+          "color": [
+            "#ffffff",
+            "#f6f7f9",
+          ],
+          "opacity": 0.3,
+        },
+      },
+      "splitLine": {
+        "lineStyle": {
+          "color": "#e2e8f0",
+          "opacity": 0.5,
+        },
+      },
+    },
+    "series": [
+      {
+        "data": [
+          {
+            "name": "1997",
+            "value": [
+              565238.13,
+              266773,
+            ],
+          },
+          {
+            "name": "1998",
+            "value": [
+              612482.65,
+              282417,
+            ],
+          },
+        ],
+        "type": "radar",
+      },
+    ],
+    "textStyle": {
+      "color": "#0f172a",
+    },
+    "title": undefined,
+    "tooltip": {
+      "backgroundColor": "#ffffff",
+      "borderColor": "#e2e8f0",
+      "textStyle": {
+        "color": "#0f172a",
+      },
+    },
+  },
+  "scatter": {
+    "backgroundColor": "transparent",
+    "color": [
+      "#4f46e5",
+      "#0ea5e9",
+      "#10b981",
+      "#f59e0b",
+      "#ef4444",
+      "#a855f7",
+      "#ec4899",
+      "#14b8a6",
+    ],
+    "legend": {
+      "bottom": 0,
+      "textStyle": {
+        "color": "#0f172a",
+      },
+      "type": "scroll",
+    },
+    "series": [
+      {
+        "data": [
+          [
+            0,
+            565238.13,
+          ],
+          [
+            1,
+            266773,
+          ],
+        ],
+        "name": "1997",
+        "symbolSize": 10,
+        "type": "scatter",
+      },
+      {
+        "data": [
+          [
+            0,
+            612482.65,
+          ],
+          [
+            1,
+            282417,
+          ],
+        ],
+        "name": "1998",
+        "symbolSize": 10,
+        "type": "scatter",
+      },
+    ],
+    "textStyle": {
+      "color": "#0f172a",
+    },
+    "title": undefined,
+    "tooltip": {
+      "backgroundColor": "#ffffff",
+      "borderColor": "#e2e8f0",
+      "textStyle": {
+        "color": "#0f172a",
+      },
+    },
+    "xAxis": {
+      "axisLabel": {
+        "color": "#475569",
+        "ellipsis": "…",
+        "hideOverlap": true,
+        "overflow": "truncate",
+        "rotate": 0,
+        "width": 100,
+      },
+      "axisLine": {
+        "lineStyle": {
+          "color": "#e2e8f0",
+        },
+      },
+      "axisTick": {
+        "lineStyle": {
+          "color": "#e2e8f0",
+        },
+      },
+      "data": [
+        "Store Sales",
+        "Unit Sales",
+      ],
+      "name": undefined,
+      "nameTextStyle": {
+        "color": "#0f172a",
+      },
+      "splitLine": {
+        "lineStyle": {
+          "color": "#e2e8f0",
+          "opacity": 0.5,
+        },
+      },
+      "type": "category",
+    },
+    "yAxis": {
+      "axisLabel": {
+        "color": "#475569",
+      },
+      "axisLine": {
+        "lineStyle": {
+          "color": "#e2e8f0",
+        },
+      },
+      "axisTick": {
+        "lineStyle": {
+          "color": "#e2e8f0",
+        },
+      },
+      "name": undefined,
+      "nameTextStyle": {
+        "color": "#0f172a",
+      },
+      "splitLine": {
+        "lineStyle": {
+          "color": "#e2e8f0",
+          "opacity": 0.5,
+        },
+      },
+      "type": "value",
+    },
+  },
+  "stackedArea": {
+    "backgroundColor": "transparent",
+    "color": [
+      "#4f46e5",
+      "#0ea5e9",
+      "#10b981",
+      "#f59e0b",
+      "#ef4444",
+      "#a855f7",
+      "#ec4899",
+      "#14b8a6",
+    ],
+    "grid": {
+      "bottom": 36,
+      "left": 48,
+      "right": 16,
+      "top": 24,
+    },
+    "legend": {
+      "bottom": 0,
+      "textStyle": {
+        "color": "#0f172a",
+      },
+      "type": "scroll",
+    },
+    "series": [
+      {
+        "areaStyle": {},
+        "data": [
+          565238.13,
+          612482.65,
+        ],
+        "name": "Store Sales",
+        "smooth": true,
+        "stack": "total",
+        "type": "line",
+        "yAxisIndex": 0,
+      },
+      {
+        "areaStyle": {},
+        "data": [
+          266773,
+          282417,
+        ],
+        "name": "Unit Sales",
+        "smooth": true,
+        "stack": "total",
+        "type": "line",
+        "yAxisIndex": 0,
+      },
+    ],
+    "textStyle": {
+      "color": "#0f172a",
+    },
+    "title": undefined,
+    "tooltip": {
+      "backgroundColor": "#ffffff",
+      "borderColor": "#e2e8f0",
+      "textStyle": {
+        "color": "#0f172a",
+      },
+      "trigger": "axis",
+    },
+    "xAxis": {
+      "axisLabel": {
+        "color": "#475569",
+        "ellipsis": "…",
+        "hideOverlap": true,
+        "overflow": "truncate",
+        "rotate": 0,
+        "width": 100,
+      },
+      "axisLine": {
+        "lineStyle": {
+          "color": "#e2e8f0",
+        },
+      },
+      "axisTick": {
+        "lineStyle": {
+          "color": "#e2e8f0",
+        },
+      },
+      "data": [
+        "1997",
+        "1998",
+      ],
+      "name": undefined,
+      "nameTextStyle": {
+        "color": "#0f172a",
+      },
+      "splitLine": {
+        "lineStyle": {
+          "color": "#e2e8f0",
+          "opacity": 0.5,
+        },
+      },
+      "type": "category",
+    },
+    "yAxis": {
+      "axisLabel": {
+        "color": "#475569",
+      },
+      "axisLine": {
+        "lineStyle": {
+          "color": "#e2e8f0",
+        },
+      },
+      "axisTick": {
+        "lineStyle": {
+          "color": "#e2e8f0",
+        },
+      },
+      "name": undefined,
+      "nameTextStyle": {
+        "color": "#0f172a",
+      },
+      "splitLine": {
+        "lineStyle": {
+          "color": "#e2e8f0",
+          "opacity": 0.5,
+        },
+      },
+      "type": "value",
+    },
+  },
+  "stackedBar": {
+    "backgroundColor": "transparent",
+    "color": [
+      "#4f46e5",
+      "#0ea5e9",
+      "#10b981",
+      "#f59e0b",
+      "#ef4444",
+      "#a855f7",
+      "#ec4899",
+      "#14b8a6",
+    ],
+    "grid": {
+      "bottom": 36,
+      "left": 48,
+      "right": 16,
+      "top": 24,
+    },
+    "legend": {
+      "bottom": 0,
+      "textStyle": {
+        "color": "#0f172a",
+      },
+      "type": "scroll",
+    },
+    "series": [
+      {
+        "areaStyle": undefined,
+        "data": [
+          565238.13,
+          612482.65,
+        ],
+        "name": "Store Sales",
+        "smooth": false,
+        "stack": "total",
+        "type": "bar",
+        "yAxisIndex": 0,
+      },
+      {
+        "areaStyle": undefined,
+        "data": [
+          266773,
+          282417,
+        ],
+        "name": "Unit Sales",
+        "smooth": false,
+        "stack": "total",
+        "type": "bar",
+        "yAxisIndex": 0,
+      },
+    ],
+    "textStyle": {
+      "color": "#0f172a",
+    },
+    "title": undefined,
+    "tooltip": {
+      "backgroundColor": "#ffffff",
+      "borderColor": "#e2e8f0",
+      "textStyle": {
+        "color": "#0f172a",
+      },
+      "trigger": "axis",
+    },
+    "xAxis": {
+      "axisLabel": {
+        "color": "#475569",
+        "ellipsis": "…",
+        "hideOverlap": true,
+        "overflow": "truncate",
+        "rotate": 0,
+        "width": 100,
+      },
+      "axisLine": {
+        "lineStyle": {
+          "color": "#e2e8f0",
+        },
+      },
+      "axisTick": {
+        "lineStyle": {
+          "color": "#e2e8f0",
+        },
+      },
+      "data": [
+        "1997",
+        "1998",
+      ],
+      "name": undefined,
+      "nameTextStyle": {
+        "color": "#0f172a",
+      },
+      "splitLine": {
+        "lineStyle": {
+          "color": "#e2e8f0",
+          "opacity": 0.5,
+        },
+      },
+      "type": "category",
+    },
+    "yAxis": {
+      "axisLabel": {
+        "color": "#475569",
+      },
+      "axisLine": {
+        "lineStyle": {
+          "color": "#e2e8f0",
+        },
+      },
+      "axisTick": {
+        "lineStyle": {
+          "color": "#e2e8f0",
+        },
+      },
+      "name": undefined,
+      "nameTextStyle": {
+        "color": "#0f172a",
+      },
+      "splitLine": {
+        "lineStyle": {
+          "color": "#e2e8f0",
+          "opacity": 0.5,
+        },
+      },
+      "type": "value",
+    },
+  },
+  "stackedLine": {
+    "backgroundColor": "transparent",
+    "color": [
+      "#4f46e5",
+      "#0ea5e9",
+      "#10b981",
+      "#f59e0b",
+      "#ef4444",
+      "#a855f7",
+      "#ec4899",
+      "#14b8a6",
+    ],
+    "grid": {
+      "bottom": 36,
+      "left": 48,
+      "right": 16,
+      "top": 24,
+    },
+    "legend": {
+      "bottom": 0,
+      "textStyle": {
+        "color": "#0f172a",
+      },
+      "type": "scroll",
+    },
+    "series": [
+      {
+        "areaStyle": undefined,
+        "data": [
+          565238.13,
+          612482.65,
+        ],
+        "name": "Store Sales",
+        "smooth": true,
+        "stack": "total",
+        "type": "line",
+        "yAxisIndex": 0,
+      },
+      {
+        "areaStyle": undefined,
+        "data": [
+          266773,
+          282417,
+        ],
+        "name": "Unit Sales",
+        "smooth": true,
+        "stack": "total",
+        "type": "line",
+        "yAxisIndex": 0,
+      },
+    ],
+    "textStyle": {
+      "color": "#0f172a",
+    },
+    "title": undefined,
+    "tooltip": {
+      "backgroundColor": "#ffffff",
+      "borderColor": "#e2e8f0",
+      "textStyle": {
+        "color": "#0f172a",
+      },
+      "trigger": "axis",
+    },
+    "xAxis": {
+      "axisLabel": {
+        "color": "#475569",
+        "ellipsis": "…",
+        "hideOverlap": true,
+        "overflow": "truncate",
+        "rotate": 0,
+        "width": 100,
+      },
+      "axisLine": {
+        "lineStyle": {
+          "color": "#e2e8f0",
+        },
+      },
+      "axisTick": {
+        "lineStyle": {
+          "color": "#e2e8f0",
+        },
+      },
+      "data": [
+        "1997",
+        "1998",
+      ],
+      "name": undefined,
+      "nameTextStyle": {
+        "color": "#0f172a",
+      },
+      "splitLine": {
+        "lineStyle": {
+          "color": "#e2e8f0",
+          "opacity": 0.5,
+        },
+      },
+      "type": "category",
+    },
+    "yAxis": {
+      "axisLabel": {
+        "color": "#475569",
+      },
+      "axisLine": {
+        "lineStyle": {
+          "color": "#e2e8f0",
+        },
+      },
+      "axisTick": {
+        "lineStyle": {
+          "color": "#e2e8f0",
+        },
+      },
+      "name": undefined,
+      "nameTextStyle": {
+        "color": "#0f172a",
+      },
+      "splitLine": {
+        "lineStyle": {
+          "color": "#e2e8f0",
+          "opacity": 0.5,
+        },
+      },
+      "type": "value",
+    },
+  },
+  "sunburst": {
+    "backgroundColor": "transparent",
+    "color": [
+      "#4f46e5",
+      "#0ea5e9",
+      "#10b981",
+      "#f59e0b",
+      "#ef4444",
+      "#a855f7",
+      "#ec4899",
+      "#14b8a6",
+    ],
+    "series": [
+      {
+        "center": [
+          "25%",
+          "58.64%",
+        ],
+        "data": [
+          {
+            "name": "1997",
+            "value": 565238.13,
+          },
+          {
+            "name": "1998",
+            "value": 612482.65,
+          },
+        ],
+        "label": {
+          "color": "#fff",
+          "show": true,
+        },
+        "name": "Store Sales",
+        "radius": [
+          0,
+          "19.32%",
+        ],
+        "type": "sunburst",
+      },
+      {
+        "center": [
+          "75%",
+          "58.64%",
+        ],
+        "data": [
+          {
+            "name": "1997",
+            "value": 266773,
+          },
+          {
+            "name": "1998",
+            "value": 282417,
+          },
+        ],
+        "label": {
+          "color": "#fff",
+          "show": true,
+        },
+        "name": "Unit Sales",
+        "radius": [
+          0,
+          "19.32%",
+        ],
+        "type": "sunburst",
+      },
+    ],
+    "textStyle": {
+      "color": "#0f172a",
+    },
+    "title": [
+      {
+        "left": "25%",
+        "text": "Store Sales",
+        "textAlign": "center",
+        "textStyle": {
+          "color": "#0f172a",
+          "fontSize": 12,
+        },
+        "top": "2%",
+      },
+      {
+        "left": "75%",
+        "text": "Unit Sales",
+        "textAlign": "center",
+        "textStyle": {
+          "color": "#0f172a",
+          "fontSize": 12,
+        },
+        "top": "2%",
+      },
+    ],
+    "tooltip": {
+      "backgroundColor": "#ffffff",
+      "borderColor": "#e2e8f0",
+      "textStyle": {
+        "color": "#0f172a",
+      },
+    },
+  },
+  "treemap": {
+    "backgroundColor": "transparent",
+    "color": [
+      "#4f46e5",
+      "#0ea5e9",
+      "#10b981",
+      "#f59e0b",
+      "#ef4444",
+      "#a855f7",
+      "#ec4899",
+      "#14b8a6",
+    ],
+    "series": [
+      {
+        "breadcrumb": {
+          "show": false,
+        },
+        "data": [
+          {
+            "name": "1997",
+            "value": 565238.13,
+          },
+          {
+            "name": "1998",
+            "value": 612482.65,
+          },
+        ],
+        "height": "78.72%",
+        "label": {
+          "color": "#fff",
+        },
+        "left": "2%",
+        "name": "Store Sales",
+        "top": "19.28%",
+        "type": "treemap",
+        "width": "46%",
+      },
+      {
+        "breadcrumb": {
+          "show": false,
+        },
+        "data": [
+          {
+            "name": "1997",
+            "value": 266773,
+          },
+          {
+            "name": "1998",
+            "value": 282417,
+          },
+        ],
+        "height": "78.72%",
+        "label": {
+          "color": "#fff",
+        },
+        "left": "52%",
+        "name": "Unit Sales",
+        "top": "19.28%",
+        "type": "treemap",
+        "width": "46%",
+      },
+    ],
+    "textStyle": {
+      "color": "#0f172a",
+    },
+    "title": [
+      {
+        "left": "25%",
+        "text": "Store Sales",
+        "textAlign": "center",
+        "textStyle": {
+          "color": "#0f172a",
+          "fontSize": 12,
+        },
+        "top": "2%",
+      },
+      {
+        "left": "75%",
+        "text": "Unit Sales",
+        "textAlign": "center",
+        "textStyle": {
+          "color": "#0f172a",
+          "fontSize": 12,
+        },
+        "top": "2%",
+      },
+    ],
+    "tooltip": {
+      "backgroundColor": "#ffffff",
+      "borderColor": "#e2e8f0",
+      "textStyle": {
+        "color": "#0f172a",
+      },
+    },
+  },
+  "waterfall": {
+    "backgroundColor": "transparent",
+    "color": [
+      "#4f46e5",
+      "#0ea5e9",
+      "#10b981",
+      "#f59e0b",
+      "#ef4444",
+      "#a855f7",
+      "#ec4899",
+      "#14b8a6",
+    ],
+    "grid": {
+      "bottom": 36,
+      "left": 48,
+      "right": 16,
+      "top": 24,
+    },
+    "legend": {
+      "bottom": 0,
+      "textStyle": {
+        "color": "#0f172a",
+      },
+      "type": "scroll",
+    },
+    "series": [
+      {
+        "data": [
+          0,
+          565238.13,
+        ],
+        "emphasis": {
+          "itemStyle": {
+            "borderColor": "transparent",
+            "color": "transparent",
+          },
+        },
+        "itemStyle": {
+          "borderColor": "transparent",
+          "color": "transparent",
+        },
+        "name": "",
+        "stack": "waterfall",
+        "type": "bar",
+      },
+      {
+        "data": [
+          565238.13,
+          612482.65,
+        ],
+        "itemStyle": {
+          "color": "#4c9ee6",
+        },
+        "name": "Store Sales",
+        "stack": "waterfall",
+        "type": "bar",
+      },
+      {
+        "data": [
+          null,
+          null,
+        ],
+        "itemStyle": {
+          "color": "#e66c6c",
+        },
+        "name": "-Store Sales",
+        "stack": "waterfall",
+        "type": "bar",
+      },
+    ],
+    "textStyle": {
+      "color": "#0f172a",
+    },
+    "title": undefined,
+    "tooltip": {
+      "backgroundColor": "#ffffff",
+      "borderColor": "#e2e8f0",
+      "textStyle": {
+        "color": "#0f172a",
+      },
+      "trigger": "axis",
+    },
+    "xAxis": {
+      "axisLabel": {
+        "color": "#475569",
+        "ellipsis": "…",
+        "hideOverlap": true,
+        "overflow": "truncate",
+        "rotate": 0,
+        "width": 100,
+      },
+      "axisLine": {
+        "lineStyle": {
+          "color": "#e2e8f0",
+        },
+      },
+      "axisTick": {
+        "lineStyle": {
+          "color": "#e2e8f0",
+        },
+      },
+      "data": [
+        "1997",
+        "1998",
+      ],
+      "name": undefined,
+      "nameTextStyle": {
+        "color": "#0f172a",
+      },
+      "splitLine": {
+        "lineStyle": {
+          "color": "#e2e8f0",
+          "opacity": 0.5,
+        },
+      },
+      "type": "category",
+    },
+    "yAxis": {
+      "axisLabel": {
+        "color": "#475569",
+      },
+      "axisLine": {
+        "lineStyle": {
+          "color": "#e2e8f0",
+        },
+      },
+      "axisTick": {
+        "lineStyle": {
+          "color": "#e2e8f0",
+        },
+      },
+      "name": undefined,
+      "nameTextStyle": {
+        "color": "#0f172a",
+      },
+      "splitLine": {
+        "lineStyle": {
+          "color": "#e2e8f0",
+          "opacity": 0.5,
+        },
+      },
+      "type": "value",
+    },
+  },
+}
+`;
+
+exports[`buildChartOption — coverage of all 15 types > snapshot of every type's structure (non-compact / workspace) 1`] = `
+{
+  "area": {
+    "backgroundColor": "transparent",
+    "color": [
+      "#4f46e5",
+      "#0ea5e9",
+      "#10b981",
+      "#f59e0b",
+      "#ef4444",
+      "#a855f7",
+      "#ec4899",
+      "#14b8a6",
+    ],
+    "grid": {
+      "bottom": 60,
+      "left": 60,
+      "right": 40,
+      "top": 40,
+    },
+    "legend": {
+      "textStyle": {
+        "color": "#0f172a",
+      },
+      "top": 10,
+    },
+    "series": [
+      {
+        "areaStyle": {},
+        "data": [
+          565238.13,
+          612482.65,
+        ],
+        "name": "Store Sales",
+        "smooth": true,
+        "stack": undefined,
+        "type": "line",
+        "yAxisIndex": 0,
+      },
+      {
+        "areaStyle": {},
+        "data": [
+          266773,
+          282417,
+        ],
+        "name": "Unit Sales",
+        "smooth": true,
+        "stack": undefined,
+        "type": "line",
+        "yAxisIndex": 0,
+      },
+    ],
+    "textStyle": {
+      "color": "#0f172a",
+    },
+    "title": undefined,
+    "tooltip": {
+      "backgroundColor": "#ffffff",
+      "borderColor": "#e2e8f0",
+      "textStyle": {
+        "color": "#0f172a",
+      },
+      "trigger": "axis",
+    },
+    "xAxis": {
+      "axisLabel": {
+        "color": "#475569",
+        "ellipsis": "…",
+        "hideOverlap": true,
+        "overflow": "truncate",
+        "rotate": 0,
+        "width": 120,
+      },
+      "axisLine": {
+        "lineStyle": {
+          "color": "#e2e8f0",
+        },
+      },
+      "axisTick": {
+        "lineStyle": {
+          "color": "#e2e8f0",
+        },
+      },
+      "data": [
+        "1997",
+        "1998",
+      ],
+      "name": undefined,
+      "nameTextStyle": {
+        "color": "#0f172a",
+      },
+      "splitLine": {
+        "lineStyle": {
+          "color": "#e2e8f0",
+          "opacity": 0.5,
+        },
+      },
+      "type": "category",
+    },
+    "yAxis": {
+      "axisLabel": {
+        "color": "#475569",
+      },
+      "axisLine": {
+        "lineStyle": {
+          "color": "#e2e8f0",
+        },
+      },
+      "axisTick": {
+        "lineStyle": {
+          "color": "#e2e8f0",
+        },
+      },
+      "name": undefined,
+      "nameTextStyle": {
+        "color": "#0f172a",
+      },
+      "splitLine": {
+        "lineStyle": {
+          "color": "#e2e8f0",
+          "opacity": 0.5,
+        },
+      },
+      "type": "value",
+    },
+  },
+  "bar": {
+    "backgroundColor": "transparent",
+    "color": [
+      "#4f46e5",
+      "#0ea5e9",
+      "#10b981",
+      "#f59e0b",
+      "#ef4444",
+      "#a855f7",
+      "#ec4899",
+      "#14b8a6",
+    ],
+    "grid": {
+      "bottom": 60,
+      "left": 60,
+      "right": 40,
+      "top": 40,
+    },
+    "legend": {
+      "textStyle": {
+        "color": "#0f172a",
+      },
+      "top": 10,
+    },
+    "series": [
+      {
+        "areaStyle": undefined,
+        "data": [
+          565238.13,
+          612482.65,
+        ],
+        "name": "Store Sales",
+        "smooth": false,
+        "stack": undefined,
+        "type": "bar",
+        "yAxisIndex": 0,
+      },
+      {
+        "areaStyle": undefined,
+        "data": [
+          266773,
+          282417,
+        ],
+        "name": "Unit Sales",
+        "smooth": false,
+        "stack": undefined,
+        "type": "bar",
+        "yAxisIndex": 0,
+      },
+    ],
+    "textStyle": {
+      "color": "#0f172a",
+    },
+    "title": undefined,
+    "tooltip": {
+      "backgroundColor": "#ffffff",
+      "borderColor": "#e2e8f0",
+      "textStyle": {
+        "color": "#0f172a",
+      },
+      "trigger": "axis",
+    },
+    "xAxis": {
+      "axisLabel": {
+        "color": "#475569",
+        "ellipsis": "…",
+        "hideOverlap": true,
+        "overflow": "truncate",
+        "rotate": 0,
+        "width": 120,
+      },
+      "axisLine": {
+        "lineStyle": {
+          "color": "#e2e8f0",
+        },
+      },
+      "axisTick": {
+        "lineStyle": {
+          "color": "#e2e8f0",
+        },
+      },
+      "data": [
+        "1997",
+        "1998",
+      ],
+      "name": undefined,
+      "nameTextStyle": {
+        "color": "#0f172a",
+      },
+      "splitLine": {
+        "lineStyle": {
+          "color": "#e2e8f0",
+          "opacity": 0.5,
+        },
+      },
+      "type": "category",
+    },
+    "yAxis": {
+      "axisLabel": {
+        "color": "#475569",
+      },
+      "axisLine": {
+        "lineStyle": {
+          "color": "#e2e8f0",
+        },
+      },
+      "axisTick": {
+        "lineStyle": {
+          "color": "#e2e8f0",
+        },
+      },
+      "name": undefined,
+      "nameTextStyle": {
+        "color": "#0f172a",
+      },
+      "splitLine": {
+        "lineStyle": {
+          "color": "#e2e8f0",
+          "opacity": 0.5,
+        },
+      },
+      "type": "value",
+    },
+  },
+  "bubble": {
+    "backgroundColor": "transparent",
+    "color": [
+      "#4f46e5",
+      "#0ea5e9",
+      "#10b981",
+      "#f59e0b",
+      "#ef4444",
+      "#a855f7",
+      "#ec4899",
+      "#14b8a6",
+    ],
+    "legend": {
+      "textStyle": {
+        "color": "#0f172a",
+      },
+      "top": 10,
+    },
+    "series": [
+      {
+        "data": [
+          [
+            0,
+            565238.13,
+          ],
+          [
+            1,
+            266773,
+          ],
+        ],
+        "name": "1997",
+        "symbolSize": [Function],
+        "type": "scatter",
+      },
+      {
+        "data": [
+          [
+            0,
+            612482.65,
+          ],
+          [
+            1,
+            282417,
+          ],
+        ],
+        "name": "1998",
+        "symbolSize": [Function],
+        "type": "scatter",
+      },
+    ],
+    "textStyle": {
+      "color": "#0f172a",
+    },
+    "title": undefined,
+    "tooltip": {
+      "backgroundColor": "#ffffff",
+      "borderColor": "#e2e8f0",
+      "textStyle": {
+        "color": "#0f172a",
+      },
+    },
+    "xAxis": {
+      "axisLabel": {
+        "color": "#475569",
+        "ellipsis": "…",
+        "hideOverlap": true,
+        "overflow": "truncate",
+        "rotate": 0,
+        "width": 120,
+      },
+      "axisLine": {
+        "lineStyle": {
+          "color": "#e2e8f0",
+        },
+      },
+      "axisTick": {
+        "lineStyle": {
+          "color": "#e2e8f0",
+        },
+      },
+      "data": [
+        "Store Sales",
+        "Unit Sales",
+      ],
+      "name": undefined,
+      "nameTextStyle": {
+        "color": "#0f172a",
+      },
+      "splitLine": {
+        "lineStyle": {
+          "color": "#e2e8f0",
+          "opacity": 0.5,
+        },
+      },
+      "type": "category",
+    },
+    "yAxis": {
+      "axisLabel": {
+        "color": "#475569",
+      },
+      "axisLine": {
+        "lineStyle": {
+          "color": "#e2e8f0",
+        },
+      },
+      "axisTick": {
+        "lineStyle": {
+          "color": "#e2e8f0",
+        },
+      },
+      "name": undefined,
+      "nameTextStyle": {
+        "color": "#0f172a",
+      },
+      "splitLine": {
+        "lineStyle": {
+          "color": "#e2e8f0",
+          "opacity": 0.5,
+        },
+      },
+      "type": "value",
+    },
+  },
+  "donut": {
+    "backgroundColor": "transparent",
+    "color": [
+      "#4f46e5",
+      "#0ea5e9",
+      "#10b981",
+      "#f59e0b",
+      "#ef4444",
+      "#a855f7",
+      "#ec4899",
+      "#14b8a6",
+    ],
+    "series": [
+      {
+        "center": [
+          "25%",
+          "58.64%",
+        ],
+        "data": [
+          {
+            "name": "1997",
+            "value": 565238.13,
+          },
+          {
+            "name": "1998",
+            "value": 612482.65,
+          },
+        ],
+        "label": {
+          "color": "#fff",
+          "formatter": "{b}",
+          "position": "inside",
+          "show": true,
+        },
+        "labelLine": {
+          "show": false,
+        },
+        "name": "Store Sales",
+        "radius": [
+          "10.626000000000001%",
+          "19.32%",
+        ],
+        "type": "pie",
+      },
+      {
+        "center": [
+          "75%",
+          "58.64%",
+        ],
+        "data": [
+          {
+            "name": "1997",
+            "value": 266773,
+          },
+          {
+            "name": "1998",
+            "value": 282417,
+          },
+        ],
+        "label": {
+          "color": "#fff",
+          "formatter": "{b}",
+          "position": "inside",
+          "show": true,
+        },
+        "labelLine": {
+          "show": false,
+        },
+        "name": "Unit Sales",
+        "radius": [
+          "10.626000000000001%",
+          "19.32%",
+        ],
+        "type": "pie",
+      },
+    ],
+    "textStyle": {
+      "color": "#0f172a",
+    },
+    "title": [
+      {
+        "left": "25%",
+        "text": "Store Sales",
+        "textAlign": "center",
+        "textStyle": {
+          "color": "#0f172a",
+          "fontSize": 12,
+        },
+        "top": "2%",
+      },
+      {
+        "left": "75%",
+        "text": "Unit Sales",
+        "textAlign": "center",
+        "textStyle": {
+          "color": "#0f172a",
+          "fontSize": 12,
+        },
+        "top": "2%",
+      },
+    ],
+    "tooltip": {
+      "backgroundColor": "#ffffff",
+      "borderColor": "#e2e8f0",
+      "textStyle": {
+        "color": "#0f172a",
+      },
+      "trigger": "item",
+    },
+  },
+  "heatmap": {
+    "backgroundColor": "transparent",
+    "color": [
+      "#4f46e5",
+      "#0ea5e9",
+      "#10b981",
+      "#f59e0b",
+      "#ef4444",
+      "#a855f7",
+      "#ec4899",
+      "#14b8a6",
+    ],
+    "grid": {
+      "bottom": 80,
+      "left": 120,
+      "right": 40,
+      "top": 40,
+    },
+    "series": [
+      {
+        "data": [
+          [
+            0,
+            0,
+            565238.13,
+          ],
+          [
+            1,
+            0,
+            266773,
+          ],
+          [
+            0,
+            1,
+            612482.65,
+          ],
+          [
+            1,
+            1,
+            282417,
+          ],
+        ],
+        "emphasis": {
+          "itemStyle": {
+            "shadowBlur": 10,
+          },
+        },
+        "label": {
+          "show": false,
+        },
+        "type": "heatmap",
+      },
+    ],
+    "textStyle": {
+      "color": "#0f172a",
+    },
+    "title": undefined,
+    "tooltip": {
+      "backgroundColor": "#ffffff",
+      "borderColor": "#e2e8f0",
+      "textStyle": {
+        "color": "#0f172a",
+      },
+    },
+    "visualMap": {
+      "bottom": 10,
+      "calculable": true,
+      "left": "center",
+      "max": 612482.65,
+      "min": 266773,
+      "orient": "horizontal",
+      "textStyle": {
+        "color": "#475569",
+      },
+    },
+    "xAxis": {
+      "axisLabel": {
+        "color": "#475569",
+        "ellipsis": "…",
+        "hideOverlap": true,
+        "overflow": "truncate",
+        "rotate": 0,
+        "width": 120,
+      },
+      "axisLine": {
+        "lineStyle": {
+          "color": "#e2e8f0",
+        },
+      },
+      "axisTick": {
+        "lineStyle": {
+          "color": "#e2e8f0",
+        },
+      },
+      "data": [
+        "Store Sales",
+        "Unit Sales",
+      ],
+      "name": undefined,
+      "nameTextStyle": {
+        "color": "#0f172a",
+      },
+      "splitLine": {
+        "lineStyle": {
+          "color": "#e2e8f0",
+          "opacity": 0.5,
+        },
+      },
+      "type": "category",
+    },
+    "yAxis": {
+      "axisLabel": {
+        "color": "#475569",
+      },
+      "axisLine": {
+        "lineStyle": {
+          "color": "#e2e8f0",
+        },
+      },
+      "axisTick": {
+        "lineStyle": {
+          "color": "#e2e8f0",
+        },
+      },
+      "data": [
+        "1997",
+        "1998",
+      ],
+      "inverse": true,
+      "name": undefined,
+      "nameTextStyle": {
+        "color": "#0f172a",
+      },
+      "splitLine": {
+        "lineStyle": {
+          "color": "#e2e8f0",
+          "opacity": 0.5,
+        },
+      },
+      "type": "category",
+    },
+  },
+  "line": {
+    "backgroundColor": "transparent",
+    "color": [
+      "#4f46e5",
+      "#0ea5e9",
+      "#10b981",
+      "#f59e0b",
+      "#ef4444",
+      "#a855f7",
+      "#ec4899",
+      "#14b8a6",
+    ],
+    "grid": {
+      "bottom": 60,
+      "left": 60,
+      "right": 40,
+      "top": 40,
+    },
+    "legend": {
+      "textStyle": {
+        "color": "#0f172a",
+      },
+      "top": 10,
+    },
+    "series": [
+      {
+        "areaStyle": undefined,
+        "data": [
+          565238.13,
+          612482.65,
+        ],
+        "name": "Store Sales",
+        "smooth": true,
+        "stack": undefined,
+        "type": "line",
+        "yAxisIndex": 0,
+      },
+      {
+        "areaStyle": undefined,
+        "data": [
+          266773,
+          282417,
+        ],
+        "name": "Unit Sales",
+        "smooth": true,
+        "stack": undefined,
+        "type": "line",
+        "yAxisIndex": 0,
+      },
+    ],
+    "textStyle": {
+      "color": "#0f172a",
+    },
+    "title": undefined,
+    "tooltip": {
+      "backgroundColor": "#ffffff",
+      "borderColor": "#e2e8f0",
+      "textStyle": {
+        "color": "#0f172a",
+      },
+      "trigger": "axis",
+    },
+    "xAxis": {
+      "axisLabel": {
+        "color": "#475569",
+        "ellipsis": "…",
+        "hideOverlap": true,
+        "overflow": "truncate",
+        "rotate": 0,
+        "width": 120,
+      },
+      "axisLine": {
+        "lineStyle": {
+          "color": "#e2e8f0",
+        },
+      },
+      "axisTick": {
+        "lineStyle": {
+          "color": "#e2e8f0",
+        },
+      },
+      "data": [
+        "1997",
+        "1998",
+      ],
+      "name": undefined,
+      "nameTextStyle": {
+        "color": "#0f172a",
+      },
+      "splitLine": {
+        "lineStyle": {
+          "color": "#e2e8f0",
+          "opacity": 0.5,
+        },
+      },
+      "type": "category",
+    },
+    "yAxis": {
+      "axisLabel": {
+        "color": "#475569",
+      },
+      "axisLine": {
+        "lineStyle": {
+          "color": "#e2e8f0",
+        },
+      },
+      "axisTick": {
+        "lineStyle": {
+          "color": "#e2e8f0",
+        },
+      },
+      "name": undefined,
+      "nameTextStyle": {
+        "color": "#0f172a",
+      },
+      "splitLine": {
+        "lineStyle": {
+          "color": "#e2e8f0",
+          "opacity": 0.5,
+        },
+      },
+      "type": "value",
+    },
+  },
+  "pie": {
+    "backgroundColor": "transparent",
+    "color": [
+      "#4f46e5",
+      "#0ea5e9",
+      "#10b981",
+      "#f59e0b",
+      "#ef4444",
+      "#a855f7",
+      "#ec4899",
+      "#14b8a6",
+    ],
+    "series": [
+      {
+        "center": [
+          "25%",
+          "58.64%",
+        ],
+        "data": [
+          {
+            "name": "1997",
+            "value": 565238.13,
+          },
+          {
+            "name": "1998",
+            "value": 612482.65,
+          },
+        ],
+        "label": {
+          "color": "#fff",
+          "formatter": "{b}",
+          "position": "inside",
+          "show": true,
+        },
+        "labelLine": {
+          "show": false,
+        },
+        "name": "Store Sales",
+        "radius": [
+          0,
+          "19.32%",
+        ],
+        "type": "pie",
+      },
+      {
+        "center": [
+          "75%",
+          "58.64%",
+        ],
+        "data": [
+          {
+            "name": "1997",
+            "value": 266773,
+          },
+          {
+            "name": "1998",
+            "value": 282417,
+          },
+        ],
+        "label": {
+          "color": "#fff",
+          "formatter": "{b}",
+          "position": "inside",
+          "show": true,
+        },
+        "labelLine": {
+          "show": false,
+        },
+        "name": "Unit Sales",
+        "radius": [
+          0,
+          "19.32%",
+        ],
+        "type": "pie",
+      },
+    ],
+    "textStyle": {
+      "color": "#0f172a",
+    },
+    "title": [
+      {
+        "left": "25%",
+        "text": "Store Sales",
+        "textAlign": "center",
+        "textStyle": {
+          "color": "#0f172a",
+          "fontSize": 12,
+        },
+        "top": "2%",
+      },
+      {
+        "left": "75%",
+        "text": "Unit Sales",
+        "textAlign": "center",
+        "textStyle": {
+          "color": "#0f172a",
+          "fontSize": 12,
+        },
+        "top": "2%",
+      },
+    ],
+    "tooltip": {
+      "backgroundColor": "#ffffff",
+      "borderColor": "#e2e8f0",
+      "textStyle": {
+        "color": "#0f172a",
+      },
+      "trigger": "item",
+    },
+  },
+  "radar": {
+    "backgroundColor": "transparent",
+    "color": [
+      "#4f46e5",
+      "#0ea5e9",
+      "#10b981",
+      "#f59e0b",
+      "#ef4444",
+      "#a855f7",
+      "#ec4899",
+      "#14b8a6",
+    ],
+    "legend": {
+      "textStyle": {
+        "color": "#0f172a",
+      },
+      "top": 10,
+    },
+    "radar": {
+      "axisLine": {
+        "lineStyle": {
+          "color": "#e2e8f0",
+        },
+      },
+      "axisName": {
+        "color": "#475569",
+      },
+      "indicator": [
+        {
+          "max": 612482.65,
+          "name": "Store Sales",
+        },
+        {
+          "max": 612482.65,
+          "name": "Unit Sales",
+        },
+      ],
+      "splitArea": {
+        "areaStyle": {
+          "color": [
+            "#ffffff",
+            "#f6f7f9",
+          ],
+          "opacity": 0.3,
+        },
+      },
+      "splitLine": {
+        "lineStyle": {
+          "color": "#e2e8f0",
+          "opacity": 0.5,
+        },
+      },
+    },
+    "series": [
+      {
+        "data": [
+          {
+            "name": "1997",
+            "value": [
+              565238.13,
+              266773,
+            ],
+          },
+          {
+            "name": "1998",
+            "value": [
+              612482.65,
+              282417,
+            ],
+          },
+        ],
+        "type": "radar",
+      },
+    ],
+    "textStyle": {
+      "color": "#0f172a",
+    },
+    "title": undefined,
+    "tooltip": {
+      "backgroundColor": "#ffffff",
+      "borderColor": "#e2e8f0",
+      "textStyle": {
+        "color": "#0f172a",
+      },
+    },
+  },
+  "scatter": {
+    "backgroundColor": "transparent",
+    "color": [
+      "#4f46e5",
+      "#0ea5e9",
+      "#10b981",
+      "#f59e0b",
+      "#ef4444",
+      "#a855f7",
+      "#ec4899",
+      "#14b8a6",
+    ],
+    "legend": {
+      "textStyle": {
+        "color": "#0f172a",
+      },
+      "top": 10,
+    },
+    "series": [
+      {
+        "data": [
+          [
+            0,
+            565238.13,
+          ],
+          [
+            1,
+            266773,
+          ],
+        ],
+        "name": "1997",
+        "symbolSize": 10,
+        "type": "scatter",
+      },
+      {
+        "data": [
+          [
+            0,
+            612482.65,
+          ],
+          [
+            1,
+            282417,
+          ],
+        ],
+        "name": "1998",
+        "symbolSize": 10,
+        "type": "scatter",
+      },
+    ],
+    "textStyle": {
+      "color": "#0f172a",
+    },
+    "title": undefined,
+    "tooltip": {
+      "backgroundColor": "#ffffff",
+      "borderColor": "#e2e8f0",
+      "textStyle": {
+        "color": "#0f172a",
+      },
+    },
+    "xAxis": {
+      "axisLabel": {
+        "color": "#475569",
+        "ellipsis": "…",
+        "hideOverlap": true,
+        "overflow": "truncate",
+        "rotate": 0,
+        "width": 120,
+      },
+      "axisLine": {
+        "lineStyle": {
+          "color": "#e2e8f0",
+        },
+      },
+      "axisTick": {
+        "lineStyle": {
+          "color": "#e2e8f0",
+        },
+      },
+      "data": [
+        "Store Sales",
+        "Unit Sales",
+      ],
+      "name": undefined,
+      "nameTextStyle": {
+        "color": "#0f172a",
+      },
+      "splitLine": {
+        "lineStyle": {
+          "color": "#e2e8f0",
+          "opacity": 0.5,
+        },
+      },
+      "type": "category",
+    },
+    "yAxis": {
+      "axisLabel": {
+        "color": "#475569",
+      },
+      "axisLine": {
+        "lineStyle": {
+          "color": "#e2e8f0",
+        },
+      },
+      "axisTick": {
+        "lineStyle": {
+          "color": "#e2e8f0",
+        },
+      },
+      "name": undefined,
+      "nameTextStyle": {
+        "color": "#0f172a",
+      },
+      "splitLine": {
+        "lineStyle": {
+          "color": "#e2e8f0",
+          "opacity": 0.5,
+        },
+      },
+      "type": "value",
+    },
+  },
+  "stackedArea": {
+    "backgroundColor": "transparent",
+    "color": [
+      "#4f46e5",
+      "#0ea5e9",
+      "#10b981",
+      "#f59e0b",
+      "#ef4444",
+      "#a855f7",
+      "#ec4899",
+      "#14b8a6",
+    ],
+    "grid": {
+      "bottom": 60,
+      "left": 60,
+      "right": 40,
+      "top": 40,
+    },
+    "legend": {
+      "textStyle": {
+        "color": "#0f172a",
+      },
+      "top": 10,
+    },
+    "series": [
+      {
+        "areaStyle": {},
+        "data": [
+          565238.13,
+          612482.65,
+        ],
+        "name": "Store Sales",
+        "smooth": true,
+        "stack": "total",
+        "type": "line",
+        "yAxisIndex": 0,
+      },
+      {
+        "areaStyle": {},
+        "data": [
+          266773,
+          282417,
+        ],
+        "name": "Unit Sales",
+        "smooth": true,
+        "stack": "total",
+        "type": "line",
+        "yAxisIndex": 0,
+      },
+    ],
+    "textStyle": {
+      "color": "#0f172a",
+    },
+    "title": undefined,
+    "tooltip": {
+      "backgroundColor": "#ffffff",
+      "borderColor": "#e2e8f0",
+      "textStyle": {
+        "color": "#0f172a",
+      },
+      "trigger": "axis",
+    },
+    "xAxis": {
+      "axisLabel": {
+        "color": "#475569",
+        "ellipsis": "…",
+        "hideOverlap": true,
+        "overflow": "truncate",
+        "rotate": 0,
+        "width": 120,
+      },
+      "axisLine": {
+        "lineStyle": {
+          "color": "#e2e8f0",
+        },
+      },
+      "axisTick": {
+        "lineStyle": {
+          "color": "#e2e8f0",
+        },
+      },
+      "data": [
+        "1997",
+        "1998",
+      ],
+      "name": undefined,
+      "nameTextStyle": {
+        "color": "#0f172a",
+      },
+      "splitLine": {
+        "lineStyle": {
+          "color": "#e2e8f0",
+          "opacity": 0.5,
+        },
+      },
+      "type": "category",
+    },
+    "yAxis": {
+      "axisLabel": {
+        "color": "#475569",
+      },
+      "axisLine": {
+        "lineStyle": {
+          "color": "#e2e8f0",
+        },
+      },
+      "axisTick": {
+        "lineStyle": {
+          "color": "#e2e8f0",
+        },
+      },
+      "name": undefined,
+      "nameTextStyle": {
+        "color": "#0f172a",
+      },
+      "splitLine": {
+        "lineStyle": {
+          "color": "#e2e8f0",
+          "opacity": 0.5,
+        },
+      },
+      "type": "value",
+    },
+  },
+  "stackedBar": {
+    "backgroundColor": "transparent",
+    "color": [
+      "#4f46e5",
+      "#0ea5e9",
+      "#10b981",
+      "#f59e0b",
+      "#ef4444",
+      "#a855f7",
+      "#ec4899",
+      "#14b8a6",
+    ],
+    "grid": {
+      "bottom": 60,
+      "left": 60,
+      "right": 40,
+      "top": 40,
+    },
+    "legend": {
+      "textStyle": {
+        "color": "#0f172a",
+      },
+      "top": 10,
+    },
+    "series": [
+      {
+        "areaStyle": undefined,
+        "data": [
+          565238.13,
+          612482.65,
+        ],
+        "name": "Store Sales",
+        "smooth": false,
+        "stack": "total",
+        "type": "bar",
+        "yAxisIndex": 0,
+      },
+      {
+        "areaStyle": undefined,
+        "data": [
+          266773,
+          282417,
+        ],
+        "name": "Unit Sales",
+        "smooth": false,
+        "stack": "total",
+        "type": "bar",
+        "yAxisIndex": 0,
+      },
+    ],
+    "textStyle": {
+      "color": "#0f172a",
+    },
+    "title": undefined,
+    "tooltip": {
+      "backgroundColor": "#ffffff",
+      "borderColor": "#e2e8f0",
+      "textStyle": {
+        "color": "#0f172a",
+      },
+      "trigger": "axis",
+    },
+    "xAxis": {
+      "axisLabel": {
+        "color": "#475569",
+        "ellipsis": "…",
+        "hideOverlap": true,
+        "overflow": "truncate",
+        "rotate": 0,
+        "width": 120,
+      },
+      "axisLine": {
+        "lineStyle": {
+          "color": "#e2e8f0",
+        },
+      },
+      "axisTick": {
+        "lineStyle": {
+          "color": "#e2e8f0",
+        },
+      },
+      "data": [
+        "1997",
+        "1998",
+      ],
+      "name": undefined,
+      "nameTextStyle": {
+        "color": "#0f172a",
+      },
+      "splitLine": {
+        "lineStyle": {
+          "color": "#e2e8f0",
+          "opacity": 0.5,
+        },
+      },
+      "type": "category",
+    },
+    "yAxis": {
+      "axisLabel": {
+        "color": "#475569",
+      },
+      "axisLine": {
+        "lineStyle": {
+          "color": "#e2e8f0",
+        },
+      },
+      "axisTick": {
+        "lineStyle": {
+          "color": "#e2e8f0",
+        },
+      },
+      "name": undefined,
+      "nameTextStyle": {
+        "color": "#0f172a",
+      },
+      "splitLine": {
+        "lineStyle": {
+          "color": "#e2e8f0",
+          "opacity": 0.5,
+        },
+      },
+      "type": "value",
+    },
+  },
+  "stackedLine": {
+    "backgroundColor": "transparent",
+    "color": [
+      "#4f46e5",
+      "#0ea5e9",
+      "#10b981",
+      "#f59e0b",
+      "#ef4444",
+      "#a855f7",
+      "#ec4899",
+      "#14b8a6",
+    ],
+    "grid": {
+      "bottom": 60,
+      "left": 60,
+      "right": 40,
+      "top": 40,
+    },
+    "legend": {
+      "textStyle": {
+        "color": "#0f172a",
+      },
+      "top": 10,
+    },
+    "series": [
+      {
+        "areaStyle": undefined,
+        "data": [
+          565238.13,
+          612482.65,
+        ],
+        "name": "Store Sales",
+        "smooth": true,
+        "stack": "total",
+        "type": "line",
+        "yAxisIndex": 0,
+      },
+      {
+        "areaStyle": undefined,
+        "data": [
+          266773,
+          282417,
+        ],
+        "name": "Unit Sales",
+        "smooth": true,
+        "stack": "total",
+        "type": "line",
+        "yAxisIndex": 0,
+      },
+    ],
+    "textStyle": {
+      "color": "#0f172a",
+    },
+    "title": undefined,
+    "tooltip": {
+      "backgroundColor": "#ffffff",
+      "borderColor": "#e2e8f0",
+      "textStyle": {
+        "color": "#0f172a",
+      },
+      "trigger": "axis",
+    },
+    "xAxis": {
+      "axisLabel": {
+        "color": "#475569",
+        "ellipsis": "…",
+        "hideOverlap": true,
+        "overflow": "truncate",
+        "rotate": 0,
+        "width": 120,
+      },
+      "axisLine": {
+        "lineStyle": {
+          "color": "#e2e8f0",
+        },
+      },
+      "axisTick": {
+        "lineStyle": {
+          "color": "#e2e8f0",
+        },
+      },
+      "data": [
+        "1997",
+        "1998",
+      ],
+      "name": undefined,
+      "nameTextStyle": {
+        "color": "#0f172a",
+      },
+      "splitLine": {
+        "lineStyle": {
+          "color": "#e2e8f0",
+          "opacity": 0.5,
+        },
+      },
+      "type": "category",
+    },
+    "yAxis": {
+      "axisLabel": {
+        "color": "#475569",
+      },
+      "axisLine": {
+        "lineStyle": {
+          "color": "#e2e8f0",
+        },
+      },
+      "axisTick": {
+        "lineStyle": {
+          "color": "#e2e8f0",
+        },
+      },
+      "name": undefined,
+      "nameTextStyle": {
+        "color": "#0f172a",
+      },
+      "splitLine": {
+        "lineStyle": {
+          "color": "#e2e8f0",
+          "opacity": 0.5,
+        },
+      },
+      "type": "value",
+    },
+  },
+  "sunburst": {
+    "backgroundColor": "transparent",
+    "color": [
+      "#4f46e5",
+      "#0ea5e9",
+      "#10b981",
+      "#f59e0b",
+      "#ef4444",
+      "#a855f7",
+      "#ec4899",
+      "#14b8a6",
+    ],
+    "series": [
+      {
+        "center": [
+          "25%",
+          "58.64%",
+        ],
+        "data": [
+          {
+            "name": "1997",
+            "value": 565238.13,
+          },
+          {
+            "name": "1998",
+            "value": 612482.65,
+          },
+        ],
+        "label": {
+          "color": "#fff",
+          "show": true,
+        },
+        "name": "Store Sales",
+        "radius": [
+          0,
+          "19.32%",
+        ],
+        "type": "sunburst",
+      },
+      {
+        "center": [
+          "75%",
+          "58.64%",
+        ],
+        "data": [
+          {
+            "name": "1997",
+            "value": 266773,
+          },
+          {
+            "name": "1998",
+            "value": 282417,
+          },
+        ],
+        "label": {
+          "color": "#fff",
+          "show": true,
+        },
+        "name": "Unit Sales",
+        "radius": [
+          0,
+          "19.32%",
+        ],
+        "type": "sunburst",
+      },
+    ],
+    "textStyle": {
+      "color": "#0f172a",
+    },
+    "title": [
+      {
+        "left": "25%",
+        "text": "Store Sales",
+        "textAlign": "center",
+        "textStyle": {
+          "color": "#0f172a",
+          "fontSize": 12,
+        },
+        "top": "2%",
+      },
+      {
+        "left": "75%",
+        "text": "Unit Sales",
+        "textAlign": "center",
+        "textStyle": {
+          "color": "#0f172a",
+          "fontSize": 12,
+        },
+        "top": "2%",
+      },
+    ],
+    "tooltip": {
+      "backgroundColor": "#ffffff",
+      "borderColor": "#e2e8f0",
+      "textStyle": {
+        "color": "#0f172a",
+      },
+    },
+  },
+  "treemap": {
+    "backgroundColor": "transparent",
+    "color": [
+      "#4f46e5",
+      "#0ea5e9",
+      "#10b981",
+      "#f59e0b",
+      "#ef4444",
+      "#a855f7",
+      "#ec4899",
+      "#14b8a6",
+    ],
+    "series": [
+      {
+        "breadcrumb": {
+          "show": false,
+        },
+        "data": [
+          {
+            "name": "1997",
+            "value": 565238.13,
+          },
+          {
+            "name": "1998",
+            "value": 612482.65,
+          },
+        ],
+        "height": "78.72%",
+        "label": {
+          "color": "#fff",
+        },
+        "left": "2%",
+        "name": "Store Sales",
+        "top": "19.28%",
+        "type": "treemap",
+        "width": "46%",
+      },
+      {
+        "breadcrumb": {
+          "show": false,
+        },
+        "data": [
+          {
+            "name": "1997",
+            "value": 266773,
+          },
+          {
+            "name": "1998",
+            "value": 282417,
+          },
+        ],
+        "height": "78.72%",
+        "label": {
+          "color": "#fff",
+        },
+        "left": "52%",
+        "name": "Unit Sales",
+        "top": "19.28%",
+        "type": "treemap",
+        "width": "46%",
+      },
+    ],
+    "textStyle": {
+      "color": "#0f172a",
+    },
+    "title": [
+      {
+        "left": "25%",
+        "text": "Store Sales",
+        "textAlign": "center",
+        "textStyle": {
+          "color": "#0f172a",
+          "fontSize": 12,
+        },
+        "top": "2%",
+      },
+      {
+        "left": "75%",
+        "text": "Unit Sales",
+        "textAlign": "center",
+        "textStyle": {
+          "color": "#0f172a",
+          "fontSize": 12,
+        },
+        "top": "2%",
+      },
+    ],
+    "tooltip": {
+      "backgroundColor": "#ffffff",
+      "borderColor": "#e2e8f0",
+      "textStyle": {
+        "color": "#0f172a",
+      },
+    },
+  },
+  "waterfall": {
+    "backgroundColor": "transparent",
+    "color": [
+      "#4f46e5",
+      "#0ea5e9",
+      "#10b981",
+      "#f59e0b",
+      "#ef4444",
+      "#a855f7",
+      "#ec4899",
+      "#14b8a6",
+    ],
+    "grid": {
+      "bottom": 60,
+      "left": 60,
+      "right": 40,
+      "top": 30,
+    },
+    "legend": {
+      "textStyle": {
+        "color": "#0f172a",
+      },
+      "top": 10,
+    },
+    "series": [
+      {
+        "data": [
+          0,
+          565238.13,
+        ],
+        "emphasis": {
+          "itemStyle": {
+            "borderColor": "transparent",
+            "color": "transparent",
+          },
+        },
+        "itemStyle": {
+          "borderColor": "transparent",
+          "color": "transparent",
+        },
+        "name": "",
+        "stack": "waterfall",
+        "type": "bar",
+      },
+      {
+        "data": [
+          565238.13,
+          612482.65,
+        ],
+        "itemStyle": {
+          "color": "#4c9ee6",
+        },
+        "name": "Store Sales",
+        "stack": "waterfall",
+        "type": "bar",
+      },
+      {
+        "data": [
+          null,
+          null,
+        ],
+        "itemStyle": {
+          "color": "#e66c6c",
+        },
+        "name": "-Store Sales",
+        "stack": "waterfall",
+        "type": "bar",
+      },
+    ],
+    "textStyle": {
+      "color": "#0f172a",
+    },
+    "title": undefined,
+    "tooltip": {
+      "backgroundColor": "#ffffff",
+      "borderColor": "#e2e8f0",
+      "textStyle": {
+        "color": "#0f172a",
+      },
+      "trigger": "axis",
+    },
+    "xAxis": {
+      "axisLabel": {
+        "color": "#475569",
+        "ellipsis": "…",
+        "hideOverlap": true,
+        "overflow": "truncate",
+        "rotate": 0,
+        "width": 120,
+      },
+      "axisLine": {
+        "lineStyle": {
+          "color": "#e2e8f0",
+        },
+      },
+      "axisTick": {
+        "lineStyle": {
+          "color": "#e2e8f0",
+        },
+      },
+      "data": [
+        "1997",
+        "1998",
+      ],
+      "name": undefined,
+      "nameTextStyle": {
+        "color": "#0f172a",
+      },
+      "splitLine": {
+        "lineStyle": {
+          "color": "#e2e8f0",
+          "opacity": 0.5,
+        },
+      },
+      "type": "category",
+    },
+    "yAxis": {
+      "axisLabel": {
+        "color": "#475569",
+      },
+      "axisLine": {
+        "lineStyle": {
+          "color": "#e2e8f0",
+        },
+      },
+      "axisTick": {
+        "lineStyle": {
+          "color": "#e2e8f0",
+        },
+      },
+      "name": undefined,
+      "nameTextStyle": {
+        "color": "#0f172a",
+      },
+      "splitLine": {
+        "lineStyle": {
+          "color": "#e2e8f0",
+          "opacity": 0.5,
+        },
+      },
+      "type": "value",
+    },
+  },
+}
+`;

--- a/saiku-ui/src/lib/charts/build.test.ts
+++ b/saiku-ui/src/lib/charts/build.test.ts
@@ -1,0 +1,345 @@
+/*
+ * Unit tests for the single canonical chart-option builder (#1076).
+ *
+ * Covers all 15 chart types, both presentation modes (compact = dashboard
+ * tiles, non-compact = workspace), and the features that previously only
+ * existed on the workspace path (dual-axis split, trend lines) — now shared.
+ */
+
+import { describe, test, expect } from "vitest";
+import { buildChartOption, type ChartProjection } from "$lib/charts/build";
+import { DEFAULT_CHART_OPTIONS, type ChartOptions } from "$lib/views/chartTypes";
+
+/** Two row categories × two measures. */
+function sample(): ChartProjection {
+  return {
+    rowCategories: ["1997", "1998"],
+    columnCategories: ["Store Sales", "Unit Sales"],
+    matrix: [
+      [565238.13, 266773],
+      [612482.65, 282417],
+    ],
+  };
+}
+
+/** Single measure (the small-multiples M=1 case). */
+function singleMeasure(): ChartProjection {
+  return {
+    rowCategories: ["1997", "1998"],
+    columnCategories: ["Store Sales"],
+    matrix: [[1], [2]],
+  };
+}
+
+function opts(over: Partial<ChartOptions> = {}): ChartOptions {
+  return { ...DEFAULT_CHART_OPTIONS, ...over };
+}
+
+const ALL_TYPES = [
+  "bar",
+  "stackedBar",
+  "line",
+  "stackedLine",
+  "area",
+  "stackedArea",
+  "pie",
+  "donut",
+  "heatmap",
+  "radar",
+  "scatter",
+  "bubble",
+  "treemap",
+  "sunburst",
+  "waterfall",
+] as const;
+
+describe("buildChartOption — coverage of all 15 types", () => {
+  test("every supported type produces a non-null option with series (both modes)", () => {
+    for (const t of ALL_TYPES) {
+      for (const compact of [false, true]) {
+        const opt = buildChartOption(sample(), t, opts(), undefined, { compact });
+        expect(opt, `${t} compact=${compact}`).not.toBeNull();
+        expect(Array.isArray((opt as Record<string, unknown>).series)).toBe(true);
+      }
+    }
+  });
+
+  test("snapshot of every type's structure (non-compact / workspace)", () => {
+    const out: Record<string, unknown> = {};
+    for (const t of ALL_TYPES) {
+      out[t] = buildChartOption(sample(), t, opts(), undefined, { compact: false });
+    }
+    expect(out).toMatchSnapshot();
+  });
+
+  test("snapshot of every type's structure (compact / dashboard)", () => {
+    const out: Record<string, unknown> = {};
+    for (const t of ALL_TYPES) {
+      out[t] = buildChartOption(sample(), t, opts(), undefined, { compact: true });
+    }
+    expect(out).toMatchSnapshot();
+  });
+});
+
+describe("buildChartOption — cartesian (bar/line/area)", () => {
+  test("bar emits a category xAxis + one series per measure", () => {
+    const opt = buildChartOption(sample(), "bar", opts({ dualAxis: false })) as Record<string, unknown>;
+    const xAxis = opt.xAxis as { data: string[]; type: string };
+    expect(xAxis.type).toBe("category");
+    expect(xAxis.data).toEqual(["1997", "1998"]);
+    const series = opt.series as Array<{ name: string; type: string; data: (number | null)[] }>;
+    expect(series).toHaveLength(2);
+    expect(series[0].name).toBe("Store Sales");
+    expect(series[0].type).toBe("bar");
+    expect(series[0].data).toEqual([565238.13, 612482.65]);
+    expect(series[1].data).toEqual([266773, 282417]);
+  });
+
+  test("single-axis stacked uses one 'total' stack group", () => {
+    const opt = buildChartOption(sample(), "stackedBar", opts({ dualAxis: false })) as Record<string, unknown>;
+    const series = opt.series as Array<{ stack?: string }>;
+    expect(series.every((s) => s.stack === "total")).toBe(true);
+  });
+
+  test("line uses type=line, no areaStyle; area adds areaStyle", () => {
+    const line = buildChartOption(sample(), "line", opts()) as Record<string, unknown>;
+    const ls = line.series as Array<{ type: string; areaStyle?: object }>;
+    expect(ls[0].type).toBe("line");
+    expect(ls[0].areaStyle).toBeUndefined();
+    const area = buildChartOption(sample(), "area", opts()) as Record<string, unknown>;
+    const as = area.series as Array<{ areaStyle?: object }>;
+    expect(as[0].areaStyle).toBeDefined();
+  });
+
+  test("compact draws missing cells as gaps (null); non-compact as 0", () => {
+    const gappy: ChartProjection = {
+      rowCategories: ["a", "b"],
+      columnCategories: ["m"],
+      matrix: [[null], [5]],
+    };
+    const compact = buildChartOption(gappy, "bar", opts({ dualAxis: false }), undefined, {
+      compact: true,
+    }) as Record<string, unknown>;
+    const roomy = buildChartOption(gappy, "bar", opts({ dualAxis: false }), undefined, {
+      compact: false,
+    }) as Record<string, unknown>;
+    expect((compact.series as Array<{ data: (number | null)[] }>)[0].data).toEqual([null, 5]);
+    expect((roomy.series as Array<{ data: (number | null)[] }>)[0].data).toEqual([0, 5]);
+  });
+});
+
+describe("buildChartOption — dual axis (#1076 brings this to both surfaces)", () => {
+  // Unit Sales magnitudes here are >1% of Store Sales, so they stay on one axis;
+  // a tiny second series drops to the right axis.
+  const disparate: ChartProjection = {
+    rowCategories: ["a", "b"],
+    columnCategories: ["Big", "Tiny"],
+    matrix: [
+      [100000, 1],
+      [120000, 2],
+    ],
+  };
+
+  test("dualAxis=true splits a crushed low-magnitude series to a right axis", () => {
+    const opt = buildChartOption(disparate, "bar", opts({ dualAxis: true })) as Record<string, unknown>;
+    expect(Array.isArray(opt.yAxis)).toBe(true);
+    const yAxis = opt.yAxis as Array<{ position: string }>;
+    expect(yAxis).toHaveLength(2);
+    expect(yAxis[0].position).toBe("left");
+    expect(yAxis[1].position).toBe("right");
+    const series = opt.series as Array<{ name: string; yAxisIndex: number }>;
+    expect(series.find((s) => s.name === "Big")?.yAxisIndex).toBe(0);
+    expect(series.find((s) => s.name === "Tiny")?.yAxisIndex).toBe(1);
+  });
+
+  test("dualAxis=false keeps a single y-axis", () => {
+    const opt = buildChartOption(disparate, "bar", opts({ dualAxis: false })) as Record<string, unknown>;
+    expect(Array.isArray(opt.yAxis)).toBe(false);
+    const series = opt.series as Array<{ yAxisIndex: number }>;
+    expect(series.every((s) => s.yAxisIndex === 0)).toBe(true);
+  });
+
+  test("explicit per-series pin overrides the auto decision", () => {
+    const opt = buildChartOption(
+      sample(),
+      "bar",
+      opts({ dualAxis: false, seriesAxis: { "Unit Sales": "right" } }),
+    ) as Record<string, unknown>;
+    const yAxis = opt.yAxis as Array<{ position: string }>;
+    expect(Array.isArray(yAxis)).toBe(true);
+    const series = opt.series as Array<{ name: string; yAxisIndex: number }>;
+    expect(series.find((s) => s.name === "Unit Sales")?.yAxisIndex).toBe(1);
+  });
+});
+
+describe("buildChartOption — trend lines (#1076 brings this to both surfaces)", () => {
+  const ts: ChartProjection = {
+    rowCategories: ["a", "b", "c", "d"],
+    columnCategories: ["m"],
+    matrix: [[1], [2], [3], [4]],
+  };
+
+  test("linear trend appends a dashed line series labelled '(trend)'", () => {
+    const opt = buildChartOption(ts, "line", opts({ trendLine: "linear" })) as Record<string, unknown>;
+    const series = opt.series as Array<{ name: string; type: string; lineStyle?: { type: string } }>;
+    // 1 data series + 1 trend series.
+    expect(series).toHaveLength(2);
+    const trend = series[1];
+    expect(trend.name).toBe("m (trend)");
+    expect(trend.type).toBe("line");
+    expect(trend.lineStyle?.type).toBe("dashed");
+  });
+
+  test("moving average names the series with its period", () => {
+    const opt = buildChartOption(ts, "line", opts({ trendLine: "ma", trendPeriod: 3 })) as Record<
+      string,
+      unknown
+    >;
+    const series = opt.series as Array<{ name: string }>;
+    expect(series[1].name).toBe("m (MA3)");
+  });
+
+  test("trendLine=none adds no extra series", () => {
+    const opt = buildChartOption(ts, "line", opts({ trendLine: "none" })) as Record<string, unknown>;
+    expect((opt.series as unknown[]).length).toBe(1);
+  });
+
+  test("bar charts never get a trend series (line-only)", () => {
+    const opt = buildChartOption(ts, "bar", opts({ trendLine: "linear" })) as Record<string, unknown>;
+    expect((opt.series as unknown[]).length).toBe(1);
+  });
+});
+
+describe("buildChartOption — title & legend", () => {
+  test("non-compact honours a user title + legend position", () => {
+    const opt = buildChartOption(sample(), "bar", opts({ title: "My chart", legendPosition: "bottom" })) as Record<
+      string,
+      unknown
+    >;
+    expect((opt.title as { text: string }).text).toBe("My chart");
+    expect((opt.legend as { bottom: number }).bottom).toBe(10);
+  });
+
+  test("compact ignores legendPosition and pins a bottom scroll legend", () => {
+    const opt = buildChartOption(sample(), "bar", opts({ legendPosition: "left" }), undefined, {
+      compact: true,
+    }) as Record<string, unknown>;
+    const legend = opt.legend as { type: string; bottom: number };
+    expect(legend.type).toBe("scroll");
+    expect(legend.bottom).toBe(0);
+  });
+
+  test("compact pie merges no overall title — just per-measure cell titles", () => {
+    const opt = buildChartOption(sample(), "pie", opts({ title: "" }), undefined, {
+      compact: true,
+    }) as Record<string, unknown>;
+    const titles = opt.title as Array<{ text: string }>;
+    expect(titles.map((t) => t.text)).toEqual(["Store Sales", "Unit Sales"]);
+  });
+
+  test("non-compact pie prepends the user title to the cell titles", () => {
+    const opt = buildChartOption(sample(), "pie", opts({ title: "Overall" })) as Record<string, unknown>;
+    const titles = opt.title as Array<{ text: string }>;
+    expect(titles.map((t) => t.text)).toEqual(["Overall", "Store Sales", "Unit Sales"]);
+  });
+});
+
+describe("buildChartOption — small multiples (pie/donut/treemap/sunburst)", () => {
+  test("2-measure pie fans out into 2 series, each sliced by row category", () => {
+    const opt = buildChartOption(sample(), "pie", opts()) as Record<string, unknown>;
+    const series = opt.series as Array<{ type: string; name: string; data: { name: string; value: number }[] }>;
+    expect(series).toHaveLength(2);
+    expect(series.every((s) => s.type === "pie")).toBe(true);
+    expect(series.map((s) => s.name)).toEqual(["Store Sales", "Unit Sales"]);
+    expect(series[0].data.map((d) => d.name)).toEqual(["1997", "1998"]);
+    expect(series[0].data[0].value).toBeCloseTo(565238.13, 2);
+  });
+
+  test("1-measure pie renders a single chart with a single title", () => {
+    const opt = buildChartOption(singleMeasure(), "pie", opts()) as Record<string, unknown>;
+    const series = opt.series as Array<{ type: string }>;
+    expect(series).toHaveLength(1);
+    expect((opt.title as unknown[]).length).toBe(1);
+  });
+
+  test("donut keeps a non-zero inner radius", () => {
+    const opt = buildChartOption(sample(), "donut", opts()) as Record<string, unknown>;
+    const series = opt.series as Array<{ radius: (string | number)[] }>;
+    expect(Array.isArray(series[0].radius)).toBe(true);
+    expect(parseFloat(String(series[0].radius[0]))).toBeGreaterThan(0);
+  });
+
+  test("treemap fans out one series per measure, items = rows", () => {
+    const opt = buildChartOption(sample(), "treemap", opts()) as Record<string, unknown>;
+    const series = opt.series as Array<{ type: string; data: { name: string; value: number }[] }>;
+    expect(series).toHaveLength(2);
+    expect(series.every((s) => s.type === "treemap")).toBe(true);
+    expect(series[0].data[0].name).toBe("1997");
+  });
+});
+
+describe("buildChartOption — matrix types (heatmap/radar/scatter/waterfall)", () => {
+  test("heatmap emits [col,row,value] tuples + a visualMap", () => {
+    const opt = buildChartOption(sample(), "heatmap", opts()) as Record<string, unknown>;
+    const series = opt.series as Array<{ type: string; data: [number, number, number][] }>;
+    expect(series[0].type).toBe("heatmap");
+    expect(series[0].data).toHaveLength(4);
+    expect(opt.visualMap).toBeDefined();
+  });
+
+  test("radar uses cols as indicators + rows as series entries", () => {
+    const opt = buildChartOption(sample(), "radar", opts()) as Record<string, unknown>;
+    const radar = opt.radar as { indicator: { name: string }[] };
+    expect(radar.indicator.map((i) => i.name)).toEqual(["Store Sales", "Unit Sales"]);
+    const series = opt.series as Array<{ data: unknown[] }>;
+    expect(series[0].data).toHaveLength(2);
+  });
+
+  test("waterfall emits three stacked series (spacer + pos + neg)", () => {
+    const opt = buildChartOption(sample(), "waterfall", opts()) as Record<string, unknown>;
+    const series = opt.series as Array<{ stack: string }>;
+    expect(series).toHaveLength(3);
+    expect(series.every((s) => s.stack === "waterfall")).toBe(true);
+  });
+});
+
+describe("buildChartOption — theme tokens", () => {
+  const dark = {
+    fg: "#e5e7eb",
+    fgMuted: "#9ca3af",
+    bg: "#0b1220",
+    bgMuted: "#111827",
+    border: "#334155",
+    accent: "#818cf8",
+    chartColors: ["#aaa111", "#bbb222"],
+  };
+
+  test("bar threads palette + text/axis/tooltip colours from tk", () => {
+    const opt = buildChartOption(sample(), "bar", opts(), dark) as Record<string, unknown>;
+    expect(opt.backgroundColor).toBe("transparent");
+    expect(opt.color).toEqual(dark.chartColors);
+    expect((opt.textStyle as { color: string }).color).toBe("#e5e7eb");
+    const xAxis = opt.xAxis as { axisLabel: { color: string }; axisLine: { lineStyle: { color: string } } };
+    expect(xAxis.axisLabel.color).toBe("#9ca3af");
+    expect(xAxis.axisLine.lineStyle.color).toBe("#334155");
+    const tooltip = opt.tooltip as { backgroundColor: string; textStyle: { color: string } };
+    expect(tooltip.backgroundColor).toBe("#0b1220");
+    expect(tooltip.textStyle.color).toBe("#e5e7eb");
+  });
+
+  test("defaults to the light fallback when tk is omitted", () => {
+    const opt = buildChartOption(sample(), "bar", opts()) as Record<string, unknown>;
+    expect((opt.textStyle as { color: string }).color).toBe("#0f172a");
+  });
+});
+
+describe("buildChartOption — rejection", () => {
+  test("returns null for unknown chart kinds", () => {
+    expect(buildChartOption(sample(), "made-up")).toBeNull();
+    expect(buildChartOption(sample(), "")).toBeNull();
+  });
+
+  test("returns null when the projection has no rows", () => {
+    expect(buildChartOption({ rowCategories: [], columnCategories: [], matrix: [] }, "bar")).toBeNull();
+  });
+});

--- a/saiku-ui/src/lib/charts/build.ts
+++ b/saiku-ui/src/lib/charts/build.ts
@@ -1,0 +1,524 @@
+/*
+ * The single, canonical chart-option builder for Saiku (#1076).
+ *
+ * Before this module the workspace (ChartView.svelte) and the dashboard
+ * (chartOptions.ts) each re-implemented the same 15 ECharts chart types with
+ * subtly different configs — so dashboard tiles silently lacked dual-axis,
+ * trend lines and rollup filtering, and every new feature meant two PRs that
+ * kept drifting. This builder is the one place both surfaces go through.
+ *
+ * Both surfaces project their native result shape into a {@link ChartProjection}
+ * ({rowCategories, columnCategories, matrix}) and call buildChartOption() with
+ * the full {@link ChartOptions}, the active {@link ThemeTokens}, and a
+ * {@link ChartGeometry}. The two surfaces differ only in *presentation density*,
+ * captured by the single `compact` geometry flag:
+ *
+ *   - workspace (compact = false): roomy grid margins, configurable legend,
+ *     geometry-derived axis-label truncation width, missing values drawn as 0.
+ *   - dashboard tiles (compact = true): tile-tight margins, bottom scroll
+ *     legend, fixed label width (+rotate when crowded), missing values as gaps.
+ *
+ * Surface-specific concerns stay OUT of here: cellset/AiQueryResponse parsing,
+ * rollup-row filtering (needs cellset depth), the ECharts instance lifecycle,
+ * click→drillthrough, host sizing, and reading live theme tokens from the DOM.
+ *
+ * Pure: no DOM, no fetches, no ECharts import. Tests live alongside.
+ */
+
+import type { ChartType, ChartOptions } from "$lib/views/chartTypes";
+import { DEFAULT_CHART_OPTIONS, SERIES_AXIS_THRESHOLD, isChartType } from "$lib/views/chartTypes";
+import { assignSeriesAxes } from "$lib/views/cellsetUtils";
+import { axisLabelConfig, deriveAxisLabelWidth } from "$lib/views/chartAxisLabel";
+import { cellRadiusPct, gridCells, MAX_LABELLED_SLICES } from "$lib/dashboard/smallMultiples";
+import { type ThemeTokens, DEFAULT_THEME_TOKENS } from "$lib/views/chartTheme";
+
+/** The shared, already-projected chart input both surfaces produce. Rollup
+ *  rows are filtered (and parent context promoted into labels) by the caller
+ *  BEFORE projection — the builder treats `rowCategories`/`matrix` as final. */
+export interface ChartProjection {
+  /** Category labels — one per row (the x-axis categories / pie slices). */
+  rowCategories: string[];
+  /** Series labels — one per measure column (the legend entries). */
+  columnCategories: string[];
+  /** Values: matrix[row][col]. `null` = a genuinely missing cell. */
+  matrix: (number | null)[][];
+}
+
+/** Canvas geometry + presentation density. `aspect` (w/h) keeps small-multiple
+ *  radii on-screen-constant; `chartWidth` drives derived axis-label width in the
+ *  roomy (non-compact) mode; `compact` selects the dashboard-tile cosmetics. */
+export interface ChartGeometry {
+  aspect?: number;
+  chartWidth?: number;
+  compact?: boolean;
+}
+
+/* ----------------------------- helpers ----------------------------- */
+
+function legendConfig(o: ChartOptions, tk: ThemeTokens): Record<string, unknown> {
+  if (!o.showLegend) return { show: false };
+  const position: Record<string, unknown> = { textStyle: { color: tk.fg } };
+  if (o.legendPosition === "top") position.top = 10;
+  else if (o.legendPosition === "bottom") position.bottom = 10;
+  else if (o.legendPosition === "left") {
+    position.left = 10;
+    position.top = "middle";
+    position.orient = "vertical";
+  } else if (o.legendPosition === "right") {
+    position.right = 10;
+    position.top = "middle";
+    position.orient = "vertical";
+  }
+  return position;
+}
+
+function titleConfig(o: ChartOptions, tk: ThemeTokens): Record<string, unknown> | undefined {
+  if (!o.title) return undefined;
+  return { text: o.title, left: "center", textStyle: { color: tk.fg } };
+}
+
+function linearRegression(vals: (number | null)[]): number[] {
+  const n = vals.length;
+  let sumX = 0,
+    sumY = 0,
+    sumXY = 0,
+    sumXX = 0,
+    count = 0;
+  for (let i = 0; i < n; i++) {
+    const y = vals[i];
+    if (y == null || !Number.isFinite(y)) continue;
+    sumX += i;
+    sumY += y;
+    sumXY += i * y;
+    sumXX += i * i;
+    count += 1;
+  }
+  if (count < 2) return vals.map(() => 0);
+  const meanX = sumX / count;
+  const meanY = sumY / count;
+  const denom = sumXX - sumX * meanX;
+  const slope = denom === 0 ? 0 : (sumXY - sumX * meanY) / denom;
+  const intercept = meanY - slope * meanX;
+  return vals.map((_, i) => slope * i + intercept);
+}
+
+function movingAverage(vals: (number | null)[], period: number): (number | null)[] {
+  const out: (number | null)[] = [];
+  for (let i = 0; i < vals.length; i++) {
+    if (i < period - 1) {
+      out.push(null);
+      continue;
+    }
+    let sum = 0;
+    let c = 0;
+    for (let k = i - period + 1; k <= i; k++) {
+      const v = vals[k];
+      if (v != null && Number.isFinite(v)) {
+        sum += v;
+        c += 1;
+      }
+    }
+    out.push(c ? sum / c : null);
+  }
+  return out;
+}
+
+function weightedMovingAverage(vals: (number | null)[], period: number): (number | null)[] {
+  const out: (number | null)[] = [];
+  for (let i = 0; i < vals.length; i++) {
+    if (i < period - 1) {
+      out.push(null);
+      continue;
+    }
+    let num = 0,
+      den = 0;
+    for (let k = 0; k < period; k++) {
+      const v = vals[i - period + 1 + k];
+      if (v != null && Number.isFinite(v)) {
+        num += (k + 1) * v;
+        den += k + 1;
+      }
+    }
+    out.push(den ? num / den : null);
+  }
+  return out;
+}
+
+function trendSeries(
+  name: string,
+  vals: (number | null)[],
+  o: ChartOptions,
+  tk: ThemeTokens,
+): Record<string, unknown>[] {
+  if (o.trendLine === "none") return [];
+  const period = Math.max(2, o.trendPeriod || 3);
+  let data: (number | null)[] = [];
+  let seriesName = name;
+  if (o.trendLine === "linear") {
+    data = linearRegression(vals);
+    seriesName = `${name} (trend)`;
+  } else if (o.trendLine === "ma") {
+    data = movingAverage(vals, period);
+    seriesName = `${name} (MA${period})`;
+  } else if (o.trendLine === "wma") {
+    data = weightedMovingAverage(vals, period);
+    seriesName = `${name} (WMA${period})`;
+  }
+  return [
+    {
+      type: "line",
+      name: seriesName,
+      data,
+      smooth: true,
+      showSymbol: false,
+      lineStyle: { type: "dashed", width: 2, color: tk.fgMuted },
+      itemStyle: { color: tk.fgMuted },
+    },
+  ];
+}
+
+/* ----------------------------- builder ----------------------------- */
+
+/**
+ * Build an ECharts option object for one chart, from an already-projected
+ * {@link ChartProjection}. Returns null when the kind isn't supported or the
+ * projection has no rows.
+ *
+ * @param projection rows/cols/matrix (rollup-filtered by the caller)
+ * @param type       one of the 15 supported chart types
+ * @param options    full ChartOptions (title/legend/axes/trend/dual-axis)
+ * @param tk         active theme tokens (text/axis/palette colours)
+ * @param geom       canvas geometry + the `compact` density flag
+ */
+export function buildChartOption(
+  projection: ChartProjection,
+  type: ChartType | string,
+  options: ChartOptions = DEFAULT_CHART_OPTIONS,
+  tk: ThemeTokens = DEFAULT_THEME_TOKENS,
+  geom: ChartGeometry = {},
+): Record<string, unknown> | null {
+  if (!isChartType(type)) return null;
+  const t: ChartType = type;
+  const rows = projection.rowCategories;
+  const cols = projection.columnCategories;
+  const matrix = projection.matrix;
+  if (matrix.length === 0) return null;
+
+  const o = options;
+  const compact = geom.compact ?? false;
+  const aspect = Number.isFinite(geom.aspect) && (geom.aspect ?? 0) > 0 ? (geom.aspect as number) : 1;
+
+  // Theme-derived fragments — identical across both surfaces.
+  const common = {
+    backgroundColor: "transparent",
+    color: tk.chartColors,
+    textStyle: { color: tk.fg },
+  };
+  const axisLabel = { color: tk.fgMuted };
+  const axisLine = { lineStyle: { color: tk.border } };
+  const axisTick = { lineStyle: { color: tk.border } };
+  const splitLine = { lineStyle: { color: tk.border, opacity: 0.5 } };
+  const nameTextStyle = { color: tk.fg };
+  const tooltipStyle = { backgroundColor: tk.bg, borderColor: tk.border, textStyle: { color: tk.fg } };
+
+  // Category-axis label: compact uses a fixed truncation width (tiles are
+  // small); roomy mode derives the per-label width from the canvas width and
+  // category count. `rotate` is only used by the compact bar branch when
+  // categories crowd. The full label always shows in the axis-pointer tooltip.
+  const catCount = Math.max(rows.length, cols.length, 1);
+  const catLabelWidth = compact ? 100 : deriveAxisLabelWidth(geom.chartWidth ?? 0, catCount);
+  const catLabel = (rotate = 0) => ({ color: tk.fgMuted, rotate, ...axisLabelConfig(catLabelWidth) });
+
+  const legend = compact
+    ? o.showLegend
+      ? { type: "scroll", bottom: 0, textStyle: { color: tk.fg } }
+      : { show: false }
+    : legendConfig(o, tk);
+  const title = titleConfig(o, tk);
+  const xName = o.xAxisLabel || undefined;
+  const yName = o.yAxisLabel || undefined;
+
+  const baseAxis = { type: "category" as const, axisLabel, axisLine, axisTick, splitLine, nameTextStyle };
+  const valueAxis = { type: "value" as const, axisLabel, axisLine, axisTick, splitLine, nameTextStyle };
+
+  // Pie / donut / treemap / sunburst encode a SINGLE measure. With M measures
+  // we fan out into M small-multiple charts — one per measure — laid out in a
+  // grid inside the same option (M series, one per cell). M=1 is a single chart.
+  if (t === "pie" || t === "donut" || t === "treemap" || t === "sunburst") {
+    const cells = gridCells(cols.length);
+    const cellTitles = cells.map((cell, m) => ({
+      text: cols[m],
+      left: cell.centerXPct + "%",
+      top: cell.topPct + "%",
+      textAlign: "center" as const,
+      textStyle: { color: tk.fg, fontSize: 12 },
+    }));
+    const titles = title ? [title, ...cellTitles] : cellTitles;
+    // Name slices directly when few enough to read; else lean on the tooltip.
+    // Inside the slices for a small-multiple grid (leader lines would cross
+    // between neighbours); outside for a single chart where there's room.
+    const showSliceLabels = rows.length <= MAX_LABELLED_SLICES;
+    const sliceLabelInside = cells.length > 1;
+
+    if (t === "pie" || t === "donut") {
+      return {
+        ...common,
+        title: titles,
+        tooltip: { trigger: "item", ...tooltipStyle },
+        series: cells.map((cell, m) => {
+          const outer = cellRadiusPct(cell, aspect);
+          return {
+            type: "pie",
+            name: cols[m],
+            radius: t === "donut" ? [outer * 0.55 + "%", outer + "%"] : [0, outer + "%"],
+            center: [cell.centerXPct + "%", cell.centerYPct + "%"],
+            label: {
+              show: showSliceLabels,
+              position: sliceLabelInside ? "inside" : "outside",
+              formatter: "{b}",
+              color: sliceLabelInside ? "#fff" : tk.fg,
+            },
+            labelLine: { show: showSliceLabels && !sliceLabelInside },
+            data: rows.map((name, i) => ({ name, value: matrix[i][m] ?? 0 })),
+          };
+        }),
+      };
+    }
+
+    if (t === "treemap") {
+      return {
+        ...common,
+        title: titles,
+        tooltip: tooltipStyle,
+        series: cells.map((cell, m) => ({
+          type: "treemap",
+          name: cols[m],
+          left: cell.leftPct + "%",
+          top: cell.topPct + cell.heightPct * 0.18 + "%",
+          width: cell.widthPct + "%",
+          height: cell.heightPct * 0.82 + "%",
+          label: { color: "#fff" },
+          breadcrumb: { show: false },
+          data: rows.map((name, i) => ({ name, value: matrix[i][m] ?? 0 })).filter((d) => d.value > 0),
+        })),
+      };
+    }
+
+    // sunburst
+    return {
+      ...common,
+      title: titles,
+      tooltip: tooltipStyle,
+      series: cells.map((cell, m) => ({
+        type: "sunburst",
+        name: cols[m],
+        center: [cell.centerXPct + "%", cell.centerYPct + "%"],
+        radius: [0, cellRadiusPct(cell, aspect) + "%"],
+        label: { show: showSliceLabels, color: "#fff" },
+        data: rows.map((name, i) => ({ name, value: matrix[i][m] ?? 0 })).filter((d) => d.value > 0),
+      })),
+    };
+  }
+
+  if (t === "heatmap") {
+    const data: [number, number, number][] = [];
+    for (let i = 0; i < matrix.length; i++) {
+      for (let j = 0; j < (matrix[i]?.length ?? 0); j++) {
+        data.push([j, i, matrix[i][j] ?? 0]);
+      }
+    }
+    const values = data.map((d) => d[2]);
+    const min = values.length ? Math.min(...values) : 0;
+    const max = values.length ? Math.max(...values) : 1;
+    return {
+      ...common,
+      title,
+      tooltip: tooltipStyle,
+      grid: compact
+        ? { left: 120, top: 24, right: 16, bottom: 64 }
+        : { left: 120, top: 40, right: 40, bottom: 80 },
+      xAxis: { ...baseAxis, axisLabel: catLabel(), data: cols, name: xName },
+      yAxis: { ...baseAxis, data: rows, inverse: true, name: yName },
+      visualMap: {
+        min,
+        max,
+        calculable: true,
+        orient: "horizontal",
+        left: "center",
+        bottom: compact ? 8 : 10,
+        textStyle: { color: tk.fgMuted },
+      },
+      series: [
+        { type: "heatmap", data, label: { show: false }, emphasis: { itemStyle: { shadowBlur: 10 } } },
+      ],
+    };
+  }
+
+  if (t === "radar") {
+    const max = Math.max(0, ...matrix.flatMap((r) => r.map((v) => Math.abs(v ?? 0))));
+    return {
+      ...common,
+      title,
+      tooltip: tooltipStyle,
+      legend,
+      radar: {
+        indicator: cols.map((c) => ({ name: c, max: max || 1 })),
+        axisName: { color: tk.fgMuted },
+        axisLine: { lineStyle: { color: tk.border } },
+        splitLine: { lineStyle: { color: tk.border, opacity: 0.5 } },
+        splitArea: { areaStyle: { color: [tk.bg, tk.bgMuted], opacity: 0.3 } },
+      },
+      series: [
+        { type: "radar", data: rows.map((r, i) => ({ name: r, value: matrix[i].map((v) => v ?? 0) })) },
+      ],
+    };
+  }
+
+  if (t === "scatter" || t === "bubble") {
+    const bubbleMax = Math.max(1, ...matrix.flatMap((r) => r.map((v) => Math.abs(v ?? 0))));
+    return {
+      ...common,
+      title,
+      tooltip: tooltipStyle,
+      legend,
+      xAxis: { ...baseAxis, axisLabel: catLabel(), data: cols, name: xName },
+      yAxis: { ...valueAxis, name: yName },
+      series: rows.map((name, i) => ({
+        type: "scatter",
+        name,
+        symbolSize:
+          t === "bubble"
+            ? (val: unknown) => {
+                const v = Array.isArray(val) ? (val[1] as number) : (val as number);
+                return Math.max(6, Math.sqrt(Math.abs(v) / bubbleMax) * 40);
+              }
+            : 10,
+        data: matrix[i].map((v, j) => [j, v ?? 0]),
+      })),
+    };
+  }
+
+  if (t === "waterfall") {
+    const vals = matrix.map((r) => r[0] ?? 0);
+    const spacers: number[] = [];
+    const positives: (number | null)[] = [];
+    const negatives: (number | null)[] = [];
+    let running = 0;
+    for (const v of vals) {
+      if (v >= 0) {
+        spacers.push(running);
+        positives.push(v);
+        negatives.push(null);
+      } else {
+        spacers.push(running + v);
+        positives.push(null);
+        negatives.push(-v);
+      }
+      running += v;
+    }
+    return {
+      ...common,
+      title,
+      tooltip: { trigger: "axis", ...tooltipStyle },
+      legend,
+      grid: compact
+        ? { top: 24, left: 48, right: 16, bottom: 36 }
+        : { left: 60, top: title ? 50 : 30, right: 40, bottom: 60 },
+      xAxis: { ...baseAxis, axisLabel: catLabel(), data: rows, name: xName },
+      yAxis: { ...valueAxis, name: yName },
+      series: [
+        {
+          type: "bar",
+          name: "",
+          stack: "waterfall",
+          itemStyle: { borderColor: "transparent", color: "transparent" },
+          emphasis: { itemStyle: { borderColor: "transparent", color: "transparent" } },
+          data: spacers,
+        },
+        {
+          type: "bar",
+          name: cols[0] ?? "Positive",
+          stack: "waterfall",
+          data: positives,
+          itemStyle: { color: "#4c9ee6" },
+        },
+        {
+          type: "bar",
+          name: `-${cols[0] ?? "Negative"}`,
+          stack: "waterfall",
+          data: negatives,
+          itemStyle: { color: "#e66c6c" },
+        },
+      ],
+    };
+  }
+
+  // bar / stackedBar / line / stackedLine / area / stackedArea
+  const isStacked = t.startsWith("stacked");
+  // includes("bar") is case-sensitive — "stackedBar" has a capital B, so the
+  // naive check returned false and stacked-bar fell through to the line branch.
+  const lower = t.toLowerCase();
+  const kindBase: "bar" | "line" = lower.includes("bar") ? "bar" : "line";
+  const areaStyle = t === "area" || t === "stackedArea" ? {} : undefined;
+
+  // Dual y-axis: auto-split low-magnitude series to the right so a dominant
+  // series doesn't crush them to the zero line (Event Count in thousands vs
+  // Avg Tone in single digits). Per-series picks in o.seriesAxis always win;
+  // o.dualAxis=false reverts to single-axis. assignSeriesAxes returns all-left
+  // when dualAxis is off, so hasRight is false and we emit a single y-axis.
+  const seriesSides = assignSeriesAxes(cols, matrix, {
+    dualAxis: o.dualAxis,
+    seriesAxis: o.seriesAxis,
+    threshold: SERIES_AXIS_THRESHOLD,
+  });
+  const hasRight = seriesSides.some((s) => s === "right");
+  const yAxis = hasRight
+    ? [
+        { ...valueAxis, name: yName, position: "left" as const },
+        // Drop the right axis's splitLine so left-axis gridlines aren't doubled.
+        { ...valueAxis, name: undefined, position: "right" as const, splitLine: { show: false } },
+      ]
+    : { ...valueAxis, name: yName };
+
+  const base = cols.map((name, c) => ({
+    type: kindBase,
+    name,
+    // Single-axis stacked → one "total" group (matches both surfaces' prior
+    // output); dual-axis stacked → separate groups per side so each axis stacks
+    // independently.
+    stack: isStacked
+      ? hasRight
+        ? seriesSides[c] === "right"
+          ? "total-right"
+          : "total-left"
+        : "total"
+      : undefined,
+    areaStyle,
+    smooth: kindBase === "line",
+    yAxisIndex: hasRight ? (seriesSides[c] === "right" ? 1 : 0) : 0,
+    // Compact (tiles) draws missing cells as gaps; roomy (workspace) as 0.
+    data: matrix.map((row) => row[c] ?? (compact ? null : 0)),
+  }));
+  const trend =
+    kindBase === "line" && cols.length > 0
+      ? trendSeries(
+          cols[0],
+          matrix.map((row) => row[0] ?? null),
+          o,
+          tk,
+        )
+      : [];
+
+  return {
+    ...common,
+    title,
+    tooltip: { trigger: "axis", ...tooltipStyle },
+    legend,
+    grid: compact
+      ? { top: 24, left: 48, right: 16, bottom: 36 }
+      : { left: 60, top: title ? 50 : 40, right: hasRight ? 60 : 40, bottom: 60 },
+    xAxis: { ...baseAxis, axisLabel: catLabel(compact && rows.length > 8 ? 30 : 0), data: rows, name: xName },
+    yAxis,
+    series: [...base, ...trend],
+  };
+}

--- a/saiku-ui/src/lib/dashboard/chartOptions.ts
+++ b/saiku-ui/src/lib/dashboard/chartOptions.ts
@@ -1,90 +1,59 @@
 /*
- * AiQueryResponse → ECharts option builder for dashboard chart tiles.
+ * AiQueryResponse → ECharts option adapter for dashboard chart tiles.
  *
- * Covers the same 15 chart types as the workspace's ChartView so the
- * dashboard offers the full palette: bar, stackedBar, line, stackedLine,
- * area, stackedArea, pie, donut, heatmap, radar, scatter, bubble,
- * treemap, sunburst, waterfall. The chart-type-specific option shapes
- * mirror ChartView's buildOption logic; the only difference is the
- * input projector (AiQueryResponse vs the workspace's CellDataSet).
+ * Since #1076 the actual ECharts option for all 15 chart types is built by the
+ * single shared builder in `$lib/charts/build` — the same one the workspace
+ * (ChartView.svelte) uses. This module is now just the dashboard *adapter*:
+ *   1. projectFromAiQueryResponse() — turn an AiQueryResponse into the shared
+ *      {rowCategories, columnCategories, matrix} projection.
+ *   2. buildChartOption() — project, then call the shared builder in `compact`
+ *      mode (tile-tight cosmetics) with the dashboard's current baseline
+ *      ChartOptions, so tiles render exactly as before.
+ *
+ * Tile-specific chart options (dual-axis, trend lines, title, …) flow in once
+ * the chart-tile editor (#1077) is wired; today the baseline reproduces the
+ * pre-#1076 dashboard look (single axis, no trend, bottom scroll legend).
  *
  * Pure: no DOM, no fetches. Tests live alongside.
  */
 
 import type { AiCell, AiQueryResponse } from "$lib/api/aiQuery";
-import { axisLabelConfig } from "$lib/views/chartAxisLabel";
-import { cellRadiusPct, gridCells, MAX_LABELLED_SLICES } from "$lib/dashboard/smallMultiples";
+import type { ChartOptions } from "$lib/views/chartTypes";
+import { DEFAULT_CHART_OPTIONS, isChartType } from "$lib/views/chartTypes";
 import { type ThemeTokens, DEFAULT_THEME_TOKENS } from "$lib/views/chartTheme";
+import { buildChartOption as buildSharedChartOption, type ChartProjection } from "$lib/charts/build";
 
-/**
- * Truncating axisLabel for a dashboard tile's category axis. Tiles are small,
- * so a fixed cap keeps deep member captions from overflowing; ECharts shows
- * the full label in the axis-pointer tooltip on hover. `rotate` is preserved
- * for callers that crowd many categories. Width default suits a tile.
- */
-function categoryAxisLabel(rotate = 0): Record<string, unknown> {
-  return { rotate, ...axisLabelConfig(100) };
-}
+/** All chart kinds the workspace exposes. Kept as an alias to the canonical
+ *  ChartType so existing imports (`import type { ChartKind }`) still resolve. */
+export type { ChartType as ChartKind } from "$lib/views/chartTypes";
 
-/** All chart kinds the workspace exposes — matches chartTypes.ts. */
-export type ChartKind =
-  | "bar"
-  | "stackedBar"
-  | "line"
-  | "stackedLine"
-  | "area"
-  | "stackedArea"
-  | "pie"
-  | "donut"
-  | "heatmap"
-  | "radar"
-  | "scatter"
-  | "bubble"
-  | "treemap"
-  | "sunburst"
-  | "waterfall";
+/** Re-exported supported-kind guard (single source of truth in chartTypes.ts). */
+export const isSupportedChartKind = isChartType;
 
-const KNOWN: ReadonlySet<string> = new Set<ChartKind>([
-  "bar",
-  "stackedBar",
-  "line",
-  "stackedLine",
-  "area",
-  "stackedArea",
-  "pie",
-  "donut",
-  "heatmap",
-  "radar",
-  "scatter",
-  "bubble",
-  "treemap",
-  "sunburst",
-  "waterfall",
-]);
-
-export function isSupportedChartKind(kind: string): kind is ChartKind {
-  return KNOWN.has(kind);
-}
-
-interface ChartProjection {
-  rowCategories: string[];
-  columnCategories: string[];
-  matrix: (number | null)[][];
-}
+/** Dashboard baseline chart options — reproduces the pre-#1076 tile look:
+ *  single y-axis, no trend line, no overall title, bottom scroll legend. The
+ *  chart-tile editor (#1077) will override these per tile. */
+const DASHBOARD_BASELINE: ChartOptions = {
+  ...DEFAULT_CHART_OPTIONS,
+  title: "",
+  trendLine: "none",
+  dualAxis: false,
+  hideRollupRows: false,
+};
 
 function isAiCell(v: unknown): v is AiCell {
   return typeof v === "object" && v !== null && "formatted" in (v as object);
 }
 
-/** Normalise an AiQueryResponse into the same {rowCategories, cols,
- *  matrix} shape ChartView's parseCellset emits — so the builder
- *  switches below match the workspace's logic 1:1. */
-function projectFromAiQueryResponse(response: AiQueryResponse): ChartProjection {
+/** Normalise an AiQueryResponse into the shared {rowCategories,
+ *  columnCategories, matrix} projection — the same shape ChartView's
+ *  parseCellset path produces, so both surfaces feed the builder identically. */
+export function projectFromAiQueryResponse(response: AiQueryResponse): ChartProjection {
   const rows = response.data ?? [];
   if (rows.length === 0) return { rowCategories: [], columnCategories: [], matrix: [] };
 
-  // Pick row-header columns (plain string keys) vs measure columns
-  // (AiCell keys) from the first row's shape — insertion order.
+  // Pick row-header columns (plain string keys) vs measure columns (AiCell
+  // keys) from the first row's shape — insertion order.
   const firstRow = rows[0];
   const headerKeys: string[] = [];
   const measureKeys: string[] = [];
@@ -108,306 +77,24 @@ function projectFromAiQueryResponse(response: AiQueryResponse): ChartProjection 
   return { rowCategories, columnCategories: measureKeys, matrix };
 }
 
-/* ----------------------------- builder ----------------------------- */
-
-/** Build an ECharts option object for the given chart kind, projected
- *  from an AiQueryResponse. Returns null when the response has no rows
- *  or the kind isn't recognised.
+/**
+ * Build an ECharts option object for a dashboard chart tile from an
+ * AiQueryResponse. Returns null when the response has no rows or the kind
+ * isn't recognised.
  *
- *  `tk` carries the active theme tokens (see chartTheme.ts) so the chart
- *  text/axes/palette repaint on a light/dark/system flip. It's optional and
- *  defaults to the light fallback so the pure callers (tests) stay DOM-free
- *  and structurally unchanged; ChartTile passes the live resolved tokens. */
+ * `aspect` (canvas w/h) keeps small-multiple radii on-screen-constant; `tk`
+ * carries the active theme tokens (chartTheme.ts) so tiles repaint on a
+ * light/dark/system flip. Both default to keep the pure callers (tests)
+ * DOM-free and structurally unchanged.
+ */
 export function buildChartOption(
   response: AiQueryResponse,
   kind: string,
   aspect = 1,
   tk: ThemeTokens = DEFAULT_THEME_TOKENS,
 ): Record<string, unknown> | null {
-  if (!isSupportedChartKind(kind)) return null;
-  const p = projectFromAiQueryResponse(response);
-  if (p.matrix.length === 0) return null;
-  const t = kind;
-
-  const rows = p.rowCategories;
-  const cols = p.columnCategories;
-  const matrix = p.matrix;
-
-  // Theme-aware shared config — mirrors ChartView.buildOption so dashboard
-  // tiles and the workspace chart colour identically. `common` themes the
-  // canvas (transparent so the tile bg shows through), the categorical
-  // palette, and default text; the axis/legend/tooltip helpers carry the
-  // fg/border tokens into each branch.
-  const common = {
-    backgroundColor: "transparent",
-    color: tk.chartColors,
-    textStyle: { color: tk.fg },
-  };
-  const axisLabel = { color: tk.fgMuted };
-  const axisLine = { lineStyle: { color: tk.border } };
-  const axisTick = { lineStyle: { color: tk.border } };
-  const splitLine = { lineStyle: { color: tk.border, opacity: 0.5 } };
-  const nameTextStyle = { color: tk.fg };
-  const legendStyle = { textStyle: { color: tk.fg } };
-  const tooltipStyle = { backgroundColor: tk.bg, borderColor: tk.border, textStyle: { color: tk.fg } };
-
-  // Pie / donut / treemap / sunburst encode a SINGLE measure. With M measures
-  // we fan out into M small-multiple charts — one per measure — laid out in a
-  // grid inside the same option (M series, one per cell). Each chart shows the
-  // row categories as its items, sized by that one measure. M=1 is just a
-  // single full-box chart (no special branch).
-  const cells = gridCells(cols.length);
-  const titles = cells.map((cell, m) => ({
-    text: cols[m],
-    left: cell.centerXPct + "%",
-    top: cell.topPct + "%",
-    textAlign: "center",
-    textStyle: { color: tk.fg, fontSize: 12 },
-  }));
-  // Category identification: a shared category legend collides with the
-  // per-measure titles and bloats off-screen once there are many categories.
-  // Instead we name the slices directly when there are few enough to read, and
-  // lean on the tooltip beyond that. Inside the slices for a small-multiple grid
-  // (leader lines would cross between neighbouring charts); outside (with leader
-  // lines) for a single chart where there's room.
-  const showSliceLabels = rows.length <= MAX_LABELLED_SLICES;
-  const sliceLabelInside = cells.length > 1;
-
-  if (t === "pie" || t === "donut") {
-    return {
-      ...common,
-      tooltip: { trigger: "item", ...tooltipStyle },
-      title: titles,
-      series: cells.map((cell, m) => {
-        const outer = cellRadiusPct(cell, aspect);
-        return {
-          type: "pie",
-          name: cols[m],
-          radius: t === "donut" ? [outer * 0.55 + "%", outer + "%"] : [0, outer + "%"],
-          center: [cell.centerXPct + "%", cell.centerYPct + "%"],
-          label: {
-            show: showSliceLabels,
-            position: sliceLabelInside ? "inside" : "outside",
-            formatter: "{b}",
-            color: sliceLabelInside ? "#fff" : tk.fg,
-          },
-          labelLine: { show: showSliceLabels && !sliceLabelInside },
-          data: rows.map((name, i) => ({ name, value: matrix[i][m] ?? 0 })),
-        };
-      }),
-    };
-  }
-
-  if (t === "treemap") {
-    return {
-      ...common,
-      tooltip: tooltipStyle,
-      title: titles,
-      series: cells.map((cell, m) => ({
-        type: "treemap",
-        name: cols[m],
-        left: cell.leftPct + "%",
-        top: cell.topPct + cell.heightPct * 0.18 + "%",
-        width: cell.widthPct + "%",
-        height: cell.heightPct * 0.82 + "%",
-        label: { color: "#fff" },
-        breadcrumb: { show: false },
-        data: rows.map((name, i) => ({ name, value: matrix[i][m] ?? 0 })).filter((d) => d.value > 0),
-      })),
-    };
-  }
-
-  if (t === "sunburst") {
-    return {
-      ...common,
-      tooltip: tooltipStyle,
-      title: titles,
-      series: cells.map((cell, m) => ({
-        type: "sunburst",
-        name: cols[m],
-        center: [cell.centerXPct + "%", cell.centerYPct + "%"],
-        radius: [0, cellRadiusPct(cell, aspect) + "%"],
-        label: { show: showSliceLabels, color: "#fff" },
-        data: rows.map((name, i) => ({ name, value: matrix[i][m] ?? 0 })).filter((d) => d.value > 0),
-      })),
-    };
-  }
-
-  if (t === "heatmap") {
-    const data: [number, number, number][] = [];
-    for (let i = 0; i < matrix.length; i++) {
-      for (let j = 0; j < (matrix[i]?.length ?? 0); j++) {
-        data.push([j, i, matrix[i][j] ?? 0]);
-      }
-    }
-    const values = data.map((d) => d[2]);
-    const min = values.length ? Math.min(...values) : 0;
-    const max = values.length ? Math.max(...values) : 1;
-    return {
-      ...common,
-      tooltip: tooltipStyle,
-      grid: { left: 120, top: 24, right: 16, bottom: 64 },
-      xAxis: {
-        type: "category",
-        data: cols,
-        axisLabel: { ...categoryAxisLabel(), color: tk.fgMuted },
-        axisLine,
-        axisTick,
-      },
-      yAxis: { type: "category", data: rows, inverse: true, axisLabel, axisLine, axisTick },
-      visualMap: {
-        min,
-        max,
-        calculable: true,
-        orient: "horizontal",
-        left: "center",
-        bottom: 8,
-        textStyle: { color: tk.fgMuted },
-      },
-      series: [{ type: "heatmap", data, label: { show: false } }],
-    };
-  }
-
-  if (t === "radar") {
-    const max = Math.max(0, ...matrix.flatMap((r) => r.map((v) => Math.abs(v ?? 0))));
-    return {
-      ...common,
-      tooltip: tooltipStyle,
-      legend: { type: "scroll", bottom: 0, ...legendStyle },
-      radar: {
-        indicator: cols.map((c) => ({ name: c, max: max || 1 })),
-        axisName: { color: tk.fgMuted },
-        axisLine: { lineStyle: { color: tk.border } },
-        splitLine: { lineStyle: { color: tk.border, opacity: 0.5 } },
-        splitArea: { areaStyle: { color: [tk.bg, tk.bgMuted], opacity: 0.3 } },
-      },
-      series: [
-        {
-          type: "radar",
-          data: rows.map((r, i) => ({ name: r, value: matrix[i].map((v) => v ?? 0) })),
-        },
-      ],
-    };
-  }
-
-  if (t === "scatter" || t === "bubble") {
-    const max = Math.max(1, ...matrix.flatMap((r) => r.map((v) => Math.abs(v ?? 0))));
-    return {
-      ...common,
-      tooltip: tooltipStyle,
-      legend: { type: "scroll", bottom: 0, ...legendStyle },
-      xAxis: {
-        type: "category",
-        data: cols,
-        axisLabel: { ...categoryAxisLabel(), color: tk.fgMuted },
-        axisLine,
-        axisTick,
-        splitLine,
-        nameTextStyle,
-      },
-      yAxis: { type: "value", axisLabel, axisLine, axisTick, splitLine, nameTextStyle },
-      series: rows.map((name, i) => ({
-        type: "scatter",
-        name,
-        symbolSize:
-          t === "bubble"
-            ? (val: unknown) => {
-                const v = Array.isArray(val) ? (val[1] as number) : (val as number);
-                return Math.max(6, Math.sqrt(Math.abs(v) / max) * 40);
-              }
-            : 10,
-        data: matrix[i].map((v, j) => [j, v ?? 0]),
-      })),
-    };
-  }
-
-  if (t === "waterfall") {
-    const vals = matrix.map((r) => r[0] ?? 0);
-    const spacers: number[] = [];
-    const positives: (number | null)[] = [];
-    const negatives: (number | null)[] = [];
-    let running = 0;
-    for (const v of vals) {
-      if (v >= 0) {
-        spacers.push(running);
-        positives.push(v);
-        negatives.push(null);
-      } else {
-        spacers.push(running + v);
-        positives.push(null);
-        negatives.push(-v);
-      }
-      running += v;
-    }
-    return {
-      ...common,
-      tooltip: { trigger: "axis", ...tooltipStyle },
-      legend: { type: "scroll", bottom: 0, ...legendStyle },
-      grid: { top: 24, left: 48, right: 16, bottom: 36 },
-      xAxis: {
-        type: "category",
-        data: rows,
-        axisLabel: { ...categoryAxisLabel(), color: tk.fgMuted },
-        axisLine,
-        axisTick,
-        splitLine,
-        nameTextStyle,
-      },
-      yAxis: { type: "value", axisLabel, axisLine, axisTick, splitLine, nameTextStyle },
-      series: [
-        {
-          type: "bar",
-          name: "",
-          stack: "waterfall",
-          itemStyle: { borderColor: "transparent", color: "transparent" },
-          emphasis: { itemStyle: { borderColor: "transparent", color: "transparent" } },
-          data: spacers,
-        },
-        {
-          type: "bar",
-          name: cols[0] ?? "Positive",
-          stack: "waterfall",
-          data: positives,
-          itemStyle: { color: "#4c9ee6" },
-        },
-        {
-          type: "bar",
-          name: `-${cols[0] ?? "Negative"}`,
-          stack: "waterfall",
-          data: negatives,
-          itemStyle: { color: "#e66c6c" },
-        },
-      ],
-    };
-  }
-
-  // bar / stackedBar / line / stackedLine / area / stackedArea
-  const isStacked = t.startsWith("stacked");
-  const lower = t.toLowerCase();
-  const kindBase: "bar" | "line" = lower.includes("bar") ? "bar" : "line";
-  const areaStyle = t === "area" || t === "stackedArea" ? {} : undefined;
-  return {
-    ...common,
-    tooltip: { trigger: "axis", ...tooltipStyle },
-    legend: { type: "scroll", bottom: 0, ...legendStyle },
-    grid: { top: 24, left: 48, right: 16, bottom: 36 },
-    xAxis: {
-      type: "category",
-      data: rows,
-      axisLabel: { ...categoryAxisLabel(rows.length > 8 ? 30 : 0), color: tk.fgMuted },
-      axisLine,
-      axisTick,
-      splitLine,
-      nameTextStyle,
-    },
-    yAxis: { type: "value", axisLabel, axisLine, axisTick, splitLine, nameTextStyle },
-    series: cols.map((name, c) => ({
-      name,
-      type: kindBase,
-      stack: isStacked ? "total" : undefined,
-      areaStyle,
-      smooth: kindBase === "line",
-      data: matrix.map((row) => row[c] ?? null),
-    })),
-  };
+  if (!isChartType(kind)) return null;
+  const projection = projectFromAiQueryResponse(response);
+  if (projection.matrix.length === 0) return null;
+  return buildSharedChartOption(projection, kind, DASHBOARD_BASELINE, tk, { aspect, compact: true });
 }

--- a/saiku-ui/src/lib/views/ChartView.svelte
+++ b/saiku-ui/src/lib/views/ChartView.svelte
@@ -2,19 +2,13 @@
   import { onMount, onDestroy } from "svelte";
   import * as echarts from "echarts";
   import type { QueryResult } from "$lib/api/query";
-  import { assignSeriesAxes, deriveLeafRows, parseCellset, toNumber } from "$lib/views/cellsetUtils";
+  import { deriveLeafRows, parseCellset, toNumber } from "$lib/views/cellsetUtils";
   import type { ChartType, ChartOptions } from "$lib/views/chartTypes";
-  import { DEFAULT_CHART_OPTIONS, SERIES_AXIS_THRESHOLD } from "$lib/views/chartTypes";
-  import { axisLabelConfig, deriveAxisLabelWidth } from "$lib/views/chartAxisLabel";
-  import {
-    cellRadiusPct,
-    gridCells,
-    isSingleMeasureKind,
-    MAX_LABELLED_SLICES,
-    smallMultipleRowCount,
-  } from "$lib/dashboard/smallMultiples";
+  import { DEFAULT_CHART_OPTIONS } from "$lib/views/chartTypes";
+  import { isSingleMeasureKind, smallMultipleRowCount } from "$lib/dashboard/smallMultiples";
   import { theme } from "$lib/stores/theme.svelte";
-  import { type ThemeTokens, resolveThemeTokens } from "$lib/views/chartTheme";
+  import { resolveThemeTokens } from "$lib/views/chartTheme";
+  import { buildChartOption } from "$lib/charts/build";
 
   interface Props {
     result: QueryResult;
@@ -35,109 +29,23 @@
     return isSingleMeasureKind(type) && measureCount > 1 ? smallMultipleRowCount(measureCount) : 1;
   });
 
-  function legendConfig(o: ChartOptions, tk: ThemeTokens) {
-    if (!o.showLegend) return { show: false };
-    const position: Record<string, unknown> = { textStyle: { color: tk.fg } };
-    if (o.legendPosition === "top") position.top = 10;
-    else if (o.legendPosition === "bottom") position.bottom = 10;
-    else if (o.legendPosition === "left") { position.left = 10; position.top = "middle"; position.orient = "vertical"; }
-    else if (o.legendPosition === "right") { position.right = 10; position.top = "middle"; position.orient = "vertical"; }
-    return position;
-  }
-
-  function titleConfig(o: ChartOptions, tk: ThemeTokens) {
-    if (!o.title) return undefined;
-    return { text: o.title, left: "center", textStyle: { color: tk.fg } };
-  }
-
-  function linearRegression(vals: (number | null)[]): number[] {
-    const n = vals.length;
-    let sumX = 0, sumY = 0, sumXY = 0, sumXX = 0, count = 0;
-    for (let i = 0; i < n; i++) {
-      const y = vals[i];
-      if (y == null || !Number.isFinite(y)) continue;
-      sumX += i;
-      sumY += y;
-      sumXY += i * y;
-      sumXX += i * i;
-      count += 1;
-    }
-    if (count < 2) return vals.map(() => 0);
-    const meanX = sumX / count;
-    const meanY = sumY / count;
-    const denom = sumXX - sumX * meanX;
-    const slope = denom === 0 ? 0 : (sumXY - sumX * meanY) / denom;
-    const intercept = meanY - slope * meanX;
-    return vals.map((_, i) => slope * i + intercept);
-  }
-
-  function movingAverage(vals: (number | null)[], period: number): (number | null)[] {
-    const out: (number | null)[] = [];
-    for (let i = 0; i < vals.length; i++) {
-      if (i < period - 1) { out.push(null); continue; }
-      let sum = 0; let c = 0;
-      for (let k = i - period + 1; k <= i; k++) {
-        const v = vals[k];
-        if (v != null && Number.isFinite(v)) { sum += v; c += 1; }
-      }
-      out.push(c ? sum / c : null);
-    }
-    return out;
-  }
-
-  function weightedMovingAverage(vals: (number | null)[], period: number): (number | null)[] {
-    const out: (number | null)[] = [];
-    for (let i = 0; i < vals.length; i++) {
-      if (i < period - 1) { out.push(null); continue; }
-      let num = 0, den = 0;
-      for (let k = 0; k < period; k++) {
-        const v = vals[i - period + 1 + k];
-        if (v != null && Number.isFinite(v)) { num += (k + 1) * v; den += k + 1; }
-      }
-      out.push(den ? num / den : null);
-    }
-    return out;
-  }
-
-  function trendSeries(name: string, vals: (number | null)[], o: ChartOptions, tk: ThemeTokens) {
-    if (o.trendLine === "none") return [];
-    const period = Math.max(2, o.trendPeriod || 3);
-    let data: (number | null)[] = [];
-    let seriesName = name;
-    if (o.trendLine === "linear") {
-      data = linearRegression(vals);
-      seriesName = `${name} (trend)`;
-    } else if (o.trendLine === "ma") {
-      data = movingAverage(vals, period);
-      seriesName = `${name} (MA${period})`;
-    } else if (o.trendLine === "wma") {
-      data = weightedMovingAverage(vals, period);
-      seriesName = `${name} (WMA${period})`;
-    }
-    return [{
-      type: "line" as const,
-      name: seriesName,
-      data,
-      smooth: true,
-      showSymbol: false,
-      lineStyle: { type: "dashed" as const, width: 2, color: tk.fgMuted },
-      itemStyle: { color: tk.fgMuted },
-    }];
-  }
-
-  function buildOption(r: QueryResult, t: ChartType, o: ChartOptions): echarts.EChartsOption {
+  // Project the workspace cellset into the shared {rows, cols, matrix} shape and
+  // delegate to the single canonical builder (#1076). The workspace is the
+  // "roomy" (non-compact) surface; rollup filtering (which needs cellset depth)
+  // happens here, before projection, since the builder treats rows as final.
+  function buildOption(r: QueryResult, t: ChartType, o: ChartOptions): Record<string, unknown> | null {
     const tk = resolveThemeTokens();
     const parsed = parseCellset(r);
-    // Multi-level row hierarchies (Year > Quarter, Country > City, …) come
-    // back with both rollup and leaf rows in the same cellset. Showing the
-    // rollups on a chart dwarfs the leaves; deriveLeafRows drops them and
-    // promotes each leaf's parent context into the label (e.g. "2024 / Q1").
-    // The grid view is untouched.
+    // Multi-level row hierarchies (Year > Quarter, Country > City, …) come back
+    // with both rollup and leaf rows in the same cellset. Showing the rollups on
+    // a chart dwarfs the leaves; deriveLeafRows drops them and promotes each
+    // leaf's parent context into the label (e.g. "2024 / Q1"). The grid view is
+    // untouched.
     let rows = parsed.rowCategories;
     let matrix: (number | null)[][] = parsed.dataRows.map((row) => row.map(toNumber));
     if (o.hideRollupRows) {
-      // deriveLeafRows is a no-op for single-level rowsets (all rows at the
-      // same depth) and for empty results, so no extra guard is needed here.
+      // deriveLeafRows is a no-op for single-level rowsets (all rows at the same
+      // depth) and for empty results, so no extra guard is needed here.
       const leaf = deriveLeafRows(parsed);
       if (leaf.indices.length > 0 && leaf.indices.length < matrix.length) {
         rows = leaf.labels;
@@ -146,310 +54,35 @@
     }
     const cols = parsed.columnCategories;
 
-    const axisLabel = { color: tk.fgMuted };
-    const axisLine = { lineStyle: { color: tk.border } };
-    const axisTick = { lineStyle: { color: tk.border } };
-    const splitLine = { lineStyle: { color: tk.border, opacity: 0.5 } };
-    const nameTextStyle = { color: tk.fg };
-
-    // Truncate long category labels (e.g. deep member captions) so they don't
-    // overflow the plot and break the layout. ECharts shows the full,
-    // untruncated label in the axis-pointer tooltip on hover. Width is derived
-    // from the available chart width divided by the number of categories.
+    // Aspect-aware radius keeps each small-multiple the same on-screen size
+    // regardless of how many there are (#1053); chartWidth drives the derived
+    // per-label axis truncation width.
+    const aspect = host && host.clientHeight > 0 ? host.clientWidth / host.clientHeight : 1;
     const chartWidth = host?.clientWidth ?? 0;
-    const catCount = Math.max(rows.length, cols.length, 1);
-    const truncLabel = {
-      color: tk.fgMuted,
-      ...axisLabelConfig(deriveAxisLabelWidth(chartWidth, catCount)),
-    };
-
-    const baseAxis = {
-      type: "category" as const,
-      axisLabel, axisLine, axisTick, splitLine, nameTextStyle,
-    };
-    // Bottom category axis that truncates long labels with an ellipsis.
-    const categoryAxis = {
-      ...baseAxis,
-      axisLabel: truncLabel,
-    };
-    const valueAxis = {
-      type: "value" as const,
-      axisLabel, axisLine, axisTick, splitLine, nameTextStyle,
-    };
-    const legend = legendConfig(o, tk);
-    const title = titleConfig(o, tk);
-    const tooltip = {
-      trigger: "axis" as const,
-      backgroundColor: tk.bg,
-      borderColor: tk.border,
-      textStyle: { color: tk.fg },
-    };
-    const itemTooltip = {
-      backgroundColor: tk.bg,
-      borderColor: tk.border,
-      textStyle: { color: tk.fg },
-    };
-    const xName = o.xAxisLabel || undefined;
-    const yName = o.yAxisLabel || undefined;
-
-    const common = {
-      backgroundColor: "transparent",
-      color: tk.chartColors,
-      textStyle: { color: tk.fg },
-    };
-
-    // Pie / donut / treemap / sunburst encode a SINGLE measure. With M measures
-    // we fan out into M small-multiple charts — one per measure — in a grid
-    // inside the same option (M series, one per cell). Each chart shows the row
-    // categories as its items, sized by that one measure. M=1 is a single
-    // full-box chart. The user's overall chart title (if any) is kept alongside
-    // the per-measure cell titles in ECharts' title array.
-    if (t === "pie" || t === "donut" || t === "treemap" || t === "sunburst") {
-      const cells = gridCells(cols.length);
-      // Aspect-aware radius keeps each chart the same on-screen size regardless
-      // of how many small multiples there are (#1053).
-      const aspect = host && host.clientHeight > 0 ? host.clientWidth / host.clientHeight : 1;
-      const cellTitles = cells.map((cell, m) => ({
-        text: cols[m],
-        left: cell.centerXPct + "%",
-        top: cell.topPct + "%",
-        textAlign: "center" as const,
-        textStyle: { color: tk.fg, fontSize: 12 },
-      }));
-      const titles = title ? [title, ...cellTitles] : cellTitles;
-      // Category identification: a shared category legend collides with the
-      // per-measure titles and bloats off-screen once there are many categories.
-      // Name the slices directly when few enough to read, else lean on the
-      // tooltip. Inside the slices for a small-multiple grid (leader lines would
-      // cross between neighbours); outside for a single chart where there's room.
-      const showSliceLabels = rows.length <= MAX_LABELLED_SLICES;
-      const sliceLabelInside = cells.length > 1;
-
-      if (t === "pie" || t === "donut") {
-        return {
-          ...common,
-          title: titles,
-          tooltip: { trigger: "item", ...itemTooltip },
-          series: cells.map((cell, m) => {
-            const outer = cellRadiusPct(cell, aspect);
-            return {
-              type: "pie",
-              name: cols[m],
-              radius: t === "donut" ? [outer * 0.55 + "%", outer + "%"] : [0, outer + "%"],
-              center: [cell.centerXPct + "%", cell.centerYPct + "%"],
-              label: {
-                show: showSliceLabels,
-                position: sliceLabelInside ? "inside" : "outside",
-                formatter: "{b}",
-                color: sliceLabelInside ? "#fff" : tk.fg,
-              },
-              labelLine: { show: showSliceLabels && !sliceLabelInside },
-              data: rows.map((name, i) => ({ name, value: matrix[i][m] ?? 0 })),
-            };
-          }),
-        };
-      }
-
-      if (t === "treemap") {
-        return {
-          ...common,
-          title: titles,
-          tooltip: itemTooltip,
-          series: cells.map((cell, m) => ({
-            type: "treemap",
-            name: cols[m],
-            left: cell.leftPct + "%",
-            top: cell.topPct + cell.heightPct * 0.18 + "%",
-            width: cell.widthPct + "%",
-            height: cell.heightPct * 0.82 + "%",
-            label: { color: "#fff" },
-            breadcrumb: { show: false },
-            data: rows.map((name, i) => ({ name, value: matrix[i][m] ?? 0 })).filter((d) => d.value > 0),
-          })),
-        };
-      }
-
-      // sunburst
-      return {
-        ...common,
-        title: titles,
-        tooltip: itemTooltip,
-        series: cells.map((cell, m) => ({
-          type: "sunburst",
-          name: cols[m],
-          center: [cell.centerXPct + "%", cell.centerYPct + "%"],
-          radius: [0, cellRadiusPct(cell, aspect) + "%"],
-          label: { show: showSliceLabels, color: "#fff" },
-          data: rows.map((name, i) => ({ name, value: matrix[i][m] ?? 0 })).filter((d) => d.value > 0),
-        })),
-      };
-    }
-
-    if (t === "heatmap") {
-      const data: [number, number, number][] = [];
-      for (let i = 0; i < matrix.length; i++) {
-        for (let j = 0; j < (matrix[i]?.length ?? 0); j++) {
-          data.push([j, i, matrix[i][j] ?? 0]);
-        }
-      }
-      const values = data.map((d) => d[2]);
-      const min = values.length ? Math.min(...values) : 0;
-      const max = values.length ? Math.max(...values) : 1;
-      return {
-        ...common,
-        title,
-        tooltip: itemTooltip,
-        grid: { left: 120, top: 40, right: 40, bottom: 80 },
-        xAxis: { ...categoryAxis, data: cols, name: xName },
-        yAxis: { ...baseAxis, data: rows, inverse: true, name: yName },
-        visualMap: {
-          min, max, calculable: true, orient: "horizontal",
-          left: "center", bottom: 10,
-          textStyle: { color: tk.fgMuted },
-        },
-        series: [{ type: "heatmap", data, label: { show: false }, emphasis: { itemStyle: { shadowBlur: 10 } } }],
-      };
-    }
-
-    if (t === "radar") {
-      const max = Math.max(0, ...matrix.flatMap((r) => r.map((v) => Math.abs(v ?? 0))));
-      return {
-        ...common,
-        title,
-        tooltip: itemTooltip,
-        legend,
-        radar: {
-          indicator: cols.map((c) => ({ name: c, max: max || 1 })),
-          axisName: { color: tk.fgMuted },
-          axisLine: { lineStyle: { color: tk.border } },
-          splitLine: { lineStyle: { color: tk.border, opacity: 0.5 } },
-          splitArea: { areaStyle: { color: [tk.bg, tk.bgMuted], opacity: 0.3 } },
-        },
-        series: [{ type: "radar", data: rows.map((r, i) => ({ name: r, value: matrix[i].map((v) => v ?? 0) })) }],
-      };
-    }
-
-    if (t === "scatter" || t === "bubble") {
-      return {
-        ...common,
-        title,
-        tooltip: itemTooltip,
-        legend,
-        xAxis: { ...categoryAxis, data: cols, name: xName },
-        yAxis: { ...valueAxis, name: yName },
-        series: rows.map((name, i) => ({
-          type: "scatter",
-          name,
-          symbolSize: t === "bubble"
-            ? (val: unknown) => {
-                const v = Array.isArray(val) ? (val[1] as number) : (val as number);
-                const max = Math.max(1, ...matrix.flatMap((r) => r.map((vv) => Math.abs(vv ?? 0))));
-                return Math.max(6, Math.sqrt(Math.abs(v) / max) * 40);
-              }
-            : 10,
-          data: matrix[i].map((v, j) => [j, v ?? 0]),
-        })),
-      };
-    }
-
-    if (t === "waterfall") {
-      const vals = matrix.map((r) => r[0] ?? 0);
-      const spacers: number[] = [];
-      const positives: (number | null)[] = [];
-      const negatives: (number | null)[] = [];
-      let running = 0;
-      for (const v of vals) {
-        if (v >= 0) {
-          spacers.push(running);
-          positives.push(v);
-          negatives.push(null);
-        } else {
-          spacers.push(running + v);
-          positives.push(null);
-          negatives.push(-v);
-        }
-        running += v;
-      }
-      return {
-        ...common,
-        title,
-        tooltip,
-        legend,
-        grid: { left: 60, top: title ? 50 : 30, right: 40, bottom: 60 },
-        xAxis: { ...categoryAxis, data: rows, name: xName },
-        yAxis: { ...valueAxis, name: yName },
-        series: [
-          { type: "bar", name: "", stack: "waterfall", itemStyle: { borderColor: "transparent", color: "transparent" }, data: spacers, emphasis: { itemStyle: { borderColor: "transparent", color: "transparent" } } },
-          { type: "bar", name: cols[0] ?? "Positive", stack: "waterfall", data: positives, itemStyle: { color: "#4c9ee6" } },
-          { type: "bar", name: `-${cols[0] ?? "Negative"}`, stack: "waterfall", data: negatives, itemStyle: { color: "#e66c6c" } },
-        ],
-      };
-    }
-
-    // bar / stackedBar / line / stackedLine / area / stackedArea
-    const isStacked = t.startsWith("stacked");
-    // includes("bar") is case-sensitive — "stackedBar" has a capital B,
-    // so the naive check returned false and stacked-bar fell through to
-    // the line branch (i.e. was drawn as a stacked line).
-    const lower = t.toLowerCase();
-    const kind: "bar" | "line" = lower.includes("bar") ? "bar" : "line";
-    const areaStyle = t === "area" || t === "stackedArea" ? {} : undefined;
-
-    // Dual y-axis: auto-split low-magnitude series to the right when
-    // they'd otherwise be crushed to the zero line by a dominant series
-    // (Event Count in thousands vs Avg Tone in single digits, etc.).
-    // Per-series picks in o.seriesAxis always win; explicit auto-disable
-    // via o.dualAxis=false reverts to single-axis.
-    const seriesSides = assignSeriesAxes(cols, matrix, {
-      dualAxis: o.dualAxis,
-      seriesAxis: o.seriesAxis,
-      threshold: SERIES_AXIS_THRESHOLD,
+    return buildChartOption({ rowCategories: rows, columnCategories: cols, matrix }, t, o, tk, {
+      aspect,
+      chartWidth,
+      compact: false,
     });
-    const hasRight = seriesSides.some((s) => s === "right");
-    const yAxis = hasRight
-      ? [
-          { ...valueAxis, name: yName, position: "left" as const },
-          // Render the right axis without splitLine duplicates so the
-          // gridlines from the left axis aren't double-drawn.
-          { ...valueAxis, name: undefined, position: "right" as const, splitLine: { show: false } },
-        ]
-      : { ...valueAxis, name: yName };
-
-    const base = cols.map((name, c) => ({
-      type: kind as "bar" | "line",
-      name,
-      stack: isStacked ? (seriesSides[c] === "right" ? "total-right" : "total-left") : undefined,
-      areaStyle,
-      smooth: kind === "line",
-      yAxisIndex: hasRight ? (seriesSides[c] === "right" ? 1 : 0) : 0,
-      data: matrix.map((row) => row[c] ?? 0),
-    }));
-    const trend = kind === "line" && cols.length > 0
-      ? trendSeries(cols[0], matrix.map((row) => row[0] ?? null), o, tk)
-      : [];
-
-    return {
-      ...common,
-      title, tooltip, legend,
-      grid: { left: 60, top: title ? 50 : 40, right: hasRight ? 60 : 40, bottom: 60 },
-      xAxis: { ...categoryAxis, data: rows, name: xName },
-      yAxis,
-      series: [...base, ...trend],
-    };
   }
 
   function render() {
     if (!chart) return;
-    let opt: echarts.EChartsCoreOption;
+    let opt: Record<string, unknown> | null;
     try {
       opt = buildOption(result, type, options);
     } catch (err) {
       // If buildOption throws (e.g. cellset shape doesn't fit the requested
       // chart type), clear the canvas instead of leaving the previous chart's
       // series on screen. Without this, switching from a "broken" chart to a
-      // valid one would still render the broken state because the stale
-      // series would merge with the new option.
+      // valid one would still render the broken state because the stale series
+      // would merge with the new option.
       console.warn("[saiku] chart buildOption failed; clearing canvas:", err);
+      chart.clear();
+      return;
+    }
+    if (!opt) {
+      // Unsupported kind / empty projection — clear rather than keep stale series.
       chart.clear();
       return;
     }
@@ -528,4 +161,3 @@
     /* height + min-height are set inline = smallMultipleRows × the single size. */
   }
 </style>
-

--- a/saiku-ui/src/lib/views/chartTypes.ts
+++ b/saiku-ui/src/lib/views/chartTypes.ts
@@ -33,6 +33,17 @@ export const CHART_TYPES: { id: ChartType; label: string; group: string }[] = [
   { id: "bubble", label: "Bubble", group: "Points" },
 ];
 
+/** Set of all supported chart-type ids, derived from CHART_TYPES so it can
+ *  never drift from the palette. */
+const CHART_TYPE_SET: ReadonlySet<string> = new Set(CHART_TYPES.map((c) => c.id));
+
+/** Type guard: is `kind` one of the supported chart types? The single source
+ *  of truth for "can we render this kind", shared by the workspace and the
+ *  dashboard (re-exported from chartOptions.ts as isSupportedChartKind). */
+export function isChartType(kind: string): kind is ChartType {
+  return CHART_TYPE_SET.has(kind);
+}
+
 export type TrendLineMode = "none" | "linear" | "ma" | "wma";
 
 export interface ChartOptions {


### PR DESCRIPTION
## Summary

The workspace (`ChartView.svelte`) and the dashboard (`chartOptions.ts`) each re-implemented the same 15 ECharts chart types side-by-side. They had drifted: dashboard tiles silently lacked **dual-axis**, **trend lines** and **rollup-row filtering** because that work only ever landed on the workspace path, and every new chart feature meant two PRs. This unifies both onto one shared builder — the foundation for the rest of the viz epic (#1077–#1092).

## The change

- **New `$lib/charts/build.ts`** — one canonical `buildChartOption(projection, type, options, tk, geom)` for all 15 chart types. It's the *union* of both surfaces' behaviour (title / legend / axis-labels + dual-axis + trend lines), with a single `compact` geometry flag that carries the dashboard tile cosmetics (tight margins, bottom-scroll legend, fixed-width axis labels, gap-vs-zero null fill). Pure — no DOM, no ECharts import.
- **`chartTypes.ts`** — promote `isChartType()` (derived from `CHART_TYPES`) as the single supported-kind guard.
- **`chartOptions.ts`** — now a thin dashboard *adapter*: `projectFromAiQueryResponse()` + a `buildChartOption()` that projects then calls the shared builder in `compact` mode with the pre-#1076 baseline options. **Public signature unchanged**, so `ChartTile.svelte` and the existing tests are untouched.
- **`ChartView.svelte`** — projects the cellset (incl. rollup filtering, which needs cellset depth) then delegates to the shared builder in roomy mode; ~320 fewer lines (inline builder + trend math + legend/title helpers removed).

Both surfaces render **identically today** (the existing dashboard test passes unchanged). Dashboards now gain dual-axis + trend lines "for free" the moment the chart-tile editor (#1077) wires per-tile options.

## Verified

- `npm run check` → 0 errors / 0 warnings
- `npx vitest run` → **552 passing** (incl. new `charts/build.test.ts`)
- Local browser test (user-confirmed): workspace charts — all 15 types, dual-axis split, trend line, rollup-leaf charting, theme flip — render identically.

## Test plan

- [x] Existing workspace charts render identically (visual + tooltip + dual-axis)
- [x] Existing dashboard tiles render identically (existing `chartOptions.test.ts` green, unchanged)
- [x] Vitest snapshots on `buildChartOption` output for each of the 15 types (compact + roomy)
- [x] Net removal of duplicated builder code (the two ~400-line switches → one shared builder)

## Notes

- Surface-specific concerns stay out of the builder: cellset/AiQueryResponse parsing, rollup filtering, the ECharts instance lifecycle, click→drillthrough, host sizing, live theme-token reads.
- The shared-builder snapshot file is large (auto-generated, pins all 15 types × both modes) — that's the per-type regression guard the issue asked for.
- Security: UI-only refactor; no new endpoints, no `{@html}`, no auth/path/injection surface; operates on already-fetched data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)