### PR TITLE
Close Connection in code

### DIFF
--- a/saiku-core/saiku-service/src/main/java/org/saiku/datasources/connection/SaikuOlapConnection.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/datasources/connection/SaikuOlapConnection.java
@@ -126,20 +126,21 @@ public class SaikuOlapConnection implements ISaikuConnection {
                 }
 
                 Class.forName(driver);
-                Connection connection = DriverManager.getConnection(url, username, password);
+                try (Connection connection = DriverManager.getConnection(url, username, password)) {
 
-                if (connection != null) {
-                    final OlapWrapper wrapper = (OlapWrapper) connection;
-                    OlapConnection tmpolapConnection = wrapper.unwrap(OlapConnection.class);
+                    if (connection != null) {
+                        final OlapWrapper wrapper = (OlapWrapper) connection;
+                        OlapConnection tmpolapConnection = wrapper.unwrap(OlapConnection.class);
 
-                    if (tmpolapConnection == null) {
-                        throw new Exception("Connection is null");
+                        if (tmpolapConnection == null) {
+                            throw new Exception("Connection is null");
+                        }
+
+                        log.info("Catalogs:" + tmpolapConnection.getOlapCatalogs().size());
+                        olapConnection = tmpolapConnection;
+                        initialized = true;
+                        return true;
                     }
-
-                    log.info("Catalogs:" + tmpolapConnection.getOlapCatalogs().size());
-                    olapConnection = tmpolapConnection;
-                    initialized = true;
-                    return true;
                 }
             } else if (props.containsKey("enabled")
                     && props.getProperty("enabled").equals("false")) {


### PR DESCRIPTION
This might be minor, but it jumped out in saiku-core/saiku-service/src/main/java/org/saiku/datasources/connection/SaikuOlapConnection.java: The resource opened there can leak if code exits on an error path. this patch moves the allocation into try-with-resources so cleanup happens on every exit path.

Happy to revise the approach or close this if it doesn’t fit — you know the codebase far better than I do.