### PR TITLE
fix(workspace): AI Query drawer width — don't overflow narrow viewports

### DIFF
--- a/saiku-ui/src/lib/views/AiQueryDrawer.svelte
+++ b/saiku-ui/src/lib/views/AiQueryDrawer.svelte
@@ -439,7 +439,8 @@
     top: 0;
     right: 0;
     bottom: 0;
-    width: min(420px, 100vw);
+    width: min(380px, 92vw);
+    max-width: 100vw;
     background: var(--bg);
     border-left: 1px solid var(--border);
     box-shadow: -8px 0 24px rgba(0, 0, 0, 0.08);
@@ -449,6 +450,14 @@
     transition: transform 0.18s ease-out;
     z-index: 100;
     color: var(--fg);
+  }
+  /* On narrow viewports the drawer takes most of the screen so nothing
+     overflows past the right edge — caught visually on demo verification
+     when the original 420px drawer clipped at the right of the window. */
+  @media (max-width: 900px) {
+    .ai-drawer {
+      width: min(360px, 100vw);
+    }
   }
   .ai-drawer--open {
     transform: translateX(0);


### PR DESCRIPTION
## Summary

The 420px-wide drawer + \`transform: translateX(100%)\` was getting positioned past the right edge of certain viewport widths on demo.saiku.bi — Tom screenshotted the drawer clipped at the right of the visible window, with the Send button and assistant response hidden.

Tighten the sizing:
- Default width = \`min(380px, 92vw)\` — small gutter so the drawer never abuts the very edge of the viewport.
- \`max-width: 100vw\` belt-and-braces against any container math weirdness.
- \`@media (max-width: 900px)\` shrinks to \`min(360px, 100vw)\` so phone-sized windows show the whole panel.

## Verified

- 530/530 vitest pass
- svelte-check: 0 errors / 0 warnings

## Out of scope

The other bug Tom spotted in the same screenshot — Edit in canvas returns 0 rows on a fresh cube — is a server-side regression filed as **#1131**. The client-side fix from #1127 landed correctly (\`query.run()\` fires with \`type=MDX\` and the right \`mdx\` string), but the server's execute path is silently regenerating empty MDX from the queryModel-cached prior state. Different code, different PR.