### PR TITLE
feat(dashboard): "filter affects N tiles" hover feedback (closes #924)

### DIFF
--- a/saiku-ui/src/lib/dashboard/filterAffinity.test.ts
+++ b/saiku-ui/src/lib/dashboard/filterAffinity.test.ts
@@ -1,0 +1,147 @@
+import { describe, it, expect } from "vitest";
+import {
+  computeFilterAffinity,
+  isFilterableTile,
+  type AffinityTile,
+  type FilterTarget,
+} from "$lib/dashboard/filterAffinity";
+import type { SchemaLike } from "$lib/dashboard/effectiveQuery";
+import type { CubeRef } from "$lib/api/dashboards";
+
+/* ---- fixtures ---- */
+
+const salesCube: CubeRef = {
+  connectionName: "foodmart",
+  catalog: "FoodMart",
+  schema: "FoodMart",
+  cubeName: "Sales",
+};
+const hrCube: CubeRef = { ...salesCube, cubeName: "HR" };
+
+// Sales resolves Product → Product → Product Subcategory; HR does not.
+const salesSchema: SchemaLike = {
+  dimensions: {
+    product: {
+      name: "Product",
+      hierarchies: {
+        product: {
+          name: "Product",
+          levels: { "product subcategory": { name: "Product Subcategory" } },
+        },
+      },
+    },
+  },
+};
+const hrSchema: SchemaLike = {
+  dimensions: {
+    employees: {
+      name: "Employees",
+      hierarchies: { employees: { name: "Employees", levels: { department: { name: "Department" } } } },
+    },
+  },
+};
+
+function cubeKey(c: CubeRef): string {
+  return `${c.connectionName}/${c.catalog}/${c.schema}/${c.cubeName}`;
+}
+
+/** A schema resolver backed by a fixed map — mirrors schemaCache.peek. */
+function schemaResolver(map: Record<string, SchemaLike>) {
+  return (cube: CubeRef): SchemaLike | null => map[cubeKey(cube)] ?? null;
+}
+
+const inline = { kind: "inline" as const, body: {} };
+
+const productTarget: FilterTarget = {
+  dimension: "Product",
+  hierarchy: "Product",
+  level: "Product Subcategory",
+};
+
+describe("isFilterableTile", () => {
+  it("is true for chart/table tiles with a query", () => {
+    expect(isFilterableTile({ type: "chart", query: inline })).toBe(true);
+    expect(isFilterableTile({ type: "table", query: inline })).toBe(true);
+  });
+  it("is true for a KPI tile with a measure (it slices its cube via active filters)", () => {
+    expect(isFilterableTile({ type: "kpi", query: undefined, kpi: { measure: "[Measures].[Store Sales]" } })).toBe(
+      true,
+    );
+  });
+  it("is false for chart/table without a query, a measure-less KPI, and text/image", () => {
+    expect(isFilterableTile({ type: "chart", query: undefined })).toBe(false);
+    expect(isFilterableTile({ type: "text", query: undefined })).toBe(false);
+    expect(isFilterableTile({ type: "image", query: undefined })).toBe(false);
+    expect(isFilterableTile({ type: "kpi", query: undefined, kpi: undefined })).toBe(false);
+  });
+});
+
+describe("computeFilterAffinity", () => {
+  const resolve = schemaResolver({
+    [cubeKey(salesCube)]: salesSchema,
+    [cubeKey(hrCube)]: hrSchema,
+  });
+
+  it("counts a tile as affected when the filter resolves in its cube schema", () => {
+    const tiles: AffinityTile[] = [{ id: "a", type: "chart", cube: salesCube, query: inline }];
+    const r = computeFilterAffinity(productTarget, tiles, resolve);
+    expect([...r.affected]).toEqual(["a"]);
+    expect(r.affectedCount).toBe(1);
+    expect(r.totalCount).toBe(1);
+  });
+
+  it("does not affect a tile whose cube schema can't resolve the target (different cube)", () => {
+    const tiles: AffinityTile[] = [{ id: "hr", type: "table", cube: hrCube, query: inline }];
+    const r = computeFilterAffinity(productTarget, tiles, resolve);
+    expect(r.affected.has("hr")).toBe(false);
+    expect(r.affectedCount).toBe(0);
+    expect(r.totalCount).toBe(1);
+  });
+
+  it("partitions a mixed board and reports N of M against ALL tiles", () => {
+    const tiles: AffinityTile[] = [
+      { id: "chart-sales", type: "chart", cube: salesCube, query: inline }, // hit
+      { id: "table-sales", type: "table", cube: salesCube, query: inline }, // hit
+      { id: "kpi-sales", type: "kpi", cube: salesCube, kpi: { measure: "[Measures].[Store Sales]" } }, // hit (KPI slices its cube)
+      { id: "table-hr", type: "table", cube: hrCube, query: inline }, // miss (cube)
+      { id: "text", type: "text", query: undefined }, // miss (not filterable)
+      { id: "kpi-blank", type: "kpi", cube: salesCube, kpi: undefined }, // miss (no measure)
+    ];
+    const r = computeFilterAffinity(productTarget, tiles, resolve);
+    expect([...r.affected].sort()).toEqual(["chart-sales", "kpi-sales", "table-sales"]);
+    expect(r.affectedCount).toBe(3);
+    expect(r.totalCount).toBe(6);
+  });
+
+  it("treats a tile with no cube as not-affected", () => {
+    const tiles: AffinityTile[] = [{ id: "nocube", type: "chart", query: inline }];
+    const r = computeFilterAffinity(productTarget, tiles, resolve);
+    expect(r.affectedCount).toBe(0);
+    expect(r.totalCount).toBe(1);
+  });
+
+  it("treats an unloaded schema as not-affected (conservative hint)", () => {
+    const tiles: AffinityTile[] = [{ id: "a", type: "chart", cube: salesCube, query: inline }];
+    const r = computeFilterAffinity(productTarget, tiles, () => null);
+    expect(r.affectedCount).toBe(0);
+    expect(r.totalCount).toBe(1);
+  });
+
+  it("is alias-aware (synonym dimension resolves to canonical)", () => {
+    const aliased: SchemaLike = { ...salesSchema, dimensionAliases: { merchandise: "product" } };
+    const resolveAlias = schemaResolver({ [cubeKey(salesCube)]: aliased });
+    const tiles: AffinityTile[] = [{ id: "a", type: "chart", cube: salesCube, query: inline }];
+    const r = computeFilterAffinity(
+      { dimension: "Merchandise", hierarchy: "Product", level: "Product Subcategory" },
+      tiles,
+      resolveAlias,
+    );
+    expect(r.affected.has("a")).toBe(true);
+  });
+
+  it("reports 0 of 0 for an empty dashboard", () => {
+    const r = computeFilterAffinity(productTarget, [], resolve);
+    expect(r.affectedCount).toBe(0);
+    expect(r.totalCount).toBe(0);
+  });
+});

--- a/saiku-ui/src/lib/dashboard/filterAffinity.ts
+++ b/saiku-ui/src/lib/dashboard/filterAffinity.ts
@@ -1,0 +1,74 @@
+/*
+ * Filter affinity (#924). Pure compatibility check answering "which tiles
+ * does this dashboard filter actually narrow?" — used to render the
+ * "Affects N of M tiles" hover hint on a panel filter and to highlight /
+ * dim the grid tiles accordingly.
+ *
+ * It reuses the SAME resolveTarget compatibility the filter-merge uses
+ * (effectiveQuery.ts), so the hint can never disagree with what merging
+ * actually does: a filter affects a tile iff the tile is a chart/table
+ * with a cube whose loaded schema resolves the filter's dim/hier/level
+ * (alias-aware). No DOM, no fetch — the caller supplies a schema resolver
+ * (typically schemaCache.peek) so this unit-tests cleanly.
+ */
+
+import { resolveTarget, type SchemaLike } from "$lib/dashboard/effectiveQuery";
+import type { CubeRef, DashboardTile } from "$lib/api/dashboards";
+
+/** The dim/hier/level a panel filter targets. */
+export interface FilterTarget {
+  dimension: string;
+  hierarchy: string;
+  level: string;
+}
+
+/** Just the tile fields the affinity check reads — keeps callers (and
+ *  tests) from having to build a whole DashboardTile. */
+export type AffinityTile = Pick<DashboardTile, "id" | "type" | "cube" | "query" | "kpi">;
+
+export interface FilterAffinity {
+  /** ids of filterable tiles whose cube schema resolves the filter target. */
+  affected: Set<string>;
+  affectedCount: number;
+  /** total tiles on the dashboard — the denominator of "N of M". */
+  totalCount: number;
+}
+
+/** Tiles a panel filter can actually narrow:
+ *   - chart / table tiles that carry a query, and
+ *   - KPI tiles with a measure (they carry no query — slicing comes purely
+ *     from the dashboard-active filters applied to their cube).
+ *  Text and image tiles never consume filters, so they always dim. */
+export function isFilterableTile(tile: Pick<DashboardTile, "type" | "query" | "kpi">): boolean {
+  if (tile.type === "chart" || tile.type === "table") return !!tile.query;
+  if (tile.type === "kpi") return !!tile.kpi?.measure;
+  return false;
+}
+
+/** Pure: which tiles a filter affects. `schemaFor` returns the loaded
+ *  schema for a tile's cube (or null when not cached yet / no cube).
+ *
+ *  A tile counts as affected iff it is filterable, has a cube, that cube's
+ *  schema is loaded, AND the filter's dim/hier/level resolves in it. A
+ *  tile whose schema isn't loaded (or whose cube can't be determined) is
+ *  treated as NOT affected — a conservative hint never promises a narrow
+ *  it can't prove. `totalCount` is every tile on the dashboard so the
+ *  badge reads "N of M" against the full board, and every non-affected
+ *  tile (incl. text/image/kpi) dims. */
+export function computeFilterAffinity(
+  target: FilterTarget,
+  tiles: readonly AffinityTile[],
+  schemaFor: (cube: CubeRef) => SchemaLike | null,
+): FilterAffinity {
+  const affected = new Set<string>();
+  for (const t of tiles) {
+    if (!isFilterableTile(t)) continue;
+    if (!t.cube) continue;
+    const schema = schemaFor(t.cube);
+    if (!schema) continue;
+    if (resolveTarget(schema, target.dimension, target.hierarchy, target.level)) {
+      affected.add(t.id);
+    }
+  }
+  return { affected, affectedCount: affected.size, totalCount: tiles.length };
+}

--- a/saiku-ui/src/lib/stores/filterAffinity.svelte.ts
+++ b/saiku-ui/src/lib/stores/filterAffinity.svelte.ts
@@ -1,0 +1,47 @@
+/*
+ * Filter-affinity hover state (#924). A tiny broadcast store so the
+ * filter panel (where the hover happens) can tell the dashboard grid
+ * which tiles a hovered filter affects — the panel and the grid live in
+ * separate component subtrees, so a shared store is the clean conduit.
+ *
+ * The panel sets it on mouse-enter / focus-in of a filter row and clears
+ * it on leave; the row reads `affectedCount`/`totalCount` for its badge,
+ * and each Tile reads `active` + `isAffected(id)` to highlight or dim.
+ * Purely presentational and transient — never persisted.
+ */
+
+import type { FilterAffinity } from "$lib/dashboard/filterAffinity";
+
+class FilterAffinityHoverStore {
+  /** Panel-filter id currently hovered, or null when nothing is hovered. */
+  hoveredFilterId = $state<string | null>(null);
+  /** Tile ids the hovered filter narrows. */
+  affected = $state<Set<string>>(new Set());
+  affectedCount = $state(0);
+  totalCount = $state(0);
+
+  /** True while a filter is being hovered — gates the grid highlight/dim. */
+  get active(): boolean {
+    return this.hoveredFilterId !== null;
+  }
+
+  set(filterId: string, affinity: FilterAffinity): void {
+    this.hoveredFilterId = filterId;
+    this.affected = affinity.affected;
+    this.affectedCount = affinity.affectedCount;
+    this.totalCount = affinity.totalCount;
+  }
+
+  clear(): void {
+    this.hoveredFilterId = null;
+    this.affected = new Set();
+    this.affectedCount = 0;
+    this.totalCount = 0;
+  }
+
+  isAffected(tileId: string): boolean {
+    return this.affected.has(tileId);
+  }
+}
+
+export const filterAffinityHover = new FilterAffinityHoverStore();

--- a/saiku-ui/src/lib/views/dashboard/DashboardFilterPanel.svelte
+++ b/saiku-ui/src/lib/views/dashboard/DashboardFilterPanel.svelte
@@ -22,6 +22,11 @@
   import { activeFilters, targetKey } from "$lib/stores/activeFilters.svelte";
   import { schemaCache } from "$lib/stores/schemaCache.svelte";
   import type { SchemaLike } from "$lib/dashboard/effectiveQuery";
+  // issue #924: "affects N of M tiles" hover hint. Compute which tiles a
+  // filter narrows (same resolveTarget compat the merge uses) + broadcast
+  // it to the grid via the shared hover store.
+  import { computeFilterAffinity } from "$lib/dashboard/filterAffinity";
+  import { filterAffinityHover } from "$lib/stores/filterAffinity.svelte";
   import {
     ancestorSelections,
     memberDescendsFromAny,
@@ -651,6 +656,31 @@
     dashboardStore.setPanelCollapsed(!panel.collapsed);
   }
 
+  /* ===================== issue #924: affects-N-tiles hint ================
+   * On hover / focus of a filter row, work out which tiles its
+   * dim/hier/level resolves against — reusing the exact resolveTarget
+   * compat the filter-merge uses, so the hint never lies — and broadcast
+   * it so the grid highlights the hits + dims the misses and this row
+   * shows an "Affects N of M tiles" badge. Clears on leave/blur. */
+  function hoverFilter(f: PanelFilter): void {
+    const tiles = dashboardStore.current?.layout.tiles ?? [];
+    // Prime any not-yet-cached tile cube so a moment-later re-hover
+    // resolves (peek is sync; get is fire-and-forget, ticks schemaCache).
+    for (const t of tiles) {
+      if (t.cube) void schemaCache.get(t.cube).catch(() => {});
+    }
+    const affinity = computeFilterAffinity(
+      { dimension: f.dimension, hierarchy: f.hierarchy, level: f.level },
+      tiles,
+      (cube) => schemaCache.peek(cube) as SchemaLike | null,
+    );
+    filterAffinityHover.set(f.id, affinity);
+  }
+
+  function unhoverFilter(): void {
+    filterAffinityHover.clear();
+  }
+
   /* --------------------------- drag-reorder ---------------------------- */
 
   interface DragState {
@@ -765,6 +795,10 @@
               class:picker--source={drag?.fromId === f.id}
               data-panel-filter-id={f.id}
               onpointerdown={(e) => onPickerPointerDown(e, f.id)}
+              onmouseenter={() => hoverFilter(f)}
+              onmouseleave={unhoverFilter}
+              onfocusin={() => hoverFilter(f)}
+              onfocusout={unhoverFilter}
             >
               {#if !readOnly}
                 <span class="grip" data-drag-handle aria-hidden="true">
@@ -772,6 +806,12 @@
                 </span>
               {/if}
               <span class="picker-label">{f.level}</span>
+              <!-- issue #924: how many tiles this filter narrows, shown while hovered. -->
+              {#if filterAffinityHover.hoveredFilterId === f.id}
+                <span class="affects-badge" aria-live="polite">
+                  Affects {filterAffinityHover.affectedCount} of {filterAffinityHover.totalCount} tiles
+                </span>
+              {/if}
               {#if f.widget === "cascading-select"}
                 <!-- issue #922: N stacked dropdowns walking the hierarchy. -->
                 {@const levels = cascadeLevels(f)}
@@ -1064,6 +1104,16 @@
     text-transform: uppercase;
     letter-spacing: 0.04em;
     color: var(--fg-muted);
+  }
+  /* issue #924: "affects N of M tiles" hover badge. */
+  .affects-badge {
+    font-size: 0.6875rem;
+    line-height: 1;
+    padding: 0.125rem 0.375rem;
+    border-radius: 999px;
+    background: var(--accent);
+    color: var(--accent-fg, #fff);
+    white-space: nowrap;
   }
   .picker-select {
     padding: 0.125rem 0.25rem;

--- a/saiku-ui/src/lib/views/dashboard/DashboardFilterPanel.svelte
+++ b/saiku-ui/src/lib/views/dashboard/DashboardFilterPanel.svelte
@@ -742,7 +742,11 @@
   }
 </script>
 
-{#if panel}
+<!-- issue #924: render the panel chrome in edit mode even before a
+     filterPanel exists, so "+ Add filter" is always reachable on a fresh
+     dashboard (committing the first filter lazily creates the panel via
+     ensurePanel). In readOnly we still only show it once filters exist. -->
+{#if panel || !readOnly}
   <section class="panel" aria-label="Dashboard filter panel">
     <header class="panel-header">
       <button
@@ -759,8 +763,8 @@
         {/if}
         <span class="panel-title">
           Filters
-          {#if panel.filters.length > 0}
-            <span class="count">({panel.filters.length})</span>
+          {#if (panel?.filters.length ?? 0) > 0}
+            <span class="count">({panel?.filters.length})</span>
           {/if}
         </span>
       </button>
@@ -769,13 +773,13 @@
       {/if}
     </header>
     {#if !collapsed}
-      {#if panel.filters.length === 0 && !adding}
+      {#if (panel?.filters.length ?? 0) === 0 && !adding}
         <p class="empty">
           No filters yet — click <em>+ Add filter</em> to register one,
           or use <em>Suggest filters</em> in the toolbar.
         </p>
       {/if}
-      {#if panel.filters.length > 0}
+      {#if (panel?.filters.length ?? 0) > 0}
         <!-- svelte-ignore a11y_no_static_element_interactions — pointer events implement drag-to-reorder; keyboard reordering would be a separate UX (kbd shortcuts on focused picker). -->
         <div
           class="picker-row"
@@ -784,7 +788,7 @@
           onpointerup={onPickerPointerUp}
           onpointercancel={onPickerPointerCancel}
         >
-          {#each panel.filters as f (f.id)}
+          {#each panel?.filters ?? [] as f (f.id)}
             {@const cat = memberCatalogues[f.id]}
             {@const selected = selectedForPicker(f)}
             {@const displayOptions = displayedOptionsFor(f)}

--- a/saiku-ui/src/lib/views/dashboard/Tile.svelte
+++ b/saiku-ui/src/lib/views/dashboard/Tile.svelte
@@ -15,6 +15,8 @@
 
   import { dashboardStore } from "$lib/stores/dashboard.svelte";
   import { activeFilters } from "$lib/stores/activeFilters.svelte";
+  // issue #924: highlight tiles a hovered panel filter narrows, dim the rest.
+  import { filterAffinityHover } from "$lib/stores/filterAffinity.svelte";
   import type { DashboardTile, DashboardFilter } from "$lib/api/dashboards";
   import ChartTile from "$lib/views/dashboard/tiles/ChartTile.svelte";
   import TableTile from "$lib/views/dashboard/tiles/TableTile.svelte";
@@ -150,7 +152,13 @@
      kebab button (⋮) in the header is the keyboard-accessible
      equivalent — same menu, same actions — so no a11y regression
      from suppressing the contextmenu-handler-needs-a-role rule. -->
-<div class="tile" data-tile-type={tile.type} oncontextmenu={openContextMenu}>
+<div
+  class="tile"
+  class:tile--filter-hit={filterAffinityHover.active && filterAffinityHover.isAffected(tile.id)}
+  class:tile--filter-miss={filterAffinityHover.active && !filterAffinityHover.isAffected(tile.id)}
+  data-tile-type={tile.type}
+  oncontextmenu={openContextMenu}
+>
   <header
     class="tile-header"
     class:tile-header--draggable={!readOnly}
@@ -272,6 +280,20 @@
     border-radius: 6px;
     background: var(--bg);
     overflow: hidden;
+    /* issue #924: smooth the highlight/dim when a filter is hovered. */
+    transition:
+      opacity 0.12s ease,
+      box-shadow 0.12s ease;
+  }
+  /* issue #924: a hovered panel filter previews its reach — compatible
+     tiles get a 1px accent ring (inset, so layout doesn't shift), tiles
+     it won't touch fade back. Purely transient; clears on mouse-out. */
+  .tile--filter-hit {
+    box-shadow: inset 0 0 0 1px var(--accent);
+    border-color: var(--accent);
+  }
+  .tile--filter-miss {
+    opacity: 0.5;
   }
   /* #942: comment badge sits between the title and the edit actions. */
   .tile-comment-badge {


### PR DESCRIPTION
## Summary
Adds the "filter affects N tiles" feedback from #924 (Dashboard F2). Hovering (or focusing) a panel filter now shows an **"Affects N of M tiles"** badge and previews the filter's reach on the grid: compatible tiles get a 1px accent ring, the rest dim to 50%. Everything clears on mouse-out.

## The change
- **`$lib/dashboard/filterAffinity.ts`** (pure, 10 unit tests): `computeFilterAffinity(target, tiles, schemaFor)` returns the set of tile ids a filter narrows + counts. A tile is affected iff it's a chart/table with a query (or a **KPI tile with a measure** — those slice their cube purely via active filters) whose cube schema resolves the filter's dim/hier/level. It reuses the **exact `resolveTarget` compat the filter-merge uses** (`effectiveQuery.ts`), so the hint can never disagree with what slicing actually does. Alias-aware; an unloaded schema or cube-less tile counts as not-affected (a conservative hint never over-promises).
- **`$lib/stores/filterAffinity.svelte.ts`**: a tiny transient broadcast store so the panel (where the hover happens) and the grid tiles (a separate subtree) stay in sync. Never persisted.
- **`DashboardFilterPanel.svelte`**: `onmouseenter`/`onmouseleave` + `onfocusin`/`onfocusout` on each filter row compute affinity and set/clear the store; the row renders the badge while hovered. Primes `schemaCache` for tile cubes so the resolve lands.
- **`Tile.svelte`**: `.tile--filter-hit` (inset 1px accent ring, no layout shift) / `.tile--filter-miss` (opacity 0.5), gated on the hover store, with a 0.12s transition.
- **Drive-by fix (same area, needed to reach the feature):** the unified filter panel was gated behind `{#if panel}`, so on a fresh dashboard there was **no `+ Add filter` button at all** (only "Suggest filters" could create the first filter). Now the panel chrome renders whenever editing (`panel || !readOnly`), with null-safe inner refs; committing the first filter lazily creates the panel via `ensurePanel()`. readOnly still shows it only once filters exist.

## Note on the issue's "affected code"
The issue cited `FilterTile.svelte`, but filters were since unified into `DashboardFilterPanel.svelte` (saiku#996) — the per-filter-tile model is gone — so the hover lives on the panel rows, and the highlight/dim lands on the grid tiles via `Tile.svelte`.

## Verified
- `npm run check` → **0 / 0**.
- `npm test` → **569 passed** (incl. 10 new `filterAffinity.test.ts`).
- Production build → ✓.
- Rebased clean onto current `origin/development` (now carries #921 + #1076; no conflicts).
- **User-verified locally** (dev server → :8087 FoodMart): built a dashboard of 2 Store-Sales-by-Product-Subcategory charts + a KPI + a text tile, added a Product Subcategory panel filter, hovered → "Affects 3 of 4 tiles" with the three Sales tiles ringed and the text tile dimmed; cleared on mouse-out.

## Test plan
1. Open a dashboard with a couple of chart/table tiles (Sales, rows = Product → Product Subcategory) + one text tile.
2. Filter panel → **+ Add filter** → cube Sales, Product / Product / Product Subcategory → Add.
3. Hover the filter row → badge "Affects N of M tiles"; compatible tiles ring, the text tile dims; mouse-out clears. Tab into the row's control for the focus path.

## Notes
- Pure resolution lives in `filterAffinity.ts` (no DOM/fetch) so it unit-tests cleanly; the panel supplies the schema resolver (`schemaCache.peek`).
- **No backend change; no chart-internals touched** — zero overlap with OG's #1076 chart-codepath work.
- Does **not** self-merge — for OG's security gate + merge to `development`.

Closes #924

🤖 Generated with [Claude Code](https://claude.com/claude-code)
