### PR TITLE
feat(a11y): ARIA + screen-reader chart summaries (closes #1090)

### DIFF
--- a/saiku-ui/src/lib/charts/a11y.test.ts
+++ b/saiku-ui/src/lib/charts/a11y.test.ts
@@ -1,0 +1,91 @@
+/*
+ * Unit tests for the chart screen-reader summary (#1090).
+ */
+
+import { describe, test, expect } from "vitest";
+import { chartTypeLabel, chartSummary, chartAriaLabel } from "$lib/charts/a11y";
+import type { ChartProjection } from "$lib/charts/build";
+
+function sample(): ChartProjection {
+  return {
+    rowCategories: ["1997", "1998"],
+    columnCategories: ["Store Sales", "Unit Sales"],
+    matrix: [
+      [565238.13, 266773],
+      [612482.65, 282417],
+    ],
+  };
+}
+
+describe("chartTypeLabel", () => {
+  test("maps known ids to their human label, falls back to Chart", () => {
+    expect(chartTypeLabel("bar")).toBe("Bar");
+    expect(chartTypeLabel("stackedBar")).toBe("Stacked bar");
+    expect(chartTypeLabel("pie")).toBe("Pie");
+    expect(chartTypeLabel("nonsense")).toBe("Chart");
+  });
+});
+
+describe("chartSummary", () => {
+  test("builds a caption naming the type, series, and category count", () => {
+    const s = chartSummary("bar", "", sample());
+    expect(s.empty).toBe(false);
+    expect(s.caption).toContain("Bar chart");
+    expect(s.caption).toContain("Store Sales, Unit Sales");
+    expect(s.caption).toContain("2 categories");
+  });
+
+  test("includes the title in the caption when present", () => {
+    const s = chartSummary("line", "Sales over time", sample());
+    expect(s.caption).toContain("“Sales over time”");
+    expect(s.caption).toContain("Line chart");
+  });
+
+  test("table headers have a blank corner then the series names", () => {
+    const s = chartSummary("bar", "", sample());
+    expect(s.headers).toEqual(["", "Store Sales", "Unit Sales"]);
+  });
+
+  test("one row per category, category label first then formatted values", () => {
+    const s = chartSummary("bar", "", sample());
+    expect(s.rows).toHaveLength(2);
+    expect(s.rows[0][0]).toBe("1997");
+    // Locale-formatted numbers (grouping); exact separator is locale-dependent
+    // so assert the digits survive.
+    expect(s.rows[0][1].replace(/[^0-9.]/g, "")).toBe("565238.13");
+    expect(s.rows[1][0]).toBe("1998");
+  });
+
+  test("renders missing cells as an em-dash", () => {
+    const gappy: ChartProjection = {
+      rowCategories: ["a"],
+      columnCategories: ["m"],
+      matrix: [[null]],
+    };
+    const s = chartSummary("bar", "", gappy);
+    expect(s.rows[0][1]).toBe("—");
+  });
+
+  test("singular 'category' for a single row", () => {
+    const one: ChartProjection = { rowCategories: ["a"], columnCategories: ["m"], matrix: [[1]] };
+    expect(chartSummary("bar", "", one).caption).toContain("1 category");
+  });
+
+  test("empty projection → empty=true, no-data caption, no rows", () => {
+    const s = chartSummary("bar", "", { rowCategories: [], columnCategories: [], matrix: [] });
+    expect(s.empty).toBe(true);
+    expect(s.caption).toContain("no data");
+    expect(s.rows).toEqual([]);
+  });
+
+  test("honors a custom formatter", () => {
+    const s = chartSummary("bar", "", sample(), (v) => (v == null ? "n/a" : `$${v}`));
+    expect(s.rows[0][1]).toBe("$565238.13");
+  });
+});
+
+describe("chartAriaLabel", () => {
+  test("returns the summary caption", () => {
+    expect(chartAriaLabel("bar", "T", sample())).toBe(chartSummary("bar", "T", sample()).caption);
+  });
+});

--- a/saiku-ui/src/lib/charts/a11y.ts
+++ b/saiku-ui/src/lib/charts/a11y.ts
@@ -1,0 +1,75 @@
+/*
+ * Screen-reader accessibility for charts (#1090).
+ *
+ * An ECharts chart renders to a <canvas> that is invisible to assistive tech.
+ * Both surfaces (workspace ChartView, dashboard ChartTile) therefore hide the
+ * canvas from screen readers (aria-hidden) and expose the SAME data as a
+ * visually-hidden HTML <table> — a navigable, robust representation a screen
+ * reader can read row-by-row. This module builds that table model + a concise
+ * caption from the shared {@link ChartProjection}, so the logic is pure and
+ * unit-tested in one place.
+ *
+ * Pure: no DOM, no ECharts. Tests live alongside.
+ */
+
+import { CHART_TYPES } from "$lib/views/chartTypes";
+import type { ChartProjection } from "$lib/charts/build";
+
+const TYPE_LABEL = new Map<string, string>(CHART_TYPES.map((c) => [c.id, c.label]));
+
+/** Human chart-type label (e.g. "bar" → "Bar"), falling back to "Chart". */
+export function chartTypeLabel(type: string): string {
+  return TYPE_LABEL.get(type) ?? "Chart";
+}
+
+/** Accessible data-table model + caption for one chart. */
+export interface ChartSummary {
+  /** One-line summary used as the table caption / accessible name. */
+  caption: string;
+  /** Column headers — first cell is the (blank) category corner, then the
+   *  series (column-category) names. */
+  headers: string[];
+  /** One row per category: [categoryLabel, ...formatted values]. */
+  rows: string[][];
+  /** True when there's nothing to summarise (no categories or no series). */
+  empty: boolean;
+}
+
+/** Default value formatter — locale number, em-dash for missing. */
+function defaultFormat(v: number | null): string {
+  if (v == null || !Number.isFinite(v)) return "—";
+  return v.toLocaleString();
+}
+
+/**
+ * Build the accessible summary (caption + data table) for a chart.
+ *
+ * @param type    chart type id (bar, line, …)
+ * @param title   optional user title (empty string when none)
+ * @param p       the projected {rowCategories, columnCategories, matrix}
+ * @param format  value formatter (defaults to locale number)
+ */
+export function chartSummary(
+  type: string,
+  title: string,
+  p: ChartProjection,
+  format: (v: number | null) => string = defaultFormat,
+): ChartSummary {
+  const tl = chartTypeLabel(type);
+  const cats = p.rowCategories;
+  const series = p.columnCategories;
+  const empty = cats.length === 0 || series.length === 0;
+  const titlePart = title ? `“${title}”: ` : "";
+  const caption = empty
+    ? `${titlePart}${tl} chart with no data.`
+    : `${titlePart}${tl} chart of ${series.join(", ")} across ${cats.length} ` +
+      `${cats.length === 1 ? "category" : "categories"}.`;
+  const headers = ["", ...series];
+  const rows = cats.map((cat, i) => [cat, ...series.map((_, c) => format(p.matrix[i]?.[c] ?? null))]);
+  return { caption, headers, rows, empty };
+}
+
+/** Concise accessible name for the chart region (the summary caption). */
+export function chartAriaLabel(type: string, title: string, p: ChartProjection): string {
+  return chartSummary(type, title, p).caption;
+}

--- a/saiku-ui/src/lib/views/ChartView.svelte
+++ b/saiku-ui/src/lib/views/ChartView.svelte
@@ -8,7 +8,8 @@
   import { isSingleMeasureKind, smallMultipleRowCount } from "$lib/dashboard/smallMultiples";
   import { theme } from "$lib/stores/theme.svelte";
   import { resolveThemeTokens } from "$lib/views/chartTheme";
-  import { buildChartOption } from "$lib/charts/build";
+  import { buildChartOption, type ChartProjection } from "$lib/charts/build";
+  import { chartSummary } from "$lib/charts/a11y";
 
   interface Props {
     result: QueryResult;
@@ -29,12 +30,11 @@
     return isSingleMeasureKind(type) && measureCount > 1 ? smallMultipleRowCount(measureCount) : 1;
   });
 
-  // Project the workspace cellset into the shared {rows, cols, matrix} shape and
-  // delegate to the single canonical builder (#1076). The workspace is the
-  // "roomy" (non-compact) surface; rollup filtering (which needs cellset depth)
-  // happens here, before projection, since the builder treats rows as final.
-  function buildOption(r: QueryResult, t: ChartType, o: ChartOptions): Record<string, unknown> | null {
-    const tk = resolveThemeTokens();
+  // Project the workspace cellset into the shared {rows, cols, matrix} shape.
+  // Rollup filtering (which needs cellset depth) happens here, before
+  // projection, since the builder treats rows as final. Shared by the chart
+  // builder and the a11y data-table mirror (#1090) so both see the same data.
+  function projectResult(r: QueryResult, o: ChartOptions): ChartProjection {
     const parsed = parseCellset(r);
     // Multi-level row hierarchies (Year > Quarter, Country > City, …) come back
     // with both rollup and leaf rows in the same cellset. Showing the rollups on
@@ -52,19 +52,25 @@
         matrix = leaf.indices.map((i) => matrix[i]);
       }
     }
-    const cols = parsed.columnCategories;
+    return { rowCategories: rows, columnCategories: parsed.columnCategories, matrix };
+  }
 
+  // Delegate to the single canonical builder (#1076). The workspace is the
+  // "roomy" (non-compact) surface.
+  function buildOption(r: QueryResult, t: ChartType, o: ChartOptions): Record<string, unknown> | null {
+    const tk = resolveThemeTokens();
+    const p = projectResult(r, o);
     // Aspect-aware radius keeps each small-multiple the same on-screen size
     // regardless of how many there are (#1053); chartWidth drives the derived
     // per-label axis truncation width.
     const aspect = host && host.clientHeight > 0 ? host.clientWidth / host.clientHeight : 1;
     const chartWidth = host?.clientWidth ?? 0;
-    return buildChartOption({ rowCategories: rows, columnCategories: cols, matrix }, t, o, tk, {
-      aspect,
-      chartWidth,
-      compact: false,
-    });
+    return buildChartOption(p, t, o, tk, { aspect, chartWidth, compact: false });
   }
+
+  // #1090: accessible data-table mirror of the chart for screen readers. The
+  // canvas is aria-hidden (invisible to AT anyway); this exposes the same data.
+  let a11y = $derived(chartSummary(type, options.title ?? "", projectResult(result, options)));
 
   function render() {
     if (!chart) return;
@@ -136,11 +142,37 @@
 </script>
 
 <div class="chart-scroll">
+  <!-- #1090: the canvas is decorative to assistive tech; the sr-only table below
+       is the accessible representation, so hide the canvas from screen readers. -->
   <div
     class="chart"
     bind:this={host}
+    aria-hidden="true"
     style="height: {smallMultipleRows * 60}vh; min-height: {smallMultipleRows * 320}px;"
   ></div>
+  <!-- #1090: visually-hidden data-table mirror for screen readers. -->
+  <table class="sr-only">
+    <caption>{a11y.caption}</caption>
+    {#if !a11y.empty}
+      <thead>
+        <tr>
+          {#each a11y.headers as h, i (i)}
+            <th scope="col">{h}</th>
+          {/each}
+        </tr>
+      </thead>
+      <tbody>
+        {#each a11y.rows as row, ri (ri)}
+          <tr>
+            <th scope="row">{row[0]}</th>
+            {#each row.slice(1) as cell, ci (ci)}
+              <td>{cell}</td>
+            {/each}
+          </tr>
+        {/each}
+      </tbody>
+    {/if}
+  </table>
 </div>
 
 <style>
@@ -159,5 +191,18 @@
   .chart {
     width: 100%;
     /* height + min-height are set inline = smallMultipleRows × the single size. */
+  }
+  /* #1090: visually hide the a11y data table while keeping it in the
+     accessibility tree (standard sr-only / visually-hidden pattern). */
+  .sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
   }
 </style>

--- a/saiku-ui/src/lib/views/dashboard/tiles/ChartTile.svelte
+++ b/saiku-ui/src/lib/views/dashboard/tiles/ChartTile.svelte
@@ -31,7 +31,13 @@
     inferRowAxesFromReference,
     type RowAxisRef,
   } from "$lib/dashboard/filterSuggestions";
-  import { buildChartOption, isSupportedChartKind } from "$lib/dashboard/chartOptions";
+  import {
+    buildChartOption,
+    isSupportedChartKind,
+    projectFromAiQueryResponse,
+  } from "$lib/dashboard/chartOptions";
+  // #1090: accessible data-table mirror of the chart for screen readers.
+  import { chartSummary } from "$lib/charts/a11y";
   import { isSingleMeasureKind, smallMultipleRowCount } from "$lib/dashboard/smallMultiples";
   import { theme } from "$lib/stores/theme.svelte";
   import { resolveThemeTokens } from "$lib/views/chartTheme";
@@ -114,6 +120,15 @@
     const kind = tile.chartType ?? "bar";
     const measureCount = response?.metadata?.columns?.length ?? 0;
     return isSingleMeasureKind(kind) && measureCount > 1 ? smallMultipleRowCount(measureCount) : 1;
+  });
+
+  // #1090: accessible data-table mirror for screen readers (the canvas is
+  // aria-hidden). Built from the same projection the chart builder uses, so it
+  // always matches what's drawn. Null until a successful response.
+  let a11y = $derived.by(() => {
+    const r = response;
+    if (!r || r.status !== "SUCCESS") return null;
+    return chartSummary(tile.chartType ?? "bar", tile.title ?? "", projectFromAiQueryResponse(r));
   });
 
   /* ----------------------------- lifecycle --------------------------- */
@@ -372,7 +387,34 @@
   <div class="placeholder">Tile has no query binding — open ⚙ to set one.</div>
 {:else}
   <div class="chart-tile">
-    <div class="canvas" bind:this={host} style="height: {smallMultipleRows * 100}%"></div>
+    <!-- #1090: the canvas is decorative to assistive tech; the sr-only table is
+         the accessible representation, so hide the canvas from screen readers. -->
+    <div class="canvas" bind:this={host} aria-hidden="true" style="height: {smallMultipleRows * 100}%"></div>
+    {#if a11y}
+      <!-- #1090: visually-hidden data-table mirror for screen readers. -->
+      <table class="sr-only">
+        <caption>{a11y.caption}</caption>
+        {#if !a11y.empty}
+          <thead>
+            <tr>
+              {#each a11y.headers as h, i (i)}
+                <th scope="col">{h}</th>
+              {/each}
+            </tr>
+          </thead>
+          <tbody>
+            {#each a11y.rows as row, ri (ri)}
+              <tr>
+                <th scope="row">{row[0]}</th>
+                {#each row.slice(1) as cell, ci (ci)}
+                  <td>{cell}</td>
+                {/each}
+              </tr>
+            {/each}
+          </tbody>
+        {/if}
+      </table>
+    {/if}
     {#if loading && !response}
       <div class="overlay solid"><TileLoading variant={loadingVariant} /></div>
     {:else if error}
@@ -404,6 +446,19 @@
   .canvas {
     /* height is set inline = smallMultipleRows * 100% (100% for a single chart). */
     width: 100%;
+  }
+  /* #1090: visually hide the a11y data table while keeping it in the
+     accessibility tree (standard sr-only / visually-hidden pattern). */
+  .sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
   }
   .overlay {
     position: absolute;


### PR DESCRIPTION
## Summary

Charts render to a `<canvas>` that is invisible to assistive tech — today they're blank rectangles to a screen reader. This hides the canvas from AT and exposes the **same data as a visually-hidden HTML `<table>` mirror** on both surfaces (workspace + dashboard tiles), so a screen reader reads the chart's data row-by-row.

## The change

- **NEW `$lib/charts/a11y.ts`** — pure `chartSummary(type, title, projection)` → `{ caption, headers, rows, empty }` + `chartTypeLabel` + `chartAriaLabel`. Caption names the chart type, series, and category count; the table is categories × series with locale-formatted values (em-dash for gaps).
- **ChartView.svelte** (workspace) — extracted `projectResult()` (shared by the chart builder and the a11y mirror so they always agree), set `aria-hidden` on the canvas, render the `sr-only` data table.
- **ChartTile.svelte** (dashboard) — a11y summary from the response projection; same `aria-hidden` canvas + `sr-only` table.
- `sr-only` visually-hidden CSS on both surfaces.

## Verified

- `npm run check` → 0 errors / 0 warnings
- `npx vitest run` → **579 passing** (incl. new `a11y.test.ts`, 10 tests)
- Local browser test (user-confirmed): charts visually unchanged; each chart exposes an `aria-hidden` canvas + an `sr-only` data table with a caption (verified via DOM + accessibility tree).

## Test plan

- [x] Charts render with zero visible change (canvas output unchanged)
- [x] Each chart has `aria-hidden` canvas + an `sr-only` `<table>` mirror with caption + data
- [x] Unit tests on the pure summary helper (type label, caption, table model, gaps, empty, custom format)

## Notes

- Auto-generated a11y only. The issue's optional **per-tile "alt text override"** field lives in the chart-tile editor (**#1077**, currently paused), so it's deferred to that ticket.
- UI-only — no backend, no new endpoints, no `{@html}` (all table text is escaped Svelte interpolation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)