### PR TITLE
fix(query): #1131 ThinQuery.setQueryModel was silently clobbering type (auto-merge race follow-up)

### DIFF
--- a/saiku-core/saiku-service/src/main/java/org/saiku/olap/query2/ThinQuery.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/olap/query2/ThinQuery.java
@@ -63,9 +63,17 @@ public class ThinQuery implements ISaikuQuery {
      */
     public void setQueryModel(ThinQueryModel queryModel) {
         this.queryModel = queryModel;
-        if (queryModel != null) {
-            this.type = Type.QUERYMODEL;
-        }
+        // saiku#1131: do NOT auto-set type=QUERYMODEL here. Jackson invokes
+        // setters in JSON property order; a request body that explicitly
+        // says {"type":"MDX", "queryModel":{...empty...}, "mdx":"SELECT ..."}
+        // (the workspace's Edit-in-canvas shape — queryModel is the prior
+        // QUERYMODEL state, kept on the wire for round-trip) would get its
+        // type silently clobbered back to QUERYMODEL when Jackson calls
+        // setQueryModel after setType. The downstream converter then
+        // regenerates MDX from the (empty) queryModel and Mondrian runs
+        // "SELECT FROM [Sales]" — 0 rows — even though the wire carried a
+        // valid mdx. Java callers that build ThinQuery imperatively must
+        // set type explicitly; the QUERYMODEL constructor already does.
     }
 
     /**


### PR DESCRIPTION
## Why this is a follow-up

PR #1134 was supposed to ship the real #1131 fix. It auto-merged when its **first** commit went green on CI — but that first commit was only the defensive \`createQuery\` refresh, not the actual root cause. The second commit (this one, \`feaa03ee0\` on the now-closed branch) was pushed after auto-merge already fired, so it never landed on \`development\`.

Verified just now by Playwright on the redeployed demo: same \`"mdx":"SELECT\\nFROM [Sales]"\` response, same 0 rows × 1 cols result.

## The actual fix

\`ThinQuery.setQueryModel()\` had this side-effect:

\`\`\`java
public void setQueryModel(ThinQueryModel queryModel) {
    this.queryModel = queryModel;
    if (queryModel != null) {
        this.type = Type.QUERYMODEL;  // <- bug
    }
}
\`\`\`

Jackson invokes setters in JSON-property order, so a body like:

\`\`\`json
{ "type": "MDX", "queryModel": { ...empty... }, "mdx": "SELECT NON EMPTY..." }
\`\`\`

…got \`type=MDX\` set, then \`setQueryModel\` silently flipped it back to QUERYMODEL. The downstream converter then ran on the empty model and Mondrian executed \`SELECT FROM [Sales]\` — 0 rows.

Removed the side-effect; comment block in source explains the gotcha so a future engineer doesn't re-add it.

## Reproduced + verified locally before pushing this time

Built launcher fat-jar + ran on :8090 + curl reproduced the bug (`mdx-in-response: SELECT FROM [Sales]`) → applied fix → rebuilt → curl returns `USA | 565,238.13` and the full multi-line MDX in the response header.

## Verified

- 479/479 \`mvn -pl saiku-core/saiku-service -am test\` pass
- 530/530 vitest pass
- svelte-check 0/0
- End-to-end local launcher curl test passes

## Behaviour change to flag

Tools → MDX modal will now actually execute the user's typed MDX. Pre-fix it silently ran the queryModel-converted MDX. Worth a CHANGELOG bullet in the next release.