### PR TITLE
feat(charts): brush + zoom (dataZoom) on cartesian charts (closes #1080)

### DIFF
--- a/saiku-ui/src/lib/charts/__snapshots__/build.test.ts.snap
+++ b/saiku-ui/src/lib/charts/__snapshots__/build.test.ts.snap
@@ -14,6 +14,13 @@ exports[`buildChartOption — coverage of all 15 types > snapshot of every type'
       "#ec4899",
       "#14b8a6",
     ],
+    "dataZoom": [
+      {
+        "filterMode": "none",
+        "type": "inside",
+        "xAxisIndex": 0,
+      },
+    ],
     "grid": {
       "bottom": 36,
       "left": 48,
@@ -138,6 +145,13 @@ exports[`buildChartOption — coverage of all 15 types > snapshot of every type'
       "#a855f7",
       "#ec4899",
       "#14b8a6",
+    ],
+    "dataZoom": [
+      {
+        "filterMode": "none",
+        "type": "inside",
+        "xAxisIndex": 0,
+      },
     ],
     "grid": {
       "bottom": 36,
@@ -264,6 +278,19 @@ exports[`buildChartOption — coverage of all 15 types > snapshot of every type'
       "#ec4899",
       "#14b8a6",
     ],
+    "dataZoom": [
+      {
+        "filterMode": "none",
+        "type": "inside",
+        "xAxisIndex": 0,
+      },
+    ],
+    "grid": {
+      "bottom": 36,
+      "left": 48,
+      "right": 16,
+      "top": 24,
+    },
     "legend": {
       "bottom": 0,
       "textStyle": {
@@ -640,6 +667,13 @@ exports[`buildChartOption — coverage of all 15 types > snapshot of every type'
       "#ec4899",
       "#14b8a6",
     ],
+    "dataZoom": [
+      {
+        "filterMode": "none",
+        "type": "inside",
+        "xAxisIndex": 0,
+      },
+    ],
     "grid": {
       "bottom": 36,
       "left": 48,
@@ -962,6 +996,19 @@ exports[`buildChartOption — coverage of all 15 types > snapshot of every type'
       "#ec4899",
       "#14b8a6",
     ],
+    "dataZoom": [
+      {
+        "filterMode": "none",
+        "type": "inside",
+        "xAxisIndex": 0,
+      },
+    ],
+    "grid": {
+      "bottom": 36,
+      "left": 48,
+      "right": 16,
+      "top": 24,
+    },
     "legend": {
       "bottom": 0,
       "textStyle": {
@@ -1085,6 +1132,13 @@ exports[`buildChartOption — coverage of all 15 types > snapshot of every type'
       "#a855f7",
       "#ec4899",
       "#14b8a6",
+    ],
+    "dataZoom": [
+      {
+        "filterMode": "none",
+        "type": "inside",
+        "xAxisIndex": 0,
+      },
     ],
     "grid": {
       "bottom": 36,
@@ -1211,6 +1265,13 @@ exports[`buildChartOption — coverage of all 15 types > snapshot of every type'
       "#ec4899",
       "#14b8a6",
     ],
+    "dataZoom": [
+      {
+        "filterMode": "none",
+        "type": "inside",
+        "xAxisIndex": 0,
+      },
+    ],
     "grid": {
       "bottom": 36,
       "left": 48,
@@ -1335,6 +1396,13 @@ exports[`buildChartOption — coverage of all 15 types > snapshot of every type'
       "#a855f7",
       "#ec4899",
       "#14b8a6",
+    ],
+    "dataZoom": [
+      {
+        "filterMode": "none",
+        "type": "inside",
+        "xAxisIndex": 0,
+      },
     ],
     "grid": {
       "bottom": 36,
@@ -1655,6 +1723,13 @@ exports[`buildChartOption — coverage of all 15 types > snapshot of every type'
       "#ec4899",
       "#14b8a6",
     ],
+    "dataZoom": [
+      {
+        "filterMode": "none",
+        "type": "inside",
+        "xAxisIndex": 0,
+      },
+    ],
     "grid": {
       "bottom": 36,
       "left": 48,
@@ -1804,8 +1879,22 @@ exports[`buildChartOption — coverage of all 15 types > snapshot of every type'
       "#ec4899",
       "#14b8a6",
     ],
+    "dataZoom": [
+      {
+        "filterMode": "none",
+        "type": "inside",
+        "xAxisIndex": 0,
+      },
+      {
+        "bottom": 8,
+        "filterMode": "none",
+        "height": 16,
+        "type": "slider",
+        "xAxisIndex": 0,
+      },
+    ],
     "grid": {
-      "bottom": 60,
+      "bottom": 76,
       "left": 60,
       "right": 40,
       "top": 40,
@@ -1928,8 +2017,22 @@ exports[`buildChartOption — coverage of all 15 types > snapshot of every type'
       "#ec4899",
       "#14b8a6",
     ],
+    "dataZoom": [
+      {
+        "filterMode": "none",
+        "type": "inside",
+        "xAxisIndex": 0,
+      },
+      {
+        "bottom": 8,
+        "filterMode": "none",
+        "height": 16,
+        "type": "slider",
+        "xAxisIndex": 0,
+      },
+    ],
     "grid": {
-      "bottom": 60,
+      "bottom": 76,
       "left": 60,
       "right": 40,
       "top": 40,
@@ -2052,6 +2155,26 @@ exports[`buildChartOption — coverage of all 15 types > snapshot of every type'
       "#ec4899",
       "#14b8a6",
     ],
+    "dataZoom": [
+      {
+        "filterMode": "none",
+        "type": "inside",
+        "xAxisIndex": 0,
+      },
+      {
+        "bottom": 8,
+        "filterMode": "none",
+        "height": 16,
+        "type": "slider",
+        "xAxisIndex": 0,
+      },
+    ],
+    "grid": {
+      "bottom": 76,
+      "left": 60,
+      "right": 40,
+      "top": 40,
+    },
     "legend": {
       "textStyle": {
         "color": "#0f172a",
@@ -2427,8 +2550,22 @@ exports[`buildChartOption — coverage of all 15 types > snapshot of every type'
       "#ec4899",
       "#14b8a6",
     ],
+    "dataZoom": [
+      {
+        "filterMode": "none",
+        "type": "inside",
+        "xAxisIndex": 0,
+      },
+      {
+        "bottom": 8,
+        "filterMode": "none",
+        "height": 16,
+        "type": "slider",
+        "xAxisIndex": 0,
+      },
+    ],
     "grid": {
-      "bottom": 60,
+      "bottom": 76,
       "left": 60,
       "right": 40,
       "top": 40,
@@ -2747,6 +2884,26 @@ exports[`buildChartOption — coverage of all 15 types > snapshot of every type'
       "#ec4899",
       "#14b8a6",
     ],
+    "dataZoom": [
+      {
+        "filterMode": "none",
+        "type": "inside",
+        "xAxisIndex": 0,
+      },
+      {
+        "bottom": 8,
+        "filterMode": "none",
+        "height": 16,
+        "type": "slider",
+        "xAxisIndex": 0,
+      },
+    ],
+    "grid": {
+      "bottom": 76,
+      "left": 60,
+      "right": 40,
+      "top": 40,
+    },
     "legend": {
       "textStyle": {
         "color": "#0f172a",
@@ -2870,8 +3027,22 @@ exports[`buildChartOption — coverage of all 15 types > snapshot of every type'
       "#ec4899",
       "#14b8a6",
     ],
+    "dataZoom": [
+      {
+        "filterMode": "none",
+        "type": "inside",
+        "xAxisIndex": 0,
+      },
+      {
+        "bottom": 8,
+        "filterMode": "none",
+        "height": 16,
+        "type": "slider",
+        "xAxisIndex": 0,
+      },
+    ],
     "grid": {
-      "bottom": 60,
+      "bottom": 76,
       "left": 60,
       "right": 40,
       "top": 40,
@@ -2994,8 +3165,22 @@ exports[`buildChartOption — coverage of all 15 types > snapshot of every type'
       "#ec4899",
       "#14b8a6",
     ],
+    "dataZoom": [
+      {
+        "filterMode": "none",
+        "type": "inside",
+        "xAxisIndex": 0,
+      },
+      {
+        "bottom": 8,
+        "filterMode": "none",
+        "height": 16,
+        "type": "slider",
+        "xAxisIndex": 0,
+      },
+    ],
     "grid": {
-      "bottom": 60,
+      "bottom": 76,
       "left": 60,
       "right": 40,
       "top": 40,
@@ -3118,8 +3303,22 @@ exports[`buildChartOption — coverage of all 15 types > snapshot of every type'
       "#ec4899",
       "#14b8a6",
     ],
+    "dataZoom": [
+      {
+        "filterMode": "none",
+        "type": "inside",
+        "xAxisIndex": 0,
+      },
+      {
+        "bottom": 8,
+        "filterMode": "none",
+        "height": 16,
+        "type": "slider",
+        "xAxisIndex": 0,
+      },
+    ],
     "grid": {
-      "bottom": 60,
+      "bottom": 76,
       "left": 60,
       "right": 40,
       "top": 40,
@@ -3436,8 +3635,22 @@ exports[`buildChartOption — coverage of all 15 types > snapshot of every type'
       "#ec4899",
       "#14b8a6",
     ],
+    "dataZoom": [
+      {
+        "filterMode": "none",
+        "type": "inside",
+        "xAxisIndex": 0,
+      },
+      {
+        "bottom": 8,
+        "filterMode": "none",
+        "height": 16,
+        "type": "slider",
+        "xAxisIndex": 0,
+      },
+    ],
     "grid": {
-      "bottom": 60,
+      "bottom": 76,
       "left": 60,
       "right": 40,
       "top": 30,

--- a/saiku-ui/src/lib/charts/build.test.ts
+++ b/saiku-ui/src/lib/charts/build.test.ts
@@ -394,6 +394,67 @@ describe("buildChartOption — map (#1071)", () => {
   });
 });
 
+describe("buildChartOption — dataZoom zoom + pan (#1080)", () => {
+  // The cartesian families that get x-axis zoom/pan.
+  const CARTESIAN = [
+    "bar",
+    "stackedBar",
+    "line",
+    "stackedLine",
+    "area",
+    "stackedArea",
+    "scatter",
+    "bubble",
+    "waterfall",
+  ] as const;
+  // Non-cartesian types must NEVER get dataZoom (it would be meaningless / break layout).
+  const NON_CARTESIAN = ["pie", "donut", "treemap", "sunburst", "heatmap", "radar", "map"] as const;
+
+  test("every cartesian type (roomy) gets an inside zoom + a bottom slider", () => {
+    for (const t of CARTESIAN) {
+      const opt = buildChartOption(sample(), t, opts(), undefined, { compact: false }) as Record<
+        string,
+        unknown
+      >;
+      const dz = opt.dataZoom as Array<{ type: string; xAxisIndex: number }>;
+      expect(Array.isArray(dz), `${t} dataZoom is array`).toBe(true);
+      expect(dz.map((d) => d.type), `${t} has inside + slider`).toEqual(["inside", "slider"]);
+      // x-axis only — value-axis zoom fights magnitude comparison.
+      expect(dz.every((d) => d.xAxisIndex === 0)).toBe(true);
+    }
+  });
+
+  test("every cartesian type (compact) gets an inside zoom but NO slider", () => {
+    for (const t of CARTESIAN) {
+      const opt = buildChartOption(sample(), t, opts(), undefined, { compact: true }) as Record<
+        string,
+        unknown
+      >;
+      const dz = opt.dataZoom as Array<{ type: string }>;
+      expect(dz.map((d) => d.type), `${t} compact = inside only`).toEqual(["inside"]);
+    }
+  });
+
+  test("non-cartesian types never get dataZoom (roomy or compact)", () => {
+    for (const t of NON_CARTESIAN) {
+      for (const compact of [false, true]) {
+        const proj = t === "map" ? { rowCategories: ["USA"], columnCategories: ["m"], matrix: [[5]] } : sample();
+        const opt = buildChartOption(proj, t, opts(), undefined, { compact }) as Record<string, unknown>;
+        expect(opt.dataZoom, `${t} compact=${compact} has no dataZoom`).toBeUndefined();
+      }
+    }
+  });
+
+  test("dataZoom uses filterMode 'none' so zooming never drops data from the series", () => {
+    const opt = buildChartOption(sample(), "bar", opts(), undefined, { compact: false }) as Record<
+      string,
+      unknown
+    >;
+    const dz = opt.dataZoom as Array<{ filterMode: string }>;
+    expect(dz.every((d) => d.filterMode === "none")).toBe(true);
+  });
+});
+
 describe("buildChartOption — rejection", () => {
   test("returns null for unknown chart kinds", () => {
     expect(buildChartOption(sample(), "made-up")).toBeNull();

--- a/saiku-ui/src/lib/charts/build.ts
+++ b/saiku-ui/src/lib/charts/build.ts
@@ -192,6 +192,36 @@ function colorRampFor(ramp: ChartColorRamp | undefined): string[] {
   return COLOR_RAMPS[ramp ?? "blues"] ?? COLOR_RAMPS.blues;
 }
 
+/* issue #1080: x-axis zoom + pan for CARTESIAN charts (bar/line/area family,
+ * scatter/bubble, waterfall). Brush/selection events are out of scope (#1085) —
+ * this is zoom/pan only.
+ *
+ * Roomy (workspace) gets BOTH an `inside` zoom (mouse-wheel + drag-to-pan) and a
+ * thin bottom `slider` so the zoomed window is visible and resettable by hand.
+ * Compact (dashboard tiles) gets ONLY the `inside` zoom — tiles are too small to
+ * spend vertical space on a slider, and dashboard charts are usually glanceable
+ * rather than explored. Both are x-axis-only (zooming the value axis fights the
+ * "compare magnitudes" job a bar/line chart does).
+ *
+ * Behaviour is always-on for the surface (driven by the existing `compact` geom
+ * flag) — no new persisted ChartOptions field, so dashboard save (#1077, paused)
+ * stays untouched. The builder stays pure: this just shapes option JSON; the
+ * echarts instance/lifecycle lives in the .svelte components. */
+function dataZoomConfig(compact: boolean): Record<string, unknown>[] {
+  const inside = { type: "inside", xAxisIndex: 0, filterMode: "none" as const };
+  if (compact) return [inside];
+  return [
+    inside,
+    {
+      type: "slider",
+      xAxisIndex: 0,
+      filterMode: "none" as const,
+      bottom: 8,
+      height: 16,
+    },
+  ];
+}
+
 /* Escape HTML — the map tooltip uses an ECharts function formatter whose return
  * value is inserted as innerHTML (renderMode "html"), and the region name is
  * data-derived (an aliased cube member caption). Without escaping, a hostile
@@ -459,6 +489,12 @@ export function buildChartOption(
       title,
       tooltip: tooltipStyle,
       legend,
+      // #1080: roomy gets a slider + inside zoom; compact gets inside-only. The
+      // roomy slider sits at the bottom, so reserve a little extra grid bottom.
+      grid: compact
+        ? { top: 24, left: 48, right: 16, bottom: 36 }
+        : { left: 60, top: title ? 50 : 40, right: 40, bottom: 76 },
+      dataZoom: dataZoomConfig(compact),
       xAxis: { ...baseAxis, axisLabel: catLabel(), data: cols, name: xName },
       yAxis: { ...valueAxis, name: yName },
       series: rows.map((name, i) => ({
@@ -501,7 +537,8 @@ export function buildChartOption(
       legend,
       grid: compact
         ? { top: 24, left: 48, right: 16, bottom: 36 }
-        : { left: 60, top: title ? 50 : 30, right: 40, bottom: 60 },
+        : { left: 60, top: title ? 50 : 30, right: 40, bottom: 76 },
+      dataZoom: dataZoomConfig(compact), // #1080: x-axis zoom + pan
       xAxis: { ...baseAxis, axisLabel: catLabel(), data: rows, name: xName },
       yAxis: { ...valueAxis, name: yName },
       series: [
@@ -594,7 +631,8 @@ export function buildChartOption(
     legend,
     grid: compact
       ? { top: 24, left: 48, right: 16, bottom: 36 }
-      : { left: 60, top: title ? 50 : 40, right: hasRight ? 60 : 40, bottom: 60 },
+      : { left: 60, top: title ? 50 : 40, right: hasRight ? 60 : 40, bottom: 76 },
+    dataZoom: dataZoomConfig(compact), // #1080: x-axis zoom + pan
     xAxis: { ...baseAxis, axisLabel: catLabel(compact && rows.length > 8 ? 30 : 0), data: rows, name: xName },
     yAxis,
     series: [...base, ...trend],


### PR DESCRIPTION
## Summary

Adds ECharts **dataZoom** (x-axis zoom + pan) to all cartesian chart types in the shared builder, on both surfaces. Workspace charts get an inside-zoom + a bottom slider; dashboard tiles get inside-zoom only (no slider — tiles are small).

## The change
- `$lib/charts/build.ts`: cartesian types (bar, stackedBar, line, stackedLine, area, stackedArea, scatter, bubble, waterfall) emit a `dataZoom` (inside; + slider in roomy/non-compact mode). Non-cartesian types (pie/donut/treemap/sunburst/heatmap/radar/map) are untouched. Stays pure (no echarts/DOM import); driven off the existing `compact` geom flag — no new persisted ChartOptions field.

## Verified
- `npm run check` 0/0; `npx vitest run` **596** passing (+5 dataZoom assertions; 2 all-types snapshots legitimately updated).
- Local browser test (user-confirmed): wheel-zoom + pan + slider on cartesian charts in the workspace; no zoom on pie/map; tiles zoom without a slider.

## Notes
- Brush/selection events (→ cross-filter) are **#1085**, out of scope. Reset is via dragging the slider handles to full range (a dedicated reset button can come later).
- UI-only; no backend, no new endpoints, no `{@html}`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)