### PR TITLE
fix(ui/ai-drawer): auto-run AI MDX in canvas, keep drawer open for follow-ups

### DIFF
--- a/saiku-ui/src/lib/views/AiQueryDrawer.svelte
+++ b/saiku-ui/src/lib/views/AiQueryDrawer.svelte
@@ -209,6 +209,14 @@
       },
     ];
     inflight = false;
+
+    // Auto-render the AI's MDX in the workspace canvas behind the drawer
+    // so the user sees the data immediately. The drawer stays open — each
+    // follow-up question updates the canvas in place. Edit-in-canvas
+    // becomes a no-op repeat for the user who explicitly clicks it.
+    if (mdx) {
+      onEditInCanvas(mdx);
+    }
   }
 
   function clearConversation(): void {

--- a/saiku-ui/src/lib/views/Workspace.svelte
+++ b/saiku-ui/src/lib/views/Workspace.svelte
@@ -55,12 +55,18 @@
    *  Closes the drawer so the user sees their cellset; the canvas
    *  re-renders with the result and existing grid / chart / drill /
    *  export features keep working. */
+  /**
+   * Push AI-generated MDX into the active workspace tab and run it.
+   * The drawer stays open so the user can keep iterating — every
+   * AI response auto-runs in the canvas behind the drawer, and the
+   * conversation thread persists. Closing the drawer is a separate
+   * user action (X or Esc).
+   */
   async function handleEditInCanvas(mdx: string): Promise<void> {
     if (!query.current) return;
     query.current.mdx = mdx;
     query.current.type = "MDX";
     query.current.name = "";
-    aiDrawerOpen = false;
     await query.run();
   }
 


### PR DESCRIPTION
## Summary

- Each successful AI response now auto-runs the generated MDX in the workspace canvas — no more clicking "Edit in canvas" just to see the data the AI already returned.
- Drawer stays open after Edit-in-canvas so the conversation thread persists and follow-ups update the canvas in place.

## Background

Tom on the demo: "what's the point of returning 1 row but not showing it? cant we just show it in the main screen whilst continuing the conversation?"

Previously the AI returned MDX + a "N rows returned" summary, but the canvas behind the drawer stayed empty until the user explicitly clicked Edit in canvas, which also closed the drawer. That's an artificial split between "the AI knows the answer" and "you can see the answer."

## Test plan

- [x] svelte-check: 0 errors
- [x] vitest: 592/592 pass
- [ ] On demo: open drawer, ask question, verify canvas auto-populates AND drawer stays open
- [ ] Ask follow-up question, verify canvas updates AND prior conversation is intact
- [ ] Close drawer, reopen — conversation thread persists