### PR TITLE
feat(workspace): hide queryModel-only UI when type=MDX

### DIFF
--- a/saiku-ui/src/lib/i18n/en.json
+++ b/saiku-ui/src/lib/i18n/en.json
@@ -389,6 +389,7 @@
   "workspace.aiQuery.empty": "Ask a question about the active cube and I'll translate it to an OLAP query. Type your question in the box below.",
   "workspace.aiQuery.activeCube": "Active cube: {cube}",
   "workspace.aiQuery.tryAsking": "Try asking:",
+  "canvas.mdxBannerText": "Running raw MDX — drop-zone editing is disabled. Switch back to build mode by clearing the MDX.",
   "workspace.aiQuery.example1": "Show me sales by country",
   "workspace.aiQuery.example2": "Top 10 products by revenue",
   "workspace.aiQuery.example3": "Quarterly sales trend",

--- a/saiku-ui/src/lib/views/QueryCanvas.svelte
+++ b/saiku-ui/src/lib/views/QueryCanvas.svelte
@@ -759,6 +759,7 @@
     </div>
   {:else}
     <div class="canvas__body">
+    {#if query.current?.type !== "MDX"}
     <aside class="dropzones">
       <!-- Dedicated MEASURES panel (restored from the pre-rewrite UI).
            Sits above COLUMNS/ROWS so the chip stack visually separates
@@ -909,7 +910,14 @@
         </div>
       </div>
     </aside>
+    {/if}
     <div class="canvas__result">
+    {#if query.current?.type === "MDX"}
+      <div class="canvas__mdx-banner" role="status">
+        <span class="canvas__mdx-badge">MDX</span>
+        <span class="canvas__mdx-text">{i18n.t("canvas.mdxBannerText")}</span>
+      </div>
+    {/if}
     <div class="view-toggle" role="tablist" aria-label={i18n.t("canvas.resultView")}>
       <button type="button" role="tab" class:active={query.viewMode === "grid"} onclick={() => (query.viewMode = "grid")}>
         {i18n.t("canvas.view.grid")}
@@ -1172,6 +1180,30 @@
     flex-direction: column;
     gap: var(--space-2);
     overflow: hidden;
+  }
+  .canvas__mdx-banner {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 6px 10px;
+    background: rgba(99, 102, 241, 0.08);
+    border: 1px solid rgba(99, 102, 241, 0.25);
+    border-radius: var(--radius-md);
+    font-size: var(--fs-sm);
+    color: var(--fg-muted);
+  }
+  .canvas__mdx-badge {
+    background: var(--accent);
+    color: white;
+    border-radius: 999px;
+    padding: 2px 8px;
+    font-size: 0.72rem;
+    font-weight: 600;
+    letter-spacing: 0.04em;
+  }
+  .canvas__mdx-text {
+    flex: 1;
+    min-width: 0;
   }
   .canvas__empty {
     display: flex;

--- a/saiku-ui/src/lib/views/WorkspaceToolbar.svelte
+++ b/saiku-ui/src/lib/views/WorkspaceToolbar.svelte
@@ -389,23 +389,27 @@
           <input type="checkbox" bind:checked={query.autorun} />
           <span>{i18n.t("toolbar.autorun")}</span>
         </label>
-        <label class="toolbar__check" title={i18n.t("toolbar.nonEmpty.hint")}>
-          <input type="checkbox" bind:checked={nonEmpty} />
-          <span>{i18n.t("toolbar.nonEmpty")}</span>
-        </label>
-        <label class="toolbar__check" title={i18n.t("toolbar.visualTotals.hint")}>
-          <input type="checkbox" bind:checked={visualTotals} />
-          <span>{i18n.t("toolbar.visualTotals")}</span>
-        </label>
+        {#if query.current?.type !== "MDX"}
+          <label class="toolbar__check" title={i18n.t("toolbar.nonEmpty.hint")}>
+            <input type="checkbox" bind:checked={nonEmpty} />
+            <span>{i18n.t("toolbar.nonEmpty")}</span>
+          </label>
+          <label class="toolbar__check" title={i18n.t("toolbar.visualTotals.hint")}>
+            <input type="checkbox" bind:checked={visualTotals} />
+            <span>{i18n.t("toolbar.visualTotals")}</span>
+          </label>
+        {/if}
         <label class="toolbar__check" title={i18n.t("toolbar.async.hint")}>
           <input type="checkbox" bind:checked={query.async} />
           <span>{i18n.t("toolbar.async")}</span>
         </label>
       </div>
     {/if}
-    <button class="tb-btn" title={i18n.t("toolbar.swap")} aria-label={i18n.t("toolbar.swap")} onclick={() => query.swapAxes()}>
-      <ArrowLeftRight size={18} />
-    </button>
+    {#if query.current?.type !== "MDX"}
+      <button class="tb-btn" title={i18n.t("toolbar.swap")} aria-label={i18n.t("toolbar.swap")} onclick={() => query.swapAxes()}>
+        <ArrowLeftRight size={18} />
+      </button>
+    {/if}
   </div>
   {#if onAskAi}
     <div class="toolbar__sep"></div>


### PR DESCRIPTION
## Summary

- Hide the dropzones aside (MEASURES / COLUMNS / ROWS / FILTER), the swap-axes button, and the nonEmpty / visualTotals options when the workspace runs raw MDX.
- Add an \`MDX\` chip + helper-text banner above the result view-toggle so users know why the dropzones disappeared.

## Background

Tom: "hide the dropzones etc and other interactivity that you cant use when its running mdx mode"

When a workspace runs raw MDX (AI Ask response, manual MDX paste, AI follow-up chain), the dropzones and queryModel-axis toggles edit a representation the running query bypasses entirely. Showing them implies they affect the result — they don't.

## Test plan

- [x] svelte-check: 0 errors
- [x] vitest: 592/592 pass
- [ ] On demo: Ask AI a question → canvas runs MDX → dropzones aside hidden, MDX banner shown, swap-axes hidden
- [ ] Clear the MDX (e.g., New query) → dropzones reappear, banner gone