### PR TITLE
feat(ai/ask): scope guardrail — refuse off-topic questions

### DIFF
--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ai/ask/AnthropicNlAskProvider.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ai/ask/AnthropicNlAskProvider.java
@@ -36,17 +36,28 @@ public final class AnthropicNlAskProvider implements NlAskProvider {
     private static final String ENDPOINT = "https://api.anthropic.com/v1/messages";
     private static final String API_VERSION = "2023-06-01";
     private static final String TOOL_NAME = "emit_query";
+    private static final String REFUSAL_TOOL_NAME = "refuse_off_topic";
 
-    private static final String SYSTEM_PROMPT = "You are a Mondrian OLAP query assistant. Your job is to "
-            + "translate a user's natural-language question into a single AiQueryRequest by calling the "
-            + "emit_query tool. CRITICAL RULES: (1) Every name field MUST refer to a member, measure, "
+    private static final String SYSTEM_PROMPT = "You are a Mondrian OLAP query assistant scoped to a "
+            + "single cube. Your job is to translate a user's natural-language question about the "
+            + "cube's data into a single AiQueryRequest by calling the emit_query tool. "
+            + "SCOPE GUARDRAIL: If the user's question is NOT about querying this cube's data — e.g. "
+            + "general knowledge, coding help, weather, math, prose composition, jokes, advice, "
+            + "personal questions, or anything you couldn't answer with measures/dimensions from the "
+            + "schema below — you MUST call the refuse_off_topic tool with a one-sentence reason. "
+            + "Do not attempt to answer off-topic questions with prose, and do not invent a cube "
+            + "query just to satisfy the user. Borderline cases (analytical questions phrased in "
+            + "domain terms that map to the schema) should still call emit_query. "
+            + "CRITICAL RULES for emit_query: (1) Every name field MUST refer to a member, measure, "
             + "dimension, hierarchy or level present in the provided cube schema — never invent names. "
             + "(2) Echo the connectionName, catalog, schema and cubeName from the provided cube ref "
             + "exactly. (3) Prefer rows for the dimension the user wants to break down by; use columns "
             + "only when the user explicitly compares across two axes. (4) Put time / region restrictions "
             + "in filters (the slicer). (5) When the user asks for 'top N' or 'bottom N', set both "
             + "`order` and `limit`. (6) Keep aggregator overrides off unless the user asks for one. "
-            + "Always call emit_query — never respond with prose.";
+            + "Always call exactly one tool — never respond with prose.";
+
+    private static final String REFUSAL_REASON_PREFIX = "OFF_TOPIC: ";
 
     private static final ObjectMapper MAPPER = new ObjectMapper();
 
@@ -140,9 +151,27 @@ public final class AnthropicNlAskProvider implements NlAskProvider {
         tool.put("description", "Emit a structured AiQueryRequest matching the cube schema.");
         tool.set("input_schema", MAPPER.readTree(request.requestJsonSchema()));
 
+        // Refusal path — the model picks this when the user's question isn't
+        // about the cube. Stops Saiku's AI key from becoming a free general
+        // LLM proxy.
+        ObjectNode refusalTool = tools.addObject();
+        refusalTool.put("name", REFUSAL_TOOL_NAME);
+        refusalTool.put(
+                "description",
+                "Refuse a question that isn't about querying this cube's data. Call with a one-sentence reason.");
+        ObjectNode refusalSchema = refusalTool.putObject("input_schema");
+        refusalSchema.put("type", "object");
+        ObjectNode refusalProps = refusalSchema.putObject("properties");
+        ObjectNode reasonProp = refusalProps.putObject("reason");
+        reasonProp.put("type", "string");
+        reasonProp.put("description", "One-sentence explanation of why the question is off-topic.");
+        refusalSchema.putArray("required").add("reason");
+
+        // tool_choice "any" — model must call a tool, but picks emit_query OR
+        // refuse_off_topic. Was "tool" (forced emit_query) before; that path
+        // would have the model invent queries for off-topic questions.
         ObjectNode toolChoice = root.putObject("tool_choice");
-        toolChoice.put("type", "tool");
-        toolChoice.put("name", TOOL_NAME);
+        toolChoice.put("type", "any");
 
         ArrayNode messages = root.putArray("messages");
         for (NlAskMessage m : request.history()) {
@@ -183,13 +212,20 @@ public final class AnthropicNlAskProvider implements NlAskProvider {
         JsonNode content = root.path("content");
         if (content.isArray()) {
             for (JsonNode block : content) {
-                if ("tool_use".equals(block.path("type").asText())
-                        && TOOL_NAME.equals(block.path("name").asText())) {
+                if (!"tool_use".equals(block.path("type").asText())) {
+                    continue;
+                }
+                String toolName = block.path("name").asText();
+                if (TOOL_NAME.equals(toolName)) {
                     JsonNode input = block.path("input");
                     if (input.isMissingNode() || input.isNull()) {
                         return NlAskResponse.degraded("empty tool_use input", model);
                     }
                     return NlAskResponse.ok(MAPPER.writeValueAsString(input), model, inputTokens, outputTokens);
+                }
+                if (REFUSAL_TOOL_NAME.equals(toolName)) {
+                    String reason = block.path("input").path("reason").asText("Question is not about the cube.");
+                    return NlAskResponse.degraded(REFUSAL_REASON_PREFIX + reason, model);
                 }
             }
         }

--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ai/ask/OpenAINlAskProvider.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ai/ask/OpenAINlAskProvider.java
@@ -39,17 +39,27 @@ public final class OpenAINlAskProvider implements NlAskProvider {
     public static final String DEFAULT_ENDPOINT = "https://api.openai.com/v1/chat/completions";
 
     private static final String TOOL_NAME = "emit_query";
+    private static final String REFUSAL_TOOL_NAME = "refuse_off_topic";
+    private static final String REFUSAL_REASON_PREFIX = "OFF_TOPIC: ";
 
-    private static final String SYSTEM_PROMPT = "You are a Mondrian OLAP query assistant. Your job is to "
-            + "translate a user's natural-language question into a single AiQueryRequest by calling the "
-            + "emit_query function. CRITICAL RULES: (1) Every name field MUST refer to a member, measure, "
+    private static final String SYSTEM_PROMPT = "You are a Mondrian OLAP query assistant scoped to a "
+            + "single cube. Your job is to translate a user's natural-language question about the "
+            + "cube's data into a single AiQueryRequest by calling the emit_query function. "
+            + "SCOPE GUARDRAIL: If the user's question is NOT about querying this cube's data — e.g. "
+            + "general knowledge, coding help, weather, math, prose composition, jokes, advice, "
+            + "personal questions, or anything you couldn't answer with measures/dimensions from the "
+            + "schema below — you MUST call the refuse_off_topic function with a one-sentence reason. "
+            + "Do not attempt to answer off-topic questions with prose, and do not invent a cube "
+            + "query just to satisfy the user. Borderline cases (analytical questions phrased in "
+            + "domain terms that map to the schema) should still call emit_query. "
+            + "CRITICAL RULES for emit_query: (1) Every name field MUST refer to a member, measure, "
             + "dimension, hierarchy or level present in the provided cube schema — never invent names. "
             + "(2) Echo the connectionName, catalog, schema and cubeName from the provided cube ref "
             + "exactly. (3) Prefer rows for the dimension the user wants to break down by; use columns "
             + "only when the user explicitly compares across two axes. (4) Put time / region restrictions "
             + "in filters (the slicer). (5) When the user asks for 'top N' or 'bottom N', set both "
             + "`order` and `limit`. (6) Keep aggregator overrides off unless the user asks for one. "
-            + "Always call emit_query — never respond with prose.";
+            + "Always call exactly one function — never respond with prose.";
 
     private static final ObjectMapper MAPPER = new ObjectMapper();
 
@@ -144,11 +154,27 @@ public final class OpenAINlAskProvider implements NlAskProvider {
         fn.put("description", "Emit a structured AiQueryRequest matching the cube schema.");
         fn.set("parameters", MAPPER.readTree(request.requestJsonSchema()));
 
-        // Force the model to call our tool — OpenAI uses tool_choice as an object with function name.
-        ObjectNode toolChoice = root.putObject("tool_choice");
-        toolChoice.put("type", "function");
-        ObjectNode toolChoiceFn = toolChoice.putObject("function");
-        toolChoiceFn.put("name", TOOL_NAME);
+        // Refusal path — model picks this when the user's question isn't
+        // about the cube. Stops the AI key becoming a free general LLM proxy.
+        ObjectNode refusalTool = tools.addObject();
+        refusalTool.put("type", "function");
+        ObjectNode refusalFn = refusalTool.putObject("function");
+        refusalFn.put("name", REFUSAL_TOOL_NAME);
+        refusalFn.put(
+                "description",
+                "Refuse a question that isn't about querying this cube's data. Call with a one-sentence reason.");
+        ObjectNode refusalParams = refusalFn.putObject("parameters");
+        refusalParams.put("type", "object");
+        ObjectNode refusalProps = refusalParams.putObject("properties");
+        ObjectNode reasonProp = refusalProps.putObject("reason");
+        reasonProp.put("type", "string");
+        reasonProp.put("description", "One-sentence explanation of why the question is off-topic.");
+        refusalParams.putArray("required").add("reason");
+
+        // tool_choice "required" — model must call a function, picks emit_query
+        // OR refuse_off_topic. Was forced-emit_query before; that would have
+        // the model invent queries for off-topic questions.
+        root.put("tool_choice", "required");
 
         ArrayNode messages = root.putArray("messages");
         ObjectNode system = messages.addObject();
@@ -203,13 +229,23 @@ public final class OpenAINlAskProvider implements NlAskProvider {
         }
         for (JsonNode call : toolCalls) {
             JsonNode function = call.path("function");
-            if (TOOL_NAME.equals(function.path("name").asText())) {
+            String fnName = function.path("name").asText();
+            if (TOOL_NAME.equals(fnName)) {
                 String arguments = function.path("arguments").asText(null);
                 if (arguments == null || arguments.isBlank()) {
                     return NlAskResponse.degraded("empty tool_call arguments", model);
                 }
                 // arguments is itself JSON-encoded as a string per the OpenAI contract — return as-is.
                 return NlAskResponse.ok(arguments, model, inputTokens, outputTokens);
+            }
+            if (REFUSAL_TOOL_NAME.equals(fnName)) {
+                String reason = "Question is not about the cube.";
+                String argsStr = function.path("arguments").asText("");
+                if (!argsStr.isBlank()) {
+                    JsonNode args = MAPPER.readTree(argsStr);
+                    reason = args.path("reason").asText(reason);
+                }
+                return NlAskResponse.degraded(REFUSAL_REASON_PREFIX + reason, model);
             }
         }
         return NlAskResponse.degraded("tool_calls did not include emit_query", model);

--- a/saiku-core/saiku-service/src/test/java/org/saiku/service/olap/ai/ask/AnthropicNlAskProviderTest.java
+++ b/saiku-core/saiku-service/src/test/java/org/saiku/service/olap/ai/ask/AnthropicNlAskProviderTest.java
@@ -44,13 +44,22 @@ public class AnthropicNlAskProviderTest {
 
         assertEquals("claude-x", root.get("model").asText());
         assertEquals(1024, root.get("max_tokens").asInt());
-        assertEquals("tool", root.get("tool_choice").get("type").asText());
-        assertEquals("emit_query", root.get("tool_choice").get("name").asText());
+        // tool_choice "any" lets the model pick emit_query OR refuse_off_topic.
+        assertEquals("any", root.get("tool_choice").get("type").asText());
 
         JsonNode tools = root.get("tools");
-        assertEquals(1, tools.size());
+        assertEquals(2, tools.size());
         assertEquals("emit_query", tools.get(0).get("name").asText());
         assertEquals("object", tools.get(0).get("input_schema").get("type").asText());
+        assertEquals("refuse_off_topic", tools.get(1).get("name").asText());
+        assertEquals(
+                "string",
+                tools.get(1)
+                        .get("input_schema")
+                        .get("properties")
+                        .get("reason")
+                        .get("type")
+                        .asText());
 
         // System prompt embeds the cube schema + ref
         String system = root.get("system").asText();
@@ -121,6 +130,17 @@ public class AnthropicNlAskProviderTest {
         NlAskResponse resp = AnthropicNlAskProvider.parseToolResponse(body, "claude-x");
         assertTrue(resp.degraded());
         assertEquals("empty tool_use input", resp.reason());
+    }
+
+    @Test
+    public void parseToolResponseReturnsOffTopicWhenModelCallsRefusalTool() throws Exception {
+        String body = "{\"content\":["
+                + "{\"type\":\"tool_use\",\"name\":\"refuse_off_topic\","
+                + "\"input\":{\"reason\":\"That's about weather, not the Sales cube.\"}}"
+                + "]}";
+        NlAskResponse resp = AnthropicNlAskProvider.parseToolResponse(body, "claude-x");
+        assertTrue(resp.degraded());
+        assertEquals("OFF_TOPIC: That's about weather, not the Sales cube.", resp.reason());
     }
 
     @Test

--- a/saiku-core/saiku-service/src/test/java/org/saiku/service/olap/ai/ask/OpenAINlAskProviderTest.java
+++ b/saiku-core/saiku-service/src/test/java/org/saiku/service/olap/ai/ask/OpenAINlAskProviderTest.java
@@ -33,18 +33,19 @@ public class OpenAINlAskProviderTest {
 
         assertEquals("gpt-x", root.get("model").asText());
         assertEquals(1024, root.get("max_tokens").asInt());
-        assertEquals("function", root.get("tool_choice").get("type").asText());
-        assertEquals(
-                "emit_query",
-                root.get("tool_choice").get("function").get("name").asText());
+        // tool_choice "required" — model must call a function, picks emit_query OR refuse_off_topic.
+        assertEquals("required", root.get("tool_choice").asText());
 
         JsonNode tools = root.get("tools");
-        assertEquals(1, tools.size());
+        assertEquals(2, tools.size());
         assertEquals("function", tools.get(0).get("type").asText());
         assertEquals("emit_query", tools.get(0).get("function").get("name").asText());
         assertEquals(
                 "object",
                 tools.get(0).get("function").get("parameters").get("type").asText());
+        assertEquals("function", tools.get(1).get("type").asText());
+        assertEquals(
+                "refuse_off_topic", tools.get(1).get("function").get("name").asText());
 
         // System message embeds the cube schema
         JsonNode messages = root.get("messages");
@@ -131,5 +132,14 @@ public class OpenAINlAskProviderTest {
         NlAskResponse resp = OpenAINlAskProvider.parseToolResponse(body, "gpt-x");
         assertTrue(resp.degraded());
         assertEquals("empty tool_call arguments", resp.reason());
+    }
+
+    @Test
+    public void parseToolResponseReturnsOffTopicWhenModelCallsRefusalTool() throws Exception {
+        String body = "{\"choices\":[{\"message\":{\"tool_calls\":[{\"function\":{\"name\":\"refuse_off_topic\","
+                + "\"arguments\":\"{\\\"reason\\\":\\\"That's about weather, not the Sales cube.\\\"}\"}}]}}]}";
+        NlAskResponse resp = OpenAINlAskProvider.parseToolResponse(body, "gpt-x");
+        assertTrue(resp.degraded());
+        assertEquals("OFF_TOPIC: That's about weather, not the Sales cube.", resp.reason());
     }
 }

--- a/saiku-ui/src/lib/i18n/en.json
+++ b/saiku-ui/src/lib/i18n/en.json
@@ -390,6 +390,7 @@
   "workspace.aiQuery.activeCube": "Active cube: {cube}",
   "workspace.aiQuery.tryAsking": "Try asking:",
   "canvas.mdxBannerText": "Running raw MDX — drop-zone editing is disabled. Switch back to build mode by clearing the MDX.",
+  "workspace.aiQuery.offTopic": "I can only answer questions about the active cube. {reason} Try rephrasing your question in terms of measures, dimensions, or members.",
   "workspace.aiQuery.example1": "Show me sales by country",
   "workspace.aiQuery.example2": "Top 10 products by revenue",
   "workspace.aiQuery.example3": "Quarterly sales trend",

--- a/saiku-ui/src/lib/views/AiQueryDrawer.svelte
+++ b/saiku-ui/src/lib/views/AiQueryDrawer.svelte
@@ -161,12 +161,19 @@
       if (reason.toLowerCase().includes("not configured")) {
         notConfiguredBanner = reason;
       }
+      // Server-side scope guardrail — the model called refuse_off_topic
+      // because the question isn't about the cube. Render as a softer
+      // "scope" turn rather than a generic error so the user can rephrase.
+      const isOffTopic = reason.startsWith("OFF_TOPIC: ");
+      const text = isOffTopic
+        ? i18n.t("workspace.aiQuery.offTopic").replace("{reason}", reason.slice("OFF_TOPIC: ".length))
+        : reason;
       turns = [
         ...turns,
         {
           id: nextId(),
-          role: "error",
-          text: reason,
+          role: isOffTopic ? "assistant" : "error",
+          text,
         },
       ];
       inflight = false;


### PR DESCRIPTION
## Summary

- Both Anthropic + OpenAI NL Ask providers now expose two tools: \`emit_query\` (unchanged) and \`refuse_off_topic(reason)\`. System prompt instructs the model to call \`refuse_off_topic\` for anything that isn't about the cube — general knowledge, coding help, jokes, prose. tool_choice was a forced single-tool call; now it's \`any\` (Anthropic) / \`required\` (OpenAI) so the model picks the path that fits.
- Refusal surfaces as \`degraded(OFF_TOPIC: <reason>, model)\`. The drawer renders it as a soft assistant turn — "I can only answer questions about the active cube. {reason} Try rephrasing in terms of measures, dimensions, or members." — instead of a red error.

## Background

Tom: "add guardrails to ensure the users ask relevant cube based questions and don't drop into just using it as a free LLM resource". Before this PR the model was forced to emit a query for any question, so off-topic asks cost tokens and produced fabricated MDX that failed server-side validation.

## Test plan

- [x] saiku-service: 9 + 7 = 16 NlAsk tests pass (refusal-parse coverage added for both providers)
- [x] svelte-check 0 errors, vitest 592/592
- [ ] On demo: ask "What's the weather in Paris?" → refusal turn shown, no MDX run
- [ ] On demo: ask "show me sales by country" → emit_query path, canvas auto-runs as before