### PR TITLE
feat(charts): inline sparkline in cartesian chart tooltips (closes #1087)

### DIFF
--- a/saiku-ui/src/lib/charts/__snapshots__/build.test.ts.snap
+++ b/saiku-ui/src/lib/charts/__snapshots__/build.test.ts.snap
@@ -1938,6 +1938,7 @@ exports[`buildChartOption — coverage of all 15 types > snapshot of every type'
     "tooltip": {
       "backgroundColor": "#ffffff",
       "borderColor": "#e2e8f0",
+      "formatter": [Function],
       "textStyle": {
         "color": "#0f172a",
       },
@@ -2076,6 +2077,7 @@ exports[`buildChartOption — coverage of all 15 types > snapshot of every type'
     "tooltip": {
       "backgroundColor": "#ffffff",
       "borderColor": "#e2e8f0",
+      "formatter": [Function],
       "textStyle": {
         "color": "#0f172a",
       },
@@ -2609,6 +2611,7 @@ exports[`buildChartOption — coverage of all 15 types > snapshot of every type'
     "tooltip": {
       "backgroundColor": "#ffffff",
       "borderColor": "#e2e8f0",
+      "formatter": [Function],
       "textStyle": {
         "color": "#0f172a",
       },
@@ -3086,6 +3089,7 @@ exports[`buildChartOption — coverage of all 15 types > snapshot of every type'
     "tooltip": {
       "backgroundColor": "#ffffff",
       "borderColor": "#e2e8f0",
+      "formatter": [Function],
       "textStyle": {
         "color": "#0f172a",
       },
@@ -3224,6 +3228,7 @@ exports[`buildChartOption — coverage of all 15 types > snapshot of every type'
     "tooltip": {
       "backgroundColor": "#ffffff",
       "borderColor": "#e2e8f0",
+      "formatter": [Function],
       "textStyle": {
         "color": "#0f172a",
       },
@@ -3362,6 +3367,7 @@ exports[`buildChartOption — coverage of all 15 types > snapshot of every type'
     "tooltip": {
       "backgroundColor": "#ffffff",
       "borderColor": "#e2e8f0",
+      "formatter": [Function],
       "textStyle": {
         "color": "#0f172a",
       },

--- a/saiku-ui/src/lib/charts/build.test.ts
+++ b/saiku-ui/src/lib/charts/build.test.ts
@@ -455,6 +455,84 @@ describe("buildChartOption — dataZoom zoom + pan (#1080)", () => {
   });
 });
 
+describe("buildChartOption — cartesian sparkline tooltip (#1087)", () => {
+  function tipFormatter(opt: Record<string, unknown>) {
+    const tip = opt.tooltip as { formatter?: (p: unknown) => string };
+    return tip.formatter;
+  }
+
+  test("roomy bar chart gets a function formatter returning an <svg> sparkline + value", () => {
+    const opt = buildChartOption(sample(), "bar", opts(), undefined, { compact: false }) as Record<
+      string,
+      unknown
+    >;
+    const fmt = tipFormatter(opt);
+    expect(typeof fmt).toBe("function");
+    const out = fmt!([
+      { axisValueLabel: "1997", seriesName: "Store Sales", dataIndex: 0, value: 565238.13, color: "#abc" },
+      { axisValueLabel: "1997", seriesName: "Unit Sales", dataIndex: 0, value: 266773, color: "#def" },
+    ]);
+    expect(out).toContain("<svg");
+    expect(out).toContain("Store Sales");
+    expect(out).toContain("565238.13"); // existing value text is kept
+  });
+
+  test("compact tiles do NOT get the sparkline formatter (no room)", () => {
+    const opt = buildChartOption(sample(), "bar", opts(), undefined, { compact: true }) as Record<
+      string,
+      unknown
+    >;
+    expect(tipFormatter(opt)).toBeUndefined();
+  });
+
+  test("single-category charts get no sparkline formatter (no trend to draw)", () => {
+    const oneRow: ChartProjection = {
+      rowCategories: ["1997"],
+      columnCategories: ["Store Sales"],
+      matrix: [[5]],
+    };
+    const opt = buildChartOption(oneRow, "line", opts(), undefined, { compact: false }) as Record<
+      string,
+      unknown
+    >;
+    expect(tipFormatter(opt)).toBeUndefined();
+  });
+
+  test("SECURITY: formatter HTML-escapes a hostile series name (innerHTML, un-escaped by ECharts)", () => {
+    const hostile: ChartProjection = {
+      rowCategories: ["1997", "1998"],
+      columnCategories: ['<img src=x onerror=alert(1)>', "Unit Sales"],
+      matrix: [
+        [1, 2],
+        [3, 4],
+      ],
+    };
+    const opt = buildChartOption(hostile, "line", opts(), undefined, { compact: false }) as Record<
+      string,
+      unknown
+    >;
+    const fmt = tipFormatter(opt)!;
+    const out = fmt([
+      { axisValueLabel: "1997", seriesName: '<img src=x onerror=alert(1)>', dataIndex: 0, value: 1 },
+    ]);
+    expect(out).not.toContain("<img");
+    expect(out).toContain("&lt;img");
+  });
+
+  test("SECURITY: formatter HTML-escapes a hostile category (axis) label", () => {
+    const opt = buildChartOption(sample(), "bar", opts(), undefined, { compact: false }) as Record<
+      string,
+      unknown
+    >;
+    const fmt = tipFormatter(opt)!;
+    const out = fmt([
+      { axisValueLabel: '<script>alert(1)</script>', seriesName: "Store Sales", dataIndex: 0, value: 1 },
+    ]);
+    expect(out).not.toContain("<script>alert");
+    expect(out).toContain("&lt;script&gt;");
+  });
+});
+
 describe("buildChartOption — rejection", () => {
   test("returns null for unknown chart kinds", () => {
     expect(buildChartOption(sample(), "made-up")).toBeNull();

--- a/saiku-ui/src/lib/charts/build.ts
+++ b/saiku-ui/src/lib/charts/build.ts
@@ -32,6 +32,7 @@ import { assignSeriesAxes } from "$lib/views/cellsetUtils";
 import { axisLabelConfig, deriveAxisLabelWidth } from "$lib/views/chartAxisLabel";
 import { cellRadiusPct, gridCells, MAX_LABELLED_SLICES } from "$lib/dashboard/smallMultiples";
 import { type ThemeTokens, DEFAULT_THEME_TOKENS } from "$lib/views/chartTheme";
+import { buildSparklineSvg } from "$lib/charts/sparkline";
 
 /** The shared, already-projected chart input both surfaces produce. Rollup
  *  rows are filtered (and parent context promoted into labels) by the caller
@@ -231,6 +232,83 @@ function escapeHtml(s: string): string {
     /[&<>"']/g,
     (c) => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" })[c] ?? c,
   );
+}
+
+/* Cartesian (bar/line/area) tooltip with an inline sparkline (#1087).
+ *
+ * trigger:"axis" gives ECharts a default formatter that lists each series'
+ * value at the hovered category. We replace it with a FUNCTION formatter that
+ * keeps that value text AND, beneath each row, draws a tiny SVG sparkline of
+ * THAT series across ALL categories with the hovered point dotted — so a single
+ * hovered bar/point is read in the context of its whole trend.
+ *
+ * SECURITY: the return is inserted as innerHTML and is NOT escaped by ECharts
+ * (same hazard as the #1071 map tooltip). Every data-derived string here — the
+ * axis (category) label and each series name — is run through escapeHtml. The
+ * SVG itself is produced by buildSparklineSvg from PURE NUMERIC matrix columns
+ * (never from a caller string), and its only string input, the colour, is
+ * sanitised inside that builder.
+ *
+ * The sparkline data is captured by column name from the projection matrix, so
+ * trend/MA overlay series (which aren't real columns) simply get no sparkline.
+ * Gated to roomy mode by the caller — compact tiles have no room for it. */
+type AxisTipParam = {
+  axisValueLabel?: string;
+  axisValue?: string | number;
+  seriesName?: string;
+  dataIndex?: number;
+  value?: unknown;
+  marker?: string;
+  color?: string;
+};
+
+function cartesianTooltipFormatter(
+  cols: string[],
+  matrix: (number | null)[][],
+  tk: ThemeTokens,
+): (params: AxisTipParam | AxisTipParam[]) => string {
+  // Column name -> its values down the rows (the series' full trend).
+  const colSeries = new Map<string, (number | null)[]>();
+  cols.forEach((name, c) => {
+    colSeries.set(
+      name,
+      matrix.map((row) => row[c] ?? null),
+    );
+  });
+
+  return (params: AxisTipParam | AxisTipParam[]): string => {
+    const list = Array.isArray(params) ? params : [params];
+    if (list.length === 0) return "";
+    const header = escapeHtml(String(list[0]?.axisValueLabel ?? list[0]?.axisValue ?? ""));
+    const dataIndex = list[0]?.dataIndex ?? -1;
+
+    const rows = list
+      .map((p) => {
+        const name = String(p.seriesName ?? "");
+        const v = p.value;
+        const valueText = v == null || (typeof v === "number" && Number.isNaN(v)) ? "—" : String(v);
+        const safeName = escapeHtml(name);
+        // ECharts' own coloured marker dot is safe HTML it generated itself.
+        const marker = p.marker ?? "";
+        const spark = colSeries.has(name)
+          ? buildSparklineSvg(colSeries.get(name)!, {
+              width: 120,
+              height: 26,
+              color: p.color,
+              highlightIndex: dataIndex,
+            })
+          : "";
+        const row =
+          `<div style="display:flex;align-items:center;gap:6px;margin-top:4px">` +
+          `${marker}<span>${safeName}</span>` +
+          `<strong style="margin-left:auto">${escapeHtml(valueText)}</strong>` +
+          `</div>`;
+        return spark ? row + `<div style="margin-top:2px">${spark}</div>` : row;
+      })
+      .join("");
+
+    return `<div style="font-weight:600;color:${escapeHtml(tk.fg)}">${header}</div>${rows}`;
+  };
 }
 
 /* ----------------------------- builder ----------------------------- */
@@ -624,10 +702,18 @@ export function buildChartOption(
         )
       : [];
 
+  // Sparkline-in-tooltip (#1087): roomy mode only (compact tiles are too small)
+  // and only when there's more than one category — a single column has no trend
+  // to draw (matches the issue's "disabled when there's only one column").
+  const sparklineTip = !compact && rows.length > 1;
+  const cartesianTooltip = sparklineTip
+    ? { trigger: "axis" as const, ...tooltipStyle, formatter: cartesianTooltipFormatter(cols, matrix, tk) }
+    : { trigger: "axis" as const, ...tooltipStyle };
+
   return {
     ...common,
     title,
-    tooltip: { trigger: "axis", ...tooltipStyle },
+    tooltip: cartesianTooltip,
     legend,
     grid: compact
       ? { top: 24, left: 48, right: 16, bottom: 36 }

--- a/saiku-ui/src/lib/charts/sparkline.test.ts
+++ b/saiku-ui/src/lib/charts/sparkline.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect } from "vitest";
+import { buildSparklineSvg, escapeHtml } from "$lib/charts/sparkline";
+
+describe("escapeHtml", () => {
+  it("escapes the five HTML-significant characters", () => {
+    expect(escapeHtml(`<img src=x onerror="alert(1)">&'`)).toBe(
+      "&lt;img src=x onerror=&quot;alert(1)&quot;&gt;&amp;&#39;",
+    );
+  });
+});
+
+describe("buildSparklineSvg", () => {
+  it("emits a single <svg> with a polyline for a normal series", () => {
+    const svg = buildSparklineSvg([1, 2, 3, 4]);
+    expect(svg.startsWith("<svg")).toBe(true);
+    expect(svg.endsWith("</svg>")).toBe(true);
+    expect((svg.match(/<svg/g) ?? []).length).toBe(1);
+    expect(svg).toContain("<polyline");
+    expect(svg).toContain('points="');
+  });
+
+  it("returns empty string for null / empty / single-point series", () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect(buildSparklineSvg(null as any)).toBe("");
+    expect(buildSparklineSvg([])).toBe("");
+    expect(buildSparklineSvg([5])).toBe("");
+    // a lone finite point among gaps is still < 2 finite points
+    expect(buildSparklineSvg([null, 5, null])).toBe("");
+  });
+
+  it("treats null / NaN / Infinity entries as gaps but still draws the rest", () => {
+    const svg = buildSparklineSvg([1, null, 3, NaN, 5, Infinity]);
+    expect(svg).toContain("<polyline");
+    // 3 finite points -> 3 coordinate pairs in the polyline
+    const points = /points="([^"]*)"/.exec(svg)?.[1] ?? "";
+    expect(points.trim().split(/\s+/).length).toBe(3);
+  });
+
+  it("normalises geometry into the viewBox (min at bottom, max at top)", () => {
+    const svg = buildSparklineSvg([0, 10], { width: 100, height: 20 });
+    expect(svg).toContain('viewBox="0 0 100 20"');
+    const points = /points="([^"]*)"/.exec(svg)?.[1] ?? "";
+    const [p1, p2] = points.trim().split(/\s+/);
+    const y1 = Number(p1.split(",")[1]); // min -> larger y (lower on screen)
+    const y2 = Number(p2.split(",")[1]); // max -> smaller y (higher on screen)
+    expect(y1).toBeGreaterThan(y2);
+  });
+
+  it("draws a flat series on the vertical centre", () => {
+    const svg = buildSparklineSvg([7, 7, 7], { height: 28 });
+    const points = /points="([^"]*)"/.exec(svg)?.[1] ?? "";
+    const ys = points
+      .trim()
+      .split(/\s+/)
+      .map((p) => Number(p.split(",")[1]));
+    expect(new Set(ys).size).toBe(1); // all same y
+    expect(ys[0]).toBeCloseTo(14, 1); // centre of 28
+  });
+
+  it("places a highlight dot only on the hovered finite point", () => {
+    expect(buildSparklineSvg([1, 2, 3], { highlightIndex: 1 })).toContain("<circle");
+    // out-of-range index -> no dot
+    expect(buildSparklineSvg([1, 2, 3], { highlightIndex: 9 })).not.toContain("<circle");
+    // index points at a gap -> no dot
+    expect(buildSparklineSvg([1, null, 3], { highlightIndex: 1 })).not.toContain("<circle");
+  });
+
+  it("SECURITY: never emits an attacker-controlled colour; falls back to grey", () => {
+    const svg = buildSparklineSvg([1, 2, 3], { color: '"><script>alert(1)</script>' });
+    expect(svg).not.toContain("<script");
+    expect(svg).not.toContain("alert(1)");
+    expect(svg).toContain('stroke="#888"');
+  });
+
+  it("SECURITY: accepts only safe colour shapes", () => {
+    expect(buildSparklineSvg([1, 2], { color: "#1a2b3c" })).toContain('stroke="#1a2b3c"');
+    expect(buildSparklineSvg([1, 2], { color: "rgba(10, 20, 30, 0.5)" })).toContain(
+      'stroke="rgba(10, 20, 30, 0.5)"',
+    );
+    expect(buildSparklineSvg([1, 2], { color: "tomato" })).toContain('stroke="tomato"');
+    // url(javascript:...) is rejected
+    expect(buildSparklineSvg([1, 2], { color: "url(javascript:alert(1))" })).toContain(
+      'stroke="#888"',
+    );
+  });
+
+  it("SECURITY: HTML-escapes a hostile title before inserting it", () => {
+    const svg = buildSparklineSvg([1, 2, 3], {
+      title: `<img src=x onerror="alert(document.cookie)">`,
+    });
+    expect(svg).toContain("<title>");
+    // The hostile markup is neutralised: no real <img> element, angle brackets
+    // and the attribute quotes are entity-escaped so nothing can break out.
+    expect(svg).not.toContain("<img");
+    expect(svg).not.toContain('onerror="alert');
+    expect(svg).toContain("&lt;img");
+    expect(svg).toContain("&quot;");
+  });
+
+  it("respects custom width / height", () => {
+    const svg = buildSparklineSvg([1, 5, 2], { width: 200, height: 40 });
+    expect(svg).toContain('width="200"');
+    expect(svg).toContain('height="40"');
+    expect(svg).toContain('viewBox="0 0 200 40"');
+  });
+});

--- a/saiku-ui/src/lib/charts/sparkline.ts
+++ b/saiku-ui/src/lib/charts/sparkline.ts
@@ -1,0 +1,129 @@
+/*
+ * Pure inline-SVG sparkline builder (#1087).
+ *
+ * The cartesian chart tooltip (bar/line/area, trigger "axis") enriches the
+ * existing value text with a tiny line of the hovered series across ALL
+ * categories — so a single hovered bar is read in the context of its whole
+ * trend, not in isolation. The ECharts tooltip FUNCTION formatter returns a
+ * string that ECharts inserts as innerHTML (renderMode "html") and does NOT
+ * escape; this module produces that SVG fragment.
+ *
+ * SECURITY (repo lesson, mirrors the #1071 map-tooltip hardening): the
+ * formatter return is innerHTML and un-escaped. So this builder NEVER accepts
+ * caller markup — it builds the path purely from numeric data, and the one
+ * place a caller-supplied string can appear (the optional aria label / title)
+ * is HTML-escaped here. Series/category names interpolated by the formatter
+ * itself must be escaped by the caller too; this module just guarantees that
+ * what IT emits is safe.
+ *
+ * Pure: no DOM, no echarts, no fetch. Tests live alongside.
+ */
+
+/** Escape the five HTML-significant characters. Kept local so this module has
+ *  zero imports and stays trivially testable / reusable. */
+export function escapeHtml(s: string): string {
+  return s.replace(
+    /[&<>"']/g,
+    (c) => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" })[c] ?? c,
+  );
+}
+
+export interface SparklineOptions {
+  /** Pixel width of the <svg>. Default 120. */
+  width?: number;
+  /** Pixel height of the <svg>. Default 28. */
+  height?: number;
+  /** Stroke colour of the line. Sanitised to a safe colour token. Default "#888". */
+  color?: string;
+  /** Index of the hovered point to mark with a dot (-1 / out of range = none). */
+  highlightIndex?: number;
+  /** Optional accessible title; HTML-escaped before insertion. */
+  title?: string;
+}
+
+/* A colour coming from the theme/series palette is interpolated into an SVG
+ * attribute, so constrain it to shapes that cannot break out of the attribute
+ * or smuggle script: #hex, rgb()/rgba(), or a bare CSS identifier (named
+ * colour). Anything else falls back to a neutral grey. */
+const SAFE_COLOR = /^(#[0-9a-fA-F]{3,8}|rgba?\([0-9.,%\s]+\)|[a-zA-Z]+)$/;
+
+function safeColor(c: string | undefined): string {
+  if (c && SAFE_COLOR.test(c.trim())) return c.trim();
+  return "#888";
+}
+
+/** Round to at most 2 dp and strip a trailing ".0" — keeps the path compact
+ *  and the output deterministic for snapshot/equality tests. */
+function r2(n: number): number {
+  return Math.round(n * 100) / 100;
+}
+
+/**
+ * Build a self-contained inline <svg> sparkline from a numeric series.
+ *
+ * Returns "" when there is nothing meaningful to draw (no series, or fewer
+ * than two finite points — a single point is not a line). `null`/`NaN`/±Inf
+ * entries are treated as gaps: the polyline simply skips them, so a series
+ * with holes still renders its real points without inventing zeros.
+ *
+ * The geometry is computed entirely from the numbers (min/max normalised into
+ * the box, y inverted because SVG's origin is top-left), so no data-derived
+ * STRING is ever placed into markup except the optional, escaped `title`.
+ */
+export function buildSparklineSvg(
+  series: ReadonlyArray<number | null | undefined>,
+  opts: SparklineOptions = {},
+): string {
+  const width = opts.width && opts.width > 0 ? opts.width : 120;
+  const height = opts.height && opts.height > 0 ? opts.height : 28;
+  const pad = 2; // keep the stroke + dot inside the viewBox
+  const color = safeColor(opts.color);
+
+  const vals = series ?? [];
+  // Index → finite value, preserving position so x spacing stays even.
+  const finite: { i: number; v: number }[] = [];
+  for (let i = 0; i < vals.length; i++) {
+    const v = vals[i];
+    if (v != null && Number.isFinite(v)) finite.push({ i, v: v as number });
+  }
+  if (finite.length < 2) return "";
+
+  let min = Infinity;
+  let max = -Infinity;
+  for (const { v } of finite) {
+    if (v < min) min = v;
+    if (v > max) max = v;
+  }
+  const span = max - min;
+  const n = vals.length;
+  const innerW = width - pad * 2;
+  const innerH = height - pad * 2;
+
+  const xAt = (i: number) => pad + (n <= 1 ? innerW / 2 : (i / (n - 1)) * innerW);
+  // Flat series (span 0) sits on the vertical centre.
+  const yAt = (v: number) => pad + (span === 0 ? innerH / 2 : (1 - (v - min) / span) * innerH);
+
+  const points = finite.map(({ i, v }) => `${r2(xAt(i))},${r2(yAt(v))}`).join(" ");
+
+  // Optional highlight dot on the hovered point — only if it's a finite point.
+  let dot = "";
+  const hi = opts.highlightIndex;
+  if (hi != null && hi >= 0 && hi < n) {
+    const hit = finite.find((p) => p.i === hi);
+    if (hit) {
+      dot = `<circle cx="${r2(xAt(hit.i))}" cy="${r2(yAt(hit.v))}" r="2.5" fill="${color}"/>`;
+    }
+  }
+
+  const titleEl = opts.title ? `<title>${escapeHtml(opts.title)}</title>` : "";
+
+  return (
+    `<svg width="${width}" height="${height}" viewBox="0 0 ${width} ${height}" ` +
+    `xmlns="http://www.w3.org/2000/svg" style="display:block">` +
+    titleEl +
+    `<polyline points="${points}" fill="none" stroke="${color}" stroke-width="1.5" ` +
+    `stroke-linejoin="round" stroke-linecap="round"/>` +
+    dot +
+    `</svg>`
+  );
+}


### PR DESCRIPTION
## Summary

Cartesian (bar/line/area) chart tooltips now render a small **inline SVG sparkline** of the hovered series across all categories, alongside the existing value text — a quick trend-at-a-glance on hover. Workspace (roomy) only; small dashboard tiles keep the plain value list.

## The change
- NEW `$lib/charts/sparkline.ts` — a **pure** SVG sparkline builder (+ co-located tests).
- `$lib/charts/build.ts` — the cartesian tooltip uses an ECharts function formatter that embeds the sparkline; gated to roomy multi-category cartesian charts.

## Security
The tooltip formatter return is inserted as innerHTML and is NOT escaped by ECharts. All data-derived strings (series + category/axis names) are **HTML-escaped**; the SVG is built purely from numeric data. Two unit tests assert a hostile `<img onerror>` series name and a `<script>` axis label are escaped. (Applies the #1071 ECharts-formatter-XSS lesson.)

## Verified
- `npm run check` 0/0; `npx vitest run` **612** passing (11 sparkline + 5 cartesian-tooltip tests).
- Rebased clean onto development (post-#1080); local browser test user-confirmed (FoodMart Sales, Store Sales + Unit Sales × Time/Month: sparkline shows in line/bar tooltips, values intact, none on pie/map/tiles).

## Notes
- Phase 2 (grid-row hover → full mini chart-as-tooltip, + a per-chart editor toggle) deferred — needs a persisted ChartOptions field (blocked by the paused #1077). UI-only; no backend; no `{@html}`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)