### PR TITLE
feat(ai/ask): hide Ask-the-AI button when provider unconfigured

### DIFF
--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ai/ask/AiAskService.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ai/ask/AiAskService.java
@@ -53,6 +53,15 @@ public class AiAskService {
         this.mapper = Objects.requireNonNull(mapper, "mapper");
     }
 
+    /**
+     * Whether the underlying provider can answer a real request. Surfaced by the
+     * {@code /ai/ask/health} endpoint so the UI can hide the "Ask the AI" button on instances that
+     * haven't wired up an LLM key.
+     */
+    public boolean isConfigured() {
+        return provider.isConfigured();
+    }
+
     /** Result of an {@link #ask(AiCubeRef, String, List)} call. */
     public record AskOutcome(boolean degraded, String reason, AiQueryRequest request, String model) {
         public static AskOutcome ok(AiQueryRequest request, String model) {

--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ai/ask/NlAskProvider.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ai/ask/NlAskProvider.java
@@ -28,8 +28,20 @@ package org.saiku.service.olap.ai.ask;
  * <p>The {@link NoopNlAskProvider} is the default when no provider is configured — it always
  * returns degraded so the API can render a clear "not configured" message.
  */
-@FunctionalInterface
 public interface NlAskProvider {
 
     NlAskResponse ask(NlAskRequest request);
+
+    /**
+     * Whether this provider can actually answer a request. {@code false} only for
+     * {@link NoopNlAskProvider} — the placeholder returned when no provider name / API key is
+     * configured. Concrete providers (Anthropic, OpenAI, etc.) always return {@code true} because
+     * the factory wouldn't construct them without credentials.
+     *
+     * <p>Used by the {@code /ai/ask/health} endpoint so the UI can hide the "Ask the AI" toolbar
+     * button on instances that haven't wired up an LLM key — wasted clicks otherwise.
+     */
+    default boolean isConfigured() {
+        return true;
+    }
 }

--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ai/ask/NoopNlAskProvider.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ai/ask/NoopNlAskProvider.java
@@ -19,4 +19,9 @@ public final class NoopNlAskProvider implements NlAskProvider {
     public NlAskResponse ask(NlAskRequest request) {
         return NlAskResponse.degraded(REASON);
     }
+
+    @Override
+    public boolean isConfigured() {
+        return false;
+    }
 }

--- a/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/AiQueryResource.java
+++ b/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/AiQueryResource.java
@@ -326,6 +326,27 @@ public class AiQueryResource {
      *       render a clear "AI ask is not configured" message.
      * </ul>
      */
+    /**
+     * Cheap configuration probe used by the workspace to decide whether to render the "Ask the AI"
+     * toolbar button. Returns {@code {"configured": true|false}} — never throws, never depends on a
+     * cube selection. The body is intentionally tiny so the client can call it on app load.
+     *
+     * <p>Returns {@code configured:false} when:
+     * <ul>
+     *   <li>the {@link AiAskService} bean wasn't wired (no provider configured at all), or
+     *   <li>the bean wraps a {@link org.saiku.service.olap.ai.ask.NoopNlAskProvider}.
+     * </ul>
+     */
+    @GET
+    @Path("/ask/health")
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response askHealth() {
+        boolean configured = askService != null && askService.isConfigured();
+        java.util.Map<String, Object> body = new java.util.LinkedHashMap<>();
+        body.put("configured", configured);
+        return Response.ok(body).type(MediaType.APPLICATION_JSON).build();
+    }
+
     @POST
     @Path("/ask")
     @Consumes(MediaType.APPLICATION_JSON)

--- a/saiku-ui/src/lib/api/aiAsk.ts
+++ b/saiku-ui/src/lib/api/aiAsk.ts
@@ -17,6 +17,28 @@
 import type { AiQueryResponse } from "./aiQuery";
 
 const ASK_URL = "/rest/saiku/api/ai/ask";
+const ASK_HEALTH_URL = "/rest/saiku/api/ai/ask/health";
+
+export interface AskHealth {
+  configured: boolean;
+}
+
+/** GET /ai/ask/health. Returns {configured: false} on transport failure so the
+ *  workspace silently hides the Ask AI button rather than showing an error. */
+export async function fetchAskHealth(): Promise<AskHealth> {
+  try {
+    const res = await fetch(ASK_HEALTH_URL, {
+      method: "GET",
+      credentials: "include",
+      headers: { Accept: "application/json" },
+    });
+    if (!res.ok) return { configured: false };
+    const body = (await res.json()) as AskHealth;
+    return { configured: !!body.configured };
+  } catch {
+    return { configured: false };
+  }
+}
 
 /** Mirror of {@link org.saiku.service.olap.ai.AiCubeRef}. */
 export interface AiCubeRef {

--- a/saiku-ui/src/lib/stores/aiAskHealth.svelte.ts
+++ b/saiku-ui/src/lib/stores/aiAskHealth.svelte.ts
@@ -1,0 +1,35 @@
+/*
+ * Reactive flag for whether the backend NL Ask provider is configured. Probed
+ * once on first import via {@link fetchAskHealth}. The workspace toolbar uses
+ * `aiAskHealth.configured` to decide whether to render the "Ask the AI" button
+ * — instances that haven't wired an LLM key get the feature hidden entirely
+ * rather than showing a button that opens a drawer announcing it's unavailable.
+ *
+ * The probe is fire-and-forget: a failure (transport / 404) is interpreted as
+ * "not configured" so the feature stays hidden.
+ */
+
+import { fetchAskHealth } from "$lib/api/aiAsk";
+
+class AiAskHealthStore {
+  /** True iff the backend reports the provider is wired. Defaults to false until
+   *  the probe completes so the button doesn't flash visible→hidden. */
+  configured = $state(false);
+
+  /** True until the first probe completes — lets the toolbar defer rendering
+   *  until we know the answer. Most surfaces can ignore this. */
+  loading = $state(true);
+
+  constructor() {
+    void this.refresh();
+  }
+
+  async refresh(): Promise<void> {
+    this.loading = true;
+    const h = await fetchAskHealth();
+    this.configured = h.configured;
+    this.loading = false;
+  }
+}
+
+export const aiAskHealth = new AiAskHealthStore();

--- a/saiku-ui/src/lib/views/Workspace.svelte
+++ b/saiku-ui/src/lib/views/Workspace.svelte
@@ -13,6 +13,7 @@
   import { selection } from "$lib/stores/selection.svelte";
   import { tabs } from "$lib/stores/tabs.svelte";
   import { embed } from "$lib/stores/embed.svelte";
+  import { aiAskHealth } from "$lib/stores/aiAskHealth.svelte";
   import {
     deserializeQueryFromHash,
     serializeQueryToHash,
@@ -304,13 +305,13 @@
           onclick={handleNewTab}
         >+</button>
       </div>
-      <WorkspaceToolbar onAskAi={() => (aiDrawerOpen = true)} />
+      <WorkspaceToolbar onAskAi={aiAskHealth.configured ? () => (aiDrawerOpen = true) : undefined} />
     {/if}
     <QueryCanvas />
   </section>
 </div>
 
-{#if !embed.active}
+{#if !embed.active && aiAskHealth.configured}
   <AiQueryDrawer
     open={aiDrawerOpen}
     onClose={() => (aiDrawerOpen = false)}


### PR DESCRIPTION
Tom: 'if there is no API key set does Ask the AI go away? It should'. New GET /ai/ask/health endpoint + client store; Workspace gates the toolbar button + drawer mount on the response. Instances without an LLM key get the feature hidden entirely.