### PR TITLE
feat(dashboard): mobile auto-stack + hamburger toolbar + tile height stepper (closes #932)

### DIFF
--- a/saiku-ui/src/lib/dashboard/responsiveLayout.test.ts
+++ b/saiku-ui/src/lib/dashboard/responsiveLayout.test.ts
@@ -1,0 +1,130 @@
+/*
+ * Unit tests for the mobile auto-stack helpers (issue #932). Covers:
+ *   - isNarrow breakpoint boundary + unmeasured-width guard
+ *   - isPinnedToTop only matches filter tiles
+ *   - compareByPosition orders by (y, x) then id
+ *   - stackedOrder puts filters first then (y, x) order, immutably
+ *   - stackOrderMap maps ids to their stacked index
+ */
+
+import { describe, test, expect } from "vitest";
+import {
+  DEFAULT_STACK_BREAKPOINT,
+  isNarrow,
+  isPinnedToTop,
+  compareByPosition,
+  stackedOrder,
+  stackOrderMap,
+} from "$lib/dashboard/responsiveLayout";
+import type { DashboardTile, TileType } from "$lib/api/dashboards";
+
+function tile(id: string, x: number, y: number, type: TileType = "chart"): DashboardTile {
+  return { id, x, y, w: 6, h: 4, type };
+}
+
+describe("isNarrow", () => {
+  test("default breakpoint is 768", () => {
+    expect(DEFAULT_STACK_BREAKPOINT).toBe(768);
+  });
+
+  test("at and below the breakpoint is narrow", () => {
+    expect(isNarrow(640, 640)).toBe(true);
+    expect(isNarrow(500, 640)).toBe(true);
+  });
+
+  test("above the breakpoint is wide", () => {
+    expect(isNarrow(641, 640)).toBe(false);
+    expect(isNarrow(1200, 640)).toBe(false);
+  });
+
+  test("unmeasured / non-positive width is treated as wide", () => {
+    expect(isNarrow(0, 640)).toBe(false);
+    expect(isNarrow(-10, 640)).toBe(false);
+    expect(isNarrow(Number.NaN, 640)).toBe(false);
+  });
+
+  test("uses the default breakpoint when none is supplied", () => {
+    expect(isNarrow(768)).toBe(true);
+    expect(isNarrow(769)).toBe(false);
+  });
+});
+
+describe("isPinnedToTop", () => {
+  test("only filter tiles pin to the top", () => {
+    expect(isPinnedToTop(tile("f", 0, 5, "filter"))).toBe(true);
+    expect(isPinnedToTop(tile("c", 0, 0, "chart"))).toBe(false);
+    expect(isPinnedToTop(tile("t", 0, 0, "table"))).toBe(false);
+    expect(isPinnedToTop(tile("k", 0, 0, "kpi"))).toBe(false);
+  });
+});
+
+describe("compareByPosition", () => {
+  test("sorts by row then column", () => {
+    expect(compareByPosition(tile("a", 0, 0), tile("b", 0, 1))).toBeLessThan(0);
+    expect(compareByPosition(tile("a", 6, 0), tile("b", 0, 0))).toBeGreaterThan(0);
+    expect(compareByPosition(tile("a", 0, 0), tile("b", 6, 0))).toBeLessThan(0);
+  });
+
+  test("breaks ties on id for determinism", () => {
+    expect(compareByPosition(tile("a", 0, 0), tile("b", 0, 0))).toBeLessThan(0);
+    expect(compareByPosition(tile("b", 0, 0), tile("a", 0, 0))).toBeGreaterThan(0);
+    expect(compareByPosition(tile("a", 0, 0), tile("a", 0, 0))).toBe(0);
+  });
+});
+
+describe("stackedOrder", () => {
+  test("orders non-filter tiles top-to-bottom then left-to-right", () => {
+    const tiles = [
+      tile("br", 6, 1), // row 1, right
+      tile("tl", 0, 0), // row 0, left
+      tile("tr", 6, 0), // row 0, right
+      tile("bl", 0, 1), // row 1, left
+    ];
+    expect(stackedOrder(tiles).map((t) => t.id)).toEqual(["tl", "tr", "bl", "br"]);
+  });
+
+  test("filter tiles stick at the top regardless of saved position", () => {
+    const tiles = [
+      tile("chart-top", 0, 0, "chart"),
+      tile("filter-bottom", 0, 9, "filter"),
+      tile("chart-mid", 0, 1, "chart"),
+    ];
+    expect(stackedOrder(tiles).map((t) => t.id)).toEqual([
+      "filter-bottom",
+      "chart-top",
+      "chart-mid",
+    ]);
+  });
+
+  test("multiple filters keep their own (y, x) order at the top", () => {
+    const tiles = [
+      tile("f2", 0, 2, "filter"),
+      tile("c1", 0, 1, "chart"),
+      tile("f1", 0, 0, "filter"),
+    ];
+    expect(stackedOrder(tiles).map((t) => t.id)).toEqual(["f1", "f2", "c1"]);
+  });
+
+  test("does not mutate the input array or its order", () => {
+    const tiles = [tile("b", 6, 0), tile("a", 0, 0)];
+    const before = tiles.map((t) => t.id);
+    stackedOrder(tiles);
+    expect(tiles.map((t) => t.id)).toEqual(before);
+  });
+
+  test("empty input yields empty output", () => {
+    expect(stackedOrder([])).toEqual([]);
+  });
+});
+
+describe("stackOrderMap", () => {
+  test("maps each id to its stacked index", () => {
+    const tiles = [
+      tile("chart", 0, 0, "chart"),
+      tile("filter", 0, 5, "filter"),
+    ];
+    const map = stackOrderMap(tiles);
+    expect(map.get("filter")).toBe(0);
+    expect(map.get("chart")).toBe(1);
+  });
+});

--- a/saiku-ui/src/lib/dashboard/responsiveLayout.ts
+++ b/saiku-ui/src/lib/dashboard/responsiveLayout.ts
@@ -1,0 +1,83 @@
+/*
+ * Mobile auto-stack — pure ordering/layout helpers (issue #932).
+ *
+ * On narrow viewports the free-form 12-column grid is unusable, so the
+ * dashboard collapses every tile into a single full-width column. This
+ * module owns the *pure* part of that behaviour: deciding whether the
+ * viewport is narrow, and computing the stacked render order without ever
+ * touching the DOM or the saved layout.
+ *
+ * Display-only: nothing here mutates the persisted (x, y, w, h). The
+ * grid component reads the computed order and renders each tile
+ * full-width in that order; the saved positions are untouched, so
+ * switching back to a wide viewport restores the free-form layout
+ * exactly.
+ *
+ * Stacking rules (from the issue):
+ *   - filter tiles stick at the very top of the stack, in their own
+ *     (y, x) order, regardless of where they sit in the saved grid;
+ *   - every other tile follows, sorted by (y, x) — top row first, then
+ *     left-to-right within a row.
+ */
+
+import type { DashboardTile } from "$lib/api/dashboards";
+
+/** Default narrow breakpoint in CSS pixels. At or below this container
+ *  width the grid auto-stacks. Mirrors the issue's 768px default; the
+ *  task brief calls for ~640px, so we expose it as an argument and keep
+ *  the historical 768 as the default to match the existing CSS media
+ *  query in DashboardGrid.svelte. */
+export const DEFAULT_STACK_BREAKPOINT = 768;
+
+/** True when {@code width} (the grid container's content width, in px)
+ *  is at or below {@code breakpoint} and so the grid should auto-stack.
+ *  A non-positive width (container not yet measured) is treated as wide
+ *  so the free-form layout renders until the first real measurement. */
+export function isNarrow(width: number, breakpoint: number = DEFAULT_STACK_BREAKPOINT): boolean {
+  if (!Number.isFinite(width) || width <= 0) return false;
+  return width <= breakpoint;
+}
+
+/** True for tile types that pin to the top of the mobile stack. Today
+ *  that's only the "filter" tile type; isolated here so the rule has a
+ *  single home if more pinned types appear. */
+export function isPinnedToTop(tile: DashboardTile): boolean {
+  return tile.type === "filter";
+}
+
+/** Compare two tiles by saved position: row first (y ascending), then
+ *  column (x ascending), so the result reads top-to-bottom then
+ *  left-to-right. Ties (same x and y) fall back to a stable-ish id
+ *  compare so the order is deterministic across renders. */
+export function compareByPosition(a: DashboardTile, b: DashboardTile): number {
+  if (a.y !== b.y) return a.y - b.y;
+  if (a.x !== b.x) return a.x - b.x;
+  return a.id < b.id ? -1 : a.id > b.id ? 1 : 0;
+}
+
+/**
+ * Pure: compute the mobile auto-stack render order for a set of tiles.
+ *
+ * Filter tiles come first (in (y, x) order), then all remaining tiles in
+ * (y, x) order. The input array is not mutated — a new sorted array is
+ * returned. Use the returned order to drive a CSS `order` per tile (see
+ * {@link stackOrderMap}) so the DOM order from the saved layout's
+ * {@code #each} is overridden visually without re-keying the list.
+ */
+export function stackedOrder(tiles: readonly DashboardTile[]): DashboardTile[] {
+  const pinned = tiles.filter(isPinnedToTop).slice().sort(compareByPosition);
+  const rest = tiles.filter((t) => !isPinnedToTop(t)).slice().sort(compareByPosition);
+  return [...pinned, ...rest];
+}
+
+/**
+ * Pure: map each tile id to its zero-based position in the stacked
+ * order. Handy for assigning the CSS `order` property per cell when the
+ * tiles are still rendered in saved order by the template's {@code #each}.
+ */
+export function stackOrderMap(tiles: readonly DashboardTile[]): Map<string, number> {
+  const order = stackedOrder(tiles);
+  const map = new Map<string, number>();
+  order.forEach((tile, index) => map.set(tile.id, index));
+  return map;
+}

--- a/saiku-ui/src/lib/views/dashboard/DashboardGrid.svelte
+++ b/saiku-ui/src/lib/views/dashboard/DashboardGrid.svelte
@@ -2,8 +2,14 @@
   /*
    * 12-column CSS grid that holds the dashboard's tiles.
    *
-   * Auto-stacks to a single column below ~768px so the grid stays
-   * readable on phones (read-only mode forces the same stack).
+   * Mobile auto-stack (saiku#932): a ResizeObserver tracks the grid
+   * container's width; at or below stackBreakpoint (default 768px) the
+   * grid collapses to a single full-width column. Tiles are reordered via
+   * an inline CSS `order` computed from the saved (y, x) positions — filter
+   * tiles pinned to the top, then top-to-bottom / left-to-right — by the
+   * pure helpers in $lib/dashboard/responsiveLayout. This is display-only:
+   * the saved layout is never mutated and the free-form grid returns intact
+   * once the container widens. Drag/resize is suppressed while stacked.
    *
    * Edit-mode interactions (saiku#911):
    *   - Drag-to-move: the tile header (rendered with data-drag-handle
@@ -25,18 +31,67 @@
    * regardless of how the browser actually solved the 1fr columns.
    */
 
+  import { onDestroy } from "svelte";
   import { dashboardStore } from "$lib/stores/dashboard.svelte";
   import { compactUpward, repositionTile } from "$lib/dashboard/tilePlacement";
   import { tileSelection } from "$lib/stores/tileSelection.svelte";
+  import {
+    DEFAULT_STACK_BREAKPOINT,
+    isNarrow,
+    stackOrderMap,
+  } from "$lib/dashboard/responsiveLayout";
   import Tile from "$lib/views/dashboard/Tile.svelte";
 
   interface Props {
     readOnly?: boolean;
+    /** Container width (px) at or below which the grid auto-stacks into a
+     *  single full-width column. Display-only; the saved layout is never
+     *  mutated. Defaults to {@link DEFAULT_STACK_BREAKPOINT} (768px). */
+    stackBreakpoint?: number;
   }
 
-  let { readOnly = false }: Props = $props();
+  let { readOnly = false, stackBreakpoint = DEFAULT_STACK_BREAKPOINT }: Props = $props();
 
   let gridEl = $state<HTMLDivElement | null>(null);
+
+  /* ---------------- mobile auto-stack (issue #932) -------------------
+   * A ResizeObserver on the grid container (mirroring how ChartTile /
+   * KpiTile observe their canvases) tracks the content width. Below
+   * stackBreakpoint the grid collapses every tile into a single
+   * full-width column, ordered by saved (y, x) with filter tiles pinned
+   * to the top — see $lib/dashboard/responsiveLayout. This is a
+   * display-only render: drag/resize is suppressed while stacked and the
+   * persisted layout is untouched, so widening the viewport restores the
+   * free-form grid exactly. */
+  let gridWidth = $state(0);
+  let resizeObserver: ResizeObserver | null = null;
+
+  $effect(() => {
+    const el = gridEl;
+    if (!el) return;
+    resizeObserver?.disconnect();
+    resizeObserver = new ResizeObserver((entries) => {
+      const entry = entries[0];
+      if (entry) gridWidth = entry.contentRect.width;
+    });
+    resizeObserver.observe(el);
+    // Seed an immediate measurement so the first paint already reflects
+    // a narrow container (the observer's first callback is async).
+    gridWidth = el.clientWidth;
+  });
+
+  onDestroy(() => resizeObserver?.disconnect());
+
+  let stacked = $derived(isNarrow(gridWidth, stackBreakpoint));
+
+  /** Tile id → stacked render position. Drives the CSS `order` per cell
+   *  while the {#each} keeps rendering in saved order (so tile identity /
+   *  keys are stable). Only consulted when {@link stacked}. */
+  let orderMap = $derived(
+    stacked && dashboardStore.current
+      ? stackOrderMap(dashboardStore.current.layout.tiles)
+      : null,
+  );
 
   /** Origin captured when a drag or resize starts. The fields are
    *  shared between both modes — drag updates x/y, resize updates w/h
@@ -68,6 +123,9 @@
 
   function onPointerDown(e: PointerEvent): void {
     if (readOnly) return;
+    // Drag/resize is meaningless in the single-column stacked layout — the
+    // snap math has no column basis — so gestures are disabled there (#932).
+    if (stacked) return;
     if (e.button !== 0) return; // primary button only
     const target = e.target as HTMLElement | null;
     if (!target) return;
@@ -230,6 +288,7 @@
     <div
       class="grid"
       class:grid--gesturing={gesture !== null}
+      class:grid--stacked={stacked}
       style:--cols={dash.layout.cols}
       role="region"
       aria-label="Dashboard tiles"
@@ -247,9 +306,10 @@
           class:cell--dragging={isGestureTarget}
           style:grid-column="{tile.x + 1} / span {tile.w}"
           style:grid-row="{tile.y + 1} / span {tile.h}"
+          style:order={orderMap ? orderMap.get(tile.id) : undefined}
         >
           <Tile {tile} {readOnly} />
-          {#if !readOnly}
+          {#if !readOnly && !stacked}
             <span
               class="resize-handle"
               data-resize-handle={tile.id}
@@ -259,7 +319,7 @@
           {/if}
         </div>
       {/each}
-      {#if gesture}
+      {#if gesture && !stacked}
         <div
           class="ghost"
           class:ghost--resize={gesture.mode === "resize"}
@@ -352,22 +412,24 @@
     border-style: solid;
     border-width: 2px;
   }
-  /* Auto-stack: below ~768px every tile collapses to a single column
-     and drag-resize is disabled (the grid template loses its column
-     basis, so the snap math wouldn't be meaningful anyway). */
-  @media (max-width: 768px) {
-    .grid {
-      grid-template-columns: 1fr;
-      touch-action: auto;
-    }
-    .cell {
-      grid-column: 1 / span 1 !important;
-      grid-row: auto / auto !important;
-    }
-    .resize-handle,
-    .ghost {
-      display: none;
-    }
+  /* Mobile auto-stack (issue #932): on a narrow container the grid
+     collapses to a single full-width column. The breakpoint is driven by
+     a ResizeObserver in JS (configurable via the stackBreakpoint prop),
+     not a CSS media query, so it tracks the grid container's own width
+     rather than the viewport — correct when the grid is embedded in a
+     narrower panel. Each cell's `order` is set inline from the stacked
+     ordering (filters first, then saved (y, x)); drag-resize is disabled
+     because the single column has no column basis for the snap math.
+     Display-only: the saved grid-column / grid-row stay on the element
+     and simply take over again once the container widens. */
+  .grid--stacked {
+    grid-template-columns: 1fr;
+    grid-auto-rows: minmax(80px, auto);
+    touch-action: auto;
+  }
+  .grid--stacked .cell {
+    grid-column: 1 / span 1 !important;
+    grid-row: auto / auto !important;
   }
   .empty {
     padding: 3rem 1rem;


### PR DESCRIPTION
## Summary
Makes the dashboard usable on narrow screens (#932): the free-form grid **auto-stacks into a single column**, the toolbar **collapses into a hamburger**, and tiles can be **resized by a height stepper** (since drag-resize is off in the stacked view). Frontend-only, display-only for the saved layout.

## The change
- **Auto-stack** (`responsiveLayout.ts` + `DashboardGrid.svelte`): a `ResizeObserver` on the grid container collapses to one full-width column at/below the breakpoint (default 768px, container-width based). Tiles are ordered by saved (y, x) with **filter tiles pinned to the top**, via pure, unit-tested helpers (`isNarrow`, `stackedOrder`, `stackOrderMap`). Display-only — saved x/y/w/h are never mutated; widening restores the free-form grid exactly.
- **Definite stacked heights** (`stackedCellHeight`): each stacked cell gets a real `height` derived from the tile's saved row span (80px/row, floored at 160px), laid out with **flexbox**. This is what makes the tile's `height:100%` and the chart canvas resolve — charts fill their tile instead of spilling axis labels into the next tile, and the per-tile inner scrollbars are gone (single page scroll).
- **Hamburger toolbar** (`DashboardToolbar.svelte`): below the same breakpoint the secondary actions collapse into a **☰** dropdown while **Save stays visible**. Same buttons rendered via Svelte snippets (no duplication); closes on outside-click/Esc; returns inline when wide. The name field shrinks so Save + ☰ always fit.
- **Tile height stepper** (`Tile.svelte` ⋮ menu + `dashboardStore.adjustTileHeight`): a `Height − [n] +` control to grow/shrink a tile by row, cascading neighbours via `repositionTile`. Works in both layouts; the touch-friendly substitute for drag-resize, which is disabled when stacked.

## Verified
- `npm run check` **0/0** · `npm test` **640** (incl. `responsiveLayout` pure-helper tests + the `stackedCellHeight` cases) · production build ✓.
- Rebased clean onto current `origin/development`.
- **User-verified locally** through several iterations: narrowing collapses to one column with filters on top and charts fully contained (no spill / no double scrollbars); hamburger opens/closes and its sub-menus (Add tile, theme) + modals (Suggest/History/Share) work; height stepper grows/shrinks tiles in both wide and stacked views; widening restores the exact grid.

## Notes
- ⚠️ **Overlaps the sibling PRs not yet merged:** **#915** (`DashboardGrid.svelte`, `Tile.svelte`, `dashboard.svelte.ts`) and **#914** (`DashboardToolbar.svelte`, `dashboard.svelte.ts`). This PR restructures the toolbar actions into snippets and the grid into a flex stack — expect conflicts at merge. Suggested merge order: **#914 → #915 → #932**, rebasing each onto the prior; ping me and I'll rebase #932 last.
- Built by a worktree agent (the stacking core), then I added the definite-height fix, hamburger, and height stepper during local testing.
- No backend change. Does not self-merge — for OG's gate + merge to `development`.

Closes #932

🤖 Generated with [Claude Code](https://claude.com/claude-code)
