### PR TITLE
feat(dashboard): inline sparkline column for table tiles (closes #920)

### DIFF
--- a/saiku-ui/src/lib/api/dashboards.ts
+++ b/saiku-ui/src/lib/api/dashboards.ts
@@ -149,6 +149,28 @@ export interface KpiConfig {
   direction?: KpiDirection;
 }
 
+/* --- issue #920: table sparkline column ---------------------------------
+ * Opt-in trailing column on a table tile that draws a tiny inline SVG
+ * trend (line or bar) from each row's numeric measure cells. Display-only,
+ * no backend surface — the geometry is computed client-side from the
+ * already-fetched response. Pure geometry lives in
+ * $lib/dashboard/sparkline. Config carried on the table tile below.
+ */
+
+/** Sparkline glyph style. {@code "line"} = mini polyline; {@code "bar"} =
+ *  mini column chart. Defaults to "line". */
+export type SparklineType = "line" | "bar";
+
+/** Per-tile sparkline config (issue #920). Only consulted when
+ *  {@code type === "table"} and {@link SparklineConfig.enabled} is true. */
+export interface SparklineConfig {
+  /** Master opt-in. When false / unset the column is not rendered. */
+  enabled: boolean;
+  /** Glyph style. Defaults to "line". */
+  type?: SparklineType;
+}
+/* --- end issue #920 block ------------------------------------------------- */
+
 /* --- issue #918: image tile --------------------------------------------- */
 
 /** Where an image tile's bytes come from. {@code "url"} → {@link ImageConfig.src}
@@ -201,6 +223,9 @@ export interface DashboardTile {
   /** Per-column conditional formatting rules. Only consulted when
    *  {@code type === "table"}. See the issue-#919 block below. */
   conditionalFormat?: ConditionalFormatRule[];
+  /** Sparkline column config (issue #920). Only consulted when
+   *  {@code type === "table"}. See the issue-#920 block above. */
+  sparkline?: SparklineConfig;
   /** Image-tile config (issue #918). Only consulted when
    *  {@code type === "image"}. */
   image?: ImageConfig;

--- a/saiku-ui/src/lib/dashboard/sparkline.test.ts
+++ b/saiku-ui/src/lib/dashboard/sparkline.test.ts
@@ -1,0 +1,165 @@
+/*
+ * Unit tests for the pure sparkline geometry helpers (issue #920).
+ *
+ * Covers: numeric coercion / extraction, point normalisation (even x
+ * spacing, inverted y with max at top), flat-series centring, polyline /
+ * path serialisation, bar geometry, and the renderable / degenerate
+ * handling (fewer than two finite points).
+ */
+
+import { describe, expect, test } from "vitest";
+
+import {
+  numericValues,
+  pointsToPath,
+  pointsToPolyline,
+  sparklineBars,
+  sparklineGeometry,
+  sparklinePoints,
+  toNumber,
+} from "./sparkline";
+
+describe("toNumber", () => {
+  test("passes finite numbers through", () => {
+    expect(toNumber(42)).toBe(42);
+    expect(toNumber(-3.5)).toBe(-3.5);
+    expect(toNumber(0)).toBe(0);
+  });
+  test("rejects non-finite numbers", () => {
+    expect(toNumber(NaN)).toBeNull();
+    expect(toNumber(Infinity)).toBeNull();
+  });
+  test("parses numeric strings, stripping spaces and commas", () => {
+    expect(toNumber("1,234")).toBe(1234);
+    expect(toNumber(" 12 ")).toBe(12);
+    expect(toNumber("3.14")).toBeCloseTo(3.14);
+  });
+  test("rejects null, undefined, and non-numeric strings", () => {
+    expect(toNumber(null)).toBeNull();
+    expect(toNumber(undefined)).toBeNull();
+    expect(toNumber("")).toBeNull();
+    expect(toNumber("abc")).toBeNull();
+  });
+});
+
+describe("numericValues", () => {
+  test("keeps only finite numbers, preserving order", () => {
+    expect(numericValues([1, "x", "2", null, 3, NaN])).toEqual([1, 2, 3]);
+  });
+  test("empty input → empty output", () => {
+    expect(numericValues([])).toEqual([]);
+  });
+});
+
+describe("sparklinePoints", () => {
+  test("returns empty for fewer than two values", () => {
+    expect(sparklinePoints([])).toEqual([]);
+    expect(sparklinePoints([5])).toEqual([]);
+  });
+
+  test("spaces x evenly across the padded width", () => {
+    const pts = sparklinePoints([0, 1, 2], { width: 100, height: 24, pad: 2 });
+    expect(pts).toHaveLength(3);
+    // inner width = 100 - 2*2 = 96; step = 48.
+    expect(pts[0].x).toBe(2);
+    expect(pts[1].x).toBe(50);
+    expect(pts[2].x).toBe(98);
+  });
+
+  test("inverts y so the max sits at the top (smallest y)", () => {
+    const pts = sparklinePoints([0, 10], { width: 100, height: 24, pad: 2 });
+    // min (0) → bottom = height - pad = 22; max (10) → top = pad = 2.
+    expect(pts[0].y).toBe(22);
+    expect(pts[1].y).toBe(2);
+  });
+
+  test("flat series maps all points to the vertical centre", () => {
+    const pts = sparklinePoints([7, 7, 7], { width: 100, height: 24, pad: 2 });
+    // centre = pad + 0.5 * innerH = 2 + 0.5*20 = 12.
+    for (const p of pts) expect(p.y).toBe(12);
+  });
+
+  test("handles negative values via min/max range", () => {
+    const pts = sparklinePoints([-10, 0, 10], { width: 100, height: 20, pad: 0 });
+    // innerH = 20; -10 → bottom (20), 0 → mid (10), 10 → top (0).
+    expect(pts[0].y).toBe(20);
+    expect(pts[1].y).toBe(10);
+    expect(pts[2].y).toBe(0);
+  });
+});
+
+describe("pointsToPolyline / pointsToPath", () => {
+  const pts = [
+    { x: 2, y: 22 },
+    { x: 50, y: 12 },
+    { x: 98, y: 2 },
+  ];
+  test("polyline joins as 'x,y x,y …'", () => {
+    expect(pointsToPolyline(pts)).toBe("2,22 50,12 98,2");
+  });
+  test("path moves to first then lines to the rest", () => {
+    expect(pointsToPath(pts)).toBe("M 2 22 L 50 12 L 98 2");
+  });
+  test("empty points → empty strings", () => {
+    expect(pointsToPolyline([])).toBe("");
+    expect(pointsToPath([])).toBe("");
+  });
+});
+
+describe("sparklineBars", () => {
+  test("empty input → empty output", () => {
+    expect(sparklineBars([])).toEqual([]);
+  });
+
+  test("evenly slots bars across the width with positive heights", () => {
+    const bars = sparklineBars([1, 2, 4], { width: 90, height: 20, pad: 0 });
+    expect(bars).toHaveLength(3);
+    // slot = 30; barW = 21; gap = 4.5.
+    expect(bars[0].x).toBe(4.5);
+    expect(bars[1].x).toBe(34.5);
+    expect(bars[2].x).toBe(64.5);
+    // base = 0, top = 4, range = 4; innerH = 20.
+    expect(bars[0].height).toBe(5); // 1/4 * 20
+    expect(bars[2].height).toBe(20); // 4/4 * 20
+    // bars grow upward: tallest has smallest y.
+    expect(bars[2].y).toBe(0);
+  });
+
+  test("all-equal non-zero series → full-height bars", () => {
+    const bars = sparklineBars([5, 5], { width: 100, height: 24, pad: 2 });
+    // range = top(5) - base(0) = 5; magnitudes all equal but range != 0
+    // so heights are proportional: |5-0|/5 * innerH = innerH.
+    const innerH = 24 - 2 * 2;
+    for (const b of bars) expect(b.height).toBe(innerH);
+  });
+});
+
+describe("sparklineGeometry", () => {
+  test("not renderable with fewer than two finite values", () => {
+    const g = sparklineGeometry(["x", null]);
+    expect(g.renderable).toBe(false);
+    expect(g.polyline).toBe("");
+    expect(g.path).toBe("");
+    expect(g.first).toBeNull();
+    expect(g.last).toBeNull();
+    expect(g.min).toBeNull();
+  });
+
+  test("drops non-numeric cells and renders from the rest", () => {
+    const g = sparklineGeometry([1, "bad", "3", null, 5], { width: 100, height: 24, pad: 2 });
+    expect(g.renderable).toBe(true);
+    expect(g.points).toHaveLength(3); // 1, 3, 5
+    expect(g.min).toBe(1);
+    expect(g.max).toBe(5);
+    expect(g.first).toEqual(g.points[0]);
+    expect(g.last).toEqual(g.points[g.points.length - 1]);
+    expect(g.polyline).toBe(pointsToPolyline(g.points));
+    expect(g.path).toBe(pointsToPath(g.points));
+  });
+
+  test("uses default dimensions when no options given", () => {
+    const g = sparklineGeometry([1, 2, 3]);
+    expect(g.width).toBe(100);
+    expect(g.height).toBe(24);
+  });
+});

--- a/saiku-ui/src/lib/dashboard/sparkline.ts
+++ b/saiku-ui/src/lib/dashboard/sparkline.ts
@@ -1,0 +1,236 @@
+/*
+ * Pure geometry for the table-tile sparkline column (issue #920).
+ *
+ * A sparkline is a tiny inline trend drawn from a single row's numeric
+ * measure cells. This module owns ONLY the maths — turning a list of raw
+ * values into normalised SVG coordinates (polyline points / a path
+ * string, and per-bar rectangles) inside a fixed viewBox. No DOM, no
+ * fetch: TableTile.svelte collects the row's numeric values, calls these
+ * helpers, and renders the returned coordinates with inline <svg> using
+ * theme tokens for the stroke. Keeping it here means it can be
+ * unit-tested without a DOM (vitest node env), mirroring the sibling
+ * $lib/dashboard/conditionalFormat.ts engine.
+ *
+ * Coordinate system: x runs left→right across the viewBox width, evenly
+ * spaced over the points; y is inverted so the LARGEST value sits at the
+ * top (small y) — the natural reading for a trend line. A `pad` inset
+ * keeps the stroke from clipping at the box edges.
+ *
+ * Degenerate handling:
+ *   - fewer than 2 finite points  → not renderable (caller shows a dash).
+ *   - all points equal (flat)     → a centred horizontal line.
+ */
+
+/** A single normalised point inside the sparkline viewBox. */
+export interface SparkPoint {
+  x: number;
+  y: number;
+}
+
+/** Geometry options. All optional; sensible compact defaults. */
+export interface SparkOptions {
+  /** viewBox width in user units. Defaults to 100. */
+  width?: number;
+  /** viewBox height in user units. Defaults to 24. */
+  height?: number;
+  /** Inset (in user units) kept clear on every edge so the stroke and
+   *  end-point markers are not clipped. Defaults to 2. */
+  pad?: number;
+}
+
+/** Fully-resolved geometry for one row's sparkline. {@code renderable} is
+ *  false when there are fewer than two finite values — the caller renders
+ *  a placeholder dash instead. */
+export interface SparkGeometry {
+  renderable: boolean;
+  width: number;
+  height: number;
+  /** Normalised points, left→right. Empty when not renderable. */
+  points: SparkPoint[];
+  /** {@code points} as an SVG polyline `points` attribute string
+   *  ("x1,y1 x2,y2 …"). Empty string when not renderable. */
+  polyline: string;
+  /** {@code points} as an SVG path `d` string ("M x y L x y …"). Empty
+   *  string when not renderable. */
+  path: string;
+  /** The first / last drawn point — handy for an end marker. Null when
+   *  not renderable. */
+  first: SparkPoint | null;
+  last: SparkPoint | null;
+  /** The min / max of the finite input values (data space, pre-scaling).
+   *  Null when not renderable. */
+  min: number | null;
+  max: number | null;
+}
+
+const DEFAULT_WIDTH = 100;
+const DEFAULT_HEIGHT = 24;
+const DEFAULT_PAD = 2;
+
+/** Coerce an arbitrary value to a finite number, or null. Mirrors the
+ *  coercion used by the conditional-format engine: raw numbers pass
+ *  through; numeric strings have spaces / thousands-commas stripped;
+ *  everything else (null, NaN, non-numeric strings) yields null. */
+export function toNumber(value: unknown): number | null {
+  if (value == null) return null;
+  if (typeof value === "number") return Number.isFinite(value) ? value : null;
+  if (typeof value === "string") {
+    const cleaned = value.replace(/[\s,]/g, "").trim();
+    if (cleaned === "") return null;
+    const n = Number(cleaned);
+    return Number.isFinite(n) ? n : null;
+  }
+  return null;
+}
+
+/** Extract the finite numeric subset of a value list, preserving order. */
+export function numericValues(values: readonly unknown[]): number[] {
+  const out: number[] = [];
+  for (const v of values) {
+    const n = toNumber(v);
+    if (n !== null) out.push(n);
+  }
+  return out;
+}
+
+/** Round to 2 decimals to keep the emitted SVG strings compact and
+ *  deterministic (avoids long floating-point tails in attributes). */
+function r2(n: number): number {
+  return Math.round(n * 100) / 100;
+}
+
+function resolveOpts(opts?: SparkOptions): Required<SparkOptions> {
+  const width = opts?.width ?? DEFAULT_WIDTH;
+  const height = opts?.height ?? DEFAULT_HEIGHT;
+  const pad = opts?.pad ?? DEFAULT_PAD;
+  return { width, height, pad };
+}
+
+/** Map finite values to normalised points inside the (padded) viewBox.
+ *  Returns an empty array for fewer than two finite values. y is inverted
+ *  (max at top). A flat series maps to the vertical centre. */
+export function sparklinePoints(values: readonly number[], opts?: SparkOptions): SparkPoint[] {
+  if (values.length < 2) return [];
+  const { width, height, pad } = resolveOpts(opts);
+
+  let min = values[0];
+  let max = values[0];
+  for (const v of values) {
+    if (v < min) min = v;
+    if (v > max) max = v;
+  }
+
+  const innerW = Math.max(0, width - pad * 2);
+  const innerH = Math.max(0, height - pad * 2);
+  const span = max - min;
+  const stepX = innerW / (values.length - 1);
+
+  return values.map((v, i) => {
+    const x = pad + stepX * i;
+    // span === 0 → flat line through the vertical centre.
+    const t = span === 0 ? 0.5 : (v - min) / span;
+    // Invert: t=1 (max) → top (y=pad); t=0 (min) → bottom (y=height-pad).
+    const y = pad + (1 - t) * innerH;
+    return { x: r2(x), y: r2(y) };
+  });
+}
+
+/** Serialise points to an SVG polyline `points` attribute string. */
+export function pointsToPolyline(points: readonly SparkPoint[]): string {
+  return points.map((p) => `${p.x},${p.y}`).join(" ");
+}
+
+/** Serialise points to an SVG path `d` string (move to first, line to rest). */
+export function pointsToPath(points: readonly SparkPoint[]): string {
+  if (points.length === 0) return "";
+  const [head, ...rest] = points;
+  let d = `M ${head.x} ${head.y}`;
+  for (const p of rest) d += ` L ${p.x} ${p.y}`;
+  return d;
+}
+
+/** One bar in a bar-style sparkline, normalised to the viewBox. */
+export interface SparkBar {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+/** Map finite values to evenly-spaced bars inside the (padded) viewBox.
+ *  Bars grow upward from the baseline; the tallest value fills the inner
+ *  height. A flat (all-equal) non-zero series yields full-height bars; an
+ *  all-zero series yields zero-height bars. Returns an empty array for an
+ *  empty input (a single value is still drawable as one bar). */
+export function sparklineBars(values: readonly number[], opts?: SparkOptions): SparkBar[] {
+  if (values.length === 0) return [];
+  const { width, height, pad } = resolveOpts(opts);
+
+  let max = values[0];
+  let min = values[0];
+  for (const v of values) {
+    if (v > max) max = v;
+    if (v < min) min = v;
+  }
+  // Baseline is zero when the data straddles / sits at zero from below,
+  // else the smallest value — keeps the visual honest for all-positive
+  // and all-negative series alike. For the compact sparkline we scale
+  // height by max magnitude from the baseline.
+  const base = Math.min(0, min);
+  const top = Math.max(0, max);
+  const range = top - base;
+
+  const innerW = Math.max(0, width - pad * 2);
+  const innerH = Math.max(0, height - pad * 2);
+  const slot = innerW / values.length;
+  const barW = Math.max(0, slot * 0.7);
+  const gap = (slot - barW) / 2;
+
+  return values.map((v, i) => {
+    const x = pad + slot * i + gap;
+    const h = range === 0 ? innerH : (Math.abs(v - base) / range) * innerH;
+    const y = pad + (innerH - h);
+    return { x: r2(x), y: r2(y), width: r2(barW), height: r2(h) };
+  });
+}
+
+/** Top-level: turn a row's raw cell values into renderable sparkline
+ *  geometry. Non-numeric cells are dropped; fewer than two finite values
+ *  yields {@code renderable: false} so the caller can show a dash. */
+export function sparklineGeometry(values: readonly unknown[], opts?: SparkOptions): SparkGeometry {
+  const { width, height } = resolveOpts(opts);
+  const nums = numericValues(values);
+  if (nums.length < 2) {
+    return {
+      renderable: false,
+      width,
+      height,
+      points: [],
+      polyline: "",
+      path: "",
+      first: null,
+      last: null,
+      min: null,
+      max: null,
+    };
+  }
+  const points = sparklinePoints(nums, opts);
+  let min = nums[0];
+  let max = nums[0];
+  for (const n of nums) {
+    if (n < min) min = n;
+    if (n > max) max = n;
+  }
+  return {
+    renderable: true,
+    width,
+    height,
+    points,
+    polyline: pointsToPolyline(points),
+    path: pointsToPath(points),
+    first: points[0] ?? null,
+    last: points[points.length - 1] ?? null,
+    min,
+    max,
+  };
+}

--- a/saiku-ui/src/lib/views/dashboard/DashboardGrid.svelte
+++ b/saiku-ui/src/lib/views/dashboard/DashboardGrid.svelte
@@ -279,12 +279,13 @@
       <p class="hint">Use <em>Add tile</em> in the toolbar to start building.</p>
     </div>
   {:else}
-    <!-- svelte-ignore a11y_click_events_have_key_events a11y_no_noninteractive_element_interactions
-         The grid's onclick only clears the multi-selection when the user
-         clicks the empty canvas (#915) — a power-user layout aid, not a
-         primary control. Tile selection itself has keyboard-reachable
-         per-tile actions (edit / remove / kebab) so this background-clear
-         shortcut carries no keyboard responsibility of its own. -->
+    <!-- The grid's onclick only clears the multi-selection when the user clicks
+         the empty canvas (#915) — a power-user layout aid with keyboard-
+         reachable per-tile actions (edit / remove / kebab), so it carries no
+         keyboard responsibility. One code per comment — this svelte-check only
+         honours the first code in a multi-code svelte-ignore (#920). -->
+    <!-- svelte-ignore a11y_click_events_have_key_events -->
+    <!-- svelte-ignore a11y_no_noninteractive_element_interactions -->
     <div
       class="grid"
       class:grid--gesturing={gesture !== null}

--- a/saiku-ui/src/lib/views/dashboard/Tile.svelte
+++ b/saiku-ui/src/lib/views/dashboard/Tile.svelte
@@ -168,13 +168,14 @@
   const selected = $derived(!readOnly && tileSelection.isSelected(tile.id));
 </script>
 
-<!-- svelte-ignore a11y_no_static_element_interactions a11y_click_events_have_key_events
-     Right-click is a power-user shortcut for the overflow menu, and click
-     drives edit-mode multi-select (#915). The kebab button (⋮) in the
-     header is the keyboard-accessible equivalent for the menu; tile
-     selection is a power-user layout aid, not a primary navigation path,
-     so suppressing the static-handler + click-needs-keys rules here is
-     intentional rather than an a11y regression. -->
+<!-- Right-click is a power-user shortcut for the overflow menu, and click
+     drives edit-mode multi-select (#915). The kebab button (⋮) in the header
+     is the keyboard-accessible equivalent; tile selection is a power-user
+     layout aid, not a primary navigation path — so suppressing these rules is
+     intentional. NB: this svelte-check honours only the FIRST code in a
+     multi-code svelte-ignore, so they must be one-per-comment (#920). -->
+<!-- svelte-ignore a11y_no_static_element_interactions -->
+<!-- svelte-ignore a11y_click_events_have_key_events -->
 <div
   class="tile"
   class:tile--selected={selected}

--- a/saiku-ui/src/lib/views/dashboard/TileEditorModal.svelte
+++ b/saiku-ui/src/lib/views/dashboard/TileEditorModal.svelte
@@ -34,6 +34,8 @@
     type ConditionalFormatRule,
     type ConditionalFormatType,
     type ConditionalThresholdMode,
+    // Issue #920 — inline sparkline column on table tiles.
+    type SparklineType,
   } from "$lib/api/dashboards";
   import { flatten, listRepository, type RepositoryNode } from "$lib/api/repository";
   import { repositionTile } from "$lib/dashboard/tilePlacement";
@@ -124,6 +126,12 @@
       })),
     ),
   );
+  // ── Issue #920: opt-in inline sparkline column (table only) ──
+  // Working copy of the table tile's sparkline config; persisted in
+  // handleSave under the table-guarded block. Isolated so it rebases
+  // cleanly against the parallel #919 conditional-format edit.
+  let sparklineEnabled = $state<boolean>(untrack(() => tile.sparkline?.enabled ?? false));
+  let sparklineType = $state<SparklineType>(untrack(() => tile.sparkline?.type ?? "line"));
   // Query source — "reference" picks a saved .saiku from the repo,
   // "inline" pastes an AiQueryRequest body. Default to "reference" so
   // non-technical authors aren't dropped into a JSON textarea on a
@@ -490,6 +498,10 @@
           return out;
         });
       patch.conditionalFormat = cleaned.length > 0 ? cleaned : undefined;
+
+      // ── Issue #920: persist sparkline column config. Only store when
+      // enabled so a fresh / opted-out tile keeps tidy JSON. ──
+      patch.sparkline = sparklineEnabled ? { enabled: true, type: sparklineType } : undefined;
     }
 
     // ── Issue #918: image tile. URL mode persists the typed URL; upload mode
@@ -1079,6 +1091,38 @@
           <button type="button" class="btn cf-add" onclick={addConditionalRule}>
             + Add column rule
           </button>
+        </fieldset>
+      {/if}
+
+      <!-- ════════════════════════════════════════════════════════════
+           Issue #920 — Sparkline column (TABLE tiles only). Opt-in
+           trailing column drawing a tiny inline trend per row from the
+           row's numeric measure cells. Geometry maths lives in
+           $lib/dashboard/sparkline.ts; this is config capture only.
+           ════════════════════════════════════════════════════════════ -->
+      {#if tile.type === "table"}
+        <fieldset class="cf-section">
+          <legend>Sparkline column</legend>
+          <span class="hint">
+            Adds a trailing “Trend” column drawing a mini chart per row from
+            that row's numeric measure values. Needs at least two measure
+            columns to render; rows with fewer numeric values show a dash.
+          </span>
+
+          <label class="checkbox">
+            <input type="checkbox" bind:checked={sparklineEnabled} />
+            <span>Show sparkline column</span>
+          </label>
+
+          {#if sparklineEnabled}
+            <label class="field inline">
+              <span>Style</span>
+              <select bind:value={sparklineType}>
+                <option value="line">Line</option>
+                <option value="bar">Bar</option>
+              </select>
+            </label>
+          {/if}
         </fieldset>
       {/if}
     </div>

--- a/saiku-ui/src/lib/views/dashboard/tiles/TableTile.svelte
+++ b/saiku-ui/src/lib/views/dashboard/tiles/TableTile.svelte
@@ -48,6 +48,10 @@
     cellFormatToStyle,
     type CellFormat,
   } from "$lib/dashboard/conditionalFormat";
+  // Issue #920 — opt-in inline sparkline column (display-only). Pure
+  // geometry lives in $lib/dashboard/sparkline; this component only
+  // collects each row's numeric measure values and renders the SVG.
+  import { sparklineGeometry, sparklineBars, numericValues } from "$lib/dashboard/sparkline";
   // Issue #933 — shared loading / error / empty states.
   import TileLoading from "./TileLoading.svelte";
   import TileError from "./TileError.svelte";
@@ -349,6 +353,37 @@
     return v.formatted ?? "";
   }
 
+  /* ----------------------- sparkline column (#920) -------------------- */
+
+  // Opt-in trailing column that draws a tiny inline trend per row from the
+  // row's numeric measure cells. Display-only; the geometry maths lives in
+  // $lib/dashboard/sparkline. Needs >= 2 measure columns to be meaningful.
+  let sparklineEnabled = $derived(
+    tile.type === "table" &&
+      (tile.sparkline?.enabled ?? false) &&
+      (response?.metadata?.columns?.length ?? 0) >= 2,
+  );
+  let sparklineType = $derived<"line" | "bar">(tile.sparkline?.type ?? "line");
+
+  /** A row's numeric measure values, in measure-column order. Row-header
+   *  columns are excluded — only response.metadata.columns (the measures)
+   *  feed the trend. Non-numeric measure cells become null and are dropped
+   *  by the geometry helper. */
+  function rowMeasureValues(row: Record<string, AiCell | string>): unknown[] {
+    const cols = response?.metadata?.columns ?? [];
+    return cols.map((c) => {
+      const cell = row[c.caption];
+      return isAiCell(cell) ? cell.value : cell;
+    });
+  }
+
+  /** Bar geometry for a row, using the same default viewBox as
+   *  sparklineGeometry so the bars line up with the svg's 0 0 100 24 box.
+   *  Only the finite measure values feed the bars (non-numeric dropped). */
+  function sparklineBarsFor(row: Record<string, AiCell | string>) {
+    return sparklineBars(numericValues(rowMeasureValues(row)));
+  }
+
   /* --------------------------- drillthrough (#930) -------------------- */
 
   let drill = $state<TileDrillthrough | null>(null);
@@ -402,6 +437,9 @@
               {#each columns as col (col.caption)}
                 <th class:row-header={col.isRowHeader}>{col.caption}</th>
               {/each}
+              {#if sparklineEnabled}
+                <th class="spark-header">Trend</th>
+              {/if}
             </tr>
           </thead>
           <tbody>
@@ -440,6 +478,49 @@
                     {#if cf.icon}<span class="cf-icon" aria-hidden="true">{cf.icon}</span>{/if}{fmt.display}
                   </td>
                 {/each}
+                {#if sparklineEnabled}
+                  {@const g = sparklineGeometry(rowMeasureValues(row))}
+                  <td class="spark-cell">
+                    {#if g.renderable}
+                      <svg
+                        class="spark"
+                        viewBox={`0 0 ${g.width} ${g.height}`}
+                        width={g.width}
+                        height={g.height}
+                        preserveAspectRatio="none"
+                        role="img"
+                        aria-label={`Trend across ${g.points.length} measures, min ${g.min}, max ${g.max}`}
+                      >
+                        {#if sparklineType === "bar"}
+                          {#each sparklineBarsFor(row) as bar (bar.x)}
+                            <rect
+                              x={bar.x}
+                              y={bar.y}
+                              width={bar.width}
+                              height={bar.height}
+                              fill="var(--accent)"
+                            />
+                          {/each}
+                        {:else}
+                          <polyline
+                            points={g.polyline}
+                            fill="none"
+                            stroke="var(--accent)"
+                            stroke-width="1.25"
+                            stroke-linejoin="round"
+                            stroke-linecap="round"
+                            vector-effect="non-scaling-stroke"
+                          />
+                          {#if g.last}
+                            <circle cx={g.last.x} cy={g.last.y} r="1.5" fill="var(--accent)" />
+                          {/if}
+                        {/if}
+                      </svg>
+                    {:else}
+                      <span class="spark-empty" aria-hidden="true">—</span>
+                    {/if}
+                  </td>
+                {/if}
               </tr>
             {/each}
           </tbody>
@@ -497,5 +578,24 @@
     display: inline-block;
     margin-right: 0.25rem;
     font-weight: var(--weight-semibold);
+  }
+  /* Issue #920 — inline sparkline column. */
+  th.spark-header {
+    text-align: center;
+  }
+  td.spark-cell {
+    text-align: center;
+    padding: 0.125rem 0.5rem;
+    white-space: nowrap;
+  }
+  svg.spark {
+    display: block;
+    width: 64px;
+    height: 18px;
+    color: var(--accent);
+    vertical-align: middle;
+  }
+  .spark-empty {
+    color: var(--fg-muted);
   }
 </style>

--- a/saiku-ui/src/lib/views/dashboard/tiles/TableTile.svelte
+++ b/saiku-ui/src/lib/views/dashboard/tiles/TableTile.svelte
@@ -593,7 +593,6 @@
     width: 64px;
     height: 18px;
     color: var(--accent);
-    vertical-align: middle;
   }
   .spark-empty {
     color: var(--fg-muted);


### PR DESCRIPTION
## Summary
Adds an opt-in **inline sparkline ("Trend") column** to dashboard **table tiles** (#920) — a tiny per-row line/bar drawn from that row's numeric columns, so a table with a time-series (or several measures) across columns shows the shape at a glance.

## The change
- **`$lib/dashboard/sparkline.ts`** *(pure, unit-tested)* — `values[] → normalised SVG polyline / path + bar rects` with min/max scaling, inverted-y (max on top), flat-series centring, and degenerate handling (<2 points).
- **`TableTile.svelte`** — renders a trailing **Trend** column using **inline SVG** (no per-cell ECharts), stroked/filled with `var(--accent)`, from each row's numeric measure cells; rows with <2 numeric points show a muted `—`.
- **`dashboards.ts`** — a minimal `SparklineConfig { enabled; type?: "line" | "bar" }` on `DashboardTile` (table tiles only).
- **`TileEditorModal.svelte`** — table-only "Sparkline column" fieldset: enable checkbox + Line/Bar style, persisted only when enabled.

## Verified
- `npm run check` **0/0** · `npm test` **700** (incl. `sparkline` geometry tests) · production build ✓.
- Rebased clean onto current `origin/development`.
- **User-verified locally**: table with Store Sales by Product Subcategory → enabled the Trend column → line/bar render per row; degenerate rows show `—`; toggle persists across reload.

## ⚠️ Drive-by fix (please read)
The batch-1 merge (#914/#915/#932) **lost my one-code-per-comment `svelte-ignore` split** in `Tile.svelte` + `DashboardGrid.svelte` — the conflict resolution reverted them to the multi-code form, which **this svelte-check only half-honours**, so **development currently has 2 a11y warnings (red 0/0 gate)**. This PR re-applies the split (last commit) so `check` is 0/0 again. **@OG: merging this repairs development; until then every batch-2 PR (#992/#938) inherits those 2 warnings.** If you'd rather fix development directly first, cherry-pick that commit.

## Notes
- ⚠️ Overlaps **#992 (KPI YoY)** on `TileEditorModal.svelte` + `dashboards.ts` — small conflict expected; suggested order **#920 → #992**, I'll rebase #992.
- `TableTile`/`TileEditorModal` use hardcoded English (no i18n import) — followed that local convention; no en.json keys added.
- No backend change. Does not self-merge.

Closes #920

🤖 Generated with [Claude Code](https://claude.com/claude-code)
