### PR TITLE
feat(viz): click-to-drill-down on workspace charts (closes #1086)

### DIFF
--- a/saiku-ui/src/lib/charts/chartDrillCoord.test.ts
+++ b/saiku-ui/src/lib/charts/chartDrillCoord.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect } from "vitest";
+import { chartDrillTarget } from "./chartDrillCoord";
+import { parseCellset, deriveLeafRows } from "$lib/views/cellsetUtils";
+import type { CellEntry, QueryResult } from "$lib/api/query";
+
+// Helpers to assemble a cellset the same way the server does, so we exercise
+// the real parseCellset → chartDrillTarget mapping rather than a hand-rolled
+// ParsedCellset.
+const ch = (value: string): CellEntry => ({ value, type: "COLUMN_HEADER" });
+const rhh = (value: string): CellEntry => ({ value, type: "ROW_HEADER_HEADER" });
+const rh = (value: string, uniquename?: string): CellEntry => ({
+  value,
+  type: "ROW_HEADER",
+  ...(uniquename ? { properties: { uniquename } } : {}),
+});
+const dc = (value: string): CellEntry => ({ value, type: "DATA_CELL" });
+
+// Single-level rows × two measure columns:
+//   header:  [ "", Sales, Cost ]
+//   1997  :  [ 1997, 100, 40 ]
+//   1998  :  [ 1998, 200, 80 ]
+function simpleResult(): QueryResult {
+  const cellset: CellEntry[][] = [
+    [rhh(""), ch("Unit Sales"), ch("Store Cost")],
+    [rh("1997"), dc("100"), dc("40")],
+    [rh("1998"), dc("200"), dc("80")],
+  ];
+  return { cellset };
+}
+
+// Multi-level hierarchy on rows (Year > Quarter) so deriveLeafRows reindexes:
+//   1997 (rollup), 1997/Q1, 1997/Q2 — leaves are the two quarter rows.
+function hierarchyResult(): QueryResult {
+  const cellset: CellEntry[][] = [
+    [rhh(""), ch("Unit Sales")],
+    [rh("1997", "[Time].[Time].[1997]"), dc("300")],
+    [rh("Q1", "[Time].[Time].[1997].[Q1]"), dc("120")],
+    [rh("Q2", "[Time].[Time].[1997].[Q2]"), dc("180")],
+  ];
+  return { cellset };
+}
+
+describe("chartDrillTarget", () => {
+  it("maps a bar click (category + series) to absolute cellset coords", () => {
+    const parsed = parseCellset(simpleResult());
+    // headerRowCount = 1, rowHeaderColCount = 1.
+    // Click second category (1998), first series (Unit Sales).
+    expect(chartDrillTarget(parsed, 1, 0)).toEqual({ row: 2, col: 1 });
+    // First category (1997), second series (Store Cost).
+    expect(chartDrillTarget(parsed, 0, 1)).toEqual({ row: 1, col: 2 });
+  });
+
+  it("treats index 0 on both axes as valid (first bar, first series)", () => {
+    const parsed = parseCellset(simpleResult());
+    expect(chartDrillTarget(parsed, 0, 0)).toEqual({ row: 1, col: 1 });
+  });
+
+  it("returns null for negative / non-integer / non-finite indices", () => {
+    const parsed = parseCellset(simpleResult());
+    expect(chartDrillTarget(parsed, -1, 0)).toBeNull();
+    expect(chartDrillTarget(parsed, 0, -1)).toBeNull();
+    expect(chartDrillTarget(parsed, 1.5, 0)).toBeNull();
+    expect(chartDrillTarget(parsed, NaN, 0)).toBeNull();
+    expect(chartDrillTarget(parsed, 0, Infinity)).toBeNull();
+  });
+
+  it("returns null when the category index is out of range", () => {
+    const parsed = parseCellset(simpleResult());
+    expect(chartDrillTarget(parsed, 2, 0)).toBeNull(); // only 2 body rows
+  });
+
+  it("returns null when the series index addresses a non-existent column", () => {
+    const parsed = parseCellset(simpleResult());
+    expect(chartDrillTarget(parsed, 0, 2)).toBeNull(); // only 2 data cols
+  });
+
+  it("returns null on an empty cellset (background click safety)", () => {
+    const parsed = parseCellset({ cellset: [] });
+    expect(chartDrillTarget(parsed, 0, 0)).toBeNull();
+  });
+
+  it("remaps the category through leafIndices when rollup rows are hidden", () => {
+    const parsed = parseCellset(hierarchyResult());
+    const leaf = deriveLeafRows(parsed);
+    // Leaves are the two quarter rows → original body indices [1, 2].
+    expect(leaf.indices).toEqual([1, 2]);
+    // Chart category 0 == Q1 == body row 1 == absolute cellset row 2.
+    expect(chartDrillTarget(parsed, 0, 0, leaf.indices)).toEqual({ row: 2, col: 1 });
+    // Chart category 1 == Q2 == body row 2 == absolute cellset row 3.
+    expect(chartDrillTarget(parsed, 1, 0, leaf.indices)).toEqual({ row: 3, col: 1 });
+  });
+
+  it("returns null when the chart category exceeds the leaf set", () => {
+    const parsed = parseCellset(hierarchyResult());
+    const leaf = deriveLeafRows(parsed);
+    expect(chartDrillTarget(parsed, 2, 0, leaf.indices)).toBeNull(); // only 2 leaves
+  });
+
+  it("ignores leafIndices when rollups are shown (chart index == body index)", () => {
+    const parsed = parseCellset(hierarchyResult());
+    // No leafIndices → chart category 1 is the rollup's first child row.
+    expect(chartDrillTarget(parsed, 1, 0)).toEqual({ row: 2, col: 1 });
+  });
+});

--- a/saiku-ui/src/lib/charts/chartDrillCoord.ts
+++ b/saiku-ui/src/lib/charts/chartDrillCoord.ts
@@ -1,0 +1,86 @@
+/*
+ * Issue #1086 — click-to-drill on the WORKSPACE chart.
+ *
+ * The workspace grid (CellsetTable) already drills on right-click by
+ * dispatching a `saiku-drillthrough` CustomEvent carrying ABSOLUTE cellset
+ * coordinates `{ row, col }`, which QueryCanvas listens for and feeds into the
+ * existing DrillthroughModal flow. We reuse that exact mechanism for the chart
+ * so there is no new backend path: clicking a data point translates the
+ * ECharts category/series indices back into the same absolute cellset
+ * coordinates the grid would emit for that cell.
+ *
+ * The wrinkle is `hideRollupRows` (#1053): when active the chart renders only
+ * the LEAF rows of a multi-level hierarchy (via `deriveLeafRows`), so the
+ * chart's category index is an index into a FILTERED subset, not the raw
+ * cellset body rows. `leafIndices` maps each chart category back to its
+ * original body-row index; when rollups are shown it is undefined and the
+ * chart index already equals the body-row index.
+ *
+ * Kept side-effect free (no DOM, no echarts, no fetch) so it can be unit
+ * tested under the project's `node` vitest environment, mirroring
+ * `dashboard/drillthroughCoord.ts`.
+ */
+
+import type { ParsedCellset } from "$lib/views/cellsetUtils";
+
+export interface ChartDrillTarget {
+  /** Absolute cellset row index (header rows + body-row offset). */
+  row: number;
+  /** Absolute cellset column index (row-header cols + data-col offset). */
+  col: number;
+}
+
+/**
+ * Translate an ECharts click on the workspace chart into the absolute cellset
+ * coordinates the `saiku-drillthrough` event expects.
+ *
+ * @param parsed       The same parsed cellset the chart was projected from.
+ * @param categoryIndex `params.dataIndex` — the clicked category (chart row).
+ *                      For pie/donut this is the slice index.
+ * @param seriesIndex   `params.seriesIndex` — the clicked series (chart
+ *                      column = measure). Pie series may omit it; pass 0.
+ * @param leafIndices   When `hideRollupRows` reindexed the rows, the original
+ *                      body-row index for each chart category. Omit/undefined
+ *                      when rollups are shown (chart index == body-row index).
+ * @returns absolute `{ row, col }`, or `null` for any out-of-range or
+ *   non-integer index (background clicks, empty cellsets), so the caller can
+ *   treat it as a no-op exactly like the grid does.
+ */
+export function chartDrillTarget(
+  parsed: ParsedCellset,
+  categoryIndex: number,
+  seriesIndex: number,
+  leafIndices?: number[],
+): ChartDrillTarget | null {
+  if (!isNonNegativeInt(categoryIndex) || !isNonNegativeInt(seriesIndex)) return null;
+
+  const rowCount = parsed.dataRows.length;
+  if (rowCount === 0) return null;
+
+  // Resolve the chart category back to a raw body-row index.
+  let bodyRowIndex: number;
+  if (leafIndices && leafIndices.length > 0) {
+    if (categoryIndex >= leafIndices.length) return null;
+    bodyRowIndex = leafIndices[categoryIndex];
+  } else {
+    bodyRowIndex = categoryIndex;
+  }
+  if (!isNonNegativeInt(bodyRowIndex) || bodyRowIndex >= rowCount) return null;
+
+  // The series index addresses a DATA column. Guard against the rare event
+  // shape that reports a series the cellset doesn't have (e.g. a derived/
+  // synthetic series); clamp to a valid data column rather than emitting an
+  // out-of-range col.
+  const dataColCount = parsed.dataRows[bodyRowIndex]?.length ?? 0;
+  if (dataColCount === 0) return null;
+  if (seriesIndex >= dataColCount) return null;
+
+  return {
+    row: parsed.headerRowCount + bodyRowIndex,
+    col: parsed.rowHeaderColCount + seriesIndex,
+  };
+}
+
+function isNonNegativeInt(n: number): boolean {
+  return Number.isInteger(n) && n >= 0;
+}

--- a/saiku-ui/src/lib/views/ChartView.svelte
+++ b/saiku-ui/src/lib/views/ChartView.svelte
@@ -9,6 +9,8 @@
   import { theme } from "$lib/stores/theme.svelte";
   import { resolveThemeTokens } from "$lib/views/chartTheme";
   import { buildChartOption, type ChartProjection } from "$lib/charts/build";
+  // #1086: map an ECharts click back to absolute cellset coords for drillthrough.
+  import { chartDrillTarget } from "$lib/charts/chartDrillCoord";
   // #1090: accessible data-table mirror of the chart for screen readers.
   import { chartSummary } from "$lib/charts/a11y";
   // issue #1071: map charts need the GeoJSON registered with ECharts before
@@ -76,6 +78,49 @@
     return buildChartOption(p, t, o, tk, { aspect, chartWidth, compact: false });
   }
 
+  // #1086: when hideRollupRows is active the chart shows only the LEAF rows
+  // (deriveLeafRows reindexes them), so a chart category index no longer equals
+  // the cellset body-row index. Recompute the same leaf indices the projection
+  // used so the click handler can map a clicked bar/slice back to the right
+  // cellset row. Returns undefined when rollups are shown (1:1 mapping). This
+  // mirrors the row-selection branch in projectResult — kept in sync with it.
+  function currentLeafIndices(r: QueryResult, o: ChartOptions): number[] | undefined {
+    if (!o.hideRollupRows) return undefined;
+    const parsed = parseCellset(r);
+    const leaf = deriveLeafRows(parsed);
+    if (leaf.indices.length > 0 && leaf.indices.length < parsed.dataRows.length) {
+      return leaf.indices;
+    }
+    return undefined;
+  }
+
+  // #1086: ECharts click → reuse the workspace's existing drillthrough flow.
+  // The grid (CellsetTable) drills by dispatching a bubbling `saiku-drillthrough`
+  // CustomEvent with absolute cellset coords; QueryCanvas listens for it and
+  // opens the DrillthroughModal. We translate the clicked data point into the
+  // same coords and dispatch the identical event — no new backend path.
+  function handleChartClick(params: { dataIndex?: number; seriesIndex?: number }) {
+    if (!host) return;
+    const categoryIndex = params.dataIndex;
+    // Pie/donut element events sometimes omit seriesIndex; a pie is one series.
+    const seriesIndex = params.seriesIndex ?? 0;
+    if (typeof categoryIndex !== "number") return; // background click → no-op
+    const parsed = parseCellset(result);
+    const target = chartDrillTarget(
+      parsed,
+      categoryIndex,
+      seriesIndex,
+      currentLeafIndices(result, options),
+    );
+    if (!target) return; // out-of-range / "All"-style click → no-op
+    host.dispatchEvent(
+      new CustomEvent("saiku-drillthrough", {
+        bubbles: true,
+        detail: { row: target.row, col: target.col },
+      }),
+    );
+  }
+
   // #1090: accessible data-table mirror of the chart for screen readers. The
   // canvas is aria-hidden (invisible to AT anyway); this exposes the same data.
   let a11y = $derived(chartSummary(type, options.title ?? "", projectResult(result, options)));
@@ -129,6 +174,10 @@
   onMount(() => {
     if (host) {
       chart = echarts.init(host, null);
+      // #1086: click a data point → drill via the existing drillthrough flow.
+      chart.on("click", (params) =>
+        handleChartClick(params as { dataIndex?: number; seriesIndex?: number }),
+      );
       render();
       // Re-render (not just resize) so the aspect-aware small-multiple radius
       // recomputes for the new canvas size (#1053).


### PR DESCRIPTION
## Summary

Left-clicking a data point on a **workspace** chart now opens the drillthrough — reusing the exact flow the grid already uses (right-click → `saiku-drillthrough` event → DrillthroughModal). No new backend path.

## The change
- NEW `$lib/charts/chartDrillCoord.ts` — pure `chartDrillTarget()` mapping an ECharts `{dataIndex, seriesIndex}` back to the **absolute cellset `{row, col}`** the grid emits (handles the `hideRollupRows` leaf reindex via `leafIndices`).
- `ChartView.svelte` — `chart.on("click")` dispatches the same bubbling `saiku-drillthrough` event the grid does; background clicks are no-ops.

## Security review (drillthrough is sensitive — reviewed hard)
- **Coordinate-identical to the existing grid path** — same event, same coord formula, same QueryCanvas handler, same `GET /api/query/{queryName}/drillthrough?position=row:col` call. **No new endpoint, no new params.**
- `chartDrillTarget` rejects non-integer/negative indices and **bounds both indices** against the cellset (`rowCount`/`dataColCount`) → the only thing a click contributes is two bounded integers. **No SQL-metacharacter/injection vector** (`queryName`/`returns` come from the user's own session, never the click).
- Drillthrough is **scoped to the caller's session query** (`credentials: include`) — a click can only drill a cell of the user's own authorized result.
- ⚠️ It adds a new *trigger* to the existing drillthrough endpoint, so it **inherits the backend drillthrough's security posture** (row-security predicate in drillthrough SQL is a separate, backend-tracked concern — unchanged by this PR).

## Verified
- `npm run check` 0 err (2 pre-existing a11y warnings on development, not in touched files); `npx vitest run` **689** (+9 `chartDrillCoord.test.ts`).
- Rebased clean onto development (post-#1092); local browser test user-confirmed (FoodMart Sales, Unit Sales × Product Family: clicking a bar opens drillthrough; bar/line/area/pie all work; background inert).

## Notes
- Reuses the existing drillthrough; true member expand-in-place drill-down is deferred (no member-expansion endpoint; no-backend constraint). UI-only; no `{@html}`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)