### PR TITLE
fix(security): re-enable CSRF protection site-wide (closes #1150)

### DIFF
--- a/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/BasicRepositoryResource2.java
+++ b/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/BasicRepositoryResource2.java
@@ -112,7 +112,12 @@ public class BasicRepositoryResource2 implements ISaikuRepository {
         String username = sessionService.getAllSessionObjects().get("username").toString();
         List<String> roles =
                 (List<String>) sessionService.getAllSessionObjects().get("roles");
-        String[] t = type.split(",");
+        // type=null is a perfectly valid "give me everything" call — the legacy
+        // unconditional split() NPE'd whenever a Basic-auth request hit a
+        // ScopedRepo cache populated by a prior form-login (CsrfIT was the
+        // first test to expose this). The separate ScopedRepo session-bleed
+        // is filed; this just stops the resource from NPEing under it.
+        String[] t = type == null ? new String[0] : type.split(",");
         List<IRepositoryObject> l;
 
         if (path == null) {

--- a/saiku-core/saiku-web/src/main/java/org/saiku/web/security/csrf/CsrfCookieMaterializerFilter.java
+++ b/saiku-core/saiku-web/src/main/java/org/saiku/web/security/csrf/CsrfCookieMaterializerFilter.java
@@ -1,0 +1,52 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ */
+package org.saiku.web.security.csrf;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import org.springframework.security.web.csrf.CsrfToken;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+/**
+ * Forces the deferred {@link CsrfToken} to be resolved on every response, so the
+ * {@code XSRF-TOKEN} cookie is written and readable from JavaScript before the
+ * SPA fires its next mutating request.
+ *
+ * <p>Spring Security 6's default {@code CsrfTokenRequestAttributeHandler} stores the
+ * token as a {@code Supplier<CsrfToken>} attribute that's only materialised when
+ * something calls {@code getToken()} — typically the {@code CsrfFilter} on a
+ * state-changing request. That's the wrong order for an SPA: the first POST after
+ * login needs the cookie to ALREADY be present so the JS can echo it as
+ * {@code X-XSRF-TOKEN}. Without this filter, the SPA's first state-changing call
+ * would always 403 ("no token to compare against").
+ *
+ * <p>Wired ahead of the security filter chain in {@code applicationContext-saiku.xml}
+ * so every response (including the login response) carries the cookie.
+ */
+public class CsrfCookieMaterializerFilter extends OncePerRequestFilter {
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain chain)
+            throws ServletException, IOException {
+        // Resolve the token BEFORE the chain runs. By the time the servlet
+        // returns the response is committed, and adding a Set-Cookie header
+        // then is a no-op. Calling getToken() triggers the deferred supplier,
+        // which calls CookieCsrfTokenRepository.saveToken() — that writes the
+        // Set-Cookie header to the (still-uncommitted) response. CsrfFilter
+        // runs upstream of this filter and has already installed the
+        // SupplierCsrfToken attribute, so by the time we read it here it's
+        // present and live.
+        CsrfToken token = (CsrfToken) request.getAttribute(CsrfToken.class.getName());
+        if (token != null) {
+            token.getToken();
+        }
+        chain.doFilter(request, response);
+    }
+}

--- a/saiku-launcher/src/test/java/org/saiku/launcher/it/CsrfIT.java
+++ b/saiku-launcher/src/test/java/org/saiku/launcher/it/CsrfIT.java
@@ -1,0 +1,210 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.launcher.it;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.List;
+import java.util.Optional;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ * CSRF enforcement (saiku#1150).
+ *
+ * <p>Locks the contract our SPA depends on:
+ *
+ * <ol>
+ *   <li>State-changing /rest/** with a session cookie but no X-XSRF-TOKEN → 403.
+ *   <li>State-changing /rest/** with cookie + valid X-XSRF-TOKEN → reaches the handler
+ *       (returns whatever the handler returns — we just confirm it's NOT 403).
+ *   <li>HTTP Basic POST → exempt (used by IT harnesses and the MCP endpoint).
+ *   <li>POST /rest/saiku/session (login) → exempt (bootstrap — no session cookie yet).
+ *   <li>Safe methods (GET / HEAD / OPTIONS) → always exempt.
+ * </ol>
+ *
+ * <p>The non-XOR {@code CsrfTokenRequestAttributeHandler} writes the XSRF-TOKEN cookie
+ * eagerly on the first GET, which is what the SPA's
+ * {@code installAuthInterceptor()} reads from {@code document.cookie}.
+ */
+public class CsrfIT {
+
+    private static SaikuItHarness harness;
+    private static HttpClient client;
+    private static String baseUrl;
+
+    @BeforeClass
+    public static void boot() throws Exception {
+        harness = SaikuItHarness.shared();
+        client = HttpClient.newBuilder()
+                .connectTimeout(Duration.ofSeconds(5))
+                .followRedirects(HttpClient.Redirect.NEVER)
+                .build();
+        baseUrl = harness.baseUrl();
+    }
+
+    /**
+     * Tear down ScopedRepo's session cache. CsrfIT's form-login leaves an
+     * admin-bound session in ScopedRepo's fallback reference; downstream ITs
+     * that use Basic auth then see {@code username=admin} via the cached
+     * session and trip a latent NPE in BasicRepositoryResource2 (filed
+     * separately — the underlying ScopedRepo bleed is documented in
+     * decisions/session-fallback-bleed). Logging out here keeps CsrfIT
+     * self-contained.
+     */
+    @AfterClass
+    public static void clearSession() throws Exception {
+        HttpRequest logout = HttpRequest.newBuilder(URI.create(baseUrl + "/rest/saiku/session"))
+                .timeout(Duration.ofSeconds(10))
+                .DELETE()
+                .build();
+        try {
+            client.send(logout, HttpResponse.BodyHandlers.discarding());
+        } catch (Exception ignored) {
+            /* best-effort */
+        }
+    }
+
+    @Test
+    public void basicAuthPostIsExemptFromCsrf() throws Exception {
+        // Every existing IT exercises this path implicitly — assert it loud so
+        // a future regression in SaikuCsrfRequestMatcher's Authorization carve-out
+        // shows up as a focused failure, not a wall of red across the suite.
+        HttpResponse<String> resp = harness.postAuthJson("/rest/saiku/session/foo-not-real", "{}");
+        assertNotEquals("Basic-auth POST must not 403 on CSRF", 403, resp.statusCode());
+    }
+
+    @Test
+    public void loginPostIsExemptFromCsrf() throws Exception {
+        // Bootstrap: no session cookie exists yet at login time, so SaikuCsrfRequestMatcher
+        // exempts /rest/saiku/session. Without this exemption the SPA could never sign in.
+        HttpRequest login = HttpRequest.newBuilder(URI.create(baseUrl + "/rest/saiku/session"))
+                .timeout(Duration.ofSeconds(10))
+                .header("Content-Type", "application/x-www-form-urlencoded")
+                .POST(HttpRequest.BodyPublishers.ofString("username=admin&password=admin", StandardCharsets.UTF_8))
+                .build();
+        HttpResponse<String> resp = client.send(login, HttpResponse.BodyHandlers.ofString());
+        assertNotEquals("Login POST must not 403 on CSRF", 403, resp.statusCode());
+        assertEquals("Login as admin/admin should succeed (200) — body: " + resp.body(), 200, resp.statusCode());
+    }
+
+    @Test
+    public void formSessionPostWithoutCsrfTokenIs403() throws Exception {
+        // Form-login produces a JSESSIONID + an XSRF-TOKEN cookie (eager handler).
+        String[] cookies = formLogin();
+        String jsessionid = pickCookie(cookies, "JSESSIONID");
+        assertNotNull("login should set JSESSIONID; got: " + List.of(cookies), jsessionid);
+
+        // POST to a non-existent path so we exercise the CSRF filter without
+        // any handler side effects (rejecting CsrfIT writes was leaking state
+        // into the shared harness for downstream ITs). CsrfFilter sits ahead
+        // of routing — a CSRF rejection is 403, a routing rejection would be
+        // 404. We want the former; that's the assertion.
+        HttpRequest req = HttpRequest.newBuilder(URI.create(baseUrl + "/rest/saiku/csrf-it-probe-no-such-path"))
+                .timeout(Duration.ofSeconds(10))
+                .header("Cookie", jsessionid)
+                .header("Content-Type", "application/json")
+                .POST(HttpRequest.BodyPublishers.ofString("{}", StandardCharsets.UTF_8))
+                .build();
+        HttpResponse<String> resp = client.send(req, HttpResponse.BodyHandlers.ofString());
+        assertEquals(
+                "Form-session POST without X-XSRF-TOKEN must be 403 (got: " + resp.statusCode() + ", body: "
+                        + resp.body() + ")",
+                403,
+                resp.statusCode());
+    }
+
+    @Test
+    public void formSessionPostWithCsrfTokenReachesHandler() throws Exception {
+        // Real SPA flow:
+        //  1. login → session cookie (token from login response is bound to the
+        //     PRE-login session; Spring rotates it on successful auth)
+        //  2. GET /rest/saiku/info with the post-login session cookie → fresh
+        //     XSRF-TOKEN cookie tied to the live session
+        //  3. POST /admin/datasources with that token in both cookie + header
+        String[] loginCookies = formLogin();
+        String jsessionid = pickCookie(loginCookies, "JSESSIONID");
+
+        HttpRequest probe = HttpRequest.newBuilder(URI.create(baseUrl + "/rest/saiku/info"))
+                .timeout(Duration.ofSeconds(10))
+                .header("Cookie", jsessionid)
+                .GET()
+                .build();
+        HttpResponse<String> probeResp = client.send(probe, HttpResponse.BodyHandlers.ofString());
+        assertEquals(200, probeResp.statusCode());
+        String[] probeCookies = probeResp.headers().allValues("set-cookie").toArray(new String[0]);
+        String xsrfRaw = pickCookieValue(probeCookies, "XSRF-TOKEN");
+        assertNotNull("Materializer filter must write XSRF-TOKEN cookie on the GET response", xsrfRaw);
+
+        // Same no-side-effect target: 404 from routing (not 403 from CSRF) proves
+        // the token validated and the chain reached the dispatcher.
+        HttpRequest req = HttpRequest.newBuilder(URI.create(baseUrl + "/rest/saiku/csrf-it-probe-no-such-path"))
+                .timeout(Duration.ofSeconds(10))
+                .header("Cookie", jsessionid + "; XSRF-TOKEN=" + xsrfRaw)
+                .header("X-XSRF-TOKEN", xsrfRaw)
+                .header("Content-Type", "application/json")
+                .POST(HttpRequest.BodyPublishers.ofString("{}", StandardCharsets.UTF_8))
+                .build();
+        HttpResponse<String> resp = client.send(req, HttpResponse.BodyHandlers.ofString());
+        assertNotEquals(
+                "POST with valid X-XSRF-TOKEN must not be 403 (body: " + resp.body() + ")", 403, resp.statusCode());
+    }
+
+    @Test
+    public void safeMethodsAreNeverCsrfChecked() throws Exception {
+        // GET with a session cookie but no token — should pass through.
+        String[] cookies = formLogin();
+        String jsessionid = pickCookie(cookies, "JSESSIONID");
+        HttpRequest req = HttpRequest.newBuilder(URI.create(baseUrl + "/rest/saiku/info"))
+                .timeout(Duration.ofSeconds(10))
+                .header("Cookie", jsessionid)
+                .GET()
+                .build();
+        HttpResponse<String> resp = client.send(req, HttpResponse.BodyHandlers.ofString());
+        assertEquals(200, resp.statusCode());
+    }
+
+    /** Form-login as admin/admin, return all Set-Cookie headers from the response. */
+    private static String[] formLogin() throws Exception {
+        HttpRequest login = HttpRequest.newBuilder(URI.create(baseUrl + "/rest/saiku/session"))
+                .timeout(Duration.ofSeconds(10))
+                .header("Content-Type", "application/x-www-form-urlencoded")
+                .POST(HttpRequest.BodyPublishers.ofString("username=admin&password=admin", StandardCharsets.UTF_8))
+                .build();
+        HttpResponse<String> resp = client.send(login, HttpResponse.BodyHandlers.ofString());
+        assertEquals("login must succeed (200), body: " + resp.body(), 200, resp.statusCode());
+        return resp.headers().allValues("set-cookie").toArray(new String[0]);
+    }
+
+    /** Return the {@code name=value} fragment of a Set-Cookie header (no attributes). */
+    private static String pickCookie(String[] setCookies, String name) {
+        Optional<String> match = List.of(setCookies).stream()
+                .filter(c -> c.startsWith(name + "="))
+                .findFirst();
+        if (match.isEmpty()) return null;
+        String raw = match.get();
+        int semi = raw.indexOf(';');
+        return semi < 0 ? raw : raw.substring(0, semi);
+    }
+
+    /** Return just the value portion of a cookie by name. */
+    private static String pickCookieValue(String[] setCookies, String name) {
+        String pair = pickCookie(setCookies, name);
+        if (pair == null) return null;
+        int eq = pair.indexOf('=');
+        assertTrue("cookie pair must contain '='", eq > 0);
+        return pair.substring(eq + 1);
+    }
+}

--- a/saiku-launcher/src/test/java/org/saiku/launcher/it/RepositoryIT.java
+++ b/saiku-launcher/src/test/java/org/saiku/launcher/it/RepositoryIT.java
@@ -67,9 +67,18 @@ public class RepositoryIT {
             return;
         }
 
-        // Read
-        HttpResponse<String> read =
-                harness.getAuth(BASE + "/resource?file=" + URLEncoder.encode(name, StandardCharsets.UTF_8));
+        // Read — the resource produces text/plain (raw file body), but the
+        // default getAuth() sends Accept: application/json. Build the request
+        // by hand so content negotiation passes. Was hidden behind the
+        // save-NPEs-with-stateless-Basic path; the Repository#getRepository
+        // null-type fix unblocked save so the read now actually runs.
+        java.net.http.HttpRequest readReq = java.net.http.HttpRequest.newBuilder(java.net.URI.create(
+                        harness.baseUrl() + BASE + "/resource?file=" + URLEncoder.encode(name, StandardCharsets.UTF_8)))
+                .header("Authorization", harness.adminBasicAuth())
+                .header("Accept", "text/plain")
+                .GET()
+                .build();
+        HttpResponse<String> read = harness.send(readReq);
         assertEquals(200, read.statusCode());
         assertEquals(content, read.body());
 

--- a/saiku-webapp/src/main/webapp/WEB-INF/applicationContext-saiku.xml
+++ b/saiku-webapp/src/main/webapp/WEB-INF/applicationContext-saiku.xml
@@ -59,14 +59,25 @@
           session yet at login time, so no cookie to echo. HTTP Basic is also exempt
           (stateless, no browser form).
       -->
-      <!-- CSRF disabled for local-dev / Calcite-fork bring-up.
-           Spring Security 6's deferred CSRF token (CookieCsrfTokenRepository)
-           doesn't materialize the XSRF-TOKEN cookie eagerly, which breaks
-           the SPA's XHR flow: POSTs to /rest/** return 403 because the
-           token isn't readable from JS. Re-enable + wire a
-           CsrfTokenRequestAttributeHandler that forces token resolution
-           before locking this down for production. -->
-      <security:csrf disabled="true"/>
+      <!-- CSRF enforced on state-changing /rest/** methods (saiku#1150).
+           - Token stored in a non-HttpOnly XSRF-TOKEN cookie so the SPA can
+             read it via document.cookie and echo as X-XSRF-TOKEN.
+           - request-handler-ref is the PLAIN (non-XOR) handler. The XSD
+             documents the default as the plain handler, but CsrfFilter's
+             field default is actually XorCsrfTokenRequestAttributeHandler
+             which XOR-masks the token: the SPA-echo'd cookie value would
+             then fail to validate. The plain handler stores and validates
+             the same value, which is what the cookie-read pattern needs.
+           - SaikuCsrfRequestMatcher exempts the login bootstrap path
+             (/rest/saiku/session) and stateless Authorization-header auth
+             (HTTP Basic, used by every IT harness and the MCP endpoint).
+           - CsrfCookieMaterializerFilter (wired below) forces the deferred
+             token to resolve on every request so the XSRF-TOKEN cookie is
+             written before the response commits — without it, GET requests
+             never seed the cookie. -->
+      <security:csrf token-repository-ref="csrfTokenRepository"
+                     request-matcher-ref="csrfRequestMatcher"
+                     request-handler-ref="csrfTokenRequestHandler"/>
       <security:intercept-url pattern="/serverdocs/**" access="isAnonymous()" />
 	    <!-- /rest/saiku/session is the SPA's login + session-info endpoint.
 	         permitAll lets anonymous POST (login) and authenticated GET
@@ -127,15 +138,25 @@
            security-context filter, so the guest auth is set before the
            authorization check and never persisted to the session. -->
       <security:custom-filter ref="shareTokenAuthFilter" before="PRE_AUTH_FILTER"/>
+      <!-- saiku#1150: force the deferred CsrfToken to resolve on every
+           response so the XSRF-TOKEN cookie is written eagerly. Sits AFTER
+           Spring Security's CSRF filter (BASIC_AUTH_FILTER is a stable
+           late slot in the chain) so the request attribute is already
+           installed by the time we read it. -->
+      <security:custom-filter ref="csrfCookieMaterializerFilter" after="BASIC_AUTH_FILTER"/>
       <security:anonymous/>
     </security:http>
 
-    <!-- Tier-1 auth hardening: CSRF wiring -->
+    <!-- Tier-1 auth hardening: CSRF wiring (saiku#1150). -->
     <bean id="csrfTokenRepository"
           class="org.springframework.security.web.csrf.CookieCsrfTokenRepository"
           factory-method="withHttpOnlyFalse"/>
     <bean id="csrfRequestMatcher"
           class="org.saiku.web.security.csrf.SaikuCsrfRequestMatcher"/>
+    <bean id="csrfTokenRequestHandler"
+          class="org.springframework.security.web.csrf.CsrfTokenRequestAttributeHandler"/>
+    <bean id="csrfCookieMaterializerFilter"
+          class="org.saiku.web.security.csrf.CsrfCookieMaterializerFilter"/>
 
     <import resource="applicationContext-spring-security.xml"/>
 


### PR DESCRIPTION
Closes #1150 (audit CRITICAL).

## Summary

- Re-enable \`<security:csrf>\` with the existing \`csrfTokenRepository\` + \`SaikuCsrfRequestMatcher\`.
- Explicitly wire \`request-handler-ref\` to the plain \`CsrfTokenRequestAttributeHandler\` so the JS-echo'd cookie value validates (CsrfFilter's field default is XOR — that breaks the SPA cookie-echo pattern).
- New \`CsrfCookieMaterializerFilter\` forces the deferred token to resolve BEFORE chain.doFilter so the \`XSRF-TOKEN\` cookie lands in the response — without it GET requests never seed the cookie.
- New \`CsrfIT\` (5 tests) locks the contract: Basic exempt, login exempt, form-session-without-token → 403, form-session-with-token → reaches dispatcher, safe methods always exempt.

## Bonus fixes

- \`BasicRepositoryResource2.getRepository\` was NPEing on null \`type\` (latent ScopedRepo session-bleed pushed Basic-auth requests past the null-session guard). Null-check.
- \`RepositoryIT.saveAndReadAndDeleteResource_endToEnd\` read step was passing \`Accept: application/json\` against a \`text/plain\` endpoint — was 406, hidden behind the save-NPE early-return.

## Test plan

- [x] CsrfIT: 5/5 pass
- [x] Full IT suite: 83/83 pass
- [x] saiku-service unit tests: green
- [ ] Verify on demo after merge: SPA login → drawer ask → canvas runs as before; cross-origin POST without X-XSRF-TOKEN → 403