### PR TITLE
feat(viz): client-side sort + top-N controls on the chart (closes #1083)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -471,3 +471,6 @@ nbdist/
 # otherwise swallow the vendored JARs.
 !/lib/repo/
 !/lib/repo/**
+
+# Claude Code session worktrees / scratch (never commit)
+.claude/

--- a/saiku-ui/src/lib/charts/sortLimit.test.ts
+++ b/saiku-ui/src/lib/charts/sortLimit.test.ts
@@ -1,0 +1,150 @@
+/*
+ * Unit tests for the client-side category sort + top-N transform (#1083).
+ */
+
+import { describe, test, expect } from "vitest";
+import type { ChartProjection } from "$lib/charts/build";
+import { applySortLimit, isNoOp, NO_SORT_LIMIT } from "$lib/charts/sortLimit";
+
+/** Five stores, two measures. Sales (col 0) is intentionally unsorted. */
+function sample(): ChartProjection {
+  return {
+    rowCategories: ["A", "B", "C", "D", "E"],
+    columnCategories: ["Sales", "Units"],
+    matrix: [
+      [30, 1],
+      [10, 2],
+      [50, 3],
+      [20, 4],
+      [40, 5],
+    ],
+  };
+}
+
+describe("applySortLimit", () => {
+  test("no-op when off: same order, fresh object, input not mutated", () => {
+    const p = sample();
+    const out = applySortLimit(p, NO_SORT_LIMIT);
+    expect(out.rowCategories).toEqual(["A", "B", "C", "D", "E"]);
+    expect(out.matrix).toEqual(p.matrix);
+    expect(out).not.toBe(p); // new object
+    expect(p.rowCategories).toEqual(["A", "B", "C", "D", "E"]); // unmutated
+  });
+
+  test("defaults to no-op when called with no state", () => {
+    const out = applySortLimit(sample());
+    expect(out.rowCategories).toEqual(["A", "B", "C", "D", "E"]);
+  });
+
+  test("ascending by the first measure", () => {
+    const out = applySortLimit(sample(), { direction: "asc" });
+    expect(out.rowCategories).toEqual(["B", "D", "A", "E", "C"]); // 10,20,30,40,50
+    expect(out.matrix[0]).toEqual([10, 2]); // moved in lockstep with the label
+  });
+
+  test("descending by the first measure", () => {
+    const out = applySortLimit(sample(), { direction: "desc" });
+    expect(out.rowCategories).toEqual(["C", "E", "A", "D", "B"]); // 50,40,30,20,10
+  });
+
+  test("sort is stable: equal measure values keep their queried order", () => {
+    const p: ChartProjection = {
+      rowCategories: ["x1", "x2", "y", "x3"],
+      columnCategories: ["m"],
+      matrix: [[5], [5], [9], [5]],
+    };
+    const desc = applySortLimit(p, { direction: "desc" });
+    expect(desc.rowCategories).toEqual(["y", "x1", "x2", "x3"]); // 9 first, ties stable
+    const asc = applySortLimit(p, { direction: "asc" });
+    expect(asc.rowCategories).toEqual(["x1", "x2", "x3", "y"]); // ties stable, 9 last
+  });
+
+  test("measureIndex selects the column to sort by", () => {
+    // Units (col 1) ascends 1,2,3,4,5 = original order; descends reverse.
+    const out = applySortLimit(sample(), { direction: "desc", measureIndex: 1 });
+    expect(out.rowCategories).toEqual(["E", "D", "C", "B", "A"]);
+  });
+
+  test("out-of-range measureIndex clamps into the column range", () => {
+    // 99 clamps to the last column (Units, col 1); desc on 1..5 = reverse order.
+    const out = applySortLimit(sample(), { direction: "desc", measureIndex: 99 });
+    expect(out.rowCategories).toEqual(["E", "D", "C", "B", "A"]);
+    // negative clamps to the first column (Sales, col 0).
+    const neg = applySortLimit(sample(), { direction: "desc", measureIndex: -5 });
+    expect(neg.rowCategories).toEqual(["C", "E", "A", "D", "B"]);
+  });
+
+  test("top-N keeps the highest N when descending", () => {
+    const out = applySortLimit(sample(), { direction: "desc", topN: 2 });
+    expect(out.rowCategories).toEqual(["C", "E"]); // 50, 40
+    expect(out.matrix).toEqual([
+      [50, 3],
+      [40, 5],
+    ]);
+  });
+
+  test("top-N keeps the lowest N when ascending", () => {
+    const out = applySortLimit(sample(), { direction: "asc", topN: 2 });
+    expect(out.rowCategories).toEqual(["B", "D"]); // 10, 20
+  });
+
+  test("top-N with sort off keeps the first N as queried", () => {
+    const out = applySortLimit(sample(), { direction: "none", topN: 3 });
+    expect(out.rowCategories).toEqual(["A", "B", "C"]);
+  });
+
+  test("top-N clamps: N >= rowCount returns all rows", () => {
+    expect(applySortLimit(sample(), { direction: "none", topN: 99 }).rowCategories).toEqual([
+      "A",
+      "B",
+      "C",
+      "D",
+      "E",
+    ]);
+  });
+
+  test("top-N <= 0 and null are treated as no limit", () => {
+    expect(applySortLimit(sample(), { direction: "none", topN: 0 }).rowCategories.length).toBe(5);
+    expect(applySortLimit(sample(), { direction: "none", topN: -3 }).rowCategories.length).toBe(5);
+    expect(applySortLimit(sample(), { direction: "none", topN: null }).rowCategories.length).toBe(5);
+  });
+
+  test("null / NaN measure values sort to the end in both directions", () => {
+    const p: ChartProjection = {
+      rowCategories: ["a", "b", "c", "d"],
+      columnCategories: ["m"],
+      matrix: [[5], [null], [9], [NaN]],
+    };
+    const desc = applySortLimit(p, { direction: "desc" });
+    expect(desc.rowCategories).toEqual(["c", "a", "b", "d"]); // 9,5 then missing (stable)
+    const asc = applySortLimit(p, { direction: "asc" });
+    expect(asc.rowCategories).toEqual(["a", "c", "b", "d"]); // 5,9 then missing (stable)
+  });
+
+  test("empty projection is handled", () => {
+    const empty: ChartProjection = { rowCategories: [], columnCategories: [], matrix: [] };
+    const out = applySortLimit(empty, { direction: "desc", topN: 5 });
+    expect(out.rowCategories).toEqual([]);
+    expect(out.matrix).toEqual([]);
+  });
+});
+
+describe("isNoOp", () => {
+  test("off + no limit is a no-op", () => {
+    expect(isNoOp(NO_SORT_LIMIT, 5)).toBe(true);
+    expect(isNoOp({ direction: "none", topN: null }, 5)).toBe(true);
+  });
+
+  test("a sort direction is not a no-op", () => {
+    expect(isNoOp({ direction: "asc" }, 5)).toBe(false);
+  });
+
+  test("an effective top-N limit is not a no-op", () => {
+    expect(isNoOp({ direction: "none", topN: 3 }, 5)).toBe(false);
+  });
+
+  test("a top-N >= rowCount is a no-op (nothing trimmed)", () => {
+    expect(isNoOp({ direction: "none", topN: 5 }, 5)).toBe(true);
+    expect(isNoOp({ direction: "none", topN: 99 }, 5)).toBe(true);
+  });
+});

--- a/saiku-ui/src/lib/charts/sortLimit.test.ts
+++ b/saiku-ui/src/lib/charts/sortLimit.test.ts
@@ -4,7 +4,7 @@
 
 import { describe, test, expect } from "vitest";
 import type { ChartProjection } from "$lib/charts/build";
-import { applySortLimit, isNoOp, NO_SORT_LIMIT } from "$lib/charts/sortLimit";
+import { applySortLimit, sortLimitOrder, isNoOp, NO_SORT_LIMIT } from "$lib/charts/sortLimit";
 
 /** Five stores, two measures. Sales (col 0) is intentionally unsorted. */
 function sample(): ChartProjection {
@@ -20,6 +20,35 @@ function sample(): ChartProjection {
     ],
   };
 }
+
+describe("sortLimitOrder (drill-mapping permutation, #1083 + #1086)", () => {
+  test("identity [0..n-1] when off — so click-to-drill stays 1:1", () => {
+    expect(sortLimitOrder(sample(), NO_SORT_LIMIT)).toEqual([0, 1, 2, 3, 4]);
+    expect(sortLimitOrder(sample())).toEqual([0, 1, 2, 3, 4]);
+  });
+
+  test("descending order is the original indices in sorted order (50,40,30,20,10 → C,E,A,D,B)", () => {
+    expect(sortLimitOrder(sample(), { direction: "desc", measureIndex: 0, topN: null })).toEqual([2, 4, 0, 3, 1]);
+  });
+
+  test("ascending order", () => {
+    expect(sortLimitOrder(sample(), { direction: "asc", measureIndex: 0, topN: null })).toEqual([1, 3, 0, 4, 2]);
+  });
+
+  test("top-N trims AFTER sorting (desc top 2 → the two highest original rows)", () => {
+    expect(sortLimitOrder(sample(), { direction: "desc", measureIndex: 0, topN: 2 })).toEqual([2, 4]);
+  });
+
+  test("the order matches what applySortLimit actually renders (rows stay in lockstep)", () => {
+    const state = { direction: "desc" as const, measureIndex: 0, topN: 3 };
+    const order = sortLimitOrder(sample(), state);
+    const out = applySortLimit(sample(), state);
+    const original = sample();
+    // Each rendered category/row at position i must come from original row order[i].
+    out.rowCategories.forEach((cat, i) => expect(cat).toBe(original.rowCategories[order[i]]));
+    out.matrix.forEach((row, i) => expect(row).toEqual(original.matrix[order[i]]));
+  });
+});
 
 describe("applySortLimit", () => {
   test("no-op when off: same order, fresh object, input not mutated", () => {

--- a/saiku-ui/src/lib/charts/sortLimit.ts
+++ b/saiku-ui/src/lib/charts/sortLimit.ts
@@ -73,10 +73,20 @@ function compareMeasure(a: number | null, b: number | null, direction: "asc" | "
  * @param projection the already-projected {rowCategories, columnCategories, matrix}
  * @param state      component-local sort + top-N state
  */
-export function applySortLimit(
+/**
+ * The display ORDER — a permutation of input row indices in the order the
+ * categories will be shown (after sort, then top-N). Identity `[0..n-1]` when
+ * the state is a no-op.
+ *
+ * Exposed separately from {@link applySortLimit} so click-to-drill (#1086) can
+ * map a clicked chart category (its displayed index) back to the ORIGINAL
+ * projection row it came from — otherwise a click after sorting/trimming would
+ * drill the wrong cell.
+ */
+export function sortLimitOrder(
   projection: ChartProjection,
   state: ChartSortLimit = NO_SORT_LIMIT,
-): ChartProjection {
+): number[] {
   const { rowCategories, columnCategories, matrix } = projection;
   const rowCount = rowCategories.length;
 
@@ -104,6 +114,15 @@ export function applySortLimit(
     order = order.slice(0, state.topN);
   }
 
+  return order;
+}
+
+export function applySortLimit(
+  projection: ChartProjection,
+  state: ChartSortLimit = NO_SORT_LIMIT,
+): ChartProjection {
+  const { rowCategories, columnCategories, matrix } = projection;
+  const order = sortLimitOrder(projection, state);
   return {
     rowCategories: order.map((i) => rowCategories[i]),
     columnCategories,

--- a/saiku-ui/src/lib/charts/sortLimit.ts
+++ b/saiku-ui/src/lib/charts/sortLimit.ts
@@ -1,0 +1,112 @@
+/*
+ * Client-side category sort + top-N limit for charts (#1083).
+ *
+ * Today sort/limit lives in the MDX query: to "show top 10 stores by Sales,
+ * descending" a user has to rebuild the query. This module lets a chart re-order
+ * and/or trim the CATEGORIES (the row axis) it shows WITHOUT re-querying — a pure
+ * transform applied to the already-projected {@link ChartProjection} just before
+ * the ECharts option is built. It only touches rows (categories); the series
+ * (column-categories) and the per-cell values are left exactly as they came back.
+ *
+ * Scope (deliberately small — workspace-first):
+ *   - sort by the first measure column, ascending / descending / off ("none"),
+ *   - top-N: keep the first N rows AFTER sorting (so desc + N = the N highest,
+ *     asc + N = the N lowest; N with sort off = the first N as queried).
+ *
+ * Stability: rows that compare equal keep their original relative order (a
+ * stable sort), so toggling the control is predictable. Null / NaN measure
+ * values sort to the END regardless of direction (a missing value isn't the
+ * "biggest" or "smallest" — it just has no rank), again keeping original order
+ * among themselves.
+ *
+ * NOT persisted: the control state is component-local/transient in the .svelte
+ * surface (dashboard per-tile persistence is #1077, paused) — this module is
+ * pure state-in / state-out and has no opinion about storage.
+ *
+ * Pure: no DOM, no ECharts, no fetches. Tests live alongside.
+ */
+
+import type { ChartProjection } from "$lib/charts/build";
+
+/** Sort direction for the category axis. "none" = keep the queried order. */
+export type ChartSortDirection = "none" | "asc" | "desc";
+
+/** Component-local (transient) sort + limit state for one chart. */
+export interface ChartSortLimit {
+  /** Sort the categories by the chosen measure column, or leave as queried. */
+  direction: ChartSortDirection;
+  /** Which measure column to sort by (index into columnCategories). Clamped
+   *  into range; out-of-range / missing falls back to the first column. */
+  measureIndex?: number;
+  /** Keep only the first N categories AFTER sorting. null / undefined / <=0 =
+   *  no limit. Clamped to the available row count. */
+  topN?: number | null;
+}
+
+/** The off / identity state — no sort, no limit. */
+export const NO_SORT_LIMIT: ChartSortLimit = { direction: "none", measureIndex: 0, topN: null };
+
+/** True when the state would change nothing (so callers can skip the work). */
+export function isNoOp(s: ChartSortLimit, rowCount: number): boolean {
+  const limits = s.topN != null && s.topN > 0 && s.topN < rowCount;
+  return s.direction === "none" && !limits;
+}
+
+/* A row that compares "missing" (null / NaN) always sorts after a real value.
+ * Two missing rows compare equal (0) so the stable sort keeps their order. */
+function compareMeasure(a: number | null, b: number | null, direction: "asc" | "desc"): number {
+  const aMissing = a == null || Number.isNaN(a);
+  const bMissing = b == null || Number.isNaN(b);
+  if (aMissing && bMissing) return 0;
+  if (aMissing) return 1; // a after b
+  if (bMissing) return -1; // b after a
+  const diff = (a as number) - (b as number);
+  return direction === "asc" ? diff : -diff;
+}
+
+/**
+ * Re-order and/or trim the CATEGORY rows of a projection per the sort+limit
+ * state. Series (columns) and cell values are unchanged. Returns a new
+ * projection (the input is never mutated); when the state is a no-op the same
+ * row order is returned (a fresh object, still safe to use).
+ *
+ * @param projection the already-projected {rowCategories, columnCategories, matrix}
+ * @param state      component-local sort + top-N state
+ */
+export function applySortLimit(
+  projection: ChartProjection,
+  state: ChartSortLimit = NO_SORT_LIMIT,
+): ChartProjection {
+  const { rowCategories, columnCategories, matrix } = projection;
+  const rowCount = rowCategories.length;
+
+  // Index permutation so we move labels and matrix rows together in lockstep.
+  let order = rowCategories.map((_, i) => i);
+
+  if (state.direction === "asc" || state.direction === "desc") {
+    // Clamp the measure column into range; default to the first measure. Array's
+    // sort is stable (ES2019+), and we tie-break on original index defensively so
+    // equal rows keep their queried order even on older engines.
+    const colCount = columnCategories.length;
+    const col =
+      colCount > 0
+        ? Math.min(Math.max(state.measureIndex ?? 0, 0), colCount - 1)
+        : 0;
+    order = order
+      .map((idx) => ({ idx, value: matrix[idx]?.[col] ?? null }))
+      .sort((a, b) => compareMeasure(a.value, b.value, state.direction as "asc" | "desc") || a.idx - b.idx)
+      .map((e) => e.idx);
+  }
+
+  // top-N: keep the first N after sorting. Clamp to [1, rowCount]; null / <=0 =
+  // no limit. (>= rowCount is also effectively no limit.)
+  if (state.topN != null && state.topN > 0 && state.topN < rowCount) {
+    order = order.slice(0, state.topN);
+  }
+
+  return {
+    rowCategories: order.map((i) => rowCategories[i]),
+    columnCategories,
+    matrix: order.map((i) => matrix[i]),
+  };
+}

--- a/saiku-ui/src/lib/views/ChartView.svelte
+++ b/saiku-ui/src/lib/views/ChartView.svelte
@@ -12,7 +12,7 @@
   // #1086: map an ECharts click back to absolute cellset coords for drillthrough.
   import { chartDrillTarget } from "$lib/charts/chartDrillCoord";
   // #1083: client-side category sort + top-N (transient, no re-query).
-  import { applySortLimit, type ChartSortDirection } from "$lib/charts/sortLimit";
+  import { applySortLimit, sortLimitOrder, type ChartSortDirection } from "$lib/charts/sortLimit";
   // #1090: accessible data-table mirror of the chart for screen readers.
   import { chartSummary } from "$lib/charts/a11y";
   // issue #1071: map charts need the GeoJSON registered with ECharts before
@@ -58,7 +58,15 @@
   // Rollup filtering (which needs cellset depth) happens here, before
   // projection, since the builder treats rows as final. Shared by the chart
   // builder and the a11y data-table mirror (#1090) so both see the same data.
-  function projectResult(r: QueryResult, o: ChartOptions): ChartProjection {
+  // Leaf-filtered projection (BEFORE the #1083 sort/limit) + the cellset
+  // body-row index for each leaf position (undefined when 1:1). Factored out so
+  // projectResult and the drill-coordinate mapping share ONE source of truth for
+  // the rollup-leaf reindex — they must agree or click-to-drill drills the
+  // wrong row.
+  function leafProjection(
+    r: QueryResult,
+    o: ChartOptions,
+  ): { projection: ChartProjection; leafIndices: number[] | undefined } {
     const parsed = parseCellset(r);
     // Multi-level row hierarchies (Year > Quarter, Country > City, …) come back
     // with both rollup and leaf rows in the same cellset. Showing the rollups on
@@ -67,6 +75,7 @@
     // untouched.
     let rows = parsed.rowCategories;
     let matrix: (number | null)[][] = parsed.dataRows.map((row) => row.map(toNumber));
+    let leafIndices: number[] | undefined;
     if (o.hideRollupRows) {
       // deriveLeafRows is a no-op for single-level rowsets (all rows at the same
       // depth) and for empty results, so no extra guard is needed here.
@@ -74,15 +83,24 @@
       if (leaf.indices.length > 0 && leaf.indices.length < matrix.length) {
         rows = leaf.labels;
         matrix = leaf.indices.map((i) => matrix[i]);
+        leafIndices = leaf.indices;
       }
     }
+    return {
+      projection: { rowCategories: rows, columnCategories: parsed.columnCategories, matrix },
+      leafIndices,
+    };
+  }
+
+  function projectResult(r: QueryResult, o: ChartOptions): ChartProjection {
     // #1083: re-order / trim the categories CLIENT-SIDE (sort by the first
     // measure, then keep the top-N) before either the chart builder or the a11y
     // table sees them, so both stay in sync. A no-op when the controls are off.
-    return applySortLimit(
-      { rowCategories: rows, columnCategories: parsed.columnCategories, matrix },
-      { direction: sortDir, measureIndex: 0, topN },
-    );
+    return applySortLimit(leafProjection(r, o).projection, {
+      direction: sortDir,
+      measureIndex: 0,
+      topN,
+    });
   }
 
   // Delegate to the single canonical builder (#1076). The workspace is the
@@ -98,20 +116,20 @@
     return buildChartOption(p, t, o, tk, { aspect, chartWidth, compact: false });
   }
 
-  // #1086: when hideRollupRows is active the chart shows only the LEAF rows
-  // (deriveLeafRows reindexes them), so a chart category index no longer equals
-  // the cellset body-row index. Recompute the same leaf indices the projection
-  // used so the click handler can map a clicked bar/slice back to the right
-  // cellset row. Returns undefined when rollups are shown (1:1 mapping). This
-  // mirrors the row-selection branch in projectResult — kept in sync with it.
-  function currentLeafIndices(r: QueryResult, o: ChartOptions): number[] | undefined {
-    if (!o.hideRollupRows) return undefined;
-    const parsed = parseCellset(r);
-    const leaf = deriveLeafRows(parsed);
-    if (leaf.indices.length > 0 && leaf.indices.length < parsed.dataRows.length) {
-      return leaf.indices;
-    }
-    return undefined;
+  // #1086 + #1083: map a clicked chart category (its DISPLAYED index, after the
+  // rollup-leaf filter AND the client-side sort/top-N) back to the absolute
+  // cellset body-row index. Without composing the sort permutation here, a click
+  // after sorting/trimming would drill the wrong row. Returns an array indexed by
+  // displayed position → body-row index, or undefined when the mapping is 1:1
+  // (no leaf filter and no sort/limit) so chartDrillTarget treats it as identity.
+  function currentDisplayIndices(r: QueryResult, o: ChartOptions): number[] | undefined {
+    const { projection, leafIndices } = leafProjection(r, o);
+    const order = sortLimitOrder(projection, { direction: sortDir, measureIndex: 0, topN });
+    const isIdentity = leafIndices === undefined && order.every((v, i) => v === i);
+    if (isIdentity) return undefined;
+    // order[displayedPos] = leaf-projection index; leafIndices maps that to the
+    // raw cellset body row (or it's already the body row when no leaf filter).
+    return order.map((leafPos) => (leafIndices ? leafIndices[leafPos] : leafPos));
   }
 
   // #1086: ECharts click → reuse the workspace's existing drillthrough flow.
@@ -130,7 +148,7 @@
       parsed,
       categoryIndex,
       seriesIndex,
-      currentLeafIndices(result, options),
+      currentDisplayIndices(result, options),
     );
     if (!target) return; // out-of-range / "All"-style click → no-op
     host.dispatchEvent(

--- a/saiku-ui/src/lib/views/ChartView.svelte
+++ b/saiku-ui/src/lib/views/ChartView.svelte
@@ -11,6 +11,8 @@
   import { buildChartOption, type ChartProjection } from "$lib/charts/build";
   // #1086: map an ECharts click back to absolute cellset coords for drillthrough.
   import { chartDrillTarget } from "$lib/charts/chartDrillCoord";
+  // #1083: client-side category sort + top-N (transient, no re-query).
+  import { applySortLimit, type ChartSortDirection } from "$lib/charts/sortLimit";
   // #1090: accessible data-table mirror of the chart for screen readers.
   import { chartSummary } from "$lib/charts/a11y";
   // issue #1071: map charts need the GeoJSON registered with ECharts before
@@ -31,6 +33,18 @@
 
   let host: HTMLDivElement | null = null;
   let chart: echarts.ECharts | null = null;
+
+  // #1083: client-side sort + top-N controls. Transient component-local state —
+  // re-orders / trims the CATEGORIES shown without re-querying the server.
+  // Deliberately NOT persisted (dashboard per-tile persistence is #1077, paused).
+  // sortDir sorts by the first measure column; topN trims after sorting.
+  let sortDir = $state<ChartSortDirection>("none");
+  let topN = $state<number | null>(null);
+  const TOP_N_CHOICES = [5, 10, 20, 50];
+
+  // The category count available to chart (so the top-N picker can disable
+  // values that wouldn't trim anything and show what's being limited).
+  let rowCount = $derived(parseCellset(result).rowCategories.length);
 
   // #1053: single-measure kinds (pie/donut/treemap/sunburst) with >1 measure
   // render as small multiples — 2 per row. Grow the host to N rows so each
@@ -62,7 +76,13 @@
         matrix = leaf.indices.map((i) => matrix[i]);
       }
     }
-    return { rowCategories: rows, columnCategories: parsed.columnCategories, matrix };
+    // #1083: re-order / trim the categories CLIENT-SIDE (sort by the first
+    // measure, then keep the top-N) before either the chart builder or the a11y
+    // table sees them, so both stay in sync. A no-op when the controls are off.
+    return applySortLimit(
+      { rowCategories: rows, columnCategories: parsed.columnCategories, matrix },
+      { direction: sortDir, measureIndex: 0, topN },
+    );
   }
 
   // Delegate to the single canonical builder (#1076). The workspace is the
@@ -211,6 +231,9 @@
     void theme.effective;
     // #1091: repaint when the colour-blind-safe pref flips.
     void theme.colorBlindSafe;
+    // #1083: repaint when the client-side sort / top-N controls change.
+    void sortDir;
+    void topN;
     if (chart) render();
   });
 
@@ -219,6 +242,29 @@
     chart = null;
   });
 </script>
+
+<!-- #1083: client-side sort + top-N controls. Transient (not persisted): they
+     re-order / trim the categories shown without re-querying. Sort is by the
+     first measure column. -->
+<div class="chart-controls">
+  <label class="ctrl">
+    <span class="ctrl-label">Sort</span>
+    <select bind:value={sortDir} aria-label="Sort categories by the first measure">
+      <option value="none">As queried</option>
+      <option value="asc">Ascending</option>
+      <option value="desc">Descending</option>
+    </select>
+  </label>
+  <label class="ctrl">
+    <span class="ctrl-label">Top</span>
+    <select bind:value={topN} aria-label="Limit to top N categories">
+      <option value={null}>All</option>
+      {#each TOP_N_CHOICES as n (n)}
+        <option value={n} disabled={n >= rowCount}>Top {n}</option>
+      {/each}
+    </select>
+  </label>
+</div>
 
 <div class="chart-scroll">
   <!-- #1090: the canvas is decorative to assistive tech; the sr-only table below
@@ -255,6 +301,32 @@
 </div>
 
 <style>
+  /* #1083: chart-local sort + top-N controls. Sit above the canvas, themed to
+     match the rest of the workspace chrome. */
+  .chart-controls {
+    display: flex;
+    gap: 0.75rem;
+    align-items: center;
+    flex-wrap: wrap;
+    margin-bottom: 0.5rem;
+  }
+  .ctrl {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+  }
+  .ctrl-label {
+    font-size: 0.8rem;
+    color: var(--fg-muted);
+  }
+  .ctrl select {
+    font-size: 0.8rem;
+    padding: 0.2rem 0.4rem;
+    color: var(--fg);
+    background: var(--bg);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+  }
   /* #1053: the frame stays one viewport tall; small multiples grow the inner
      chart to N rows and this wrapper scrolls, keeping each chart full-size. */
   .chart-scroll {


### PR DESCRIPTION
## Summary

Chart-local **Sort** (none / ascending / descending by the first measure) + **Top-N** controls that re-order/trim the categories **client-side, with no re-query**. Workspace ChartView (dashboard tile deferred).

## The change
- NEW `$lib/charts/sortLimit.ts` — pure transform over the projection (`applySortLimit`) + `sortLimitOrder()` (the display permutation); stable sort, nulls sort last, top-N after sort. Tests included.
- `ChartView.svelte` — transient Sort/Top controls; applied in `projectResult` before the builder + a11y table see the rows (kept in sync).
- **Integration fix (with #1086):** click-to-drill now composes the sort/top-N permutation so a click after sorting/trimming drills the **correct** cell (it previously drilled the wrong, still-authorized row). `leafProjection()` is now the single source of truth for the rollup-leaf reindex shared by the projection + the drill mapping.
- Hygiene: `.gitignore` now ignores `.claude/` (fan-out worktrees were being swept into commits).

## Security
Pure client-side transform of already-fetched data — no new fetch/endpoint, no `{@html}`, no injection. The drill mapping stays integer-coordinate, session-scoped, identical-surface to the grid (per the #1086 review).

## Verified
- `npm run check` 0 errors (2 pre-existing a11y warnings on development, not in touched files); `npx vitest run` **726** (sortLimit incl. +5 `sortLimitOrder` tests).
- Rebased clean onto development (post-#1086); local browser test user-confirmed (FoodMart Sales, Store Sales × Store Name: sort/limit re-order with no network call; sorted bar drills the correct store).

## Notes
- State is transient/component-local (dashboard per-tile persistence is #1077, paused). Sort is by the first measure; a measure-picker + "Others" bucket are out of scope (the transform already supports `measureIndex`). UI-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)