### PR TITLE
chore: bump mondrian-saiku 4.8.1.22 → 4.8.1.27

### DIFF
--- a/saiku-bom/pom.xml
+++ b/saiku-bom/pom.xml
@@ -346,7 +346,7 @@
             <dependency>
                 <groupId>pentaho</groupId>
                 <artifactId>mondrian</artifactId>
-                <version>4.8.1.22</version>
+                <version>4.8.1.27</version>
                 <!-- xerces 2.12.2 + xalan 2.7.2 are transitively pulled by
                      mondrian but hijack the JDK's built-in JAXP via
                      META-INF/services overrides. Spring 6.2's tightened


### PR DESCRIPTION
Five upstream releases folded in:

- 4.8.1.23 — LookML→M4 transpiler v1 gaps closed (spiculedata/mondrian-saiku#115)
- 4.8.1.24 — native crossjoin per-arg key column (#122); SegmentCache Calcite tuple-read fix (#121)
- 4.8.1.25 — multi-file LookML resolution + Explore-JSON front-end (#116)
- 4.8.1.26 — measure-level distinct grain / sum_distinct without bridge (#119)
- 4.8.1.27 — runtime Calcite divergence telemetry guard (#90)

## Test plan

- [x] saiku-service: 481/481 unit tests pass
- [x] Smoke ITs (InfoEndpointIT, Query2ResourceIT, AiQueryIT): 14/14 pass
- [ ] Demo: verify the 6 cubes still load and Sales/HR queries return expected rows