### PR TITLE
fix(dashboard): restore #932 mobile polish (hamburger + stacked heights + height stepper) lost in merge (closes #1175)

### DIFF
--- a/saiku-ui/src/lib/dashboard/responsiveLayout.test.ts
+++ b/saiku-ui/src/lib/dashboard/responsiveLayout.test.ts
@@ -15,6 +15,8 @@ import {
   compareByPosition,
   stackedOrder,
   stackOrderMap,
+  stackedCellHeight,
+  STACK_MIN_PX,
 } from "$lib/dashboard/responsiveLayout";
 import type { DashboardTile, TileType } from "$lib/api/dashboards";
 
@@ -126,5 +128,20 @@ describe("stackOrderMap", () => {
     const map = stackOrderMap(tiles);
     expect(map.get("filter")).toBe(0);
     expect(map.get("chart")).toBe(1);
+  });
+});
+
+describe("stackedCellHeight", () => {
+  test("scales with the saved row span (80px/row + 8px gaps)", () => {
+    expect(stackedCellHeight(4)).toBe(4 * 80 + 3 * 8); // 344
+    expect(stackedCellHeight(3)).toBe(3 * 80 + 2 * 8); // 256
+  });
+  test("floors a 1-row tile at STACK_MIN_PX so it stays readable", () => {
+    expect(stackedCellHeight(1)).toBe(STACK_MIN_PX); // 80 → floored to 160
+    expect(stackedCellHeight(2)).toBe(2 * 80 + 8); // 168, above the floor
+  });
+  test("guards non-finite / zero spans", () => {
+    expect(stackedCellHeight(0)).toBe(STACK_MIN_PX);
+    expect(stackedCellHeight(NaN)).toBe(STACK_MIN_PX);
   });
 });

--- a/saiku-ui/src/lib/dashboard/responsiveLayout.ts
+++ b/saiku-ui/src/lib/dashboard/responsiveLayout.ts
@@ -38,6 +38,23 @@ export function isNarrow(width: number, breakpoint: number = DEFAULT_STACK_BREAK
   return width <= breakpoint;
 }
 
+/* Stacked-cell sizing — mirror the desktop grid's row metrics so a tile
+ * keeps roughly its authored height when collapsed into the single column.
+ * The desktop grid uses grid-auto-rows: minmax(80px, auto) with a 8px gap. */
+export const STACK_ROW_PX = 80;
+export const STACK_GAP_PX = 8;
+/** Floor so a 1-row tile (e.g. a thin KPI) is still readable when stacked. */
+export const STACK_MIN_PX = 160;
+
+/** Height (px) a tile should occupy in the stacked single-column layout,
+ *  derived from its saved row span {@code h} so a chart keeps roughly its
+ *  desktop height instead of collapsing to one auto-row. Floored at
+ *  {@link STACK_MIN_PX}. Pure. */
+export function stackedCellHeight(h: number): number {
+  const rows = Math.max(1, Math.floor(h) || 1);
+  return Math.max(STACK_MIN_PX, rows * STACK_ROW_PX + (rows - 1) * STACK_GAP_PX);
+}
+
 /** True for tile types that pin to the top of the mobile stack. Today
  *  that's only the "filter" tile type; isolated here so the rule has a
  *  single home if more pinned types appear. */

--- a/saiku-ui/src/lib/stores/dashboard.svelte.ts
+++ b/saiku-ui/src/lib/stores/dashboard.svelte.ts
@@ -31,7 +31,7 @@ import {
   type SavedDefaultMembers,
 } from "$lib/dashboard/filterDefaults";
 import { HistoryStack } from "$lib/dashboard/history";
-import { firstFreeSlot } from "$lib/dashboard/tilePlacement";
+import { firstFreeSlot, repositionTile } from "$lib/dashboard/tilePlacement";
 import { recentDashboards } from "$lib/stores/recentDashboards.svelte";
 import { session } from "$lib/stores/session.svelte";
 
@@ -252,6 +252,23 @@ class DashboardStore {
       layout: { ...this.current.layout, tiles },
     };
     this.markDirty();
+  }
+
+  /** Adjust a tile's height by `delta` rows (e.g. ±1), clamped to
+   *  [1, 24]. Cascades neighbours via repositionTile so nothing overlaps
+   *  in the free-form grid; in the mobile stacked view the larger row
+   *  span just maps to a taller cell. Powers the "Height − / +" stepper
+   *  in the tile menu (#932/#1175) — a touch-friendly alternative to
+   *  drag-resize on narrow screens. Undoable (routes via replaceTiles). */
+  adjustTileHeight(id: string, delta: number): void {
+    if (!this.current) return;
+    const layout = this.current.layout;
+    const tile = layout.tiles.find((t) => t.id === id);
+    if (!tile) return;
+    const nh = Math.max(1, Math.min(24, tile.h + delta));
+    if (nh === tile.h) return;
+    const result = repositionTile(layout, id, { x: tile.x, y: tile.y, w: tile.w, h: nh });
+    if (result.ok && result.tiles) this.replaceTiles(result.tiles);
   }
 
   /** Append a tile. Tile id must be set by the caller (we never invent

--- a/saiku-ui/src/lib/views/dashboard/DashboardGrid.svelte
+++ b/saiku-ui/src/lib/views/dashboard/DashboardGrid.svelte
@@ -39,6 +39,7 @@
     DEFAULT_STACK_BREAKPOINT,
     isNarrow,
     stackOrderMap,
+    stackedCellHeight,
   } from "$lib/dashboard/responsiveLayout";
   import Tile from "$lib/views/dashboard/Tile.svelte";
 
@@ -308,6 +309,7 @@
           style:grid-column="{tile.x + 1} / span {tile.w}"
           style:grid-row="{tile.y + 1} / span {tile.h}"
           style:order={orderMap ? orderMap.get(tile.id) : undefined}
+          style:height={stacked ? stackedCellHeight(tile.h) + "px" : undefined}
         >
           <Tile {tile} {readOnly} />
           {#if !readOnly && !stacked}
@@ -424,13 +426,20 @@
      Display-only: the saved grid-column / grid-row stay on the element
      and simply take over again once the container widens. */
   .grid--stacked {
-    grid-template-columns: 1fr;
-    grid-auto-rows: minmax(80px, auto);
+    /* Single full-width column. Flexbox (not grid) so each cell takes the
+       DEFINITE inline height we set from the tile's saved row span — that
+       definite height is what lets the tile's `height: 100%` (and the chart
+       canvas's `height: 100%`) resolve, so charts fill their tile exactly
+       instead of spilling their axis labels into the next tile. The grid
+       keeps its own overflow-y, so the column scrolls as one. */
+    display: flex;
+    flex-direction: column;
     touch-action: auto;
   }
   .grid--stacked .cell {
-    grid-column: 1 / span 1 !important;
-    grid-row: auto / auto !important;
+    width: 100%;
+    /* Height comes from the inline px (stackedCellHeight); never shrink. */
+    flex: 0 0 auto;
   }
   .empty {
     padding: 3rem 1rem;

--- a/saiku-ui/src/lib/views/dashboard/DashboardToolbar.svelte
+++ b/saiku-ui/src/lib/views/dashboard/DashboardToolbar.svelte
@@ -16,12 +16,16 @@
   import FilterSuggestionsModal from "$lib/views/dashboard/FilterSuggestionsModal.svelte";
   import PrefsMenu from "$lib/components/PrefsMenu.svelte";
   import type { TileType } from "$lib/api/dashboards";
-  import { Monitor, RotateCcw, X, Share2, History, Undo2, Redo2 } from "lucide-svelte";
+  import { Monitor, RotateCcw, X, Share2, History, Undo2, Redo2, Menu } from "lucide-svelte";
   import { i18n } from "$lib/stores/i18n.svelte";
   // #941 + #947 PR2 — share-link + version-history entry points.
   import { dashboardStore } from "$lib/stores/dashboard.svelte";
   import DashboardShareModal from "$lib/views/dashboard/DashboardShareModal.svelte";
   import HistoryPanel from "$lib/views/dashboard/HistoryPanel.svelte";
+  // #1175: collapse the action buttons into a hamburger on narrow widths
+  // (restores the #932 behaviour lost in the #914/#915/#932 merge), now with
+  // Undo/Redo folded into the collapse. Same breakpoint that stacks the grid.
+  import { isNarrow, DEFAULT_STACK_BREAKPOINT } from "$lib/dashboard/responsiveLayout";
 
   interface Props {
     name: string;
@@ -77,6 +81,49 @@
   let suggestOpen = $state(false);
   let newTagInput = $state<string>("");
 
+  // #1175: responsive hamburger. A ResizeObserver on the header tracks its
+  // width; below the stack breakpoint the secondary actions collapse into a
+  // ☰ menu (Save stays visible). Mirrors DashboardGrid's observer pattern.
+  let headerEl = $state<HTMLElement | null>(null);
+  let narrow = $state(false);
+  let menuOpen = $state(false);
+
+  $effect(() => {
+    const el = headerEl;
+    if (!el) return;
+    const ro = new ResizeObserver((entries) => {
+      narrow = isNarrow(entries[0]?.contentRect.width ?? el.clientWidth, DEFAULT_STACK_BREAKPOINT);
+    });
+    ro.observe(el);
+    narrow = isNarrow(el.clientWidth, DEFAULT_STACK_BREAKPOINT);
+    return () => ro.disconnect();
+  });
+
+  // Expanding back to wide closes the menu so it can't linger inline.
+  $effect(() => {
+    if (!narrow) menuOpen = false;
+  });
+
+  // Close the hamburger on outside click / Escape (sub-dropdowns like
+  // Add-tile / theme render inside the header, so they don't count as
+  // "outside").
+  $effect(() => {
+    if (!menuOpen) return;
+    function onDocClick(e: MouseEvent): void {
+      const t = e.target as Node | null;
+      if (t && headerEl && !headerEl.contains(t)) menuOpen = false;
+    }
+    function onKey(e: KeyboardEvent): void {
+      if (e.key === "Escape") menuOpen = false;
+    }
+    document.addEventListener("mousedown", onDocClick);
+    document.addEventListener("keydown", onKey);
+    return () => {
+      document.removeEventListener("mousedown", onDocClick);
+      document.removeEventListener("keydown", onKey);
+    };
+  });
+
   // The input is controlled by the `name` prop directly — the store is
   // the source of truth. onNameChange propagates user edits upstream and
   // the prop refreshes on the next render.
@@ -119,7 +166,13 @@
   }
 </script>
 
-<header class="toolbar" role="toolbar" aria-label="Dashboard toolbar">
+<header
+  class="toolbar"
+  class:toolbar--narrow={narrow}
+  role="toolbar"
+  aria-label="Dashboard toolbar"
+  bind:this={headerEl}
+>
   <div class="title-block">
     {#if readOnly}
       <h1 class="name-readonly">{name}</h1>
@@ -173,118 +226,149 @@
 
   <div class="spacer"></div>
 
+  <!-- #1175: wide → all actions inline; narrow → Save stays out, the rest
+       (incl. Undo/Redo) collapse into a ☰ menu. Both render the SAME
+       snippets, so there's no duplication and nothing falls outside the
+       collapse. -->
   <div class="actions">
-    {#if onPresent}
+    {#if narrow}
+      {@render saveButton()}
       <button
         type="button"
-        class="btn"
-        onclick={() => onPresent?.()}
-        title="Present — fullscreen, hide chrome (press F, Esc to exit)"
-        aria-label="Present"
+        class="btn hamburger"
+        aria-label="More actions"
+        aria-haspopup="menu"
+        aria-expanded={menuOpen}
+        title="More actions"
+        onclick={() => (menuOpen = !menuOpen)}
       >
-        <Monitor size={14} aria-hidden="true" />
-        <span>Present</span>
+        <Menu size={16} aria-hidden="true" />
       </button>
+      {#if menuOpen}
+        <div class="actions-menu" role="menu">
+          {@render secondaryActions()}
+        </div>
+      {/if}
+    {:else}
+      {@render secondaryActions()}
+      {@render saveButton()}
     {/if}
-
-    {#if !readOnly}
-      <div class="undo-redo" role="group" aria-label={i18n.t("dashboard.history.group", "Undo and redo")}>
-        <button
-          type="button"
-          class="btn icon-only"
-          onclick={() => onUndo?.()}
-          disabled={!canUndo || !onUndo}
-          aria-disabled={!canUndo || !onUndo}
-          title={i18n.t("dashboard.undo.title", "Undo (Ctrl/Cmd+Z)")}
-          aria-label={i18n.t("dashboard.undo", "Undo")}
-        >
-          <Undo2 size={14} aria-hidden="true" />
-        </button>
-        <button
-          type="button"
-          class="btn icon-only"
-          onclick={() => onRedo?.()}
-          disabled={!canRedo || !onRedo}
-          aria-disabled={!canRedo || !onRedo}
-          title={i18n.t("dashboard.redo.title", "Redo (Ctrl/Cmd+Shift+Z)")}
-          aria-label={i18n.t("dashboard.redo", "Redo")}
-        >
-          <Redo2 size={14} aria-hidden="true" />
-        </button>
-      </div>
-
-      <button
-        type="button"
-        class="btn"
-        onclick={() => (suggestOpen = true)}
-        aria-haspopup="dialog"
-        title="Suggest filter widgets from dimensions your tiles already use"
-      >
-        🔍 Suggest filters
-      </button>
-
-      <button
-        type="button"
-        class="btn"
-        onclick={() => onResetFilters?.()}
-        disabled={!canResetFilters || !onResetFilters}
-        aria-disabled={!canResetFilters || !onResetFilters}
-        title={canResetFilters
-          ? "Clear all click-filters and restore panel filters to their saved defaults"
-          : "No active filters to reset"}
-      >
-        <RotateCcw size={14} aria-hidden="true" />
-        <span>Reset filters</span>
-      </button>
-
-      <AddTileMenu onPick={(t) => onAddTile?.(t)} disabled={!onAddTile} />
-
-      <button
-        type="button"
-        class="btn primary"
-        onclick={() => onSave?.()}
-        disabled={saving || !dirty}
-        aria-disabled={saving || !dirty}
-      >
-        {#if saving}
-          Saving…
-        {:else if dirty}
-          Save
-        {:else}
-          Saved
-        {/if}
-      </button>
-    {/if}
-
-    {#if savedPath}
-      <button
-        type="button"
-        class="btn"
-        onclick={() => (historyOpen = true)}
-        title="Version history — preview and restore earlier saves"
-        aria-haspopup="dialog"
-      >
-        <History size={14} aria-hidden="true" />
-        <span>History</span>
-      </button>
-      <button
-        type="button"
-        class="btn"
-        onclick={() => (shareOpen = true)}
-        title="Share a read-only link to this dashboard"
-        aria-haspopup="dialog"
-      >
-        <Share2 size={14} aria-hidden="true" />
-        <span>Share</span>
-      </button>
-    {/if}
-
-    <!-- saiku#1050: theme (dark/light/system) + language control, parity with
-         the workspace. Shown in both editor and viewer; the whole toolbar is
-         hidden in presentation mode (#928), so it disappears on TV walls. -->
-    <PrefsMenu placement="down" />
   </div>
 </header>
+
+{#snippet secondaryActions()}
+  {#if onPresent}
+    <button
+      type="button"
+      class="btn"
+      onclick={() => onPresent?.()}
+      title="Present — fullscreen, hide chrome (press F, Esc to exit)"
+      aria-label="Present"
+    >
+      <Monitor size={14} aria-hidden="true" />
+      <span>Present</span>
+    </button>
+  {/if}
+
+  {#if !readOnly}
+    <div class="undo-redo" role="group" aria-label={i18n.t("dashboard.history.group", "Undo and redo")}>
+      <button
+        type="button"
+        class="btn icon-only"
+        onclick={() => onUndo?.()}
+        disabled={!canUndo || !onUndo}
+        aria-disabled={!canUndo || !onUndo}
+        title={i18n.t("dashboard.undo.title", "Undo (Ctrl/Cmd+Z)")}
+        aria-label={i18n.t("dashboard.undo", "Undo")}
+      >
+        <Undo2 size={14} aria-hidden="true" />
+      </button>
+      <button
+        type="button"
+        class="btn icon-only"
+        onclick={() => onRedo?.()}
+        disabled={!canRedo || !onRedo}
+        aria-disabled={!canRedo || !onRedo}
+        title={i18n.t("dashboard.redo.title", "Redo (Ctrl/Cmd+Shift+Z)")}
+        aria-label={i18n.t("dashboard.redo", "Redo")}
+      >
+        <Redo2 size={14} aria-hidden="true" />
+      </button>
+    </div>
+
+    <button
+      type="button"
+      class="btn"
+      onclick={() => (suggestOpen = true)}
+      aria-haspopup="dialog"
+      title="Suggest filter widgets from dimensions your tiles already use"
+    >
+      🔍 Suggest filters
+    </button>
+
+    <button
+      type="button"
+      class="btn"
+      onclick={() => onResetFilters?.()}
+      disabled={!canResetFilters || !onResetFilters}
+      aria-disabled={!canResetFilters || !onResetFilters}
+      title={canResetFilters
+        ? "Clear all click-filters and restore panel filters to their saved defaults"
+        : "No active filters to reset"}
+    >
+      <RotateCcw size={14} aria-hidden="true" />
+      <span>Reset filters</span>
+    </button>
+
+    <AddTileMenu onPick={(t) => onAddTile?.(t)} disabled={!onAddTile} />
+  {/if}
+
+  {#if savedPath}
+    <button
+      type="button"
+      class="btn"
+      onclick={() => (historyOpen = true)}
+      title="Version history — preview and restore earlier saves"
+      aria-haspopup="dialog"
+    >
+      <History size={14} aria-hidden="true" />
+      <span>History</span>
+    </button>
+    <button
+      type="button"
+      class="btn"
+      onclick={() => (shareOpen = true)}
+      title="Share a read-only link to this dashboard"
+      aria-haspopup="dialog"
+    >
+      <Share2 size={14} aria-hidden="true" />
+      <span>Share</span>
+    </button>
+  {/if}
+
+  <!-- saiku#1050: theme (dark/light/system) + language control. -->
+  <PrefsMenu placement="down" />
+{/snippet}
+
+{#snippet saveButton()}
+  {#if !readOnly}
+    <button
+      type="button"
+      class="btn primary"
+      onclick={() => onSave?.()}
+      disabled={saving || !dirty}
+      aria-disabled={saving || !dirty}
+    >
+      {#if saving}
+        Saving…
+      {:else if dirty}
+        Save
+      {:else}
+        Saved
+      {/if}
+    </button>
+  {/if}
+{/snippet}
 
 {#if savedPath}
   <DashboardShareModal dashboardPath={savedPath} open={shareOpen} onClose={() => (shareOpen = false)} />
@@ -378,6 +462,42 @@
     display: flex;
     gap: 0.5rem;
     align-items: center;
+    position: relative; /* anchor the #1175 hamburger dropdown */
+  }
+  /* #1175: narrow toolbar — let the name shrink so Save + ☰ always fit. */
+  .toolbar--narrow .name { min-width: 0; }
+  .hamburger { padding: 0.375rem 0.5rem; }
+  /* #1175: hamburger dropdown holding the collapsed secondary actions. */
+  .actions-menu {
+    position: absolute;
+    top: 100%;
+    right: 0;
+    margin-top: 4px;
+    display: flex;
+    flex-direction: column;
+    align-items: stretch;
+    gap: 0.25rem;
+    min-width: 12rem;
+    padding: 0.375rem;
+    background: var(--bg);
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.18);
+    z-index: 60;
+  }
+  /* Stack the collapsed buttons full-width, left-aligned, like a menu. The
+     undo/redo group lays its two buttons out in a row. */
+  .actions-menu :global(.btn) {
+    width: 100%;
+    justify-content: flex-start;
+  }
+  .actions-menu .undo-redo {
+    display: flex;
+  }
+  .actions-menu .undo-redo :global(.btn) {
+    width: auto;
+    flex: 1;
+    justify-content: center;
   }
   .btn {
     display: inline-flex;

--- a/saiku-ui/src/lib/views/dashboard/Tile.svelte
+++ b/saiku-ui/src/lib/views/dashboard/Tile.svelte
@@ -26,7 +26,7 @@
   import KpiTile from "$lib/views/dashboard/tiles/KpiTile.svelte";
   import ImageTile from "$lib/views/dashboard/tiles/ImageTile.svelte";
   import TileEditorModal from "$lib/views/dashboard/TileEditorModal.svelte";
-  import { Copy, MoreVertical, Settings2, X, MessageCircle } from "lucide-svelte";
+  import { Copy, MoreVertical, Settings2, X, MessageCircle, Minus, Plus } from "lucide-svelte";
   // #942 PR2 — per-tile comments.
   import CommentsPanel from "$lib/views/dashboard/CommentsPanel.svelte";
   import { getComments } from "$lib/api/dashboards";
@@ -254,6 +254,33 @@
       <Copy size={14} aria-hidden="true" />
       <span>Duplicate</span>
     </button>
+    <!-- #932/#1175: height stepper — a touch-friendly way to grow/shrink a
+         tile without dragging, especially in the mobile stacked layout. Stays
+         open so repeated taps work; closes on outside click / Escape. -->
+    <div class="tile-menu__row" role="group" aria-label="Tile height">
+      <span class="tile-menu__label">Height</span>
+      <button
+        type="button"
+        class="tile-menu__step"
+        aria-label="Decrease height"
+        title="Decrease height"
+        onclick={() => dashboardStore.adjustTileHeight(tile.id, -1)}
+        disabled={tile.h <= 1}
+      >
+        <Minus size={14} aria-hidden="true" />
+      </button>
+      <span class="tile-menu__val" aria-live="polite">{tile.h}</span>
+      <button
+        type="button"
+        class="tile-menu__step"
+        aria-label="Increase height"
+        title="Increase height"
+        onclick={() => dashboardStore.adjustTileHeight(tile.id, 1)}
+        disabled={tile.h >= 24}
+      >
+        <Plus size={14} aria-hidden="true" />
+      </button>
+    </div>
   </div>
 {/if}
 
@@ -424,5 +451,43 @@
   .tile-menu__item:focus {
     background: var(--bg-subtle);
     outline: none;
+  }
+  /* #932/#1175: height stepper row. */
+  .tile-menu__row {
+    display: flex;
+    align-items: center;
+    gap: 0.375rem;
+    padding: 0.25rem 0.625rem;
+  }
+  .tile-menu__label {
+    flex: 1;
+    color: var(--fg-muted);
+    font-size: 0.8125rem;
+  }
+  .tile-menu__step {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 1.5rem;
+    height: 1.5rem;
+    border: 1px solid var(--border-strong, var(--border));
+    background: var(--bg);
+    border-radius: 4px;
+    color: var(--fg);
+    cursor: pointer;
+  }
+  .tile-menu__step:hover:not(:disabled) {
+    background: var(--bg-subtle);
+  }
+  .tile-menu__step:disabled {
+    opacity: 0.4;
+    cursor: not-allowed;
+  }
+  .tile-menu__val {
+    min-width: 1.25rem;
+    text-align: center;
+    font-size: 0.8125rem;
+    color: var(--fg);
+    font-variant-numeric: tabular-nums;
   }
 </style>


### PR DESCRIPTION
## Summary
Restores the dashboard **mobile polish that was silently dropped in the #914/#915/#932 merge** (#1175). That merge lost commit `23a969cc` entirely, so development ended up with the toolbar **overflowing** at narrow widths and charts **squashed with no way to grow** in the stacked view.

## What was lost → restored
The merge kept #932's base auto-stack but dropped its follow-up polish commit. Re-applied (and improved):

- **Hamburger toolbar** (`DashboardToolbar.svelte`) — below the stack breakpoint the secondary actions collapse into a **☰** menu while **Save** stays visible; same buttons via Svelte snippets (no duplication), closes on outside-click/Esc, returns inline when wide. **Improvement vs the lost version:** #914's **Undo/Redo are folded into the collapse**, so they no longer overflow or sit outside the menu (that was the gap that made the toolbar overflow even after #914 added buttons).
- **Definite stacked tile heights** (`DashboardGrid.svelte` + `responsiveLayout.stackedCellHeight`) — stacked cells get a real `height` from the tile's saved row span, laid out with flexbox, so the tile's `height:100%` and the chart canvas resolve. No more squashed charts / spilled axis labels / inner per-tile scrollbars.
- **Tile height stepper** (`Tile.svelte` ⋮ menu + `dashboardStore.adjustTileHeight`) — `Height − [n] +` to grow/shrink a tile by row (cascades via `repositionTile`, undoable). The touch-friendly substitute for drag-resize, which is disabled when stacked — this is the "make it bigger" control.

## Verified
- `npm run check` → **0 / 0** · `npm test` (responsiveLayout 17 incl. `stackedCellHeight`) green · production build ✓.
- Branched off current `development`.
- **User-verified locally**: toolbar collapses to ☰ at narrow width (Undo/Redo inside); stacked charts render at proper height (no squash); ⋮ → Height +/- grows tiles.

## Root cause / prevention
Second merge-loss from the #914/#915/#932 integration (the first was the `svelte-ignore` split, fixed in #920). When resolving Tile/DashboardGrid/DashboardToolbar conflicts across overlapping dashboard PRs, the later branch's additive changes need to be carried, not overwritten. Logged on the board for OG.

No backend change. Does not self-merge.

Closes #1175

🤖 Generated with [Claude Code](https://claude.com/claude-code)
