### PR TITLE
fix(workspace): result/chart no longer overflows off-screen at narrow widths (closes #1176)

### DIFF
--- a/saiku-ui/src/lib/views/QueryCanvas.svelte
+++ b/saiku-ui/src/lib/views/QueryCanvas.svelte
@@ -655,6 +655,26 @@
     }
   }
 
+  // #1176: collapse the query-builder above the result when the canvas body
+  // is too narrow to show both side-by-side, so the result/chart gets the
+  // full width instead of being pushed off-screen. Container-width based
+  // (ResizeObserver), mirroring the dashboard grid's responsive stack.
+  let bodyEl = $state<HTMLDivElement | null>(null);
+  let bodyWidth = $state(0);
+  const BODY_STACK_PX = 640;
+  let bodyNarrow = $derived(bodyWidth > 0 && bodyWidth < BODY_STACK_PX);
+
+  $effect(() => {
+    const el = bodyEl;
+    if (!el) return;
+    const ro = new ResizeObserver((entries) => {
+      bodyWidth = entries[0]?.contentRect.width ?? el.clientWidth;
+    });
+    ro.observe(el);
+    bodyWidth = el.clientWidth;
+    return () => ro.disconnect();
+  });
+
   let resultHostEl = $state<HTMLDivElement | null>(null);
 
   $effect(() => {
@@ -758,7 +778,12 @@
       <p class="canvas__hint">{i18n.t("canvas.pickPrompt")}</p>
     </div>
   {:else}
-    <div class={query.current?.type === "MDX" ? "canvas__body canvas__body--mdx" : "canvas__body"}>
+    <div
+      bind:this={bodyEl}
+      class="canvas__body"
+      class:canvas__body--mdx={query.current?.type === "MDX"}
+      class:canvas__body--narrow={bodyNarrow && query.current?.type !== "MDX"}
+    >
     {#if query.current?.type !== "MDX"}
     <aside class="dropzones">
       <!-- Dedicated MEASURES panel (restored from the pre-rewrite UI).
@@ -1169,9 +1194,32 @@
     flex: 1;
     min-height: 0;
     display: grid;
-    grid-template-columns: 260px 1fr;
+    /* minmax(0, 1fr) (not bare 1fr) so the result column can shrink BELOW
+       its content's min-width instead of forcing the whole canvas wider than
+       the viewport — that overflow is what pushed the result/chart off-screen
+       at narrow widths (#1176). */
+    grid-template-columns: 260px minmax(0, 1fr);
     gap: var(--space-3);
     overflow: hidden;
+  }
+  /* #1176: when the body is too narrow to show builder + result side by
+     side, stack the builder above the result (single column) and let the
+     body scroll, so the result/chart gets the full width. Container-width
+     driven (.canvas__body--narrow toggled by a ResizeObserver). */
+  .canvas__body--narrow {
+    display: flex;
+    flex-direction: column;
+    overflow-y: auto;
+    overflow-x: hidden;
+  }
+  .canvas__body--narrow .dropzones {
+    flex: 0 0 auto;
+    overflow-y: visible; /* the body scrolls; no nested scroll area */
+  }
+  .canvas__body--narrow .canvas__result {
+    /* Give the result a usable height when stacked so the chart/grid isn't a
+       sliver; the body scrolls to reach it. */
+    min-height: 65vh;
   }
   /* MDX mode: the dropzones aside is `{#if}`-hidden, so a 260px 1fr
      grid would place the result in column 1 (260px) and leave column 2
@@ -1335,6 +1383,9 @@
     align-items: center;
     gap: var(--space-2);
     padding: var(--space-1) 0;
+    /* #1176: wrap the Grid/Chart/More + chart-type controls instead of
+       overflowing the result column at narrow widths. */
+    flex-wrap: wrap;
   }
   .view-toggle button {
     padding: var(--space-1) var(--space-3);

--- a/saiku-ui/src/lib/views/Workspace.svelte
+++ b/saiku-ui/src/lib/views/Workspace.svelte
@@ -339,7 +339,11 @@
     flex: 1;
     min-height: 0;
     display: grid;
-    grid-template-columns: 300px 1fr;
+    /* minmax(0, 1fr) (not bare 1fr) so the main column can shrink below its
+       content's min-width — otherwise the whole workspace is forced wider
+       than the viewport and the page scrolls horizontally at narrow widths
+       (#1176). */
+    grid-template-columns: 300px minmax(0, 1fr);
     gap: 1px;
     background: var(--border);
     overflow: hidden;


### PR DESCRIPTION
## Summary
Fixes the Query Editor (workspace) **overflowing off-screen at narrow widths** (#1176) — the result/chart was pushed past the right edge with a horizontal scrollbar and squished to a sliver.

## Root cause
Two fixed columns — the **300px app sidebar** (Workspace) and the **260px query-builder** (QueryCanvas) — plus a result column that **couldn't shrink** (`grid-template-columns: … 1fr`, where bare `1fr` = `minmax(auto, 1fr)` and won't go below the content's min-width). So at narrow widths the layout was forced wider than the viewport.

## The change (shell layout only — no chart internals)
- **`Workspace.svelte`** + **`QueryCanvas.svelte`**: grids use **`minmax(0, 1fr)`** so the main / result column can shrink below content min-width → no page-level horizontal scroll.
- **`QueryCanvas.svelte`**: when the canvas body is too narrow to show builder + result side-by-side, it **collapses the builder above the result** (single column) so the result/chart gets full width. Container-width based via a `ResizeObserver` (mirrors the dashboard grid's responsive stack), with the stacked result given a usable min-height.
- The result view toolbar (Grid / Chart / More + chart-type) **wraps** instead of overflowing.

## Verified
- `npm run check` → **0 / 0** · production build ✓.
- Branched off current `development`.
- **User-verified locally** at narrow width: builder stacks above, result/chart takes full width, page-level horizontal scroll gone.

## Notes
- Pure shell layout — `ChartView`'s own internal sizing/scroll (the chart's `60vh` area, and OG's #1083 Sort/Top chart controls) is **untouched**; if the chart-internal sizing needs tuning at narrow widths that's OG's chart area and a separate follow-up.
- No backend change. Does not self-merge.

Closes #1176

🤖 Generated with [Claude Code](https://claude.com/claude-code)
