### PR TITLE
fix(demo): sign + verify the demo-gate cookie expiry (closes #1156)

### DIFF
--- a/saiku-core/saiku-web/src/main/java/org/saiku/web/demo/DemoGateCookie.java
+++ b/saiku-core/saiku-web/src/main/java/org/saiku/web/demo/DemoGateCookie.java
@@ -18,10 +18,13 @@ import javax.crypto.spec.SecretKeySpec;
  * Stateless, signed marker cookie proving a visitor cleared the demo email gate.
  *
  * <p>The cookie does NOT log anyone in — it only unlocks the login form. The
- * value is {@code base64url(email) "." base64url(HMAC-SHA256(email))}; the HMAC
- * key never leaves the server, so the client can't forge or read a valid
- * marker. The email is recoverable from the cookie by the server (for the
- * verified-email log) but is opaque/tamper-evident to the client.
+ * value is {@code base64url(email "|" expiryEpochSeconds) "." base64url(HMAC-SHA256(that))};
+ * the HMAC key never leaves the server, so the client can't forge or read a
+ * valid marker. The expiry is part of the SIGNED payload (not just the cookie's
+ * {@code Max-Age}), so a captured/replayed marker stops working after it lapses
+ * and the expiry can't be tampered (#1156). The email is recoverable from the
+ * cookie by the server (for the verified-email log) but is opaque/tamper-evident
+ * to the client.
  *
  * <p>Pure crypto/string logic — no servlet types — so it's unit-tested directly
  * (saiku-web is JUnit 4 with no mocking framework).
@@ -50,17 +53,27 @@ public final class DemoGateCookie {
         return ttlSeconds;
     }
 
-    /** Build the signed cookie value for a verified email. */
+    /** Build the signed cookie value for a verified email, expiring at
+     *  {@code now + ttlSeconds}. */
     public String sign(String email) {
-        String e = normalize(email);
-        String payload = B64.encodeToString(e.getBytes(StandardCharsets.UTF_8));
-        String sig = B64.encodeToString(hmac(e));
+        return sign(email, nowEpochSeconds() + ttlSeconds);
+    }
+
+    /** Sign with an explicit absolute expiry (epoch seconds). Package-private so
+     *  unit tests can produce already-expired / not-yet-expired markers
+     *  deterministically without mocking the clock. */
+    String sign(String email, long expiresAtEpochSeconds) {
+        String content = signedContent(normalize(email), expiresAtEpochSeconds);
+        String payload = B64.encodeToString(content.getBytes(StandardCharsets.UTF_8));
+        String sig = B64.encodeToString(hmac(content));
         return payload + "." + sig;
     }
 
     /**
-     * @return true iff {@code cookieValue} is well-formed and its signature
-     *     matches this secret. Constant-time signature comparison.
+     * @return true iff {@code cookieValue} is well-formed, its signature matches
+     *     this secret (constant-time comparison), AND it has not expired. The
+     *     expiry is part of the signed payload, so it can't be extended by the
+     *     client (#1156); a legacy value with no expiry field is rejected.
      */
     public boolean verify(String cookieValue) {
         if (cookieValue == null) return false;
@@ -68,15 +81,27 @@ public final class DemoGateCookie {
         if (dot <= 0 || dot == cookieValue.length() - 1) return false;
         String payload = cookieValue.substring(0, dot);
         String sig = cookieValue.substring(dot + 1);
-        String email;
+        String content;
         byte[] presented;
         try {
-            email = new String(B64D.decode(payload), StandardCharsets.UTF_8);
+            content = new String(B64D.decode(payload), StandardCharsets.UTF_8);
             presented = B64D.decode(sig);
         } catch (IllegalArgumentException badBase64) {
             return false;
         }
-        return MessageDigest.isEqual(hmac(email), presented);
+        // Signature must cover the full payload (email + expiry) — tamper-evident.
+        if (!MessageDigest.isEqual(hmac(content), presented)) return false;
+        // ...and the marker must not be expired. Expiry is the last
+        // '|'-separated field; a value without one is an old/forged format.
+        int bar = content.lastIndexOf('|');
+        if (bar < 0) return false;
+        long expiresAt;
+        try {
+            expiresAt = Long.parseLong(content.substring(bar + 1));
+        } catch (NumberFormatException badExpiry) {
+            return false;
+        }
+        return expiresAt > nowEpochSeconds();
     }
 
     /**
@@ -88,7 +113,9 @@ public final class DemoGateCookie {
         int dot = cookieValue.indexOf('.');
         if (dot <= 0) return null;
         try {
-            return new String(B64D.decode(cookieValue.substring(0, dot)), StandardCharsets.UTF_8);
+            String content = new String(B64D.decode(cookieValue.substring(0, dot)), StandardCharsets.UTF_8);
+            int bar = content.lastIndexOf('|');
+            return bar < 0 ? content : content.substring(0, bar);
         } catch (IllegalArgumentException badBase64) {
             return null;
         }
@@ -113,6 +140,17 @@ public final class DemoGateCookie {
 
     private static String normalize(String email) {
         return email == null ? "" : email.trim().toLowerCase(Locale.ROOT);
+    }
+
+    /** The HMAC-signed content: {@code "email|expiryEpochSeconds"}. Both fields
+     *  are covered by the signature, so neither the email nor the expiry can be
+     *  tampered, and {@link #verify} additionally rejects a lapsed expiry. */
+    private static String signedContent(String normalizedEmail, long expiresAtEpochSeconds) {
+        return normalizedEmail + "|" + expiresAtEpochSeconds;
+    }
+
+    private static long nowEpochSeconds() {
+        return System.currentTimeMillis() / 1000L;
     }
 
     private byte[] hmac(String data) {

--- a/saiku-core/saiku-web/src/test/java/org/saiku/web/demo/DemoGateCookieTest.java
+++ b/saiku-core/saiku-web/src/test/java/org/saiku/web/demo/DemoGateCookieTest.java
@@ -6,6 +6,8 @@ package org.saiku.web.demo;
 
 import static org.junit.Assert.*;
 
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
 import org.junit.Test;
 
 public class DemoGateCookieTest {
@@ -57,7 +59,36 @@ public class DemoGateCookieTest {
     @Test
     public void email_normalizedForCaseAndWhitespace() {
         DemoGateCookie c = new DemoGateCookie(SECRET, 100);
-        assertEquals(c.sign("User@Example.com"), c.sign("  user@example.com "));
+        // Fixed expiry so the comparison is deterministic (sign() embeds now+ttl).
+        assertEquals(c.sign("User@Example.com", 123456789L), c.sign("  user@example.com ", 123456789L));
+    }
+
+    @Test
+    public void verify_rejectsExpiredMarker() {
+        // #1156: a marker whose signed expiry has lapsed must not validate.
+        DemoGateCookie c = new DemoGateCookie(SECRET, 100);
+        assertFalse(c.verify(c.sign("user@example.com", 1000L))); // epoch 1000s = long past
+    }
+
+    @Test
+    public void verify_acceptsNotYetExpiredMarker() {
+        DemoGateCookie c = new DemoGateCookie(SECRET, 100);
+        long future = System.currentTimeMillis() / 1000L + 3600;
+        assertTrue(c.verify(c.sign("user@example.com", future)));
+    }
+
+    @Test
+    public void verify_rejectsClientExtendedExpiry() {
+        // #1156: re-encoding the payload with a later expiry but reusing the
+        // original signature must fail — the expiry is part of the signed data.
+        DemoGateCookie c = new DemoGateCookie(SECRET, 100);
+        String v = c.sign("user@example.com", 1000L); // expired
+        String sig = v.substring(v.indexOf('.') + 1);
+        long farFuture = System.currentTimeMillis() / 1000L + 31_536_000L;
+        String forgedPayload = Base64.getUrlEncoder()
+                .withoutPadding()
+                .encodeToString(("user@example.com|" + farFuture).getBytes(StandardCharsets.UTF_8));
+        assertFalse(c.verify(forgedPayload + "." + sig));
     }
 
     @Test


### PR DESCRIPTION
## Summary
The demo-gate marker cookie (`DemoGateCookie`) HMAC'd **only the email**. The expiry lived solely in the client-controlled `Max-Age`, and `verify()` never checked it — so a captured/replayed marker stayed valid forever (Tom's audit #1156).

## The fix
- Signed payload is now `email|expiryEpochSeconds` (expiry is part of the HMAC → tamper-evident).
- `verify()` checks the signature **and** that the marker hasn't lapsed; a legacy no-expiry value is rejected (visitor just re-verifies via email).
- `sign(email)` expires at `now + ttlSeconds`; a package-private `sign(email, expiry)` makes expiry deterministically unit-testable (no clock mocking).
- `emailOf()` parses the email out of the new payload.
- Public `sign/verify/emailOf/setCookieHeader` signatures unchanged → callers (`DemoGateResource`/`DemoGateFilter`) unaffected.

## Verified
`mvn -pl :saiku-web -am test -Dtest=DemoGate*Test` → **35 pass**, incl. 3 new (`verify_rejectsExpiredMarker`, `verify_acceptsNotYetExpiredMarker`, `verify_rejectsClientExtendedExpiry`) + de-flaked the normalization test; existing DemoGateResource/Filter/Secret suites unaffected. spotless clean.

## Notes
This is our code — the #1029 demo-gate (which landed on `development` via PR #1039). UI-unaffected; backend-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)