### PR TITLE
fix(dashboards): preserve all tile/filter fields on save (closes #1179)

### DIFF
--- a/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/dashboards/DashboardResource.java
+++ b/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/dashboards/DashboardResource.java
@@ -6,6 +6,7 @@ package org.saiku.web.rest.resources.dashboards;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.DELETE;
@@ -113,21 +114,39 @@ public class DashboardResource {
     @Path("/{path:.+}")
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.APPLICATION_JSON)
-    public Response save(@PathParam("path") String path, Dashboard dashboard) {
+    public Response save(@PathParam("path") String path, String rawBody) {
         if (path == null || path.isBlank()) {
             return badRequest("path", "path required");
         }
-        if (dashboard == null) {
+        if (rawBody == null || rawBody.isBlank()) {
             return badRequest("body", "dashboard body required");
         }
-        if (dashboard.layout == null) {
+        // #1179: persist the RAW request JSON (re-pretty-printed) instead of
+        // re-serialising the typed Dashboard POJO. The Java model intentionally
+        // declares only a subset of tile/filter fields, so re-serialising the
+        // typed object silently DROPS everything else the UI sends
+        // (chartOptions, conditionalFormat, cascading, topN, …) — they worked in
+        // the session but vanished on reload. Parsing to a JsonNode keeps every
+        // field; we validate the shape from the node (object with an object
+        // `layout`) without a typed bind, so unknown fields can't be lost or
+        // trigger an unknown-property rejection.
+        JsonNode node;
+        try {
+            node = MAPPER.readTree(rawBody);
+        } catch (JsonProcessingException e) {
+            return badRequest("body", "invalid dashboard JSON: " + e.getOriginalMessage());
+        }
+        if (node == null || !node.isObject()) {
+            return badRequest("body", "dashboard body required");
+        }
+        if (!node.hasNonNull("layout") || !node.get("layout").isObject()) {
             return badRequest("layout", "layout required");
         }
         String username = currentUsername();
         List<String> roles = currentRoles();
         String body;
         try {
-            body = MAPPER.writerWithDefaultPrettyPrinter().writeValueAsString(dashboard);
+            body = MAPPER.writerWithDefaultPrettyPrinter().writeValueAsString(node);
         } catch (JsonProcessingException e) {
             log.error("dashboard {} serialisation failed", path, e);
             return Response.serverError()

--- a/saiku-core/saiku-web/src/test/java/org/saiku/web/rest/resources/dashboards/DashboardResourceTest.java
+++ b/saiku-core/saiku-web/src/test/java/org/saiku/web/rest/resources/dashboards/DashboardResourceTest.java
@@ -44,9 +44,9 @@ public class DashboardResourceTest {
     /* ------------------------------ save ------------------------------ */
 
     @Test
-    public void save_serialisesAndForwardsToDatasourceService() {
+    public void save_serialisesAndForwardsToDatasourceService() throws Exception {
         Dashboard d = sampleDashboard();
-        Response r = resource.save("/dashboards/q4.saikudash", d);
+        Response r = resource.save("/dashboards/q4.saikudash", MAPPER.writeValueAsString(d));
         assertEquals(200, r.getStatus());
         assertEquals("/dashboards/q4.saikudash", stubDs.savedPath);
         assertEquals("admin", stubDs.savedAs);
@@ -76,11 +76,7 @@ public class DashboardResourceTest {
 
     @Test
     public void save_missingLayoutReturns400() {
-        Dashboard d = new Dashboard();
-        d.id = "x";
-        d.name = "X";
-        d.layout = null;
-        Response r = resource.save("/x.saikudash", d);
+        Response r = resource.save("/x.saikudash", "{\"id\":\"x\",\"name\":\"X\"}");
         assertEquals(400, r.getStatus());
         @SuppressWarnings("unchecked")
         Map<String, Object> body = (Map<String, Object>) r.getEntity();
@@ -88,10 +84,38 @@ public class DashboardResourceTest {
     }
 
     @Test
-    public void save_datasourceServiceFailureReturns500() {
+    public void save_datasourceServiceFailureReturns500() throws Exception {
         stubDs.failOnSave = true;
-        Response r = resource.save("/x.saikudash", sampleDashboard());
+        Response r = resource.save("/x.saikudash", MAPPER.writeValueAsString(sampleDashboard()));
         assertEquals(500, r.getStatus());
+    }
+
+    @Test
+    public void save_invalidJsonReturns400() {
+        Response r = resource.save("/x.saikudash", "{not json");
+        assertEquals(400, r.getStatus());
+        @SuppressWarnings("unchecked")
+        Map<String, Object> body = (Map<String, Object>) r.getEntity();
+        assertEquals("body", body.get("field"));
+    }
+
+    @Test
+    public void save_preservesUnknownTileFields() throws Exception {
+        // #1179: the UI sends per-tile fields the Java model doesn't declare
+        // (chartOptions, conditionalFormat, cascading, topN). They must survive
+        // the save (round-trip into the stored content), not be dropped by
+        // re-serialising the typed POJO.
+        String json = "{\"id\":\"d1\",\"name\":\"D\",\"version\":1,\"layout\":{\"cols\":12,\"tiles\":["
+                + "{\"id\":\"t1\",\"x\":0,\"y\":0,\"w\":6,\"h\":4,\"type\":\"chart\",\"chartType\":\"bar\","
+                + "\"chartOptions\":{\"dualAxis\":true,\"trendLine\":\"linear\"},"
+                + "\"conditionalFormat\":[{\"column\":\"Sales\",\"type\":\"bar\"}]}]}}";
+        Response r = resource.save("/d1.saikudash", json);
+        assertEquals(200, r.getStatus());
+        JsonNode tile =
+                MAPPER.readTree(stubDs.savedContent).get("layout").get("tiles").get(0);
+        assertTrue("chartOptions must survive save", tile.has("chartOptions"));
+        assertEquals("linear", tile.get("chartOptions").get("trendLine").asText());
+        assertTrue("conditionalFormat must survive save", tile.has("conditionalFormat"));
     }
 
     /* ------------------------------ load ------------------------------ */


### PR DESCRIPTION
## Summary
`DashboardResource.save` deserialised the POST body into the typed `Dashboard`/`DashboardTile` POJOs and **re-serialised those** to disk. The Java model declares only a subset of tile/filter fields, so everything else the UI sends — **`chartOptions` (#1077), `conditionalFormat` (#919), `cascading` (#922), `topN` (#921)** — was silently dropped: it worked during the editing session but **vanished on reload**. This blocked the whole per-tile-config line (my paused #1077 had to add a typed `ChartOptions.java` just to dodge it).

## The fix
`save` now parses the body into a **`JsonNode`** (which keeps every field), validates the shape from the node (an object with an object `layout`) without a typed bind, and persists the re-pretty-printed node — so **all fields round-trip**. Invalid JSON → `400`. No typed field needed per future config.

## Security
No new surface: the content is stored in the caller's own repository (`saveFile` is auth + role scoped) and rendered by typed/escaped UI code; the client could already send these fields (they were just dropped). No `{@html}`, no new endpoint.

## Verified
`mvn -pl :saiku-web -am test -Dtest=DashboardResourceTest` → **12 pass**, incl. new `save_preservesUnknownTileFields` (chartOptions + conditionalFormat survive the round-trip) and `save_invalidJsonReturns400`; existing save tests updated to pass JSON strings. spotless clean; CI re-validates.

## Notes
Found while building #1077; with this in, #1077 can drop the `ChartOptions.java` workaround and persist via the generic path. Closes #1179.

🤖 Generated with [Claude Code](https://claude.com/claude-code)