### PR TITLE
feat(dashboard-ui): per-tile chart options editor for chart tiles (closes #1077)

### DIFF
--- a/saiku-ui/src/lib/api/dashboards.ts
+++ b/saiku-ui/src/lib/api/dashboards.ts
@@ -9,6 +9,7 @@
  */
 
 import type { ThinQuery } from "$lib/api/query";
+import type { ChartOptions } from "$lib/views/chartTypes";
 
 const REST_BASE = "/rest/saiku/api/dashboards";
 
@@ -216,6 +217,11 @@ export interface DashboardTile {
   cube?: CubeRef;
   query?: TileQuery;
   chartType?: string;
+  /** Per-tile chart options (title / axes / legend / dualAxis / seriesAxis /
+   *  trend lines). Only consulted when {@code type === "chart"}. Absent on
+   *  legacy tiles → the renderer falls back to the dashboard baseline, so the
+   *  appearance is unchanged (migration-safe). Issue #1077. */
+  chartOptions?: ChartOptions;
   text?: string;
   target?: DashboardFilter;
   widget?: FilterWidget;

--- a/saiku-ui/src/lib/charts/__snapshots__/build.test.ts.snap
+++ b/saiku-ui/src/lib/charts/__snapshots__/build.test.ts.snap
@@ -28,10 +28,10 @@ exports[`buildChartOption — coverage of all 15 types > snapshot of every type'
       "top": 24,
     },
     "legend": {
-      "bottom": 0,
       "textStyle": {
         "color": "#0f172a",
       },
+      "top": 0,
       "type": "scroll",
     },
     "series": [
@@ -160,10 +160,10 @@ exports[`buildChartOption — coverage of all 15 types > snapshot of every type'
       "top": 24,
     },
     "legend": {
-      "bottom": 0,
       "textStyle": {
         "color": "#0f172a",
       },
+      "top": 0,
       "type": "scroll",
     },
     "series": [
@@ -292,10 +292,10 @@ exports[`buildChartOption — coverage of all 15 types > snapshot of every type'
       "top": 24,
     },
     "legend": {
-      "bottom": 0,
       "textStyle": {
         "color": "#0f172a",
       },
+      "top": 0,
       "type": "scroll",
     },
     "series": [
@@ -681,10 +681,10 @@ exports[`buildChartOption — coverage of all 15 types > snapshot of every type'
       "top": 24,
     },
     "legend": {
-      "bottom": 0,
       "textStyle": {
         "color": "#0f172a",
       },
+      "top": 0,
       "type": "scroll",
     },
     "series": [
@@ -910,10 +910,10 @@ exports[`buildChartOption — coverage of all 15 types > snapshot of every type'
       "#14b8a6",
     ],
     "legend": {
-      "bottom": 0,
       "textStyle": {
         "color": "#0f172a",
       },
+      "top": 0,
       "type": "scroll",
     },
     "radar": {
@@ -1010,10 +1010,10 @@ exports[`buildChartOption — coverage of all 15 types > snapshot of every type'
       "top": 24,
     },
     "legend": {
-      "bottom": 0,
       "textStyle": {
         "color": "#0f172a",
       },
+      "top": 0,
       "type": "scroll",
     },
     "series": [
@@ -1147,10 +1147,10 @@ exports[`buildChartOption — coverage of all 15 types > snapshot of every type'
       "top": 24,
     },
     "legend": {
-      "bottom": 0,
       "textStyle": {
         "color": "#0f172a",
       },
+      "top": 0,
       "type": "scroll",
     },
     "series": [
@@ -1279,10 +1279,10 @@ exports[`buildChartOption — coverage of all 15 types > snapshot of every type'
       "top": 24,
     },
     "legend": {
-      "bottom": 0,
       "textStyle": {
         "color": "#0f172a",
       },
+      "top": 0,
       "type": "scroll",
     },
     "series": [
@@ -1411,10 +1411,10 @@ exports[`buildChartOption — coverage of all 15 types > snapshot of every type'
       "top": 24,
     },
     "legend": {
-      "bottom": 0,
       "textStyle": {
         "color": "#0f172a",
       },
+      "top": 0,
       "type": "scroll",
     },
     "series": [
@@ -1737,10 +1737,10 @@ exports[`buildChartOption — coverage of all 15 types > snapshot of every type'
       "top": 24,
     },
     "legend": {
-      "bottom": 0,
       "textStyle": {
         "color": "#0f172a",
       },
+      "top": 0,
       "type": "scroll",
     },
     "series": [

--- a/saiku-ui/src/lib/charts/build.test.ts
+++ b/saiku-ui/src/lib/charts/build.test.ts
@@ -226,13 +226,33 @@ describe("buildChartOption — title & legend", () => {
     expect((opt.legend as { bottom: number }).bottom).toBe(10);
   });
 
-  test("compact ignores legendPosition and pins a bottom scroll legend", () => {
-    const opt = buildChartOption(sample(), "bar", opts({ legendPosition: "left" }), undefined, {
+  test("compact legend defaults to a bottom scroll legend (legacy-tile parity)", () => {
+    const opt = buildChartOption(sample(), "bar", opts({ legendPosition: "bottom" }), undefined, {
       compact: true,
     }) as Record<string, unknown>;
     const legend = opt.legend as { type: string; bottom: number };
     expect(legend.type).toBe("scroll");
     expect(legend.bottom).toBe(0);
+  });
+
+  test("compact legend now honors legendPosition (#1077) while staying a scroll legend", () => {
+    const top = buildChartOption(sample(), "bar", opts({ legendPosition: "top" }), undefined, {
+      compact: true,
+    }) as Record<string, unknown>;
+    expect((top.legend as { type: string; top: number }).type).toBe("scroll");
+    expect((top.legend as { top: number }).top).toBe(0);
+    const left = buildChartOption(sample(), "bar", opts({ legendPosition: "left" }), undefined, {
+      compact: true,
+    }) as Record<string, unknown>;
+    expect((left.legend as { left: number; orient: string }).left).toBe(0);
+    expect((left.legend as { orient: string }).orient).toBe("vertical");
+  });
+
+  test("compact legend hidden when showLegend is false", () => {
+    const opt = buildChartOption(sample(), "bar", opts({ showLegend: false }), undefined, {
+      compact: true,
+    }) as Record<string, unknown>;
+    expect((opt.legend as { show: boolean }).show).toBe(false);
   });
 
   test("compact pie merges no overall title — just per-measure cell titles", () => {

--- a/saiku-ui/src/lib/charts/build.ts
+++ b/saiku-ui/src/lib/charts/build.ts
@@ -74,6 +74,29 @@ function legendConfig(o: ChartOptions, tk: ThemeTokens): Record<string, unknown>
   return position;
 }
 
+/** Compact (dashboard-tile) legend: always a scroll legend (tiles are small,
+ *  so many series must scroll), positioned by `legendPosition`. The default
+ *  ("bottom") yields `{type:"scroll", bottom:0}` — exactly the pre-#1077 tile
+ *  legend — so legacy tiles are unchanged; the chart-tile editor (#1077) can
+ *  now move it. `showLegend:false` hides it. */
+function compactLegend(o: ChartOptions, tk: ThemeTokens): Record<string, unknown> {
+  if (!o.showLegend) return { show: false };
+  const base: Record<string, unknown> = { type: "scroll", textStyle: { color: tk.fg } };
+  if (o.legendPosition === "top") base.top = 0;
+  else if (o.legendPosition === "left") {
+    base.left = 0;
+    base.top = "middle";
+    base.orient = "vertical";
+  } else if (o.legendPosition === "right") {
+    base.right = 0;
+    base.top = "middle";
+    base.orient = "vertical";
+  } else {
+    base.bottom = 0; // "bottom" / default
+  }
+  return base;
+}
+
 function titleConfig(o: ChartOptions, tk: ThemeTokens): Record<string, unknown> | undefined {
   if (!o.title) return undefined;
   return { text: o.title, left: "center", textStyle: { color: tk.fg } };
@@ -379,11 +402,7 @@ export function buildChartOption(
   const catLabelWidth = compact ? 100 : deriveAxisLabelWidth(geom.chartWidth ?? 0, catCount);
   const catLabel = (rotate = 0) => ({ color: tk.fgMuted, rotate, ...axisLabelConfig(catLabelWidth) });
 
-  const legend = compact
-    ? o.showLegend
-      ? { type: "scroll", bottom: 0, textStyle: { color: tk.fg } }
-      : { show: false }
-    : legendConfig(o, tk);
+  const legend = compact ? compactLegend(o, tk) : legendConfig(o, tk);
   const title = titleConfig(o, tk);
   const xName = o.xAxisLabel || undefined;
   const yName = o.yAxisLabel || undefined;

--- a/saiku-ui/src/lib/dashboard/chartOptions.test.ts
+++ b/saiku-ui/src/lib/dashboard/chartOptions.test.ts
@@ -5,6 +5,7 @@
 
 import { describe, test, expect } from "vitest";
 import { buildChartOption, isSupportedChartKind } from "$lib/dashboard/chartOptions";
+import { DEFAULT_CHART_OPTIONS } from "$lib/views/chartTypes";
 import type { AiQueryResponse } from "$lib/api/aiQuery";
 
 function sampleResponse(): AiQueryResponse {
@@ -239,6 +240,41 @@ describe("buildChartOption — theme tokens (#1050 repaint)", () => {
     // deterministic token set with no DOM.
     expect((opt.textStyle as { color: string }).color).toBe("#0f172a");
     expect(opt.backgroundColor).toBe("transparent");
+  });
+});
+
+describe("buildChartOption — per-tile options (#1077)", () => {
+  test("omitting options keeps the legacy baseline (single y-axis, bottom legend)", () => {
+    const opt = buildChartOption(sampleResponse(), "bar") as Record<string, unknown>;
+    // Baseline dualAxis=false → single y-axis object (not an array).
+    expect(Array.isArray(opt.yAxis)).toBe(false);
+    const legend = opt.legend as { type: string; bottom: number };
+    expect(legend.type).toBe("scroll");
+    expect(legend.bottom).toBe(0);
+  });
+
+  test("passing options enables tile dual-axis + a user title", () => {
+    const options = {
+      ...DEFAULT_CHART_OPTIONS,
+      title: "My tile",
+      dualAxis: true,
+      seriesAxis: { "Unit Sales": "right" as const },
+    };
+    const opt = buildChartOption(sampleResponse(), "bar", 1, undefined, options) as Record<string, unknown>;
+    expect(Array.isArray(opt.yAxis)).toBe(true);
+    const series = opt.series as Array<{ name: string; yAxisIndex: number }>;
+    expect(series.find((s) => s.name === "Unit Sales")?.yAxisIndex).toBe(1);
+    // Cartesian (non-pie) chart → single title object carrying the user title.
+    expect((opt.title as { text: string }).text).toBe("My tile");
+  });
+
+  test("passing options with a trend line adds a trend series on a line tile", () => {
+    const options = { ...DEFAULT_CHART_OPTIONS, dualAxis: false, trendLine: "linear" as const };
+    const opt = buildChartOption(sampleResponse(), "line", 1, undefined, options) as Record<string, unknown>;
+    const series = opt.series as Array<{ name: string }>;
+    // 2 measure series + 1 trend on the first measure.
+    expect(series.length).toBe(3);
+    expect(series[series.length - 1].name).toContain("(trend)");
   });
 });
 

--- a/saiku-ui/src/lib/dashboard/chartOptions.ts
+++ b/saiku-ui/src/lib/dashboard/chartOptions.ts
@@ -31,14 +31,18 @@ export type { ChartType as ChartKind } from "$lib/views/chartTypes";
 export const isSupportedChartKind = isChartType;
 
 /** Dashboard baseline chart options — reproduces the pre-#1076 tile look:
- *  single y-axis, no trend line, no overall title, bottom scroll legend. The
- *  chart-tile editor (#1077) will override these per tile. */
+ *  single y-axis, no trend line, no overall title, bottom scroll legend. Used
+ *  for legacy tiles that have no per-tile {@link ChartOptions}; the chart-tile
+ *  editor (#1077) overrides these per tile via the `options` arg below. */
 const DASHBOARD_BASELINE: ChartOptions = {
   ...DEFAULT_CHART_OPTIONS,
   title: "",
   trendLine: "none",
   dualAxis: false,
   hideRollupRows: false,
+  // Tiles render the legend at the bottom (the compact builder keeps it a
+  // scroll legend); baseline must say "bottom" so legacy tiles are unchanged.
+  legendPosition: "bottom",
 };
 
 function isAiCell(v: unknown): v is AiCell {
@@ -84,17 +88,21 @@ export function projectFromAiQueryResponse(response: AiQueryResponse): ChartProj
  *
  * `aspect` (canvas w/h) keeps small-multiple radii on-screen-constant; `tk`
  * carries the active theme tokens (chartTheme.ts) so tiles repaint on a
- * light/dark/system flip. Both default to keep the pure callers (tests)
- * DOM-free and structurally unchanged.
+ * light/dark/system flip. `options` are the per-tile {@link ChartOptions} set
+ * via the chart-tile editor (#1077); when omitted, the dashboard baseline is
+ * used so legacy tiles render exactly as before. All default to keep the pure
+ * callers (tests) DOM-free and structurally unchanged.
  */
 export function buildChartOption(
   response: AiQueryResponse,
   kind: string,
   aspect = 1,
   tk: ThemeTokens = DEFAULT_THEME_TOKENS,
+  options?: ChartOptions,
 ): Record<string, unknown> | null {
   if (!isChartType(kind)) return null;
   const projection = projectFromAiQueryResponse(response);
   if (projection.matrix.length === 0) return null;
-  return buildSharedChartOption(projection, kind, DASHBOARD_BASELINE, tk, { aspect, compact: true });
+  const effective = options ?? DASHBOARD_BASELINE;
+  return buildSharedChartOption(projection, kind, effective, tk, { aspect, compact: true });
 }

--- a/saiku-ui/src/lib/views/dashboard/TileEditorModal.svelte
+++ b/saiku-ui/src/lib/views/dashboard/TileEditorModal.svelte
@@ -39,7 +39,9 @@
   } from "$lib/api/dashboards";
   import { flatten, listRepository, type RepositoryNode } from "$lib/api/repository";
   import { repositionTile } from "$lib/dashboard/tilePlacement";
-  import { CHART_TYPES } from "$lib/views/chartTypes";
+  import { CHART_TYPES, DEFAULT_CHART_OPTIONS, type ChartOptions } from "$lib/views/chartTypes";
+  // #1077: reuse the workspace chart-options editor for dashboard chart tiles.
+  import ChartEditorModal from "$lib/modals/ChartEditorModal.svelte";
   // ── Issue #912: inline visual query editor (embedded QueryCanvas) ──
   import QueryCanvas from "$lib/views/QueryCanvas.svelte";
   import DimensionList from "$lib/views/DimensionList.svelte";
@@ -72,6 +74,16 @@
   let title = $state(untrack(() => tile.title ?? ""));
   let cube = $state<CubeRef | null>(untrack(() => tile.cube ?? null));
   let chartType = $state(untrack(() => tile.chartType ?? "bar"));
+  // #1077: per-tile chart options (title/axes/legend/dualAxis/seriesAxis/trend).
+  // Working copy seeded from the tile (or defaults). Only persisted if the user
+  // actually opens + saves the chart-options editor (chartOptionsTouched) — so
+  // editing a legacy chart tile's title alone never stamps default options onto
+  // it (which would change its appearance).
+  let chartOptions = $state<ChartOptions>(
+    untrack(() => ({ ...DEFAULT_CHART_OPTIONS, ...(tile.chartOptions ?? {}) })),
+  );
+  let chartOptionsTouched = $state(false);
+  let chartOptionsOpen = $state(false);
   let text = $state(untrack(() => tile.text ?? ""));
   // Position + size — numeric controls per the design's "no drag-resize"
   // call. Users rearrange via these fields; the grid auto-places tiles
@@ -419,6 +431,21 @@
     return [];
   });
 
+  // #1077: measure names for the chart-options editor's per-series axis picker.
+  // Only inline tiles expose their measures statically; reference tiles resolve
+  // at fetch time, so the picker hides (empty → ChartEditorModal omits it).
+  let chartSeriesNames = $derived(() => {
+    if (queryMode !== "inline") return [] as string[];
+    try {
+      const b = JSON.parse(inlineBodyJson) as { measures?: Array<{ name?: string }> };
+      return Array.isArray(b?.measures)
+        ? b.measures.map((m) => m?.name).filter((n): n is string => !!n)
+        : [];
+    } catch {
+      return [];
+    }
+  });
+
   function cubeKey(c: CubeRef): string {
     return `${c.connectionName}/${c.catalog}/${c.schema}/${c.cubeName}`;
   }
@@ -533,6 +560,12 @@
 
     if (tile.type === "chart") {
       patch.chartType = chartType;
+      // #1077: only persist chart options if the user actually edited them, so
+      // saving an untouched legacy chart tile preserves its existing options
+      // (and look) rather than stamping defaults onto it.
+      if (chartOptionsTouched) {
+        patch.chartOptions = chartOptions;
+      }
     }
 
     if (tile.type === "chart" || tile.type === "table") {
@@ -818,6 +851,16 @@
             {/each}
           </select>
         </label>
+        <!-- #1077: per-tile chart options via the reused workspace editor. -->
+        <div class="field">
+          <span>Chart options</span>
+          <button type="button" class="btn chart-opts-btn" onclick={() => (chartOptionsOpen = true)}>
+            Title, axes, legend, dual-axis &amp; trend…
+          </button>
+          <span class="hint">
+            {chartOptionsTouched ? "Customised for this tile." : "Using dashboard defaults."}
+          </span>
+        </div>
       {/if}
 
       {#if tile.type === "chart" || tile.type === "table"}
@@ -1331,6 +1374,23 @@
   </div>
 </div>
 
+<!-- #1077: chart-options editor (reused from the workspace), layered above the
+     tile editor. Edits a working copy; persisted with the tile on Save. -->
+{#if tile.type === "chart"}
+  <ChartEditorModal
+    initial={chartOptions}
+    {chartType}
+    seriesNames={chartSeriesNames()}
+    open={chartOptionsOpen}
+    onSave={(next) => {
+      chartOptions = next;
+      chartOptionsTouched = true;
+      chartOptionsOpen = false;
+    }}
+    onCancel={() => (chartOptionsOpen = false)}
+  />
+{/if}
+
 <style>
   .modal-backdrop {
     position: fixed;
@@ -1491,6 +1551,11 @@
     background: var(--accent);
     color: white;
     border-color: var(--accent);
+  }
+  /* #1077: chart-options launcher button. */
+  .chart-opts-btn {
+    align-self: flex-start;
+    text-align: left;
   }
   /* ── Issue #919: conditional-formatting rule editor (table only) ── */
   .cf-section {

--- a/saiku-ui/src/lib/views/dashboard/tiles/ChartTile.svelte
+++ b/saiku-ui/src/lib/views/dashboard/tiles/ChartTile.svelte
@@ -299,6 +299,8 @@
     const r = response;
     const kind = tile.chartType ?? "bar";
     void r;
+    // Re-render when the per-tile chart options change (editor save) (#1077).
+    void tile.chartOptions;
     // Re-run when the canvas resizes so the small-multiple radius tracks the
     // current aspect ratio (#1053).
     void resizeTick;
@@ -329,7 +331,9 @@
       return;
     }
     const aspect = host && host.clientHeight > 0 ? host.clientWidth / host.clientHeight : 1;
-    const option = buildChartOption(r, kind, aspect, resolveThemeTokens());
+    // #1077: per-tile chart options (title/axes/legend/dualAxis/trend). Undefined
+    // on legacy tiles → the adapter falls back to the dashboard baseline.
+    const option = buildChartOption(r, kind, aspect, resolveThemeTokens(), tile.chartOptions);
     if (option) {
       // #1092: capture the live zoom/brush before overwriting; only re-applied
       // when the chart type + category count are unchanged (resize / theme flip


### PR DESCRIPTION
## Summary
Chart tiles on a dashboard were locked to the dashboard baseline appearance — no way to set a per-tile title, move the legend, enable a dual/second axis, route a series to the right axis, or add a trend line. This wires the existing **workspace** chart-options editor (`ChartEditorModal`) into the **dashboard** tile editor so each chart tile carries its own `chartOptions`.

## The change
- **`DashboardTile.chartOptions`** (TS only, optional). **No Java model change** — #1179 now persists the raw dashboard JSON, so per-tile fields survive save/reload through the generic path. (This is why the original paused branch's `ChartOptions.java`/`DashboardTile.java` workaround was dropped.)
- **`chartOptions.ts` adapter** — `buildChartOption(…, options?)` takes optional per-tile options; absent (legacy tiles) → falls back to `DASHBOARD_BASELINE`, so existing tiles render exactly as before. Baseline pins `legendPosition: "bottom"`.
- **`build.ts` compact legend** — a new `compactLegend()` helper now **honors `legendPosition`** (still a scroll legend, since tiles are small); the default `"bottom"` reproduces the pre-#1077 tile legend byte-for-byte.
- **`TileEditorModal.svelte`** — launches `ChartEditorModal` on a working copy; options persist **only when actually edited** (`chartOptionsTouched`), so saving an untouched legacy tile never stamps defaults onto it. Passes `chartType` through so the #1071 map controls appear for map tiles, and derives inline measure names for the per-series axis picker.
- **`ChartTile.svelte`** — passes `tile.chartOptions` to the adapter and re-renders when it changes.

## Verified
- `npm run check` — 0 errors / 0 warnings
- `npm test` (vitest) — **789 passing** (3 new compact-legend tests + per-tile-options test; all-types compact snapshot refreshed to reflect honored `legendPosition`)
- `npm run build` — clean
- Built the 4.4.0 launcher (incl. #1179) and tested end-to-end against live FoodMart.

## Test plan
1. Open a dashboard with a chart tile (cube **Sales**, measures **Store Sales + Unit Sales**, rows **Product → Products → Product Family**).
2. Edit the tile → **Chart options** → set title, move legend to top, enable dual-axis, add a linear trend → Save.
3. Tile re-renders with all of the above; a sibling single-measure tile is unchanged.
4. Save the dashboard, **reload** → customizations persist (legacy tile still untouched).
5. Editing only the title of an untouched legacy tile does not stamp default options on it.

## Notes
- Migration-safe: legacy tiles (no `chartOptions`) are visually identical to before.
- Builds on #1179 (raw-JSON dashboard persistence). UI-only diff; no backend change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)