### PR TITLE
fix(dashboard): resolve real member on chart/table click-to-filter (closes #1166)

### DIFF
--- a/saiku-ui/src/lib/api/aiQuery.ts
+++ b/saiku-ui/src/lib/api/aiQuery.ts
@@ -105,6 +105,48 @@ export function isAiCell(v: unknown): v is AiCell {
   return typeof v === "object" && v !== null && "formatted" in (v as object);
 }
 
+/* ------------------------- member search (#1166) ------------------------- */
+
+/** One hit from GET /ai/members/search — a real cube member. `uniqueName`
+ *  is the server's own MDX unique name (canonical, or display-aliased
+ *  exactly as the server emits it) so it round-trips back into /ai/query
+ *  filters without us ever hand-assembling a `[dim].[hier].[member]` string. */
+export interface AiMemberHit {
+  uniqueName: string;
+  caption: string;
+  name?: string;
+}
+
+/** GET /rest/saiku/api/ai/members/search — discover real members of a level.
+ *  `dimension` + `level` are required server-side; `hierarchy` may be blank.
+ *  `q` is a case-insensitive substring match on the caption. Resolves to an
+ *  empty list on any non-OK / transport / parse failure so callers can treat
+ *  "couldn't resolve" as "no members" rather than throwing. */
+export async function searchMembers(
+  cube: { connectionName: string; catalog: string; schema: string; cubeName: string },
+  dimension: string,
+  hierarchy: string,
+  level: string,
+  q: string,
+  limit = 100,
+): Promise<AiMemberHit[]> {
+  const cubeId = `${cube.connectionName}/${cube.catalog}/${cube.schema}/${cube.cubeName}`;
+  const params = new URLSearchParams({ cubeId, dimension, level, limit: String(limit) });
+  if (hierarchy) params.set("hierarchy", hierarchy);
+  if (q) params.set("q", q);
+  try {
+    const res = await fetch(`${REST_BASE}/members/search?${params.toString()}`, {
+      credentials: "include",
+      headers: { Accept: "application/json" },
+    });
+    if (!res.ok) return [];
+    const hits: unknown = await res.json();
+    return Array.isArray(hits) ? (hits as AiMemberHit[]) : [];
+  } catch {
+    return [];
+  }
+}
+
 /* ------------------------- share view (#941 PR2) ------------------------- */
 
 /** Base for the account-free guest view surface. The token is carried in the

--- a/saiku-ui/src/lib/dashboard/clickFilterMember.test.ts
+++ b/saiku-ui/src/lib/dashboard/clickFilterMember.test.ts
@@ -1,0 +1,126 @@
+import { describe, it, expect } from "vitest";
+import {
+  leafSegment,
+  pickMemberUniqueName,
+  pickMemberUniqueNameForPath,
+} from "./clickFilterMember";
+
+describe("leafSegment", () => {
+  it("returns the last bracketed segment unwrapped", () => {
+    expect(leafSegment("[Product].[Drink].[Beer]")).toBe("Beer");
+    expect(leafSegment("[Time].[Time].[Year].&[1997]")).toBe("1997");
+  });
+
+  it("handles a single segment", () => {
+    expect(leafSegment("[All Products]")).toBe("All Products");
+  });
+
+  it("returns empty string when there is no bracketed tail", () => {
+    expect(leafSegment("Beer")).toBe("");
+    expect(leafSegment("")).toBe("");
+  });
+
+  it("preserves spaces / dots inside a segment", () => {
+    expect(leafSegment("[Store].[Store City].[San Francisco]")).toBe("San Francisco");
+  });
+});
+
+describe("pickMemberUniqueName", () => {
+  const hits = [
+    { uniqueName: "[Product].[Drink].[Beverages].[Pure Juice]", caption: "Pure Juice" },
+    { uniqueName: "[Product].[Drink].[Alcoholic Beverages].[Beer]", caption: "Beer" },
+    { uniqueName: "[Product].[Drink].[Alcoholic Beverages].[Root Beer]", caption: "Root Beer" },
+  ];
+
+  it("returns the unique name for an exact caption match", () => {
+    expect(pickMemberUniqueName(hits, "Beer")).toBe(
+      "[Product].[Drink].[Alcoholic Beverages].[Beer]",
+    );
+  });
+
+  it("prefers the exact caption over a leaf-segment collision", () => {
+    // "Root Beer"'s leaf is "Root Beer", but a click on "Beer" must not
+    // resolve to it — the exact-caption "Beer" hit wins.
+    expect(pickMemberUniqueName(hits, "Beer")).toContain(".[Beer]");
+    expect(pickMemberUniqueName(hits, "Beer")).not.toContain("Root Beer");
+  });
+
+  it("matches case-insensitively and trims/collapses whitespace", () => {
+    expect(pickMemberUniqueName(hits, "  beer ")).toBe(
+      "[Product].[Drink].[Alcoholic Beverages].[Beer]",
+    );
+    expect(pickMemberUniqueName(hits, "ROOT   BEER")).toBe(
+      "[Product].[Drink].[Alcoholic Beverages].[Root Beer]",
+    );
+  });
+
+  it("falls back to the unique name's leaf segment when no caption matches", () => {
+    const noCaptions = [{ uniqueName: "[Product].[Drink].[Alcoholic Beverages].[Beer]", caption: "" }];
+    expect(pickMemberUniqueName(noCaptions, "Beer")).toBe(
+      "[Product].[Drink].[Alcoholic Beverages].[Beer]",
+    );
+  });
+
+  it("returns null when nothing matches", () => {
+    expect(pickMemberUniqueName(hits, "Wine")).toBeNull();
+    expect(pickMemberUniqueName([], "Beer")).toBeNull();
+  });
+
+  it("returns null for a blank caption", () => {
+    expect(pickMemberUniqueName(hits, "")).toBeNull();
+    expect(pickMemberUniqueName(hits, "   ")).toBeNull();
+  });
+
+  it("skips malformed hits without a unique name", () => {
+    const messy = [
+      { uniqueName: "", caption: "Beer" },
+      { uniqueName: "[Product].[Drink].[Alcoholic Beverages].[Beer]", caption: "Beer" },
+    ];
+    expect(pickMemberUniqueName(messy, "Beer")).toBe(
+      "[Product].[Drink].[Alcoholic Beverages].[Beer]",
+    );
+  });
+});
+
+describe("pickMemberUniqueNameForPath", () => {
+  // Two members share the leaf caption "Q2" — one under 1997, one under 1998.
+  const ambiguous = [
+    { uniqueName: "[Time].[Time].[1997].[Q2]", caption: "Q2" },
+    { uniqueName: "[Time].[Time].[1998].[Q2]", caption: "Q2" },
+  ];
+
+  it("disambiguates an ambiguous leaf by the parent caption path", () => {
+    expect(pickMemberUniqueNameForPath(ambiguous, ["1997", "Q2"])).toBe(
+      "[Time].[Time].[1997].[Q2]",
+    );
+    expect(pickMemberUniqueNameForPath(ambiguous, ["1998", "Q2"])).toBe(
+      "[Time].[Time].[1998].[Q2]",
+    );
+  });
+
+  it("returns the sole match when the leaf is unambiguous", () => {
+    const one = [{ uniqueName: "[Product].[Drink].[Alcoholic Beverages].[Beer]", caption: "Beer" }];
+    expect(pickMemberUniqueNameForPath(one, ["Drink", "Beer"])).toBe(
+      "[Product].[Drink].[Alcoholic Beverages].[Beer]",
+    );
+  });
+
+  it("falls back to the first candidate when parents don't pin one", () => {
+    // Parent "2099" matches neither → stable first candidate.
+    expect(pickMemberUniqueNameForPath(ambiguous, ["2099", "Q2"])).toBe(
+      "[Time].[Time].[1997].[Q2]",
+    );
+  });
+
+  it("returns null when nothing matches the leaf", () => {
+    expect(pickMemberUniqueNameForPath(ambiguous, ["1997", "Q3"])).toBeNull();
+    expect(pickMemberUniqueNameForPath([], ["Beer"])).toBeNull();
+    expect(pickMemberUniqueNameForPath(ambiguous, [])).toBeNull();
+  });
+
+  it("matches case-insensitively on both leaf and parents", () => {
+    expect(pickMemberUniqueNameForPath(ambiguous, ["1998", "q2"])).toBe(
+      "[Time].[Time].[1998].[Q2]",
+    );
+  });
+});

--- a/saiku-ui/src/lib/dashboard/clickFilterMember.ts
+++ b/saiku-ui/src/lib/dashboard/clickFilterMember.ts
@@ -1,0 +1,111 @@
+/*
+ * Pure member-resolution helpers for chart click-to-filter (issue #1166).
+ *
+ * A chart category click gives us only the leaf *caption* the user clicked
+ * (e.g. "Beer") plus the tile's row axis (dimension / hierarchy / level).
+ * The dashboard filter contract, however, wants a real MDX *unique name*
+ * (e.g. "[Product].[Product].[Drink].[Alcoholic Beverages].[Beer]") — the
+ * server rejects a bare caption ("Beer" doesn't match the bracketed-ref
+ * regex) and can't hand-resolve it. Worse, we can't reliably rebuild the
+ * unique name on the client: it embeds the member's *ancestors* (which a
+ * single-level chart category doesn't carry) and the tile may store display
+ * aliases for the dim/hier that aren't the canonical MDX names.
+ *
+ * So instead of assembling a name, we ask the server for the level's real
+ * members (GET /ai/members/search) and pick the one whose caption matches
+ * the click — its `uniqueName` is the server's own, guaranteed to round-trip
+ * back into an /ai/query filter. This module owns only the pure matching so
+ * it's unit-testable; the fetch + caching live in the tile component.
+ */
+
+/** Minimal shape of a member-search hit this matcher needs. */
+export interface MemberHitLike {
+  uniqueName: string;
+  caption: string;
+}
+
+/** Normalise a caption for comparison: trimmed, case-folded, inner
+ *  whitespace collapsed (member captions occasionally arrive padded). */
+function norm(s: string): string {
+  return s.trim().replace(/\s+/g, " ").toLowerCase();
+}
+
+/** The trailing bracketed segment of an MDX unique name, unwrapped:
+ *  "[Product].[Drink].[Beer]" -> "Beer". Returns "" when there's no
+ *  bracketed tail (so it never accidentally matches a blank caption). */
+export function leafSegment(uniqueName: string): string {
+  const matches = uniqueName.match(/\[([^\]]*)\]/g);
+  if (!matches || matches.length === 0) return "";
+  const last = matches[matches.length - 1];
+  return last.slice(1, -1);
+}
+
+/**
+ * Pick the unique name of the member whose caption matches `caption`,
+ * preferring an exact (normalised) caption match and falling back to a
+ * match on the unique name's leaf segment. Returns null when nothing
+ * matches — the caller should then NOT emit a filter rather than push a
+ * member the server will reject (which would break every consuming tile).
+ *
+ * An exact caption match wins over a leaf match, and earlier hits win over
+ * later ones, so a substring search that returns both "Beer" and "Root
+ * Beer" resolves a "Beer" click to "Beer".
+ */
+export function pickMemberUniqueName(hits: MemberHitLike[], caption: string): string | null {
+  const target = norm(caption);
+  if (!target) return null;
+  let leafFallback: string | null = null;
+  for (const h of hits) {
+    if (!h || typeof h.uniqueName !== "string" || !h.uniqueName) continue;
+    if (typeof h.caption === "string" && norm(h.caption) === target) {
+      return h.uniqueName;
+    }
+    if (leafFallback === null && norm(leafSegment(h.uniqueName)) === target) {
+      leafFallback = h.uniqueName;
+    }
+  }
+  return leafFallback;
+}
+
+/** The (normalised) bracketed segments of a unique name:
+ *  "[Time].[Time].[Year].[Q2]" -> ["time","time","year","q2"]. */
+function segments(uniqueName: string): string[] {
+  return (uniqueName.match(/\[([^\]]*)\]/g) ?? []).map((s) => norm(s.slice(1, -1)));
+}
+
+/**
+ * Like {@link pickMemberUniqueName} but disambiguates an ambiguous leaf
+ * caption using the full ancestor caption path (last element = the clicked
+ * leaf). Tables carry the parent captions, so a "Q2" click can be pinned to
+ * "Q2 of 1997" rather than "Q2 of 1998" when both exist at the level:
+ *
+ *   - match candidates on the leaf caption (then leaf-segment fallback),
+ *   - if more than one and parent captions are known, prefer the candidate
+ *     whose unique name contains every parent caption as a segment,
+ *   - otherwise return the first candidate (stable).
+ *
+ * Returns null when nothing matches.
+ */
+export function pickMemberUniqueNameForPath(
+  hits: MemberHitLike[],
+  captionPath: string[],
+): string | null {
+  const leaf = captionPath.length ? captionPath[captionPath.length - 1] : "";
+  const target = norm(leaf);
+  if (!target) return null;
+  const valid = hits.filter((h) => h && typeof h.uniqueName === "string" && h.uniqueName);
+  let pool = valid.filter((h) => typeof h.caption === "string" && norm(h.caption) === target);
+  if (pool.length === 0) pool = valid.filter((h) => norm(leafSegment(h.uniqueName)) === target);
+  if (pool.length === 0) return null;
+  if (pool.length === 1) return pool[0].uniqueName;
+
+  const parents = captionPath.slice(0, -1).map(norm).filter(Boolean);
+  if (parents.length) {
+    const disambiguated = pool.find((h) => {
+      const segs = segments(h.uniqueName);
+      return parents.every((p) => segs.includes(p));
+    });
+    if (disambiguated) return disambiguated.uniqueName;
+  }
+  return pool[0].uniqueName;
+}

--- a/saiku-ui/src/lib/views/dashboard/tiles/ChartTile.svelte
+++ b/saiku-ui/src/lib/views/dashboard/tiles/ChartTile.svelte
@@ -17,8 +17,11 @@
   import {
     executeAiQuery,
     executeSavedQuery,
+    searchMembers,
     type AiQueryResponse,
   } from "$lib/api/aiQuery";
+  // #1166: resolve a clicked category caption to a real member unique name.
+  import { pickMemberUniqueName } from "$lib/dashboard/clickFilterMember";
   import { activeFilters } from "$lib/stores/activeFilters.svelte";
   import { schemaCache } from "$lib/stores/schemaCache.svelte";
   import {
@@ -386,6 +389,10 @@
 
   /* ----------------------------- click capture ------------------------ */
 
+  // #1166: per-(cube/dim/hier/level) cache of the level's members so a
+  // repeated click on the same chart doesn't re-hit /ai/members/search.
+  const clickMemberCache = new Map<string, Promise<{ uniqueName: string; caption: string }[]>>();
+
   function handleEChartsClick(params: echarts.ECElementEvent): void {
     if (!onClickFilter) return;
     if (!tile.query) return;
@@ -408,17 +415,39 @@
 
     // ECharts click events carry different shapes per series type. For
     // bar/line/area: params.name is the category. For pie: params.name
-    // is the slice name. In both cases that's the dashboard.click
-    // "member" value.
+    // is the slice name. In both cases that's the clicked member's caption.
     const name = typeof params.name === "string" ? params.name : null;
     if (!name) return;
-    const filter: DashboardFilter = {
-      dimension: rowAxis.dimension,
-      hierarchy: rowAxis.hierarchy,
-      level: rowAxis.level,
-      members: [name],
-    };
-    onClickFilter(filter);
+
+    const cube = resolvedCube;
+    if (!cube) return;
+
+    // #1166: the click gives us a caption ("Beer") but the filter contract
+    // needs a real MDX unique name. Hand-building "[dim].[hier].[caption]"
+    // is wrong — it omits ancestor segments and may use display aliases the
+    // cube doesn't know — so ask the server for the level's members and pick
+    // the one whose caption matches. Its uniqueName is the server's own, so
+    // it round-trips back into /ai/query. If we can't resolve it, no-op
+    // rather than push a member every consuming tile would choke on.
+    const { dimension, hierarchy, level } = rowAxis;
+    const cacheKey = `${cube.connectionName}/${cube.catalog}/${cube.schema}/${cube.cubeName}|${dimension}/${hierarchy}/${level}|${name}`;
+    let lookup = clickMemberCache.get(cacheKey);
+    if (!lookup) {
+      lookup = searchMembers(cube, dimension, hierarchy, level, name);
+      clickMemberCache.set(cacheKey, lookup);
+    }
+    void lookup.then((hits) => {
+      const uniqueName = pickMemberUniqueName(hits, name);
+      if (!uniqueName) {
+        clickMemberCache.delete(cacheKey); // don't cache a miss — allow a retry
+        console.warn(
+          `[saiku] click-to-filter: no member matched caption "${name}" in ${dimension}/${level}`,
+        );
+        return;
+      }
+      const filter: DashboardFilter = { dimension, hierarchy, level, members: [uniqueName] };
+      onClickFilter(filter);
+    });
   }
 
   /* --------------------------- drillthrough (#930) -------------------- */

--- a/saiku-ui/src/lib/views/dashboard/tiles/TableTile.svelte
+++ b/saiku-ui/src/lib/views/dashboard/tiles/TableTile.svelte
@@ -22,9 +22,12 @@
     executeAiQuery,
     executeSavedQuery,
     isAiCell,
+    searchMembers,
     type AiQueryResponse,
     type AiCell,
   } from "$lib/api/aiQuery";
+  // #1166: resolve clicked row-header captions to real member unique names.
+  import { pickMemberUniqueNameForPath } from "$lib/dashboard/clickFilterMember";
   import { activeFilters } from "$lib/stores/activeFilters.svelte";
   import { schemaCache } from "$lib/stores/schemaCache.svelte";
   import {
@@ -306,21 +309,27 @@
     return formatCell(rules, column, cellNumericSource(v), columnValues[column] ?? []);
   }
 
-  /** Build the click-filter context for a row-header cell. The dashboard
-   *  level for the click is inferred from the tile's base query — we
-   *  match the column caption against the row-axis level captions —
-   *  and the member ref is constructed as a full MDX unique name from
-   *  the row's parent-level captions so Mondrian can resolve an
-   *  ambiguous leaf (e.g. Quarter "Q2" which exists under every Year).
+  // #1166: per-(cube/dim/hier/level/q) cache of the level's members so a
+  // repeated click on the same column doesn't re-hit /ai/members/search.
+  const clickMemberCache = new Map<string, Promise<{ uniqueName: string; caption: string }[]>>();
+
+  /** Resolve the click-filter context for a row-header cell. The dashboard
+   *  level for the click is inferred from the tile's base query — we match
+   *  the column caption against the row-axis level captions — and we collect
+   *  the row's parent-level captions as the ancestor path so an ambiguous
+   *  leaf (e.g. Quarter "Q2", which exists under every Year) can be pinned
+   *  to the right member.
    *
-   *  Without the parent path, the server-side resolver fails with
-   *  "Unable to find a member with name [Q2]" because Q2 of 1997 and
-   *  Q2 of 1998 collide. */
-  function clickFilterForCell(
+   *  #1166: we no longer hand-assemble the member unique name here. The
+   *  tile's stored dim/hier may be display aliases (e.g. hierarchy "Products"
+   *  where the cube's real hierarchy is "Product"), so a constructed
+   *  "[Product].[Products].[Beer]" fails on the server with "Unable to find
+   *  a member". Instead the caller asks the server for the level's real
+   *  members and matches this caption path against them. */
+  function clickFilterContext(
     column: string,
-    cellValue: string,
     rowData: Record<string, AiCell | string>,
-  ): DashboardFilter | null {
+  ): { dimension: string; hierarchy: string; level: string; captionPath: string[] } | null {
     if (!tile.query) return null;
     let rows: Array<{ dimension: string; hierarchy: string; level: string }> | null = null;
     if (tile.query.kind === "inline") {
@@ -336,31 +345,19 @@
     if (matchIdx === -1) return null;
     const match = rows[matchIdx];
 
-    // Walk the row axes from coarsest to finest, collecting captions
-    // for every level that sits in the same dim+hier as the clicked
-    // column up to and including the clicked level. Those captions
-    // become the dotted path in the constructed unique name.
-    const pathSegments: string[] = [];
+    // Walk the row axes from coarsest to finest, collecting captions for
+    // every level in the same dim+hier up to and including the clicked one.
+    const captionPath: string[] = [];
     for (let i = 0; i <= matchIdx; i++) {
       const ax = rows[i];
       if (ax.dimension !== match.dimension || ax.hierarchy !== match.hierarchy) continue;
       const cell = rowData[ax.level];
       const cap = typeof cell === "string" ? cell : (cell?.formatted ?? "");
       if (!cap) return null;
-      pathSegments.push(cap);
+      captionPath.push(cap);
     }
-    // Mondrian unique-name format: [<dim>].[<hier>].[v1].[v2]…[vk].
-    // Captions wrapped in brackets verbatim; Saiku's existing schemas
-    // use bracket-quoted segments so spaces / dots are tolerated.
-    const uniqueName = `[${match.dimension}].[${match.hierarchy}].${pathSegments
-      .map((s) => `[${s}]`)
-      .join(".")}`;
-    return {
-      dimension: match.dimension,
-      hierarchy: match.hierarchy,
-      level: match.level,
-      members: [uniqueName],
-    };
+    if (captionPath.length === 0) return null;
+    return { dimension: match.dimension, hierarchy: match.hierarchy, level: match.level, captionPath };
   }
 
   function handleCellClick(
@@ -369,10 +366,32 @@
     isRowHeader: boolean,
     rowData: Record<string, AiCell | string>,
   ): void {
-    if (!isRowHeader) return;
-    const filter = clickFilterForCell(column, cellValue, rowData);
-    if (!filter) return;
-    onClickFilter?.(filter);
+    if (!isRowHeader || !onClickFilter) return;
+    const ctx = clickFilterContext(column, rowData);
+    if (!ctx) return;
+    const cube = resolvedCube;
+    if (!cube) return;
+
+    const { dimension, hierarchy, level, captionPath } = ctx;
+    const leaf = captionPath[captionPath.length - 1];
+    const cacheKey = `${cube.connectionName}/${cube.catalog}/${cube.schema}/${cube.cubeName}|${dimension}/${hierarchy}/${level}|${leaf}`;
+    let lookup = clickMemberCache.get(cacheKey);
+    if (!lookup) {
+      lookup = searchMembers(cube, dimension, hierarchy, level, leaf);
+      clickMemberCache.set(cacheKey, lookup);
+    }
+    void lookup.then((hits) => {
+      const uniqueName = pickMemberUniqueNameForPath(hits, captionPath);
+      if (!uniqueName) {
+        clickMemberCache.delete(cacheKey); // don't cache a miss — allow a retry
+        console.warn(
+          `[saiku] click-to-filter: no member matched "${captionPath.join(" › ")}" in ${dimension}/${level}`,
+        );
+        return;
+      }
+      const filter: DashboardFilter = { dimension, hierarchy, level, members: [uniqueName] };
+      onClickFilter?.(filter);
+    });
   }
 
   function renderCell(v: AiCell | string): string {


### PR DESCRIPTION
## Summary
Fixes **dashboard click-to-filter** (#1166). Clicking a **chart** category or a **table** row-header pushed a filter member the OLAP server couldn't resolve — `OlapException: Unable to find a member with name [[Product], [Products], [Beer]]` — which put **every consuming tile** into an error state, making cross-filtering unusable (notably on Product charts/tables).

## Root cause
The tiles produced a member the server rejects:
- **ChartTile** emitted the **bare caption** (`members: ["Beer"]`) — fails the server's bracketed-unique-name validation outright.
- **TableTile** (and the old chart code) **hand-built** `[${dimension}].[${hierarchy}].[${caption}]`. The tile's stored dim/hierarchy can be **display aliases** (e.g. hierarchy `"Products"` where the cube's real MDX hierarchy is `"Product"`), and a single-level category lacks the member's **ancestor** segments — so the assembled name (`[Product].[Products].[Beer]`) never resolves in Mondrian.

## The fix — resolve a real member, don't assemble one
On click, both tiles now ask the server for the level's **actual** members via `GET /ai/members/search` and emit the matching member's **server-provided `uniqueName`**, which is guaranteed to round-trip back into `/ai/query`. We never hand-assemble a member name again.

- **`api/aiQuery.ts`** — typed `searchMembers(cube, dim, hier, level, q, limit)` client (fails safe to `[]` on any non-OK/transport/parse error).
- **`dashboard/clickFilterMember.ts`** *(new, pure, 16 unit tests)* — `pickMemberUniqueName` (chart: exact caption match → leaf-segment fallback) and `pickMemberUniqueNameForPath` (table: disambiguates an ambiguous leaf — e.g. "Q2" under 1997 vs 1998 — using the full row caption path). Case/whitespace-insensitive.
- **`ChartTile.svelte` / `TableTile.svelte`** — async-resolve the click, emit the resolved member, with a per-tile member cache. An **unresolvable click no-ops** (+ one `console.warn`) instead of poisoning every tile with a bad member.

## Verified
- `npm run check` **0/0** · `npm test` **821** (incl. 16 new `clickFilterMember` tests) · production build ✓.
- Rebased clean onto current `origin/development`.
- **User-verified locally**: clicking a Product **table** row-header and a Product **chart** bar now cross-filters every tile correctly with no error; deeper/ambiguous levels resolve; Reset filters / chip ✕ clears.

## Security review (deep — done pre-PR; OG still owns the merge gate)
Independent adversarial review + manual checks → **CLEAN**:
- **Injection:** net **improvement** — emitted member is now 100% server-provenance; the clicked caption is only a search `q` param + client-side compare key, never re-emitted into a filter. Both hand-built-name interpolations are deleted.
- **URL/param:** `URLSearchParams` percent-encodes all parts; the packed `cubeId` is a single value (no `&`/`=` smuggling); fixed same-origin relative path → no SSRF; `credentials:"include"` matches the existing `/ai/*` calls.
- **ReDoS:** both regexes (`/\[([^\]]*)\]/g`, `/\s+/g`) are linear; loops bounded by `limit=100`.
- **XSS:** no new sink (filter chip uses auto-escaped interpolation; `console.warn` is not a DOM sink).
- **Share/guest:** fails closed twice — `onClickFilter` is `undefined` when `readOnly`, **and** `/rest/saiku/api/ai/members/search` is `isFullyAuthenticated()` (guests scoped to `/share/view/**` only) → guest 403 → `[]` → no-op.
- **Cache:** per-component-instance Map keyed by cube+dim+hier+level+caption; no cross-tile poisoning; never leaves an unhandled rejection.

## Notes
- Reuses the **existing** `/ai/members/search` endpoint (already shipped + gated for KpiTile) — **no backend change**.
- Minor documented behaviour: if an ambiguous leaf's parent path matches nothing, the matcher falls back to the first candidate — still a valid, server-provided member (no injection/auth impact), just possibly the wrong one of a rare ambiguous pair.
- Follow-up idea (not in this PR): click-the-same-member-again to toggle the filter off.
- Does not self-merge.

Closes #1166

🤖 Generated with [Claude Code](https://claude.com/claude-code)
