### PR TITLE
fix(repo): implement filesystem moveFile so catalogue folder move/rename persists (#937)

### DIFF
--- a/saiku-core/saiku-service/src/main/java/org/saiku/repository/FilesystemRepositoryManager.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/repository/FilesystemRepositoryManager.java
@@ -326,7 +326,44 @@ public class FilesystemRepositoryManager implements IRepositoryManager {
         this.getNode(path).delete();
     }
 
-    public void moveFile(String source, String target, String user, List<String> roles) throws RepositoryException {}
+    public void moveFile(String source, String target, String user, List<String> roles) throws RepositoryException {
+        // #937: catalogue folder rename/move depends on this. It used to be an
+        // empty stub, so RepositoryDatasourceManager.moveFile always returned
+        // "Move Okay" while nothing actually moved — the move silently reverted on
+        // reload. Implement a real filesystem move with the same canWrite ACL gate
+        // removeFile uses (the node is removed from its old location) plus
+        // path-traversal safety via getNode/resolveWithinDatadir on BOTH ends.
+        File src = getNode(source);
+        if (!src.exists()) {
+            throw new RepositoryException("Cannot move: source does not exist (" + source + ")");
+        }
+        Acl2 srcAcl = new Acl2(src);
+        srcAcl.setAdminRoles(userService.getAdminRoles());
+        if (!srcAcl.canWrite(src, user, roles)) {
+            throw new SaikuServiceException("You don't have permission to move " + source);
+        }
+        File dest = getNode(target);
+        if (dest.exists()) {
+            throw new RepositoryException("Cannot move: target already exists (" + target + ")");
+        }
+        File destParent = dest.getParentFile();
+        if (destParent != null && destParent.exists()) {
+            // Writing the node into its new parent requires write on that parent.
+            Acl2 destAcl = new Acl2(destParent);
+            destAcl.setAdminRoles(userService.getAdminRoles());
+            if (!destAcl.canWrite(destParent, user, roles)) {
+                throw new SaikuServiceException("You don't have permission to write to " + target);
+            }
+        }
+        if (destParent != null && !destParent.exists() && !destParent.mkdirs()) {
+            throw new RepositoryException("Cannot move: could not create destination folder for " + target);
+        }
+        try {
+            Files.move(src.toPath(), dest.toPath());
+        } catch (IOException e) {
+            throw new RepositoryException("Failed to move " + source + " to " + target + ": " + e.getMessage());
+        }
+    }
 
     public Object saveInternalFile(Object file, String path, String type) throws RepositoryException {
         File f = null;

--- a/saiku-core/saiku-service/src/test/java/org/saiku/repository/FilesystemRepositoryManagerMoveTest.java
+++ b/saiku-core/saiku-service/src/test/java/org/saiku/repository/FilesystemRepositoryManagerMoveTest.java
@@ -1,0 +1,174 @@
+package org.saiku.repository;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.io.File;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.saiku.service.user.UserService;
+
+/**
+ * Regression coverage for #937: {@link FilesystemRepositoryManager#moveFile}
+ * used to be an empty stub, so {@code RepositoryDatasourceManager.moveFile}
+ * returned "Move Okay" while nothing actually moved — catalogue folder
+ * rename/move silently reverted on reload. These tests pin the real move plus
+ * its authorization (canWrite on the source, mirroring removeFile) and
+ * path-traversal safety on the target.
+ */
+public class FilesystemRepositoryManagerMoveTest {
+
+    @Rule
+    public TemporaryFolder tmp = new TemporaryFolder();
+
+    private FilesystemRepositoryManager manager;
+    private File datadir;
+    private File adminHomeDir;
+
+    private static final List<String> ROLES_USER = Collections.singletonList("ROLE_USER");
+    private static final List<String> ROLES_ADMIN = Arrays.asList("ROLE_USER", "ROLE_ADMIN");
+
+    @Before
+    public void setUp() throws Exception {
+        resetSingleton();
+
+        datadir = tmp.newFolder("repo");
+        // <datadir>/unknown/etc bootstrap markers so getDatadir()'s lazy
+        // setup branch is skipped (same trick the ACL / traversal tests use);
+        // repo paths like "/homes/admin/x" resolve under <datadir>/unknown.
+        File unknownEtc = new File(datadir, "unknown/etc");
+        if (!unknownEtc.mkdirs()) {
+            throw new IllegalStateException("Could not create " + unknownEtc);
+        }
+        adminHomeDir = new File(datadir, "unknown/homes/admin");
+        if (!adminHomeDir.mkdirs()) {
+            throw new IllegalStateException("Could not create " + adminHomeDir);
+        }
+        // PRIVATE acl.json pinning ownership to admin, so non-owners are denied.
+        writeAclJson(adminHomeDir, adminHomeDir.getPath(), "PRIVATE", "admin");
+
+        manager = newManager(datadir.getAbsolutePath());
+        UserService us = new UserService();
+        us.setAdminRoles(Collections.singletonList("ROLE_ADMIN"));
+        injectUserService(manager, us);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        resetSingleton();
+    }
+
+    @Test
+    public void moveFile_relocatesFileAndPreservesContent() throws Exception {
+        File src = seed("q3.saikudash", "DASH_BODY");
+        // Move into a not-yet-existing sub-folder (folder rename creates the dest).
+        manager.moveFile("/homes/admin/q3.saikudash", "/homes/admin/Archive/q3.saikudash", "admin", ROLES_USER);
+
+        assertFalse("source must no longer exist after the move", src.exists());
+        File dest = new File(adminHomeDir, "Archive/q3.saikudash");
+        assertTrue("destination must exist after the move", dest.exists());
+        assertEquals(
+                "content must be preserved across the move",
+                "DASH_BODY",
+                new String(Files.readAllBytes(dest.toPath()), StandardCharsets.UTF_8));
+    }
+
+    @Test
+    public void moveFile_nonOwner_nonAdmin_is_denied_on_PRIVATE_folder() throws Exception {
+        File src = seed("owned.saikudash", "OWNED_BY_ADMIN");
+        try {
+            manager.moveFile("/homes/admin/owned.saikudash", "/homes/admin/stolen.saikudash", "bob", ROLES_USER);
+            fail("moveFile must reject a non-owner / non-admin move out of a PRIVATE folder");
+        } catch (Exception expected) {
+            // SaikuServiceException (or wrapped) — any abort is acceptable.
+        }
+        assertTrue("source must be untouched after a denied move", src.exists());
+        assertFalse(
+                "destination must not be created by a denied move",
+                new File(adminHomeDir, "stolen.saikudash").exists());
+    }
+
+    @Test
+    public void moveFile_admin_override_can_move_owner_PRIVATE_file() throws Exception {
+        File src = seed("admin-move.saikudash", "X");
+        manager.moveFile("/homes/admin/admin-move.saikudash", "/homes/admin/moved.saikudash", "admin", ROLES_ADMIN);
+        assertFalse(src.exists());
+        assertTrue(new File(adminHomeDir, "moved.saikudash").exists());
+    }
+
+    @Test
+    public void moveFile_rejects_when_target_already_exists() throws Exception {
+        File src = seed("src.saikudash", "SRC");
+        File existing = seed("dest.saikudash", "DEST");
+        try {
+            manager.moveFile("/homes/admin/src.saikudash", "/homes/admin/dest.saikudash", "admin", ROLES_USER);
+            fail("moveFile must not clobber an existing target");
+        } catch (Exception expected) {
+            // RepositoryException — target-exists guard.
+        }
+        assertTrue("source must survive a rejected move", src.exists());
+        assertEquals(
+                "existing target must not be overwritten",
+                "DEST",
+                new String(Files.readAllBytes(existing.toPath()), StandardCharsets.UTF_8));
+    }
+
+    @Test
+    public void moveFile_rejects_path_traversal_target() throws Exception {
+        File src = seed("safe.saikudash", "SAFE");
+        try {
+            manager.moveFile("/homes/admin/safe.saikudash", "/../../../../escape.saikudash", "admin", ROLES_ADMIN);
+            fail("moveFile must reject a target that escapes the datadir");
+        } catch (Exception expected) {
+            // SaikuServiceException from resolveWithinDatadir.
+        }
+        assertTrue("source must survive a rejected traversal move", src.exists());
+        assertFalse("nothing must be written outside the datadir", new File(datadir, "escape.saikudash").exists());
+    }
+
+    // ---- helpers ------------------------------------------------------
+
+    private File seed(String name, String body) throws Exception {
+        File f = new File(adminHomeDir, name);
+        Files.write(f.toPath(), body.getBytes(StandardCharsets.UTF_8));
+        return f;
+    }
+
+    private static void writeAclJson(File dir, String pathKey, String aclType, String owner) throws Exception {
+        String escapedPath = pathKey.replace("\\", "\\\\").replace("\"", "\\\"");
+        String json = "{\"" + escapedPath + "\":{\"owner\":\"" + owner + "\",\"type\":\"" + aclType
+                + "\",\"roles\":null,\"users\":null}}";
+        Files.write(new File(dir, "acl.json").toPath(), json.getBytes(StandardCharsets.UTF_8));
+    }
+
+    private static FilesystemRepositoryManager newManager(String path) throws Exception {
+        Constructor<FilesystemRepositoryManager> ctor = FilesystemRepositoryManager.class.getDeclaredConstructor(
+                String.class, String.class, ScopedRepo.class, boolean.class);
+        ctor.setAccessible(true);
+        return ctor.newInstance(path, "ROLE_USER", new ScopedRepo(), false);
+    }
+
+    private static void injectUserService(FilesystemRepositoryManager mgr, UserService us) throws Exception {
+        Field f = FilesystemRepositoryManager.class.getDeclaredField("userService");
+        f.setAccessible(true);
+        f.set(mgr, us);
+    }
+
+    private static void resetSingleton() throws Exception {
+        Field ref = FilesystemRepositoryManager.class.getDeclaredField("ref");
+        ref.setAccessible(true);
+        ref.set(null, null);
+    }
+}


### PR DESCRIPTION
## Summary
`FilesystemRepositoryManager.moveFile` was an empty stub. Since `RepositoryDatasourceManager.moveFile` returns `"Move Okay"` whenever the underlying call doesn't throw, `POST /saiku/api/repository/resource/move` reported success while the file **never moved** — so the catalogue folder rename/move feature (#937) silently reverted on reload. This implements a real, authorized, path-safe move. It is the **backend dependency** for PR #1183 (folders UI).

## The change
- **canWrite ACL gate on the source** (mirrors `removeFile`; the node leaves its old location), admin-role override intact.
- **canWrite on the destination parent** when it exists; **creates missing parent folders** for a rename into a new folder.
- **Path-traversal safety on both source and target** via `getNode`/`resolveWithinDatadir`.
- **Refuses to clobber an existing target**; surfaces IO failures as `RepositoryException`.

## Verified
- **Unit:** new `FilesystemRepositoryManagerMoveTest` — 5 cases pass (relocate+content, non-owner denied on PRIVATE, admin override, target-exists guard, traversal rejection).
- **Live (4.4.0 launcher):** the same `/resource/move` call that previously returned `200` but left `OLD=200 / NEW=404` now returns `OLD=404 / NEW=200` — the file actually relocates into an auto-created folder.
- **Security review:** CLEAN — traversal covered both ends, ACL mirrors `removeFile`, overwrite guard, atomic `Files.move` (no unsafe TOCTOU).
- Pre-existing local Windows-only golden/cache test failures are unrelated (CRLF in `*GoldenTest`, file-timing in `SaikuQueryCacheTest`); CI on Linux/mac is the gate.

## Notes
- Standalone repo bugfix; valuable independent of the UI. PR #1183 will rebase on top of this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)