### PR TITLE
fix(security): close SQL injection in password-encryption migration (#1155)

### DIFF
--- a/saiku-core/saiku-service/src/main/java/org/saiku/database/Database.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/database/Database.java
@@ -9,6 +9,7 @@ import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.sql.Connection;
 import java.sql.DatabaseMetaData;
+import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
@@ -23,6 +24,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
 
 /**
  * Created by bugg on 01/05/14.
@@ -376,23 +378,39 @@ public class Database {
     private void updateForEncyption() throws SQLException {
         Connection c = ds.getConnection();
 
-        Statement statement = c.createStatement();
-        statement.execute("ALTER TABLE users ALTER COLUMN password VARCHAR(100) DEFAULT NULL");
-
-        ResultSet result = statement.executeQuery("select username, password from users");
-
-        while (result.next()) {
-            statement = c.createStatement();
-
-            String pword = result.getString("password");
-            String hashedPassword = passwordEncoder.encode(pword);
-            String sql = "UPDATE users " + "SET password = '" + hashedPassword + "' WHERE username = '"
-                    + result.getString("username") + "'";
-            statement.executeUpdate(sql);
+        try (Statement statement = c.createStatement()) {
+            statement.execute("ALTER TABLE users ALTER COLUMN password VARCHAR(100) DEFAULT NULL");
         }
-        statement = c.createStatement();
 
-        statement.execute("INSERT INTO LOG(log) VALUES('update passwords');");
+        encryptUserPasswords(c, passwordEncoder);
+
+        try (Statement logStatement = c.createStatement()) {
+            logStatement.execute("INSERT INTO LOG(log) VALUES('update passwords');");
+        }
+    }
+
+    /**
+     * Bcrypt every user's stored password, binding the username + hash as
+     * PreparedStatement parameters.
+     *
+     * <p>saiku#1155: the previous implementation string-concatenated the
+     * DB-sourced {@code username} into the UPDATE, so a username containing a
+     * single quote broke the migration and a crafted value such as
+     * {@code x' OR '1'='1} rewrote EVERY row's password with one hash
+     * (CWE-89). Parameter binding closes that. Package-private + static so the
+     * security regression test exercises this exact code path.
+     */
+    static void encryptUserPasswords(Connection c, PasswordEncoder encoder) throws SQLException {
+        try (Statement read = c.createStatement();
+                ResultSet result = read.executeQuery("select username, password from users");
+                PreparedStatement update = c.prepareStatement("UPDATE users SET password = ? WHERE username = ?")) {
+            while (result.next()) {
+                String hashedPassword = encoder.encode(result.getString("password"));
+                update.setString(1, hashedPassword);
+                update.setString(2, result.getString("username"));
+                update.executeUpdate();
+            }
+        }
     }
 
     private void loadLegacyDatasources() throws SQLException {

--- a/saiku-core/saiku-service/src/test/java/org/saiku/database/DatabaseUpdateForEncryptionTest.java
+++ b/saiku-core/saiku-service/src/test/java/org/saiku/database/DatabaseUpdateForEncryptionTest.java
@@ -1,0 +1,98 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.database;
+
+import static org.junit.Assert.*;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.Statement;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+
+/**
+ * saiku#1155 regression — SQL injection in the password-encryption migration.
+ *
+ * <p>{@code Database.updateForEncyption} string-concatenated the DB-sourced
+ * username into the UPDATE, so a username with a single quote broke the
+ * migration and a crafted value such as {@code x' OR '1'='1} rewrote EVERY
+ * row's password with one hash (CWE-89). The fix binds the username as a
+ * PreparedStatement parameter. These tests drive the REAL production helper
+ * ({@link Database#encryptUserPasswords}) against in-memory H2; both fail on
+ * the pre-fix code (apostrophe → SQLException; payload → cross-row clobber) and
+ * pass after.
+ */
+public class DatabaseUpdateForEncryptionTest {
+
+    private Connection c;
+    private final BCryptPasswordEncoder encoder = new BCryptPasswordEncoder();
+
+    @Before
+    public void setUp() throws Exception {
+        c = DriverManager.getConnection("jdbc:h2:mem:enc_" + System.nanoTime() + ";MODE=MySQL;DB_CLOSE_DELAY=-1");
+        try (Statement s = c.createStatement()) {
+            s.execute("CREATE TABLE users (username VARCHAR(45), password VARCHAR(100))");
+        }
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        if (c != null) c.close();
+    }
+
+    private void insert(String username, String password) throws Exception {
+        try (PreparedStatement ps = c.prepareStatement("INSERT INTO users(username, password) VALUES(?, ?)")) {
+            ps.setString(1, username);
+            ps.setString(2, password);
+            ps.executeUpdate();
+        }
+    }
+
+    private String passwordOf(String username) throws Exception {
+        try (PreparedStatement ps = c.prepareStatement("SELECT password FROM users WHERE username = ?")) {
+            ps.setString(1, username);
+            try (ResultSet rs = ps.executeQuery()) {
+                assertTrue("row for [" + username + "] must exist", rs.next());
+                return rs.getString(1);
+            }
+        }
+    }
+
+    @Test
+    public void apostropheUsernameMigratesEachRowToItsOwnBcryptHash() throws Exception {
+        insert("o'brien", "pw_obrien"); // a single quote broke the old concatenated SQL
+        insert("victim", "pw_victim");
+
+        // Real production code path — must NOT throw on the apostrophe (pre-fix: SQLException).
+        Database.encryptUserPasswords(c, encoder);
+
+        String obrien = passwordOf("o'brien");
+        String victim = passwordOf("victim");
+        assertTrue("o'brien hashed to its own password", encoder.matches("pw_obrien", obrien));
+        assertTrue("victim hashed to its own password", encoder.matches("pw_victim", victim));
+        assertFalse("rows must not share a hash", obrien.equals(victim));
+    }
+
+    @Test
+    public void injectionUsernameCannotClobberOtherRows() throws Exception {
+        // victim inserted FIRST so a cross-row clobber (pre-fix) overwrites its
+        // already-correct hash when the payload row is processed afterwards.
+        insert("victim", "pw_victim");
+        insert("x' OR '1'='1", "pw_attacker");
+
+        Database.encryptUserPasswords(c, encoder);
+
+        // Post-fix: victim keeps ITS OWN password; pre-fix the OR-payload UPDATE
+        // matched every row and rewrote victim with the attacker's hash.
+        assertTrue(
+                "victim password intact (not clobbered by the OR payload)",
+                encoder.matches("pw_victim", passwordOf("victim")));
+        assertTrue("the payload row got its own hash", encoder.matches("pw_attacker", passwordOf("x' OR '1'='1")));
+    }
+}


### PR DESCRIPTION
## What

`Database.updateForEncyption()` built the password-encryption migration `UPDATE` by string-concatenating the **DB-sourced username** straight into the SQL, then ran it via `Statement.executeUpdate(sql)`.

This is a classic **SQL injection (CWE-89)**. A username containing a single quote breaks the migration outright, and a crafted value such as `x' OR '1'='1` makes the `WHERE` match every row — **rewriting every user's password with one hash**. The username is attacker-influenceable wherever accounts can be created/imported, and this code runs as a privileged migration.

## Fix

- The `UPDATE` is now a bound `PreparedStatement` (`SET password = ? WHERE username = ?`).
- The loop body is extracted to a package-private static `encryptUserPasswords(Connection, PasswordEncoder)` so the regression test exercises the **exact production code path**, not a copy.
- No behavioural change for legitimate usernames.

## Tests

New `DatabaseUpdateForEncryptionTest` (in-memory H2, drives the real helper):

- `apostropheUsernameMigratesEachRowToItsOwnBcryptHash` — a username with an apostrophe no longer breaks the migration; each row gets its own bcrypt hash.
- `injectionUsernameCannotClobberOtherRows` — an `OR '1'='1` username can no longer overwrite another user's password.

Verified **RED against the pre-fix code** (apostrophe → `SQLException`; OR-payload → cross-row clobber) and **GREEN after the fix**. `mvn spotless:apply` clean.

## Notes

- Scope: security lane (Agent SEC). **Not self-merging** — handing to the integrator for review/merge.
- Branch cut from and currently level with `development`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
