### PR TITLE
fix(security): rate-limit + size-cap the AI ask endpoint (token-cost DoS) (#1151)

### DIFF
--- a/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/AiQueryResource.java
+++ b/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/AiQueryResource.java
@@ -85,6 +85,18 @@ public class AiQueryResource {
         this.askService = s;
     }
 
+    /**
+     * saiku#1151: per-caller call-rate cap on the cost-bearing ask endpoint.
+     * Default budget; replace via {@link #setAskRateLimiter} (Spring wiring or
+     * tests). Size caps live in {@code AiAskGuard}.
+     */
+    private org.saiku.web.security.ratelimit.AiRateLimiter askRateLimiter =
+            new org.saiku.web.security.ratelimit.AiRateLimiter();
+
+    public void setAskRateLimiter(org.saiku.web.security.ratelimit.AiRateLimiter l) {
+        this.askRateLimiter = l;
+    }
+
     private final AiSchemaConverter converter = new AiSchemaConverter();
     /** Phase 2: JSON-Schema-driven shape validator. Runs first so an
      *  agent gets one structured 400 per shape failure instead of a
@@ -360,6 +372,22 @@ public class AiQueryResource {
         }
         if (body.getCube() == null || body.getCube().getCubeName() == null) {
             return badRequest("cube", "cube ref required", null);
+        }
+        // saiku#1151: cap request size + call rate before reaching the paid LLM
+        // provider. Oversize questions/histories inflate per-call token spend;
+        // unbounded call frequency is a cost-DoS. The logic lives in AiAskGuard /
+        // AiRateLimiter so it stays unit-testable and this resource keeps a thin
+        // touch.
+        org.saiku.web.security.ratelimit.AiAskGuard.Violation sizeViolation =
+                org.saiku.web.security.ratelimit.AiAskGuard.checkSize(body);
+        if (sizeViolation != null) {
+            return askLimitResponse(sizeViolation.isPayloadTooLarge() ? 413 : 400, sizeViolation.getMessage());
+        }
+        if (!askRateLimiter.tryAcquire(askRateKey())) {
+            return askLimitResponse(
+                    429,
+                    "Too many AI ask requests — limit is " + askRateLimiter.getMaxCalls() + " per "
+                            + (askRateLimiter.getWindowMs() / 1000) + "s. Please retry shortly.");
         }
         if (askService == null) {
             AiAskApi.AskResponse out = new AiAskApi.AskResponse();
@@ -1358,5 +1386,56 @@ public class AiQueryResource {
                 .entity(resp)
                 .type(MediaType.APPLICATION_JSON)
                 .build();
+    }
+
+    /**
+     * saiku#1151: a degraded {@link AiAskApi.AskResponse} for a size/rate
+     * rejection at the given HTTP status (413 oversize, 400 bad shape, 429 rate).
+     * Reuses the same envelope the configured/degraded paths use so the UI
+     * renders a clear message rather than choking on an unexpected shape.
+     */
+    private Response askLimitResponse(int status, String reason) {
+        AiAskApi.AskResponse out = new AiAskApi.AskResponse();
+        out.setDegraded(true);
+        out.setReason(reason);
+        return Response.status(status)
+                .entity(out)
+                .type(MediaType.APPLICATION_JSON)
+                .build();
+    }
+
+    /**
+     * saiku#1151: rate-limit identity = caller principal + client IP. Falls back
+     * to a constant when no request is bound to the thread (unit tests), so
+     * those callers share a single bucket.
+     */
+    private String askRateKey() {
+        jakarta.servlet.http.HttpServletRequest req = currentRequest();
+        String user = null;
+        String ip = null;
+        if (req != null) {
+            user = req.getRemoteUser();
+            if (user == null && req.getUserPrincipal() != null) {
+                user = req.getUserPrincipal().getName();
+            }
+            ip = req.getRemoteAddr();
+        }
+        return (user == null ? "anon" : user) + ":" + (ip == null ? "unknown" : ip);
+    }
+
+    /**
+     * The {@link jakarta.servlet.http.HttpServletRequest} bound to the current
+     * thread via Spring, or {@code null} when none is bound. Mirrors how this
+     * resource already reaches request state ({@code RequestContextHolder}),
+     * which works for the Spring-singleton wiring (a {@code @Context} field
+     * would not).
+     */
+    private static jakarta.servlet.http.HttpServletRequest currentRequest() {
+        org.springframework.web.context.request.RequestAttributes attrs =
+                org.springframework.web.context.request.RequestContextHolder.getRequestAttributes();
+        if (attrs instanceof org.springframework.web.context.request.ServletRequestAttributes) {
+            return ((org.springframework.web.context.request.ServletRequestAttributes) attrs).getRequest();
+        }
+        return null;
     }
 }

--- a/saiku-core/saiku-web/src/main/java/org/saiku/web/security/ratelimit/AiAskGuard.java
+++ b/saiku-core/saiku-web/src/main/java/org/saiku/web/security/ratelimit/AiAskGuard.java
@@ -1,0 +1,120 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ */
+package org.saiku.web.security.ratelimit;
+
+import java.util.List;
+import org.saiku.service.olap.ai.ask.AiAskApi;
+
+/**
+ * Size caps for the AI ask endpoint (saiku#1151). The question and prior
+ * conversation turns are forwarded verbatim to a paid LLM provider, so an
+ * oversize body inflates per-call token spend without bound. These limits cut
+ * the request off before it reaches the provider.
+ *
+ * <p>Limits are tunable via system properties so an operator can widen them for
+ * a heavier deployment without a rebuild; the defaults are generous for normal
+ * BI questions (a few sentences + a short chat history) yet cap obvious abuse.
+ */
+public final class AiAskGuard {
+
+    private AiAskGuard() {}
+
+    /** Max characters in a single {@code question}. */
+    public static final int MAX_QUESTION_CHARS = intProp("saiku.ai.ask.maxQuestionChars", 8_000);
+
+    /** Max number of prior conversation turns accepted in {@code history}. */
+    public static final int MAX_HISTORY_MESSAGES = intProp("saiku.ai.ask.maxHistoryMessages", 20);
+
+    /** Max characters in any single history message's content. */
+    public static final int MAX_MESSAGE_CHARS = intProp("saiku.ai.ask.maxMessageChars", 8_000);
+
+    /** Max combined characters across the question + all history content. */
+    public static final int MAX_TOTAL_CHARS = intProp("saiku.ai.ask.maxTotalChars", 40_000);
+
+    /**
+     * @return the first size violation found, or {@code null} if the request is
+     *     within all limits. A {@code null} body is treated as in-bounds — the
+     *     caller already rejects a null body with its own 400.
+     */
+    public static Violation checkSize(AiAskApi.AskRequest body) {
+        if (body == null) return null;
+
+        String question = body.getQuestion();
+        long total = question == null ? 0 : question.length();
+        if (question != null && question.length() > MAX_QUESTION_CHARS) {
+            return new Violation(
+                    "question",
+                    "question exceeds the " + MAX_QUESTION_CHARS + "-character limit (" + question.length() + ").",
+                    true);
+        }
+
+        List<AiAskApi.NlAskMessageDto> history = body.getHistory();
+        if (history != null) {
+            if (history.size() > MAX_HISTORY_MESSAGES) {
+                // Count overflow is a malformed/abusive request shape, not an
+                // oversize payload — surface as 400 so the client trims turns.
+                return new Violation(
+                        "history",
+                        "history exceeds the " + MAX_HISTORY_MESSAGES + "-message limit (" + history.size() + ").",
+                        false);
+            }
+            for (AiAskApi.NlAskMessageDto m : history) {
+                if (m == null || m.getContent() == null) continue;
+                if (m.getContent().length() > MAX_MESSAGE_CHARS) {
+                    return new Violation(
+                            "history",
+                            "a history message exceeds the " + MAX_MESSAGE_CHARS + "-character limit.",
+                            true);
+                }
+                total += m.getContent().length();
+            }
+        }
+
+        if (total > MAX_TOTAL_CHARS) {
+            return new Violation(
+                    "history",
+                    "combined question + history exceeds the " + MAX_TOTAL_CHARS + "-character limit (" + total + ").",
+                    true);
+        }
+        return null;
+    }
+
+    private static int intProp(String name, int def) {
+        try {
+            String v = System.getProperty(name);
+            return v == null ? def : Integer.parseInt(v.trim());
+        } catch (NumberFormatException e) {
+            return def;
+        }
+    }
+
+    /** A single size-limit breach. */
+    public static final class Violation {
+        private final String field;
+        private final String message;
+        private final boolean payloadTooLarge;
+
+        public Violation(String field, String message, boolean payloadTooLarge) {
+            this.field = field;
+            this.message = message;
+            this.payloadTooLarge = payloadTooLarge;
+        }
+
+        public String getField() {
+            return field;
+        }
+
+        public String getMessage() {
+            return message;
+        }
+
+        /** True → map to HTTP 413 (oversize). False → HTTP 400 (bad shape, e.g. too many turns). */
+        public boolean isPayloadTooLarge() {
+            return payloadTooLarge;
+        }
+    }
+}

--- a/saiku-core/saiku-web/src/main/java/org/saiku/web/security/ratelimit/AiRateLimiter.java
+++ b/saiku-core/saiku-web/src/main/java/org/saiku/web/security/ratelimit/AiRateLimiter.java
@@ -1,0 +1,87 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ */
+package org.saiku.web.security.ratelimit;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Fixed-window call-rate limiter for the cost-bearing AI ask endpoint
+ * (saiku#1151). Each natural-language ask reaches a paid LLM provider, so an
+ * unbounded call frequency is a direct cost-DoS. After {@code maxCalls} inside
+ * a {@code windowMs} window, further calls for that key are rejected until the
+ * window rolls over.
+ *
+ * <p>Deliberately servlet-free and key-string based: the caller derives the
+ * key (principal + client IP) and this class just counts. That keeps it
+ * trivially unit-testable and mirrors {@link LoginRateLimiter}'s lazy-eviction
+ * {@link ConcurrentHashMap} storage — no background thread, single-node only.
+ */
+public class AiRateLimiter {
+
+    private static final Logger log = LoggerFactory.getLogger(AiRateLimiter.class);
+
+    private final int maxCalls;
+    private final long windowMs;
+    private final Map<String, Bucket> buckets = new ConcurrentHashMap<>();
+
+    public AiRateLimiter() {
+        this(Integer.getInteger("saiku.ai.ratelimit.maxPerMinute", 30), 60_000L);
+    }
+
+    public AiRateLimiter(int maxCalls, long windowMs) {
+        this.maxCalls = maxCalls;
+        this.windowMs = windowMs;
+    }
+
+    /**
+     * Record one call for {@code key} and report whether it is within budget.
+     *
+     * @return {@code true} if the call may proceed; {@code false} if this key
+     *     has exhausted its budget for the current window. A {@code null} key
+     *     (identity could not be derived) is allowed through — fail-open here so
+     *     a wiring gap never bricks the feature; identity derivation is the
+     *     caller's responsibility.
+     */
+    public boolean tryAcquire(String key) {
+        if (key == null) return true;
+        long now = System.currentTimeMillis();
+        Bucket b = buckets.compute(key, (k, existing) -> {
+            if (existing == null || now - existing.windowStartMs > windowMs) {
+                return new Bucket(now, new AtomicInteger(1));
+            }
+            existing.count.incrementAndGet();
+            return existing;
+        });
+        boolean allowed = b.count.get() <= maxCalls;
+        if (!allowed) {
+            log.warn("AI ask rate-limit tripped key={} count={} max={}", key, b.count.get(), maxCalls);
+        }
+        return allowed;
+    }
+
+    public int getMaxCalls() {
+        return maxCalls;
+    }
+
+    public long getWindowMs() {
+        return windowMs;
+    }
+
+    private static final class Bucket {
+        final long windowStartMs;
+        final AtomicInteger count;
+
+        Bucket(long windowStartMs, AtomicInteger count) {
+            this.windowStartMs = windowStartMs;
+            this.count = count;
+        }
+    }
+}

--- a/saiku-core/saiku-web/src/test/java/org/saiku/web/rest/resources/AiAskRateLimitAndSizeTest.java
+++ b/saiku-core/saiku-web/src/test/java/org/saiku/web/rest/resources/AiAskRateLimitAndSizeTest.java
@@ -1,0 +1,174 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.web.rest.resources;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import jakarta.ws.rs.core.Response;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import org.junit.Before;
+import org.junit.Test;
+import org.saiku.olap.dto.resultset.CellDataSet;
+import org.saiku.olap.query2.ThinQuery;
+import org.saiku.service.olap.ThinQueryService;
+import org.saiku.service.olap.ai.AiAxisSelection;
+import org.saiku.service.olap.ai.AiCubeRef;
+import org.saiku.service.olap.ai.AiMeasureSelection;
+import org.saiku.service.olap.ai.AiQueryRequest;
+import org.saiku.service.olap.ai.AiSchema;
+import org.saiku.service.olap.ai.ask.AiAskApi;
+import org.saiku.service.olap.ai.ask.AiAskService;
+import org.saiku.service.olap.ai.ask.NlAskMessage;
+import org.saiku.service.olap.ai.ask.NlAskProvider;
+import org.saiku.service.olap.ai.ask.NlAskResponse;
+import org.saiku.web.security.ratelimit.AiAskGuard;
+import org.saiku.web.security.ratelimit.AiRateLimiter;
+
+/**
+ * saiku#1151 — resource-level tests that {@code POST /saiku/api/ai/ask} caps
+ * request size (413 / 400) and call rate (429) before reaching the paid LLM
+ * provider.
+ */
+public class AiAskRateLimitAndSizeTest {
+
+    private AiQueryResource resource;
+    private AiSchema schema;
+
+    @Before
+    public void setUp() {
+        schema = new AiSchema("foodmart/FoodMart/FoodMart/Sales", "Sales", "[FoodMart].[Sales]");
+        schema.measures.put(
+                AiSchema.key("Store Sales"), new AiSchema.Measure("Store Sales", "[Measures].[Store Sales]"));
+        AiSchema.Dimension time = new AiSchema.Dimension("Time", "[Time]");
+        AiSchema.Hierarchy timeBy = new AiSchema.Hierarchy("Time By", "[Time].[Time By]");
+        timeBy.levels.put(AiSchema.key("Year"), new AiSchema.Level("Year", "[Time].[Time By].[Year]"));
+        time.hierarchies.put(AiSchema.key("Time By"), timeBy);
+        schema.dimensions.put(AiSchema.key("Time"), time);
+
+        resource = new AiQueryResource();
+        resource.setCubeMetadataService(ref -> schema);
+        resource.setThinQueryService(new StubThinQuerySvc());
+        // Wire a fake ask service so the happy path reaches 200 (the guard runs
+        // before this is consulted).
+        resource.setAskService(new AiAskService(ref -> schema, stubProvider()) {
+            @Override
+            public AskOutcome ask(AiCubeRef ref, String question, List<NlAskMessage> history) {
+                return AskOutcome.ok(baseEmittedRequest(), "claude-x");
+            }
+        });
+    }
+
+    private AiAskApi.AskRequest validBody() {
+        AiAskApi.AskRequest b = new AiAskApi.AskRequest();
+        b.setQuestion("show sales by year");
+        b.setCube(new AiCubeRef("foodmart", "FoodMart", "FoodMart", "Sales"));
+        return b;
+    }
+
+    private AiQueryRequest baseEmittedRequest() {
+        AiQueryRequest req = new AiQueryRequest();
+        req.setCube(new AiCubeRef("foodmart", "FoodMart", "FoodMart", "Sales"));
+        req.setMeasures(Collections.singletonList(new AiMeasureSelection("Store Sales")));
+        req.setRows(Collections.singletonList(new AiAxisSelection("Time", "Time By", "Year")));
+        return req;
+    }
+
+    private static String repeat(char c, int n) {
+        char[] a = new char[n];
+        java.util.Arrays.fill(a, c);
+        return new String(a);
+    }
+
+    @Test
+    public void happyPathWithinLimitsReturns200() {
+        Response resp = resource.ask(validBody());
+        assertEquals(200, resp.getStatus());
+    }
+
+    @Test
+    public void oversizeQuestionReturns413() {
+        AiAskApi.AskRequest b = validBody();
+        b.setQuestion(repeat('x', AiAskGuard.MAX_QUESTION_CHARS + 1));
+        Response resp = resource.ask(b);
+        assertEquals(413, resp.getStatus());
+        AiAskApi.AskResponse body = (AiAskApi.AskResponse) resp.getEntity();
+        assertTrue(body.isDegraded());
+        assertTrue(body.getReason().contains("question exceeds"));
+    }
+
+    @Test
+    public void tooManyHistoryMessagesReturns400() {
+        AiAskApi.AskRequest b = validBody();
+        List<AiAskApi.NlAskMessageDto> history = new ArrayList<>();
+        for (int i = 0; i < AiAskGuard.MAX_HISTORY_MESSAGES + 1; i++) {
+            history.add(new AiAskApi.NlAskMessageDto("user", "hi"));
+        }
+        b.setHistory(history);
+        Response resp = resource.ask(b);
+        assertEquals(400, resp.getStatus());
+        AiAskApi.AskResponse body = (AiAskApi.AskResponse) resp.getEntity();
+        assertTrue(body.getReason().contains("history exceeds"));
+    }
+
+    @Test
+    public void oversizeHistoryMessageReturns413() {
+        AiAskApi.AskRequest b = validBody();
+        List<AiAskApi.NlAskMessageDto> history = new ArrayList<>();
+        history.add(new AiAskApi.NlAskMessageDto("user", repeat('y', AiAskGuard.MAX_MESSAGE_CHARS + 1)));
+        b.setHistory(history);
+        Response resp = resource.ask(b);
+        assertEquals(413, resp.getStatus());
+    }
+
+    @Test
+    public void combinedHistoryOverTotalReturns413() {
+        AiAskApi.AskRequest b = validBody();
+        // Each message under the per-message cap, count under the message cap,
+        // but the sum blows past the combined-total cap.
+        int per = AiAskGuard.MAX_MESSAGE_CHARS - 1;
+        int count = (AiAskGuard.MAX_TOTAL_CHARS / per) + 2;
+        // Keep the message count itself legal so the total-cap is what trips.
+        assertTrue("test setup keeps history count legal", count <= AiAskGuard.MAX_HISTORY_MESSAGES);
+        List<AiAskApi.NlAskMessageDto> history = new ArrayList<>();
+        for (int i = 0; i < count; i++) {
+            history.add(new AiAskApi.NlAskMessageDto("user", repeat('z', per)));
+        }
+        b.setHistory(history);
+        Response resp = resource.ask(b);
+        assertEquals(413, resp.getStatus());
+        AiAskApi.AskResponse body = (AiAskApi.AskResponse) resp.getEntity();
+        assertTrue(body.getReason().contains("combined"));
+    }
+
+    @Test
+    public void rateLimitReturns429AfterBudget() {
+        resource.setAskRateLimiter(new AiRateLimiter(2, 60_000L));
+        // No request is bound to the thread in this unit test, so all calls
+        // share the "anon:unknown" bucket.
+        assertEquals(200, resource.ask(validBody()).getStatus());
+        assertEquals(200, resource.ask(validBody()).getStatus());
+        Response third = resource.ask(validBody());
+        assertEquals(429, third.getStatus());
+        AiAskApi.AskResponse body = (AiAskApi.AskResponse) third.getEntity();
+        assertTrue(body.isDegraded());
+        assertTrue(body.getReason().contains("Too many AI ask requests"));
+    }
+
+    // ---------- stubs ----------
+
+    private static NlAskProvider stubProvider() {
+        return req -> NlAskResponse.ok("", "claude-x", 0, 0);
+    }
+
+    private static class StubThinQuerySvc extends ThinQueryService {
+        @Override
+        public CellDataSet execute(ThinQuery tq) {
+            return AiQueryResourceTest.buildStubCellDataSet();
+        }
+    }
+}

--- a/saiku-core/saiku-web/src/test/java/org/saiku/web/security/ratelimit/AiRateLimiterTest.java
+++ b/saiku-core/saiku-web/src/test/java/org/saiku/web/security/ratelimit/AiRateLimiterTest.java
@@ -1,0 +1,51 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.web.security.ratelimit;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+/** saiku#1151 — unit tests for the cost-DoS call-rate limiter. */
+public class AiRateLimiterTest {
+
+    @Test
+    public void allowsUpToMaxThenBlocksWithinWindow() {
+        AiRateLimiter limiter = new AiRateLimiter(3, 60_000L);
+        assertTrue("call 1 allowed", limiter.tryAcquire("user:1.2.3.4"));
+        assertTrue("call 2 allowed", limiter.tryAcquire("user:1.2.3.4"));
+        assertTrue("call 3 allowed", limiter.tryAcquire("user:1.2.3.4"));
+        assertFalse("call 4 over budget", limiter.tryAcquire("user:1.2.3.4"));
+        assertFalse("still blocked", limiter.tryAcquire("user:1.2.3.4"));
+    }
+
+    @Test
+    public void budgetIsPerKey() {
+        AiRateLimiter limiter = new AiRateLimiter(1, 60_000L);
+        assertTrue(limiter.tryAcquire("alice:1.1.1.1"));
+        assertFalse("alice exhausted", limiter.tryAcquire("alice:1.1.1.1"));
+        // A different key (different principal or IP) has its own budget.
+        assertTrue("bob unaffected", limiter.tryAcquire("bob:1.1.1.1"));
+        assertTrue("same user, different IP unaffected", limiter.tryAcquire("alice:2.2.2.2"));
+    }
+
+    @Test
+    public void windowRolloverResetsBudget() {
+        // A negative window is always "already elapsed" (now - start > -1 holds
+        // for any clock), so each call deterministically resets the bucket to a
+        // fresh window — exercising the rollover branch without sleeping.
+        AiRateLimiter limiter = new AiRateLimiter(1, -1L);
+        assertTrue(limiter.tryAcquire("user:1.2.3.4"));
+        assertTrue("window already elapsed → counter reset", limiter.tryAcquire("user:1.2.3.4"));
+        assertTrue(limiter.tryAcquire("user:1.2.3.4"));
+    }
+
+    @Test
+    public void nullKeyFailsOpen() {
+        AiRateLimiter limiter = new AiRateLimiter(0, 60_000L);
+        assertTrue("null identity is allowed through, not bricked", limiter.tryAcquire(null));
+    }
+}


### PR DESCRIPTION
## What

`POST /saiku/api/ai/ask` forwards the `question` and the full conversation `history` verbatim to a **paid LLM provider** (`askService.ask(...)`), with:

- **no bound on body size** — an oversize question or history inflates per-call token spend without limit, and
- **no call-rate limit** — unbounded call frequency multiplies that spend.

Either is a **token-cost / financial DoS** against the deployment's AI budget. There was no guard between an authenticated session and the provider call.

## Fix

Two small, isolated, unit-testable pieces + a thin resource touch:

- **`AiRateLimiter`** — fixed-window, per-caller (principal + client IP) call cap. Mirrors the existing `LoginRateLimiter` (lazy-eviction `ConcurrentHashMap`, no background thread, single-node). Default **30/min**, tunable via `-Dsaiku.ai.ratelimit.maxPerMinute`. Servlet-free / key-string based, so it's trivially testable; fails **open** on a null identity so a wiring gap can't brick the feature.
- **`AiAskGuard`** — size caps on the question, per-message content, history message-count, and combined total. Tunable via `-Dsaiku.ai.ask.*`. Oversize payload → **413**, too-many-turns → **400**.
- **`AiQueryResource.ask()`** — enforces both *before* reaching `askService.ask()`, reusing the existing degraded `AskResponse` envelope (**429** on rate trip) so the UI renders a clear message. Caller identity is read via Spring's `RequestContextHolder` — the same mechanism this resource already uses (line ~670) — which works under the Spring-singleton wiring (a `@Context` field would not); falls back to a shared bucket when no request is bound.

**Active by default** (field-initialised limiter + static guard) — **no Spring XML change required**, which also keeps this clear of the in-flight AI batch on `applicationContext-saiku.xml`.

## Tests

- `AiRateLimiterTest` — budget exhaustion, per-key isolation, window rollover, null-key fail-open.
- `AiAskRateLimitAndSizeTest` — 413 on oversize question / message / combined total, 400 on too-many turns, **429 after budget**, 200 happy path.

10/10 green (`-pl saiku-core/saiku-web -am -s <settings>`); `spotless:apply` clean. The 429/413/400 assertions are the "DoS-is-now-bounded" regression proof (pre-fix the endpoint returned 200/503 without limit).

## Notes

- Scope: security lane (Agent SEC). **Not self-merging** — handing to the integrator.
- Branch cut from + level with `development`.
- ⚠️ **Coordination:** touches `AiQueryResource.java`, which A1's unmerged batch-4 (#1051 / #907) also extends with *new methods*. My change adds a field + a guard block at the top of `ask()` + private helpers — disjoint from new endpoints, so a clean merge is expected. Suggest merging whichever lands first; I'll rebase if needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
