### PR TITLE
fix(security): refuse default admin in production + bcrypt seed passwords (#1153, #1154)

### DIFF
--- a/saiku-launcher/src/main/java/org/saiku/launcher/SaikuLauncher.java
+++ b/saiku-launcher/src/main/java/org/saiku/launcher/SaikuLauncher.java
@@ -1,13 +1,16 @@
 package org.saiku.launcher;
 
 import java.io.File;
+import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
+import java.util.Properties;
 import java.util.concurrent.Callable;
 import java.util.zip.ZipEntry;
+import java.util.zip.ZipFile;
 import java.util.zip.ZipInputStream;
 import org.eclipse.jetty.ee10.webapp.WebAppContext;
 import org.eclipse.jetty.http.HttpCookie;
@@ -68,7 +71,16 @@ public class SaikuLauncher implements Callable<Integer> {
 
         @Override
         public Integer call() throws Exception {
-            Server server = bootServer(port, host, contextPath, home);
+            Server server;
+            try {
+                server = bootServer(port, host, contextPath, home);
+            } catch (DefaultCredentialsException e) {
+                // saiku#1153: clean refusal, no stack trace — the message tells
+                // the operator exactly how to proceed. Non-zero exit so init
+                // systems / CI see the failure.
+                System.err.println(e.getMessage());
+                return 2;
+            }
             int actualPort = ((ServerConnector) server.getConnectors()[0]).getLocalPort();
             String base = "http://" + host + ":" + actualPort + contextPath;
             if (!base.endsWith("/")) base = base + "/";
@@ -127,6 +139,12 @@ public class SaikuLauncher implements Callable<Integer> {
             stageDefaultDatasource(saikuHome);
 
             Path warPath = extractWar();
+
+            // saiku#1153: refuse to serve in production while the shipped default
+            // admin password is unchanged. Demo mode (SAIKU_DEMO=true) and an
+            // explicit SAIKU_ALLOW_DEFAULT_ADMIN=true both opt out. Throws
+            // DefaultCredentialsException, which the CLI turns into a clean exit.
+            enforceDefaultCredentialPolicy(warPath);
 
             Server server = new Server();
             ServerConnector connector = new ServerConnector(server);
@@ -223,6 +241,106 @@ public class SaikuLauncher implements Callable<Integer> {
             System.out.println("  Suppress this warning with -Dsaiku.security.acknowledged=true");
             System.out.println(bar);
             System.out.println();
+        }
+
+        /* ------------------- saiku#1153: default-credential policy ----------------- */
+
+        /**
+         * The exact {@code admin} password token this build ships with after the
+         * saiku#1154 bcrypt migration. MUST stay in sync with the {@code admin=}
+         * row in {@code saiku-webapp/.../WEB-INF/users.properties}; if you
+         * regenerate that hash, update this constant too (a bcrypt salt is random,
+         * so the string changes every time it is re-encoded).
+         */
+        static final String SHIPPED_BCRYPT_ADMIN_DEFAULT =
+                "{bcrypt}$2a$10$4lJwsvvv..UqK31JmBSoCOf7hYgKurOB2sEacVVIrqA97BXc4cFju";
+
+        /** Thrown to refuse boot when the default admin password is still active. */
+        static final class DefaultCredentialsException extends RuntimeException {
+            DefaultCredentialsException(String message) {
+                super(message);
+            }
+        }
+
+        /**
+         * True when {@code adminPropertyValue} (the raw {@code admin=} value from
+         * users.properties, i.e. {@code <encodedpw>,ROLE_...}) is still the
+         * shipped default — either the legacy {@code {noop}admin} or this build's
+         * {@link #SHIPPED_BCRYPT_ADMIN_DEFAULT}. Any operator rotation produces a
+         * different hash and returns false.
+         */
+        static boolean isDefaultAdminValue(String adminPropertyValue) {
+            if (adminPropertyValue == null) return false;
+            String enc = adminPropertyValue.split(",", 2)[0].trim();
+            return enc.equals("{noop}admin") || enc.equals(SHIPPED_BCRYPT_ADMIN_DEFAULT);
+        }
+
+        /**
+         * Read the effective {@code admin} row from the bundled WAR's
+         * users.properties and report whether it is still the shipped default.
+         * Fails open (returns false) on any read error — a refusal must be a
+         * deliberate, confident decision, never a side effect of a parse glitch.
+         */
+        static boolean adminPasswordIsDefault(Path warPath) {
+            try (ZipFile zip = new ZipFile(warPath.toFile())) {
+                ZipEntry e = zip.getEntry("WEB-INF/users.properties");
+                if (e == null) return false;
+                Properties p = new Properties();
+                try (InputStream in = zip.getInputStream(e)) {
+                    p.load(in);
+                }
+                return isDefaultAdminValue(p.getProperty("admin"));
+            } catch (IOException ex) {
+                return false;
+            }
+        }
+
+        /** Pure policy decision: refuse only when the default is active AND we're
+         *  not in demo mode AND the operator hasn't explicitly opted in. */
+        static boolean shouldRefuse(boolean adminIsDefault, boolean demoMode, boolean allowOverride) {
+            return adminIsDefault && !demoMode && !allowOverride;
+        }
+
+        /** True when {@code SAIKU_ALLOW_DEFAULT_ADMIN=true} (env) or
+         *  {@code -Dsaiku.allowDefaultAdmin=true} (system property) is set. */
+        static boolean allowDefaultAdmin() {
+            String env = System.getenv("SAIKU_ALLOW_DEFAULT_ADMIN");
+            if (env != null && Boolean.parseBoolean(env.trim())) return true;
+            return Boolean.parseBoolean(System.getProperty("saiku.allowDefaultAdmin", "false"));
+        }
+
+        /**
+         * saiku#1153: stop a production boot dead when the shipped default admin
+         * password is unchanged. Demo mode and the explicit override opt out.
+         *
+         * @throws DefaultCredentialsException with an operator-facing fix-it
+         *     message when the boot should be refused.
+         */
+        static void enforceDefaultCredentialPolicy(Path warPath) {
+            if (!shouldRefuse(adminPasswordIsDefault(warPath), isDemoModeRequested(), allowDefaultAdmin())) {
+                return;
+            }
+            String bar = "============================================================";
+            String msg = String.join(
+                    System.lineSeparator(),
+                    "",
+                    bar,
+                    "  FATAL: refusing to start — the default admin password is",
+                    "  still in place (admin / admin). A network-exposed instance",
+                    "  with default credentials is compromised within seconds.",
+                    "",
+                    "  Fix one of the following, then restart:",
+                    "    * Rotate the admin password in users.properties (bcrypt):",
+                    "        htpasswd -nbBC 12 admin <newpassword>",
+                    "    * Replace the in-memory auth with LDAP / OAuth / SAML",
+                    "      (applicationContext-spring-security-memory.xml).",
+                    "",
+                    "  To start anyway (NOT for a production / exposed host), set:",
+                    "        SAIKU_ALLOW_DEFAULT_ADMIN=true",
+                    "  or run the bundled demo:  SAIKU_DEMO=true",
+                    bar,
+                    "");
+            throw new DefaultCredentialsException(msg);
         }
 
         /**

--- a/saiku-launcher/src/test/java/org/saiku/launcher/CredentialPolicyTest.java
+++ b/saiku-launcher/src/test/java/org/saiku/launcher/CredentialPolicyTest.java
@@ -1,0 +1,99 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.launcher;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+import org.saiku.launcher.SaikuLauncher.ServeCommand;
+
+/**
+ * saiku#1153 — unit tests for the default-admin-credentials boot policy. The
+ * pure decision logic ({@code isDefaultAdminValue} + {@code shouldRefuse}) is
+ * tested directly; the WAR-reading and live boot paths are exercised by the IT
+ * harness (which opts in via {@code -Dsaiku.allowDefaultAdmin=true}).
+ */
+public class CredentialPolicyTest {
+
+    @Test
+    public void legacyNoopDefaultIsDetected() {
+        assertTrue(ServeCommand.isDefaultAdminValue("{noop}admin,ROLE_USER,ROLE_ADMIN"));
+    }
+
+    @Test
+    public void shippedBcryptDefaultIsDetected() {
+        // saiku#1154 ships the admin password as a bcrypt hash; the policy must
+        // still recognise that exact shipped hash as "unchanged default".
+        assertTrue(
+                ServeCommand.isDefaultAdminValue(ServeCommand.SHIPPED_BCRYPT_ADMIN_DEFAULT + ",ROLE_USER,ROLE_ADMIN"));
+    }
+
+    @Test
+    public void rotatedPasswordIsNotDefault() {
+        assertFalse(ServeCommand.isDefaultAdminValue(
+                "{bcrypt}$2a$10$ROTATEDrotatedROTATEDrotatedROTATEDrotatedROTATEDrotat,ROLE_USER,ROLE_ADMIN"));
+    }
+
+    @Test
+    public void nullOrMissingIsNotDefault() {
+        assertFalse(ServeCommand.isDefaultAdminValue(null));
+        assertFalse(ServeCommand.isDefaultAdminValue(""));
+    }
+
+    @Test
+    public void shippedConstantStillEncodesTheWordAdmin() {
+        // Guard against the constant being edited to a non-bcrypt / wrong shape.
+        assertTrue(ServeCommand.SHIPPED_BCRYPT_ADMIN_DEFAULT.startsWith("{bcrypt}$2"));
+    }
+
+    @Test
+    public void refusesWhenDefaultInProductionWithoutOverride() {
+        assertTrue(ServeCommand.shouldRefuse(true, false, false));
+    }
+
+    @Test
+    public void demoModeStartsWithDefault() {
+        assertFalse(ServeCommand.shouldRefuse(true, true, false));
+    }
+
+    @Test
+    public void explicitOverrideStartsWithDefault() {
+        assertFalse(ServeCommand.shouldRefuse(true, false, true));
+    }
+
+    @Test
+    public void rotatedPasswordAlwaysStarts() {
+        assertFalse("a rotated password must never block boot", ServeCommand.shouldRefuse(false, false, false));
+        assertFalse(ServeCommand.shouldRefuse(false, true, false));
+        assertFalse(ServeCommand.shouldRefuse(false, false, true));
+    }
+
+    @Test
+    public void overrideReadsSystemProperty() {
+        String prev = System.getProperty("saiku.allowDefaultAdmin");
+        try {
+            System.setProperty("saiku.allowDefaultAdmin", "true");
+            assertTrue(ServeCommand.allowDefaultAdmin());
+            System.setProperty("saiku.allowDefaultAdmin", "false");
+            assertFalse(ServeCommand.allowDefaultAdmin());
+        } finally {
+            if (prev == null) {
+                System.clearProperty("saiku.allowDefaultAdmin");
+            } else {
+                System.setProperty("saiku.allowDefaultAdmin", prev);
+            }
+        }
+    }
+
+    @Test
+    public void encodingIsSplitOffRolesCorrectly() {
+        // The role list after the first comma must not affect detection.
+        assertEquals(
+                ServeCommand.isDefaultAdminValue("{noop}admin,ROLE_USER"),
+                ServeCommand.isDefaultAdminValue("{noop}admin,ROLE_USER,ROLE_ADMIN,ROLE_EXTRA"));
+    }
+}

--- a/saiku-launcher/src/test/java/org/saiku/launcher/it/SaikuItHarness.java
+++ b/saiku-launcher/src/test/java/org/saiku/launcher/it/SaikuItHarness.java
@@ -68,6 +68,10 @@ public final class SaikuItHarness {
             return existing;
         }
         Path home = Files.createTempDirectory("saiku-it-");
+        // saiku#1153: the harness authenticates as the default admin/admin seed
+        // user, so it must opt in to the default-credentials policy or bootServer
+        // refuses to start. The IT JVM is a trusted local fixture, never exposed.
+        System.setProperty("saiku.allowDefaultAdmin", "true");
         // Boot port=0 → OS picks an ephemeral port. Host 127.0.0.1 to avoid
         // firewall prompts on macOS CI runners.
         Server server = SaikuLauncher.ServeCommand.bootServer(0, "127.0.0.1", "/", home);

--- a/saiku-webapp/src/main/webapp/WEB-INF/users-demo.properties
+++ b/saiku-webapp/src/main/webapp/WEB-INF/users-demo.properties
@@ -8,6 +8,10 @@
 # the bundled demo data — keeping them in a separate file lets a real
 # deployment ship without the publicly-knowable credentials being
 # active. See saiku#897.
-bob={noop}dylan,ROLE_USER
-krishna={noop}krish2341,ROLE_USER
-smith={noop}pravah@001,ROLE_USER
+#
+# saiku#1154: stored as {bcrypt} hashes (no plaintext on disk). The
+# cleartext demo logins are unchanged and remain publicly documented:
+#   bob/dylan   krishna/krish2341   smith/pravah@001
+bob={bcrypt}$2a$10$cN/GrdZq/dD.lV6cNQ.MYeDfElhpXXFoJsbVDCAl6PXJZAgdrEJqG,ROLE_USER
+krishna={bcrypt}$2a$10$7YZ3ZUfuQRTnrljIxCCVHOvXTPLGZInixHA3HMc/oyKYwh3FvQUYq,ROLE_USER
+smith={bcrypt}$2a$10$K9bNILI6OUkA8TLYyFbYmufVdumcRe9/T9NbOFgOL7lzwwEcYBGIO,ROLE_USER

--- a/saiku-webapp/src/main/webapp/WEB-INF/users.properties
+++ b/saiku-webapp/src/main/webapp/WEB-INF/users.properties
@@ -1,12 +1,24 @@
 #Username,password,role
 #
 # In-memory users for the bundled Spring Security config. Production
-# deployments should rotate admin/admin or replace this entirely with
-# an external auth provider (LDAP / OAuth / SAML) — see
+# deployments should rotate the admin password or replace this entirely
+# with an external auth provider (LDAP / OAuth / SAML) — see
 # applicationContext-spring-security-memory.xml.
+#
+# saiku#1154: passwords are stored as {bcrypt} hashes (Spring Security's
+# DelegatingPasswordEncoder reads the {id} prefix), never plaintext, so a
+# disk/backup/log leak is not a direct credential compromise. Rotate the
+# admin password with:  htpasswd -nbBC 12 admin <newpassword>
+# (the {bcrypt}/$2y$ variant htpasswd emits is accepted).
+#
+# saiku#1153: this row ships with the default password "admin". The
+# launcher REFUSES to start in production while that default is unchanged,
+# unless SAIKU_ALLOW_DEFAULT_ADMIN=true is set; demo mode (SAIKU_DEMO=true)
+# still starts. Keep the hash below in sync with SHIPPED_BCRYPT_ADMIN_DEFAULT
+# in SaikuLauncher if you regenerate it.
 #
 # Additional demo accounts (bob / krishna / smith) live in
 # users-demo.properties and are loaded only when the "demo" Spring
 # profile is active (set spring.profiles.active=demo or, in the
 # launcher, the SAIKU_DEMO=true env var). See saiku#897.
-admin={noop}admin,ROLE_USER,ROLE_ADMIN
+admin={bcrypt}$2a$10$4lJwsvvv..UqK31JmBSoCOf7hYgKurOB2sEacVVIrqA97BXc4cFju,ROLE_USER,ROLE_ADMIN


### PR DESCRIPTION
Closes #1153, closes #1154.

## What

The bundled in-memory auth shipped `admin/admin` as **literal plaintext** (`{noop}`), and the launcher only *logged a warning* about it. Every fresh, internet-exposed install was ownable in seconds with the most guessable login in the world. Two paired HIGH-severity issues.

## #1154 — store passwords as bcrypt, not plaintext

- `users.properties` (admin) and `users-demo.properties` (bob/krishna/smith) now hold `{bcrypt}` hashes.
- **No code or XML change.** The security-memory config's `<authentication-provider>` (no explicit `<password-encoder>`) uses Spring Security 6's **`DelegatingPasswordEncoder`**, which reads the `{id}` prefix — that's *why* `{noop}admin` authenticated before. `{bcrypt}<hash>` authenticates the same way.
- Cleartext demo logins are unchanged and still publicly documented (`bob/dylan`, `krishna/krish2341`, `smith/pravah@001`).

## #1153 — launcher refuses to serve on the default admin password

- `SaikuLauncher.ServeCommand` reads the effective `admin` row from the bundled WAR and, if it's still the shipped default, **refuses to boot** with an operator-facing fix-it message (non-zero exit) — **unless**:
  - demo mode (`SAIKU_DEMO=true`) is active, **or**
  - `SAIKU_ALLOW_DEFAULT_ADMIN=true` (env) / `-Dsaiku.allowDefaultAdmin=true`.
- **Dependency-free detection** (kept spring-security-crypto *off* the launcher's own classpath): match the raw value against legacy `{noop}admin` or the exact shipped bcrypt constant `SHIPPED_BCRYPT_ADMIN_DEFAULT` (kept in sync with `users.properties`). Fails **open** on any WAR-read error — a refusal must be deliberate, never a parse glitch.
- The IT harness opts in (`-Dsaiku.allowDefaultAdmin=true`) since it authenticates as admin/admin, so CI stays green.

### Why hard-refuse over auto-generate
The issue floated auto-generating a random password to a `0600` file. I chose the hard stop because (a) writing `0600` secrets is unreliable on Windows (POSIX perms don't map — and this was developed/verified on Windows), adding a cross-platform failure mode, and (b) a hard stop is what actually closes an "exposed-by-default" bug, while demo mode keeps the marketing/demo flows friction-free. *(Approved by maintainer before implementation.)*

## Boot behavior

```
PROD, admin still default:        FATAL: refusing to start ... [exit 2]
PROD + SAIKU_ALLOW_DEFAULT_ADMIN: starts (loud warning)
DEMO (SAIKU_DEMO=true):           starts, admin/admin works (loud warning)
admin password rotated:           starts clean
```

## Tests

- **`CredentialPolicyTest`** (11) — default detection (`{noop}` + shipped bcrypt), rotated ≠ default, null/empty, refuse/allow truth table, override reads system property.
- **`AdminIT`** (integration profile) — boots the **real webapp** and authenticates as the **bcrypted** admin against admin-only endpoints: proves bcrypt login + ROLE_ADMIN end-to-end **and** the harness override path. 4/4 green.
- `spotless:apply` clean.

## Notes

- Scope: security lane (Agent SEC). **Not self-merging** — handing to the integrator.
- Branch cut from + level with `development`.
- The rotation recipe (`htpasswd -nbBC 12 admin <pw>`) is documented inline in `users.properties` and in the launcher's refusal message. Happy to add a dedicated docs page if preferred.
- ⚠️ If anyone regenerates the shipped admin hash, update `SHIPPED_BCRYPT_ADMIN_DEFAULT` to match (bcrypt salt is random). `CredentialPolicyTest` guards the constant's shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
