### PR TITLE
fix(security): zip-slip defense-in-depth in /repository/zipupload (#1157)

### DIFF
--- a/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/BasicRepositoryResource2.java
+++ b/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/BasicRepositoryResource2.java
@@ -31,6 +31,8 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.UnsupportedEncodingException;
+import java.nio.file.InvalidPathException;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -366,6 +368,21 @@ public class BasicRepositoryResource2 implements ISaikuRepository {
                     fileName = zipFile;
                 }
 
+                // saiku#1157: zip-slip defense-in-depth. Reject a traversal /
+                // absolute entry name at the zip layer BEFORE it reaches
+                // saveResource (whose resolveWithinDatadir is the primary
+                // guard) so a future regression in the path resolver can't
+                // silently re-open the hole. Fail closed with a 400 naming the
+                // offending entry; nothing further in the archive is written.
+                if (isUnsafeZipEntryName(fileName)) {
+                    log.warn("Rejected unsafe zip entry name (saiku#1157): {}", fileName);
+                    return Response.status(Status.BAD_REQUEST)
+                            .entity(output + "REJECTED: unsafe entry name '" + fileName
+                                    + "' — path traversal / absolute paths are not allowed.\r\n")
+                            .type("text/plain")
+                            .build();
+                }
+
                 output += "Saving " + fileName + "... ";
                 String fullPath = (StringUtils.isNotBlank(directory)) ? directory + "/" + fileName : fileName;
 
@@ -395,5 +412,31 @@ public class BasicRepositoryResource2 implements ISaikuRepository {
             String error = ExceptionUtils.getRootCauseMessage(e);
             return Response.serverError().entity(output + "\r\n" + error).build();
         }
+    }
+
+    /**
+     * saiku#1157: defense-in-depth zip-slip guard. Returns {@code true} when a
+     * zip archive entry name could escape the target directory and must be
+     * rejected before {@code saveResource} is called. A name is unsafe when it
+     * is blank, absolute (a unix leading {@code /}, a Windows drive like
+     * {@code C:\}, or a leading backslash / UNC path), or contains a
+     * {@code ..} path segment after separator normalisation. The downstream
+     * {@code FilesystemRepositoryManager.resolveWithinDatadir} remains the
+     * primary guard; this is a second, independent layer.
+     */
+    static boolean isUnsafeZipEntryName(String name) {
+        if (StringUtils.isBlank(name)) return true;
+        String normalized = name.replace('\\', '/');
+        if (normalized.startsWith("/")) return true; // unix-absolute or leading slash (also catches UNC)
+        if (normalized.matches("(?i)^[a-z]:/.*")) return true; // Windows drive-absolute, e.g. C:/ or C:\
+        for (String segment : normalized.split("/")) {
+            if (segment.equals("..")) return true; // traversal segment
+        }
+        try {
+            if (Paths.get(name).isAbsolute()) return true; // platform-specific backstop
+        } catch (InvalidPathException e) {
+            return true; // not a legal path on this platform → reject
+        }
+        return false;
     }
 }

--- a/saiku-core/saiku-web/src/test/java/org/saiku/web/rest/resources/ZipUploadSlipTest.java
+++ b/saiku-core/saiku-web/src/test/java/org/saiku/web/rest/resources/ZipUploadSlipTest.java
@@ -1,0 +1,98 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.web.rest.resources;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import jakarta.ws.rs.core.Response;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
+import org.glassfish.jersey.media.multipart.FormDataContentDisposition;
+import org.junit.Test;
+
+/**
+ * saiku#1157 — zip-slip defense-in-depth for {@code POST /repository/zipupload}.
+ * The entry-name guard must reject traversal / absolute archive entries before
+ * {@code saveResource} runs, independent of the downstream
+ * {@code resolveWithinDatadir} guard.
+ */
+public class ZipUploadSlipTest {
+
+    @Test
+    public void rejectsParentTraversalEntry() {
+        assertTrue(BasicRepositoryResource2.isUnsafeZipEntryName("../../etc/passwd"));
+    }
+
+    @Test
+    public void rejectsLeadingSlashAbsolute() {
+        assertTrue(BasicRepositoryResource2.isUnsafeZipEntryName("/etc/passwd"));
+    }
+
+    @Test
+    public void rejectsBackslashTraversal() {
+        assertTrue(BasicRepositoryResource2.isUnsafeZipEntryName("..\\..\\windows\\system32\\drivers\\etc\\hosts"));
+    }
+
+    @Test
+    public void rejectsWindowsDriveAbsolute() {
+        assertTrue(BasicRepositoryResource2.isUnsafeZipEntryName("C:\\windows\\evil"));
+        assertTrue(BasicRepositoryResource2.isUnsafeZipEntryName("c:/windows/evil"));
+    }
+
+    @Test
+    public void rejectsLeadingBackslashUnc() {
+        assertTrue(BasicRepositoryResource2.isUnsafeZipEntryName("\\\\server\\share\\x"));
+    }
+
+    @Test
+    public void rejectsBlankOrNull() {
+        assertTrue(BasicRepositoryResource2.isUnsafeZipEntryName(null));
+        assertTrue(BasicRepositoryResource2.isUnsafeZipEntryName("   "));
+    }
+
+    @Test
+    public void rejectsMidPathTraversalSegment() {
+        assertTrue(BasicRepositoryResource2.isUnsafeZipEntryName("homes/smith/../../../etc/x"));
+    }
+
+    @Test
+    public void allowsNormalRelativeNames() {
+        assertFalse(BasicRepositoryResource2.isUnsafeZipEntryName("report.saiku"));
+        assertFalse(BasicRepositoryResource2.isUnsafeZipEntryName("homes/smith/report.saiku"));
+        assertFalse(BasicRepositoryResource2.isUnsafeZipEntryName("nested/dir/chart.json"));
+        // ".." embedded inside a name (not a standalone path segment) is fine.
+        assertFalse(BasicRepositoryResource2.isUnsafeZipEntryName("a..b/file.txt"));
+    }
+
+    @Test
+    public void endpointReturns400AndWritesNothingOnTraversalEntry() throws Exception {
+        byte[] zip = zipWithSingleEntry("../../etc/passwd", "pwned");
+        FormDataContentDisposition fd =
+                FormDataContentDisposition.name("file").fileName("evil.zip").build();
+
+        // No repository wiring on the resource: the guard must fire and return
+        // 400 BEFORE saveResource is ever consulted, so a bare instance is enough.
+        Response r =
+                new BasicRepositoryResource2().uploadArchiveZip(null, new ByteArrayInputStream(zip), fd, "homes/smith");
+
+        assertEquals(400, r.getStatus());
+        assertTrue(
+                "response names the offending entry", r.getEntity().toString().contains("../../etc/passwd"));
+    }
+
+    private static byte[] zipWithSingleEntry(String name, String content) throws Exception {
+        ByteArrayOutputStream bos = new ByteArrayOutputStream();
+        try (ZipOutputStream zos = new ZipOutputStream(bos)) {
+            zos.putNextEntry(new ZipEntry(name));
+            zos.write(content.getBytes(java.nio.charset.StandardCharsets.UTF_8));
+            zos.closeEntry();
+        }
+        return bos.toByteArray();
+    }
+}


### PR DESCRIPTION
Closes #1157.

## What

`POST /repository/zipupload` builds each saved path from the uploaded zip entry's `ze.getName()`. Path traversal is *already* mitigated downstream by `FilesystemRepositoryManager.resolveWithinDatadir`, so this is **defense-in-depth**: validate the entry name at the zip layer too, so a future refactor of the path resolver can't silently re-open the hole without anyone noticing.

## Fix

- New `BasicRepositoryResource2.isUnsafeZipEntryName(name)` rejects an entry name that is:
  - blank/null,
  - absolute — unix leading `/`, a Windows drive (`C:\` / `c:/`), or a leading backslash / UNC,
  - or contains a `..` path **segment** after separator normalisation (so a legitimate `a..b.txt` filename is still allowed).
- `uploadArchiveZip` calls it on each entry **before** `saveResource` and **fails closed** with a `400` naming the offending entry; nothing further in the archive is written.

## Tests (`ZipUploadSlipTest`)

- Rejects `../../etc/passwd`, `/etc/passwd`, `..\..\windows\...`, `C:\...` / `c:/...`, `\\server\share\...`, blank/null, and mid-path `homes/smith/../../../etc/x`.
- Allows normal relative names (`report.saiku`, `homes/smith/report.saiku`, `a..b/file.txt`).
- **Endpoint test:** a crafted zip whose entry is `../../etc/passwd` returns **400** and never reaches `saveResource` (bare resource instance, no repo wiring — proves the guard fires first).

9/9 green; `spotless:apply` clean.

## Notes

- Scope: security lane (Agent SEC). **Not self-merging** — handing to the integrator.
- Branch cut from + level with `development`.
- The only remaining textual mention of `login.jsp`/etc. is unrelated; the downstream `resolveWithinDatadir` guard is untouched and remains the primary defense.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
