### PR TITLE
fix(security): restrict StatisticsResource to ROLE_ADMIN (cross-tenant disclosure)

### DIFF
--- a/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/StatisticsResource.java
+++ b/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/StatisticsResource.java
@@ -1,5 +1,6 @@
 package org.saiku.web.rest.resources;
 
+import jakarta.annotation.security.RolesAllowed;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
@@ -13,8 +14,18 @@ import mondrian.server.monitor.StatementInfo;
 
 /**
  * Mondrian Server Info and Stats Endpoints.
+ *
+ * <p>saiku#1165 hardening: these endpoints expose <b>server-global</b> Mondrian
+ * state — every open OLAP connection and every in-flight MDX/SQL statement
+ * across all users' sessions ({@code monitor.getConnections()} /
+ * {@code getStatements()}). That is operator-only diagnostic data, so the whole
+ * resource is restricted to {@code ROLE_ADMIN} (enforced by the registered
+ * {@code RolesAllowedDynamicFeature}, same as {@code AdminResource}). Previously
+ * it was reachable by any authenticated {@code ROLE_USER}, leaking other
+ * tenants' query text and activity.
  */
 @Path("/saiku/statistics")
+@RolesAllowed("ROLE_ADMIN")
 public class StatisticsResource {
 
     //	StringWriter sqlWriter = new StringWriter();


### PR DESCRIPTION
Found by a **round-2 deep security audit** of `development` (refs the audit index #1165 — this is a *new* finding beyond the original 8).

## What

`StatisticsResource` (`@Path("/saiku/statistics")`, endpoints `/mondrian`, `/mondrian/server`, `/mondrian/server/version`) had **no access-control annotation**. The only rule covering it is the catch-all `/rest/**` = `isFullyAuthenticated()`, so **any** authenticated `ROLE_USER` could call it.

`getMondrianStats()` returns **server-global** Mondrian state:
- `monitor.getConnections()` — every currently-open OLAP connection, and
- `monitor.getStatements()` — every in-flight MDX/SQL statement,

across **all users' sessions**. A low-privilege user could read other tenants' query text, cube/connection names, and activity — cross-tenant **information disclosure**.

## Fix

Class-level `@RolesAllowed("ROLE_ADMIN")`, identical to `AdminResource`. Enforced by the `RolesAllowedDynamicFeature` already registered in `SaikuJerseyApplication` (the same mechanism `AdminResource` uses and `AdminIT` exercises).

## Testing note (honest)

The launcher's auth is **memory-backed** (`users.properties`) and ships **only** the `admin` principal, so the IT harness has no `ROLE_USER` to assert the 403 negative directly. The role enforcement is the framework feature already proven for `AdminResource`; the change compiles cleanly (`spotless:apply` clean). If you'd like, I can add a demo-profile IT (separate boot) that logs in as `bob` and asserts 403 — flag me.

## Notes

- Scope: security lane (Agent SEC). **Not self-merging.**
- Branch off + level with `development`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
