### PR TITLE
fix(security): harden QueryDeserializer against XXE (saved-query XML)

### DIFF
--- a/saiku-core/saiku-service/src/main/java/org/saiku/olap/query/QueryDeserializer.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/olap/query/QueryDeserializer.java
@@ -43,6 +43,7 @@ import org.olap4j.query.Selection;
 import org.olap4j.query.SortOrder;
 import org.saiku.olap.dto.SaikuCube;
 import org.saiku.olap.util.exception.QueryParseException;
+import org.saiku.service.util.xml.SecureXml;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.xml.sax.InputSource;
@@ -71,7 +72,7 @@ public class QueryDeserializer {
 
     public IQuery unparse(String xml, OlapConnection connection) throws Exception {
         this.connection = connection;
-        SAXBuilder parser = new SAXBuilder();
+        SAXBuilder parser = SecureXml.secureSaxBuilder();
         source = new InputSource((new ByteArrayInputStream(xml.getBytes("UTF8"))));
         dom = parser.build(source);
         Element child = dom.getRootElement();
@@ -90,7 +91,7 @@ public class QueryDeserializer {
     }
 
     public SaikuCube getFakeCube(String xml) throws Exception {
-        SAXBuilder parser = new SAXBuilder();
+        SAXBuilder parser = SecureXml.secureSaxBuilder();
         InputSource source = new InputSource((new ByteArrayInputStream(xml.getBytes())));
         Document dom = parser.build(source);
 
@@ -109,7 +110,7 @@ public class QueryDeserializer {
 
     public SaikuCube getCube(String xml, OlapConnection con) throws Exception {
         this.connection = con;
-        SAXBuilder parser = new SAXBuilder();
+        SAXBuilder parser = SecureXml.secureSaxBuilder();
         source = new InputSource((new ByteArrayInputStream(xml.getBytes())));
         dom = parser.build(source);
 

--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/util/xml/SecureXml.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/util/xml/SecureXml.java
@@ -18,6 +18,7 @@ import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.parsers.SAXParser;
 import javax.xml.parsers.SAXParserFactory;
 import javax.xml.transform.sax.SAXSource;
+import org.jdom2.input.SAXBuilder;
 import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
 import org.xml.sax.XMLReader;
@@ -65,6 +66,25 @@ public final class SecureXml {
         dbf.setXIncludeAware(false);
         dbf.setExpandEntityReferences(false);
         return dbf.newDocumentBuilder();
+    }
+
+    /**
+     * Build a JDOM2 {@link SAXBuilder} that refuses DOCTYPE declarations and external entities.
+     * Use this instead of {@code new SAXBuilder()} anywhere user-influenced XML is parsed with
+     * JDOM2 (e.g. saved-query deserialisation in {@code QueryDeserializer}). With
+     * {@code disallow-doctype-decl} set, any inbound DOCTYPE is rejected outright, which defeats
+     * both classic XXE (file read / SSRF) and entity-expansion DoS ("billion laughs"). Saved-query
+     * XML never legitimately carries a DOCTYPE, so this is strictly hardening with no behaviour
+     * change for valid input.
+     */
+    public static SAXBuilder secureSaxBuilder() {
+        SAXBuilder builder = new SAXBuilder();
+        builder.setFeature(FEATURE_DISALLOW_DOCTYPE, true);
+        builder.setFeature(FEATURE_EXTERNAL_GENERAL_ENTITIES, false);
+        builder.setFeature(FEATURE_EXTERNAL_PARAMETER_ENTITIES, false);
+        builder.setFeature(FEATURE_LOAD_EXTERNAL_DTD, false);
+        builder.setExpandEntities(false);
+        return builder;
     }
 
     /**

--- a/saiku-core/saiku-service/src/test/java/org/saiku/olap/query/QueryDeserializerXxeTest.java
+++ b/saiku-core/saiku-service/src/test/java/org/saiku/olap/query/QueryDeserializerXxeTest.java
@@ -1,0 +1,56 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.olap.query;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import org.jdom2.JDOMException;
+import org.junit.Test;
+import org.saiku.olap.dto.SaikuCube;
+
+/**
+ * Deep-audit regression: saved-query XML deserialisation must reject DOCTYPE
+ * declarations so a crafted query body cannot mount an XXE (file read / SSRF)
+ * or entity-expansion DoS. {@link QueryDeserializer} now builds its JDOM2
+ * parser via {@code SecureXml.secureSaxBuilder()} (disallow-doctype-decl).
+ *
+ * <p>{@code getFakeCube(xml)} is the smallest reachable entry point (no OLAP
+ * connection needed) and exercises the exact hardened parser path used by the
+ * {@code POST /saiku/api/query/{name}} create flow.
+ */
+public class QueryDeserializerXxeTest {
+
+    private static final String XXE_PAYLOAD = "<?xml version=\"1.0\"?>\n"
+            + "<!DOCTYPE Query [ <!ENTITY xxe SYSTEM \"file:///etc/passwd\"> ]>\n"
+            + "<Query connection=\"c\" cube=\"&xxe;\" catalog=\"cat\" schema=\"sch\"/>";
+
+    private static final String NORMAL_QUERY =
+            "<Query connection=\"foodmart\" cube=\"Sales\" catalog=\"cat\" schema=\"sch\"/>";
+
+    @Test
+    public void doctypePayloadIsRejected() throws Exception {
+        try {
+            new QueryDeserializer().getFakeCube(XXE_PAYLOAD);
+            fail("expected the DOCTYPE-bearing payload to be rejected by the hardened parser");
+        } catch (JDOMException e) {
+            // Parse-layer rejection (disallow-doctype-decl) — exactly what we want.
+            // Pre-fix, the default SAXBuilder parsed this and expanded the entity.
+            assertTrue(
+                    "rejection should be about the disallowed DOCTYPE, was: " + e.getMessage(),
+                    e.getMessage().toUpperCase().contains("DOCTYPE"));
+        }
+    }
+
+    @Test
+    public void normalQueryStillParses() throws Exception {
+        SaikuCube cube = new QueryDeserializer().getFakeCube(NORMAL_QUERY);
+        assertNotNull("a DOCTYPE-free query must still parse", cube);
+        assertEquals("Sales", cube.getName());
+        assertEquals("foodmart", cube.getConnection());
+    }
+}


### PR DESCRIPTION
Found by a **round-2 deep security audit** of `development` (refs the audit index #1165 — a *new* finding beyond the original 8).

## What

`QueryDeserializer` built its JDOM2 parser with **`new SAXBuilder()`** (default, unsafe config) at **three** sites — `unparse`, `getFakeCube`, `getCube`. JDOM2's default `SAXBuilder` permits DOCTYPE declarations and entity expansion, so a crafted saved-query XML could mount:
- **XXE** → local file read / SSRF (e.g. `<!ENTITY xxe SYSTEM "file:///etc/passwd">`), and
- **entity-expansion DoS** ("billion laughs").

The sink is reachable by **any authenticated user** via `POST /saiku/api/query/{name}` — the `xml` form param flows through `OlapQueryService` → `QueryDeserializer`. It bypassed the project's existing `SecureXml` hardening entirely.

## Fix

- New `SecureXml.secureSaxBuilder()` — a JDOM2 `SAXBuilder` with `disallow-doctype-decl=true`, external general/parameter entities off, `load-external-dtd` off, `expandEntities=false`. **`disallow-doctype` rejects any inbound DOCTYPE outright**, which defeats both XXE and entity-expansion DoS in one move.
- `QueryDeserializer` now uses it at all three parse sites. Saved-query XML never legitimately carries a DOCTYPE, so valid input is unaffected.

## Tests (`QueryDeserializerXxeTest`)

- A `DOCTYPE` + `SYSTEM` external-entity payload is **rejected** with a `JDOMException` naming `DOCTYPE` (pre-fix, the default builder parsed it and expanded the entity).
- A normal, DOCTYPE-free query **still parses** to the right cube (`Sales` / `foodmart`).

2/2 green; `spotless:apply` clean.

## Notes

- Scope: security lane (Agent SEC). **Not self-merging.**
- Branch off + level with `development`.
- The related (lower-priority) `TransformerFactory`/XSLT factories in the PDF/FO export path are **not** in this PR — flagged separately as hardening (inputs there are fixed classpath stylesheets + already-`SecureXml` DOMs today).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
