### PR TITLE
fix(security): stop /admin/users serializing the password hash

### DIFF
--- a/saiku-core/saiku-service/src/main/java/org/saiku/database/dto/SaikuUser.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/database/dto/SaikuUser.java
@@ -1,12 +1,24 @@
 package org.saiku.database.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 /**
  * Created by bugg on 01/05/14.
  */
 public class SaikuUser {
     private String username;
     private String email;
+
+    /**
+     * saiku#1165 hardening: the stored password (a {bcrypt} hash, populated from
+     * the DB by JdbcUserDAO) must never be serialised back to a client — the
+     * admin user-management endpoints (GET /admin/users, /users/{id}) returned
+     * it otherwise. WRITE_ONLY keeps it accepting an inbound value on
+     * create/update while omitting it from every response.
+     */
+    @JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
     private String password;
+
     private String[] roles;
     private int id;
 

--- a/saiku-core/saiku-service/src/test/java/org/saiku/database/dto/SaikuUserSerializationTest.java
+++ b/saiku-core/saiku-service/src/test/java/org/saiku/database/dto/SaikuUserSerializationTest.java
@@ -1,0 +1,48 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.database.dto;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.Test;
+
+/**
+ * saiku#1165 — the admin user-management endpoints serialise {@link SaikuUser}
+ * back to the client. Its {@code password} field (a {bcrypt} hash loaded from
+ * the DB) must never leave the server, but must still be accepted inbound on
+ * create/update. {@code @JsonProperty(access = WRITE_ONLY)} enforces both.
+ */
+public class SaikuUserSerializationTest {
+
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    @Test
+    public void passwordIsNeverSerialisedOut() throws Exception {
+        SaikuUser u = new SaikuUser();
+        u.setUsername("admin");
+        u.setEmail("admin@example.com");
+        u.setRoles(new String[] {"ROLE_ADMIN"});
+        u.setPassword("{bcrypt}$2a$10$4lJwsvvv..UqK31JmBSoCOf7hYgKurOB2sEacVVIrqA97BXc4cFju");
+
+        String json = mapper.writeValueAsString(u);
+
+        assertFalse("the 'password' key must not appear in the response: " + json, json.contains("password"));
+        assertFalse("the bcrypt hash must not leak: " + json, json.contains("bcrypt"));
+        assertTrue("non-secret fields must still serialise", json.contains("admin"));
+        assertTrue("roles must still serialise", json.contains("ROLE_ADMIN"));
+    }
+
+    @Test
+    public void passwordIsStillAcceptedInbound() throws Exception {
+        // create/update must still be able to set a password from the request body.
+        String json = "{\"username\":\"bob\",\"password\":\"newSecret\",\"roles\":[\"ROLE_USER\"]}";
+        SaikuUser u = mapper.readValue(json, SaikuUser.class);
+        assertEquals("newSecret", u.getPassword());
+        assertEquals("bob", u.getUsername());
+    }
+}


### PR DESCRIPTION
Found by a **round-2 deep security audit** of `development` (refs the audit index #1165 — a *new* finding beyond the original 8).

## What

`GET /admin/users` and `GET /admin/users/{id}` return `SaikuUser` objects. The `password` field is populated from the DB by `JdbcUserDAO` (a `{bcrypt}` hash) and had **no** `@JsonIgnore`, so the hash was **serialised into the JSON response**.

Admin-only, but **password hashes must never leave the server** — they end up in browser memory, proxy logs, and admin-console network traces, enabling offline cracking if any of those is later compromised. Defense-in-depth failure.

## Fix

Annotate the field `@JsonProperty(access = JsonProperty.Access.WRITE_ONLY)`:
- **omitted** from every serialised response, and
- **still accepted inbound**, so create/update can set a password from the request body (no regression).

## Test (`SaikuUserSerializationTest`)

- Serialising a populated user produces JSON with **no `password` key and no bcrypt hash**, while non-secret fields (username, roles) remain.
- Deserialising a body containing `password` **still populates** it (inbound path intact).

2/2 green; `spotless:apply` clean.

## Notes

- Scope: security lane (Agent SEC). **Not self-merging.**
- Branch off + level with `development`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
