### PR TITLE
fix(security): rotate session id on login (session fixation)

### DIFF
--- a/saiku-core/saiku-web/src/main/java/org/saiku/web/service/SessionService.java
+++ b/saiku-core/saiku-web/src/main/java/org/saiku/web/service/SessionService.java
@@ -92,6 +92,20 @@ public class SessionService implements ISessionService {
 
             if (authorisationPredicate.isAuthorised(auth)) {
                 Object p = auth.getPrincipal();
+                // saiku#1165: defeat session fixation. Now that authentication has
+                // succeeded, rotate the HTTP session id so any pre-auth id an
+                // attacker may have planted in the victim's browser is discarded.
+                // changeSessionId() keeps the session's attributes (including the
+                // SecurityContext saved during authenticate()) and reissues the
+                // JSESSIONID cookie with the new id. This manual login flow bypasses
+                // Spring Security's SessionAuthenticationStrategy, so we rotate here.
+                try {
+                    req.changeSessionId();
+                } catch (IllegalStateException noSession) {
+                    // No active session to rotate (shouldn't happen after getSession
+                    // above) — nothing to fix; continue.
+                    log.debug("Session id rotation skipped: no active session", noSession);
+                }
                 createSession(auth, username, password);
                 return sessionHolder.get(p);
             } else {


### PR DESCRIPTION
Found by a **round-2 deep security audit** of `development` (refs the audit index #1165 — a *new* finding beyond the original 8).

## What

`SessionService.login` authenticates **manually** (`authenticationManager.authenticate(...)` + `securityContextRepository.saveContext(...)`) and **never rotated the HTTP session id**, so the pre-auth `JSESSIONID` survived authentication. Because this flow bypasses Spring Security's `UsernamePasswordAuthenticationFilter`, no `SessionAuthenticationStrategy` ran either (grep confirms none is configured).

An attacker who can plant a known `JSESSIONID` in a victim's browser (shared kiosk, sub-path cookie injection, a script gadget) keeps it valid after the victim logs in → **session fixation → hijack**. (`logout()` already invalidates; the gap was **login-only**.)

## Fix

After authentication succeeds **and** is authorised, call **`req.changeSessionId()`**:
- the session's attributes — including the `SecurityContext` saved during `authenticate()` — carry over to a **fresh** id, and
- the `JSESSIONID` cookie is reissued, so any planted pre-auth id is discarded.

Guarded against `IllegalStateException` defensively (there's always a session by that point, from the `getSession(true)` above).

## Test

The change sits on the login hot path, so the key risk is breaking login. `SessionIT` (integration profile) — which exercises the real form-login path (`postLogin_validCredentials_returns200`, `postLogin_invalidCredentials_returns401`, `logout_withAuth_returns200`, `getSession`) — stays **4/4 green** with the rotation in place. `spotless:apply` clean.

A fully deterministic fixation IT (establish a real pre-auth id, log in, assert the id changed) needs a stateful pre-auth session the Basic-auth IT harness doesn't cleanly establish; `changeSessionId()` is the standard servlet mechanism for this and the regression risk (login breakage) is covered above. Happy to add a stateful IT if you'd like.

## Notes

- Scope: security lane (Agent SEC). **Not self-merging.**
- Branch off + level with `development`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
