### PR TITLE
test(security): de-flake DemoGateCookieTest.verify_rejectsTamperedSignature

### DIFF
--- a/saiku-core/saiku-web/src/test/java/org/saiku/web/demo/DemoGateCookieTest.java
+++ b/saiku-core/saiku-web/src/test/java/org/saiku/web/demo/DemoGateCookieTest.java
@@ -24,8 +24,15 @@ public class DemoGateCookieTest {
     public void verify_rejectsTamperedSignature() {
         DemoGateCookie c = new DemoGateCookie(SECRET, 100);
         String v = c.sign("user@example.com");
-        char last = v.charAt(v.length() - 1);
-        String tampered = v.substring(0, v.length() - 1) + (last == 'A' ? 'B' : 'A');
+        // Tamper the FIRST character of the signature (right after "payload.").
+        // The previous version flipped the LAST base64 char, which was ~25% flaky:
+        // an unpadded base64 string's final character carries 4 unused trailing
+        // bits, so flipping it among A-P left the decoded HMAC bytes unchanged and
+        // the "tampered" cookie still verified. The first signature char's bits are
+        // fully significant, so this deterministically changes the decoded HMAC.
+        int dot = v.indexOf('.');
+        char first = v.charAt(dot + 1);
+        String tampered = v.substring(0, dot + 1) + (first == 'A' ? 'B' : 'A') + v.substring(dot + 2);
         assertFalse(c.verify(tampered));
     }
 


### PR DESCRIPTION
## What

`DemoGateCookieTest.verify_rejectsTamperedSignature` is **~25% flaky** and intermittently fails CI on **unrelated** PRs (it just failed on the #1159 refactor PR, which doesn't touch demo-gate code).

## Root cause

The test flips the **last** base64 char of the cookie signature and asserts `verify()` rejects it:
```java
char last = v.charAt(v.length() - 1);
String tampered = v.substring(0, v.length() - 1) + (last == 'A' ? 'B' : 'A');
```
The signature is **unpadded base64** of the HMAC. Base64's final character only carries a few significant bits — the rest are unused trailing bits. So when the original last char is in `A`–`P`, flipping it to `A`/`B` decodes to the **same HMAC bytes**, the "tampered" cookie still verifies, and `assertFalse` fails. Because the cookie payload embeds an expiry timestamp, the signature (and its last char) changes every run → intermittent (~16/64 ≈ 25%).

## Fix

Tamper the **first** signature character instead (its 6 bits are fully significant), which deterministically changes the decoded HMAC. Same assertion, now stable. 13/13 green.

## Notes

- Pre-existing flake from #1156 (not introduced by any current refactor); surfaced while landing the refactor PRs. Filed/fixed from the security lane since it's a security-test reliability issue actively blocking CI.
- Security lane (Agent SEC). **Not self-merging.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
