### PR TITLE
refactor(formatter): lift AbstractCellSetFormatter + log silent cell swallows (#1163)

### DIFF
--- a/saiku-core/saiku-service/src/main/java/org/saiku/olap/util/formatter/AbstractCellSetFormatter.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/olap/util/formatter/AbstractCellSetFormatter.java
@@ -1,0 +1,448 @@
+/*
+ *   Copyright 2012 OSBI Ltd
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package org.saiku.olap.util.formatter;
+
+import java.text.DecimalFormat;
+import java.text.DecimalFormatSymbols;
+import java.util.AbstractList;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import org.olap4j.Cell;
+import org.olap4j.CellSet;
+import org.olap4j.CellSetAxis;
+import org.olap4j.Position;
+import org.olap4j.impl.CoordinateIterator;
+import org.olap4j.impl.Olap4jUtil;
+import org.olap4j.metadata.Level;
+import org.olap4j.metadata.Member;
+import org.olap4j.metadata.Property;
+import org.saiku.olap.dto.resultset.DataCell;
+import org.saiku.olap.dto.resultset.Matrix;
+import org.saiku.olap.dto.resultset.MemberCell;
+import org.saiku.olap.util.SaikuProperties;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Package-private base class holding the byte-identical scaffolding shared by
+ * the three {@link ICellSetFormatter} implementations — {@link CellSetFormatter},
+ * {@link HierarchicalCellSetFormatter} and {@link FlattenedCellSetFormatter}.
+ *
+ * <p>Lifted here as part of issue #1163 (behaviour-preserving refactor): the
+ * nested {@code AxisInfo}/{@code AxisOrdinalInfo} descriptors, the static
+ * {@link #cellIter(int[], CellSet)} iterator, the {@code matrix} field, the
+ * {@link #format(CellSet)} driver, {@link #computeAxisInfo(CellSetAxis)}, the
+ * common two-axis {@link #formatPage}, and the shared
+ * {@link #populateCell(Matrix, Cell, java.util.List, int, int)} per-data-cell
+ * value block (including the three exception-swallow sites, in the exact
+ * {@link CellPropertyExtractor}-then-{@link Olap4jUtil#parseFormattedCellValue}
+ * overwrite order).
+ *
+ * <p>{@link #populateAxis} stays abstract: the three subclasses legitimately
+ * differ there (members[] clearing, expanded scoping, levelindex emission,
+ * same-nulling, parent-walk presence, setter order) and those bodies are
+ * preserved verbatim in each subclass.
+ *
+ * <p>The shape of the matrix output is contractually frozen — it feeds query
+ * results to the UI and the AI Query API and is pinned by
+ * {@code CellSetFormatterCharacterizationTest}.
+ */
+abstract class AbstractCellSetFormatter implements ICellSetFormatter {
+
+    private static final Logger log = LoggerFactory.getLogger(AbstractCellSetFormatter.class);
+
+    /**
+     * Description of an axis.
+     */
+    protected static class AxisInfo {
+        final List<AxisOrdinalInfo> ordinalInfos;
+
+        /**
+         * Creates an AxisInfo.
+         *
+         * @param ordinalCount
+         *            Number of hierarchies on this axis
+         */
+        AxisInfo(final int ordinalCount) {
+            ordinalInfos = new ArrayList<>(ordinalCount);
+            for (int i = 0; i < ordinalCount; i++) {
+                ordinalInfos.add(new AxisOrdinalInfo());
+            }
+        }
+
+        /**
+         * Returns the number of matrix columns required by this axis. The sum of the width of the hierarchies on this
+         * axis.
+         *
+         * @return Width of axis
+         */
+        public int getWidth() {
+            int width = 0;
+            for (final AxisOrdinalInfo info : ordinalInfos) {
+                width += info.getWidth();
+            }
+            return width;
+        }
+    }
+
+    /**
+     * Description of a particular hierarchy mapped to an axis.
+     */
+    protected static class AxisOrdinalInfo {
+        private final List<Integer> depths = new ArrayList<>();
+        private final Map<Integer, Level> depthLevel = new HashMap<>();
+
+        public int getWidth() {
+            return depths.size();
+        }
+
+        public List<Integer> getDepths() {
+            return depths;
+        }
+
+        public Level getLevel(Integer depth) {
+            return depthLevel.get(depth);
+        }
+
+        public void addLevel(Integer depth, Level level) {
+            depthLevel.put(depth, level);
+        }
+    }
+
+    /**
+     * Returns an iterator over cells in a result.
+     */
+    protected static Iterable<Cell> cellIter(final int[] pageCoords, final CellSet cellSet) {
+        return new Iterable<Cell>() {
+            public Iterator<Cell> iterator() {
+                final int[] axisDimensions = new int[cellSet.getAxes().size() - pageCoords.length];
+                assert pageCoords.length <= axisDimensions.length;
+                for (int i = 0; i < axisDimensions.length; i++) {
+                    final CellSetAxis axis = cellSet.getAxes().get(i);
+                    axisDimensions[i] = axis.getPositions().size();
+                }
+                final CoordinateIterator coordIter = new CoordinateIterator(axisDimensions, true);
+                return new Iterator<Cell>() {
+                    public boolean hasNext() {
+                        return coordIter.hasNext();
+                    }
+
+                    public Cell next() {
+                        final int[] ints = coordIter.next();
+                        final AbstractList<Integer> intList = new AbstractList<Integer>() {
+                            @Override
+                            public Integer get(final int index) {
+                                return index < ints.length ? ints[index] : pageCoords[index - ints.length];
+                            }
+
+                            @Override
+                            public int size() {
+                                return pageCoords.length + ints.length;
+                            }
+                        };
+                        return cellSet.getCell(intList);
+                    }
+
+                    public void remove() {
+                        throw new UnsupportedOperationException();
+                    }
+                };
+            }
+        };
+    }
+
+    protected Matrix matrix;
+
+    public Matrix format(final CellSet cellSet) {
+        // Compute how many rows are required to display the columns axis.
+        final CellSetAxis columnsAxis;
+        if (cellSet.getAxes().size() > 0) {
+            columnsAxis = cellSet.getAxes().get(0);
+        } else {
+            columnsAxis = null;
+        }
+        final AxisInfo columnsAxisInfo = computeAxisInfo(columnsAxis);
+
+        // Compute how many columns are required to display the rows axis.
+        final CellSetAxis rowsAxis;
+        if (cellSet.getAxes().size() > 1) {
+            rowsAxis = cellSet.getAxes().get(1);
+        } else {
+            rowsAxis = null;
+        }
+        final AxisInfo rowsAxisInfo = computeAxisInfo(rowsAxis);
+
+        if (cellSet.getAxes().size() > 2) {
+            final int[] dimensions = new int[cellSet.getAxes().size() - 2];
+            for (int i = 2; i < cellSet.getAxes().size(); i++) {
+                final CellSetAxis cellSetAxis = cellSet.getAxes().get(i);
+                dimensions[i - 2] = cellSetAxis.getPositions().size();
+            }
+            for (final int[] pageCoords : CoordinateIterator.iterate(dimensions)) {
+                matrix = formatPage(cellSet, pageCoords, columnsAxis, columnsAxisInfo, rowsAxis, rowsAxisInfo);
+            }
+        } else {
+            matrix = formatPage(cellSet, new int[] {}, columnsAxis, columnsAxisInfo, rowsAxis, rowsAxisInfo);
+        }
+
+        return matrix;
+    }
+
+    /**
+     * Computes a description of an axis.
+     *
+     * @param axis
+     *            Axis
+     * @return Description of axis
+     */
+    protected AxisInfo computeAxisInfo(final CellSetAxis axis) {
+        if (axis == null) {
+            return new AxisInfo(0);
+        }
+        final AxisInfo axisInfo =
+                new AxisInfo(axis.getAxisMetaData().getHierarchies().size());
+        int p = -1;
+        for (final Position position : axis.getPositions()) {
+            ++p;
+            int k = -1;
+            for (final Member member : position.getMembers()) {
+                ++k;
+                final AxisOrdinalInfo axisOrdinalInfo = axisInfo.ordinalInfos.get(k);
+                if (!axisOrdinalInfo.getDepths().contains(member.getDepth())) {
+                    axisOrdinalInfo.getDepths().add(member.getDepth());
+                    axisOrdinalInfo.addLevel(member.getDepth(), member.getLevel());
+                    Collections.sort(axisOrdinalInfo.depths);
+                }
+            }
+        }
+        return axisInfo;
+    }
+
+    /**
+     * Formats a two-dimensional page. This is the common implementation shared
+     * by {@link CellSetFormatter} and {@link HierarchicalCellSetFormatter};
+     * {@link FlattenedCellSetFormatter} overrides it wholesale to apply its
+     * ignorex/ignorey row/column collapsing before delegating each surviving
+     * data cell to {@link #populateCell}.
+     *
+     * @param cellSet
+     *            Cell set
+     * @param pageCoords
+     *            Coordinates of page [page, chapter, section, ...]
+     * @param columnsAxis
+     *            Columns axis
+     * @param columnsAxisInfo
+     *            Description of columns axis
+     * @param rowsAxis
+     *            Rows axis
+     * @param rowsAxisInfo
+     *            Description of rows axis
+     */
+    protected Matrix formatPage(
+            final CellSet cellSet,
+            final int[] pageCoords,
+            final CellSetAxis columnsAxis,
+            final AxisInfo columnsAxisInfo,
+            final CellSetAxis rowsAxis,
+            final AxisInfo rowsAxisInfo) {
+
+        // Figure out the dimensions of the blank rectangle in the top left
+        // corner.
+        final int yOffset = columnsAxisInfo.getWidth();
+        final int xOffsset = rowsAxisInfo.getWidth();
+
+        // Populate a string matrix
+        final Matrix matrix = new Matrix(
+                xOffsset + (columnsAxis == null ? 1 : columnsAxis.getPositions().size()),
+                yOffset + (rowsAxis == null ? 1 : rowsAxis.getPositions().size()));
+
+        // Populate corner
+        List<Level> levels = new ArrayList<>();
+        if (rowsAxis != null && rowsAxis.getPositions().size() > 0) {
+            Position p = rowsAxis.getPositions().get(0);
+            for (int m = 0; m < p.getMembers().size(); m++) {
+                AxisOrdinalInfo a = rowsAxisInfo.ordinalInfos.get(m);
+                for (Integer depth : a.getDepths()) {
+                    levels.add(a.getLevel(depth));
+                }
+            }
+            for (int x = 0; x < xOffsset; x++) {
+                Level xLevel = levels.get(x);
+                String s = xLevel.getCaption();
+                for (int y = 0; y < yOffset; y++) {
+                    final MemberCell memberInfo = new MemberCell(false, x > 0);
+                    if (y == yOffset - 1) {
+                        memberInfo.setRawValue(s);
+                        memberInfo.setFormattedValue(s);
+                        memberInfo.setProperty("__headertype", "row_header_header");
+                        memberInfo.setProperty("levelindex", "" + levels.indexOf(xLevel));
+                        memberInfo.setHierarchy(xLevel.getHierarchy().getUniqueName());
+                        memberInfo.setParentDimension(xLevel.getDimension().getName());
+                        memberInfo.setLevel(xLevel.getUniqueName());
+                    }
+                    matrix.set(x, y, memberInfo);
+                }
+            }
+        }
+        // Populate matrix with cells representing axes
+        // noinspection SuspiciousNameCombination
+        populateAxis(matrix, columnsAxis, columnsAxisInfo, true, xOffsset);
+        populateAxis(matrix, rowsAxis, rowsAxisInfo, false, yOffset);
+
+        // Populate cell values
+        for (final Cell cell : cellIter(pageCoords, cellSet)) {
+            final List<Integer> coordList = cell.getCoordinateList();
+            int x = xOffsset;
+            if (coordList.size() > 0) x += coordList.get(0);
+            int y = yOffset;
+            if (coordList.size() > 1) y += coordList.get(1);
+            populateCell(matrix, cell, coordList, x, y);
+        }
+        return matrix;
+    }
+
+    /**
+     * Builds a {@link DataCell} for a single olap4j data cell and writes it to
+     * {@code matrix} at (x, y). This block is byte-identical across all three
+     * formatters and is lifted here verbatim (issue #1163), preserving the
+     * exact {@link CellPropertyExtractor}-then-{@link Olap4jUtil#parseFormattedCellValue}
+     * property overwrite order.
+     *
+     * <p>The three {@code catch} blocks below are deliberate silent swallows
+     * carried over from the original code: their control flow is UNCHANGED
+     * (catch-and-absorb, never rethrow — the value falls through exactly as
+     * before). The only addition in #1163 is a WARN log of the exception (a
+     * generic message that never includes cell business values) so the
+     * previously-silent failures are at least observable.
+     *
+     * @param matrix
+     *            Matrix to populate
+     * @param cell
+     *            The olap4j cell
+     * @param coordList
+     *            The cell's coordinate list
+     * @param x
+     *            Target matrix x coordinate
+     * @param y
+     *            Target matrix y coordinate
+     */
+    protected void populateCell(
+            final Matrix matrix, final Cell cell, final List<Integer> coordList, final int x, final int y) {
+        final DataCell cellInfo = new DataCell(true, false, coordList);
+        cellInfo.setCoordinates(cell.getCoordinateList());
+        // saiku#773: surface the full set of olap4j StandardCellProperty
+        // values (format string, fore/back colour, font flags, action
+        // type, error text, etc.) Mondrian computes for this cell so
+        // the REST/Arrow consumers can read them.
+        cellInfo.setProperties(CellPropertyExtractor.extract(cell));
+
+        if (cell.getValue() != null) {
+            try {
+                cellInfo.setRawNumber(cell.getDoubleValue());
+            } catch (Exception e1) {
+                // #1163: previously a silent swallow. Control flow is
+                // unchanged — rawNumber simply stays unset and the cell
+                // falls through exactly as before; we only log so the
+                // failure is observable. No cell values are logged.
+                log.warn("Could not read numeric cell value; leaving rawNumber unset", e1);
+            }
+        }
+        String cellValue = cell.getFormattedValue(); // First try to get a
+        // formatted value
+
+        if (cellValue == null || cellValue.equals("null")) { // $NON-NLS-1$
+            cellValue = ""; // $NON-NLS-1$
+        }
+        if (cellValue.length() < 1) {
+            final Object value = cell.getValue();
+            if (value == null || value.equals("null")) // $NON-NLS-1$
+            cellValue = ""; // $NON-NLS-1$
+            else {
+                try {
+                    // TODO this needs to become query / execution specific
+                    DecimalFormat myFormatter =
+                            new DecimalFormat(SaikuProperties.formatDefautNumberFormat); // $NON-NLS-1$
+                    DecimalFormatSymbols dfs = new DecimalFormatSymbols(SaikuProperties.locale);
+                    myFormatter.setDecimalFormatSymbols(dfs);
+                    cellValue = myFormatter.format(cell.getValue());
+                } catch (Exception e) {
+                    // #1163: previously a silent swallow (// TODO: handle
+                    // exception). Control flow is unchanged — cellValue keeps
+                    // its prior value and the cell falls through exactly as
+                    // before; we only log so the failure is observable. No
+                    // cell values are logged.
+                    log.warn("Could not apply default number format to cell value", e);
+                }
+            }
+            // the raw value
+        }
+
+        // Format string is relevant for Excel export
+        // xmla cells can throw an error on this
+        try {
+
+            String formatString = (String) cell.getPropertyValue(Property.StandardCellProperty.FORMAT_STRING);
+            if (formatString != null && !formatString.startsWith("|")) {
+                cellInfo.setFormatString(formatString);
+            } else {
+                formatString = formatString.substring(1, formatString.length());
+                cellInfo.setFormatString(formatString.substring(0, formatString.indexOf("|")));
+            }
+        } catch (Exception e) {
+            // #1163: previously a silent swallow (// we tried). Control flow is
+            // unchanged — formatString simply stays unset (or whatever was set
+            // before the throw) and the cell falls through exactly as before;
+            // we only log so the failure is observable. No cell values are
+            // logged.
+            log.warn("Could not derive format string for cell", e);
+        }
+
+        Map<String, String> cellProperties = new HashMap<>();
+        String val = Olap4jUtil.parseFormattedCellValue(cellValue, cellProperties);
+        if (!cellProperties.isEmpty()) {
+            cellInfo.setProperties(cellProperties);
+        }
+        cellInfo.setFormattedValue(val);
+        matrix.set(x, y, cellInfo);
+    }
+
+    /**
+     * Populates cells in the matrix corresponding to a particular axis. The
+     * three implementations legitimately differ (see class javadoc); each
+     * subclass supplies its body verbatim.
+     *
+     * @param matrix
+     *            Matrix to populate
+     * @param axis
+     *            Axis
+     * @param axisInfo
+     *            Description of axis
+     * @param isColumns
+     *            True if columns, false if rows
+     * @param offset
+     *            Ordinal of first cell to populate in matrix
+     */
+    protected abstract void populateAxis(
+            final Matrix matrix,
+            final CellSetAxis axis,
+            final AxisInfo axisInfo,
+            final boolean isColumns,
+            final int offset);
+}

--- a/saiku-core/saiku-service/src/main/java/org/saiku/olap/util/formatter/CellSetFormatter.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/olap/util/formatter/CellSetFormatter.java
@@ -15,336 +15,26 @@
  */
 package org.saiku.olap.util.formatter;
 
-import java.text.DecimalFormat;
-import java.text.DecimalFormatSymbols;
-import java.util.AbstractList;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import org.olap4j.Cell;
-import org.olap4j.CellSet;
 import org.olap4j.CellSetAxis;
 import org.olap4j.Position;
-import org.olap4j.impl.CoordinateIterator;
 import org.olap4j.impl.Olap4jUtil;
 import org.olap4j.metadata.Hierarchy;
-import org.olap4j.metadata.Level;
 import org.olap4j.metadata.Member;
-import org.olap4j.metadata.Property;
-import org.saiku.olap.dto.resultset.DataCell;
 import org.saiku.olap.dto.resultset.Matrix;
 import org.saiku.olap.dto.resultset.MemberCell;
-import org.saiku.olap.util.SaikuProperties;
 
-public class CellSetFormatter implements ICellSetFormatter {
-    /**
-     * Description of an axis.
-     */
-    private static class AxisInfo {
-        final List<AxisOrdinalInfo> ordinalInfos;
-
-        /**
-         * Creates an AxisInfo.
-         *
-         * @param ordinalCount
-         *            Number of hierarchies on this axis
-         */
-        AxisInfo(final int ordinalCount) {
-            ordinalInfos = new ArrayList<>(ordinalCount);
-            for (int i = 0; i < ordinalCount; i++) {
-                ordinalInfos.add(new AxisOrdinalInfo());
-            }
-        }
-
-        /**
-         * Returns the number of matrix columns required by this axis. The sum of the width of the hierarchies on this
-         * axis.
-         *
-         * @return Width of axis
-         */
-        public int getWidth() {
-            int width = 0;
-            for (final AxisOrdinalInfo info : ordinalInfos) {
-                width += info.getWidth();
-            }
-            return width;
-        }
-    }
-
-    /**
-     * Description of a particular hierarchy mapped to an axis.
-     */
-    private static class AxisOrdinalInfo {
-        private final List<Integer> depths = new ArrayList<>();
-        private final Map<Integer, Level> depthLevel = new HashMap<>();
-
-        public int getWidth() {
-            return depths.size();
-        }
-
-        public List<Integer> getDepths() {
-            return depths;
-        }
-
-        public Level getLevel(Integer depth) {
-            return depthLevel.get(depth);
-        }
-
-        public void addLevel(Integer depth, Level level) {
-            depthLevel.put(depth, level);
-        }
-    }
-
-    /**
-     * Returns an iterator over cells in a result.
-     */
-    private static Iterable<Cell> cellIter(final int[] pageCoords, final CellSet cellSet) {
-        return new Iterable<Cell>() {
-            public Iterator<Cell> iterator() {
-                final int[] axisDimensions = new int[cellSet.getAxes().size() - pageCoords.length];
-                assert pageCoords.length <= axisDimensions.length;
-                for (int i = 0; i < axisDimensions.length; i++) {
-                    final CellSetAxis axis = cellSet.getAxes().get(i);
-                    axisDimensions[i] = axis.getPositions().size();
-                }
-                final CoordinateIterator coordIter = new CoordinateIterator(axisDimensions, true);
-                return new Iterator<Cell>() {
-                    public boolean hasNext() {
-                        return coordIter.hasNext();
-                    }
-
-                    public Cell next() {
-                        final int[] ints = coordIter.next();
-                        final AbstractList<Integer> intList = new AbstractList<Integer>() {
-                            @Override
-                            public Integer get(final int index) {
-                                return index < ints.length ? ints[index] : pageCoords[index - ints.length];
-                            }
-
-                            @Override
-                            public int size() {
-                                return pageCoords.length + ints.length;
-                            }
-                        };
-                        return cellSet.getCell(intList);
-                    }
-
-                    public void remove() {
-                        throw new UnsupportedOperationException();
-                    }
-                };
-            }
-        };
-    }
-
-    private Matrix matrix;
-
-    public Matrix format(final CellSet cellSet) {
-        // Compute how many rows are required to display the columns axis.
-        final CellSetAxis columnsAxis;
-        if (cellSet.getAxes().size() > 0) {
-            columnsAxis = cellSet.getAxes().get(0);
-        } else {
-            columnsAxis = null;
-        }
-        final AxisInfo columnsAxisInfo = computeAxisInfo(columnsAxis);
-
-        // Compute how many columns are required to display the rows axis.
-        final CellSetAxis rowsAxis;
-        if (cellSet.getAxes().size() > 1) {
-            rowsAxis = cellSet.getAxes().get(1);
-        } else {
-            rowsAxis = null;
-        }
-        final AxisInfo rowsAxisInfo = computeAxisInfo(rowsAxis);
-
-        if (cellSet.getAxes().size() > 2) {
-            final int[] dimensions = new int[cellSet.getAxes().size() - 2];
-            for (int i = 2; i < cellSet.getAxes().size(); i++) {
-                final CellSetAxis cellSetAxis = cellSet.getAxes().get(i);
-                dimensions[i - 2] = cellSetAxis.getPositions().size();
-            }
-            for (final int[] pageCoords : CoordinateIterator.iterate(dimensions)) {
-                matrix = formatPage(cellSet, pageCoords, columnsAxis, columnsAxisInfo, rowsAxis, rowsAxisInfo);
-            }
-        } else {
-            matrix = formatPage(cellSet, new int[] {}, columnsAxis, columnsAxisInfo, rowsAxis, rowsAxisInfo);
-        }
-
-        return matrix;
-    }
-
-    /**
-     * Computes a description of an axis.
-     *
-     * @param axis
-     *            Axis
-     * @return Description of axis
-     */
-    private AxisInfo computeAxisInfo(final CellSetAxis axis) {
-        if (axis == null) {
-            return new AxisInfo(0);
-        }
-        final AxisInfo axisInfo =
-                new AxisInfo(axis.getAxisMetaData().getHierarchies().size());
-        int p = -1;
-        for (final Position position : axis.getPositions()) {
-            ++p;
-            int k = -1;
-            for (final Member member : position.getMembers()) {
-                ++k;
-                final AxisOrdinalInfo axisOrdinalInfo = axisInfo.ordinalInfos.get(k);
-                if (!axisOrdinalInfo.getDepths().contains(member.getDepth())) {
-                    axisOrdinalInfo.getDepths().add(member.getDepth());
-                    axisOrdinalInfo.addLevel(member.getDepth(), member.getLevel());
-                    Collections.sort(axisOrdinalInfo.depths);
-                }
-            }
-        }
-        return axisInfo;
-    }
-
-    /**
-     * Formats a two-dimensional page.
-     *
-     * @param cellSet
-     *            Cell set
-     * @param pageCoords
-     *            Coordinates of page [page, chapter, section, ...]
-     * @param columnsAxis
-     *            Columns axis
-     * @param columnsAxisInfo
-     *            Description of columns axis
-     * @param rowsAxis
-     *            Rows axis
-     * @param rowsAxisInfo
-     *            Description of rows axis
-     */
-    private Matrix formatPage(
-            final CellSet cellSet,
-            final int[] pageCoords,
-            final CellSetAxis columnsAxis,
-            final AxisInfo columnsAxisInfo,
-            final CellSetAxis rowsAxis,
-            final AxisInfo rowsAxisInfo) {
-
-        // Figure out the dimensions of the blank rectangle in the top left
-        // corner.
-        final int yOffset = columnsAxisInfo.getWidth();
-        final int xOffsset = rowsAxisInfo.getWidth();
-
-        // Populate a string matrix
-        final Matrix matrix = new Matrix(
-                xOffsset + (columnsAxis == null ? 1 : columnsAxis.getPositions().size()),
-                yOffset + (rowsAxis == null ? 1 : rowsAxis.getPositions().size()));
-
-        // Populate corner
-        List<Level> levels = new ArrayList<>();
-        if (rowsAxis != null && rowsAxis.getPositions().size() > 0) {
-            Position p = rowsAxis.getPositions().get(0);
-            for (int m = 0; m < p.getMembers().size(); m++) {
-                AxisOrdinalInfo a = rowsAxisInfo.ordinalInfos.get(m);
-                for (Integer depth : a.getDepths()) {
-                    levels.add(a.getLevel(depth));
-                }
-            }
-            for (int x = 0; x < xOffsset; x++) {
-                Level xLevel = levels.get(x);
-                String s = xLevel.getCaption();
-                for (int y = 0; y < yOffset; y++) {
-                    final MemberCell memberInfo = new MemberCell(false, x > 0);
-                    if (y == yOffset - 1) {
-                        memberInfo.setRawValue(s);
-                        memberInfo.setFormattedValue(s);
-                        memberInfo.setProperty("__headertype", "row_header_header");
-                        memberInfo.setProperty("levelindex", "" + levels.indexOf(xLevel));
-                        memberInfo.setHierarchy(xLevel.getHierarchy().getUniqueName());
-                        memberInfo.setParentDimension(xLevel.getDimension().getName());
-                        memberInfo.setLevel(xLevel.getUniqueName());
-                    }
-                    matrix.set(x, y, memberInfo);
-                }
-            }
-        }
-        // Populate matrix with cells representing axes
-        // noinspection SuspiciousNameCombination
-        populateAxis(matrix, columnsAxis, columnsAxisInfo, true, xOffsset);
-        populateAxis(matrix, rowsAxis, rowsAxisInfo, false, yOffset);
-
-        // Populate cell values
-        for (final Cell cell : cellIter(pageCoords, cellSet)) {
-            final List<Integer> coordList = cell.getCoordinateList();
-            int x = xOffsset;
-            if (coordList.size() > 0) x += coordList.get(0);
-            int y = yOffset;
-            if (coordList.size() > 1) y += coordList.get(1);
-            final DataCell cellInfo = new DataCell(true, false, coordList);
-            cellInfo.setCoordinates(cell.getCoordinateList());
-            // saiku#773: surface the full set of olap4j StandardCellProperty
-            // values (format string, fore/back colour, font flags, action
-            // type, error text, etc.) Mondrian computes for this cell so
-            // the REST/Arrow consumers can read them.
-            cellInfo.setProperties(CellPropertyExtractor.extract(cell));
-
-            if (cell.getValue() != null) {
-                try {
-                    cellInfo.setRawNumber(cell.getDoubleValue());
-                } catch (Exception e1) {
-                }
-            }
-            String cellValue = cell.getFormattedValue(); // First try to get a
-            // formatted value
-
-            if (cellValue == null || cellValue.equals("null")) { // $NON-NLS-1$
-                cellValue = ""; // $NON-NLS-1$
-            }
-            if (cellValue.length() < 1) {
-                final Object value = cell.getValue();
-                if (value == null || value.equals("null")) // $NON-NLS-1$
-                cellValue = ""; // $NON-NLS-1$
-                else {
-                    try {
-                        // TODO this needs to become query / execution specific
-                        DecimalFormat myFormatter =
-                                new DecimalFormat(SaikuProperties.formatDefautNumberFormat); // $NON-NLS-1$
-                        DecimalFormatSymbols dfs = new DecimalFormatSymbols(SaikuProperties.locale);
-                        myFormatter.setDecimalFormatSymbols(dfs);
-                        cellValue = myFormatter.format(cell.getValue());
-                    } catch (Exception e) {
-                        // TODO: handle exception
-                    }
-                }
-                // the raw value
-            }
-
-            // Format string is relevant for Excel export
-            // xmla cells can throw an error on this
-            try {
-
-                String formatString = (String) cell.getPropertyValue(Property.StandardCellProperty.FORMAT_STRING);
-                if (formatString != null && !formatString.startsWith("|")) {
-                    cellInfo.setFormatString(formatString);
-                } else {
-                    formatString = formatString.substring(1, formatString.length());
-                    cellInfo.setFormatString(formatString.substring(0, formatString.indexOf("|")));
-                }
-            } catch (Exception e) {
-                // we tried
-            }
-
-            Map<String, String> cellProperties = new HashMap<>();
-            String val = Olap4jUtil.parseFormattedCellValue(cellValue, cellProperties);
-            if (!cellProperties.isEmpty()) {
-                cellInfo.setProperties(cellProperties);
-            }
-            cellInfo.setFormattedValue(val);
-            matrix.set(x, y, cellInfo);
-        }
-        return matrix;
-    }
+/**
+ * Default ("flat") cell-set formatter. Shares all the scaffolding —
+ * {@code format}, {@code computeAxisInfo}, the two-axis {@code formatPage} and
+ * the per-data-cell {@code populateCell} block — with
+ * {@link AbstractCellSetFormatter}; only {@link #populateAxis} is specific to
+ * this formatter (preserved verbatim through issue #1163).
+ */
+public class CellSetFormatter extends AbstractCellSetFormatter {
 
     /**
      * Populates cells in the matrix corresponding to a particular axis.
@@ -360,7 +50,8 @@ public class CellSetFormatter implements ICellSetFormatter {
      * @param offset
      *            Ordinal of first cell to populate in matrix
      */
-    private void populateAxis(
+    @Override
+    protected void populateAxis(
             final Matrix matrix,
             final CellSetAxis axis,
             final AxisInfo axisInfo,
@@ -381,12 +72,12 @@ public class CellSetFormatter implements ICellSetFormatter {
             for (int j = 0; j < memberList.size(); j++) {
                 Member member = memberList.get(j);
                 final AxisOrdinalInfo ordinalInfo = axisInfo.ordinalInfos.get(j);
-                List<Integer> depths = ordinalInfo.depths;
+                List<Integer> depths = ordinalInfo.getDepths();
                 Collections.sort(depths);
                 lvls.put(member.getHierarchy(), depths);
                 if (ordinalInfo.getDepths().size() > 0
                         && member.getDepth() < ordinalInfo.getDepths().get(0)) break;
-                final int y = yOffset + ordinalInfo.depths.indexOf(member.getDepth());
+                final int y = yOffset + ordinalInfo.getDepths().indexOf(member.getDepth());
                 members[y] = member;
                 yOffset += ordinalInfo.getWidth();
             }

--- a/saiku-core/saiku-service/src/main/java/org/saiku/olap/util/formatter/FlattenedCellSetFormatter.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/olap/util/formatter/FlattenedCellSetFormatter.java
@@ -15,241 +15,40 @@
  */
 package org.saiku.olap.util.formatter;
 
-import java.text.DecimalFormat;
-import java.text.DecimalFormatSymbols;
-import java.util.AbstractList;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashMap;
-import java.util.Iterator;
 import java.util.List;
-import java.util.Map;
 import org.olap4j.Cell;
 import org.olap4j.CellSet;
 import org.olap4j.CellSetAxis;
 import org.olap4j.Position;
-import org.olap4j.impl.CoordinateIterator;
 import org.olap4j.impl.Olap4jUtil;
 import org.olap4j.metadata.Level;
 import org.olap4j.metadata.Member;
-import org.olap4j.metadata.Property;
-import org.saiku.olap.dto.resultset.DataCell;
 import org.saiku.olap.dto.resultset.Matrix;
 import org.saiku.olap.dto.resultset.MemberCell;
-import org.saiku.olap.util.SaikuProperties;
 
-public class FlattenedCellSetFormatter implements ICellSetFormatter {
-
-    /**
-     * Description of an axis.
-     */
-    private static class AxisInfo {
-        final List<AxisOrdinalInfo> ordinalInfos;
-
-        /**
-         * Creates an AxisInfo.
-         *
-         * @param ordinalCount Number of hierarchies on this axis
-         */
-        AxisInfo(final int ordinalCount) {
-            ordinalInfos = new ArrayList<>(ordinalCount);
-
-            // For each index from 0 to the number of hierarchies  ...
-            for (int i = 0; i < ordinalCount; i++) {
-                // Associate an AxisOrdinalInfo instance
-                ordinalInfos.add(new AxisOrdinalInfo());
-            }
-        }
-
-        /**
-         * Returns the number of matrix columns required by this axis. The sum of
-         * the width of the hierarchies on this axis.
-         *
-         * @return Width of axis
-         */
-        public int getWidth() {
-            int width = 0;
-            for (final AxisOrdinalInfo info : ordinalInfos) {
-                width += info.getWidth();
-            }
-            return width;
-        }
-    }
-
-    /**
-     * Description of a particular hierarchy mapped to an axis.
-     */
-    private static class AxisOrdinalInfo {
-        private final List<Integer> depths = new ArrayList<>();
-        private final Map<Integer, Level> depthLevel = new HashMap<>();
-
-        public int getWidth() {
-            return depths.size();
-        }
-
-        public List<Integer> getDepths() {
-            return depths;
-        }
-
-        public Level getLevel(Integer depth) {
-            return depthLevel.get(depth);
-        }
-
-        public void addLevel(Integer depth, Level level) {
-            depthLevel.put(depth, level);
-        }
-    }
-
-    /**
-     * Returns an iterator over cells in a result.
-     */
-    private static Iterable<Cell> cellIter(final int[] pageCoords, final CellSet cellSet) {
-        return new Iterable<Cell>() {
-            public Iterator<Cell> iterator() {
-                final int[] axisDimensions = new int[cellSet.getAxes().size() - pageCoords.length];
-                assert pageCoords.length <= axisDimensions.length;
-                for (int i = 0; i < axisDimensions.length; i++) {
-                    final CellSetAxis axis = cellSet.getAxes().get(i);
-                    axisDimensions[i] = axis.getPositions().size();
-                }
-                final CoordinateIterator coordIter = new CoordinateIterator(axisDimensions, true);
-                return new Iterator<Cell>() {
-                    public boolean hasNext() {
-                        return coordIter.hasNext();
-                    }
-
-                    public Cell next() {
-                        final int[] ints = coordIter.next();
-                        final AbstractList<Integer> intList = new AbstractList<Integer>() {
-                            @Override
-                            public Integer get(final int index) {
-                                return index < ints.length ? ints[index] : pageCoords[index - ints.length];
-                            }
-
-                            @Override
-                            public int size() {
-                                return pageCoords.length + ints.length;
-                            }
-                        };
-                        return cellSet.getCell(intList);
-                    }
-
-                    public void remove() {
-                        throw new UnsupportedOperationException();
-                    }
-                };
-            }
-        };
-    }
-
-    private Matrix matrix;
+/**
+ * Flattened cell-set formatter. Shares the scaffolding —
+ * {@code format}, {@code computeAxisInfo} and the per-data-cell
+ * {@code populateCell} block — with {@link AbstractCellSetFormatter}, but
+ * overrides {@link #formatPage} wholesale to apply its ignorex/ignorey row and
+ * column collapsing (delegating each surviving data cell back to
+ * {@link #populateCell}), and overrides {@link #populateAxis} (preserved
+ * verbatim through issue #1163, including the saiku#788
+ * {@code Arrays.fill(members, null)} clear and the STICKY {@code expanded} flag
+ * declared outside the inner loop and never reset).
+ */
+public class FlattenedCellSetFormatter extends AbstractCellSetFormatter {
 
     private final List<Integer> ignorex = new ArrayList<>();
     private final List<Integer> ignorey = new ArrayList<>();
-
-    /**
-     * This is the main method of a cellset formatter, it receives a cellset as
-     * input and converts it on a matrix, a bidimensional representation of query
-     * values, arranged in a xy cartesian coordinate system.
-     * @param cellSet
-     * @return
-     */
-    public Matrix format(final CellSet cellSet) {
-        // Compute how many rows are required to display the columns axis.
-        final CellSetAxis columnsAxis;
-
-        // If the axes are not empty, the first one is the column axis
-        if (cellSet.getAxes().size() > 0) {
-            // As a convention, the columns axis is associated with the index 0
-            columnsAxis = cellSet.getAxes().get(0);
-        } else {
-            columnsAxis = null;
-        }
-
-        final AxisInfo columnsAxisInfo = computeAxisInfo(columnsAxis);
-
-        // Compute how many columns are required to display the rows axis.
-        final CellSetAxis rowsAxis;
-
-        // If there are more than one axis, the second one is the rows axis
-        if (cellSet.getAxes().size() > 1) {
-            // As a convention, the rows axis is associated with the index 1
-            rowsAxis = cellSet.getAxes().get(1);
-        } else {
-            rowsAxis = null;
-        }
-
-        final AxisInfo rowsAxisInfo = computeAxisInfo(rowsAxis);
-
-        if (cellSet.getAxes().size() > 2) {
-            final int[] dimensions = new int[cellSet.getAxes().size() - 2];
-            for (int i = 2; i < cellSet.getAxes().size(); i++) {
-                final CellSetAxis cellSetAxis = cellSet.getAxes().get(i);
-                dimensions[i - 2] = cellSetAxis.getPositions().size();
-            }
-            for (final int[] pageCoords : CoordinateIterator.iterate(dimensions)) {
-                matrix = formatPage(cellSet, pageCoords, columnsAxis, columnsAxisInfo, rowsAxis, rowsAxisInfo);
-            }
-        } else {
-            matrix = formatPage(cellSet, new int[] {}, columnsAxis, columnsAxisInfo, rowsAxis, rowsAxisInfo);
-        }
-
-        return matrix;
-    }
-
-    /**
-     * Computes a description of an axis. Each axis is composed by many positions,
-     * each position is then composed by many members. A member is a 'point' on a
-     * dimension of a cube. Every member belongs to a Level of a Hierarchy. The
-     * member's depth is its distance to the root member.
-     *
-     * @param axis Axis
-     * @return Description of axis
-     */
-    private AxisInfo computeAxisInfo(final CellSetAxis axis) {
-        if (axis == null) {
-            return new AxisInfo(0);
-        }
-
-        // An axis info is created by informing the number of hierarchies of axis
-        final AxisInfo axisInfo =
-                new AxisInfo(axis.getAxisMetaData().getHierarchies().size());
-        int p = -1;
-
-        // For each axis position
-        for (final Position position : axis.getPositions()) {
-            ++p;
-            int k = -1;
-
-            // For each member of the axis
-            for (final Member member : position.getMembers()) {
-                ++k;
-
-                // Fetch the AxisOrdinalInfo instance of the position index k
-                final AxisOrdinalInfo axisOrdinalInfo = axisInfo.ordinalInfos.get(k);
-
-                // We avoid duplicating information for members with the same depth
-                if (!axisOrdinalInfo.getDepths().contains(member.getDepth())) {
-                    axisOrdinalInfo.getDepths().add(member.getDepth());
-                    // For each depth of the hiearchy, add its level
-                    axisOrdinalInfo.addLevel(member.getDepth(), member.getLevel());
-                    Collections.sort(axisOrdinalInfo.depths);
-                }
-            }
-        }
-
-        // The axisInfo object, contains a collection of the hiearchy's levels
-        // sorted by their depths.
-        return axisInfo;
-    }
 
     /**
      * Formats a two-dimensional page.
      *
      * @param cellSet
      *            Cell set
-     * @param pageCoords
-     *            Print writer
      * @param pageCoords
      *            Coordinates of page [page, chapter, section, ...]
      * @param columnsAxis
@@ -261,7 +60,8 @@ public class FlattenedCellSetFormatter implements ICellSetFormatter {
      * @param rowsAxisInfo
      *            Description of rows axis
      */
-    private Matrix formatPage(
+    @Override
+    protected Matrix formatPage(
             final CellSet cellSet,
             final int[] pageCoords,
             final CellSetAxis columnsAxis,
@@ -374,63 +174,7 @@ public class FlattenedCellSetFormatter implements ICellSetFormatter {
                 }
             }
 
-            final DataCell cellInfo = new DataCell(true, false, coordList);
-            cellInfo.setCoordinates(cell.getCoordinateList());
-            // saiku#773: surface olap4j StandardCellProperty values.
-            cellInfo.setProperties(CellPropertyExtractor.extract(cell));
-
-            if (cell.getValue() != null) {
-                try {
-                    cellInfo.setRawNumber(cell.getDoubleValue());
-                } catch (Exception e1) {
-                }
-            }
-            String cellValue = cell.getFormattedValue(); // First try to get a
-            // formatted value
-
-            if (cellValue == null || cellValue.equals("null")) { // $NON-NLS-1$
-                cellValue = ""; // $NON-NLS-1$
-            }
-            if (cellValue.length() < 1) {
-                final Object value = cell.getValue();
-                if (value == null || value.equals("null")) // $NON-NLS-1$
-                cellValue = ""; // $NON-NLS-1$
-                else {
-                    try {
-                        // TODO this needs to become query / execution specific
-                        DecimalFormat myFormatter =
-                                new DecimalFormat(SaikuProperties.formatDefautNumberFormat); // $NON-NLS-1$
-                        DecimalFormatSymbols dfs = new DecimalFormatSymbols(SaikuProperties.locale);
-                        myFormatter.setDecimalFormatSymbols(dfs);
-                        cellValue = myFormatter.format(cell.getValue());
-                    } catch (Exception e) {
-                        // TODO: handle exception
-                    }
-                }
-                // the raw value
-            }
-
-            // Format string is relevant for Excel export
-            // xmla cells can throw an error on this
-            try {
-                String formatString = (String) cell.getPropertyValue(Property.StandardCellProperty.FORMAT_STRING);
-                if (formatString != null && !formatString.startsWith("|")) {
-                    cellInfo.setFormatString(formatString);
-                } else {
-                    formatString = formatString.substring(1, formatString.length());
-                    cellInfo.setFormatString(formatString.substring(0, formatString.indexOf("|")));
-                }
-            } catch (Exception e) {
-                // we tried
-            }
-
-            Map<String, String> cellProperties = new HashMap<>();
-            String val = Olap4jUtil.parseFormattedCellValue(cellValue, cellProperties);
-            if (!cellProperties.isEmpty()) {
-                cellInfo.setProperties(cellProperties);
-            }
-            cellInfo.setFormattedValue(val);
-            matrix.set(x, y, cellInfo);
+            populateCell(matrix, cell, coordList, x, y);
         }
         return matrix;
     }
@@ -449,7 +193,8 @@ public class FlattenedCellSetFormatter implements ICellSetFormatter {
      * @param oldoffset
      *            Ordinal of first cell to populate in matrix
      */
-    private void populateAxis(
+    @Override
+    protected void populateAxis(
             final Matrix matrix,
             final CellSetAxis axis,
             final AxisInfo axisInfo,
@@ -484,7 +229,7 @@ public class FlattenedCellSetFormatter implements ICellSetFormatter {
             for (int j = 0; j < memberList.size(); j++) {
                 Member member = memberList.get(j);
                 final AxisOrdinalInfo ordinalInfo = axisInfo.ordinalInfos.get(j);
-                List<Integer> depths = ordinalInfo.depths;
+                List<Integer> depths = ordinalInfo.getDepths();
                 Collections.sort(depths);
 
                 // saiku#788: previously this branch unconditionally dropped any
@@ -501,7 +246,7 @@ public class FlattenedCellSetFormatter implements ICellSetFormatter {
                 }
 
                 // It stores each position's member in members array sorted by its depth
-                final int y = yOffset + ordinalInfo.depths.indexOf(member.getDepth());
+                final int y = yOffset + ordinalInfo.getDepths().indexOf(member.getDepth());
                 members[y] = member;
                 yOffset += ordinalInfo.getWidth();
             }

--- a/saiku-core/saiku-service/src/main/java/org/saiku/olap/util/formatter/HierarchicalCellSetFormatter.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/olap/util/formatter/HierarchicalCellSetFormatter.java
@@ -15,332 +15,25 @@
  */
 package org.saiku.olap.util.formatter;
 
-import java.text.DecimalFormat;
-import java.text.DecimalFormatSymbols;
 import java.util.*;
-import org.olap4j.Cell;
-import org.olap4j.CellSet;
 import org.olap4j.CellSetAxis;
 import org.olap4j.Position;
-import org.olap4j.impl.CoordinateIterator;
 import org.olap4j.impl.Olap4jUtil;
 import org.olap4j.metadata.Hierarchy;
-import org.olap4j.metadata.Level;
 import org.olap4j.metadata.Member;
-import org.olap4j.metadata.Property;
-import org.saiku.olap.dto.resultset.DataCell;
 import org.saiku.olap.dto.resultset.Matrix;
 import org.saiku.olap.dto.resultset.MemberCell;
-import org.saiku.olap.util.SaikuProperties;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
-public class HierarchicalCellSetFormatter implements ICellSetFormatter {
-
-    private static final Logger log = LoggerFactory.getLogger(HierarchicalCellSetFormatter.class);
-
-    /**
-     * Description of an axis.
-     */
-    private static class AxisInfo {
-        final List<AxisOrdinalInfo> ordinalInfos;
-
-        /**
-         * Creates an AxisInfo.
-         *
-         * @param ordinalCount
-         *            Number of hierarchies on this axis
-         */
-        AxisInfo(final int ordinalCount) {
-            ordinalInfos = new ArrayList<>(ordinalCount);
-            for (int i = 0; i < ordinalCount; i++) {
-                ordinalInfos.add(new AxisOrdinalInfo());
-            }
-        }
-
-        /**
-         * Returns the number of matrix columns required by this axis. The sum of the width of the hierarchies on this
-         * axis.
-         *
-         * @return Width of axis
-         */
-        public int getWidth() {
-            int width = 0;
-            for (final AxisOrdinalInfo info : ordinalInfos) {
-                width += info.getWidth();
-            }
-            return width;
-        }
-    }
-
-    /**
-     * Description of a particular hierarchy mapped to an axis.
-     */
-    private static class AxisOrdinalInfo {
-        private final List<Integer> depths = new ArrayList<>();
-        private final Map<Integer, Level> depthLevel = new HashMap<>();
-
-        public int getWidth() {
-            return depths.size();
-        }
-
-        public List<Integer> getDepths() {
-            return depths;
-        }
-
-        public Level getLevel(Integer depth) {
-            return depthLevel.get(depth);
-        }
-
-        public void addLevel(Integer depth, Level level) {
-            depthLevel.put(depth, level);
-        }
-    }
-
-    /**
-     * Returns an iterator over cells in a result.
-     */
-    private static Iterable<Cell> cellIter(final int[] pageCoords, final CellSet cellSet) {
-        return new Iterable<Cell>() {
-            public Iterator<Cell> iterator() {
-                final int[] axisDimensions = new int[cellSet.getAxes().size() - pageCoords.length];
-                assert pageCoords.length <= axisDimensions.length;
-                for (int i = 0; i < axisDimensions.length; i++) {
-                    final CellSetAxis axis = cellSet.getAxes().get(i);
-                    axisDimensions[i] = axis.getPositions().size();
-                }
-                final CoordinateIterator coordIter = new CoordinateIterator(axisDimensions, true);
-                return new Iterator<Cell>() {
-                    public boolean hasNext() {
-                        return coordIter.hasNext();
-                    }
-
-                    public Cell next() {
-                        final int[] ints = coordIter.next();
-                        final AbstractList<Integer> intList = new AbstractList<Integer>() {
-                            @Override
-                            public Integer get(final int index) {
-                                return index < ints.length ? ints[index] : pageCoords[index - ints.length];
-                            }
-
-                            @Override
-                            public int size() {
-                                return pageCoords.length + ints.length;
-                            }
-                        };
-                        return cellSet.getCell(intList);
-                    }
-
-                    public void remove() {
-                        throw new UnsupportedOperationException();
-                    }
-                };
-            }
-        };
-    }
-
-    private Matrix matrix;
-
-    public Matrix format(final CellSet cellSet) {
-        // Compute how many rows are required to display the columns axis.
-        final CellSetAxis columnsAxis;
-        if (cellSet.getAxes().size() > 0) {
-            columnsAxis = cellSet.getAxes().get(0);
-        } else {
-            columnsAxis = null;
-        }
-        final AxisInfo columnsAxisInfo = computeAxisInfo(columnsAxis);
-
-        // Compute how many columns are required to display the rows axis.
-        final CellSetAxis rowsAxis;
-        if (cellSet.getAxes().size() > 1) {
-            rowsAxis = cellSet.getAxes().get(1);
-        } else {
-            rowsAxis = null;
-        }
-        final AxisInfo rowsAxisInfo = computeAxisInfo(rowsAxis);
-
-        if (cellSet.getAxes().size() > 2) {
-            final int[] dimensions = new int[cellSet.getAxes().size() - 2];
-            for (int i = 2; i < cellSet.getAxes().size(); i++) {
-                final CellSetAxis cellSetAxis = cellSet.getAxes().get(i);
-                dimensions[i - 2] = cellSetAxis.getPositions().size();
-            }
-            for (final int[] pageCoords : CoordinateIterator.iterate(dimensions)) {
-                matrix = formatPage(cellSet, pageCoords, columnsAxis, columnsAxisInfo, rowsAxis, rowsAxisInfo);
-            }
-        } else {
-            matrix = formatPage(cellSet, new int[] {}, columnsAxis, columnsAxisInfo, rowsAxis, rowsAxisInfo);
-        }
-
-        return matrix;
-    }
-
-    /**
-     * Computes a description of an axis.
-     *
-     * @param axis
-     *            Axis
-     * @return Description of axis
-     */
-    private AxisInfo computeAxisInfo(final CellSetAxis axis) {
-        if (axis == null) {
-            return new AxisInfo(0);
-        }
-        final AxisInfo axisInfo =
-                new AxisInfo(axis.getAxisMetaData().getHierarchies().size());
-        int p = -1;
-        for (final Position position : axis.getPositions()) {
-            ++p;
-            int k = -1;
-            for (final Member member : position.getMembers()) {
-                ++k;
-                final AxisOrdinalInfo axisOrdinalInfo = axisInfo.ordinalInfos.get(k);
-                if (!axisOrdinalInfo.getDepths().contains(member.getDepth())) {
-                    axisOrdinalInfo.getDepths().add(member.getDepth());
-                    axisOrdinalInfo.addLevel(member.getDepth(), member.getLevel());
-                    Collections.sort(axisOrdinalInfo.depths);
-                }
-            }
-        }
-        return axisInfo;
-    }
-
-    /**
-     * Formats a two-dimensional page.
-     *
-     * @param cellSet
-     *            Cell set
-     * @param pageCoords
-     *            Coordinates of page [page, chapter, section, ...]
-     * @param columnsAxis
-     *            Columns axis
-     * @param columnsAxisInfo
-     *            Description of columns axis
-     * @param rowsAxis
-     *            Rows axis
-     * @param rowsAxisInfo
-     *            Description of rows axis
-     */
-    private Matrix formatPage(
-            final CellSet cellSet,
-            final int[] pageCoords,
-            final CellSetAxis columnsAxis,
-            final AxisInfo columnsAxisInfo,
-            final CellSetAxis rowsAxis,
-            final AxisInfo rowsAxisInfo) {
-
-        // Figure out the dimensions of the blank rectangle in the top left
-        // corner.
-        final int yOffset = columnsAxisInfo.getWidth();
-        final int xOffsset = rowsAxisInfo.getWidth();
-
-        // Populate a string matrix
-        final Matrix matrix = new Matrix(
-                xOffsset + (columnsAxis == null ? 1 : columnsAxis.getPositions().size()),
-                yOffset + (rowsAxis == null ? 1 : rowsAxis.getPositions().size()));
-
-        // Populate corner
-        List<Level> levels = new ArrayList<>();
-        if (rowsAxis != null && rowsAxis.getPositions().size() > 0) {
-            Position p = rowsAxis.getPositions().get(0);
-            for (int m = 0; m < p.getMembers().size(); m++) {
-                AxisOrdinalInfo a = rowsAxisInfo.ordinalInfos.get(m);
-                for (Integer depth : a.getDepths()) {
-                    levels.add(a.getLevel(depth));
-                }
-            }
-            for (int x = 0; x < xOffsset; x++) {
-                Level xLevel = levels.get(x);
-                String s = xLevel.getCaption();
-                for (int y = 0; y < yOffset; y++) {
-                    final MemberCell memberInfo = new MemberCell(false, x > 0);
-                    if (y == yOffset - 1) {
-                        memberInfo.setRawValue(s);
-                        memberInfo.setFormattedValue(s);
-                        memberInfo.setProperty("__headertype", "row_header_header");
-                        memberInfo.setProperty("levelindex", "" + levels.indexOf(xLevel));
-                        memberInfo.setHierarchy(xLevel.getHierarchy().getUniqueName());
-                        memberInfo.setParentDimension(xLevel.getDimension().getName());
-                        memberInfo.setLevel(xLevel.getUniqueName());
-                    }
-                    matrix.set(x, y, memberInfo);
-                }
-            }
-        }
-        // Populate matrix with cells representing axes
-        // noinspection SuspiciousNameCombination
-        populateAxis(matrix, columnsAxis, columnsAxisInfo, true, xOffsset);
-        populateAxis(matrix, rowsAxis, rowsAxisInfo, false, yOffset);
-
-        // Populate cell values
-        for (final Cell cell : cellIter(pageCoords, cellSet)) {
-            final List<Integer> coordList = cell.getCoordinateList();
-            int x = xOffsset;
-            if (coordList.size() > 0) x += coordList.get(0);
-            int y = yOffset;
-            if (coordList.size() > 1) y += coordList.get(1);
-            final DataCell cellInfo = new DataCell(true, false, coordList);
-            cellInfo.setCoordinates(cell.getCoordinateList());
-            // saiku#773: surface olap4j StandardCellProperty values.
-            cellInfo.setProperties(CellPropertyExtractor.extract(cell));
-
-            if (cell.getValue() != null) {
-                try {
-                    cellInfo.setRawNumber(cell.getDoubleValue());
-                } catch (Exception e1) {
-                }
-            }
-            String cellValue = cell.getFormattedValue(); // First try to get a
-            // formatted value
-
-            if (cellValue == null || cellValue.equals("null")) { // $NON-NLS-1$
-                cellValue = ""; // $NON-NLS-1$
-            }
-            if (cellValue.length() < 1) {
-                final Object value = cell.getValue();
-                if (value == null || value.equals("null")) // $NON-NLS-1$
-                cellValue = ""; // $NON-NLS-1$
-                else {
-                    try {
-                        // TODO this needs to become query / execution specific
-                        DecimalFormat myFormatter =
-                                new DecimalFormat(SaikuProperties.formatDefautNumberFormat); // $NON-NLS-1$
-                        DecimalFormatSymbols dfs = new DecimalFormatSymbols(SaikuProperties.locale);
-                        myFormatter.setDecimalFormatSymbols(dfs);
-                        cellValue = myFormatter.format(cell.getValue());
-                    } catch (Exception e) {
-                        // TODO: handle exception
-                    }
-                }
-                // the raw value
-            }
-
-            // Format string is relevant for Excel export
-            // xmla cells can throw an error on this
-            try {
-
-                String formatString = (String) cell.getPropertyValue(Property.StandardCellProperty.FORMAT_STRING);
-                if (formatString != null && !formatString.startsWith("|")) {
-                    cellInfo.setFormatString(formatString);
-                } else {
-                    formatString = formatString.substring(1, formatString.length());
-                    cellInfo.setFormatString(formatString.substring(0, formatString.indexOf("|")));
-                }
-            } catch (Exception e) {
-                // we tried
-            }
-
-            Map<String, String> cellProperties = new HashMap<>();
-            String val = Olap4jUtil.parseFormattedCellValue(cellValue, cellProperties);
-            if (!cellProperties.isEmpty()) {
-                cellInfo.setProperties(cellProperties);
-            }
-            cellInfo.setFormattedValue(val);
-            matrix.set(x, y, cellInfo);
-        }
-        return matrix;
-    }
+/**
+ * Hierarchical cell-set formatter. Shares all the scaffolding —
+ * {@code format}, {@code computeAxisInfo}, the two-axis {@code formatPage} and
+ * the per-data-cell {@code populateCell} block — with
+ * {@link AbstractCellSetFormatter}; only {@link #populateAxis} is specific to
+ * this formatter (preserved verbatim through issue #1163, including the
+ * saiku#845 {@code Arrays.fill(members, null)} clear and the {@code same}-nulling
+ * of repeated row members).
+ */
+public class HierarchicalCellSetFormatter extends AbstractCellSetFormatter {
 
     /**
      * Populates cells in the matrix corresponding to a particular axis.
@@ -356,7 +49,8 @@ public class HierarchicalCellSetFormatter implements ICellSetFormatter {
      * @param offset
      *            Ordinal of first cell to populate in matrix
      */
-    private void populateAxis(
+    @Override
+    protected void populateAxis(
             final Matrix matrix,
             final CellSetAxis axis,
             final AxisInfo axisInfo,
@@ -385,12 +79,12 @@ public class HierarchicalCellSetFormatter implements ICellSetFormatter {
             for (int j = 0; j < memberList.size(); j++) {
                 Member member = memberList.get(j);
                 final AxisOrdinalInfo ordinalInfo = axisInfo.ordinalInfos.get(j);
-                List<Integer> depths = ordinalInfo.depths;
+                List<Integer> depths = ordinalInfo.getDepths();
                 Collections.sort(depths);
                 lvls.put(member.getHierarchy(), depths);
                 if (ordinalInfo.getDepths().size() > 0
                         && member.getDepth() < ordinalInfo.getDepths().get(0)) break;
-                final int y = yOffset + ordinalInfo.depths.indexOf(member.getDepth());
+                final int y = yOffset + ordinalInfo.getDepths().indexOf(member.getDepth());
                 members[y] = member;
                 yOffset += ordinalInfo.getWidth();
             }

--- a/saiku-core/saiku-service/src/test/java/org/saiku/olap/util/formatter/CellSetFormatterCharacterizationTest.java
+++ b/saiku-core/saiku-service/src/test/java/org/saiku/olap/util/formatter/CellSetFormatterCharacterizationTest.java
@@ -1,0 +1,632 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.olap.util.formatter;
+
+import static org.junit.Assert.assertEquals;
+
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+import org.junit.Test;
+import org.olap4j.Axis;
+import org.olap4j.Cell;
+import org.olap4j.CellSet;
+import org.olap4j.CellSetAxis;
+import org.olap4j.CellSetAxisMetaData;
+import org.olap4j.Position;
+import org.olap4j.metadata.Dimension;
+import org.olap4j.metadata.Hierarchy;
+import org.olap4j.metadata.Level;
+import org.olap4j.metadata.Member;
+import org.olap4j.metadata.Property;
+import org.saiku.olap.dto.resultset.AbstractBaseCell;
+import org.saiku.olap.dto.resultset.DataCell;
+import org.saiku.olap.dto.resultset.Matrix;
+import org.saiku.olap.dto.resultset.MemberCell;
+
+/**
+ * Characterization (golden) test for the three {@link ICellSetFormatter}
+ * implementations — {@link CellSetFormatter}, {@link HierarchicalCellSetFormatter}
+ * and {@link FlattenedCellSetFormatter}.
+ *
+ * <p>This test is a SAFETY NET for the behaviour-preserving refactor in
+ * issue #1163 (lifting the shared scaffolding into a common base class). It
+ * serialises the <b>entire</b> {@link Matrix} output — width, height, offset
+ * and every populated coordinate's full cell state (cell class, rawValue,
+ * formattedValue, parentDimension, expanded, lastRow, uniqueName, hierarchy,
+ * level, rawNumber, formatString, coordinates and the complete properties map
+ * including {@code levelindex} / {@code __headertype}) — into a deterministic
+ * string, then pins it with hard-coded golden literals.
+ *
+ * <p>The goldens were captured GREEN against the UNMODIFIED pre-refactor code
+ * and must stay byte-identical afterwards. Four cellset shapes are covered per
+ * formatter:
+ * <ul>
+ *   <li>{@code flatSingleDim} — one dimension on rows, one measure on columns;</li>
+ *   <li>{@code mixedDepth}    — three row positions at different hierarchy depths
+ *       (the saiku#788 / #845 path with the {@code Arrays.fill(members,null)}
+ *       clear and the parent-walk);</li>
+ *   <li>{@code noAxes}        — a cellset with zero axes (single scalar cell);</li>
+ *   <li>{@code throwingCell}  — a data cell whose {@code getDoubleValue()} throws
+ *       and whose {@code FORMAT_STRING} is null (exercises the three
+ *       exception-swallow sites).</li>
+ * </ul>
+ *
+ * <p>Because the matrix shapes differ per formatter, each formatter has its own
+ * golden literal. The serialiser sorts coordinates and property keys so the
+ * output is stable across JVM/map-iteration order.
+ */
+public class CellSetFormatterCharacterizationTest {
+
+    /* ===================================================================== */
+    /*  Tests                                                                */
+    /* ===================================================================== */
+
+    @Test
+    public void flatSingleDim_allThreeFormatters() {
+        CellSet cs = flatSingleDimCellSet();
+        assertEquals(GOLDEN_FLAT_FLAT, serialize(new CellSetFormatter().format(cs)));
+        assertEquals(GOLDEN_FLAT_HIER, serialize(new HierarchicalCellSetFormatter().format(cs)));
+        assertEquals(GOLDEN_FLAT_FLATTENED, serialize(new FlattenedCellSetFormatter().format(cs)));
+    }
+
+    @Test
+    public void mixedDepth_allThreeFormatters() {
+        // Each formatter must get a fresh cellset because the fake cells track
+        // no state, but the formatters do (FlattenedCellSetFormatter keeps
+        // ignorex/ignorey instance lists). A fresh cellset keeps them isolated.
+        assertEquals(GOLDEN_MIXED_FLAT, serialize(new CellSetFormatter().format(mixedDepthCellSet())));
+        assertEquals(GOLDEN_MIXED_HIER, serialize(new HierarchicalCellSetFormatter().format(mixedDepthCellSet())));
+        assertEquals(GOLDEN_MIXED_FLATTENED, serialize(new FlattenedCellSetFormatter().format(mixedDepthCellSet())));
+    }
+
+    @Test
+    public void noAxes_allThreeFormatters() {
+        assertEquals(GOLDEN_NOAXES_FLAT, serialize(new CellSetFormatter().format(noAxesCellSet())));
+        assertEquals(GOLDEN_NOAXES_HIER, serialize(new HierarchicalCellSetFormatter().format(noAxesCellSet())));
+        assertEquals(GOLDEN_NOAXES_FLATTENED, serialize(new FlattenedCellSetFormatter().format(noAxesCellSet())));
+    }
+
+    @Test
+    public void throwingCellNullFormat_allThreeFormatters() {
+        assertEquals(GOLDEN_THROW_FLAT, serialize(new CellSetFormatter().format(throwingCellSet())));
+        assertEquals(GOLDEN_THROW_HIER, serialize(new HierarchicalCellSetFormatter().format(throwingCellSet())));
+        assertEquals(GOLDEN_THROW_FLATTENED, serialize(new FlattenedCellSetFormatter().format(throwingCellSet())));
+    }
+
+    /* ===================================================================== */
+    /*  Matrix serialiser — deterministic, full cell state                    */
+    /* ===================================================================== */
+
+    private static String serialize(Matrix m) {
+        StringBuilder sb = new StringBuilder();
+        sb.append("width=").append(m.getMatrixWidth());
+        sb.append(" height=").append(m.getMatrixHeight());
+        sb.append(" offset=").append(m.getOffset());
+        sb.append('\n');
+
+        // Sort the populated coordinates (x then y) so iteration order is stable.
+        List<List<Integer>> coords = new ArrayList<>(m.getMap().keySet());
+        coords.sort((a, b) -> {
+            int cx = Integer.compare(a.get(0), b.get(0));
+            return cx != 0 ? cx : Integer.compare(a.get(1), b.get(1));
+        });
+
+        for (List<Integer> c : coords) {
+            AbstractBaseCell cell = m.getMap().get(c);
+            sb.append('(').append(c.get(0)).append(',').append(c.get(1)).append(") ");
+            sb.append(describe(cell));
+            sb.append('\n');
+        }
+        return sb.toString();
+    }
+
+    private static String describe(AbstractBaseCell cell) {
+        if (cell == null) return "null";
+        StringBuilder sb = new StringBuilder();
+        sb.append(cell.getClass().getSimpleName());
+        sb.append("{raw=").append(q(cell.getRawValue()));
+        sb.append(", fmt=").append(q(cell.getFormattedValue()));
+        sb.append(", parentDim=").append(q(cell.getParentDimension()));
+
+        if (cell instanceof MemberCell) {
+            MemberCell mc = (MemberCell) cell;
+            sb.append(", expanded=").append(mc.isExpanded());
+            sb.append(", lastRow=").append(mc.isLastRow());
+            sb.append(", uniqueName=").append(q(mc.getUniqueName()));
+            sb.append(", hierarchy=").append(q(mc.getHierarchy()));
+            sb.append(", level=").append(q(mc.getLevel()));
+        } else if (cell instanceof DataCell) {
+            DataCell dc = (DataCell) cell;
+            sb.append(", rawNumber=").append(dc.getRawNumber());
+            sb.append(", formatString=").append(q(dc.getFormatString()));
+            sb.append(", coordinates=").append(dc.getCoordinates());
+        }
+
+        // Properties map — sort keys for determinism.
+        Map<String, String> props = new TreeMap<>(cell.getProperties());
+        sb.append(", props=").append(props);
+        sb.append('}');
+        return sb.toString();
+    }
+
+    private static String q(String s) {
+        return s == null ? "<null>" : "'" + s + "'";
+    }
+
+    /* ===================================================================== */
+    /*  Cellset fixtures                                                      */
+    /* ===================================================================== */
+
+    /** Flat single-dim: rows = Product Family (3 members), cols = 1 measure. */
+    private static CellSet flatSingleDimCellSet() {
+        Dimension productDim = proxy(Dimension.class, map("getName", "Product"));
+        Hierarchy productH = proxy(
+                Hierarchy.class,
+                map("getName", "Products", "getUniqueName", "[Product].[Products]", "getDimension", productDim));
+        Level familyLevel = level("Product Family", "[Product].[Products].[Product Family]", productH, productDim, 2);
+
+        Member drink = member("Drink", "[Product].[Products].[Drink]", productDim, productH, familyLevel, 2, null);
+        Member food = member("Food", "[Product].[Products].[Food]", productDim, productH, familyLevel, 2, null);
+        Member nonconsum = member(
+                "Non-Consumable", "[Product].[Products].[Non-Consumable]", productDim, productH, familyLevel, 2, null);
+
+        List<Position> rowPositions = Arrays.asList(
+                pos(Collections.singletonList(drink)),
+                pos(Collections.singletonList(food)),
+                pos(Collections.singletonList(nonconsum)));
+
+        Dimension measDim = proxy(Dimension.class, map("getName", "Measures"));
+        Hierarchy measH = proxy(
+                Hierarchy.class, map("getName", "Measures", "getUniqueName", "[Measures]", "getDimension", measDim));
+        Level measLvl = level("MeasuresLevel", "[Measures].[MeasuresLevel]", measH, measDim, 0);
+        Member storeSales = member("Store Sales", "[Measures].[Store Sales]", measDim, measH, measLvl, 0, null);
+        List<Position> colPositions = Collections.singletonList(pos(Collections.singletonList(storeSales)));
+
+        Map<List<Integer>, Cell> cells = new HashMap<>();
+        cells.put(Arrays.asList(0, 0), cell(48836.21, "$48,836.21", "$#,##0.00", Arrays.asList(0, 0)));
+        cells.put(Arrays.asList(0, 1), cell(191940.0, "$191,940.00", "$#,##0.00", Arrays.asList(0, 1)));
+        cells.put(Arrays.asList(0, 2), cell(50236.88, "$50,236.88", "$#,##0.00", Arrays.asList(0, 2)));
+
+        return twoAxisCellSet(productH, measH, rowPositions, colPositions, cells);
+    }
+
+    /** Mixed depth: three row positions at depths 2,3,4 of one hierarchy. */
+    private static CellSet mixedDepthCellSet() {
+        Dimension productDim = proxy(Dimension.class, map("getName", "Product"));
+        Hierarchy productH = proxy(
+                Hierarchy.class,
+                map("getName", "Products", "getUniqueName", "[Product].[Products]", "getDimension", productDim));
+        Level familyLevel = level("Product Family", "[Product].[Products].[Product Family]", productH, productDim, 2);
+        Level deptLevel =
+                level("Product Department", "[Product].[Products].[Product Department]", productH, productDim, 3);
+        Level catLevel = level("Product Category", "[Product].[Products].[Product Category]", productH, productDim, 4);
+
+        Member drink = member("Drink", "[Product].[Products].[Drink]", productDim, productH, familyLevel, 2, null);
+        Member beverages = member(
+                "Beverages", "[Product].[Products].[Drink].[Beverages]", productDim, productH, deptLevel, 3, drink);
+        Member drinks = member(
+                "Drinks",
+                "[Product].[Products].[Drink].[Beverages].[Drinks]",
+                productDim,
+                productH,
+                catLevel,
+                4,
+                beverages);
+
+        List<Position> rowPositions = Arrays.asList(
+                pos(Collections.singletonList(drink)),
+                pos(Collections.singletonList(beverages)),
+                pos(Collections.singletonList(drinks)));
+
+        Dimension measDim = proxy(Dimension.class, map("getName", "Measures"));
+        Hierarchy measH = proxy(
+                Hierarchy.class, map("getName", "Measures", "getUniqueName", "[Measures]", "getDimension", measDim));
+        Level measLvl = level("MeasuresLevel", "[Measures].[MeasuresLevel]", measH, measDim, 0);
+        Member storeSales = member("Store Sales", "[Measures].[Store Sales]", measDim, measH, measLvl, 0, null);
+        List<Position> colPositions = Collections.singletonList(pos(Collections.singletonList(storeSales)));
+
+        Map<List<Integer>, Cell> cells = new HashMap<>();
+        cells.put(Arrays.asList(0, 0), cell(48836.21, "$48,836.21", "$#,##0.00", Arrays.asList(0, 0)));
+        cells.put(Arrays.asList(0, 1), cell(27748.53, "$27,748.53", "$#,##0.00", Arrays.asList(0, 1)));
+        cells.put(Arrays.asList(0, 2), cell(5642.29, "$5,642.29", "$#,##0.00", Arrays.asList(0, 2)));
+
+        return twoAxisCellSet(productH, measH, rowPositions, colPositions, cells);
+    }
+
+    /** No axes at all: a single scalar cell at coordinate []. */
+    private static CellSet noAxesCellSet() {
+        final List<CellSetAxis> axes = Collections.emptyList();
+        final Map<List<Integer>, Cell> cells = new HashMap<>();
+        cells.put(
+                Collections.<Integer>emptyList(),
+                cell(123456.78, "$123,456.78", "$#,##0.00", Collections.<Integer>emptyList()));
+        return cellSetProxy(axes, cells);
+    }
+
+    /**
+     * A data cell whose getDoubleValue() throws and whose FORMAT_STRING is null.
+     * Single dim on rows, one measure column, one cell.
+     */
+    private static CellSet throwingCellSet() {
+        Dimension productDim = proxy(Dimension.class, map("getName", "Product"));
+        Hierarchy productH = proxy(
+                Hierarchy.class,
+                map("getName", "Products", "getUniqueName", "[Product].[Products]", "getDimension", productDim));
+        Level familyLevel = level("Product Family", "[Product].[Products].[Product Family]", productH, productDim, 2);
+        Member drink = member("Drink", "[Product].[Products].[Drink]", productDim, productH, familyLevel, 2, null);
+        List<Position> rowPositions = Collections.singletonList(pos(Collections.singletonList(drink)));
+
+        Dimension measDim = proxy(Dimension.class, map("getName", "Measures"));
+        Hierarchy measH = proxy(
+                Hierarchy.class, map("getName", "Measures", "getUniqueName", "[Measures]", "getDimension", measDim));
+        Level measLvl = level("MeasuresLevel", "[Measures].[MeasuresLevel]", measH, measDim, 0);
+        Member storeSales = member("Store Sales", "[Measures].[Store Sales]", measDim, measH, measLvl, 0, null);
+        List<Position> colPositions = Collections.singletonList(pos(Collections.singletonList(storeSales)));
+
+        Map<List<Integer>, Cell> cells = new HashMap<>();
+        cells.put(Arrays.asList(0, 0), throwingCell(Arrays.asList(0, 0)));
+
+        return twoAxisCellSet(productH, measH, rowPositions, colPositions, cells);
+    }
+
+    /* ===================================================================== */
+    /*  Cellset / proxy plumbing                                              */
+    /* ===================================================================== */
+
+    private static CellSet twoAxisCellSet(
+            Hierarchy rowH,
+            Hierarchy colH,
+            List<Position> rowPositions,
+            List<Position> colPositions,
+            Map<List<Integer>, Cell> cellByCoord) {
+        CellSetAxisMetaData rowAxisMeta =
+                proxy(CellSetAxisMetaData.class, map("getHierarchies", Collections.singletonList(rowH)));
+        CellSetAxisMetaData colAxisMeta =
+                proxy(CellSetAxisMetaData.class, map("getHierarchies", Collections.singletonList(colH)));
+
+        CellSetAxis rowAxis = proxy(
+                CellSetAxis.class,
+                map(
+                        "getAxisOrdinal",
+                        Axis.ROWS,
+                        "getPositions",
+                        rowPositions,
+                        "getPositionCount",
+                        rowPositions.size(),
+                        "getAxisMetaData",
+                        rowAxisMeta));
+        CellSetAxis colAxis = proxy(
+                CellSetAxis.class,
+                map(
+                        "getAxisOrdinal",
+                        Axis.COLUMNS,
+                        "getPositions",
+                        colPositions,
+                        "getPositionCount",
+                        colPositions.size(),
+                        "getAxisMetaData",
+                        colAxisMeta));
+
+        // olap4j ordering: axes are [columns, rows].
+        List<CellSetAxis> axes = Arrays.asList(colAxis, rowAxis);
+        return cellSetProxy(axes, cellByCoord);
+    }
+
+    private static CellSet cellSetProxy(final List<CellSetAxis> axes, final Map<List<Integer>, Cell> cellByCoord) {
+        InvocationHandler h = new InvocationHandler() {
+            @Override
+            public Object invoke(Object p, Method m, Object[] a) {
+                switch (m.getName()) {
+                    case "getAxes":
+                        return axes;
+                    case "getCell":
+                        if (a != null && a.length == 1 && a[0] instanceof List) {
+                            return cellByCoord.get(a[0]);
+                        }
+                        return null;
+                    case "getFilterAxes":
+                        return Collections.emptyList();
+                    case "toString":
+                        return "CellSet@fake";
+                    case "equals":
+                        return p == a[0];
+                    case "hashCode":
+                        return System.identityHashCode(p);
+                    default:
+                        return defaultReturn(m);
+                }
+            }
+        };
+        return (CellSet) Proxy.newProxyInstance(
+                CellSetFormatterCharacterizationTest.class.getClassLoader(), new Class<?>[] {CellSet.class}, h);
+    }
+
+    private static Cell cell(double v, String formatted, final String formatString, List<Integer> coord) {
+        Map<String, Object> answers = new HashMap<>();
+        answers.put("isEmpty", Boolean.FALSE);
+        answers.put("isNull", Boolean.FALSE);
+        answers.put("isError", Boolean.FALSE);
+        answers.put("getValue", v);
+        answers.put("getDoubleValue", v);
+        answers.put("getFormattedValue", formatted);
+        answers.put("getCoordinateList", coord);
+        // FORMAT_STRING is read both by CellPropertyExtractor and by the
+        // formatter's own format-string block; expose it via getPropertyValue.
+        final Map<Property, Object> propValues = new HashMap<>();
+        if (formatString != null) propValues.put(Property.StandardCellProperty.FORMAT_STRING, formatString);
+        return cellProxy(answers, propValues);
+    }
+
+    /**
+     * A cell whose getDoubleValue() throws (exercises the rawNumber swallow),
+     * with a null FORMAT_STRING (exercises the format-string swallow's NPE
+     * branch). getValue() returns a non-null, non-numeric value so the
+     * DecimalFormat block is hit as well.
+     */
+    private static Cell throwingCell(List<Integer> coord) {
+        Map<String, Object> answers = new HashMap<>();
+        answers.put("isEmpty", Boolean.FALSE);
+        answers.put("isNull", Boolean.FALSE);
+        answers.put("isError", Boolean.FALSE);
+        // Non-numeric value: DecimalFormat.format(Object) on a String throws,
+        // hitting the second swallow site too; getFormattedValue is blank.
+        answers.put("getValue", "not-a-number");
+        answers.put("getFormattedValue", "");
+        answers.put("getCoordinateList", coord);
+        answers.put("__throwDouble", Boolean.TRUE);
+        // No FORMAT_STRING -> getPropertyValue returns null -> the format-string
+        // block's else branch calls .substring on null -> NPE -> swallowed.
+        return cellProxy(answers, new HashMap<Property, Object>());
+    }
+
+    private static Cell cellProxy(final Map<String, Object> answers, final Map<Property, Object> propValues) {
+        InvocationHandler h = new InvocationHandler() {
+            @Override
+            public Object invoke(Object p, Method m, Object[] a) {
+                String name = m.getName();
+                if ("getDoubleValue".equals(name) && Boolean.TRUE.equals(answers.get("__throwDouble"))) {
+                    throw new RuntimeException("getDoubleValue blew up");
+                }
+                if ("getPropertyValue".equals(name) && a != null && a.length >= 1 && a[0] instanceof Property) {
+                    return propValues.get(a[0]);
+                }
+                if ("toString".equals(name)) return "Cell@fake";
+                if ("equals".equals(name)) return p == a[0];
+                if ("hashCode".equals(name)) return System.identityHashCode(p);
+                if (answers.containsKey(name)) return answers.get(name);
+                return defaultReturn(m);
+            }
+        };
+        return (Cell) Proxy.newProxyInstance(
+                CellSetFormatterCharacterizationTest.class.getClassLoader(), new Class<?>[] {Cell.class}, h);
+    }
+
+    private static Level level(String name, String uniqueName, Hierarchy h, Dimension d, int depth) {
+        Map<String, Object> answers = new HashMap<>();
+        answers.put("getName", name);
+        answers.put("getCaption", name);
+        answers.put("getUniqueName", uniqueName);
+        answers.put("getHierarchy", h);
+        answers.put("getDimension", d);
+        answers.put("getDepth", depth);
+        return proxy(Level.class, answers);
+    }
+
+    private static Member member(
+            String caption, String uniqueName, Dimension d, Hierarchy h, Level l, int depth, Member parent) {
+        Map<String, Object> answers = new HashMap<>();
+        answers.put("getCaption", caption);
+        answers.put("getName", caption);
+        answers.put("getUniqueName", uniqueName);
+        answers.put("getDimension", d);
+        answers.put("getHierarchy", h);
+        answers.put("getLevel", l);
+        answers.put("getDepth", depth);
+        answers.put("getParentMember", parent);
+        return proxy(Member.class, answers);
+    }
+
+    private static Position pos(List<Member> members) {
+        return proxy(Position.class, map("getMembers", members, "getOrdinal", 0));
+    }
+
+    private static Map<String, Object> map(Object... kv) {
+        Map<String, Object> m = new HashMap<>();
+        for (int i = 0; i + 1 < kv.length; i += 2) m.put((String) kv[i], kv[i + 1]);
+        return m;
+    }
+
+    @SuppressWarnings("unchecked")
+    private static <T> T proxy(final Class<T> iface, final Map<String, Object> answers) {
+        Object obj = Proxy.newProxyInstance(
+                CellSetFormatterCharacterizationTest.class.getClassLoader(),
+                new Class<?>[] {iface},
+                new InvocationHandler() {
+                    @Override
+                    public Object invoke(Object p, Method m, Object[] a) {
+                        if ("toString".equals(m.getName())) return iface.getSimpleName() + "@fake";
+                        if ("equals".equals(m.getName())) return p == a[0];
+                        if ("hashCode".equals(m.getName())) return System.identityHashCode(p);
+                        if (answers.containsKey(m.getName())) return answers.get(m.getName());
+                        return defaultReturn(m);
+                    }
+                });
+        return (T) obj;
+    }
+
+    private static Object defaultReturn(Method m) {
+        Class<?> rt = m.getReturnType();
+        if (rt == boolean.class) return Boolean.FALSE;
+        if (rt == int.class) return 0;
+        if (rt == long.class) return 0L;
+        if (rt == double.class) return 0d;
+        if (rt == float.class) return 0f;
+        if (rt == short.class) return (short) 0;
+        if (rt == byte.class) return (byte) 0;
+        if (rt == char.class) return (char) 0;
+        if (rt == void.class) return null;
+        return null;
+    }
+
+    /* ===================================================================== */
+    /*  Golden literals — captured GREEN on the pre-refactor code.            */
+    /*  (filled in after the first capture run)                               */
+    /* ===================================================================== */
+
+    private static final String GOLDEN_FLAT_FLAT =
+            """
+            width=2 height=4 offset=1
+            (0,0) MemberCell{raw='Product Family', fmt='Product Family', parentDim='Product', expanded=false, lastRow=false, uniqueName=<null>, hierarchy='[Product].[Products]', level='[Product].[Products].[Product Family]', props={__headertype=row_header_header, levelindex=0}}
+            (0,1) MemberCell{raw='[Product].[Products].[Drink]', fmt='Drink', parentDim='Product', expanded=false, lastRow=false, uniqueName='[Product].[Products].[Drink]', hierarchy='[Product].[Products]', level='[Product].[Products].[Product Family]', props={levelindex=0}}
+            (0,2) MemberCell{raw='[Product].[Products].[Food]', fmt='Food', parentDim='Product', expanded=false, lastRow=true, uniqueName='[Product].[Products].[Food]', hierarchy='[Product].[Products]', level='[Product].[Products].[Product Family]', props={levelindex=0}}
+            (0,3) MemberCell{raw='[Product].[Products].[Non-Consumable]', fmt='Non-Consumable', parentDim='Product', expanded=false, lastRow=false, uniqueName='[Product].[Products].[Non-Consumable]', hierarchy='[Product].[Products]', level='[Product].[Products].[Product Family]', props={levelindex=0}}
+            (1,0) MemberCell{raw='[Measures].[Store Sales]', fmt='Store Sales', parentDim='Measures', expanded=false, lastRow=false, uniqueName='[Measures].[Store Sales]', hierarchy='[Measures]', level='[Measures].[MeasuresLevel]', props={levelindex=0}}
+            (1,1) DataCell{raw=<null>, fmt='$48,836.21', parentDim=<null>, rawNumber=48836.21, formatString='$#,##0.00', coordinates=[0, 0], props={formatString=$#,##0.00}}
+            (1,2) DataCell{raw=<null>, fmt='$191,940.00', parentDim=<null>, rawNumber=191940.0, formatString='$#,##0.00', coordinates=[0, 1], props={formatString=$#,##0.00}}
+            (1,3) DataCell{raw=<null>, fmt='$50,236.88', parentDim=<null>, rawNumber=50236.88, formatString='$#,##0.00', coordinates=[0, 2], props={formatString=$#,##0.00}}
+            """;
+
+    private static final String GOLDEN_FLAT_HIER =
+            """
+            width=2 height=4 offset=1
+            (0,0) MemberCell{raw='Product Family', fmt='Product Family', parentDim='Product', expanded=false, lastRow=false, uniqueName=<null>, hierarchy='[Product].[Products]', level='[Product].[Products].[Product Family]', props={__headertype=row_header_header, levelindex=0}}
+            (0,1) MemberCell{raw='[Product].[Products].[Drink]', fmt='Drink', parentDim='Product', expanded=false, lastRow=false, uniqueName='[Product].[Products].[Drink]', hierarchy='[Product].[Products]', level='[Product].[Products].[Product Family]', props={levelindex=0}}
+            (0,2) MemberCell{raw='[Product].[Products].[Food]', fmt='Food', parentDim='Product', expanded=false, lastRow=true, uniqueName='[Product].[Products].[Food]', hierarchy='[Product].[Products]', level='[Product].[Products].[Product Family]', props={levelindex=0}}
+            (0,3) MemberCell{raw='[Product].[Products].[Non-Consumable]', fmt='Non-Consumable', parentDim='Product', expanded=false, lastRow=false, uniqueName='[Product].[Products].[Non-Consumable]', hierarchy='[Product].[Products]', level='[Product].[Products].[Product Family]', props={levelindex=0}}
+            (1,0) MemberCell{raw='[Measures].[Store Sales]', fmt='Store Sales', parentDim='Measures', expanded=false, lastRow=false, uniqueName='[Measures].[Store Sales]', hierarchy='[Measures]', level='[Measures].[MeasuresLevel]', props={levelindex=0}}
+            (1,1) DataCell{raw=<null>, fmt='$48,836.21', parentDim=<null>, rawNumber=48836.21, formatString='$#,##0.00', coordinates=[0, 0], props={formatString=$#,##0.00}}
+            (1,2) DataCell{raw=<null>, fmt='$191,940.00', parentDim=<null>, rawNumber=191940.0, formatString='$#,##0.00', coordinates=[0, 1], props={formatString=$#,##0.00}}
+            (1,3) DataCell{raw=<null>, fmt='$50,236.88', parentDim=<null>, rawNumber=50236.88, formatString='$#,##0.00', coordinates=[0, 2], props={formatString=$#,##0.00}}
+            """;
+
+    private static final String GOLDEN_FLAT_FLATTENED =
+            """
+            width=2 height=4 offset=1
+            (0,0) MemberCell{raw='Product Family', fmt='Product Family', parentDim='Product', expanded=false, lastRow=false, uniqueName=<null>, hierarchy='[Product].[Products]', level='[Product].[Products].[Product Family]', props={__headertype=row_header_header, levelindex=0}}
+            (0,1) MemberCell{raw='[Product].[Products].[Drink]', fmt='Drink', parentDim='Product', expanded=false, lastRow=false, uniqueName='[Product].[Products].[Drink]', hierarchy='[Product].[Products]', level='[Product].[Products].[Product Family]', props={}}
+            (0,2) MemberCell{raw='[Product].[Products].[Food]', fmt='Food', parentDim='Product', expanded=false, lastRow=true, uniqueName='[Product].[Products].[Food]', hierarchy='[Product].[Products]', level='[Product].[Products].[Product Family]', props={}}
+            (0,3) MemberCell{raw='[Product].[Products].[Non-Consumable]', fmt='Non-Consumable', parentDim='Product', expanded=false, lastRow=false, uniqueName='[Product].[Products].[Non-Consumable]', hierarchy='[Product].[Products]', level='[Product].[Products].[Product Family]', props={}}
+            (1,0) MemberCell{raw='[Measures].[Store Sales]', fmt='Store Sales', parentDim='Measures', expanded=false, lastRow=false, uniqueName='[Measures].[Store Sales]', hierarchy='[Measures]', level='[Measures].[MeasuresLevel]', props={}}
+            (1,1) DataCell{raw=<null>, fmt='$48,836.21', parentDim=<null>, rawNumber=48836.21, formatString='$#,##0.00', coordinates=[0, 0], props={formatString=$#,##0.00}}
+            (1,2) DataCell{raw=<null>, fmt='$191,940.00', parentDim=<null>, rawNumber=191940.0, formatString='$#,##0.00', coordinates=[0, 1], props={formatString=$#,##0.00}}
+            (1,3) DataCell{raw=<null>, fmt='$50,236.88', parentDim=<null>, rawNumber=50236.88, formatString='$#,##0.00', coordinates=[0, 2], props={formatString=$#,##0.00}}
+            """;
+
+    private static final String GOLDEN_MIXED_FLAT =
+            """
+            width=4 height=4 offset=1
+            (0,0) MemberCell{raw='Product Family', fmt='Product Family', parentDim='Product', expanded=false, lastRow=false, uniqueName=<null>, hierarchy='[Product].[Products]', level='[Product].[Products].[Product Family]', props={__headertype=row_header_header, levelindex=0}}
+            (0,1) MemberCell{raw='[Product].[Products].[Drink]', fmt='Drink', parentDim='Product', expanded=false, lastRow=false, uniqueName='[Product].[Products].[Drink]', hierarchy='[Product].[Products]', level='[Product].[Products].[Product Family]', props={levelindex=0}}
+            (0,2) MemberCell{raw='[Product].[Products].[Drink]', fmt='Drink', parentDim='Product', expanded=false, lastRow=false, uniqueName='[Product].[Products].[Drink]', hierarchy='[Product].[Products]', level='[Product].[Products].[Product Family]', props={}}
+            (0,3) MemberCell{raw='[Product].[Products].[Drink]', fmt='Drink', parentDim='Product', expanded=false, lastRow=false, uniqueName='[Product].[Products].[Drink]', hierarchy='[Product].[Products]', level='[Product].[Products].[Product Family]', props={}}
+            (1,0) MemberCell{raw='Product Department', fmt='Product Department', parentDim='Product', expanded=false, lastRow=false, uniqueName=<null>, hierarchy='[Product].[Products]', level='[Product].[Products].[Product Department]', props={__headertype=row_header_header, levelindex=1}}
+            (1,1) MemberCell{raw=<null>, fmt=<null>, parentDim=<null>, expanded=false, lastRow=false, uniqueName=<null>, hierarchy=<null>, level=<null>, props={}}
+            (1,2) MemberCell{raw='[Product].[Products].[Drink].[Beverages]', fmt='Beverages', parentDim='Product', expanded=true, lastRow=true, uniqueName='[Product].[Products].[Drink].[Beverages]', hierarchy='[Product].[Products]', level='[Product].[Products].[Product Department]', props={levelindex=1}}
+            (1,3) MemberCell{raw='[Product].[Products].[Drink].[Beverages]', fmt='Beverages', parentDim='Product', expanded=false, lastRow=false, uniqueName='[Product].[Products].[Drink].[Beverages]', hierarchy='[Product].[Products]', level='[Product].[Products].[Product Department]', props={}}
+            (2,0) MemberCell{raw='Product Category', fmt='Product Category', parentDim='Product', expanded=false, lastRow=false, uniqueName=<null>, hierarchy='[Product].[Products]', level='[Product].[Products].[Product Category]', props={__headertype=row_header_header, levelindex=2}}
+            (2,1) MemberCell{raw=<null>, fmt=<null>, parentDim=<null>, expanded=false, lastRow=false, uniqueName=<null>, hierarchy=<null>, level=<null>, props={}}
+            (2,2) MemberCell{raw=<null>, fmt=<null>, parentDim=<null>, expanded=false, lastRow=false, uniqueName=<null>, hierarchy=<null>, level=<null>, props={}}
+            (2,3) MemberCell{raw='[Product].[Products].[Drink].[Beverages].[Drinks]', fmt='Drinks', parentDim='Product', expanded=true, lastRow=false, uniqueName='[Product].[Products].[Drink].[Beverages].[Drinks]', hierarchy='[Product].[Products]', level='[Product].[Products].[Product Category]', props={levelindex=2}}
+            (3,0) MemberCell{raw='[Measures].[Store Sales]', fmt='Store Sales', parentDim='Measures', expanded=false, lastRow=false, uniqueName='[Measures].[Store Sales]', hierarchy='[Measures]', level='[Measures].[MeasuresLevel]', props={levelindex=0}}
+            (3,1) DataCell{raw=<null>, fmt='$48,836.21', parentDim=<null>, rawNumber=48836.21, formatString='$#,##0.00', coordinates=[0, 0], props={formatString=$#,##0.00}}
+            (3,2) DataCell{raw=<null>, fmt='$27,748.53', parentDim=<null>, rawNumber=27748.53, formatString='$#,##0.00', coordinates=[0, 1], props={formatString=$#,##0.00}}
+            (3,3) DataCell{raw=<null>, fmt='$5,642.29', parentDim=<null>, rawNumber=5642.29, formatString='$#,##0.00', coordinates=[0, 2], props={formatString=$#,##0.00}}
+            """;
+
+    private static final String GOLDEN_MIXED_HIER =
+            """
+            width=4 height=4 offset=1
+            (0,0) MemberCell{raw='Product Family', fmt='Product Family', parentDim='Product', expanded=false, lastRow=false, uniqueName=<null>, hierarchy='[Product].[Products]', level='[Product].[Products].[Product Family]', props={__headertype=row_header_header, levelindex=0}}
+            (0,1) MemberCell{raw='[Product].[Products].[Drink]', fmt='Drink', parentDim='Product', expanded=false, lastRow=false, uniqueName='[Product].[Products].[Drink]', hierarchy='[Product].[Products]', level='[Product].[Products].[Product Family]', props={levelindex=0}}
+            (0,2) MemberCell{raw=<null>, fmt=<null>, parentDim=<null>, expanded=false, lastRow=false, uniqueName=<null>, hierarchy=<null>, level=<null>, props={}}
+            (0,3) MemberCell{raw=<null>, fmt=<null>, parentDim=<null>, expanded=false, lastRow=false, uniqueName=<null>, hierarchy=<null>, level=<null>, props={}}
+            (1,0) MemberCell{raw='Product Department', fmt='Product Department', parentDim='Product', expanded=false, lastRow=false, uniqueName=<null>, hierarchy='[Product].[Products]', level='[Product].[Products].[Product Department]', props={__headertype=row_header_header, levelindex=1}}
+            (1,1) MemberCell{raw=<null>, fmt=<null>, parentDim=<null>, expanded=false, lastRow=false, uniqueName=<null>, hierarchy=<null>, level=<null>, props={}}
+            (1,2) MemberCell{raw='[Product].[Products].[Drink].[Beverages]', fmt='Beverages', parentDim='Product', expanded=true, lastRow=true, uniqueName='[Product].[Products].[Drink].[Beverages]', hierarchy='[Product].[Products]', level='[Product].[Products].[Product Department]', props={levelindex=1}}
+            (1,3) MemberCell{raw=<null>, fmt=<null>, parentDim=<null>, expanded=false, lastRow=false, uniqueName=<null>, hierarchy=<null>, level=<null>, props={}}
+            (2,0) MemberCell{raw='Product Category', fmt='Product Category', parentDim='Product', expanded=false, lastRow=false, uniqueName=<null>, hierarchy='[Product].[Products]', level='[Product].[Products].[Product Category]', props={__headertype=row_header_header, levelindex=2}}
+            (2,1) MemberCell{raw=<null>, fmt=<null>, parentDim=<null>, expanded=false, lastRow=false, uniqueName=<null>, hierarchy=<null>, level=<null>, props={}}
+            (2,2) MemberCell{raw=<null>, fmt=<null>, parentDim=<null>, expanded=false, lastRow=false, uniqueName=<null>, hierarchy=<null>, level=<null>, props={}}
+            (2,3) MemberCell{raw='[Product].[Products].[Drink].[Beverages].[Drinks]', fmt='Drinks', parentDim='Product', expanded=true, lastRow=false, uniqueName='[Product].[Products].[Drink].[Beverages].[Drinks]', hierarchy='[Product].[Products]', level='[Product].[Products].[Product Category]', props={levelindex=2}}
+            (3,0) MemberCell{raw='[Measures].[Store Sales]', fmt='Store Sales', parentDim='Measures', expanded=false, lastRow=false, uniqueName='[Measures].[Store Sales]', hierarchy='[Measures]', level='[Measures].[MeasuresLevel]', props={levelindex=0}}
+            (3,1) DataCell{raw=<null>, fmt='$48,836.21', parentDim=<null>, rawNumber=48836.21, formatString='$#,##0.00', coordinates=[0, 0], props={formatString=$#,##0.00}}
+            (3,2) DataCell{raw=<null>, fmt='$27,748.53', parentDim=<null>, rawNumber=27748.53, formatString='$#,##0.00', coordinates=[0, 1], props={formatString=$#,##0.00}}
+            (3,3) DataCell{raw=<null>, fmt='$5,642.29', parentDim=<null>, rawNumber=5642.29, formatString='$#,##0.00', coordinates=[0, 2], props={formatString=$#,##0.00}}
+            """;
+
+    private static final String GOLDEN_MIXED_FLATTENED =
+            """
+            width=4 height=4 offset=1
+            (0,0) MemberCell{raw='Product Family', fmt='Product Family', parentDim='Product', expanded=false, lastRow=false, uniqueName=<null>, hierarchy='[Product].[Products]', level='[Product].[Products].[Product Family]', props={__headertype=row_header_header, levelindex=0}}
+            (0,1) MemberCell{raw='[Product].[Products].[Drink]', fmt='Drink', parentDim='Product', expanded=false, lastRow=false, uniqueName='[Product].[Products].[Drink]', hierarchy='[Product].[Products]', level='[Product].[Products].[Product Family]', props={}}
+            (0,2) MemberCell{raw='[Product].[Products].[Drink]', fmt='Drink', parentDim='Product', expanded=false, lastRow=false, uniqueName='[Product].[Products].[Drink]', hierarchy='[Product].[Products]', level='[Product].[Products].[Product Family]', props={}}
+            (0,3) MemberCell{raw='[Product].[Products].[Drink]', fmt='Drink', parentDim='Product', expanded=false, lastRow=false, uniqueName='[Product].[Products].[Drink]', hierarchy='[Product].[Products]', level='[Product].[Products].[Product Family]', props={}}
+            (1,0) MemberCell{raw='Product Department', fmt='Product Department', parentDim='Product', expanded=false, lastRow=false, uniqueName=<null>, hierarchy='[Product].[Products]', level='[Product].[Products].[Product Department]', props={__headertype=row_header_header, levelindex=1}}
+            (1,1) MemberCell{raw=<null>, fmt=<null>, parentDim=<null>, expanded=false, lastRow=false, uniqueName=<null>, hierarchy=<null>, level=<null>, props={}}
+            (1,2) MemberCell{raw='[Product].[Products].[Drink].[Beverages]', fmt='Beverages', parentDim='Product', expanded=true, lastRow=true, uniqueName='[Product].[Products].[Drink].[Beverages]', hierarchy='[Product].[Products]', level='[Product].[Products].[Product Department]', props={}}
+            (1,3) MemberCell{raw='[Product].[Products].[Drink].[Beverages]', fmt='Beverages', parentDim='Product', expanded=false, lastRow=false, uniqueName='[Product].[Products].[Drink].[Beverages]', hierarchy='[Product].[Products]', level='[Product].[Products].[Product Department]', props={}}
+            (2,0) MemberCell{raw='Product Category', fmt='Product Category', parentDim='Product', expanded=false, lastRow=false, uniqueName=<null>, hierarchy='[Product].[Products]', level='[Product].[Products].[Product Category]', props={__headertype=row_header_header, levelindex=2}}
+            (2,1) MemberCell{raw=<null>, fmt=<null>, parentDim=<null>, expanded=false, lastRow=false, uniqueName=<null>, hierarchy=<null>, level=<null>, props={}}
+            (2,2) MemberCell{raw=<null>, fmt=<null>, parentDim=<null>, expanded=true, lastRow=false, uniqueName=<null>, hierarchy=<null>, level=<null>, props={}}
+            (2,3) MemberCell{raw='[Product].[Products].[Drink].[Beverages].[Drinks]', fmt='Drinks', parentDim='Product', expanded=true, lastRow=false, uniqueName='[Product].[Products].[Drink].[Beverages].[Drinks]', hierarchy='[Product].[Products]', level='[Product].[Products].[Product Category]', props={}}
+            (3,0) MemberCell{raw='[Measures].[Store Sales]', fmt='Store Sales', parentDim='Measures', expanded=false, lastRow=false, uniqueName='[Measures].[Store Sales]', hierarchy='[Measures]', level='[Measures].[MeasuresLevel]', props={}}
+            (3,1) DataCell{raw=<null>, fmt='$48,836.21', parentDim=<null>, rawNumber=48836.21, formatString='$#,##0.00', coordinates=[0, 0], props={formatString=$#,##0.00}}
+            (3,2) DataCell{raw=<null>, fmt='$27,748.53', parentDim=<null>, rawNumber=27748.53, formatString='$#,##0.00', coordinates=[0, 1], props={formatString=$#,##0.00}}
+            (3,3) DataCell{raw=<null>, fmt='$5,642.29', parentDim=<null>, rawNumber=5642.29, formatString='$#,##0.00', coordinates=[0, 2], props={formatString=$#,##0.00}}
+            """;
+
+    private static final String GOLDEN_NOAXES_FLAT =
+            """
+            width=1 height=1 offset=0
+            (0,0) DataCell{raw=<null>, fmt='$123,456.78', parentDim=<null>, rawNumber=123456.78, formatString='$#,##0.00', coordinates=[], props={formatString=$#,##0.00}}
+            """;
+
+    private static final String GOLDEN_NOAXES_HIER =
+            """
+            width=1 height=1 offset=0
+            (0,0) DataCell{raw=<null>, fmt='$123,456.78', parentDim=<null>, rawNumber=123456.78, formatString='$#,##0.00', coordinates=[], props={formatString=$#,##0.00}}
+            """;
+
+    private static final String GOLDEN_NOAXES_FLATTENED =
+            """
+            width=1 height=1 offset=0
+            (0,0) DataCell{raw=<null>, fmt='$123,456.78', parentDim=<null>, rawNumber=123456.78, formatString='$#,##0.00', coordinates=[], props={formatString=$#,##0.00}}
+            """;
+
+    private static final String GOLDEN_THROW_FLAT =
+            """
+            width=2 height=2 offset=1
+            (0,0) MemberCell{raw='Product Family', fmt='Product Family', parentDim='Product', expanded=false, lastRow=false, uniqueName=<null>, hierarchy='[Product].[Products]', level='[Product].[Products].[Product Family]', props={__headertype=row_header_header, levelindex=0}}
+            (0,1) MemberCell{raw='[Product].[Products].[Drink]', fmt='Drink', parentDim='Product', expanded=false, lastRow=false, uniqueName='[Product].[Products].[Drink]', hierarchy='[Product].[Products]', level='[Product].[Products].[Product Family]', props={levelindex=0}}
+            (1,0) MemberCell{raw='[Measures].[Store Sales]', fmt='Store Sales', parentDim='Measures', expanded=false, lastRow=false, uniqueName='[Measures].[Store Sales]', hierarchy='[Measures]', level='[Measures].[MeasuresLevel]', props={levelindex=0}}
+            (1,1) DataCell{raw=<null>, fmt='', parentDim=<null>, rawNumber=null, formatString=<null>, coordinates=[0, 0], props={}}
+            """;
+
+    private static final String GOLDEN_THROW_HIER =
+            """
+            width=2 height=2 offset=1
+            (0,0) MemberCell{raw='Product Family', fmt='Product Family', parentDim='Product', expanded=false, lastRow=false, uniqueName=<null>, hierarchy='[Product].[Products]', level='[Product].[Products].[Product Family]', props={__headertype=row_header_header, levelindex=0}}
+            (0,1) MemberCell{raw='[Product].[Products].[Drink]', fmt='Drink', parentDim='Product', expanded=false, lastRow=false, uniqueName='[Product].[Products].[Drink]', hierarchy='[Product].[Products]', level='[Product].[Products].[Product Family]', props={levelindex=0}}
+            (1,0) MemberCell{raw='[Measures].[Store Sales]', fmt='Store Sales', parentDim='Measures', expanded=false, lastRow=false, uniqueName='[Measures].[Store Sales]', hierarchy='[Measures]', level='[Measures].[MeasuresLevel]', props={levelindex=0}}
+            (1,1) DataCell{raw=<null>, fmt='', parentDim=<null>, rawNumber=null, formatString=<null>, coordinates=[0, 0], props={}}
+            """;
+
+    private static final String GOLDEN_THROW_FLATTENED =
+            """
+            width=2 height=2 offset=1
+            (0,0) MemberCell{raw='Product Family', fmt='Product Family', parentDim='Product', expanded=false, lastRow=false, uniqueName=<null>, hierarchy='[Product].[Products]', level='[Product].[Products].[Product Family]', props={__headertype=row_header_header, levelindex=0}}
+            (0,1) MemberCell{raw='[Product].[Products].[Drink]', fmt='Drink', parentDim='Product', expanded=false, lastRow=false, uniqueName='[Product].[Products].[Drink]', hierarchy='[Product].[Products]', level='[Product].[Products].[Product Family]', props={}}
+            (1,0) MemberCell{raw='[Measures].[Store Sales]', fmt='Store Sales', parentDim='Measures', expanded=false, lastRow=false, uniqueName='[Measures].[Store Sales]', hierarchy='[Measures]', level='[Measures].[MeasuresLevel]', props={}}
+            (1,1) DataCell{raw=<null>, fmt='', parentDim=<null>, rawNumber=null, formatString=<null>, coordinates=[0, 0], props={}}
+            """;
+}


### PR DESCRIPTION
Closes #1163. Behavior-preserving refactor produced via a security-reviewed workflow (implement in isolated worktree with characterization tests + full module gate → adversarial security/behavior review).

## What

`CellSetFormatter`, `HierarchicalCellSetFormatter`, and `FlattenedCellSetFormatter` shared 60–80% of an axis-walker (and the same silent `// TODO: handle exception` swallows). Lifted the common scaffolding into a new package-private `AbstractCellSetFormatter` (the `AxisInfo`/`AxisOrdinalInfo` types, `cellIter`, the `matrix` field, `format`, `computeAxisInfo`, the common two-axis `formatPage`, and a shared `populateCell`). Each subclass now overrides only `populateAxis`; `FlattenedCellSetFormatter` also overrides `formatPage` (its cell-skip logic).

## Why this is in the security lane / behavior preservation

The formatter output (the `AbstractBaseCell[][]` matrix) feeds query results to the UI and the AI API — any drift is a data-integrity issue. This is a **pure reorganization, zero behavior change**:

- **Characterization-first:** new `CellSetFormatterCharacterizationTest` serializes the *entire* matrix output (dimensions + every cell's class/value/formatted/props incl. `levelindex`/`expanded`/etc.) for **all three formatters** across 4 cellset shapes (flat, mixed-depth rows, no-axes, and a throwing-`getDoubleValue`/null-`FORMAT_STRING` cell). Captured **green against the unmodified code first**, then re-run **byte-identical** after the refactor.
- The three `populateAxis` bodies are **preserved verbatim** (their legitimate differences — `Arrays.fill`+sticky `expanded` in Flattened (saiku#788), same-nulling in Hierarchical, `levelindex`+parent-walk in CellSetFormatter — are all pinned by the mixed-depth golden). The one forced change is `ordinalInfo.depths` → `ordinalInfo.getDepths()` (the field moved into the base; the getter returns the same live list, so `Collections.sort`/`indexOf` behave identically).
- The 3 exception swallows are lifted with **identical control flow** (catch-and-absorb, never rethrow) — only a **WARN log** (no cell business values) + an explanatory comment added, addressing the issue's "audit the silent swallows" ask without changing behavior.
- **Public API intact:** `ICellSetFormatter.format(CellSet)`, the three public no-arg constructors, and all three FQNs (`org.saiku.olap.util.formatter.*`) — `CellSetFormatterFactory` and Spring resolve by FQN string.

## Verification

- **Gate green:** full `saiku-service` suite — 469 tests, 0 failures (excluding the repo's 10 pre-existing Windows-only environmental failures, which fail on pristine `development` and don't occur on Linux CI); `spotless` clean.
- **Adversarial review** (independent agent, diff vs `development`): behavior preserved ✅, security preserved ✅, verdict **approve**.
- Rebased onto current `development`.

## Notes

- Security lane (Agent SEC). **Not self-merging.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
