### PR TITLE
refactor(ui): extract createUserKeyedListStore for favourite + recent dashboards (#1162)

### DIFF
--- a/saiku-ui/src/lib/stores/favouriteDashboards.svelte.ts
+++ b/saiku-ui/src/lib/stores/favouriteDashboards.svelte.ts
@@ -12,97 +12,47 @@
  * dashboard's own name in the catalogue render, not by toggle
  * order. The UI render handles that sort.
  *
- * Reactivity model: read methods (`all`, `isFavourite`) are pure —
- * they re-read localStorage on every call and use a `version` counter
- * as a tracking dep so $derived consumers re-evaluate whenever a
- * mutation runs. This keeps the read path free of $state writes
- * (which Svelte 5 forbids inside $derived).
+ * As of #1162 the shared mechanics (per-user localStorage key,
+ * version-counter reactivity, try/swallow IO) live in
+ * {@link createUserKeyedListStore}; this file is a thin wrapper that
+ * fixes the favourites semantics (uncapped, membership toggle) and
+ * re-exposes the original public method names so consumers compile
+ * unchanged.
  */
 
-import { session } from "$lib/stores/session.svelte";
+import { createUserKeyedListStore, type UserKeyedListStore } from "$lib/stores/userKeyedListStore.svelte";
 
 const STORAGE_PREFIX = "saiku:favourites:";
 
-function storageKey(username: string | null | undefined): string | null {
-  if (!username) return null;
-  return `${STORAGE_PREFIX}${username}`;
-}
-
-function loadFromStorage(username: string | null | undefined): Set<string> {
-  if (typeof window === "undefined") return new Set();
-  const key = storageKey(username);
-  if (!key) return new Set();
-  try {
-    const raw = window.localStorage.getItem(key);
-    if (!raw) return new Set();
-    const parsed = JSON.parse(raw);
-    if (!Array.isArray(parsed)) return new Set();
-    return new Set(parsed.filter((p): p is string => typeof p === "string"));
-  } catch {
-    return new Set();
-  }
-}
-
-function saveToStorage(username: string | null | undefined, paths: Set<string>): void {
-  if (typeof window === "undefined") return;
-  const key = storageKey(username);
-  if (!key) return;
-  try {
-    window.localStorage.setItem(key, JSON.stringify(Array.from(paths)));
-  } catch {
-    // Same rationale as recentDashboards: localStorage failures are
-    // a UX inconvenience, not a contract violation. Swallow silently.
-  }
-}
-
 class FavouriteDashboardsStore {
-  /** Re-render trigger. Mutations bump this so $derived consumers
-   *  notice a write. Read methods only *read* this — never write. */
-  private version = $state<number>(0);
+  // SET semantics: no cap, membership toggle, de-dupe on load (the original
+  // Set-backed store collapsed duplicates from a corrupt/tampered blob).
+  private readonly store: UserKeyedListStore = createUserKeyedListStore({
+    prefix: STORAGE_PREFIX,
+    dedupeOnLoad: true,
+  });
 
   /** True if {@code path} is currently favourited for the active user. */
   isFavourite(path: string): boolean {
-    void this.version; // tracking dep — re-evaluate when mutations bump
-    const u = session.current?.username ?? null;
-    return loadFromStorage(u).has(path);
+    return this.store.has(path);
   }
 
   /** All favourite paths for the current user. Order is insertion-
-   *  order of the underlying Set, which is *not* alphabetical — the
+   *  order of the underlying list, which is *not* alphabetical — the
    *  catalogue render sorts when displaying. Empty when no user. */
   all(): string[] {
-    void this.version; // tracking dep
-    const u = session.current?.username ?? null;
-    return Array.from(loadFromStorage(u));
+    return this.store.all();
   }
 
   /** Flip the favourite state for {@code path}. No-op when no user. */
   toggle(path: string): void {
-    if (!path) return;
-    const u = session.current?.username ?? null;
-    if (!u) return;
-    const current = loadFromStorage(u);
-    const next = new Set(current);
-    if (next.has(path)) {
-      next.delete(path);
-    } else {
-      next.add(path);
-    }
-    saveToStorage(u, next);
-    this.version++;
+    this.store.toggle(path);
   }
 
   /** Force-remove a path — used when the catalogue deletes a
    *  dashboard, so a stale favourite chip doesn't survive. */
   remove(path: string): void {
-    const u = session.current?.username ?? null;
-    if (!u) return;
-    const current = loadFromStorage(u);
-    if (!current.has(path)) return;
-    const next = new Set(current);
-    next.delete(path);
-    saveToStorage(u, next);
-    this.version++;
+    this.store.remove(path);
   }
 }
 

--- a/saiku-ui/src/lib/stores/recentDashboards.svelte.ts
+++ b/saiku-ui/src/lib/stores/recentDashboards.svelte.ts
@@ -11,14 +11,15 @@
  * ticket adds it, the in-memory state shape doesn't change, only the
  * load / save IO does.
  *
- * Reactivity model: read methods (`all`) are pure — they re-read
- * localStorage on every call and use a `version` counter as a tracking
- * dep so $derived consumers re-evaluate whenever a mutation runs.
- * This keeps the read path free of $state writes (which Svelte 5
- * forbids inside $derived).
+ * As of #1162 the shared mechanics (per-user localStorage key,
+ * version-counter reactivity, try/swallow IO) live in
+ * {@link createUserKeyedListStore}; this file is a thin wrapper that
+ * fixes the recents semantics (cap = RECENTS_CAP, dedupe-to-front) and
+ * re-exposes the original public method names so consumers compile
+ * unchanged.
  */
 
-import { session } from "$lib/stores/session.svelte";
+import { createUserKeyedListStore, type UserKeyedListStore } from "$lib/stores/userKeyedListStore.svelte";
 
 /** Hard cap on the number of entries we keep. Beyond this and the
  *  "recently viewed" section just becomes another catalogue list. */
@@ -26,86 +27,38 @@ export const RECENTS_CAP = 10;
 
 const STORAGE_PREFIX = "saiku:recents:";
 
-function storageKey(username: string | null | undefined): string | null {
-  if (!username) return null;
-  return `${STORAGE_PREFIX}${username}`;
-}
-
-function loadFromStorage(username: string | null | undefined): string[] {
-  if (typeof window === "undefined") return [];
-  const key = storageKey(username);
-  if (!key) return [];
-  try {
-    const raw = window.localStorage.getItem(key);
-    if (!raw) return [];
-    const parsed = JSON.parse(raw);
-    if (!Array.isArray(parsed)) return [];
-    return parsed.filter((p): p is string => typeof p === "string").slice(0, RECENTS_CAP);
-  } catch {
-    return [];
-  }
-}
-
-function saveToStorage(username: string | null | undefined, paths: string[]): void {
-  if (typeof window === "undefined") return;
-  const key = storageKey(username);
-  if (!key) return;
-  try {
-    window.localStorage.setItem(key, JSON.stringify(paths));
-  } catch {
-    // localStorage may be unavailable (private mode, quota). Failing
-    // silently is the right call: the recents list is a convenience,
-    // not a contract.
-  }
-}
-
 class RecentDashboardsStore {
-  /** Re-render trigger. Mutations bump this so $derived consumers
-   *  notice a write. Read methods only *read* this — never write. */
-  private version = $state<number>(0);
+  // ORDERED-LIST semantics: capped, dedupe-to-front (most-recent first).
+  private readonly store: UserKeyedListStore = createUserKeyedListStore({
+    prefix: STORAGE_PREFIX,
+    cap: RECENTS_CAP,
+    dedupe: true,
+  });
 
   /** All recent paths for the current user, most-recent first, capped
    *  at {@link RECENTS_CAP}. Empty when there's no current user. */
   all(): string[] {
-    void this.version; // tracking dep — re-evaluate when mutations bump
-    const u = session.current?.username ?? null;
-    return loadFromStorage(u);
+    return this.store.all();
   }
 
   /** Push a path onto the recents list for the current user. If the
    *  path is already present, it moves to the front (dedup). Trims to
    *  RECENTS_CAP entries. No-op when there's no current user. */
   push(path: string): void {
-    if (!path) return;
-    const u = session.current?.username ?? null;
-    if (!u) return;
-    const current = loadFromStorage(u);
-    const filtered = current.filter((p) => p !== path);
-    const next = [path, ...filtered].slice(0, RECENTS_CAP);
-    saveToStorage(u, next);
-    this.version++;
+    this.store.addFront(path);
   }
 
   /** Remove a single path — used when the catalogue deletes a
    *  dashboard so its row doesn't linger in the recents section. */
   remove(path: string): void {
-    const u = session.current?.username ?? null;
-    if (!u) return;
-    const current = loadFromStorage(u);
-    const next = current.filter((p) => p !== path);
-    if (next.length === current.length) return;
-    saveToStorage(u, next);
-    this.version++;
+    this.store.remove(path);
   }
 
   /** Drop the entire list for the current user. Exposed mainly for
    *  the unit-test harness; the UI doesn't surface a "clear" affordance
    *  in the first cut. */
   clear(): void {
-    const u = session.current?.username ?? null;
-    if (!u) return;
-    saveToStorage(u, []);
-    this.version++;
+    this.store.clear();
   }
 }
 

--- a/saiku-ui/src/lib/stores/userKeyedListStore.svelte.test.ts
+++ b/saiku-ui/src/lib/stores/userKeyedListStore.svelte.test.ts
@@ -1,0 +1,143 @@
+/*
+ * Unit tests for the generic createUserKeyedListStore (#1162).
+ *
+ * Mirrors the favourites / recents harness — mocks session.current and
+ * installs an in-memory localStorage shim before importing the store —
+ * and exercises the generic abstraction directly across its two
+ * configurations (uncapped set-toggle vs capped dedupe-to-front list),
+ * covering cap behaviour, dedupe, and per-user isolation.
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+let currentUsername: string | null = "alice";
+
+vi.mock("$lib/stores/session.svelte", () => ({
+  session: {
+    get current() {
+      return currentUsername == null ? null : { username: currentUsername };
+    },
+  },
+}));
+
+function installFakeLocalStorage(): void {
+  const store = new Map<string, string>();
+  const fakeStorage: Storage = {
+    getItem: (k) => store.get(k) ?? null,
+    setItem: (k, v) => {
+      store.set(k, v);
+    },
+    removeItem: (k) => {
+      store.delete(k);
+    },
+    clear: () => store.clear(),
+    get length() {
+      return store.size;
+    },
+    key: (i) => Array.from(store.keys())[i] ?? null,
+  };
+  vi.stubGlobal("window", { localStorage: fakeStorage });
+}
+
+let createUserKeyedListStore: typeof import("./userKeyedListStore.svelte").createUserKeyedListStore;
+
+beforeEach(async () => {
+  installFakeLocalStorage();
+  currentUsername = "alice";
+  vi.resetModules();
+  const mod = await import("./userKeyedListStore.svelte");
+  createUserKeyedListStore = mod.createUserKeyedListStore;
+});
+
+describe("createUserKeyedListStore — cap behaviour", () => {
+  it("trims to cap on addFront, keeping most-recent first", () => {
+    const s = createUserKeyedListStore({ prefix: "t:cap:", cap: 3, dedupe: true });
+    for (let i = 0; i < 6; i++) s.addFront(`item-${i}`);
+    expect(s.all()).toEqual(["item-5", "item-4", "item-3"]);
+  });
+
+  it("an uncapped store keeps every entry", () => {
+    const s = createUserKeyedListStore({ prefix: "t:uncapped:" });
+    for (let i = 0; i < 25; i++) s.toggle(`item-${i}`);
+    expect(s.all()).toHaveLength(25);
+  });
+
+  it("clamps an over-length stored blob on read", () => {
+    const key = "t:clamp:alice";
+    window.localStorage.setItem(key, JSON.stringify(["a", "b", "c", "d", "e"]));
+    const s = createUserKeyedListStore({ prefix: "t:clamp:", cap: 2 });
+    expect(s.all()).toEqual(["a", "b"]);
+  });
+});
+
+describe("createUserKeyedListStore — dedupe", () => {
+  it("dedupe:true moves an existing entry to the front", () => {
+    const s = createUserKeyedListStore({ prefix: "t:dedup:", dedupe: true });
+    s.addFront("a");
+    s.addFront("b");
+    s.addFront("a");
+    expect(s.all()).toEqual(["a", "b"]);
+  });
+
+  it("dedupe:false leaves an already-present entry untouched", () => {
+    const s = createUserKeyedListStore({ prefix: "t:nodedup:" });
+    s.addFront("a");
+    s.addFront("b");
+    s.addFront("a");
+    expect(s.all()).toEqual(["b", "a"]);
+  });
+
+  it("toggle adds then removes (set membership)", () => {
+    const s = createUserKeyedListStore({ prefix: "t:toggle:" });
+    s.toggle("x");
+    expect(s.has("x")).toBe(true);
+    s.toggle("x");
+    expect(s.has("x")).toBe(false);
+    expect(s.all()).toEqual([]);
+  });
+});
+
+describe("createUserKeyedListStore — dedupeOnLoad (favourites Set parity)", () => {
+  it("dedupeOnLoad:true collapses duplicates from a corrupt blob, keeping first-occurrence order", () => {
+    window.localStorage.setItem("t:dol:alice", JSON.stringify(["a", "a", "b", "a", "c"]));
+    const s = createUserKeyedListStore({ prefix: "t:dol:", dedupeOnLoad: true });
+    expect(s.all()).toEqual(["a", "b", "c"]);
+  });
+
+  it("default (no dedupeOnLoad) preserves duplicates from a corrupt blob", () => {
+    window.localStorage.setItem("t:nodol:alice", JSON.stringify(["a", "a", "b"]));
+    const s = createUserKeyedListStore({ prefix: "t:nodol:" });
+    expect(s.all()).toEqual(["a", "a", "b"]);
+  });
+});
+
+describe("createUserKeyedListStore — per-user isolation", () => {
+  it("keeps each user's list under a distinct key", () => {
+    const s = createUserKeyedListStore({ prefix: "t:iso:", cap: 5, dedupe: true });
+    s.addFront("alice-1");
+    currentUsername = "bob";
+    expect(s.all()).toEqual([]);
+    s.addFront("bob-1");
+    expect(s.all()).toEqual(["bob-1"]);
+    currentUsername = "alice";
+    expect(s.all()).toEqual(["alice-1"]);
+    expect(s.has("bob-1")).toBe(false);
+  });
+
+  it("no-ops every mutation when there is no current user", () => {
+    const s = createUserKeyedListStore({ prefix: "t:nouser:", dedupe: true });
+    currentUsername = null;
+    s.addFront("a");
+    s.toggle("b");
+    s.remove("c");
+    s.clear();
+    expect(s.all()).toEqual([]);
+  });
+
+  it("ignores empty items on addFront and toggle", () => {
+    const s = createUserKeyedListStore({ prefix: "t:empty:" });
+    s.addFront("");
+    s.toggle("");
+    expect(s.all()).toEqual([]);
+  });
+});

--- a/saiku-ui/src/lib/stores/userKeyedListStore.svelte.ts
+++ b/saiku-ui/src/lib/stores/userKeyedListStore.svelte.ts
@@ -1,0 +1,193 @@
+/*
+ * Generic per-user, localStorage-backed ordered-list store (#1162).
+ *
+ * Extracted from the near-identical favouriteDashboards + recentDashboards
+ * stores, which shared ~80% of their code: a per-user localStorage key
+ * layout (`<prefix><username>`), a `version` reactivity counter, try/swallow
+ * IO, `session.current?.username` plumbing, and the loadFromStorage /
+ * saveToStorage skeleton.
+ *
+ * The two consumers differ only in semantics, captured by the options:
+ *   - favourites: SET semantics — `cap` unset, membership toggle, sorted by
+ *     the catalogue render (insertion order in storage).
+ *   - recents: ORDERED-LIST semantics — `cap = 10`, dedupe-to-front so the
+ *     most-recently-pushed entry sits at index 0.
+ *
+ * Items are persisted as a JSON array of strings (the existing on-disk
+ * layout, unchanged). `T` is constrained to `string` to keep the storage
+ * format identical to the pre-refactor stores; the generic parameter is
+ * kept so the abstraction can broaden later without churning callers.
+ *
+ * Reactivity model (unchanged from the originals): read methods are pure —
+ * they re-read localStorage on every call and read the `version` counter as
+ * a tracking dep so Svelte 5 $derived / $effect consumers re-evaluate
+ * whenever a mutation runs. The read path never writes $state (which Svelte
+ * 5 forbids inside $derived).
+ */
+
+import { session } from "$lib/stores/session.svelte";
+
+export interface UserKeyedListStoreOptions {
+  /** localStorage key prefix; the active username is appended to form the key. */
+  prefix: string;
+  /**
+   * Optional hard cap on stored entries. When set, the list is trimmed to
+   * the first `cap` items on both load and save (so a corrupt over-length
+   * blob is also clamped on read). When unset, the list is unbounded.
+   */
+  cap?: number;
+  /**
+   * When true, `addFront` removes any existing equal entry before
+   * prepending, giving dedupe-to-front (most-recent-first) ordering.
+   * When false/unset, `addFront` is a no-op for an already-present entry.
+   */
+  dedupe?: boolean;
+  /**
+   * When true, duplicates are collapsed (keeping the first occurrence, so
+   * order is preserved) when reading from storage. This matches the
+   * favourites store's original SET semantics, which silently de-duplicated
+   * a corrupt / externally-edited blob on load. The store itself never
+   * writes duplicates, so this only affects already-tampered storage.
+   */
+  dedupeOnLoad?: boolean;
+}
+
+export class UserKeyedListStore<T extends string = string> {
+  private readonly prefix: string;
+  private readonly cap?: number;
+  private readonly dedupe: boolean;
+  private readonly dedupeOnLoad: boolean;
+
+  /** Re-render trigger. Mutations bump this so $derived consumers notice a
+   *  write. Read methods only *read* this — never write. */
+  private version = $state<number>(0);
+
+  constructor(options: UserKeyedListStoreOptions) {
+    this.prefix = options.prefix;
+    this.cap = options.cap;
+    this.dedupe = options.dedupe ?? false;
+    this.dedupeOnLoad = options.dedupeOnLoad ?? false;
+  }
+
+  private storageKey(username: string | null | undefined): string | null {
+    if (!username) return null;
+    return `${this.prefix}${username}`;
+  }
+
+  private applyCap(items: T[]): T[] {
+    return this.cap === undefined ? items : items.slice(0, this.cap);
+  }
+
+  private loadFromStorage(username: string | null | undefined): T[] {
+    if (typeof window === "undefined") return [];
+    const key = this.storageKey(username);
+    if (!key) return [];
+    try {
+      const raw = window.localStorage.getItem(key);
+      if (!raw) return [];
+      const parsed = JSON.parse(raw);
+      if (!Array.isArray(parsed)) return [];
+      const strings = parsed.filter((p): p is T => typeof p === "string");
+      // dedupeOnLoad mirrors the favourites store's original Set-on-load, which
+      // collapsed duplicates from a corrupt/hand-edited blob. Set preserves
+      // first-occurrence order, matching the old insertion-ordered iteration.
+      const deduped = this.dedupeOnLoad ? ([...new Set(strings)] as T[]) : strings;
+      return this.applyCap(deduped);
+    } catch {
+      // Corrupt / unavailable localStorage is a UX inconvenience, not a
+      // contract violation. Treat as empty and swallow.
+      return [];
+    }
+  }
+
+  private saveToStorage(username: string | null | undefined, items: T[]): void {
+    if (typeof window === "undefined") return;
+    const key = this.storageKey(username);
+    if (!key) return;
+    try {
+      window.localStorage.setItem(key, JSON.stringify(items));
+    } catch {
+      // localStorage may be unavailable (private mode, quota). Failing
+      // silently is the right call: these lists are a convenience, not a
+      // contract.
+    }
+  }
+
+  private get username(): string | null {
+    return session.current?.username ?? null;
+  }
+
+  /** All entries for the current user, in storage order (capped when a cap
+   *  is configured). Empty when there's no current user. */
+  all(): T[] {
+    void this.version; // tracking dep — re-evaluate when mutations bump
+    return this.loadFromStorage(this.username);
+  }
+
+  /** True if {@code item} is present for the active user. */
+  has(item: T): boolean {
+    void this.version; // tracking dep
+    return this.loadFromStorage(this.username).includes(item);
+  }
+
+  /**
+   * Prepend {@code item} to the list (most-recent-first). With `dedupe`,
+   * any existing equal entry is removed first so the item moves to the
+   * front; without it, an already-present entry is left untouched. The
+   * result is clamped to `cap`. No-op for an empty item or no current user.
+   */
+  addFront(item: T): void {
+    if (!item) return;
+    const u = this.username;
+    if (!u) return;
+    const current = this.loadFromStorage(u);
+    if (!this.dedupe && current.includes(item)) return;
+    const filtered = this.dedupe ? current.filter((p) => p !== item) : current;
+    const next = this.applyCap([item, ...filtered]);
+    this.saveToStorage(u, next);
+    this.version++;
+  }
+
+  /**
+   * Membership toggle (SET semantics): add {@code item} if absent, remove
+   * it if present. New entries are appended (insertion order preserved).
+   * No-op for an empty item or no current user.
+   */
+  toggle(item: T): void {
+    if (!item) return;
+    const u = this.username;
+    if (!u) return;
+    const current = this.loadFromStorage(u);
+    const next = current.includes(item)
+      ? current.filter((p) => p !== item)
+      : this.applyCap([...current, item]);
+    this.saveToStorage(u, next);
+    this.version++;
+  }
+
+  /** Remove a single {@code item}. No-op when absent or no current user. */
+  remove(item: T): void {
+    const u = this.username;
+    if (!u) return;
+    const current = this.loadFromStorage(u);
+    const next = current.filter((p) => p !== item);
+    if (next.length === current.length) return;
+    this.saveToStorage(u, next);
+    this.version++;
+  }
+
+  /** Drop the entire list for the current user. No-op when no current user. */
+  clear(): void {
+    const u = this.username;
+    if (!u) return;
+    this.saveToStorage(u, []);
+    this.version++;
+  }
+}
+
+/** Factory mirroring the requested `createUserKeyedListStore<T>(...)` API. */
+export function createUserKeyedListStore<T extends string = string>(
+  options: UserKeyedListStoreOptions,
+): UserKeyedListStore<T> {
+  return new UserKeyedListStore<T>(options);
+}


### PR DESCRIPTION
Closes #1162. Behavior-preserving refactor produced via a security-reviewed workflow (implement in isolated worktree with vitest + `npm run check` gate → adversarial behavior review), with a parity tweak applied after review.

## What

`favouriteDashboards.svelte.ts` and `recentDashboards.svelte.ts` shared ~80% of their code (per-user localStorage key, `version` reactivity counter, try/swallow IO, `session.current?.username` plumbing, load/save skeleton). Extracted a generic **`createUserKeyedListStore<T>({ prefix, cap?, dedupe?, dedupeOnLoad? })`**; each store is now a thin wrapper that fixes its semantics and re-exposes the original public method names, so all consumers compile unchanged.

## Behavior preservation

- **favourites** — SET semantics: uncapped, membership `toggle`, insertion order. **`dedupeOnLoad: true`** so a corrupt/hand-edited localStorage blob is de-duplicated on read, exactly matching the original `Set`-backed load. *(This is the one divergence the adversarial review flagged — now fixed for exact parity.)*
- **recents** — ORDERED-LIST semantics: `cap = 10`, dedupe-to-front (`addFront`), most-recent-first; clamp on load + save. Unchanged from the original array+slice behavior.
- Per-user isolation (key = `prefix + username`, prefixes `saiku:favourites:` / `saiku:recents:` unchanged), the `version`-counter reactivity (read methods read `version` as a tracking dep so `$derived`/`$effect` consumers re-evaluate), the try/swallow IO, and the SSR `typeof window` guard are all preserved. Public export + method names identical.

## Verification

- Existing suites pass unchanged: **favouriteDashboards 9/9, recentDashboards 11/11**. New `userKeyedListStore` test covers cap, dedupe(-to-front), dedupe-on-load parity, and per-user isolation.
- `npm run check` (svelte-check + tsc): **0 errors**.
- **Adversarial review** (independent agent, diff vs `development`): behavior preserved ✅, verdict **approve** (its one flagged edge case — favourites de-dupe on load — is the parity tweak now included here).
- Rebased onto current `development`. No overlap with A1's unmerged frontend branches (they don't touch these stores).

## Notes
- Security lane (Agent SEC). **Not self-merging.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
