### PR TITLE
fix(security): stop datasource credential disclosure to non-admins (HIGH)

### DIFF
--- a/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/objects/DataSourceMapper.java
+++ b/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/objects/DataSourceMapper.java
@@ -16,6 +16,7 @@
 
 package org.saiku.web.rest.objects;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.Properties;
 import java.util.UUID;
 import org.saiku.datasources.datasource.SaikuDatasource;
@@ -31,7 +32,16 @@ public class DataSourceMapper {
     private String schema;
     private String driver;
     private String username;
+
+    /**
+     * saiku#1165: the backend datasource password must never be serialised back
+     * to a client (it was leaking via GET .../org.saiku.datasources/{id}).
+     * WRITE_ONLY omits it from every response while still accepting an inbound
+     * value on datasource create/update.
+     */
+    @JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
     private String password;
+
     private String connectiontype;
     private String id;
     private String path;

--- a/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/DataSourceResource.java
+++ b/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/DataSourceResource.java
@@ -53,8 +53,13 @@ public class DataSourceResource {
      */
     @GET
     @Produces({"application/json"})
+    @RolesAllowed("ROLE_ADMIN")
     public Collection<SaikuDatasource> getDatasources() {
-        // TODO: admin security?
+        // saiku#1165: ADMIN-only. This returns full connection config (incl.
+        // credentials); the role filter below is a no-op (RepositoryDatasourceManager
+        // ignores roles), so without this gate any authenticated ROLE_USER could read
+        // every datasource's backend password. Regular users get cube metadata via
+        // /discover, not here.
         try {
             return datasourceService
                     .getDatasources(userService.getCurrentUserRoles())
@@ -90,6 +95,7 @@ public class DataSourceResource {
     @GET
     @Produces({"application/json"})
     @Path("/{id}")
+    @RolesAllowed("ROLE_ADMIN")
     @ReturnType("org.saiku.web.rest.objects.DataSourceMapper")
     public Response getDatasourceById(@PathParam("id") String id) {
         try {

--- a/saiku-core/saiku-web/src/test/java/org/saiku/web/rest/objects/DataSourceMapperSerializationTest.java
+++ b/saiku-core/saiku-web/src/test/java/org/saiku/web/rest/objects/DataSourceMapperSerializationTest.java
@@ -1,0 +1,47 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.web.rest.objects;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.Test;
+
+/**
+ * saiku#1165 — the datasource backend password must never be serialised back to
+ * a client (it was leaking via GET .../org.saiku.datasources/{id}), but must
+ * still be accepted inbound on create/update. {@code @JsonProperty(WRITE_ONLY)}
+ * enforces both.
+ */
+public class DataSourceMapperSerializationTest {
+
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    @Test
+    public void passwordIsNeverSerialisedOut() throws Exception {
+        DataSourceMapper m = new DataSourceMapper();
+        m.setConnectionname("foodmart");
+        m.setUsername("dbuser");
+        m.setJdbcurl("jdbc:postgresql://db/foodmart");
+        m.setPassword("super-secret-db-pw");
+
+        String json = mapper.writeValueAsString(m);
+
+        assertFalse("'password' key must not appear in the response: " + json, json.contains("password"));
+        assertFalse("the secret value must not leak: " + json, json.contains("super-secret-db-pw"));
+        assertTrue("non-secret fields still serialise", json.contains("foodmart"));
+        assertTrue("username still serialises", json.contains("dbuser"));
+    }
+
+    @Test
+    public void passwordIsStillAcceptedInbound() throws Exception {
+        String json = "{\"connectionname\":\"ds\",\"username\":\"u\",\"password\":\"inbound-pw\"}";
+        DataSourceMapper m = mapper.readValue(json, DataSourceMapper.class);
+        assertEquals("inbound-pw", m.getPassword());
+        assertEquals("ds", m.getConnectionname());
+    }
+}


### PR DESCRIPTION
Found by the round-3 deep security audit (refs #1165).

## What (HIGH — credential disclosure / broken authz)

`GET /rest/saiku/{username}/org.saiku.datasources` and `.../{id}` (`DataSourceResource.getDatasources` / `getDatasourceById`) had **no `@RolesAllowed`**, so they sat behind only `/rest/** = isFullyAuthenticated()` — reachable by **any** authenticated `ROLE_USER` (e.g. the demo `bob`/`krishna`/`smith`). They return a `DataSourceMapper` whose `getPassword()` was Jackson-serialised with no guard, and the apparent role filter is a **no-op** (`RepositoryDatasourceManager.getDatasources(roles)` ignores `roles` and returns every datasource). Net: a non-admin could enumerate and read the **cleartext backend DB password + JDBC URL + username for every datasource**. (The sibling DELETE/PUT were already `@RolesAllowed("ROLE_ADMIN")`; the read paths were left open with a literal `// TODO: admin security?`.)

## Fix (two layers)

1. **`@RolesAllowed("ROLE_ADMIN")`** on both read methods — full connection config (incl. credentials) is admin-only data. Regular users get cube/datasource metadata via `/discover` (the SPA's `datasources` store uses that, not this endpoint), so no non-admin functionality is affected.
2. **Defense-in-depth:** `@JsonProperty(access = WRITE_ONLY)` on `DataSourceMapper.password` — the password is omitted from **every** serialised response (so it can't leak even if a future endpoint forgets the role gate) while still being accepted **inbound** on create/update.

## Tests

`DataSourceMapperSerializationTest` — serialising a mapper yields JSON with no `password` key and no secret value (other fields intact); deserialising a body with `password` still populates it. Green; `spotless:apply` clean.

Role-deny is the same `RolesAllowedDynamicFeature` mechanism proven by `AdminResource`/`AdminIT` (the memory-auth harness has no non-admin principal for a direct negative IT).

## Notes
- Security lane (Agent SEC). **Not self-merging.**
- Related (separate, flagged in #1165): stored datasource passwords are encrypted with hard-coded compiled-in 3DES keys (`TripleDesPasswordEncoder`) — that needs a key-management + migration design and is **not** in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
