### PR TITLE
fix(security): block SSRF/XXE/file-read via SVG export (Batik) (HIGH)

### DIFF
--- a/saiku-core/saiku-web/src/main/java/org/saiku/web/export/PdfReport.java
+++ b/saiku-core/saiku-web/src/main/java/org/saiku/web/export/PdfReport.java
@@ -93,6 +93,9 @@ public class PdfReport {
     }
 
     private void addSvgImage(String svg, Document document, PdfWriter pdfWriter) {
+        // saiku#1165: reject external refs / DOCTYPE before Batik parses it
+        // (SSRF / local-file-read / XXE via user-supplied SVG).
+        org.saiku.web.svg.SvgSecurity.requireSafe(svg);
         document.newPage();
         StringBuilder stringBuffer = new StringBuilder(svg);
         if (!svg.startsWith("<svg xmlns=\"http://www.w3.org/2000/svg\" ")) {

--- a/saiku-core/saiku-web/src/main/java/org/saiku/web/svg/Converter.java
+++ b/saiku-core/saiku-web/src/main/java/org/saiku/web/svg/Converter.java
@@ -4,9 +4,11 @@ package org.saiku.web.svg;
  * @author Tomasz Nurkiewicz
  * @since 1/15/13, 10:29 AM
  */
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
 import org.apache.batik.transcoder.*;
 import org.apache.batik.transcoder.image.JPEGTranscoder;
 import org.apache.batik.transcoder.image.PNGTranscoder;
@@ -76,13 +78,26 @@ abstract class BatikConverter extends Converter {
         super(contentType, extension);
     }
 
-    public void convert(InputStream in, OutputStream out, Integer size) throws TranscoderException {
+    /** saiku#1165: cap the in-memory SVG so a giant payload can't OOM the server. */
+    private static final int MAX_SVG_BYTES = 20 * 1024 * 1024;
+
+    public void convert(InputStream in, OutputStream out, Integer size) throws TranscoderException, IOException {
+        // saiku#1165: read the SVG, reject external references / DOCTYPE (SSRF /
+        // local-file-read / XXE via Batik), then transcode from the validated copy.
+        byte[] svg = in.readNBytes(MAX_SVG_BYTES + 1);
+        if (svg.length > MAX_SVG_BYTES) {
+            throw new TranscoderException("SVG exceeds the " + MAX_SVG_BYTES + "-byte export limit");
+        }
+        SvgSecurity.requireSafe(new String(svg, StandardCharsets.UTF_8));
+
         Transcoder t = createTranscoder();
+        // Defense-in-depth: never run on-load scripts during transcode.
+        t.addTranscodingHint(SVGAbstractTranscoder.KEY_EXECUTE_ONLOAD, Boolean.FALSE);
         if (size != null) {
             final float sizeBound = Math.max(Math.min(size, 2000.0f), 32.0f);
             t.addTranscodingHint(SVGAbstractTranscoder.KEY_WIDTH, sizeBound);
         }
-        t.transcode(new TranscoderInput(in), new TranscoderOutput(out));
+        t.transcode(new TranscoderInput(new ByteArrayInputStream(svg)), new TranscoderOutput(out));
     }
 
     protected abstract Transcoder createTranscoder();

--- a/saiku-core/saiku-web/src/main/java/org/saiku/web/svg/PdfReport.java
+++ b/saiku-core/saiku-web/src/main/java/org/saiku/web/svg/PdfReport.java
@@ -61,6 +61,9 @@ public class PdfReport {
 
             // do we want to add a svg image?
             if (StringUtils.isNotBlank(svg)) {
+                // saiku#1165: reject external refs / DOCTYPE before Batik parses it
+                // (SSRF / local-file-read / XXE via user-supplied SVG).
+                SvgSecurity.requireSafe(svg);
                 document.newPage();
                 StringBuilder s1 = new StringBuilder(svg);
                 if (!svg.startsWith("<svg xmlns=\"http://www.w3.org/2000/svg\" ")) {

--- a/saiku-core/saiku-web/src/main/java/org/saiku/web/svg/SvgSecurity.java
+++ b/saiku-core/saiku-web/src/main/java/org/saiku/web/svg/SvgSecurity.java
@@ -1,0 +1,62 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ */
+package org.saiku.web.svg;
+
+import java.util.Locale;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * saiku#1165 hardening for user-supplied SVG fed to Batik transcoders.
+ *
+ * <p>The chart/PDF export endpoints accept an SVG string from any authenticated
+ * user and hand it to Batik. By default Batik resolves external references and
+ * DOCTYPE entities, so a crafted SVG can mount SSRF
+ * ({@code <image href="http://169.254.169.254/...">}), local file read
+ * ({@code href="file:///etc/passwd"}) or XXE. Saiku's chart SVGs are always
+ * self-contained (inline geometry + optional inline {@code data:} images), so we
+ * reject anything that would make Batik reach off-document: a DOCTYPE
+ * declaration, or any {@code href}/{@code xlink:href}/{@code url(...)} target
+ * that is not a {@code data:} URI or a same-document {@code #fragment}. This is
+ * version-independent (no reliance on Batik-internal security hooks) and pairs
+ * with {@code KEY_EXECUTE_ONLOAD=false} on the transcoders.
+ */
+public final class SvgSecurity {
+
+    private SvgSecurity() {}
+
+    /** Captures the target of href / xlink:href (double- or single-quoted) and CSS url(...). */
+    private static final Pattern REFERENCE = Pattern.compile(
+            "(?:xlink:href|href)\\s*=\\s*\"([^\"]*)\"" + "|(?:xlink:href|href)\\s*=\\s*'([^']*)'"
+                    + "|url\\(\\s*['\"]?([^'\")]*)",
+            Pattern.CASE_INSENSITIVE);
+
+    /**
+     * @throws IllegalArgumentException if the SVG contains a DOCTYPE or any
+     *     external (non-{@code data:}, non-{@code #fragment}) reference.
+     */
+    public static void requireSafe(String svg) {
+        if (svg == null) {
+            return;
+        }
+        if (svg.toLowerCase(Locale.ROOT).contains("<!doctype")) {
+            throw new IllegalArgumentException("SVG DOCTYPE declarations are not allowed");
+        }
+        Matcher m = REFERENCE.matcher(svg);
+        while (m.find()) {
+            String ref = m.group(1) != null ? m.group(1) : m.group(2) != null ? m.group(2) : m.group(3);
+            if (ref == null) {
+                continue;
+            }
+            ref = ref.trim();
+            if (ref.isEmpty() || ref.startsWith("#") || ref.regionMatches(true, 0, "data:", 0, 5)) {
+                continue; // same-document fragment or inline data: URI — safe
+            }
+            throw new IllegalArgumentException("External references are not allowed in exported SVG: " + ref);
+        }
+    }
+}

--- a/saiku-core/saiku-web/src/test/java/org/saiku/web/svg/SvgSecurityTest.java
+++ b/saiku-core/saiku-web/src/test/java/org/saiku/web/svg/SvgSecurityTest.java
@@ -1,0 +1,62 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.web.svg;
+
+import static org.junit.Assert.fail;
+
+import org.junit.Test;
+
+/**
+ * saiku#1165 — SVG export must reject anything that would make Batik fetch an
+ * external resource (SSRF / local-file-read) or expand external entities (XXE).
+ */
+public class SvgSecurityTest {
+
+    private static void rejected(String svg) {
+        try {
+            SvgSecurity.requireSafe(svg);
+            fail("expected rejection for: " + svg);
+        } catch (IllegalArgumentException expected) {
+            // good
+        }
+    }
+
+    @Test
+    public void rejectsDoctype() {
+        rejected("<?xml version=\"1.0\"?><!DOCTYPE svg [<!ENTITY x SYSTEM \"file:///etc/passwd\">]><svg/>");
+    }
+
+    @Test
+    public void rejectsHttpImageHref() {
+        rejected(
+                "<svg xmlns=\"http://www.w3.org/2000/svg\"><image xlink:href=\"http://169.254.169.254/latest/meta-data/\"/></svg>");
+    }
+
+    @Test
+    public void rejectsFileHref() {
+        rejected("<svg><image href=\"file:///etc/passwd\"/></svg>");
+    }
+
+    @Test
+    public void rejectsHttpsAndCssUrl() {
+        rejected("<svg><image href=\"https://evil.example.com/x.png\"/></svg>");
+        rejected("<svg><rect style=\"fill:url('http://evil/x')\"/></svg>");
+    }
+
+    @Test
+    public void rejectsBareAbsolutePathHref() {
+        rejected("<svg><image href=\"/etc/passwd\"/></svg>");
+    }
+
+    @Test
+    public void allowsSelfContainedSvg() {
+        // No refs at all — the normal ECharts chart export.
+        SvgSecurity.requireSafe("<svg xmlns=\"http://www.w3.org/2000/svg\"><path d=\"M0 0 L10 10\"/></svg>");
+        // Inline data: image and same-document fragment refs are safe.
+        SvgSecurity.requireSafe("<svg><image href=\"data:image/png;base64,AAAA\"/><use xlink:href=\"#g1\"/></svg>");
+        // null is a no-op (blank-svg paths skip transcoding anyway).
+        SvgSecurity.requireSafe(null);
+    }
+}


### PR DESCRIPTION
Found by the round-3 deep security audit (refs #1165).

## What (HIGH — SSRF / local-file-read / XXE)

The chart/PDF export endpoints accept an **SVG string from any authenticated user** and hand it to Batik with no restriction:
- `POST .../export/saiku/chart` → `Converter`/`BatikConverter` (PNG/JPG/TIFF/PDF transcoders)
- `POST .../export/pdf/...` → `PdfReport.addSvgImage` / `PdfReport.pdf` (`PrintTranscoder`)

Batik by default resolves external references and DOCTYPE entities, so a crafted SVG yields:
- **SSRF** — `<image xlink:href="http://169.254.169.254/latest/meta-data/">` (cloud metadata / internal hosts),
- **local file read** — `href="file:///etc/passwd"` embedded into the rendered image returned to the attacker,
- **XXE** — a DOCTYPE with external entities.

This is a different surface from the already-hardened `DashboardImageResource` upload.

## Fix

Saiku's chart SVGs are always **self-contained** (inline geometry + optional inline `data:` images), so a shared **`SvgSecurity.requireSafe(svg)`** rejects anything that would make Batik go off-document — a `<!DOCTYPE` declaration, or any `href`/`xlink:href`/`url(...)` whose target isn't a `data:` URI or a same-document `#fragment`. Applied at all three entry points (`BatikConverter.convert`, both `PdfReport` SVG paths). Version-independent (no reliance on Batik-internal security hooks). Plus:
- `KEY_EXECUTE_ONLOAD=false` on the transcoders (no on-load script execution),
- a 20 MB cap on the in-memory SVG (OOM guard).

## Tests

`SvgSecurityTest` — rejects DOCTYPE, `http`/`https`/`file` hrefs, `url(http://…)`, and bare absolute paths; **allows** self-contained SVG, inline `data:` images, `#fragment` refs, and null. Green; `spotless:apply` clean (full saiku-web compiles incl. both PdfReport paths).

## Notes
- Security lane (Agent SEC). **Not self-merging.**
- The legitimate ECharts export is self-contained, so no real export is affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
