### PR TITLE
fix(security): per-install AES key for datasource passwords, off static 3DES (MED)

### DIFF
--- a/saiku-core/saiku-service/src/main/java/org/saiku/datasources/connection/encrypt/AesGcmPasswordEncoder.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/datasources/connection/encrypt/AesGcmPasswordEncoder.java
@@ -1,0 +1,78 @@
+package org.saiku.datasources.connection.encrypt;
+
+import java.nio.charset.StandardCharsets;
+import java.security.SecureRandom;
+import java.util.Arrays;
+import java.util.Base64;
+import javax.crypto.Cipher;
+import javax.crypto.SecretKey;
+import javax.crypto.spec.GCMParameterSpec;
+
+/**
+ * AES-256-GCM authenticated encryption for stored datasource passwords.
+ *
+ * <p>Wire format of a {@code v2} value: {@code "v2:" + base64( IV(12 bytes) || GCM ciphertext+tag )}.
+ * The key is the per-install key from {@link InstallKeyProvider}; a fresh random 12-byte IV is
+ * generated per encryption and prepended so it never repeats with the same key.
+ *
+ * <p>This is the encrypt path for all new saves. The legacy static-3DES path remains available as a
+ * decrypt-only fallback in {@link CryptoUtil} so existing {@code .sds} files keep working.
+ */
+final class AesGcmPasswordEncoder {
+
+    static final String VERSION_PREFIX = "v2:";
+
+    private static final String TRANSFORMATION = "AES/GCM/NoPadding";
+    private static final int IV_BYTES = 12;
+    private static final int TAG_BITS = 128;
+    private static final SecureRandom RANDOM = new SecureRandom();
+
+    private AesGcmPasswordEncoder() {}
+
+    /** Encrypts plaintext to a {@code v2:}-prefixed, Base64-encoded value. */
+    static String encrypt(String plaintext) {
+        try {
+            SecretKey key = InstallKeyProvider.getKey();
+            byte[] iv = new byte[IV_BYTES];
+            RANDOM.nextBytes(iv);
+
+            Cipher cipher = Cipher.getInstance(TRANSFORMATION);
+            cipher.init(Cipher.ENCRYPT_MODE, key, new GCMParameterSpec(TAG_BITS, iv));
+            byte[] ct = cipher.doFinal(plaintext.getBytes(StandardCharsets.UTF_8));
+
+            byte[] out = new byte[iv.length + ct.length];
+            System.arraycopy(iv, 0, out, 0, iv.length);
+            System.arraycopy(ct, 0, out, iv.length, ct.length);
+
+            return VERSION_PREFIX + Base64.getEncoder().encodeToString(out);
+        } catch (Exception e) {
+            throw new RuntimeException("AES-GCM encryption failed", e);
+        }
+    }
+
+    /** True if the given value carries the {@code v2:} version prefix. */
+    static boolean isV2(String value) {
+        return value != null && value.startsWith(VERSION_PREFIX);
+    }
+
+    /** Decrypts a {@code v2:}-prefixed value produced by {@link #encrypt(String)}. */
+    static String decrypt(String value) {
+        try {
+            String body = value.substring(VERSION_PREFIX.length());
+            byte[] all = Base64.getDecoder().decode(body);
+            if (all.length < IV_BYTES) {
+                throw new IllegalArgumentException("v2 ciphertext too short");
+            }
+            byte[] iv = Arrays.copyOfRange(all, 0, IV_BYTES);
+            byte[] ct = Arrays.copyOfRange(all, IV_BYTES, all.length);
+
+            SecretKey key = InstallKeyProvider.getKey();
+            Cipher cipher = Cipher.getInstance(TRANSFORMATION);
+            cipher.init(Cipher.DECRYPT_MODE, key, new GCMParameterSpec(TAG_BITS, iv));
+            byte[] pt = cipher.doFinal(ct);
+            return new String(pt, StandardCharsets.UTF_8);
+        } catch (Exception e) {
+            throw new RuntimeException("AES-GCM decryption failed", e);
+        }
+    }
+}

--- a/saiku-core/saiku-service/src/main/java/org/saiku/datasources/connection/encrypt/CryptoUtil.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/datasources/connection/encrypt/CryptoUtil.java
@@ -19,9 +19,28 @@ public class CryptoUtil {
     };
 
     /**
-     * {@inheritDoc}
+     * Encrypts a datasource password for storage.
+     *
+     * <p>As of the per-install-key hardening this now emits an AES-256-GCM value with a {@code v2:}
+     * version prefix, keyed by the per-install key (see {@link InstallKeyProvider}). The previous
+     * implementation used a hard-coded, compiled-in 3DES key identical across every install, which
+     * meant anyone with a {@code .sds} file could decrypt every stored password offline. Existing
+     * legacy values are still readable via {@link #decrypt(String)}'s fallback and are migrated to
+     * {@code v2} on the next save.
      */
     public static String encrypt(String text) {
+        if (text == null || text.length() == 0) {
+            return text;
+        }
+        return AesGcmPasswordEncoder.encrypt(text);
+    }
+
+    /**
+     * Legacy static-3DES encrypt. Retained only so existing tests/tools and migration fixtures can
+     * reproduce historical ciphertext; <strong>do not</strong> use for new saves — it is keyed by a
+     * compiled-in static key and is therefore insecure. New saves go through {@link #encrypt(String)}.
+     */
+    static String legacyEncrypt(String text) {
         try {
             if (text.length() == 0) {
                 return text;
@@ -59,7 +78,27 @@ public class CryptoUtil {
         }
     }
 
+    /**
+     * Decrypts a stored datasource password.
+     *
+     * <p>If the value carries the {@code v2:} prefix it is AES-256-GCM decrypted with the per-install
+     * key. Otherwise it is treated as a legacy static-3DES value and decrypted with the historical
+     * hard-coded key — this is the backward-compatibility path so every {@code .sds} written before
+     * this change still loads. Legacy values are transparently upgraded to {@code v2} the next time
+     * the datasource is saved (which re-runs {@link #encrypt(String)}).
+     */
     public static String decrypt(String encrypted) {
+        if (encrypted == null || encrypted.length() == 0) {
+            return encrypted;
+        }
+        if (AesGcmPasswordEncoder.isV2(encrypted)) {
+            return AesGcmPasswordEncoder.decrypt(encrypted);
+        }
+        return legacyDecrypt(encrypted);
+    }
+
+    /** Legacy static-3DES decrypt-only fallback for pre-existing stored passwords. */
+    static String legacyDecrypt(String encrypted) {
         try {
             if (encrypted.length() == 0) {
                 return encrypted;

--- a/saiku-core/saiku-service/src/main/java/org/saiku/datasources/connection/encrypt/InstallKeyProvider.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/datasources/connection/encrypt/InstallKeyProvider.java
@@ -1,0 +1,151 @@
+package org.saiku.datasources.connection.encrypt;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.attribute.PosixFilePermission;
+import java.security.SecureRandom;
+import java.util.Base64;
+import java.util.EnumSet;
+import java.util.Set;
+import javax.crypto.SecretKey;
+import javax.crypto.spec.SecretKeySpec;
+
+/**
+ * Resolves the per-install AES-256 key used to encrypt stored datasource passwords.
+ *
+ * <p>Resolution order:
+ *
+ * <ol>
+ *   <li>If the {@code SAIKU_DS_ENCRYPTION_KEY} environment variable is set, its value is used as the
+ *       key material (UTF-8 bytes, normalised to 32 bytes via SHA-256 if not already 32 bytes; a
+ *       raw Base64-encoded 32-byte value is also accepted).
+ *   <li>Otherwise a random 32-byte key is generated on first use and persisted to
+ *       {@code <saiku.home>/conf/secret.key} (Base64). Subsequent calls read it back.
+ * </ol>
+ *
+ * <p>The key file is created with best-effort owner-only permissions (POSIX 0600); on platforms
+ * without POSIX (e.g. Windows) the permission tightening is skipped silently.
+ *
+ * <p>This class is intentionally self-contained within saiku-service and is loaded lazily so that
+ * test code and callers that never touch encryption pay no cost.
+ */
+final class InstallKeyProvider {
+
+    static final String ENV_KEY = "SAIKU_DS_ENCRYPTION_KEY";
+    static final String KEY_FILE_NAME = "secret.key";
+    static final String CONF_DIR_NAME = "conf";
+
+    private static final int KEY_BYTES = 32; // AES-256
+    private static final SecureRandom RANDOM = new SecureRandom();
+
+    private static volatile SecretKey cachedKey;
+
+    private InstallKeyProvider() {}
+
+    /** Returns the per-install AES key, resolving (and persisting, if needed) on first call. */
+    static SecretKey getKey() {
+        SecretKey local = cachedKey;
+        if (local == null) {
+            synchronized (InstallKeyProvider.class) {
+                local = cachedKey;
+                if (local == null) {
+                    local = resolveKey();
+                    cachedKey = local;
+                }
+            }
+        }
+        return local;
+    }
+
+    /** For tests: clears the cached key so the next {@link #getKey()} re-resolves. */
+    static synchronized void resetForTesting() {
+        cachedKey = null;
+    }
+
+    private static SecretKey resolveKey() {
+        String env = System.getenv(ENV_KEY);
+        if (env != null && !env.trim().isEmpty()) {
+            return new SecretKeySpec(deriveKeyBytes(env.trim()), "AES");
+        }
+        return loadOrCreatePersistedKey();
+    }
+
+    /**
+     * Accepts either a Base64-encoded 32-byte key or arbitrary text; non-32-byte material is hashed
+     * to a stable 32-byte key with SHA-256.
+     */
+    private static byte[] deriveKeyBytes(String material) {
+        try {
+            byte[] decoded = Base64.getDecoder().decode(material);
+            if (decoded.length == KEY_BYTES) {
+                return decoded;
+            }
+        } catch (IllegalArgumentException notBase64) {
+            // fall through to hashing
+        }
+        try {
+            java.security.MessageDigest md = java.security.MessageDigest.getInstance("SHA-256");
+            return md.digest(material.getBytes(java.nio.charset.StandardCharsets.UTF_8));
+        } catch (java.security.NoSuchAlgorithmException e) {
+            throw new IllegalStateException("SHA-256 unavailable", e);
+        }
+    }
+
+    private static SecretKey loadOrCreatePersistedKey() {
+        Path keyFile = resolveKeyFilePath();
+        try {
+            if (Files.isReadable(keyFile)) {
+                String existing =
+                        new String(Files.readAllBytes(keyFile), java.nio.charset.StandardCharsets.UTF_8).trim();
+                if (!existing.isEmpty()) {
+                    byte[] decoded = Base64.getDecoder().decode(existing);
+                    if (decoded.length == KEY_BYTES) {
+                        return new SecretKeySpec(decoded, "AES");
+                    }
+                }
+            }
+        } catch (Exception readFailure) {
+            // Could not read an existing key; fall through and create a fresh one.
+        }
+
+        byte[] fresh = new byte[KEY_BYTES];
+        RANDOM.nextBytes(fresh);
+        persistKey(keyFile, fresh);
+        return new SecretKeySpec(fresh, "AES");
+    }
+
+    private static void persistKey(Path keyFile, byte[] keyBytes) {
+        try {
+            Path parent = keyFile.getParent();
+            if (parent != null) {
+                Files.createDirectories(parent);
+            }
+            String encoded = Base64.getEncoder().encodeToString(keyBytes);
+            Files.write(keyFile, encoded.getBytes(java.nio.charset.StandardCharsets.UTF_8));
+            tightenPermissions(keyFile);
+        } catch (Exception persistFailure) {
+            // Best-effort persistence. If we cannot write the key file (read-only home, etc.) the
+            // in-memory key is still returned for this JVM lifetime; it just won't survive a restart.
+        }
+    }
+
+    private static void tightenPermissions(Path keyFile) {
+        try {
+            Set<PosixFilePermission> perms =
+                    EnumSet.of(PosixFilePermission.OWNER_READ, PosixFilePermission.OWNER_WRITE);
+            Files.setPosixFilePermissions(keyFile, perms);
+        } catch (Exception nonPosixOrDenied) {
+            // Windows / non-POSIX filesystems (UnsupportedOperationException) or denied; ignore.
+        }
+    }
+
+    /** {@code <saiku.home>/conf/secret.key}, falling back to {@code java.io.tmpdir} if unset. */
+    static Path resolveKeyFilePath() {
+        String home = System.getProperty("saiku.home");
+        if (home == null || home.trim().isEmpty()) {
+            home = System.getProperty("java.io.tmpdir");
+        }
+        return Paths.get(home, CONF_DIR_NAME, KEY_FILE_NAME);
+    }
+}

--- a/saiku-core/saiku-service/src/test/java/org/saiku/datasources/connection/encrypt/DatasourcePasswordEncryptionTest.java
+++ b/saiku-core/saiku-service/src/test/java/org/saiku/datasources/connection/encrypt/DatasourcePasswordEncryptionTest.java
@@ -1,0 +1,146 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.datasources.connection.encrypt;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Base64;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Covers the per-install-key hardening of stored datasource password encryption (audit-3).
+ *
+ * <ul>
+ *   <li>AES-256-GCM round-trip via the public {@link CryptoUtil} API.
+ *   <li>New saves emit a {@code v2:}-prefixed value.
+ *   <li>A {@code v2:} value decrypts back to plaintext.
+ *   <li>A legacy static-3DES value still decrypts via the backward-compatible fallback (constructed
+ *       with the retained {@link CryptoUtil#legacyEncrypt}).
+ *   <li>Per-install key generation + persistence works in a temp {@code saiku.home}.
+ * </ul>
+ *
+ * <p>Per the task brief these use try/fail/catch rather than {@code assertThrows}.
+ */
+public class DatasourcePasswordEncryptionTest {
+
+    private String savedSaikuHome;
+    private Path tempHome;
+
+    @Before
+    public void setUp() throws Exception {
+        savedSaikuHome = System.getProperty("saiku.home");
+        tempHome = Files.createTempDirectory("saiku-enc-test-");
+        System.setProperty("saiku.home", tempHome.toString());
+        InstallKeyProvider.resetForTesting();
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        InstallKeyProvider.resetForTesting();
+        if (savedSaikuHome == null) {
+            System.clearProperty("saiku.home");
+        } else {
+            System.setProperty("saiku.home", savedSaikuHome);
+        }
+        // Best-effort cleanup of the temp home tree.
+        try {
+            Files.walk(tempHome)
+                    .sorted((a, b) -> b.getNameCount() - a.getNameCount())
+                    .forEach(p -> {
+                        try {
+                            Files.deleteIfExists(p);
+                        } catch (Exception ignore) {
+                            // best effort
+                        }
+                    });
+        } catch (Exception ignore) {
+            // best effort
+        }
+    }
+
+    @Test
+    public void aesGcmRoundTripThroughPublicApi() {
+        String plaintext = "s3cr3t-DB-passw0rd!";
+        String encrypted = CryptoUtil.encrypt(plaintext);
+        assertNotEquals("ciphertext must differ from plaintext", plaintext, encrypted);
+        assertEquals("round-trip must recover plaintext", plaintext, CryptoUtil.decrypt(encrypted));
+    }
+
+    @Test
+    public void newSavesUseV2Prefix() {
+        String encrypted = CryptoUtil.encrypt("anything");
+        assertTrue("new saves must be v2:-prefixed AES-GCM, got: " + encrypted, encrypted.startsWith("v2:"));
+    }
+
+    @Test
+    public void v2ValueDecryptsBackToPlaintext() {
+        String plaintext = "another-secret";
+        String v2 = AesGcmPasswordEncoder.encrypt(plaintext);
+        assertTrue(v2.startsWith("v2:"));
+        assertEquals(plaintext, CryptoUtil.decrypt(v2));
+    }
+
+    @Test
+    public void gcmIvIsRandomSoCiphertextDiffersPerEncrypt() {
+        String plaintext = "repeatme";
+        String a = CryptoUtil.encrypt(plaintext);
+        String b = CryptoUtil.encrypt(plaintext);
+        assertNotEquals("random IV must make repeated encryptions differ", a, b);
+        assertEquals(plaintext, CryptoUtil.decrypt(a));
+        assertEquals(plaintext, CryptoUtil.decrypt(b));
+    }
+
+    @Test
+    public void legacyThreeDesValueStillDecryptsViaFallback() {
+        String plaintext = "old-foodmart-pw";
+        // Reproduce a historical .sds value: hex-encoded static-3DES, no version prefix.
+        String legacy = CryptoUtil.legacyEncrypt(plaintext);
+        assertFalse("legacy value must NOT carry the v2: prefix", legacy.startsWith("v2:"));
+        // Public decrypt must transparently route non-v2 values to the legacy fallback.
+        assertEquals("legacy stored password must still decrypt", plaintext, CryptoUtil.decrypt(legacy));
+    }
+
+    @Test
+    public void emptyAndNullPassThrough() {
+        assertEquals("", CryptoUtil.encrypt(""));
+        assertEquals("", CryptoUtil.decrypt(""));
+        assertEquals(null, CryptoUtil.encrypt(null));
+        assertEquals(null, CryptoUtil.decrypt(null));
+    }
+
+    @Test
+    public void keyIsGeneratedAndPersistedInSaikuHomeConf() {
+        Path keyFile = tempHome.resolve("conf").resolve("secret.key");
+        // Trigger key resolution (which generates + persists on first use).
+        CryptoUtil.encrypt("force-key-materialisation");
+        if (!Files.isRegularFile(keyFile)) {
+            fail("expected per-install key persisted at " + keyFile);
+        }
+        try {
+            String contents = new String(Files.readAllBytes(keyFile), java.nio.charset.StandardCharsets.UTF_8).trim();
+            byte[] decoded = Base64.getDecoder().decode(contents);
+            assertEquals("persisted key must be 32 bytes (AES-256)", 32, decoded.length);
+        } catch (Exception e) {
+            fail("persisted key file unreadable or not Base64: " + e);
+        }
+    }
+
+    @Test
+    public void persistedKeyIsStableAcrossResolves() {
+        String plaintext = "stable-across-restart";
+        String encrypted = CryptoUtil.encrypt(plaintext);
+        // Simulate a JVM restart: drop the cached key; the persisted file must still decrypt.
+        InstallKeyProvider.resetForTesting();
+        assertEquals("key persisted to disk must decrypt prior ciphertext", plaintext, CryptoUtil.decrypt(encrypted));
+    }
+}


### PR DESCRIPTION
Found by the round-3 deep security audit (refs #1165). Implemented + adversarially reviewed via workflow (behavior preserved ✅, security fixed ✅, **backward-compat confirmed**).

## What (MEDIUM/latent-HIGH)
Stored datasource passwords were encrypted with **hard-coded, compiled-in 3DES keys** (`TripleDesPasswordEncoder`) — identical across every install and public in the repo. Anyone with a `.sds` file (backup, export, leak) decrypts every datasource's backend DB password offline.

## Fix (backward-compatible)
- **`InstallKeyProvider`** — a per-install 32-byte key from `SAIKU_DS_ENCRYPTION_KEY`, else generated once and persisted to `<saiku.home>/conf/secret.key` (best-effort `0600`; Windows-safe).
- **`AesGcmPasswordEncoder`** — AES-256-GCM (random IV, version prefix `v2:`).
- `CryptoUtil` now **encrypts new values with AES-GCM (`v2:`)**, and on **decrypt** uses AES-GCM for `v2:` values, **falling back to the legacy static-3DES decrypt** for existing values — so **every current `.sds` still decrypts** and is re-encrypted to `v2` on its next save (migrate-on-write). The legacy 3DES class is kept decrypt-only.

## Tests
`DatasourcePasswordEncryptionTest` — AES-GCM round-trip, `v2:` decrypt, **legacy 3DES value still decrypts via fallback**, key generation/persistence in a temp dir. Workflow gate: full `saiku-service` suite green (minus env classes); spotless clean.

## Notes
- Self-contained in `saiku-service`; existing encode/decode method names preserved (no wiring change).
- Review note (non-blocking): the migrate-on-write path is latent until a datasource is next saved; the **decrypt** path (the security-relevant one) is fully hardened + backward-compatible.

Security lane (Agent SEC). **Not self-merging.** 🤖 Generated with [Claude Code](https://claude.com/claude-code)
