### PR TITLE
fix(security): forwarded-proto + Server-banner suppression + multipart caps (MED)

### DIFF
--- a/saiku-launcher/src/main/java/org/saiku/launcher/SaikuLauncher.java
+++ b/saiku-launcher/src/main/java/org/saiku/launcher/SaikuLauncher.java
@@ -14,6 +14,9 @@ import java.util.zip.ZipFile;
 import java.util.zip.ZipInputStream;
 import org.eclipse.jetty.ee10.webapp.WebAppContext;
 import org.eclipse.jetty.http.HttpCookie;
+import org.eclipse.jetty.server.ForwardedRequestCustomizer;
+import org.eclipse.jetty.server.HttpConfiguration;
+import org.eclipse.jetty.server.HttpConnectionFactory;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.ServerConnector;
 import org.eclipse.jetty.session.DefaultSessionCache;
@@ -147,7 +150,36 @@ public class SaikuLauncher implements Callable<Integer> {
             enforceDefaultCredentialPolicy(warPath);
 
             Server server = new Server();
-            ServerConnector connector = new ServerConnector(server);
+            // saiku#1165 audit-3: harden the HTTP transport.
+            //  * ForwardedRequestCustomizer — honour X-Forwarded-Proto / -Host
+            //    from a TLS-terminating reverse proxy so request.isSecure() is
+            //    true on a forwarded HTTPS request. Without it, the Secure flag
+            //    on the XSRF-TOKEN cookie is dropped behind a proxy. When the
+            //    forwarded headers are ABSENT (direct HTTP, e.g. the IT harness)
+            //    isSecure() stays false — no behaviour change for direct hits.
+            //
+            //    IMPORTANT: X-Forwarded-For is DELIBERATELY NOT trusted
+            //    (setForwardedForHeader(null)). Saiku binds plain HTTP directly
+            //    by default (no proxy assumed), and LoginRateLimiter / AuditLogger
+            //    intentionally key off getRemoteAddr() and only honour
+            //    X-Forwarded-For when saiku.auth.trustForwardedFor=true. If the
+            //    customizer rewrote getRemoteAddr() from X-Forwarded-For, any
+            //    client could spoof its IP per request and evade the login rate
+            //    limit + forge the audit trail. So we restore only the scheme/host
+            //    here and leave client-IP resolution to the existing controls.
+            //  * sendServerVersion=false — suppress the "Server: Jetty/<ver>"
+            //    banner (version disclosure / fingerprinting).
+            //  * sendXPoweredBy=false — likewise drop X-Powered-By.
+            HttpConfiguration httpConfig = new HttpConfiguration();
+            ForwardedRequestCustomizer forwarded = new ForwardedRequestCustomizer();
+            forwarded.setForwardedForHeader(null); // do not let X-Forwarded-For override getRemoteAddr()
+            httpConfig.addCustomizer(forwarded);
+            httpConfig.setSendServerVersion(false);
+            httpConfig.setSendXPoweredBy(false);
+            // Keep Jetty's default request-header size unless an operator tunes it.
+            httpConfig.setRequestHeaderSize(
+                    Integer.getInteger("saiku.http.requestHeaderSize", httpConfig.getRequestHeaderSize()));
+            ServerConnector connector = new ServerConnector(server, new HttpConnectionFactory(httpConfig));
             connector.setHost(host);
             connector.setPort(port);
             server.addConnector(connector);
@@ -156,6 +188,12 @@ public class SaikuLauncher implements Callable<Integer> {
             webapp.setContextPath(contextPath);
             webapp.setWar(warPath.toString());
             webapp.setExtractWAR(true);
+
+            // saiku#1165 audit-3: global backstop on form-urlencoded request
+            // bodies (the per-endpoint caps only covered specific resources).
+            // Multipart/file uploads are bounded separately by the Jersey
+            // servlet's <multipart-config> in web.xml. Default 2 MB; tunable.
+            webapp.setMaxFormContentSize(Integer.getInteger("saiku.http.maxFormContentSize", 2_000_000));
 
             // Tier-1 auth hardening: JSESSIONID cookie attrs.
             //   HttpOnly = true   (always — no JS needs to read it)

--- a/saiku-launcher/src/test/java/org/saiku/launcher/it/JettyHardeningIT.java
+++ b/saiku-launcher/src/test/java/org/saiku/launcher/it/JettyHardeningIT.java
@@ -1,0 +1,47 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.launcher.it;
+
+import static org.junit.Assert.assertFalse;
+
+import java.net.http.HttpResponse;
+import java.util.Locale;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ * saiku#1165 audit-3 — verifies the embedded Jetty transport is hardened:
+ * the {@code Server} response banner must NOT disclose the Jetty version
+ * (sendServerVersion=false on the connector's HttpConfiguration).
+ *
+ * <p>Kept deliberately minimal: any reachable path is enough to assert the
+ * connector-level header suppression, since the banner is stamped by the
+ * connector, not by the resource.
+ */
+public class JettyHardeningIT {
+
+    private static SaikuItHarness harness;
+
+    @BeforeClass
+    public static void boot() throws Exception {
+        harness = SaikuItHarness.shared();
+    }
+
+    @Test
+    public void serverBannerDoesNotDiscloseJetty() throws Exception {
+        HttpResponse<String> resp = harness.getAnon("/rest/saiku/info");
+        String server = resp.headers().firstValue("Server").orElse("");
+        assertFalse(
+                "Server header must not disclose Jetty (was: '" + server + "')",
+                server.toLowerCase(Locale.ROOT).contains("jetty"));
+    }
+
+    @Test
+    public void noXPoweredByHeader() throws Exception {
+        HttpResponse<String> resp = harness.getAnon("/ui/");
+        String xpb = resp.headers().firstValue("X-Powered-By").orElse("");
+        assertFalse("X-Powered-By must be suppressed (was: '" + xpb + "')", xpb.length() > 0);
+    }
+}

--- a/saiku-webapp/src/main/webapp/WEB-INF/web.xml
+++ b/saiku-webapp/src/main/webapp/WEB-INF/web.xml
@@ -259,6 +259,17 @@
       		<param-value>org.saiku.web.rest.SaikuJerseyApplication</param-value>
     	</init-param>
     	<load-on-startup>1</load-on-startup>
+    	<!-- saiku#1165 audit-3: global upload backstop on the REST surface.
+    	     Individual endpoints may impose tighter caps; these are the outer
+    	     limits the container enforces before a request reaches Jersey, so a
+    	     hostile multipart body can't exhaust memory/disk. 50 MB per file,
+    	     50 MB per request, with a 256 KB in-memory threshold (larger parts
+    	     spill to a temp file). -->
+    	<multipart-config>
+    		<max-file-size>52428800</max-file-size>
+    		<max-request-size>52428800</max-request-size>
+    		<file-size-threshold>262144</file-size-threshold>
+    	</multipart-config>
   	</servlet>
 
 	  <servlet-mapping>


### PR DESCRIPTION
Found by the round-3 deep security audit (refs #1165). Implemented via workflow; the **adversarial review caught a regression in the first cut, now fixed**.

## What
- **MED** — no Jetty `ForwardedRequestCustomizer`, so behind a TLS-terminating reverse proxy `request.isSecure()` is `false` and the **XSRF-TOKEN cookie loses its `Secure` flag**.
- **HARDENING** — Jetty `Server:` version banner exposed (fingerprinting).
- **MED** — no global multipart / form-content size cap (per-endpoint caps only).

## Fix
In `SaikuLauncher.bootServer`, build the connector from an explicit `HttpConfiguration`:
- `ForwardedRequestCustomizer` with **`setForwardedForHeader(null)`** — honours `X-Forwarded-Proto`/`-Host` (so `isSecure()` is correct behind TLS → the XSRF cookie `Secure` flag is restored) but **deliberately does NOT trust `X-Forwarded-For`**.
- `setSendServerVersion(false)` + `setSendXPoweredBy(false)` — drop the banner.
- `setMaxFormContentSize(...)` + a `<multipart-config>` on the Jersey servlet in `web.xml` — global upload/form size backstop (tunable).

### Why `X-Forwarded-For` is not trusted (the review's catch)
Saiku binds plain HTTP directly by default (no proxy assumed). `LoginRateLimiter` and `AuditLogger` intentionally key off `getRemoteAddr()` and only honour `X-Forwarded-For` when `saiku.auth.trustForwardedFor=true`. The first cut added an unconditional `ForwardedRequestCustomizer`, which would have rewritten `getRemoteAddr()` from the attacker-controllable `X-Forwarded-For` header — letting a client spoof its IP per request to **evade the login rate limit and forge the audit trail**. `setForwardedForHeader(null)` keeps those controls intact while still fixing the cookie-Secure goal.

## Tests
`JettyHardeningIT` (integration) — asserts the `Server` header no longer discloses Jetty; `InfoEndpointIT` confirms boot still works. spotless clean.

Security lane (Agent SEC). **Not self-merging.** 🤖 Generated with [Claude Code](https://claude.com/claude-code)
