### PR TITLE
fix(security): admin route-level authz + XSRF-TOKEN SameSite (HARDENING/LOW)

### DIFF
--- a/saiku-core/saiku-web/src/main/java/org/saiku/web/security/csrf/SaikuCsrfTokenRepository.java
+++ b/saiku-core/saiku-web/src/main/java/org/saiku/web/security/csrf/SaikuCsrfTokenRepository.java
@@ -1,0 +1,34 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ */
+package org.saiku.web.security.csrf;
+
+import org.springframework.security.web.csrf.CookieCsrfTokenRepository;
+
+/**
+ * Factory for the XSRF-TOKEN cookie repository (saiku#1165 audit-3).
+ *
+ * <p>Spring's {@link CookieCsrfTokenRepository#withHttpOnlyFalse()} (the SPA must
+ * read the cookie to echo it back as the {@code X-XSRF-TOKEN} header) does not
+ * emit a {@code SameSite} attribute, leaving the CSRF cookie as the one Saiku
+ * cookie without one (JSESSIONID is {@code SameSite=Lax}, the demo-gate cookie
+ * {@code Strict}). Add {@code SameSite=Lax} to match JSESSIONID — defense in
+ * depth; the cookie stays non-HttpOnly so the SPA double-submit pattern keeps
+ * working. A {@code cookieCustomizer} can't be expressed in the security XML, so
+ * this factory wires it. {@code Secure} is left to the cookie's own
+ * request-driven default (now correct behind TLS via the
+ * {@code ForwardedRequestCustomizer}).
+ */
+public final class SaikuCsrfTokenRepository {
+
+    private SaikuCsrfTokenRepository() {}
+
+    public static CookieCsrfTokenRepository create() {
+        CookieCsrfTokenRepository repository = CookieCsrfTokenRepository.withHttpOnlyFalse();
+        repository.setCookieCustomizer(cookie -> cookie.sameSite("Lax"));
+        return repository;
+    }
+}

--- a/saiku-webapp/src/main/webapp/WEB-INF/applicationContext-saiku.xml
+++ b/saiku-webapp/src/main/webapp/WEB-INF/applicationContext-saiku.xml
@@ -108,6 +108,11 @@
 	         full auth. Order matters: more specific patterns precede /rest/**. -->
 	    <security:intercept-url pattern="/rest/saiku/share/view/**" access="hasRole('SHARE_GUEST') or isFullyAuthenticated()" />
 	    <security:intercept-url pattern="/rest/saiku/share/**" access="isFullyAuthenticated()" />
+      <!-- saiku#1165 audit-3: route-level admin gate (defense in depth). The
+           admin resources already carry @RolesAllowed("ROLE_ADMIN"), but this
+           ensures a future un-annotated /admin resource can't be reached by a
+           non-admin. Must precede /rest/** (more specific first). -->
+      <security:intercept-url pattern="/rest/saiku/admin/**" access="hasRole('ADMIN')" />
       <security:intercept-url pattern="/rest/**" access="isFullyAuthenticated()" />
       <security:intercept-url pattern="/json/**" access="isFullyAuthenticated()" />
       <security:intercept-url pattern="/WEB-INF/classes/legacy-schema" access="isAnonymous()" />
@@ -148,9 +153,11 @@
     </security:http>
 
     <!-- Tier-1 auth hardening: CSRF wiring (saiku#1150). -->
+    <!-- saiku#1165 audit-3: XSRF-TOKEN cookie via factory so it carries
+         SameSite=Lax (matching JSESSIONID); stays non-HttpOnly for the SPA. -->
     <bean id="csrfTokenRepository"
-          class="org.springframework.security.web.csrf.CookieCsrfTokenRepository"
-          factory-method="withHttpOnlyFalse"/>
+          class="org.saiku.web.security.csrf.SaikuCsrfTokenRepository"
+          factory-method="create"/>
     <bean id="csrfRequestMatcher"
           class="org.saiku.web.security.csrf.SaikuCsrfRequestMatcher"/>
     <bean id="csrfTokenRequestHandler"


### PR DESCRIPTION
Found by the round-3 deep security audit (refs #1165).

## What
1. **HARDENING** — admin authorization was enforced **only** by JAX-RS `@RolesAllowed("ROLE_ADMIN")`. The Spring URL chain had no `intercept-url` scoping `/rest/saiku/admin/**`, so a future un-annotated admin resource would be reachable by any authenticated user.
2. **LOW** — the `XSRF-TOKEN` cookie (`CookieCsrfTokenRepository.withHttpOnlyFalse`) had no `SameSite` attribute (JSESSIONID is `SameSite=Lax`, demo-gate `Strict`).

## Fix
1. Added `<security:intercept-url pattern="/rest/saiku/admin/**" access="hasRole('ADMIN')"/>` **before** the `/rest/**` rule — a route-level admin gate independent of any single resource's annotation. No behavior change for real admins (they hold `ROLE_ADMIN`).
2. New `SaikuCsrfTokenRepository.create()` factory wires `CookieCsrfTokenRepository.withHttpOnlyFalse()` **plus a `cookieCustomizer` setting `SameSite=Lax`** (a lambda customizer can't be expressed in the security XML). The cookie stays **non-HttpOnly** so the SPA double-submit pattern keeps working; `Secure` is now correct behind TLS via the companion `ForwardedRequestCustomizer` change.

## Verification (integration)
`CsrfIT` (CSRF still enforced + the readable XSRF cookie round-trips), `AdminIT` (admin gate still passes for admin), `SessionIT` (login/logout) — all green. spotless clean.

Security lane (Agent SEC). **Not self-merging.** 🤖 Generated with [Claude Code](https://claude.com/claude-code)
