### PR TITLE
chore(deps): batch dependabot maven bumps (#883/#885/#886/#887/#888)

### DIFF
--- a/saiku-bom/pom.xml
+++ b/saiku-bom/pom.xml
@@ -34,7 +34,7 @@
              log4j-slf4j-impl, the slf4j-1.x → log4j2 binding. -->
         <log4j2.version>2.24.3</log4j2.version>
         <!-- Batik 1.8 has CVE-2022-38398/40146/41704/42890/44729/44730. 1.17 fixes them. -->
-        <batik.version>1.17</batik.version>
+        <batik.version>1.19</batik.version>
         <jersey.version>3.1.9</jersey.version>
         <saiku-query.version>0.4-SNAPSHOT</saiku-query.version>
         <jackson.version>2.18.6</jackson.version>
@@ -84,7 +84,7 @@
             <dependency>
                 <groupId>org.mozilla</groupId>
                 <artifactId>rhino</artifactId>
-                <version>1.7.14.1</version>
+                <version>1.9.1</version>
             </dependency>
             <dependency>
                 <groupId>org.jvnet.mimepull</groupId>

--- a/saiku-core/saiku-olap-util/pom.xml
+++ b/saiku-core/saiku-olap-util/pom.xml
@@ -20,7 +20,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
-				<version>2.0.2</version>
+				<version>3.15.0</version>
 				<configuration>
 					<source>${maven.compiler.source}</source>
 					<target>${maven.compiler.target}</target>

--- a/saiku-webapp/pom.xml
+++ b/saiku-webapp/pom.xml
@@ -85,7 +85,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-war-plugin</artifactId>
-                <version>3.4.0</version>
+                <version>3.5.1</version>
                 <executions>
                     <execution>
                         <!-- First step is to disable the default-war build step. -->
@@ -230,7 +230,7 @@
             </plugin>
             <plugin>
                 <artifactId>maven-war-plugin</artifactId>
-                <version>3.4.0</version>
+                <version>3.5.1</version>
                 <configuration>
                     <warSourceExcludes>WEB-INF/saiku-beans.xml</warSourceExcludes>
                     <webResources>
@@ -244,10 +244,11 @@
             <plugin>
                 <groupId>com.github.eirslett</groupId>
                 <artifactId>frontend-maven-plugin</artifactId>
-                <!-- 1.15.1 fixes Node 22 tarball extraction permission errors
-                     on Linux CI runners that bit the dist job (1.15.0 chokes
-                     on share/doc/node/* permission bits during extraction). -->
-                <version>1.15.1</version>
+                <!-- 1.15.1 fixed Node 22 tarball extraction permission errors;
+                     2.0.0 carries forward that fix + drops Maven 3.x support
+                     (we're on 3.9+ via the dist build). Goal surface (npm/node
+                     install + npm ci) is unchanged. -->
+                <version>2.0.0</version>
                 <configuration>
                     <workingDirectory>${project.basedir}/../saiku-ui</workingDirectory>
                     <!-- Use saiku-webapp/target/node — local to this module,
@@ -424,7 +425,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jxr-plugin</artifactId>
-                <version>3.4.0</version>
+                <version>3.5.1</version>
                 <configuration>
                     <aggregate>true</aggregate>
                 </configuration>


### PR DESCRIPTION
Folds the five maven-side dependabot PRs whose CI was red only because dependabot's auto-issued GITHUB_TOKEN can't pull cross-org from spiculedata/mondrian-saiku's GitHub Packages. Each was validated locally with GH_PACKAGES_TOKEN.

| Bump | Test |
|---|---|
| #883 maven-war-plugin 3.4.0 → 3.5.1 | saiku-webapp package clean |
| #886 batik 1.17 → 1.19 | ExporterIT 4/4 green |
| #885 maven-compiler-plugin 2.0.2 → 3.15.0 (olap-util only) | saiku-olap-util compile clean |
| #888 rhino 1.7.14.1 → 1.9.1 | saiku-web compile clean |
| #887 frontend-maven-plugin 1.15.1 → 2.0.0 | clean+package; node install + npm ci + npm run build all green on 2.0.0 |

Closes #883, #885, #886, #887, #888.