### PR TITLE
chore: bump mondrian 4.8.1.27 → 4.8.1.30 + sync Bank showcase

### DIFF
--- a/saiku-bom/pom.xml
+++ b/saiku-bom/pom.xml
@@ -346,7 +346,7 @@
             <dependency>
                 <groupId>pentaho</groupId>
                 <artifactId>mondrian</artifactId>
-                <version>4.8.1.27</version>
+                <version>4.8.1.30</version>
                 <!-- xerces 2.12.2 + xalan 2.7.2 are transitively pulled by
                      mondrian but hijack the JDK's built-in JAXP via
                      META-INF/services overrides. Spring 6.2's tightened

--- a/saiku-launcher/src/main/resources/seed/Bank.xml
+++ b/saiku-launcher/src/main/resources/seed/Bank.xml
@@ -6,21 +6,25 @@
   the Customer dimension is linked through the account_owner bridge table
   (mm_owner) with an ownership weight rather than a foreign key on the fact.
 
-  Three cubes over the SAME fact table:
+  Two cubes over the SAME fact table show the two allocation styles:
     - "Joint Accounts (Full Count)" — every owner sees the full balance;
       totals de-duplicate on the account grain at every level (incl. the
       Segment roll-up), so the grand total is the true 13000, not 21000.
     - "Joint Accounts (Weighted)"   — each balance split by ownership weight,
       reconciling to 13000.
-    - "Account Statistics"          — a plain star (no bridge) over the same
-      fact, exposing avg / min / max alongside the additive total + account
-      count for distributional comparison.
 
   Companion data: bank.sql (tables mm_*), loaded into the demo H2 database.
   Requires the Calcite query backend (the Saiku default) — bridge queries
   cannot be evaluated by the legacy SQL generator.
 -->
 <Schema name="Bank" metamodelVersion="4.0">
+
+  <!-- Bounded query-context parameter (#105): the tenant supplied per query
+       (e.g. session.tenant), enumerated + typed, bound by the Tenant role. -->
+  <QueryParameter name="tenant" type="Numeric" defaultValue="1">
+    <QueryParameterValue>1</QueryParameterValue>
+    <QueryParameterValue>2</QueryParameterValue>
+  </QueryParameter>
 
   <PhysicalSchema>
     <Table name="mm_fact">
@@ -30,6 +34,7 @@
     <Table name="mm_customer"/>
     <Table name="mm_branch"/>
     <Table name="mm_date"/>
+    <Table name="mm_txn"/>
   </PhysicalSchema>
 
   <!-- The many-to-many dimension. Customers roll up into segments; full-count
@@ -131,12 +136,13 @@
     </MeasureGroups>
   </Cube>
 
-  <!-- Plain star (no bridge) over the same fact, exposing the non-additive
-       leaf aggregators median / percentile (mondrian-saiku #104) alongside
-       the additive total. Computed at the queried grain via
-       PERCENTILE_CONT(...) WITHIN GROUP (ORDER BY column); not rolled up.
-       Requires the Calcite backend (the Saiku default) on a database that
-       supports PERCENTILE_CONT — the demo's H2 datasource qualifies. -->
+  <!-- =================================================================
+       Cube 3 — Account Statistics. A plain star (no bridge) over the same
+       fact, showing the non-additive leaf aggregators median / percentile
+       (#104). Computed at the queried grain via PERCENTILE_CONT; requires
+       the Calcite backend on a PERCENTILE_CONT-capable database (the demo's
+       H2 datasource qualifies).
+       ================================================================= -->
   <Cube name="Account Statistics">
     <Dimensions>
       <Dimension source="Branch"/>
@@ -160,5 +166,88 @@
       </MeasureGroup>
     </MeasureGroups>
   </Cube>
+
+  <!-- Degenerate dimension on the fact: native Tier (binning) over balance
+       and native Duration (account age) over open_date..as_of_date (#108). -->
+  <Dimension name="Account" table="mm_fact" key="Account Id">
+    <Attributes>
+      <Attribute name="Account Id" hasHierarchy="false">
+        <Key><Column name="account_id"/></Key>
+      </Attribute>
+      <Attribute name="Balance Tier" hasHierarchy="true">
+        <Tier column="balance">
+          <Bin boundary="1000" label="Small"/>
+          <Bin boundary="3000" label="Medium"/>
+          <Bin label="Large"/>
+        </Tier>
+      </Attribute>
+      <Attribute name="Age Years" hasHierarchy="true">
+        <Duration startColumn="open_date" endColumn="as_of_date" unit="YEAR"/>
+      </Attribute>
+    </Attributes>
+  </Dimension>
+
+  <!-- Native tier + duration over the fact via the degenerate Account dim. -->
+  <Cube name="Accounts">
+    <Dimensions>
+      <Dimension source="Account"/>
+      <Dimension source="Branch"/>
+    </Dimensions>
+    <MeasureGroups>
+      <MeasureGroup name="Balances" table="mm_fact">
+        <Measures>
+          <Measure name="Balance" column="balance" aggregator="sum"
+                   formatString="#,###"/>
+        </Measures>
+        <DimensionLinks>
+          <FactLink dimension="Account"/>
+          <ForeignKeyLink dimension="Branch" foreignKeyColumn="branch_id"/>
+        </DimensionLinks>
+      </MeasureGroup>
+    </MeasureGroups>
+  </Cube>
+
+  <!-- Measure-level distinct grain (#119): mm_txn fans out (one txn repeated
+       per line). Distinct Amount de-dups on txn_id before summing; Naive
+       Amount shows the double-count the distinct grain avoids. -->
+  <Cube name="Transactions">
+    <Dimensions/>
+    <MeasureGroups>
+      <MeasureGroup name="Txns" table="mm_txn">
+        <Measures>
+          <Measure name="Distinct Amount" column="amount" aggregator="sum"
+                   distinctKeyColumn="txn_id" formatString="#,###"/>
+          <Measure name="Naive Amount" column="amount" aggregator="sum"
+                   formatString="#,###"/>
+        </Measures>
+        <DimensionLinks/>
+      </MeasureGroup>
+    </MeasureGroups>
+  </Cube>
+
+  <!-- Predicate row-security (#106): filter fact rows by the bound tenant
+       query parameter (#105). Enforced in the Calcite path. -->
+  <Role name="Tenant">
+    <SchemaGrant access="all">
+      <CubeGrant cube="Accounts" access="all">
+        <PredicateGrant measureGroup="Balances" column="tenant"
+                        operator="eq" parameter="tenant"/>
+      </CubeGrant>
+    </SchemaGrant>
+  </Role>
+
+  <!-- Member/Hierarchy-grant row-security (#107) on the bridge dimension:
+       the Premium role sees only Premium-segment customers; the bridge
+       fan-out is constrained to visible owners (Standard-only accounts drop). -->
+  <Role name="Premium">
+    <SchemaGrant access="all">
+      <CubeGrant cube="Joint Accounts (Full Count)" access="all">
+        <HierarchyGrant hierarchy="[Customer].[By Segment]" access="custom"
+                        bottomLevel="[Customer].[By Segment].[Customer]">
+          <MemberGrant member="[Customer].[By Segment].[Premium]" access="all"/>
+        </HierarchyGrant>
+      </CubeGrant>
+    </SchemaGrant>
+  </Role>
 
 </Schema>

--- a/saiku-launcher/src/main/resources/seed/bank.lkml
+++ b/saiku-launcher/src/main/resources/seed/bank.lkml
@@ -1,0 +1,93 @@
+# Synthetic Looker model for the Bank demo — demonstrates Looker -> M4 migration.
+# Over the same mm_* tables as demo/bank.sql + demo/Bank.mondrian.xml.
+#
+# Covered import paths:
+#   many-to-many bridge two-hop  -> <BridgeLink>            (#124)
+#   access_filter on a column    -> <PredicateGrant>        (#106)
+#   access_filter on a dim key   -> <HierarchyGrant>        (#115)
+#   sum_distinct (same-view key) -> measure-level distinct grain (#117/#119)
+#   type: tier                   -> <Tier>                  (#108)
+#   dimension_group type:duration-> <Duration>             (#108)
+#   type: median / percentile    -> median/percentile measures (#104)
+#
+# Transpile with the schema CLI / LookML importer; see demo/lookml/README.md.
+
+view: account_fact {
+  sql_table_name: mm_fact ;;
+  dimension: account_id {
+    type: number
+    primary_key: yes
+    sql: ${TABLE}.account_id ;;
+  }
+  # type: tier -> native <Tier> binning over the balance column.
+  dimension: balance_tier {
+    type: tier
+    tiers: [1000, 3000]
+    sql: ${TABLE}.balance ;;
+  }
+  # type: duration -> native <Duration> (account age in years).
+  dimension_group: account_age {
+    type: duration
+    intervals: [year]
+    sql_start: ${TABLE}.open_date ;;
+    sql_end: ${TABLE}.as_of_date ;;
+  }
+  measure: balance { type: sum sql: ${TABLE}.balance ;; }
+  measure: median_balance { type: median sql: ${TABLE}.balance ;; }
+  measure: p90_balance {
+    type: percentile
+    percentile: 90
+    sql: ${TABLE}.balance ;;
+  }
+  # NOTE: `tenant` is intentionally NOT declared as a dimension, so the
+  # access_filter below maps to a PredicateGrant (arbitrary fact column),
+  # not a member/hierarchy grant.
+}
+
+view: account_owner {
+  sql_table_name: mm_owner ;;
+  dimension: account_id { type: number sql: ${TABLE}.account_id ;; }
+  dimension: customer_id { sql: ${TABLE}.customer_id ;; }
+}
+
+view: customer {
+  sql_table_name: mm_customer ;;
+  dimension: customer_id {
+    primary_key: yes
+    sql: ${TABLE}.customer_id ;;
+  }
+  # A modelled dimension key -> access_filter on it becomes a HierarchyGrant.
+  dimension: segment { type: string sql: ${TABLE}.segment ;; }
+}
+
+view: txn {
+  sql_table_name: mm_txn ;;
+  dimension: txn_id { type: number sql: ${TABLE}.txn_id ;; }
+  # sum_distinct on a same-view non-primary-key column -> measure-level
+  # distinct grain (#119): de-dups on txn_id before summing.
+  measure: distinct_amount {
+    type: sum_distinct
+    sql_distinct_key: ${TABLE}.txn_id ;;
+    sql: ${TABLE}.amount ;;
+  }
+}
+
+# The bridge two-hop: fact -> owners (one_to_many) -> customer (many_to_one).
+explore: account_fact {
+  join: account_owner {
+    type: left_outer
+    relationship: one_to_many
+    sql_on: ${account_fact.account_id} = ${account_owner.account_id} ;;
+  }
+  join: customer {
+    type: left_outer
+    relationship: many_to_one
+    sql_on: ${account_owner.customer_id} = ${customer.customer_id} ;;
+  }
+  # Predicate row-security on an arbitrary fact column, bound to a user attribute.
+  access_filter: { field: account_fact.tenant user_attribute: tenant }
+  # Member-level row-security on a modelled dimension key.
+  access_filter: { field: customer.segment user_attribute: segment }
+}
+
+explore: txn {}

--- a/saiku-launcher/src/main/resources/seed/bank.sql
+++ b/saiku-launcher/src/main/resources/seed/bank.sql
@@ -1,29 +1,29 @@
--- Saiku demo: joint bank accounts — a bridge (many-to-many) dimension.
---
--- Loaded by Database.loadBank() via RUNSCRIPT into the SAME H2 database as
--- FoodMart (distinct mm_* table names, no clash). Quoted-lowercase
--- identifiers match how Mondrian references them, mirroring foodmart_h2.sql.
---
--- One account has one balance but can be co-owned by several customers, so
--- the Customer dimension is linked through the account_owner bridge table
--- (mm_owner) with an ownership weight. Two cubes (full-count and weighted)
--- over the one fact demonstrate both allocation styles.
---
--- Deterministic and tiny so the numbers are verifiable by hand:
---   total balance 13000, total fees 130.
+-- Saiku demo: joint bank accounts — comprehensive feature showcase.
+-- Base rows are REUSED VERBATIM from the shipped
+-- ../saiku/saiku-launcher/src/main/resources/seed/bank.sql — KEEP IN SYNC.
+-- Additions here are backward-compatible (new columns/table only):
+--   mm_fact.tenant      -> predicate row-security (#106) + query parameter (#105)
+--   mm_fact.open_date   -> account-age duration (#108), paired with a FIXED as_of
+--   mm_fact.as_of_date  -> fixed reference date so duration numbers are stable
+--   mm_txn              -> measure-level distinct grain (#119)
+-- Loaded into H2. Total balance 13000, fees 130 (unchanged from the base).
 
 DROP TABLE IF EXISTS "mm_fact";
 DROP TABLE IF EXISTS "mm_owner";
 DROP TABLE IF EXISTS "mm_customer";
 DROP TABLE IF EXISTS "mm_branch";
 DROP TABLE IF EXISTS "mm_date";
+DROP TABLE IF EXISTS "mm_txn";
 
 CREATE TABLE "mm_fact" (
     "account_id" INTEGER,
     "date_key"   INTEGER,
     "branch_id"  VARCHAR(8),
     "balance"    INTEGER,
-    "fees"       INTEGER
+    "fees"       INTEGER,
+    "tenant"     INTEGER,
+    "open_date"  DATE,
+    "as_of_date" DATE
 );
 CREATE TABLE "mm_owner" (
     "account_id"  INTEGER,
@@ -43,46 +43,63 @@ CREATE TABLE "mm_date" (
     "date_key" INTEGER,
     "yr"       INTEGER
 );
+CREATE TABLE "mm_txn" (
+    "txn_id"     INTEGER,
+    "line_no"    INTEGER,
+    "account_id" INTEGER,
+    "amount"     INTEGER
+);
 
-INSERT INTO "mm_fact" ("account_id","date_key","branch_id","balance","fees") VALUES
-    (1, 2024, 'LON', 1000, 10),
-    (2, 2024, 'LON',  500,  5),
-    (3, 2025, 'LDS',  300,  3),
-    (4, 2024, 'LON', 2000, 20),
-    (5, 2024, 'LDS', 1500, 15),
-    (6, 2025, 'LDS',  700,  7),
-    (7, 2025, 'LON', 4000, 40),
-    (8, 2025, 'LDS', 3000, 30);
+-- Base fact rows (balance/fees verbatim from shipped). tenant: LON branch=1,
+-- LDS branch=2 (a clean partition for the predicate-RLS demo). open_date chosen
+-- so as_of 2025-01-01 gives whole-year ages; as_of_date constant for stability.
+INSERT INTO "mm_fact"
+  ("account_id","date_key","branch_id","balance","fees","tenant","open_date","as_of_date") VALUES
+    (1, 2024, 'LON', 1000, 10, 1, DATE '2020-01-01', DATE '2025-01-01'),
+    (2, 2024, 'LON',  500,  5, 1, DATE '2021-01-01', DATE '2025-01-01'),
+    (3, 2025, 'LDS',  300,  3, 2, DATE '2023-01-01', DATE '2025-01-01'),
+    (4, 2024, 'LON', 2000, 20, 1, DATE '2019-01-01', DATE '2025-01-01'),
+    (5, 2024, 'LDS', 1500, 15, 2, DATE '2022-01-01', DATE '2025-01-01'),
+    (6, 2025, 'LDS',  700,  7, 2, DATE '2024-01-01', DATE '2025-01-01'),
+    (7, 2025, 'LON', 4000, 40, 1, DATE '2015-01-01', DATE '2025-01-01'),
+    (8, 2025, 'LDS', 3000, 30, 2, DATE '2018-01-01', DATE '2025-01-01');
 
 INSERT INTO "mm_owner" ("account_id","customer_id","weight") VALUES
-    (1, 'alice', 0.50),
-    (1, 'bob',   0.50),
-    (2, 'bob',   1.00),
-    (3, 'alice', 0.25),
-    (3, 'carol', 0.75),
-    (4, 'erin',  0.50),
-    (4, 'frank', 0.50),
-    (5, 'frank', 1.00),
-    (6, 'grace', 0.40),
-    (6, 'heidi', 0.60),
-    (7, 'erin',  0.50),
-    (7, 'grace', 0.50),
+    (1, 'alice', 0.50), (1, 'bob',   0.50), (2, 'bob',   1.00),
+    (3, 'alice', 0.25), (3, 'carol', 0.75), (4, 'erin',  0.50),
+    (4, 'frank', 0.50), (5, 'frank', 1.00), (6, 'grace', 0.40),
+    (6, 'heidi', 0.60), (7, 'erin',  0.50), (7, 'grace', 0.50),
     (8, 'heidi', 1.00);
 
 INSERT INTO "mm_customer" ("customer_id","customer_name","segment") VALUES
-    ('alice', 'Alice', 'Premium'),
-    ('bob',   'Bob',   'Premium'),
-    ('carol', 'Carol', 'Standard'),
-    ('dave',  'Dave',  'Standard'),
-    ('erin',  'Erin',  'Premium'),
-    ('frank', 'Frank', 'Standard'),
-    ('grace', 'Grace', 'Premium'),
-    ('heidi', 'Heidi', 'Standard');
+    ('alice', 'Alice', 'Premium'), ('bob',   'Bob',   'Premium'),
+    ('carol', 'Carol', 'Standard'),('dave',  'Dave',  'Standard'),
+    ('erin',  'Erin',  'Premium'), ('frank', 'Frank', 'Standard'),
+    ('grace', 'Grace', 'Premium'), ('heidi', 'Heidi', 'Standard');
 
 INSERT INTO "mm_branch" ("branch_id","branch_name") VALUES
-    ('LON', 'London'),
-    ('LDS', 'Leeds');
+    ('LON', 'London'), ('LDS', 'Leeds');
 
-INSERT INTO "mm_date" ("date_key","yr") VALUES
-    (2024, 2024),
-    (2025, 2025);
+INSERT INTO "mm_date" ("date_key","yr") VALUES (2024, 2024), (2025, 2025);
+
+-- Transactions: a FAN-OUT table for measure-level distinct grain (#119).
+-- Each txn repeats its sale amount across lines (a denormalised join would
+-- double-count). Distinct sum over txn_id de-dups to the true per-txn total.
+--   txn 100: 3 lines @ 100  -> distinct 100
+--   txn 200: 1 line  @ 50   -> distinct 50
+--   txn 300: 2 lines @ 300  -> distinct 300
+-- Distinct sum = 100+50+300 = 450 ; naive SUM = 300+50+600 = 950.
+INSERT INTO "mm_txn" ("txn_id","line_no","account_id","amount") VALUES
+    (100, 1, 1, 100), (100, 2, 1, 100), (100, 3, 1, 100),
+    (200, 1, 2,  50),
+    (300, 1, 3, 300), (300, 2, 3, 300);
+
+-- Golden values (asserted in BankShowcaseH2EndToEndTest):
+--   Balance grand total ........................ 13000
+--   Full-count Balance by Customer: Alice 1300, Bob 1500, Carol 300 ...
+--   Weighted  Balance by Customer:  Alice 575,  Bob 1000, Carol 225 ...
+--   Median Balance (all) ....................... avg of middle balances
+--   Distinct Amount (Transactions) ............. 450   (naive sum 950)
+--   Predicate RLS tenant=1 (LON) Balance ....... 7500 ; tenant=2 (LDS) 5500
+--   Member-grant 'Premium' segment excludes Standard-only owners (see test)
+--   Account age (years, as_of 2025-01-01): acct7=10, acct8=7, acct4=6 ...


### PR DESCRIPTION
Three mondrian-saiku releases + the full Bank showcase pulled into the demo seed.

## Mondrian

- 4.8.1.28 — Accounts cube (#108), Tenant predicate role (#106), Premium bridge role (#107)
- 4.8.1.29 — Transactions cube (#119), Looker→M4 migration (#129)
- 4.8.1.30 — release tag

## Bank showcase sync (saiku-launcher/src/main/resources/seed/)

- bank.sql 88→105 lines: adds tenant, open_date, as_of_date, mm_txn
- Bank.xml 164→253 lines: 3 cubes → 5 cubes; adds Accounts + Transactions; adds Tenant + Premium roles
- bank.lkml new: synthetic Looker model paired with Bank.xml — the Looker→M4 migration story fixture

## Test plan

- [x] saiku-service: 512/512 unit tests pass
- [x] saiku-launcher IT suite: 86/86 pass (boots H2 + Mondrian + Calcite over the new schema)
- [ ] Demo: verify 9 cubes (FoodMart 4 + Bank 5) appear, Tenant/Premium roles applied, account-age + transaction distinct grain return expected numbers