### PR TITLE
chore: bump mondrian 4.8.1.30 → 4.8.1.31 + Monthly Revenue cube + Bank.yaml

### DIFF
--- a/saiku-bom/pom.xml
+++ b/saiku-bom/pom.xml
@@ -346,7 +346,7 @@
             <dependency>
                 <groupId>pentaho</groupId>
                 <artifactId>mondrian</artifactId>
-                <version>4.8.1.30</version>
+                <version>4.8.1.31</version>
                 <!-- xerces 2.12.2 + xalan 2.7.2 are transitively pulled by
                      mondrian but hijack the JDK's built-in JAXP via
                      META-INF/services overrides. Spring 6.2's tightened

--- a/saiku-core/saiku-service/src/main/java/org/saiku/database/Database.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/database/Database.java
@@ -202,14 +202,14 @@ public class Database {
 
         Connection c = ds2.getConnection();
         DatabaseMetaData dbm = c.getMetaData();
-        // Guard on mm_txn — the LATEST table added to bank.sql (saiku#1217 /
-        // mondrian-saiku#119, Bank Transactions cube). Older bank.sql versions
-        // created mm_owner first, so checking mm_owner makes upgrades from a
-        // pre-#1217 demo silently skip the new RUNSCRIPT and leave Mondrian
-        // crashing on "Table 'mm_txn' does not exist". The new bank.sql is
-        // idempotent (DROP IF EXISTS / CREATE TABLE) so re-running it on a
-        // partially-seeded database is safe.
-        ResultSet tables = dbm.getTables(null, null, "mm_txn", null);
+        // Guard on the latest table in bank.sql (mm_monthly, the monthly
+        // fixture for the Monthly Revenue cube + TimeCalc demos —
+        // mondrian-saiku#112 / saiku#1220). Upgrading from a pre-#1220
+        // demo will find this table missing and re-run the (idempotent
+        // DROP IF EXISTS / CREATE TABLE) bank.sql to add it. Older guards
+        // on mm_owner / mm_txn would short-circuit and leave Mondrian
+        // crashing on "Table 'mm_calendar' does not exist".
+        ResultSet tables = dbm.getTables(null, null, "mm_monthly", null);
         if (tables.next()) {
             // Already loaded.
             return;

--- a/saiku-launcher/src/main/java/org/saiku/launcher/SaikuLauncher.java
+++ b/saiku-launcher/src/main/java/org/saiku/launcher/SaikuLauncher.java
@@ -447,6 +447,12 @@ public class SaikuLauncher implements Callable<Integer> {
             // story has a discoverable fixture in <home>/data/ for anyone
             // running the demo locally.
             stageResource("/seed/bank.lkml", dataDir.resolve("bank.lkml"));
+            // Bank.yaml — the M4 YAML round-trip of Bank.xml (mondrian-saiku
+            // #112 + #130). Same schema, same cubes, same roles — just the
+            // YAML representation produced by the M4 YAML converter. Staged
+            // alongside Bank.xml so the round-trip story is verifiable in
+            // <home>/data/.
+            stageResource("/seed/Bank.yaml", dataDir.resolve("Bank.yaml"));
         }
 
         /** Copy a classpath seed resource to {@code target} if it is missing,

--- a/saiku-launcher/src/main/resources/seed/Bank.xml
+++ b/saiku-launcher/src/main/resources/seed/Bank.xml
@@ -35,6 +35,8 @@
     <Table name="mm_branch"/>
     <Table name="mm_date"/>
     <Table name="mm_txn"/>
+    <Table name="mm_calendar"/>
+    <Table name="mm_monthly"/>
   </PhysicalSchema>
 
   <!-- The many-to-many dimension. Customers roll up into segments; full-count
@@ -249,5 +251,58 @@
       </CubeGrant>
     </SchemaGrant>
   </Role>
+
+  <!-- A typed Time dimension (Year > Quarter > Month) for time intelligence. -->
+  <Dimension name="Calendar" table="mm_calendar" key="Month" type="TIME">
+    <Attributes>
+      <Attribute name="Year" levelType="TimeYears" hasHierarchy="false">
+        <Key><Column name="yr"/></Key>
+      </Attribute>
+      <Attribute name="Quarter" levelType="TimeQuarters" hasHierarchy="false">
+        <Key><Column name="quarter"/></Key>
+      </Attribute>
+      <Attribute name="Month" levelType="TimeMonths" hasHierarchy="false">
+        <Key><Column name="month_key"/></Key>
+        <Name><Column name="month_name"/></Name>
+        <OrderBy><Column name="month_key"/></OrderBy>
+      </Attribute>
+    </Attributes>
+    <Hierarchies>
+      <Hierarchy name="Calendar" allMemberName="All Periods">
+        <Level attribute="Year"/>
+        <Level attribute="Quarter"/>
+        <Level attribute="Month"/>
+      </Hierarchy>
+    </Hierarchies>
+  </Dimension>
+
+  <!-- #112 declarative time intelligence over a monthly revenue series. -->
+  <Cube name="Monthly Revenue">
+    <Dimensions>
+      <Dimension source="Calendar"/>
+    </Dimensions>
+    <MeasureGroups>
+      <MeasureGroup name="Revenue" table="mm_monthly">
+        <Measures>
+          <Measure name="Revenue" column="revenue" aggregator="sum"
+                   formatString="#,###"/>
+        </Measures>
+        <DimensionLinks>
+          <ForeignKeyLink dimension="Calendar" foreignKeyColumn="month_key"/>
+        </DimensionLinks>
+      </MeasureGroup>
+    </MeasureGroups>
+    <TimeCalcs>
+      <TimeCalc name="Revenue YoY"  type="yoy"     measure="Revenue"
+                timeDimension="Calendar" formatString="0.0%"/>
+      <TimeCalc name="Revenue PoP"  type="pop"     measure="Revenue"
+                timeDimension="Calendar" formatString="0.0%"/>
+      <TimeCalc name="Revenue YTD"  type="ytd"     measure="Revenue"
+                timeDimension="Calendar" formatString="#,###"/>
+      <TimeCalc name="Revenue R3"   type="rolling" measure="Revenue"
+                timeDimension="Calendar" window="3" function="avg"
+                formatString="#,###"/>
+    </TimeCalcs>
+  </Cube>
 
 </Schema>

--- a/saiku-launcher/src/main/resources/seed/Bank.yaml
+++ b/saiku-launcher/src/main/resources/seed/Bank.yaml
@@ -1,0 +1,304 @@
+schema:
+  name: "Bank"
+  metamodel_version: "4.0"
+physical_schema:
+  tables:
+  - name: "mm_fact"
+    key:
+    - "account_id"
+  - name: "mm_owner"
+  - name: "mm_customer"
+  - name: "mm_branch"
+  - name: "mm_date"
+  - name: "mm_txn"
+  - name: "mm_calendar"
+  - name: "mm_monthly"
+shared_dimensions:
+  Customer:
+    table: "mm_customer"
+    key: "Customer"
+    attributes:
+    - name: "Segment"
+      key:
+      - "segment"
+    - name: "Customer"
+      key:
+      - "customer_id"
+      name_column: "customer_name"
+    hierarchies:
+    - name: "By Segment"
+      all_member_name: "All Customers"
+      levels:
+      - "Segment"
+      - "Customer"
+  Branch:
+    table: "mm_branch"
+    key: "Branch"
+    attributes:
+    - name: "Branch"
+      key:
+      - "branch_id"
+      name_column: "branch_name"
+  Date:
+    table: "mm_date"
+    key: "Date Id"
+    type: "TIME"
+    attributes:
+    - name: "Date Id"
+      key:
+      - "date_key"
+      has_hierarchy: false
+    - name: "Year"
+      key:
+      - "yr"
+      level_type: "TimeYears"
+      has_hierarchy: false
+    hierarchies:
+    - name: "Calendar"
+      all_member_name: "All Years"
+      levels:
+      - "Year"
+  Account:
+    table: "mm_fact"
+    key: "Account Id"
+    attributes:
+    - name: "Account Id"
+      key:
+      - "account_id"
+      has_hierarchy: false
+    - name: "Balance Tier"
+      tier:
+        column: "balance"
+        bins:
+        - boundary: "1000"
+          label: "Small"
+        - boundary: "3000"
+          label: "Medium"
+        - label: "Large"
+    - name: "Age Years"
+      duration:
+        start_column: "open_date"
+        end_column: "as_of_date"
+        unit: "YEAR"
+  Calendar:
+    table: "mm_calendar"
+    key: "Month"
+    type: "TIME"
+    attributes:
+    - name: "Year"
+      key:
+      - "yr"
+      level_type: "TimeYears"
+      has_hierarchy: false
+    - name: "Quarter"
+      key:
+      - "quarter"
+      level_type: "TimeQuarters"
+      has_hierarchy: false
+    - name: "Month"
+      key:
+      - "month_key"
+      name_column: "month_name"
+      order_by_column: "month_key"
+      level_type: "TimeMonths"
+      has_hierarchy: false
+    hierarchies:
+    - name: "Calendar"
+      all_member_name: "All Periods"
+      levels:
+      - "Year"
+      - "Quarter"
+      - "Month"
+cubes:
+  Joint Accounts (Full Count):
+    dimensions:
+    - source: "Customer"
+    - source: "Branch"
+    - source: "Date"
+    measure_groups:
+    - name: "Balances"
+      table: "mm_fact"
+      measures:
+      - name: "Balance"
+        column: "balance"
+        aggregator: "sum"
+        format_string: "#,###"
+      - name: "Fees"
+        column: "fees"
+        aggregator: "sum"
+        format_string: "#,###"
+      dimension_links:
+      - type: "foreign_key"
+        dimension: "Branch"
+        foreign_key_column: "branch_id"
+      - type: "foreign_key"
+        dimension: "Date"
+        foreign_key_column: "date_key"
+      - type: "bridge"
+        dimension: "Customer"
+        bridge_table: "mm_owner"
+        fact_foreign_key_column: "account_id"
+        bridge_fact_key_column: "account_id"
+        bridge_dimension_key_column: "customer_id"
+  Joint Accounts (Weighted):
+    dimensions:
+    - source: "Customer"
+    - source: "Branch"
+    - source: "Date"
+    measure_groups:
+    - name: "Balances"
+      table: "mm_fact"
+      measures:
+      - name: "Balance"
+        column: "balance"
+        aggregator: "sum"
+        format_string: "#,###"
+      - name: "Fees"
+        column: "fees"
+        aggregator: "sum"
+        format_string: "#,###"
+      dimension_links:
+      - type: "foreign_key"
+        dimension: "Branch"
+        foreign_key_column: "branch_id"
+      - type: "foreign_key"
+        dimension: "Date"
+        foreign_key_column: "date_key"
+      - type: "bridge"
+        dimension: "Customer"
+        bridge_table: "mm_owner"
+        fact_foreign_key_column: "account_id"
+        bridge_fact_key_column: "account_id"
+        bridge_dimension_key_column: "customer_id"
+        aggregation: "weighted"
+        weight_column: "weight"
+  Account Statistics:
+    dimensions:
+    - source: "Branch"
+    - source: "Date"
+    measure_groups:
+    - name: "Balances"
+      table: "mm_fact"
+      measures:
+      - name: "Total Balance"
+        column: "balance"
+        aggregator: "sum"
+        format_string: "#,###"
+      - name: "Median Balance"
+        column: "balance"
+        aggregator: "median"
+        format_string: "#,###"
+      - name: "P90 Balance"
+        column: "balance"
+        aggregator: "percentile"
+        percentile: "90"
+        format_string: "#,###"
+      dimension_links:
+      - type: "foreign_key"
+        dimension: "Branch"
+        foreign_key_column: "branch_id"
+      - type: "foreign_key"
+        dimension: "Date"
+        foreign_key_column: "date_key"
+  Accounts:
+    dimensions:
+    - source: "Account"
+    - source: "Branch"
+    measure_groups:
+    - name: "Balances"
+      table: "mm_fact"
+      measures:
+      - name: "Balance"
+        column: "balance"
+        aggregator: "sum"
+        format_string: "#,###"
+      dimension_links:
+      - type: "fact"
+        dimension: "Account"
+      - type: "foreign_key"
+        dimension: "Branch"
+        foreign_key_column: "branch_id"
+  Transactions:
+    measure_groups:
+    - name: "Txns"
+      table: "mm_txn"
+      measures:
+      - name: "Distinct Amount"
+        column: "amount"
+        aggregator: "sum"
+        distinct_key_column: "txn_id"
+        format_string: "#,###"
+      - name: "Naive Amount"
+        column: "amount"
+        aggregator: "sum"
+        format_string: "#,###"
+  Monthly Revenue:
+    dimensions:
+    - source: "Calendar"
+    measure_groups:
+    - name: "Revenue"
+      table: "mm_monthly"
+      measures:
+      - name: "Revenue"
+        column: "revenue"
+        aggregator: "sum"
+        format_string: "#,###"
+      dimension_links:
+      - type: "foreign_key"
+        dimension: "Calendar"
+        foreign_key_column: "month_key"
+    time_calcs:
+    - name: "Revenue YoY"
+      type: "yoy"
+      measure: "Revenue"
+      time_dimension: "Calendar"
+      format_string: "0.0%"
+    - name: "Revenue PoP"
+      type: "pop"
+      measure: "Revenue"
+      time_dimension: "Calendar"
+      format_string: "0.0%"
+    - name: "Revenue YTD"
+      type: "ytd"
+      measure: "Revenue"
+      time_dimension: "Calendar"
+      format_string: "#,###"
+    - name: "Revenue R3"
+      type: "rolling"
+      measure: "Revenue"
+      time_dimension: "Calendar"
+      window: 3
+      function: "avg"
+      format_string: "#,###"
+roles:
+- name: "Tenant"
+  schema_grant:
+    access: "all"
+    cubes:
+    - cube: "Accounts"
+      access: "all"
+      predicate_grants:
+      - measure_group: "Balances"
+        column: "tenant"
+        operator: "eq"
+        parameter: "tenant"
+- name: "Premium"
+  schema_grant:
+    access: "all"
+    cubes:
+    - cube: "Joint Accounts (Full Count)"
+      access: "all"
+      hierarchies:
+      - hierarchy: "[Customer].[By Segment]"
+        access: "custom"
+        bottom_level: "[Customer].[By Segment].[Customer]"
+        members:
+        - member: "[Customer].[By Segment].[Premium]"
+          access: "all"
+parameters:
+- name: "tenant"
+  type: "Numeric"
+  default_value: "1"
+  allowed_values:
+  - "1"
+  - "2"

--- a/saiku-launcher/src/main/resources/seed/bank.sql
+++ b/saiku-launcher/src/main/resources/seed/bank.sql
@@ -14,6 +14,8 @@ DROP TABLE IF EXISTS "mm_customer";
 DROP TABLE IF EXISTS "mm_branch";
 DROP TABLE IF EXISTS "mm_date";
 DROP TABLE IF EXISTS "mm_txn";
+DROP TABLE IF EXISTS "mm_calendar";
+DROP TABLE IF EXISTS "mm_monthly";
 
 CREATE TABLE "mm_fact" (
     "account_id" INTEGER,
@@ -93,6 +95,34 @@ INSERT INTO "mm_txn" ("txn_id","line_no","account_id","amount") VALUES
     (100, 1, 1, 100), (100, 2, 1, 100), (100, 3, 1, 100),
     (200, 1, 2,  50),
     (300, 1, 3, 300), (300, 2, 3, 300);
+
+-- Time-intelligence fixture (#112): a monthly calendar + revenue series.
+-- 3 months x 2 years. Golden values (summed Revenue):
+--   2024: Jan 100, Feb 200, Mar 300 ; 2025: Jan 150, Feb 250, Mar 350
+--   YoY  2025 Jan = (150-100)/100 = 0.5
+--   PoP  2024 Feb = (200-100)/100 = 1.0
+--   YTD  2024 Mar = 100+200+300 = 600
+--   Rolling-3 avg 2025 Mar = (150+250+350)/3 = 250
+CREATE TABLE "mm_calendar" (
+    "month_key"  INTEGER,
+    "month_name" VARCHAR(8),
+    "quarter"    VARCHAR(8),
+    "yr"         INTEGER
+);
+CREATE TABLE "mm_monthly" (
+    "month_key" INTEGER,
+    "revenue"   INTEGER
+);
+INSERT INTO "mm_calendar" ("month_key","month_name","quarter","yr") VALUES
+    (202401, 'Jan', '2024-Q1', 2024),
+    (202402, 'Feb', '2024-Q1', 2024),
+    (202403, 'Mar', '2024-Q1', 2024),
+    (202501, 'Jan', '2025-Q1', 2025),
+    (202502, 'Feb', '2025-Q1', 2025),
+    (202503, 'Mar', '2025-Q1', 2025);
+INSERT INTO "mm_monthly" ("month_key","revenue") VALUES
+    (202401, 100), (202402, 200), (202403, 300),
+    (202501, 150), (202502, 250), (202503, 350);
 
 -- Golden values (asserted in BankShowcaseH2EndToEndTest):
 --   Balance grand total ........................ 13000


### PR DESCRIPTION
mondrian-saiku 4.8.1.31 closes the time-intelligence + YAML round-trip showcase work. Pulls the full Bank demo through.

## What's new

- **Monthly Revenue cube** — typed Time dimension (Year > Quarter > Month) over the new \`mm_calendar\` table, with declarative \`<TimeCalc>\` measures (revenue, prior-month revenue, MoM growth). Demonstrates mondrian-saiku#112.
- **Bank.yaml** — the M4 YAML representation of Bank.xml produced by the converter. Same schema, three representations now ship in \`<home>/data/\`: \`Bank.xml\`, \`Bank.yaml\`, \`bank.lkml\`.
- **mm_calendar + mm_monthly** in bank.sql — typed time hierarchy + monthly fact fixture.

## Schema changes

| File | 4.8.1.30 | 4.8.1.31 |
|---|---|---|
| Bank.xml | 5 cubes, 253 lines | 6 cubes, 308 lines |
| bank.sql | 105 lines | 135 lines |
| Bank.yaml | — | 304 lines (new) |

## Other bits

- Launcher stages Bank.yaml on first boot.
- \`Database.loadBank()\` guard advanced to \`mm_monthly\` (the newest table) so demos upgrading from a pre-#1220 H2 file re-run the idempotent script.

## Test plan

- [x] saiku-launcher IT suite: 88/88 pass
- [ ] Demo: verify 10 cubes (FoodMart 6 + Bank 6), Monthly Revenue cube returns MoM growth values