### PR TITLE
fix(security): opt-in Content-Security-Policy (enforced + report-only) (HARDENING)

### DIFF
--- a/saiku-core/saiku-web/src/main/java/org/saiku/web/servlet/SecurityHeadersFilter.java
+++ b/saiku-core/saiku-web/src/main/java/org/saiku/web/servlet/SecurityHeadersFilter.java
@@ -65,18 +65,55 @@ public class SecurityHeadersFilter implements Filter {
             if (isSecure(request)) {
                 setIfAbsent(resp, "Strict-Transport-Security", "max-age=31536000; includeSubDomains");
             }
-            // Frame protection: OPT-IN so the cross-origin ?embed=1 feature keeps
-            // working by default. Configure saiku.security.frameAncestors to enable.
+            // Content-Security-Policy.
+            //  * A full enforced CSP is OPT-IN via saiku.security.csp — a strict
+            //    script-src on the SvelteKit + monaco (blob: workers) + ECharts SPA
+            //    must be validated in a browser first, so the default is unset and
+            //    nothing breaks out of the box. saiku.security.cspReportOnly emits a
+            //    Content-Security-Policy-Report-Only header so operators can observe
+            //    violations before enforcing. Recommended starting policy (tune per
+            //    deployment): default-src 'self'; script-src 'self'; style-src 'self'
+            //    'unsafe-inline'; img-src 'self' data: blob:; font-src 'self' data:;
+            //    worker-src 'self' blob:; connect-src 'self'; object-src 'none';
+            //    base-uri 'self'; frame-ancestors 'none'.
+            //  * When no full CSP is set, frame protection remains the opt-in
+            //    frame-ancestors directive (off by default so the cross-origin
+            //    ?embed=1 feature works).
+            String csp = prop("saiku.security.csp");
             String frameAncestors = frameAncestors();
-            if (frameAncestors != null) {
+            if (csp != null) {
+                setIfAbsent(resp, "Content-Security-Policy", csp);
+            } else if (frameAncestors != null) {
                 setIfAbsent(resp, "Content-Security-Policy", "frame-ancestors " + frameAncestors);
+            }
+            // X-Frame-Options (legacy browsers) still derives from frame-ancestors.
+            if (frameAncestors != null) {
                 String xfo = xFrameOptionsFor(frameAncestors);
                 if (xfo != null) {
                     setIfAbsent(resp, "X-Frame-Options", xfo);
                 }
             }
+            String cspReportOnly = prop("saiku.security.cspReportOnly");
+            if (cspReportOnly != null) {
+                setIfAbsent(resp, "Content-Security-Policy-Report-Only", cspReportOnly);
+            }
         }
         chain.doFilter(request, response);
+    }
+
+    /** Configured enforced full CSP, or {@code null} (default — unset so the SPA isn't broken). */
+    static String csp() {
+        return prop("saiku.security.csp");
+    }
+
+    /** Configured Content-Security-Policy-Report-Only value, or {@code null}. */
+    static String cspReportOnly() {
+        return prop("saiku.security.cspReportOnly");
+    }
+
+    private static String prop(String name) {
+        String v = System.getProperty(name);
+        return (v == null || v.isBlank()) ? null : v.trim();
     }
 
     /**
@@ -84,8 +121,7 @@ public class SecurityHeadersFilter implements Filter {
      * (the default — framing is left unrestricted so {@code ?embed=1} works).
      */
     static String frameAncestors() {
-        String v = System.getProperty("saiku.security.frameAncestors");
-        return (v == null || v.isBlank()) ? null : v.trim();
+        return prop("saiku.security.frameAncestors");
     }
 
     /**

--- a/saiku-core/saiku-web/src/test/java/org/saiku/web/servlet/SecurityHeadersFilterTest.java
+++ b/saiku-core/saiku-web/src/test/java/org/saiku/web/servlet/SecurityHeadersFilterTest.java
@@ -62,6 +62,40 @@ public class SecurityHeadersFilterTest {
         assertNull(SecurityHeadersFilter.xFrameOptionsFor("'self' https://wiki.example.com"));
     }
 
+    @Test
+    public void cspIsOffByDefaultAndReadsProperty() {
+        String prev = System.getProperty("saiku.security.csp");
+        try {
+            System.clearProperty("saiku.security.csp");
+            assertNull("no enforced CSP by default — SPA must not be broken", SecurityHeadersFilter.csp());
+            System.setProperty("saiku.security.csp", "  default-src 'self'  ");
+            assertEquals("default-src 'self'", SecurityHeadersFilter.csp());
+        } finally {
+            if (prev == null) {
+                System.clearProperty("saiku.security.csp");
+            } else {
+                System.setProperty("saiku.security.csp", prev);
+            }
+        }
+    }
+
+    @Test
+    public void cspReportOnlyIsOffByDefaultAndReadsProperty() {
+        String prev = System.getProperty("saiku.security.cspReportOnly");
+        try {
+            System.clearProperty("saiku.security.cspReportOnly");
+            assertNull(SecurityHeadersFilter.cspReportOnly());
+            System.setProperty("saiku.security.cspReportOnly", "default-src 'self'");
+            assertEquals("default-src 'self'", SecurityHeadersFilter.cspReportOnly());
+        } finally {
+            if (prev == null) {
+                System.clearProperty("saiku.security.cspReportOnly");
+            } else {
+                System.setProperty("saiku.security.cspReportOnly", prev);
+            }
+        }
+    }
+
     private static void restore(String prev) {
         if (prev == null) {
             System.clearProperty(PROP);


### PR DESCRIPTION
Closes the last open item from the round-3 audit (refs #1165).

## What
The `SecurityHeadersFilter` emitted no application `Content-Security-Policy` (only the opt-in `frame-ancestors`), so there was no CSP defense-in-depth against reflected/stored XSS in the SPA or server-rendered surfaces.

## Why opt-in (not enforced-by-default)
The SPA uses **monaco** (blob: web workers — `configureMonacoWorkers`), **ECharts**, and SvelteKit hydration; a strict `script-src`/`worker-src` must be validated in a real browser or it breaks the UI. Shipping an enforced default would risk breaking the app, so this adds the **mechanism + a reasoned baseline** and leaves it **default-unset** (mirrors how `frameAncestors` is opt-in to preserve `?embed=1`).

## Fix
`SecurityHeadersFilter` now supports two new properties:
- **`saiku.security.csp`** — when set, emitted verbatim as `Content-Security-Policy` (a full policy supersedes the frame-ancestors-only header; the operator includes `frame-ancestors` in it).
- **`saiku.security.cspReportOnly`** — emitted as `Content-Security-Policy-Report-Only` so operators can **observe violations before enforcing** (safe rollout).

Both default unset → no behavior change out of the box. The always-on headers and the existing `frame-ancestors`/`X-Frame-Options` logic are unchanged.

### Recommended starting policy (documented in the filter javadoc; tune per deployment)
```
default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline';
img-src 'self' data: blob:; font-src 'self' data:; worker-src 'self' blob:;
connect-src 'self'; object-src 'none'; base-uri 'self'; frame-ancestors 'none'
```
(`style-src 'unsafe-inline'` for Svelte inline styles; `worker-src blob:` for monaco; add `'unsafe-eval'` to `script-src` only if a monaco feature requires it — verify via the report-only mode first.)

## Tests
`SecurityHeadersFilterTest` — `csp()` / `cspReportOnly()` default-off + property read. Green; spotless clean.

Security lane (Agent SEC). **Not self-merging.** 🤖 Generated with [Claude Code](https://claude.com/claude-code)
