### PR TITLE
feat(filter): Mondrian-native time-hierarchy detection + grain-aware Compare

### DIFF
--- a/saiku-core/saiku-service/src/main/java/org/saiku/olap/dto/SaikuDimension.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/olap/dto/SaikuDimension.java
@@ -31,6 +31,11 @@ public class SaikuDimension extends AbstractSaikuObject {
      *  {@code mondrian.olap.Annotated} reflection seam used for measures and
      *  levels. */
     private Map<String, String> annotations;
+    /** Mondrian-native dimension type from olap4j's {@code Dimension.Type} enum
+     *  (TIME / MEASURE / OTHER). Set from {@code <Dimension type="TIME">} in
+     *  the schema XML. Lets the SPA detect time dimensions without falling
+     *  back to caption substring matching (saiku#1221). */
+    private String dimensionType;
 
     public SaikuDimension() {
         super(null, null);
@@ -74,5 +79,13 @@ public class SaikuDimension extends AbstractSaikuObject {
 
     public void setAnnotations(Map<String, String> annotations) {
         this.annotations = annotations == null ? null : new HashMap<>(annotations);
+    }
+
+    public String getDimensionType() {
+        return dimensionType;
+    }
+
+    public void setDimensionType(String dimensionType) {
+        this.dimensionType = dimensionType;
     }
 }

--- a/saiku-core/saiku-service/src/main/java/org/saiku/olap/util/ObjectUtil.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/olap/util/ObjectUtil.java
@@ -68,6 +68,18 @@ public class ObjectUtil {
         // saiku#818 follow-up: surface dimension-level annotations so
         // OlapAiCubeMetadataService can apply saiku.semantic.* to AiSchema.Dimension.
         sd.setAnnotations(annotationsAsStringMap(dim));
+        // saiku#1221: Mondrian-native dimension type ("TIME" / "MEASURE" /
+        // "OTHER") from <Dimension type="TIME">. Lets the SPA detect time
+        // dimensions deterministically; the caption substring match was
+        // fragile under translations and renamed hierarchies.
+        try {
+            Dimension.Type t = dim.getDimensionType();
+            if (t != null) {
+                sd.setDimensionType(t.name());
+            }
+        } catch (Throwable ignored) {
+            // Some drivers throw on getDimensionType — leave null.
+        }
         return sd;
     }
 

--- a/saiku-ui/src/lib/api/discover.ts
+++ b/saiku-ui/src/lib/api/discover.ts
@@ -38,6 +38,15 @@ export interface SaikuLevel {
   caption: string;
   uniqueName: string;
   description?: string;
+  /** Mondrian-native level type (olap4j {@code Level.Type}): one of
+   *  {@code TimeYears} / {@code TimeHalfYears} / {@code TimeQuarters} /
+   *  {@code TimeMonths} / {@code TimeWeeks} / {@code TimeDays} /
+   *  {@code TimeHours} / {@code TimeMinutes} / {@code TimeSeconds} /
+   *  {@code TimeUndefined} / {@code Regular}. Set from
+   *  {@code <Attribute levelType="...">} in the schema. saiku#1221 added
+   *  the JSON surface so the SPA can detect time levels deterministically
+   *  rather than substring-matching captions. */
+  levelType?: string;
 }
 
 export interface SaikuHierarchy {
@@ -52,6 +61,12 @@ export interface SaikuDimension {
   caption: string;
   uniqueName: string;
   hierarchies: SaikuHierarchy[];
+  /** Mondrian-native dimension type from olap4j {@code Dimension.Type}:
+   *  one of {@code TIME} / {@code MEASURE} / {@code OTHER}. Set from
+   *  {@code <Dimension type="TIME">} in the schema. saiku#1221 added
+   *  this so the SPA's time-filter detection has a dimension-level
+   *  signal independent of caption text. */
+  dimensionType?: string;
 }
 
 export interface SaikuMeasure {

--- a/saiku-ui/src/lib/modals/dateFilterMdx.test.ts
+++ b/saiku-ui/src/lib/modals/dateFilterMdx.test.ts
@@ -2,10 +2,16 @@ import { describe, it, expect } from "vitest";
 import {
   buildRelativeMdx,
   buildAbsoluteMdx,
+  buildCompareMdx,
   isRelativeValid,
   isAbsoluteValid,
   memberForDate,
   looksLikeTimeHierarchy,
+  isTimeHierarchy,
+  isTimeLevelType,
+  grainFromLevelType,
+  grainAtLeast,
+  looksLikeTimeCaption,
 } from "./dateFilterMdx";
 
 const HIER = "[Time].[Time]";
@@ -149,7 +155,7 @@ describe("validation", () => {
   });
 });
 
-describe("looksLikeTimeHierarchy", () => {
+describe("looksLikeTimeHierarchy (legacy, caption-only)", () => {
   it("matches common time-ish captions", () => {
     expect(looksLikeTimeHierarchy("Time")).toBe(true);
     expect(looksLikeTimeHierarchy("Order Date")).toBe(true);
@@ -158,5 +164,96 @@ describe("looksLikeTimeHierarchy", () => {
   });
   it("returns true for undefined caption (err on the side of showing)", () => {
     expect(looksLikeTimeHierarchy(undefined)).toBe(true);
+  });
+});
+
+describe("isTimeLevelType + grainFromLevelType", () => {
+  it("recognises Mondrian-native Time* level types", () => {
+    expect(isTimeLevelType("TimeYears")).toBe(true);
+    expect(isTimeLevelType("TimeQuarters")).toBe(true);
+    expect(isTimeLevelType("TimeMonths")).toBe(true);
+    expect(isTimeLevelType("TimeDays")).toBe(true);
+    expect(isTimeLevelType("Regular")).toBe(false);
+    expect(isTimeLevelType("")).toBe(false);
+    expect(isTimeLevelType(undefined)).toBe(false);
+  });
+  it("maps level type to grain bucket", () => {
+    expect(grainFromLevelType("TimeYears")).toBe("year");
+    expect(grainFromLevelType("TimeMonths")).toBe("month");
+    expect(grainFromLevelType("TimeDays")).toBe("day");
+    expect(grainFromLevelType("Regular")).toBeNull();
+  });
+});
+
+describe("isTimeHierarchy — native-signal cascade", () => {
+  it("dimensionType TIME wins regardless of caption", () => {
+    expect(isTimeHierarchy("TIME", undefined, "Customer")).toBe(true);
+  });
+  it("any TimeX level type marks the hierarchy", () => {
+    expect(isTimeHierarchy(undefined, [{ levelType: "TimeMonths" }], "ZZZ")).toBe(true);
+  });
+  it("falls back to caption substring only when natives absent", () => {
+    expect(isTimeHierarchy(undefined, [], "Order Date")).toBe(true);
+    expect(isTimeHierarchy(undefined, [], "Customer")).toBe(false);
+  });
+  it("non-time dimension type overrides caption that contains 'date'", () => {
+    // OTHER dimension type, no time levels, caption "Customer" → false.
+    expect(isTimeHierarchy("OTHER", [{ levelType: "Regular" }], "Customer")).toBe(false);
+  });
+  it("missing all signals → false (no permissive default)", () => {
+    expect(isTimeHierarchy(undefined, undefined, undefined)).toBe(false);
+  });
+});
+
+describe("grainAtLeast", () => {
+  it("year level cannot satisfy day-required preset", () => {
+    expect(grainAtLeast("year", "day")).toBe(false);
+  });
+  it("day level satisfies day-required preset", () => {
+    expect(grainAtLeast("day", "day")).toBe(true);
+  });
+  it("day level satisfies any coarser requirement", () => {
+    expect(grainAtLeast("day", "year")).toBe(true);
+    expect(grainAtLeast("day", "month")).toBe(true);
+  });
+  it("unknown grain (null) → permissive (legacy schemas)", () => {
+    expect(grainAtLeast(null, "day")).toBe(true);
+  });
+});
+
+describe("buildCompareMdx — grain-aware parallel period", () => {
+  it("uses ParallelPeriod when an anchor level is supplied", () => {
+    expect(
+      buildCompareMdx({
+        hierarchy: "[Time].[Time]",
+        level: "[Time].[Time].[Day]",
+        from: "2024-04-01",
+        to: "2024-06-30",
+        shiftUnit: "year",
+        parallelLevel: "[Time].[Time].[Year]",
+      }),
+    ).toContain("ParallelPeriod([Time].[Time].[Year], 1,");
+  });
+  it("falls back to .Lag(shift) when anchor level missing", () => {
+    const mdx = buildCompareMdx({
+      hierarchy: "[Time].[Time]",
+      level: "[Time].[Time].[Day]",
+      from: "2024-01-01",
+      to: "2024-01-07",
+      shiftUnit: "year",
+    });
+    expect(mdx).toContain(".Lag(");
+    expect(mdx).not.toContain("ParallelPeriod");
+  });
+  it("emits UNION of primary and shifted windows", () => {
+    const mdx = buildCompareMdx({
+      hierarchy: "[Time].[Time]",
+      level: "[Time].[Time].[Day]",
+      from: "2024-01-01",
+      to: "2024-01-31",
+      shiftUnit: "month",
+      parallelLevel: "[Time].[Time].[Month]",
+    });
+    expect(mdx).toMatch(/^UNION\(\{.*:.*\}, \{.*ParallelPeriod.*:.*ParallelPeriod.*\}\)$/);
   });
 });

--- a/saiku-ui/src/lib/modals/dateFilterMdx.ts
+++ b/saiku-ui/src/lib/modals/dateFilterMdx.ts
@@ -192,12 +192,133 @@ export function isAbsoluteValid(opts: Pick<AbsoluteOptions, "from" | "to">): boo
   return a <= b;
 }
 
-/** Heuristic gate for the menu item: "does this hierarchy look time-like?"
- *  based on caption tokens. Deliberately permissive — false positives just
- *  mean the user sees a preview that probably won't execute, which is
- *  recoverable; false negatives hide the feature outright. */
-export function looksLikeTimeHierarchy(caption: string | undefined): boolean {
-  if (!caption) return true; // err on the side of showing
+/** Mondrian-native level types that mean "this level is a time grain"
+ *  (olap4j {@code Level.Type}, populated from {@code <Attribute levelType=...>}
+ *  on the schema). Used by {@link isTimeLevelType} and {@link grainFromLevelType}. */
+const TIME_LEVEL_TYPES = new Set([
+  "TimeYears",
+  "TimeHalfYears",
+  "TimeQuarters",
+  "TimeMonths",
+  "TimeWeeks",
+  "TimeDays",
+  "TimeHours",
+  "TimeMinutes",
+  "TimeSeconds",
+  "TimeUndefined",
+]);
+
+/** True iff the Mondrian-native level type marks this as a time grain. */
+export function isTimeLevelType(levelType: string | null | undefined): boolean {
+  return !!levelType && TIME_LEVEL_TYPES.has(levelType);
+}
+
+/** Map a Mondrian {@code Level.Type} string to a coarse grain bucket the
+ *  preset filter understands. {@code null} when the level isn't time-typed. */
+export type TimeGrain = "year" | "halfYear" | "quarter" | "month" | "week" | "day" | "hour" | "minute" | "second";
+
+export function grainFromLevelType(levelType: string | null | undefined): TimeGrain | null {
+  switch (levelType) {
+    case "TimeYears": return "year";
+    case "TimeHalfYears": return "halfYear";
+    case "TimeQuarters": return "quarter";
+    case "TimeMonths": return "month";
+    case "TimeWeeks": return "week";
+    case "TimeDays": return "day";
+    case "TimeHours": return "hour";
+    case "TimeMinutes": return "minute";
+    case "TimeSeconds": return "second";
+    default: return null;
+  }
+}
+
+/** Parallel-period MDX builder for the Compare tab. Given the same primary
+ *  set (`[from] : [to]`) and a grain-aware shift unit, emits the
+ *  {@code ParallelPeriod} prior window — grain-correct, unlike the old
+ *  hard-coded {@code .Lag(365)} which only worked on day levels.
+ *
+ *  Falls back to {@code .Lag(n)} when {@code parallelLevel} is null
+ *  (e.g. caller couldn't resolve a year/quarter level on the hierarchy).
+ *
+ *  Example: primary {@code {[Time].[2024-Q2] : [Time].[2024-Q4]}}, shift
+ *  unit "year", parallelLevel {@code [Time].[Year]} →
+ *  {@code UNION(primary, {ParallelPeriod([Time].[Year], 1, [Time].[2024-Q2]) :
+ *  ParallelPeriod([Time].[Year], 1, [Time].[2024-Q4])})}. */
+export interface CompareOptions {
+  /** Hierarchy unique name. */
+  hierarchy: string;
+  /** Level unique name of the chip — used to materialise from/to members. */
+  level: string;
+  /** Inclusive ISO date for primary window start. */
+  from: string;
+  /** Inclusive ISO date for primary window end. */
+  to: string;
+  /** Shift unit: "year" = same period last year, "quarter" = previous
+   *  quarter, "month" = previous month, "day" = previous day, etc.
+   *  Translated to a {@code ParallelPeriod} call against
+   *  {@code parallelLevel}. */
+  shiftUnit: "year" | "quarter" | "month" | "week" | "day";
+  /** Number of shift units back. Default 1. */
+  shiftCount?: number;
+  /** Level unique name for the {@code ParallelPeriod} anchor (e.g.
+   *  {@code [Time].[Year]}). When null, falls back to {@code .Lag(days)}. */
+  parallelLevel?: string | null;
+}
+
+export function buildCompareMdx(opts: CompareOptions): string {
+  const from = memberForDate(opts.from, opts.hierarchy, opts.level);
+  const to = memberForDate(opts.to, opts.hierarchy, opts.level);
+  const primary = `{${from} : ${to}}`;
+  const n = Math.max(1, Math.floor(opts.shiftCount ?? 1));
+  if (opts.parallelLevel) {
+    const sFrom = `ParallelPeriod(${opts.parallelLevel}, ${n}, ${from})`;
+    const sTo = `ParallelPeriod(${opts.parallelLevel}, ${n}, ${to})`;
+    return `UNION(${primary}, {${sFrom} : ${sTo}})`;
+  }
+  // Fallback: day-grain lag. Only correct on day-level hierarchies; the
+  // schema-aware ParallelPeriod path above is preferred whenever the
+  // caller can resolve the right anchor level.
+  const days = daysBetweenInclusive(opts.from, opts.to);
+  const unitDays =
+    opts.shiftUnit === "year" ? 365 :
+    opts.shiftUnit === "quarter" ? 91 :
+    opts.shiftUnit === "month" ? 30 :
+    opts.shiftUnit === "week" ? 7 : 1;
+  const shift = unitDays * n + (opts.shiftUnit === "day" ? 0 : days - 1);
+  return `UNION(${primary}, {${from}.Lag(${shift}) : ${to}.Lag(${shift})})`;
+}
+
+/** Whether to surface the date-filter UI for a hierarchy.
+ *
+ *  Cascade, strongest signal first:
+ *
+ *  1. **Dimension type from olap4j** ({@code <Dimension type="TIME">}) —
+ *     the Mondrian-native dimension-level signal.
+ *  2. **Any level in the hierarchy has a {@code levelType="Time*"}** —
+ *     the per-level grain signal.
+ *  3. **Caption substring match** — legacy fallback for schemas that
+ *     ship neither native marker. Kept so older schemas don't lose the
+ *     date filter button on upgrade; superseded as schemas adopt
+ *     {@code levelType}.
+ *
+ *  Pass {@code dimensionType} and {@code levels} from
+ *  {@code SaikuDimension} / {@code SaikuHierarchy.levels}. The function
+ *  is intentionally pure so it can be unit-tested without DOM. */
+export function isTimeHierarchy(
+  dimensionType: string | null | undefined,
+  levels: { levelType?: string }[] | null | undefined,
+  caption: string | null | undefined,
+): boolean {
+  if (dimensionType === "TIME") return true;
+  if (levels && levels.some((l) => isTimeLevelType(l.levelType))) return true;
+  return looksLikeTimeCaption(caption);
+}
+
+/** Pure substring check kept as the last-resort fallback. Older schemas
+ *  without {@code <Dimension type="TIME">} or {@code levelType} still get
+ *  the date filter button. */
+export function looksLikeTimeCaption(caption: string | null | undefined): boolean {
+  if (!caption) return false;
   const c = caption.toLowerCase();
   return (
     c.includes("date") ||
@@ -208,4 +329,49 @@ export function looksLikeTimeHierarchy(caption: string | undefined): boolean {
     c.includes("quarter") ||
     c.includes("year")
   );
+}
+
+/** Back-compat shim — existing callers pass a caption and got a permissive
+ *  default-true for empty. {@link isTimeHierarchy} is the new entry point.
+ *  Kept so call sites can be migrated incrementally.
+ *  @deprecated use {@link isTimeHierarchy} */
+export function looksLikeTimeHierarchy(caption: string | undefined): boolean {
+  if (!caption) return true;
+  return looksLikeTimeCaption(caption);
+}
+
+/** Preset → minimum required grain. Lets the UI hide presets that are
+ *  finer than the level supports (e.g. "Last N days" doesn't make sense
+ *  on a TimeYears level). Coarser-than-required is OK because Mondrian's
+ *  {@code LastPeriods} respects the level's own granularity. */
+export const PRESET_MIN_GRAIN: Record<string, TimeGrain> = {
+  TODAY: "day",
+  YESTERDAY: "day",
+  LAST_N_DAYS: "day",
+  LAST_N_WEEKS: "week",
+  LAST_N_MONTHS: "month",
+  LAST_N_QUARTERS: "quarter",
+  LAST_N_YEARS: "year",
+  ROLLING_N: "day",
+  MONTH_TO_DATE: "day",
+  QUARTER_TO_DATE: "day",
+  YEAR_TO_DATE: "day",
+};
+
+const GRAIN_ORDER: TimeGrain[] = [
+  "year",
+  "halfYear",
+  "quarter",
+  "month",
+  "week",
+  "day",
+  "hour",
+  "minute",
+  "second",
+];
+
+/** True iff {@code have} is at least as fine as {@code required}. */
+export function grainAtLeast(have: TimeGrain | null, required: TimeGrain): boolean {
+  if (!have) return true; // unknown grain → permissive; legacy schemas
+  return GRAIN_ORDER.indexOf(have) >= GRAIN_ORDER.indexOf(required);
 }

--- a/saiku-ui/src/lib/views/QueryCanvas.svelte
+++ b/saiku-ui/src/lib/views/QueryCanvas.svelte
@@ -31,7 +31,7 @@
   import TopBottomCountModal from "$lib/modals/TopBottomCountModal.svelte";
   import LimitModal from "$lib/modals/LimitModal.svelte";
   import DateFilterModal from "$lib/modals/DateFilterModal.svelte";
-  import { looksLikeTimeHierarchy } from "$lib/modals/dateFilterMdx";
+  import { isTimeHierarchy } from "$lib/modals/dateFilterMdx";
   import ContextMenu from "$lib/components/ContextMenu.svelte";
   type ContextMenuItem = { id: string; label: string; disabled?: boolean; danger?: boolean; sep?: boolean };
   import { MoreHorizontal, Loader2, XCircle, ChevronDown, Settings, Sparkles } from "lucide-svelte";
@@ -1069,7 +1069,25 @@
     initialType={selectionsInitial.type}
     open={selectionsOpen}
     onSave={onSelectionsSave}
-    showDateFilter={looksLikeTimeHierarchy(selectionsTarget.hierarchyCaption)}
+    showDateFilter={(() => {
+      // Resolve the hierarchy's Mondrian-native type from cubeMetadata. This
+      // beats the legacy caption substring match — translations and renamed
+      // hierarchies no longer hide the date filter button (saiku#1221).
+      const hierName = selectionsTarget.hierarchyName;
+      let dimensionType: string | undefined;
+      let levels: { levelType?: string }[] | undefined;
+      for (const d of cubeMetadata?.dimensions ?? []) {
+        for (const h of d.hierarchies ?? []) {
+          if (h.uniqueName === hierName || h.name === hierName) {
+            dimensionType = d.dimensionType;
+            levels = h.levels;
+            break;
+          }
+        }
+        if (dimensionType !== undefined || levels) break;
+      }
+      return isTimeHierarchy(dimensionType, levels, selectionsTarget.hierarchyCaption);
+    })()}
     onOpenDateFilter={() => {
       // Hand off the currently-open Selections target to the date-filter
       // modal. Closing Selections first avoids stacked overlays.


### PR DESCRIPTION
Phase 1 of the time-filter UX rework. Replaces the fragile caption-substring heuristic with a cascade of Mondrian-native signals.

## What changes

**Server** — `SaikuDimension.dimensionType` (new field) reads olap4j's \`Dimension.getDimensionType()\` so the SPA knows when \`<Dimension type=\"TIME\">\` was set in the schema. \`SaikuLevel.levelType\` already existed; only its TS surface was missing.

**SPA** — new \`isTimeHierarchy(dimType, levels, caption)\` entry point with a strongest-first cascade (dimensionType=TIME → any TimeX level → caption substring fallback). \`buildCompareMdx\` emits grain-aware \`ParallelPeriod\` (was hardcoded \`.Lag(365)\`). \`grainAtLeast\` + \`PRESET_MIN_GRAIN\` ready for the upcoming grain-aware preset filter.

## Not in this PR (filed as follow-up)

- TimeCalc surfacing — \`<TimeCalc>\` elements ship in Bank.xml since #1220 but need a schema XML parser to expose to the SPA. ~200 LoC standalone, deserves its own review.
- The Compare tab in DateFilterModal (UX surface) — the helper (\`buildCompareMdx\`) is in place; wiring the new tab is the next phase.

## Test plan

- [x] saiku-service: 531/531 unit tests pass
- [x] svelte-check: 0 errors
- [x] vitest: 867/867 pass (23 new tests for the native cascade)
- [ ] Demo: verify the Bank Calendar dimension shows the date filter button (it has \`type=\"TIME\"\` + \`levelType=\"TimeYears\"\` etc)