### PR TITLE
fix(quality): close leaked streams/ResultSets/CellSets — try-with-resources sweep (#1191)

### DIFF
--- a/saiku-core/saiku-olap-util/src/main/java/mondrian/olap4j/SaikuMondrianHelper.java
+++ b/saiku-core/saiku-olap-util/src/main/java/mondrian/olap4j/SaikuMondrianHelper.java
@@ -170,39 +170,34 @@ public class SaikuMondrianHelper {
     }
 
     public static List<org.olap4j.metadata.Member> getMDXMemberLookup(OlapConnection con, String cube, Level level) {
-        OlapStatement statement = null;
-        try {
-            statement = con.createStatement();
-        } catch (OlapException e) {
-            e.printStackTrace();
+        String l;
+        RolapCubeDimension o = (RolapCubeDimension) ((MondrianOlap4jDimension) level.getDimension()).getOlapElement();
+        if (isHanger(o)) {
+            l = level.getHierarchy().getUniqueName();
+        } else {
+            l = level.getUniqueName();
         }
-        try {
-            String l = null;
-            RolapCubeDimension o =
-                    (RolapCubeDimension) ((MondrianOlap4jDimension) level.getDimension()).getOlapElement();
-            if (isHanger(o)) {
-                l = level.getHierarchy().getUniqueName();
-            } else {
-                l = level.getUniqueName();
-            }
-            CellSet cellSet = statement.executeOlapQuery("with member [Measures].[Zero] as 0\n"
-                    + " select AddCalculatedMembers(" + l
-                    + ".Members) on 0\n"
-                    + " from [" + cube + "]\n"
-                    + " where [Measures].[Zero]");
-
+        // try-with-resources so the OlapStatement and CellSet are always closed — the method
+        // materialises the members into a List, so the cell set can be released here. This also
+        // removes the prior NPE risk where a failed createStatement() left statement == null
+        // and the next block dereferenced it (saiku#1191).
+        try (OlapStatement statement = con.createStatement();
+                CellSet cellSet = statement.executeOlapQuery("with member [Measures].[Zero] as 0\n"
+                        + " select AddCalculatedMembers(" + l
+                        + ".Members) on 0\n"
+                        + " from [" + cube + "]\n"
+                        + " where [Measures].[Zero]")) {
             List<org.olap4j.metadata.Member> members = new ArrayList<org.olap4j.metadata.Member>();
             List<CellSetAxis> cellSetAxes = cellSet.getAxes();
             CellSetAxis columnsAxis = cellSetAxes.get(0);
-            // Print headings.
-            System.out.print("\t");
-            // CellSetAxis columnsAxis = cellSetAxes.get(Axis.COLUMNS.ordinal());
             for (Position position : columnsAxis.getPositions()) {
                 org.olap4j.metadata.Member m = position.getMembers().get(0);
                 members.add(m);
             }
             return members;
-        } catch (OlapException e) {
+        } catch (java.sql.SQLException e) {
+            // OlapException (from executeOlapQuery) and the implicit close() of the
+            // OlapStatement/CellSet both surface as SQLException — OlapException extends it.
             e.printStackTrace();
         }
         return null;

--- a/saiku-core/saiku-service/src/main/java/org/saiku/olap/discover/OlapMetaExplorer.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/olap/discover/OlapMetaExplorer.java
@@ -15,8 +15,10 @@
  */
 package org.saiku.olap.discover;
 
+import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.sql.Statement;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -336,10 +338,21 @@ public class OlapMetaExplorer {
                 if (isMondrian(nativeCube)) {
                     if (SaikuMondrianHelper.hasAnnotation(l, MondrianDictionary.SQLMemberLookup)) {
                         if (search) {
+                            // getSQLMemberLookup returns a live ResultSet backed by its own JDBC
+                            // Connection + Statement (opened from the Mondrian RolapConnection's
+                            // DataSource). The helper can't close them without losing the ResultSet,
+                            // and this caller previously dropped all three — a JDBC connection leak on
+                            // every SQL member search. Materialise, then close the ResultSet and its
+                            // owning Statement + Connection (saiku#1191).
                             ResultSet rs = SaikuMondrianHelper.getSQLMemberLookup(
                                     con, MondrianDictionary.SQLMemberLookup, l, searchString);
-                            simpleMembers = ObjectUtil.convert2simple(rs);
-                            log.debug("Found " + simpleMembers.size() + " members using SQL lookup for level " + level);
+                            try {
+                                simpleMembers = ObjectUtil.convert2simple(rs);
+                                log.debug("Found " + simpleMembers.size() + " members using SQL lookup for level "
+                                        + level);
+                            } finally {
+                                closeResultSetWithOwner(rs);
+                            }
                             return simpleMembers;
                         } else {
                             return new ArrayList<>();
@@ -394,6 +407,47 @@ public class OlapMetaExplorer {
         }
 
         return new ArrayList<>();
+    }
+
+    /**
+     * Close a ResultSet returned by {@link SaikuMondrianHelper#getSQLMemberLookup} together with the
+     * JDBC Statement and Connection that own it. The lookup helper opens a fresh connection from the
+     * Mondrian DataSource and hands back only the ResultSet, so closing the ResultSet alone would
+     * leak the Statement and (pooled) Connection. Best-effort and null-safe (saiku#1191).
+     */
+    private static void closeResultSetWithOwner(ResultSet rs) {
+        if (rs == null) {
+            return;
+        }
+        Statement st = null;
+        Connection cn = null;
+        try {
+            st = rs.getStatement();
+            if (st != null) {
+                cn = st.getConnection();
+            }
+        } catch (SQLException ignored) {
+            // best-effort recovery of the owning Statement/Connection
+        }
+        try {
+            rs.close();
+        } catch (SQLException ignored) {
+            // ignore
+        }
+        if (st != null) {
+            try {
+                st.close();
+            } catch (SQLException ignored) {
+                // ignore
+            }
+        }
+        if (cn != null) {
+            try {
+                cn.close();
+            } catch (SQLException ignored) {
+                // ignore
+            }
+        }
     }
 
     public List<SaikuMember> getMemberChildren(SaikuCube cube, String uniqueMemberName) throws SaikuOlapException {

--- a/saiku-core/saiku-service/src/main/java/org/saiku/olap/util/SaikuProperties.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/olap/util/SaikuProperties.java
@@ -190,8 +190,9 @@ public class SaikuProperties extends Properties {
     }
 
     private void load(final PropertySource source) {
-        try {
-            instance.load(source.openStream());
+        // try-with-resources so the property source's stream is always closed (saiku#1191).
+        try (InputStream in = source.openStream()) {
+            instance.load(in);
             if (populateCount == 0) {
                 log.info("Saiku: properties loaded from '" + source.getDescription() + "'");
                 instance.list(System.out);

--- a/saiku-core/saiku-service/src/main/java/org/saiku/repository/FilesystemRepositoryManager.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/repository/FilesystemRepositoryManager.java
@@ -502,8 +502,8 @@ public class FilesystemRepositoryManager implements IRepositoryManager {
         List<MondrianSchema> schema = new ArrayList<>();
 
         for (File file : files) {
-            try {
-                Scanner scanner = new Scanner(file);
+            // try-with-resources so each Scanner (and its file handle) is closed (saiku#1191).
+            try (Scanner scanner = new Scanner(file)) {
 
                 while (scanner.hasNextLine()) {
                     String line = scanner.nextLine();

--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/datasource/RepositoryDatasourceManager.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/datasource/RepositoryDatasourceManager.java
@@ -166,9 +166,8 @@ public class RepositoryDatasourceManager implements IDatasourceManager, Applicat
             // in the bean-graph init (saiku-cloud tenant scoping uses it).
             return p;
         }
-        InputStream input;
-        try {
-            input = new FileInputStream(externalparameters);
+        // try-with-resources so the external-params file handle is always closed (saiku#1191).
+        try (InputStream input = new FileInputStream(externalparameters)) {
             p.load(input);
         } catch (IOException e) {
             log.debug("file did not exist");
@@ -178,10 +177,9 @@ public class RepositoryDatasourceManager implements IDatasourceManager, Applicat
 
     public String[] getAvailablePropertiesKeys() {
         Properties p = new Properties();
-        InputStream input;
 
-        try {
-            input = new FileInputStream(externalparameters);
+        // try-with-resources so the external-params file handle is always closed (saiku#1191).
+        try (InputStream input = new FileInputStream(externalparameters)) {
             p.load(input);
         } catch (IOException e) {
             log.debug("file did not exist");

--- a/saiku-core/saiku-web/src/main/java/org/saiku/web/export/JSConverter.java
+++ b/saiku-core/saiku-web/src/main/java/org/saiku/web/export/JSConverter.java
@@ -60,13 +60,20 @@ public class JSConverter {
     }
 
     private static void loadJavascriptScripts(Context javascriptContext, Scriptable globalScope) throws IOException {
-        // fetch the .js files and put them on scope of the javascriptContext to be executed
-        Reader underscoreReader = new InputStreamReader(JSConverter.class.getResourceAsStream("underscore.js"));
-        javascriptContext.evaluateReader(globalScope, underscoreReader, "underscore.js", 1, null);
-        Reader saikuRendererReader = new InputStreamReader(JSConverter.class.getResourceAsStream("SaikuRenderer.js"));
-        javascriptContext.evaluateReader(globalScope, saikuRendererReader, "SaikuRenderer.js", 1, null);
-        String result = IOUtils.toString(JSConverter.class.getResourceAsStream("SaikuTableRenderer.js"));
-        javascriptContext.evaluateString(globalScope, result, "SaikuTableRenderer.js", 1, null);
+        // fetch the .js files and put them on scope of the javascriptContext to be executed.
+        // Each resource stream is closed via try-with-resources so a failed/partial export
+        // can't leak the underlying classpath InputStreams (saiku#1191).
+        try (Reader underscoreReader = new InputStreamReader(JSConverter.class.getResourceAsStream("underscore.js"))) {
+            javascriptContext.evaluateReader(globalScope, underscoreReader, "underscore.js", 1, null);
+        }
+        try (Reader saikuRendererReader =
+                new InputStreamReader(JSConverter.class.getResourceAsStream("SaikuRenderer.js"))) {
+            javascriptContext.evaluateReader(globalScope, saikuRendererReader, "SaikuRenderer.js", 1, null);
+        }
+        try (InputStream tableRendererStream = JSConverter.class.getResourceAsStream("SaikuTableRenderer.js")) {
+            String result = IOUtils.toString(tableRendererStream);
+            javascriptContext.evaluateString(globalScope, result, "SaikuTableRenderer.js", 1, null);
+        }
     }
 
     private static String appendSaikuCommercialIfNecessary(String content) {
@@ -86,19 +93,11 @@ public class JSConverter {
 
     private static String getVersion() {
         Properties prop = new Properties();
-        InputStream input = null;
         String version = "";
         ClassLoader classloader = Thread.currentThread().getContextClassLoader();
-        InputStream is = classloader.getResourceAsStream("org/saiku/web/rest/resources/version.properties");
-        try {
-
-            // input = new FileInputStream("version.properties");
-
-            // load a properties file
+        // try-with-resources so the version.properties stream is always closed (saiku#1191).
+        try (InputStream is = classloader.getResourceAsStream("org/saiku/web/rest/resources/version.properties")) {
             prop.load(is);
-
-            // get the property value and print it out
-            System.out.println(prop.getProperty("VERSION"));
             version = prop.getProperty("VERSION");
         } catch (IOException e) {
             e.printStackTrace();

--- a/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/AdminResource.java
+++ b/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/AdminResource.java
@@ -617,12 +617,9 @@ public class AdminResource {
         Properties prop = new Properties();
         String version = "";
         ClassLoader classloader = Thread.currentThread().getContextClassLoader();
-        InputStream is = classloader.getResourceAsStream("org/saiku/web/rest/resources/version.properties");
-        try {
-            // load a properties file
+        // try-with-resources so the version.properties stream is always closed (saiku#1191).
+        try (InputStream is = classloader.getResourceAsStream("org/saiku/web/rest/resources/version.properties")) {
             prop.load(is);
-
-            // get the property value and print it out
             version = prop.getProperty("VERSION");
         } catch (IOException ex) {
             log.error("IO Exception when reading input stream", ex);

--- a/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/BasicRepositoryResource2.java
+++ b/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/BasicRepositoryResource2.java
@@ -346,6 +346,7 @@ public class BasicRepositoryResource2 implements ISaikuRepository {
             @FormDataParam("directory") String directory) {
         String zipFile = fileDetail.getFileName();
         String output = "";
+        ZipInputStream zis = null;
         try {
             if (StringUtils.isBlank(zipFile)) throw new Exception("You must specify a zip file to upload");
 
@@ -361,7 +362,7 @@ public class BasicRepositoryResource2 implements ISaikuRepository {
             final int maxEntries = intProp("saiku.repo.zipMaxEntries", 1000);
             long totalBytes = 0;
             int entryCount = 0;
-            ZipInputStream zis = new ZipInputStream(uploadedInputStream);
+            zis = new ZipInputStream(uploadedInputStream);
             ZipEntry ze = zis.getNextEntry();
             byte[] doc = null;
             boolean isFile = false;
@@ -418,9 +419,7 @@ public class BasicRepositoryResource2 implements ISaikuRepository {
 
             if (!isFile) {
                 zis.closeEntry();
-                zis.close();
             }
-            uploadedInputStream.close();
 
             output += " SUCCESSFUL!\r\n";
             return Response.ok(output).build();
@@ -437,6 +436,25 @@ public class BasicRepositoryResource2 implements ISaikuRepository {
             log.error("Cannot unzip resources " + zipFile, e);
             String error = ExceptionUtils.getRootCauseMessage(e);
             return Response.serverError().entity(output + "\r\n" + error).build();
+        } finally {
+            // saiku#1191: close the zip + multipart streams on every path — the success
+            // path used to do this inline, but the unsafe-entry early return and the
+            // zip-bomb/size-limit throws (saiku#1157/#1165) skipped it and leaked the
+            // upload stream. Closing the ZipInputStream also closes the wrapped
+            // uploadedInputStream; the second close is a null-safe no-op fallback for the
+            // case where an error fired before the ZipInputStream was created.
+            if (zis != null) {
+                try {
+                    zis.close();
+                } catch (IOException ignored) {
+                    // ignore
+                }
+            }
+            try {
+                uploadedInputStream.close();
+            } catch (IOException ignored) {
+                // ignore
+            }
         }
     }
 

--- a/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/Query2Resource.java
+++ b/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/Query2Resource.java
@@ -1023,9 +1023,10 @@ public class Query2Resource {
                         "<!DOCTYPE html><html><head><meta http-equiv=\"Content-Type\" content=\"text/html; charset=utf-8\">\n";
                 if (css) {
                     html += "<style>\n";
-                    InputStream is = JSConverter.class.getResourceAsStream("saiku.table.full.css");
-                    String cssContent = IOUtils.toString(is);
-                    html += cssContent;
+                    // try-with-resources so the bundled CSS stream is always closed (saiku#1191).
+                    try (InputStream is = JSConverter.class.getResourceAsStream("saiku.table.full.css")) {
+                        html += IOUtils.toString(is);
+                    }
                     html += "</style>\n";
                 }
                 html += "</head>\n<body><div class='workspace_results'>\n";


### PR DESCRIPTION
Closes #1191.

## Approach
Before touching anything I ran a **deep resource-leak sweep** (3 module-scoped audit passes over saiku-web / saiku-service / the smaller modules). That surfaced 16 HIGH-confidence candidates. I **verified each one** rather than trusting the raw output:

- **10 real leaks + 1 olap4j JDBC-connection leak** → fixed here
- **5 false positives rejected** — `PrintWriter` wrapping an in-memory `StringWriter` (`OlapQuery.getMdx`, `OlapQueryService`/`ThinQueryService` drillthrough). Closing a `StringWriter` is a documented no-op with no OS resource, so there's nothing to leak. Left untouched.

## Fixes (try-with-resources unless noted)
| Module | Site | Resource |
|---|---|---|
| saiku-web | `JSConverter.loadJavascriptScripts` | 3 classpath JS streams |
| saiku-web | `JSConverter.getVersion` | `version.properties` stream |
| saiku-web | `Query2Resource.exportHtml` | bundled CSS `InputStream` |
| saiku-web | `AdminResource.getVersion` | `version.properties` `InputStream` |
| saiku-web | `BasicRepositoryResource2.uploadArchiveZip` | `ZipInputStream` + multipart stream — **finally** |
| saiku-service | `FilesystemRepositoryManager.getAllSchema` | `Scanner` per file |
| saiku-service | `RepositoryDatasourceManager` ×2 | `FileInputStream` over external-params |
| saiku-service | `SaikuProperties.load` | `PropertySource.openStream()` |
| saiku-olap-util | `SaikuMondrianHelper.getMDXMemberLookup` | `OlapStatement` + `CellSet` |
| saiku-service | `OlapMetaExplorer` (caller) | closes `getSQLMemberLookup`'s `ResultSet`→`Statement`→`Connection` |

### Two worth a closer look
- **`BasicRepositoryResource2`** (admin `/zipupload`): the success path closed the streams inline, but the **unsafe-entry early-return (#1157)** and the **zip-bomb/size-limit throws (#1165)** skipped it → the upload stream leaked on exactly the abuse paths. Now a `finally` closes on every path. I used a `finally` rather than a wholesale try-with-resources reindent to keep the diff small on this security-hardened method. `ZipUploadBombTest` + `ZipUploadSlipTest` still green.
- **`OlapMetaExplorer` / `getSQLMemberLookup`**: the helper (in saiku-olap-util) opens its own JDBC `Connection`+`Statement` from the Mondrian DataSource and returns only the `ResultSet`; the caller materialised it and dropped all three → a **DB connection leak on every SQL member search**. The helper can't close them without losing the ResultSet, and saiku-olap-util can't reach saiku-service's `ObjectUtil`, so the close lives caller-side (`rs.getStatement().getConnection()` — the same idiom already used at `QueryResource:673`). This is the one path with no live-Mondrian test in the suite; the close logic is standard null-safe JDBC.

`getMDXMemberLookup` also drops a latent NPE (failed `createStatement()` left `statement == null`, then dereferenced) and a stray `System.out.print`.

## Verification
`mvn ... spotless:apply test` green across the 3 modules — **242 tests, 0 failures**, including the zip hardening suites.

Security lane (Agent SEC). **Not self-merging.** 🤖 Generated with [Claude Code](https://claude.com/claude-code)
