### PR TITLE
chore: bump mondrian-saiku 4.8.1.31 → 4.8.1.32

### DIFF
--- a/saiku-bom/pom.xml
+++ b/saiku-bom/pom.xml
@@ -365,7 +365,7 @@
             <dependency>
                 <groupId>pentaho</groupId>
                 <artifactId>mondrian</artifactId>
-                <version>4.8.1.31</version>
+                <version>4.8.1.32</version>
                 <!-- xerces 2.12.2 + xalan 2.7.2 are transitively pulled by
                      mondrian but hijack the JDK's built-in JAXP via
                      META-INF/services overrides. Spring 6.2's tightened


### PR DESCRIPTION
Two upstream fixes shipped:

- **#112 / #133** `fix/timecalc-empty-prior` — YoY/PoP returns blank instead of Infinity% on zero/missing prior. Directly improves the just-shipped TimeCalc surfacing (#1225) — Revenue YoY for a brand-new month no longer shows as misleading infinite percentage.
- **#112 / #132** `feat/currency-conversion` — `<CurrencyConversion>` round-trips through M4 YAML; multi-currency Revenue (USD) fixture available for future demo work.

## Test plan
- [x] saiku-launcher IT suite: 88/88 pass
