### PR TITLE
refactor(dashboard): extract TileEditorImage delegate from TileEditorModal

### DIFF
--- a/saiku-ui/src/lib/views/dashboard/TileEditorImage.svelte
+++ b/saiku-ui/src/lib/views/dashboard/TileEditorImage.svelte
@@ -1,0 +1,107 @@
+<script lang="ts">
+  /*
+   * Image-tile editor fields — extracted from TileEditorModal.svelte (saiku#1229).
+   *
+   * Owns the URL / upload / fit / caption / alt controls for an image tile.
+   * State is held as $bindable() props so the parent stays the persistence
+   * boundary (handleSave still reads imageFile / imageUrl / etc to build the
+   * ImageConfig payload). The parent decides when this component renders —
+   * gated on `{#if tile.type === "image"}` upstream.
+   *
+   * No business logic; pure UI surface. Lifted out of the 1726-line parent
+   * so the image-tile editor can be reviewed + tested in isolation, and so
+   * the same pattern can be repeated for chart/table/filter/kpi/text
+   * delegates per #1229's split plan.
+   */
+  import type { ImageSource, ImageFit } from "$lib/api/dashboards";
+
+  interface Props {
+    imageMode: ImageSource;
+    imageUrl: string;
+    imageExistingSrc: string;
+    imageFit: ImageFit;
+    imageCaption: string;
+    imageAlt: string;
+    imageFile: File | null;
+    /** Cleared when the user picks a new file — propagates back to the parent's
+     *  body-error display so a previously-rejected upload's error message
+     *  vanishes once the user starts over. */
+    onFileChosen?: () => void;
+  }
+
+  let {
+    imageMode = $bindable(),
+    imageUrl = $bindable(),
+    imageExistingSrc,
+    imageFit = $bindable(),
+    imageCaption = $bindable(),
+    imageAlt = $bindable(),
+    imageFile = $bindable(),
+    onFileChosen,
+  }: Props = $props();
+</script>
+
+<fieldset class="mode">
+  <legend>Image source</legend>
+  <label class="radio">
+    <input type="radio" bind:group={imageMode} value="url" />
+    <span>URL</span>
+  </label>
+  <label class="radio">
+    <input type="radio" bind:group={imageMode} value="upload" />
+    <span>Upload file</span>
+  </label>
+</fieldset>
+
+{#if imageMode === "url"}
+  <label class="field">
+    <span>Image URL (http/https)</span>
+    <input
+      type="url"
+      bind:value={imageUrl}
+      placeholder="https://example.com/logo.png"
+    />
+  </label>
+{:else}
+  <label class="field">
+    <span>Upload image{imageExistingSrc ? " (replaces current)" : ""}</span>
+    <input
+      type="file"
+      accept="image/png,image/jpeg,image/gif,image/webp"
+      onchange={(e) => {
+        imageFile = (e.currentTarget as HTMLInputElement).files?.[0] ?? null;
+        onFileChosen?.();
+      }}
+    />
+    <span class="hint">
+      PNG, JPEG, GIF or WebP, up to 2&nbsp;MB. Stored privately in your
+      repository.{imageExistingSrc && !imageFile ? " An image is already set." : ""}
+    </span>
+  </label>
+{/if}
+
+<label class="field">
+  <span>Fit</span>
+  <select bind:value={imageFit}>
+    <option value="contain">Contain (whole image, letterboxed)</option>
+    <option value="cover">Cover (fill tile, crop edges)</option>
+    <option value="fill">Fill (stretch to tile)</option>
+    <option value="scale-down">Scale down (never upscale)</option>
+  </select>
+</label>
+
+<label class="field">
+  <span>Caption (optional)</span>
+  <input type="text" bind:value={imageCaption} placeholder="e.g. Q4 campaign" />
+</label>
+
+<label class="field">
+  <span>Alt text (accessibility)</span>
+  <input type="text" bind:value={imageAlt} placeholder="Describe the image" />
+</label>
+
+<style>
+  /* Inherits .field, .mode, .radio, .hint from the parent's stylesheet so
+     the visual treatment is identical to the inline version. Scoped styles
+     for image-specific surface only would split the look across files. */
+</style>

--- a/saiku-ui/src/lib/views/dashboard/TileEditorModal.svelte
+++ b/saiku-ui/src/lib/views/dashboard/TileEditorModal.svelte
@@ -42,6 +42,7 @@
   import { CHART_TYPES, DEFAULT_CHART_OPTIONS, type ChartOptions } from "$lib/views/chartTypes";
   // #1077: reuse the workspace chart-options editor for dashboard chart tiles.
   import ChartEditorModal from "$lib/modals/ChartEditorModal.svelte";
+  import TileEditorImage from "$lib/views/dashboard/TileEditorImage.svelte";
   // ── Issue #912: inline visual query editor (embedded QueryCanvas) ──
   import QueryCanvas from "$lib/views/QueryCanvas.svelte";
   import DimensionList from "$lib/views/DimensionList.svelte";
@@ -779,64 +780,19 @@
       {/if}
 
       {#if tile.type === "image"}
-        <fieldset class="mode">
-          <legend>Image source</legend>
-          <label class="radio">
-            <input type="radio" bind:group={imageMode} value="url" />
-            <span>URL</span>
-          </label>
-          <label class="radio">
-            <input type="radio" bind:group={imageMode} value="upload" />
-            <span>Upload file</span>
-          </label>
-        </fieldset>
-
-        {#if imageMode === "url"}
-          <label class="field">
-            <span>Image URL (http/https)</span>
-            <input
-              type="url"
-              bind:value={imageUrl}
-              placeholder="https://example.com/logo.png"
-            />
-          </label>
-        {:else}
-          <label class="field">
-            <span>Upload image{imageExistingSrc ? " (replaces current)" : ""}</span>
-            <input
-              type="file"
-              accept="image/png,image/jpeg,image/gif,image/webp"
-              onchange={(e) => {
-                imageFile = (e.currentTarget as HTMLInputElement).files?.[0] ?? null;
-                bodyError = null;
-              }}
-            />
-            <span class="hint">
-              PNG, JPEG, GIF or WebP, up to 2&nbsp;MB. Stored privately in your
-              repository.{imageExistingSrc && !imageFile ? " An image is already set." : ""}
-            </span>
-          </label>
-        {/if}
-
-        <label class="field">
-          <span>Fit</span>
-          <select bind:value={imageFit}>
-            <option value="contain">Contain (whole image, letterboxed)</option>
-            <option value="cover">Cover (fill tile, crop edges)</option>
-            <option value="fill">Fill (stretch to tile)</option>
-            <option value="scale-down">Scale down (never upscale)</option>
-          </select>
-        </label>
-
-        <label class="field">
-          <span>Caption (optional)</span>
-          <input type="text" bind:value={imageCaption} placeholder="e.g. Q4 campaign" />
-        </label>
-
-        <label class="field">
-          <span>Alt text (accessibility)</span>
-          <input type="text" bind:value={imageAlt} placeholder="Describe the image" />
-        </label>
+        <!-- saiku#1229: image tile editor extracted to TileEditorImage.
+             Parent stays the persistence boundary (handleSave still reads
+             imageFile / imageUrl / etc to build the ImageConfig payload). -->
+        <TileEditorImage
+          bind:imageMode
+          bind:imageUrl
+          imageExistingSrc={imageExistingSrc}
+          bind:imageFit
+          bind:imageCaption
+          bind:imageAlt
+          bind:imageFile
+          onFileChosen={() => { bodyError = null; }}
+        />
       {/if}
 
       {#if tile.type !== "text" && tile.type !== "image"}


### PR DESCRIPTION
Proof-of-pattern PR for #1229 (TileEditorModal split). Pulls the image-tile editor out of the 1726-line parent into a self-contained delegate. Parent drops to 1682; pattern (state held as $bindable() props, parent persists) is ready to repeat for text/chart/table/filter/kpi per #1229's plan.

Closes part of #1229 — text/chart/table/filter/kpi delegates remain as their own follow-up PRs.

## Test plan
- [x] svelte-check 0 errors
- [x] vitest 867/867
