### PR TITLE
refactor(tiles): extract TileQueryState shared fetch lifecycle (closes #1231)

### DIFF
--- a/saiku-ui/src/lib/hooks/useTileQuery.svelte.ts
+++ b/saiku-ui/src/lib/hooks/useTileQuery.svelte.ts
@@ -1,0 +1,166 @@
+/*
+ * Shared fetch state + effect body for ChartTile / TableTile
+ * (saiku#1231). Both tiles share the SAME pattern:
+ *
+ *   tile.query → effectiveQueryFor() (or saved-query reference) →
+ *   executeAiQuery() / executeSavedQuery() → loading / error / response
+ *
+ * plus retry, auto-refresh, share-viewer overrides, and JSON-dedupe so
+ * an unchanged query doesn't fire a duplicate fetch.
+ *
+ * KpiTile intentionally NOT covered here — it builds its body inline
+ * with prior-period expansion, no tile.query, and a different dedupe
+ * key. Extracting it would need a different rune (issue #1231 calls
+ * this out as a known scope boundary).
+ *
+ * Pattern: state held on a class so the consumer instantiates once
+ * (`const query = new TileQueryState()`); the effect body is a free
+ * function the consumer calls from inside its own $effect so reactive
+ * deps register on the COMPONENT's scope, not the class's. Returning
+ * `$state` from a factory closure can capture the wrong context — see
+ * the Risk note in #1231.
+ */
+
+import {
+  executeAiQuery,
+  executeSavedQuery,
+  type AiQueryResponse,
+} from "$lib/api/aiQuery";
+import {
+  effectiveQueryFor,
+  applicableSavedFilters,
+  type SchemaLike,
+} from "$lib/dashboard/effectiveQuery";
+import { TileAutoRefresh } from "$lib/dashboard/tileAutoRefresh.svelte";
+import type { ActiveFilter } from "$lib/stores/activeFilters.svelte";
+import type { DashboardTile } from "$lib/api/dashboards";
+
+/** Reactive state container for one tile's fetch lifecycle. */
+export class TileQueryState {
+  loading = $state(false);
+  error = $state<string | null>(null);
+  response = $state<AiQueryResponse | null>(null);
+
+  /** Bumped by {@link retry} to force a refetch with unchanged inputs. */
+  retryTick = $state(0);
+  /** Bumped by {@link triggerAutoRefresh} on the configured cadence. */
+  refreshTick = $state(0);
+
+  /** Per-tile auto-refresh timer ({@link arm}, {@link startHeartbeat}). */
+  auto = new TileAutoRefresh();
+
+  /** Internal JSON dedupe key — not reactive (it would re-trigger the
+   *  effect we're running inside). Cleared by retry / refresh to force
+   *  a re-fetch with unchanged inputs. */
+  lastQueryJson = "";
+
+  retry(): void {
+    this.lastQueryJson = "";
+    this.retryTick++;
+  }
+
+  triggerAutoRefresh(): void {
+    this.lastQueryJson = "";
+    this.refreshTick++;
+  }
+}
+
+export interface TileQueryDeps {
+  tile: DashboardTile;
+  activeFilters: ActiveFilter[];
+  schema: SchemaLike | null;
+  /** Share-viewer prefetched response — when set, render this verbatim
+   *  and skip the live fetch (no /ai/query access in the guest view). */
+  sharedResponse: AiQueryResponse | null;
+}
+
+/**
+ * Effect body shared by ChartTile + TableTile. Call from inside the
+ * consumer's $effect; read state.retryTick + state.refreshTick before
+ * calling so they register as reactive deps.
+ *
+ * Mutates `state` in place — assigns loading / error / response /
+ * lastQueryJson as the fetch progresses.
+ */
+export function runTileQueryEffect(
+  state: TileQueryState,
+  deps: TileQueryDeps,
+): void {
+  const { tile, activeFilters, schema, sharedResponse } = deps;
+
+  // Share viewer (#941): render the prefetched guest response; never
+  // fetch live (a share guest has no session / no /ai/query access).
+  if (sharedResponse) {
+    state.response = sharedResponse;
+    state.loading = false;
+    state.error = null;
+    return;
+  }
+
+  const tileQuery = tile.query;
+  if (!tileQuery) return;
+
+  if (tileQuery.kind === "reference") {
+    // Reference tile: server loads the saved ThinQuery, merges any
+    // applicable dashboard filters onto it via ThinQueryFilterMerge,
+    // then runs it. Filter applicability is checked client-side first
+    // against the tile's cube schema so we don't ship filters the
+    // server would have to drop anyway.
+    const refFilters = applicableSavedFilters(schema, activeFilters);
+    const key = `ref:${tileQuery.path}|${JSON.stringify(refFilters)}`;
+    if (key === state.lastQueryJson) return;
+    state.lastQueryJson = key;
+    state.loading = true;
+    state.error = null;
+    void (async () => {
+      try {
+        const r = await executeSavedQuery(
+          tileQuery.path,
+          refFilters.map((f) => ({
+            dimension: f.dimension,
+            hierarchy: f.hierarchy,
+            level: f.level,
+            members: f.members ?? [],
+          })),
+        );
+        state.response = r;
+        if (r.status !== "SUCCESS")
+          state.error = r.error ?? `Query failed: ${r.status}`;
+        else state.auto.markUpdated(); // #931
+      } catch (e: unknown) {
+        state.error = e instanceof Error ? e.message : String(e);
+        state.response = null;
+      } finally {
+        state.loading = false;
+      }
+    })();
+    return;
+  }
+
+  // Inline tile: merge active filters into the base body via the
+  // effective-query builder, then POST to /ai/query.
+  const effective = effectiveQueryFor(tile, activeFilters, schema);
+  if (!effective) return;
+  const json = JSON.stringify(effective);
+  if (json === state.lastQueryJson) return; // no-op; avoid duplicate fetches
+  state.lastQueryJson = json;
+
+  state.loading = true;
+  state.error = null;
+  void (async () => {
+    try {
+      const r = await executeAiQuery(effective, "records");
+      state.response = r;
+      if (r.status !== "SUCCESS") {
+        state.error = r.error ?? `Query failed: ${r.status}`;
+      } else {
+        state.auto.markUpdated(); // #931
+      }
+    } catch (e: unknown) {
+      state.error = e instanceof Error ? e.message : String(e);
+      state.response = null;
+    } finally {
+      state.loading = false;
+    }
+  })();
+}

--- a/saiku-ui/src/lib/views/dashboard/tiles/ChartTile.svelte
+++ b/saiku-ui/src/lib/views/dashboard/tiles/ChartTile.svelte
@@ -15,20 +15,19 @@
   import * as echarts from "echarts";
   import type { DashboardTile, DashboardFilter } from "$lib/api/dashboards";
   import {
-    executeAiQuery,
-    executeSavedQuery,
     searchMembers,
     type AiQueryResponse,
   } from "$lib/api/aiQuery";
+  // #1231 — shared fetch state + effect body across ChartTile / TableTile.
+  import {
+    TileQueryState,
+    runTileQueryEffect,
+  } from "$lib/hooks/useTileQuery.svelte";
   // #1166: resolve a clicked category caption to a real member unique name.
   import { pickMemberUniqueName } from "$lib/dashboard/clickFilterMember";
   import { activeFilters } from "$lib/stores/activeFilters.svelte";
   import { schemaCache } from "$lib/stores/schemaCache.svelte";
-  import {
-    effectiveQueryFor,
-    applicableSavedFilters,
-    type SchemaLike,
-  } from "$lib/dashboard/effectiveQuery";
+  import { type SchemaLike } from "$lib/dashboard/effectiveQuery";
   import {
     inferCubeFromReference,
     inferRowAxesFromReference,
@@ -63,7 +62,6 @@
   // injected via context; tiles render from it instead of fetching live.
   import { getShareViewResponse } from "$lib/dashboard/shareViewContext";
   // Issue #931 — per-tile auto-refresh: timer wiring + "last updated" indicator.
-  import { TileAutoRefresh } from "$lib/dashboard/tileAutoRefresh.svelte";
   import { isAutoRefreshOn } from "$lib/dashboard/autoRefresh";
   import TileRefreshIndicator from "./TileRefreshIndicator.svelte";
 
@@ -94,17 +92,22 @@
   // aspect-aware small-multiple radius when the canvas size changes (#1053).
   let resizeTick = $state(0);
 
-  let loading = $state(false);
-  let error = $state<string | null>(null);
-  let response = $state<AiQueryResponse | null>(null);
+  // #1231 — fetch lifecycle (loading / error / response / dedupe cache /
+  // retry tick / refresh tick / auto-refresh) lives on TileQueryState so
+  // ChartTile + TableTile share the same plumbing. KpiTile builds its
+  // body inline and does NOT use this hook. The `let foo = $derived(q.foo)`
+  // aliases below keep the rest of the script + template reading off
+  // local names; assignments only happen inside runTileQueryEffect.
+  const q = new TileQueryState();
+  let response = $derived(q.response);
+  let loading = $derived(q.loading);
+  let error = $derived(q.error);
+  const auto = q.auto;
+  function retry(): void {
+    q.retry();
+  }
   let schema = $state<SchemaLike | null>(null);
   let unsupported = $state(false);
-
-  // Issue #933 — retry re-runs the deduped fetch effect by clearing its
-  // last-query cache and bumping a tick the effect reads. Empty = a
-  // successful query with zero rows; hasEffectiveFilters gates the
-  // empty-state "Reset filters" affordance.
-  let retryTick = $state(0);
   // issue #1071: bumped once the world GeoJSON finishes registering, to
   // re-run the render effect and paint the map (registration is async).
   let mapReadyTick = $state(0);
@@ -114,10 +117,6 @@
   let hasEffectiveFilters = $derived(
     activeFilters.all.some((f) => (f.filter.members?.length ?? 0) > 0),
   );
-  function retry(): void {
-    lastQueryJson = "";
-    retryTick++;
-  }
   function resetFilters(): void {
     activeFilters.resetTransient();
     dashboardStore.resetPanelFiltersToSaved();
@@ -125,21 +124,16 @@
 
   /* --- issue #931: auto-refresh ------------------------------------------
    * A per-tile timer re-fires the existing (filter-aware) fetch on the
-   * configured cadence. We clear the fetch effect's dedupe cache + bump a
-   * tick the effect reads — same mechanism as retry() — so the re-run picks
-   * up the CURRENT effective query (active filters included). Never auto-
-   * refreshes in the share viewer (no live /ai/query access). */
-  const auto = new TileAutoRefresh();
-  let refreshTick = $state(0);
-  function triggerAutoRefresh(): void {
-    lastQueryJson = "";
-    refreshTick++;
-  }
+   * configured cadence. q.triggerAutoRefresh clears the dedupe cache +
+   * bumps q.refreshTick the fetch effect reads — same mechanism as
+   * q.retry() — so the re-run picks up the CURRENT effective query
+   * (active filters included). Never auto-refreshes in the share viewer
+   * (no live /ai/query access). */
   let autoRefreshOn = $derived(!sharedResponse && isAutoRefreshOn(tile.refreshInterval));
   // Arm / re-arm whenever the interval changes (config edit) or the tile
   // re-renders — the returned teardown clears the prior timer so they never
   // stack ("reset on re-render / config change").
-  $effect(() => auto.arm(tile.refreshInterval, triggerAutoRefresh));
+  $effect(() => auto.arm(tile.refreshInterval, () => q.triggerAutoRefresh()));
   // Heartbeat keeps the "X ago" label fresh; only while the indicator shows.
   $effect(() => {
     if (autoRefreshOn && auto.lastUpdated > 0) return auto.startHeartbeat();
@@ -250,82 +244,17 @@
 
   /* ----------------------------- fetch effect ------------------------- */
 
-  let lastQueryJson = $state<string>("");
-
   $effect(() => {
-    // #941 share viewer: render the prefetched guest response; never fetch live
-    // (a share guest has no session / no /ai/query access).
-    if (sharedResponse) {
-      response = sharedResponse;
-      loading = false;
-      error = null;
-      return;
-    }
-    const tileQuery = tile.query;
-    const active = activeFilters.all;
-    const s = schema;
-    void s;
-    // #933 — retry() bumps this to force a refetch with unchanged inputs.
-    void retryTick;
-    // #931 — auto-refresh bumps this to re-run with the current effective query.
-    void refreshTick;
-    if (!tileQuery) return;
-
-    if (tileQuery.kind === "reference") {
-      const refFilters = applicableSavedFilters(schema, active);
-      const key = `ref:${tileQuery.path}|${JSON.stringify(refFilters)}`;
-      if (key === lastQueryJson) return;
-      lastQueryJson = key;
-      loading = true;
-      error = null;
-      void (async () => {
-        try {
-          const r = await executeSavedQuery(
-            tileQuery.path,
-            refFilters.map((f) => ({
-              dimension: f.dimension,
-              hierarchy: f.hierarchy,
-              level: f.level,
-              members: f.members ?? [],
-            })),
-          );
-          response = r;
-          if (r.status !== "SUCCESS") error = r.error ?? `Query failed: ${r.status}`;
-          else auto.markUpdated(); // #931
-        } catch (e: unknown) {
-          error = e instanceof Error ? e.message : String(e);
-          response = null;
-        } finally {
-          loading = false;
-        }
-      })();
-      return;
-    }
-
-    const effective = effectiveQueryFor(tile, active, schema);
-    if (!effective) return;
-    const json = JSON.stringify(effective);
-    if (json === lastQueryJson) return;
-    lastQueryJson = json;
-
-    loading = true;
-    error = null;
-    void (async () => {
-      try {
-        const r = await executeAiQuery(effective, "records");
-        response = r;
-        if (r.status !== "SUCCESS") {
-          error = r.error ?? `Query failed: ${r.status}`;
-        } else {
-          auto.markUpdated(); // #931
-        }
-      } catch (e: unknown) {
-        error = e instanceof Error ? e.message : String(e);
-        response = null;
-      } finally {
-        loading = false;
-      }
-    })();
+    // Reactive deps the effect body reads internally — read here so the
+    // effect framework registers them on the COMPONENT's scope.
+    void q.retryTick;
+    void q.refreshTick;
+    runTileQueryEffect(q, {
+      tile,
+      activeFilters: activeFilters.all,
+      schema,
+      sharedResponse: sharedResponse ?? null,
+    });
   });
 
   /* ----------------------------- render effect ------------------------ */

--- a/saiku-ui/src/lib/views/dashboard/tiles/TableTile.svelte
+++ b/saiku-ui/src/lib/views/dashboard/tiles/TableTile.svelte
@@ -19,22 +19,20 @@
 
   import type { DashboardTile, DashboardFilter } from "$lib/api/dashboards";
   import {
-    executeAiQuery,
-    executeSavedQuery,
     isAiCell,
     searchMembers,
-    type AiQueryResponse,
     type AiCell,
   } from "$lib/api/aiQuery";
+  // #1231 — shared fetch state + effect body across ChartTile / TableTile.
+  import {
+    TileQueryState,
+    runTileQueryEffect,
+  } from "$lib/hooks/useTileQuery.svelte";
   // #1166: resolve clicked row-header captions to real member unique names.
   import { pickMemberUniqueNameForPath } from "$lib/dashboard/clickFilterMember";
   import { activeFilters } from "$lib/stores/activeFilters.svelte";
   import { schemaCache } from "$lib/stores/schemaCache.svelte";
-  import {
-    effectiveQueryFor,
-    applicableSavedFilters,
-    type SchemaLike,
-  } from "$lib/dashboard/effectiveQuery";
+  import { type SchemaLike } from "$lib/dashboard/effectiveQuery";
   import {
     inferCubeFromReference,
     inferRowAxesFromReference,
@@ -63,7 +61,6 @@
   // #941 share viewer (PR2): render from a prefetched guest response when present.
   import { getShareViewResponse } from "$lib/dashboard/shareViewContext";
   // Issue #931 — per-tile auto-refresh: timer wiring + "last updated" indicator.
-  import { TileAutoRefresh } from "$lib/dashboard/tileAutoRefresh.svelte";
   import { isAutoRefreshOn } from "$lib/dashboard/autoRefresh";
   import TileRefreshIndicator from "./TileRefreshIndicator.svelte";
 
@@ -81,21 +78,24 @@
   // svelte-ignore state_referenced_locally
   const sharedResponse = getShareViewResponse(tile.id);
 
-  let loading = $state(false);
-  let error = $state<string | null>(null);
-  let response = $state<AiQueryResponse | null>(null);
+  // #1231 — shared fetch lifecycle (loading / error / response / dedupe
+  // cache / retry tick / refresh tick / auto-refresh) lives on
+  // TileQueryState. Local $derived aliases keep the rest of the script +
+  // template reading off local names; assignments only happen inside
+  // runTileQueryEffect.
+  const q = new TileQueryState();
+  let response = $derived(q.response);
+  let loading = $derived(q.loading);
+  let error = $derived(q.error);
+  const auto = q.auto;
+  function retry(): void {
+    q.retry();
+  }
   let schema = $state<SchemaLike | null>(null);
 
-  // Issue #933 — retry re-fires the deduped fetch effect; hasEffectiveFilters
-  // gates the empty-state "Reset filters" affordance.
-  let retryTick = $state(0);
   let hasEffectiveFilters = $derived(
     activeFilters.all.some((f) => (f.filter.members?.length ?? 0) > 0),
   );
-  function retry(): void {
-    lastQueryJson = "";
-    retryTick++;
-  }
   function resetFilters(): void {
     activeFilters.resetTransient();
     dashboardStore.resetPanelFiltersToSaved();
@@ -106,14 +106,8 @@
    * configured cadence by clearing the dedupe cache + bumping a tick the
    * fetch effect reads (same mechanism as retry()), so the re-run uses the
    * CURRENT effective query. Never auto-refreshes in the share viewer. */
-  const auto = new TileAutoRefresh();
-  let refreshTick = $state(0);
-  function triggerAutoRefresh(): void {
-    lastQueryJson = "";
-    refreshTick++;
-  }
   let autoRefreshOn = $derived(!sharedResponse && isAutoRefreshOn(tile.refreshInterval));
-  $effect(() => auto.arm(tile.refreshInterval, triggerAutoRefresh));
+  $effect(() => auto.arm(tile.refreshInterval, () => q.triggerAutoRefresh()));
   $effect(() => {
     if (autoRefreshOn && auto.lastUpdated > 0) return auto.startHeartbeat();
   });
@@ -165,88 +159,15 @@
 
   // Recompute the effective query whenever the active filter set or
   // schema changes; refetch on identity change.
-  let lastQueryJson = $state<string>("");
-
   $effect(() => {
-    // #941 share viewer: render the prefetched guest response; never fetch live.
-    if (sharedResponse) {
-      response = sharedResponse;
-      loading = false;
-      error = null;
-      return;
-    }
-    const tileQuery = tile.query;
-    const active = activeFilters.all;
-    const s = schema;
-    void s;
-    // #933 — retry() bumps this to force a refetch with unchanged inputs.
-    void retryTick;
-    // #931 — auto-refresh bumps this to re-run with the current effective query.
-    void refreshTick;
-    if (!tileQuery) return;
-
-    if (tileQuery.kind === "reference") {
-      // Reference tile: server loads the saved ThinQuery, merges any
-      // applicable dashboard filters onto it via ThinQueryFilterMerge,
-      // then runs it. Filter applicability is checked client-side first
-      // against the tile's cube schema so we don't ship filters the
-      // server would have to drop anyway.
-      const refFilters = applicableSavedFilters(schema, active);
-      const key = `ref:${tileQuery.path}|${JSON.stringify(refFilters)}`;
-      if (key === lastQueryJson) return;
-      lastQueryJson = key;
-      loading = true;
-      error = null;
-      void (async () => {
-        try {
-          const r = await executeSavedQuery(
-            tileQuery.path,
-            refFilters.map((f) => ({
-              dimension: f.dimension,
-              hierarchy: f.hierarchy,
-              level: f.level,
-              members: f.members ?? [],
-            })),
-          );
-          response = r;
-          if (r.status !== "SUCCESS") error = r.error ?? `Query failed: ${r.status}`;
-          else auto.markUpdated(); // #931
-        } catch (e: unknown) {
-          error = e instanceof Error ? e.message : String(e);
-          response = null;
-        } finally {
-          loading = false;
-        }
-      })();
-      return;
-    }
-
-    // Inline tile: merge active filters into the base body via the
-    // effective-query builder, then POST to /ai/query.
-    const effective = effectiveQueryFor(tile, active, schema);
-    if (!effective) return;
-    const json = JSON.stringify(effective);
-    if (json === lastQueryJson) return; // no-op; avoid duplicate fetches
-    lastQueryJson = json;
-
-    loading = true;
-    error = null;
-    void (async () => {
-      try {
-        const r = await executeAiQuery(effective, "records");
-        response = r;
-        if (r.status !== "SUCCESS") {
-          error = r.error ?? `Query failed: ${r.status}`;
-        } else {
-          auto.markUpdated(); // #931
-        }
-      } catch (e: unknown) {
-        error = e instanceof Error ? e.message : String(e);
-        response = null;
-      } finally {
-        loading = false;
-      }
-    })();
+    void q.retryTick;
+    void q.refreshTick;
+    runTileQueryEffect(q, {
+      tile,
+      activeFilters: activeFilters.all,
+      schema,
+      sharedResponse: sharedResponse ?? null,
+    });
   });
 
   // Derived: a flat list of column captions (row headers first, then


### PR DESCRIPTION
## Summary

ChartTile + TableTile shared the exact same fetch pattern. Pulled into a shared module: \`src/lib/hooks/useTileQuery.svelte.ts\`.

\`\`\`
tile.query → effectiveQueryFor() | applicableSavedFilters() →
executeAiQuery() | executeSavedQuery() →
{loading, error, response} + retry/refresh-tick + auto-refresh
\`\`\`

### Hook shape

- \`TileQueryState\` — class holding reactive fields (\`loading\`, \`error\`, \`response\`, \`retryTick\`, \`refreshTick\`) + \`auto\`-refresh wiring + \`retry()\` / \`triggerAutoRefresh()\` helpers + private dedupe cache.
- \`runTileQueryEffect(state, deps)\` — pure function the consumer calls from inside its own \`$effect\`. Reading \`state.retryTick\` / \`state.refreshTick\` in the consumer's effect registers the deps on the **component** scope, which sidesteps the "factory closure captures wrong context" risk noted in the original issue.

Consumers keep their existing local names via thin \`$derived\` aliases (\`let response = $derived(q.response)\`, etc.) so the rest of the script + template stays untouched. The only writes to \`response\` / \`loading\` / \`error\` happen inside the hook, so read-only \`$derived\` views are sufficient.

### Scope boundary

**KpiTile intentionally NOT migrated** — it builds its request body inline with prior-period expansion + a custom dedupe key + no \`tile.query\`. The issue called out this risk explicitly; KpiTile's bespoke flow doesn't fit \`TileQueryState\`'s shape and would require a thinner primitive than is justified for one consumer.

### Diff weight

| File | Before | After |
|---|---:|---:|
| \`ChartTile.svelte\` | 610 | 532 (-78) |
| \`TableTile.svelte\` | 668 | 547 (-121) |
| \`hooks/useTileQuery.svelte.ts\` | — | new (~165 lines) |

## Test plan

- [x] \`npx svelte-check\` — 0 errors, 0 warnings
- [x] \`npm test -- --run\` — 867/867 pass across 62 files
- [ ] Manual smoke once deployed:
  - chart tile loads on dashboard open, applies dashboard filters
  - table tile loads + filters apply
  - retry on a failed query re-runs
  - auto-refresh fires on the configured cadence
  - share-viewer (\`/share\`) renders prefetched response without a live fetch
- [ ] Unit-testing \`TileQueryState\` is deferred — the codebase's vitest runs under \`node\`, so \`$state\` reactivity isn't directly exercisable. Coverage comes through the hook's two consumers' existing E2E flows.

Closes #1231. Next from #1235 backlog: #1232 AxisFilterModal shell.