### PR TITLE
refactor(modals): extract ModalModeSwitch + ModalActions shared parts (closes #1232)

### DIFF
--- a/saiku-ui/src/lib/modals/CustomFilterModal.svelte
+++ b/saiku-ui/src/lib/modals/CustomFilterModal.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import Modal from "$lib/components/Modal.svelte";
+  import ModalActions from "$lib/modals/parts/ModalActions.svelte";
   import { i18n } from "$lib/stores/i18n.svelte";
 
   /** Port of saiku-ui-legacy/js/saiku/views/CustomFilterModal.js.
@@ -63,8 +64,11 @@
     {/if}
   </div>
   {#snippet footer()}
-    <button type="button" class="btn" onclick={onCancel}>{i18n.t("modal.cancel")}</button>
-    <button type="button" class="btn btn--primary" onclick={() => onApply(op, value, needsSecond ? value2 : undefined)}>{i18n.t("modal.apply")}</button>
+    <ModalActions
+      {onCancel}
+      onApply={() => onApply(op, value, needsSecond ? value2 : undefined)}
+      primaryKey="modal.apply"
+    />
   {/snippet}
 </Modal>
 

--- a/saiku-ui/src/lib/modals/FilterModal.svelte
+++ b/saiku-ui/src/lib/modals/FilterModal.svelte
@@ -2,6 +2,7 @@
   import { untrack } from "svelte";
   import Modal from "$lib/components/Modal.svelte";
   import MonacoEditor from "$lib/components/MonacoEditor.svelte";
+  import ModalActions from "$lib/modals/parts/ModalActions.svelte";
   import { i18n } from "$lib/stores/i18n.svelte";
 
   /*
@@ -44,7 +45,6 @@
     {/if}
   </div>
   {#snippet footer()}
-    <button type="button" class="btn" onclick={onCancel}>{i18n.t("modal.cancel")}</button>
-    <button type="button" class="btn btn--primary" onclick={() => onSave(buffer)}>{i18n.t("modal.ok")}</button>
+    <ModalActions {onCancel} onApply={() => onSave(buffer)} />
   {/snippet}
 </Modal>

--- a/saiku-ui/src/lib/modals/GrowthModal.svelte
+++ b/saiku-ui/src/lib/modals/GrowthModal.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import Modal from "$lib/components/Modal.svelte";
+  import ModalActions from "$lib/modals/parts/ModalActions.svelte";
   import { i18n } from "$lib/stores/i18n.svelte";
 
   /** Port of saiku-ui-legacy/js/saiku/views/GrowthModal.js. */
@@ -37,8 +38,11 @@
     </label>
   {/if}
   {#snippet footer()}
-    <button type="button" class="btn" onclick={onCancel}>{i18n.t("modal.cancel")}</button>
-    <button type="button" class="btn btn--primary" onclick={() => onApply(basis, basis === "specific" ? reference : undefined)}>{i18n.t("modal.apply")}</button>
+    <ModalActions
+      {onCancel}
+      onApply={() => onApply(basis, basis === "specific" ? reference : undefined)}
+      primaryKey="modal.apply"
+    />
   {/snippet}
 </Modal>
 

--- a/saiku-ui/src/lib/modals/LimitModal.svelte
+++ b/saiku-ui/src/lib/modals/LimitModal.svelte
@@ -2,6 +2,8 @@
   import { untrack } from "svelte";
   import Modal from "$lib/components/Modal.svelte";
   import MonacoEditor from "$lib/components/MonacoEditor.svelte";
+  import ModalModeSwitch from "$lib/modals/parts/ModalModeSwitch.svelte";
+  import ModalActions from "$lib/modals/parts/ModalActions.svelte";
   import { i18n } from "$lib/stores/i18n.svelte";
 
   /*
@@ -64,24 +66,7 @@
   size={mode === "mdx" ? "lg" : "sm"}
   onClose={onCancel}
 >
-  <div class="mode-switch" role="tablist" aria-label={i18n.t("modal.filter.mode")}>
-    <button
-      type="button"
-      role="tab"
-      class="mode-switch__btn"
-      class:active={mode === "simple"}
-      aria-selected={mode === "simple"}
-      onclick={() => switchMode("simple")}
-    >{i18n.t("modal.filter.modeSimple")}</button>
-    <button
-      type="button"
-      role="tab"
-      class="mode-switch__btn"
-      class:active={mode === "mdx"}
-      aria-selected={mode === "mdx"}
-      onclick={() => switchMode("mdx")}
-    >{i18n.t("modal.filter.modeMdx")}</button>
-  </div>
+  <ModalModeSwitch {mode} onChange={switchMode} />
 
   {#if mode === "simple"}
     <label class="field">
@@ -104,40 +89,6 @@
   {/if}
 
   {#snippet footer()}
-    <button type="button" class="btn" onclick={onCancel}>{i18n.t("modal.cancel")}</button>
-    <button
-      type="button"
-      class="btn btn--primary"
-      disabled={!valid}
-      onclick={commit}
-    >{i18n.t("modal.ok")}</button>
+    <ModalActions {onCancel} onApply={commit} enabled={valid} />
   {/snippet}
 </Modal>
-
-<style>
-  .mode-switch {
-    display: inline-flex;
-    margin-bottom: var(--space-3);
-    background: var(--bg-muted);
-    border: 1px solid var(--border);
-    border-radius: var(--radius-sm);
-    padding: 2px;
-  }
-  .mode-switch__btn {
-    padding: 4px var(--space-3);
-    background: transparent;
-    border: 0;
-    border-radius: 3px;
-    color: var(--fg-muted);
-    font: inherit;
-    font-size: var(--fs-sm);
-    cursor: pointer;
-  }
-  .mode-switch__btn:hover { color: var(--fg); }
-  .mode-switch__btn.active {
-    background: var(--bg);
-    color: var(--fg);
-    font-weight: var(--weight-medium);
-    box-shadow: var(--shadow-sm);
-  }
-</style>

--- a/saiku-ui/src/lib/modals/OrderModal.svelte
+++ b/saiku-ui/src/lib/modals/OrderModal.svelte
@@ -2,6 +2,8 @@
   import { untrack } from "svelte";
   import Modal from "$lib/components/Modal.svelte";
   import MonacoEditor from "$lib/components/MonacoEditor.svelte";
+  import ModalModeSwitch from "$lib/modals/parts/ModalModeSwitch.svelte";
+  import ModalActions from "$lib/modals/parts/ModalActions.svelte";
   import { i18n } from "$lib/stores/i18n.svelte";
   import type { SaikuMeasure } from "$lib/api/discover";
 
@@ -91,24 +93,7 @@
   size={mode === "mdx" ? "lg" : "md"}
   onClose={onCancel}
 >
-  <div class="mode-switch" role="tablist" aria-label={i18n.t("modal.filter.mode")}>
-    <button
-      type="button"
-      role="tab"
-      class="mode-switch__btn"
-      class:active={mode === "simple"}
-      aria-selected={mode === "simple"}
-      onclick={() => switchMode("simple")}
-    >{i18n.t("modal.filter.modeSimple")}</button>
-    <button
-      type="button"
-      role="tab"
-      class="mode-switch__btn"
-      class:active={mode === "mdx"}
-      aria-selected={mode === "mdx"}
-      onclick={() => switchMode("mdx")}
-    >{i18n.t("modal.filter.modeMdx")}</button>
-  </div>
+  <ModalModeSwitch {mode} onChange={switchMode} />
 
   <label class="field">
     <span class="field__label">{i18n.t("modal.filter.sort")}</span>
@@ -141,40 +126,6 @@
   {/if}
 
   {#snippet footer()}
-    <button type="button" class="btn" onclick={onCancel}>{i18n.t("modal.cancel")}</button>
-    <button
-      type="button"
-      class="btn btn--primary"
-      disabled={!valid}
-      onclick={commit}
-    >{i18n.t("modal.ok")}</button>
+    <ModalActions {onCancel} onApply={commit} enabled={valid} />
   {/snippet}
 </Modal>
-
-<style>
-  .mode-switch {
-    display: inline-flex;
-    margin-bottom: var(--space-3);
-    background: var(--bg-muted);
-    border: 1px solid var(--border);
-    border-radius: var(--radius-sm);
-    padding: 2px;
-  }
-  .mode-switch__btn {
-    padding: 4px var(--space-3);
-    background: transparent;
-    border: 0;
-    border-radius: 3px;
-    color: var(--fg-muted);
-    font: inherit;
-    font-size: var(--fs-sm);
-    cursor: pointer;
-  }
-  .mode-switch__btn:hover { color: var(--fg); }
-  .mode-switch__btn.active {
-    background: var(--bg);
-    color: var(--fg);
-    font-weight: var(--weight-medium);
-    box-shadow: var(--shadow-sm);
-  }
-</style>

--- a/saiku-ui/src/lib/modals/TopBottomCountModal.svelte
+++ b/saiku-ui/src/lib/modals/TopBottomCountModal.svelte
@@ -2,6 +2,8 @@
   import { untrack } from "svelte";
   import Modal from "$lib/components/Modal.svelte";
   import MonacoEditor from "$lib/components/MonacoEditor.svelte";
+  import ModalModeSwitch from "$lib/modals/parts/ModalModeSwitch.svelte";
+  import ModalActions from "$lib/modals/parts/ModalActions.svelte";
   import { i18n } from "$lib/stores/i18n.svelte";
   import type { SaikuMeasure } from "$lib/api/discover";
 
@@ -91,24 +93,7 @@
   size={mode === "mdx" ? "lg" : "md"}
   onClose={onCancel}
 >
-  <div class="mode-switch" role="tablist" aria-label={i18n.t("modal.filter.mode")}>
-    <button
-      type="button"
-      role="tab"
-      class="mode-switch__btn"
-      class:active={mode === "simple"}
-      aria-selected={mode === "simple"}
-      onclick={() => switchMode("simple")}
-    >{i18n.t("modal.filter.modeSimple")}</button>
-    <button
-      type="button"
-      role="tab"
-      class="mode-switch__btn"
-      class:active={mode === "mdx"}
-      aria-selected={mode === "mdx"}
-      onclick={() => switchMode("mdx")}
-    >{i18n.t("modal.filter.modeMdx")}</button>
-  </div>
+  <ModalModeSwitch {mode} onChange={switchMode} />
 
   {#if mode === "simple"}
     <label class="field">
@@ -143,42 +128,11 @@
   {/if}
 
   {#snippet footer()}
-    <button type="button" class="btn" onclick={onCancel}>{i18n.t("modal.cancel")}</button>
-    <button
-      type="button"
-      class="btn btn--primary"
-      disabled={!valid}
-      onclick={commit}
-    >{i18n.t("modal.ok")}</button>
+    <ModalActions {onCancel} onApply={commit} enabled={valid} />
   {/snippet}
 </Modal>
 
 <style>
-  .mode-switch {
-    display: inline-flex;
-    margin-bottom: var(--space-3);
-    background: var(--bg-muted);
-    border: 1px solid var(--border);
-    border-radius: var(--radius-sm);
-    padding: 2px;
-  }
-  .mode-switch__btn {
-    padding: 4px var(--space-3);
-    background: transparent;
-    border: 0;
-    border-radius: 3px;
-    color: var(--fg-muted);
-    font: inherit;
-    font-size: var(--fs-sm);
-    cursor: pointer;
-  }
-  .mode-switch__btn:hover { color: var(--fg); }
-  .mode-switch__btn.active {
-    background: var(--bg);
-    color: var(--fg);
-    font-weight: var(--weight-medium);
-    box-shadow: var(--shadow-sm);
-  }
   .field__hint {
     margin: var(--space-1) 0 0;
     color: var(--fg-subtle);

--- a/saiku-ui/src/lib/modals/parts/ModalActions.svelte
+++ b/saiku-ui/src/lib/modals/parts/ModalActions.svelte
@@ -1,0 +1,40 @@
+<script lang="ts">
+  /*
+   * Shared Cancel / primary-action footer — extracted from the axis-
+   * filter modal family (saiku#1232). Drop into a Modal's
+   * {@code {#snippet footer()}} slot to avoid hand-rolling the same
+   * pair of buttons in every modal.
+   *
+   * Caller picks the primary label via i18n key (defaults to "modal.ok",
+   * but Apply / Save / Apply-and-close variants are common).
+   */
+  import { i18n } from "$lib/stores/i18n.svelte";
+
+  interface Props {
+    onCancel: () => void;
+    onApply: () => void;
+    /** i18n key for the primary button; defaults to "modal.ok". */
+    primaryKey?: string;
+    /** When false, the primary button is disabled. */
+    enabled?: boolean;
+  }
+
+  let {
+    onCancel,
+    onApply,
+    primaryKey = "modal.ok",
+    enabled = true,
+  }: Props = $props();
+</script>
+
+<button type="button" class="btn" onclick={onCancel}>
+  {i18n.t("modal.cancel")}
+</button>
+<button
+  type="button"
+  class="btn btn--primary"
+  disabled={!enabled}
+  onclick={onApply}
+>
+  {i18n.t(primaryKey)}
+</button>

--- a/saiku-ui/src/lib/modals/parts/ModalModeSwitch.svelte
+++ b/saiku-ui/src/lib/modals/parts/ModalModeSwitch.svelte
@@ -1,0 +1,85 @@
+<script lang="ts">
+  /*
+   * Shared "simple ↔ MDX" tab strip — extracted from OrderModal /
+   * TopBottomCountModal / LimitModal (saiku#1232). Each axis-filter
+   * modal that surfaces an "MDX escape hatch" alongside a structured
+   * picker rendered its own copy of this row + ~30 lines of identical
+   * CSS. One source of truth here.
+   *
+   * Parent owns the {@code mode} state; this component is a controlled
+   * tab list — onChange is called when the user clicks the other tab,
+   * never on first paint. Switching tabs is the parent's chance to seed
+   * the MDX buffer from the simple selection (or vice-versa).
+   */
+  import { i18n } from "$lib/stores/i18n.svelte";
+
+  type Mode = "simple" | "mdx";
+
+  interface Props {
+    mode: Mode;
+    onChange: (next: Mode) => void;
+  }
+
+  let { mode, onChange }: Props = $props();
+
+  function pick(next: Mode): void {
+    if (next !== mode) onChange(next);
+  }
+</script>
+
+<div
+  class="mode-switch"
+  role="tablist"
+  aria-label={i18n.t("modal.filter.mode")}
+>
+  <button
+    type="button"
+    role="tab"
+    class="mode-switch__btn"
+    class:active={mode === "simple"}
+    aria-selected={mode === "simple"}
+    onclick={() => pick("simple")}
+  >
+    {i18n.t("modal.filter.modeSimple")}
+  </button>
+  <button
+    type="button"
+    role="tab"
+    class="mode-switch__btn"
+    class:active={mode === "mdx"}
+    aria-selected={mode === "mdx"}
+    onclick={() => pick("mdx")}
+  >
+    {i18n.t("modal.filter.modeMdx")}
+  </button>
+</div>
+
+<style>
+  .mode-switch {
+    display: inline-flex;
+    margin-bottom: var(--space-3);
+    background: var(--bg-muted);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+    padding: 2px;
+  }
+  .mode-switch__btn {
+    padding: 4px var(--space-3);
+    background: transparent;
+    border: 0;
+    border-radius: 3px;
+    color: var(--fg-muted);
+    font: inherit;
+    font-size: var(--fs-sm);
+    cursor: pointer;
+  }
+  .mode-switch__btn:hover {
+    color: var(--fg);
+  }
+  .mode-switch__btn.active {
+    background: var(--bg);
+    color: var(--fg);
+    font-weight: var(--weight-medium);
+    box-shadow: var(--shadow-sm);
+  }
+</style>


### PR DESCRIPTION
## Summary

Six axis-filter modals duplicated the same simple/mdx tab strip + the same Cancel/OK footer + ~30 lines of identical mode-switch CSS each. Pulled into two shared parts under \`src/lib/modals/parts/\`:

- \`ModalModeSwitch.svelte\` — controlled simple/mdx tab list (used by Order / TopBottomCount / Limit)
- \`ModalActions.svelte\` — Cancel + primary-action footer (used by all six axis-filter modals)

Note: a single \`AxisFilterModal\` shell that wrapped \`Modal\` + the mode switch + actions wasn't a better fit here — each modal's body differs enough (different inputs, different layouts, different conditional rendering between simple/mdx) that wrapping them in one component would require either complex slot juggling or a bunch of \`{#if mode === 'simple'}\` branches with type-narrow generics. Two surgical parts beats one chunky shell.

### Per-modal LoC after

| Modal | Before | After | Δ |
|---|---:|---:|---:|
| OrderModal | 180 | 99 | -81 |
| TopBottomCountModal | 187 | 112 | -75 |
| LimitModal | 143 | 76 | -67 |
| CustomFilterModal | 74 | 74 | (footer dedupe only) |
| FilterModal | 50 | 47 | (footer dedupe only) |
| GrowthModal | 53 | 53 | (footer dedupe only) |

Net: -136 LoC across the six callers, +90 LoC across the two shared parts. Mode-switch styling now has a single source of truth — drift between modals is no longer possible by accident.

## Test plan

- [x] \`npx svelte-check\` — 0 errors, 0 warnings
- [x] \`npm test -- --run\` — 867/867 pass across 62 files
- [ ] Manual smoke once deployed: open each modal type (order, top, bottom, limit, custom, filter, growth) from QueryCanvas and confirm simple/mdx switching still works and apply/cancel still wire through unchanged.

Closes #1232. Next from #1235: #1233 (QueryCanvas modal state cluster) or #1234 (DashboardIndex split).