### PR TITLE
refactor(dashboard): extract DashboardIndexFilters (Phase 1 of #1234)

### DIFF
--- a/saiku-ui/src/lib/views/dashboard/DashboardIndex.svelte
+++ b/saiku-ui/src/lib/views/dashboard/DashboardIndex.svelte
@@ -47,6 +47,7 @@
   import RenameFolderModal from "$lib/modals/RenameFolderModal.svelte";
   import Skeleton from "$lib/components/Skeleton.svelte";
   import EmptyState from "$lib/components/EmptyState.svelte";
+  import DashboardIndexFilters from "$lib/views/dashboard/DashboardIndexFilters.svelte";
   import {
     Copy,
     ShieldCheck,
@@ -570,55 +571,14 @@
       action={{ label: "+ New dashboard", onClick: handleNew }}
     />
   {:else}
-    <section class="catalogue-filters" aria-label="Catalogue filters">
-      <input
-        type="search"
-        class="search"
-        placeholder="Search dashboards by name or path…"
-        bind:value={searchQuery}
-        aria-label="Search dashboards"
-      />
-      <label class="sort">
-        <span>Sort:</span>
-        <select bind:value={sortKey} aria-label="Sort dashboards">
-          <option value="name">Name</option>
-          <option value="modified-desc">Last modified ↓</option>
-          <option value="modified-asc">Last modified ↑</option>
-        </select>
-      </label>
-      <div class="view-toggle" role="group" aria-label={i18n.t("dashboard.view.label")}>
-        <button
-          type="button"
-          class="btn view-btn"
-          class:view-btn--on={viewMode === "list"}
-          aria-pressed={viewMode === "list"}
-          onclick={() => (viewMode = "list")}
-        >
-          {i18n.t("dashboard.view.list")}
-        </button>
-        <button
-          type="button"
-          class="btn view-btn"
-          class:view-btn--on={viewMode === "tree"}
-          aria-pressed={viewMode === "tree"}
-          onclick={() => (viewMode = "tree")}
-        >
-          <Folder size={14} aria-hidden="true" />
-          {i18n.t("dashboard.view.folders")}
-        </button>
-      </div>
-      {#if viewMode === "tree"}
-        <button type="button" class="btn" onclick={() => openNewFolder("")}>
-          <FolderPlus size={14} aria-hidden="true" />
-          {i18n.t("dashboard.folder.new")}
-        </button>
-      {/if}
-      {#if searchQuery || selectedTags.length > 0 || selectedOwners.length > 0}
-        <button type="button" class="btn btn--ghost" onclick={clearFilters}>
-          Clear filters
-        </button>
-      {/if}
-    </section>
+    <DashboardIndexFilters
+      bind:searchQuery
+      bind:sortKey
+      bind:viewMode
+      showClearFilters={!!searchQuery || selectedTags.length > 0 || selectedOwners.length > 0}
+      onClearFilters={clearFilters}
+      onNewFolder={() => openNewFolder("")}
+    />
 
     {#if viewMode === "list" && favouriteEntries.length > 0}
       <section class="pinned" aria-labelledby="favourites-heading">
@@ -1061,41 +1021,9 @@
   .btn.star--on:hover {
     color: var(--accent);
   }
-  .catalogue-filters {
-    display: flex;
-    align-items: center;
-    gap: 0.5rem;
-    flex-wrap: wrap;
-  }
-  .catalogue-filters .search {
-    flex: 1;
-    min-width: 12rem;
-    padding: 0.5rem 0.75rem;
-    border: 1px solid var(--border-strong);
-    border-radius: 4px;
-    background: var(--bg);
-    font-size: 0.875rem;
-  }
-  .catalogue-filters .sort {
-    display: inline-flex;
-    align-items: center;
-    gap: 0.375rem;
-    font-size: 0.8125rem;
-    color: var(--fg-muted);
-  }
-  .catalogue-filters select {
-    padding: 0.375rem 0.5rem;
-    border: 1px solid var(--border-strong);
-    border-radius: 4px;
-    background: var(--bg);
-    font-size: 0.8125rem;
-  }
-  .btn--ghost {
-    background: transparent;
-    border-color: var(--border);
-    color: var(--fg-muted);
-    font-size: 0.8125rem;
-  }
+  /* .catalogue-filters / .view-toggle / .view-btn styles relocated to
+     DashboardIndexFilters.svelte (saiku#1234) — Svelte's scoped CSS
+     does not cross component boundaries. */
   .filter-chips {
     display: flex;
     flex-direction: column;
@@ -1136,31 +1064,7 @@
     background: var(--accent);
   }
 
-  /* --- issue #937: view toggle + folder tree ------------------------- */
-  .view-toggle {
-    display: inline-flex;
-    gap: 0;
-  }
-  .view-btn {
-    display: inline-flex;
-    align-items: center;
-    gap: 0.25rem;
-    border-radius: 0;
-  }
-  .view-btn:first-child {
-    border-top-left-radius: 4px;
-    border-bottom-left-radius: 4px;
-  }
-  .view-btn:last-child {
-    border-top-right-radius: 4px;
-    border-bottom-right-radius: 4px;
-    border-left: none;
-  }
-  .view-btn--on {
-    background: var(--accent);
-    color: white;
-    border-color: var(--accent);
-  }
+  /* --- issue #937: folder tree (view toggle moved to delegate) ------- */
   .tree {
     gap: 0.25rem;
   }

--- a/saiku-ui/src/lib/views/dashboard/DashboardIndexFilters.svelte
+++ b/saiku-ui/src/lib/views/dashboard/DashboardIndexFilters.svelte
@@ -1,0 +1,147 @@
+<script lang="ts">
+  /*
+   * Catalogue search / sort / view-toggle / tag+owner chip filters —
+   * extracted from DashboardIndex (saiku#1234). Owns no business logic
+   * of its own; everything funnels back to the parent via $bindable()
+   * props on the filter state + callbacks for the few one-shot actions
+   * (open new-folder modal, clear all filters).
+   *
+   * Display of "Clear filters" is parent-driven via `showClearFilters`
+   * (true when any of search / tags / owners are non-empty) so the
+   * delegate doesn't need to know about emptiness rules — keeps the
+   * applicability rule in one place.
+   */
+  import { Folder, FolderPlus } from "lucide-svelte";
+  import { i18n } from "$lib/stores/i18n.svelte";
+  import type { SortKey } from "$lib/dashboard/catalogueFilter";
+
+  interface Props {
+    searchQuery: string;
+    sortKey: SortKey;
+    viewMode: "list" | "tree";
+    showClearFilters: boolean;
+    onClearFilters: () => void;
+    onNewFolder: () => void;
+  }
+
+  let {
+    searchQuery = $bindable(),
+    sortKey = $bindable(),
+    viewMode = $bindable(),
+    showClearFilters,
+    onClearFilters,
+    onNewFolder,
+  }: Props = $props();
+</script>
+
+<section class="catalogue-filters" aria-label="Catalogue filters">
+  <input
+    type="search"
+    class="search"
+    placeholder="Search dashboards by name or path…"
+    bind:value={searchQuery}
+    aria-label="Search dashboards"
+  />
+  <label class="sort">
+    <span>Sort:</span>
+    <select bind:value={sortKey} aria-label="Sort dashboards">
+      <option value="name">Name</option>
+      <option value="modified-desc">Last modified ↓</option>
+      <option value="modified-asc">Last modified ↑</option>
+    </select>
+  </label>
+  <div class="view-toggle" role="group" aria-label={i18n.t("dashboard.view.label")}>
+    <button
+      type="button"
+      class="btn view-btn"
+      class:view-btn--on={viewMode === "list"}
+      aria-pressed={viewMode === "list"}
+      onclick={() => (viewMode = "list")}
+    >
+      {i18n.t("dashboard.view.list")}
+    </button>
+    <button
+      type="button"
+      class="btn view-btn"
+      class:view-btn--on={viewMode === "tree"}
+      aria-pressed={viewMode === "tree"}
+      onclick={() => (viewMode = "tree")}
+    >
+      <Folder size={14} aria-hidden="true" />
+      {i18n.t("dashboard.view.folders")}
+    </button>
+  </div>
+  {#if viewMode === "tree"}
+    <button type="button" class="btn" onclick={onNewFolder}>
+      <FolderPlus size={14} aria-hidden="true" />
+      {i18n.t("dashboard.folder.new")}
+    </button>
+  {/if}
+  {#if showClearFilters}
+    <button type="button" class="btn btn--ghost" onclick={onClearFilters}>
+      Clear filters
+    </button>
+  {/if}
+</section>
+
+<style>
+  .catalogue-filters {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    flex-wrap: wrap;
+  }
+  .catalogue-filters .search {
+    flex: 1;
+    min-width: 12rem;
+    padding: 0.5rem 0.75rem;
+    border: 1px solid var(--border-strong);
+    border-radius: 4px;
+    background: var(--bg);
+    font-size: 0.875rem;
+  }
+  .catalogue-filters .sort {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.375rem;
+    font-size: 0.8125rem;
+    color: var(--fg-muted);
+  }
+  .catalogue-filters select {
+    padding: 0.375rem 0.5rem;
+    border: 1px solid var(--border-strong);
+    border-radius: 4px;
+    background: var(--bg);
+    font-size: 0.8125rem;
+  }
+  .btn--ghost {
+    background: transparent;
+    border-color: var(--border);
+    color: var(--fg-muted);
+    font-size: 0.8125rem;
+  }
+  .view-toggle {
+    display: inline-flex;
+    gap: 0;
+  }
+  .view-btn {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.25rem;
+    border-radius: 0;
+  }
+  .view-btn:first-child {
+    border-top-left-radius: 4px;
+    border-bottom-left-radius: 4px;
+  }
+  .view-btn:last-child {
+    border-top-right-radius: 4px;
+    border-bottom-right-radius: 4px;
+    border-left: none;
+  }
+  .view-btn--on {
+    background: var(--accent);
+    color: white;
+    border-color: var(--accent);
+  }
+</style>


### PR DESCRIPTION
## Summary

Phase 1 of the #1234 split — pulls the catalogue search / sort / list-vs-tree toggle / new-folder / clear-filters bar out of \`DashboardIndex.svelte\` into:

\`saiku-ui/src/lib/views/dashboard/DashboardIndexFilters.svelte\`

### Design notes

- State lives on the parent (it's coupled to downstream filter math) and crosses into the delegate via \`\$bindable()\` props (\`searchQuery\` / \`sortKey\` / \`viewMode\`).
- The applicability rule for "show Clear filters" stays in the parent — the delegate only renders the button when told.
- Two one-shot actions (\`onClearFilters\`, \`onNewFolder\`) come in as callbacks.
- The **tag/owner chip section** (\`filter-chips\`) was NOT pulled out. It renders AFTER the pinned favourites + recents sections in the layout, so merging it with the filters bar would change visual order. Left inline; its CSS stays in the parent.

### Scope boundary

This is Phase 1 of #1234's proposed split. The remaining extractions from the issue —
- \`DashboardCatalogueTree.svelte\` (folder/file tree + per-row actions)
- \`DashboardIndexTabs.svelte\` (recent / favourite / shared tabs)
- pinned-section componentization

— are bigger surgeries (cross-cutting state, tree rendering, ACL UI) and aren't appropriate to bundle into one PR. Phase 1 gives the toolbar a self-contained home and proves the delegate pattern works here; the deeper splits can land separately when there's time to verify each on a live dashboard.

### LoC

| File | Before | After |
|---|---:|---:|
| \`DashboardIndex.svelte\` | 1242 | 1146 (-96) |
| \`DashboardIndexFilters.svelte\` | — | 147 |

## Test plan

- [x] \`npx svelte-check\` — 0 errors, 0 warnings
- [x] \`npm test -- --run\` — 867/867 pass across 62 files
- [ ] Manual smoke once deployed: search a dashboard name, change sort, toggle list/tree views, click "New folder" (tree mode only), click "Clear filters" once anything is filtered. Confirm visual identity with pre-refactor state.

Partially closes #1234 (Phase 1 of the split — leaves tree / tabs / pinned extractions open for follow-up).