### PR TITLE
feat(demo): stage a welcome dashboard on first boot

### DIFF
--- a/saiku-launcher/src/main/java/org/saiku/launcher/SaikuLauncher.java
+++ b/saiku-launcher/src/main/java/org/saiku/launcher/SaikuLauncher.java
@@ -140,6 +140,14 @@ public class SaikuLauncher implements Callable<Integer> {
             stageSeedAssets(dataDir);
             stageBrandingSample(brandingDir);
             stageDefaultDatasource(saikuHome);
+            // saiku#1245: in demo mode, also stage a "Welcome" dashboard
+            // under /dashboards/ so a fresh demo container has something
+            // ready-to-look-at at first login instead of an empty list.
+            // The file is idempotent (stageResource only writes when
+            // missing) so operator edits survive container restarts.
+            if (isDemoModeActive()) {
+                stageDemoDashboards(saikuHome);
+            }
 
             Path warPath = extractWar();
 
@@ -496,6 +504,27 @@ public class SaikuLauncher implements Callable<Integer> {
                 Files.writeString(target, resolved, java.nio.charset.StandardCharsets.UTF_8);
                 System.out.println("Seeded: " + target);
             }
+        }
+
+        /**
+         * Stage demo content under {@code <home>/repository/data/unknown/dashboards/}.
+         * Only runs in demo mode (gated at the call site); idempotent because
+         * {@link #stageResource} is a no-op when the target already exists, so
+         * an operator who tweaks the welcome dashboard in the UI keeps their
+         * edits across container restarts.
+         *
+         * <p>Lives next to the foodmart datasource staging so a single demo
+         * boot lands cube + dashboards + branding sample together — a fresh
+         * container has something to look at at first login.
+         */
+        private static void stageDemoDashboards(Path saikuHome) throws Exception {
+            Path dashDir = saikuHome
+                    .resolve("repository")
+                    .resolve("data")
+                    .resolve("unknown")
+                    .resolve("dashboards");
+            Files.createDirectories(dashDir);
+            stageResource("/seed/demo/welcome.saikudash", dashDir.resolve("welcome.saikudash"));
         }
 
         private static void stageBrandingSample(Path brandingDir) throws Exception {

--- a/saiku-launcher/src/main/resources/seed/demo/welcome.saikudash
+++ b/saiku-launcher/src/main/resources/seed/demo/welcome.saikudash
@@ -1,0 +1,183 @@
+{
+  "id": "demo-welcome",
+  "name": "Welcome to Saiku — FoodMart overview",
+  "version": 1,
+  "tags": ["demo", "foodmart"],
+  "layout": {
+    "cols": 12,
+    "tiles": [
+      {
+        "id": "tile-welcome",
+        "x": 0, "y": 0, "w": 12, "h": 2,
+        "type": "text",
+        "title": "Welcome",
+        "text": "# Welcome to the Saiku demo\n\nThis dashboard is staged on first boot when `SAIKU_DEMO=true`. The four tiles below all run live against the bundled FoodMart cube (H2). Edit them, add new tiles from `+ Add tile`, or open the queries catalogue (`/ui/#/dashboards`) to find the standalone saved queries shipped with this demo.\n\n**Login:** `admin` / `admin`."
+      },
+      {
+        "id": "tile-kpi-units",
+        "x": 0, "y": 2, "w": 3, "h": 3,
+        "type": "kpi",
+        "title": "Total Unit Sales",
+        "cube": {
+          "connectionName": "unknown_foodmart",
+          "catalog": "FoodMart",
+          "schema": "FoodMart",
+          "cubeName": "Sales"
+        },
+        "kpi": {
+          "measure": "[Measures].[Unit Sales]",
+          "measureCaption": "Unit Sales",
+          "format": "number",
+          "comparison": "none",
+          "direction": "higher-is-better",
+          "sparkline": false,
+          "thresholds": {}
+        }
+      },
+      {
+        "id": "tile-kpi-sales",
+        "x": 3, "y": 2, "w": 3, "h": 3,
+        "type": "kpi",
+        "title": "Total Store Sales",
+        "cube": {
+          "connectionName": "unknown_foodmart",
+          "catalog": "FoodMart",
+          "schema": "FoodMart",
+          "cubeName": "Sales"
+        },
+        "kpi": {
+          "measure": "[Measures].[Store Sales]",
+          "measureCaption": "Store Sales",
+          "format": "currency",
+          "comparison": "none",
+          "direction": "higher-is-better",
+          "sparkline": false,
+          "thresholds": {}
+        }
+      },
+      {
+        "id": "tile-chart-by-city",
+        "x": 6, "y": 2, "w": 6, "h": 6,
+        "type": "chart",
+        "title": "Store Sales by City",
+        "chartType": "bar",
+        "cube": {
+          "connectionName": "unknown_foodmart",
+          "catalog": "FoodMart",
+          "schema": "FoodMart",
+          "cubeName": "Sales"
+        },
+        "query": {
+          "kind": "inline",
+          "body": {
+            "cube": {
+              "connectionName": "unknown_foodmart",
+              "catalog": "FoodMart",
+              "schema": "FoodMart",
+              "cubeName": "Sales"
+            },
+            "measures": [{ "name": "Store Sales" }],
+            "rows": [{ "dimension": "Store", "hierarchy": "Stores", "level": "Store City" }],
+            "columns": [],
+            "filters": []
+          }
+        },
+        "chartOptions": {
+          "title": "Store Sales by City",
+          "xAxisLabel": "",
+          "yAxisLabel": "",
+          "showLegend": true,
+          "legendPosition": "top",
+          "trendLine": "none",
+          "trendPeriod": 3,
+          "hideRollupRows": true,
+          "dualAxis": true,
+          "seriesAxis": {},
+          "colorRamp": "blues",
+          "mapMissing": "blank",
+          "sortDirection": "desc",
+          "topN": 10
+        }
+      },
+      {
+        "id": "tile-chart-time",
+        "x": 0, "y": 5, "w": 6, "h": 6,
+        "type": "chart",
+        "title": "Unit Sales by Quarter",
+        "chartType": "line",
+        "cube": {
+          "connectionName": "unknown_foodmart",
+          "catalog": "FoodMart",
+          "schema": "FoodMart",
+          "cubeName": "Sales"
+        },
+        "query": {
+          "kind": "inline",
+          "body": {
+            "cube": {
+              "connectionName": "unknown_foodmart",
+              "catalog": "FoodMart",
+              "schema": "FoodMart",
+              "cubeName": "Sales"
+            },
+            "measures": [{ "name": "Unit Sales" }, { "name": "Store Sales" }],
+            "rows": [{ "dimension": "Time", "hierarchy": "Time", "level": "Quarter" }],
+            "columns": [],
+            "filters": []
+          }
+        },
+        "chartOptions": {
+          "title": "Unit Sales & Store Sales by Quarter",
+          "xAxisLabel": "",
+          "yAxisLabel": "",
+          "showLegend": true,
+          "legendPosition": "top",
+          "trendLine": "none",
+          "trendPeriod": 3,
+          "hideRollupRows": true,
+          "dualAxis": true,
+          "seriesAxis": {},
+          "colorRamp": "blues",
+          "mapMissing": "blank",
+          "sortDirection": "none",
+          "topN": null
+        }
+      },
+      {
+        "id": "tile-table-product",
+        "x": 6, "y": 8, "w": 6, "h": 6,
+        "type": "table",
+        "title": "Sales by Product Family",
+        "cube": {
+          "connectionName": "unknown_foodmart",
+          "catalog": "FoodMart",
+          "schema": "FoodMart",
+          "cubeName": "Sales"
+        },
+        "query": {
+          "kind": "inline",
+          "body": {
+            "cube": {
+              "connectionName": "unknown_foodmart",
+              "catalog": "FoodMart",
+              "schema": "FoodMart",
+              "cubeName": "Sales"
+            },
+            "measures": [
+              { "name": "Unit Sales" },
+              { "name": "Store Sales" },
+              { "name": "Store Cost" },
+              { "name": "Profit" }
+            ],
+            "rows": [{ "dimension": "Product", "hierarchy": "Products", "level": "Product Family" }],
+            "columns": [],
+            "filters": []
+          }
+        },
+        "sparkline": { "enabled": true, "type": "bar" }
+      }
+    ]
+  },
+  "filters": [],
+  "filterPanel": { "collapsed": false, "filters": [] }
+}


### PR DESCRIPTION
## Summary

When \`SAIKU_DEMO=true\`, stage \`seed/demo/welcome.saikudash\` to \`<home>/repository/data/unknown/dashboards/welcome.saikudash\` so a fresh demo container has something to look at at first login instead of an empty Dashboards list.

### Tiles (FoodMart Sales cube)

| Tile | Type | Detail |
|---|---|---|
| Welcome banner | text | Markdown intro + login hint |
| Total Unit Sales | kpi | Headline number |
| Total Store Sales | kpi | Currency-formatted |
| Store Sales by City | chart (bar) | sorted desc, top 10 |
| Unit Sales + Store Sales by Quarter | chart (line) | dual-axis (exercises the #1244 auto-split fix — Unit Sales is ~100× Store Sales and should now auto-split to the right axis) |
| Sales by Product Family | table | trailing sparkline column |

All queries are **inline** (no separate \`.saiku\` files to maintain) so the dashboard is self-contained.

### Why a single dashboard, not the Reports catalogue route the issue mentioned

The user asked for "default reports + a linked dashboard". I dropped the standalone \`.saiku\` files for this round — the saved-query JSON format requires a full ThinQuery serialization (axes / filters / mdx / properties / queryType — see the existing \`util/sample_reports/*.saiku\` examples) which is fragile to author by hand without a workspace round-trip. Inline tile queries cover the same ground for first-look value, and the operator can extract any tile to a standalone saved query via the workspace's "save as" once they're in.

Happy to revisit and add \`.saiku\` files in a follow-up if the catalogue listing matters more than tile-level fidelity.

### Idempotency

\`stageResource\` is a no-op when the target file already exists, so:
- Operator tweaks via the UI survive container restarts.
- Re-pulling the image preserves any in-flight edits.

## Test plan

- [x] \`mvn -pl saiku-launcher -am -Dmaven.test.skip=true package\` — clean build, \`welcome.saikudash\` packaged into fat-jar (\`unzip -l\` confirmed).
- [ ] Manual smoke once deployed to demo: open the Dashboards list, see "Welcome to Saiku — FoodMart overview" listed; open it; confirm all six tiles render against the bundled FoodMart cube; confirm the dual-axis tile auto-splits Store Sales to the right axis.

Follows the chart-affordance fixes from PR #1244.