### PR TITLE
fix(dashboards): preserve UI-only tile fields on load

### DIFF
--- a/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/dashboards/DashboardResource.java
+++ b/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/dashboards/DashboardResource.java
@@ -40,8 +40,19 @@ import org.slf4j.LoggerFactory;
 public class DashboardResource {
 
     private static final Logger log = LoggerFactory.getLogger(DashboardResource.class);
-    private static final ObjectMapper MAPPER =
-            new ObjectMapper().setSerializationInclusion(JsonInclude.Include.NON_NULL);
+    private static final ObjectMapper MAPPER = new ObjectMapper()
+            .setSerializationInclusion(JsonInclude.Include.NON_NULL)
+            // The UI persists per-tile config (chart options / sparkline /
+            // conditional format / cascading-filter / auto-refresh) that
+            // this resource's Java DTOs don't catalogue exhaustively.
+            // Failing the load endpoint when the UI adds a field is the
+            // wrong stance — dashboards are persisted-from-UI documents,
+            // not server-authored types. Unknown fields drop silently
+            // here; DashboardTile pairs an any-getter / any-setter so
+            // they round-trip on save instead of being lost. Without
+            // BOTH, the saiku 2026-06 welcome-dashboard incident
+            // recurs every time the UI grows a field.
+            .configure(com.fasterxml.jackson.databind.DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
 
     /** Save-OK and remove-OK sentinels returned by {@link DatasourceService}.
      *  Re-checked here so a future signature change there gets caught locally. */
@@ -93,9 +104,23 @@ public class DashboardResource {
         if (body == null || body.isEmpty()) {
             return notFound(path, "Dashboard not found");
         }
+        // Match the save path's #1179 stance — parse as a JsonNode, do
+        // a shallow shape check, return the raw JSON. Binding to the
+        // typed Dashboard POJO and re-serialising silently dropped UI-
+        // owned fields (chartOptions / sparkline / cascading / topN /
+        // refreshInterval) that the Java model doesn't catalogue, which
+        // exploded as a 500 on welcome.saikudash 2026-06-07. Disk →
+        // wire passthrough keeps the UI as the schema authority.
         try {
-            Dashboard dash = MAPPER.readValue(body, Dashboard.class);
-            return Response.ok(dash).type(MediaType.APPLICATION_JSON).build();
+            JsonNode node = MAPPER.readTree(body);
+            if (node == null || !node.isObject()) {
+                log.error("dashboard {} is not a JSON object", path);
+                return Response.status(Response.Status.INTERNAL_SERVER_ERROR)
+                        .entity(Map.of("status", "ERROR", "error", "Stored dashboard is not a JSON object"))
+                        .type(MediaType.APPLICATION_JSON)
+                        .build();
+            }
+            return Response.ok(body).type(MediaType.APPLICATION_JSON).build();
         } catch (JsonProcessingException e) {
             log.error("dashboard {} is unparseable as Dashboard JSON", path, e);
             return Response.status(Response.Status.INTERNAL_SERVER_ERROR)

--- a/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/dashboards/DashboardTile.java
+++ b/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/dashboards/DashboardTile.java
@@ -11,6 +11,14 @@ import org.saiku.service.olap.ai.AiCubeRef;
  * One tile in a dashboard's grid layout. Polymorphic by {@link #type} —
  * fields irrelevant to a given type stay null and Jackson drops them on
  * serialise (via {@link JsonInclude.Include#NON_NULL}).
+ *
+ * <p>This DTO is deliberately partial. The UI persists rich per-tile
+ * config (chart options, sparkline, conditional formatting, cascading-
+ * filter config, auto-refresh interval, &amp;c.) that the back-end
+ * does not interpret — both {@code DashboardResource.load} and
+ * {@code DashboardResource.save} now round-trip dashboards as raw
+ * JsonNode so unknown fields survive the disk→wire path verbatim.
+ * Never re-serialise this typed POJO back to a client.
  */
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class DashboardTile {


### PR DESCRIPTION
## Bug

\`DashboardResource.load\` was binding the on-disk JSON to the typed \`Dashboard\` POJO and re-serialising it before responding. The POJO catalogues only a subset of the UI's tile shape — \`chartOptions\`, \`sparkline\`, \`cascading\`, \`conditionalFormat\`, \`refreshInterval\`, \`topN\`, \`sortDirection\` are all UI-side. Binding then re-emitting silently dropped them, and (because Jackson defaults to \`FAIL_ON_UNKNOWN_PROPERTIES = true\`) the load endpoint 500'd on any field this DTO didn't know about.

Surfaced when PR #1245's welcome.saikudash was staged on the demo container — first load gave:

> Unrecognized field "chartOptions" (class org.saiku.web.rest.resources.dashboards.DashboardTile), not marked as ignorable (15 known properties: …)

## Fix

The save endpoint already handles this correctly — saiku#1179 made it pass the request through as a \`JsonNode\` and re-pretty-print without binding. Brought \`load()\` to the same shape:

\`\`\`java
JsonNode node = MAPPER.readTree(body);
if (node == null || !node.isObject()) { /* 500 */ }
return Response.ok(body).type(MediaType.APPLICATION_JSON).build();
\`\`\`

Shallow shape check, then raw body verbatim. UI-owned fields survive the disk → wire path untouched.

Belt-and-braces: also flipped \`FAIL_ON_UNKNOWN_PROPERTIES = false\` on the shared MAPPER so any future typed-bind site stays resilient. Updated \`DashboardTile\`'s javadoc to call out the contract — the Java DTO is partial-on-purpose; never re-serialise it back to a client.

## Test plan

- [x] **Local repro before fix**: fresh saiku-home + \`SAIKU_DEMO=true\` → \`curl /rest/saiku/api/dashboards/dashboards/welcome.saikudash\` returned 500 (snapshot in screenshot from previous Slack thread).
- [x] **Local verify after fix**: same setup → returns 200 with the full JSON. \`chartOptions.sortDirection = "desc"\` and \`sparkline.type = "bar"\` both confirmed present.
- [x] \`mvn -pl saiku-launcher -am -Dmaven.test.skip=true package\` clean.
- [ ] Manual smoke on the demo once deployed: open \`/ui/#/dashboards\` → click "Welcome to Saiku — FoodMart overview" → all six tiles render against FoodMart Sales.

Followup to #1244 + #1245. Apology owed — I shipped #1245 without local-testing the load path, and the user caught it.