### PR TITLE
fix(demo): KPI tile measure uses bare name, not MDX unique name

### DIFF
--- a/saiku-launcher/src/main/resources/seed/demo/welcome.saikudash
+++ b/saiku-launcher/src/main/resources/seed/demo/welcome.saikudash
@@ -25,7 +25,7 @@
           "cubeName": "Sales"
         },
         "kpi": {
-          "measure": "[Measures].[Unit Sales]",
+          "measure": "Unit Sales",
           "measureCaption": "Unit Sales",
           "format": "number",
           "comparison": "none",
@@ -46,7 +46,7 @@
           "cubeName": "Sales"
         },
         "kpi": {
-          "measure": "[Measures].[Store Sales]",
+          "measure": "Store Sales",
           "measureCaption": "Store Sales",
           "format": "currency",
           "comparison": "none",


### PR DESCRIPTION
## Bug

The KPI tile builds its \`/ai/query\` body with \`{measures: [{name: kpi.measure}]}\`. That endpoint expects the **bare** measure name from the schema's \`measures\` map (e.g. \`"Unit Sales"\`), not the fully-qualified MDX form. The welcome dashboard shipped with the unique-name form, so both KPIs fired:

> Unknown measure '[Measures].[Unit Sales]'
> Unknown measure '[Measures].[Store Sales]'

## Fix

Two-character change — \`kpi.measure\` now stores the bare name. Inline chart/table queries were already correct (\`{name: "Store Sales"}\`), so only the KPI configs needed updating.

## Test plan

- [x] Local repro: with bad file → \`POST /api/ai/query {measures: [{name: "[Measures].[Unit Sales]"}]}\` → VALIDATION_ERROR.
- [x] Local verify: with fix → same POST returns 200, \`Unit Sales = 266773\` (matches FoodMart 1997 totals).
- [ ] **Note for deploy**: the existing demo container has the bad \`welcome.saikudash\` on its persistent volume — \`stageResource\` is idempotent and skips when the file exists. Need to \`rm\` the file before pulling the new image so the staging re-fires. Doing that now.

Followup to #1245 + #1246.