### PR TITLE
fix(export): null-guard CSV/Excel exporters when cellset has no header

### DIFF
--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/util/export/CsvExporter.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/util/export/CsvExporter.java
@@ -139,7 +139,10 @@ public class CsvExporter {
             AbstractBaseCell[][] rowData = table.getCellSetBody();
             AbstractBaseCell[][] rowHeader = table.getCellSetHeaders();
 
-            boolean offset = rowHeader.length > 0;
+            // Null-guard: a measures-only query (no COLUMNS dimension on the
+            // cellset) returns a null header. Without this the CSV export NPEs
+            // through to a 500. See saiku 2026-06 export bug.
+            boolean offset = rowHeader != null && rowHeader.length > 0;
             String[][] result = new String[(offset ? 1 : 0) + rowData.length][];
             if (offset) {
                 List<String> cols = new ArrayList<>();

--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/util/export/excel/ExcelWorksheetBuilder.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/util/export/excel/ExcelWorksheetBuilder.java
@@ -903,6 +903,12 @@ public class ExcelWorksheetBuilder {
 
         int width = 0;
         int x = 0;
+        // Null-guard: a measures-only query (no hierarchy on COLUMNS or ROWS)
+        // can leave the cellset with a null/empty header band. NPE'd through
+        // to the export endpoint as a 500 — see saiku 2026-06 export bug.
+        if (rowsetHeader == null) {
+            return 0;
+        }
         boolean exit = (rowsetHeader.length < 1 || rowsetHeader[0][0].getRawValue() != null);
         String cellValue = null;
 
@@ -925,6 +931,11 @@ public class ExcelWorksheetBuilder {
      * @return
      */
     private int findTopLeftCornerHeight() {
+        // Same null-guard as findTopLeftCornerWidth — measures-only queries
+        // yield a null header band.
+        if (rowsetHeader == null) {
+            return 0;
+        }
         return rowsetHeader.length > 0 ? rowsetHeader.length - 1 : 0;
     }
 


### PR DESCRIPTION
## Bug

\`CsvExporter.getCsv\` and \`ExcelWorksheetBuilder.findTopLeftCorner{Width,Height}\` unconditionally read \`.length\` on the cellset's header rows. A measures-only query (no hierarchy on the COLUMNS axis) yields a null header band and the export endpoints NPE'd through to a 500.

From the demo container logs after the user hit the workspace toolbar's CSV / XLS export:

\`\`\`
java.lang.NullPointerException: Cannot read the array length
  because "rowHeader" is null
  at org.saiku.service.util.export.CsvExporter.getCsv(CsvExporter.java:142)
  at org.saiku.service.util.export.CsvExporter.exportCsv(CsvExporter.java:50)
  …

java.lang.NullPointerException: Cannot read the array length
  because "this.rowsetHeader" is null
  at o.s.s.util.export.excel.ExcelWorksheetBuilder.findTopLeftCornerWidth(ExcelWorksheetBuilder.java:906)
  at o.s.s.util.export.excel.ExcelWorksheetBuilder.init(ExcelWorksheetBuilder.java:103)
\`\`\`

## Fix

Three small null-checks — \`header == null\` treated as "no header band". Matches the existing \`isHeaderEmpty\` checks already in place elsewhere in \`ExcelWorksheetBuilder\` (lines 297-302, 380-382) but for the corner-resolving helpers they were missing.

## Test plan

- [x] \`mvn -pl saiku-core/saiku-service -am test-compile\` clean.
- [ ] Manual smoke once deployed: open the workspace, run a measures-only query, click Export → CSV / XLS; confirm both download instead of 500.