### PR TITLE
fix(chart): scatter/bubble/heatmap/waterfall UX + table each-key dup

### DIFF
--- a/saiku-ui/src/lib/charts/__snapshots__/build.test.ts.snap
+++ b/saiku-ui/src/lib/charts/__snapshots__/build.test.ts.snap
@@ -286,7 +286,7 @@ exports[`buildChartOption — coverage of all 15 types > snapshot of every type'
       },
     ],
     "grid": {
-      "bottom": 36,
+      "bottom": 56,
       "left": 48,
       "right": 16,
       "top": 24,
@@ -526,8 +526,8 @@ exports[`buildChartOption — coverage of all 15 types > snapshot of every type'
       "#14b8a6",
     ],
     "grid": {
-      "bottom": 64,
-      "left": 120,
+      "bottom": 60,
+      "left": 96,
       "right": 16,
       "top": 24,
     },
@@ -578,15 +578,16 @@ exports[`buildChartOption — coverage of all 15 types > snapshot of every type'
       },
     },
     "visualMap": {
-      "bottom": 8,
-      "calculable": true,
-      "left": "center",
+      "calculable": false,
+      "itemHeight": 140,
       "max": 612482.65,
       "min": 266773,
-      "orient": "horizontal",
+      "orient": "vertical",
+      "right": 16,
       "textStyle": {
         "color": "#475569",
       },
+      "top": "center",
     },
     "xAxis": {
       "axisLabel": {
@@ -1004,7 +1005,7 @@ exports[`buildChartOption — coverage of all 15 types > snapshot of every type'
       },
     ],
     "grid": {
-      "bottom": 36,
+      "bottom": 56,
       "left": 48,
       "right": 16,
       "top": 24,
@@ -1731,7 +1732,7 @@ exports[`buildChartOption — coverage of all 15 types > snapshot of every type'
       },
     ],
     "grid": {
-      "bottom": 36,
+      "bottom": 56,
       "left": 48,
       "right": 16,
       "top": 24,
@@ -2151,7 +2152,7 @@ exports[`buildChartOption — coverage of all 15 types > snapshot of every type'
       },
     ],
     "grid": {
-      "bottom": 40,
+      "bottom": 56,
       "left": 60,
       "right": 40,
       "top": 40,
@@ -2390,9 +2391,9 @@ exports[`buildChartOption — coverage of all 15 types > snapshot of every type'
       "#14b8a6",
     ],
     "grid": {
-      "bottom": 80,
+      "bottom": 60,
       "left": 120,
-      "right": 40,
+      "right": 96,
       "top": 40,
     },
     "series": [
@@ -2442,15 +2443,16 @@ exports[`buildChartOption — coverage of all 15 types > snapshot of every type'
       },
     },
     "visualMap": {
-      "bottom": 10,
-      "calculable": true,
-      "left": "center",
+      "calculable": false,
+      "itemHeight": 140,
       "max": 612482.65,
       "min": 266773,
-      "orient": "horizontal",
+      "orient": "vertical",
+      "right": 16,
       "textStyle": {
         "color": "#475569",
       },
+      "top": "center",
     },
     "xAxis": {
       "axisLabel": {
@@ -2867,7 +2869,7 @@ exports[`buildChartOption — coverage of all 15 types > snapshot of every type'
       },
     ],
     "grid": {
-      "bottom": 40,
+      "bottom": 56,
       "left": 60,
       "right": 40,
       "top": 40,
@@ -3593,7 +3595,7 @@ exports[`buildChartOption — coverage of all 15 types > snapshot of every type'
       },
     ],
     "grid": {
-      "bottom": 40,
+      "bottom": 56,
       "left": 60,
       "right": 40,
       "top": 30,

--- a/saiku-ui/src/lib/charts/build.test.ts
+++ b/saiku-ui/src/lib/charts/build.test.ts
@@ -421,19 +421,25 @@ describe("buildChartOption — map (#1071)", () => {
 });
 
 describe("buildChartOption — dataZoom zoom + pan (#1080)", () => {
-  // The cartesian families that get x-axis zoom/pan.
-  const CARTESIAN = [
+  // Cartesian families that get the visible bottom slider when there
+  // are enough categories. Bar / line / area variants — long category
+  // axes (time series, big region lists) benefit from panning.
+  const SLIDER_CARTESIAN = [
     "bar",
     "stackedBar",
     "line",
     "stackedLine",
     "area",
     "stackedArea",
-    "scatter",
-    "bubble",
-    "waterfall",
   ] as const;
-  // Non-cartesian types must NEVER get dataZoom (it would be meaningless / break layout).
+  // Cartesian families that get ONLY inside-zoom (no visible slider).
+  // saiku 2026-06 user feedback: scatter / bubble distributions don't
+  // pan, waterfall is a single sequence, heatmap shows everything at
+  // once + the slider competed visually with the visualMap legend.
+  const INSIDE_ONLY_CARTESIAN = ["scatter", "bubble", "waterfall"] as const;
+  // Types that never get dataZoom at all (slider or inside-zoom).
+  // Heatmap was added to this group 2026-06 — the visualMap legend
+  // is the navigation, panning the matrix isn't a sensible gesture.
   const NON_CARTESIAN = ["pie", "donut", "treemap", "sunburst", "heatmap", "radar", "map"] as const;
 
   // Big enough to trip the slider gate — the screenshot bug fix only emits
@@ -447,8 +453,8 @@ describe("buildChartOption — dataZoom zoom + pan (#1080)", () => {
     return { rowCategories: rows, columnCategories: cols, matrix };
   }
 
-  test("dense cartesian (roomy) gets an inside zoom + a bottom slider", () => {
-    for (const t of CARTESIAN) {
+  test("dense bar / line / area (roomy) gets an inside zoom + a bottom slider", () => {
+    for (const t of SLIDER_CARTESIAN) {
       const opt = buildChartOption(denseSample(), t, opts(), undefined, {
         compact: false,
       }) as Record<string, unknown>;
@@ -458,16 +464,27 @@ describe("buildChartOption — dataZoom zoom + pan (#1080)", () => {
         dz.map((d) => d.type),
         `${t} has inside + slider`,
       ).toEqual(["inside", "slider"]);
-      // x-axis only — value-axis zoom fights magnitude comparison.
       expect(dz.every((d) => d.xAxisIndex === 0)).toBe(true);
     }
   });
 
-  test("sparse cartesian (roomy) hides the slider — empty track would be a UI bug", () => {
-    // sample() has 2 rows / 2 cols — well below the gate. Inside-zoom
-    // stays armed (it's invisible until used) but the visible slider
-    // is suppressed so we don't draw an empty track under the bars.
-    for (const t of CARTESIAN) {
+  test("scatter / bubble / waterfall never get the visible slider", () => {
+    // Distributions / single-sequence layouts don't pan usefully — the
+    // slider just adds clutter (user feedback 2026-06-07). Inside-zoom
+    // stays armed for mouse-wheel users.
+    for (const t of INSIDE_ONLY_CARTESIAN) {
+      for (const make of [denseSample, sample]) {
+        const opt = buildChartOption(make(), t, opts(), undefined, {
+          compact: false,
+        }) as Record<string, unknown>;
+        const dz = opt.dataZoom as Array<{ type: string }>;
+        expect(dz.map((d) => d.type), `${t} inside-only`).toEqual(["inside"]);
+      }
+    }
+  });
+
+  test("sparse bar / line / area (roomy) hides the slider — empty track would be a UI bug", () => {
+    for (const t of SLIDER_CARTESIAN) {
       const opt = buildChartOption(sample(), t, opts(), undefined, {
         compact: false,
       }) as Record<string, unknown>;
@@ -479,7 +496,7 @@ describe("buildChartOption — dataZoom zoom + pan (#1080)", () => {
   });
 
   test("every cartesian type (compact) gets an inside zoom but NO slider", () => {
-    for (const t of CARTESIAN) {
+    for (const t of [...SLIDER_CARTESIAN, ...INSIDE_ONLY_CARTESIAN]) {
       const opt = buildChartOption(denseSample(), t, opts(), undefined, {
         compact: true,
       }) as Record<string, unknown>;

--- a/saiku-ui/src/lib/charts/build.ts
+++ b/saiku-ui/src/lib/charts/build.ts
@@ -235,14 +235,22 @@ function colorRampFor(ramp: ChartColorRamp | undefined): string[] {
  * `categoryCount` gates the visible slider — with one or a handful of bars the
  * slider has nothing meaningful to zoom and just steals vertical space (and
  * draws an empty track under the chart, which reads as a UI bug). The inside
- * (mouse-wheel) zoom stays armed regardless; it's invisible until used. */
+ * (mouse-wheel) zoom stays armed regardless; it's invisible until used.
+ *
+ * For scatter / bubble / heatmap / waterfall — pass {visibleSlider: false}.
+ * On those types the slider competes visually with the visualMap legend
+ * (heatmap) and adds no useful navigation (scatter / bubble don't "scroll"
+ * over time, waterfalls are single-sequence). Inside-zoom still works
+ * for mouse-wheel users. */
 const ZOOM_SLIDER_MIN_CATEGORIES = 12;
 function dataZoomConfig(
   compact: boolean,
   categoryCount: number,
+  visibleSlider = true,
 ): Record<string, unknown>[] {
   const inside = { type: "inside", xAxisIndex: 0, filterMode: "none" as const };
   if (compact) return [inside];
+  if (!visibleSlider) return [inside];
   if (categoryCount < ZOOM_SLIDER_MIN_CATEGORIES) return [inside];
   return [
     inside,
@@ -516,20 +524,42 @@ export function buildChartOption(
       ...common,
       title,
       tooltip: tooltipStyle,
+      // Reserve a little extra left padding for vertical visualMap and
+      // leave the bottom narrow now that the heatmap no longer paints
+      // a horizontal legend there. Rotated x-axis labels need ~60px
+      // bottom room.
       grid: compact
-        ? { left: 120, top: 24, right: 16, bottom: 64 }
-        : { left: 120, top: 40, right: 40, bottom: 80 },
-      xAxis: { ...baseAxis, axisLabel: catLabel(), data: cols, name: xName },
+        ? { left: 96, top: 24, right: 16, bottom: 60 }
+        : { left: 120, top: 40, right: 96, bottom: 60 },
+      xAxis: {
+        ...baseAxis,
+        // Heatmap categories had the same readability problem as scatter
+        // / bar (user feedback 2026-06-07): "Alcohol…" / "Breakfa…" /
+        // "Eggs / …" with no way to read full names. Rotate when crowded.
+        axisLabel: catLabel(cols.length > 8 ? 30 : 0),
+        data: cols,
+        name: xName,
+      },
       yAxis: { ...baseAxis, data: rows, inverse: true, name: yName },
+      // visualMap moved to the right edge (vertical, non-calculable).
+      // The horizontal `calculable: true` legend at the bottom looked
+      // like a second draggable slider next to dataZoom — the user
+      // called it "actually 2 drag bars" 2026-06-07. Vertical + on the
+      // right is the standard heatmap layout and lifts the ambiguity.
       visualMap: {
         min,
         max,
-        calculable: true,
-        orient: "horizontal",
-        left: "center",
-        bottom: compact ? 8 : 10,
+        calculable: false,
+        orient: "vertical",
+        right: 16,
+        top: "center",
+        itemHeight: 140,
         textStyle: { color: tk.fgMuted },
       },
+      // Heatmap doesn't get the bottom slider either — the colour-band
+      // already shows the full distribution at a glance and the slider
+      // adds visual noise. Inside-zoom is also off (heatmaps aren't
+      // "panned over time" like a long bar chart is).
       series: [
         { type: "heatmap", data, label: { show: false }, emphasis: { itemStyle: { shadowBlur: 10 } } },
       ],
@@ -624,16 +654,21 @@ export function buildChartOption(
       // #1080: roomy gets a slider + inside zoom; compact gets inside-only. The
       // roomy slider sits at the bottom, so reserve a little extra grid bottom.
       grid: compact
-        ? { top: 24, left: 48, right: 16, bottom: 36 }
-        : {
-            left: 60,
-            top: title ? 50 : 40,
-            right: 40,
-            bottom: cols.length >= ZOOM_SLIDER_MIN_CATEGORIES ? 76 : 40,
-          },
-      // scatter / bubble: x-axis is `cols`, so slider gate keys off cols.length.
-      dataZoom: dataZoomConfig(compact, cols.length),
-      xAxis: { ...baseAxis, axisLabel: catLabel(), data: cols, name: xName },
+        ? { top: 24, left: 48, right: 16, bottom: 56 }
+        : { left: 60, top: title ? 50 : 40, right: 40, bottom: 56 },
+      // scatter / bubble: never draw the visible slider (the points
+      // already show the full distribution and the slider added clutter
+      // per user feedback 2026-06-07). Inside-zoom stays for mouse-wheel.
+      dataZoom: dataZoomConfig(compact, cols.length, false),
+      xAxis: {
+        ...baseAxis,
+        // Rotate when categories crowd — same rule the bar branch uses
+        // and the only way to keep "Alcohol…" / "Breakfa…" readable when
+        // there are 30+ entries.
+        axisLabel: catLabel(cols.length > 8 ? 30 : 0),
+        data: cols,
+        name: xName,
+      },
       yAxis: { ...valueAxis, name: yName },
       series: rows.map((name, i) => ({
         type: "scatter",
@@ -678,16 +713,17 @@ export function buildChartOption(
       tooltip: { trigger: "axis", ...tooltipStyle },
       legend,
       grid: compact
-        ? { top: 24, left: 48, right: 16, bottom: 36 }
-        : {
-            left: 60,
-            top: title ? 50 : 30,
-            right: 40,
-            bottom: rows.length >= ZOOM_SLIDER_MIN_CATEGORIES ? 76 : 40,
-          },
-      // waterfall: x-axis is `rows`.
-      dataZoom: dataZoomConfig(compact, rows.length), // #1080: x-axis zoom + pan
-      xAxis: { ...baseAxis, axisLabel: catLabel(), data: rows, name: xName },
+        ? { top: 24, left: 48, right: 16, bottom: 56 }
+        : { left: 60, top: title ? 50 : 30, right: 40, bottom: 56 },
+      // waterfall is a single ordered sequence — no useful "zoom window"
+      // semantics. Inside-zoom stays for power users, slider hidden.
+      dataZoom: dataZoomConfig(compact, rows.length, false),
+      xAxis: {
+        ...baseAxis,
+        axisLabel: catLabel(rows.length > 8 ? 30 : 0),
+        data: rows,
+        name: xName,
+      },
       yAxis: { ...valueAxis, name: yName },
       series: [
         {
@@ -803,7 +839,16 @@ export function buildChartOption(
         },
     // bar / line / area: x-axis is `rows`.
     dataZoom: dataZoomConfig(compact, rows.length), // #1080: x-axis zoom + pan
-    xAxis: { ...baseAxis, axisLabel: catLabel(compact && rows.length > 8 ? 30 : 0), data: rows, name: xName },
+    xAxis: {
+      ...baseAxis,
+      // Rotate when categories crowd — same rule in roomy + compact;
+      // a 30-row scatter / bar with horizontal labels collapses to
+      // "Alcohol…" / "Breakfa…" / "Eggs / …" etc., which the user
+      // flagged as unreadable on 2026-06-07.
+      axisLabel: catLabel(rows.length > 8 ? 30 : 0),
+      data: rows,
+      name: xName,
+    },
     yAxis,
     series: [...base, ...trend],
   };

--- a/saiku-ui/src/lib/views/dashboard/tiles/TableTile.svelte
+++ b/saiku-ui/src/lib/views/dashboard/tiles/TableTile.svelte
@@ -401,7 +401,7 @@
         <table>
           <thead>
             <tr>
-              {#each columns as col (col.caption)}
+              {#each columns as col, ci (ci)}
                 <th class:row-header={col.isRowHeader}>{col.caption}</th>
               {/each}
               {#if sparklineEnabled}
@@ -412,7 +412,7 @@
           <tbody>
             {#each rows as row, i (i)}
               <tr>
-                {#each columns as col (col.caption)}
+                {#each columns as col, ci (ci)}
                   {@const v = row[col.caption]}
                   {@const fmt = parseFormattedCell(renderCell(v))}
                   {@const cf = cellFormatFor(col.caption, v)}


### PR DESCRIPTION
## Summary

Five fixes from a workspace screenshot review.

### 1. Scatter / bubble / waterfall: drop the visible zoom slider
Distributions and single-sequence layouts don't pan usefully — the slider just adds clutter (user: "drag bar thing make sense? I don't really think so"). Inside-zoom (mouse wheel) stays armed for power users.

### 2. Heatmap: visualMap moved to right edge (vertical, non-calculable)
The horizontal \`calculable: true\` legend at the bottom looked like a second draggable slider next to the inside-zoom band (user: "actually 2 drag bars, wtf"). Vertical legend on the right is the standard heatmap layout and lifts the ambiguity. Heatmap also loses its dataZoom entirely — the colour band shows the full distribution; panning the matrix isn't a sensible gesture.

### 3. Rotated x-axis labels in roomy mode when categories crowd
Was only rotating in compact mode. Bar / scatter / bubble / heatmap / waterfall now all rotate by 30° when there are >8 categories (user: "x axis is unreadable. again does the drag bar thing make sense?"). Full label still shows in the axis-pointer tooltip.

### 4. Tighter cartesian bottom padding now the slider/legend are gone
Was reserving 76px under the chart for the slider track even when the slider wasn't drawn; collapsed to 56px (40px chart pad + room for rotated labels).

### 5. TableTile: switch inner each-key from \`col.caption\` to column index
Multi-measure queries can produce columns with duplicate captions, which Svelte 5 strictly rejects:

> Uncaught Error: https://svelte.dev/e/each_key_duplicate

Index keys lose tile-internal column-reorder identity but match the default the outer rows loop already uses.

## Test plan

- [x] \`npx svelte-check\` — 0 errors, 0 warnings
- [x] \`npm test -- --run\` — 870/870 (added tests for the slider gating split, refreshed snapshots)
- [ ] Manual smoke once deployed: open scatter / bubble / waterfall — no slider, rotated x-axis labels readable. Open heatmap — single vertical colour legend on the right, x-axis labels rotated, no double-bar at the bottom. Open a multi-measure table dashboard tile — no more \`each_key_duplicate\` in the console.

## Not addressed in this PR

- "Bubble should encode a second measure as size" — would need measure-count info the current \`ChartProjection\` doesn't carry. Filed for follow-up.
- "Chart options seem sad" — vague enough I want a concrete repro before reshaping the form.