### PR TITLE
fix(chart): pie multiples cap, scrollbar, rotated labels, dup-keys

### DIFF
--- a/saiku-ui/src/lib/charts/build.ts
+++ b/saiku-ui/src/lib/charts/build.ts
@@ -418,7 +418,17 @@ export function buildChartOption(
   // categories crowd. The full label always shows in the axis-pointer tooltip.
   const catCount = Math.max(rows.length, cols.length, 1);
   const catLabelWidth = compact ? 100 : deriveAxisLabelWidth(geom.chartWidth ?? 0, catCount);
-  const catLabel = (rotate = 0) => ({ color: tk.fgMuted, rotate, ...axisLabelConfig(catLabelWidth) });
+  // Rotated labels read diagonally — they don't compete with siblings for
+  // horizontal slot width, so they can hold ~2x the chars before clipping.
+  // Without this, scatter / heatmap labels rotated 30° still truncated to
+  // "Beer..." / "Drink..." even though there was room (user feedback
+  // 2026-06-07 "x axis is unreadable").
+  const ROTATED_LABEL_WIDTH = 160;
+  const catLabel = (rotate = 0) => ({
+    color: tk.fgMuted,
+    rotate,
+    ...axisLabelConfig(rotate !== 0 ? ROTATED_LABEL_WIDTH : catLabelWidth),
+  });
 
   const legend = compact ? compactLegend(o, tk) : legendConfig(o, tk);
   const title = titleConfig(o, tk);
@@ -432,20 +442,41 @@ export function buildChartOption(
   // we fan out into M small-multiple charts — one per measure — laid out in a
   // grid inside the same option (M series, one per cell). M=1 is a single chart.
   if (t === "pie" || t === "donut" || t === "treemap" || t === "sunburst") {
-    const cells = gridCells(cols.length);
-    const cellTitles = cells.map((cell, m) => ({
-      text: cols[m],
-      left: cell.centerXPct + "%",
-      top: cell.topPct + "%",
-      textAlign: "center" as const,
-      textStyle: { color: tk.fg, fontSize: 12 },
-    }));
+    // Beyond this many measures we collapse to a single chart whose slices
+    // are summed across rows — the screenshot bug 2026-06-07 had 24+
+    // tiny pies with vast whitespace because gridCells fanned the layout
+    // across every column. A single pie with the columns as slices is the
+    // useful default for "Store Sales by Product Category".
+    const MAX_SMALL_MULTIPLES = 6;
+    const collapseToSingle = cols.length > MAX_SMALL_MULTIPLES;
+    const cells = gridCells(collapseToSingle ? 1 : cols.length);
+    // When collapsed, the single cell's title is just the chart title (set
+    // by titleConfig); skip the per-cell title so we don't draw two stacked
+    // labels.
+    const cellTitles = collapseToSingle
+      ? []
+      : cells.map((cell, m) => ({
+          text: cols[m],
+          left: cell.centerXPct + "%",
+          top: cell.topPct + "%",
+          textAlign: "center" as const,
+          textStyle: { color: tk.fg, fontSize: 12 },
+        }));
     const titles = title ? [title, ...cellTitles] : cellTitles;
     // Name slices directly when few enough to read; else lean on the tooltip.
     // Inside the slices for a small-multiple grid (leader lines would cross
     // between neighbours); outside for a single chart where there's room.
-    const showSliceLabels = rows.length <= MAX_LABELLED_SLICES;
+    const showSliceLabels =
+      (collapseToSingle ? cols.length : rows.length) <= MAX_LABELLED_SLICES;
     const sliceLabelInside = cells.length > 1;
+    // Pre-compute the collapsed dataset (one slice per column, value =
+    // sum of that column across all rows).
+    const collapsedData = collapseToSingle
+      ? cols.map((name, c) => ({
+          name,
+          value: matrix.reduce((sum, row) => sum + (row[c] ?? 0), 0),
+        }))
+      : null;
 
     if (t === "pie" || t === "donut") {
       return {
@@ -456,7 +487,7 @@ export function buildChartOption(
           const outer = cellRadiusPct(cell, aspect);
           return {
             type: "pie",
-            name: cols[m],
+            name: collapsedData ? "Total" : cols[m],
             radius: t === "donut" ? [outer * 0.55 + "%", outer + "%"] : [0, outer + "%"],
             center: [cell.centerXPct + "%", cell.centerYPct + "%"],
             label: {
@@ -466,10 +497,10 @@ export function buildChartOption(
               color: sliceLabelInside ? "#fff" : tk.fg,
             },
             labelLine: { show: showSliceLabels && !sliceLabelInside },
-            // #1091: a same-bg border separates adjacent slices for monochrome
-            // / low-vision readers; absent when high-contrast is off.
             ...itemStyleHC,
-            data: rows.map((name, i) => ({ name, value: matrix[i][m] ?? 0 })),
+            data:
+              collapsedData ??
+              rows.map((name, i) => ({ name, value: matrix[i][m] ?? 0 })),
           };
         }),
       };
@@ -482,14 +513,16 @@ export function buildChartOption(
         tooltip: tooltipStyle,
         series: cells.map((cell, m) => ({
           type: "treemap",
-          name: cols[m],
+          name: collapsedData ? "Total" : cols[m],
           left: cell.leftPct + "%",
           top: cell.topPct + cell.heightPct * 0.18 + "%",
           width: cell.widthPct + "%",
           height: cell.heightPct * 0.82 + "%",
           label: { color: "#fff" },
           breadcrumb: { show: false },
-          data: rows.map((name, i) => ({ name, value: matrix[i][m] ?? 0 })).filter((d) => d.value > 0),
+          data: (
+            collapsedData ?? rows.map((name, i) => ({ name, value: matrix[i][m] ?? 0 }))
+          ).filter((d) => d.value > 0),
         })),
       };
     }
@@ -501,11 +534,13 @@ export function buildChartOption(
       tooltip: tooltipStyle,
       series: cells.map((cell, m) => ({
         type: "sunburst",
-        name: cols[m],
+        name: collapsedData ? "Total" : cols[m],
         center: [cell.centerXPct + "%", cell.centerYPct + "%"],
         radius: [0, cellRadiusPct(cell, aspect) + "%"],
         label: { show: showSliceLabels, color: "#fff" },
-        data: rows.map((name, i) => ({ name, value: matrix[i][m] ?? 0 })).filter((d) => d.value > 0),
+        data: (
+          collapsedData ?? rows.map((name, i) => ({ name, value: matrix[i][m] ?? 0 }))
+        ).filter((d) => d.value > 0),
       })),
     };
   }

--- a/saiku-ui/src/lib/modals/ChartEditorModal.svelte
+++ b/saiku-ui/src/lib/modals/ChartEditorModal.svelte
@@ -149,7 +149,11 @@
         <span class="series-axis__title">{i18n.t("modal.chart.seriesAxis")}</span>
         <p class="hint">{i18n.t("modal.chart.seriesAxis.hint")}</p>
         <div class="series-axis__list">
-          {#each seriesNames as name (name)}
+          <!-- Defensive: use index keys because seriesNames is derived
+               from cellset columnCategories which can hold duplicates
+               when a query has multi-measure × multi-hierarchy cols
+               (Svelte 5 hard-fails on each_key_duplicate). -->
+          {#each seriesNames as name, ni (ni)}
             <div class="series-axis__row">
               <span class="series-axis__name" title={name}>{name}</span>
               <select

--- a/saiku-ui/src/lib/views/ChartView.svelte
+++ b/saiku-ui/src/lib/views/ChartView.svelte
@@ -262,7 +262,13 @@
      user feedback). The floating toolbar above the canvas felt like
      toolbar clutter; the persisted option lives with the rest of the
      chart config now. -->
-<div class="chart-scroll">
+<!-- Scrollbar only when small-multiples grow the canvas beyond the
+     wrapper height. With a single chart we render the canvas at exactly
+     60vh / 320px so the wrapper's overflow can stay hidden — otherwise
+     ECharts' internal padding shoves the content over by a pixel or two
+     and a phantom vertical scrollbar appears (user feedback 2026-06-07
+     "scrollbar that isn't needed"). -->
+<div class="chart-scroll" class:chart-scroll--scrollable={smallMultipleRows > 1}>
   <!-- #1090: the canvas is decorative to assistive tech; the sr-only table below
        is the accessible representation, so hide the canvas from screen readers. -->
   <div
@@ -304,11 +310,15 @@
     width: 100%;
     height: 60vh;
     min-height: 320px;
-    overflow-y: auto;
+    overflow-y: hidden;
     overflow-x: hidden;
     background: var(--bg);
     border: 1px solid var(--border);
     border-radius: var(--radius-sm);
+  }
+  /* Only show the scrollbar when small-multiples actually overflow. */
+  .chart-scroll--scrollable {
+    overflow-y: auto;
   }
   .chart {
     width: 100%;

--- a/saiku-ui/src/lib/views/dashboard/DashboardFilterPanel.svelte
+++ b/saiku-ui/src/lib/views/dashboard/DashboardFilterPanel.svelte
@@ -767,7 +767,7 @@
                     onchange={(e) => setTopN(f.id, { measure: (e.target as HTMLSelectElement).value })}
                   >
                     <option value="">— measure —</option>
-                    {#each measures as m (m)}
+                    {#each measures as m, _im (_im)}
                       <option value={m}>{m}</option>
                     {/each}
                   </select>
@@ -838,7 +838,7 @@
             <span>Dimension</span>
             <select bind:value={addDimension} disabled={!addCube}>
               <option value="">— pick —</option>
-              {#each addDimensionOptions() as d (d)}
+              {#each addDimensionOptions() as d, _id (_id)}
                 <option value={d}>{d}</option>
               {/each}
             </select>
@@ -847,7 +847,7 @@
             <span>Hierarchy</span>
             <select bind:value={addHierarchy} disabled={!addDimension}>
               <option value="">— pick —</option>
-              {#each addHierarchyOptions() as h (h)}
+              {#each addHierarchyOptions() as h, _ih (_ih)}
                 <option value={h}>{h}</option>
               {/each}
             </select>
@@ -856,7 +856,7 @@
             <span>Level</span>
             <select bind:value={addLevel} disabled={!addHierarchy}>
               <option value="">— pick —</option>
-              {#each addLevelOptions() as l (l)}
+              {#each addLevelOptions() as l, _il (_il)}
                 <option value={l}>{l}</option>
               {/each}
             </select>

--- a/saiku-ui/src/lib/views/dashboard/TileEditorFilter.svelte
+++ b/saiku-ui/src/lib/views/dashboard/TileEditorFilter.svelte
@@ -47,7 +47,7 @@
   <span>Dimension</span>
   <select bind:value={filterTarget.dimension} disabled={!cubePicked}>
     <option value="">— pick —</option>
-    {#each dimensions as d (d)}
+    {#each dimensions as d, _id (_id)}
       <option value={d}>{d}</option>
     {/each}
   </select>
@@ -56,7 +56,7 @@
   <span>Hierarchy</span>
   <select bind:value={filterTarget.hierarchy} disabled={!filterTarget.dimension}>
     <option value="">— pick —</option>
-    {#each hierarchies as h (h)}
+    {#each hierarchies as h, _ih (_ih)}
       <option value={h}>{h}</option>
     {/each}
   </select>
@@ -65,7 +65,7 @@
   <span>Level</span>
   <select bind:value={filterTarget.level} disabled={!filterTarget.hierarchy}>
     <option value="">— pick —</option>
-    {#each levels as l (l)}
+    {#each levels as l, _il (_il)}
       <option value={l}>{l}</option>
     {/each}
   </select>
@@ -78,7 +78,7 @@
       <span>Start level</span>
       <select bind:value={cascadeStartLevel} disabled={!filterTarget.hierarchy}>
         <option value="">— use level above —</option>
-        {#each levels as l (l)}
+        {#each levels as l, _il (_il)}
           <option value={l}>{l}</option>
         {/each}
       </select>

--- a/saiku-ui/src/lib/views/dashboard/TileEditorKpi.svelte
+++ b/saiku-ui/src/lib/views/dashboard/TileEditorKpi.svelte
@@ -119,7 +119,7 @@
       <span>Dimension</span>
       <select bind:value={kpiConfig.timeLevel!.dimension} disabled={!cubePicked}>
         <option value="">— pick —</option>
-        {#each dimensions as d (d)}
+        {#each dimensions as d, _id (_id)}
           <option value={d}>{d}</option>
         {/each}
       </select>
@@ -131,7 +131,7 @@
         disabled={!kpiConfig.timeLevel?.dimension}
       >
         <option value="">— pick —</option>
-        {#each hierarchies as h (h)}
+        {#each hierarchies as h, _ih (_ih)}
           <option value={h}>{h}</option>
         {/each}
       </select>
@@ -143,7 +143,7 @@
         disabled={!kpiConfig.timeLevel?.hierarchy}
       >
         <option value="">— pick —</option>
-        {#each levels as l (l)}
+        {#each levels as l, _il (_il)}
           <option value={l}>{l}</option>
         {/each}
       </select>


### PR DESCRIPTION
## Summary

Four screenshot bugs from a workspace pass 2026-06-07.

### 1. Pie / donut / treemap / sunburst — single chart above 6 cells
The grid layout fanned one chart per column, so a query with 24 product categories produced 24 tiny pies separated by vast whitespace ("Beer and Wine / Store Sales", "Carbonated Beverages / Store Sales", "Drinks / Store Sales", ...).

Beyond \`MAX_SMALL_MULTIPLES = 6\` we now render a **single chart** whose slices are summed across rows — the useful default for "Store Sales by Product Category". \`M = 1..6\` keeps the small-multiples behaviour for genuine measure-fanout cases.

### 2. Donut workspace scrollbar
\`.chart-scroll\` always set \`overflow-y: auto\`, so a single chart that exactly fits its wrapper still painted a phantom vertical scrollbar (ECharts' internal layout pad shoves the content over by a pixel or two). Hidden by default; \`.chart-scroll--scrollable\` opt-in when \`smallMultipleRows > 1\`.

### 3. X-axis labels still truncated to "Beer..." / "Drink..." even when rotated
Rotated labels read diagonally and don't compete with neighbours for horizontal slot width — they can hold the full caption without overlap. Widened the truncation cap to 160px when \`rotate != 0\` instead of using the cramped per-category derivation.

### 4. Defensive: \`each_key_duplicate\` in dashboard + workspace flows
Several dashboard pickers used \`{#each xs as x (x)}\` with bare string keys (measure / dimension / hierarchy / level names). Svelte 5 hard-fails on duplicate keys; even one cube alias or a duplicated cellset column triggers it. Switched to index keys in \`TileEditorKpi\` / \`TileEditorFilter\` / \`DashboardFilterPanel\` / \`ChartEditorModal\`.

## Test plan

- [x] \`npx svelte-check\` — 0 errors, 0 warnings
- [x] \`npm test -- --run\` — 870/870
- [ ] Manual smoke once deployed:
  - Workspace pie/donut with multi-category single-measure → single chart, no whitespace
  - Workspace donut with M=1 → no scrollbar
  - Workspace scatter / heatmap / bar with crowded x-axis → full labels visible at 30°
  - No more \`each_key_duplicate\` console errors

## Deferred

- Heatmap y-axis crowding when \`rows.length\` is huge — needs a separate label gating rule, filing for follow-up.