### PR TITLE
fix(export): pin commons-compress to 1.27.1 (POI XLSX)

### DIFF
--- a/saiku-bom/pom.xml
+++ b/saiku-bom/pom.xml
@@ -182,6 +182,25 @@
                 <artifactId>poi-ooxml</artifactId>
                 <version>5.4.0</version>
             </dependency>
+            <!--
+                POI 5.4.0 compiles against commons-compress 1.27.1 which
+                changed the ZipArchiveOutputStream.putArchiveEntry signature.
+                Without pinning, transitive deps from hadoop/curator drag
+                1.21 onto the runtime classpath and XLSX export NPEs with:
+
+                    NoSuchMethodError: 'void ...ZipArchiveOutputStream
+                      .putArchiveEntry(...ZipArchiveEntry)'
+                        at o.a.poi.openxml4j.opc.internal
+                            .ZipContentTypeManager.saveImpl:67
+
+                Pinned via BOM so the WAR + launcher both pick up the
+                right version. See saiku 2026-06 export-failure bug.
+            -->
+            <dependency>
+                <groupId>org.apache.commons</groupId>
+                <artifactId>commons-compress</artifactId>
+                <version>1.27.1</version>
+            </dependency>
             <dependency>
                 <groupId>org.olap4j</groupId>
                 <artifactId>olap4j-xmla</artifactId>


### PR DESCRIPTION
## Bug

XLSX export 500s with:

\`\`\`
java.lang.NoSuchMethodError: 'void
  org.apache.commons.compress.archivers.zip
    .ZipArchiveOutputStream.putArchiveEntry(...ZipArchiveEntry)'
  at org.apache.poi.openxml4j.opc.internal
      .ZipContentTypeManager.saveImpl(ZipContentTypeManager.java:67)
  at o.s.s.util.export.excel.ExcelWorksheetBuilder.build:204
\`\`\`

POI 5.4.0 compiles against commons-compress 1.27.1 (the \`putArchiveEntry\` signature changed in that line). Without a pin the dependency-management resolves to **1.21** (dragged in by hadoop / curator transitives) and the launcher fat-jar ships the wrong version. \`mvn dependency:tree -Dverbose=true\` confirms it:

\`\`\`
(commons-compress:jar:1.27.1:compile - omitted for conflict with 1.21)
commons-compress:jar:1.21:compile
\`\`\`

## Fix

Added a managed entry to \`saiku-bom\` pinning commons-compress to 1.27.1. The launcher fat-jar now bundles \`commons-compress-1.27.1.jar\`.

## Test plan

- [x] \`mvn dependency:tree | grep commons-compress\` resolves to 1.27.1
- [x] \`unzip -l saiku-launcher/target/saiku-*.jar | grep commons-compress\` shows 1.27.1
- [x] **Local end-to-end verification** (fresh \`/tmp/saiku-local-test\`, SAIKU_DEMO=true):
  - Built a Sales by Store City query via \`/api/query/execute\`
  - \`curl /api/query/<id>/export/xls\` → 200, ~5KB Microsoft OOXML
  - \`curl /api/query/<id>/export/csv\` → 200, well-formed CSV
- [ ] Manual smoke once deployed: workspace toolbar → Export → XLS / CSV / PDF, all download instead of 500.

Followup to #1248 (which null-guarded the export helpers — separate failure mode the version mismatch was hiding behind).