### PR TITLE
fix(chart): x-axis label width per-axis, not max(rows, cols)

### DIFF
--- a/saiku-ui/src/lib/charts/build.test.ts
+++ b/saiku-ui/src/lib/charts/build.test.ts
@@ -675,3 +675,47 @@ describe("buildChartOption — high contrast (#1091)", () => {
     expect(hcPos).not.toBe(hcNeg);
   });
 });
+
+describe("buildChartOption — x-axis label width per axis", () => {
+  // saiku 2026-06-07 user feedback "thats not even fucking angled and
+  // still cut off and is literally the only value on the axis" — root
+  // cause was catLabel computing width against max(rows, cols), so a
+  // single-category x-axis got cramped to the 40px MIN clamp just
+  // because the y side had ~50 series.
+  //
+  // Each chart family asserts that the x-axis label width tracks ITS
+  // OWN category count, not the bigger of the two.
+
+  function lopsided(xCount: number, yCount: number): ChartProjection {
+    return {
+      rowCategories: Array.from({ length: yCount }, (_, i) => `r${i}`),
+      columnCategories: Array.from({ length: xCount }, (_, i) => `c${i}`),
+      matrix: Array.from({ length: yCount }, () =>
+        Array.from({ length: xCount }, (_, j) => 100 + j),
+      ),
+    };
+  }
+
+  test("scatter with 3 x-categories + 50 y-series gets a roomy x-label width", () => {
+    // chartWidth=1400, axisCategoryCount=3 → per=466 → clamped MAX 160.
+    // Old behaviour: max(3, 50) = 50, per=28, clamped MIN 40 → "CA /…".
+    const opt = buildChartOption(lopsided(3, 50), "scatter", opts(), undefined, {
+      compact: false,
+      chartWidth: 1400,
+    }) as Record<string, unknown>;
+    const xAxis = opt.xAxis as { axisLabel: { width: number } };
+    expect(xAxis.axisLabel.width).toBeGreaterThanOrEqual(120);
+  });
+
+  test("bar with 50 x-categories gets a cramped (rotated) x-label width", () => {
+    const opt = buildChartOption(lopsided(2, 50), "bar", opts(), undefined, {
+      compact: false,
+      chartWidth: 1400,
+    }) as Record<string, unknown>;
+    const xAxis = opt.xAxis as { axisLabel: { width: number; rotate: number } };
+    // Rotate kicks in past 8 categories on the x-axis; rotated labels
+    // get the 160px width budget (they read diagonally).
+    expect(xAxis.axisLabel.rotate).toBe(30);
+    expect(xAxis.axisLabel.width).toBe(160);
+  });
+});

--- a/saiku-ui/src/lib/charts/build.ts
+++ b/saiku-ui/src/lib/charts/build.ts
@@ -416,19 +416,26 @@ export function buildChartOption(
   // small); roomy mode derives the per-label width from the canvas width and
   // category count. `rotate` is only used by the compact bar branch when
   // categories crowd. The full label always shows in the axis-pointer tooltip.
-  const catCount = Math.max(rows.length, cols.length, 1);
-  const catLabelWidth = compact ? 100 : deriveAxisLabelWidth(geom.chartWidth ?? 0, catCount);
-  // Rotated labels read diagonally — they don't compete with siblings for
-  // horizontal slot width, so they can hold ~2x the chars before clipping.
-  // Without this, scatter / heatmap labels rotated 30° still truncated to
-  // "Beer..." / "Drink..." even though there was room (user feedback
-  // 2026-06-07 "x axis is unreadable").
+  // Per-axis label width: divide chart width by the count of categories
+  // ON THAT AXIS, not max(rows, cols) — the earlier max() left scatter /
+  // bubble's single-category x-axis cramped to 40px just because the
+  // y-side had 50+ series (user feedback 2026-06-07: a single "Cust…"
+  // label clipped to 5 chars on a 1400px-wide chart). Callers pass the
+  // axis-specific count explicitly via {@link catLabel}.
   const ROTATED_LABEL_WIDTH = 160;
-  const catLabel = (rotate = 0) => ({
-    color: tk.fgMuted,
-    rotate,
-    ...axisLabelConfig(rotate !== 0 ? ROTATED_LABEL_WIDTH : catLabelWidth),
-  });
+  const catLabel = (rotate = 0, axisCategoryCount = cols.length || 1) => {
+    if (rotate !== 0) {
+      return {
+        color: tk.fgMuted,
+        rotate,
+        ...axisLabelConfig(ROTATED_LABEL_WIDTH),
+      };
+    }
+    const w = compact
+      ? 100
+      : deriveAxisLabelWidth(geom.chartWidth ?? 0, axisCategoryCount);
+    return { color: tk.fgMuted, rotate, ...axisLabelConfig(w) };
+  };
 
   const legend = compact ? compactLegend(o, tk) : legendConfig(o, tk);
   const title = titleConfig(o, tk);
@@ -755,7 +762,9 @@ export function buildChartOption(
       dataZoom: dataZoomConfig(compact, rows.length, false),
       xAxis: {
         ...baseAxis,
-        axisLabel: catLabel(rows.length > 8 ? 30 : 0),
+        // waterfall's x-axis is `rows`; pass rows.length so the
+        // per-label width is computed against the right dim.
+        axisLabel: catLabel(rows.length > 8 ? 30 : 0, rows.length),
         data: rows,
         name: xName,
       },
@@ -876,11 +885,12 @@ export function buildChartOption(
     dataZoom: dataZoomConfig(compact, rows.length), // #1080: x-axis zoom + pan
     xAxis: {
       ...baseAxis,
-      // Rotate when categories crowd — same rule in roomy + compact;
-      // a 30-row scatter / bar with horizontal labels collapses to
-      // "Alcohol…" / "Breakfa…" / "Eggs / …" etc., which the user
-      // flagged as unreadable on 2026-06-07.
-      axisLabel: catLabel(rows.length > 8 ? 30 : 0),
+      // bar / line / area: x-axis is `rows`. Pass rows.length so the
+      // per-label width is computed against the right dim — the old
+      // max(rows, cols) cramped scatter / bar single-category x-axes
+      // to 40px when the y side had many series ("Cust…" / "CA /…"
+      // 2026-06-07 screenshot).
+      axisLabel: catLabel(rows.length > 8 ? 30 : 0, rows.length),
       data: rows,
       name: xName,
     },


### PR DESCRIPTION
## Bug

PR #1251's "rotated labels widen to 160px" missed the non-rotated case. \`catLabel\` still computed per-label width against \`catCount = max(rows.length, cols.length)\`, so a scatter / bubble with ONE x-category but 50 y-axis series got the 40px MIN clamp on the x-axis.

User flagged it: "thats not even fucking angled and still cut off and is literally the only value on the axis" — the single label rendered as **"Cust…"**.

A second screenshot showed the same root cause with 3 x-categories + 50 y-series: **"CA /…", "OR /…", "WA /…"** all clipped to ~5 chars on a 1400px-wide chart.

## Fix

\`catLabel\` now takes an explicit \`axisCategoryCount\`; each chart branch passes the dim that's actually on the x-axis:

| Chart family | x-axis dim | axisCategoryCount |
|---|---|---|
| scatter / bubble / heatmap | cols | \`cols.length\` (default) |
| bar / line / area / waterfall | rows | \`rows.length\` (explicit) |

## Test plan

- [x] \`npx svelte-check\` clean
- [x] \`npm test -- --run\` 872/872 (added 2 tests pinning the behaviour)
- [x] Local repro: scatter with 3 cols × 50 rows + chartWidth=1400 → x-axis label width >= 120 (not the old 40)
- [x] Local repro: bar with 50 rows → rotate=30, width=160
- [ ] Manual smoke once deployed: open scatter / bubble with few x-categories + many series, confirm full labels visible.