### PR TITLE
fix(pdf): bundle Xalan + serializer, make secureDocumentBuilder namespace-aware

### DIFF
--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/util/xml/SecureXml.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/util/xml/SecureXml.java
@@ -65,6 +65,14 @@ public final class SecureXml {
         dbf.setFeature(FEATURE_LOAD_EXTERNAL_DTD, false);
         dbf.setXIncludeAware(false);
         dbf.setExpandEntityReferences(false);
+        // Namespace awareness is REQUIRED for downstream consumers that
+        // read prefixed attributes / elements (XSLT compilation in
+        // PdfReport, for one — without it Xalan reads `xsl:stylesheet`
+        // as a non-qualified element and fails with "stylesheet requires
+        // attribute: version", which produced an empty 15-byte PDF on
+        // 2026-06-07). Matches the SAX factory above which DOES set
+        // this; the omission here was an oversight.
+        dbf.setNamespaceAware(true);
         return dbf.newDocumentBuilder();
     }
 

--- a/saiku-core/saiku-web/pom.xml
+++ b/saiku-core/saiku-web/pom.xml
@@ -136,6 +136,28 @@
             <groupId>org.apache.xmlgraphics</groupId>
             <artifactId>fop</artifactId>
         </dependency>
+        <!--
+            JDK 21's bundled XSLTC TransformerFactory NPEs when compiling
+            xhtml2fo.xsl with the JDK-internal Xalan ("Cannot invoke
+            String.hashCode() because this._stringRep is null" inside
+            XSLTC.compile) — bug confirmed 2026-06-07 on the demo
+            container: PDF export produced a 15-byte file with just the
+            "%PDF-1.4" header.
+
+            Adding Apache Xalan to the classpath lets the JAXP SPI pick
+            it over the broken JDK-internal one. Sized at ~3 MB; we pay
+            it only on saiku-web.
+        -->
+        <dependency>
+            <groupId>xalan</groupId>
+            <artifactId>xalan</artifactId>
+            <version>2.7.3</version>
+        </dependency>
+        <dependency>
+            <groupId>xalan</groupId>
+            <artifactId>serializer</artifactId>
+            <version>2.7.3</version>
+        </dependency>
         <dependency>
             <groupId>commons-collections</groupId>
             <artifactId>commons-collections</artifactId>

--- a/saiku-webapp/pom.xml
+++ b/saiku-webapp/pom.xml
@@ -108,15 +108,30 @@
                             <goal>war</goal>
                         </goals>
                         <configuration>
-                            <!-- xerces/xalan are dragged in transitively (mondrian +
-                                 hadoop via hive-jdbc) but their META-INF/services
-                                 javax.xml.parsers.* overrides hijack JAXP. Spring 6.2's
-                                 stricter namespace validation breaks against
-                                 xerces for applicationContext.xml's
-                                 <mvc:annotation-driven/>. JDK 21 has internal
-                                 xerces+xalan that respects JAXP's resolver chain
-                                 — strip the external copies from WEB-INF/lib so
-                                 the JDK's implementation wins. -->
+                            <!-- xerces is dragged in transitively (mondrian +
+                                 hadoop via hive-jdbc) but its
+                                 META-INF/services javax.xml.parsers.* override
+                                 hijacks JAXP and Spring 6.2's stricter
+                                 namespace validation breaks against it for
+                                 applicationContext.xml's
+                                 <mvc:annotation-driven/>. JDK 21 has an
+                                 internal xerces that respects JAXP's resolver
+                                 chain — strip the external copy so the JDK's
+                                 implementation wins.
+
+                                 xalan IS bundled (was previously stripped):
+                                 JDK 21's built-in XSLTC NPEs when compiling
+                                 the xhtml2fo.xsl PDF-export stylesheet
+                                 ("Cannot invoke String.hashCode() because
+                                 this._stringRep is null" inside XSLTC.compile,
+                                 2026-06-07 demo bug). Apache Xalan's
+                                 TransformerFactory handles the XSL correctly;
+                                 its SPI registration doesn't conflict with
+                                 Spring (Spring's complaint was about Xerces's
+                                 DocumentBuilderFactory, not Xalan's
+                                 TransformerFactory). The matching serializer
+                                 jar is kept alongside xalan because xalan
+                                 calls into it. -->
                             <!-- netty-3.7.0 (from zookeeper via hive-jdbc) and
                                  netty-all-4.0.23 (from hadoop-hdfs) collide with
                                  the netty-common/buffer 4.1.117 that arrow-memory-netty
@@ -125,7 +140,7 @@
                                  UnsupportedOperationException on memoryAddress(),
                                  crashing arrow's NettyAllocationManager.<clinit>
                                  the first time a query executes. -->
-                            <packagingExcludes>WEB-INF/lib/saiku-query-${saiku-query.version}.jar,WEB-INF/lib/xercesImpl-*.jar,WEB-INF/lib/xalan-*.jar,WEB-INF/lib/serializer-*.jar,WEB-INF/lib/netty-3.*.jar,WEB-INF/lib/netty-all-*.jar</packagingExcludes>
+                            <packagingExcludes>WEB-INF/lib/saiku-query-${saiku-query.version}.jar,WEB-INF/lib/xercesImpl-*.jar,WEB-INF/lib/netty-3.*.jar,WEB-INF/lib/netty-all-*.jar</packagingExcludes>
                         </configuration>
                     </execution>
                 </executions>


### PR DESCRIPTION
## Bug

PDF export produced a 15-byte empty file (just \`%PDF-1.4\` header). Two compounding bugs.

### 1. JDK 21's bundled XSLTC NPEs compiling xhtml2fo.xsl
\`\`\`
TransformerConfigurationException: Cannot invoke
  String.hashCode() because this._stringRep is null
  at XSLTC.compile(Unknown Source)
  at PdfReport.getTransformer:238
\`\`\`

\`saiku-webapp\`'s \`packagingExcludes\` previously stripped \`xalan-*.jar\` because Xerces's SPI override broke Spring 6.2 — but the comment conflated **xerces** and **xalan**. Only xerces's \`DocumentBuilderFactory\` registration breaks Spring; xalan's \`TransformerFactory\` is fine. Added \`xalan + serializer 2.7.3\` as explicit deps on \`saiku-web\` and narrowed the packaging exclude to **xerces only**.

### 2. SecureXml.secureDocumentBuilder() wasn't namespace-aware
Without \`setNamespaceAware(true)\` the parsed DOM treats \`xsl:stylesheet\` as a non-qualified element. Xalan reads it as a generic stylesheet missing the \`version\` attribute and produces an empty document. The companion \`secureSAXParserFactory()\` already had the call — this was an oversight. Same shape would surface for any future XML parsed through this helper that uses prefixed names.

## Test plan

- [x] \`mvn -pl saiku-launcher -am package\` clean; launcher fat-jar bundles \`xalan-2.7.3.jar\` + \`serializer-2.7.3.jar\`.
- [x] **Local verify** (fresh saiku-home, SAIKU_DEMO=true):
  - PDF export: **6.5 KB, valid 1-page PDF** (was 15 bytes)
  - XLS export: 4.9 KB OOXML
  - CSV export: 334 B well-formed
- [ ] Manual smoke once deployed: workspace toolbar → Export → PDF / XLS / CSV all download as valid files.

Followup to #1248 (CSV/Excel null-guard) and #1252 (commons-compress pin) — completing the export-pipeline triage.