### PR TITLE
chore(build): green development — spotless drift + stale DashboardResource test

### DIFF
--- a/saiku-core/saiku-service/src/main/java/org/saiku/olap/discover/OlapMetaExplorer.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/olap/discover/OlapMetaExplorer.java
@@ -153,8 +153,7 @@ public class OlapMetaExplorer {
                                     schem.getName(),
                                     cub.isVisible());
                             if (catalogUrl != null) {
-                                sc.setTimeCalcs(
-                                        org.saiku.olap.util.TimeCalcParser.parse(catalogUrl, cub.getName()));
+                                sc.setTimeCalcs(org.saiku.olap.util.TimeCalcParser.parse(catalogUrl, cub.getName()));
                             }
                             cubes.add(sc);
                         }

--- a/saiku-core/saiku-service/src/test/java/org/saiku/olap/util/TimeCalcParserTest.java
+++ b/saiku-core/saiku-service/src/test/java/org/saiku/olap/util/TimeCalcParserTest.java
@@ -26,28 +26,27 @@ import org.xml.sax.SAXException;
  *  most assertions feed a {@link Document} parsed from an in-memory string. */
 public class TimeCalcParserTest {
 
-    private static final String BANK_SCHEMA_FRAGMENT =
-            "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
-                    + "<Schema name='Bank'>\n"
-                    + "  <Cube name='Monthly Revenue'>\n"
-                    + "    <MeasureGroups/>\n"
-                    + "    <TimeCalcs>\n"
-                    + "      <TimeCalc name='Revenue YoY' type='yoy' measure='Revenue'\n"
-                    + "                timeDimension='Calendar' formatString='0.0%'/>\n"
-                    + "      <TimeCalc name='Revenue PoP' type='pop' measure='Revenue'\n"
-                    + "                timeDimension='Calendar' formatString='0.0%'/>\n"
-                    + "      <TimeCalc name='Revenue YTD' type='ytd' measure='Revenue'\n"
-                    + "                timeDimension='Calendar' formatString='#,###'/>\n"
-                    + "      <TimeCalc name='Revenue R3' type='rolling' measure='Revenue'\n"
-                    + "                timeDimension='Calendar' window='3' function='avg'\n"
-                    + "                formatString='#,###'/>\n"
-                    + "    </TimeCalcs>\n"
-                    + "  </Cube>\n"
-                    + "  <Cube name='Accounts'>\n"
-                    + "    <!-- no TimeCalcs here — parser must return empty list for this cube -->\n"
-                    + "    <MeasureGroups/>\n"
-                    + "  </Cube>\n"
-                    + "</Schema>\n";
+    private static final String BANK_SCHEMA_FRAGMENT = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
+            + "<Schema name='Bank'>\n"
+            + "  <Cube name='Monthly Revenue'>\n"
+            + "    <MeasureGroups/>\n"
+            + "    <TimeCalcs>\n"
+            + "      <TimeCalc name='Revenue YoY' type='yoy' measure='Revenue'\n"
+            + "                timeDimension='Calendar' formatString='0.0%'/>\n"
+            + "      <TimeCalc name='Revenue PoP' type='pop' measure='Revenue'\n"
+            + "                timeDimension='Calendar' formatString='0.0%'/>\n"
+            + "      <TimeCalc name='Revenue YTD' type='ytd' measure='Revenue'\n"
+            + "                timeDimension='Calendar' formatString='#,###'/>\n"
+            + "      <TimeCalc name='Revenue R3' type='rolling' measure='Revenue'\n"
+            + "                timeDimension='Calendar' window='3' function='avg'\n"
+            + "                formatString='#,###'/>\n"
+            + "    </TimeCalcs>\n"
+            + "  </Cube>\n"
+            + "  <Cube name='Accounts'>\n"
+            + "    <!-- no TimeCalcs here — parser must return empty list for this cube -->\n"
+            + "    <MeasureGroups/>\n"
+            + "  </Cube>\n"
+            + "</Schema>\n";
 
     private static Document doc(String xml) throws IOException, SAXException, ParserConfigurationException {
         return SecureXml.secureDocumentBuilder().parse(new ByteArrayInputStream(xml.getBytes(StandardCharsets.UTF_8)));
@@ -116,7 +115,8 @@ public class TimeCalcParserTest {
 
     @Test
     public void extractsCatalogUrlFromMondrianConnectionString() {
-        String dsl = "jdbc:mondrian:Jdbc=jdbc:h2:/app/data/foodmart;Catalog=file:/app/data/Bank.xml;JdbcDrivers=org.h2.Driver";
+        String dsl =
+                "jdbc:mondrian:Jdbc=jdbc:h2:/app/data/foodmart;Catalog=file:/app/data/Bank.xml;JdbcDrivers=org.h2.Driver";
         assertEquals("file:/app/data/Bank.xml", TimeCalcParser.extractCatalogUrl(dsl));
     }
 

--- a/saiku-core/saiku-web/src/test/java/org/saiku/web/rest/resources/dashboards/DashboardResourceTest.java
+++ b/saiku-core/saiku-web/src/test/java/org/saiku/web/rest/resources/dashboards/DashboardResourceTest.java
@@ -125,7 +125,10 @@ public class DashboardResourceTest {
         stubDs.stored.put("/dashboards/q4.saikudash", MAPPER.writeValueAsString(sampleDashboard()));
         Response r = resource.load("/dashboards/q4.saikudash");
         assertEquals(200, r.getStatus());
-        Dashboard d = (Dashboard) r.getEntity();
+        // #1246: load() now returns the RAW JSON body (UI is the schema authority;
+        // it no longer re-serialises a typed Dashboard POJO, which dropped UI-owned
+        // fields). The entity is the JSON string — parse it to assert the content.
+        Dashboard d = MAPPER.readValue((String) r.getEntity(), Dashboard.class);
         assertEquals("Q4 Sales", d.name);
         assertEquals(2, d.layout.tiles.size());
     }


### PR DESCRIPTION
`development` has been RED since the 4.5.0 push, for TWO reasons (both from changes merged outside our gate):
1. **spotless drift** — `f54bde975` landed without `spotless:apply` (OlapMetaExplorer.java + TimeCalcParserTest.java). Fixed via `spotless:apply` (behavior-neutral).
2. **stale test** — #1246 changed `DashboardResource.load()` to return raw JSON (UI is schema authority), but `DashboardResourceTest.load_returnsParsedDashboard` still cast the entity to `Dashboard` → ClassCastException. Updated the test to parse the JSON (test-only, matches shipped behavior).

Greens `mvn verify` for the whole team (QA/DEV/SEC PRs were all blocked behind this). Found by AGENT QA / Verity (#1) + AGENT LEAD (#2).