### PR TITLE
fix(security): stop QueryResource leaking raw error detail to clients (#1165)

### DIFF
--- a/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/QueryResource.java
+++ b/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/QueryResource.java
@@ -35,7 +35,6 @@ import java.sql.Statement;
 import java.util.*;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.saiku.olap.dto.*;
 import org.saiku.olap.dto.filter.SaikuFilter;
 import org.saiku.olap.dto.resultset.CellDataSet;
@@ -488,8 +487,9 @@ public class QueryResource {
             return RestUtil.convert(cs, limit);
         } catch (Exception e) {
             log.error("Cannot execute query (" + queryName + ")", e);
-            String error = ExceptionUtils.getRootCauseMessage(e);
-            return new QueryResult(error);
+            // saiku#1165: detail is logged server-side above; return a generic
+            // message so Mondrian/SQL internals don't leak in QueryResult.error.
+            return new QueryResult(GENERIC_ERROR);
         }
     }
 
@@ -536,8 +536,9 @@ public class QueryResource {
             return RestUtil.convert(cs, limit);
         } catch (Exception e) {
             log.error("Cannot execute query (" + queryName + ") using mdx:\n" + mdx, e);
-            String error = ExceptionUtils.getRootCauseMessage(e);
-            return new QueryResult(error);
+            // saiku#1165: detail is logged server-side above; return a generic
+            // message so Mondrian/SQL internals don't leak in QueryResult.error.
+            return new QueryResult(GENERIC_ERROR);
         }
     }
 
@@ -555,8 +556,9 @@ public class QueryResource {
             return executeMdx(queryName, null, mdx, limit);
         } catch (Exception e) {
             log.error("Cannot execute query (" + queryName + ") using mdx:\n" + mdx, e);
-            String error = ExceptionUtils.getRootCauseMessage(e);
-            return new QueryResult(error);
+            // saiku#1165: detail is logged server-side above; return a generic
+            // message so Mondrian/SQL internals don't leak in QueryResult.error.
+            return new QueryResult(GENERIC_ERROR);
         }
     }
 
@@ -620,8 +622,8 @@ public class QueryResource {
 
         } catch (Exception e) {
             log.error("Cannot get explain plan for query (" + queryName + ")", e);
-            String error = ExceptionUtils.getRootCauseMessage(e);
-            rsc = new QueryResult(error);
+            // saiku#1165: detail logged server-side above; generic to the client.
+            rsc = new QueryResult(GENERIC_ERROR);
         }
         // no need to close resultset, its an EmptyResultset
         return rsc;
@@ -661,8 +663,8 @@ public class QueryResource {
 
         } catch (Exception e) {
             log.error("Cannot execute query (" + queryName + ")", e);
-            String error = ExceptionUtils.getRootCauseMessage(e);
-            rsc = new QueryResult(error);
+            // saiku#1165: detail logged server-side above; generic to the client.
+            rsc = new QueryResult(GENERIC_ERROR);
 
         } finally {
             if (rs != null) {
@@ -789,8 +791,9 @@ public class QueryResource {
             return RestUtil.convert(cs, limit);
         } catch (Exception e) {
             log.error("Cannot execute query (" + queryName + ")", e);
-            String error = ExceptionUtils.getRootCauseMessage(e);
-            return new QueryResult(error);
+            // saiku#1165: detail is logged server-side above; return a generic
+            // message so Mondrian/SQL internals don't leak in QueryResult.error.
+            return new QueryResult(GENERIC_ERROR);
         }
     }
 

--- a/saiku-core/saiku-web/src/test/java/org/saiku/web/rest/resources/QueryResourceErrorLeakTest.java
+++ b/saiku-core/saiku-web/src/test/java/org/saiku/web/rest/resources/QueryResourceErrorLeakTest.java
@@ -1,0 +1,59 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.web.rest.resources;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+
+import org.junit.Test;
+import org.saiku.olap.dto.resultset.CellDataSet;
+import org.saiku.service.olap.OlapQueryService;
+import org.saiku.web.rest.objects.resultset.QueryResult;
+
+/**
+ * saiku#1165 regression: the legacy v1 {@link QueryResource} must NOT serialise raw
+ * exception / root-cause text (Mondrian or SQL internals, driver messages, paths) back to the
+ * client. On any failure it returns a generic {@code "Internal error"} in {@link
+ * QueryResult#getError()}; the detail is logged server-side only.
+ *
+ * <p>This locks a fix that silently regressed once: six catch sites used to do {@code new
+ * QueryResult(ExceptionUtils.getRootCauseMessage(e))}, and a squash-merge dropped the
+ * remediation so the leak shipped to {@code development}. Without this test a future edit could
+ * reopen it with the suite still green.
+ */
+public class QueryResourceErrorLeakTest {
+
+    /** A realistic sensitive root-cause: a JDBC URL with embedded credentials. */
+    private static final String SECRET =
+            "jdbc:postgresql://10.0.0.5:5432/warehouse?user=svc&password=hunter2 [SQLState=28000]";
+
+    private static QueryResource resourceFailingWith(final RuntimeException boom) {
+        QueryResource r = new QueryResource();
+        r.setOlapQueryService(new OlapQueryService() {
+            @Override
+            public CellDataSet execute(String queryName) {
+                throw boom;
+            }
+
+            @Override
+            public CellDataSet execute(String queryName, String formatter) {
+                throw boom;
+            }
+        });
+        return r;
+    }
+
+    @Test
+    public void execute_returnsGenericError_andDoesNotLeakRootCause() {
+        QueryResult res = resourceFailingWith(new RuntimeException(SECRET)).execute("q", 0);
+
+        assertNotNull(res);
+        assertEquals("Internal error", res.getError());
+        assertFalse(
+                "raw exception detail must never reach the client",
+                res.getError().contains("password=hunter2"));
+    }
+}


### PR DESCRIPTION
Refs #1165. **Live information-disclosure leak on `development`** — found while resolving the dangling `security/harden-exception-leakage` branch.

## The leak
The legacy v1 `QueryResource` (`@Deprecated`, but still wired + authenticated) returned `ExceptionUtils.getRootCauseMessage(e)` directly to the client at **6 catch sites** — `new QueryResult(error)` serialised over HTTP 200. That exposes Mondrian/SQL internals, driver messages, and paths to any authenticated caller.

**Proven, not theoretical.** The regression test stubs the service to throw a credential-bearing message; against current `development` it returns:
```
RuntimeException: jdbc:postgresql://10.0.0.5:5432/warehouse?user=svc&password=hunter2 [SQLState=28000]
```
i.e. a JDBC URL with an embedded DB password, straight to the client.

## How it got here
This is the remediation a **squash-merge of #1211 dropped**. #1211 landed `GenericExceptionMapper` + converted the `Response.serverError()` sites to `GENERIC_ERROR`, but the six `QueryResult(error)` sites never made it in — so the leak is currently live. (The stale `security/harden-exception-leakage` branch still carried this fix but is otherwise an ancient snapshot; not resurrecting it — re-landed fresh off current `development`.)

## Fix
- Replace all 6 sites with the existing `GENERIC_ERROR` (`"Internal error"`) constant; full detail still logged server-side via the pre-existing `log.error(...)`.
- Drop the now-unused `ExceptionUtils` import.

## Verification
- `QueryResourceErrorLeakTest` — **RED pre-fix** (returned the raw JDBC URL), **GREEN post-fix**. Locks against silent regression (this leak already regressed once via squash-merge).
- `mvn spotless:apply test` green (QueryResourceErrorLeakTest + GenericExceptionMapperTest, 6/6).

## Note for LEAD (not in this PR — out of my lane to delete unprompted)
`saiku-core/.../rest/exception/GenericFailureExceptionMapper.java` still exists in `development` but is **no longer registered** (`SaikuJerseyApplication` registers `GenericExceptionMapper`). It's inert dead code — safe to delete in a cleanup, not a security risk, so I left it.

Security lane (Agent SEC). **Not self-merging** — handing to LEAD. 🤖 Generated with [Claude Code](https://claude.com/claude-code)
