### PR TITLE
test(security): cover all 6 QueryResource error-leak catch sites (#1165 follow-up)

### DIFF
--- a/saiku-core/saiku-web/src/test/java/org/saiku/web/rest/resources/QueryResourceErrorLeakTest.java
+++ b/saiku-core/saiku-web/src/test/java/org/saiku/web/rest/resources/QueryResourceErrorLeakTest.java
@@ -8,6 +8,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 
+import java.sql.ResultSet;
 import org.junit.Test;
 import org.saiku.olap.dto.resultset.CellDataSet;
 import org.saiku.service.olap.OlapQueryService;
@@ -23,6 +24,13 @@ import org.saiku.web.rest.objects.resultset.QueryResult;
  * QueryResult(ExceptionUtils.getRootCauseMessage(e))}, and a squash-merge dropped the
  * remediation so the leak shipped to {@code development}. Without this test a future edit could
  * reopen it with the suite still green.
+ *
+ * <p>QA #1261 follow-up: the original test pinned only ONE of the six hardened catch sites
+ * ({@code execute(queryName, limit)}). A partial revert on any other endpoint would have
+ * reopened the leak with the suite still green, so this now exercises ALL six reachable
+ * {@code new QueryResult(GENERIC_ERROR)} sites — {@code execute}×2, {@code executeMdx}×2,
+ * {@code getExplainPlan}, {@code drillthrough} — each via the first {@link OlapQueryService}
+ * call inside its {@code try} block.
  */
 public class QueryResourceErrorLeakTest {
 
@@ -30,6 +38,13 @@ public class QueryResourceErrorLeakTest {
     private static final String SECRET =
             "jdbc:postgresql://10.0.0.5:5432/warehouse?user=svc&password=hunter2 [SQLState=28000]";
 
+    private static final String MDX = "SELECT {[Measures].[X]} ON COLUMNS FROM [Sales]";
+
+    /**
+     * A {@link QueryResource} whose {@link OlapQueryService} throws {@code boom} from every entry
+     * point reached first inside the six hardened catch sites — so each endpoint must convert the
+     * failure into the generic error rather than echoing the cause.
+     */
     private static QueryResource resourceFailingWith(final RuntimeException boom) {
         QueryResource r = new QueryResource();
         r.setOlapQueryService(new OlapQueryService() {
@@ -42,18 +57,67 @@ public class QueryResourceErrorLeakTest {
             public CellDataSet execute(String queryName, String formatter) {
                 throw boom;
             }
+
+            @Override
+            public void qm2mdx(String queryName) {
+                throw boom;
+            }
+
+            @Override
+            public ResultSet explain(String queryName) {
+                throw boom;
+            }
+
+            @Override
+            public ResultSet drillthrough(String queryName, int maxrows, String returns) {
+                throw boom;
+            }
         });
         return r;
     }
 
-    @Test
-    public void execute_returnsGenericError_andDoesNotLeakRootCause() {
-        QueryResult res = resourceFailingWith(new RuntimeException(SECRET)).execute("q", 0);
-
+    /** Every hardened path must return the generic message and never echo the root cause. */
+    private static void assertGenericNoLeak(QueryResult res) {
         assertNotNull(res);
         assertEquals("Internal error", res.getError());
         assertFalse(
-                "raw exception detail must never reach the client",
+                "raw exception detail must never reach the client: " + res.getError(),
                 res.getError().contains("password=hunter2"));
+    }
+
+    /** Site 1: GET /{queryname}/result — execute(queryName, limit) → olapQueryService.execute(name). */
+    @Test
+    public void execute_returnsGenericError_andDoesNotLeakRootCause() {
+        assertGenericNoLeak(resourceFailingWith(new RuntimeException(SECRET)).execute("q", 0));
+    }
+
+    /** Site 6: GET /{queryname}/result/{format} — execute(name, format, limit) → execute(name, format). */
+    @Test
+    public void executeWithFormat_returnsGenericError_andDoesNotLeak() {
+        assertGenericNoLeak(resourceFailingWith(new RuntimeException(SECRET)).execute("q", "flat", 0));
+    }
+
+    /** Site 2: POST /{queryname}/result/{format} — executeMdx(4-arg) → olapQueryService.qm2mdx(name). */
+    @Test
+    public void executeMdxWithFormat_returnsGenericError_andDoesNotLeak() {
+        assertGenericNoLeak(resourceFailingWith(new RuntimeException(SECRET)).executeMdx("q", "flat", MDX, 0));
+    }
+
+    /** Site 3: POST /{queryname}/result — executeMdx(3-arg) delegates to the 4-arg handler. */
+    @Test
+    public void executeMdx_returnsGenericError_andDoesNotLeak() {
+        assertGenericNoLeak(resourceFailingWith(new RuntimeException(SECRET)).executeMdx("q", MDX, 0));
+    }
+
+    /** Site 4: GET /{queryname}/explain — getExplainPlan(name) → olapQueryService.explain(name). */
+    @Test
+    public void getExplainPlan_returnsGenericError_andDoesNotLeak() {
+        assertGenericNoLeak(resourceFailingWith(new RuntimeException(SECRET)).getExplainPlan("q"));
+    }
+
+    /** Site 5: GET /{queryname}/drillthrough — drillthrough(...) → olapQueryService.drillthrough(name, maxrows, returns). */
+    @Test
+    public void drillthrough_returnsGenericError_andDoesNotLeak() {
+        assertGenericNoLeak(resourceFailingWith(new RuntimeException(SECRET)).drillthrough("q", 100, null, null));
     }
 }


### PR DESCRIPTION
## What this does

Follow-up to SEC's #1261 (LEAD-invited on the Colab Board). #1261 hardened **six** `QueryResource` catch sites to return the generic `"Internal error"` instead of the raw root-cause (which had been leaking a JDBC URL with an embedded DB password to clients). But `QueryResourceErrorLeakTest` pinned only **one** site (`execute(queryName, limit)`) — a partial revert on any other endpoint would have reopened the leak with the suite still green.

This **parameterizes the test across all six reachable sites**, each driven through a stub `OlapQueryService` that throws a JDBC-URL-with-password from the first service call inside its `try`:

| Site | Endpoint | Throw point |
|---|---|---|
| 1 | `GET /{q}/result` execute(q,limit) | execute(name) |
| 6 | `GET /{q}/result/{fmt}` execute(q,fmt,limit) | execute(name,fmt) |
| 2 | `POST /{q}/result/{fmt}` executeMdx(4-arg) | qm2mdx(name) |
| 3 | `POST /{q}/result` executeMdx(3-arg) | (delegates to site 2) |
| 4 | `GET /{q}/explain` getExplainPlan(q) | explain(name) |
| 5 | `GET /{q}/drillthrough` drillthrough(...) | drillthrough(name,maxrows,returns) |

Each asserts the error equals `Internal error` AND does not contain `password=hunter2`. Because the `Internal error` string is produced **only** by the `GENERIC_ERROR` catch path, every test provably exercises its site — a revert to leaking flips both assertions RED.

## Verification
- `mvn -pl saiku-core/saiku-web -am -s <settings> -Dtest=QueryResourceErrorLeakTest test` -> **6 tests, 0 failures** (JDK 21).
- Test-only, spotless-clean. Branched off the greened `development` (`396cb0e8`).

Handing to @AGENT LEAD to gate + merge — **not self-merging.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
