### PR TITLE
fix(security): include role-set in cellset cache key to stop cross-role leak (#1114)

### DIFF
--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/cache/QueryCacheKey.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/cache/QueryCacheKey.java
@@ -9,16 +9,19 @@ package org.saiku.service.cache;
 
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.PropertyAccessor;
 import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import java.security.MessageDigest;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.TreeSet;
 import org.saiku.olap.dto.SaikuCube;
 import org.saiku.olap.query2.ThinAxis;
 import org.saiku.olap.query2.ThinHierarchy;
@@ -56,8 +59,30 @@ public final class QueryCacheKey {
         return m;
     }
 
-    /** Hash a {@link ThinQuery} with the given cube-metadata version fingerprint. */
+    /**
+     * Hash a {@link ThinQuery} with the given cube-metadata version fingerprint.
+     *
+     * <p>Equivalent to {@link #of(ThinQuery, String, Collection)} with no roles. Retained
+     * for callers that don't apply per-role schema masking; produces a byte-identical key
+     * (the role-set is omitted from the canonical JSON when empty).
+     */
     public static String of(ThinQuery query, String cubeVersion) {
+        return of(query, cubeVersion, null);
+    }
+
+    /**
+     * Hash a {@link ThinQuery} with the given cube-metadata version fingerprint and the
+     * active session's Mondrian role-set.
+     *
+     * <p><b>The role-set must be part of the key (saiku#1114).</b> With Mondrian role-based
+     * schema masking (the {@code <Role>} element) two users with different roles running the
+     * SAME MDX get DIFFERENT results, but would otherwise share one cached cellset — a silent
+     * cross-role data leak. Roles are de-duplicated and sorted so the key is independent of
+     * role-binding order; an empty/absent role-set is omitted from the canonical JSON, so the
+     * key stays byte-identical to the legacy two-arg form and existing single-role caches keep
+     * hitting.
+     */
+    public static String of(ThinQuery query, String cubeVersion, Collection<String> roles) {
         if (query == null) {
             throw new IllegalArgumentException("query");
         }
@@ -76,6 +101,7 @@ public final class QueryCacheKey {
             view.cube = query.getCube();
             view.queryModel = query.getQueryModel();
             view.cubeVersion = cubeVersion == null ? "" : cubeVersion;
+            view.roles = canonicalRoles(roles);
 
             byte[] json = MAPPER.writeValueAsBytes(view);
             MessageDigest md = MessageDigest.getInstance("SHA-256");
@@ -84,6 +110,24 @@ public final class QueryCacheKey {
         } catch (Exception e) {
             throw new RuntimeException("Failed to build QueryCacheKey", e);
         }
+    }
+
+    /**
+     * De-duplicate + sort role names so the key is deterministic regardless of role-binding
+     * order ({@code [admin, reader]} and {@code [reader, admin]} hash the same). Null/blank
+     * entries are dropped; an empty result is omitted from the JSON (see {@link CanonicalView}).
+     */
+    private static List<String> canonicalRoles(Collection<String> roles) {
+        if (roles == null || roles.isEmpty()) {
+            return java.util.Collections.emptyList();
+        }
+        TreeSet<String> sorted = new TreeSet<>();
+        for (String r : roles) {
+            if (r != null && !r.trim().isEmpty()) {
+                sorted.add(r.trim());
+            }
+        }
+        return new ArrayList<>(sorted);
     }
 
     /**
@@ -158,6 +202,11 @@ public final class QueryCacheKey {
         public SaikuCube cube;
         public ThinQueryModel queryModel;
         public String cubeVersion;
+
+        // Omitted when empty so a no-role key is byte-identical to the legacy two-arg key
+        // (existing on-disk caches stay valid); present + sorted once roles are in play.
+        @JsonInclude(JsonInclude.Include.NON_EMPTY)
+        public List<String> roles;
 
         @JsonIgnore
         public Object getName() {

--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ThinQueryService.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ThinQueryService.java
@@ -91,6 +91,7 @@ import org.saiku.service.olap.totals.AxisInfo;
 import org.saiku.service.olap.totals.TotalNode;
 import org.saiku.service.olap.totals.TotalsListsBuilder;
 import org.saiku.service.olap.totals.aggregators.TotalAggregator;
+import org.saiku.service.user.UserService;
 import org.saiku.service.util.KeyValue;
 import org.saiku.service.util.QueryContext;
 import org.saiku.service.util.QueryContext.ObjectKey;
@@ -120,6 +121,16 @@ public class ThinQueryService implements Serializable {
 
     /** Optional disk-backed Arrow cache. Null (or disabled) ⇒ always execute live. */
     private SaikuQueryCache queryCache;
+
+    /**
+     * Optional — current user's Saiku role-set, mixed into the cache key so role-masked
+     * cellsets never leak across roles (saiku#1114). Null in non-Spring/standalone contexts.
+     */
+    private UserService userService;
+
+    public void setUserService(UserService userService) {
+        this.userService = userService;
+    }
 
     public void setOlapDiscoverService(OlapDiscoverService os) {
         this.olapDiscoverService = os;
@@ -165,7 +176,9 @@ public class ThinQueryService implements Serializable {
         createQuery(tq);
 
         final String cubeVersion = QueryCacheKey.cubeVersion(tq);
-        final String key = QueryCacheKey.of(tq, cubeVersion);
+        // Mix the caller's role-set into the key so a role-masked cellset is never served
+        // to a different role from cache (saiku#1114). Empty role-set ⇒ same key as before.
+        final String key = QueryCacheKey.of(tq, cubeVersion, currentRolesForCacheKey());
 
         if (queryCache == null || !queryCache.isEnabled()) {
             CachedQueryResult r = runAndMaterialise(tq);
@@ -187,6 +200,25 @@ public class ThinQueryService implements Serializable {
                 result.rows,
                 tq.getName());
         return result;
+    }
+
+    /**
+     * The current user's Saiku role-set for cache-key isolation, or empty when it can't be
+     * resolved (no Spring/session context — boot, scheduled tasks, standalone). Never throws:
+     * a missing context must not fail the query, and an empty set hashes to the legacy key.
+     */
+    private java.util.Collection<String> currentRolesForCacheKey() {
+        if (userService == null) {
+            return java.util.Collections.emptyList();
+        }
+        try {
+            String[] roles = userService.getCurrentUserRoles();
+            return roles == null ? java.util.Collections.emptyList() : java.util.Arrays.asList(roles);
+        } catch (Exception e) {
+            // No security/session context available — degrade to an unkeyed (role-less) cache
+            // entry rather than failing the query.
+            return java.util.Collections.emptyList();
+        }
     }
 
     /** Live-execute the query and encode the CellSet to Arrow IPC bytes. */

--- a/saiku-core/saiku-service/src/test/java/org/saiku/service/cache/QueryCacheKeyTest.java
+++ b/saiku-core/saiku-service/src/test/java/org/saiku/service/cache/QueryCacheKeyTest.java
@@ -1,0 +1,65 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.service.cache;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+
+import java.util.Arrays;
+import java.util.Collections;
+import org.junit.Test;
+import org.saiku.olap.query2.ThinQuery;
+
+/**
+ * saiku#1114: the cellset cache key must include the active session's Mondrian role-set, or a
+ * role-masked cellset can be served from cache to a different role — a silent cross-role data
+ * leak. These tests lock that the role-set participates in the key, is order/duplicate
+ * insensitive, and that an empty role-set stays byte-compatible with the legacy two-arg key so
+ * existing single-role caches keep hitting.
+ */
+public class QueryCacheKeyTest {
+
+    private static final String CUBE_VERSION = "conn|cat|schema|Sales";
+
+    private static ThinQuery query() {
+        ThinQuery q = new ThinQuery();
+        q.setMdx("SELECT {[Measures].[Sales]} ON 0 FROM [Sales]");
+        return q;
+    }
+
+    /** The security crux: same MDX, different roles ⇒ different cache key (no shared cellset). */
+    @Test
+    public void differentRolesProduceDifferentKeys() {
+        String reader = QueryCacheKey.of(query(), CUBE_VERSION, Collections.singletonList("reader"));
+        String manager = QueryCacheKey.of(query(), CUBE_VERSION, Collections.singletonList("manager"));
+        assertNotEquals("a role-masked cellset must not be keyed identically across roles", reader, manager);
+    }
+
+    /** The key is a set: binding order and duplicates must not change it. */
+    @Test
+    public void roleOrderAndDuplicatesDoNotMatter() {
+        String a = QueryCacheKey.of(query(), CUBE_VERSION, Arrays.asList("admin", "reader"));
+        String b = QueryCacheKey.of(query(), CUBE_VERSION, Arrays.asList("reader", "admin", "admin"));
+        assertEquals(a, b);
+    }
+
+    /** Same query + same role-set ⇒ same key (so the second execution still hits cache). */
+    @Test
+    public void sameQuerySameRolesAreStable() {
+        String a = QueryCacheKey.of(query(), CUBE_VERSION, Arrays.asList("reader"));
+        String b = QueryCacheKey.of(query(), CUBE_VERSION, Arrays.asList(" reader ")); // trimmed
+        assertEquals(a, b);
+    }
+
+    /** Backward-compat: an empty/null role-set hashes identically to the legacy two-arg key. */
+    @Test
+    public void emptyRolesMatchLegacyTwoArgKey() {
+        String legacy = QueryCacheKey.of(query(), CUBE_VERSION);
+        assertEquals(legacy, QueryCacheKey.of(query(), CUBE_VERSION, null));
+        assertEquals(legacy, QueryCacheKey.of(query(), CUBE_VERSION, Collections.emptyList()));
+        // and a role-bearing key must differ from the legacy/no-role key
+        assertNotEquals(legacy, QueryCacheKey.of(query(), CUBE_VERSION, Collections.singletonList("reader")));
+    }
+}

--- a/saiku-webapp/src/main/webapp/WEB-INF/saiku-beans.xml
+++ b/saiku-webapp/src/main/webapp/WEB-INF/saiku-beans.xml
@@ -162,6 +162,8 @@
         <aop:scoped-proxy/>
         <property name="olapDiscoverService" ref="olapDiscoverServiceBean"/>
         <property name="queryCache" ref="saikuQueryCacheBean"/>
+        <!-- saiku#1114: role-set mixed into the cellset cache key so role-masked results never leak across roles -->
+        <property name="userService" ref="userServiceBean"/>
     </bean>
 
     <bean id="platformBean" class="org.saiku.service.PlatformUtilsService">


### PR DESCRIPTION
Closes #1114.

## The vulnerability
`QueryCacheKey.of()` hashed `type | mdx | queryType | cube | queryModel | cubeVersion` but **not the caller's Mondrian role-set**. With role-based schema masking (the Mondrian `<Role>` element) two users with different roles running the **same MDX** compute **different** results — but shared a single cached cellset (whichever executed first won). That's a silent **cross-role data disclosure**.

Latent on the single-role demo; **real the moment per-role masking is configured** (which #779 / #1104 introduce, and which cube-YAML `<Role>` configs already allow today).

## Fix
- **`QueryCacheKey`** — new `of(query, cubeVersion, roles)` overload. Roles are **de-duplicated + sorted** (so `[admin, reader]` and `[reader, admin]` hash the same) and folded into the canonical JSON. An empty/absent role-set is **omitted** via `@JsonInclude(NON_EMPTY)`, so the key stays **byte-identical to the legacy two-arg key** — existing single-role on-disk caches keep hitting, no mass invalidation. The old `of(query, cubeVersion)` now delegates with no roles.
- **`ThinQueryService`** — inject `UserService`; mix `getCurrentUserRoles()` into the key at the single cache-key site. **Null-safe + exception-safe**: no security/session context (boot, scheduled tasks, standalone) degrades to a role-less key rather than failing the query.
- **`saiku-beans.xml`** — wire `userServiceBean` into `thinQueryBean`.

### Why the session role-set (conservative-safe)
There is no `SaikuRoleProvider` yet and Saiku doesn't expose the applied Mondrian role via a readable API in this module, so the key uses the **session's Saiku role-set** — the canonical identity available. This is fail-safe: different role-sets → different keys (**never** a leak); two role-sets that happen to map to the same masking just get separate cache entries (a minor efficiency cost, not a correctness/security one).

## Verification
`QueryCacheKeyTest` (new):
- different roles → different keys (the security crux)
- role order / duplicates don't change the key
- empty/null roles == legacy two-arg key (back-compat)
- role-bearing key != legacy key

**Proven RED→GREEN:** against a simulated role-blind key the two security assertions failed (two roles produced one key; role-bearing key == legacy key); with the fix all 4 pass. `mvn spotless:apply test` green, spotless clean.

Security lane (Agent SEC). **Not self-merging** — handing to LEAD. 🤖 Generated with [Claude Code](https://claude.com/claude-code)
