### PR TITLE
feat(dashboard): wire drillthrough Export CSV (#1051 part 2)

### DIFF
--- a/saiku-ui/src/lib/api/aiQuery.csvurl.test.ts
+++ b/saiku-ui/src/lib/api/aiQuery.csvurl.test.ts
@@ -1,0 +1,43 @@
+/*
+ * Unit tests for the drillthrough CSV export URL builder (issue #1051).
+ * Pure string construction — no network, no DOM.
+ */
+import { describe, expect, test } from "vitest";
+import { aiDrillthroughCsvUrl } from "./aiQuery";
+
+describe("aiDrillthroughCsvUrl", () => {
+  test("no options -> bare export path", () => {
+    expect(aiDrillthroughCsvUrl("q-123")).toBe(
+      "/rest/saiku/api/ai/query/q-123/drillthrough/export/csv",
+    );
+  });
+
+  test("encodes the queryId", () => {
+    expect(aiDrillthroughCsvUrl("a b/c")).toBe(
+      "/rest/saiku/api/ai/query/a%20b%2Fc/drillthrough/export/csv",
+    );
+  });
+
+  test("serialises position, maxRows and returns", () => {
+    const url = aiDrillthroughCsvUrl("q1", {
+      position: "2:1",
+      maxRows: 10000,
+      returns: ["[Time].[Year]", "[Measures].[Unit Sales]"],
+    });
+    const qs = new URLSearchParams(url.split("?")[1]);
+    expect(url.startsWith("/rest/saiku/api/ai/query/q1/drillthrough/export/csv?")).toBe(true);
+    expect(qs.get("position")).toBe("2:1");
+    expect(qs.get("maxrows")).toBe("10000");
+    expect(qs.get("returns")).toBe("[Time].[Year],[Measures].[Unit Sales]");
+  });
+
+  test("omits empty returns array", () => {
+    const url = aiDrillthroughCsvUrl("q1", { returns: [] });
+    expect(url).toBe("/rest/saiku/api/ai/query/q1/drillthrough/export/csv");
+  });
+
+  test("maxRows=0 is still serialised (not treated as absent)", () => {
+    const url = aiDrillthroughCsvUrl("q1", { maxRows: 0 });
+    expect(new URLSearchParams(url.split("?")[1]).get("maxrows")).toBe("0");
+  });
+});

--- a/saiku-ui/src/lib/api/aiQuery.ts
+++ b/saiku-ui/src/lib/api/aiQuery.ts
@@ -451,6 +451,28 @@ export async function forecastQuery(
   }
 }
 
+/** Build the GET URL for the CSV export of a drillthrough (issue #1051).
+ *  Mirrors {@link aiDrillthrough}'s params (position / maxRows / returns) but
+ *  targets the streaming text/csv endpoint. The URL is same-origin and the
+ *  browser sends session credentials automatically, so the download can be
+ *  triggered with `window.open(url)` / an `<a download>` — no fetch needed. */
+export function aiDrillthroughCsvUrl(queryId: string, opts: AiDrillthroughOptions = {}): string {
+  const params = new URLSearchParams();
+  if (opts.position) params.set("position", opts.position);
+  if (opts.maxRows != null) params.set("maxrows", String(opts.maxRows));
+  if (opts.returns && opts.returns.length) params.set("returns", opts.returns.join(","));
+  const qs = params.toString();
+  return `${REST_BASE}/query/${encodeURIComponent(queryId)}/drillthrough/export/csv${qs ? `?${qs}` : ""}`;
+}
+
+/** Trigger a browser download of the drillthrough CSV (issue #1051). The
+ *  endpoint sets `Content-Disposition: attachment`, so opening the
+ *  same-origin authenticated GET in a new tab streams the file straight to
+ *  the user's downloads — the same mechanism the Workspace export uses. */
+export function downloadAiDrillthroughCsv(queryId: string, opts: AiDrillthroughOptions = {}): void {
+  window.open(aiDrillthroughCsvUrl(queryId, opts), "_blank");
+}
+
 export async function executeSavedQuery(
   path: string,
   filters: SavedQueryFilter[] = [],

--- a/saiku-ui/src/lib/views/dashboard/tiles/TileDrillthrough.svelte
+++ b/saiku-ui/src/lib/views/dashboard/tiles/TileDrillthrough.svelte
@@ -16,7 +16,7 @@
 
   import DrillthroughModal from "$lib/modals/DrillthroughModal.svelte";
   import DrillthroughResultModal from "$lib/modals/DrillthroughResultModal.svelte";
-  import { aiDrillthrough } from "$lib/api/aiQuery";
+  import { aiDrillthrough, downloadAiDrillthroughCsv } from "$lib/api/aiQuery";
   import { drillthroughToQueryResult } from "$lib/dashboard/drillthroughCoord";
   import { datasources } from "$lib/stores/datasources.svelte";
   import { session } from "$lib/stores/session.svelte";
@@ -102,13 +102,21 @@
     }
   }
 
-  function exportCsv(_opts: { dimensions: string[]; measures: string[] }): void {
-    // The AI Query drillthrough surface (/ai/query/{queryId}/drillthrough)
-    // is JSON-only — it has no CSV export sibling (unlike the workspace
-    // ThinQuery path). Rather than open a 404, run the in-modal drillthrough
-    // so the user still sees the rows. CSV export from a dashboard tile can
-    // be a follow-up if a server-side endpoint lands.
-    void runDrillthrough({ ..._opts, maxRows: 10000 });
+  function exportCsv(opts: { dimensions: string[]; measures: string[] }): void {
+    // Issue #1051: stream the drillthrough as a CSV file from the AI Query
+    // surface (GET /ai/query/{queryId}/drillthrough/export/csv). The endpoint
+    // sets Content-Disposition: attachment, so opening the same-origin
+    // authenticated URL downloads the file directly — same mechanism the
+    // Workspace export uses. Honours the picked returns + the captured
+    // cell position, replacing the earlier JSON-refetch fallback.
+    pickerOpen = false;
+    if (!activeQueryId) return;
+    const returns = [...opts.dimensions, ...opts.measures];
+    downloadAiDrillthroughCsv(activeQueryId, {
+      position: activePosition ?? undefined,
+      maxRows: 10000,
+      returns: returns.length ? returns : undefined,
+    });
   }
 </script>
 


### PR DESCRIPTION
## Summary
Recovers the **UI half of #1051** — wires the dashboard drillthrough modal's **Export CSV** to the new AI CSV endpoint. **Part 2 of 2** — depends on the backend endpoint (**merge `feat/issue-1051-drillthrough-csv-backend` / PR #1267 first**). Compiles + builds independently; calls the endpoint at runtime.

## The change
- **`aiQuery.ts`** — `aiDrillthroughCsvUrl()` (builds the GET URL with position / maxRows / returns) + `downloadAiDrillthroughCsv()` (opens the same-origin authenticated URL; `Content-Disposition: attachment` triggers the file download — same mechanism as the workspace export).
- **`TileDrillthrough.svelte`** — `onExportCsv` now streams the real CSV via the captured `queryId` + `position` + picked `returns`, **replacing the old JSON-refetch fallback**.
- **`aiQuery.csvurl.test.ts`** *(new)* — 5 URL-builder tests (param encoding, omit-when-absent).

## Verify
- `npm run check` **0/0** · `npm test` (csvurl) **5 passed** · branch off **current** `development`.
- **User-verified locally** (combined launcher): tile → right-click → drillthrough → Export CSV → real CSV file of the underlying fact rows.

## Notes
- ⚠️ **Merge order: backend PR #1267 → this.** Rebased onto current `development` (atop the now-merged #907 — `aiQuery.ts` keeps both `detectAnomalies` and the CSV helpers). Reopened #1051 + assigned. Not self-merging.

Part of #1051 (UI). Needs PR #1267.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
