### PR TITLE
test(security): pin the #1114 cache-key call-site wiring (ThinQueryService feeds roles in)

### DIFF
--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ThinQueryService.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ThinQueryService.java
@@ -178,7 +178,7 @@ public class ThinQueryService implements Serializable {
         final String cubeVersion = QueryCacheKey.cubeVersion(tq);
         // Mix the caller's role-set into the key so a role-masked cellset is never served
         // to a different role from cache (saiku#1114). Empty role-set ⇒ same key as before.
-        final String key = QueryCacheKey.of(tq, cubeVersion, currentRolesForCacheKey());
+        final String key = cacheKeyFor(tq, cubeVersion);
 
         if (queryCache == null || !queryCache.isEnabled()) {
             CachedQueryResult r = runAndMaterialise(tq);
@@ -200,6 +200,18 @@ public class ThinQueryService implements Serializable {
                 result.rows,
                 tq.getName());
         return result;
+    }
+
+    /**
+     * Package-private seam (saiku#1114) so the role-aware cache key is unit-testable without a
+     * live olap connection: builds the cellset cache key for {@code tq} exactly as {@link
+     * #executeCached} does, mixing in the current user's Mondrian role-set via {@link
+     * #currentRolesForCacheKey()}. The original #1114 leak was the call-site omitting the
+     * role-set — this IS that call-site, so the wiring (not just {@link QueryCacheKey#of}) is
+     * pinned by {@code ThinQueryServiceCacheKeyTest}.
+     */
+    String cacheKeyFor(ThinQuery tq, String cubeVersion) {
+        return QueryCacheKey.of(tq, cubeVersion, currentRolesForCacheKey());
     }
 
     /**

--- a/saiku-core/saiku-service/src/test/java/org/saiku/service/olap/ThinQueryServiceCacheKeyTest.java
+++ b/saiku-core/saiku-service/src/test/java/org/saiku/service/olap/ThinQueryServiceCacheKeyTest.java
@@ -1,0 +1,82 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.service.olap;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+
+import org.junit.Test;
+import org.saiku.olap.query2.ThinQuery;
+import org.saiku.service.cache.QueryCacheKey;
+import org.saiku.service.user.UserService;
+
+/**
+ * saiku#1114 <b>call-site</b> (wiring) coverage. {@code QueryCacheKeyTest} already proves {@link
+ * QueryCacheKey#of} is role-aware; this proves {@link ThinQueryService}'s cache-key build
+ * actually FEEDS the current user's role-set into it. The original #1114 leak was precisely a
+ * call-site omission, so a future revert of the call-site back to a role-blind key would reopen
+ * the cross-role cache leak with the {@code QueryCacheKey} unit test still green — this turns
+ * that regression RED.
+ *
+ * <p>Exercises the package-private {@link ThinQueryService#cacheKeyFor(ThinQuery, String)} seam
+ * (the exact key {@code executeCached} computes) with a stub {@link UserService}, so no live
+ * olap connection is needed.
+ */
+public class ThinQueryServiceCacheKeyTest {
+
+    private static final String CUBE_VERSION = "conn|cat|schema|Sales";
+
+    private static ThinQuery query() {
+        ThinQuery q = new ThinQuery();
+        q.setMdx("SELECT {[Measures].[Sales]} ON 0 FROM [Sales]");
+        return q;
+    }
+
+    private static ThinQueryService serviceWithRoles(final String... roles) {
+        ThinQueryService s = new ThinQueryService();
+        s.setUserService(new UserService() {
+            @Override
+            public String[] getCurrentUserRoles() {
+                return roles;
+            }
+        });
+        return s;
+    }
+
+    /** The crux: the call-site must mix roles in, so two roles can't share a cached cellset. */
+    @Test
+    public void callSiteMixesRolesIn_differentRolesDifferentKeys() {
+        String reader = serviceWithRoles("reader").cacheKeyFor(query(), CUBE_VERSION);
+        String manager = serviceWithRoles("manager").cacheKeyFor(query(), CUBE_VERSION);
+        assertNotEquals("executeCached's key must include the session role-set (saiku#1114)", reader, manager);
+    }
+
+    /** A role-bearing key must differ from the role-less / legacy key. */
+    @Test
+    public void roleKeyDiffersFromLegacyKey() {
+        String roled = serviceWithRoles("reader").cacheKeyFor(query(), CUBE_VERSION);
+        assertNotEquals(QueryCacheKey.of(query(), CUBE_VERSION), roled);
+    }
+
+    /** No UserService (boot / standalone) ⇒ role-less key, byte-identical to the legacy two-arg key. */
+    @Test
+    public void noUserServiceDegradesToLegacyKey() {
+        ThinQueryService s = new ThinQueryService(); // userService unset
+        assertEquals(QueryCacheKey.of(query(), CUBE_VERSION), s.cacheKeyFor(query(), CUBE_VERSION));
+    }
+
+    /** A UserService that throws (no security context) must degrade to the legacy key, never fail the query. */
+    @Test
+    public void throwingUserServiceDegradesToLegacyKey() {
+        ThinQueryService s = new ThinQueryService();
+        s.setUserService(new UserService() {
+            @Override
+            public String[] getCurrentUserRoles() {
+                throw new IllegalStateException("no security context");
+            }
+        });
+        assertEquals(QueryCacheKey.of(query(), CUBE_VERSION), s.cacheKeyFor(query(), CUBE_VERSION));
+    }
+}


### PR DESCRIPTION
## What this does

Follow-up to SEC's #1266 (#1114 cross-role cache leak), the wiring-coverage gap I flagged in my QA review. **Juan picked the "tiny production seam + unit test" approach.**

`QueryCacheKeyTest` (in #1266) proves `QueryCacheKey.of()` is role-aware — but **not** that `ThinQueryService.executeCached` actually *feeds* the session role-set into it. The original #1114 leak was exactly that **call-site omission**, so a future revert of the call-site to a role-blind key would reopen the cross-role cache leak with the unit test still green.

### The seam (behaviour-preserving, no-op extraction)
`executeCached` already builds the key inline. This extracts it into a package-private:
```java
String cacheKeyFor(ThinQuery tq, String cubeVersion) {
    return QueryCacheKey.of(tq, cubeVersion, currentRolesForCacheKey());
}
```
`executeCached` now calls `cacheKeyFor(tq, cubeVersion)` — **the key is byte-identical**; the only point is to make the role-mixing wiring unit-testable without a live olap connection. ⚠️ @AGENT SEC / @AGENT LEAD — this is the one production touch (a pure extraction in your just-merged #1266 code); flagging it explicitly.

### The test
`ThinQueryServiceCacheKeyTest` (same package, stub `UserService`, no infra):
- two roles -> **different keys** (the crux — revert to role-blind -> RED)
- role key != legacy two-arg key
- null `UserService` -> degrades to the legacy key
- throwing `UserService` -> degrades to the legacy key (never fails the query)

## Verification
- `mvn -pl saiku-core/saiku-service -am -s <settings> -Dtest=ThinQueryServiceCacheKeyTest,QueryCacheKeyTest test` -> **4/0 + 4/0** (JDK 21); `QueryCacheKeyTest` still green confirms the extraction is behaviour-preserving.
- spotless-clean, off current `development` (post-#1266).

Handing to @AGENT LEAD to gate + merge — **not self-merging.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
