### PR TITLE
feat(ai): time-series forecast — backend + /ai/forecast (#908 part 1)

### DIFF
--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ai/forecast/AiForecastRequest.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ai/forecast/AiForecastRequest.java
@@ -1,0 +1,74 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.service.olap.ai.forecast;
+
+import org.saiku.service.olap.ai.AiQueryRequest;
+
+/**
+ * Body for {@code POST /saiku/api/ai/forecast} (saiku#908).
+ *
+ * <pre>{@code
+ * {
+ *   "query": { ...AiQueryRequest... },
+ *   "method": "ets" | "arima" | "prophet",
+ *   "horizon": 12,
+ *   "timeAxis": "[Time].[Time].[Month]",
+ *   "confidence": 0.95
+ * }
+ * }</pre>
+ *
+ * <p>{@code query} is executed through the same path {@code /ai/query} uses; the
+ * numeric measure series are extracted in time order and each is projected
+ * {@code horizon} steps by the chosen {@code method}. {@code confidence} is the
+ * prediction-interval level (default 0.95); {@code horizon} defaults to 6.
+ */
+public class AiForecastRequest {
+
+    private AiQueryRequest query;
+    private String method;
+    private Integer horizon;
+    private String timeAxis;
+    private Double confidence;
+
+    public AiQueryRequest getQuery() {
+        return query;
+    }
+
+    public void setQuery(AiQueryRequest v) {
+        this.query = v;
+    }
+
+    public String getMethod() {
+        return method;
+    }
+
+    public void setMethod(String v) {
+        this.method = v;
+    }
+
+    public Integer getHorizon() {
+        return horizon;
+    }
+
+    public void setHorizon(Integer v) {
+        this.horizon = v;
+    }
+
+    public String getTimeAxis() {
+        return timeAxis;
+    }
+
+    public void setTimeAxis(String v) {
+        this.timeAxis = v;
+    }
+
+    public Double getConfidence() {
+        return confidence;
+    }
+
+    public void setConfidence(Double v) {
+        this.confidence = v;
+    }
+}

--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ai/forecast/ArimaForecaster.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ai/forecast/ArimaForecaster.java
@@ -1,0 +1,38 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.service.olap.ai.forecast;
+
+import java.util.List;
+import org.saiku.service.olap.ai.AiValidationException;
+
+/**
+ * ARIMA(p,d,q) forecaster — STUB (saiku#908).
+ *
+ * <p>Auto-fitting ARIMA orders via AIC/BIC needs a vetted optimiser + linear
+ * algebra (Levinson-Durbin / MLE), which we will not pull as a heavy/unvetted
+ * JVM dependency right now. Until a clean in-tree implementation lands,
+ * {@link #forecast} throws a structured {@link AiValidationException} so the
+ * REST layer returns the same self-correcting 400 envelope agents already
+ * understand — exactly as {@code StlAnomalyDetector} does in the sibling
+ * {@code ai.anomaly} package. {@code ets} is fully implemented and covers the
+ * common trend case.
+ */
+public class ArimaForecaster implements Forecaster {
+
+    public static final String METHOD = "arima";
+
+    @Override
+    public String method() {
+        return METHOD;
+    }
+
+    @Override
+    public List<ForecastPoint> forecast(double[] series, int horizon, double confidence) {
+        throw new AiValidationException(
+                "method",
+                "ARIMA forecasting is not yet supported. Use 'ets' (exponential smoothing) for now.",
+                List.of(EtsForecaster.METHOD));
+    }
+}

--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ai/forecast/EtsForecaster.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ai/forecast/EtsForecaster.java
@@ -1,0 +1,181 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.service.olap.ai.forecast;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Exponential smoothing with a linear trend (Holt's method) — the default
+ * {@code ets} forecaster (saiku#908). Dependency-free, deterministic, in-JVM.
+ *
+ * <p>Holt's recurrences over the gap-stripped series:
+ *
+ * <pre>{@code
+ *   level_t = a * x_t       + (1-a) * (level_{t-1} + trend_{t-1})
+ *   trend_t = b * (level_t - level_{t-1}) + (1-b) * trend_{t-1}
+ *   forecast(level_n, trend_n, h) = level_n + h * trend_n
+ * }</pre>
+ *
+ * <p>The smoothing parameters {@code a} (alpha) and {@code b} (beta) are fit by
+ * a coarse grid search that minimises the in-sample one-step SSE — good enough
+ * for a dashboard forecast without an optimisation dependency. Prediction
+ * intervals are {@code forecast +/- z * sigma * sqrt(h)} where {@code sigma} is
+ * the one-step residual standard deviation and {@code z} the normal quantile
+ * for the requested confidence; intervals therefore widen monotonically with
+ * the horizon.
+ *
+ * <p>Seasonal Holt-Winters is a documented future extension (it needs a known
+ * seasonal period); this implementation captures level + trend, which covers
+ * the common "where is this measure heading" case.
+ */
+public class EtsForecaster implements Forecaster {
+
+    public static final String METHOD = "ets";
+
+    private static final double[] GRID = {0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9};
+
+    @Override
+    public String method() {
+        return METHOD;
+    }
+
+    @Override
+    public List<ForecastPoint> forecast(double[] series, int horizon, double confidence) {
+        double[] x = stripGaps(series);
+        double z = normalQuantile(0.5 + confidence / 2.0);
+        List<ForecastPoint> out = new ArrayList<>(Math.max(0, horizon));
+
+        if (x.length == 0) {
+            // Nothing to fit — caller should have skipped, but be defensive.
+            for (int h = 1; h <= horizon; h++) out.add(new ForecastPoint(Double.NaN, Double.NaN, Double.NaN));
+            return out;
+        }
+        if (x.length == 1) {
+            // A single observation: flat forecast, no spread information.
+            for (int h = 1; h <= horizon; h++) out.add(new ForecastPoint(x[0], x[0], x[0]));
+            return out;
+        }
+
+        double bestAlpha = 0.5;
+        double bestBeta = 0.1;
+        double bestSse = Double.POSITIVE_INFINITY;
+        for (double a : GRID) {
+            for (double b : GRID) {
+                double sse = fitSse(x, a, b);
+                if (sse < bestSse) {
+                    bestSse = sse;
+                    bestAlpha = a;
+                    bestBeta = b;
+                }
+            }
+        }
+
+        // Re-run the best fit to recover the final level/trend + residual sigma.
+        Fit fit = run(x, bestAlpha, bestBeta);
+        double sigma = fit.residualStd();
+        for (int h = 1; h <= horizon; h++) {
+            double point = fit.level + h * fit.trend;
+            double spread = z * sigma * Math.sqrt(h);
+            out.add(new ForecastPoint(point, point - spread, point + spread));
+        }
+        return out;
+    }
+
+    /** One-step in-sample SSE for given smoothing params (for the grid search). */
+    private static double fitSse(double[] x, double alpha, double beta) {
+        return run(x, alpha, beta).sse;
+    }
+
+    private static Fit run(double[] x, double alpha, double beta) {
+        double level = x[0];
+        double trend = x[1] - x[0];
+        double sse = 0.0;
+        int errs = 0;
+        for (int t = 1; t < x.length; t++) {
+            double predicted = level + trend; // one-step-ahead forecast of x[t]
+            double err = x[t] - predicted;
+            sse += err * err;
+            errs++;
+            double prevLevel = level;
+            level = alpha * x[t] + (1 - alpha) * (prevLevel + trend);
+            trend = beta * (level - prevLevel) + (1 - beta) * trend;
+        }
+        double variance = errs > 0 ? sse / errs : 0.0;
+        return new Fit(level, trend, sse, Math.sqrt(variance));
+    }
+
+    private record Fit(double level, double trend, double sse, double residualStdValue) {
+        double residualStd() {
+            return residualStdValue;
+        }
+    }
+
+    /** Drop {@link Double#NaN} gaps, preserving order. */
+    private static double[] stripGaps(double[] series) {
+        if (series == null) return new double[0];
+        double[] tmp = new double[series.length];
+        int n = 0;
+        for (double v : series) {
+            if (!Double.isNaN(v)) tmp[n++] = v;
+        }
+        double[] out = new double[n];
+        System.arraycopy(tmp, 0, out, 0, n);
+        return out;
+    }
+
+    /**
+     * Inverse standard-normal CDF (probit) via Acklam's rational approximation
+     * — |error| &lt; 1.15e-9, dependency-free. Used to turn a confidence level
+     * into the prediction-interval z-multiplier.
+     */
+    static double normalQuantile(double p) {
+        if (p <= 0) return Double.NEGATIVE_INFINITY;
+        if (p >= 1) return Double.POSITIVE_INFINITY;
+        final double[] a = {
+            -3.969683028665376e+01,
+            2.209460984245205e+02,
+            -2.759285104469687e+02,
+            1.383577518672690e+02,
+            -3.066479806614716e+01,
+            2.506628277459239e+00
+        };
+        final double[] b = {
+            -5.447609879822406e+01,
+            1.615858368580409e+02,
+            -1.556989798598866e+02,
+            6.680131188771972e+01,
+            -1.328068155288572e+01
+        };
+        final double[] c = {
+            -7.784894002430293e-03,
+            -3.223964580411365e-01,
+            -2.400758277161838e+00,
+            -2.549732539343734e+00,
+            4.374664141464968e+00,
+            2.938163982698783e+00
+        };
+        final double[] d = {7.784695709041462e-03, 3.224671290700398e-01, 2.445134137142996e+00, 3.754408661907416e+00};
+        final double plow = 0.02425;
+        final double phigh = 1 - plow;
+        double q;
+        double r;
+        if (p < plow) {
+            q = Math.sqrt(-2 * Math.log(p));
+            return (((((c[0] * q + c[1]) * q + c[2]) * q + c[3]) * q + c[4]) * q + c[5])
+                    / ((((d[0] * q + d[1]) * q + d[2]) * q + d[3]) * q + 1);
+        } else if (p <= phigh) {
+            q = p - 0.5;
+            r = q * q;
+            return (((((a[0] * r + a[1]) * r + a[2]) * r + a[3]) * r + a[4]) * r + a[5])
+                    * q
+                    / (((((b[0] * r + b[1]) * r + b[2]) * r + b[3]) * r + b[4]) * r + 1);
+        } else {
+            q = Math.sqrt(-2 * Math.log(1 - p));
+            return -(((((c[0] * q + c[1]) * q + c[2]) * q + c[3]) * q + c[4]) * q + c[5])
+                    / ((((d[0] * q + d[1]) * q + d[2]) * q + d[3]) * q + 1);
+        }
+    }
+}

--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ai/forecast/ForecastAssembler.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ai/forecast/ForecastAssembler.java
@@ -1,0 +1,96 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.service.olap.ai.forecast;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import org.saiku.service.olap.ai.AiCell;
+import org.saiku.service.olap.ai.AiQueryMetadata;
+import org.saiku.service.olap.ai.AiQueryResponse;
+import org.saiku.service.olap.ai.AiValidationException;
+
+/**
+ * Builds the forecast block for an already-executed {@link AiQueryResponse}
+ * (records format) by extracting each measure series in time order and running
+ * a {@link Forecaster} over it (saiku#908).
+ *
+ * <p>Unlike the sibling anomaly augmenter, forecasting does NOT mutate the
+ * observed {@code data} — the future points live in a separate, keyed block
+ * ({@code measureCaption -> [ForecastPoint x horizon]}) that the chart tile
+ * appends as a dashed continuation with a confidence band. Time members are
+ * expected down the rows axis (one row per point, in order) and measures across
+ * the columns — the same layout the anomaly path assumes.
+ */
+public final class ForecastAssembler {
+
+    private ForecastAssembler() {}
+
+    /**
+     * @return ordered map of measure caption -&gt; horizon forecast points.
+     * @throws AiValidationException if the response carries no numeric measure
+     *     series to forecast, or horizon/confidence are out of range
+     */
+    public static Map<String, List<ForecastPoint>> assemble(
+            AiQueryResponse resp, Forecaster forecaster, int horizon, double confidence, String timeAxis) {
+        if (horizon < 1) {
+            throw new AiValidationException("horizon", "horizon must be >= 1", null);
+        }
+        if (confidence <= 0 || confidence >= 1 || Double.isNaN(confidence)) {
+            throw new AiValidationException("confidence", "confidence must be between 0 and 1 (exclusive)", null);
+        }
+        Map<String, List<ForecastPoint>> out = new LinkedHashMap<>();
+        if (resp == null) return out;
+        List<Map<String, Object>> data = resp.getData();
+        if (data == null || data.isEmpty()) {
+            // Nothing observed → nothing to project. Not an error.
+            return out;
+        }
+
+        List<String> measureCols = measureColumnKeys(resp.getMetadata());
+        if (measureCols.isEmpty()) {
+            throw new AiValidationException(
+                    "timeAxis",
+                    "No numeric measure columns found in the result for time axis '" + timeAxis
+                            + "'. Forecasting needs at least one measure plotted over time.",
+                    null);
+        }
+
+        for (String col : measureCols) {
+            double[] series = new double[data.size()];
+            int finite = 0;
+            for (int r = 0; r < data.size(); r++) {
+                Object raw = data.get(r).get(col);
+                Double v = (raw instanceof AiCell) ? ((AiCell) raw).getValue() : null;
+                if (v == null || v.isNaN()) {
+                    series[r] = Double.NaN;
+                } else {
+                    series[r] = v;
+                    finite++;
+                }
+            }
+            // A column with no usable points can't be forecast — skip it (a
+            // mixed result may still have other forecastable measures).
+            if (finite == 0) continue;
+            out.put(col, forecaster.forecast(series, horizon, confidence));
+        }
+        return out;
+    }
+
+    /** Measure-column keys, from the metadata's declared column captions
+     *  (these key the records map for data columns). Mirrors AnomalyAugmenter. */
+    private static List<String> measureColumnKeys(AiQueryMetadata meta) {
+        List<String> keys = new ArrayList<>();
+        if (meta != null && meta.getColumns() != null) {
+            for (AiQueryMetadata.Caption c : meta.getColumns()) {
+                if (c != null && c.getCaption() != null && !c.getCaption().isEmpty()) {
+                    keys.add(c.getCaption());
+                }
+            }
+        }
+        return keys;
+    }
+}

--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ai/forecast/ForecastPoint.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ai/forecast/ForecastPoint.java
@@ -1,0 +1,41 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.service.olap.ai.forecast;
+
+/**
+ * One forecast horizon point produced by a {@link Forecaster} (saiku#908):
+ * the point estimate plus the lower/upper bounds of the prediction interval
+ * at the requested confidence level. {@code forecast} is always {@code true}
+ * so the wire payload is self-describing alongside observed cells.
+ */
+public class ForecastPoint {
+
+    private final double value;
+    private final double lower;
+    private final double upper;
+    private final boolean forecast = true;
+
+    public ForecastPoint(double value, double lower, double upper) {
+        this.value = value;
+        this.lower = lower;
+        this.upper = upper;
+    }
+
+    public double getValue() {
+        return value;
+    }
+
+    public double getLower() {
+        return lower;
+    }
+
+    public double getUpper() {
+        return upper;
+    }
+
+    public boolean isForecast() {
+        return forecast;
+    }
+}

--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ai/forecast/Forecaster.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ai/forecast/Forecaster.java
@@ -1,0 +1,35 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.service.olap.ai.forecast;
+
+import java.util.List;
+
+/**
+ * Server-side statistical forecasting over a single numeric time series
+ * (saiku#908). Implementations are deliberately dependency-free and
+ * deterministic — NO LLM, NO external model, all computation in-JVM (mirrors
+ * the {@code ai.anomaly} package).
+ *
+ * <p>The contract: {@link #forecast(double[], int, double)} returns exactly
+ * {@code horizon} {@link ForecastPoint}s — the projected continuation of the
+ * series, each with a prediction interval at {@code confidence}. Implementations
+ * must skip {@link Double#NaN} gaps when fitting and must produce intervals that
+ * widen (never shrink) as the horizon step increases.
+ */
+public interface Forecaster {
+
+    /** Stable identifier matching the {@code method} request field. */
+    String method();
+
+    /**
+     * Forecast {@code horizon} steps beyond {@code series}.
+     *
+     * @param series numeric points in time order; {@link Double#NaN} marks a gap
+     * @param horizon number of future points to project (&gt;= 1)
+     * @param confidence prediction-interval confidence in (0,1), e.g. 0.95
+     * @return exactly {@code horizon} forecast points, in time order
+     */
+    List<ForecastPoint> forecast(double[] series, int horizon, double confidence);
+}

--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ai/forecast/Forecasters.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ai/forecast/Forecasters.java
@@ -1,0 +1,59 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.service.olap.ai.forecast;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import org.saiku.service.olap.ai.AiValidationException;
+
+/**
+ * Registry / factory for {@link Forecaster} implementations keyed by their
+ * {@code method} id (saiku#908). Unknown methods raise an
+ * {@link AiValidationException} carrying the candidate list so the REST layer
+ * returns a self-correcting 400. Mirrors {@code AnomalyDetectors}.
+ */
+public final class Forecasters {
+
+    private static final Map<String, Forecaster> REGISTRY = new LinkedHashMap<>();
+
+    static {
+        register(new EtsForecaster());
+        // arima + prophet are registered but throw on forecast() until impls land.
+        register(new ArimaForecaster());
+        register(new ProphetForecaster());
+    }
+
+    private Forecasters() {}
+
+    private static void register(Forecaster f) {
+        REGISTRY.put(f.method().toLowerCase(Locale.ROOT), f);
+    }
+
+    /** Method ids known to the registry (includes the arima/prophet stubs). */
+    public static List<String> methods() {
+        return List.copyOf(REGISTRY.keySet());
+    }
+
+    /**
+     * Resolve a forecaster by method id (case-insensitive). Defaults to
+     * {@code ets} when {@code method} is null/blank.
+     *
+     * @throws AiValidationException with {@code field="method"} + the candidate
+     *     list when the method is unknown
+     */
+    public static Forecaster forMethod(String method) {
+        String key = (method == null || method.isBlank())
+                ? EtsForecaster.METHOD
+                : method.trim().toLowerCase(Locale.ROOT);
+        Forecaster f = REGISTRY.get(key);
+        if (f == null) {
+            throw new AiValidationException(
+                    "method", "Unknown forecast method '" + method + "'. Supported: " + methods(), methods());
+        }
+        return f;
+    }
+}

--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ai/forecast/ProphetForecaster.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ai/forecast/ProphetForecaster.java
@@ -1,0 +1,35 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.service.olap.ai.forecast;
+
+import java.util.List;
+import org.saiku.service.olap.ai.AiValidationException;
+
+/**
+ * Prophet forecaster — STUB (saiku#908).
+ *
+ * <p>Prophet (change-points + holiday effects) has no clean pure-JVM port; the
+ * issue lists it as a stretch goal behind a py4j / REST shim. We deliberately
+ * do NOT add that out-of-process dependency now, so {@link #forecast} throws a
+ * structured {@link AiValidationException} (self-correcting 400) until/unless a
+ * vetted integration lands. Use {@code ets} for in-JVM forecasting.
+ */
+public class ProphetForecaster implements Forecaster {
+
+    public static final String METHOD = "prophet";
+
+    @Override
+    public String method() {
+        return METHOD;
+    }
+
+    @Override
+    public List<ForecastPoint> forecast(double[] series, int horizon, double confidence) {
+        throw new AiValidationException(
+                "method",
+                "Prophet forecasting is not yet supported (no in-JVM implementation). Use 'ets' for now.",
+                List.of(EtsForecaster.METHOD));
+    }
+}

--- a/saiku-core/saiku-service/src/test/java/org/saiku/service/olap/ai/forecast/EtsForecasterTest.java
+++ b/saiku-core/saiku-service/src/test/java/org/saiku/service/olap/ai/forecast/EtsForecasterTest.java
@@ -1,0 +1,94 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.service.olap.ai.forecast;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.util.List;
+import org.junit.Test;
+
+/** Locks the Holt's-linear ETS forecaster (saiku#908). */
+public class EtsForecasterTest {
+
+    private final EtsForecaster ets = new EtsForecaster();
+
+    @Test
+    public void capturesLinearTrend() {
+        // Perfect line y = x: 1..10. Holt's should reproduce slope 1 and
+        // continue 11, 12, 13 (errors are zero so the fit is exact).
+        double[] s = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
+        List<ForecastPoint> f = ets.forecast(s, 3, 0.95);
+        assertEquals(3, f.size());
+        assertEquals(11.0, f.get(0).getValue(), 0.01);
+        assertEquals(12.0, f.get(1).getValue(), 0.01);
+        assertEquals(13.0, f.get(2).getValue(), 0.01);
+    }
+
+    @Test
+    public void intervalWidensWithHorizon() {
+        // Noisy upward series → sigma > 0, so the PI must widen with h.
+        double[] s = {1, 2.1, 2.9, 4.2, 4.8, 6.1, 6.9, 8.2, 8.7, 10.3};
+        List<ForecastPoint> f = ets.forecast(s, 5, 0.95);
+        double w1 = f.get(0).getUpper() - f.get(0).getLower();
+        double w5 = f.get(4).getUpper() - f.get(4).getLower();
+        assertTrue("interval should be positive", w1 > 0);
+        assertTrue("interval should widen with horizon (w5 > w1)", w5 > w1);
+        // sqrt-of-h growth: w(5)/w(1) ≈ sqrt(5).
+        assertEquals(Math.sqrt(5.0), w5 / w1, 0.001);
+    }
+
+    @Test
+    public void flatSeries_forecastsFlat_withTinyInterval() {
+        double[] s = {5, 5, 5, 5, 5, 5};
+        List<ForecastPoint> f = ets.forecast(s, 3, 0.95);
+        assertEquals(5.0, f.get(0).getValue(), 1e-9);
+        assertEquals(0.0, f.get(0).getUpper() - f.get(0).getLower(), 1e-9);
+    }
+
+    @Test
+    public void returnsExactlyHorizonPoints() {
+        double[] s = {3, 6, 9, 12};
+        assertEquals(1, ets.forecast(s, 1, 0.9).size());
+        assertEquals(12, ets.forecast(s, 12, 0.9).size());
+    }
+
+    @Test
+    public void singlePoint_isFlat() {
+        double[] s = {7};
+        List<ForecastPoint> f = ets.forecast(s, 2, 0.95);
+        assertEquals(7.0, f.get(0).getValue(), 1e-9);
+        assertEquals(7.0, f.get(1).getLower(), 1e-9);
+    }
+
+    @Test
+    public void skipsNaNGaps() {
+        // Gaps must not break the fit; trend still ~1.
+        double[] s = {1, 2, Double.NaN, 4, 5, Double.NaN, 7, 8};
+        List<ForecastPoint> f = ets.forecast(s, 1, 0.95);
+        assertTrue("forecast should be finite", !Double.isNaN(f.get(0).getValue()));
+        assertTrue("continues upward", f.get(0).getValue() > 8.0);
+    }
+
+    @Test
+    public void higherConfidence_widerInterval() {
+        double[] s = {1, 2.1, 2.9, 4.2, 4.8, 6.1, 6.9, 8.2};
+        double w90 = width(ets.forecast(s, 1, 0.90).get(0));
+        double w99 = width(ets.forecast(s, 1, 0.99).get(0));
+        assertTrue("99% interval wider than 90%", w99 > w90);
+    }
+
+    @Test
+    public void normalQuantile_matchesKnownZ() {
+        assertEquals(1.6449, EtsForecaster.normalQuantile(0.95), 1e-3);
+        assertEquals(1.9600, EtsForecaster.normalQuantile(0.975), 1e-3);
+        assertEquals(2.5758, EtsForecaster.normalQuantile(0.995), 1e-3);
+        assertEquals(0.0, EtsForecaster.normalQuantile(0.5), 1e-6);
+    }
+
+    private static double width(ForecastPoint p) {
+        return p.getUpper() - p.getLower();
+    }
+}

--- a/saiku-core/saiku-service/src/test/java/org/saiku/service/olap/ai/forecast/ForecastAssemblerTest.java
+++ b/saiku-core/saiku-service/src/test/java/org/saiku/service/olap/ai/forecast/ForecastAssemblerTest.java
@@ -1,0 +1,103 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.service.olap.ai.forecast;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.Test;
+import org.saiku.service.olap.ai.AiCell;
+import org.saiku.service.olap.ai.AiQueryMetadata;
+import org.saiku.service.olap.ai.AiQueryResponse;
+import org.saiku.service.olap.ai.AiValidationException;
+
+/** Locks the records→forecast-block assembler (saiku#908). */
+public class ForecastAssemblerTest {
+
+    private static AiQueryResponse responseWith(String measure, double... values) {
+        AiQueryResponse resp = new AiQueryResponse();
+        AiQueryMetadata meta = new AiQueryMetadata();
+        List<AiQueryMetadata.Caption> cols = new ArrayList<>();
+        cols.add(new AiQueryMetadata.Caption(measure, measure));
+        meta.setColumns(cols);
+        resp.setMetadata(meta);
+        List<Map<String, Object>> data = new ArrayList<>();
+        for (int i = 0; i < values.length; i++) {
+            Map<String, Object> row = new LinkedHashMap<>();
+            row.put("Month", "M" + (i + 1)); // row-header column (plain string)
+            row.put(measure, new AiCell(values[i], String.valueOf(values[i]), null));
+            data.add(row);
+        }
+        resp.setData(data);
+        return resp;
+    }
+
+    @Test
+    public void forecastsEachMeasure_continuingTheTrend() {
+        AiQueryResponse resp = responseWith("Sales", 1, 2, 3, 4, 5, 6);
+        Map<String, List<ForecastPoint>> block =
+                ForecastAssembler.assemble(resp, new EtsForecaster(), 3, 0.95, "[Time].[Month]");
+        assertTrue(block.containsKey("Sales"));
+        List<ForecastPoint> f = block.get("Sales");
+        assertEquals(3, f.size());
+        assertEquals(7.0, f.get(0).getValue(), 0.01);
+        assertEquals(9.0, f.get(2).getValue(), 0.01);
+    }
+
+    @Test
+    public void emptyData_yieldsEmptyBlock_noThrow() {
+        AiQueryResponse resp = new AiQueryResponse();
+        resp.setData(new ArrayList<>());
+        Map<String, List<ForecastPoint>> block =
+                ForecastAssembler.assemble(resp, new EtsForecaster(), 6, 0.95, "[Time].[Month]");
+        assertTrue(block.isEmpty());
+    }
+
+    @Test
+    public void noMeasureColumns_throwsValidation() {
+        AiQueryResponse resp = new AiQueryResponse();
+        AiQueryMetadata meta = new AiQueryMetadata();
+        meta.setColumns(new ArrayList<>()); // no measure columns
+        resp.setMetadata(meta);
+        List<Map<String, Object>> data = new ArrayList<>();
+        Map<String, Object> row = new LinkedHashMap<>();
+        row.put("Month", "M1");
+        data.add(row);
+        resp.setData(data);
+        try {
+            ForecastAssembler.assemble(resp, new EtsForecaster(), 6, 0.95, "[Time].[Month]");
+            fail("expected AiValidationException");
+        } catch (AiValidationException e) {
+            assertEquals("timeAxis", e.getField());
+        }
+    }
+
+    @Test
+    public void badHorizon_throwsValidation() {
+        AiQueryResponse resp = responseWith("Sales", 1, 2, 3);
+        try {
+            ForecastAssembler.assemble(resp, new EtsForecaster(), 0, 0.95, "[Time].[Month]");
+            fail("expected AiValidationException for horizon < 1");
+        } catch (AiValidationException e) {
+            assertEquals("horizon", e.getField());
+        }
+    }
+
+    @Test
+    public void badConfidence_throwsValidation() {
+        AiQueryResponse resp = responseWith("Sales", 1, 2, 3);
+        try {
+            ForecastAssembler.assemble(resp, new EtsForecaster(), 6, 1.5, "[Time].[Month]");
+            fail("expected AiValidationException for confidence out of range");
+        } catch (AiValidationException e) {
+            assertEquals("confidence", e.getField());
+        }
+    }
+}

--- a/saiku-core/saiku-service/src/test/java/org/saiku/service/olap/ai/forecast/ForecastersTest.java
+++ b/saiku-core/saiku-service/src/test/java/org/saiku/service/olap/ai/forecast/ForecastersTest.java
@@ -1,0 +1,66 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.service.olap.ai.forecast;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import org.junit.Test;
+import org.saiku.service.olap.ai.AiValidationException;
+
+/** Locks the forecaster registry + stub behaviour (saiku#908). */
+public class ForecastersTest {
+
+    @Test
+    public void defaultsToEts() {
+        assertEquals("ets", Forecasters.forMethod(null).method());
+        assertEquals("ets", Forecasters.forMethod("").method());
+        assertEquals("ets", Forecasters.forMethod("  ").method());
+    }
+
+    @Test
+    public void resolvesCaseInsensitively() {
+        assertEquals("ets", Forecasters.forMethod("ETS").method());
+        assertEquals("arima", Forecasters.forMethod("Arima").method());
+    }
+
+    @Test
+    public void unknownMethod_throwsWithCandidates() {
+        try {
+            Forecasters.forMethod("magic");
+            fail("expected AiValidationException");
+        } catch (AiValidationException e) {
+            assertEquals("method", e.getField());
+            assertTrue(e.getAvailable().contains("ets"));
+        }
+    }
+
+    @Test
+    public void registryListsAllMethods() {
+        assertTrue(Forecasters.methods().containsAll(java.util.List.of("ets", "arima", "prophet")));
+    }
+
+    @Test
+    public void arimaStub_throwsValidation_suggestingEts() {
+        try {
+            Forecasters.forMethod("arima").forecast(new double[] {1, 2, 3}, 3, 0.95);
+            fail("expected AiValidationException from ARIMA stub");
+        } catch (AiValidationException e) {
+            assertEquals("method", e.getField());
+            assertTrue(e.getAvailable().contains("ets"));
+        }
+    }
+
+    @Test
+    public void prophetStub_throwsValidation() {
+        try {
+            Forecasters.forMethod("prophet").forecast(new double[] {1, 2, 3}, 3, 0.95);
+            fail("expected AiValidationException from Prophet stub");
+        } catch (AiValidationException e) {
+            assertEquals("method", e.getField());
+        }
+    }
+}

--- a/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/AiQueryResource.java
+++ b/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/AiQueryResource.java
@@ -458,6 +458,114 @@ public class AiQueryResource {
     }
 
     /**
+     * Server-side statistical forecast over a time-series query (saiku#908),
+     * Tier-3: in-JVM via {@link org.saiku.service.olap.ai.forecast.Forecaster},
+     * NO LLM / NO external model. Runs {@code body.query} through the SAME path
+     * {@code /ai/query} uses, extracts each measure series in time order, and
+     * projects {@code horizon} future points with prediction intervals at the
+     * requested {@code confidence}.
+     *
+     * <p>Echoes the typed {@link AiQueryResponse} (records, observed data
+     * untouched) plus a sibling {@code forecast} block keyed by measure caption
+     * — {@code {method, horizon, confidence, timeAxis, series:{caption:[{value,
+     * lower,upper,forecast}]}}} — which the chart tile appends as a dashed
+     * continuation with a confidence band. Unknown method / bad horizon /
+     * confidence return the self-correcting 400 envelope; {@code arima} and
+     * {@code prophet} are registered stubs that 400 until impls land.
+     */
+    @POST
+    @Path("/forecast")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response forecast(org.saiku.service.olap.ai.forecast.AiForecastRequest body) {
+        long start = System.currentTimeMillis();
+        if (body == null) {
+            return badRequest("body", "request body required", null);
+        }
+        AiQueryRequest req = body.getQuery();
+        if (req == null) {
+            return badRequest("query", "query (an AiQueryRequest) is required", null);
+        }
+        String timeAxis = body.getTimeAxis();
+        if (timeAxis == null || timeAxis.isBlank()) {
+            return badRequest("timeAxis", "timeAxis (the time axis unique name) is required", null);
+        }
+
+        // Resolve forecaster + params up-front so bad inputs fail fast with a
+        // clean 400 before we execute the (expensive) query.
+        org.saiku.service.olap.ai.forecast.Forecaster forecaster;
+        try {
+            forecaster = org.saiku.service.olap.ai.forecast.Forecasters.forMethod(body.getMethod());
+        } catch (AiValidationException e) {
+            return badRequest(e.getField(), e.getMessage(), e.getAvailable());
+        }
+        int horizon = body.getHorizon() == null ? 6 : body.getHorizon();
+        if (horizon < 1 || horizon > 365) {
+            return badRequest("horizon", "horizon must be between 1 and 365", null);
+        }
+        double confidence = body.getConfidence() == null ? 0.95 : body.getConfidence();
+        if (confidence <= 0 || confidence >= 1 || Double.isNaN(confidence)) {
+            return badRequest("confidence", "confidence must be between 0 and 1 (exclusive)", null);
+        }
+
+        AiSchema schema;
+        ThinQuery tq;
+        try {
+            schemaValidator.assertValid(MAPPER.valueToTree(req));
+            if (req.getCube() == null) {
+                return badRequest("query.cube", "cube ref required", null);
+            }
+            schema = cubeMetadataService.getSchema(req.getCube());
+            tq = converter.convert(req, schema);
+        } catch (AiValidationException e) {
+            return badRequest(e.getField(), e.getMessage(), e.getAvailable());
+        } catch (RuntimeException e) {
+            log.error("AI forecast query validation failed", e);
+            return error("validation failed: " + e.getMessage());
+        }
+
+        CellDataSet cds;
+        try {
+            cds = thinQueryService.execute(tq);
+        } catch (RuntimeException e) {
+            Response translated = translateMondrianLookupError(e);
+            if (translated != null) return translated;
+            Response pathErr = translatePhysPathNpe(e);
+            if (pathErr != null) return pathErr;
+            log.error("AI forecast query execution failed", e);
+            return error("execute failed: " + describeDeepestCause(e));
+        }
+
+        AiQueryResponse resp = buildResponse(tq, cds, start, "records");
+        Map<String, List<org.saiku.service.olap.ai.forecast.ForecastPoint>> series;
+        try {
+            series = org.saiku.service.olap.ai.forecast.ForecastAssembler.assemble(
+                    resp, forecaster, horizon, confidence, timeAxis);
+        } catch (AiValidationException e) {
+            return badRequest(e.getField(), e.getMessage(), e.getAvailable());
+        } catch (RuntimeException e) {
+            // arima/prophet stubs throw AiValidationException (handled above);
+            // anything else here is a real forecaster bug → 500.
+            log.error("AI forecast failed", e);
+            return error("forecast failed: " + e.getMessage());
+        }
+        resp.setRuntimeMs(System.currentTimeMillis() - start);
+
+        // Echo the typed response plus a sibling forecast block (observed data
+        // untouched), mirroring the /anomaly envelope.
+        Map<String, Object> out = new LinkedHashMap<>();
+        out.put("response", resp);
+        Map<String, Object> summary = new LinkedHashMap<>();
+        summary.put("method", forecaster.method());
+        summary.put("horizon", horizon);
+        summary.put("confidence", confidence);
+        summary.put("timeAxis", timeAxis);
+        summary.put("series", series);
+        out.put("forecast", summary);
+        return Response.ok(out).type(MediaType.APPLICATION_JSON).build();
+    }
+
+    /**
      * Natural-language ask endpoint.
      *
      * <p>Body: {@code {question: string, cube: AiCubeRef, history?: [{role, content}]}}.


### PR DESCRIPTION
## Summary
Adds **server-side time-series forecasting** (#908) — Tier-3: in-JVM, **no LLM, no external model, no new dependency** (mirrors the merged #907 anomaly package). **Part 1 of 2** (UI ships separately — merge this first).

## The change
- **`olap/ai/forecast/`** *(new)* — `Forecaster` interface; **`EtsForecaster`** (Holt's linear trend: grid-fit α/β minimising one-step SSE; prediction intervals `forecast ± z·σ·√h` that widen with horizon; Acklam probit for the z-multiplier); **`ArimaForecaster` + `ProphetForecaster` stubs** that return a clean "not yet supported" `AiValidationException` (exactly like #907's `StlAnomalyDetector`); `Forecasters` registry; `ForecastAssembler` (extracts each measure series in time order → forecast block); `ForecastPoint {value,lower,upper,forecast}`; `AiForecastRequest`.
- **`AiQueryResource`** — `POST /saiku/api/ai/forecast`: runs the query through the **same path** as `/ai/query`, returns the observed records response **unchanged** plus a sibling `forecast` block `{method, horizon, confidence, timeAxis, series:{caption:[points]}}`. Validates method / horizon (1–365) / confidence (0–1) via the self-correcting `badRequest` envelope.

## Verify
- `mvn -pl saiku-core/saiku-web -am test -Dtest=*Forecast*,Ets*,Forecasters*` → **19 tests, 0 fail**; saiku-web compiles; spotless clean. Branch off current `development`.
- Tests lock the issue's acceptance criteria: ETS captures a linear trend (continues 11,12,13); the **CI widens ~√h** with the horizon; higher confidence → wider; NaN-gap skip; flat & single-point series; registry default/unknown/stub-throws; assembler per-measure + empty/no-measure/bad-param.
- **User-verified end-to-end** via the combined launcher (FoodMart Unit Sales / Month → 6-point ETS forecast with a widening band).

## Notes
- No external/model dependency (Tier-3 — independent of AI foundation #902–906). Pairs with #907 (shares the time-series UI controls). Reopened/assigned #908. Not self-merging.

Part of #908 (backend). UI PR to follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
