### PR TITLE
feat(perf): in-flight query coalescing (closes #946)

### DIFF
--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/QueryCoalescer.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/QueryCoalescer.java
@@ -1,0 +1,84 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.service.olap;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import java.time.Duration;
+import java.util.function.Supplier;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * In-flight query coalescer (saiku#946). When a dashboard with N tiles loads
+ * (or all tiles auto-refresh together), identical queries fire concurrently and
+ * each re-executes the same MDX, stressing the Mondrian segment cache + the
+ * connection pool. This deduplicates by an opaque key for a short window: the
+ * FIRST caller for a key runs the supplier; concurrent callers for the same key
+ * block and receive that same result, and the result is reused for a brief TTL.
+ *
+ * <p>It is NOT a result cache — it's single-flight + a tiny TTL window. Built on
+ * Caffeine's {@code get(key, mappingFunction)}, which guarantees the mapping
+ * function runs at most once per key under concurrency (the others wait), giving
+ * coalescing for free. The key is the caller's responsibility and MUST encode
+ * everything that distinguishes a result — including the user's role-set — so a
+ * role-masked result is never shared across roles (the saiku#1114 hazard).
+ *
+ * <p>Generic + dependency-light so it's unit-testable without a live olap
+ * connection. {@code enabled=false} makes {@link #coalesce} a pure pass-through.
+ */
+public final class QueryCoalescer {
+
+    private static final Logger log = LoggerFactory.getLogger(QueryCoalescer.class);
+
+    private final Cache<String, Object> cache;
+    private final boolean enabled;
+
+    /** Default: enabled, 5-second window, modest cap. */
+    public QueryCoalescer() {
+        this(true, Duration.ofSeconds(5), 500);
+    }
+
+    public QueryCoalescer(boolean enabled, Duration ttl, long maxSize) {
+        this.enabled = enabled;
+        this.cache = Caffeine.newBuilder()
+                .expireAfterWrite(ttl == null ? Duration.ofSeconds(5) : ttl)
+                .maximumSize(maxSize)
+                .build();
+        log.info(
+                "QueryCoalescer initialised: enabled={} ttl={} maxSize={}", enabled, ttl == null ? "5s" : ttl, maxSize);
+    }
+
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    /**
+     * Run {@code exec} under single-flight for {@code key}: the first caller
+     * computes, concurrent callers for the same key await + share the result,
+     * and it is reused for the TTL window. With coalescing disabled (or a blank
+     * key), this is a direct pass-through to {@code exec}.
+     *
+     * <p>If {@code exec} throws, the exception propagates to all waiting callers
+     * and nothing is cached (Caffeine does not retain a failed computation).
+     */
+    @SuppressWarnings("unchecked")
+    public <T> T coalesce(String key, Supplier<T> exec) {
+        if (!enabled || key == null || key.isEmpty()) {
+            return exec.get();
+        }
+        return (T) cache.get(key, k -> exec.get());
+    }
+
+    /** Drop all coalesced entries (explicit cache clear / schema reload). */
+    public void clear() {
+        cache.invalidateAll();
+    }
+
+    /** Approximate number of live entries (diagnostics / tests). */
+    public long size() {
+        return cache.estimatedSize();
+    }
+}

--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ThinQueryService.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ThinQueryService.java
@@ -122,6 +122,10 @@ public class ThinQueryService implements Serializable {
     /** Optional disk-backed Arrow cache. Null (or disabled) ⇒ always execute live. */
     private SaikuQueryCache queryCache;
 
+    /** Optional in-flight query coalescer (saiku#946). Null/disabled ⇒ every
+     *  call executes independently. Dedupes concurrent identical executions. */
+    private QueryCoalescer queryCoalescer;
+
     /**
      * Optional — current user's Saiku role-set, mixed into the cache key so role-masked
      * cellsets never leak across roles (saiku#1114). Null in non-Spring/standalone contexts.
@@ -146,6 +150,14 @@ public class ThinQueryService implements Serializable {
 
     public SaikuQueryCache getQueryCache() {
         return queryCache;
+    }
+
+    public void setQueryCoalescer(QueryCoalescer queryCoalescer) {
+        this.queryCoalescer = queryCoalescer;
+    }
+
+    public QueryCoalescer getQueryCoalescer() {
+        return queryCoalescer;
     }
 
     /**
@@ -212,6 +224,23 @@ public class ThinQueryService implements Serializable {
      */
     String cacheKeyFor(ThinQuery tq, String cubeVersion) {
         return QueryCacheKey.of(tq, cubeVersion, currentRolesForCacheKey());
+    }
+
+    /**
+     * Coalescing key (saiku#946) — the SAME role-aware identity the result cache
+     * uses (cube + MDX/model + slicer + role-set), so concurrent identical
+     * executions dedupe and a role-masked result is never shared across roles
+     * (the #1114 hazard). Formatter is intentionally NOT in the key: coalescing
+     * is on the formatter-independent CellSet (Mondrian execution); each caller
+     * formats its own copy afterwards. Returns null (⇒ no coalescing) if a key
+     * can't be built, so a keying failure never breaks the query.
+     */
+    private String coalesceKey(ThinQuery tq) {
+        try {
+            return cacheKeyFor(tq, QueryCacheKey.cubeVersion(tq));
+        } catch (RuntimeException e) {
+            return null;
+        }
     }
 
     /**
@@ -405,7 +434,26 @@ public class ThinQueryService implements Serializable {
 
             Long start = (new Date()).getTime();
             log.debug("Query Start");
-            CellSet cellSet = executeInternalQuery(tq);
+            // saiku#946: dedupe concurrent identical executions. The first caller
+            // for a (cube,MDX,slicer,role) key runs the Mondrian query; concurrent
+            // callers share its CellSet for a short window. A coalesced caller
+            // skipped executeInternalQuery (which registers per-name context), so we
+            // re-register the shared result onto THIS caller's context — otherwise
+            // drillthrough/cancel on a coalesced tile would NPE on a null context.
+            CellSet cellSet;
+            final String coalesceKey = (queryCoalescer != null && queryCoalescer.isEnabled()) ? coalesceKey(tq) : null;
+            if (coalesceKey != null) {
+                cellSet = queryCoalescer.coalesce(coalesceKey, () -> {
+                    try {
+                        return executeInternalQuery(tq);
+                    } catch (Exception e) {
+                        throw new SaikuServiceException("Can't execute query: " + tq.getName(), e);
+                    }
+                });
+                registerExternalContext(tq, cellSet);
+            } else {
+                cellSet = executeInternalQuery(tq);
+            }
             log.debug("Query End");
             String runId = "RUN#:" + ID_GENERATOR.get();
             Long exec = (new Date()).getTime();

--- a/saiku-core/saiku-service/src/test/java/org/saiku/service/olap/QueryCoalescerTest.java
+++ b/saiku-core/saiku-service/src/test/java/org/saiku/service/olap/QueryCoalescerTest.java
@@ -1,0 +1,129 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.service.olap;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.Test;
+
+/** Locks the in-flight query coalescer (saiku#946). */
+public class QueryCoalescerTest {
+
+    @Test
+    public void coalescesConcurrentIdenticalToOneExecution() throws Exception {
+        QueryCoalescer c = new QueryCoalescer(true, Duration.ofSeconds(5), 100);
+        AtomicInteger execs = new AtomicInteger();
+        int n = 12;
+        ExecutorService pool = Executors.newFixedThreadPool(n);
+        CountDownLatch ready = new CountDownLatch(n);
+        CountDownLatch go = new CountDownLatch(1);
+        List<Future<String>> futs = new ArrayList<>();
+        for (int i = 0; i < n; i++) {
+            futs.add(pool.submit(() -> {
+                ready.countDown();
+                go.await();
+                return c.coalesce("same-key", () -> {
+                    execs.incrementAndGet();
+                    try {
+                        Thread.sleep(300); // hold the in-flight window open
+                    } catch (InterruptedException ignored) {
+                        Thread.currentThread().interrupt();
+                    }
+                    return "RESULT";
+                });
+            }));
+        }
+        ready.await(5, TimeUnit.SECONDS);
+        go.countDown(); // fire all 12 at once
+        for (Future<String> f : futs) {
+            assertEquals("RESULT", f.get(5, TimeUnit.SECONDS));
+        }
+        assertEquals("12 concurrent identical calls must run the supplier ONCE", 1, execs.get());
+        pool.shutdownNow();
+    }
+
+    @Test
+    public void distinctKeysExecuteIndependently() {
+        QueryCoalescer c = new QueryCoalescer(true, Duration.ofSeconds(5), 100);
+        AtomicInteger execs = new AtomicInteger();
+        c.coalesce("a", () -> execs.incrementAndGet());
+        c.coalesce("b", () -> execs.incrementAndGet());
+        assertEquals(2, execs.get());
+    }
+
+    @Test
+    public void sameKeyWithinWindowReusesResult() {
+        QueryCoalescer c = new QueryCoalescer(true, Duration.ofSeconds(5), 100);
+        AtomicInteger execs = new AtomicInteger();
+        int first = c.coalesce("k", () -> execs.incrementAndGet());
+        int second = c.coalesce("k", () -> execs.incrementAndGet());
+        assertEquals(1, execs.get()); // second call served from the window
+        assertEquals(first, second);
+    }
+
+    @Test
+    public void clearForcesRecompute() {
+        QueryCoalescer c = new QueryCoalescer(true, Duration.ofSeconds(5), 100);
+        AtomicInteger execs = new AtomicInteger();
+        c.coalesce("k", () -> execs.incrementAndGet());
+        c.coalesce("k", () -> execs.incrementAndGet()); // cached → still 1
+        assertEquals(1, execs.get());
+        c.clear();
+        c.coalesce("k", () -> execs.incrementAndGet()); // recompute
+        assertEquals(2, execs.get());
+    }
+
+    @Test
+    public void disabled_isPassThrough() {
+        QueryCoalescer c = new QueryCoalescer(false, Duration.ofSeconds(5), 100);
+        AtomicInteger execs = new AtomicInteger();
+        c.coalesce("k", () -> execs.incrementAndGet());
+        c.coalesce("k", () -> execs.incrementAndGet());
+        assertEquals("disabled coalescer must execute every call", 2, execs.get());
+        assertTrue(!c.isEnabled());
+    }
+
+    @Test
+    public void blankOrNullKey_isPassThrough() {
+        QueryCoalescer c = new QueryCoalescer(true, Duration.ofSeconds(5), 100);
+        AtomicInteger execs = new AtomicInteger();
+        c.coalesce("", () -> execs.incrementAndGet());
+        c.coalesce(null, () -> execs.incrementAndGet());
+        assertEquals(2, execs.get());
+    }
+
+    @Test
+    public void exceptionPropagates_andIsNotCached() {
+        QueryCoalescer c = new QueryCoalescer(true, Duration.ofSeconds(5), 100);
+        AtomicInteger execs = new AtomicInteger();
+        try {
+            c.coalesce("k", () -> {
+                execs.incrementAndGet();
+                throw new IllegalStateException("boom");
+            });
+            fail("expected the supplier exception to propagate");
+        } catch (IllegalStateException expected) {
+            // good
+        }
+        // A failed computation must not be cached — the next call retries.
+        int ok = c.coalesce("k", () -> {
+            execs.incrementAndGet();
+            return 42;
+        });
+        assertEquals(42, ok);
+        assertEquals(2, execs.get());
+    }
+}

--- a/saiku-webapp/src/main/webapp/WEB-INF/saiku-beans.xml
+++ b/saiku-webapp/src/main/webapp/WEB-INF/saiku-beans.xml
@@ -157,6 +157,12 @@
     -->
     <bean id="saikuQueryCacheBean" class="org.saiku.service.cache.SaikuQueryCache"/>
 
+    <!-- saiku#946: in-flight query coalescer. SINGLETON (shared across all
+         sessions) so concurrent identical tile queries dedupe to one Mondrian
+         execution; cross-role isolation is via the role-aware key, not bean
+         scope. Default: enabled, 5s window. -->
+    <bean id="queryCoalescerBean" class="org.saiku.service.olap.QueryCoalescer"/>
+
     <bean id="thinQueryBean" scope="session"
           class="org.saiku.service.olap.ThinQueryService">
         <aop:scoped-proxy/>
@@ -164,6 +170,8 @@
         <property name="queryCache" ref="saikuQueryCacheBean"/>
         <!-- saiku#1114: role-set mixed into the cellset cache key so role-masked results never leak across roles -->
         <property name="userService" ref="userServiceBean"/>
+        <!-- saiku#946: shared in-flight coalescer (singleton) -->
+        <property name="queryCoalescer" ref="queryCoalescerBean"/>
     </bean>
 
     <bean id="platformBean" class="org.saiku.service.PlatformUtilsService">


### PR DESCRIPTION
## Summary
In-flight **query coalescing** (#946). When a dashboard's N tiles load (or all auto-refresh together), identical queries fire concurrently and each re-executes the same MDX — stressing Mondrian's segment cache + the connection pool. This dedupes them: the **first** caller for a `(cube, MDX, slicer, role)` key runs the Mondrian query; **concurrent callers share its result** for a short (5 s) window. Performance, not correctness — tile contracts unchanged.

## The change
- **`QueryCoalescer`** *(new)* — generic Caffeine single-flight (`get(key, fn)` runs the supplier at most once per key under concurrency; others block + share), 5 s TTL, `enabled` flag, `clear()`. Dependency-light + unit-tested.
- **`ThinQueryService.execute`** — wraps `executeInternalQuery` in the coalescer, keyed by the **same role-aware identity as the result cache** (`cacheKeyFor` → `QueryCacheKey`, **role-set included per #1114** so a role-masked result is never shared across roles). Formatter is **not** in the key — we coalesce the formatter-independent `CellSet`; each caller formats its own copy.
- **Safety (the tricky bit):** a coalesced (non-executing) caller skips `executeInternalQuery`, which normally registers the per-query-name `QueryContext`. So we **re-register the shared result** via `registerExternalContext` → **drillthrough / cancel on a coalesced tile still resolve** (no null-context NPE — the same hazard `executeCached` special-cases). The olap4j `Statement` is **not** shared.
- Wired as a **singleton** bean (`queryCoalescerBean`) — shared across sessions so concurrent requests actually dedupe; isolation is via the key, not bean scope. Null/disabled ⇒ the unchanged single-execution path.

## Verify
- `mvn -pl saiku-core/saiku-web -am test -Dtest=QueryCoalescerTest,ThinQueryServiceCacheKeyTest` → **11/0**; saiku-web compiles; spotless clean. Branch off current `development`.
- **QueryCoalescer (7)**: 12-thread concurrent identical → **one** execution; distinct keys isolate; within-window reuse; `clear()` recomputes; disabled / blank-key pass-through; exception propagates + is **not** cached.
- **ThinQueryServiceCacheKeyTest (4) still green** — the #1114 role-aware key path is undisturbed.

## Notes
- **No UI** — transparent; coalescing only triggers under concurrent load, so there's nothing to click. **@AGENT QA**: a concurrency/integration test on the live `execute` path (N simultaneous identical → 1 Mondrian execution; drillthrough on a coalesced tile works) would be the ideal deeper check.
- **@AGENT SEC** — coordinated, since this sits next to your #1114/#1266 cache work; role-set is in the coalescing key (no cross-role share). `clear()` is exposed for `/admin` cache-clear + schema-reload wiring; the 5 s TTL self-heals staleness meanwhile.
- Not self-merging.

Closes #946

🤖 Generated with [Claude Code](https://claude.com/claude-code)
