### PR TITLE
fix(security): stop AI Query API echoing exception detail to clients (closes #1282)

### DIFF
--- a/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/AiQueryResource.java
+++ b/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/AiQueryResource.java
@@ -207,7 +207,7 @@ public class AiQueryResource {
             tq = MAPPER.readValue(raw, ThinQuery.class);
         } catch (com.fasterxml.jackson.core.JsonProcessingException e) {
             log.error("saved-query {} is not a valid ThinQuery JSON", path, e);
-            return badRequest("path", "Saved query is not valid ThinQuery JSON: " + e.getMessage(), null);
+            return badRequest("path", "Saved query is not valid ThinQuery JSON", null);
         }
         // Saved queries written by older builds stored the file path in
         // tq.name, which contains slashes. Jetty 12's strict URI rules
@@ -247,7 +247,7 @@ public class AiQueryResource {
             cds = thinQueryService.execute(tq);
         } catch (RuntimeException e) {
             log.error("saved-query execution failed for {}", path, e);
-            return error("execute failed: " + describeDeepestCause(e));
+            return error("execute failed");
         }
         AiQueryResponse resp = buildResponse(tq, cds, start, "records");
         return Response.ok(resp).type(MediaType.APPLICATION_JSON).build();
@@ -279,7 +279,7 @@ public class AiQueryResource {
             return badRequest(e.getField(), e.getMessage(), e.getAvailable());
         } catch (RuntimeException e) {
             log.error("AI query validation failed", e);
-            return error("validation failed: " + e.getMessage());
+            return error("validation failed");
         }
 
         CellDataSet cds;
@@ -301,7 +301,7 @@ public class AiQueryResource {
             Response pathErr = translatePhysPathNpe(e);
             if (pathErr != null) return pathErr;
             log.error("AI query execution failed", e);
-            return error("execute failed: " + describeDeepestCause(e));
+            return error("execute failed");
         }
 
         // saiku#915 / saiku-cloud MCP smoke-test 2026-05-23: a follow-up
@@ -412,7 +412,7 @@ public class AiQueryResource {
             return badRequest(e.getField(), e.getMessage(), e.getAvailable());
         } catch (RuntimeException e) {
             log.error("AI anomaly query validation failed", e);
-            return error("validation failed: " + e.getMessage());
+            return error("validation failed");
         }
 
         CellDataSet cds;
@@ -424,7 +424,7 @@ public class AiQueryResource {
             Response pathErr = translatePhysPathNpe(e);
             if (pathErr != null) return pathErr;
             log.error("AI anomaly query execution failed", e);
-            return error("execute failed: " + describeDeepestCause(e));
+            return error("execute failed");
         }
 
         // Always build in records format — that is the shape the augmenter and
@@ -438,7 +438,7 @@ public class AiQueryResource {
             // STL stub throws AiValidationException (handled above); any other
             // failure here is a real bug in the detector — surface it as a 500.
             log.error("AI anomaly detection failed", e);
-            return error("anomaly detection failed: " + e.getMessage());
+            return error("anomaly detection failed");
         }
 
         int anomalyCount = org.saiku.service.olap.ai.anomaly.AnomalyAugmenter.countAnomalies(resp);
@@ -523,7 +523,7 @@ public class AiQueryResource {
             return badRequest(e.getField(), e.getMessage(), e.getAvailable());
         } catch (RuntimeException e) {
             log.error("AI forecast query validation failed", e);
-            return error("validation failed: " + e.getMessage());
+            return error("validation failed");
         }
 
         CellDataSet cds;
@@ -535,7 +535,7 @@ public class AiQueryResource {
             Response pathErr = translatePhysPathNpe(e);
             if (pathErr != null) return pathErr;
             log.error("AI forecast query execution failed", e);
-            return error("execute failed: " + describeDeepestCause(e));
+            return error("execute failed");
         }
 
         AiQueryResponse resp = buildResponse(tq, cds, start, "records");
@@ -549,7 +549,7 @@ public class AiQueryResource {
             // arima/prophet stubs throw AiValidationException (handled above);
             // anything else here is a real forecaster bug → 500.
             log.error("AI forecast failed", e);
-            return error("forecast failed: " + e.getMessage());
+            return error("forecast failed");
         }
         resp.setRuntimeMs(System.currentTimeMillis() - start);
 
@@ -708,7 +708,7 @@ public class AiQueryResource {
             log.warn("AI ask execution failed after successful translation", e);
             AiQueryResponse aiResp = new AiQueryResponse();
             aiResp.setStatus(org.saiku.service.olap.ai.AiQueryResponse.Status.EXECUTION_ERROR);
-            aiResp.setError("execute failed: " + describeDeepestCause(e));
+            aiResp.setError("execute failed");
             aiResp.setRuntimeMs(System.currentTimeMillis() - start);
             out.setResponse(aiResp);
         }
@@ -774,22 +774,6 @@ public class AiQueryResource {
         return null;
     }
 
-    /** Walk the cause chain to the deepest exception with a non-null
-     *  message; return "ClassName: message". The Spring/JAX-RS wrappers
-     *  ({@code SaikuServiceException}, {@code OlapException},
-     *  {@code MondrianException}) all flatten to the same useless "Can't
-     *  execute query: <uuid>" surface; the real signal is at the leaf. */
-    private static String describeDeepestCause(Throwable t) {
-        Throwable deepest = t;
-        for (Throwable cur = t; cur != null; cur = cur.getCause()) {
-            if (cur.getMessage() != null && !cur.getMessage().isEmpty()) {
-                deepest = cur;
-            }
-        }
-        if (deepest == t) return t.getMessage();
-        return deepest.getClass().getSimpleName() + ": " + deepest.getMessage();
-    }
-
     /**
      * Preview-only: run the converter to produce MDX without executing.
      * Useful for cost estimation, audit logs, and "show the user what's
@@ -820,7 +804,7 @@ public class AiQueryResource {
             return badRequest(e.getField(), e.getMessage(), e.getAvailable());
         } catch (RuntimeException e) {
             log.error("AI query preview failed", e);
-            return error("preview failed: " + e.getMessage());
+            return error("preview failed");
         }
     }
 
@@ -841,7 +825,7 @@ public class AiQueryResource {
             return Response.ok(cubes).type(MediaType.APPLICATION_JSON).build();
         } catch (RuntimeException e) {
             log.error("AI cube listing failed", e);
-            return error("listing failed: " + e.getMessage());
+            return error("listing failed");
         }
     }
 
@@ -865,7 +849,7 @@ public class AiQueryResource {
             return badRequest(e.getField(), e.getMessage(), e.getAvailable());
         } catch (RuntimeException e) {
             log.error("AI schema fetch failed for {}", cubeId, e);
-            return error("schema fetch failed: " + e.getMessage());
+            return error("schema fetch failed");
         }
     }
 
@@ -904,7 +888,7 @@ public class AiQueryResource {
             return badRequest(e.getField(), e.getMessage(), e.getAvailable());
         } catch (RuntimeException e) {
             log.error("AI member search failed for {}/{}/{} q={}", dimension, hierarchy, level, q, e);
-            return error("member search failed: " + e.getMessage());
+            return error("member search failed");
         }
     }
 
@@ -944,7 +928,7 @@ public class AiQueryResource {
             return badRequest(e.getField(), e.getMessage(), e.getAvailable());
         } catch (RuntimeException e) {
             log.error("AI async submit validation failed", e);
-            return error("validation failed: " + e.getMessage());
+            return error("validation failed");
         }
         AsyncQueryHandle handle;
         try {
@@ -956,7 +940,7 @@ public class AiQueryResource {
             handle = asyncQueryService.submit(tq, attrs);
         } catch (RuntimeException e) {
             log.error("AI async submit failed", e);
-            return error("submit failed: " + e.getMessage());
+            return error("submit failed");
         }
         AiQueryResponse resp = new AiQueryResponse();
         resp.setQueryId(handle.getId());
@@ -1353,7 +1337,7 @@ public class AiQueryResource {
                     .build();
         }
         log.error("AI drillthrough failed for {}", queryId, e);
-        return error("drillthrough failed: " + e.getMessage());
+        return error("drillthrough failed");
     }
 
     /**
@@ -1500,7 +1484,7 @@ public class AiQueryResource {
                         .build();
             }
             log.error("AI drillthrough CSV export failed for {}", queryId, e);
-            return error("drillthrough CSV export failed: " + e.getMessage());
+            return error("drillthrough CSV export failed");
         } finally {
             JdbcCleanup.closeQuietly(rs);
         }
@@ -1559,7 +1543,7 @@ public class AiQueryResource {
                 return Response.ok(body).type(MediaType.APPLICATION_JSON).build();
             }
             log.error("AI drillthrough column discovery failed for {}", queryId, e);
-            return error("drillthrough column discovery failed: " + e.getMessage());
+            return error("drillthrough column discovery failed");
         }
     }
 

--- a/saiku-core/saiku-web/src/test/java/org/saiku/web/rest/resources/AiQueryErrorEchoTest.java
+++ b/saiku-core/saiku-web/src/test/java/org/saiku/web/rest/resources/AiQueryErrorEchoTest.java
@@ -1,0 +1,86 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.web.rest.resources;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+
+import jakarta.ws.rs.core.Response;
+import java.util.Collections;
+import org.junit.Before;
+import org.junit.Test;
+import org.saiku.olap.dto.resultset.CellDataSet;
+import org.saiku.olap.query2.ThinQuery;
+import org.saiku.service.olap.ThinQueryService;
+import org.saiku.service.olap.ai.AiAxisSelection;
+import org.saiku.service.olap.ai.AiCubeRef;
+import org.saiku.service.olap.ai.AiMeasureSelection;
+import org.saiku.service.olap.ai.AiQueryRequest;
+import org.saiku.service.olap.ai.AiQueryResponse;
+import org.saiku.service.olap.ai.AiSchema;
+
+/**
+ * saiku#1282 regression: the AI Query API must NOT echo raw exception detail to the client. On an
+ * unexpected execution failure it returns a generic message (e.g. "execute failed") and logs the
+ * detail server-side only — the same info-disclosure class as the #1261 QueryResource leak. The
+ * structured {@code AiValidationException} errors (field + candidate list) are intentional and stay.
+ *
+ * <p>Drives the real {@link AiQueryResource#executeAi} with a {@link ThinQueryService} whose
+ * execute() throws a credential-bearing message, and asserts the response carries only the generic
+ * text — never the secret. Mirrors {@code AiQueryResourceTest}'s stub-injection style.
+ */
+public class AiQueryErrorEchoTest {
+
+    /** A realistic deepest-cause: a JDBC URL with an embedded password. */
+    private static final String SECRET =
+            "jdbc:postgresql://10.0.0.5:5432/warehouse?user=svc&password=hunter2 [SQLState=28000]";
+
+    private AiQueryResource resource;
+
+    @Before
+    public void setUp() {
+        AiSchema schema = new AiSchema("foodmart/FoodMart/FoodMart/Sales", "Sales", "[FoodMart].[Sales]");
+        schema.measures.put(
+                AiSchema.key("Store Sales"), new AiSchema.Measure("Store Sales", "[Measures].[Store Sales]"));
+        AiSchema.Dimension time = new AiSchema.Dimension("Time", "[Time]");
+        AiSchema.Hierarchy timeBy = new AiSchema.Hierarchy("Time By", "[Time].[Time By]");
+        timeBy.levels.put(AiSchema.key("Year"), new AiSchema.Level("Year", "[Time].[Time By].[Year]"));
+        time.hierarchies.put(AiSchema.key("Time By"), timeBy);
+        schema.dimensions.put(AiSchema.key("Time"), time);
+
+        resource = new AiQueryResource();
+        resource.setCubeMetadataService(ref -> schema);
+        // A service whose execution blows up with a sensitive message.
+        resource.setThinQueryService(new ThinQueryService() {
+            @Override
+            public CellDataSet execute(ThinQuery tq) {
+                throw new RuntimeException(SECRET);
+            }
+        });
+    }
+
+    private AiQueryRequest baseRequest() {
+        AiQueryRequest req = new AiQueryRequest();
+        req.setCube(new AiCubeRef("foodmart", "FoodMart", "FoodMart", "Sales"));
+        req.setMeasures(Collections.singletonList(new AiMeasureSelection("Store Sales")));
+        req.setRows(Collections.singletonList(new AiAxisSelection("Time", "Time By", "Year")));
+        return req;
+    }
+
+    @Test
+    public void executeFailureReturnsGenericError_doesNotEchoExceptionDetail() {
+        Response resp = resource.executeAi(baseRequest(), "records");
+
+        assertEquals(500, resp.getStatus());
+        AiQueryResponse body = (AiQueryResponse) resp.getEntity();
+        assertNotNull(body);
+        assertEquals(AiQueryResponse.Status.EXECUTION_ERROR, body.getStatus());
+        assertEquals("execute failed", body.getError());
+        assertFalse(
+                "raw exception detail must never reach the client: " + body.getError(),
+                body.getError() != null && body.getError().contains("password=hunter2"));
+    }
+}


### PR DESCRIPTION
Closes #1282. Sibling of #1261, found in the post-4.5.0 audit (flagged by QA/LEAD as SEC lane).

## The leak
`AiQueryResource` returned **raw exception detail to the client** on unexpected failures:
- `error("execute failed: " + describeDeepestCause(e))` (query / saved-query / anomaly / forecast / ask), and
- `"<op> failed: " + e.getMessage()` across validation / preview / cube-listing / schema-fetch / member-search / async-submit / **drillthrough × 3** (+ the saved-query JSON-parse echo).

`describeDeepestCause` walks to the deepest cause, so an unexpected DB error leaks **JDBC/SQL internals — e.g. a JDBC URL with an embedded password** — exactly the #1261 class, now on the AI surface.

## Fix
Every leak site **already** `log.error(..., e)` server-side, so detail is preserved in logs. Return a **generic per-op message** to the client instead (`"execute failed"`, `"drillthrough failed"`, …). `describeDeepestCause` is now unused → **removed**.

**Kept (intentional):** the `AiValidationException` structured errors — `badRequest(field, message, available)` / `setError(ve.getMessage())` in `VALIDATION_ERROR` paths. Those are controlled, agent-facing self-correction guidance (the AI Query API contract), not raw internals. (Verified each remaining `.getMessage()` echo at lines 702/1187/1406 is inside a `catch (AiValidationException)`.)

## Verification
`AiQueryErrorEchoTest` drives the real `executeAi` with a `ThinQueryService` whose `execute()` throws a credential-bearing message; asserts the response error is the generic `"execute failed"` and **never** contains the secret. **Proven RED pre-fix** (re-introducing `+ e.getMessage()` flips it RED), **GREEN post-fix**. `AiQueryResourceTest` (36) still green; `mvn spotless:apply test` clean.

Security lane (Agent SEC). **Not self-merging** — handing to LEAD. 🤖 Generated with [Claude Code](https://claude.com/claude-code)
