### PR TITLE
fix(pdf): drop legacy header/footer, surface saved name + build version

### DIFF
--- a/saiku-core/saiku-web/src/main/java/org/saiku/web/export/JSConverter.java
+++ b/saiku-core/saiku-web/src/main/java/org/saiku/web/export/JSConverter.java
@@ -70,11 +70,11 @@ public class JSConverter {
     }
 
     private static String appendSaikuCommercialIfNecessary(String content) {
-        if (getVersion() != null && !getVersion().contains("EE")) {
-            content = content
-                    + "<div style='margin-top:10px;'><h5>Export Provided By Saiku Analytics Community Edition(http://meteorite.bi)"
-                    + "</h5></div>";
-        }
+        // The "Export Provided By Saiku Analytics Community Edition
+        // (http://meteorite.bi)" footer was dropped 2026-06-08 (user
+        // feedback: stale branding + dead URL). The method name + call
+        // are kept so existing entrypoints don't need rewriting; it now
+        // just normalises non-breaking spaces.
         content = content.replaceAll("&nbsp;", " ");
         content = content.replaceAll("&nbsp", " ");
         return content;

--- a/saiku-core/saiku-web/src/main/java/org/saiku/web/export/PdfReport.java
+++ b/saiku-core/saiku-web/src/main/java/org/saiku/web/export/PdfReport.java
@@ -10,9 +10,6 @@ import java.awt.print.PageFormat;
 import java.awt.print.Paper;
 import java.io.*;
 import java.net.URISyntaxException;
-import java.text.DateFormat;
-import java.text.SimpleDateFormat;
-import java.util.Date;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.transform.Result;
@@ -51,13 +48,27 @@ public class PdfReport {
     }
 
     public byte[] createPdf(QueryResult queryResult, String svg) throws Exception {
+        return createPdf(queryResult, svg, null);
+    }
+
+    /**
+     * Render the given query result as a PDF.
+     *
+     * <p>{@code documentName}, when non-blank, is set as the HTML
+     * {@code <title>} so the FO stylesheet picks it up as the running
+     * page header. Pass the saved-query name or the user-supplied
+     * filename from the {@code ?name=} query parameter; null / blank
+     * falls back to "Saiku Export" so the header is still populated
+     * for legacy callers.
+     */
+    public byte[] createPdf(QueryResult queryResult, String svg, String documentName) throws Exception {
         Rectangle queryResultSize = getQueryResultSize(queryResult);
 
         Document document = createDocumentWithSizeToContainQueryResult(queryResultSize);
         document.open();
 
         ByteArrayOutputStream pdf = new ByteArrayOutputStream();
-        populatePdf(queryResult, pdf, queryResultSize);
+        populatePdf(queryResult, pdf, queryResultSize, documentName);
 
         // do we want to add a svg image?
         if (StringUtils.isNotBlank(svg)) {
@@ -149,8 +160,10 @@ public class PdfReport {
      * @param queryResultSize
      * @throws Exception
      */
-    private void populatePdf(QueryResult queryResult, OutputStream pdf, Rectangle queryResultSize) throws Exception {
-        String htmlContent = generateContentAsHtmlString(queryResult);
+    private void populatePdf(
+            QueryResult queryResult, OutputStream pdf, Rectangle queryResultSize, String documentName)
+            throws Exception {
+        String htmlContent = generateContentAsHtmlString(queryResult, documentName);
         org.w3c.dom.Document htmlDom = DomConverter.getDom(htmlContent);
         org.w3c.dom.Document foDoc = FoConverter.getFo(htmlDom);
 
@@ -173,19 +186,38 @@ public class PdfReport {
         }
     }
 
-    private String generateContentAsHtmlString(QueryResult queryResult) throws IOException {
+    private String generateContentAsHtmlString(QueryResult queryResult, String documentName) throws IOException {
         pdfPerformanceLogger.queryToHtmlStart();
-        String contentBeforeQueryResult = createExportedByMessage();
         String queryResultContent = JSConverter.convertToHtml(queryResult);
         pdfPerformanceLogger.setQueryToHtmlStop();
         pdfPerformanceLogger.renderStart();
-        return contentBeforeQueryResult + queryResultContent;
+        // Wrap the table HTML in a full document so xhtml2fo.xsl finds a
+        // <title> for the running header (no more "Saiku Export - <date>"
+        // banner — user feedback 2026-06-08) and so page numbering in the
+        // bottom static-content band keeps working.
+        String title = (documentName == null || documentName.isBlank()) ? "Saiku Export" : documentName;
+        return "<html><head><title>" + escapeHtml(title) + "</title></head><body>"
+                + queryResultContent
+                + "</body></html>";
     }
 
-    private String createExportedByMessage() {
-        DateFormat dateFormat = new SimpleDateFormat("dd/MM/yyyy HH:mm");
-        Date date = new Date();
-        return "<p>" + "Saiku Export - " + dateFormat.format(date) + "</p>";
+    /** Minimal escape for HTML text content — the document name comes
+     *  from a user-supplied path/filename so guard against the obvious
+     *  injection vector even though the consumer is FO, not a browser. */
+    private static String escapeHtml(String s) {
+        StringBuilder sb = new StringBuilder(s.length());
+        for (int i = 0; i < s.length(); i++) {
+            char c = s.charAt(i);
+            switch (c) {
+                case '&' -> sb.append("&amp;");
+                case '<' -> sb.append("&lt;");
+                case '>' -> sb.append("&gt;");
+                case '"' -> sb.append("&quot;");
+                case '\'' -> sb.append("&#39;");
+                default -> sb.append(c);
+            }
+        }
+        return sb.toString();
     }
 
     private byte[] fo2Pdf(org.w3c.dom.Document foDocument, String styleSheet, Rectangle size) {

--- a/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/Query2Resource.java
+++ b/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/Query2Resource.java
@@ -944,11 +944,15 @@ public class Query2Resource {
         try {
             CellDataSet cellData = thinQueryService.getFormattedResult(queryName, format);
             QueryResult queryResult = RestUtil.convert(cellData);
-            PdfReport pdf = new PdfReport();
-            byte[] doc = pdf.createPdf(queryResult, svg);
+            // The download filename — falls back to "export" so users
+            // who didn't pass ?name= still get a sensible default.
             if (name == null || name.equals("")) {
                 name = "export";
             }
+            PdfReport pdf = new PdfReport();
+            // Pass the document name through so it lands as the PDF's
+            // running page header (xhtml2fo.xsl reads <head><title>).
+            byte[] doc = pdf.createPdf(queryResult, svg, name);
             return Response.ok(doc)
                     .type("application/pdf")
                     .header("content-disposition", "attachment; filename = " + name + ".pdf")

--- a/saiku-core/saiku-web/src/main/java/org/saiku/web/svg/PdfReport.java
+++ b/saiku-core/saiku-web/src/main/java/org/saiku/web/svg/PdfReport.java
@@ -20,10 +20,7 @@ import java.awt.print.PageFormat;
 import java.awt.print.Paper;
 import java.io.ByteArrayOutputStream;
 import java.io.StringReader;
-import java.text.DateFormat;
-import java.text.SimpleDateFormat;
 import java.util.ArrayList;
-import java.util.Date;
 import org.apache.batik.transcoder.TranscoderInput;
 import org.apache.batik.transcoder.print.PrintTranscoder;
 import org.apache.commons.lang3.StringUtils;
@@ -37,6 +34,14 @@ public class PdfReport {
     private static final Logger log = LoggerFactory.getLogger(PdfReport.class);
 
     public byte[] pdf(CellDataSet c, String svg) {
+        return pdf(c, svg, null);
+    }
+
+    /** Same as {@link #pdf(CellDataSet, String)} but uses the supplied
+     *  document name as the running header (with a " — Page X" suffix
+     *  to surface page numbering). 2026-06-08 — replaces the stale
+     *  "Saiku Export - dd/MM/yyyy" header. */
+    public byte[] pdf(CellDataSet c, String svg, String documentName) {
         section.setRowBody(c.getCellSetBody());
         section.setRowHeader(c.getCellSetHeaders());
 
@@ -49,10 +54,13 @@ public class PdfReport {
         try {
             PdfWriter writer = PdfWriter.getInstance(document, baos);
             document.open();
-            DateFormat dateFormat = new SimpleDateFormat("dd/MM/yyyy");
-            Date date = new Date();
-            document.setHeader(
-                    new HeaderFooter(new Phrase("Saiku Export - " + dateFormat.format(date) + " Page: "), null));
+            String header = (documentName == null || documentName.isBlank()) ? "Saiku Export" : documentName;
+            // iText's HeaderFooter takes a "numbered" flag — true appends
+            // the current page number to the Phrase, giving "<name> 1",
+            // "<name> 2", &c. with no extra layout work.
+            HeaderFooter hf = new HeaderFooter(new Phrase(header + "    Page "), true);
+            hf.setBorder(0);
+            document.setHeader(hf);
 
             ArrayList<ReportData.Section> rowGroups =
                     section.section(c.getCellSetBody(), c.getCellSetHeaders(), 0, dim, null);

--- a/saiku-ui/src/lib/i18n/en.json
+++ b/saiku-ui/src/lib/i18n/en.json
@@ -175,6 +175,7 @@
   "modal.delete.confirm": "Permanently delete {kind} \"{path}\"? This cannot be undone.",
   "modal.about.title": "About Saiku",
   "modal.about.tagline": "Saiku — modernised stack.",
+  "modal.about.version": "Build",
   "modal.about.community": "Join the community on Slack",
   "modal.save.title": "Save query",
   "modal.save.folder": "Folder",

--- a/saiku-ui/src/lib/views/Workspace.svelte
+++ b/saiku-ui/src/lib/views/Workspace.svelte
@@ -20,6 +20,7 @@
     type ThinQuery,
   } from "$lib/api/query";
   import { datasources } from "$lib/stores/datasources.svelte";
+  import { platform } from "$lib/stores/platform.svelte";
   import {
     findCubeByRef,
     parseStarterCubeRef,
@@ -321,6 +322,16 @@
 
 <Modal title={i18n.t("modal.about.title")} open={aboutOpen} size="sm" onClose={() => (aboutOpen = false)}>
   <p>{i18n.t("modal.about.tagline")}</p>
+  <!-- Build version surfaced from /rest/saiku/admin/version, populated
+       on app boot by platform.loadVersion(). The Maven build filters
+       version.properties so the value tracks ${project.version} on the
+       deployed jar — no manual sync needed. -->
+  {#if platform.version}
+    <p class="about-version">
+      {i18n.t("modal.about.version")}
+      <code>{platform.version}</code>
+    </p>
+  {/if}
   <p>
     <strong>{session.username}</strong> · {session.roles.join(", ")}
   </p>


### PR DESCRIPTION
## What

Two adjacent surface tweaks the user asked for.

### PDF template

The exported PDF was opening with \`Saiku Export - dd/MM/yyyy HH:mm\` and closing with \`Export Provided By Saiku Analytics Community Edition (http://meteorite.bi)\` — stale branding + a dead URL. Replaced with:

- **Document name as the page header** — the value of the existing \`?name=\` query parameter (already used for the download filename) now wraps the HTML in a \`<title>\` so \`xhtml2fo.xsl\` picks it up for the running page header. Falls back to \`Saiku Export\` when blank.
- **Page numbering** stays exactly where it was — the bottom \`<fo:static-content>\` band already renders \`page X of Y\` via \`fo:page-number\` + \`fo:page-number-citation\`.
- **No top date prose, no Community-Edition footer.**
- Mirror update on the older iText path (\`org.saiku.web.svg.PdfReport\`): new \`pdf(c, svg, documentName)\` overload with a borderless \`HeaderFooter(name + \" Page \", numbered=true)\`.

### About modal

Added the build version to the **About Saiku** modal as a small \"Build: \`4.5.0\`\" line. The \`platform\` store already calls \`/rest/saiku/admin/version\` on boot — just renders the existing field. The Maven build filters \`version.properties\` so the value tracks \`\${project.version}\` on the deployed jar with no manual sync.

## Test plan

- [x] \`mvn -pl saiku-launcher -am package\` clean; \`version.properties\` in the WAR shows \`VERSION=4.5.0\`.
- [x] \`npx svelte-check\` + \`npm test --run\` clean (872/872).
- [x] Local e2e: \`/admin/version\` returns \`4.5.0\`; PDF export with \`?name=Store%20Sales%20by%20City\` downloads a 1-page document with NO \"Saiku Export -\", \"Provided By\", or \"meteorite\" strings in the binary.
- [ ] Manual smoke once deployed:
  - Workspace toolbar → Export → PDF → confirm the page header reads the saved query name, page-number band intact.
  - Click About Saiku in the topbar — \"Build: 4.5.0\" appears.