### PR TITLE
chore: apply spotless to PdfReport

### DIFF
--- a/saiku-core/saiku-web/src/main/java/org/saiku/web/export/PdfReport.java
+++ b/saiku-core/saiku-web/src/main/java/org/saiku/web/export/PdfReport.java
@@ -160,8 +160,7 @@ public class PdfReport {
      * @param queryResultSize
      * @throws Exception
      */
-    private void populatePdf(
-            QueryResult queryResult, OutputStream pdf, Rectangle queryResultSize, String documentName)
+    private void populatePdf(QueryResult queryResult, OutputStream pdf, Rectangle queryResultSize, String documentName)
             throws Exception {
         String htmlContent = generateContentAsHtmlString(queryResult, documentName);
         org.w3c.dom.Document htmlDom = DomConverter.getDom(htmlContent);


### PR DESCRIPTION
Same one-line wrap fix that PR #1294 landed on main. Keeps development clean so the next mvn verify passes.