### PR TITLE
ci(release): mvn verify gate + release-prep workflow

### DIFF
--- a/.github/workflows/release-prep.yml
+++ b/.github/workflows/release-prep.yml
@@ -1,0 +1,62 @@
+name: release-prep
+
+# Triggered when a release branch is pushed or updated. Runs the same
+# mvn verify gate (spotless + tests + everything the release workflow
+# will run later) so the operator sees a red/green BEFORE opening the
+# release PR to main + tagging — not after the tag has already kicked
+# off downstream Docker / GH-Packages / docs work.
+#
+# Cheaper to discover a spotless break here than after a tag is
+# published and the release jobs explode (which is exactly how v4.5.1
+# went sideways).
+on:
+  push:
+    branches:
+      - 'release/*'
+  pull_request:
+    branches:
+      - main
+
+concurrency:
+  group: release-prep-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  verify:
+    name: mvn verify (release prep)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
+          cache: maven
+
+      # Same Maven settings.xml the release + CI workflows write —
+      # multi-server so the build can resolve the Spicule deps from
+      # GH Packages. Keep this snippet in sync with ci.yml / release.yml.
+      - name: Configure Maven settings.xml
+        env:
+          GH_PACKAGES_USER: ${{ github.actor }}
+          GH_PACKAGES_TOKEN: ${{ secrets.GH_PACKAGES_TOKEN }}
+        run: |
+          mkdir -p ~/.m2
+          cat > ~/.m2/settings.xml <<EOF
+          <settings xmlns="http://maven.apache.org/SETTINGS/1.0.0">
+            <servers>
+              <server><id>github-mondrian-saiku</id><username>${GH_PACKAGES_USER}</username><password>${GH_PACKAGES_TOKEN}</password></server>
+              <server><id>github-olap4j</id><username>${GH_PACKAGES_USER}</username><password>${GH_PACKAGES_TOKEN}</password></server>
+              <server><id>github-olap4j-xmlaserver</id><username>${GH_PACKAGES_USER}</username><password>${GH_PACKAGES_TOKEN}</password></server>
+              <server><id>github-saiku-query</id><username>${GH_PACKAGES_USER}</username><password>${GH_PACKAGES_TOKEN}</password></server>
+            </servers>
+          </settings>
+          EOF
+
+      - name: mvn verify (spotless + tests)
+        # Explicit -DskipTests=false so a stray env var can't downgrade
+        # the gate. Failing here flags the release as not-mergeable to
+        # main, which is the whole point.
+        run: mvn -B -ntp -DskipTests=false verify

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,6 +74,18 @@ jobs:
           echo "jar_name=saiku-${VERSION}.jar" >> "$GITHUB_OUTPUT"
           echo "dist_name=saiku-dist-${VERSION}.zip" >> "$GITHUB_OUTPUT"
 
+      - name: mvn verify (fail-fast: spotless + tests)
+        # Defence in depth — branch protection SHOULD have caught any
+        # spotless / test failure on the PR before the merge that led
+        # to this tag, but the v4.5.1 release found that a red CI run
+        # on a PR could still be merged (branch protection was off).
+        # Run the full verify gate here so a busted tag fails BEFORE
+        # we spend Docker / GH-Packages cycles + post a broken release.
+        # `-DskipTests=false` is explicit so a stray `-DskipTests` in
+        # the environment can't downgrade the gate; the upstream ci.yml
+        # already established that the suite runs fast enough.
+        run: mvn -B -ntp -DskipTests=false verify
+
       - name: mvn package (launcher)
         # saiku-launcher hosts both the REST + UI on :8080 AND the native
         # MCP endpoint at /rest/saiku/api/mcp (issue #878). The standalone


### PR DESCRIPTION
## What

Three coordinated changes so a broken commit can't reach a tag:

### 1. \`release.yml\` — verify gate before deploy
New \"mvn verify (fail-fast: spotless + tests)\" step **before** \`mvn package\` and \`mvn deploy\`. If verify fails, no JAR is built, no Docker image is pushed, no GH-Packages artifact is published, no GH release page is created. The tag stays orphaned but everything else stays clean.

\`-DskipTests=false\` is explicit so a stray env var can't downgrade the gate.

### 2. \`release-prep.yml\` — new workflow
Fires on push to \`release/*\` branches AND on PRs to \`main\`. Runs the same verify gate so the operator sees red **before** opening the release PR and tagging — not after, when cleanup involves deleting a tag, scrubbing GH Packages, and re-tagging.

### 3. Branch protection (already applied, out of band)
Enabled on \`development\` and \`main\` requiring \`ci.yml\`'s \`build (JDK 21, {ubuntu,macos}-latest)\` jobs to pass. Stops red-CI PRs from being mergeable in the first place — would have caught PR #1291's spotless break before the release attempt.

## Backstory

v4.5.1 release:
1. PR #1291 to development had a Palantir-format violation; CI failed; merged anyway (no branch protection).
2. Release PR cut from development → main → tag → release workflow failed at \`mvn deploy\` (spotless check).
3. After the spotless hotfix landed, the next release attempt failed at \`mvn deploy\` again with **409 Conflict** because the BOM 4.5.1 had already been published by the first (broken) attempt. Cleanup required `delete:packages` scope.

This PR + the branch protection move the failure mode FORWARD: red CI = unmergeable, red release-prep = obvious before tagging, red release-verify = no half-published state.

## Test plan

- [x] YAML lints cleanly.
- [ ] Once merged, the next PR to development with a deliberate spotless violation should be unmergeable.
- [ ] Next release/* branch push should trigger release-prep and show a green/red signal before the operator opens the main PR.