### PR TITLE
ci(release): tolerate missing labels on docs-site auto-PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,11 +37,15 @@ jobs:
               - 'lib/repo/**'
               - 'pom.xml'
               - '**/pom.xml'
-              - '.github/workflows/ci.yml'
+              # Any workflow file edit (ci.yml, release.yml, release-prep.yml,
+              # claude.yml, …) re-runs the build so branch-protected required
+              # jobs aren't silently skipped — a workflow-only PR otherwise
+              # sits as BLOCKED waiting for required checks that never fire.
+              - '.github/workflows/**'
               - '.github/test-floors.json'
             ui:
               - 'saiku-ui/**'
-              - '.github/workflows/ci.yml'
+              - '.github/workflows/**'
             docs:
               - 'docs/**'
               - 'README.md'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -354,12 +354,19 @@ jobs:
           git add docs-site/src/content/docs/help/changelog.mdx
           git commit -m "docs(changelog): draft entry for ${VERSION}"
           git push -u origin "$BRANCH"
-          gh pr create \
+          # Create the PR first; labels added separately so a missing
+          # label on saiku-cloud never aborts the release (v4.5.1's
+          # rebuild failed here because the `docs` label hadn't been
+          # created upstream — the PR was actually pushed fine).
+          PR_URL=$(gh pr create \
             --repo spiculedata/saiku-cloud \
             --base develop \
             --head "$BRANCH" \
             --title "docs(changelog): draft entry for ${VERSION}" \
             --body "Auto-opened by the saiku release workflow. The new section at the top of \`help/changelog.mdx\` is a draft — replace the placeholder bullet with a customer-facing summary of what changed, then merge.
 
-          See [saiku release ${VERSION}](https://github.com/${{ github.repository }}/releases/tag/${VERSION}) for the full notes." \
-            --label docs,release
+          See [saiku release ${VERSION}](https://github.com/${{ github.repository }}/releases/tag/${VERSION}) for the full notes.")
+          echo "Opened: $PR_URL"
+          # Best-effort labelling — surface a warning but don't fail.
+          gh pr edit "$PR_URL" --repo spiculedata/saiku-cloud --add-label docs --add-label release \
+            || echo "::warning::Failed to add docs/release labels to $PR_URL (probably missing on saiku-cloud — create them with: gh label create docs -R spiculedata/saiku-cloud)"


### PR DESCRIPTION
v4.5.1's rebuild failed at the very last step because \`gh pr create --label docs,release\` errored when the labels didn't exist on saiku-cloud — even though the PR itself was pushed fine (branch + commit landed; only the labelling step aborted, which then failed the whole release).

Split into two calls:
1. Create the PR (must succeed)
2. \`gh pr edit --add-label\` best-effort — downgrades to a workflow warning on failure

Release no longer fails on a missing-label edge case.

Companion: created the \`docs\` + \`release\` labels on saiku-cloud out of band so the next release picks them up cleanly anyway.