### PR TITLE
fix(ui): scope first-run tour + survive double-slash dashboard URLs

### DIFF
--- a/saiku-ui/src/lib/api/dashboards.test.ts
+++ b/saiku-ui/src/lib/api/dashboards.test.ts
@@ -13,6 +13,8 @@ import {
   cloneDashboardWithFreshIds,
   cloneTileWithFreshId,
   normaliseDashboardPath,
+  normaliseRepoPath,
+  toRepoRelative,
   type Dashboard,
   type DashboardTile,
 } from "./dashboards";
@@ -62,6 +64,51 @@ describe("normaliseDashboardPath", () => {
 
   it("allows a homes/... path even without a current user", () => {
     expect(normaliseDashboardPath("homes/other/x.saikudash", "")).toBe("homes/other/x.saikudash");
+  });
+});
+
+describe("normaliseRepoPath", () => {
+  // Regression: the user-reported 2026-06-08 dashboard URL contained
+  // a double slash (/ui/dashboards//homes/<uuid>/foo.saikudash/) and
+  // refused to refresh because SvelteKit's [...path] router couldn't
+  // make sense of it. Producer-side normalisation here keeps that
+  // URL well-formed before it ever reaches the router.
+  it("strips leading slashes", () => {
+    expect(normaliseRepoPath("/homes/admin/foo.saikudash")).toBe("homes/admin/foo.saikudash");
+  });
+
+  it("strips trailing slashes", () => {
+    expect(normaliseRepoPath("homes/admin/foo.saikudash/")).toBe("homes/admin/foo.saikudash");
+  });
+
+  it("collapses runs of slashes", () => {
+    expect(normaliseRepoPath("homes///admin//foo.saikudash")).toBe("homes/admin/foo.saikudash");
+  });
+
+  it("handles the user-reported `/homes/<uuid>/foo.saikudash/` shape", () => {
+    expect(normaliseRepoPath("/homes/771b40ff-8f4c-456e-ac69-a7dba1c88c5a/foo.saikudash/")).toBe(
+      "homes/771b40ff-8f4c-456e-ac69-a7dba1c88c5a/foo.saikudash",
+    );
+  });
+
+  it("is a no-op on already-clean paths", () => {
+    expect(normaliseRepoPath("homes/admin/foo.saikudash")).toBe("homes/admin/foo.saikudash");
+    expect(normaliseRepoPath("")).toBe("");
+  });
+});
+
+describe("toRepoRelative", () => {
+  it("normalises a leading slash after stripping the data prefix", () => {
+    // Listed JCR paths sometimes already include a leading slash on
+    // the captured remainder — the normaliser absorbs it so URL
+    // builders downstream don't end up with `/dashboards/` + `/foo`.
+    expect(
+      toRepoRelative("/Users/op/saiku-home/repository/data/unknown/homes/admin/foo.saikudash"),
+    ).toBe("homes/admin/foo.saikudash");
+  });
+
+  it("returns already-relative input cleaned up", () => {
+    expect(toRepoRelative("/homes/admin/foo.saikudash/")).toBe("homes/admin/foo.saikudash");
   });
 });
 

--- a/saiku-ui/src/lib/api/dashboards.ts
+++ b/saiku-ui/src/lib/api/dashboards.ts
@@ -610,9 +610,16 @@ function encodePath(path: string): string {
  *  `homes/...` pass through. Everything else gets the user's home prefixed
  *  so non-admins don't trip the saveFile ACL gate from saiku#895. */
 export function normaliseDashboardPath(rawPath: string, username: string): string {
-  const p = toRepoRelative(rawPath).trim();
+  const trimmed = rawPath.trim();
+  if (!trimmed) throw new Error("Dashboard path is required");
+  // The leading-slash signal ("this is an explicit absolute repo path,
+  // don't prefix with homes/<user>") has to be captured BEFORE the
+  // toRepoRelative + normaliseRepoPath pass strips it. Without this
+  // the per-user home-prefix path swallows the user's intent.
+  const isAbsolute = trimmed.startsWith("/");
+  const p = isAbsolute ? normaliseRepoPath(trimmed) : toRepoRelative(trimmed).trim();
   if (!p) throw new Error("Dashboard path is required");
-  if (p.startsWith("/")) return p.slice(1);
+  if (isAbsolute) return p;
   if (p.startsWith("homes/")) return p;
   if (!username) throw new Error("Cannot resolve home: no current user");
   return `homes/${username}/${p}`;
@@ -623,13 +630,28 @@ export function normaliseDashboardPath(rawPath: string, username: string): strin
  *  down to the repo-relative form the dashboards REST API expects
  *  ({@code homes/admin/foo}). Absolute paths from `listRepository(...)` need
  *  this; already-relative inputs (from the editor or hand-typed) pass
- *  through unchanged. */
+ *  through unchanged.
+ *
+ *  Also normalises any leading / trailing / duplicate slashes — some
+ *  workspace seedings include a leading `/` on the JCR path
+ *  (`/homes/<uuid>/foo.saikudash`) which downstream URL builders would
+ *  otherwise turn into `/ui/dashboards//homes/<uuid>/foo.saikudash`. The
+ *  double slash breaks SvelteKit's [...path] router on refresh
+ *  (user-reported 2026-06-08). */
 export function toRepoRelative(path: string): string {
   // Match anything up to and including `/data/<workspace>/`; the capture
   // group is the repo-relative remainder. Falls through to the input
   // when the pattern doesn't match (already-relative paths).
   const m = path.match(/^.*?\/data\/[^/]+\/(.+)$/);
-  return m ? m[1] : path;
+  const candidate = m ? m[1] : path;
+  return normaliseRepoPath(candidate);
+}
+
+/** Strip leading + trailing slashes and collapse duplicate slashes. Safe
+ *  to call on both repo paths (`homes/admin/foo.saikudash`) and the rest
+ *  segment of a URL (`/homes/admin/foo.saikudash/`). */
+export function normaliseRepoPath(path: string): string {
+  return path.replace(/\/+/g, "/").replace(/^\/+|\/+$/g, "");
 }
 
 async function readError(res: Response): Promise<string> {

--- a/saiku-ui/src/lib/components/Tour.svelte
+++ b/saiku-ui/src/lib/components/Tour.svelte
@@ -2,6 +2,7 @@
   import { browser } from "$app/environment";
   import { onMount } from "svelte";
   import { i18n } from "$lib/stores/i18n.svelte";
+  import { session } from "$lib/stores/session.svelte";
 
   interface Step {
     selector: string;
@@ -16,7 +17,16 @@
     { selector: ".view-toggle", titleKey: "tour.gridChart.title", bodyKey: "tour.gridChart.body" },
   ];
 
-  const STORAGE_KEY = "saiku.tour.done";
+  /** Per-user storage key — a second user on the same browser should
+   *  get their own first-time experience. Falls back to a global key
+   *  for anonymous / pre-session bootstrap (which shouldn't ever
+   *  reach this code path, since the parent route gates on
+   *  session.current). 2026-06-08. */
+  const STORAGE_KEY_FALLBACK = "saiku.tour.done";
+  function storageKey(): string {
+    const u = session.current?.username;
+    return u ? `saiku.tour.done.${u}` : STORAGE_KEY_FALLBACK;
+  }
 
   let active = $state<boolean>(false);
   let stepIdx = $state<number>(0);
@@ -29,11 +39,29 @@
     anchor = el ? el.getBoundingClientRect() : null;
   }
 
+  /** The first step's target — the cubes select — only exists on the
+   *  workspace route. If it's missing the user is on a route where
+   *  the tour wouldn't anchor anywhere meaningful, so don't start. */
+  function workspaceVisible(): boolean {
+    return !!document.querySelector(STEPS[0].selector);
+  }
+
   onMount(() => {
     if (!browser) return;
-    if (localStorage.getItem(STORAGE_KEY) === "1") return;
-    active = true;
-    requestAnimationFrame(updateAnchor);
+    if (localStorage.getItem(storageKey()) === "1") return;
+    // Migration: an earlier release wrote the flag under a global key.
+    // Honour it so users who already finished the tour aren't shown it
+    // again after the per-user split lands.
+    if (localStorage.getItem(STORAGE_KEY_FALLBACK) === "1") {
+      localStorage.setItem(storageKey(), "1");
+      return;
+    }
+    // Wait a tick for the workspace render then bail if it isn't here.
+    requestAnimationFrame(() => {
+      if (!workspaceVisible()) return;
+      active = true;
+      updateAnchor();
+    });
     const onResize = () => updateAnchor();
     window.addEventListener("resize", onResize);
     window.addEventListener("scroll", onResize, true);
@@ -69,12 +97,12 @@
 
   function finish() {
     active = false;
-    if (browser) localStorage.setItem(STORAGE_KEY, "1");
+    if (browser) localStorage.setItem(storageKey(), "1");
   }
 
   export function restart() {
     if (!browser) return;
-    localStorage.removeItem(STORAGE_KEY);
+    localStorage.removeItem(storageKey());
     stepIdx = 0;
     active = true;
     requestAnimationFrame(updateAnchor);

--- a/saiku-ui/src/routes/+layout.svelte
+++ b/saiku-ui/src/routes/+layout.svelte
@@ -10,7 +10,6 @@
   import ToastStack from "$lib/components/ToastStack.svelte";
   import UpgradeBanner from "$lib/components/UpgradeBanner.svelte";
   import { LogOut, Shield, Home, LayoutDashboard, UserRound } from "lucide-svelte";
-  import Tour from "$lib/components/Tour.svelte";
   import SessionExpiredBanner from "$lib/components/SessionExpiredBanner.svelte";
   import { i18n } from "$lib/stores/i18n.svelte";
   import { installAuthInterceptor, onAuthFailure } from "$lib/api/http";
@@ -125,7 +124,9 @@
     {@render children()}
   </main>
   <ToastStack />
-  {#if session.current}<Tour />{/if}
+  <!-- Tour mount moved to the workspace route (+page.svelte) so it
+       only fires where its target selectors actually exist
+       (#cubes-select et al). 2026-06-08 user feedback. -->
   <SessionExpiredBanner
     open={sessionError.open}
     statusLabel={sessionError.statusLabel}

--- a/saiku-ui/src/routes/+page.svelte
+++ b/saiku-ui/src/routes/+page.svelte
@@ -2,12 +2,19 @@
   import { session } from "$lib/stores/session.svelte";
   import LoginForm from "$lib/views/LoginForm.svelte";
   import Workspace from "$lib/views/Workspace.svelte";
+  // The first-run tour highlights workspace-only affordances (cubes
+  // picker, dropzones, view toggle), so mount it on this route only —
+  // previously it lived in +layout.svelte and fired on every page
+  // (dashboards, admin, share viewer) where its target selectors
+  // didn't exist, anchoring its bubble nowhere useful.
+  import Tour from "$lib/components/Tour.svelte";
 </script>
 
 {#if session.loading}
   <div class="loading">Loading…</div>
 {:else if session.current}
   <Workspace session={session.current} />
+  <Tour />
 {:else}
   <LoginForm />
 {/if}

--- a/saiku-ui/src/routes/dashboards/[...path]/+page.ts
+++ b/saiku-ui/src/routes/dashboards/[...path]/+page.ts
@@ -9,6 +9,7 @@
  * blocking the route render.
  */
 
+import { normaliseRepoPath } from "$lib/api/dashboards";
 import type { PageLoad } from "./$types";
 
 // Dynamic route, can't be prerendered. Saiku's root layout prerenders by
@@ -17,8 +18,13 @@ export const prerender = false;
 
 export const load: PageLoad = ({ params }) => {
   // params.path is the raw rest segment — SvelteKit returns it as a single
-  // string with slashes preserved (NOT an array). Leading/trailing slashes
-  // are trimmed by the router already.
-  const path = params.path ?? "";
+  // string with slashes preserved (NOT an array). The router usually trims
+  // leading / trailing slashes, but URLs that opened from older clients can
+  // still carry `//homes/<uuid>/foo.saikudash/` (the double slash is the
+  // tell — listed JCR paths sometimes have a leading slash that the URL
+  // builder concatenated to the route prefix). Normalise defensively so
+  // refresh always lands on the same dashboard regardless of how the URL
+  // was constructed (user-reported 2026-06-08).
+  const path = normaliseRepoPath(params.path ?? "");
   return { dashboardPath: path };
 };


### PR DESCRIPTION
Two adjacent papercuts from a fresh-eyes session.

## Tour mode

The first-run tour was mounted in \`+layout.svelte\` and fired on every route — including \`/dashboards\` and \`/admin\` where its target selectors (\`#cubes-select\`, \`.workspace__sidebar\`, \`.dropzone\`, \`.view-toggle\`) don't exist. Users saw the bubble floating anchorless on unrelated pages.

Plus the localStorage key (\`saiku.tour.done\`) was global, so a second user on the same browser never got their first-time experience.

Fixed:
- Move \`<Tour />\` out of \`+layout.svelte\` into the workspace route's \`+page.svelte\` so it only mounts where it can anchor.
- Per-user storage key: \`saiku.tour.done.<username>\`, with a one-shot migration that honours the old global key so existing users don't see the tour again.
- Defensive: even on the workspace route, only activate if \`document.querySelector(\"#cubes-select\")\` resolves — a slow cube fetch shouldn't anchor the bubble nowhere.

## Dashboard URL refresh

URLs like \`/ui/dashboards//homes/<uuid>/foo.saikudash/\` couldn't survive a refresh (SvelteKit's \`[...path]\` router didn't normalise the double slash). Root cause: some listed JCR paths include a leading slash, and the URL builders did \`\${base}/dashboards/\${path}\` without normalising.

Fixed:
- \`normaliseRepoPath()\` — strips leading/trailing slashes and collapses runs. Exported for any caller that needs to feed a repo-relative path into a URL.
- \`toRepoRelative()\` now runs its output through \`normaliseRepoPath\`. Every link / goto / favourite-store entry that derives from a listed JCR path is well-formed at the source.
- \`normaliseDashboardPath()\` preserves the leading-slash signal (\"this is an explicit absolute repo path\") explicitly before delegating to the normaliser — the existing test-suite intent stays intact.
- \`+page.ts\` load defensively re-normalises \`params.path\` so a URL from an older client or a hand-typed double slash still routes cleanly.

## Test plan

- [x] \`npx svelte-check\` clean
- [x] \`npm test -- --run\` — 961/961 (added 7 regression tests for normaliseRepoPath + toRepoRelative pinning the user-reported \`/homes/<uuid>/foo.saikudash/\` shape)
- [ ] Manual smoke once deployed:
  - First login on a fresh browser → tour fires on the workspace, NOT on /dashboards or /admin
  - Second login as a different user on the same browser → that user also gets the tour
  - Visit the user-reported URL with double slash → refresh works