### PR TITLE
ci: add aggregator gate for stable branch protection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -207,3 +207,36 @@ jobs:
           path: saiku-dist-${{ steps.ver.outputs.version }}.zip
           if-no-files-found: error
           retention-days: 30
+
+  # Single aggregator status check. Branch protection requires only `ci`,
+  # which makes the rule stable across:
+  #   - matrix jobs whose display names interpolate ${{ matrix.os }}
+  #     (the un-expanded template name never appears as a status check)
+  #   - path-filtered jobs that legitimately skip on PRs that don't touch
+  #     their inputs (UI-only, workflow-only, docs-only)
+  # `if: always()` runs the gate regardless of upstream outcomes; the
+  # script then fails if any upstream reports anything other than
+  # success/skipped — so a real build failure still blocks the merge.
+  ci:
+    name: ci
+    needs: [changes, build, ui, dist]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify upstream jobs passed or were skipped
+        run: |
+          set -euo pipefail
+          fail=0
+          for entry in \
+            "changes=${{ needs.changes.result }}" \
+            "build=${{ needs.build.result }}" \
+            "ui=${{ needs.ui.result }}" \
+            "dist=${{ needs.dist.result }}"; do
+            name="${entry%%=*}"
+            result="${entry#*=}"
+            case "$result" in
+              success|skipped) echo "ok: $name=$result" ;;
+              *) echo "::error::$name=$result"; fail=1 ;;
+            esac
+          done
+          exit "$fail"


### PR DESCRIPTION
## Summary

- Adds a single `ci` aggregator job that depends on `changes / build / ui / dist` and reports SUCCESS only when every upstream is success-or-skipped, FAILURE otherwise
- Lets branch protection require **one** stable status check (`ci`) instead of literal matrix names like `build (JDK 21, ubuntu-latest)` that don't appear when path-filtered jobs skip
- Real failures still block — `if: always()` runs the gate regardless, and the script returns non-zero on any non-success/non-skipped upstream

## Background

PRs #1296 and #1298 were caught by branch protection because the required check names (`build (JDK 21, ubuntu-latest)` etc.) never appear on UI-only or workflow-only PRs — the build job's path filter legitimately skipped them. I admin-merged both and temporarily disabled protection. This restores it on a stable foundation.

## Test plan

- [ ] CI on this PR shows the new `ci` job running and passing
- [ ] After merge: re-enable branch protection on `development` with `ci` as the single required check
- [ ] Verify a follow-up UI-only or workflow-only PR no longer wedges