### PR TITLE
release: 4.5.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -207,3 +207,36 @@ jobs:
           path: saiku-dist-${{ steps.ver.outputs.version }}.zip
           if-no-files-found: error
           retention-days: 30
+
+  # Single aggregator status check. Branch protection requires only `ci`,
+  # which makes the rule stable across:
+  #   - matrix jobs whose display names interpolate ${{ matrix.os }}
+  #     (the un-expanded template name never appears as a status check)
+  #   - path-filtered jobs that legitimately skip on PRs that don't touch
+  #     their inputs (UI-only, workflow-only, docs-only)
+  # `if: always()` runs the gate regardless of upstream outcomes; the
+  # script then fails if any upstream reports anything other than
+  # success/skipped — so a real build failure still blocks the merge.
+  ci:
+    name: ci
+    needs: [changes, build, ui, dist]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify upstream jobs passed or were skipped
+        run: |
+          set -euo pipefail
+          fail=0
+          for entry in \
+            "changes=${{ needs.changes.result }}" \
+            "build=${{ needs.build.result }}" \
+            "ui=${{ needs.ui.result }}" \
+            "dist=${{ needs.dist.result }}"; do
+            name="${entry%%=*}"
+            result="${entry#*=}"
+            case "$result" in
+              success|skipped) echo "ok: $name=$result" ;;
+              *) echo "::error::$name=$result"; fail=1 ;;
+            esac
+          done
+          exit "$fail"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,11 +37,15 @@ jobs:
               - 'lib/repo/**'
               - 'pom.xml'
               - '**/pom.xml'
-              - '.github/workflows/ci.yml'
+              # Any workflow file edit (ci.yml, release.yml, release-prep.yml,
+              # claude.yml, …) re-runs the build so branch-protected required
+              # jobs aren't silently skipped — a workflow-only PR otherwise
+              # sits as BLOCKED waiting for required checks that never fire.
+              - '.github/workflows/**'
               - '.github/test-floors.json'
             ui:
               - 'saiku-ui/**'
-              - '.github/workflows/ci.yml'
+              - '.github/workflows/**'
             docs:
               - 'docs/**'
               - 'README.md'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,14 +52,10 @@ jobs:
               - 'CLAUDE.md'
 
   build:
-    name: build (JDK 21, ${{ matrix.os }})
+    name: build (JDK 21, ubuntu-latest)
     needs: changes
     if: needs.changes.outputs.java == 'true' || github.event_name == 'push'
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu-latest, macos-latest]
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - name: Set up JDK 21

--- a/.github/workflows/release-prep.yml
+++ b/.github/workflows/release-prep.yml
@@ -1,0 +1,62 @@
+name: release-prep
+
+# Triggered when a release branch is pushed or updated. Runs the same
+# mvn verify gate (spotless + tests + everything the release workflow
+# will run later) so the operator sees a red/green BEFORE opening the
+# release PR to main + tagging — not after the tag has already kicked
+# off downstream Docker / GH-Packages / docs work.
+#
+# Cheaper to discover a spotless break here than after a tag is
+# published and the release jobs explode (which is exactly how v4.5.1
+# went sideways).
+on:
+  push:
+    branches:
+      - 'release/*'
+  pull_request:
+    branches:
+      - main
+
+concurrency:
+  group: release-prep-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  verify:
+    name: mvn verify (release prep)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
+          cache: maven
+
+      # Same Maven settings.xml the release + CI workflows write —
+      # multi-server so the build can resolve the Spicule deps from
+      # GH Packages. Keep this snippet in sync with ci.yml / release.yml.
+      - name: Configure Maven settings.xml
+        env:
+          GH_PACKAGES_USER: ${{ github.actor }}
+          GH_PACKAGES_TOKEN: ${{ secrets.GH_PACKAGES_TOKEN }}
+        run: |
+          mkdir -p ~/.m2
+          cat > ~/.m2/settings.xml <<EOF
+          <settings xmlns="http://maven.apache.org/SETTINGS/1.0.0">
+            <servers>
+              <server><id>github-mondrian-saiku</id><username>${GH_PACKAGES_USER}</username><password>${GH_PACKAGES_TOKEN}</password></server>
+              <server><id>github-olap4j</id><username>${GH_PACKAGES_USER}</username><password>${GH_PACKAGES_TOKEN}</password></server>
+              <server><id>github-olap4j-xmlaserver</id><username>${GH_PACKAGES_USER}</username><password>${GH_PACKAGES_TOKEN}</password></server>
+              <server><id>github-saiku-query</id><username>${GH_PACKAGES_USER}</username><password>${GH_PACKAGES_TOKEN}</password></server>
+            </servers>
+          </settings>
+          EOF
+
+      - name: mvn verify (spotless + tests)
+        # Explicit -DskipTests=false so a stray env var can't downgrade
+        # the gate. Failing here flags the release as not-mergeable to
+        # main, which is the whole point.
+        run: mvn -B -ntp -DskipTests=false verify

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,6 +74,18 @@ jobs:
           echo "jar_name=saiku-${VERSION}.jar" >> "$GITHUB_OUTPUT"
           echo "dist_name=saiku-dist-${VERSION}.zip" >> "$GITHUB_OUTPUT"
 
+      - name: mvn verify (fail-fast: spotless + tests)
+        # Defence in depth — branch protection SHOULD have caught any
+        # spotless / test failure on the PR before the merge that led
+        # to this tag, but the v4.5.1 release found that a red CI run
+        # on a PR could still be merged (branch protection was off).
+        # Run the full verify gate here so a busted tag fails BEFORE
+        # we spend Docker / GH-Packages cycles + post a broken release.
+        # `-DskipTests=false` is explicit so a stray `-DskipTests` in
+        # the environment can't downgrade the gate; the upstream ci.yml
+        # already established that the suite runs fast enough.
+        run: mvn -B -ntp -DskipTests=false verify
+
       - name: mvn package (launcher)
         # saiku-launcher hosts both the REST + UI on :8080 AND the native
         # MCP endpoint at /rest/saiku/api/mcp (issue #878). The standalone

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -354,12 +354,19 @@ jobs:
           git add docs-site/src/content/docs/help/changelog.mdx
           git commit -m "docs(changelog): draft entry for ${VERSION}"
           git push -u origin "$BRANCH"
-          gh pr create \
+          # Create the PR first; labels added separately so a missing
+          # label on saiku-cloud never aborts the release (v4.5.1's
+          # rebuild failed here because the `docs` label hadn't been
+          # created upstream — the PR was actually pushed fine).
+          PR_URL=$(gh pr create \
             --repo spiculedata/saiku-cloud \
             --base develop \
             --head "$BRANCH" \
             --title "docs(changelog): draft entry for ${VERSION}" \
             --body "Auto-opened by the saiku release workflow. The new section at the top of \`help/changelog.mdx\` is a draft — replace the placeholder bullet with a customer-facing summary of what changed, then merge.
 
-          See [saiku release ${VERSION}](https://github.com/${{ github.repository }}/releases/tag/${VERSION}) for the full notes." \
-            --label docs,release
+          See [saiku release ${VERSION}](https://github.com/${{ github.repository }}/releases/tag/${VERSION}) for the full notes.")
+          echo "Opened: $PR_URL"
+          # Best-effort labelling — surface a warning but don't fail.
+          gh pr edit "$PR_URL" --repo spiculedata/saiku-cloud --add-label docs --add-label release \
+            || echo "::warning::Failed to add docs/release labels to $PR_URL (probably missing on saiku-cloud — create them with: gh label create docs -R spiculedata/saiku-cloud)"

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <groupId>org.saikuanalytics</groupId>
     <artifactId>saiku</artifactId>
     <packaging>pom</packaging>
-    <version>4.5.0</version>
+    <version>4.5.1</version>
     <name>Saiku Module Project</name>
     <scm>
         <developerConnection>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <groupId>org.saikuanalytics</groupId>
     <artifactId>saiku</artifactId>
     <packaging>pom</packaging>
-    <version>4.5.1</version>
+    <version>4.5.2</version>
     <name>Saiku Module Project</name>
     <scm>
         <developerConnection>

--- a/saiku-bom/pom.xml
+++ b/saiku-bom/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.saikuanalytics</groupId>
     <artifactId>saiku-bom</artifactId>
-    <version>4.5.0</version>
+    <version>4.5.1</version>
     <packaging>pom</packaging>
     <name>Saiku BOM</name>
     <description>Central dependency-version catalogue for Saiku modules.</description>

--- a/saiku-bom/pom.xml
+++ b/saiku-bom/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.saikuanalytics</groupId>
     <artifactId>saiku-bom</artifactId>
-    <version>4.5.1</version>
+    <version>4.5.2</version>
     <packaging>pom</packaging>
     <name>Saiku BOM</name>
     <description>Central dependency-version catalogue for Saiku modules.</description>

--- a/saiku-core/pom.xml
+++ b/saiku-core/pom.xml
@@ -2,14 +2,14 @@
     <parent>
         <artifactId>saiku</artifactId>
         <groupId>org.saikuanalytics</groupId>
-        <version>4.5.1</version>
+        <version>4.5.2</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>
     <artifactId>saiku-core</artifactId>
     <packaging>pom</packaging>
     <name>saiku - core libraries</name>
-    <version>4.5.1</version>
+    <version>4.5.2</version>
 
     <modules>
         <module>saiku-olap-util</module>

--- a/saiku-core/pom.xml
+++ b/saiku-core/pom.xml
@@ -2,14 +2,14 @@
     <parent>
         <artifactId>saiku</artifactId>
         <groupId>org.saikuanalytics</groupId>
-        <version>4.5.0</version>
+        <version>4.5.1</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>
     <artifactId>saiku-core</artifactId>
     <packaging>pom</packaging>
     <name>saiku - core libraries</name>
-    <version>4.5.0</version>
+    <version>4.5.1</version>
 
     <modules>
         <module>saiku-olap-util</module>

--- a/saiku-core/saiku-olap-util/pom.xml
+++ b/saiku-core/saiku-olap-util/pom.xml
@@ -3,11 +3,11 @@
     <parent>
         <artifactId>saiku-core</artifactId>
         <groupId>org.saikuanalytics</groupId>
-        <version>4.5.0</version>
+        <version>4.5.1</version>
     </parent>
 	<artifactId>saiku-olap-util</artifactId>
 	<packaging>jar</packaging>
-	<version>4.5.0</version>
+	<version>4.5.1</version>
 	<name>saiku olap util</name>
 	<properties>
 		<maven.compiler.source>1.8</maven.compiler.source>

--- a/saiku-core/saiku-olap-util/pom.xml
+++ b/saiku-core/saiku-olap-util/pom.xml
@@ -3,11 +3,11 @@
     <parent>
         <artifactId>saiku-core</artifactId>
         <groupId>org.saikuanalytics</groupId>
-        <version>4.5.1</version>
+        <version>4.5.2</version>
     </parent>
 	<artifactId>saiku-olap-util</artifactId>
 	<packaging>jar</packaging>
-	<version>4.5.1</version>
+	<version>4.5.2</version>
 	<name>saiku olap util</name>
 	<properties>
 		<maven.compiler.source>1.8</maven.compiler.source>

--- a/saiku-core/saiku-semantic/pom.xml
+++ b/saiku-core/saiku-semantic/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <artifactId>saiku-core</artifactId>
         <groupId>org.saikuanalytics</groupId>
-        <version>4.5.1</version>
+        <version>4.5.2</version>
     </parent>
 
     <artifactId>saiku-semantic</artifactId>

--- a/saiku-core/saiku-semantic/pom.xml
+++ b/saiku-core/saiku-semantic/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <artifactId>saiku-core</artifactId>
         <groupId>org.saikuanalytics</groupId>
-        <version>4.5.0</version>
+        <version>4.5.1</version>
     </parent>
 
     <artifactId>saiku-semantic</artifactId>

--- a/saiku-core/saiku-service/pom.xml
+++ b/saiku-core/saiku-service/pom.xml
@@ -2,12 +2,12 @@
     <parent>
         <artifactId>saiku-core</artifactId>
         <groupId>org.saikuanalytics</groupId>
-        <version>4.5.1</version>
+        <version>4.5.2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>jar</packaging>
     <artifactId>saiku-service</artifactId>
-    <version>4.5.1</version>
+    <version>4.5.2</version>
     <name>saiku - services</name>
     <build>
         <plugins>

--- a/saiku-core/saiku-service/pom.xml
+++ b/saiku-core/saiku-service/pom.xml
@@ -2,12 +2,12 @@
     <parent>
         <artifactId>saiku-core</artifactId>
         <groupId>org.saikuanalytics</groupId>
-        <version>4.5.0</version>
+        <version>4.5.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>jar</packaging>
     <artifactId>saiku-service</artifactId>
-    <version>4.5.0</version>
+    <version>4.5.1</version>
     <name>saiku - services</name>
     <build>
         <plugins>

--- a/saiku-core/saiku-web/pom.xml
+++ b/saiku-core/saiku-web/pom.xml
@@ -2,11 +2,11 @@
     <parent>
         <artifactId>saiku-core</artifactId>
         <groupId>org.saikuanalytics</groupId>
-        <version>4.5.0</version>
+        <version>4.5.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>saiku-web</artifactId>
-    <version>4.5.0</version>
+    <version>4.5.1</version>
     <name>saiku - web</name>
     <packaging>jar</packaging>
 

--- a/saiku-core/saiku-web/pom.xml
+++ b/saiku-core/saiku-web/pom.xml
@@ -2,11 +2,11 @@
     <parent>
         <artifactId>saiku-core</artifactId>
         <groupId>org.saikuanalytics</groupId>
-        <version>4.5.1</version>
+        <version>4.5.2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>saiku-web</artifactId>
-    <version>4.5.1</version>
+    <version>4.5.2</version>
     <name>saiku - web</name>
     <packaging>jar</packaging>
 

--- a/saiku-core/saiku-web/src/main/java/org/saiku/web/export/PdfReport.java
+++ b/saiku-core/saiku-web/src/main/java/org/saiku/web/export/PdfReport.java
@@ -160,8 +160,7 @@ public class PdfReport {
      * @param queryResultSize
      * @throws Exception
      */
-    private void populatePdf(
-            QueryResult queryResult, OutputStream pdf, Rectangle queryResultSize, String documentName)
+    private void populatePdf(QueryResult queryResult, OutputStream pdf, Rectangle queryResultSize, String documentName)
             throws Exception {
         String htmlContent = generateContentAsHtmlString(queryResult, documentName);
         org.w3c.dom.Document htmlDom = DomConverter.getDom(htmlContent);

--- a/saiku-launcher/pom.xml
+++ b/saiku-launcher/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.saikuanalytics</groupId>
         <artifactId>saiku</artifactId>
-        <version>4.5.1</version>
+        <version>4.5.2</version>
     </parent>
 
     <artifactId>saiku-launcher</artifactId>

--- a/saiku-launcher/pom.xml
+++ b/saiku-launcher/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.saikuanalytics</groupId>
         <artifactId>saiku</artifactId>
-        <version>4.5.0</version>
+        <version>4.5.1</version>
     </parent>
 
     <artifactId>saiku-launcher</artifactId>

--- a/saiku-ui/package-lock.json
+++ b/saiku-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "saiku-ui",
-  "version": "3.17.1",
+  "version": "3.18.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "saiku-ui",
-      "version": "3.17.1",
+      "version": "3.18.2",
       "dependencies": {
         "apache-arrow": "^15.0.2",
         "echarts": "^6.0.0",

--- a/saiku-ui/package.json
+++ b/saiku-ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "saiku-ui",
   "private": true,
-  "version": "3.18.0",
+  "version": "3.18.1",
   "type": "module",
   "scripts": {
     "dev": "vite dev",

--- a/saiku-ui/package.json
+++ b/saiku-ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "saiku-ui",
   "private": true,
-  "version": "3.18.1",
+  "version": "3.18.2",
   "type": "module",
   "scripts": {
     "dev": "vite dev",

--- a/saiku-ui/src/lib/api/dashboards.test.ts
+++ b/saiku-ui/src/lib/api/dashboards.test.ts
@@ -13,6 +13,8 @@ import {
   cloneDashboardWithFreshIds,
   cloneTileWithFreshId,
   normaliseDashboardPath,
+  normaliseRepoPath,
+  toRepoRelative,
   type Dashboard,
   type DashboardTile,
 } from "./dashboards";
@@ -62,6 +64,51 @@ describe("normaliseDashboardPath", () => {
 
   it("allows a homes/... path even without a current user", () => {
     expect(normaliseDashboardPath("homes/other/x.saikudash", "")).toBe("homes/other/x.saikudash");
+  });
+});
+
+describe("normaliseRepoPath", () => {
+  // Regression: the user-reported 2026-06-08 dashboard URL contained
+  // a double slash (/ui/dashboards//homes/<uuid>/foo.saikudash/) and
+  // refused to refresh because SvelteKit's [...path] router couldn't
+  // make sense of it. Producer-side normalisation here keeps that
+  // URL well-formed before it ever reaches the router.
+  it("strips leading slashes", () => {
+    expect(normaliseRepoPath("/homes/admin/foo.saikudash")).toBe("homes/admin/foo.saikudash");
+  });
+
+  it("strips trailing slashes", () => {
+    expect(normaliseRepoPath("homes/admin/foo.saikudash/")).toBe("homes/admin/foo.saikudash");
+  });
+
+  it("collapses runs of slashes", () => {
+    expect(normaliseRepoPath("homes///admin//foo.saikudash")).toBe("homes/admin/foo.saikudash");
+  });
+
+  it("handles the user-reported `/homes/<uuid>/foo.saikudash/` shape", () => {
+    expect(normaliseRepoPath("/homes/771b40ff-8f4c-456e-ac69-a7dba1c88c5a/foo.saikudash/")).toBe(
+      "homes/771b40ff-8f4c-456e-ac69-a7dba1c88c5a/foo.saikudash",
+    );
+  });
+
+  it("is a no-op on already-clean paths", () => {
+    expect(normaliseRepoPath("homes/admin/foo.saikudash")).toBe("homes/admin/foo.saikudash");
+    expect(normaliseRepoPath("")).toBe("");
+  });
+});
+
+describe("toRepoRelative", () => {
+  it("normalises a leading slash after stripping the data prefix", () => {
+    // Listed JCR paths sometimes already include a leading slash on
+    // the captured remainder — the normaliser absorbs it so URL
+    // builders downstream don't end up with `/dashboards/` + `/foo`.
+    expect(
+      toRepoRelative("/Users/op/saiku-home/repository/data/unknown/homes/admin/foo.saikudash"),
+    ).toBe("homes/admin/foo.saikudash");
+  });
+
+  it("returns already-relative input cleaned up", () => {
+    expect(toRepoRelative("/homes/admin/foo.saikudash/")).toBe("homes/admin/foo.saikudash");
   });
 });
 

--- a/saiku-ui/src/lib/api/dashboards.ts
+++ b/saiku-ui/src/lib/api/dashboards.ts
@@ -610,9 +610,16 @@ function encodePath(path: string): string {
  *  `homes/...` pass through. Everything else gets the user's home prefixed
  *  so non-admins don't trip the saveFile ACL gate from saiku#895. */
 export function normaliseDashboardPath(rawPath: string, username: string): string {
-  const p = toRepoRelative(rawPath).trim();
+  const trimmed = rawPath.trim();
+  if (!trimmed) throw new Error("Dashboard path is required");
+  // The leading-slash signal ("this is an explicit absolute repo path,
+  // don't prefix with homes/<user>") has to be captured BEFORE the
+  // toRepoRelative + normaliseRepoPath pass strips it. Without this
+  // the per-user home-prefix path swallows the user's intent.
+  const isAbsolute = trimmed.startsWith("/");
+  const p = isAbsolute ? normaliseRepoPath(trimmed) : toRepoRelative(trimmed).trim();
   if (!p) throw new Error("Dashboard path is required");
-  if (p.startsWith("/")) return p.slice(1);
+  if (isAbsolute) return p;
   if (p.startsWith("homes/")) return p;
   if (!username) throw new Error("Cannot resolve home: no current user");
   return `homes/${username}/${p}`;
@@ -623,13 +630,28 @@ export function normaliseDashboardPath(rawPath: string, username: string): strin
  *  down to the repo-relative form the dashboards REST API expects
  *  ({@code homes/admin/foo}). Absolute paths from `listRepository(...)` need
  *  this; already-relative inputs (from the editor or hand-typed) pass
- *  through unchanged. */
+ *  through unchanged.
+ *
+ *  Also normalises any leading / trailing / duplicate slashes — some
+ *  workspace seedings include a leading `/` on the JCR path
+ *  (`/homes/<uuid>/foo.saikudash`) which downstream URL builders would
+ *  otherwise turn into `/ui/dashboards//homes/<uuid>/foo.saikudash`. The
+ *  double slash breaks SvelteKit's [...path] router on refresh
+ *  (user-reported 2026-06-08). */
 export function toRepoRelative(path: string): string {
   // Match anything up to and including `/data/<workspace>/`; the capture
   // group is the repo-relative remainder. Falls through to the input
   // when the pattern doesn't match (already-relative paths).
   const m = path.match(/^.*?\/data\/[^/]+\/(.+)$/);
-  return m ? m[1] : path;
+  const candidate = m ? m[1] : path;
+  return normaliseRepoPath(candidate);
+}
+
+/** Strip leading + trailing slashes and collapse duplicate slashes. Safe
+ *  to call on both repo paths (`homes/admin/foo.saikudash`) and the rest
+ *  segment of a URL (`/homes/admin/foo.saikudash/`). */
+export function normaliseRepoPath(path: string): string {
+  return path.replace(/\/+/g, "/").replace(/^\/+|\/+$/g, "");
 }
 
 async function readError(res: Response): Promise<string> {

--- a/saiku-ui/src/lib/components/Tour.svelte
+++ b/saiku-ui/src/lib/components/Tour.svelte
@@ -2,6 +2,7 @@
   import { browser } from "$app/environment";
   import { onMount } from "svelte";
   import { i18n } from "$lib/stores/i18n.svelte";
+  import { session } from "$lib/stores/session.svelte";
 
   interface Step {
     selector: string;
@@ -16,7 +17,16 @@
     { selector: ".view-toggle", titleKey: "tour.gridChart.title", bodyKey: "tour.gridChart.body" },
   ];
 
-  const STORAGE_KEY = "saiku.tour.done";
+  /** Per-user storage key — a second user on the same browser should
+   *  get their own first-time experience. Falls back to a global key
+   *  for anonymous / pre-session bootstrap (which shouldn't ever
+   *  reach this code path, since the parent route gates on
+   *  session.current). 2026-06-08. */
+  const STORAGE_KEY_FALLBACK = "saiku.tour.done";
+  function storageKey(): string {
+    const u = session.current?.username;
+    return u ? `saiku.tour.done.${u}` : STORAGE_KEY_FALLBACK;
+  }
 
   let active = $state<boolean>(false);
   let stepIdx = $state<number>(0);
@@ -29,11 +39,29 @@
     anchor = el ? el.getBoundingClientRect() : null;
   }
 
+  /** The first step's target — the cubes select — only exists on the
+   *  workspace route. If it's missing the user is on a route where
+   *  the tour wouldn't anchor anywhere meaningful, so don't start. */
+  function workspaceVisible(): boolean {
+    return !!document.querySelector(STEPS[0].selector);
+  }
+
   onMount(() => {
     if (!browser) return;
-    if (localStorage.getItem(STORAGE_KEY) === "1") return;
-    active = true;
-    requestAnimationFrame(updateAnchor);
+    if (localStorage.getItem(storageKey()) === "1") return;
+    // Migration: an earlier release wrote the flag under a global key.
+    // Honour it so users who already finished the tour aren't shown it
+    // again after the per-user split lands.
+    if (localStorage.getItem(STORAGE_KEY_FALLBACK) === "1") {
+      localStorage.setItem(storageKey(), "1");
+      return;
+    }
+    // Wait a tick for the workspace render then bail if it isn't here.
+    requestAnimationFrame(() => {
+      if (!workspaceVisible()) return;
+      active = true;
+      updateAnchor();
+    });
     const onResize = () => updateAnchor();
     window.addEventListener("resize", onResize);
     window.addEventListener("scroll", onResize, true);
@@ -69,12 +97,12 @@
 
   function finish() {
     active = false;
-    if (browser) localStorage.setItem(STORAGE_KEY, "1");
+    if (browser) localStorage.setItem(storageKey(), "1");
   }
 
   export function restart() {
     if (!browser) return;
-    localStorage.removeItem(STORAGE_KEY);
+    localStorage.removeItem(storageKey());
     stepIdx = 0;
     active = true;
     requestAnimationFrame(updateAnchor);

--- a/saiku-ui/src/routes/+layout.svelte
+++ b/saiku-ui/src/routes/+layout.svelte
@@ -10,7 +10,6 @@
   import ToastStack from "$lib/components/ToastStack.svelte";
   import UpgradeBanner from "$lib/components/UpgradeBanner.svelte";
   import { LogOut, Shield, Home, LayoutDashboard, UserRound } from "lucide-svelte";
-  import Tour from "$lib/components/Tour.svelte";
   import SessionExpiredBanner from "$lib/components/SessionExpiredBanner.svelte";
   import { i18n } from "$lib/stores/i18n.svelte";
   import { installAuthInterceptor, onAuthFailure } from "$lib/api/http";
@@ -125,7 +124,9 @@
     {@render children()}
   </main>
   <ToastStack />
-  {#if session.current}<Tour />{/if}
+  <!-- Tour mount moved to the workspace route (+page.svelte) so it
+       only fires where its target selectors actually exist
+       (#cubes-select et al). 2026-06-08 user feedback. -->
   <SessionExpiredBanner
     open={sessionError.open}
     statusLabel={sessionError.statusLabel}

--- a/saiku-ui/src/routes/+page.svelte
+++ b/saiku-ui/src/routes/+page.svelte
@@ -2,12 +2,19 @@
   import { session } from "$lib/stores/session.svelte";
   import LoginForm from "$lib/views/LoginForm.svelte";
   import Workspace from "$lib/views/Workspace.svelte";
+  // The first-run tour highlights workspace-only affordances (cubes
+  // picker, dropzones, view toggle), so mount it on this route only —
+  // previously it lived in +layout.svelte and fired on every page
+  // (dashboards, admin, share viewer) where its target selectors
+  // didn't exist, anchoring its bubble nowhere useful.
+  import Tour from "$lib/components/Tour.svelte";
 </script>
 
 {#if session.loading}
   <div class="loading">Loading…</div>
 {:else if session.current}
   <Workspace session={session.current} />
+  <Tour />
 {:else}
   <LoginForm />
 {/if}

--- a/saiku-ui/src/routes/dashboards/[...path]/+page.ts
+++ b/saiku-ui/src/routes/dashboards/[...path]/+page.ts
@@ -9,6 +9,7 @@
  * blocking the route render.
  */
 
+import { normaliseRepoPath } from "$lib/api/dashboards";
 import type { PageLoad } from "./$types";
 
 // Dynamic route, can't be prerendered. Saiku's root layout prerenders by
@@ -17,8 +18,13 @@ export const prerender = false;
 
 export const load: PageLoad = ({ params }) => {
   // params.path is the raw rest segment — SvelteKit returns it as a single
-  // string with slashes preserved (NOT an array). Leading/trailing slashes
-  // are trimmed by the router already.
-  const path = params.path ?? "";
+  // string with slashes preserved (NOT an array). The router usually trims
+  // leading / trailing slashes, but URLs that opened from older clients can
+  // still carry `//homes/<uuid>/foo.saikudash/` (the double slash is the
+  // tell — listed JCR paths sometimes have a leading slash that the URL
+  // builder concatenated to the route prefix). Normalise defensively so
+  // refresh always lands on the same dashboard regardless of how the URL
+  // was constructed (user-reported 2026-06-08).
+  const path = normaliseRepoPath(params.path ?? "");
   return { dashboardPath: path };
 };

--- a/saiku-webapp/pom.xml
+++ b/saiku-webapp/pom.xml
@@ -305,17 +305,6 @@
                             <arguments>run build</arguments>
                             <environmentVariables>
                                 <SAIKU_BASE_PATH>/ui</SAIKU_BASE_PATH>
-                                <!-- Vite/Rollup peak heap on this build is ~2.5GB
-                                     on the GitHub Actions macos-latest runner
-                                     (smaller default heap than ubuntu's). V8's
-                                     ~1.7GB default ceiling triggers an OOM
-                                     ("Ineffective mark-compacts near heap
-                                     limit") during `npm run build`, failing
-                                     CI intermittently even when nothing
-                                     changed. 4GB gives comfortable headroom
-                                     on every runner class without affecting
-                                     dev machines. -->
-                                <NODE_OPTIONS>--max-old-space-size=4096</NODE_OPTIONS>
                             </environmentVariables>
                         </configuration>
                     </execution>

--- a/saiku-webapp/pom.xml
+++ b/saiku-webapp/pom.xml
@@ -305,6 +305,17 @@
                             <arguments>run build</arguments>
                             <environmentVariables>
                                 <SAIKU_BASE_PATH>/ui</SAIKU_BASE_PATH>
+                                <!-- Vite/Rollup peak heap on this build is ~2.5GB
+                                     on the GitHub Actions macos-latest runner
+                                     (smaller default heap than ubuntu's). V8's
+                                     ~1.7GB default ceiling triggers an OOM
+                                     ("Ineffective mark-compacts near heap
+                                     limit") during `npm run build`, failing
+                                     CI intermittently even when nothing
+                                     changed. 4GB gives comfortable headroom
+                                     on every runner class without affecting
+                                     dev machines. -->
+                                <NODE_OPTIONS>--max-old-space-size=4096</NODE_OPTIONS>
                             </environmentVariables>
                         </configuration>
                     </execution>

--- a/saiku-webapp/pom.xml
+++ b/saiku-webapp/pom.xml
@@ -2,11 +2,11 @@
     <parent>
         <artifactId>saiku</artifactId>
         <groupId>org.saikuanalytics</groupId>
-        <version>4.5.0</version>
+        <version>4.5.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>saiku-webapp</artifactId>
-    <version>4.5.0</version>
+    <version>4.5.1</version>
     <name>saiku - webapp</name>
     <packaging>war</packaging>
     <build>

--- a/saiku-webapp/pom.xml
+++ b/saiku-webapp/pom.xml
@@ -2,11 +2,11 @@
     <parent>
         <artifactId>saiku</artifactId>
         <groupId>org.saikuanalytics</groupId>
-        <version>4.5.1</version>
+        <version>4.5.2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>saiku-webapp</artifactId>
-    <version>4.5.1</version>
+    <version>4.5.2</version>
     <name>saiku - webapp</name>
     <packaging>war</packaging>
     <build>


### PR DESCRIPTION
## Summary

Bug-fix release.

- **fix(ui)**: tour mode only shows on first visit per user, anchored to the workspace route. Per-user storage key with one-shot migration from the legacy global flag. (#1298)
- **fix(ui)**: dashboard URLs with extra slashes (e.g. `/ui/dashboards//homes/<uuid>/foo.saikudash/`) survive refresh. Producer side normalises slashes before navigate; route loader re-normalises on the way in. 7 regression tests added in `dashboards.test.ts`. (#1298)
- **ci**: `release.yml` runs `mvn -B -ntp -DskipITs=false verify` before package/publish so spotless / test failures fail fast. New `release-prep.yml` runs the same gate on every push to `release/*`. (#1296)
- **ci**: docs-PR creation tolerates missing labels on the docs repo. (#1297)
- **ci**: single `ci` aggregator status check so branch protection stays stable across UI-only / workflow-only PRs whose path-filtered build jobs legitimately skip. (#1299)

## Test plan

- [x] release-prep ran `mvn verify` green on this branch
- [ ] After merge to `main`, tag `v4.5.2` to fire `release.yml`
- [ ] Confirm artifacts publish to GitHub Packages without 409 conflicts
- [ ] Confirm `docker.yml` republishes `ghcr.io/spiculedata/saiku:4.5.2` + `:latest`
- [ ] Confirm auto-PR opens on `spiculedata/saiku-cloud` docs-site with the new changelog entry
- [ ] Sync `main` back to `development`