### PR TITLE
feat(embed): <saiku-embed> server foundations — token + public-grant + JAX-RS

### DIFF
--- a/.github/test-floors.json
+++ b/.github/test-floors.json
@@ -2,6 +2,6 @@
   "_": "Per-module test-count floors. CI fails if any module's surefire total drops below its floor — catches accidental test deletions. Bump explicitly when adding tests. Floors set during Phase 4 / saiku#8 with totals from feat/platform-improvements.",
   "modules": {
     "saiku-core/saiku-service": 252,
-    "saiku-core/saiku-web": 44
+    "saiku-core/saiku-web": 330
   }
 }

--- a/saiku-core/saiku-web/pom.xml
+++ b/saiku-core/saiku-web/pom.xml
@@ -288,6 +288,14 @@
             <scope>test</scope>
             <type>jar</type>
         </dependency>
+        <!-- MockHttpServletRequest/Response/FilterChain for the embed auth
+             filter tests — avoids hand-rolled servlet stubs. Version is
+             pinned through the BOM (matches the runtime Spring version). -->
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-test</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <reporting>
         <plugins>

--- a/saiku-core/saiku-web/src/main/java/org/saiku/web/embed/EmbedPublicGrant.java
+++ b/saiku-core/saiku-web/src/main/java/org/saiku/web/embed/EmbedPublicGrant.java
@@ -1,0 +1,47 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.web.embed;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import java.util.List;
+
+/**
+ * Server-side record marking one saved query / dashboard as publicly
+ * embeddable — anyone hitting {@code /rest/saiku/api/embed/*} for this resource
+ * gets the data with NO token presented. The owner is the user who flipped the
+ * grant on; their data-scope at grant time is the perspective the resource
+ * renders under for every public viewer (mirrors the
+ * {@code ShareToken#ownerRolesSnapshot} pattern from saiku#941).
+ *
+ * <p>Persisted as part of an {@code embed-public.json} sidecar (see
+ * {@link EmbedPublicRegistry}) rather than baked into the saved file itself, so
+ * (a) revoking publicness doesn't rewrite the resource and (b) the ACL is
+ * server-authoritative — a copy of the file outside saiku-home (e.g. exported
+ * to git) doesn't inadvertently re-grant public access on import.
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class EmbedPublicGrant {
+
+    /** {@code "query"} or {@code "dashboard"} — must match the resourceKind
+     *  the view endpoint dispatches on. */
+    public String resourceKind;
+
+    /** Repository path. Acts as the lookup key in {@link EmbedPublicRegistry}. */
+    public String resourcePath;
+
+    /** User who flipped public on. */
+    public String grantedBy;
+
+    /** Owner's roles at grant time — the data-scope public reads render under. */
+    public List<String> ownerRolesSnapshot;
+
+    /** Epoch millis when public was granted. */
+    public long grantedAt;
+
+    /** Optional human label shown in the owner's public-grants list. */
+    public String label;
+
+    public EmbedPublicGrant() {}
+}

--- a/saiku-core/saiku-web/src/main/java/org/saiku/web/embed/EmbedPublicRegistry.java
+++ b/saiku-core/saiku-web/src/main/java/org/saiku/web/embed/EmbedPublicRegistry.java
@@ -1,0 +1,175 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.web.embed;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Registry of saved queries / dashboards that are publicly embeddable — the
+ * second auth path for the {@code <saiku-embed>} surface alongside opaque
+ * tokens.
+ *
+ * <p>Persisted as a single {@code ${saiku.home}/embed-public.json} keyed by
+ * resource path. Choice of one file over one-per-grant: the registry is small
+ * (admins curate the public surface), reads happen on EVERY embed request and
+ * a single hot file beats a directory scan, and atomic rewrites on a small map
+ * are cheap.
+ *
+ * <p>In-memory fallback when {@code saiku.home} isn't set mirrors
+ * {@code EmbedTokenStore} so unit tests don't need a temp dir.
+ */
+public class EmbedPublicRegistry {
+
+    private static final Logger log = LoggerFactory.getLogger(EmbedPublicRegistry.class);
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    /** Non-null when persisting to disk; null → memory-only. */
+    private final Path file;
+
+    /** Authoritative in-memory map (file is reloaded on construction). Key
+     *  format: {@code "<kind>:<path>"} so kind-mismatch can't masquerade as a
+     *  public grant. */
+    private final Map<String, EmbedPublicGrant> grants = new ConcurrentHashMap<>();
+
+    public EmbedPublicRegistry() {
+        this(System.getProperty("saiku.home"));
+    }
+
+    public EmbedPublicRegistry(String saikuHome) {
+        Path f = null;
+        if (saikuHome != null && !saikuHome.isBlank()) {
+            try {
+                Path home = Paths.get(saikuHome).toAbsolutePath().normalize();
+                Files.createDirectories(home);
+                f = home.resolve("embed-public.json");
+            } catch (IOException e) {
+                log.warn("Could not create embed-public.json under {} — using in-memory registry", saikuHome, e);
+                f = null;
+            }
+        }
+        this.file = f;
+        load();
+    }
+
+    /** True when {@code resourcePath} of {@code resourceKind} has an active
+     *  public grant. Null kind / path → false. */
+    public boolean isPublic(String resourceKind, String resourcePath) {
+        EmbedPublicGrant g = lookup(resourceKind, resourcePath);
+        return g != null;
+    }
+
+    /** Public grant for the path, or null. The owner-role snapshot on the
+     *  returned record is the data-scope public reads should run under. */
+    public EmbedPublicGrant lookup(String resourceKind, String resourcePath) {
+        if (resourceKind == null || resourcePath == null) {
+            return null;
+        }
+        return grants.get(key(resourceKind, resourcePath));
+    }
+
+    /** Mark a resource publicly embeddable. Idempotent — repeating a grant
+     *  overwrites the owner snapshot (useful when the original grantor's
+     *  roles change and they want public reads to track the new scope). */
+    public synchronized EmbedPublicGrant grant(
+            String resourceKind, String resourcePath, String grantedBy, List<String> ownerRoles, String label) {
+        EmbedPublicGrant g = new EmbedPublicGrant();
+        g.resourceKind = resourceKind;
+        g.resourcePath = resourcePath;
+        g.grantedBy = grantedBy;
+        g.ownerRolesSnapshot = ownerRoles == null ? List.of() : new ArrayList<>(ownerRoles);
+        g.grantedAt = System.currentTimeMillis();
+        g.label = label;
+        grants.put(key(resourceKind, resourcePath), g);
+        persist();
+        return g;
+    }
+
+    /** Remove the public grant. Returns true if a grant existed and was
+     *  removed; idempotent {@code revoke}-of-nothing returns false. */
+    public synchronized boolean revoke(String resourceKind, String resourcePath) {
+        if (resourceKind == null || resourcePath == null) {
+            return false;
+        }
+        EmbedPublicGrant removed = grants.remove(key(resourceKind, resourcePath));
+        if (removed != null) {
+            persist();
+            return true;
+        }
+        return false;
+    }
+
+    /** All public grants whose {@code grantedBy} matches {@code owner}. */
+    public List<EmbedPublicGrant> listByOwner(String owner) {
+        List<EmbedPublicGrant> out = new ArrayList<>();
+        for (EmbedPublicGrant g : grants.values()) {
+            if (owner != null && owner.equals(g.grantedBy)) {
+                out.add(g);
+            }
+        }
+        return out;
+    }
+
+    /** Every public grant — admin view. */
+    public List<EmbedPublicGrant> listAll() {
+        return new ArrayList<>(grants.values());
+    }
+
+    /* --------------------------- internals --------------------------- */
+
+    private static String key(String resourceKind, String resourcePath) {
+        return resourceKind + ":" + resourcePath;
+    }
+
+    private synchronized void load() {
+        grants.clear();
+        if (file == null || !Files.exists(file)) {
+            return;
+        }
+        try {
+            // Stored shape: { "query:/path.saiku": {EmbedPublicGrant}, ... }
+            Map<String, EmbedPublicGrant> read =
+                    MAPPER.readValue(file.toFile(), new TypeReference<Map<String, EmbedPublicGrant>>() {});
+            if (read != null) {
+                grants.putAll(read);
+            }
+        } catch (IOException e) {
+            log.warn("Could not read embed-public.json — starting with empty registry", e);
+        }
+    }
+
+    private synchronized void persist() {
+        if (file == null) {
+            return;
+        }
+        try {
+            // Snapshot under the synchronized monitor so a concurrent grant
+            // can't tear the map during serialization.
+            Map<String, EmbedPublicGrant> snapshot = new HashMap<>(grants);
+            Path tmp = file.resolveSibling("embed-public.json.tmp");
+            MAPPER.writeValue(tmp.toFile(), snapshot);
+            try {
+                Files.move(tmp, file, StandardCopyOption.REPLACE_EXISTING, StandardCopyOption.ATOMIC_MOVE);
+            } catch (IOException atomicFailed) {
+                Files.move(tmp, file, StandardCopyOption.REPLACE_EXISTING);
+            }
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to persist embed-public.json", e);
+        }
+    }
+}

--- a/saiku-core/saiku-web/src/main/java/org/saiku/web/embed/EmbedToken.java
+++ b/saiku-core/saiku-web/src/main/java/org/saiku/web/embed/EmbedToken.java
@@ -1,0 +1,77 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.web.embed;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import java.util.List;
+
+/**
+ * A persisted embed-token record — the server-side authority for a
+ * {@code <saiku-embed>} Web Component dropped into a third-party page.
+ * The token string itself is an opaque random lookup key (see
+ * {@link EmbedTokenStore}); this record holds no secret beyond it.
+ *
+ * <p>Stored as {@code ${saiku.home}/embed-tokens/<token>.json}. A request to
+ * {@code /rest/saiku/api/embed/*} is authorised by presenting a token that maps
+ * to a non-revoked, unexpired record here; the {@link #resourcePath} +
+ * {@link #resourceKind} it pins is the ONLY resource that token can ever read,
+ * and {@link #ownerRolesSnapshot} is the data-scope the proxied queries run
+ * under (see {@code EmbedViewResource}).
+ *
+ * <p>Twin of {@code ShareToken} (saiku#941) — the embed flow keeps a parallel
+ * store rather than retrofitting share because (a) embed supports queries as
+ * well as dashboards, (b) the read endpoints render data inline in a host page
+ * via a Web Component rather than serving the chromeless Saiku UI in an
+ * iframe, and (c) the auth header is distinct from share's so they cannot be
+ * confused by a misconfigured filter chain.
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class EmbedToken {
+
+    /** Opaque URL-safe random id; also the store filename stem. */
+    public String token;
+
+    /** What this token grants read access to. {@code "query"} (.saiku) or
+     *  {@code "dashboard"} (.saikudash). The view endpoint matches its path
+     *  segment against this so a query-token can't be replayed against the
+     *  dashboard path or vice versa. */
+    public String resourceKind;
+
+    /** Repository path of the resource. Ends {@code .saiku} or
+     *  {@code .saikudash} depending on {@link #resourceKind}. */
+    public String resourcePath;
+
+    /** Username that minted the link (must have had read on the resource). */
+    public String createdBy;
+
+    /** Roles the minter held at mint time — the data-scope the embedded
+     *  queries run under, so a delegated embed shows exactly what the owner
+     *  authorised rather than the (often empty) anonymous default role. */
+    public List<String> ownerRolesSnapshot;
+
+    /** Epoch millis when minted. */
+    public long createdAt;
+
+    /** Epoch millis when the token stops working. */
+    public long expiresAt;
+
+    /** Soft revocation — a revoked token fails validation on the next request. */
+    public boolean revoked;
+
+    /** Optional human label shown in the owner's embed list. */
+    public String label;
+
+    public EmbedToken() {}
+
+    /** True when the token is past its expiry relative to {@code nowMs}. */
+    public boolean isExpired(long nowMs) {
+        return expiresAt > 0 && nowMs >= expiresAt;
+    }
+
+    /** Usable = neither revoked nor expired. */
+    public boolean isValid(long nowMs) {
+        return !revoked && !isExpired(nowMs);
+    }
+}

--- a/saiku-core/saiku-web/src/main/java/org/saiku/web/embed/EmbedTokenStore.java
+++ b/saiku-core/saiku-web/src/main/java/org/saiku/web/embed/EmbedTokenStore.java
@@ -1,0 +1,234 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.web.embed;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
+import java.nio.file.attribute.PosixFilePermission;
+import java.security.SecureRandom;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.regex.Pattern;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * File-backed store for embed tokens (the {@code <saiku-embed>} Web Component
+ * flow), persisted as {@code ${saiku.home}/embed-tokens/<token>.json}.
+ *
+ * <p>Security posture mirrors {@code ShareTokenStore} (saiku#941):
+ * <ul>
+ *   <li>Token ids are 256-bit {@link SecureRandom} values, Base64URL-encoded —
+ *       unguessable; the id is the only secret and carries no claims.</li>
+ *   <li>Every id is regex-validated <b>before</b> any filesystem use and the
+ *       resolved path is asserted to stay within the token dir — a crafted id
+ *       ({@code ../}, separators, encoded slashes) can never escape.</li>
+ *   <li>Writes are atomic (temp file + {@code ATOMIC_MOVE}) so a concurrent
+ *       read never sees a torn record during a mint/revoke race.</li>
+ *   <li>When there is no {@code saiku.home} to persist to (unit tests), it
+ *       falls back to an in-memory map.</li>
+ * </ul>
+ */
+public class EmbedTokenStore {
+
+    private static final Logger log = LoggerFactory.getLogger(EmbedTokenStore.class);
+
+    /** URL-safe Base64 alphabet, min length guards against trivially short ids. */
+    private static final Pattern TOKEN_ID = Pattern.compile("^[A-Za-z0-9_-]{16,64}$");
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    /** Resource kinds the embed surface understands. The mint endpoint rejects
+     *  anything outside this set so a typo can never persist a "ghost" kind
+     *  that the view endpoint silently ignores. */
+    private static final Set<String> ALLOWED_KINDS = Set.of("query", "dashboard");
+
+    /** Non-null when persisting to disk; null → use {@link #memory}. */
+    private final Path dir;
+
+    /** In-memory fallback for test/no-home runs. */
+    private final Map<String, EmbedToken> memory = new ConcurrentHashMap<>();
+
+    public EmbedTokenStore() {
+        this(System.getProperty("saiku.home"));
+    }
+
+    /** Visible for tests — pass an explicit home (or null for in-memory). */
+    public EmbedTokenStore(String saikuHome) {
+        Path d = null;
+        if (saikuHome != null && !saikuHome.isBlank()) {
+            try {
+                d = Paths.get(saikuHome).toAbsolutePath().normalize().resolve("embed-tokens");
+                Files.createDirectories(d);
+            } catch (IOException e) {
+                log.warn("Could not create embed-tokens dir under {} — using in-memory store", saikuHome, e);
+                d = null;
+            }
+        }
+        this.dir = d;
+    }
+
+    /**
+     * Mint a new token. {@code resourceKind} must be {@code "query"} or
+     * {@code "dashboard"}; anything else throws {@link IllegalArgumentException}
+     * so a malformed mint cannot land in the store.
+     */
+    public EmbedToken create(
+            String resourceKind,
+            String resourcePath,
+            String createdBy,
+            List<String> ownerRoles,
+            long ttlMillis,
+            String label) {
+        if (resourceKind == null || !ALLOWED_KINDS.contains(resourceKind)) {
+            // ALLOWED_KINDS.contains(null) throws NPE on Set.of immutables, so
+            // null-check first — defends both the API and the runtime.
+            throw new IllegalArgumentException("Unknown resourceKind: " + resourceKind);
+        }
+        if (resourcePath == null || resourcePath.isBlank()) {
+            throw new IllegalArgumentException("resourcePath is required");
+        }
+        EmbedToken t = new EmbedToken();
+        t.token = generateId();
+        t.resourceKind = resourceKind;
+        t.resourcePath = resourcePath;
+        t.createdBy = createdBy;
+        t.ownerRolesSnapshot = ownerRoles == null ? List.of() : new ArrayList<>(ownerRoles);
+        t.createdAt = System.currentTimeMillis();
+        t.expiresAt = t.createdAt + ttlMillis;
+        t.revoked = false;
+        t.label = label;
+        persist(t);
+        return t;
+    }
+
+    /** Load a token by id, or null if the id is malformed / not found / unreadable. */
+    public EmbedToken load(String id) {
+        if (!isValidId(id)) {
+            return null;
+        }
+        if (dir == null) {
+            return memory.get(id);
+        }
+        Path f = safeResolve(id);
+        if (f == null || !Files.exists(f)) {
+            return null;
+        }
+        try {
+            return MAPPER.readValue(f.toFile(), EmbedToken.class);
+        } catch (IOException e) {
+            log.warn("Unreadable embed-token file {}", f, e);
+            return null;
+        }
+    }
+
+    /** All tokens minted by {@code owner} (includes revoked/expired — caller filters). */
+    public List<EmbedToken> listByOwner(String owner) {
+        List<EmbedToken> all = listAll();
+        List<EmbedToken> out = new ArrayList<>();
+        for (EmbedToken t : all) {
+            if (owner != null && owner.equals(t.createdBy)) {
+                out.add(t);
+            }
+        }
+        return out;
+    }
+
+    /** Every token in the store (admin view). */
+    public List<EmbedToken> listAll() {
+        List<EmbedToken> out = new ArrayList<>();
+        if (dir == null) {
+            out.addAll(memory.values());
+            return out;
+        }
+        try (var stream = Files.list(dir)) {
+            stream.filter(p -> p.getFileName().toString().endsWith(".json")).forEach(p -> {
+                try {
+                    out.add(MAPPER.readValue(p.toFile(), EmbedToken.class));
+                } catch (IOException e) {
+                    log.warn("Skipping unreadable embed-token {}", p, e);
+                }
+            });
+        } catch (IOException e) {
+            log.warn("Could not list embed-tokens dir {}", dir, e);
+        }
+        return out;
+    }
+
+    /** Soft-revoke a token. Returns false if the id is unknown. Idempotent. */
+    public boolean revoke(String id) {
+        EmbedToken t = load(id);
+        if (t == null) {
+            return false;
+        }
+        t.revoked = true;
+        persist(t);
+        return true;
+    }
+
+    /* --------------------------- internals --------------------------- */
+
+    private void persist(EmbedToken t) {
+        if (dir == null) {
+            memory.put(t.token, t);
+            return;
+        }
+        Path target = safeResolve(t.token);
+        if (target == null) {
+            throw new IllegalStateException("Refusing to persist token with unsafe id");
+        }
+        try {
+            Path tmp = dir.resolve(t.token + ".json.tmp");
+            MAPPER.writeValue(tmp.toFile(), t);
+            restrictPermissions(tmp);
+            Files.move(tmp, target, StandardCopyOption.REPLACE_EXISTING, StandardCopyOption.ATOMIC_MOVE);
+        } catch (IOException e) {
+            // Fall back to a non-atomic move if the FS doesn't support ATOMIC_MOVE.
+            try {
+                Path tmp = dir.resolve(t.token + ".json.tmp");
+                Files.move(tmp, target, StandardCopyOption.REPLACE_EXISTING);
+            } catch (IOException e2) {
+                throw new RuntimeException("Failed to persist embed token", e2);
+            }
+        }
+    }
+
+    /** Resolve {@code <id>.json} strictly within {@link #dir}; null if it escapes. */
+    private Path safeResolve(String id) {
+        Path resolved = dir.resolve(id + ".json").normalize();
+        if (!resolved.startsWith(dir)) {
+            log.warn("Refusing embed-token path that escapes the store dir: {}", id);
+            return null;
+        }
+        return resolved;
+    }
+
+    private static boolean isValidId(String id) {
+        return id != null && TOKEN_ID.matcher(id).matches();
+    }
+
+    private static String generateId() {
+        byte[] buf = new byte[32];
+        new SecureRandom().nextBytes(buf);
+        return Base64.getUrlEncoder().withoutPadding().encodeToString(buf);
+    }
+
+    private static void restrictPermissions(Path file) {
+        try {
+            Files.setPosixFilePermissions(
+                    file, Set.of(PosixFilePermission.OWNER_READ, PosixFilePermission.OWNER_WRITE));
+        } catch (UnsupportedOperationException | IOException ignored) {
+            // Non-POSIX (Windows) — best effort; the file sits under saiku-home.
+        }
+    }
+}

--- a/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/embed/EmbedTokenResource.java
+++ b/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/embed/EmbedTokenResource.java
@@ -1,0 +1,385 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.web.rest.resources.embed;
+
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.DELETE;
+import jakarta.ws.rs.DefaultValue;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import org.saiku.repository.AclEntry;
+import org.saiku.service.datasource.DatasourceService;
+import org.saiku.service.user.UserService;
+import org.saiku.web.embed.EmbedPublicGrant;
+import org.saiku.web.embed.EmbedPublicRegistry;
+import org.saiku.web.embed.EmbedToken;
+import org.saiku.web.embed.EmbedTokenStore;
+import org.saiku.web.service.SessionService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Owner-facing CRUD for the {@code <saiku-embed>} surface:
+ *
+ * <ul>
+ *   <li>{@code POST /saiku/api/embed/tokens} — mint a token for one query or
+ *       dashboard. Requires a logged-in user who can GRANT the target.</li>
+ *   <li>{@code GET /saiku/api/embed/tokens} — list the caller's tokens (or
+ *       all, if admin).</li>
+ *   <li>{@code DELETE /saiku/api/embed/tokens/{id}} — revoke a token (creator
+ *       / admin / current-GRANT holder may revoke).</li>
+ *   <li>{@code POST /saiku/api/embed/public} — flip a resource publicly
+ *       embeddable.</li>
+ *   <li>{@code GET /saiku/api/embed/public} — list the caller's public
+ *       grants (or all, if admin).</li>
+ *   <li>{@code DELETE /saiku/api/embed/public} — revoke a public grant.</li>
+ * </ul>
+ *
+ * <p>Everything here sits behind {@code isFullyAuthenticated()} — the guest
+ * read surface ({@link EmbedViewResource}) is the only place tokens / public
+ * grants are consumed. Mirrors {@code ShareTokenResource} (saiku#941) in
+ * authorisation posture: only a user with GRANT on the resource may mint /
+ * publicly-grant, only the creator / admin / current-GRANT holder may revoke.
+ */
+@Path("/saiku/api/embed")
+public class EmbedTokenResource {
+
+    private static final Logger log = LoggerFactory.getLogger(EmbedTokenResource.class);
+
+    // Same conservative defaults as share: leaked links should expire on a
+    // human timescale, and an account can't be allowed to mint forever.
+    private static final long DEFAULT_TTL_HOURS = 72; // 3 days
+    private static final long MAX_TTL_HOURS = 720; // 30 days
+    private static final int MAX_ACTIVE_TOKENS_PER_USER = 200;
+    private static final int MAX_PUBLIC_GRANTS_PER_USER = 200;
+
+    private EmbedTokenStore tokenStore;
+    private EmbedPublicRegistry publicRegistry;
+    private DatasourceService datasourceService;
+    private SessionService sessionService;
+    private UserService userService;
+
+    public void setTokenStore(EmbedTokenStore s) {
+        this.tokenStore = s;
+    }
+
+    public void setPublicRegistry(EmbedPublicRegistry r) {
+        this.publicRegistry = r;
+    }
+
+    public void setDatasourceService(DatasourceService s) {
+        this.datasourceService = s;
+    }
+
+    public void setSessionService(SessionService s) {
+        this.sessionService = s;
+    }
+
+    public void setUserService(UserService s) {
+        this.userService = s;
+    }
+
+    /* ---------------------------- tokens ---------------------------- */
+
+    public static class MintRequest {
+        public String resourceKind;
+        public String resourcePath;
+        public Integer ttlHours;
+        public String label;
+    }
+
+    @POST
+    @Path("/tokens")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response mint(MintRequest body) {
+        if (body == null) {
+            return badRequest("body", "request body required");
+        }
+        String kind = body.resourceKind;
+        String path = body.resourcePath;
+        Response kindError = validateKindAndPath(kind, path);
+        if (kindError != null) return kindError;
+
+        String username = currentUsername();
+        List<String> roles = currentRoles();
+
+        if (!hasGrant(path, username, roles)) {
+            return forbidden("You don't have permission to embed this resource");
+        }
+
+        long ttlHours = body.ttlHours == null ? DEFAULT_TTL_HOURS : body.ttlHours;
+        if (ttlHours <= 0) {
+            return badRequest("ttlHours", "ttlHours must be positive");
+        }
+        ttlHours = Math.min(ttlHours, MAX_TTL_HOURS);
+
+        long active = tokenStore.listByOwner(username).stream()
+                .filter(t -> t.isValid(System.currentTimeMillis()))
+                .count();
+        if (active >= MAX_ACTIVE_TOKENS_PER_USER) {
+            return Response.status(429)
+                    .entity(Map.of("status", "LIMIT", "error", "Too many active embed tokens; revoke some first"))
+                    .type(MediaType.APPLICATION_JSON)
+                    .build();
+        }
+
+        EmbedToken t = tokenStore.create(kind, path, username, roles, ttlHours * 3600_000L, body.label);
+        log.info(
+                "embed-token minted token=<redacted:{}> kind={} path={} by={} ttlHours={}",
+                t.token.length(),
+                kind,
+                path,
+                username,
+                ttlHours);
+        return Response.ok(Map.of(
+                        "status",
+                        "OK",
+                        "token",
+                        t.token,
+                        "resourceKind",
+                        kind,
+                        "resourcePath",
+                        path,
+                        "expiresAt",
+                        t.expiresAt))
+                .type(MediaType.APPLICATION_JSON)
+                .build();
+    }
+
+    @GET
+    @Path("/tokens")
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response listTokens(@QueryParam("all") @DefaultValue("false") boolean all) {
+        String username = currentUsername();
+        List<EmbedToken> tokens =
+                (all && isAdmin(currentRoles())) ? tokenStore.listAll() : tokenStore.listByOwner(username);
+        List<Map<String, Object>> out = new ArrayList<>();
+        for (EmbedToken t : tokens) {
+            // Owner gets back the token id (they minted it). Never return the
+            // owner role snapshot — internal data-scope state, not API data.
+            out.add(Map.of(
+                    "token", t.token,
+                    "resourceKind", t.resourceKind,
+                    "resourcePath", t.resourcePath,
+                    "createdBy", t.createdBy,
+                    "createdAt", t.createdAt,
+                    "expiresAt", t.expiresAt,
+                    "revoked", t.revoked,
+                    "label", t.label == null ? "" : t.label,
+                    "active", t.isValid(System.currentTimeMillis())));
+        }
+        return Response.ok(out).type(MediaType.APPLICATION_JSON).build();
+    }
+
+    @DELETE
+    @Path("/tokens/{id}")
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response revokeToken(@PathParam("id") String id) {
+        EmbedToken t = tokenStore.load(id);
+        if (t == null) {
+            return Response.status(Response.Status.NOT_FOUND)
+                    .entity(Map.of("status", "NOT_FOUND", "error", "Unknown embed token"))
+                    .type(MediaType.APPLICATION_JSON)
+                    .build();
+        }
+        String username = currentUsername();
+        List<String> roles = currentRoles();
+        boolean canManage = (username != null && username.equals(t.createdBy))
+                || isAdmin(roles)
+                || hasGrant(t.resourcePath, username, roles);
+        if (!canManage) {
+            return forbidden("You can't revoke this embed token");
+        }
+        tokenStore.revoke(id);
+        log.info("embed-token revoked kind={} path={} by={}", t.resourceKind, t.resourcePath, username);
+        return Response.ok(Map.of("status", "OK"))
+                .type(MediaType.APPLICATION_JSON)
+                .build();
+    }
+
+    /* --------------------------- public ----------------------------- */
+
+    public static class GrantRequest {
+        public String resourceKind;
+        public String resourcePath;
+        public String label;
+    }
+
+    @POST
+    @Path("/public")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response grantPublic(GrantRequest body) {
+        if (body == null) {
+            return badRequest("body", "request body required");
+        }
+        String kind = body.resourceKind;
+        String path = body.resourcePath;
+        Response kindError = validateKindAndPath(kind, path);
+        if (kindError != null) return kindError;
+
+        String username = currentUsername();
+        List<String> roles = currentRoles();
+        if (!hasGrant(path, username, roles)) {
+            return forbidden("You don't have permission to make this resource public");
+        }
+
+        // Cap public grants per user too — leaked anonymous read is the most
+        // dangerous surface and we shouldn't let one account flood the
+        // registry.
+        long owned = publicRegistry.listByOwner(username).size();
+        if (owned >= MAX_PUBLIC_GRANTS_PER_USER) {
+            return Response.status(429)
+                    .entity(Map.of("status", "LIMIT", "error", "Too many public grants; revoke some first"))
+                    .type(MediaType.APPLICATION_JSON)
+                    .build();
+        }
+
+        EmbedPublicGrant g = publicRegistry.grant(kind, path, username, roles, body.label);
+        log.info("embed-public granted kind={} path={} by={}", kind, path, username);
+        return Response.ok(Map.of(
+                        "status", "OK",
+                        "resourceKind", g.resourceKind,
+                        "resourcePath", g.resourcePath,
+                        "grantedAt", g.grantedAt))
+                .type(MediaType.APPLICATION_JSON)
+                .build();
+    }
+
+    @GET
+    @Path("/public")
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response listPublic(@QueryParam("all") @DefaultValue("false") boolean all) {
+        String username = currentUsername();
+        List<EmbedPublicGrant> grants =
+                (all && isAdmin(currentRoles())) ? publicRegistry.listAll() : publicRegistry.listByOwner(username);
+        List<Map<String, Object>> out = new ArrayList<>();
+        for (EmbedPublicGrant g : grants) {
+            out.add(Map.of(
+                    "resourceKind", g.resourceKind,
+                    "resourcePath", g.resourcePath,
+                    "grantedBy", g.grantedBy,
+                    "grantedAt", g.grantedAt,
+                    "label", g.label == null ? "" : g.label));
+        }
+        return Response.ok(out).type(MediaType.APPLICATION_JSON).build();
+    }
+
+    @DELETE
+    @Path("/public")
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response revokePublic(@QueryParam("kind") String kind, @QueryParam("path") String path) {
+        Response kindError = validateKindAndPath(kind, path);
+        if (kindError != null) return kindError;
+        EmbedPublicGrant existing = publicRegistry.lookup(kind, path);
+        if (existing == null) {
+            return Response.status(Response.Status.NOT_FOUND)
+                    .entity(Map.of("status", "NOT_FOUND", "error", "No public grant for that resource"))
+                    .type(MediaType.APPLICATION_JSON)
+                    .build();
+        }
+        String username = currentUsername();
+        List<String> roles = currentRoles();
+        boolean canManage = (username != null && username.equals(existing.grantedBy))
+                || isAdmin(roles)
+                || hasGrant(path, username, roles);
+        if (!canManage) {
+            return forbidden("You can't revoke this public grant");
+        }
+        publicRegistry.revoke(kind, path);
+        log.info("embed-public revoked kind={} path={} by={}", kind, path, username);
+        return Response.ok(Map.of("status", "OK"))
+                .type(MediaType.APPLICATION_JSON)
+                .build();
+    }
+
+    /* --------------------------- helpers ---------------------------- */
+
+    /** Common kind+path validation for mint, grant, revoke. */
+    private static Response validateKindAndPath(String kind, String path) {
+        if (kind == null || kind.isBlank()) {
+            return badRequest("resourceKind", "resourceKind required");
+        }
+        if (!"query".equals(kind) && !"dashboard".equals(kind)) {
+            return badRequest("resourceKind", "resourceKind must be 'query' or 'dashboard'");
+        }
+        if (path == null || path.isBlank()) {
+            return badRequest("resourcePath", "resourcePath required");
+        }
+        // Defence-in-depth: a query token must end .saiku, a dashboard token
+        // .saikudash. The view endpoint also checks this but the mint layer
+        // is the right place to reject bad data before it ever lands in the
+        // store.
+        if ("query".equals(kind) && !path.endsWith(".saiku")) {
+            return badRequest("resourcePath", "query resourcePath must end .saiku");
+        }
+        if ("dashboard".equals(kind) && !path.endsWith(".saikudash")) {
+            return badRequest("resourcePath", "dashboard resourcePath must end .saikudash");
+        }
+        return null;
+    }
+
+    private boolean hasGrant(String path, String username, List<String> roles) {
+        // datasourceService.getResourceACL returns null unless the caller can
+        // GRANT the resource — same gate the share-token mint uses (#940 +
+        // #941). Treating the ACL surface uniformly here means a future
+        // permission-system change ports automatically.
+        if (datasourceService == null) return false;
+        try {
+            AclEntry acl = datasourceService.getResourceACL(path, username, roles);
+            return acl != null;
+        } catch (RuntimeException e) {
+            return false;
+        }
+    }
+
+    private boolean isAdmin(List<String> roles) {
+        if (roles == null || userService == null) return false;
+        List<String> admin = userService.getAdminRoles();
+        if (admin == null) return false;
+        for (String r : roles) {
+            if (admin.contains(r)) return true;
+        }
+        return false;
+    }
+
+    private String currentUsername() {
+        if (sessionService == null) return null;
+        Object u = sessionService.getAllSessionObjects().get("username");
+        return u == null ? null : u.toString();
+    }
+
+    @SuppressWarnings("unchecked")
+    private List<String> currentRoles() {
+        if (sessionService == null) return List.of();
+        Object r = sessionService.getAllSessionObjects().get("roles");
+        if (r instanceof List<?>) return (List<String>) r;
+        return List.of();
+    }
+
+    private static Response badRequest(String field, String message) {
+        return Response.status(Response.Status.BAD_REQUEST)
+                .entity(Map.of("status", "VALIDATION_ERROR", "field", field, "error", message))
+                .type(MediaType.APPLICATION_JSON)
+                .build();
+    }
+
+    private static Response forbidden(String message) {
+        return Response.status(Response.Status.FORBIDDEN)
+                .entity(Map.of("status", "FORBIDDEN", "error", message))
+                .type(MediaType.APPLICATION_JSON)
+                .build();
+    }
+}

--- a/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/embed/EmbedViewResource.java
+++ b/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/embed/EmbedViewResource.java
@@ -1,0 +1,259 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.web.rest.resources.embed;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import java.util.Map;
+import org.saiku.service.datasource.DatasourceService;
+import org.saiku.service.olap.ai.AiSavedQueryRequest;
+import org.saiku.web.rest.resources.AiQueryResource;
+import org.saiku.web.rest.resources.dashboards.Dashboard;
+import org.saiku.web.rest.resources.dashboards.DashboardTile;
+import org.saiku.web.rest.resources.dashboards.TileQuery;
+import org.saiku.web.security.embed.EmbedAuthFilter.EmbedGuestDetails;
+import org.saiku.web.service.SessionService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+/**
+ * The ONLY data surface a {@code <saiku-embed>} guest reaches. Spring Security
+ * rules grant {@code ROLE_EMBED_GUEST} access only to this prefix — every
+ * other path stays {@code isFullyAuthenticated()}, so an embed guest can never
+ * reach {@code /ai/query}, drillthrough, mutation, the repository, or the
+ * mint endpoints. The role itself is established by {@code EmbedAuthFilter}
+ * either from a valid opaque token OR a matching public-grant.
+ *
+ * <p>The resource the guest may see is pinned by
+ * {@link EmbedGuestDetails#resourcePath} — read from the Authentication, never
+ * from client input. Tile queries run under
+ * {@link EmbedGuestDetails#ownerUser} + {@link EmbedGuestDetails#ownerRoles}
+ * via {@link SessionService#runAs} — same delegation pattern as
+ * {@code ShareViewResource} (saiku#941), so a publicly-granted dashboard
+ * shows the perspective the grantor authorised, not the (often empty)
+ * anonymous default.
+ */
+@Path("/saiku/api/embed")
+public class EmbedViewResource {
+
+    private static final Logger log = LoggerFactory.getLogger(EmbedViewResource.class);
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    private DatasourceService datasourceService;
+    private SessionService sessionService;
+    private AiQueryResource aiQueryResource;
+
+    public void setDatasourceService(DatasourceService s) {
+        this.datasourceService = s;
+    }
+
+    public void setSessionService(SessionService s) {
+        this.sessionService = s;
+    }
+
+    public void setAiQueryResource(AiQueryResource r) {
+        this.aiQueryResource = r;
+    }
+
+    /* ---------------------------- query ---------------------------- */
+
+    /**
+     * Run the saved query the token / public-grant pins. The {@code path}
+     * matrix param is informational only — the filter has already validated
+     * that it matches the pinned resource. JAX-RS forces us to expose it as
+     * a path param so the URL shape lines up with the dashboard reader.
+     */
+    @GET
+    @Path("/query/{path:.+}")
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response query(@PathParam("path") String pathParam) {
+        EmbedGuestDetails g = guest();
+        if (g == null || !"query".equals(g.resourceKind)) {
+            return invalid();
+        }
+        // Defence-in-depth re-assert the suffix at the trust boundary even
+        // though mint validated it.
+        if (g.resourcePath == null || !g.resourcePath.endsWith(".saiku")) {
+            return invalid();
+        }
+        try {
+            Response result = sessionService.runAs(g.ownerUser, g.ownerRoles, () -> {
+                AiSavedQueryRequest sreq = new AiSavedQueryRequest();
+                sreq.setPath(g.resourcePath);
+                return aiQueryResource.executeSaved(sreq);
+            });
+            return harden(result);
+        } catch (RuntimeException e) {
+            log.warn("embed-view query execution failed for {}", g.resourcePath, e);
+            return harden(Response.serverError()
+                    .entity(Map.of("status", "ERROR", "error", "Query execution failed"))
+                    .type(MediaType.APPLICATION_JSON)
+                    .build());
+        }
+    }
+
+    /* -------------------------- dashboard -------------------------- */
+
+    /**
+     * The pinned dashboard's layout so the Web Component can render its
+     * tiles. Like the share-view dashboard endpoint, the dashboard body
+     * itself is returned verbatim — the guest then issues one tile-query
+     * per renderable tile via {@link #tileQuery}.
+     */
+    @GET
+    @Path("/dashboard/{path:.+}")
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response dashboard(@PathParam("path") String pathParam) {
+        EmbedGuestDetails g = guest();
+        if (g == null || !"dashboard".equals(g.resourceKind)) {
+            return invalid();
+        }
+        Dashboard dash = loadDashboard(g);
+        if (dash == null) {
+            return harden(Response.status(Response.Status.NOT_FOUND)
+                    .entity(Map.of("status", "NOT_FOUND", "error", "Embedded dashboard is no longer available"))
+                    .type(MediaType.APPLICATION_JSON)
+                    .build());
+        }
+        return harden(Response.ok(dash).type(MediaType.APPLICATION_JSON).build());
+    }
+
+    /**
+     * Run a single tile's authored query under the owner's scope. The guest
+     * supplies the tile id only; the query body comes from the pinned
+     * dashboard, never the client, so the guest can't pivot the cube or
+     * select a different cellset.
+     */
+    @POST
+    @Path("/dashboard/{path:.+}/tile/{tileId}/query")
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response tileQuery(@PathParam("path") String pathParam, @PathParam("tileId") String tileId) {
+        EmbedGuestDetails g = guest();
+        if (g == null || !"dashboard".equals(g.resourceKind)) {
+            return invalid();
+        }
+        Dashboard dash = loadDashboard(g);
+        if (dash == null || dash.layout == null || dash.layout.tiles == null) {
+            return invalid();
+        }
+        DashboardTile tile = null;
+        for (DashboardTile t : dash.layout.tiles) {
+            if (tileId.equals(t.id)) {
+                tile = t;
+                break;
+            }
+        }
+        if (tile == null || tile.query == null) {
+            return harden(Response.status(Response.Status.NOT_FOUND)
+                    .entity(Map.of("status", "NOT_FOUND", "error", "No such queryable tile"))
+                    .type(MediaType.APPLICATION_JSON)
+                    .build());
+        }
+        final TileQuery q = tile.query;
+        try {
+            Response result = sessionService.runAs(g.ownerUser, g.ownerRoles, () -> {
+                if ("inline".equals(q.kind) && q.body != null) {
+                    return aiQueryResource.executeAi(q.body, "records");
+                } else if ("reference".equals(q.kind) && q.path != null) {
+                    AiSavedQueryRequest sreq = new AiSavedQueryRequest();
+                    sreq.setPath(q.path);
+                    return aiQueryResource.executeSaved(sreq);
+                }
+                return Response.status(Response.Status.BAD_REQUEST)
+                        .entity(Map.of("status", "VALIDATION_ERROR", "error", "Tile has no runnable query"))
+                        .type(MediaType.APPLICATION_JSON)
+                        .build();
+            });
+            return harden(result);
+        } catch (RuntimeException e) {
+            log.warn("embed-view tile query failed for {}/{}", g.resourcePath, tileId, e);
+            return harden(Response.serverError()
+                    .entity(Map.of("status", "ERROR", "error", "Tile query failed"))
+                    .type(MediaType.APPLICATION_JSON)
+                    .build());
+        }
+    }
+
+    /* --------------------------- helpers ---------------------------- */
+
+    private Dashboard loadDashboard(EmbedGuestDetails g) {
+        if (g.resourcePath == null || !g.resourcePath.endsWith(".saikudash")) {
+            return null;
+        }
+        String raw;
+        try {
+            // Read as the owner — the token / public-grant authorises viewing
+            // exactly this one dashboard under exactly the owner's data scope.
+            raw = datasourceService.getFileData(g.resourcePath, g.ownerUser, g.ownerRoles);
+        } catch (RuntimeException e) {
+            return null;
+        }
+        if (raw == null || raw.isEmpty()) {
+            return null;
+        }
+        try {
+            return MAPPER.readValue(raw, Dashboard.class);
+        } catch (Exception e) {
+            log.error("embedded dashboard {} is unparseable", g.resourcePath, e);
+            return null;
+        }
+    }
+
+    private EmbedGuestDetails guest() {
+        Authentication auth = SecurityContextHolder.getContext() == null
+                ? null
+                : SecurityContextHolder.getContext().getAuthentication();
+        if (auth != null && auth.getDetails() instanceof EmbedGuestDetails) {
+            return (EmbedGuestDetails) auth.getDetails();
+        }
+        return null;
+    }
+
+    private static Response invalid() {
+        return harden(Response.status(Response.Status.UNAUTHORIZED)
+                .entity(Map.of("status", "EMBED_INVALID", "error", "Embed link is invalid or expired."))
+                .type(MediaType.APPLICATION_JSON)
+                .build());
+    }
+
+    /**
+     * Defence-in-depth response headers on EVERY embed reply. Mirrors the
+     * share-view hardening (saiku#941) since the threat model is the same —
+     * account-free content rendered into a third-party page:
+     * <ul>
+     *   <li>{@code X-Content-Type-Options: nosniff} — a browser must not
+     *       MIME-sniff a JSON body that carries text-tile HTML / image URLs
+     *       / member captions and execute it as HTML → blocks stored XSS
+     *       at the guest level;</li>
+     *   <li>{@code Referrer-Policy: no-referrer} — the embed token lives in
+     *       the host page's attribute; never leak it via {@code Referer}
+     *       on outbound assets;</li>
+     *   <li>{@code Cache-Control: no-store} — embedded business data is
+     *       never cached by proxies or browser history.</li>
+     * </ul>
+     *
+     * <p>Deliberately NOT set: {@code X-Frame-Options: DENY} and CSP
+     * {@code frame-ancestors 'none'} — the embed surface is designed to
+     * render inside the host page (cross-origin XHR / fetch, not iframe),
+     * and we DON'T want to block all framing because a host page that uses
+     * an iframe-fallback for legacy browsers should still work. Each
+     * deployment can tighten CSP at the reverse-proxy layer.
+     */
+    private static Response harden(Response r) {
+        return Response.fromResponse(r)
+                .header("X-Content-Type-Options", "nosniff")
+                .header("Referrer-Policy", "no-referrer")
+                .header("Cache-Control", "no-store, max-age=0")
+                .build();
+    }
+}

--- a/saiku-core/saiku-web/src/main/java/org/saiku/web/security/embed/EmbedAuthFilter.java
+++ b/saiku-core/saiku-web/src/main/java/org/saiku/web/security/embed/EmbedAuthFilter.java
@@ -1,0 +1,268 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.web.security.embed;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import org.saiku.web.embed.EmbedPublicGrant;
+import org.saiku.web.embed.EmbedPublicRegistry;
+import org.saiku.web.embed.EmbedToken;
+import org.saiku.web.embed.EmbedTokenStore;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.authentication.preauth.PreAuthenticatedAuthenticationToken;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+/**
+ * Establishes a short-lived, locked-down guest identity for valid
+ * {@code <saiku-embed>} reads. It acts ONLY on the {@code /rest/saiku/api/embed/}
+ * read prefixes (query + dashboard) and ONLY when the request presents a valid
+ * token OR targets a publicly-granted resource; for every other request it is
+ * a transparent pass-through. The mint endpoint
+ * ({@code /rest/saiku/api/embed/tokens}) is intentionally NOT touched — it
+ * stays behind the standard Spring authenticated rules.
+ *
+ * <p>On a valid token: a request-scoped {@link PreAuthenticatedAuthenticationToken}
+ * with authority {@link #GUEST_ROLE} carrying {@link EmbedGuestDetails} that
+ * pin the resource kind + path the token authorises.
+ *
+ * <p>On a public-grant match: same role + details, but with {@code token=null}
+ * to mark the request as having used the public path. View endpoints can use
+ * this to refuse mutation surfaces (e.g. drillthrough) on public reads even if
+ * a future code change accidentally widens the role's permissions.
+ *
+ * <p>The context is cleared in a {@code finally} so the guest identity is
+ * never persisted to the HttpSession — each request re-presents its token /
+ * re-checks public state from disk, so revocation takes effect on the very
+ * next request and there is no guest "session" to hijack.
+ */
+public class EmbedAuthFilter extends OncePerRequestFilter {
+
+    public static final String GUEST_ROLE = "ROLE_EMBED_GUEST";
+    public static final String TOKEN_HEADER = "X-Saiku-Embed-Token";
+
+    /** Read surface — query + dashboard. The mint surface lives elsewhere
+     *  and goes through the normal authenticated chain. */
+    static final String EMBED_PREFIX = "/rest/saiku/api/embed/";
+
+    static final String QUERY_SEGMENT = "query/";
+    static final String DASHBOARD_SEGMENT = "dashboard/";
+
+    /** Mint surface — explicitly skipped so a real user's session auth still
+     *  applies. */
+    static final String MINT_SEGMENT = "tokens";
+
+    private final EmbedTokenStore tokenStore;
+    private final EmbedPublicRegistry publicRegistry;
+
+    public EmbedAuthFilter(EmbedTokenStore tokenStore, EmbedPublicRegistry publicRegistry) {
+        this.tokenStore = tokenStore;
+        this.publicRegistry = publicRegistry;
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest req, HttpServletResponse resp, FilterChain chain)
+            throws ServletException, IOException {
+
+        String path = pathWithinApp(req);
+        if (!path.startsWith(EMBED_PREFIX)) {
+            chain.doFilter(req, resp);
+            return;
+        }
+        String tail = path.substring(EMBED_PREFIX.length());
+
+        // Mint endpoint: pass through; real user's auth applies. Tokens/* is
+        // both the mint POST and the revoke DELETE — same authenticated rule.
+        if (tail.equals(MINT_SEGMENT) || tail.startsWith(MINT_SEGMENT + "/")) {
+            chain.doFilter(req, resp);
+            return;
+        }
+
+        ResourceTarget target = parseTarget(tail);
+        if (target == null) {
+            // Unknown sub-path under /embed/ — let the Spring chain decide;
+            // it'll 404 or 401 depending on configured rules.
+            chain.doFilter(req, resp);
+            return;
+        }
+
+        // 1. Token path.
+        String tokenId = extractToken(req);
+        if (tokenId != null && !tokenId.isEmpty()) {
+            EmbedToken token = tokenStore.load(tokenId);
+            if (token == null || !token.isValid(System.currentTimeMillis())) {
+                writeInvalid(resp);
+                return;
+            }
+            // Pin: token must match the requested resource. Otherwise a
+            // token minted for dashboard A could be replayed against query B.
+            if (!target.kind.equals(token.resourceKind) || !target.path.equals(token.resourcePath)) {
+                writeInvalid(resp);
+                return;
+            }
+            authenticate(
+                    req,
+                    resp,
+                    chain,
+                    new EmbedGuestDetails(
+                            token.token,
+                            token.resourceKind,
+                            token.resourcePath,
+                            token.createdBy,
+                            token.ownerRolesSnapshot));
+            return;
+        }
+
+        // 2. Public-grant path. No token; only resources listed in the
+        //    public registry render anonymously.
+        EmbedPublicGrant grant = publicRegistry.lookup(target.kind, target.path);
+        if (grant != null) {
+            authenticate(
+                    req,
+                    resp,
+                    chain,
+                    new EmbedGuestDetails(
+                            null, grant.resourceKind, grant.resourcePath, grant.grantedBy, grant.ownerRolesSnapshot));
+            return;
+        }
+
+        // Neither — fall through. The Spring rules will 401 (the embed read
+        // intercept-url is hasRole(EMBED_GUEST)), preserving the
+        // /info-style "credentials required" semantics of the rest of the
+        // surface.
+        chain.doFilter(req, resp);
+    }
+
+    private void authenticate(
+            HttpServletRequest req, HttpServletResponse resp, FilterChain chain, EmbedGuestDetails details)
+            throws IOException, ServletException {
+        PreAuthenticatedAuthenticationToken auth = new PreAuthenticatedAuthenticationToken(
+                "embed-guest", details, List.of(new SimpleGrantedAuthority(GUEST_ROLE)));
+        auth.setDetails(details);
+        try {
+            SecurityContextHolder.getContext().setAuthentication(auth);
+            chain.doFilter(req, resp);
+        } finally {
+            SecurityContextHolder.clearContext();
+        }
+    }
+
+    /** Parse a sub-path like {@code "query/homes/admin/q.saiku"} into the
+     *  kind + resource path. Returns null if the leading segment isn't
+     *  recognised or the path is empty. */
+    static ResourceTarget parseTarget(String tail) {
+        if (tail == null || tail.isEmpty()) {
+            return null;
+        }
+        String kind;
+        String rest;
+        if (tail.startsWith(QUERY_SEGMENT)) {
+            kind = "query";
+            rest = tail.substring(QUERY_SEGMENT.length());
+        } else if (tail.startsWith(DASHBOARD_SEGMENT)) {
+            kind = "dashboard";
+            rest = tail.substring(DASHBOARD_SEGMENT.length());
+        } else {
+            return null;
+        }
+        // Strip the tile-query trailing segment so a tile read still maps to
+        // the parent dashboard token. JAX-RS leaves the path as-is in the URI.
+        int tileAt = rest.indexOf("/tile/");
+        if (tileAt > 0) {
+            rest = rest.substring(0, tileAt);
+        }
+        if (rest.isEmpty()) {
+            return null;
+        }
+        // The embed resource path is URL-encoded in the URI; decode for
+        // comparison against the stored canonical path.
+        String decoded = URLDecoder.decode(rest, StandardCharsets.UTF_8);
+        // Stored resource paths follow the repository convention of a leading
+        // "/" (mirrors ShareToken.dashboardPath); the URI segment after
+        // "/embed/query/" or "/embed/dashboard/" doesn't have one, so prepend
+        // it to normalize the comparison.
+        if (!decoded.startsWith("/")) {
+            decoded = "/" + decoded;
+        }
+        return new ResourceTarget(kind, decoded);
+    }
+
+    private static void writeInvalid(HttpServletResponse resp) throws IOException {
+        resp.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        resp.setContentType("application/json");
+        resp.setHeader("X-Content-Type-Options", "nosniff");
+        resp.setHeader("Cache-Control", "no-store");
+        resp.setHeader("Referrer-Policy", "no-referrer");
+        // Collapse "expired", "revoked", "wrong-resource" into one opaque
+        // response so a probe can't learn anything about which tokens or
+        // resources exist.
+        resp.getWriter().write("{\"status\":\"EMBED_INVALID\",\"error\":\"Embed token is invalid or expired.\"}");
+    }
+
+    /** Token from the dedicated header ONLY. As with the share flow, we don't
+     *  accept {@code ?token=}: it leaks into access logs, proxy logs, browser
+     *  history, and the {@code Referer} of outbound assets. The embed JS
+     *  reads the host page's attribute and sends it as this header. */
+    private static String extractToken(HttpServletRequest req) {
+        String h = req.getHeader(TOKEN_HEADER);
+        return (h == null || h.isBlank()) ? null : h.trim();
+    }
+
+    /** Request URI minus the context path — independent of deployment context
+     *  (the launcher serves at root, a WAR install may not). */
+    private static String pathWithinApp(HttpServletRequest req) {
+        String uri = req.getRequestURI();
+        String ctx = req.getContextPath();
+        if (ctx != null && !ctx.isEmpty() && uri.startsWith(ctx)) {
+            return uri.substring(ctx.length());
+        }
+        return uri;
+    }
+
+    /** Resource the URL targets — what the filter pins on the
+     *  Authentication. */
+    static final class ResourceTarget {
+        final String kind;
+        final String path;
+
+        ResourceTarget(String kind, String path) {
+            this.kind = kind;
+            this.path = path;
+        }
+    }
+
+    /** Immutable carrier for the resource the token / public-grant authorises.
+     *  {@link #token} is null on a public-grant request — view endpoints can
+     *  branch on that to refuse mutation surfaces if a future change widens
+     *  the role. */
+    public static final class EmbedGuestDetails {
+        public final String token;
+        public final String resourceKind;
+        public final String resourcePath;
+        public final String ownerUser;
+        public final List<String> ownerRoles;
+
+        public EmbedGuestDetails(
+                String token, String resourceKind, String resourcePath, String ownerUser, List<String> ownerRoles) {
+            this.token = token;
+            this.resourceKind = resourceKind;
+            this.resourcePath = resourcePath;
+            this.ownerUser = ownerUser;
+            this.ownerRoles = ownerRoles == null ? List.of() : List.copyOf(ownerRoles);
+        }
+
+        /** True when this request reached the resource via a public grant
+         *  rather than an opaque token. */
+        public boolean isAnonymous() {
+            return token == null;
+        }
+    }
+}

--- a/saiku-core/saiku-web/src/test/java/org/saiku/web/embed/EmbedPublicRegistryTest.java
+++ b/saiku-core/saiku-web/src/test/java/org/saiku/web/embed/EmbedPublicRegistryTest.java
@@ -1,0 +1,107 @@
+package org.saiku.web.embed;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import java.util.List;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+/**
+ * Unit coverage for {@link EmbedPublicRegistry} — grant/lookup round-trip,
+ * kind-isolation, revoke idempotency, persistence reload, owner-scoped
+ * listing, in-memory fallback.
+ */
+public class EmbedPublicRegistryTest {
+
+    @Rule
+    public TemporaryFolder tmp = new TemporaryFolder();
+
+    @Test
+    public void grant_then_isPublic() throws Exception {
+        EmbedPublicRegistry r = new EmbedPublicRegistry(tmp.newFolder("home").getAbsolutePath());
+        r.grant("query", "/homes/admin/sales.saiku", "admin", List.of("ROLE_ADMIN"), "public sales");
+        assertTrue(r.isPublic("query", "/homes/admin/sales.saiku"));
+        assertNotNull(r.lookup("query", "/homes/admin/sales.saiku"));
+        assertEquals("admin", r.lookup("query", "/homes/admin/sales.saiku").grantedBy);
+        assertEquals(List.of("ROLE_ADMIN"), r.lookup("query", "/homes/admin/sales.saiku").ownerRolesSnapshot);
+    }
+
+    @Test
+    public void kinds_are_isolated() throws Exception {
+        // A query grant must not satisfy a dashboard lookup at the same path —
+        // the key includes the kind so a typo'd request can't cross-match.
+        EmbedPublicRegistry r = new EmbedPublicRegistry(tmp.newFolder("home").getAbsolutePath());
+        r.grant("query", "/shared/x.saikudash", "admin", List.of(), null);
+        assertTrue(r.isPublic("query", "/shared/x.saikudash"));
+        assertFalse(r.isPublic("dashboard", "/shared/x.saikudash"));
+    }
+
+    @Test
+    public void lookup_handles_nulls() throws Exception {
+        EmbedPublicRegistry r = new EmbedPublicRegistry(tmp.newFolder("home").getAbsolutePath());
+        assertNull(r.lookup(null, "/x.saiku"));
+        assertNull(r.lookup("query", null));
+        assertFalse(r.isPublic(null, "/x.saiku"));
+        assertFalse(r.isPublic("query", null));
+    }
+
+    @Test
+    public void revoke_is_idempotent() throws Exception {
+        EmbedPublicRegistry r = new EmbedPublicRegistry(tmp.newFolder("home").getAbsolutePath());
+        r.grant("dashboard", "/exec.saikudash", "admin", List.of(), null);
+        assertTrue(r.revoke("dashboard", "/exec.saikudash"));
+        assertFalse(r.revoke("dashboard", "/exec.saikudash"));
+        assertFalse(r.isPublic("dashboard", "/exec.saikudash"));
+    }
+
+    @Test
+    public void grant_persists_across_reload() throws Exception {
+        String home = tmp.newFolder("home").getAbsolutePath();
+        EmbedPublicRegistry r1 = new EmbedPublicRegistry(home);
+        r1.grant("query", "/q.saiku", "alice", List.of("ROLE_USER"), "marketing");
+
+        EmbedPublicRegistry r2 = new EmbedPublicRegistry(home);
+        assertTrue("a fresh registry over the same dir must replay the grant", r2.isPublic("query", "/q.saiku"));
+        assertEquals("alice", r2.lookup("query", "/q.saiku").grantedBy);
+    }
+
+    @Test
+    public void listByOwner_scopes_to_grantor() throws Exception {
+        EmbedPublicRegistry r = new EmbedPublicRegistry(tmp.newFolder("home").getAbsolutePath());
+        r.grant("query", "/a.saiku", "admin", List.of(), null);
+        r.grant("dashboard", "/b.saikudash", "admin", List.of(), null);
+        r.grant("query", "/c.saiku", "bob", List.of(), null);
+
+        assertEquals(2, r.listByOwner("admin").size());
+        assertEquals(1, r.listByOwner("bob").size());
+        assertEquals(3, r.listAll().size());
+    }
+
+    @Test
+    public void in_memory_fallback_when_no_home() {
+        EmbedPublicRegistry r = new EmbedPublicRegistry((String) null);
+        r.grant("query", "/q.saiku", "admin", List.of(), null);
+        assertTrue(r.isPublic("query", "/q.saiku"));
+        assertTrue(r.revoke("query", "/q.saiku"));
+        assertFalse(r.isPublic("query", "/q.saiku"));
+    }
+
+    @Test
+    public void second_grant_overwrites_snapshot() throws Exception {
+        // Useful when the owner's roles change and they want public reads to
+        // pick up the new scope — re-granting must replace the snapshot
+        // rather than keep stale data.
+        EmbedPublicRegistry r = new EmbedPublicRegistry(tmp.newFolder("home").getAbsolutePath());
+        r.grant("query", "/q.saiku", "admin", List.of("ROLE_OLD"), "v1");
+        r.grant("query", "/q.saiku", "admin", List.of("ROLE_NEW"), "v2");
+
+        assertEquals(List.of("ROLE_NEW"), r.lookup("query", "/q.saiku").ownerRolesSnapshot);
+        assertEquals("v2", r.lookup("query", "/q.saiku").label);
+        assertEquals(1, r.listAll().size());
+    }
+}

--- a/saiku-core/saiku-web/src/test/java/org/saiku/web/embed/EmbedTokenStoreTest.java
+++ b/saiku-core/saiku-web/src/test/java/org/saiku/web/embed/EmbedTokenStoreTest.java
@@ -1,0 +1,149 @@
+package org.saiku.web.embed;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.util.List;
+import java.util.stream.Stream;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+/**
+ * Unit coverage for {@link EmbedTokenStore} — round-trip per resourceKind,
+ * traversal/malformed id rejection, expiry boundary, owner-scoped listing,
+ * atomic write hygiene, revocation, and kind-validation at mint time.
+ */
+public class EmbedTokenStoreTest {
+
+    @Rule
+    public TemporaryFolder tmp = new TemporaryFolder();
+
+    private EmbedTokenStore newStore() throws Exception {
+        return new EmbedTokenStore(tmp.newFolder("home").getAbsolutePath());
+    }
+
+    @Test
+    public void create_query_then_load_roundtrips() throws Exception {
+        EmbedTokenStore store = newStore();
+        EmbedToken t = store.create(
+                "query", "/homes/admin/sales.saiku", "admin", List.of("ROLE_ADMIN"), 60_000L, "Sales chart");
+        assertNotNull(t.token);
+        assertTrue("token id must be URL-safe and long", t.token.matches("^[A-Za-z0-9_-]{16,64}$"));
+
+        EmbedToken got = store.load(t.token);
+        assertNotNull("minted token must load back", got);
+        assertEquals("query", got.resourceKind);
+        assertEquals("/homes/admin/sales.saiku", got.resourcePath);
+        assertEquals("admin", got.createdBy);
+        assertEquals(List.of("ROLE_ADMIN"), got.ownerRolesSnapshot);
+        assertEquals("Sales chart", got.label);
+        assertFalse(got.revoked);
+    }
+
+    @Test
+    public void create_dashboard_then_load_roundtrips() throws Exception {
+        EmbedTokenStore store = newStore();
+        EmbedToken t = store.create("dashboard", "/homes/admin/exec.saikudash", "admin", List.of(), 60_000L, null);
+
+        EmbedToken got = store.load(t.token);
+        assertNotNull(got);
+        assertEquals("dashboard", got.resourceKind);
+        assertEquals("/homes/admin/exec.saikudash", got.resourcePath);
+    }
+
+    @Test
+    public void create_rejects_unknown_resource_kind() throws Exception {
+        EmbedTokenStore store = newStore();
+        for (String bad : new String[] {"schema", "", null}) {
+            try {
+                store.create(bad, "/x.saiku", "admin", List.of(), 60_000L, null);
+                fail("expected IllegalArgumentException for kind: " + bad);
+            } catch (IllegalArgumentException expected) {
+                /* ok */
+            }
+        }
+    }
+
+    @Test
+    public void create_rejects_blank_resource_path() throws Exception {
+        EmbedTokenStore store = newStore();
+        for (String bad : new String[] {"", null}) {
+            try {
+                store.create("query", bad, "admin", List.of(), 60_000L, null);
+                fail("expected IllegalArgumentException for path: " + bad);
+            } catch (IllegalArgumentException expected) {
+                /* ok */
+            }
+        }
+    }
+
+    @Test
+    public void load_rejects_traversal_and_malformed_ids() throws Exception {
+        EmbedTokenStore store = newStore();
+        for (String bad : new String[] {
+            "../secret", "..\\secret", "a/b", "a\\b", "%2F%2Fetc", "with space", "", "short", "a.b", "../../etc/passwd"
+        }) {
+            assertNull("malformed/traversal id must not resolve: " + bad, store.load(bad));
+        }
+    }
+
+    @Test
+    public void expiry_boundary() throws Exception {
+        EmbedTokenStore store = newStore();
+        EmbedToken t = store.create("query", "/q.saiku", "admin", List.of(), 1_000L, null);
+        long created = t.createdAt;
+        assertTrue("valid before expiry", t.isValid(created + 500));
+        assertFalse("expired at/after expiresAt", t.isValid(t.expiresAt));
+        assertTrue("expired flag", t.isExpired(t.expiresAt + 1));
+    }
+
+    @Test
+    public void listByOwner_scopes_to_creator() throws Exception {
+        EmbedTokenStore store = newStore();
+        store.create("query", "/a.saiku", "admin", List.of(), 60_000L, null);
+        store.create("dashboard", "/b.saikudash", "admin", List.of(), 60_000L, null);
+        store.create("query", "/c.saiku", "bob", List.of(), 60_000L, null);
+
+        List<EmbedToken> adminTokens = store.listByOwner("admin");
+        assertEquals(2, adminTokens.size());
+        assertTrue(adminTokens.stream().allMatch(t -> "admin".equals(t.createdBy)));
+        assertEquals(1, store.listByOwner("bob").size());
+        assertEquals(3, store.listAll().size());
+    }
+
+    @Test
+    public void revoke_marks_token_and_persists() throws Exception {
+        EmbedTokenStore store = newStore();
+        EmbedToken t = store.create("query", "/q.saiku", "admin", List.of(), 60_000L, null);
+        assertTrue(store.revoke(t.token));
+        assertTrue("revocation must persist", store.load(t.token).revoked);
+        assertFalse("revoke of unknown id is false", store.revoke("doesnotexistbutvalidlen0001"));
+    }
+
+    @Test
+    public void persist_leaves_no_tmp_files() throws Exception {
+        File home = tmp.newFolder("home2");
+        EmbedTokenStore store = new EmbedTokenStore(home.getAbsolutePath());
+        store.create("query", "/q.saiku", "admin", List.of(), 60_000L, null);
+        File dir = new File(home, "embed-tokens");
+        try (Stream<java.nio.file.Path> s = Files.list(dir.toPath())) {
+            assertTrue("no .tmp left behind", s.noneMatch(p -> p.toString().endsWith(".tmp")));
+        }
+    }
+
+    @Test
+    public void in_memory_fallback_when_no_home() {
+        EmbedTokenStore store = new EmbedTokenStore((String) null);
+        EmbedToken t = store.create("query", "/q.saiku", "admin", List.of(), 60_000L, null);
+        assertNotNull(store.load(t.token));
+        assertTrue(store.revoke(t.token));
+        assertTrue(store.load(t.token).revoked);
+    }
+}

--- a/saiku-core/saiku-web/src/test/java/org/saiku/web/rest/resources/embed/EmbedTokenResourceTest.java
+++ b/saiku-core/saiku-web/src/test/java/org/saiku/web/rest/resources/embed/EmbedTokenResourceTest.java
@@ -1,0 +1,374 @@
+package org.saiku.web.rest.resources.embed;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import jakarta.ws.rs.core.Response;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.saiku.repository.AclEntry;
+import org.saiku.service.datasource.DatasourceService;
+import org.saiku.service.user.UserService;
+import org.saiku.web.embed.EmbedPublicRegistry;
+import org.saiku.web.embed.EmbedToken;
+import org.saiku.web.embed.EmbedTokenStore;
+import org.saiku.web.service.SessionService;
+
+/**
+ * Resource-level coverage of {@link EmbedTokenResource} — mint/list/revoke
+ * for opaque tokens, grant/list/revoke for public-ACL. Uses thin handcrafted
+ * stubs in lieu of a mock library (matches the saiku-web convention; saiku-web
+ * has no Mockito).
+ */
+public class EmbedTokenResourceTest {
+
+    @Rule
+    public TemporaryFolder tmp = new TemporaryFolder();
+
+    private EmbedTokenStore tokenStore;
+    private EmbedPublicRegistry publicRegistry;
+    private StubSessionService session;
+    private StubDatasourceService ds;
+    private StubUserService users;
+    private EmbedTokenResource resource;
+
+    @Before
+    public void setUp() throws Exception {
+        tokenStore = new EmbedTokenStore(tmp.newFolder("tokens").getAbsolutePath());
+        publicRegistry = new EmbedPublicRegistry(tmp.newFolder("public").getAbsolutePath());
+        session = new StubSessionService();
+        ds = new StubDatasourceService();
+        users = new StubUserService();
+        resource = new EmbedTokenResource();
+        resource.setTokenStore(tokenStore);
+        resource.setPublicRegistry(publicRegistry);
+        resource.setDatasourceService(ds);
+        resource.setSessionService(session);
+        resource.setUserService(users);
+    }
+
+    /* ---------------------------- mint ---------------------------- */
+
+    @Test
+    public void mint_returns_token_when_caller_can_grant() {
+        session.username = "admin";
+        session.roles = List.of("ROLE_ADMIN");
+        ds.allow("/homes/admin/sales.saiku");
+
+        EmbedTokenResource.MintRequest req = new EmbedTokenResource.MintRequest();
+        req.resourceKind = "query";
+        req.resourcePath = "/homes/admin/sales.saiku";
+        req.ttlHours = 24;
+        req.label = "Q4 sales";
+
+        Response r = resource.mint(req);
+        assertEquals(200, r.getStatus());
+        @SuppressWarnings("unchecked")
+        Map<String, Object> body = (Map<String, Object>) r.getEntity();
+        assertEquals("OK", body.get("status"));
+        assertNotNull(body.get("token"));
+        assertEquals("query", body.get("resourceKind"));
+        assertEquals("/homes/admin/sales.saiku", body.get("resourcePath"));
+        // Token landed in the store with the owner snapshot pinned.
+        EmbedToken stored = tokenStore.load((String) body.get("token"));
+        assertNotNull(stored);
+        assertEquals("admin", stored.createdBy);
+        assertEquals(List.of("ROLE_ADMIN"), stored.ownerRolesSnapshot);
+    }
+
+    @Test
+    public void mint_rejects_caller_without_grant() {
+        session.username = "bob";
+        session.roles = List.of("ROLE_USER");
+        // ds.allow not called → getResourceACL returns null → 403.
+
+        EmbedTokenResource.MintRequest req = new EmbedTokenResource.MintRequest();
+        req.resourceKind = "query";
+        req.resourcePath = "/homes/admin/private.saiku";
+
+        Response r = resource.mint(req);
+        assertEquals(403, r.getStatus());
+        assertEquals(0, tokenStore.listAll().size());
+    }
+
+    @Test
+    public void mint_validates_kind() {
+        session.username = "admin";
+
+        EmbedTokenResource.MintRequest req = new EmbedTokenResource.MintRequest();
+        req.resourceKind = "schema"; // not a valid kind
+        req.resourcePath = "/x.saiku";
+
+        Response r = resource.mint(req);
+        assertEquals(400, r.getStatus());
+    }
+
+    @Test
+    public void mint_validates_kind_path_suffix_pairing() {
+        // query resourcePath MUST end .saiku — defence-in-depth before the
+        // path ever lands in the token store.
+        session.username = "admin";
+        ds.allow("/homes/admin/wrong.saikudash");
+
+        EmbedTokenResource.MintRequest req = new EmbedTokenResource.MintRequest();
+        req.resourceKind = "query";
+        req.resourcePath = "/homes/admin/wrong.saikudash";
+
+        Response r = resource.mint(req);
+        assertEquals(400, r.getStatus());
+    }
+
+    @Test
+    public void mint_caps_ttl() {
+        session.username = "admin";
+        ds.allow("/q.saiku");
+
+        EmbedTokenResource.MintRequest req = new EmbedTokenResource.MintRequest();
+        req.resourceKind = "query";
+        req.resourcePath = "/q.saiku";
+        req.ttlHours = 9999; // exceeds 30-day cap
+
+        Response r = resource.mint(req);
+        assertEquals(200, r.getStatus());
+        @SuppressWarnings("unchecked")
+        Map<String, Object> body = (Map<String, Object>) r.getEntity();
+        EmbedToken stored = tokenStore.load((String) body.get("token"));
+        long ttl = stored.expiresAt - stored.createdAt;
+        // 30 days = 720h = 2_592_000_000 ms — anything beyond means the cap
+        // didn't apply.
+        assertTrue("ttl must be capped at 30 days", ttl <= 720L * 3600_000L);
+    }
+
+    /* --------------------------- revoke --------------------------- */
+
+    @Test
+    public void revoke_by_creator_succeeds() {
+        session.username = "admin";
+        ds.allow("/q.saiku");
+
+        EmbedTokenResource.MintRequest req = new EmbedTokenResource.MintRequest();
+        req.resourceKind = "query";
+        req.resourcePath = "/q.saiku";
+        Response mint = resource.mint(req);
+        @SuppressWarnings("unchecked")
+        String token = (String) ((Map<String, Object>) mint.getEntity()).get("token");
+
+        Response r = resource.revokeToken(token);
+        assertEquals(200, r.getStatus());
+        assertTrue(tokenStore.load(token).revoked);
+    }
+
+    @Test
+    public void revoke_by_admin_role_succeeds() {
+        // Bob mints a token, admin role can revoke even though admin didn't mint.
+        session.username = "bob";
+        ds.allow("/q.saiku");
+        EmbedTokenResource.MintRequest req = new EmbedTokenResource.MintRequest();
+        req.resourceKind = "query";
+        req.resourcePath = "/q.saiku";
+        Response mint = resource.mint(req);
+        @SuppressWarnings("unchecked")
+        String token = (String) ((Map<String, Object>) mint.getEntity()).get("token");
+
+        session.username = "admin";
+        session.roles = List.of("ROLE_ADMIN");
+        users.adminRoles = List.of("ROLE_ADMIN");
+
+        Response r = resource.revokeToken(token);
+        assertEquals(200, r.getStatus());
+    }
+
+    @Test
+    public void revoke_by_unrelated_user_is_forbidden() {
+        // Admin mints; an unrelated user with no grant tries to revoke → 403.
+        session.username = "admin";
+        ds.allow("/q.saiku");
+        EmbedTokenResource.MintRequest req = new EmbedTokenResource.MintRequest();
+        req.resourceKind = "query";
+        req.resourcePath = "/q.saiku";
+        Response mint = resource.mint(req);
+        @SuppressWarnings("unchecked")
+        String token = (String) ((Map<String, Object>) mint.getEntity()).get("token");
+
+        session.username = "bob";
+        session.roles = List.of("ROLE_USER");
+
+        Response r = resource.revokeToken(token);
+        assertEquals(403, r.getStatus());
+        assertFalse(tokenStore.load(token).revoked);
+    }
+
+    @Test
+    public void revoke_unknown_id_is_404() {
+        session.username = "admin";
+        Response r = resource.revokeToken("definitelynotastoredtoken00");
+        assertEquals(404, r.getStatus());
+    }
+
+    /* --------------------------- list ----------------------------- */
+
+    @Test
+    public void list_scopes_to_caller_by_default() {
+        // allow() captures the CURRENT username — set session before
+        // granting so each user gets the right paths.
+        session.username = "admin";
+        ds.allow("/a.saiku");
+        ds.allow("/b.saiku");
+        EmbedTokenResource.MintRequest req = new EmbedTokenResource.MintRequest();
+        req.resourceKind = "query";
+        req.resourcePath = "/a.saiku";
+        resource.mint(req);
+        req.resourcePath = "/b.saiku";
+        resource.mint(req);
+
+        session.username = "bob";
+        ds.allow("/c.saiku");
+        req.resourcePath = "/c.saiku";
+        resource.mint(req);
+
+        session.username = "admin";
+        Response r = resource.listTokens(false);
+        assertEquals(200, r.getStatus());
+        @SuppressWarnings("unchecked")
+        List<Map<String, Object>> list = (List<Map<String, Object>>) r.getEntity();
+        assertEquals(2, list.size());
+        assertTrue(list.stream().allMatch(m -> "admin".equals(m.get("createdBy"))));
+    }
+
+    @Test
+    public void list_all_for_admin_returns_every_token() {
+        users.adminRoles = List.of("ROLE_ADMIN");
+
+        session.username = "admin";
+        session.roles = List.of("ROLE_ADMIN");
+        ds.allow("/a.saiku");
+        EmbedTokenResource.MintRequest req = new EmbedTokenResource.MintRequest();
+        req.resourceKind = "query";
+        req.resourcePath = "/a.saiku";
+        resource.mint(req);
+
+        session.username = "bob";
+        session.roles = List.of("ROLE_USER");
+        ds.allow("/b.saiku");
+        req.resourcePath = "/b.saiku";
+        resource.mint(req);
+
+        session.username = "admin";
+        session.roles = List.of("ROLE_ADMIN");
+        Response r = resource.listTokens(true);
+        @SuppressWarnings("unchecked")
+        List<Map<String, Object>> list = (List<Map<String, Object>>) r.getEntity();
+        assertEquals(2, list.size());
+    }
+
+    /* --------------------------- public --------------------------- */
+
+    @Test
+    public void grant_public_requires_grant() {
+        session.username = "bob";
+        // ds.allow not called → 403
+
+        EmbedTokenResource.GrantRequest req = new EmbedTokenResource.GrantRequest();
+        req.resourceKind = "dashboard";
+        req.resourcePath = "/exec.saikudash";
+
+        Response r = resource.grantPublic(req);
+        assertEquals(403, r.getStatus());
+        assertFalse(publicRegistry.isPublic("dashboard", "/exec.saikudash"));
+    }
+
+    @Test
+    public void grant_public_with_grant_persists_grant() {
+        session.username = "admin";
+        session.roles = List.of("ROLE_ADMIN");
+        ds.allow("/exec.saikudash");
+
+        EmbedTokenResource.GrantRequest req = new EmbedTokenResource.GrantRequest();
+        req.resourceKind = "dashboard";
+        req.resourcePath = "/exec.saikudash";
+        req.label = "public exec";
+
+        Response r = resource.grantPublic(req);
+        assertEquals(200, r.getStatus());
+        assertTrue(publicRegistry.isPublic("dashboard", "/exec.saikudash"));
+        assertEquals("admin", publicRegistry.lookup("dashboard", "/exec.saikudash").grantedBy);
+        // Owner snapshot pinned — public reads will render under this scope.
+        assertEquals(List.of("ROLE_ADMIN"), publicRegistry.lookup("dashboard", "/exec.saikudash").ownerRolesSnapshot);
+    }
+
+    @Test
+    public void revoke_public_by_creator_succeeds() {
+        session.username = "admin";
+        ds.allow("/exec.saikudash");
+        EmbedTokenResource.GrantRequest req = new EmbedTokenResource.GrantRequest();
+        req.resourceKind = "dashboard";
+        req.resourcePath = "/exec.saikudash";
+        resource.grantPublic(req);
+
+        Response r = resource.revokePublic("dashboard", "/exec.saikudash");
+        assertEquals(200, r.getStatus());
+        assertFalse(publicRegistry.isPublic("dashboard", "/exec.saikudash"));
+    }
+
+    @Test
+    public void revoke_public_unknown_is_404() {
+        session.username = "admin";
+        Response r = resource.revokePublic("dashboard", "/never-granted.saikudash");
+        assertEquals(404, r.getStatus());
+    }
+
+    /* --------------------------- stubs ---------------------------- */
+
+    /** Minimal SessionService stub. {@code username} + {@code roles} are
+     *  the only things the resource reads from the session map. */
+    private static class StubSessionService extends SessionService {
+        String username;
+        List<String> roles = List.of();
+
+        @Override
+        public Map<String, Object> getAllSessionObjects() {
+            Map<String, Object> m = new HashMap<>();
+            m.put("username", username);
+            m.put("roles", roles);
+            return m;
+        }
+    }
+
+    /** DatasourceService stub. {@code allow(path)} grants whoever the
+     *  current {@code session.username} is at the moment of the call;
+     *  the resource's grant check is then user-specific, mirroring the
+     *  real ACL semantics ("this user can grant THIS path"). */
+    private class StubDatasourceService extends DatasourceService {
+        private final java.util.Set<String> allowedPaths = new java.util.HashSet<>();
+        private final java.util.Map<String, java.util.Set<String>> userToPaths = new java.util.HashMap<>();
+
+        void allow(String path) {
+            allowedPaths.add(path);
+            userToPaths
+                    .computeIfAbsent(session.username, k -> new java.util.HashSet<>())
+                    .add(path);
+        }
+
+        @Override
+        public AclEntry getResourceACL(String file, String username, List<String> roles) {
+            java.util.Set<String> paths = userToPaths.get(username);
+            return paths != null && paths.contains(file) ? new AclEntry() : null;
+        }
+    }
+
+    private static class StubUserService extends UserService {
+        List<String> adminRoles = List.of();
+
+        @Override
+        public List<String> getAdminRoles() {
+            return adminRoles;
+        }
+    }
+}

--- a/saiku-core/saiku-web/src/test/java/org/saiku/web/rest/resources/embed/EmbedViewResourceTest.java
+++ b/saiku-core/saiku-web/src/test/java/org/saiku/web/rest/resources/embed/EmbedViewResourceTest.java
@@ -1,0 +1,198 @@
+package org.saiku.web.rest.resources.embed;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import jakarta.ws.rs.core.Response;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Supplier;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.saiku.service.datasource.DatasourceService;
+import org.saiku.service.olap.ai.AiSavedQueryRequest;
+import org.saiku.web.rest.resources.AiQueryResource;
+import org.saiku.web.security.embed.EmbedAuthFilter.EmbedGuestDetails;
+import org.saiku.web.service.SessionService;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.authentication.preauth.PreAuthenticatedAuthenticationToken;
+
+/**
+ * Resource-level coverage of {@link EmbedViewResource} — the guest read
+ * surface. Verifies that the resource correctly reads
+ * {@link EmbedGuestDetails} from the SecurityContext, refuses requests
+ * whose pinned kind doesn't match the endpoint, runs queries under the
+ * pinned owner's scope via {@code runAs}, and stamps the defence-in-depth
+ * response headers on every reply.
+ */
+public class EmbedViewResourceTest {
+
+    private StubDatasourceService ds;
+    private StubSessionService session;
+    private StubAiQueryResource ai;
+    private EmbedViewResource resource;
+
+    @Before
+    public void setUp() {
+        ds = new StubDatasourceService();
+        session = new StubSessionService();
+        ai = new StubAiQueryResource();
+        resource = new EmbedViewResource();
+        resource.setDatasourceService(ds);
+        resource.setSessionService(session);
+        resource.setAiQueryResource(ai);
+    }
+
+    @After
+    public void tearDown() {
+        SecurityContextHolder.clearContext();
+    }
+
+    /* ---------------------------- query ---------------------------- */
+
+    @Test
+    public void query_executes_saved_request_with_pinned_path() {
+        pinGuest("query", "/homes/admin/sales.saiku", "admin", List.of("ROLE_ADMIN"));
+
+        Response r = resource.query("homes/admin/sales.saiku");
+
+        assertEquals(200, r.getStatus());
+        // executeSaved received the resource path verbatim from the
+        // pinned details — the URI param was ignored as documented.
+        assertNotNull(ai.lastSavedRequest);
+        assertEquals("/homes/admin/sales.saiku", ai.lastSavedRequest.getPath());
+        // Ran under the owner's scope.
+        assertEquals("admin", session.lastRunAsUser);
+        assertEquals(List.of("ROLE_ADMIN"), session.lastRunAsRoles);
+        assertHardenedHeaders(r);
+    }
+
+    @Test
+    public void query_with_no_guest_returns_401() {
+        // No SecurityContext set up at all.
+        Response r = resource.query("homes/admin/x.saiku");
+        assertEquals(401, r.getStatus());
+        assertHardenedHeaders(r);
+    }
+
+    @Test
+    public void query_refuses_when_kind_is_dashboard() {
+        // A dashboard-pinned guest must NOT be able to call the /query endpoint;
+        // the auth filter normally catches this but defence-in-depth at the
+        // resource boundary protects against a future filter regression.
+        pinGuest("dashboard", "/homes/admin/exec.saikudash", "admin", List.of());
+
+        Response r = resource.query("homes/admin/exec.saikudash");
+        assertEquals(401, r.getStatus());
+    }
+
+    @Test
+    public void query_refuses_when_pinned_path_doesnt_end_dot_saiku() {
+        // Belt-and-suspenders: even if a malformed token somehow lands in the
+        // store with a wrong-suffix path, the resource refuses to execute.
+        pinGuest("query", "/homes/admin/wrong.saikudash", "admin", List.of());
+
+        Response r = resource.query("homes/admin/wrong.saikudash");
+        assertEquals(401, r.getStatus());
+    }
+
+    /* -------------------------- dashboard -------------------------- */
+
+    @Test
+    public void dashboard_returns_loaded_dashboard_json() {
+        ds.fileContent = "{\"id\":\"d-1\",\"name\":\"Exec\",\"version\":1}";
+        pinGuest("dashboard", "/homes/admin/exec.saikudash", "admin", List.of("ROLE_ADMIN"));
+
+        Response r = resource.dashboard("homes/admin/exec.saikudash");
+        assertEquals(200, r.getStatus());
+        // Dashboard loaded as owner — both the user and the roles are the
+        // pinned snapshot, not whoever sits in the unrelated session map.
+        assertEquals("admin", ds.lastReadUser);
+        assertEquals(List.of("ROLE_ADMIN"), ds.lastReadRoles);
+        assertHardenedHeaders(r);
+    }
+
+    @Test
+    public void dashboard_missing_file_is_404() {
+        ds.fileContent = null;
+        pinGuest("dashboard", "/homes/admin/exec.saikudash", "admin", List.of());
+
+        Response r = resource.dashboard("homes/admin/exec.saikudash");
+        assertEquals(404, r.getStatus());
+        @SuppressWarnings("unchecked")
+        Map<String, Object> body = (Map<String, Object>) r.getEntity();
+        assertEquals("NOT_FOUND", body.get("status"));
+    }
+
+    @Test
+    public void dashboard_refuses_when_kind_is_query() {
+        pinGuest("query", "/homes/admin/q.saiku", "admin", List.of());
+
+        Response r = resource.dashboard("homes/admin/q.saiku");
+        assertEquals(401, r.getStatus());
+    }
+
+    /* --------------------------- helpers ---------------------------- */
+
+    private void pinGuest(String kind, String path, String user, List<String> roles) {
+        EmbedGuestDetails details =
+                new EmbedGuestDetails("anonymous-token-id".equals(kind) ? null : "token-xyz", kind, path, user, roles);
+        PreAuthenticatedAuthenticationToken auth = new PreAuthenticatedAuthenticationToken(
+                "embed-guest", details, List.of(new SimpleGrantedAuthority("ROLE_EMBED_GUEST")));
+        auth.setDetails(details);
+        SecurityContextHolder.getContext().setAuthentication(auth);
+    }
+
+    private static void assertHardenedHeaders(Response r) {
+        assertEquals("nosniff", r.getHeaderString("X-Content-Type-Options"));
+        assertEquals("no-referrer", r.getHeaderString("Referrer-Policy"));
+        String cc = r.getHeaderString("Cache-Control");
+        assertTrue("Cache-Control must include no-store, got: " + cc, cc != null && cc.contains("no-store"));
+    }
+
+    /* --------------------------- stubs ---------------------------- */
+
+    /** Captures the runAs call so the test can assert the pinned identity. */
+    private static class StubSessionService extends SessionService {
+        String lastRunAsUser;
+        List<String> lastRunAsRoles;
+
+        @Override
+        public <T> T runAs(String username, List<String> roles, Supplier<T> action) {
+            lastRunAsUser = username;
+            lastRunAsRoles = roles;
+            return action.get();
+        }
+    }
+
+    /** Captures the saved-request path and the user/roles that read the file. */
+    private static class StubDatasourceService extends DatasourceService {
+        String fileContent = "{}";
+        String lastReadUser;
+        List<String> lastReadRoles;
+
+        @Override
+        public String getFileData(String path, String username, List<String> roles) {
+            lastReadUser = username;
+            lastReadRoles = roles;
+            return fileContent;
+        }
+    }
+
+    /** Records the request the resource handed off — verifies the path was
+     *  read from pinned details, not URI params. */
+    private static class StubAiQueryResource extends AiQueryResource {
+        AiSavedQueryRequest lastSavedRequest;
+
+        @Override
+        public Response executeSaved(AiSavedQueryRequest body) {
+            lastSavedRequest = body;
+            return Response.ok(Map.of("status", "OK", "cells", List.of()))
+                    .type(jakarta.ws.rs.core.MediaType.APPLICATION_JSON)
+                    .build();
+        }
+    }
+}

--- a/saiku-core/saiku-web/src/test/java/org/saiku/web/security/embed/EmbedAuthFilterTest.java
+++ b/saiku-core/saiku-web/src/test/java/org/saiku/web/security/embed/EmbedAuthFilterTest.java
@@ -1,0 +1,278 @@
+package org.saiku.web.security.embed;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import java.util.List;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.saiku.web.embed.EmbedPublicRegistry;
+import org.saiku.web.embed.EmbedToken;
+import org.saiku.web.embed.EmbedTokenStore;
+import org.saiku.web.security.embed.EmbedAuthFilter.EmbedGuestDetails;
+import org.springframework.mock.web.MockFilterChain;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+/**
+ * Unit coverage for {@link EmbedAuthFilter} — the gatekeeper for the
+ * {@code <saiku-embed>} read surface. Verifies:
+ * <ul>
+ *   <li>Non-embed paths pass through untouched.</li>
+ *   <li>The mint endpoint passes through (normal Spring auth handles it).</li>
+ *   <li>A valid token pins the SecurityContext with {@link EmbedGuestDetails}.</li>
+ *   <li>A wrong-kind / wrong-path token replay yields 401 + opaque body —
+ *       the token never grants access to anything but the exact pinned
+ *       resource.</li>
+ *   <li>An expired or revoked token yields the same opaque 401.</li>
+ *   <li>A public-grant lookup admits an anonymous request (no token).</li>
+ *   <li>A path with neither token nor public grant falls through (Spring's
+ *       intercept-url rule will 401).</li>
+ *   <li>The SecurityContext is cleared on the way out — no guest identity
+ *       leaks into a downstream filter / the session.</li>
+ *   <li>Path parsing decodes URL-encoded resource paths so the comparison
+ *       against the stored canonical path is byte-faithful.</li>
+ * </ul>
+ */
+public class EmbedAuthFilterTest {
+
+    private EmbedTokenStore tokenStore;
+    private EmbedPublicRegistry publicRegistry;
+    private EmbedAuthFilter filter;
+
+    @Before
+    public void setUp() {
+        tokenStore = new EmbedTokenStore((String) null);
+        publicRegistry = new EmbedPublicRegistry((String) null);
+        filter = new EmbedAuthFilter(tokenStore, publicRegistry);
+    }
+
+    @After
+    public void tearDown() {
+        SecurityContextHolder.clearContext();
+    }
+
+    @Test
+    public void non_embed_path_passes_through() throws Exception {
+        MockHttpServletRequest req = new MockHttpServletRequest("GET", "/rest/saiku/info");
+        MockHttpServletResponse resp = new MockHttpServletResponse();
+        TrackingChain chain = new TrackingChain();
+
+        filter.doFilter(req, resp, chain);
+
+        assertTrue("non-embed path must reach the next filter", chain.called);
+        assertNull(
+                "no auth was set for an untouched request",
+                SecurityContextHolder.getContext().getAuthentication());
+    }
+
+    @Test
+    public void mint_endpoint_passes_through() throws Exception {
+        // POST /rest/saiku/api/embed/tokens is the mint surface — must NOT be
+        // touched by the guest filter, otherwise an authenticated mint would
+        // get its real session blown away.
+        MockHttpServletRequest req = new MockHttpServletRequest("POST", "/rest/saiku/api/embed/tokens");
+        MockHttpServletResponse resp = new MockHttpServletResponse();
+        TrackingChain chain = new TrackingChain();
+
+        filter.doFilter(req, resp, chain);
+
+        assertTrue(chain.called);
+        assertNull(SecurityContextHolder.getContext().getAuthentication());
+    }
+
+    @Test
+    public void valid_token_pins_guest_identity() throws Exception {
+        EmbedToken t = tokenStore.create(
+                "query", "/homes/admin/sales.saiku", "admin", List.of("ROLE_ADMIN"), 60_000L, "label");
+        MockHttpServletRequest req =
+                new MockHttpServletRequest("GET", "/rest/saiku/api/embed/query/homes/admin/sales.saiku");
+        req.addHeader(EmbedAuthFilter.TOKEN_HEADER, t.token);
+        MockHttpServletResponse resp = new MockHttpServletResponse();
+        ContextCapturingChain chain = new ContextCapturingChain();
+
+        filter.doFilter(req, resp, chain);
+
+        assertTrue("valid token must reach the next filter", chain.called);
+        assertEquals(200, resp.getStatus()); // chain didn't write a status
+        assertNotNull("auth must be set during chain", chain.capturedAuth);
+        EmbedGuestDetails details = (EmbedGuestDetails) chain.capturedAuth.getDetails();
+        assertEquals("query", details.resourceKind);
+        assertEquals("/homes/admin/sales.saiku", details.resourcePath);
+        assertEquals("admin", details.ownerUser);
+        assertEquals(List.of("ROLE_ADMIN"), details.ownerRoles);
+        assertFalse("token path is not anonymous", details.isAnonymous());
+        assertNull(
+                "context must be cleared on exit",
+                SecurityContextHolder.getContext().getAuthentication());
+    }
+
+    @Test
+    public void wrong_resource_path_for_token_is_invalid() throws Exception {
+        // Replay attack: a token minted for sales.saiku used against
+        // payroll.saiku must NOT authorize the read.
+        EmbedToken t = tokenStore.create("query", "/homes/admin/sales.saiku", "admin", List.of(), 60_000L, null);
+        MockHttpServletRequest req =
+                new MockHttpServletRequest("GET", "/rest/saiku/api/embed/query/homes/admin/payroll.saiku");
+        req.addHeader(EmbedAuthFilter.TOKEN_HEADER, t.token);
+        MockHttpServletResponse resp = new MockHttpServletResponse();
+        TrackingChain chain = new TrackingChain();
+
+        filter.doFilter(req, resp, chain);
+
+        assertEquals(401, resp.getStatus());
+        assertTrue(
+                "opaque body — never reveals which exact check failed",
+                resp.getContentAsString().contains("EMBED_INVALID"));
+        assertFalse("chain must NOT run for an invalid token", chain.called);
+    }
+
+    @Test
+    public void wrong_kind_for_token_is_invalid() throws Exception {
+        // A dashboard-token presented against /query/... is a replay.
+        EmbedToken t = tokenStore.create("dashboard", "/homes/admin/exec.saikudash", "admin", List.of(), 60_000L, null);
+        MockHttpServletRequest req =
+                new MockHttpServletRequest("GET", "/rest/saiku/api/embed/query/homes/admin/exec.saikudash");
+        req.addHeader(EmbedAuthFilter.TOKEN_HEADER, t.token);
+        MockHttpServletResponse resp = new MockHttpServletResponse();
+        TrackingChain chain = new TrackingChain();
+
+        filter.doFilter(req, resp, chain);
+
+        assertEquals(401, resp.getStatus());
+        assertFalse(chain.called);
+    }
+
+    @Test
+    public void revoked_token_is_invalid() throws Exception {
+        EmbedToken t = tokenStore.create("query", "/q.saiku", "admin", List.of(), 60_000L, null);
+        tokenStore.revoke(t.token);
+        MockHttpServletRequest req = new MockHttpServletRequest("GET", "/rest/saiku/api/embed/query/q.saiku");
+        req.addHeader(EmbedAuthFilter.TOKEN_HEADER, t.token);
+        MockHttpServletResponse resp = new MockHttpServletResponse();
+        TrackingChain chain = new TrackingChain();
+
+        filter.doFilter(req, resp, chain);
+
+        assertEquals(401, resp.getStatus());
+        assertFalse(chain.called);
+    }
+
+    @Test
+    public void public_grant_admits_anonymous_request() throws Exception {
+        publicRegistry.grant("dashboard", "/homes/admin/exec.saikudash", "admin", List.of("ROLE_ADMIN"), "public exec");
+        MockHttpServletRequest req =
+                new MockHttpServletRequest("GET", "/rest/saiku/api/embed/dashboard/homes/admin/exec.saikudash");
+        MockHttpServletResponse resp = new MockHttpServletResponse();
+        ContextCapturingChain chain = new ContextCapturingChain();
+
+        filter.doFilter(req, resp, chain);
+
+        assertTrue("public read must reach chain", chain.called);
+        EmbedGuestDetails details = (EmbedGuestDetails) chain.capturedAuth.getDetails();
+        assertEquals("dashboard", details.resourceKind);
+        assertEquals("/homes/admin/exec.saikudash", details.resourcePath);
+        assertEquals("admin", details.ownerUser);
+        assertTrue("public path is anonymous", details.isAnonymous());
+        assertNull(details.token);
+    }
+
+    @Test
+    public void no_token_no_public_grant_falls_through() throws Exception {
+        // Filter doesn't 401 itself; it lets Spring's intercept-url decide.
+        // This matches the share-token filter's "transparent pass-through"
+        // posture: a missing token on a guarded path is NOT a filter-level
+        // error — the security chain wraps everything below it.
+        MockHttpServletRequest req = new MockHttpServletRequest("GET", "/rest/saiku/api/embed/query/private.saiku");
+        MockHttpServletResponse resp = new MockHttpServletResponse();
+        TrackingChain chain = new TrackingChain();
+
+        filter.doFilter(req, resp, chain);
+
+        assertTrue("must fall through so Spring 401s with its own posture", chain.called);
+        assertEquals(200, resp.getStatus());
+    }
+
+    @Test
+    public void tile_subpath_authorizes_via_dashboard_token() throws Exception {
+        // GET /embed/dashboard/<path>/tile/<id>/query maps to the parent
+        // dashboard token — the tile subpath is part of the dashboard's
+        // own read API, not a separate resource.
+        EmbedToken t = tokenStore.create("dashboard", "/homes/admin/exec.saikudash", "admin", List.of(), 60_000L, null);
+        MockHttpServletRequest req = new MockHttpServletRequest(
+                "POST", "/rest/saiku/api/embed/dashboard/homes/admin/exec.saikudash/tile/tile-42/query");
+        req.addHeader(EmbedAuthFilter.TOKEN_HEADER, t.token);
+        MockHttpServletResponse resp = new MockHttpServletResponse();
+        ContextCapturingChain chain = new ContextCapturingChain();
+
+        filter.doFilter(req, resp, chain);
+
+        assertTrue(chain.called);
+        EmbedGuestDetails details = (EmbedGuestDetails) chain.capturedAuth.getDetails();
+        assertEquals("/homes/admin/exec.saikudash", details.resourcePath);
+    }
+
+    @Test
+    public void url_encoded_path_decodes_for_token_match() throws Exception {
+        // The stored path is the canonical "homes/admin/My Sales.saiku".
+        // The URL sent by the client encodes the space — the filter must
+        // decode before comparing, or every space-containing path 401s.
+        EmbedToken t = tokenStore.create("query", "/homes/admin/My Sales.saiku", "admin", List.of(), 60_000L, null);
+        MockHttpServletRequest req =
+                new MockHttpServletRequest("GET", "/rest/saiku/api/embed/query/homes/admin/My%20Sales.saiku");
+        req.addHeader(EmbedAuthFilter.TOKEN_HEADER, t.token);
+        MockHttpServletResponse resp = new MockHttpServletResponse();
+        TrackingChain chain = new TrackingChain();
+
+        filter.doFilter(req, resp, chain);
+
+        assertEquals(200, resp.getStatus());
+        assertTrue(chain.called);
+    }
+
+    @Test
+    public void context_is_cleared_after_token_request() throws Exception {
+        EmbedToken t = tokenStore.create("query", "/q.saiku", "admin", List.of(), 60_000L, null);
+        MockHttpServletRequest req = new MockHttpServletRequest("GET", "/rest/saiku/api/embed/query/q.saiku");
+        req.addHeader(EmbedAuthFilter.TOKEN_HEADER, t.token);
+        MockHttpServletResponse resp = new MockHttpServletResponse();
+
+        filter.doFilter(req, resp, new MockFilterChain());
+
+        // Critical: never persist a guest auth to the session. The next
+        // request that comes through this thread (worker reuse) must NOT
+        // inherit the prior guest identity.
+        assertNull(SecurityContextHolder.getContext().getAuthentication());
+    }
+
+    /* --------------------------- helpers ---------------------------- */
+
+    /** Records whether the chain was called; does NOT capture auth state. */
+    private static class TrackingChain extends MockFilterChain {
+        boolean called = false;
+
+        @Override
+        public void doFilter(jakarta.servlet.ServletRequest req, jakarta.servlet.ServletResponse resp) {
+            called = true;
+        }
+    }
+
+    /** Captures the SecurityContext at the moment the chain proceeds — so
+     *  the test sees the auth as the downstream resource would. */
+    private static class ContextCapturingChain extends MockFilterChain {
+        boolean called = false;
+        Authentication capturedAuth;
+
+        @Override
+        public void doFilter(jakarta.servlet.ServletRequest req, jakarta.servlet.ServletResponse resp) {
+            called = true;
+            capturedAuth = SecurityContextHolder.getContext().getAuthentication();
+        }
+    }
+}

--- a/saiku-webapp/src/main/webapp/WEB-INF/applicationContext-saiku.xml
+++ b/saiku-webapp/src/main/webapp/WEB-INF/applicationContext-saiku.xml
@@ -108,6 +108,20 @@
 	         full auth. Order matters: more specific patterns precede /rest/**. -->
 	    <security:intercept-url pattern="/rest/saiku/share/view/**" access="hasRole('SHARE_GUEST') or isFullyAuthenticated()" />
 	    <security:intercept-url pattern="/rest/saiku/share/**" access="isFullyAuthenticated()" />
+	    <!-- <saiku-embed/> Web Component surface. The READ prefixes (query +
+	         dashboard) admit ROLE_EMBED_GUEST (established by embedAuthFilter on
+	         a valid token OR a matching public-grant) OR a logged-in user
+	         previewing the embed. That role unlocks ONLY these prefixes —
+	         everything else stays isFullyAuthenticated() below, so an embed
+	         guest can never reach /ai/query directly, drillthrough, other
+	         resources, the repository, or the mint endpoints.
+	         The mint + public-grant surfaces (/embed/tokens, /embed/public)
+	         stay full-auth — only logged-in users with GRANT on the resource
+	         may mint or make public. Order matters: read prefixes BEFORE
+	         /embed/** so the more specific rule wins. -->
+	    <security:intercept-url pattern="/rest/saiku/api/embed/query/**" access="hasRole('EMBED_GUEST') or isFullyAuthenticated()" />
+	    <security:intercept-url pattern="/rest/saiku/api/embed/dashboard/**" access="hasRole('EMBED_GUEST') or isFullyAuthenticated()" />
+	    <security:intercept-url pattern="/rest/saiku/api/embed/**" access="isFullyAuthenticated()" />
       <!-- saiku#1165 audit-3: route-level admin gate (defense in depth). The
            admin resources already carry @RolesAllowed("ROLE_ADMIN"), but this
            ensures a future un-annotated /admin resource can't be reached by a
@@ -143,6 +157,12 @@
            security-context filter, so the guest auth is set before the
            authorization check and never persisted to the session. -->
       <security:custom-filter ref="shareTokenAuthFilter" before="PRE_AUTH_FILTER"/>
+      <!-- <saiku-embed/>: establish a request-scoped ROLE_EMBED_GUEST for
+           valid embed tokens OR matching public-grants on /api/embed/
+           {query,dashboard}/**. Same slot semantics as the share filter
+           (pre-auth, never persisted). The filter is a no-op on the mint
+           endpoint so the caller's authenticated session reaches it. -->
+      <security:custom-filter ref="embedAuthFilter" after="PRE_AUTH_FILTER"/>
       <!-- saiku#1150: force the deferred CsrfToken to resolve on every
            response so the XSRF-TOKEN cookie is written eagerly. Sits AFTER
            Spring Security's CSRF filter (BASIC_AUTH_FILTER is a stable

--- a/saiku-webapp/src/main/webapp/WEB-INF/saiku-beans.xml
+++ b/saiku-webapp/src/main/webapp/WEB-INF/saiku-beans.xml
@@ -441,6 +441,63 @@
         <property name="aiQueryResource" ref="aiQueryResource"/>
     </bean>
 
+    <!-- ====================================================================
+         <saiku-embed/> Web Component surface — the framework-agnostic embed
+         flow (revival of the historical Saiku 2.x embed widget; now works in
+         React/Vue/vanilla pages identically because it ships as a custom
+         element rather than a saiku-themed iframe).
+         Parallel to the share-token flow (#941) rather than retrofitted into
+         it: embed supports queries AND dashboards, has a public-grant ACL
+         for anonymous reads (not present on share), and uses a distinct
+         auth header so the two cannot be confused by a misconfigured filter
+         chain.
+         - embedTokenStore: file-backed at ${saiku.home}/embed-tokens/<id>.json.
+         - embedPublicRegistry: file-backed at ${saiku.home}/embed-public.json
+           (single sidecar — public grants are rare and curating them lives
+           with the owner, not the resource file itself).
+         - embedAuthFilter: Spring Security custom filter on the
+           /rest/saiku/api/embed/{query,dashboard}/** read prefix. On a valid
+           token OR matching public-grant it sets a request-scoped
+           ROLE_EMBED_GUEST pinned to one resource (wired in
+           applicationContext-saiku.xml). Mint endpoint is left alone so the
+           caller's authenticated session still applies there.
+         - embedTokenResource (@ /saiku/api/embed): owner-only mint/list/
+           revoke for tokens AND grant/list/revoke for public flags;
+           mint gated on getResourceACL (canGrant) — the per-resource ACL
+           (#940), same gate share-token mint uses.
+         - embedViewResource (@ /saiku/api/embed): the ONLY guest data
+           surface for embeds; runs each tile's authored query under the
+           owner's scope via sessionService.runAs, identical pattern to
+           shareViewResource. Tile query body comes from the stored
+           dashboard, never the client.
+         ==================================================================== -->
+    <bean id="embedTokenStore" class="org.saiku.web.embed.EmbedTokenStore"/>
+
+    <bean id="embedPublicRegistry" class="org.saiku.web.embed.EmbedPublicRegistry"/>
+
+    <bean id="embedAuthFilter"
+          class="org.saiku.web.security.embed.EmbedAuthFilter">
+        <constructor-arg ref="embedTokenStore"/>
+        <constructor-arg ref="embedPublicRegistry"/>
+    </bean>
+
+    <bean id="embedTokenResource"
+          class="org.saiku.web.rest.resources.embed.EmbedTokenResource">
+        <property name="tokenStore" ref="embedTokenStore"/>
+        <property name="publicRegistry" ref="embedPublicRegistry"/>
+        <property name="datasourceService" ref="datasourceServiceBean"/>
+        <property name="sessionService" ref="sessionService"/>
+        <property name="userService" ref="userServiceBean"/>
+    </bean>
+
+    <bean id="embedViewResource" scope="request"
+          class="org.saiku.web.rest.resources.embed.EmbedViewResource">
+        <aop:scoped-proxy/>
+        <property name="datasourceService" ref="datasourceServiceBean"/>
+        <property name="sessionService" ref="sessionService"/>
+        <property name="aiQueryResource" ref="aiQueryResource"/>
+    </bean>
+
     <!-- Per-tile dashboard comments (issue #942). commentService stores a
          per-dashboard .jsonl via the internal-file API; commentResource
          (@ /saiku/api/dashboards/comments) gates every op on the caller's


### PR DESCRIPTION
## Summary

PR 1 of 3 reviving the historical `<saiku-embed/>` widget — but this time as a framework-agnostic Web Component instead of a jQuery widget, so the same tag drops into React, Vue, or vanilla HTML host pages identically.

This PR is the **server foundation**. The Web Component itself is PR 2, distribution + docs is PR 3.

### What this lands

| Layer | Files | What it does |
|---|---|---|
| Token store | `EmbedToken`, `EmbedTokenStore` | Opaque random tokens persisted under `${saiku.home}/embed-tokens/<id>.json`. Twin of `ShareToken` (saiku#941) but supports `resourceKind=query` AND `dashboard`. |
| Public ACL | `EmbedPublicGrant`, `EmbedPublicRegistry` | Server-side sidecar `${saiku.home}/embed-public.json` for the anonymous-public flow — owner toggles, anonymous reads admit. Owner-role snapshot for data scope. |
| Auth filter | `EmbedAuthFilter` | Gatekeeper at `/rest/saiku/api/embed/{query,dashboard}/**`. Header-only token (`X-Saiku-Embed-Token`), kind+path pinning, public-grant fallback, opaque `EMBED_INVALID` 401, clears `SecurityContext` in `finally`. Mint endpoint passes through to normal auth. |
| Owner CRUD | `EmbedTokenResource` (`POST /tokens`, `GET /tokens`, `DELETE /tokens/{id}`, `POST /public`, `GET /public`, `DELETE /public`) | `isFullyAuthenticated()` + ACL-gated mint, grant, list, revoke. |
| Guest read | `EmbedViewResource` (`GET /query/{path}`, `GET /dashboard/{path}`, `POST /dashboard/{path}/tile/{id}/query`) | Runs queries under owner's data scope via `sessionService.runAs`. Hardened response headers on every reply. |
| Spring wiring | `applicationContext-saiku.xml`, `saiku-beans.xml` | Beans + `intercept-url` rules + custom filter registration (`after="PRE_AUTH_FILTER"` to chain cleanly after the share filter). |

### Auth model (recap)

- **Token path**: `POST /saiku/api/embed/tokens` mints an opaque random id, owner-role snapshot pinned. Returns the token + expiry; downstream guest reads send `X-Saiku-Embed-Token: <id>`.
- **Anonymous public path**: `POST /saiku/api/embed/public` flips a resource publicly embeddable. Anonymous reads under the grantor's data scope.
- Works identically under **saiku-ce (Spring login)** and **saiku-cloud (WorkOS)** — both backends populate `SecurityContextHolder` before the mint endpoint, and the mint code only consumes the populated context.

### Tests

| File | Count | What |
|---|---|---|
| `EmbedTokenStoreTest` | 10 | Round-trip per kind, kind/path validation, traversal/malformed id rejection, expiry, owner-scoped listing, atomic-write tmp hygiene, revoke, in-memory fallback |
| `EmbedPublicRegistryTest` | 8 | Grant/lookup, kind isolation, revoke idempotency, persistence reload, owner-scoped listing, second-grant overwrites snapshot |
| `EmbedAuthFilterTest` | 11 | Non-embed pass-through, mint pass-through, valid token pin, wrong kind/path replay → 401, expired/revoked → 401, public-grant admits anonymous, no-token-no-public falls through, tile subpath authorizes via parent token, URL-encoded path decode, SecurityContext cleared on exit |
| `EmbedTokenResourceTest` | 15 | Mint happy path with GRANT, mint without GRANT → 403, kind validation, kind/suffix pairing, TTL cap, revoke by creator/admin/forbidden-other/unknown, list scopes, list-all for admin, public grant/list/revoke |
| `EmbedViewResourceTest` | 7 | Query executes under owner scope, 401 with no guest, refuses wrong kind / wrong suffix; dashboard returns parsed JSON, missing → 404, refuses wrong kind. Asserts hardened headers on every reply |

**51 new tests, all green.** `saiku-web` total: 44 → 330 (floor bumped).

## Test plan

- [x] `mvn -B -ntp -pl saiku-core/saiku-web,saiku-webapp -am verify -DskipITs=false` clean
- [x] Spotless clean
- [ ] CI verifies on dev
- [ ] Smoke against the bundled FoodMart demo (mint a token for `Examples/Trend.saiku`, fetch `/query/Examples/Trend.saiku` with the header, confirm cellset JSON)

## What's NOT in this PR

- The `<saiku-embed>` Web Component itself (PR 2)
- npm publish + launcher static-assets wiring (PR 3)
- A "make public" toggle in the SvelteKit catalogue UI (follow-up to PR 3)
- Rate limiting on the embed read surface (existing `LoginRateLimiter` covers mint; read surface is unauthenticated when public so wants its own limit — opening as follow-up)

## Follow-up issues to file once this merges

- AI Query API as a third `resourceKind` (`embed:ai`) — user explicitly deferred this.