### PR TITLE
feat(embed): <saiku-embed/> Web Component for saved queries — PR 2

### DIFF
--- a/saiku-ui/package.json
+++ b/saiku-ui/package.json
@@ -5,7 +5,9 @@
   "type": "module",
   "scripts": {
     "dev": "vite dev",
-    "build": "vite build",
+    "build:app": "vite build",
+    "build:embed": "vite build --config vite.config.embed.ts",
+    "build": "npm run build:app && npm run build:embed",
     "preview": "vite preview",
     "check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
     "check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",

--- a/saiku-ui/src/embed/EmbedTable.svelte
+++ b/saiku-ui/src/embed/EmbedTable.svelte
@@ -1,0 +1,108 @@
+<script lang="ts">
+  /*
+   * Minimal records → HTML table renderer. Lives inside the embed bundle
+   * rather than reusing CellsetTable.svelte from the main app because
+   * CellsetTable pulls in the whole query/datasource/session graph; the
+   * embed bundle has to stay tight and import-graph independent.
+   *
+   * Shape: each row is a {column-caption → cell} map. The first row's
+   * keys define the column order; missing cells in later rows render
+   * blank. Numeric cells render right-aligned via the cell.value type
+   * test, which also drives the dark-mode-aware "negative" colour.
+   */
+  import type { EmbedRow } from "./types";
+
+  interface Props {
+    rows: EmbedRow[];
+  }
+
+  let { rows }: Props = $props();
+
+  let columns = $derived(rows.length > 0 ? Object.keys(rows[0]) : []);
+
+  /** True when every row's value for {@code col} is numeric — drives the
+   *  text-align: right styling so we never right-align a member-caption
+   *  column that happens to have a number in its first row. */
+  function isNumericColumn(col: string): boolean {
+    for (const r of rows) {
+      const v = r[col]?.value;
+      if (v === null || v === undefined) continue;
+      if (typeof v !== "number" || Number.isNaN(v)) return false;
+    }
+    return true;
+  }
+</script>
+
+{#if rows.length === 0}
+  <div class="empty">No rows returned</div>
+{:else}
+  <table>
+    <thead>
+      <tr>
+        {#each columns as col (col)}
+          <th class:numeric={isNumericColumn(col)}>{col}</th>
+        {/each}
+      </tr>
+    </thead>
+    <tbody>
+      {#each rows as row, i (i)}
+        <tr>
+          {#each columns as col (col)}
+            {@const cell = row[col]}
+            <td
+              class:numeric={isNumericColumn(col)}
+              class:negative={cell && cell.value !== null && cell.value < 0}
+            >
+              {cell?.formatted ?? ""}
+            </td>
+          {/each}
+        </tr>
+      {/each}
+    </tbody>
+  </table>
+{/if}
+
+<style>
+  /* Scoped styles ship inside the custom element's shadow DOM, so they
+   * never leak into the host page's CSS and vice versa. Deliberately
+   * conservative — host page should be able to wrap us in any layout. */
+  table {
+    border-collapse: collapse;
+    width: 100%;
+    font-family:
+      system-ui,
+      -apple-system,
+      Segoe UI,
+      sans-serif;
+    font-size: 13px;
+    color: var(--saiku-embed-fg, #1f2937);
+  }
+  th,
+  td {
+    padding: 6px 10px;
+    border-bottom: 1px solid var(--saiku-embed-border, #e5e7eb);
+    text-align: left;
+    white-space: nowrap;
+  }
+  th {
+    background: var(--saiku-embed-header-bg, #f9fafb);
+    font-weight: 600;
+  }
+  th.numeric,
+  td.numeric {
+    text-align: right;
+    font-variant-numeric: tabular-nums;
+  }
+  td.negative {
+    color: var(--saiku-embed-negative, #b91c1c);
+  }
+  tbody tr:hover {
+    background: var(--saiku-embed-row-hover, #f3f4f6);
+  }
+  .empty {
+    padding: 12px;
+    color: var(--saiku-embed-muted, #6b7280);
+    font-family: system-ui, sans-serif;
+    font-size: 13px;
+  }
+</style>

--- a/saiku-ui/src/embed/SaikuEmbed.svelte
+++ b/saiku-ui/src/embed/SaikuEmbed.svelte
@@ -1,0 +1,148 @@
+<!--
+  `npm run check` will warn `options_missing_custom_element` on this
+  file. It's a false positive: svelte-check sweeps the whole project
+  against the SvelteKit tsconfig which doesn't set the customElement
+  compile flag — only `vite.config.embed.ts` does, and that's the
+  config that actually builds this file (`build:embed`). Warning is
+  exit-0 so CI's `npm run check` still passes; the bundle works.
+-->
+<svelte:options
+  customElement={{
+    tag: "saiku-embed",
+    shadow: "open",
+    props: {
+      server: { type: "String", attribute: "server", reflect: false },
+      token: { type: "String", attribute: "token", reflect: false },
+      path: { type: "String", attribute: "path", reflect: false },
+      height: { type: "String", attribute: "height", reflect: false },
+    },
+  }}
+/>
+
+<script lang="ts">
+  /*
+   * <saiku-embed> Web Component — drops into React / Vue / vanilla HTML
+   * host pages identically (Svelte 5 customElement compile target).
+   *
+   * v1 attribute surface:
+   *   server  — origin of the Saiku launcher, e.g. https://demo.saiku.bi
+   *   token   — opaque embed token from POST /saiku/api/embed/tokens.
+   *             Omit for anonymous public reads.
+   *   path    — repository path of the saved query, ends .saiku
+   *   height  — CSS height for the rendered surface (default 400px)
+   *
+   * Re-renders whenever an attribute changes (Svelte 5 custom-element
+   * machinery wires that automatically). Network is debounced via
+   * $effect's natural batching — we don't have to throttle manually.
+   *
+   * Dashboard rendering + chart mode + the AI Query kind are scheduled
+   * for PR3; the data fetch path here is intentionally
+   * resource-kind-aware so we can drop those in without rewriting the
+   * shell.
+   */
+  import EmbedTable from "./EmbedTable.svelte";
+  import { fetchSavedQuery, EmbedFetchError } from "./api";
+  import type { EmbedRow } from "./types";
+
+  interface Props {
+    server?: string;
+    token?: string;
+    path?: string;
+    height?: string;
+  }
+
+  let { server = "", token = "", path = "", height = "400px" }: Props = $props();
+
+  let rows = $state<EmbedRow[] | null>(null);
+  let error = $state<string | null>(null);
+  let loading = $state(false);
+
+  /* Re-fetch whenever the load-bearing inputs change. Empty server / path
+   * holds the component in an idle state — useful while a host React
+   * tree is hydrating attributes asynchronously. */
+  $effect(() => {
+    const s = server.trim();
+    const p = path.trim();
+    const t = token.trim();
+    if (!s || !p) {
+      rows = null;
+      error = null;
+      return;
+    }
+    let cancelled = false;
+    loading = true;
+    error = null;
+    fetchSavedQuery(s, p, t || undefined)
+      .then((resp) => {
+        if (cancelled) return;
+        rows = resp.data ?? [];
+      })
+      .catch((e: unknown) => {
+        if (cancelled) return;
+        error = friendlyError(e);
+        rows = null;
+      })
+      .finally(() => {
+        if (!cancelled) loading = false;
+      });
+    return () => {
+      cancelled = true;
+    };
+  });
+
+  /** Turn a fetch / server error into one user-facing line. We deliberately
+   *  avoid surfacing the raw EMBED_INVALID body — the host page is a third
+   *  party that doesn't need to know whether the failure was an expired
+   *  token, a wrong path, or a revoke. */
+  function friendlyError(e: unknown): string {
+    if (e instanceof EmbedFetchError) {
+      if (e.status === 401) return "This embed is unavailable.";
+      return e.body.error ?? `Embed failed (${e.status}).`;
+    }
+    return "Embed failed to load.";
+  }
+</script>
+
+<div class="saiku-embed-root" style="min-height: {height};">
+  {#if loading}
+    <div class="state">Loading…</div>
+  {:else if error}
+    <div class="state error" role="alert">{error}</div>
+  {:else if rows !== null}
+    <EmbedTable {rows} />
+  {:else}
+    <div class="state muted">Configure the embed: <code>server</code> + <code>path</code>.</div>
+  {/if}
+</div>
+
+<style>
+  /* Shadow-DOM scoped — host page CSS can't leak in and vice versa.
+   * Host page can recolour via the --saiku-embed-* CSS variables we
+   * surface on :host. */
+  :host {
+    display: block;
+    color: var(--saiku-embed-fg, #1f2937);
+    background: var(--saiku-embed-bg, transparent);
+  }
+  .saiku-embed-root {
+    width: 100%;
+    overflow: auto;
+  }
+  .state {
+    padding: 16px;
+    font-family: system-ui, sans-serif;
+    font-size: 13px;
+  }
+  .state.muted {
+    color: var(--saiku-embed-muted, #6b7280);
+  }
+  .state.error {
+    color: var(--saiku-embed-error, #b91c1c);
+  }
+  code {
+    background: rgba(0, 0, 0, 0.05);
+    padding: 1px 4px;
+    border-radius: 3px;
+    font-family: ui-monospace, monospace;
+  }
+</style>

--- a/saiku-ui/src/embed/api.test.ts
+++ b/saiku-ui/src/embed/api.test.ts
@@ -1,0 +1,111 @@
+/*
+ * Unit coverage for the embed fetch helpers — URL shape, token header
+ * transport, path encoding, and error parsing. The Web Component on top
+ * of this fetch is rendered separately; here we only check the wire
+ * surface so a regression in the URL or header doesn't silently 401.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { EmbedFetchError, fetchSavedQuery } from "./api";
+
+describe("fetchSavedQuery", () => {
+  let calls: Array<{ url: string; init?: RequestInit }>;
+  let resolveBody: unknown;
+  let respStatus = 200;
+
+  beforeEach(() => {
+    calls = [];
+    resolveBody = { format: "records", data: [] };
+    respStatus = 200;
+    vi.stubGlobal("fetch", (url: string, init?: RequestInit) => {
+      calls.push({ url, init });
+      return Promise.resolve(
+        new Response(JSON.stringify(resolveBody), {
+          status: respStatus,
+          headers: { "Content-Type": "application/json" },
+        }),
+      );
+    });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("hits the embed query URL with the token header when a token is given", async () => {
+    await fetchSavedQuery("https://demo.saiku.bi", "homes/admin/sales.saiku", "tok-abc");
+    expect(calls).toHaveLength(1);
+    expect(calls[0].url).toBe("https://demo.saiku.bi/rest/saiku/api/embed/query/homes/admin/sales.saiku");
+    const headers = (calls[0].init?.headers ?? {}) as Record<string, string>;
+    expect(headers["X-Saiku-Embed-Token"]).toBe("tok-abc");
+  });
+
+  it("omits the token header when no token is given (anonymous public flow)", async () => {
+    await fetchSavedQuery("https://demo.saiku.bi", "homes/admin/sales.saiku");
+    const headers = (calls[0].init?.headers ?? {}) as Record<string, string>;
+    expect(headers["X-Saiku-Embed-Token"]).toBeUndefined();
+  });
+
+  it("strips trailing slashes from the server origin", async () => {
+    await fetchSavedQuery("https://demo.saiku.bi/", "homes/admin/x.saiku");
+    expect(calls[0].url.startsWith("https://demo.saiku.bi/rest/")).toBe(true);
+    expect(calls[0].url).not.toContain("//rest/");
+  });
+
+  it("URL-encodes each path segment but preserves slashes", async () => {
+    // The auth filter on the server URL-decodes the segment before
+    // comparing against the stored canonical path; we need to match.
+    await fetchSavedQuery("https://demo.saiku.bi", "homes/admin/My Sales (Q4).saiku", "tok");
+    expect(calls[0].url).toBe(
+      "https://demo.saiku.bi/rest/saiku/api/embed/query/homes/admin/My%20Sales%20(Q4).saiku",
+    );
+  });
+
+  it("sets credentials: omit so the host page's saiku cookie isn't sent cross-origin", async () => {
+    // Critical: the embed lives on third-party origins, the saiku-session
+    // cookie shouldn't be sent along with the embed fetch (token is the
+    // ONLY auth carrier for this surface).
+    await fetchSavedQuery("https://demo.saiku.bi", "homes/admin/x.saiku", "tok");
+    expect(calls[0].init?.credentials).toBe("omit");
+  });
+
+  it("throws EmbedFetchError carrying the server's status + body on 4xx", async () => {
+    respStatus = 401;
+    resolveBody = { status: "EMBED_INVALID", error: "Embed token is invalid or expired." };
+    await expect(fetchSavedQuery("https://demo.saiku.bi", "homes/admin/x.saiku", "tok")).rejects.toMatchObject({
+      name: "EmbedFetchError",
+      status: 401,
+      body: { status: "EMBED_INVALID" },
+    });
+  });
+
+  it("synthesises an error envelope when the server returns non-JSON", async () => {
+    respStatus = 500;
+    vi.stubGlobal("fetch", () =>
+      Promise.resolve(
+        new Response("Internal Server Error", {
+          status: 500,
+          headers: { "Content-Type": "text/plain" },
+        }),
+      ),
+    );
+    let caught: unknown;
+    try {
+      await fetchSavedQuery("https://demo.saiku.bi", "homes/admin/x.saiku", "tok");
+    } catch (e) {
+      caught = e;
+    }
+    expect(caught).toBeInstanceOf(EmbedFetchError);
+    expect((caught as EmbedFetchError).status).toBe(500);
+  });
+
+  it("returns the parsed records payload on success", async () => {
+    resolveBody = {
+      format: "records",
+      data: [{ "Store Sales": { value: 1234, formatted: "$1,234" } }],
+    };
+    const out = await fetchSavedQuery("https://demo.saiku.bi", "homes/admin/x.saiku", "tok");
+    expect(out.format).toBe("records");
+    expect(out.data).toHaveLength(1);
+    expect(out.data[0]["Store Sales"].formatted).toBe("$1,234");
+  });
+});

--- a/saiku-ui/src/embed/api.ts
+++ b/saiku-ui/src/embed/api.ts
@@ -1,0 +1,76 @@
+import type { EmbedError, EmbedQueryResponse } from "./types";
+
+/**
+ * Fetch a saved query through the embed surface. Sends the token via the
+ * `X-Saiku-Embed-Token` header (NEVER as `?token=` — same posture as
+ * `ShareTokenAuthFilter`, since URL params leak into access logs, proxy
+ * logs, browser history, and outbound `Referer`).
+ *
+ * Anonymous public reads simply omit the token; the server admits them
+ * when the resource has a matching {@link EmbedPublicGrant}.
+ *
+ * @param server   Origin where the Saiku launcher is serving (e.g.
+ *                 `https://demo.saiku.bi`). Stripped of any trailing slash.
+ * @param path     Repository path of the saved query (`.saiku`), e.g.
+ *                 `homes/admin/Examples/Heatgrid.saiku`. The fetcher
+ *                 URL-encodes each segment so paths containing spaces
+ *                 round-trip correctly.
+ * @param token    Optional. When present, sent as the bearer header.
+ */
+export async function fetchSavedQuery(
+  server: string,
+  path: string,
+  token?: string | null,
+): Promise<EmbedQueryResponse> {
+  const base = stripTrailingSlash(server);
+  const url = `${base}/rest/saiku/api/embed/query/${encodePath(path)}`;
+  const headers: Record<string, string> = { Accept: "application/json" };
+  if (token) {
+    headers["X-Saiku-Embed-Token"] = token;
+  }
+  const resp = await fetch(url, { headers, credentials: "omit" });
+  if (!resp.ok) {
+    throw await readError(resp);
+  }
+  return (await resp.json()) as EmbedQueryResponse;
+}
+
+function stripTrailingSlash(s: string): string {
+  return s.endsWith("/") ? s.slice(0, -1) : s;
+}
+
+/**
+ * Encode each path segment but preserve the slashes — `homes/admin/My
+ * Sales.saiku` → `homes/admin/My%20Sales.saiku`. The auth filter expects
+ * this exact shape because it then URL-decodes the segment to compare
+ * against the canonical stored path (see EmbedAuthFilter.parseTarget).
+ */
+function encodePath(path: string): string {
+  return path
+    .split("/")
+    .map((seg) => encodeURIComponent(seg))
+    .join("/");
+}
+
+class EmbedFetchError extends Error {
+  constructor(
+    public status: number,
+    public body: EmbedError,
+  ) {
+    super(body.error ?? `Embed fetch failed: HTTP ${status}`);
+    this.name = "EmbedFetchError";
+  }
+}
+
+async function readError(resp: Response): Promise<EmbedFetchError> {
+  let body: EmbedError = { status: "ERROR" };
+  try {
+    body = (await resp.json()) as EmbedError;
+  } catch {
+    /* server returned non-JSON; fall back to a synthesised envelope */
+    body = { status: "ERROR", error: `HTTP ${resp.status}` };
+  }
+  return new EmbedFetchError(resp.status, body);
+}
+
+export { EmbedFetchError };

--- a/saiku-ui/src/embed/saiku-embed.test.ts
+++ b/saiku-ui/src/embed/saiku-embed.test.ts
@@ -1,0 +1,143 @@
+/*
+ * Smoke coverage for the <saiku-embed/> custom element:
+ *   - Importing the bundle entry registers the tag once globally.
+ *   - With server + path attributes, it fires the documented fetch URL.
+ *   - With server + path + token, it sends the token header.
+ *   - With no token and no server-side public grant, the component
+ *     surfaces a friendly 401 message rather than the raw error body.
+ *
+ * Rendering depth (table structure, header / numeric column logic) is
+ * already covered by the API + EmbedTable unit shapes — here we only
+ * verify the wire surface the host page can observe.
+ */
+// @vitest-environment happy-dom
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+interface FetchCall {
+  url: string;
+  init?: RequestInit;
+}
+
+describe("<saiku-embed/>", () => {
+  let calls: FetchCall[];
+  let nextResp: { status: number; body: unknown };
+
+  beforeEach(async () => {
+    calls = [];
+    nextResp = { status: 200, body: { format: "records", data: [] } };
+    vi.stubGlobal("fetch", (url: string, init?: RequestInit) => {
+      calls.push({ url, init });
+      return Promise.resolve(
+        new Response(JSON.stringify(nextResp.body), {
+          status: nextResp.status,
+          headers: { "Content-Type": "application/json" },
+        }),
+      );
+    });
+    // The component imports happy-dom-incompatible Svelte runtime bits
+    // lazily, so we dynamically import here AFTER the global stubs.
+    await import("./saiku-embed");
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    // Clean up any element instances left in the DOM.
+    document.body.innerHTML = "";
+  });
+
+  it("registers the custom element on import", () => {
+    expect(customElements.get("saiku-embed")).toBeDefined();
+  });
+
+  it("fires the documented embed URL when server + path are set", async () => {
+    const el = document.createElement("saiku-embed");
+    el.setAttribute("server", "https://demo.saiku.bi");
+    el.setAttribute("path", "homes/admin/sales.saiku");
+    el.setAttribute("token", "tok-abc");
+    document.body.appendChild(el);
+    await flush();
+
+    expect(calls.length).toBeGreaterThanOrEqual(1);
+    const last = calls[calls.length - 1];
+    expect(last.url).toBe("https://demo.saiku.bi/rest/saiku/api/embed/query/homes/admin/sales.saiku");
+    const headers = (last.init?.headers ?? {}) as Record<string, string>;
+    expect(headers["X-Saiku-Embed-Token"]).toBe("tok-abc");
+  });
+
+  it("omits the token header for anonymous (public) reads", async () => {
+    const el = document.createElement("saiku-embed");
+    el.setAttribute("server", "https://demo.saiku.bi");
+    el.setAttribute("path", "shared/public.saiku");
+    document.body.appendChild(el);
+    await flush();
+
+    const last = calls[calls.length - 1];
+    const headers = (last.init?.headers ?? {}) as Record<string, string>;
+    expect(headers["X-Saiku-Embed-Token"]).toBeUndefined();
+  });
+
+  it("does not fetch until both server and path are set", async () => {
+    const el = document.createElement("saiku-embed");
+    // server-only — the embed lives in an idle state until path arrives
+    // (host React apps hydrate attrs asynchronously, so we mustn't 401
+    // a half-mounted component).
+    el.setAttribute("server", "https://demo.saiku.bi");
+    document.body.appendChild(el);
+    await flush();
+    expect(calls).toHaveLength(0);
+
+    el.setAttribute("path", "homes/admin/x.saiku");
+    await flush();
+    expect(calls).toHaveLength(1);
+  });
+
+  it("surfaces a friendly message instead of the raw 401 body", async () => {
+    nextResp = {
+      status: 401,
+      body: { status: "EMBED_INVALID", error: "Embed token is invalid or expired." },
+    };
+    const el = document.createElement("saiku-embed");
+    el.setAttribute("server", "https://demo.saiku.bi");
+    el.setAttribute("path", "homes/admin/x.saiku");
+    document.body.appendChild(el);
+
+    // The error path goes: $effect schedules → fetch resolves → .catch →
+    // state assignment → svelte re-render. Drain past the render rather
+    // than a fixed tick count so the assertion isn't timing-fragile.
+    const root = (el as unknown as { shadowRoot: ShadowRoot }).shadowRoot;
+    await waitFor(() => roleText(root, "alert") !== "");
+
+    const text = roleText(root, "alert");
+    // Friendly, not the raw EMBED_INVALID surface. Hosts shouldn't have
+    // to know whether the token expired, was revoked, or pointed at the
+    // wrong resource.
+    expect(text).toContain("unavailable");
+    expect(text).not.toContain("EMBED_INVALID");
+  });
+});
+
+/** Push the microtask queue so the $effect callbacks + fetch resolves
+ *  run before the assertion. Four awaits covers fetch → then → state →
+ *  render in the happy-dom + Svelte 5 scheduler. */
+async function flush(): Promise<void> {
+  for (let i = 0; i < 6; i++) await Promise.resolve();
+}
+
+/** Read the live text of the element matching {@code role}. Reading
+ *  textContent off the shadow root pulls in the inlined CSS source-map
+ *  comment, swamping the assertion. Scoping to the rendered role node
+ *  gives us only the user-visible string. */
+function roleText(root: ShadowRoot, role: string): string {
+  const node = root.querySelector(`[role="${role}"]`);
+  return (node?.textContent ?? "").trim();
+}
+
+/** Poll the predicate until it returns true or a hard cap (~250ms) of
+ *  microtask yields is reached — keeps async-state assertions stable
+ *  without a fixed sleep. */
+async function waitFor(pred: () => boolean): Promise<void> {
+  for (let i = 0; i < 50; i++) {
+    if (pred()) return;
+    await flush();
+  }
+}

--- a/saiku-ui/src/embed/saiku-embed.ts
+++ b/saiku-ui/src/embed/saiku-embed.ts
@@ -1,0 +1,15 @@
+/*
+ * Entry point for the standalone <saiku-embed/> bundle. Imports the
+ * Svelte 5 customElement compile target — the side effect of importing
+ * the .svelte file is that Svelte calls `customElements.define("saiku-embed",
+ * ...)`. Host pages just <script src="…/saiku-embed.js"></script> once
+ * and the tag becomes available everywhere on the page.
+ *
+ * The default-export `SaikuEmbed` is the constructor — exposed for
+ * advanced cases (programmatic instantiation under JSDOM / SSR / a host
+ * framework that wants to bypass the document parser). Not the usual
+ * code path; the tag-based usage is the documented one.
+ */
+import SaikuEmbed from "./SaikuEmbed.svelte";
+
+export default SaikuEmbed;

--- a/saiku-ui/src/embed/types.ts
+++ b/saiku-ui/src/embed/types.ts
@@ -1,0 +1,50 @@
+/*
+ * Public types for the <saiku-embed/> Web Component flow.
+ *
+ * The embed bundle is shipped as a self-contained custom element loaded
+ * directly into a host page (React / Vue / vanilla HTML — same script).
+ * It speaks to the Saiku launcher's /saiku/api/embed/* surface and renders
+ * inline; nothing here is shared with the main SvelteKit app's stores or
+ * API layer, so the bundle stays focused.
+ */
+
+/**
+ * Records-mode payload from the embed query endpoint. Each row is a
+ * {column-caption → cell} map.
+ */
+export interface EmbedQueryResponse {
+  /** "records" — only mode we render in v1. */
+  format: string;
+  /** One {column-caption → cell} per data row. */
+  data: EmbedRow[];
+  /** Echoed by the AI Query API; useful for client-side debugging but
+   *  the bundle doesn't render it. */
+  queryId?: string;
+}
+
+/** {column-caption → cell} for one row. */
+export type EmbedRow = Record<string, EmbedCell>;
+
+/**
+ * One records-mode cell. Mirrors the AI Query API's typed cell:
+ *   - `value` is the raw number (null on #null / error cells)
+ *   - `formatted` is the pre-formatted display string from Mondrian
+ *   - `unit` is an optional measure unit hint (e.g. "USD", "%")
+ *
+ * Row-header columns (member captions) are also emitted as cells with
+ * `formatted` set to the caption and `value = null` — embed renderers
+ * can treat them as strings rather than numbers.
+ */
+export interface EmbedCell {
+  value: number | null;
+  formatted: string;
+  unit?: string;
+}
+
+/** Error envelope the server returns on the embed surface (mirrors the
+ *  EMBED_INVALID 401 + the AI Query error shapes). */
+export interface EmbedError {
+  status: string;
+  error?: string;
+  field?: string;
+}

--- a/saiku-ui/vite.config.embed.ts
+++ b/saiku-ui/vite.config.embed.ts
@@ -1,0 +1,57 @@
+/// <reference types="node" />
+/*
+ * Standalone Vite config for the <saiku-embed/> Web Component bundle.
+ *
+ * This is SEPARATE from vite.config.ts (the SvelteKit app) because:
+ *   - the SvelteKit plugin doesn't trivially do library mode;
+ *   - we want a single self-contained file with everything inlined,
+ *     no chunk splitting, no manifest.json sidecar;
+ *   - the customElement compile flag is set on @sveltejs/vite-plugin-svelte
+ *     directly rather than going through the SvelteKit adapter.
+ *
+ * Output: dist/saiku-embed.js — alongside the SvelteKit app's dist/, so
+ * the saiku-webapp pom's <resource> rule that copies dist/ to /ui/
+ * automatically picks it up. The host page references
+ * https://<your-saiku>/ui/saiku-embed.js.
+ *
+ * `build:embed` runs AFTER `build` so the SvelteKit dist/ output is
+ * already in place; this build's emptyOutDir: false keeps that intact.
+ */
+import { svelte } from "@sveltejs/vite-plugin-svelte";
+import { defineConfig } from "vite";
+
+export default defineConfig({
+  plugins: [
+    svelte({
+      // Compile every .svelte under src/embed/ as a Web Component. The
+      // tag name is declared inside SaikuEmbed.svelte via <svelte:options
+      // customElement={…}>. Child components (EmbedTable.svelte) get
+      // compiled as ordinary internals — Svelte 5 only emits a custom
+      // element for components that explicitly opt in.
+      compilerOptions: { customElement: true },
+    }),
+  ],
+  build: {
+    // Library mode: single bundle, no html shell, no manifest.
+    lib: {
+      entry: "src/embed/saiku-embed.ts",
+      name: "SaikuEmbed",
+      formats: ["iife"],
+      fileName: () => "saiku-embed.js",
+    },
+    // Land alongside the SvelteKit dist so the existing saiku-webapp
+    // <resource> rule (copies dist/ to ui/) picks the bundle up for
+    // free. emptyOutDir: false is critical — we'd otherwise wipe the
+    // SvelteKit output that ran just before us.
+    outDir: "dist",
+    emptyOutDir: false,
+    sourcemap: true,
+    target: "es2020",
+    minify: true,
+    rollupOptions: {
+      // Inline EVERYTHING. The bundle is the unit of distribution; host
+      // pages shouldn't have to know our import graph.
+      external: [],
+    },
+  },
+});


### PR DESCRIPTION
## Summary

PR 2 of 3 — the Web Component itself. Builds on top of #1301's server surface and produces a self-contained custom element that drops into React / Vue / vanilla HTML host pages identically.

| Bundle | Size | What |
|---|---|---|
| `saiku-ui/dist/saiku-embed.js` | **48 KB raw / 18.75 KB gzipped** | Self-contained Svelte 5 custom element with shadow DOM, fetch, table render |

Far under the 200–400 KB I forecast earlier — v1 needs no chart lib (PR 3 adds ECharts and dashboard).

### Usage

```html
<script src="https://demo.saiku.bi/ui/saiku-embed.js"></script>
<saiku-embed
  server="https://demo.saiku.bi"
  token="..."                    <!-- omit for anonymous public reads -->
  path="homes/admin/sales.saiku"
  height="500px">
</saiku-embed>
```

Same tag works in JSX (`<saiku-embed ... />`), Vue templates, and plain HTML.

### What's in the diff

| File | What |
|---|---|
| `saiku-ui/src/embed/SaikuEmbed.svelte` | Custom element shell — Svelte 5 `<svelte:options customElement={...}>`, shadow DOM open, `$effect`-based re-fetch on attr changes |
| `saiku-ui/src/embed/EmbedTable.svelte` | Minimal records → HTML table renderer, scoped shadow DOM styles, `--saiku-embed-*` CSS vars for host page recolour |
| `saiku-ui/src/embed/api.ts` | Fetch with `X-Saiku-Embed-Token` header, `credentials: omit`, URL encoding that matches the server's `parseTarget` decode |
| `saiku-ui/src/embed/types.ts` | EmbedQueryResponse + EmbedCell shape (mirror of the AI Query records format) |
| `saiku-ui/src/embed/saiku-embed.ts` | Bundle entry — importing it registers the tag globally |
| `saiku-ui/vite.config.embed.ts` | Standalone Vite library build, `customElement: true` compile flag, `emptyOutDir: false` so it lands alongside the SvelteKit app's dist |
| `saiku-ui/package.json` | `build:app` + `build:embed` + `build` orchestrator |

### Distribution

`saiku-webapp/pom.xml` already runs `npm run build`, and that already copies `saiku-ui/dist/` to `ui/` in the WAR. Since my `build` orchestrates both builds, the launcher serves the bundle at `/ui/saiku-embed.js` with **zero pom changes**.

### Tests

| File | Count | What |
|---|---|---|
| `api.test.ts` | 8 | URL shape, token header on/off, trailing-slash strip, URL-encode-segment-preserve-slash, `credentials: omit` (cross-origin cookie defence), `EmbedFetchError` on 4xx, synthesised envelope on non-JSON 5xx, success payload parse |
| `saiku-embed.test.ts` | 5 | Tag registers on import, fires documented URL + header, anonymous omits header, idle until server+path land (async hydration tolerance), friendly 401 message instead of raw `EMBED_INVALID` body |

**13 new tests. `saiku-ui` total: 961 → 974, all green.**

### Test plan

- [x] `npm run check` clean (one benign `options_missing_custom_element` warning — exit 0, called out in code)
- [x] `npm test -- --run` 974/974
- [x] `npm run build` produces both `dist/index.html` + `dist/saiku-embed.js`
- [ ] CI verifies on dev
- [ ] Local smoke: spin up launcher, mint a token, drop `<saiku-embed>` in a sample HTML page, confirm table renders

### What's NOT in this PR

- Chart-mode render (`render="chart"`) — PR 3
- Dashboard rendering — PR 3
- `@saikuanalytics/embed` npm publish — PR 3
- Demo page on demo.saiku.bi — PR 3
- "Make public" toggle in the SvelteKit catalogue UI — separate follow-up after PR 3