### PR TITLE
chore(embed): rename npm scope to @concepttocloud/saiku-embed

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -256,13 +256,13 @@ jobs:
 
   npm-embed:
     # Publishes the <saiku-embed/> Web Component bundle to npm as
-    # @saikuanalytics/embed on every tag push. The bundle is also
+    # @concepttocloud/saiku-embed on every tag push. The bundle is also
     # served at /ui/saiku-embed.js from the launcher — the npm release
     # is the convenience path for React / Vue / SPA users who want to
     # `npm install` it. Best-effort: a failed publish (already-released
     # version on a re-run) skips silently rather than failing the
     # release.
-    name: Publish @saikuanalytics/embed to npm
+    name: Publish @concepttocloud/saiku-embed to npm
     if: github.event_name == 'push'
     runs-on: ubuntu-latest
     needs: [jar]

--- a/saiku-ui/embed-npm/package.template.json
+++ b/saiku-ui/embed-npm/package.template.json
@@ -1,5 +1,5 @@
 {
-  "name": "@saikuanalytics/embed",
+  "name": "@concepttocloud/saiku-embed",
   "version": "0.0.0-PLACEHOLDER",
   "description": "<saiku-embed> Web Component — drop a saved Saiku query or dashboard into any page.",
   "license": "Apache-2.0",
@@ -22,7 +22,7 @@
   "homepage": "https://github.com/spiculedata/saiku",
   "repository": {
     "type": "git",
-    "url": "https://github.com/spiculedata/saiku.git",
+    "url": "git+https://github.com/spiculedata/saiku.git",
     "directory": "saiku-ui/src/embed"
   },
   "bugs": {

--- a/saiku-ui/src/embed/README.md
+++ b/saiku-ui/src/embed/README.md
@@ -14,11 +14,11 @@ so the host page doesn't have to know anything about Saiku internals.
 Or via npm (for React / Vue / SPA projects that bundle their own JS):
 
 ```bash
-npm install @saikuanalytics/embed
+npm install @concepttocloud/saiku-embed
 ```
 
 ```ts
-import "@saikuanalytics/embed";
+import "@concepttocloud/saiku-embed";
 ```
 
 The import has the side effect of registering the `saiku-embed` tag


### PR DESCRIPTION
Quick rename of the published npm package — `@saikuanalytics` isn't a scope we own, `@concepttocloud` is. First manual publish (`@concepttocloud/saiku-embed@3.18.2`) verified the token + shape; release.yml's npm-embed job will pick this up automatically on the next tagged release.

## Test plan
- [x] `npm publish` succeeded manually (3.18.2 live on registry.npmjs.org)
- [x] `NPM_TOKEN` secret added to the repo
- [ ] CI verifies on dev
- [ ] Next tagged release fires the auto-publish path