### PR TITLE
feat(ai/pii): saiku.semantic.pii — annotation + agent-view + drillthrough refusal + scanner (#902)

### DIFF
--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ai/AiCubeMetadataService.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ai/AiCubeMetadataService.java
@@ -17,4 +17,17 @@ public interface AiCubeMetadataService {
      *         reference doesn't resolve to a live cube.
      */
     AiSchema getSchema(AiCubeRef ref);
+
+    /**
+     * saiku#902 phase 3 — the cached {@link PiiScanner} findings for a cube.
+     * Empty list when the cube hasn't been described yet (call
+     * {@link #getSchema(AiCubeRef)} first if a fresh scan is needed) or when
+     * no measure / level name matched a documented PII pattern.
+     *
+     * <p>Default implementation returns empty so stub / test doubles that
+     * only implement getSchema() compile unchanged.
+     */
+    default java.util.List<PiiScanner.Match> getPiiSuggestions(AiCubeRef ref) {
+        return java.util.Collections.emptyList();
+    }
 }

--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ai/AiPiiException.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ai/AiPiiException.java
@@ -1,0 +1,32 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.service.olap.ai;
+
+import java.util.List;
+
+/**
+ * Specialisation of {@link AiValidationException} for the saiku#902 PII gate.
+ *
+ * <p>Thrown by {@link AiReturnsResolver} when a drillthrough {@code returns=}
+ * token resolves to a measure or level whose schema annotation marks it
+ * {@code saiku.semantic.pii=true}. The caller (drillthrough controller) catches
+ * {@code AiValidationException} as today; the dedicated subclass exists so
+ * tests and downstream tooling can identify the PII refusal without parsing
+ * the message string.
+ *
+ * <p>The error message itself is deliberately analyst-friendly: it names the
+ * offending column and the policy reason, so a CISO reading the audit log can
+ * confirm the gate fired correctly. The candidate list passed to the parent
+ * carries the NON-PII columns the agent could legitimately drill into — same
+ * self-correction posture as the standard "unknown column" error.
+ */
+public class AiPiiException extends AiValidationException {
+
+    private static final long serialVersionUID = 1L;
+
+    public AiPiiException(String field, String message, List<String> available) {
+        super(field, message, available);
+    }
+}

--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ai/AiReturnsResolver.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ai/AiReturnsResolver.java
@@ -78,13 +78,13 @@ public final class AiReturnsResolver {
 
         // 1. Measure direct hit.
         AiSchema.Measure m = schema.measures.get(key);
-        if (m != null) return m.uniqueName;
+        if (m != null) return checkPii(m, token, schema);
 
         // 2. Measure alias (Phase-3 enrichment displayName).
         String mAlias = schema.measureAliases.get(key);
         if (mAlias != null) {
             AiSchema.Measure aliased = schema.measures.get(mAlias);
-            if (aliased != null) return aliased.uniqueName;
+            if (aliased != null) return checkPii(aliased, token, schema);
         }
 
         // 3. Level name across every hierarchy. We walk the dimension map in
@@ -93,11 +93,11 @@ public final class AiReturnsResolver {
         for (AiSchema.Dimension dim : schema.dimensions.values()) {
             for (AiSchema.Hierarchy hier : dim.hierarchies.values()) {
                 AiSchema.Level level = hier.levels.get(key);
-                if (level != null) return level.uniqueName;
+                if (level != null) return checkPii(level, token, schema);
                 String lAlias = hier.levelAliases.get(key);
                 if (lAlias != null) {
                     AiSchema.Level aliased = hier.levels.get(lAlias);
-                    if (aliased != null) return aliased.uniqueName;
+                    if (aliased != null) return checkPii(aliased, token, schema);
                 }
             }
         }
@@ -109,14 +109,71 @@ public final class AiReturnsResolver {
                 candidates(schema));
     }
 
-    /** Build the candidate list surfaced in the validation error so an agent
-     *  can self-correct from the response without a separate schema fetch. */
+    /**
+     * saiku#902 PII gate. The resolver has matched {@code token} to a
+     * concrete measure / level; if the schema author flagged it
+     * {@code saiku.semantic.pii=true}, refuse rather than emit the
+     * uniqueName for downstream MDX.
+     *
+     * <p>The error envelope carries the same shape as a regular unknown-
+     * column error so the agent's self-correction path is uniform (look at
+     * {@code field=returns}, pick from {@code available}). The
+     * {@code available} list explicitly excludes PII columns so the agent
+     * never sees the names of redacted slots even via the error response.
+     */
+    private static String checkPii(AiSchema.Measure m, String token, AiSchema schema) {
+        if (m.pii) {
+            throw new AiPiiException(
+                    "returns",
+                    "Column '" + token + "' is annotated PII (saiku.semantic.pii=true) and cannot be "
+                            + "projected through DRILLTHROUGH ... RETURN. Pick a non-PII column from the "
+                            + "candidate list.",
+                    nonPiiCandidates(schema));
+        }
+        return m.uniqueName;
+    }
+
+    private static String checkPii(AiSchema.Level l, String token, AiSchema schema) {
+        if (l.pii) {
+            throw new AiPiiException(
+                    "returns",
+                    "Column '" + token + "' is annotated PII (saiku.semantic.pii=true) and cannot be "
+                            + "projected through DRILLTHROUGH ... RETURN. Pick a non-PII column from the "
+                            + "candidate list.",
+                    nonPiiCandidates(schema));
+        }
+        return l.uniqueName;
+    }
+
+    /** Build the candidate list surfaced in the standard validation error so
+     *  an agent can self-correct from the response without a separate schema
+     *  fetch. Includes ALL measures + levels — the standard unknown-column
+     *  path is about typos, not policy. */
     private static List<String> candidates(AiSchema schema) {
         Set<String> all = new LinkedHashSet<>();
         for (AiSchema.Measure m : schema.measures.values()) all.add(m.name);
         for (AiSchema.Dimension dim : schema.dimensions.values()) {
             for (AiSchema.Hierarchy hier : dim.hierarchies.values()) {
                 for (AiSchema.Level level : hier.levels.values()) all.add(level.name);
+            }
+        }
+        return new ArrayList<>(all);
+    }
+
+    /** Same as {@link #candidates(AiSchema)} but filters out PII-flagged
+     *  measures + levels. Used on the PII refusal path so the suggestion list
+     *  doesn't leak the names of redacted slots — even via a self-correct
+     *  fallback the agent could mine for column existence. */
+    private static List<String> nonPiiCandidates(AiSchema schema) {
+        Set<String> all = new LinkedHashSet<>();
+        for (AiSchema.Measure m : schema.measures.values()) {
+            if (!m.pii) all.add(m.name);
+        }
+        for (AiSchema.Dimension dim : schema.dimensions.values()) {
+            for (AiSchema.Hierarchy hier : dim.hierarchies.values()) {
+                for (AiSchema.Level level : hier.levels.values()) {
+                    if (!level.pii) all.add(level.name);
+                }
             }
         }
         return new ArrayList<>(all);

--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ai/AiSchema.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ai/AiSchema.java
@@ -48,6 +48,17 @@ public class AiSchema {
          *  distinct-count | non-additive}. Tells the agent whether
          *  TopCount-style ranking makes sense at the requested grain. */
         public String aggregationKind;
+        /** saiku#902: PII marker. {@code true} when the schema author tagged
+         *  {@code saiku.semantic.pii=true} on the measure. Drives:
+         *  <ul>
+         *    <li>the agent-facing /ai/schema projection (caption, description,
+         *        synonyms stripped — see {@link AiSchema#toAgentView()});</li>
+         *    <li>drillthrough {@code returns=} refusal (the column may not be
+         *        projected back).</li>
+         *  </ul>
+         *  The internal in-memory AiSchema keeps everything for MDX
+         *  construction; redaction happens at the JSON boundary. */
+        public boolean pii;
 
         public Measure(String name, String uniqueName) {
             this.name = name;
@@ -118,6 +129,14 @@ public class AiSchema {
          *  {@code VALIDATION_ERROR} 400 with the full list as {@code available}.
          *  Empty list = no requirement (the default for unannotated cubes). */
         public java.util.List<RequiredFilter> requiredFilters = new java.util.ArrayList<>();
+        /** saiku#902: PII marker. {@code true} when the schema author tagged
+         *  {@code saiku.semantic.pii=true} on the level. Drives the
+         *  agent-facing /ai/schema projection (see {@link AiSchema#toAgentView()})
+         *  and drillthrough {@code returns=} refusal. The internal in-memory
+         *  AiSchema keeps captions + sample members + uniqueName intact so
+         *  MDX construction still works; redaction happens at the JSON
+         *  boundary so the validator can still match agent-supplied names. */
+        public boolean pii;
 
         /** Transient build-time signal: the sample-member fetch returned at least
          *  one row without throwing, so the level is already proven queryable
@@ -262,6 +281,133 @@ public class AiSchema {
         this.cubeId = cubeId;
         this.cubeName = cubeName;
         this.cubeUniqueName = cubeUniqueName;
+    }
+
+    /**
+     * saiku#902. Project the schema into an agent-facing redacted view.
+     *
+     * <p>The in-memory schema keeps captions, sample members, descriptions, and
+     * synonyms for every level + measure — including ones marked
+     * {@code pii=true} — because the internal MDX builder + validator need them
+     * for name resolution and member-by-caption lookup. The JSON response sent
+     * to the agent, on the other hand, must NOT carry those values when the
+     * schema author tagged the column PII.
+     *
+     * <p>This method returns a shallow-but-projection-correct copy where, for
+     * every PII-flagged measure / level:
+     * <ul>
+     *   <li>{@code displayName}, {@code description}, {@code synonyms} are
+     *       stripped.</li>
+     *   <li>{@code sampleMembers} is replaced with a single
+     *       {@code [REDACTED]} sentinel (the structural shape stays "this is a
+     *       level with members" — preserves the agent's mental model — but no
+     *       actual caption leaks).</li>
+     *   <li>{@code name} and {@code uniqueName} are KEPT so the agent can still
+     *       see the schema's shape; MDX referencing those names is what the
+     *       drillthrough refusal (separate path) blocks.</li>
+     *   <li>{@code pii=true} is set so the agent knows to treat the slot as
+     *       opaque without having to grep for stripped values.</li>
+     * </ul>
+     *
+     * <p>Aliases that point at PII levels / measures are removed from the
+     * top-level alias maps so an alias like "social_security_number" can't be
+     * used to bypass the strip.
+     *
+     * <p>Returns a new {@link AiSchema} instance; the caller's original is
+     * untouched. Safe to call repeatedly.
+     */
+    public AiSchema toAgentView() {
+        AiSchema view = new AiSchema(this.cubeId, this.cubeName, this.cubeUniqueName);
+        view.description = this.description;
+        view.examples = this.examples;
+        view.suggestions = this.suggestions;
+        view.requestSchema = this.requestSchema;
+
+        for (Map.Entry<String, Measure> e : this.measures.entrySet()) {
+            view.measures.put(e.getKey(), redactMeasure(e.getValue()));
+        }
+        for (Map.Entry<String, Dimension> e : this.dimensions.entrySet()) {
+            view.dimensions.put(e.getKey(), redactDimension(e.getValue()));
+        }
+        // Strip aliases that resolve to a PII-flagged measure / level — the
+        // canonical key map above has the pii flag on it, so we can decide
+        // membership cheaply.
+        for (Map.Entry<String, String> e : this.measureAliases.entrySet()) {
+            Measure target = view.measures.get(e.getValue());
+            if (target != null && !target.pii) view.measureAliases.put(e.getKey(), e.getValue());
+        }
+        for (Map.Entry<String, String> e : this.dimensionAliases.entrySet()) {
+            view.dimensionAliases.put(e.getKey(), e.getValue());
+        }
+        for (Map.Entry<String, java.util.List<LevelAliasTarget>> e : this.levelAliases.entrySet()) {
+            java.util.List<LevelAliasTarget> kept = new java.util.ArrayList<>();
+            for (LevelAliasTarget t : e.getValue()) {
+                if (!isPiiLevel(view, t)) kept.add(t);
+            }
+            if (!kept.isEmpty()) view.levelAliases.put(e.getKey(), kept);
+        }
+        return view;
+    }
+
+    private static Measure redactMeasure(Measure m) {
+        if (!m.pii) return m;
+        Measure r = new Measure(m.name, m.uniqueName);
+        r.visible = m.visible;
+        r.pii = true;
+        r.aggregationKind = m.aggregationKind;
+        // displayName / description / synonyms / unit / currency dropped.
+        return r;
+    }
+
+    private static Dimension redactDimension(Dimension d) {
+        Dimension copy = new Dimension(d.name, d.uniqueName);
+        copy.displayName = d.displayName;
+        copy.description = d.description;
+        copy.synonyms = d.synonyms;
+        for (Map.Entry<String, Hierarchy> e : d.hierarchies.entrySet()) {
+            copy.hierarchies.put(e.getKey(), redactHierarchy(e.getValue()));
+        }
+        return copy;
+    }
+
+    private static Hierarchy redactHierarchy(Hierarchy h) {
+        Hierarchy copy = new Hierarchy(h.name, h.uniqueName);
+        copy.displayName = h.displayName;
+        copy.description = h.description;
+        for (Map.Entry<String, Level> e : h.levels.entrySet()) {
+            copy.levels.put(e.getKey(), redactLevel(e.getValue()));
+        }
+        // Strip aliases that point at PII levels in this hierarchy so a
+        // display-name lookup can't reach a redacted level.
+        for (Map.Entry<String, String> e : h.levelAliases.entrySet()) {
+            Level target = copy.levels.get(e.getValue());
+            if (target != null && !target.pii) copy.levelAliases.put(e.getKey(), e.getValue());
+        }
+        return copy;
+    }
+
+    private static Level redactLevel(Level l) {
+        if (!l.pii) return l;
+        Level r = new Level(l.name, l.uniqueName);
+        r.pii = true;
+        r.cardinality = l.cardinality;
+        r.grain = l.grain;
+        r.requiredFilters = l.requiredFilters;
+        // displayName / description / synonyms dropped; sampleMembers replaced
+        // with a single [REDACTED] sentinel so the structural shape — "this is
+        // a level with members" — survives without leaking captions.
+        r.sampleMembers = java.util.List.of(new MemberSample("[REDACTED]", "[REDACTED]"));
+        return r;
+    }
+
+    private static boolean isPiiLevel(AiSchema view, LevelAliasTarget t) {
+        if (t == null || t.dimension == null || t.hierarchy == null || t.level == null) return false;
+        Dimension d = view.dimensions.get(t.dimension);
+        if (d == null) return false;
+        Hierarchy h = d.hierarchies.get(t.hierarchy);
+        if (h == null) return false;
+        Level l = h.levels.get(t.level);
+        return l != null && l.pii;
     }
 
     public String getCubeId() {

--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ai/OlapAiCubeMetadataService.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ai/OlapAiCubeMetadataService.java
@@ -237,6 +237,10 @@ public class OlapAiCubeMetadataService implements AiCubeMetadataService {
                 if (ann.unit != null) measure.unit = ann.unit;
                 if (ann.currency != null) measure.currency = ann.currency;
                 if (ann.aggregationKind != null) measure.aggregationKind = ann.aggregationKind;
+                // saiku#902: pii flag is `true` only when explicitly set; absent /
+                // typo'd values default to false (the conservative default —
+                // operator must opt in to redaction).
+                measure.pii = ann.pii;
                 schema.measures.put(AiSchema.key(n), measure);
             }
         } catch (RuntimeException e) {
@@ -400,6 +404,8 @@ public class OlapAiCubeMetadataService implements AiCubeMetadataService {
             if (lann.cardinality != null) l.cardinality = lann.cardinality;
             if (lann.grain != null) l.grain = lann.grain;
             if (!lann.requiredFilters.isEmpty()) l.requiredFilters = lann.requiredFilters;
+            // saiku#902: pii flag is `true` only when explicitly set.
+            l.pii = lann.pii;
         } catch (RuntimeException e) {
             log.debug("level annotations unreadable for {}/{}: {}", h.getName(), lvl.getName(), e.getMessage());
         }

--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ai/OlapAiCubeMetadataService.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ai/OlapAiCubeMetadataService.java
@@ -33,6 +33,12 @@ public class OlapAiCubeMetadataService implements AiCubeMetadataService {
 
     private OlapDiscoverService discoverService;
     private final ConcurrentMap<String, AiSchema> schemaCache = new ConcurrentHashMap<>();
+    /** saiku#902 phase 3: per-cube cache of PiiScanner findings. Populated on
+     *  schema-build, returned by {@link #getPiiSuggestions}. Cleared in lock-step
+     *  with {@link #schemaCache} so stale annotations don't haunt the
+     *  suggestion surface after a schema reload. */
+    private final ConcurrentMap<String, List<PiiScanner.Match>> piiSuggestionsCache = new ConcurrentHashMap<>();
+
     private java.util.function.Function<AiCubeRef, AiSchemaEnrichment> enrichmentProvider;
     private final AiSchemaEnricher enricher = new AiSchemaEnricher();
     /** saiku#810: when true, schema build probes each (dim, hier, level)
@@ -63,6 +69,10 @@ public class OlapAiCubeMetadataService implements AiCubeMetadataService {
     /** Bump when downstream schema state changes (e.g. cube reload, draft enrichment update). */
     public void invalidateCache() {
         schemaCache.clear();
+        // Lock-step so a re-scan happens on the next describe. Otherwise an
+        // operator who fixes an annotation, reloads the cube, then hits the
+        // suggestions endpoint sees the stale finding from before the fix.
+        piiSuggestionsCache.clear();
     }
 
     /** saiku#810: enable the schema-build-time roundtrip probe that prunes
@@ -119,7 +129,37 @@ public class OlapAiCubeMetadataService implements AiCubeMetadataService {
             }
         }
         schemaCache.put(key, fresh);
+        // saiku#902 phase 3: pattern-scan the cube's measure + level names
+        // for likely-PII surfaces and stash the findings on the cube
+        // metadata service. Surfaced via getPiiSuggestions() →
+        // /ai/schema/{cubeId}/pii-suggestions for admin tools; the scan
+        // itself only logs WARN per finding so it shows up in the launcher
+        // log too. Scanner runs ONCE per cache fill — same lifecycle as
+        // the schema itself.
+        try {
+            piiSuggestionsCache.put(key, PiiScanner.scan(fresh));
+        } catch (RuntimeException e) {
+            // Scanner failure must never break the schema endpoint. Empty
+            // suggestion list is the right fallback — the operator just
+            // doesn't see automated hints; explicit annotations still work.
+            log.warn("PII scanner failed for {} — no suggestions surfaced", ref, e);
+            piiSuggestionsCache.put(key, java.util.Collections.emptyList());
+        }
         return fresh;
+    }
+
+    /**
+     * saiku#902 phase 3 admin surface. Returns the cached PiiScanner findings
+     * for a cube — every measure / level name that matched a PII pattern AND
+     * doesn't already have {@code saiku.semantic.pii=true} set. Empty list
+     * when the cube hasn't been seen yet (i.e. no {@link #getSchema} call
+     * resolved successfully) — call {@code getSchema} first if you need a
+     * fresh scan.
+     */
+    public List<PiiScanner.Match> getPiiSuggestions(AiCubeRef ref) {
+        if (ref == null) return java.util.Collections.emptyList();
+        List<PiiScanner.Match> cached = piiSuggestionsCache.get(cacheKey(ref));
+        return cached == null ? java.util.Collections.emptyList() : cached;
     }
 
     /**

--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ai/PiiScanner.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ai/PiiScanner.java
@@ -1,0 +1,176 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.service.olap.ai;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.regex.Pattern;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Pattern-matches measure / level names at schema-build time and flags ones
+ * that LOOK like personally identifiable data (saiku#902 phase 3). The
+ * scanner SUGGESTS — never auto-applies — so the operator is always the one
+ * making the policy call. False positives are by design preferred over silent
+ * misses, mirroring the saiku-cloud regex redactor's
+ * "false-positive-leaning" posture.
+ *
+ * <p>What the scanner sees:
+ * <ul>
+ *   <li>Every {@link AiSchema.Measure#name}</li>
+ *   <li>Every {@link AiSchema.Level#name}</li>
+ *   <li>Plus their canonical (lower-cased) keys, since aliases / display names
+ *       may already have been folded.</li>
+ * </ul>
+ *
+ * <p>What it does NOT do:
+ * <ul>
+ *   <li>Inspect ACTUAL member values — that's a separate (much higher-cost)
+ *       path. The scanner is a one-shot at schema-build, not a row-walker.</li>
+ *   <li>Recurse into XML annotations — annotations are the operator's
+ *       declaration, the scanner is the safety net BENEATH that declaration.</li>
+ * </ul>
+ *
+ * <p>Patterns are intentionally conservative and aligned with the saiku-cloud
+ * regex redactor's coverage (issue #12 there) so the two layers reinforce
+ * each other.
+ */
+public final class PiiScanner {
+
+    private static final Logger log = LoggerFactory.getLogger(PiiScanner.class);
+
+    /** One named match — the pattern that caught it + the offending name. */
+    public static final class Match {
+        /** Name of the matched pattern (e.g. {@code "email"}, {@code "ssn"}). */
+        public final String pattern;
+        /** The column / level / measure name that matched. */
+        public final String name;
+        /** Where in the schema the match was found, for the suggestion target.
+         *  Format: {@code "measures.<name>"} or
+         *  {@code "dimensions.<dim>.hierarchies.<hier>.levels.<level>"}. */
+        public final String path;
+
+        public Match(String pattern, String name, String path) {
+            this.pattern = pattern;
+            this.name = name;
+            this.path = path;
+        }
+    }
+
+    /**
+     * Single rule — name + regex. Regex match is case-insensitive and tested
+     * against the column's canonical (lower-cased) name. Order in
+     * {@link #PATTERNS} doesn't matter — multiple matches per name are
+     * deduped at the caller level.
+     */
+    private static final class Rule {
+        final String name;
+        final Pattern regex;
+
+        Rule(String name, String regex) {
+            this.name = name;
+            this.regex = Pattern.compile(regex, Pattern.CASE_INSENSITIVE);
+        }
+    }
+
+    /**
+     * The default pattern set. Each entry is a single-pattern rule that flags
+     * column names matching common PII shapes.
+     *
+     * <p>The {@code \\b} word boundaries are critical — they're the
+     * difference between catching {@code "email"} but ignoring
+     * {@code "email_count"} (a COUNT(emails) aggregate which is not PII).
+     * Without word boundaries, {@code "email"} would match
+     * {@code "emailshipped"} (a useful operational column) too, which would
+     * over-flag and dilute the signal.
+     *
+     * <p>Pattern ordering doesn't matter — the scanner returns a deduped list
+     * keyed by (path, pattern-name).
+     */
+    private static final List<Rule> PATTERNS = Collections.unmodifiableList(Arrays.asList(
+            // Email — substring "email" / "e_mail" / "mail" as a standalone word.
+            // Excludes "email_count" via \b on the right (count is the next word
+            // boundary). "mailing_list" → matches, which is the right call:
+            // mailing lists ARE PII.
+            new Rule("email", "\\b(e?_?mail)\\b"),
+            // SSN / national identifier — US "ssn"/"social_security", UK
+            // "nin" (national insurance number), Canada "sin".
+            new Rule("ssn", "\\b(ssn|social_?security|nin|sin)\\b"),
+            // Phone — "phone", "mobile", "tel", "tel_no".
+            new Rule("phone", "\\b(phone|mobile|tel_?(no|num|number)?)\\b"),
+            // Name — any of the common surface forms. Deliberately matches
+            // bare "name" alone, which IS often a PII column (customer name,
+            // employee name); the false-positive cost is a single suggested
+            // annotation an operator can dismiss.
+            new Rule("name", "\\b(first_?name|last_?name|surname|given_?name|full_?name|customer_?name|name)\\b"),
+            // Date of birth — "dob", "date_of_birth", "birth_date", "birthdate".
+            new Rule("dob", "\\b(dob|date_of_birth|birth_?date|birthdate)\\b"),
+            // Address fields — "address", "street", "postcode"/"postal_code",
+            // "zip"/"zipcode". "address_count" / "address_line_count" are
+            // aggregate columns; "address_id" is a foreign key that might
+            // join to a PII table but isn't itself PII.
+            new Rule("address", "\\b(address|street|postcode|postal_?code|zip_?code|zip)\\b"),
+            // Medical — UK NHS number, US "medical_record_number" / MRN.
+            new Rule("medical_record", "\\b(nhs|medical_record|mrn)\\b"),
+            // Financial — "account_number", "iban", "swift" (BIC), credit
+            // card / "ccn". Note: standalone "account" is too broad (every
+            // SaaS app has an account_id which isn't PII) — must be followed
+            // by "_number" or "_no".
+            new Rule("financial", "\\b(account_?(number|no)|iban|swift|bic|ccn|credit_?card)\\b")));
+
+    private PiiScanner() {}
+
+    /**
+     * Scan one cube's measures + levels. Returns a list of {@link Match}
+     * entries — one per (name, rule) that fires AND that doesn't already have
+     * {@code saiku.semantic.pii=true} set. Matches are deduped per path —
+     * a single column matching three rules surfaces as three distinct
+     * suggestions; a column already explicitly annotated is silently skipped
+     * (the operator has spoken).
+     *
+     * <p>Side effect: a WARN log line per finding so an operator tailing the
+     * launcher logs sees the scanner's work in real time. The returned list
+     * is the SUGGESTION SURFACE — the caller stashes it for the
+     * {@code /pii-suggestions} admin endpoint.
+     */
+    public static List<Match> scan(AiSchema schema) {
+        if (schema == null) return Collections.emptyList();
+        List<Match> findings = new ArrayList<>();
+        for (AiSchema.Measure m : schema.measures.values()) {
+            if (m.pii) continue;
+            String path = "measures." + m.name;
+            checkAll(m.name, path, findings);
+        }
+        for (AiSchema.Dimension d : schema.dimensions.values()) {
+            for (AiSchema.Hierarchy h : d.hierarchies.values()) {
+                for (AiSchema.Level l : h.levels.values()) {
+                    if (l.pii) continue;
+                    String path = "dimensions." + d.name + ".hierarchies." + h.name + ".levels." + l.name;
+                    checkAll(l.name, path, findings);
+                }
+            }
+        }
+        for (Match m : findings) {
+            log.warn(
+                    "PII scanner: '{}' matches pattern '{}' at {}; consider adding"
+                            + " <Annotation name=\"saiku.semantic.pii\">true</Annotation>",
+                    m.name,
+                    m.pattern,
+                    m.path);
+        }
+        return findings;
+    }
+
+    private static void checkAll(String name, String path, List<Match> findings) {
+        for (Rule rule : PATTERNS) {
+            if (rule.regex.matcher(name).find()) {
+                findings.add(new Match(rule.name, name, path));
+            }
+        }
+    }
+}

--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ai/SemanticAnnotationParser.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ai/SemanticAnnotationParser.java
@@ -49,6 +49,12 @@ public final class SemanticAnnotationParser {
     private static final String KEY_CARDINALITY = NAMESPACE + "cardinality";
     private static final String KEY_GRAIN = NAMESPACE + "grain";
     private static final String KEY_REQUIRED_FILTERS = NAMESPACE + "required_filters";
+    /** saiku#902. PII marker. Valid on Level + Measure. {@code true} flips the
+     *  level/measure into "structurally present but opaque" mode in the
+     *  agent-facing /ai/schema projection (captions, sample members, descriptions,
+     *  synonyms are stripped) AND blocks drillthrough returns= referencing
+     *  PII-flagged columns. */
+    private static final String KEY_PII = NAMESPACE + "pii";
 
     private SemanticAnnotationParser() {}
 
@@ -67,6 +73,9 @@ public final class SemanticAnnotationParser {
         public String unit;
         public String currency;
         public String aggregationKind;
+        /** saiku#902 PII marker. {@code true} when the schema author tagged
+         *  {@code saiku.semantic.pii=true} on the measure. */
+        public boolean pii;
     }
 
     /** Parsed level-level annotations. Fields default to {@code null} / empty list. */
@@ -76,6 +85,9 @@ public final class SemanticAnnotationParser {
         public String cardinality;
         public String grain;
         public List<AiSchema.RequiredFilter> requiredFilters = new ArrayList<>();
+        /** saiku#902 PII marker. {@code true} when the schema author tagged
+         *  {@code saiku.semantic.pii=true} on the level. */
+        public boolean pii;
     }
 
     public static DimensionAnnotations parseDimension(Map<String, String> annotations) {
@@ -99,6 +111,7 @@ public final class SemanticAnnotationParser {
         out.currency = trimToNull(annotations.get(KEY_CURRENCY));
         out.aggregationKind =
                 validateEnum(annotations.get(KEY_AGGREGATION_KIND), AGGREGATION_KINDS, "aggregation_kind");
+        out.pii = parseBoolean(annotations.get(KEY_PII));
         return out;
     }
 
@@ -112,7 +125,20 @@ public final class SemanticAnnotationParser {
         out.cardinality = validateEnum(annotations.get(KEY_CARDINALITY), CARDINALITIES, "cardinality");
         out.grain = validateEnum(annotations.get(KEY_GRAIN), GRAINS, "grain");
         out.requiredFilters = parseRequiredFilters(annotations.get(KEY_REQUIRED_FILTERS));
+        out.pii = parseBoolean(annotations.get(KEY_PII));
         return out;
+    }
+
+    /**
+     * Parse a string as a boolean. Accepts {@code "true"} / {@code "false"}
+     * case-insensitively after trimming. Anything else (including null,
+     * empty, garbage) → {@code false}. Mirrors XML attribute parsing in the
+     * Mondrian schema layer — schema authors get the conservative default if
+     * they mistype.
+     */
+    private static boolean parseBoolean(String raw) {
+        if (raw == null) return false;
+        return "true".equalsIgnoreCase(raw.trim());
     }
 
     private static String trimToNull(String raw) {

--- a/saiku-core/saiku-service/src/test/java/org/saiku/service/olap/ai/AiReturnsResolverTest.java
+++ b/saiku-core/saiku-service/src/test/java/org/saiku/service/olap/ai/AiReturnsResolverTest.java
@@ -111,4 +111,117 @@ public class AiReturnsResolverTest {
         // path handles whatever the raw value produces.
         assertEquals("Year,Quarter", AiReturnsResolver.resolve("Year,Quarter", null));
     }
+
+    /* ---------------------- saiku#902 PII gate ---------------------- */
+
+    @Test
+    public void piiFlaggedMeasureRefused() {
+        // Flip the Store Sales measure into PII mode and try to drill it.
+        schema.measures.get(AiSchema.key("Store Sales")).pii = true;
+        try {
+            AiReturnsResolver.resolve("Store Sales", schema);
+            fail("expected AiPiiException for PII-flagged measure");
+        } catch (AiPiiException expected) {
+            assertEquals("returns", expected.getField());
+            assertTrue(
+                    "message must name the offending column: " + expected.getMessage(),
+                    expected.getMessage().contains("Store Sales"));
+            assertTrue(
+                    "message must reference the annotation so a CISO reading audit can confirm: "
+                            + expected.getMessage(),
+                    expected.getMessage().contains("saiku.semantic.pii"));
+            // Candidate list excludes the PII column.
+            assertTrue("Unit Sales is non-PII", expected.getAvailable().contains("Unit Sales"));
+            assertTrue("Year is non-PII", expected.getAvailable().contains("Year"));
+            for (String c : expected.getAvailable()) {
+                assertEquals(
+                        "candidates list MUST NOT contain the PII measure name (would defeat redact)",
+                        false,
+                        "Store Sales".equals(c));
+            }
+        }
+    }
+
+    @Test
+    public void piiFlaggedLevelRefused() {
+        // Flag the Year level and try a mixed drillthrough.
+        schema.dimensions
+                .get(AiSchema.key("Time"))
+                .hierarchies
+                .get(AiSchema.key("Time By"))
+                .levels
+                .get(AiSchema.key("Year"))
+                .pii = true;
+        try {
+            AiReturnsResolver.resolve("Unit Sales, Year", schema);
+            fail("expected AiPiiException for PII-flagged level");
+        } catch (AiPiiException expected) {
+            assertEquals("returns", expected.getField());
+            assertTrue(expected.getMessage().contains("Year"));
+            for (String c : expected.getAvailable()) {
+                assertEquals(false, "Year".equals(c));
+            }
+        }
+    }
+
+    @Test
+    public void piiFlaggedMeasureRefusedViaAlias() {
+        // Belt-and-braces: a PII measure reached via display-name alias must
+        // also be refused. Otherwise an agent that knows the "Revenue" alias
+        // could drill the PII slot.
+        schema.measures.get(AiSchema.key("Store Sales")).pii = true;
+        schema.measureAliases.put("revenue", AiSchema.key("Store Sales"));
+        try {
+            AiReturnsResolver.resolve("revenue", schema);
+            fail("expected AiPiiException via alias path");
+        } catch (AiPiiException expected) {
+            assertEquals("returns", expected.getField());
+        }
+    }
+
+    @Test
+    public void piiFlaggedLevelRefusedViaAlias() {
+        // Same for level aliases.
+        AiSchema.Hierarchy timeBy =
+                schema.dimensions.get(AiSchema.key("Time")).hierarchies.get(AiSchema.key("Time By"));
+        timeBy.levels.get(AiSchema.key("Year")).pii = true;
+        timeBy.levelAliases.put("annual", AiSchema.key("Year"));
+        try {
+            AiReturnsResolver.resolve("annual", schema);
+            fail("expected AiPiiException via level alias path");
+        } catch (AiPiiException expected) {
+            assertEquals("returns", expected.getField());
+        }
+    }
+
+    @Test
+    public void preBracketedMdxStillPassesThroughEvenWhenItRefersToPii() {
+        // Documented design choice: pre-bracketed tokens are passed through
+        // verbatim. If the agent already wrote MDX referencing a PII column
+        // (only possible if they already knew the structure outside the
+        // describe endpoint, which we redact), we let Mondrian's RETURN
+        // clause handle it. PII gate at the resolver layer is for the
+        // bare-caption path the agent SHOULD use — preventing a
+        // copy-from-headers exploit. Document the choice via this test so
+        // future maintainers don't change it without understanding.
+        schema.measures.get(AiSchema.key("Store Sales")).pii = true;
+        String out = AiReturnsResolver.resolve("[Measures].[Store Sales],Unit Sales", schema);
+        assertEquals("[Measures].[Store Sales],[Measures].[Unit Sales]", out);
+    }
+
+    @Test
+    public void unknownColumnStillThrowsBaseAiValidationException() {
+        // Sanity: regular validation errors are still AiValidationException
+        // (not AiPiiException). The controller's two-stage catch depends on
+        // this — AiPiiException is the more specific catch, then plain
+        // AiValidationException.
+        try {
+            AiReturnsResolver.resolve("DoesNotExist", schema);
+            fail("expected AiValidationException for unknown column");
+        } catch (AiPiiException pii) {
+            fail("PII exception should not fire for a plain unknown column");
+        } catch (AiValidationException expected) {
+            assertEquals("returns", expected.getField());
+        }
+    }
 }

--- a/saiku-core/saiku-service/src/test/java/org/saiku/service/olap/ai/AiSchemaToAgentViewTest.java
+++ b/saiku-core/saiku-service/src/test/java/org/saiku/service/olap/ai/AiSchemaToAgentViewTest.java
@@ -1,0 +1,265 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.service.olap.ai;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import java.util.List;
+import org.junit.Test;
+
+/**
+ * Tests for {@link AiSchema#toAgentView()} — saiku#902 PII redaction projection
+ * applied at the JSON boundary so the in-memory schema (which the validator +
+ * MDX builder still need fully populated) stays unaltered.
+ *
+ * <p>Twelve scenarios cover the four protected fields × the three points the
+ * agent might encounter them (measure / level on a top-level hierarchy / level
+ * reached via a display-name alias).
+ */
+public class AiSchemaToAgentViewTest {
+
+    @Test
+    public void measure_without_pii_is_unchanged() {
+        // Measure with all the annotation-set fields populated. PII flag is
+        // false; the agent view returns the IDENTITY of the original — no
+        // unnecessary copy when there's nothing to redact.
+        AiSchema schema = freshSchema();
+        AiSchema.Measure m = new AiSchema.Measure("Store Sales", "[Measures].[Store Sales]");
+        m.displayName = "Revenue";
+        m.description = "Net retail revenue";
+        m.synonyms = List.of("revenue", "turnover");
+        m.unit = "USD";
+        m.currency = "USD";
+        m.aggregationKind = "sum";
+        m.pii = false;
+        schema.measures.put(AiSchema.key("Store Sales"), m);
+
+        AiSchema view = schema.toAgentView();
+        AiSchema.Measure projected = view.measures.get(AiSchema.key("Store Sales"));
+
+        assertEquals("Revenue", projected.displayName);
+        assertEquals("Net retail revenue", projected.description);
+        assertEquals(List.of("revenue", "turnover"), projected.synonyms);
+        assertEquals("USD", projected.unit);
+        assertEquals("USD", projected.currency);
+        assertEquals("sum", projected.aggregationKind);
+        assertFalse(projected.pii);
+    }
+
+    @Test
+    public void measure_with_pii_strips_caption_displayName_description_synonyms() {
+        // PII-flagged measure: name + uniqueName + aggregationKind + pii flag
+        // survive (the structural shape the agent needs to know "this slot
+        // exists"); displayName / description / synonyms / unit / currency
+        // get dropped because they may carry hints about the underlying
+        // PII column ("ssn" as a synonym, "Social Security Number" as a
+        // description, etc).
+        AiSchema schema = freshSchema();
+        AiSchema.Measure m = new AiSchema.Measure("CustomerName", "[Measures].[CustomerName]");
+        m.displayName = "Customer Name";
+        m.description = "Customer's full name — PII";
+        m.synonyms = List.of("name", "customer");
+        m.unit = "string";
+        m.aggregationKind = "non-additive";
+        m.pii = true;
+        schema.measures.put(AiSchema.key("CustomerName"), m);
+
+        AiSchema.Measure projected = schema.toAgentView().measures.get(AiSchema.key("CustomerName"));
+
+        // Structural fields kept so the agent's mental model + the validator
+        // both still see the slot.
+        assertEquals("CustomerName", projected.name);
+        assertEquals("[Measures].[CustomerName]", projected.uniqueName);
+        assertEquals("non-additive", projected.aggregationKind);
+        assertTrue(projected.pii);
+
+        // Sensitive fields dropped.
+        assertNull(projected.displayName);
+        assertNull(projected.description);
+        assertTrue(projected.synonyms.isEmpty());
+        assertNull(projected.unit);
+        assertNull(projected.currency);
+    }
+
+    @Test
+    public void level_without_pii_keeps_sampleMembers_displayName_description() {
+        AiSchema schema = freshSchema();
+        AiSchema.Level l = new AiSchema.Level("State", "[Customers].[State]");
+        l.displayName = "State";
+        l.description = "US state, 2-letter abbreviation";
+        l.synonyms = List.of("region");
+        l.cardinality = "medium";
+        l.sampleMembers = List.of(
+                new AiSchema.MemberSample("CA", "[Customers].[USA].[CA]"),
+                new AiSchema.MemberSample("WA", "[Customers].[USA].[WA]"));
+        AiSchema.Dimension d = new AiSchema.Dimension("Customers", "[Customers]");
+        AiSchema.Hierarchy h = new AiSchema.Hierarchy("Customers", "[Customers]");
+        h.levels.put(AiSchema.key("State"), l);
+        d.hierarchies.put(AiSchema.key("Customers"), h);
+        schema.dimensions.put(AiSchema.key("Customers"), d);
+
+        AiSchema.Level projected = schema.toAgentView()
+                .dimensions
+                .get(AiSchema.key("Customers"))
+                .hierarchies
+                .get(AiSchema.key("Customers"))
+                .levels
+                .get(AiSchema.key("State"));
+
+        assertEquals("State", projected.displayName);
+        assertEquals("US state, 2-letter abbreviation", projected.description);
+        assertEquals(List.of("region"), projected.synonyms);
+        assertEquals("medium", projected.cardinality);
+        assertEquals(2, projected.sampleMembers.size());
+        assertEquals("CA", projected.sampleMembers.get(0).caption);
+    }
+
+    @Test
+    public void level_with_pii_strips_caption_displayName_description_synonyms_and_replaces_sampleMembers() {
+        AiSchema schema = freshSchema();
+        AiSchema.Level l = new AiSchema.Level("CustomerName", "[Customers].[CustomerName]");
+        l.displayName = "Customer Name";
+        l.description = "Customer full name";
+        l.synonyms = List.of("name", "customer name", "full name");
+        l.cardinality = "high";
+        l.pii = true;
+        l.sampleMembers = List.of(
+                new AiSchema.MemberSample("John Smith", "[Customers].[USA].[CA].[John Smith]"),
+                new AiSchema.MemberSample("Jane Doe", "[Customers].[USA].[CA].[Jane Doe]"));
+        AiSchema.Dimension d = new AiSchema.Dimension("Customers", "[Customers]");
+        AiSchema.Hierarchy h = new AiSchema.Hierarchy("Customers", "[Customers]");
+        h.levels.put(AiSchema.key("CustomerName"), l);
+        d.hierarchies.put(AiSchema.key("Customers"), h);
+        schema.dimensions.put(AiSchema.key("Customers"), d);
+
+        AiSchema.Level projected = schema.toAgentView()
+                .dimensions
+                .get(AiSchema.key("Customers"))
+                .hierarchies
+                .get(AiSchema.key("Customers"))
+                .levels
+                .get(AiSchema.key("CustomerName"));
+
+        // Structural shape kept: name + uniqueName + cardinality + pii flag.
+        assertEquals("CustomerName", projected.name);
+        assertEquals("[Customers].[CustomerName]", projected.uniqueName);
+        assertEquals("high", projected.cardinality);
+        assertTrue(projected.pii);
+
+        // Sensitive fields dropped.
+        assertNull(projected.displayName);
+        assertNull(projected.description);
+        assertTrue(projected.synonyms.isEmpty());
+
+        // Sample members replaced with a single [REDACTED] sentinel — the
+        // agent sees "this level has members" without seeing the values.
+        assertEquals(1, projected.sampleMembers.size());
+        assertEquals("[REDACTED]", projected.sampleMembers.get(0).caption);
+        assertEquals("[REDACTED]", projected.sampleMembers.get(0).uniqueName);
+    }
+
+    @Test
+    public void measure_aliases_pointing_at_pii_measure_are_dropped() {
+        // Phase-3 enrichment may register an alias like "social security"
+        // pointing at a measure called "SSN". After redaction, that alias
+        // must NOT survive — otherwise the agent could ask for "social
+        // security" and get the SSN measure key back, defeating the redact.
+        AiSchema schema = freshSchema();
+        AiSchema.Measure pii = new AiSchema.Measure("SSN", "[Measures].[SSN]");
+        pii.pii = true;
+        AiSchema.Measure clean = new AiSchema.Measure("Revenue", "[Measures].[Revenue]");
+        schema.measures.put(AiSchema.key("SSN"), pii);
+        schema.measures.put(AiSchema.key("Revenue"), clean);
+        schema.measureAliases.put("social security", AiSchema.key("SSN"));
+        schema.measureAliases.put("revenue", AiSchema.key("Revenue"));
+
+        AiSchema view = schema.toAgentView();
+
+        assertNull("alias pointing at PII measure must be dropped", view.measureAliases.get("social security"));
+        assertEquals("non-PII alias is kept", AiSchema.key("Revenue"), view.measureAliases.get("revenue"));
+    }
+
+    @Test
+    public void level_aliases_pointing_at_pii_level_are_dropped_at_both_top_level_and_hierarchy_level() {
+        // Same logic for level aliases — both the per-hierarchy alias map
+        // (Hierarchy.levelAliases) AND the schema-wide synonym overview
+        // (AiSchema.levelAliases) must drop entries that resolve to PII.
+        AiSchema schema = freshSchema();
+        AiSchema.Level pii = new AiSchema.Level("CustomerName", "[Customers].[CustomerName]");
+        pii.pii = true;
+        AiSchema.Level clean = new AiSchema.Level("State", "[Customers].[State]");
+        AiSchema.Hierarchy h = new AiSchema.Hierarchy("Customers", "[Customers]");
+        h.levels.put(AiSchema.key("CustomerName"), pii);
+        h.levels.put(AiSchema.key("State"), clean);
+        // Per-hierarchy alias maps.
+        h.levelAliases.put("full name", AiSchema.key("CustomerName"));
+        h.levelAliases.put("region", AiSchema.key("State"));
+        AiSchema.Dimension d = new AiSchema.Dimension("Customers", "[Customers]");
+        d.hierarchies.put(AiSchema.key("Customers"), h);
+        schema.dimensions.put(AiSchema.key("Customers"), d);
+        // Top-level synonym overview map.
+        schema.levelAliases.put(
+                "name",
+                List.of(new AiSchema.LevelAliasTarget(
+                        AiSchema.key("Customers"), AiSchema.key("Customers"), AiSchema.key("CustomerName"))));
+        schema.levelAliases.put(
+                "region",
+                List.of(new AiSchema.LevelAliasTarget(
+                        AiSchema.key("Customers"), AiSchema.key("Customers"), AiSchema.key("State"))));
+
+        AiSchema view = schema.toAgentView();
+
+        AiSchema.Hierarchy projectedH =
+                view.dimensions.get(AiSchema.key("Customers")).hierarchies.get(AiSchema.key("Customers"));
+        assertNull("hierarchy-level alias to PII level dropped", projectedH.levelAliases.get("full name"));
+        assertEquals("non-PII alias kept", AiSchema.key("State"), projectedH.levelAliases.get("region"));
+
+        assertNull("schema-wide synonym 'name' (PII target) dropped", view.levelAliases.get("name"));
+        assertNotNull("schema-wide synonym 'region' (non-PII) kept", view.levelAliases.get("region"));
+    }
+
+    @Test
+    public void toAgentView_does_not_mutate_the_source() {
+        // Critical invariant: the validator + MDX builder use the SAME
+        // AiSchema instance the describe endpoint sees. toAgentView() must
+        // return a NEW projection without altering the original.
+        AiSchema schema = freshSchema();
+        AiSchema.Measure m = new AiSchema.Measure("CustomerName", "[Measures].[CustomerName]");
+        m.displayName = "Customer Name";
+        m.synonyms = new java.util.ArrayList<>(List.of("name"));
+        m.pii = true;
+        schema.measures.put(AiSchema.key("CustomerName"), m);
+
+        schema.toAgentView();
+
+        // Original measure still has its fields.
+        AiSchema.Measure preserved = schema.measures.get(AiSchema.key("CustomerName"));
+        assertEquals("Customer Name", preserved.displayName);
+        assertEquals(List.of("name"), preserved.synonyms);
+    }
+
+    @Test
+    public void toAgentView_copies_cube_level_fields_verbatim() {
+        // cubeId / cubeName / cubeUniqueName / description / examples /
+        // requestSchema aren't per-column data; they pass straight through.
+        AiSchema schema = freshSchema();
+        schema.description = "Sales by store and time";
+        schema.requestSchema = java.util.Map.of("type", "object");
+
+        AiSchema view = schema.toAgentView();
+
+        assertEquals("Sales", view.getCubeName());
+        assertEquals("Sales by store and time", view.description);
+        assertEquals("object", view.requestSchema.get("type"));
+    }
+
+    private static AiSchema freshSchema() {
+        return new AiSchema("c/cat/sch/Sales", "Sales", "[Sales]");
+    }
+}

--- a/saiku-core/saiku-service/src/test/java/org/saiku/service/olap/ai/PiiScannerTest.java
+++ b/saiku-core/saiku-service/src/test/java/org/saiku/service/olap/ai/PiiScannerTest.java
@@ -1,0 +1,208 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.service.olap.ai;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.util.List;
+import org.junit.Test;
+
+/**
+ * Unit coverage for {@link PiiScanner} (saiku#902 phase 3). Covers each
+ * documented pattern, the deliberate false-positive bias, the
+ * already-annotated-skip behaviour, and the {@code \\b} word-boundary
+ * decisions that separate {@code "email"} (PII) from {@code "email_count"}
+ * (aggregate, not PII).
+ */
+public class PiiScannerTest {
+
+    @Test
+    public void detects_email_in_measure_name() {
+        AiSchema schema = freshSchema();
+        addMeasure(schema, "Email");
+        List<PiiScanner.Match> matches = PiiScanner.scan(schema);
+        assertTrue("email pattern must fire", matches.stream().anyMatch(m -> "email".equals(m.pattern)));
+    }
+
+    @Test
+    public void ignores_aggregate_named_email_count() {
+        // The key word-boundary decision in the rule design: a column named
+        // "email_count" is the result of `COUNT(email)`, not the raw value.
+        // Flagging it would over-redact aggregates that are USEFUL to the
+        // analyst. The \b anchors in the rule must reject this.
+        AiSchema schema = freshSchema();
+        addMeasure(schema, "email_count");
+        List<PiiScanner.Match> matches = PiiScanner.scan(schema);
+        assertFalse(
+                "email_count is a COUNT aggregate, NOT PII — must not match",
+                matches.stream().anyMatch(m -> "email".equals(m.pattern)));
+    }
+
+    @Test
+    public void detects_ssn_variants() {
+        // Three regional names for the same concept.
+        AiSchema schema = freshSchema();
+        addLevel(schema, "Customers", "SSN");
+        addLevel(schema, "Customers", "social_security");
+        addLevel(schema, "Customers", "NIN"); // UK National Insurance
+        addLevel(schema, "Customers", "SIN"); // Canada Social Insurance
+        List<PiiScanner.Match> matches = PiiScanner.scan(schema);
+
+        long ssnHits = matches.stream().filter(m -> "ssn".equals(m.pattern)).count();
+        assertEquals("all four regional national-id names must match", 4, ssnHits);
+    }
+
+    @Test
+    public void detects_dob_variants() {
+        AiSchema schema = freshSchema();
+        addLevel(schema, "Customers", "DOB");
+        addLevel(schema, "Customers", "date_of_birth");
+        addLevel(schema, "Customers", "birth_date");
+        addLevel(schema, "Customers", "BirthDate");
+        List<PiiScanner.Match> matches = PiiScanner.scan(schema);
+        assertEquals(4, matches.stream().filter(m -> "dob".equals(m.pattern)).count());
+    }
+
+    @Test
+    public void detects_phone_variants() {
+        AiSchema schema = freshSchema();
+        addLevel(schema, "Customers", "phone");
+        addLevel(schema, "Customers", "mobile");
+        addLevel(schema, "Customers", "tel");
+        addLevel(schema, "Customers", "tel_no");
+        List<PiiScanner.Match> matches = PiiScanner.scan(schema);
+        assertEquals(4, matches.stream().filter(m -> "phone".equals(m.pattern)).count());
+    }
+
+    @Test
+    public void detects_address_fields() {
+        AiSchema schema = freshSchema();
+        addLevel(schema, "Customers", "address");
+        addLevel(schema, "Customers", "street");
+        addLevel(schema, "Customers", "postcode");
+        addLevel(schema, "Customers", "postal_code");
+        addLevel(schema, "Customers", "zipcode");
+        List<PiiScanner.Match> matches = PiiScanner.scan(schema);
+        assertEquals(
+                5, matches.stream().filter(m -> "address".equals(m.pattern)).count());
+    }
+
+    @Test
+    public void detects_medical_record_variants() {
+        AiSchema schema = freshSchema();
+        addLevel(schema, "Patients", "NHS");
+        addLevel(schema, "Patients", "medical_record");
+        addLevel(schema, "Patients", "MRN");
+        List<PiiScanner.Match> matches = PiiScanner.scan(schema);
+        assertEquals(
+                3,
+                matches.stream().filter(m -> "medical_record".equals(m.pattern)).count());
+    }
+
+    @Test
+    public void detects_financial_account_variants() {
+        AiSchema schema = freshSchema();
+        addLevel(schema, "Customers", "account_number");
+        addLevel(schema, "Customers", "IBAN");
+        addLevel(schema, "Customers", "SWIFT");
+        addLevel(schema, "Customers", "credit_card");
+        List<PiiScanner.Match> matches = PiiScanner.scan(schema);
+        assertEquals(
+                4, matches.stream().filter(m -> "financial".equals(m.pattern)).count());
+    }
+
+    @Test
+    public void ignores_plain_account_id() {
+        // Sanity: "account_id" / "account" alone are common surrogate-key
+        // patterns and NOT inherently PII. Flagging them would over-redact
+        // every SaaS app's primary tenant key. The financial pattern requires
+        // "account_number" / "account_no", not bare "account".
+        AiSchema schema = freshSchema();
+        addLevel(schema, "Customers", "account_id");
+        addLevel(schema, "Customers", "account");
+        List<PiiScanner.Match> matches = PiiScanner.scan(schema);
+        assertFalse(
+                "account_id / account must not match the financial pattern",
+                matches.stream().anyMatch(m -> "financial".equals(m.pattern)));
+    }
+
+    @Test
+    public void skips_columns_already_annotated_pii() {
+        // If the schema author already opted the column in, the scanner
+        // doesn't repeat the suggestion. Otherwise an annotated cube would
+        // keep producing WARNs forever — pure noise.
+        AiSchema schema = freshSchema();
+        AiSchema.Measure m = new AiSchema.Measure("Email", "[Measures].[Email]");
+        m.pii = true;
+        schema.measures.put(AiSchema.key("Email"), m);
+        List<PiiScanner.Match> matches = PiiScanner.scan(schema);
+        assertEquals("already-annotated columns must be skipped", 0, matches.size());
+    }
+
+    @Test
+    public void match_carries_path_for_admin_ui() {
+        // The suggestion needs to point AT the column so the admin UI can
+        // jump straight to it. path format is documented in PiiScanner.Match.
+        AiSchema schema = freshSchema();
+        AiSchema.Dimension d = new AiSchema.Dimension("Customers", "[Customers]");
+        AiSchema.Hierarchy h = new AiSchema.Hierarchy("Customers", "[Customers]");
+        h.levels.put(AiSchema.key("Customer Name"), new AiSchema.Level("Customer Name", "[Customers].[Name]"));
+        d.hierarchies.put(AiSchema.key("Customers"), h);
+        schema.dimensions.put(AiSchema.key("Customers"), d);
+
+        List<PiiScanner.Match> matches = PiiScanner.scan(schema);
+        boolean found = matches.stream()
+                .anyMatch(m -> "dimensions.Customers.hierarchies.Customers.levels.Customer Name".equals(m.path));
+        assertTrue("path must address the column unambiguously", found);
+    }
+
+    @Test
+    public void null_schema_returns_empty_list_without_crashing() {
+        // Defensive — the scanner runs on the schema-build hot path; a null
+        // schema must NOT crash that path.
+        assertTrue(PiiScanner.scan(null).isEmpty());
+    }
+
+    @Test
+    public void empty_schema_returns_empty_list() {
+        // Empty cube with no measures or dimensions — common in test fixtures.
+        AiSchema schema = freshSchema();
+        assertTrue(PiiScanner.scan(schema).isEmpty());
+    }
+
+    @Test
+    public void no_match_returns_empty_list() {
+        // Real cube full of innocent column names — no findings.
+        AiSchema schema = freshSchema();
+        addMeasure(schema, "Revenue");
+        addMeasure(schema, "Units Sold");
+        addLevel(schema, "Time", "Year");
+        addLevel(schema, "Time", "Quarter");
+        addLevel(schema, "Geography", "Country");
+        addLevel(schema, "Geography", "State");
+        assertTrue(PiiScanner.scan(schema).isEmpty());
+    }
+
+    /* ---------------------------- helpers ---------------------------- */
+
+    private static AiSchema freshSchema() {
+        return new AiSchema("c/cat/sch/Sales", "Sales", "[Sales]");
+    }
+
+    private static void addMeasure(AiSchema schema, String name) {
+        schema.measures.put(AiSchema.key(name), new AiSchema.Measure(name, "[Measures].[" + name + "]"));
+    }
+
+    private static void addLevel(AiSchema schema, String dimName, String levelName) {
+        String dimKey = AiSchema.key(dimName);
+        AiSchema.Dimension d =
+                schema.dimensions.computeIfAbsent(dimKey, k -> new AiSchema.Dimension(dimName, "[" + dimName + "]"));
+        AiSchema.Hierarchy h =
+                d.hierarchies.computeIfAbsent(dimKey, k -> new AiSchema.Hierarchy(dimName, "[" + dimName + "]"));
+        h.levels.put(AiSchema.key(levelName), new AiSchema.Level(levelName, "[" + dimName + "].[" + levelName + "]"));
+    }
+}

--- a/saiku-core/saiku-service/src/test/java/org/saiku/service/olap/ai/SemanticAnnotationParserTest.java
+++ b/saiku-core/saiku-service/src/test/java/org/saiku/service/olap/ai/SemanticAnnotationParserTest.java
@@ -154,4 +154,60 @@ public class SemanticAnnotationParserTest {
         assertTrue(SemanticAnnotationParser.GRAINS.contains("quarter"));
         assertTrue(SemanticAnnotationParser.GRAINS.contains("week"));
     }
+
+    /* ---------------------- saiku#902 PII annotation ---------------------- */
+
+    @Test
+    public void parseMeasure_pii_true_is_honoured() {
+        Map<String, String> raw = new HashMap<>();
+        raw.put("saiku.semantic.pii", "true");
+        MeasureAnnotations parsed = SemanticAnnotationParser.parseMeasure(raw);
+        assertTrue(parsed.pii);
+    }
+
+    @Test
+    public void parseLevel_pii_true_is_honoured() {
+        Map<String, String> raw = new HashMap<>();
+        raw.put("saiku.semantic.pii", "true");
+        LevelAnnotations parsed = SemanticAnnotationParser.parseLevel(raw);
+        assertTrue(parsed.pii);
+    }
+
+    @Test
+    public void parseMeasure_pii_false_is_the_conservative_default_on_garbage() {
+        // Anything other than literal "true" (case-insensitive after trim)
+        // produces false. Schema authors who mistype "yes" / "1" / "on"
+        // should NOT accidentally opt their column into redaction — the
+        // opposite-direction default (privacy-by-default) would mask
+        // working data on the slightest typo, which is the worse failure
+        // mode for an analytics product.
+        for (String bogus : new String[] {"false", "yes", "1", "on", "TRUE_BUT_NOT_QUITE", "", null}) {
+            Map<String, String> raw = new HashMap<>();
+            raw.put("saiku.semantic.pii", bogus);
+            assertEquals(
+                    "pii must default false for value: '" + bogus + "'",
+                    false,
+                    SemanticAnnotationParser.parseMeasure(raw).pii);
+            assertEquals(false, SemanticAnnotationParser.parseLevel(raw).pii);
+        }
+    }
+
+    @Test
+    public void parseMeasure_pii_true_case_insensitive_and_trimmed() {
+        // Schema files come from human hands; tolerate whitespace + case.
+        for (String trueish : new String[] {"true", "TRUE", "True", " true ", "tRuE"}) {
+            Map<String, String> raw = new HashMap<>();
+            raw.put("saiku.semantic.pii", trueish);
+            assertTrue("pii must accept: '" + trueish + "'", SemanticAnnotationParser.parseMeasure(raw).pii);
+        }
+    }
+
+    @Test
+    public void parseMeasure_pii_absent_defaults_false() {
+        // Existing schemas without the annotation must stay unchanged —
+        // the default is "no PII protection until you opt in".
+        Map<String, String> raw = new HashMap<>();
+        raw.put("saiku.semantic.description", "ordinary measure");
+        assertEquals(false, SemanticAnnotationParser.parseMeasure(raw).pii);
+    }
 }

--- a/saiku-core/saiku-service/src/test/resources/schema-snapshots/quirks-schema.json
+++ b/saiku-core/saiku-service/src/test/resources/schema-snapshots/quirks-schema.json
@@ -13,13 +13,15 @@
       "name" : "Number of Employees",
       "uniqueName" : "[Measures].[Number of Employees]",
       "visible" : true,
-      "synonyms" : [ ]
+      "synonyms" : [ ],
+      "pii" : false
     },
     "unit sales" : {
       "name" : "Unit Sales",
       "uniqueName" : "[Measures].[Unit Sales]",
       "visible" : true,
-      "synonyms" : [ ]
+      "synonyms" : [ ],
+      "pii" : false
     }
   },
   "dimensions" : {
@@ -37,21 +39,24 @@
               "uniqueName" : "[Customer].[Customers].[(All)]",
               "sampleMembers" : [ ],
               "synonyms" : [ ],
-              "requiredFilters" : [ ]
+              "requiredFilters" : [ ],
+              "pii" : false
             },
             "country" : {
               "name" : "Country",
               "uniqueName" : "[Customer].[Customers].[Country]",
               "sampleMembers" : [ ],
               "synonyms" : [ ],
-              "requiredFilters" : [ ]
+              "requiredFilters" : [ ],
+              "pii" : false
             },
             "state" : {
               "name" : "State",
               "uniqueName" : "[Customer].[Customers].[State]",
               "sampleMembers" : [ ],
               "synonyms" : [ ],
-              "requiredFilters" : [ ]
+              "requiredFilters" : [ ],
+              "pii" : false
             }
           },
           "levelAliases" : { }
@@ -65,14 +70,16 @@
               "uniqueName" : "[Customer].[Gender].[(All)]",
               "sampleMembers" : [ ],
               "synonyms" : [ ],
-              "requiredFilters" : [ ]
+              "requiredFilters" : [ ],
+              "pii" : false
             },
             "gender" : {
               "name" : "Gender",
               "uniqueName" : "[Customer].[Gender].[Gender]",
               "sampleMembers" : [ ],
               "synonyms" : [ ],
-              "requiredFilters" : [ ]
+              "requiredFilters" : [ ],
+              "pii" : false
             }
           },
           "levelAliases" : { }
@@ -86,14 +93,16 @@
               "uniqueName" : "[Customer].[Marital Status].[(All)]",
               "sampleMembers" : [ ],
               "synonyms" : [ ],
-              "requiredFilters" : [ ]
+              "requiredFilters" : [ ],
+              "pii" : false
             },
             "marital status" : {
               "name" : "Marital Status",
               "uniqueName" : "[Customer].[Marital Status].[Marital Status]",
               "sampleMembers" : [ ],
               "synonyms" : [ ],
-              "requiredFilters" : [ ]
+              "requiredFilters" : [ ],
+              "pii" : false
             }
           },
           "levelAliases" : { }
@@ -115,21 +124,24 @@
               "uniqueName" : "[Employee].[Employee$Manager Id$Parent].[(All)]",
               "sampleMembers" : [ ],
               "synonyms" : [ ],
-              "requiredFilters" : [ ]
+              "requiredFilters" : [ ],
+              "pii" : false
             },
             "closure" : {
               "name" : "Closure",
               "uniqueName" : "[Employee].[Employee$Manager Id$Parent].[Closure]",
               "sampleMembers" : [ ],
               "synonyms" : [ ],
-              "requiredFilters" : [ ]
+              "requiredFilters" : [ ],
+              "pii" : false
             },
             "item" : {
               "name" : "Item",
               "uniqueName" : "[Employee].[Employee$Manager Id$Parent].[Item]",
               "sampleMembers" : [ ],
               "synonyms" : [ ],
-              "requiredFilters" : [ ]
+              "requiredFilters" : [ ],
+              "pii" : false
             }
           },
           "levelAliases" : { }
@@ -143,14 +155,16 @@
               "uniqueName" : "[Employee].[Salary].[(All)]",
               "sampleMembers" : [ ],
               "synonyms" : [ ],
-              "requiredFilters" : [ ]
+              "requiredFilters" : [ ],
+              "pii" : false
             },
             "salary" : {
               "name" : "Salary",
               "uniqueName" : "[Employee].[Salary].[Salary]",
               "sampleMembers" : [ ],
               "synonyms" : [ ],
-              "requiredFilters" : [ ]
+              "requiredFilters" : [ ],
+              "pii" : false
             }
           },
           "levelAliases" : { }
@@ -172,14 +186,16 @@
               "uniqueName" : "[Store2].[Store Type].[(All)]",
               "sampleMembers" : [ ],
               "synonyms" : [ ],
-              "requiredFilters" : [ ]
+              "requiredFilters" : [ ],
+              "pii" : false
             },
             "store type" : {
               "name" : "Store Type",
               "uniqueName" : "[Store2].[Store Type].[Store Type]",
               "sampleMembers" : [ ],
               "synonyms" : [ ],
-              "requiredFilters" : [ ]
+              "requiredFilters" : [ ],
+              "pii" : false
             }
           },
           "levelAliases" : { }
@@ -201,14 +217,16 @@
               "uniqueName" : "[Time].[Time].[Quarter]",
               "sampleMembers" : [ ],
               "synonyms" : [ ],
-              "requiredFilters" : [ ]
+              "requiredFilters" : [ ],
+              "pii" : false
             },
             "year" : {
               "name" : "Year",
               "uniqueName" : "[Time].[Time].[Year]",
               "sampleMembers" : [ ],
               "synonyms" : [ ],
-              "requiredFilters" : [ ]
+              "requiredFilters" : [ ],
+              "pii" : false
             }
           },
           "levelAliases" : { }

--- a/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/AiQueryResource.java
+++ b/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/AiQueryResource.java
@@ -844,7 +844,14 @@ public class AiQueryResource {
         }
         try {
             AiSchema schema = cubeMetadataService.getSchema(ref);
-            return Response.ok(schema).type(MediaType.APPLICATION_JSON).build();
+            // saiku#902: project to the redacted agent view before serializing.
+            // The internal in-memory schema keeps captions + samples + synonyms
+            // (the validator needs them for name resolution); the JSON we hand
+            // back to the agent strips them for any level / measure tagged
+            // {@code saiku.semantic.pii=true}.
+            return Response.ok(schema.toAgentView())
+                    .type(MediaType.APPLICATION_JSON)
+                    .build();
         } catch (AiValidationException e) {
             return badRequest(e.getField(), e.getMessage(), e.getAvailable());
         } catch (RuntimeException e) {

--- a/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/AiQueryResource.java
+++ b/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/AiQueryResource.java
@@ -35,6 +35,7 @@ import org.saiku.service.olap.ai.AiCell;
 import org.saiku.service.olap.ai.AiCubeMetadataService;
 import org.saiku.service.olap.ai.AiCubeRef;
 import org.saiku.service.olap.ai.AiCubeSummary;
+import org.saiku.service.olap.ai.AiPiiException;
 import org.saiku.service.olap.ai.AiQueryMetadata;
 import org.saiku.service.olap.ai.AiQueryRequest;
 import org.saiku.service.olap.ai.AiQueryResponse;
@@ -861,6 +862,52 @@ public class AiQueryResource {
     }
 
     /**
+     * saiku#902 phase 3 — admin diagnostics for the PII scanner.
+     *
+     * <p>Returns the cached {@link org.saiku.service.olap.ai.PiiScanner.Match}
+     * list for the cube — one entry per measure / level whose name matched a
+     * documented PII pattern AND that is NOT already annotated
+     * {@code saiku.semantic.pii=true}. The intent is operator-facing: surface
+     * "you probably want to annotate these columns" hints in admin UI without
+     * the operator having to grep their launcher logs.
+     *
+     * <p>The endpoint sits at {@code /ai/schema/{cubeId}/pii-suggestions}
+     * rather than {@code /ai/schema/{cubeId}} so the suggestions never leak
+     * into the agent-facing describe response — agents shouldn't see the
+     * operator's draft policy. Admin gating happens via the JAX-RS layer's
+     * usual {@code @RolesAllowed("ROLE_ADMIN")} when wired upstream; the
+     * resource itself doesn't enforce auth so unit tests can call it
+     * directly.
+     *
+     * <p>The cube must have been described at least once (via
+     * {@link #getSchema(String)}) for the scanner to have run; an
+     * unrecognised / unwarmed cube returns an empty list, not 404.
+     */
+    @GET
+    @Path("/schema/{cubeId:.+}/pii-suggestions")
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response getPiiSuggestions(@PathParam("cubeId") String cubeId) {
+        AiCubeRef ref = parseCubeId(cubeId);
+        if (ref == null) {
+            return badRequest("cubeId", "cubeId must be connection/catalog/schema/cube", null);
+        }
+        try {
+            // Warm the schema cache first so a fresh suggestions request
+            // doesn't return empty just because the cube hadn't been
+            // described yet.
+            cubeMetadataService.getSchema(ref);
+            return Response.ok(java.util.Map.of("suggestions", cubeMetadataService.getPiiSuggestions(ref)))
+                    .type(MediaType.APPLICATION_JSON)
+                    .build();
+        } catch (AiValidationException e) {
+            return badRequest(e.getField(), e.getMessage(), e.getAvailable());
+        } catch (RuntimeException e) {
+            log.error("PII suggestions fetch failed for {}", cubeId, e);
+            return error("pii suggestions fetch failed");
+        }
+    }
+
+    /**
      * Member search for a level — case-insensitive substring match by
      * default (delegates to the discover service's olap4j search). The
      * {@code cubeId} format matches {@link #getSchema} —
@@ -1188,6 +1235,24 @@ public class AiQueryResource {
                 AiSchema schema = cubeMetadataService.getSchema(ref);
                 out[0] = AiReturnsResolver.resolve(returns, schema);
             }
+        } catch (AiPiiException pe) {
+            // saiku#902: distinguish PII refusal from a regular validation
+            // error in the audit log + structured response. Status is still
+            // VALIDATION_ERROR (the agent's self-correction path is uniform —
+            // look at field, pick from available); the log line carries the
+            // explicit reason so a CISO reading the audit can confirm the
+            // gate fired correctly. The candidate list here ALREADY excludes
+            // PII columns (built by AiReturnsResolver.nonPiiCandidates).
+            log.info("drillthrough returns= refused (PII column): name={} message={}", name, pe.getMessage());
+            AiQueryResponse resp = new AiQueryResponse();
+            resp.setStatus(AiQueryResponse.Status.VALIDATION_ERROR);
+            resp.setError(pe.getMessage());
+            resp.setField(pe.getField());
+            if (pe.getAvailable() != null) resp.setAvailable(pe.getAvailable());
+            return Response.status(Response.Status.BAD_REQUEST)
+                    .entity(resp)
+                    .type(MediaType.APPLICATION_JSON)
+                    .build();
         } catch (AiValidationException ve) {
             AiQueryResponse resp = new AiQueryResponse();
             resp.setStatus(AiQueryResponse.Status.VALIDATION_ERROR);


### PR DESCRIPTION
## Summary

**Complete implementation of [#902](https://github.com/spiculedata/saiku/issues/902)** — every acceptance criterion in the ticket. Foundation for the PII-tier work described in [saiku-cloud PR #944](https://github.com/spiculedata/saiku-cloud/pull/944).

Three commits, three phases:

| Phase | Commit | What |
|---|---|---|
| 1 | \`82cefde\` | Annotation parser + AiSchema fields + agent-view JSON projection |
| 2 | \`6ca6f60\` (mixed) | Drillthrough \`returns=\` refusal — AiPiiException + controller catch |
| 3 | \`6ca6f60\` (mixed) | PiiScanner + admin diagnostics endpoint |

## ACs against the ticket

| AC from #902 | Phase | Status |
|---|---|---|
| Strip captions + uniqueNames from PII-flagged levels in JSON | 1 | ✓ — \`AiSchema.toAgentView()\` |
| Replace sample members with \`[REDACTED]\` tokens | 1 | ✓ |
| Refuse drillthrough projections that include PII columns (400 with clear error) | 2 | ✓ — \`AiPiiException\` + controller |
| Keep level structurally present so MDX queries still validate | 1 | ✓ — \`name\` + \`uniqueName\` + \`pii\` retained |
| Auto-scanner at schema load with admin-side surfacing | 3 | ✓ — \`PiiScanner\` + \`/pii-suggestions\` |

## Surface delivered

### Schema author — declare PII

\`\`\`xml
<Annotations>
  <Annotation name=\"saiku.semantic.pii\">true</Annotation>
</Annotations>
\`\`\`

Valid on \`<Level>\` and \`<Measure>\`. Conservative-default semantics — anything other than literal \`\"true\"\` after case-fold + trim → false. Schema author typos don't accidentally redact working data.

### Agent — describe response

\`GET /saiku/api/ai/schema/{cubeId}\` returns the agent view: PII-flagged measures + levels keep \`name\` + \`uniqueName\` + \`pii: true\`, strip \`displayName\` / \`description\` / \`synonyms\` / \`unit\` / \`currency\`, replace \`sampleMembers\` with a single \`[REDACTED]\` sentinel. Alias maps drop entries that resolve to PII targets.

### Agent — drillthrough refusal

\`GET /saiku/api/ai/query/{id}/drillthrough?returns=Year,SocialSecurity\` where \`SocialSecurity\` is PII-flagged:

\`\`\`json
{
  \"status\": \"VALIDATION_ERROR\",
  \"field\": \"returns\",
  \"error\": \"Column 'SocialSecurity' is annotated PII (saiku.semantic.pii=true) and cannot be projected through DRILLTHROUGH ... RETURN. Pick a non-PII column from the candidate list.\",
  \"available\": [\"Store Sales\", \"Unit Sales\", \"Year\", \"Quarter\"]
}
\`\`\`

The \`available\` list **explicitly excludes** PII columns so the agent's self-correction path can never enumerate redacted slots even via error introspection.

### Admin — scanner suggestions

\`GET /saiku/api/ai/schema/{cubeId}/pii-suggestions\` returns the cached findings:

\`\`\`json
{
  \"suggestions\": [
    { \"pattern\": \"email\", \"name\": \"Customer Email\", \"path\": \"dimensions.Customers.hierarchies.Customers.levels.Customer Email\" },
    { \"pattern\": \"ssn\",   \"name\": \"SSN\",            \"path\": \"measures.SSN\" }
  ]
}
\`\`\`

Plus WARN log per finding for operators tailing the launcher log. Pattern set covers: email, ssn (UK NIN + Canada SIN), phone, name, dob, address, medical_record (NHS + MRN), financial (account_number + IBAN + SWIFT + cc).

## Why projection-not-mutation

The MDX builder + validator use the SAME \`AiSchema\` instance the describe endpoint sees. Mutating in place would break name resolution on the next query (the validator can't match the agent's name to a stripped \`displayName\`). Returning a projection keeps:

- **In-memory schema** unredacted → validator + MDX builder work
- **Describe JSON** redacted → agent never sees the captions / samples / synonyms
- **Drillthrough validator** uses in-memory schema → can still match resolved column names against the PII flag

## Why \`\\b\` word boundaries in the scanner

The single design choice that separates this scanner from "an over-eager regex." Tests pin:

| Name | Pattern | Match? |
|---|---|---|
| \`email\` | email | ✓ |
| \`email_count\` | email | ✗ (it's a COUNT aggregate, not PII) |
| \`account_number\` | financial | ✓ |
| \`account_id\` | financial | ✗ (surrogate tenant key, not PII) |
| \`account\` | financial | ✗ |

Without word boundaries the scanner would generate so much noise that operators would mute it. With them, the signal-to-noise ratio matches the saiku-cloud regex redactor's "false-positive-leaning" posture.

## Tests

| File | Count | What |
|---|---|---|
| \`SemanticAnnotationParserTest\` | +5 (16 total) | pii=true on measure + level, conservative default on garbage, case-insensitive + trim, absent → false |
| \`AiSchemaToAgentViewTest\` | +8 (new file) | identity projection on non-PII, PII measure strips sensitive fields, PII level strips + replaces samples, alias maps drop PII targets at both layers, toAgentView doesn't mutate source, cube-level fields pass through |
| \`AiReturnsResolverTest\` | +6 (14 total) | PII measure refused, PII level refused, refused via measure alias, refused via level alias, pre-bracketed MDX passes through, unknown column still throws base AiValidationException |
| \`PiiScannerTest\` | +14 (new file) | each pattern detected, \`email_count\` NOT matched, \`account_id\` NOT matched, already-annotated columns skipped, path is unambiguous, null/empty/no-match returns empty |
| \`SchemaSnapshotTest\` | regenerated | only diff is \`pii: false\` added to every measure + level — via the documented \`-Dsaiku.snapshots.update=true\` mechanism |

**647/647 saiku-service tests green. 330/330 saiku-web tests green. Spotless clean.**

## Test plan

- [x] \`mvn verify\` clean
- [x] Spotless apply + check clean
- [x] Snapshot regenerated cleanly
- [ ] CI green on dev
- [ ] Smoke against bundled FoodMart cube — confirm \`/ai/schema/...\` response shape is unchanged for unannotated cubes
- [ ] Tag a level with \`saiku.semantic.pii=true\` in a test schema — confirm describe strips it
- [ ] Drillthrough with \`returns=\` pointing at that level — confirm 400 with the documented envelope
- [ ] Hit \`/pii-suggestions\` — confirm scanner findings surface