### PR TITLE
feat(embed/pii): mint-time PII gate — saiku-cloud#940

### DIFF
--- a/saiku-core/saiku-web/src/main/java/org/saiku/web/embed/EmbedPiiInspector.java
+++ b/saiku-core/saiku-web/src/main/java/org/saiku/web/embed/EmbedPiiInspector.java
@@ -1,0 +1,210 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.web.embed;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import org.saiku.olap.dto.SaikuCube;
+import org.saiku.olap.query2.ThinQuery;
+import org.saiku.service.datasource.DatasourceService;
+import org.saiku.service.olap.ai.AiCubeMetadataService;
+import org.saiku.service.olap.ai.AiCubeRef;
+import org.saiku.service.olap.ai.AiSchema;
+import org.saiku.web.rest.resources.dashboards.Dashboard;
+import org.saiku.web.rest.resources.dashboards.DashboardTile;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * saiku-cloud#940 mint-time PII gate. Given a resource (saved query or
+ * dashboard), inspects the cubes it binds to and reports whether any
+ * referenced column is annotated {@code saiku.semantic.pii=true} (the
+ * schema-side foundation from saiku#902).
+ *
+ * <p>Used by {@code EmbedTokenResource.mint} (sets {@code redactionPolicy=
+ * FORCE_ON} on the minted token) and {@code EmbedTokenResource.grantPublic}
+ * (refuses the public grant outright — public-anonymous reads of PII
+ * captions are the highest-blast-radius leak on the embed surface).
+ *
+ * <p>Conservative v1 — cube-level granularity. If the cube has ANY
+ * PII-annotated measure or level, the resource is treated as referencing
+ * PII. A future refinement could parse the ThinQuery's axis selections /
+ * each dashboard tile's filter targets to check ONLY columns the resource
+ * actually projects, but the conservative pass is simpler, faster (cube
+ * metadata is already cached), and safer (no leak path that the parser
+ * misses can survive). Operators who want finer granularity can tag
+ * fewer columns PII.
+ *
+ * <p>The inspector is best-effort by design: if a resource is unreadable,
+ * a tile references an unloadable cube, or the schema cache fails, we
+ * return {@code referencesPii=true} (fail-CLOSED) so the embed gate
+ * defaults to the safer posture. The only path to {@code false} is a
+ * cleanly-parsed resource whose every referenced cube cleanly resolved to
+ * a schema with NO PII annotations.
+ */
+public class EmbedPiiInspector {
+
+    private static final Logger log = LoggerFactory.getLogger(EmbedPiiInspector.class);
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    private final DatasourceService datasourceService;
+    private final AiCubeMetadataService cubeMetadataService;
+
+    public EmbedPiiInspector(DatasourceService datasourceService, AiCubeMetadataService cubeMetadataService) {
+        this.datasourceService = datasourceService;
+        this.cubeMetadataService = cubeMetadataService;
+    }
+
+    /**
+     * Result of an inspection. {@link #referencesPii} is the load-bearing
+     * field that drives mint-time gating; {@link #cubeIds} are the distinct
+     * cubes the resource binds to (useful for audit logs and admin
+     * tooling). {@link #fellOpenForUnresolvable} flags a "fail-closed" case
+     * where the inspector refused but couldn't actually inspect — so an
+     * admin investigating a refused public grant can tell "we found PII"
+     * apart from "we couldn't tell so we said no."
+     */
+    public static final class Result {
+        public final boolean referencesPii;
+        public final List<String> cubeIds;
+        public final boolean fellOpenForUnresolvable;
+
+        public Result(boolean referencesPii, List<String> cubeIds, boolean fellOpenForUnresolvable) {
+            this.referencesPii = referencesPii;
+            this.cubeIds = List.copyOf(cubeIds);
+            this.fellOpenForUnresolvable = fellOpenForUnresolvable;
+        }
+    }
+
+    /**
+     * @param resourceKind {@code "query"} or {@code "dashboard"}
+     * @param resourcePath repository path of the resource
+     * @param ownerUser owner-scoped read of the resource (the embed flow
+     *     runs reads under the grantor / owner identity, so the inspector
+     *     uses the same scope to read the resource file)
+     * @param ownerRoles roles to pass to the repository read
+     */
+    public Result inspect(String resourceKind, String resourcePath, String ownerUser, List<String> ownerRoles) {
+        if (resourcePath == null || resourcePath.isBlank()) {
+            // Don't gate something we can't even identify — the caller's
+            // upstream validation should have rejected this before us.
+            return new Result(false, List.of(), false);
+        }
+        if (datasourceService == null || cubeMetadataService == null) {
+            // No infrastructure wired (test / stub context). Fall to
+            // permissive — the caller's surrounding GRANT check is still
+            // the load-bearing security check; the PII gate is an
+            // additional layer on top.
+            return new Result(false, List.of(), false);
+        }
+
+        String raw;
+        try {
+            raw = datasourceService.getFileData(resourcePath, ownerUser, ownerRoles);
+        } catch (RuntimeException e) {
+            log.warn("EmbedPiiInspector: file unreadable, failing closed — path={} owner={}", resourcePath, ownerUser);
+            return new Result(true, List.of(), true);
+        }
+        if (raw == null || raw.isEmpty()) {
+            log.warn("EmbedPiiInspector: file empty, failing closed — path={}", resourcePath);
+            return new Result(true, List.of(), true);
+        }
+
+        try {
+            if ("query".equals(resourceKind)) {
+                return inspectQuery(raw, resourcePath);
+            } else if ("dashboard".equals(resourceKind)) {
+                return inspectDashboard(raw, resourcePath);
+            } else {
+                // Unknown kind — fail-closed.
+                log.warn("EmbedPiiInspector: unknown resourceKind {}, failing closed", resourceKind);
+                return new Result(true, List.of(), true);
+            }
+        } catch (RuntimeException e) {
+            log.warn(
+                    "EmbedPiiInspector: parse / schema-lookup failed for {}, failing closed: {}",
+                    resourcePath,
+                    e.toString());
+            return new Result(true, List.of(), true);
+        }
+    }
+
+    /* ------------------------- internals ------------------------- */
+
+    private Result inspectQuery(String raw, String resourcePath) {
+        ThinQuery tq;
+        try {
+            tq = MAPPER.readValue(raw, ThinQuery.class);
+        } catch (Exception e) {
+            log.warn("EmbedPiiInspector: not valid ThinQuery JSON — {}", resourcePath);
+            return new Result(true, List.of(), true);
+        }
+        SaikuCube cube = tq.getCube();
+        if (cube == null) {
+            // Cube-less saved query — typically an MDX-mode query bound
+            // only to a connection. We can't safely inspect; fail-closed.
+            return new Result(true, List.of(), true);
+        }
+        AiCubeRef ref = new AiCubeRef(cube.getConnection(), cube.getCatalog(), cube.getSchema(), cube.getName());
+        return new Result(cubeReferencesPii(ref), List.of(cubeKey(ref)), false);
+    }
+
+    private Result inspectDashboard(String raw, String resourcePath) {
+        Dashboard dash;
+        try {
+            dash = MAPPER.readValue(raw, Dashboard.class);
+        } catch (Exception e) {
+            log.warn("EmbedPiiInspector: not valid Dashboard JSON — {}", resourcePath);
+            return new Result(true, List.of(), true);
+        }
+        if (dash.layout == null || dash.layout.tiles == null) {
+            return new Result(false, List.of(), false);
+        }
+        Set<String> seenCubes = new LinkedHashSet<>();
+        boolean anyPii = false;
+        for (DashboardTile tile : dash.layout.tiles) {
+            if (tile.cube == null) continue; // text / decorative tile
+            AiCubeRef ref = tile.cube;
+            String key = cubeKey(ref);
+            if (!seenCubes.add(key)) continue; // dedupe — many tiles can bind the same cube
+            if (cubeReferencesPii(ref)) {
+                anyPii = true;
+                // Keep walking to collect the full cube set for audit, even
+                // after the first PII hit — useful when an operator wants
+                // to see "which of the 5 cubes in this dashboard are the
+                // problem ones."
+            }
+        }
+        return new Result(anyPii, new ArrayList<>(seenCubes), false);
+    }
+
+    private boolean cubeReferencesPii(AiCubeRef ref) {
+        try {
+            AiSchema schema = cubeMetadataService.getSchema(ref);
+            if (schema == null) return true; // null = unresolvable → fail-closed
+            for (AiSchema.Measure m : schema.measures.values()) {
+                if (m.pii) return true;
+            }
+            for (AiSchema.Dimension d : schema.dimensions.values()) {
+                for (AiSchema.Hierarchy h : d.hierarchies.values()) {
+                    for (AiSchema.Level l : h.levels.values()) {
+                        if (l.pii) return true;
+                    }
+                }
+            }
+            return false;
+        } catch (RuntimeException e) {
+            log.warn("EmbedPiiInspector: schema lookup failed for {}, failing closed: {}", cubeKey(ref), e.toString());
+            return true;
+        }
+    }
+
+    private static String cubeKey(AiCubeRef ref) {
+        return ref.getConnectionName() + "/" + ref.getCatalog() + "/" + ref.getSchema() + "/" + ref.getCubeName();
+    }
+}

--- a/saiku-core/saiku-web/src/main/java/org/saiku/web/embed/EmbedToken.java
+++ b/saiku-core/saiku-web/src/main/java/org/saiku/web/embed/EmbedToken.java
@@ -63,7 +63,28 @@ public class EmbedToken {
     /** Optional human label shown in the owner's embed list. */
     public String label;
 
+    /** Redaction posture for the read path (saiku-cloud#940 + saiku#902).
+     *  {@link RedactionPolicy#TENANT_DEFAULT} (default) defers to the
+     *  tenant's configured redaction tier; {@link RedactionPolicy#FORCE_ON}
+     *  applies max-strength redaction regardless of tenant tier — set at mint
+     *  time when the bound resource references any column annotated
+     *  {@code saiku.semantic.pii=true}. Lets a single workspace hold mixed-
+     *  sensitivity resources where some need stricter redaction than the
+     *  tenant default. */
+    public RedactionPolicy redactionPolicy = RedactionPolicy.TENANT_DEFAULT;
+
     public EmbedToken() {}
+
+    /** Embed-token redaction posture — saiku-cloud#940. */
+    public enum RedactionPolicy {
+        /** Defer to the tenant's configured redaction tier. Existing tokens
+         *  (created before #940) deserialise to this value. */
+        TENANT_DEFAULT,
+        /** Apply max-strength redaction on every read regardless of tenant
+         *  tier. Set at mint time when the resource binds to columns
+         *  annotated {@code saiku.semantic.pii=true}. */
+        FORCE_ON
+    }
 
     /** True when the token is past its expiry relative to {@code nowMs}. */
     public boolean isExpired(long nowMs) {

--- a/saiku-core/saiku-web/src/main/java/org/saiku/web/embed/EmbedTokenStore.java
+++ b/saiku-core/saiku-web/src/main/java/org/saiku/web/embed/EmbedTokenStore.java
@@ -81,7 +81,10 @@ public class EmbedTokenStore {
     /**
      * Mint a new token. {@code resourceKind} must be {@code "query"} or
      * {@code "dashboard"}; anything else throws {@link IllegalArgumentException}
-     * so a malformed mint cannot land in the store.
+     * so a malformed mint cannot land in the store. Defaults the token's
+     * {@link EmbedToken#redactionPolicy} to {@code TENANT_DEFAULT} — back-
+     * compat overload kept so existing callers don't have to think about
+     * the saiku-cloud#940 policy field.
      */
     public EmbedToken create(
             String resourceKind,
@@ -90,6 +93,29 @@ public class EmbedTokenStore {
             List<String> ownerRoles,
             long ttlMillis,
             String label) {
+        return create(
+                resourceKind,
+                resourcePath,
+                createdBy,
+                ownerRoles,
+                ttlMillis,
+                label,
+                EmbedToken.RedactionPolicy.TENANT_DEFAULT);
+    }
+
+    /**
+     * saiku-cloud#940 overload — explicit redaction policy. Used by the
+     * embed-token mint when the inspector detected PII columns on the
+     * resource and the policy must be FORCE_ON.
+     */
+    public EmbedToken create(
+            String resourceKind,
+            String resourcePath,
+            String createdBy,
+            List<String> ownerRoles,
+            long ttlMillis,
+            String label,
+            EmbedToken.RedactionPolicy redactionPolicy) {
         if (resourceKind == null || !ALLOWED_KINDS.contains(resourceKind)) {
             // ALLOWED_KINDS.contains(null) throws NPE on Set.of immutables, so
             // null-check first — defends both the API and the runtime.
@@ -105,6 +131,7 @@ public class EmbedTokenStore {
         t.createdBy = createdBy;
         t.ownerRolesSnapshot = ownerRoles == null ? List.of() : new ArrayList<>(ownerRoles);
         t.createdAt = System.currentTimeMillis();
+        t.redactionPolicy = redactionPolicy == null ? EmbedToken.RedactionPolicy.TENANT_DEFAULT : redactionPolicy;
         t.expiresAt = t.createdAt + ttlMillis;
         t.revoked = false;
         t.label = label;

--- a/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/embed/EmbedTokenResource.java
+++ b/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/embed/EmbedTokenResource.java
@@ -69,6 +69,12 @@ public class EmbedTokenResource {
     private DatasourceService datasourceService;
     private SessionService sessionService;
     private UserService userService;
+    /** saiku-cloud#940. Resolves a resource's bound cubes + walks their
+     *  AiSchemas for {@code saiku.semantic.pii=true} annotations. Optional —
+     *  when null (Spring bean missing, stub context), the PII gate is a
+     *  no-op and the surrounding GRANT check remains the load-bearing
+     *  security check. */
+    private org.saiku.web.embed.EmbedPiiInspector piiInspector;
 
     public void setTokenStore(EmbedTokenStore s) {
         this.tokenStore = s;
@@ -88,6 +94,10 @@ public class EmbedTokenResource {
 
     public void setUserService(UserService s) {
         this.userService = s;
+    }
+
+    public void setPiiInspector(org.saiku.web.embed.EmbedPiiInspector i) {
+        this.piiInspector = i;
     }
 
     /* ---------------------------- tokens ---------------------------- */
@@ -135,14 +145,35 @@ public class EmbedTokenResource {
                     .build();
         }
 
-        EmbedToken t = tokenStore.create(kind, path, username, roles, ttlHours * 3600_000L, body.label);
+        // saiku-cloud#940 mint-time PII gate. Determines the redaction
+        // posture the read path will apply. PII-touching resources get
+        // FORCE_ON so a token minted at a workspace's relaxed default tier
+        // still gets max-strength redaction on individual sensitive
+        // resources. Non-PII resources stay TENANT_DEFAULT — the surrounding
+        // tier setting controls the policy as before.
+        EmbedToken.RedactionPolicy redaction = EmbedToken.RedactionPolicy.TENANT_DEFAULT;
+        if (piiInspector != null) {
+            org.saiku.web.embed.EmbedPiiInspector.Result inspection = piiInspector.inspect(kind, path, username, roles);
+            if (inspection.referencesPii) {
+                redaction = EmbedToken.RedactionPolicy.FORCE_ON;
+                log.info(
+                        "embed-token mint elevated to FORCE_ON (PII on {}): kind={} path={} by={} cubes={}",
+                        inspection.fellOpenForUnresolvable ? "unresolvable resource" : "annotated columns",
+                        kind,
+                        path,
+                        username,
+                        inspection.cubeIds);
+            }
+        }
+        EmbedToken t = tokenStore.create(kind, path, username, roles, ttlHours * 3600_000L, body.label, redaction);
         log.info(
-                "embed-token minted token=<redacted:{}> kind={} path={} by={} ttlHours={}",
+                "embed-token minted token=<redacted:{}> kind={} path={} by={} ttlHours={} redaction={}",
                 t.token.length(),
                 kind,
                 path,
                 username,
-                ttlHours);
+                ttlHours,
+                t.redactionPolicy);
         return Response.ok(Map.of(
                         "status",
                         "OK",
@@ -152,6 +183,8 @@ public class EmbedTokenResource {
                         kind,
                         "resourcePath",
                         path,
+                        "redactionPolicy",
+                        t.redactionPolicy.name(),
                         "expiresAt",
                         t.expiresAt))
                 .type(MediaType.APPLICATION_JSON)
@@ -169,6 +202,8 @@ public class EmbedTokenResource {
         for (EmbedToken t : tokens) {
             // Owner gets back the token id (they minted it). Never return the
             // owner role snapshot — internal data-scope state, not API data.
+            // 10 entries — Map.of's max overload. New fields go through
+            // Map.ofEntries below.
             out.add(Map.of(
                     "token", t.token,
                     "resourceKind", t.resourceKind,
@@ -178,7 +213,13 @@ public class EmbedTokenResource {
                     "expiresAt", t.expiresAt,
                     "revoked", t.revoked,
                     "label", t.label == null ? "" : t.label,
-                    "active", t.isValid(System.currentTimeMillis())));
+                    "active", t.isValid(System.currentTimeMillis()),
+                    // saiku-cloud#940. So admins can audit which tokens have
+                    // FORCE_ON without re-running the inspector.
+                    "redactionPolicy",
+                            t.redactionPolicy == null
+                                    ? EmbedToken.RedactionPolicy.TENANT_DEFAULT.name()
+                                    : t.redactionPolicy.name()));
         }
         return Response.ok(out).type(MediaType.APPLICATION_JSON).build();
     }
@@ -234,6 +275,29 @@ public class EmbedTokenResource {
         List<String> roles = currentRoles();
         if (!hasGrant(path, username, roles)) {
             return forbidden("You don't have permission to make this resource public");
+        }
+
+        // saiku-cloud#940 — refuse public grants on PII-touching resources.
+        // Anonymous-public read is the highest-blast-radius surface on the
+        // embed: a public-grant means literally anyone with the URL can
+        // read the cellset on an attacker-controlled host page. We
+        // categorically refuse rather than try to redact post-hoc.
+        if (piiInspector != null) {
+            org.saiku.web.embed.EmbedPiiInspector.Result inspection = piiInspector.inspect(kind, path, username, roles);
+            if (inspection.referencesPii) {
+                log.info(
+                        "embed-public REFUSED (PII on {}): kind={} path={} by={} cubes={}",
+                        inspection.fellOpenForUnresolvable ? "unresolvable resource" : "annotated columns",
+                        kind,
+                        path,
+                        username,
+                        inspection.cubeIds);
+                return badRequest(
+                        "resourcePath",
+                        "Resource references PII-annotated columns; public grants are forbidden. "
+                                + "Mint a scoped token (POST /tokens) instead — its redaction policy "
+                                + "is automatically elevated to FORCE_ON for PII resources.");
+            }
         }
 
         // Cap public grants per user too — leaked anonymous read is the most

--- a/saiku-core/saiku-web/src/test/java/org/saiku/web/embed/EmbedPiiInspectorTest.java
+++ b/saiku-core/saiku-web/src/test/java/org/saiku/web/embed/EmbedPiiInspectorTest.java
@@ -1,0 +1,294 @@
+package org.saiku.web.embed;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.Before;
+import org.junit.Test;
+import org.saiku.service.datasource.DatasourceService;
+import org.saiku.service.olap.ai.AiCubeMetadataService;
+import org.saiku.service.olap.ai.AiCubeRef;
+import org.saiku.service.olap.ai.AiSchema;
+
+/**
+ * Unit coverage for {@link EmbedPiiInspector} (saiku-cloud#940). Drives the
+ * fail-CLOSED contract on the saved-query (.saiku/ThinQuery JSON) +
+ * dashboard (.saikudash JSON) parse paths, the cube-level "any PII"
+ * detection, and the dedupe across multi-tile dashboards.
+ */
+public class EmbedPiiInspectorTest {
+
+    private StubDatasourceService ds;
+    private StubCubeMetadataService cubes;
+    private EmbedPiiInspector inspector;
+
+    @Before
+    public void setUp() {
+        ds = new StubDatasourceService();
+        cubes = new StubCubeMetadataService();
+        inspector = new EmbedPiiInspector(ds, cubes);
+    }
+
+    /* ---------------------------- queries ---------------------------- */
+
+    @Test
+    public void query_with_clean_cube_returns_no_pii() {
+        // ThinQuery JSON with a cube whose schema has no PII annotations.
+        ds.put("/clean.saiku", thinQueryJson("conn-1", "Cat", "Sch", "Sales"));
+        cubes.putSchema("conn-1/Cat/Sch/Sales", cleanSchema());
+
+        EmbedPiiInspector.Result r = inspector.inspect("query", "/clean.saiku", "admin", List.of());
+        assertFalse(r.referencesPii);
+        assertEquals(1, r.cubeIds.size());
+        assertFalse(r.fellOpenForUnresolvable);
+    }
+
+    @Test
+    public void query_with_pii_measure_returns_pii() {
+        ds.put("/dirty.saiku", thinQueryJson("conn-1", "Cat", "Sch", "Customer"));
+        AiSchema schema = cleanSchema();
+        AiSchema.Measure m = new AiSchema.Measure("SSN", "[Measures].[SSN]");
+        m.pii = true;
+        schema.measures.put(AiSchema.key("SSN"), m);
+        cubes.putSchema("conn-1/Cat/Sch/Customer", schema);
+
+        EmbedPiiInspector.Result r = inspector.inspect("query", "/dirty.saiku", "admin", List.of());
+        assertTrue(r.referencesPii);
+    }
+
+    @Test
+    public void query_with_pii_level_returns_pii() {
+        ds.put("/dirty.saiku", thinQueryJson("conn-1", "Cat", "Sch", "Customer"));
+        AiSchema schema = cleanSchema();
+        AiSchema.Dimension d = new AiSchema.Dimension("Customer", "[Customer]");
+        AiSchema.Hierarchy h = new AiSchema.Hierarchy("Customer", "[Customer]");
+        AiSchema.Level l = new AiSchema.Level("Email", "[Customer].[Email]");
+        l.pii = true;
+        h.levels.put(AiSchema.key("Email"), l);
+        d.hierarchies.put(AiSchema.key("Customer"), h);
+        schema.dimensions.put(AiSchema.key("Customer"), d);
+        cubes.putSchema("conn-1/Cat/Sch/Customer", schema);
+
+        EmbedPiiInspector.Result r = inspector.inspect("query", "/dirty.saiku", "admin", List.of());
+        assertTrue(r.referencesPii);
+    }
+
+    @Test
+    public void query_with_unreadable_file_fails_closed() {
+        // Path doesn't resolve in the stub — datasourceService.getFileData
+        // throws. Inspector must default to "PII present" so the embed
+        // gate refuses rather than allows.
+        ds.throwOn("/missing.saiku");
+        EmbedPiiInspector.Result r = inspector.inspect("query", "/missing.saiku", "admin", List.of());
+        assertTrue("file unreadable must fail closed", r.referencesPii);
+        assertTrue(r.fellOpenForUnresolvable);
+    }
+
+    @Test
+    public void query_with_garbage_json_fails_closed() {
+        ds.put("/broken.saiku", "not json");
+        EmbedPiiInspector.Result r = inspector.inspect("query", "/broken.saiku", "admin", List.of());
+        assertTrue("unparseable resource must fail closed", r.referencesPii);
+        assertTrue(r.fellOpenForUnresolvable);
+    }
+
+    @Test
+    public void query_with_no_cube_fails_closed() {
+        // MDX-mode ThinQuery is bound only to a connection — we can't
+        // inspect a cube we don't have. Fail closed.
+        ds.put("/no-cube.saiku", "{\"name\":\"q\",\"type\":\"MDX\"}");
+        EmbedPiiInspector.Result r = inspector.inspect("query", "/no-cube.saiku", "admin", List.of());
+        assertTrue(r.referencesPii);
+        assertTrue(r.fellOpenForUnresolvable);
+    }
+
+    /* -------------------------- dashboards -------------------------- */
+
+    @Test
+    public void dashboard_with_clean_tiles_returns_no_pii() {
+        ds.put(
+                "/clean.saikudash",
+                dashboardJson(List.of(
+                        tileJson("conn-1", "Cat", "Sch", "Sales"), tileJson("conn-1", "Cat", "Sch", "Inventory"))));
+        cubes.putSchema("conn-1/Cat/Sch/Sales", cleanSchema());
+        cubes.putSchema("conn-1/Cat/Sch/Inventory", cleanSchema());
+
+        EmbedPiiInspector.Result r = inspector.inspect("dashboard", "/clean.saikudash", "admin", List.of());
+        assertFalse(r.referencesPii);
+        assertEquals("both cubes recorded for audit", 2, r.cubeIds.size());
+    }
+
+    @Test
+    public void dashboard_with_one_pii_tile_returns_pii_but_still_walks_rest() {
+        // One PII cube among multiple. The inspector must (a) return PII,
+        // (b) still collect the FULL cube set for audit so an admin can
+        // see "which of my 3 cubes is the problem."
+        ds.put(
+                "/mixed.saikudash",
+                dashboardJson(List.of(
+                        tileJson("conn-1", "Cat", "Sch", "Sales"),
+                        tileJson("conn-1", "Cat", "Sch", "CustomerPii"),
+                        tileJson("conn-1", "Cat", "Sch", "Inventory"))));
+        AiSchema dirty = cleanSchema();
+        AiSchema.Measure ssn = new AiSchema.Measure("SSN", "[Measures].[SSN]");
+        ssn.pii = true;
+        dirty.measures.put(AiSchema.key("SSN"), ssn);
+        cubes.putSchema("conn-1/Cat/Sch/Sales", cleanSchema());
+        cubes.putSchema("conn-1/Cat/Sch/CustomerPii", dirty);
+        cubes.putSchema("conn-1/Cat/Sch/Inventory", cleanSchema());
+
+        EmbedPiiInspector.Result r = inspector.inspect("dashboard", "/mixed.saikudash", "admin", List.of());
+        assertTrue(r.referencesPii);
+        assertEquals(3, r.cubeIds.size());
+        assertTrue(r.cubeIds.stream().anyMatch(c -> c.endsWith("/CustomerPii")));
+    }
+
+    @Test
+    public void dashboard_dedupes_cubes_across_tiles() {
+        // Two tiles bind the SAME cube — the inspector should only schema-
+        // lookup once and the cubeIds list should have one entry.
+        ds.put(
+                "/dupe.saikudash",
+                dashboardJson(
+                        List.of(tileJson("conn-1", "Cat", "Sch", "Sales"), tileJson("conn-1", "Cat", "Sch", "Sales"))));
+        cubes.putSchema("conn-1/Cat/Sch/Sales", cleanSchema());
+
+        EmbedPiiInspector.Result r = inspector.inspect("dashboard", "/dupe.saikudash", "admin", List.of());
+        assertFalse(r.referencesPii);
+        assertEquals(1, r.cubeIds.size());
+        assertEquals(1, cubes.lookups);
+    }
+
+    @Test
+    public void dashboard_with_text_only_tiles_returns_no_pii() {
+        // No cube-bound tiles at all — the dashboard is just text /
+        // markdown. Nothing to inspect; the result must be permissive
+        // because there IS no PII column anywhere.
+        ds.put(
+                "/text.saikudash",
+                "{\"id\":\"d\",\"name\":\"text\",\"version\":1,\"layout\":{\"cols\":12,\"tiles\":[]}}");
+        EmbedPiiInspector.Result r = inspector.inspect("dashboard", "/text.saikudash", "admin", List.of());
+        assertFalse(r.referencesPii);
+        assertTrue(r.cubeIds.isEmpty());
+    }
+
+    @Test
+    public void dashboard_with_one_cube_schema_lookup_failure_fails_closed_for_that_cube() {
+        // Schema lookup throws for one cube. Treated as PII (fail-closed)
+        // so the embed gate refuses rather than allows a possibly-PII
+        // cube we can't inspect.
+        ds.put(
+                "/partial.saikudash",
+                dashboardJson(List.of(
+                        tileJson("conn-1", "Cat", "Sch", "Sales"), tileJson("conn-1", "Cat", "Sch", "Broken"))));
+        cubes.putSchema("conn-1/Cat/Sch/Sales", cleanSchema());
+        cubes.throwOn("conn-1/Cat/Sch/Broken");
+
+        EmbedPiiInspector.Result r = inspector.inspect("dashboard", "/partial.saikudash", "admin", List.of());
+        assertTrue("unresolvable cube must fail closed", r.referencesPii);
+    }
+
+    /* -------------------------- defaults -------------------------- */
+
+    @Test
+    public void unknown_kind_fails_closed() {
+        ds.put("/x.weird", "{}");
+        EmbedPiiInspector.Result r = inspector.inspect("schema", "/x.weird", "admin", List.of());
+        assertTrue(r.referencesPii);
+        assertTrue(r.fellOpenForUnresolvable);
+    }
+
+    @Test
+    public void null_or_blank_path_is_permissive() {
+        // The caller's upstream validation rejects blank paths before we
+        // see them — don't double-gate something that can't even be
+        // identified.
+        assertFalse(inspector.inspect("query", null, "admin", List.of()).referencesPii);
+        assertFalse(inspector.inspect("query", "", "admin", List.of()).referencesPii);
+    }
+
+    @Test
+    public void null_infrastructure_is_permissive_so_callers_can_run_without_it() {
+        // No datasource / cube metadata services wired (stub / test
+        // context). Inspector is a no-op; the surrounding GRANT check
+        // remains the load-bearing security check.
+        EmbedPiiInspector noop = new EmbedPiiInspector(null, null);
+        EmbedPiiInspector.Result r = noop.inspect("query", "/anything.saiku", "admin", List.of());
+        assertFalse(r.referencesPii);
+    }
+
+    /* --------------------------- helpers --------------------------- */
+
+    private static AiSchema cleanSchema() {
+        return new AiSchema("c/cat/sch/Cube", "Cube", "[Cube]");
+    }
+
+    private static String thinQueryJson(String conn, String cat, String sch, String cube) {
+        return "{\"name\":\"q\",\"type\":\"QUERYMODEL\",\"cube\":{\"connection\":\"" + conn + "\",\"catalog\":\"" + cat
+                + "\",\"schema\":\"" + sch + "\",\"name\":\"" + cube + "\"}}";
+    }
+
+    private static String dashboardJson(List<String> tileJsons) {
+        StringBuilder sb =
+                new StringBuilder("{\"id\":\"d\",\"name\":\"\",\"version\":1,\"layout\":{\"cols\":12,\"tiles\":[");
+        for (int i = 0; i < tileJsons.size(); i++) {
+            if (i > 0) sb.append(',');
+            sb.append(tileJsons.get(i));
+        }
+        sb.append("]}}");
+        return sb.toString();
+    }
+
+    private static String tileJson(String conn, String cat, String sch, String cube) {
+        return "{\"id\":\"t\",\"x\":0,\"y\":0,\"w\":1,\"h\":1,\"type\":\"chart\",\"cube\":{\"connectionName\":\"" + conn
+                + "\",\"catalog\":\"" + cat + "\",\"schema\":\"" + sch + "\",\"cubeName\":\"" + cube + "\"}}";
+    }
+
+    /* --------------------------- stubs --------------------------- */
+
+    private static class StubDatasourceService extends DatasourceService {
+        private final Map<String, String> files = new HashMap<>();
+        private final java.util.Set<String> throwPaths = new java.util.HashSet<>();
+
+        void put(String path, String content) {
+            files.put(path, content);
+        }
+
+        void throwOn(String path) {
+            throwPaths.add(path);
+        }
+
+        @Override
+        public String getFileData(String path, String username, List<String> roles) {
+            if (throwPaths.contains(path)) throw new RuntimeException("simulated unreadable");
+            return files.get(path);
+        }
+    }
+
+    private static class StubCubeMetadataService implements AiCubeMetadataService {
+        private final Map<String, AiSchema> schemas = new HashMap<>();
+        private final java.util.Set<String> throwKeys = new java.util.HashSet<>();
+        int lookups = 0;
+
+        void putSchema(String cubeKey, AiSchema schema) {
+            schemas.put(cubeKey, schema);
+        }
+
+        void throwOn(String cubeKey) {
+            throwKeys.add(cubeKey);
+        }
+
+        @Override
+        public AiSchema getSchema(AiCubeRef ref) {
+            lookups++;
+            String key =
+                    ref.getConnectionName() + "/" + ref.getCatalog() + "/" + ref.getSchema() + "/" + ref.getCubeName();
+            if (throwKeys.contains(key)) throw new RuntimeException("simulated cube failure");
+            return schemas.get(key);
+        }
+    }
+}

--- a/saiku-core/saiku-web/src/test/java/org/saiku/web/rest/resources/embed/EmbedTokenResourceTest.java
+++ b/saiku-core/saiku-web/src/test/java/org/saiku/web/rest/resources/embed/EmbedTokenResourceTest.java
@@ -324,6 +324,148 @@ public class EmbedTokenResourceTest {
         assertEquals(404, r.getStatus());
     }
 
+    /* ------------------- saiku-cloud#940 PII gate ------------------- */
+
+    @Test
+    public void mint_without_inspector_defaults_redactionPolicy_to_tenant_default() {
+        // No piiInspector wired (the existing happy-path tests already
+        // exercise this — proving the new field defaults correctly).
+        session.username = "admin";
+        ds.allow("/q.saiku");
+        EmbedTokenResource.MintRequest req = new EmbedTokenResource.MintRequest();
+        req.resourceKind = "query";
+        req.resourcePath = "/q.saiku";
+        Response r = resource.mint(req);
+        assertEquals(200, r.getStatus());
+        @SuppressWarnings("unchecked")
+        Map<String, Object> body = (Map<String, Object>) r.getEntity();
+        assertEquals("TENANT_DEFAULT", body.get("redactionPolicy"));
+        // Stored value matches the response.
+        EmbedToken stored = tokenStore.load((String) body.get("token"));
+        assertEquals(EmbedToken.RedactionPolicy.TENANT_DEFAULT, stored.redactionPolicy);
+    }
+
+    @Test
+    public void mint_with_pii_resource_elevates_redactionPolicy_to_force_on() {
+        // Inspector says PII present → mint succeeds with FORCE_ON.
+        session.username = "admin";
+        ds.allow("/sensitive.saiku");
+        StubInspector inspector = new StubInspector();
+        inspector.piiPaths.add("/sensitive.saiku");
+        resource.setPiiInspector(inspector);
+
+        EmbedTokenResource.MintRequest req = new EmbedTokenResource.MintRequest();
+        req.resourceKind = "query";
+        req.resourcePath = "/sensitive.saiku";
+        Response r = resource.mint(req);
+        assertEquals(200, r.getStatus());
+        @SuppressWarnings("unchecked")
+        Map<String, Object> body = (Map<String, Object>) r.getEntity();
+        assertEquals("FORCE_ON", body.get("redactionPolicy"));
+        EmbedToken stored = tokenStore.load((String) body.get("token"));
+        assertEquals(EmbedToken.RedactionPolicy.FORCE_ON, stored.redactionPolicy);
+    }
+
+    @Test
+    public void mint_with_non_pii_resource_keeps_tenant_default() {
+        // Inspector says clean → mint stays at TENANT_DEFAULT.
+        session.username = "admin";
+        ds.allow("/clean.saiku");
+        resource.setPiiInspector(new StubInspector()); // no PII paths
+
+        EmbedTokenResource.MintRequest req = new EmbedTokenResource.MintRequest();
+        req.resourceKind = "query";
+        req.resourcePath = "/clean.saiku";
+        Response r = resource.mint(req);
+        assertEquals(200, r.getStatus());
+        @SuppressWarnings("unchecked")
+        Map<String, Object> body = (Map<String, Object>) r.getEntity();
+        assertEquals("TENANT_DEFAULT", body.get("redactionPolicy"));
+    }
+
+    @Test
+    public void grant_public_with_pii_resource_is_refused_400() {
+        // The load-bearing test for this whole PR — public grants on PII
+        // resources must NEVER succeed.
+        session.username = "admin";
+        ds.allow("/sensitive.saikudash");
+        StubInspector inspector = new StubInspector();
+        inspector.piiPaths.add("/sensitive.saikudash");
+        resource.setPiiInspector(inspector);
+
+        EmbedTokenResource.GrantRequest req = new EmbedTokenResource.GrantRequest();
+        req.resourceKind = "dashboard";
+        req.resourcePath = "/sensitive.saikudash";
+        Response r = resource.grantPublic(req);
+        assertEquals(400, r.getStatus());
+        @SuppressWarnings("unchecked")
+        Map<String, Object> body = (Map<String, Object>) r.getEntity();
+        assertEquals("VALIDATION_ERROR", body.get("status"));
+        assertEquals("resourcePath", body.get("field"));
+        assertTrue(((String) body.get("error")).contains("PII"));
+        assertFalse(
+                "public registry must remain untouched", publicRegistry.isPublic("dashboard", "/sensitive.saikudash"));
+    }
+
+    @Test
+    public void grant_public_with_non_pii_resource_still_succeeds() {
+        // Sanity: the gate only fires for PII. A clean resource passes.
+        session.username = "admin";
+        ds.allow("/clean.saikudash");
+        resource.setPiiInspector(new StubInspector()); // no PII paths
+
+        EmbedTokenResource.GrantRequest req = new EmbedTokenResource.GrantRequest();
+        req.resourceKind = "dashboard";
+        req.resourcePath = "/clean.saikudash";
+        Response r = resource.grantPublic(req);
+        assertEquals(200, r.getStatus());
+        assertTrue(publicRegistry.isPublic("dashboard", "/clean.saikudash"));
+    }
+
+    @Test
+    public void grant_public_pii_gate_fires_AFTER_grant_check() {
+        // Order matters: someone without GRANT on the resource should get
+        // 403 even if the resource is PII — the inspector might leak
+        // structural facts about the resource via its log message if it
+        // runs first. Verify the existing FORBIDDEN path still wins.
+        session.username = "bob"; // no GRANT
+        StubInspector inspector = new StubInspector();
+        inspector.piiPaths.add("/admin-only.saikudash");
+        resource.setPiiInspector(inspector);
+
+        EmbedTokenResource.GrantRequest req = new EmbedTokenResource.GrantRequest();
+        req.resourceKind = "dashboard";
+        req.resourcePath = "/admin-only.saikudash";
+        Response r = resource.grantPublic(req);
+        assertEquals(403, r.getStatus());
+        // Inspector was never asked — it's wired but the 403 short-circuits.
+        assertEquals(0, inspector.calls);
+    }
+
+    @Test
+    public void list_tokens_surfaces_redactionPolicy_for_admin_audit() {
+        // Operator running `gh ... /tokens` needs to see WHICH tokens are
+        // elevated to FORCE_ON so an audit can spot a misconfigured
+        // tenant. The response payload must carry the field.
+        session.username = "admin";
+        ds.allow("/q.saiku");
+        StubInspector inspector = new StubInspector();
+        inspector.piiPaths.add("/q.saiku");
+        resource.setPiiInspector(inspector);
+
+        EmbedTokenResource.MintRequest req = new EmbedTokenResource.MintRequest();
+        req.resourceKind = "query";
+        req.resourcePath = "/q.saiku";
+        resource.mint(req);
+
+        Response r = resource.listTokens(false);
+        assertEquals(200, r.getStatus());
+        @SuppressWarnings("unchecked")
+        List<Map<String, Object>> list = (List<Map<String, Object>>) r.getEntity();
+        assertEquals(1, list.size());
+        assertEquals("FORCE_ON", list.get(0).get("redactionPolicy"));
+    }
+
     /* --------------------------- stubs ---------------------------- */
 
     /** Minimal SessionService stub. {@code username} + {@code roles} are
@@ -369,6 +511,27 @@ public class EmbedTokenResourceTest {
         @Override
         public List<String> getAdminRoles() {
             return adminRoles;
+        }
+    }
+
+    /** Stub inspector for the saiku-cloud#940 gate tests. Paths added to
+     *  {@code piiPaths} produce a {@code referencesPii=true} result; every
+     *  other path returns false. {@code calls} counts invocations so a
+     *  test can assert "the gate did NOT fire because a prior check
+     *  short-circuited" (e.g. the FORBIDDEN-vs-PII ordering test). */
+    private static class StubInspector extends org.saiku.web.embed.EmbedPiiInspector {
+        final java.util.Set<String> piiPaths = new java.util.HashSet<>();
+        int calls = 0;
+
+        StubInspector() {
+            super(null, null);
+        }
+
+        @Override
+        public Result inspect(String kind, String path, String owner, List<String> roles) {
+            calls++;
+            boolean pii = piiPaths.contains(path);
+            return new Result(pii, pii ? List.of("test-cube") : List.of(), false);
         }
     }
 }


### PR DESCRIPTION
## Summary

Closes [saiku-cloud#940](https://github.com/spiculedata/saiku-cloud/issues/940) on the saiku-engine side. Builds on the saiku#902 schema annotation foundation (merged in #1306) and the `<saiku-embed/>` surface from PRs #1301-#1303 + #1304.

**The gate fires after the GRANT check passes:**

| Endpoint | PII detected | Behaviour |
|---|---|---|
| `POST /saiku/api/embed/tokens` | yes | mint succeeds with `redactionPolicy=FORCE_ON` |
| `POST /saiku/api/embed/tokens` | no | mint succeeds with `redactionPolicy=TENANT_DEFAULT` (current behaviour) |
| `POST /saiku/api/embed/public` | yes | **400 VALIDATION_ERROR, field=resourcePath** — refuse outright |
| `POST /saiku/api/embed/public` | no | grant proceeds as before |

### Why refuse public outright

Public anonymous reads are the highest-blast-radius surface on the embed: a public-grant means literally anyone with the URL can read the cellset on an attacker-controlled host page. We categorically refuse rather than try to redact post-hoc — a token mint stays available, and the response carries an explicit hint to use it instead.

### Conservative cube-level granularity for v1

If the resource's cube has ANY `pii`-annotated measure or level, the resource is treated as PII. A future refinement could parse the ThinQuery's axis selections / each dashboard tile's filter targets to check ONLY columns the resource actually projects, but the conservative pass is simpler, faster (cube metadata is already cached), and safer (no leak path that the parser misses can survive).

### Fail-CLOSED on everything that isn't proven safe

| Failure mode | Result |
|---|---|
| File unreadable | `referencesPii=true`, `fellOpenForUnresolvable=true` |
| Garbage JSON | same |
| MDX-mode query (no cube) | same |
| Unknown resource kind | same |
| Cube schema-lookup failure | same |
| Clean parse + no PII annotations on any referenced cube | `referencesPii=false` |

The only path to `false` is a cleanly-parsed resource whose every referenced cube cleanly resolved to a schema with NO PII annotations.

## What's in the diff

| File | Lines | What |
|---|---|---|
| `EmbedToken.java` | +30 | New `RedactionPolicy { TENANT_DEFAULT, FORCE_ON }` enum + field |
| `EmbedTokenStore.java` | +20 | New `create()` overload accepting policy; legacy signature delegates with TENANT_DEFAULT |
| `EmbedPiiInspector.java` | new | Resolves resource → cubes → AiSchema PII walk, with fail-CLOSED defaults |
| `EmbedTokenResource.java` | +50 | Wires inspector into mint + grantPublic, surfaces policy on list response |
| `EmbedPiiInspectorTest.java` | new | 14 tests covering every fail-closed path + the dedupe |
| `EmbedTokenResourceTest.java` | +7 | mint elevation, public refusal, list audit, FORBIDDEN-before-PII ordering |

## ACs against the ticket

| AC | Status |
|---|---|
| `POST /embed/public` rejects with 400 + `field=resourcePath` when the resource references any `saiku.semantic.pii=true` column | ✓ |
| `POST /embed/tokens` succeeds but the resulting `EmbedToken` carries `redactionPolicy=FORCE_ON` when the resource references PII columns | ✓ |
| `EmbedViewResource.query` applies max-strength redaction when `redactionPolicy=FORCE_ON` | **deferred — saiku-cloud gateway PiiRedactor companion ticket** |
| Tests cover (a) public-grant refused, (b) token allowed with policy flag, (c) read-time enforcement | (a) + (b) ✓; (c) deferred to read-time PR |

### Why the read-time piece is deferred

The actual response redaction lives in saiku-cloud's gateway (PiiRedactor — saiku-cloud#12, already shipped). This PR delivers the **field** + **mint-time elevation** so the gateway has something to read from. The cleanest read-time implementation is a follow-up PR on saiku-cloud that:
1. Loads the EmbedToken
2. If `redactionPolicy=FORCE_ON`, runs the redactor with max-strength settings regardless of tenant tier

That's saiku-cloud territory and best filed as a separate ticket.

## Tests

**72/72 embed tests in saiku-web.** **351/351 across saiku-service + saiku-web. Spotless clean.**

| File | Count | What |
|---|---|---|
| `EmbedPiiInspectorTest` | 14 new | Query / dashboard / dedupe / fail-CLOSED edge cases |
| `EmbedTokenResourceTest` | +7 (22 total) | mint elevation, public refusal, list endpoint surfacing, FORBIDDEN-before-PII ordering |

## Test plan

- [x] `mvn verify` clean
- [x] Spotless apply + check clean
- [ ] CI green on dev
- [ ] Smoke against the bundled FoodMart cube — tag a level with `saiku.semantic.pii=true`, mint a token for a saved query touching it, confirm `redactionPolicy=FORCE_ON` in the response
- [ ] Try `POST /embed/public` on the same resource — confirm 400 with the documented error envelope
- [ ] Confirm `GET /embed/tokens` lists the `redactionPolicy` field

## Follow-ups

- Read-time enforcement (saiku-cloud gateway PiiRedactor for FORCE_ON tokens)
- Per-column granularity refinement (parse ThinQuery axes + dashboard tile filters — future ticket)
- Surface `redactionPolicy` in the saiku-ui catalogue UI when listing tokens (saiku-cloud dashboard)