### PR TITLE
feat(embed): emit X-Saiku-Embed-Redaction-Policy header — saiku-cloud#948 engine side

### DIFF
--- a/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/embed/EmbedViewResource.java
+++ b/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/embed/EmbedViewResource.java
@@ -92,7 +92,7 @@ public class EmbedViewResource {
                 sreq.setPath(g.resourcePath);
                 return aiQueryResource.executeSaved(sreq);
             });
-            return harden(result);
+            return withPolicyHeader(harden(result), g);
         } catch (RuntimeException e) {
             log.warn("embed-view query execution failed for {}", g.resourcePath, e);
             return harden(Response.serverError()
@@ -125,7 +125,8 @@ public class EmbedViewResource {
                     .type(MediaType.APPLICATION_JSON)
                     .build());
         }
-        return harden(Response.ok(dash).type(MediaType.APPLICATION_JSON).build());
+        return withPolicyHeader(
+                harden(Response.ok(dash).type(MediaType.APPLICATION_JSON).build()), g);
     }
 
     /**
@@ -174,7 +175,7 @@ public class EmbedViewResource {
                         .type(MediaType.APPLICATION_JSON)
                         .build();
             });
-            return harden(result);
+            return withPolicyHeader(harden(result), g);
         } catch (RuntimeException e) {
             log.warn("embed-view tile query failed for {}/{}", g.resourcePath, tileId, e);
             return harden(Response.serverError()
@@ -224,6 +225,32 @@ public class EmbedViewResource {
                 .entity(Map.of("status", "EMBED_INVALID", "error", "Embed link is invalid or expired."))
                 .type(MediaType.APPLICATION_JSON)
                 .build());
+    }
+
+    /**
+     * saiku-cloud#948 header — signals the saiku-cloud gateway to apply
+     * max-strength redaction on the response body, regardless of the
+     * tenant's tier or per-tenant mask config. Set when the bound token has
+     * {@link org.saiku.web.embed.EmbedToken.RedactionPolicy#FORCE_ON};
+     * absent (NOT set to {@code TENANT_DEFAULT}) otherwise so the gateway
+     * has a cheap presence check rather than a value parse. The header
+     * itself is engine-emit-only — no client can synthesise it because the
+     * gateway is the only consumer and it strips trust-region headers from
+     * inbound requests.
+     *
+     * <p>Public-grant requests carry {@code TENANT_DEFAULT} (the public-
+     * grant flow has no token to elevate). Tokens that pre-date #1307
+     * deserialise to {@code TENANT_DEFAULT} too — neither gets the header,
+     * neither triggers gateway-side max-strength.
+     */
+    public static final String REDACTION_POLICY_HEADER = "X-Saiku-Embed-Redaction-Policy";
+
+    private static Response withPolicyHeader(Response r, EmbedGuestDetails g) {
+        if (g == null || g.redactionPolicy == null) return r;
+        if (g.redactionPolicy != org.saiku.web.embed.EmbedToken.RedactionPolicy.FORCE_ON) return r;
+        return Response.fromResponse(r)
+                .header(REDACTION_POLICY_HEADER, g.redactionPolicy.name())
+                .build();
     }
 
     /**

--- a/saiku-core/saiku-web/src/main/java/org/saiku/web/security/embed/EmbedAuthFilter.java
+++ b/saiku-core/saiku-web/src/main/java/org/saiku/web/security/embed/EmbedAuthFilter.java
@@ -117,7 +117,11 @@ public class EmbedAuthFilter extends OncePerRequestFilter {
                             token.resourceKind,
                             token.resourcePath,
                             token.createdBy,
-                            token.ownerRolesSnapshot));
+                            token.ownerRolesSnapshot,
+                            // saiku-cloud#948: carry the policy forward so
+                            // the view resource can stamp the gateway-
+                            // facing redaction-policy header.
+                            token.redactionPolicy));
             return;
         }
 
@@ -249,14 +253,41 @@ public class EmbedAuthFilter extends OncePerRequestFilter {
         public final String resourcePath;
         public final String ownerUser;
         public final List<String> ownerRoles;
+        /** saiku-cloud#948. Carries the token's redaction policy forward so
+         *  {@code EmbedViewResource} can stamp the
+         *  {@code X-Saiku-Embed-Redaction-Policy} response header for the
+         *  saiku-cloud gateway's PiiRedactor to honour. Defaults to
+         *  {@link org.saiku.web.embed.EmbedToken.RedactionPolicy#TENANT_DEFAULT}
+         *  for public-grant requests (no token to elevate from). */
+        public final org.saiku.web.embed.EmbedToken.RedactionPolicy redactionPolicy;
 
         public EmbedGuestDetails(
                 String token, String resourceKind, String resourcePath, String ownerUser, List<String> ownerRoles) {
+            this(
+                    token,
+                    resourceKind,
+                    resourcePath,
+                    ownerUser,
+                    ownerRoles,
+                    org.saiku.web.embed.EmbedToken.RedactionPolicy.TENANT_DEFAULT);
+        }
+
+        /** saiku-cloud#948 — explicit-policy constructor. */
+        public EmbedGuestDetails(
+                String token,
+                String resourceKind,
+                String resourcePath,
+                String ownerUser,
+                List<String> ownerRoles,
+                org.saiku.web.embed.EmbedToken.RedactionPolicy redactionPolicy) {
             this.token = token;
             this.resourceKind = resourceKind;
             this.resourcePath = resourcePath;
             this.ownerUser = ownerUser;
             this.ownerRoles = ownerRoles == null ? List.of() : List.copyOf(ownerRoles);
+            this.redactionPolicy = redactionPolicy == null
+                    ? org.saiku.web.embed.EmbedToken.RedactionPolicy.TENANT_DEFAULT
+                    : redactionPolicy;
         }
 
         /** True when this request reached the resource via a public grant

--- a/saiku-core/saiku-web/src/test/java/org/saiku/web/rest/resources/embed/EmbedViewResourceTest.java
+++ b/saiku-core/saiku-web/src/test/java/org/saiku/web/rest/resources/embed/EmbedViewResourceTest.java
@@ -2,6 +2,7 @@ package org.saiku.web.rest.resources.embed;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 import jakarta.ws.rs.core.Response;
@@ -135,11 +136,83 @@ public class EmbedViewResourceTest {
         assertEquals(401, r.getStatus());
     }
 
+    /* ----------------- saiku-cloud#948 force-on header ----------------- */
+
+    @Test
+    public void query_response_stamps_force_on_header_when_token_policy_is_force_on() {
+        pinGuestWithPolicy(
+                "query",
+                "/homes/admin/sales.saiku",
+                "admin",
+                List.of("ROLE_ADMIN"),
+                org.saiku.web.embed.EmbedToken.RedactionPolicy.FORCE_ON);
+
+        Response r = resource.query("homes/admin/sales.saiku");
+
+        assertEquals(200, r.getStatus());
+        assertEquals(
+                "FORCE_ON",
+                r.getHeaderString(org.saiku.web.rest.resources.embed.EmbedViewResource.REDACTION_POLICY_HEADER));
+    }
+
+    @Test
+    public void query_response_omits_header_for_tenant_default_policy() {
+        // Default policy → no header → gateway falls back to tenant tier
+        // config. Pinned so we never leak a TENANT_DEFAULT value that
+        // could confuse a gateway expecting only FORCE_ON.
+        pinGuestWithPolicy(
+                "query",
+                "/homes/admin/clean.saiku",
+                "admin",
+                List.of(),
+                org.saiku.web.embed.EmbedToken.RedactionPolicy.TENANT_DEFAULT);
+
+        Response r = resource.query("homes/admin/clean.saiku");
+
+        assertEquals(200, r.getStatus());
+        assertNull(
+                "TENANT_DEFAULT must NOT stamp the policy header",
+                r.getHeaderString(org.saiku.web.rest.resources.embed.EmbedViewResource.REDACTION_POLICY_HEADER));
+    }
+
+    @Test
+    public void dashboard_response_stamps_force_on_header() {
+        // Dashboard path covered separately from query.
+        ds.fileContent = "{\"id\":\"d-1\",\"name\":\"Exec\",\"version\":1}";
+        pinGuestWithPolicy(
+                "dashboard",
+                "/homes/admin/exec.saikudash",
+                "admin",
+                List.of("ROLE_ADMIN"),
+                org.saiku.web.embed.EmbedToken.RedactionPolicy.FORCE_ON);
+
+        Response r = resource.dashboard("homes/admin/exec.saikudash");
+
+        assertEquals(200, r.getStatus());
+        assertEquals(
+                "FORCE_ON",
+                r.getHeaderString(org.saiku.web.rest.resources.embed.EmbedViewResource.REDACTION_POLICY_HEADER));
+    }
+
     /* --------------------------- helpers ---------------------------- */
 
     private void pinGuest(String kind, String path, String user, List<String> roles) {
         EmbedGuestDetails details =
                 new EmbedGuestDetails("anonymous-token-id".equals(kind) ? null : "token-xyz", kind, path, user, roles);
+        PreAuthenticatedAuthenticationToken auth = new PreAuthenticatedAuthenticationToken(
+                "embed-guest", details, List.of(new SimpleGrantedAuthority("ROLE_EMBED_GUEST")));
+        auth.setDetails(details);
+        SecurityContextHolder.getContext().setAuthentication(auth);
+    }
+
+    /** saiku-cloud#948 — pin with an explicit redaction policy. */
+    private void pinGuestWithPolicy(
+            String kind,
+            String path,
+            String user,
+            List<String> roles,
+            org.saiku.web.embed.EmbedToken.RedactionPolicy policy) {
+        EmbedGuestDetails details = new EmbedGuestDetails("token-xyz", kind, path, user, roles, policy);
         PreAuthenticatedAuthenticationToken auth = new PreAuthenticatedAuthenticationToken(
                 "embed-guest", details, List.of(new SimpleGrantedAuthority("ROLE_EMBED_GUEST")));
         auth.setDetails(details);


### PR DESCRIPTION
## Summary

Engine side of saiku-cloud#948. Carries the EmbedToken's `redactionPolicy` through to the response so the saiku-cloud gateway's PiiRedactor can elevate to max-strength when a FORCE_ON token's read crosses the trust boundary.

## What lands

| Layer | Change |
|---|---|
| `EmbedGuestDetails` | New `redactionPolicy` field carried on the SecurityContext details. Back-compat ctor preserves existing 5-arg call sites |
| `EmbedAuthFilter` | Populates the policy from `token.redactionPolicy` on the token path; public-grant path carries `TENANT_DEFAULT` (no token to elevate) |
| `EmbedViewResource` | New `REDACTION_POLICY_HEADER` constant + `withPolicyHeader()` helper; wired into query / dashboard / tileQuery success paths |

## Wire shape

```
HTTP/1.1 200 OK
X-Content-Type-Options: nosniff
Referrer-Policy: no-referrer
Cache-Control: no-store
X-Saiku-Embed-Redaction-Policy: FORCE_ON      ← when bound token policy is FORCE_ON; absent otherwise
```

**Presence-only signal**, not value parsing — a gateway can do a cheap `hasHeader` check rather than a string compare. Engine never sends `TENANT_DEFAULT` as a header value.

## Tests

| Scenario | Status |
|---|---|
| query() FORCE_ON token → header present with value "FORCE_ON" | ✓ |
| query() TENANT_DEFAULT → header absent | ✓ |
| dashboard() FORCE_ON token → header present | ✓ |

**75/75 embed tests green** (72 + 3 new). Spotless clean.

## What this PR alone does

On the OSS launcher: nothing. The launcher has no PII redactor, so the header is informational only.
On saiku-cloud: still nothing until the gateway-side companion PR consumes it. That's the next PR.

## Companion PR

The saiku-cloud gateway-side companion (PiiRedactor.redactForceOn() + ProxyController header detection) lands separately. Both PRs are independent and ship in their own repos.

## Test plan

- [x] `mvn -B -ntp -pl saiku-core/saiku-web test` clean
- [x] Spotless applied + check clean
- [ ] CI green on dev
- [ ] Manual: mint a FORCE_ON token via curl, fetch the embed response, confirm `X-Saiku-Embed-Redaction-Policy: FORCE_ON` is present