### PR TITLE
feat(embed): per-column PII granularity in EmbedPiiInspector — saiku-cloud#949

### DIFF
--- a/saiku-core/saiku-web/src/main/java/org/saiku/web/embed/EmbedPiiInspector.java
+++ b/saiku-core/saiku-web/src/main/java/org/saiku/web/embed/EmbedPiiInspector.java
@@ -10,13 +10,24 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 import org.saiku.olap.dto.SaikuCube;
+import org.saiku.olap.query2.ThinAxis;
+import org.saiku.olap.query2.ThinHierarchy;
+import org.saiku.olap.query2.ThinLevel;
+import org.saiku.olap.query2.ThinMeasure;
 import org.saiku.olap.query2.ThinQuery;
+import org.saiku.olap.query2.ThinQueryModel;
 import org.saiku.service.datasource.DatasourceService;
+import org.saiku.service.olap.ai.AiAxisSelection;
 import org.saiku.service.olap.ai.AiCubeMetadataService;
 import org.saiku.service.olap.ai.AiCubeRef;
+import org.saiku.service.olap.ai.AiFilterSelection;
+import org.saiku.service.olap.ai.AiMeasureSelection;
+import org.saiku.service.olap.ai.AiQueryRequest;
 import org.saiku.service.olap.ai.AiSchema;
 import org.saiku.web.rest.resources.dashboards.Dashboard;
+import org.saiku.web.rest.resources.dashboards.DashboardFilter;
 import org.saiku.web.rest.resources.dashboards.DashboardTile;
+import org.saiku.web.rest.resources.dashboards.KpiConfig;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -31,14 +42,21 @@ import org.slf4j.LoggerFactory;
  * (refuses the public grant outright — public-anonymous reads of PII
  * captions are the highest-blast-radius leak on the embed surface).
  *
- * <p>Conservative v1 — cube-level granularity. If the cube has ANY
- * PII-annotated measure or level, the resource is treated as referencing
- * PII. A future refinement could parse the ThinQuery's axis selections /
- * each dashboard tile's filter targets to check ONLY columns the resource
- * actually projects, but the conservative pass is simpler, faster (cube
- * metadata is already cached), and safer (no leak path that the parser
- * misses can survive). Operators who want finer granularity can tag
- * fewer columns PII.
+ * <p><b>Per-column granularity (saiku-cloud#949).</b> When the resource
+ * parses cleanly into a {@link ThinQuery} with a {@link ThinQueryModel}
+ * (or a dashboard tile carries enough refs to enumerate columns), the
+ * inspector walks ONLY the dimensions/hierarchies/levels/measures the
+ * resource actually projects and reports PII iff one of THOSE is
+ * annotated. This avoids over-flagging finely-tagged cubes where a single
+ * PII level on an otherwise-clean cube would have flipped every saved
+ * query on that cube to {@code FORCE_ON} under v1.
+ *
+ * <p>Per-column extraction can fail for plenty of legitimate reasons —
+ * MDX-mode queries with no model, a tile shape we don't recognise, a
+ * malformed axis. Every such failure falls back to the conservative
+ * v1 cube-level scan rather than weakening the safety floor. The
+ * fallback is a one-line WARN log so an admin investigating the
+ * over-flag can find the trigger.
  *
  * <p>The inspector is best-effort by design: if a resource is unreadable,
  * a tile references an unloadable cube, or the schema cache fails, we
@@ -119,7 +137,7 @@ public class EmbedPiiInspector {
             if ("query".equals(resourceKind)) {
                 return inspectQuery(raw, resourcePath);
             } else if ("dashboard".equals(resourceKind)) {
-                return inspectDashboard(raw, resourcePath);
+                return inspectDashboard(raw, resourcePath, ownerUser, ownerRoles);
             } else {
                 // Unknown kind — fail-closed.
                 log.warn("EmbedPiiInspector: unknown resourceKind {}, failing closed", resourceKind);
@@ -151,10 +169,37 @@ public class EmbedPiiInspector {
             return new Result(true, List.of(), true);
         }
         AiCubeRef ref = new AiCubeRef(cube.getConnection(), cube.getCatalog(), cube.getSchema(), cube.getName());
-        return new Result(cubeReferencesPii(ref), List.of(cubeKey(ref)), false);
+
+        AiSchema schema;
+        try {
+            schema = cubeMetadataService.getSchema(ref);
+        } catch (RuntimeException e) {
+            log.warn("EmbedPiiInspector: schema lookup failed for {}, failing closed: {}", cubeKey(ref), e.toString());
+            return new Result(true, List.of(cubeKey(ref)), true);
+        }
+        if (schema == null) {
+            // Unresolvable schema — fail-closed.
+            return new Result(true, List.of(cubeKey(ref)), true);
+        }
+
+        // saiku-cloud#949: per-column refinement. Extract the dim/hier/level
+        // and measure refs the query actually projects. If extraction
+        // succeeds, check ONLY those against the schema's PII flags.
+        ColumnRefs refs = extractRefsFromThinQuery(tq);
+        if (refs == null || refs.isEmpty()) {
+            // No model (MDX-mode), no axes populated, or extraction threw —
+            // fall back to v1 cube-level scan. Cube-level scan is conservative:
+            // any PII column anywhere flips the result to true, so the
+            // safety floor holds.
+            log.debug(
+                    "EmbedPiiInspector: per-column extraction empty for {} — falling back to cube-level scan",
+                    resourcePath);
+            return new Result(schemaHasAnyPii(schema), List.of(cubeKey(ref)), false);
+        }
+        return new Result(refsHitPii(schema, refs), List.of(cubeKey(ref)), false);
     }
 
-    private Result inspectDashboard(String raw, String resourcePath) {
+    private Result inspectDashboard(String raw, String resourcePath, String ownerUser, List<String> ownerRoles) {
         Dashboard dash;
         try {
             dash = MAPPER.readValue(raw, Dashboard.class);
@@ -166,13 +211,68 @@ public class EmbedPiiInspector {
             return new Result(false, List.of(), false);
         }
         Set<String> seenCubes = new LinkedHashSet<>();
+        // Per-walk schema cache so a multi-tile dashboard binding the same
+        // cube performs ONE schema lookup, not one per tile. The per-tile
+        // column refs differ but the schema is invariant for the duration
+        // of the inspection. {@code Boolean.TRUE} = schema unresolvable /
+        // threw → that tile fails closed; {@code null} value = never looked
+        // up yet.
+        java.util.Map<String, AiSchema> schemaCache = new java.util.HashMap<>();
+        java.util.Set<String> brokenCubes = new java.util.HashSet<>();
         boolean anyPii = false;
         for (DashboardTile tile : dash.layout.tiles) {
-            if (tile.cube == null) continue; // text / decorative tile
+            // Text / image / decorative tiles can't bind PII. Skip.
+            if (tile.cube == null && tile.target == null && (tile.query == null || tile.query.path == null)) {
+                continue;
+            }
+            // Reference-style tile: read the referenced saved query under
+            // the owner's scope and recurse on inspectQuery. This recursion
+            // is bounded — saved queries do not nest, so depth is 1.
+            if (tile.query != null && "reference".equals(tile.query.kind) && tile.query.path != null) {
+                Result inner = inspectReferencedQuery(tile.query.path, ownerUser, ownerRoles);
+                seenCubes.addAll(inner.cubeIds);
+                if (inner.referencesPii) {
+                    anyPii = true;
+                }
+                continue;
+            }
+            // Tile binds to a cube directly (inline query / filter widget
+            // / KPI). Use the tile's cube as the schema home; extract the
+            // tile's referenced columns and lookup against that one cube.
             AiCubeRef ref = tile.cube;
+            if (ref == null) {
+                // No cube to inspect (e.g. filter widget with no target
+                // wired yet) — skip cleanly; nothing to leak.
+                continue;
+            }
             String key = cubeKey(ref);
-            if (!seenCubes.add(key)) continue; // dedupe — many tiles can bind the same cube
-            if (cubeReferencesPii(ref)) {
+            seenCubes.add(key);
+            if (brokenCubes.contains(key)) {
+                // Already failed to resolve this cube on a previous tile;
+                // every other tile bound to it fails closed too.
+                anyPii = true;
+                continue;
+            }
+            AiSchema schema = schemaCache.get(key);
+            if (schema == null && !schemaCache.containsKey(key)) {
+                try {
+                    schema = cubeMetadataService.getSchema(ref);
+                } catch (RuntimeException e) {
+                    log.warn("EmbedPiiInspector: schema lookup failed for {}, failing closed: {}", key, e.toString());
+                    brokenCubes.add(key);
+                    anyPii = true;
+                    continue;
+                }
+                if (schema == null) {
+                    brokenCubes.add(key);
+                    anyPii = true;
+                    continue;
+                }
+                schemaCache.put(key, schema);
+            }
+            ColumnRefs refs = extractRefsFromTile(tile);
+            boolean tilePii = (refs == null || refs.isEmpty()) ? schemaHasAnyPii(schema) : refsHitPii(schema, refs);
+            if (tilePii) {
                 anyPii = true;
                 // Keep walking to collect the full cube set for audit, even
                 // after the first PII hit — useful when an operator wants
@@ -183,25 +283,230 @@ public class EmbedPiiInspector {
         return new Result(anyPii, new ArrayList<>(seenCubes), false);
     }
 
-    private boolean cubeReferencesPii(AiCubeRef ref) {
+    /**
+     * Inspect a saved-query tile-reference under the owner's scope. Mirrors
+     * the top-level {@link #inspectQuery} but reads the file inline rather
+     * than from the inspect() entry point so we keep cube-ids merging into
+     * the parent dashboard's audit set.
+     */
+    private Result inspectReferencedQuery(String path, String ownerUser, List<String> ownerRoles) {
+        String raw;
         try {
-            AiSchema schema = cubeMetadataService.getSchema(ref);
-            if (schema == null) return true; // null = unresolvable → fail-closed
-            for (AiSchema.Measure m : schema.measures.values()) {
-                if (m.pii) return true;
-            }
-            for (AiSchema.Dimension d : schema.dimensions.values()) {
-                for (AiSchema.Hierarchy h : d.hierarchies.values()) {
-                    for (AiSchema.Level l : h.levels.values()) {
-                        if (l.pii) return true;
+            raw = datasourceService.getFileData(path, ownerUser, ownerRoles);
+        } catch (RuntimeException e) {
+            log.warn("EmbedPiiInspector: referenced saved-query unreadable, failing closed — path={}", path);
+            return new Result(true, List.of(), true);
+        }
+        if (raw == null || raw.isEmpty()) {
+            log.warn("EmbedPiiInspector: referenced saved-query empty, failing closed — path={}", path);
+            return new Result(true, List.of(), true);
+        }
+        try {
+            return inspectQuery(raw, path);
+        } catch (RuntimeException e) {
+            log.warn("EmbedPiiInspector: referenced saved-query parse failed, failing closed — path={}", path, e);
+            return new Result(true, List.of(), true);
+        }
+    }
+
+    /* ------------------------- column refs ------------------------- */
+
+    /**
+     * The dim/hier/level + measure columns a resource projects. Used as
+     * the input to the per-column PII check (saiku-cloud#949).
+     *
+     * <p>Levels are keyed by lowercased {@code dim/hierarchy/level} short
+     * names so they match the AiSchema map keys (see {@link AiSchema#key(String)}).
+     * Measures are keyed by lowercased short name only — measures live
+     * directly on the cube, not under a hierarchy.
+     */
+    static final class ColumnRefs {
+        final Set<String> levelKeys = new LinkedHashSet<>(); // "dimKey/hierKey/levelKey"
+        final Set<String> measureKeys = new LinkedHashSet<>();
+
+        boolean isEmpty() {
+            return levelKeys.isEmpty() && measureKeys.isEmpty();
+        }
+
+        void addLevel(String dim, String hier, String level) {
+            if (dim == null || hier == null || level == null) return;
+            levelKeys.add(AiSchema.key(dim) + "/" + AiSchema.key(hier) + "/" + AiSchema.key(level));
+        }
+
+        void addMeasure(String name) {
+            if (name == null) return;
+            measureKeys.add(AiSchema.key(name));
+        }
+    }
+
+    /**
+     * Walk a {@link ThinQuery}'s axes + measure details to collect the
+     * dim/hier/level + measure refs it projects. Returns {@code null} if
+     * the query has no queryModel (MDX-mode); the caller treats that as
+     * "fall back to cube-level scan."
+     */
+    private static ColumnRefs extractRefsFromThinQuery(ThinQuery tq) {
+        ThinQueryModel model = tq.getQueryModel();
+        if (model == null || model.getAxes() == null) {
+            return null;
+        }
+        ColumnRefs out = new ColumnRefs();
+        try {
+            for (ThinAxis axis : model.getAxes().values()) {
+                if (axis == null || axis.getHierarchies() == null) continue;
+                for (ThinHierarchy hier : axis.getHierarchies()) {
+                    String dim = hier.getDimension();
+                    // ThinHierarchy.name is populated with the unique name
+                    // (e.g. "[Customer].[Customers]") by Thin.convertHierarchy.
+                    // AiSchema keys hierarchies by short name, so extract
+                    // the last bracket segment.
+                    String hierShort = lastBracketSegment(hier.getName());
+                    if (hier.getLevels() != null) {
+                        for (ThinLevel level : hier.getLevels().values()) {
+                            if (level == null) continue;
+                            out.addLevel(dim, hierShort, level.getName());
+                        }
                     }
                 }
             }
-            return false;
+            // Measures from the details slot. The details axis carries the
+            // measure list across both row-pivot and column-pivot layouts.
+            if (model.getDetails() != null && model.getDetails().getMeasures() != null) {
+                for (ThinMeasure m : model.getDetails().getMeasures()) {
+                    if (m != null) out.addMeasure(m.getName());
+                }
+            }
         } catch (RuntimeException e) {
-            log.warn("EmbedPiiInspector: schema lookup failed for {}, failing closed: {}", cubeKey(ref), e.toString());
-            return true;
+            log.warn("EmbedPiiInspector: ThinQuery walk threw, falling back to cube-level scan: {}", e.toString());
+            return null;
         }
+        return out;
+    }
+
+    /**
+     * Walk a single {@link DashboardTile} for the dim/hier/level + measure
+     * refs it actually projects. Covers:
+     * <ul>
+     *   <li>{@code kpi.measure} — KPI tile's primary measure</li>
+     *   <li>{@code target} — filter widget's driven dim/hier/level</li>
+     *   <li>{@code query.body} (inline {@link AiQueryRequest}) — rows /
+     *       columns / filters / measures</li>
+     * </ul>
+     * Reference-style queries are handled at the dashboard walker level
+     * (recurse into the saved file), not here.
+     *
+     * <p>Returns {@code null} when no per-column refs could be extracted,
+     * which the caller treats as "fall back to cube-level scan."
+     */
+    private static ColumnRefs extractRefsFromTile(DashboardTile tile) {
+        ColumnRefs out = new ColumnRefs();
+        try {
+            KpiConfig kpi = tile.kpi;
+            if (kpi != null && kpi.measure != null) {
+                out.addMeasure(lastBracketSegment(kpi.measure));
+            }
+            DashboardFilter target = tile.target;
+            if (target != null) {
+                out.addLevel(target.dimension, target.hierarchy, target.level);
+            }
+            if (tile.query != null && "inline".equals(tile.query.kind) && tile.query.body != null) {
+                AiQueryRequest body = tile.query.body;
+                if (body.getRows() != null) {
+                    for (AiAxisSelection s : body.getRows()) {
+                        if (s != null) out.addLevel(s.getDimension(), s.getHierarchy(), s.getLevel());
+                    }
+                }
+                if (body.getColumns() != null) {
+                    for (AiAxisSelection s : body.getColumns()) {
+                        if (s != null) out.addLevel(s.getDimension(), s.getHierarchy(), s.getLevel());
+                    }
+                }
+                if (body.getFilters() != null) {
+                    for (AiFilterSelection f : body.getFilters()) {
+                        if (f != null) out.addLevel(f.getDimension(), f.getHierarchy(), f.getLevel());
+                    }
+                }
+                if (body.getMeasures() != null) {
+                    for (AiMeasureSelection m : body.getMeasures()) {
+                        if (m != null) out.addMeasure(m.getName());
+                    }
+                }
+            }
+        } catch (RuntimeException e) {
+            log.warn("EmbedPiiInspector: dashboard tile walk threw, falling back to cube-level scan: {}", e.toString());
+            return null;
+        }
+        return out.isEmpty() ? null : out;
+    }
+
+    /**
+     * Check whether any of the supplied column refs maps to a PII-annotated
+     * schema entry. An unknown ref (one that doesn't resolve to anything in
+     * the schema map) is treated as "not PII" — that's the right call for
+     * the embed gate because:
+     * <ul>
+     *   <li>It cannot expose PII data — the engine will reject the query at
+     *       run time anyway if the ref doesn't resolve to a real column;</li>
+     *   <li>The cube-level fallback already covers the "we couldn't read
+     *       the schema" case, so we never get here with a null schema.</li>
+     * </ul>
+     */
+    private static boolean refsHitPii(AiSchema schema, ColumnRefs refs) {
+        for (String mKey : refs.measureKeys) {
+            AiSchema.Measure m = schema.measures.get(mKey);
+            if (m != null && m.pii) return true;
+        }
+        for (String lKey : refs.levelKeys) {
+            String[] parts = lKey.split("/", 3);
+            if (parts.length != 3) continue;
+            AiSchema.Dimension d = schema.dimensions.get(parts[0]);
+            if (d == null) continue;
+            AiSchema.Hierarchy h = d.hierarchies.get(parts[1]);
+            if (h == null) continue;
+            AiSchema.Level l = h.levels.get(parts[2]);
+            if (l != null && l.pii) return true;
+        }
+        return false;
+    }
+
+    /**
+     * v1 cube-level scan kept as the safety fallback. Returns true iff ANY
+     * measure or level on the cube carries the PII flag. Used when:
+     * <ul>
+     *   <li>per-column extraction returns null (MDX-mode, unparseable);</li>
+     *   <li>per-column extraction returns empty (no axes populated yet);</li>
+     *   <li>extraction throws.</li>
+     * </ul>
+     */
+    private static boolean schemaHasAnyPii(AiSchema schema) {
+        if (schema == null) return true;
+        for (AiSchema.Measure m : schema.measures.values()) {
+            if (m.pii) return true;
+        }
+        for (AiSchema.Dimension d : schema.dimensions.values()) {
+            for (AiSchema.Hierarchy h : d.hierarchies.values()) {
+                for (AiSchema.Level l : h.levels.values()) {
+                    if (l.pii) return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Return the last bracketed segment of a Mondrian-style unique name.
+     * {@code [Customer].[Customers]} → {@code "Customers"};
+     * {@code [Customers]} → {@code "Customers"}; a non-bracketed input
+     * passes through unchanged so the helper composes with short-name
+     * inputs from KPI / filter widget refs.
+     */
+    static String lastBracketSegment(String name) {
+        if (name == null || name.isEmpty()) return name;
+        int open = name.lastIndexOf('[');
+        if (open < 0) return name;
+        int close = name.indexOf(']', open);
+        if (close < 0) return name.substring(open + 1);
+        return name.substring(open + 1, close);
     }
 
     private static String cubeKey(AiCubeRef ref) {

--- a/saiku-core/saiku-web/src/test/java/org/saiku/web/embed/EmbedPiiInspectorTest.java
+++ b/saiku-core/saiku-web/src/test/java/org/saiku/web/embed/EmbedPiiInspectorTest.java
@@ -192,6 +192,199 @@ public class EmbedPiiInspectorTest {
         assertTrue("unresolvable cube must fail closed", r.referencesPii);
     }
 
+    /* --------------------- per-column (saiku-cloud#949) --------------------- */
+
+    @Test
+    public void query_referencing_only_clean_levels_on_dirty_cube_is_not_pii() {
+        // Cube has a PII level "Email" under [Customer].[Customers], but the
+        // saved query touches only [Time].[Quarter] × [Product].[Family].
+        // v1 would have returned true (the cube has PII somewhere); the
+        // per-column refinement must return false.
+        ds.put(
+                "/clean-axes.saiku",
+                thinQueryWithAxes(
+                        "conn-1",
+                        "Cat",
+                        "Sch",
+                        "Sales",
+                        List.of(
+                                new LevelRef("Time", "[Time].[Time]", "Quarter"),
+                                new LevelRef("Product", "[Product].[Product]", "Family")),
+                        List.of("Store Sales")));
+        AiSchema schema = cleanSchema();
+        // PII column lives on a totally different dim/hier/level.
+        AiSchema.Dimension cust = new AiSchema.Dimension("Customer", "[Customer]");
+        AiSchema.Hierarchy custHier = new AiSchema.Hierarchy("Customers", "[Customer].[Customers]");
+        AiSchema.Level email = new AiSchema.Level("Email", "[Customer].[Customers].[Email]");
+        email.pii = true;
+        custHier.levels.put(AiSchema.key("Email"), email);
+        cust.hierarchies.put(AiSchema.key("Customers"), custHier);
+        schema.dimensions.put(AiSchema.key("Customer"), cust);
+        // Add clean dims/hiers/levels for what the query touches.
+        addClean(schema, "Time", "Time", "Quarter");
+        addClean(schema, "Product", "Product", "Family");
+        addCleanMeasure(schema, "Store Sales");
+        cubes.putSchema("conn-1/Cat/Sch/Sales", schema);
+
+        EmbedPiiInspector.Result r = inspector.inspect("query", "/clean-axes.saiku", "admin", List.of());
+        assertFalse("query touches only clean columns — must NOT be PII", r.referencesPii);
+    }
+
+    @Test
+    public void query_referencing_a_pii_level_on_dirty_cube_is_pii() {
+        // Same cube as above but this query DOES touch the PII column.
+        // Per-column refinement must agree with v1's "yes, PII."
+        ds.put(
+                "/touches-pii.saiku",
+                thinQueryWithAxes(
+                        "conn-1",
+                        "Cat",
+                        "Sch",
+                        "Customer",
+                        List.of(
+                                new LevelRef("Customer", "[Customer].[Customers]", "Email"),
+                                new LevelRef("Time", "[Time].[Time]", "Quarter")),
+                        List.of("Headcount")));
+        AiSchema schema = cleanSchema();
+        AiSchema.Dimension cust = new AiSchema.Dimension("Customer", "[Customer]");
+        AiSchema.Hierarchy custHier = new AiSchema.Hierarchy("Customers", "[Customer].[Customers]");
+        AiSchema.Level email = new AiSchema.Level("Email", "[Customer].[Customers].[Email]");
+        email.pii = true;
+        custHier.levels.put(AiSchema.key("Email"), email);
+        cust.hierarchies.put(AiSchema.key("Customers"), custHier);
+        schema.dimensions.put(AiSchema.key("Customer"), cust);
+        addClean(schema, "Time", "Time", "Quarter");
+        addCleanMeasure(schema, "Headcount");
+        cubes.putSchema("conn-1/Cat/Sch/Customer", schema);
+
+        EmbedPiiInspector.Result r = inspector.inspect("query", "/touches-pii.saiku", "admin", List.of());
+        assertTrue(r.referencesPii);
+    }
+
+    @Test
+    public void query_referencing_a_pii_measure_is_pii() {
+        // Measure is the PII source. Per-column scan must catch it.
+        ds.put(
+                "/pii-measure.saiku",
+                thinQueryWithAxes(
+                        "conn-1",
+                        "Cat",
+                        "Sch",
+                        "Customer",
+                        List.of(new LevelRef("Time", "[Time].[Time]", "Quarter")),
+                        List.of("SSN Count")));
+        AiSchema schema = cleanSchema();
+        addClean(schema, "Time", "Time", "Quarter");
+        AiSchema.Measure ssn = new AiSchema.Measure("SSN Count", "[Measures].[SSN Count]");
+        ssn.pii = true;
+        schema.measures.put(AiSchema.key("SSN Count"), ssn);
+        cubes.putSchema("conn-1/Cat/Sch/Customer", schema);
+
+        EmbedPiiInspector.Result r = inspector.inspect("query", "/pii-measure.saiku", "admin", List.of());
+        assertTrue(r.referencesPii);
+    }
+
+    @Test
+    public void query_with_no_query_model_falls_back_to_cube_level_scan() {
+        // No queryModel means we can't enumerate columns — must fall back
+        // to the v1 conservative cube-level scan. Cube has PII → result
+        // is true.
+        ds.put("/no-model.saiku", thinQueryJson("conn-1", "Cat", "Sch", "Customer"));
+        AiSchema schema = cleanSchema();
+        AiSchema.Measure ssn = new AiSchema.Measure("SSN", "[Measures].[SSN]");
+        ssn.pii = true;
+        schema.measures.put(AiSchema.key("SSN"), ssn);
+        cubes.putSchema("conn-1/Cat/Sch/Customer", schema);
+
+        EmbedPiiInspector.Result r = inspector.inspect("query", "/no-model.saiku", "admin", List.of());
+        assertTrue("MDX-mode query on dirty cube must fall back to cube-level", r.referencesPii);
+    }
+
+    @Test
+    public void dashboard_reference_tile_recurses_into_saved_query() {
+        // The tile is a reference to a saved query at /tile.saiku. The
+        // reference's cube is different from the tile's nominal cube ref
+        // (which is null for reference-style tiles), so the inspector must
+        // read the file and inspect THAT cube's schema. Saved query is
+        // clean — the dashboard should be clean too.
+        ds.put("/dash.saikudash", dashboardJson(List.of(referenceTileJson("/tile.saiku"))));
+        ds.put(
+                "/tile.saiku",
+                thinQueryWithAxes(
+                        "conn-1",
+                        "Cat",
+                        "Sch",
+                        "Sales",
+                        List.of(new LevelRef("Time", "[Time].[Time]", "Quarter")),
+                        List.of("Units")));
+        AiSchema schema = cleanSchema();
+        addClean(schema, "Time", "Time", "Quarter");
+        addCleanMeasure(schema, "Units");
+        cubes.putSchema("conn-1/Cat/Sch/Sales", schema);
+
+        EmbedPiiInspector.Result r = inspector.inspect("dashboard", "/dash.saikudash", "admin", List.of());
+        assertFalse(r.referencesPii);
+    }
+
+    @Test
+    public void dashboard_reference_tile_recurses_and_flags_pii() {
+        // Same shape as above but the saved query DOES touch a PII column.
+        ds.put("/dash.saikudash", dashboardJson(List.of(referenceTileJson("/dirty-tile.saiku"))));
+        ds.put(
+                "/dirty-tile.saiku",
+                thinQueryWithAxes(
+                        "conn-1",
+                        "Cat",
+                        "Sch",
+                        "Customer",
+                        List.of(new LevelRef("Customer", "[Customer].[Customers]", "Email")),
+                        List.of("Headcount")));
+        AiSchema schema = cleanSchema();
+        AiSchema.Dimension cust = new AiSchema.Dimension("Customer", "[Customer]");
+        AiSchema.Hierarchy custHier = new AiSchema.Hierarchy("Customers", "[Customer].[Customers]");
+        AiSchema.Level email = new AiSchema.Level("Email", "[Customer].[Customers].[Email]");
+        email.pii = true;
+        custHier.levels.put(AiSchema.key("Email"), email);
+        cust.hierarchies.put(AiSchema.key("Customers"), custHier);
+        schema.dimensions.put(AiSchema.key("Customer"), cust);
+        addCleanMeasure(schema, "Headcount");
+        cubes.putSchema("conn-1/Cat/Sch/Customer", schema);
+
+        EmbedPiiInspector.Result r = inspector.inspect("dashboard", "/dash.saikudash", "admin", List.of());
+        assertTrue(r.referencesPii);
+    }
+
+    @Test
+    public void dashboard_kpi_tile_flags_only_pii_measure() {
+        // KPI tile carries a `kpi.measure` unique name. v1 would have
+        // checked the whole cube; per-column must check ONLY the KPI's
+        // measure.
+        ds.put(
+                "/kpi.saikudash",
+                dashboardJson(List.of(kpiTileJson("conn-1", "Cat", "Sch", "Customer", "[Measures].[Headcount]"))));
+        AiSchema schema = cleanSchema();
+        // Clean measure on dirty cube — must NOT flag.
+        addCleanMeasure(schema, "Headcount");
+        AiSchema.Measure ssn = new AiSchema.Measure("SSN Count", "[Measures].[SSN Count]");
+        ssn.pii = true;
+        schema.measures.put(AiSchema.key("SSN Count"), ssn);
+        cubes.putSchema("conn-1/Cat/Sch/Customer", schema);
+
+        EmbedPiiInspector.Result r = inspector.inspect("dashboard", "/kpi.saikudash", "admin", List.of());
+        assertFalse("KPI on clean measure, dirty cube — must not flag", r.referencesPii);
+    }
+
+    @Test
+    public void lastBracketSegment_extracts_innermost_unique_name() {
+        // Unit coverage for the helper that maps "[Customer].[Customers]"
+        // → "Customers" so ThinHierarchy.name lookups hit AiSchema's
+        // short-name keys.
+        assertEquals("Customers", EmbedPiiInspector.lastBracketSegment("[Customer].[Customers]"));
+        assertEquals("Customers", EmbedPiiInspector.lastBracketSegment("[Customers]"));
+        assertEquals("Plain", EmbedPiiInspector.lastBracketSegment("Plain"));
+        assertEquals(null, EmbedPiiInspector.lastBracketSegment(null));
+    }
+
     /* -------------------------- defaults -------------------------- */
 
     @Test
@@ -246,6 +439,94 @@ public class EmbedPiiInspectorTest {
     private static String tileJson(String conn, String cat, String sch, String cube) {
         return "{\"id\":\"t\",\"x\":0,\"y\":0,\"w\":1,\"h\":1,\"type\":\"chart\",\"cube\":{\"connectionName\":\"" + conn
                 + "\",\"catalog\":\"" + cat + "\",\"schema\":\"" + sch + "\",\"cubeName\":\"" + cube + "\"}}";
+    }
+
+    /** A reference-style tile pointing at a saved-query path on disk. */
+    private static String referenceTileJson(String savedQueryPath) {
+        return "{\"id\":\"t\",\"x\":0,\"y\":0,\"w\":1,\"h\":1,\"type\":\"chart\","
+                + "\"query\":{\"kind\":\"reference\",\"path\":\"" + savedQueryPath + "\"}}";
+    }
+
+    /** A KPI tile bound to a specific measure unique name. */
+    private static String kpiTileJson(String conn, String cat, String sch, String cube, String measureUniqueName) {
+        return "{\"id\":\"t\",\"x\":0,\"y\":0,\"w\":1,\"h\":1,\"type\":\"chart\","
+                + "\"cube\":{\"connectionName\":\"" + conn + "\",\"catalog\":\"" + cat
+                + "\",\"schema\":\"" + sch + "\",\"cubeName\":\"" + cube + "\"},"
+                + "\"kpi\":{\"measure\":\"" + measureUniqueName + "\"}}";
+    }
+
+    /**
+     * Build a ThinQuery JSON with axis selections — the per-column
+     * inspector needs queryModel.axes populated to extract column refs.
+     * Hierarchy names are stored as Mondrian unique names (the same shape
+     * the engine emits) so the inspector exercises lastBracketSegment.
+     */
+    private static String thinQueryWithAxes(
+            String conn, String cat, String sch, String cube, List<LevelRef> levels, List<String> measureNames) {
+        StringBuilder sb = new StringBuilder();
+        sb.append("{\"name\":\"q\",\"type\":\"QUERYMODEL\",\"cube\":{\"connection\":\"")
+                .append(conn)
+                .append("\",\"catalog\":\"")
+                .append(cat)
+                .append("\",\"schema\":\"")
+                .append(sch)
+                .append("\",\"name\":\"")
+                .append(cube)
+                .append("\"},\"queryModel\":{");
+        sb.append("\"axes\":{\"ROWS\":{\"location\":\"ROWS\",\"hierarchies\":[");
+        for (int i = 0; i < levels.size(); i++) {
+            if (i > 0) sb.append(',');
+            LevelRef ref = levels.get(i);
+            sb.append("{\"name\":\"")
+                    .append(ref.hierUniqueName)
+                    .append("\",\"dimension\":\"")
+                    .append(ref.dim)
+                    .append("\",\"levels\":{\"")
+                    .append(ref.level)
+                    .append("\":{\"name\":\"")
+                    .append(ref.level)
+                    .append("\"}}}");
+        }
+        sb.append("]}},");
+        sb.append("\"details\":{\"axis\":\"COLUMNS\",\"location\":\"BOTTOM\",\"measures\":[");
+        for (int i = 0; i < measureNames.size(); i++) {
+            if (i > 0) sb.append(',');
+            sb.append("{\"name\":\"").append(measureNames.get(i)).append("\"}");
+        }
+        sb.append("]}}}");
+        return sb.toString();
+    }
+
+    /** Triple naming a level under a dim/hier. Hierarchy is the unique
+     *  name (matching ThinHierarchy.name on disk). */
+    private static class LevelRef {
+        final String dim;
+        final String hierUniqueName;
+        final String level;
+
+        LevelRef(String dim, String hierUniqueName, String level) {
+            this.dim = dim;
+            this.hierUniqueName = hierUniqueName;
+            this.level = level;
+        }
+    }
+
+    private static void addClean(AiSchema schema, String dim, String hier, String level) {
+        AiSchema.Dimension d = schema.dimensions.get(AiSchema.key(dim));
+        if (d == null) {
+            d = new AiSchema.Dimension(dim, "[" + dim + "]");
+            schema.dimensions.put(AiSchema.key(dim), d);
+        }
+        AiSchema.Hierarchy h = d.hierarchies.get(AiSchema.key(hier));
+        if (h == null) {
+            h = new AiSchema.Hierarchy(hier, "[" + dim + "].[" + hier + "]");
+            d.hierarchies.put(AiSchema.key(hier), h);
+        }
+        h.levels.put(AiSchema.key(level), new AiSchema.Level(level, "[" + dim + "].[" + hier + "].[" + level + "]"));
+    }
+
+    private static void addCleanMeasure(AiSchema schema, String name) {
+        schema.measures.put(AiSchema.key(name), new AiSchema.Measure(name, "[Measures].[" + name + "]"));
     }
 
     /* --------------------------- stubs --------------------------- */


### PR DESCRIPTION
## Summary

Refines the v1 cube-level scan from #1307 to walk **only the columns the resource actually projects**. Fixes the over-flag where one PII level on an otherwise-clean cube would have flipped every saved query on that cube to \`FORCE_ON\` / refused for public grants.

## The win

| Scenario | v1 (cube-level) | v2 (per-column) |
|---|---|---|
| Query touching \`[Time] × [Product] × Store Sales\` on cube whose only PII column is \`[Customer].[Email]\` | flagged (false positive) | not flagged ✓ |
| Query touching \`[Customer].[Email]\` | flagged | flagged ✓ |
| Query touching \`[Measures].[SSN Count]\` | flagged | flagged ✓ |
| MDX-mode query (no \`queryModel\`) | flagged | falls back to cube-level → flagged ✓ (safety floor) |
| Malformed axis / unknown shape | flagged | falls back to cube-level (safety floor) |

## What walks what

**Saved queries** (\`extractRefsFromThinQuery\`):
- \`queryModel.axes[*].hierarchies[*]\` → \`(dimension, lastBracketSegment(name))\` + each \`levels[*]\`
- \`queryModel.details.measures[*].name\`

**Dashboards** (\`extractRefsFromTile\`):
- \`tile.kpi.measure\` (KPI tile primary measure)
- \`tile.target.dim/hier/level\` (filter widget)
- \`tile.query.body\` rows/columns/filters/measures (inline \`AiQueryRequest\`)
- \`tile.query.kind=\"reference\"\` → recurse into the referenced \`.saiku\` under owner scope (depth bounded at 1; saved queries don't nest)

A per-walk schema cache (\`HashMap<cubeKey, AiSchema>\`) means a multi-tile dashboard binding the same cube still performs **one** metadata lookup, even though each tile's column ref-set differs.

## Safety floor

Every fallback path (no \`queryModel\`, empty axes, walk throws, unresolvable cube, unreadable referenced query) returns the **v1 cube-level scan** result — \`true\` whenever the cube has any PII column anywhere. No path weakens the v1 safety guarantee; the refinement is purely additive.

## Tests

14 v1 tests still pass + 8 new per-column tests. 22/22 total. Full saiku-web suite: 359/359 green; spotless clean.

| Layer | Test | Status |
|---|---|---|
| Query | clean axes on dirty cube → not PII | ✓ |
| Query | PII level → PII | ✓ |
| Query | PII measure → PII | ✓ |
| Query | MDX-mode → cube-level fallback | ✓ |
| Dashboard | reference tile recurses cleanly | ✓ |
| Dashboard | reference tile recurses to PII | ✓ |
| Dashboard | KPI on clean measure of dirty cube → not PII | ✓ |
| Helper | \`lastBracketSegment\` unit | ✓ |

## Closes

saiku-cloud#949

## Follow-ups

Last item on Tom's earlier \"all of the above\":
- **#950** — dashboard surfacing of \`redactionPolicy\` in the embed-token list + public-grant UX nudge (\"this resource references PII columns — mint a scoped token instead\").

## Test plan

- [x] 22/22 inspector tests green
- [x] 359/359 saiku-web suite green
- [ ] CI green on development
- [ ] Manual: mint an embed token for a saved query that touches only \`Store Sales × Time × Product\` on a cube whose only PII column is \`[Customer].[Email]\` → expect \`redactionPolicy=TENANT_DEFAULT\` (was \`FORCE_ON\` under v1)
- [ ] Manual: mint an embed token for a saved query that touches \`[Customer].[Email]\` → expect \`redactionPolicy=FORCE_ON\` (unchanged from v1)