### PR TITLE
feat(security): deployment switch to disable anonymous embed public-grant reads (closes #1305)

### DIFF
--- a/saiku-core/saiku-web/src/main/java/org/saiku/web/embed/EmbedPublicRegistry.java
+++ b/saiku-core/saiku-web/src/main/java/org/saiku/web/embed/EmbedPublicRegistry.java
@@ -47,6 +47,21 @@ public class EmbedPublicRegistry {
      *  public grant. */
     private final Map<String, EmbedPublicGrant> grants = new ConcurrentHashMap<>();
 
+    /** Deployment switch (saiku#1305): when {@code false}, the token-less
+     *  public-grant embed path is disabled entirely — anonymous reads fail
+     *  closed and existing {@code embed-public.json} grants are ignored.
+     *  Default {@code true} preserves single-tenant / intentional-public use. */
+    public static final String ALLOW_PUBLIC_PROP = "saiku.embed.allowPublic";
+
+    /** True when anonymous public-grant embed reads are permitted (default
+     *  {@code true}). Read live (not cached) so a deployment can flip it; the
+     *  boot log records the value seen at startup. Consulted by both
+     *  {@code EmbedAuthFilter} (read path) and {@code EmbedTokenResource}
+     *  (grant-mint path) so the switch governs every public-grant door. */
+    public static boolean publicEmbedsEnabled() {
+        return Boolean.parseBoolean(System.getProperty(ALLOW_PUBLIC_PROP, "true"));
+    }
+
     public EmbedPublicRegistry() {
         this(System.getProperty("saiku.home"));
     }
@@ -65,6 +80,29 @@ public class EmbedPublicRegistry {
         }
         this.file = f;
         load();
+        logBootPosture();
+    }
+
+    /** One-shot startup banner line so the public-embed posture is visible
+     *  alongside the frame-ancestors / default-admin lines (saiku#1305). */
+    private void logBootPosture() {
+        if (publicEmbedsEnabled()) {
+            if (grants.isEmpty()) {
+                log.info("Embed public-grant reads ENABLED ({}=true); no public grants active.", ALLOW_PUBLIC_PROP);
+            } else {
+                log.warn(
+                        "Embed public-grant reads ENABLED ({}=true) with {} active grant(s) — those resources are"
+                                + " readable anonymously. Set {}=false to fail closed for multi-tenant.",
+                        ALLOW_PUBLIC_PROP,
+                        grants.size(),
+                        ALLOW_PUBLIC_PROP);
+            }
+        } else {
+            log.info(
+                    "Embed public-grant reads DISABLED ({}=false) — anonymous embed reads fail closed; existing"
+                            + " embed-public.json grants are ignored.",
+                    ALLOW_PUBLIC_PROP);
+        }
     }
 
     /** True when {@code resourcePath} of {@code resourceKind} has an active

--- a/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/embed/EmbedTokenResource.java
+++ b/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/embed/EmbedTokenResource.java
@@ -263,6 +263,12 @@ public class EmbedTokenResource {
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.APPLICATION_JSON)
     public Response grantPublic(GrantRequest body) {
+        // saiku#1305 — fail closed: when the deployment disables anonymous public
+        // embeds (saiku.embed.allowPublic=false), refuse to mint any new public
+        // grant. Pairs with EmbedAuthFilter ignoring existing grants while off.
+        if (!EmbedPublicRegistry.publicEmbedsEnabled()) {
+            return forbidden("Public embed grants are disabled on this deployment (saiku.embed.allowPublic=false).");
+        }
         if (body == null) {
             return badRequest("body", "request body required");
         }

--- a/saiku-core/saiku-web/src/main/java/org/saiku/web/security/embed/EmbedAuthFilter.java
+++ b/saiku-core/saiku-web/src/main/java/org/saiku/web/security/embed/EmbedAuthFilter.java
@@ -125,17 +125,27 @@ public class EmbedAuthFilter extends OncePerRequestFilter {
             return;
         }
 
-        // 2. Public-grant path. No token; only resources listed in the
-        //    public registry render anonymously.
-        EmbedPublicGrant grant = publicRegistry.lookup(target.kind, target.path);
-        if (grant != null) {
-            authenticate(
-                    req,
-                    resp,
-                    chain,
-                    new EmbedGuestDetails(
-                            null, grant.resourceKind, grant.resourcePath, grant.grantedBy, grant.ownerRolesSnapshot));
-            return;
+        // 2. Public-grant path. No token; only resources listed in the public
+        //    registry render anonymously — and ONLY when the deployment permits
+        //    anonymous public embeds (saiku#1305, saiku.embed.allowPublic). When
+        //    disabled, skip the lookup entirely so existing embed-public.json
+        //    grants are IGNORED (fail closed) and the request falls through to
+        //    the Spring 401, exactly as if no grant existed.
+        if (EmbedPublicRegistry.publicEmbedsEnabled()) {
+            EmbedPublicGrant grant = publicRegistry.lookup(target.kind, target.path);
+            if (grant != null) {
+                authenticate(
+                        req,
+                        resp,
+                        chain,
+                        new EmbedGuestDetails(
+                                null,
+                                grant.resourceKind,
+                                grant.resourcePath,
+                                grant.grantedBy,
+                                grant.ownerRolesSnapshot));
+                return;
+            }
         }
 
         // Neither — fall through. The Spring rules will 401 (the embed read

--- a/saiku-core/saiku-web/src/test/java/org/saiku/web/rest/resources/embed/EmbedTokenResourceTest.java
+++ b/saiku-core/saiku-web/src/test/java/org/saiku/web/rest/resources/embed/EmbedTokenResourceTest.java
@@ -57,6 +57,25 @@ public class EmbedTokenResourceTest {
     /* ---------------------------- mint ---------------------------- */
 
     @Test
+    public void grant_public_refused_when_allowPublic_disabled() {
+        // saiku#1305 — fail closed: with the deployment switch off, no new
+        // public grant may be minted (the gate is the first check in
+        // grantPublic, before grant/PII/cap logic).
+        System.setProperty(EmbedPublicRegistry.ALLOW_PUBLIC_PROP, "false");
+        try {
+            session.username = "admin";
+            session.roles = List.of("ROLE_ADMIN");
+            EmbedTokenResource.GrantRequest req = new EmbedTokenResource.GrantRequest();
+            req.resourceKind = "dashboard";
+            req.resourcePath = "/homes/admin/exec.saikudash";
+            Response r = resource.grantPublic(req);
+            assertEquals(403, r.getStatus());
+        } finally {
+            System.clearProperty(EmbedPublicRegistry.ALLOW_PUBLIC_PROP);
+        }
+    }
+
+    @Test
     public void mint_returns_token_when_caller_can_grant() {
         session.username = "admin";
         session.roles = List.of("ROLE_ADMIN");

--- a/saiku-core/saiku-web/src/test/java/org/saiku/web/security/embed/EmbedAuthFilterTest.java
+++ b/saiku-core/saiku-web/src/test/java/org/saiku/web/security/embed/EmbedAuthFilterTest.java
@@ -56,6 +56,7 @@ public class EmbedAuthFilterTest {
     @After
     public void tearDown() {
         SecurityContextHolder.clearContext();
+        System.clearProperty(EmbedPublicRegistry.ALLOW_PUBLIC_PROP);
     }
 
     @Test
@@ -249,6 +250,47 @@ public class EmbedAuthFilterTest {
         // request that comes through this thread (worker reuse) must NOT
         // inherit the prior guest identity.
         assertNull(SecurityContextHolder.getContext().getAuthentication());
+    }
+
+    @Test
+    public void public_grant_ignored_when_allowPublic_disabled() throws Exception {
+        // saiku#1305 — with the deployment switch off, an EXISTING public grant
+        // must NOT serve anonymously: the filter skips the registry lookup and
+        // falls through to Spring's 401, exactly as if no grant existed.
+        // (Negative control: drop the publicEmbedsEnabled() guard and this
+        // reverts to the admit path — capturedAuth becomes non-null → RED.)
+        System.setProperty(EmbedPublicRegistry.ALLOW_PUBLIC_PROP, "false");
+        publicRegistry.grant("dashboard", "/homes/admin/exec.saikudash", "admin", List.of("ROLE_ADMIN"), "public exec");
+        MockHttpServletRequest req =
+                new MockHttpServletRequest("GET", "/rest/saiku/api/embed/dashboard/homes/admin/exec.saikudash");
+        MockHttpServletResponse resp = new MockHttpServletResponse();
+        ContextCapturingChain chain = new ContextCapturingChain();
+
+        filter.doFilter(req, resp, chain);
+
+        assertTrue("must fall through to the Spring chain (which will 401)", chain.called);
+        assertNull("public grant must NOT authenticate anonymously while the switch is off", chain.capturedAuth);
+        assertNull(
+                "no guest identity set when public embeds are disabled",
+                SecurityContextHolder.getContext().getAuthentication());
+    }
+
+    @Test
+    public void public_grant_admits_when_allowPublic_explicitly_true() throws Exception {
+        // The default path still works when the switch is explicitly on.
+        System.setProperty(EmbedPublicRegistry.ALLOW_PUBLIC_PROP, "true");
+        publicRegistry.grant("dashboard", "/homes/admin/exec.saikudash", "admin", List.of("ROLE_ADMIN"), "public exec");
+        MockHttpServletRequest req =
+                new MockHttpServletRequest("GET", "/rest/saiku/api/embed/dashboard/homes/admin/exec.saikudash");
+        MockHttpServletResponse resp = new MockHttpServletResponse();
+        ContextCapturingChain chain = new ContextCapturingChain();
+
+        filter.doFilter(req, resp, chain);
+
+        assertTrue(chain.called);
+        assertNotNull("explicit allowPublic=true still admits the public grant", chain.capturedAuth);
+        EmbedGuestDetails details = (EmbedGuestDetails) chain.capturedAuth.getDetails();
+        assertTrue("public path is anonymous", details.isAnonymous());
     }
 
     /* --------------------------- helpers ---------------------------- */


### PR DESCRIPTION
## Summary
The `<saiku-embed>` surface has a token-less **public-grant** path that serves a granted resource anonymously under the grantor's role snapshot. There was no server-side way to turn it off — so a multi-tenant deployment had no fail-closed guarantee that an accidental or over-broad public grant couldn't expose a tenant's dashboard with no token, bypassing the per-tenant proxy/token isolation model. This adds that off-switch. (Came out of the InvoicePlanner analytics-embed security review.)

## The change
- New deployment switch **`saiku.embed.allowPublic`** (default `true`, consistent with the existing `-Dsaiku.*` knobs). Single source of truth: `EmbedPublicRegistry.publicEmbedsEnabled()`.
- When **false**:
  - `EmbedAuthFilter` skips the public-grant lookup entirely → existing `embed-public.json` grants are **ignored** and the request falls through to the standard `hasRole(EMBED_GUEST)` **401** (fail closed). The opaque-token path is untouched.
  - `EmbedTokenResource.grantPublic` returns **403** — no new public grants can be minted.
- A one-shot **boot-log** line records the posture (and WARNs when left permissive with live grants).
- Default (`true`) preserves today's single-tenant / intentional-public behaviour unchanged.

## Verified
- saiku-web targeted tests **GREEN: 44/0** — `EmbedAuthFilterTest` (13, incl. 2 new wiring tests), `EmbedTokenResourceTest` (23, incl. the mint-refusal), `EmbedPublicRegistryTest` (8). spotless clean.
- Launcher fat-jar builds and boots cleanly with the switch (Spring constructs the registry bean at startup without error).

## Test plan (from the issue)
- [x] `allowPublic=false` + publicly-granted resource without a token → 401 (`public_grant_ignored_when_allowPublic_disabled`).
- [x] switch off → `POST /embed/public` refuses to create a public grant → 403 (`grant_public_refused_when_allowPublic_disabled`).
- [x] pre-existing `embed-public.json` grant is not honoured while off (same filter test — the grant is in the registry and gets ignored).
- [x] default (unset/true) preserves behaviour — public grant serves anonymously (`public_grant_admits_when_allowPublic_explicitly_true` + existing admit test).
- [x] boot log records the posture (code path runs at bean construction; INFO line).

## Notes
- Hardening for the embed feature shipped in #1301–#1304; complements the multi-tenant work tracked in #1104. +126/-11, 5 files.