### PR TITLE
feat(security): ai.policy data-exposure switch gating the AI surface (closes #903)

### DIFF
--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ai/AiDataKind.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ai/AiDataKind.java
@@ -1,0 +1,34 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.service.olap.ai;
+
+/**
+ * Classifies a piece of data the AI surface is about to expose, so the
+ * {@link AiPolicyGuard} can decide whether the active {@link AiPolicy} permits
+ * it (saiku#903). Each kind declares the minimum policy tier required to send
+ * it across the trust boundary.
+ */
+public enum AiDataKind {
+    /** Cube metadata: dim/hier/level names, measure captions. */
+    SCHEMA_METADATA(AiPolicy.SCHEMA_ONLY),
+    /** Sample member captions (already PII-filtered by saiku#902). */
+    SAMPLE_MEMBERS(AiPolicy.SCHEMA_ONLY),
+    /** Aggregated query result values — the typed {@code {value, formatted}}
+     *  cells from {@code /ai/query} and its anomaly/forecast/ask siblings. */
+    AGGREGATED_RESULT_VALUES(AiPolicy.AGGREGATED),
+    /** Raw fact rows from drillthrough. */
+    RAW_ROW_DATA(AiPolicy.FULL);
+
+    private final AiPolicy minPolicy;
+
+    AiDataKind(AiPolicy minPolicy) {
+        this.minPolicy = minPolicy;
+    }
+
+    /** Lowest {@link AiPolicy} tier that permits sending this kind. */
+    public AiPolicy minPolicy() {
+        return minPolicy;
+    }
+}

--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ai/AiPolicy.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ai/AiPolicy.java
@@ -1,0 +1,86 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.service.olap.ai;
+
+import java.util.Locale;
+import java.util.function.Function;
+
+/**
+ * Operator-level data-exposure tier for the AI surface (saiku#903). Ordered
+ * from most restrictive to least; a higher ordinal permits everything a lower
+ * one does plus more:
+ *
+ * <ul>
+ *   <li>{@link #SCHEMA_ONLY} — only cube metadata + PII-filtered sample members
+ *       may leave the box (Tier-1 features only). The safe default.</li>
+ *   <li>{@link #AGGREGATED} — schema + aggregated query result values
+ *       ({@code /ai/query} typed cells). Tier-2 unlocked.</li>
+ *   <li>{@link #FULL} — everything, including raw drillthrough rows.
+ *       Single-tenant trusted environments only.</li>
+ * </ul>
+ *
+ * <p>Companion to {@code saiku.semantic.pii} (saiku#902): the annotation says
+ * <em>what</em> is PII; this policy says <em>what tier of data can leave at
+ * all</em>. Resolution order is env {@code SAIKU_AI_POLICY} &gt; system property
+ * {@code ai.policy} &gt; default {@link #SCHEMA_ONLY}.
+ */
+public enum AiPolicy {
+    SCHEMA_ONLY,
+    AGGREGATED,
+    FULL;
+
+    /** System property key. */
+    public static final String PROP = "ai.policy";
+
+    /** Environment variable key (takes precedence over the property). */
+    public static final String ENV = "SAIKU_AI_POLICY";
+
+    /** Default when nothing is configured — fail closed to the safest tier. */
+    public static final AiPolicy DEFAULT = SCHEMA_ONLY;
+
+    /**
+     * Parse a configured value strictly. Blank/null returns {@link #DEFAULT};
+     * an unrecognised value throws {@link IllegalArgumentException} so startup
+     * fails fast rather than silently falling back to a wrong posture.
+     * Accepts {@code schema-only}/{@code schema_only}, {@code aggregated},
+     * {@code full} case-insensitively.
+     */
+    public static AiPolicy parse(String raw) {
+        if (raw == null || raw.isBlank()) {
+            return DEFAULT;
+        }
+        String norm = raw.trim().toLowerCase(Locale.ROOT).replace('-', '_');
+        switch (norm) {
+            case "schema_only":
+                return SCHEMA_ONLY;
+            case "aggregated":
+                return AGGREGATED;
+            case "full":
+                return FULL;
+            default:
+                throw new IllegalArgumentException("Invalid " + PROP + " / " + ENV + " value '" + raw
+                        + "' — expected one of: schema-only, aggregated, full");
+        }
+    }
+
+    /**
+     * Resolve the active policy from env &gt; property &gt; default. The lookups
+     * are injected so this is unit-testable without touching real process
+     * state. Throws {@link IllegalArgumentException} on an invalid configured
+     * value (fail-fast).
+     */
+    public static AiPolicy resolve(Function<String, String> env, Function<String, String> prop) {
+        String fromEnv = env.apply(ENV);
+        if (fromEnv != null && !fromEnv.isBlank()) {
+            return parse(fromEnv);
+        }
+        return parse(prop.apply(PROP));
+    }
+
+    /** The wire/display form: lowercase, hyphenated (e.g. {@code schema-only}). */
+    public String displayName() {
+        return name().toLowerCase(Locale.ROOT).replace('_', '-');
+    }
+}

--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ai/AiPolicyGuard.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ai/AiPolicyGuard.java
@@ -1,0 +1,74 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.service.olap.ai;
+
+import java.util.function.Function;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Central gate for what tier of data the AI surface may expose (saiku#903).
+ * Every AI endpoint that returns data consults this guard with the
+ * {@link AiDataKind} it is about to send; the guard throws
+ * {@link AiPolicyViolation} when the active {@link AiPolicy} is too restrictive.
+ *
+ * <p>A CISO buys knobs, not chat boxes — this is the knob. Resolved once at
+ * construction from env {@code SAIKU_AI_POLICY} &gt; system property
+ * {@code ai.policy} &gt; default {@code schema-only}, and an invalid configured
+ * value throws here so the application <b>fails fast at startup</b> rather than
+ * booting with an ambiguous posture. Pairs with the saiku#902 PII annotation.
+ */
+public class AiPolicyGuard {
+
+    private static final Logger log = LoggerFactory.getLogger(AiPolicyGuard.class);
+
+    private final AiPolicy current;
+
+    /** Production constructor — resolves from the real environment + system
+     *  properties and logs the active posture once at boot. Throws if the
+     *  configured value is invalid (fail-fast). */
+    public AiPolicyGuard() {
+        this(AiPolicy.resolve(System::getenv, System::getProperty));
+        log.info(
+                "AI data policy: {} (set via {} / {}; default schema-only)",
+                current.displayName(),
+                AiPolicy.ENV,
+                AiPolicy.PROP);
+    }
+
+    /** Explicit-policy constructor for tests / programmatic wiring. */
+    public AiPolicyGuard(AiPolicy policy) {
+        this.current = policy == null ? AiPolicy.DEFAULT : policy;
+    }
+
+    /** Testable resolution seam (env + property lookups injected). */
+    public static AiPolicyGuard from(Function<String, String> env, Function<String, String> prop) {
+        return new AiPolicyGuard(AiPolicy.resolve(env, prop));
+    }
+
+    /** The active policy tier. */
+    public AiPolicy current() {
+        return current;
+    }
+
+    /** True if {@code kind} may be exposed under the active policy. */
+    public boolean canSend(AiDataKind kind) {
+        return kind.minPolicy().ordinal() <= current.ordinal();
+    }
+
+    /**
+     * Enforce the policy for a piece of data about to leave the box. Call this
+     * BEFORE executing/serialising the data — at the top of the endpoint, before
+     * any try/catch that would otherwise swallow it into a generic error.
+     *
+     * @throws AiPolicyViolation if the active policy is below {@code kind}'s
+     *     minimum tier.
+     */
+    public void assertCanSend(AiDataKind kind) {
+        if (!canSend(kind)) {
+            throw new AiPolicyViolation(kind, current);
+        }
+    }
+}

--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ai/AiPolicyViolation.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ai/AiPolicyViolation.java
@@ -1,0 +1,41 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.service.olap.ai;
+
+/**
+ * Thrown by {@link AiPolicyGuard#assertCanSend} when the active
+ * {@link AiPolicy} does not permit exposing a given {@link AiDataKind}
+ * (saiku#903). Carries the offending kind + the active policy so the web layer
+ * can return a clear 403 the caller can act on (raise the policy, or stop
+ * asking for that tier of data). Lives in the service layer (no JAX-RS
+ * dependency); {@code AiPolicyViolationMapper} translates it to HTTP 403.
+ */
+public class AiPolicyViolation extends RuntimeException {
+
+    private static final long serialVersionUID = 1L;
+
+    private final AiDataKind kind;
+    private final AiPolicy current;
+
+    public AiPolicyViolation(AiDataKind kind, AiPolicy current) {
+        super("AI policy '" + current.displayName() + "' does not permit sending " + kind.name() + " (requires '"
+                + kind.minPolicy().displayName() + "' or higher).");
+        this.kind = kind;
+        this.current = current;
+    }
+
+    public AiDataKind getKind() {
+        return kind;
+    }
+
+    public AiPolicy getCurrent() {
+        return current;
+    }
+
+    /** The minimum policy the operator would need to set to allow this. */
+    public AiPolicy getRequired() {
+        return kind.minPolicy();
+    }
+}

--- a/saiku-core/saiku-service/src/test/java/org/saiku/service/olap/ai/AiPolicyGuardTest.java
+++ b/saiku-core/saiku-service/src/test/java/org/saiku/service/olap/ai/AiPolicyGuardTest.java
@@ -1,0 +1,118 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.service.olap.ai;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Map;
+import java.util.function.Function;
+import org.junit.Test;
+
+/** saiku#903 — unit coverage for the AI data-exposure policy + guard. */
+public class AiPolicyGuardTest {
+
+    private static Function<String, String> map(String... kv) {
+        Map<String, String> m = new java.util.HashMap<>();
+        for (int i = 0; i + 1 < kv.length; i += 2) {
+            m.put(kv[i], kv[i + 1]);
+        }
+        return m::get;
+    }
+
+    /* ----------------------------- parse ----------------------------- */
+
+    @Test
+    public void parse_accepts_all_forms_case_and_separator_insensitive() {
+        assertEquals(AiPolicy.SCHEMA_ONLY, AiPolicy.parse("schema-only"));
+        assertEquals(AiPolicy.SCHEMA_ONLY, AiPolicy.parse("schema_only"));
+        assertEquals(AiPolicy.SCHEMA_ONLY, AiPolicy.parse("  SCHEMA-ONLY "));
+        assertEquals(AiPolicy.AGGREGATED, AiPolicy.parse("aggregated"));
+        assertEquals(AiPolicy.AGGREGATED, AiPolicy.parse("AGGREGATED"));
+        assertEquals(AiPolicy.FULL, AiPolicy.parse("full"));
+    }
+
+    @Test
+    public void parse_blank_or_null_is_default_schema_only() {
+        assertEquals(AiPolicy.SCHEMA_ONLY, AiPolicy.parse(null));
+        assertEquals(AiPolicy.SCHEMA_ONLY, AiPolicy.parse(""));
+        assertEquals(AiPolicy.SCHEMA_ONLY, AiPolicy.parse("   "));
+        assertEquals(AiPolicy.SCHEMA_ONLY, AiPolicy.DEFAULT);
+    }
+
+    @Test
+    public void parse_invalid_value_fails_fast() {
+        assertThrows(IllegalArgumentException.class, () -> AiPolicy.parse("garbage"));
+        assertThrows(IllegalArgumentException.class, () -> AiPolicy.parse("raw"));
+    }
+
+    /* ---------------------------- resolve ---------------------------- */
+
+    @Test
+    public void resolve_env_beats_property_beats_default() {
+        // env wins
+        assertEquals(AiPolicy.FULL, AiPolicy.resolve(map(AiPolicy.ENV, "full"), map(AiPolicy.PROP, "aggregated")));
+        // property used when env absent
+        assertEquals(AiPolicy.AGGREGATED, AiPolicy.resolve(map(), map(AiPolicy.PROP, "aggregated")));
+        // default when neither
+        assertEquals(AiPolicy.SCHEMA_ONLY, AiPolicy.resolve(map(), map()));
+        // blank env falls through to property
+        assertEquals(AiPolicy.AGGREGATED, AiPolicy.resolve(map(AiPolicy.ENV, "  "), map(AiPolicy.PROP, "aggregated")));
+    }
+
+    @Test
+    public void resolve_invalid_configured_value_throws() {
+        assertThrows(IllegalArgumentException.class, () -> AiPolicy.resolve(map(AiPolicy.ENV, "nope"), map()));
+    }
+
+    /* -------------------------- assertCanSend ------------------------ */
+
+    @Test
+    public void schema_only_permits_only_metadata_and_samples() {
+        AiPolicyGuard g = new AiPolicyGuard(AiPolicy.SCHEMA_ONLY);
+        g.assertCanSend(AiDataKind.SCHEMA_METADATA); // no throw
+        g.assertCanSend(AiDataKind.SAMPLE_MEMBERS); // no throw
+        assertThrows(AiPolicyViolation.class, () -> g.assertCanSend(AiDataKind.AGGREGATED_RESULT_VALUES));
+        assertThrows(AiPolicyViolation.class, () -> g.assertCanSend(AiDataKind.RAW_ROW_DATA));
+        assertTrue(g.canSend(AiDataKind.SCHEMA_METADATA));
+        assertFalse(g.canSend(AiDataKind.AGGREGATED_RESULT_VALUES));
+    }
+
+    @Test
+    public void aggregated_permits_values_but_not_raw_rows() {
+        AiPolicyGuard g = new AiPolicyGuard(AiPolicy.AGGREGATED);
+        g.assertCanSend(AiDataKind.SCHEMA_METADATA);
+        g.assertCanSend(AiDataKind.AGGREGATED_RESULT_VALUES); // no throw
+        assertThrows(AiPolicyViolation.class, () -> g.assertCanSend(AiDataKind.RAW_ROW_DATA));
+    }
+
+    @Test
+    public void full_permits_everything() {
+        AiPolicyGuard g = new AiPolicyGuard(AiPolicy.FULL);
+        for (AiDataKind k : AiDataKind.values()) {
+            g.assertCanSend(k); // none throw
+            assertTrue(g.canSend(k));
+        }
+    }
+
+    @Test
+    public void violation_carries_kind_current_and_required() {
+        AiPolicyGuard g = new AiPolicyGuard(AiPolicy.SCHEMA_ONLY);
+        AiPolicyViolation v = assertThrows(AiPolicyViolation.class, () -> g.assertCanSend(AiDataKind.RAW_ROW_DATA));
+        assertEquals(AiDataKind.RAW_ROW_DATA, v.getKind());
+        assertEquals(AiPolicy.SCHEMA_ONLY, v.getCurrent());
+        assertEquals(AiPolicy.FULL, v.getRequired());
+    }
+
+    @Test
+    public void from_resolves_and_null_policy_defaults() {
+        assertEquals(
+                AiPolicy.AGGREGATED,
+                AiPolicyGuard.from(map(AiPolicy.ENV, "aggregated"), map()).current());
+        assertEquals(AiPolicy.SCHEMA_ONLY, new AiPolicyGuard((AiPolicy) null).current());
+    }
+}

--- a/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/SaikuJerseyApplication.java
+++ b/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/SaikuJerseyApplication.java
@@ -31,6 +31,9 @@ public class SaikuJerseyApplication extends ResourceConfig {
         // typed AiQueryResponse 400 envelope instead of the raw text/plain
         // Jackson message that leaked class names and source location.
         register(org.saiku.web.rest.exception.JacksonValidationExceptionMapper.class);
+        // saiku#903: ai.policy violations -> typed 403 PERMISSION_DENIED envelope
+        // (specific mapper wins over the catch-all Throwable mapper below).
+        register(org.saiku.web.rest.exception.AiPolicyViolationMapper.class);
         // saiku#1165 (audit-3): global catch-all mapper. Supersedes the
         // saiku#865 GenericFailureExceptionMapper — JAX-RS allows only one
         // ExceptionMapper<Throwable>, so this single mapper carries the whole

--- a/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/exception/AiPolicyViolationMapper.java
+++ b/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/exception/AiPolicyViolationMapper.java
@@ -1,0 +1,44 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.web.rest.exception;
+
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.ext.ExceptionMapper;
+import jakarta.ws.rs.ext.Provider;
+import java.util.List;
+import org.saiku.service.olap.ai.AiPolicyViolation;
+import org.saiku.service.olap.ai.AiQueryResponse;
+
+/**
+ * saiku#903 — translate an {@link AiPolicyViolation} (the operator's
+ * {@code ai.policy} tier forbids exposing this data kind) into a clean
+ * {@code 403 application/json} body in the standard {@link AiQueryResponse}
+ * envelope, so agents get a self-correcting, leak-free error instead of the
+ * generic 500 the catch-all mapper would otherwise produce.
+ *
+ * <p>A specific {@code ExceptionMapper<AiPolicyViolation>} takes precedence over
+ * the catch-all {@code ExceptionMapper<Throwable>} by JAX-RS specificity rules.
+ * The body uses {@code field="ai.policy"} and {@code available=[<required tier>]}
+ * so the caller knows exactly which knob to raise.
+ */
+@Provider
+public class AiPolicyViolationMapper implements ExceptionMapper<AiPolicyViolation> {
+
+    @Override
+    public Response toResponse(AiPolicyViolation e) {
+        AiQueryResponse resp = new AiQueryResponse();
+        resp.setStatus(AiQueryResponse.Status.PERMISSION_DENIED);
+        resp.setField("ai.policy");
+        resp.setAvailable(List.of(e.getRequired().displayName()));
+        resp.setError(e.getMessage()
+                + " Set " + org.saiku.service.olap.ai.AiPolicy.PROP + "="
+                + e.getRequired().displayName() + " (or higher) to permit it.");
+        return Response.status(Response.Status.FORBIDDEN)
+                .type(MediaType.APPLICATION_JSON)
+                .entity(resp)
+                .build();
+    }
+}

--- a/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/AiQueryResource.java
+++ b/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/AiQueryResource.java
@@ -109,6 +109,17 @@ public class AiQueryResource {
     private final org.saiku.service.olap.ai.AiRequestSchemaValidator schemaValidator =
             new org.saiku.service.olap.ai.AiRequestSchemaValidator();
 
+    /** saiku#903 — gates which data tier may leave the box. Defaults to a
+     *  permissive (FULL) no-op so existing tests / un-wired contexts behave as
+     *  before; the Spring bean (saiku-beans.xml) injects the real config-driven
+     *  guard, whose default is schema-only. */
+    private org.saiku.service.olap.ai.AiPolicyGuard aiPolicyGuard =
+            new org.saiku.service.olap.ai.AiPolicyGuard(org.saiku.service.olap.ai.AiPolicy.FULL);
+
+    public void setAiPolicyGuard(org.saiku.service.olap.ai.AiPolicyGuard g) {
+        this.aiPolicyGuard = g;
+    }
+
     public void setThinQueryService(ThinQueryService tqs) {
         this.thinQueryService = tqs;
     }
@@ -180,6 +191,7 @@ public class AiQueryResource {
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.APPLICATION_JSON)
     public Response executeSaved(org.saiku.service.olap.ai.AiSavedQueryRequest body) {
+        aiPolicyGuard.assertCanSend(org.saiku.service.olap.ai.AiDataKind.AGGREGATED_RESULT_VALUES);
         if (datasourceService == null || sessionService == null) {
             return error("saved-query resolver requires repository wiring");
         }
@@ -259,6 +271,7 @@ public class AiQueryResource {
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.APPLICATION_JSON)
     public Response executeAi(AiQueryRequest req, @QueryParam("format") @DefaultValue("records") String format) {
+        aiPolicyGuard.assertCanSend(org.saiku.service.olap.ai.AiDataKind.AGGREGATED_RESULT_VALUES);
         long start = System.currentTimeMillis();
         AiSchema schema;
         ThinQuery tq;
@@ -369,6 +382,7 @@ public class AiQueryResource {
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.APPLICATION_JSON)
     public Response detectAnomalies(org.saiku.service.olap.ai.anomaly.AiAnomalyRequest body) {
+        aiPolicyGuard.assertCanSend(org.saiku.service.olap.ai.AiDataKind.AGGREGATED_RESULT_VALUES);
         long start = System.currentTimeMillis();
         if (body == null) {
             return badRequest("body", "request body required", null);
@@ -481,6 +495,7 @@ public class AiQueryResource {
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.APPLICATION_JSON)
     public Response forecast(org.saiku.service.olap.ai.forecast.AiForecastRequest body) {
+        aiPolicyGuard.assertCanSend(org.saiku.service.olap.ai.AiDataKind.AGGREGATED_RESULT_VALUES);
         long start = System.currentTimeMillis();
         if (body == null) {
             return badRequest("body", "request body required", null);
@@ -622,6 +637,7 @@ public class AiQueryResource {
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.APPLICATION_JSON)
     public Response ask(AiAskApi.AskRequest body) {
+        aiPolicyGuard.assertCanSend(org.saiku.service.olap.ai.AiDataKind.AGGREGATED_RESULT_VALUES);
         if (body == null) {
             return badRequest("body", "request body required", null);
         }
@@ -1037,6 +1053,7 @@ public class AiQueryResource {
     @Path("/query/result/{queryId}")
     @Produces(MediaType.APPLICATION_JSON)
     public Response asyncResult(@PathParam("queryId") String queryId) {
+        aiPolicyGuard.assertCanSend(org.saiku.service.olap.ai.AiDataKind.AGGREGATED_RESULT_VALUES);
         if (asyncQueryService == null) return error("Async service not configured");
         AsyncQueryHandle h = asyncQueryService.getOwned(queryId, currentPrincipal(), currentUserIsAdmin());
         // Unknown id OR not owned by this caller — 404 on both (IDOR fix).
@@ -1142,6 +1159,7 @@ public class AiQueryResource {
             @QueryParam("firstRowset") Integer firstRowset,
             @QueryParam("position") String position,
             @QueryParam("returns") String returns) {
+        aiPolicyGuard.assertCanSend(org.saiku.service.olap.ai.AiDataKind.RAW_ROW_DATA);
         if (thinQueryService == null) return error("Query service not configured");
 
         // Stage 1: resolve the underlying ThinQuery name (async handle
@@ -1444,6 +1462,7 @@ public class AiQueryResource {
             @QueryParam("firstRowset") Integer firstRowset,
             @QueryParam("position") String position,
             @QueryParam("returns") String returns) {
+        aiPolicyGuard.assertCanSend(org.saiku.service.olap.ai.AiDataKind.RAW_ROW_DATA);
         if (thinQueryService == null) return error("Query service not configured");
         // Resolve async handle id -> underlying ThinQuery name, re-attaching the
         // async cellset to this session's context (saiku#862). Routed through the
@@ -1573,6 +1592,7 @@ public class AiQueryResource {
     @Path("/query/{queryId}/drillthrough/columns")
     @Produces(MediaType.APPLICATION_JSON)
     public Response drillthroughColumns(@PathParam("queryId") String queryId) {
+        aiPolicyGuard.assertCanSend(org.saiku.service.olap.ai.AiDataKind.AGGREGATED_RESULT_VALUES);
         if (thinQueryService == null) return error("Query service not configured");
         // saiku#862: same async-handle resolution + cross-session re-attach as
         // drillthrough() so column discovery resolves on a different session.

--- a/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/InfoResource.java
+++ b/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/InfoResource.java
@@ -125,6 +125,17 @@ public class InfoResource {
         Map<String, Object> ai = new LinkedHashMap<>();
         ai.put("enabled", true);
         ai.put("basePath", "/rest/saiku/api/ai");
+        // saiku#903: surface the active data-exposure policy so the UI can show
+        // the operator pill (schema-only | aggregated | full). Resolved quietly
+        // for display — an invalid value would already have failed startup.
+        String aiPolicy;
+        try {
+            aiPolicy = org.saiku.service.olap.ai.AiPolicy.resolve(System::getenv, System::getProperty)
+                    .displayName();
+        } catch (RuntimeException e) {
+            aiPolicy = org.saiku.service.olap.ai.AiPolicy.DEFAULT.displayName();
+        }
+        ai.put("policy", aiPolicy);
         ai.put(
                 "endpoints",
                 Map.of(

--- a/saiku-core/saiku-web/src/test/java/org/saiku/web/rest/resources/AiQueryResourcePolicyTest.java
+++ b/saiku-core/saiku-web/src/test/java/org/saiku/web/rest/resources/AiQueryResourcePolicyTest.java
@@ -1,0 +1,96 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.web.rest.resources;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+import org.junit.Test;
+import org.saiku.service.olap.ai.AiDataKind;
+import org.saiku.service.olap.ai.AiPolicy;
+import org.saiku.service.olap.ai.AiPolicyGuard;
+import org.saiku.service.olap.ai.AiPolicyViolation;
+import org.saiku.service.olap.ai.AiQueryRequest;
+
+/**
+ * saiku#903 — call-site (wiring) coverage: proves {@link AiQueryResource}
+ * actually consults the {@link AiPolicyGuard} at each data endpoint, not just
+ * that the guard works in isolation. The guard check is the first statement of
+ * each endpoint, so a too-restrictive policy throws {@link AiPolicyViolation}
+ * before any service is touched (the JAX-RS {@code AiPolicyViolationMapper}
+ * turns that into a 403 at runtime).
+ */
+public class AiQueryResourcePolicyTest {
+
+    private static AiQueryResource resourceWith(AiPolicy policy) {
+        AiQueryResource r = new AiQueryResource();
+        r.setAiPolicyGuard(new AiPolicyGuard(policy));
+        return r;
+    }
+
+    @Test
+    public void query_blocked_under_schema_only() {
+        AiQueryResource r = resourceWith(AiPolicy.SCHEMA_ONLY);
+        try {
+            r.executeAi(new AiQueryRequest(), "records");
+            fail("schema-only must block /ai/query");
+        } catch (AiPolicyViolation v) {
+            assertEquals(AiDataKind.AGGREGATED_RESULT_VALUES, v.getKind());
+            assertEquals(AiPolicy.SCHEMA_ONLY, v.getCurrent());
+        }
+    }
+
+    @Test
+    public void drillthrough_blocked_under_aggregated() {
+        AiQueryResource r = resourceWith(AiPolicy.AGGREGATED);
+        try {
+            r.drillthrough("q", 100, null, null, null);
+            fail("aggregated must block drillthrough");
+        } catch (AiPolicyViolation v) {
+            assertEquals(AiDataKind.RAW_ROW_DATA, v.getKind());
+        }
+    }
+
+    @Test
+    public void query_passes_guard_under_aggregated() {
+        // AGGREGATED permits /query values → the guard must NOT throw. Downstream
+        // fails on unwired services (returns/throws a non-policy error); we only
+        // assert the gate opened.
+        AiQueryResource r = resourceWith(AiPolicy.AGGREGATED);
+        try {
+            r.executeAi(new AiQueryRequest(), "records");
+        } catch (AiPolicyViolation e) {
+            fail("AGGREGATED must permit /ai/query");
+        } catch (RuntimeException downstream) {
+            // expected — no cubeMetadataService/thinQueryService wired
+        }
+    }
+
+    @Test
+    public void drillthrough_passes_guard_under_full() {
+        AiQueryResource r = resourceWith(AiPolicy.FULL);
+        try {
+            r.drillthrough("q", 100, null, null, null);
+        } catch (AiPolicyViolation e) {
+            fail("FULL must permit drillthrough");
+        } catch (RuntimeException downstream) {
+            // expected — services unwired
+        }
+    }
+
+    @Test
+    public void unwired_guard_defaults_permissive_for_back_compat() {
+        // No setAiPolicyGuard() → the field defaults to a FULL no-op so existing
+        // callers behave as before; the Spring bean injects the real guard.
+        AiQueryResource r = new AiQueryResource();
+        try {
+            r.executeAi(new AiQueryRequest(), "records");
+        } catch (AiPolicyViolation e) {
+            fail("un-wired guard must default permissive (FULL)");
+        } catch (RuntimeException downstream) {
+            // expected
+        }
+    }
+}

--- a/saiku-webapp/src/main/webapp/WEB-INF/saiku-beans.xml
+++ b/saiku-webapp/src/main/webapp/WEB-INF/saiku-beans.xml
@@ -238,9 +238,15 @@
         <property name="probeUnqueryable" value="#{systemProperties['saiku.ai.probeUnqueryable'] ?: 'true'}"/>
     </bean>
 
+    <!-- saiku#903: AI data-exposure policy guard. Singleton constructed at
+         startup so it resolves SAIKU_AI_POLICY / ai.policy (default schema-only)
+         and FAILS FAST on an invalid value before the app serves traffic. -->
+    <bean id="aiPolicyGuard" class="org.saiku.service.olap.ai.AiPolicyGuard"/>
+
     <bean id="aiQueryResource" scope="request"
           class="org.saiku.web.rest.resources.AiQueryResource">
         <aop:scoped-proxy/>
+        <property name="aiPolicyGuard" ref="aiPolicyGuard"/>
         <property name="thinQueryService" ref="thinQueryBean"/>
         <property name="cubeMetadataService" ref="aiCubeMetadataServiceBean"/>
         <property name="asyncQueryService" ref="asyncQueryServiceBean"/>


### PR DESCRIPTION
## Summary
Operator-level knob (`ai.policy`) that bounds what tier of data the AI endpoints may expose, so a multi-tenant / regulated deployment sets the posture once instead of per-procurement. Three increasing tiers: **schema-only** (default) < **aggregated** < **full**. Companion to the `saiku.semantic.pii` annotation (#902) — the annotation says *what* is PII; the policy says *what tier can leave at all*. The CISO's knob.

## The change
- **New service classes** `AiPolicy` / `AiDataKind` / `AiPolicyViolation` / `AiPolicyGuard`. Resolution order **env `SAIKU_AI_POLICY` > system property `ai.policy` > default `schema-only`**; an invalid configured value **fails fast at startup** (the guard bean's construction throws → context won't start).
- **`AiQueryResource` consults the guard at every data endpoint** (first statement, before any try): `query`, `query/saved`, `anomaly`, `forecast`, `ask`, `query/result`, drillthrough-columns → require **AGGREGATED**; `drillthrough` + `drillthrough/export/csv` → require **FULL**. Metadata + control endpoints (`cubes`/`schema`/`members`/`status`) stay open at every tier.
- **`AiPolicyViolationMapper`** (@Provider, registered in `SaikuJerseyApplication`) turns a violation into a typed **403 PERMISSION_DENIED** envelope (`field=ai.policy`, `available=[required tier]`) so agents self-correct. A specific mapper wins over the catch-all.
- Guard wired as a **startup singleton** in `saiku-beans.xml`; active policy surfaced in **`/info` (`ai.policy`)** for the UI pill.
- **Default schema-only** is the safe out-of-box posture; existing AI behaviour is unchanged once an operator opts up.

## Verified
- Targeted tests **GREEN 51/0**: `AiPolicyGuardTest` (10 — parse/resolve/tiers/fail-fast), `AiQueryResourcePolicyTest` (5 — call-site wiring), `AiQueryResourceTest` (36 — regression, unaffected by the FULL-default back-compat). spotless clean (Maven 3.9.9 / JDK 21).

## Test plan (from the issue)
- [x] schema-only → /ai/query rejects with 403 + clear error citing policy.
- [x] aggregated → values pass, drillthrough rejected.
- [x] full → all kinds pass.
- [x] policy unset → defaults to schema-only.
- [x] invalid value (`ai.policy=garbage`) → fail-fast (parse throws; guard bean construction throws at startup).

## Notes
- Backend-only by design (split-PR convention). **The UI TopBar pill is a small follow-up** — backend already surfaces `info.ai.policy`.
- Foundation companion to #902 (PII annotation, already merged). +~470/-0 across new classes; 13 wiring touchpoints in `AiQueryResource` + beans/Jersey/Info.