### PR TITLE
test(security): cover drillthrough-CSV policy gate + AiPolicyViolation 403 mapper (#903 follow-up)

### DIFF
--- a/saiku-core/saiku-web/src/test/java/org/saiku/web/rest/exception/AiPolicyViolationMapperTest.java
+++ b/saiku-core/saiku-web/src/test/java/org/saiku/web/rest/exception/AiPolicyViolationMapperTest.java
@@ -1,0 +1,59 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.web.rest.exception;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import jakarta.ws.rs.core.Response;
+import java.util.List;
+import java.util.Locale;
+import org.junit.Test;
+import org.saiku.service.olap.ai.AiDataKind;
+import org.saiku.service.olap.ai.AiPolicy;
+import org.saiku.service.olap.ai.AiPolicyViolation;
+import org.saiku.service.olap.ai.AiQueryResponse;
+
+/**
+ * saiku#903 follow-up: locks the JAX-RS {@link AiPolicyViolationMapper} envelope.
+ * The endpoint call-site tests ({@code AiQueryResourcePolicyTest}) prove the guard
+ * THROWS; this proves the throw becomes the right client response — a typed
+ * {@code 403 PERMISSION_DENIED} with {@code field=ai.policy}, {@code available=[required tier]},
+ * a remediation hint naming the knob, and (the security point SEC verified by code
+ * review) no internal cause / SQL / credential leaked into the body.
+ */
+public class AiPolicyViolationMapperTest {
+
+    @Test
+    public void maps_violation_to_403_permission_denied_envelope() {
+        // SCHEMA_ONLY policy asked to send RAW_ROW_DATA → the required tier is FULL.
+        AiPolicyViolation v = new AiPolicyViolation(AiDataKind.RAW_ROW_DATA, AiPolicy.SCHEMA_ONLY);
+        Response r = new AiPolicyViolationMapper().toResponse(v);
+
+        assertEquals(403, r.getStatus());
+        AiQueryResponse body = (AiQueryResponse) r.getEntity();
+        assertEquals(AiQueryResponse.Status.PERMISSION_DENIED, body.getStatus());
+        assertEquals("ai.policy", body.getField());
+        // available points the caller at exactly the knob value that would permit it.
+        assertEquals(List.of(AiPolicy.FULL.displayName()), body.getAvailable());
+    }
+
+    @Test
+    public void error_message_names_the_knob_and_required_tier_and_does_not_leak() {
+        AiPolicyViolation v = new AiPolicyViolation(AiDataKind.AGGREGATED_RESULT_VALUES, AiPolicy.SCHEMA_ONLY);
+        AiQueryResponse body =
+                (AiQueryResponse) new AiPolicyViolationMapper().toResponse(v).getEntity();
+        String msg = body.getError();
+
+        assertTrue("remediation names the ai.policy knob: " + msg, msg.contains(AiPolicy.PROP));
+        assertTrue("remediation names the required tier: " + msg, msg.contains(AiPolicy.AGGREGATED.displayName()));
+        // A policy refusal must never echo backend internals (the #1261/#1283 leak class).
+        String lower = msg.toLowerCase(Locale.ROOT);
+        assertFalse(
+                "policy 403 must not leak internals: " + msg,
+                lower.contains("jdbc:") || lower.contains("sqlstate") || lower.contains("password"));
+    }
+}

--- a/saiku-core/saiku-web/src/test/java/org/saiku/web/rest/resources/AiQueryResourcePolicyTest.java
+++ b/saiku-core/saiku-web/src/test/java/org/saiku/web/rest/resources/AiQueryResourcePolicyTest.java
@@ -81,6 +81,34 @@ public class AiQueryResourcePolicyTest {
     }
 
     @Test
+    public void drillthrough_csv_export_blocked_under_aggregated() {
+        // saiku#903 follow-up (SEC rec b): the SECOND RAW_ROW_DATA path — the CSV
+        // export at the #1284 IDOR / raw-PII site — must be gated too, not just
+        // /drillthrough. Without this, only one of the two raw-row endpoints was
+        // call-site tested.
+        AiQueryResource r = resourceWith(AiPolicy.AGGREGATED);
+        try {
+            r.drillthroughExportCsv("q", 100, null, null, null);
+            fail("aggregated must block drillthrough CSV export (raw rows)");
+        } catch (AiPolicyViolation v) {
+            assertEquals(AiDataKind.RAW_ROW_DATA, v.getKind());
+            assertEquals(AiPolicy.AGGREGATED, v.getCurrent());
+        }
+    }
+
+    @Test
+    public void drillthrough_csv_export_passes_guard_under_full() {
+        AiQueryResource r = resourceWith(AiPolicy.FULL);
+        try {
+            r.drillthroughExportCsv("q", 100, null, null, null);
+        } catch (AiPolicyViolation e) {
+            fail("FULL must permit drillthrough CSV export");
+        } catch (RuntimeException downstream) {
+            // expected — services unwired; we only assert the gate opened
+        }
+    }
+
+    @Test
     public void unwired_guard_defaults_permissive_for_back_compat() {
         // No setAiPolicyGuard() → the field defaults to a FULL no-op so existing
         // callers behave as before; the Spring bean injects the real guard.


### PR DESCRIPTION
Follows #1317 (#903 ai.policy switch). The #1317 review surfaced two test-coverage gaps — both confirmed and now closed. **Test-only, no production change.**

- **`AiQueryResourcePolicyTest`** — there are two `RAW_ROW_DATA` endpoints but only `/drillthrough` had a policy call-site test. This adds the second: the **drillthrough CSV export** (the raw-PII / #1284 IDOR site) blocks under `AGGREGATED` and passes under `FULL`. I verified the endpoint already calls `assertCanSend(RAW_ROW_DATA)` as its first statement — this just locks it, so a future drop of that guard goes RED.
- **`AiPolicyViolationMapperTest`** (new) — the mapper that turns an `AiPolicyViolation` into the client 403 had no test. This locks the envelope: `403 PERMISSION_DENIED`, `field=ai.policy`, `available=[required tier]`, a remediation hint naming the `ai.policy` knob, and **leak-free** (no `jdbc:` / `sqlstate` / `password` in the body — the #1261/#1283 leak class).

`mvn -pl saiku-core/saiku-web -am -s <settings> -Dtest=AiQueryResourcePolicyTest,AiPolicyViolationMapperTest test` → **9/0** (5 existing policy tests + 2 new call-site + 2 mapper). Off current `development`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
