### PR TITLE
feat(security): k-anonymity small-cell suppression on AI results (closes #905)

### DIFF
--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ai/AiCell.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ai/AiCell.java
@@ -37,6 +37,13 @@ public class AiCell {
     @JsonInclude(JsonInclude.Include.NON_NULL)
     private org.saiku.service.olap.ai.anomaly.AnomalyPoint anomaly;
 
+    /** saiku#905 — true when k-anonymity small-cell suppression masked this
+     *  cell because its underlying row count was below {@code ai.kAnonymity}.
+     *  {@code NON_DEFAULT} so ordinary (unsuppressed) cells stay lean on the
+     *  wire. The UI renders suppressed cells distinctively. */
+    @JsonInclude(JsonInclude.Include.NON_DEFAULT)
+    private boolean suppressed;
+
     public AiCell() {}
 
     public AiCell(Double value, String formatted, String unit) {
@@ -90,6 +97,14 @@ public class AiCell {
 
     public void setAnomaly(org.saiku.service.olap.ai.anomaly.AnomalyPoint v) {
         this.anomaly = v;
+    }
+
+    public boolean isSuppressed() {
+        return suppressed;
+    }
+
+    public void setSuppressed(boolean v) {
+        this.suppressed = v;
     }
 
     /** Best-effort: parse a Mondrian-formatted string back into a Double,

--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ai/KAnonymityFilter.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ai/KAnonymityFilter.java
@@ -1,0 +1,204 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.service.olap.ai;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.function.Function;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * K-anonymity small-cell suppression (saiku#905). Masks any aggregated cell
+ * whose underlying row count is below {@code ai.kAnonymity} (default 5) before
+ * the result crosses the AI boundary — the standard small-cell control from
+ * healthcare/government statistical releases. A "SUM of salary by department"
+ * looks anonymised until a department of one makes the sum that person's salary;
+ * this closes that leak, which the PII annotation (#902) and policy switch
+ * (#903) cannot reach because they operate on schema/policy, not cardinality.
+ *
+ * <p>Config (env &gt; system property &gt; default), fail-soft to the SAFE
+ * default on a bad value:
+ * <ul>
+ *   <li>{@code SAIKU_AI_KANONYMITY} / {@code ai.kAnonymity} — threshold k
+ *       (default 5; {@code 0} disables; negative/invalid → default 5).</li>
+ *   <li>{@code SAIKU_AI_KANONYMITY_MASK} / {@code ai.kAnonymity.maskValue} —
+ *       {@code null} (default → value null, formatted {@code —}),
+ *       a number like {@code -1}, or any token e.g. {@code REDACTED} /
+ *       {@code <5}.</li>
+ * </ul>
+ *
+ * <p>This class only decides + masks; deriving the per-cell row count is the
+ * caller's job (saiku#905 v1: an in-result count measure; the shadow-count
+ * query for arbitrary cubes is the follow-up).
+ */
+public class KAnonymityFilter {
+
+    private static final Logger log = LoggerFactory.getLogger(KAnonymityFilter.class);
+
+    public static final String ENV_K = "SAIKU_AI_KANONYMITY";
+    public static final String PROP_K = "ai.kAnonymity";
+    public static final int DEFAULT_K = 5;
+    public static final String ENV_MASK = "SAIKU_AI_KANONYMITY_MASK";
+    public static final String PROP_MASK = "ai.kAnonymity.maskValue";
+    public static final String DEFAULT_MASK = "null";
+
+    private final int threshold;
+    private final String maskValue;
+
+    /** Production constructor — resolves config from the real environment +
+     *  system properties and logs the active posture once at boot. */
+    public KAnonymityFilter() {
+        this(resolveThreshold(System::getenv, System::getProperty), resolveMask(System::getenv, System::getProperty));
+        if (enabled()) {
+            log.info("AI k-anonymity suppression ENABLED (k={}, mask={})", threshold, maskValue);
+        } else {
+            log.info("AI k-anonymity suppression DISABLED ({}=0)", PROP_K);
+        }
+    }
+
+    /** Explicit constructor for tests / programmatic wiring. */
+    public KAnonymityFilter(int threshold, String maskValue) {
+        this.threshold = Math.max(0, threshold);
+        this.maskValue = (maskValue == null || maskValue.isBlank()) ? DEFAULT_MASK : maskValue.trim();
+    }
+
+    /** Testable factory (env + property lookups injected). */
+    public static KAnonymityFilter from(Function<String, String> env, Function<String, String> prop) {
+        return new KAnonymityFilter(resolveThreshold(env, prop), resolveMask(env, prop));
+    }
+
+    static int resolveThreshold(Function<String, String> env, Function<String, String> prop) {
+        String raw = env.apply(ENV_K);
+        if (raw == null || raw.isBlank()) {
+            raw = prop.apply(PROP_K);
+        }
+        if (raw == null || raw.isBlank()) {
+            return DEFAULT_K;
+        }
+        try {
+            int v = Integer.parseInt(raw.trim());
+            if (v < 0) {
+                log.warn("Invalid {} '{}' (negative) — defaulting to {}", PROP_K, raw, DEFAULT_K);
+                return DEFAULT_K;
+            }
+            return v;
+        } catch (NumberFormatException e) {
+            // Fail SAFE: an unparseable threshold protects at the default rather
+            // than silently disabling suppression.
+            log.warn("Invalid {} '{}' (not an integer) — defaulting to {}", PROP_K, raw, DEFAULT_K);
+            return DEFAULT_K;
+        }
+    }
+
+    static String resolveMask(Function<String, String> env, Function<String, String> prop) {
+        String raw = env.apply(ENV_MASK);
+        if (raw == null || raw.isBlank()) {
+            raw = prop.apply(PROP_MASK);
+        }
+        return (raw == null || raw.isBlank()) ? DEFAULT_MASK : raw.trim();
+    }
+
+    public int threshold() {
+        return threshold;
+    }
+
+    public String maskValue() {
+        return maskValue;
+    }
+
+    /** Suppression is active only when k &gt; 0. */
+    public boolean enabled() {
+        return threshold > 0;
+    }
+
+    /**
+     * True when a cell backed by {@code rowCount} underlying records must be
+     * masked: enabled, the count is known ({@code &gt; 0}) and below k. A count
+     * of exactly k is NOT masked (inclusive), and an unknown count
+     * ({@code &lt;= 0}) is left to the caller (we don't mask what we can't
+     * measure).
+     */
+    public boolean shouldSuppress(int rowCount) {
+        return enabled() && rowCount > 0 && rowCount < threshold;
+    }
+
+    /** Mask a single cell in place per the configured {@code maskValue} and
+     *  flag it suppressed. */
+    public void mask(AiCell cell) {
+        if (cell == null) {
+            return;
+        }
+        cell.setSuppressed(true);
+        cell.setUnit(null);
+        if ("null".equalsIgnoreCase(maskValue)) {
+            cell.setValue(null);
+            cell.setFormatted("—");
+            return;
+        }
+        try {
+            double num = Double.parseDouble(maskValue);
+            cell.setValue(num);
+            cell.setFormatted(maskValue);
+        } catch (NumberFormatException notNumeric) {
+            // A token like REDACTED or "<5": no numeric value, show the token.
+            cell.setValue(null);
+            cell.setFormatted(maskValue);
+        }
+    }
+
+    /**
+     * Apply suppression to a records-format result (saiku#905 v1). For each row
+     * whose {@code countKey} measure cell reports a row count below k, mask
+     * every measure cell in that row (including the count cell — a count of 3
+     * is itself disclosive). Row-header (String) values are untouched.
+     *
+     * @param rows the records payload ({@code Map<caption, AiCell|String>} per row)
+     * @param countKey the measure caption carrying the underlying row count
+     * @param measureKeys the measure-column captions to mask when the row is small
+     * @return number of rows suppressed
+     */
+    public int applyToRecords(List<Map<String, Object>> rows, String countKey, Collection<String> measureKeys) {
+        if (!enabled() || rows == null || countKey == null || measureKeys == null) {
+            return 0;
+        }
+        int suppressed = 0;
+        for (Map<String, Object> row : rows) {
+            if (row == null) {
+                continue;
+            }
+            Object countCell = row.get(countKey);
+            if (!(countCell instanceof AiCell)) {
+                continue;
+            }
+            Double cv = ((AiCell) countCell).getValue();
+            if (cv == null) {
+                continue;
+            }
+            int rowCount = (int) Math.round(cv);
+            if (!shouldSuppress(rowCount)) {
+                continue;
+            }
+            for (String mk : measureKeys) {
+                Object c = row.get(mk);
+                if (c instanceof AiCell) {
+                    mask((AiCell) c);
+                }
+            }
+            suppressed++;
+        }
+        if (suppressed > 0) {
+            log.debug("k-anon suppressed {} small cell-row(s) (k={})", suppressed, threshold);
+        }
+        return suppressed;
+    }
+
+    /** Lowercase display name of the configured mask, for {@code /info}. */
+    public String describe() {
+        return enabled() ? ("k=" + threshold + ",mask=" + maskValue.toLowerCase(Locale.ROOT)) : "disabled";
+    }
+}

--- a/saiku-core/saiku-service/src/test/java/org/saiku/service/olap/ai/KAnonymityFilterTest.java
+++ b/saiku-core/saiku-service/src/test/java/org/saiku/service/olap/ai/KAnonymityFilterTest.java
@@ -1,0 +1,147 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.service.olap.ai;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import org.junit.Test;
+
+/** saiku#905 — unit coverage for k-anonymity small-cell suppression. */
+public class KAnonymityFilterTest {
+
+    private static Function<String, String> map(String... kv) {
+        Map<String, String> m = new java.util.HashMap<>();
+        for (int i = 0; i + 1 < kv.length; i += 2) {
+            m.put(kv[i], kv[i + 1]);
+        }
+        return m::get;
+    }
+
+    /* ----------------------------- config ---------------------------- */
+
+    @Test
+    public void resolveThreshold_env_beats_prop_beats_default() {
+        assertEquals(8, KAnonymityFilter.resolveThreshold(map(KAnonymityFilter.ENV_K, "8"), map()));
+        assertEquals(3, KAnonymityFilter.resolveThreshold(map(), map(KAnonymityFilter.PROP_K, "3")));
+        assertEquals(KAnonymityFilter.DEFAULT_K, KAnonymityFilter.resolveThreshold(map(), map()));
+        assertEquals(0, KAnonymityFilter.resolveThreshold(map(), map(KAnonymityFilter.PROP_K, "0")));
+    }
+
+    @Test
+    public void resolveThreshold_invalid_fails_safe_to_default() {
+        assertEquals(
+                KAnonymityFilter.DEFAULT_K,
+                KAnonymityFilter.resolveThreshold(map(), map(KAnonymityFilter.PROP_K, "abc")));
+        assertEquals(
+                KAnonymityFilter.DEFAULT_K,
+                KAnonymityFilter.resolveThreshold(map(), map(KAnonymityFilter.PROP_K, "-4")));
+    }
+
+    @Test
+    public void resolveMask_defaults_to_null_token() {
+        assertEquals("null", KAnonymityFilter.resolveMask(map(), map()));
+        assertEquals("REDACTED", KAnonymityFilter.resolveMask(map(), map(KAnonymityFilter.PROP_MASK, "REDACTED")));
+        assertEquals(
+                "-1",
+                KAnonymityFilter.resolveMask(
+                        map(KAnonymityFilter.ENV_MASK, "-1"), map(KAnonymityFilter.PROP_MASK, "REDACTED")));
+    }
+
+    /* --------------------------- decisions --------------------------- */
+
+    @Test
+    public void enabled_only_when_threshold_positive() {
+        assertTrue(new KAnonymityFilter(5, null).enabled());
+        assertFalse(new KAnonymityFilter(0, null).enabled());
+    }
+
+    @Test
+    public void shouldSuppress_is_below_k_inclusive_boundary() {
+        KAnonymityFilter f = new KAnonymityFilter(5, null);
+        assertTrue(f.shouldSuppress(3));
+        assertTrue(f.shouldSuppress(1));
+        assertFalse("k itself is not masked (inclusive)", f.shouldSuppress(5));
+        assertFalse(f.shouldSuppress(6));
+        assertFalse("unknown/zero count is not masked", f.shouldSuppress(0));
+        assertFalse(new KAnonymityFilter(0, null).shouldSuppress(2));
+    }
+
+    /* ----------------------------- mask ------------------------------ */
+
+    @Test
+    public void mask_null_token_clears_value_and_flags() {
+        AiCell c = new AiCell(42.0, "42", null);
+        new KAnonymityFilter(5, "null").mask(c);
+        assertTrue(c.isSuppressed());
+        assertNull(c.getValue());
+        assertEquals("—", c.getFormatted());
+    }
+
+    @Test
+    public void mask_numeric_token_sets_that_value() {
+        AiCell c = new AiCell(42.0, "42", null);
+        new KAnonymityFilter(5, "-1").mask(c);
+        assertTrue(c.isSuppressed());
+        assertEquals(Double.valueOf(-1.0), c.getValue());
+        assertEquals("-1", c.getFormatted());
+    }
+
+    @Test
+    public void mask_text_token_shows_token_no_value() {
+        AiCell c = new AiCell(42.0, "42", null);
+        new KAnonymityFilter(5, "REDACTED").mask(c);
+        assertTrue(c.isSuppressed());
+        assertNull(c.getValue());
+        assertEquals("REDACTED", c.getFormatted());
+    }
+
+    /* ------------------------- applyToRecords ------------------------ */
+
+    private static Map<String, Object> row(String dim, double count, double sales) {
+        Map<String, Object> r = new LinkedHashMap<>();
+        r.put("Product", dim);
+        r.put("Fact Count", new AiCell(count, String.valueOf((int) count), null));
+        r.put("Store Sales", new AiCell(sales, "$" + sales, null));
+        return r;
+    }
+
+    @Test
+    public void applyToRecords_masks_small_rows_keeps_the_rest() {
+        List<Map<String, Object>> rows = new ArrayList<>();
+        rows.add(row("Tiny", 3, 99.0)); // below k=5 -> masked
+        rows.add(row("Big", 5, 500.0)); // exactly k -> kept
+        List<String> measures = java.util.Arrays.asList("Fact Count", "Store Sales");
+
+        int n = new KAnonymityFilter(5, "null").applyToRecords(rows, "Fact Count", measures);
+
+        assertEquals(1, n);
+        // small row: both measure cells masked (incl. the count cell itself)
+        assertTrue(((AiCell) rows.get(0).get("Store Sales")).isSuppressed());
+        assertNull(((AiCell) rows.get(0).get("Store Sales")).getValue());
+        assertTrue(((AiCell) rows.get(0).get("Fact Count")).isSuppressed());
+        // row-header String untouched
+        assertEquals("Tiny", rows.get(0).get("Product"));
+        // big row: intact
+        assertFalse(((AiCell) rows.get(1).get("Store Sales")).isSuppressed());
+        assertEquals(Double.valueOf(500.0), ((AiCell) rows.get(1).get("Store Sales")).getValue());
+    }
+
+    @Test
+    public void applyToRecords_disabled_is_noop() {
+        List<Map<String, Object>> rows = new ArrayList<>();
+        rows.add(row("Tiny", 1, 10.0));
+        int n = new KAnonymityFilter(0, "null").applyToRecords(rows, "Fact Count", java.util.List.of("Store Sales"));
+        assertEquals(0, n);
+        assertFalse(((AiCell) rows.get(0).get("Store Sales")).isSuppressed());
+    }
+}

--- a/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/AiQueryResource.java
+++ b/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/AiQueryResource.java
@@ -130,17 +130,46 @@ public class AiQueryResource {
         this.kAnonymityFilter = f;
     }
 
+    /** saiku#905 — matches a column caption that names a row-count measure
+     *  (e.g. "Fact Count", "Count", "Distinct Count", "Row Count") on a whole-
+     *  word boundary, so ordinary numeric measures that merely *contain* the
+     *  substring — {@code Discount}, {@code Account}, {@code Counter} — are NOT
+     *  mistaken for the count column. Keying suppression off a non-count measure
+     *  would silently leak the very small cells k-anonymity exists to mask
+     *  (SEC #1324 / QA finding). Trailing plural {@code s} is allowed
+     *  ("Counts") but {@code Discounts}/{@code Counter} stay excluded. */
+    private static final java.util.regex.Pattern COUNT_MEASURE =
+            java.util.regex.Pattern.compile("\\bcounts?\\b", java.util.regex.Pattern.CASE_INSENSITIVE);
+
     /**
      * saiku#905 v1 — apply k-anonymity small-cell suppression to a records
      * payload using an in-result count measure (a measure column whose caption
-     * contains "count", e.g. Mondrian's "Fact Count"): any row whose count is
-     * below k has all its measure cells masked. No-op when suppression is
-     * disabled, there's no count column, or the payload is empty. The
-     * shadow-count query for cubes that don't surface a count measure is the
+     * names a count on a word boundary, e.g. Mondrian's "Fact Count"): any row
+     * whose count is below k has all its measure cells masked. No-op when
+     * suppression is disabled, there's no count column, or the payload is empty.
+     * The shadow-count query for cubes that don't surface a count measure is the
      * saiku#905 follow-up. Package-private so the wiring is unit-testable
-     * without standing up a CellDataSet.
+     * without standing up a CellDataSet. Convenience overload for the records
+     * (non-matrix) path.
      */
     void applyKAnonymity(java.util.List<java.util.Map<String, Object>> records) {
+        applyKAnonymity(records, false);
+    }
+
+    /**
+     * saiku#905 v1 — as {@link #applyKAnonymity(java.util.List)}, with the
+     * output-mode gate folded in as a testable seam. When {@code matrix} is
+     * true this is a deliberate no-op: the {@code format=matrix} output is a
+     * known v1 gap (small cells are NOT suppressed there) tracked as the
+     * saiku#905-B follow-up — multi-tenant / embed deployments post-filter at
+     * the proxy in the meantime (SEC #1324). Routing the skip through this
+     * method (instead of an outer {@code if}) lets QA lock the gap contract
+     * without constructing a CellDataSet.
+     */
+    void applyKAnonymity(java.util.List<java.util.Map<String, Object>> records, boolean matrix) {
+        if (matrix) {
+            return; // saiku#905-B known gap: matrix output is not k-anon-suppressed in v1
+        }
         if (!kAnonymityFilter.enabled() || records == null || records.isEmpty()) {
             return;
         }
@@ -154,7 +183,7 @@ public class AiQueryResource {
         }
         String countKey = null;
         for (String k : measureKeys) {
-            if (k.toLowerCase(java.util.Locale.ROOT).contains("count")) {
+            if (COUNT_MEASURE.matcher(k).find()) {
                 countKey = k;
                 break;
             }
@@ -1830,9 +1859,9 @@ public class AiQueryResource {
 
             // saiku#905: k-anonymity small-cell suppression on the records
             // payload (mutates cells in place; resp already holds this list).
-            if (!useMatrix) {
-                applyKAnonymity(records);
-            }
+            // The output-mode gate lives inside the method (matrix = v1 no-op,
+            // saiku#905-B) so the skip is a unit-testable seam.
+            applyKAnonymity(records, useMatrix);
         }
         resp.setRuntimeMs(System.currentTimeMillis() - startedAt);
         return resp;

--- a/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/AiQueryResource.java
+++ b/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/AiQueryResource.java
@@ -120,6 +120,50 @@ public class AiQueryResource {
         this.aiPolicyGuard = g;
     }
 
+    /** saiku#905 — k-anonymity small-cell suppression. Defaults to disabled
+     *  (k=0) so existing tests / un-wired contexts behave as before; the Spring
+     *  bean injects the real config-driven filter (default k=5). */
+    private org.saiku.service.olap.ai.KAnonymityFilter kAnonymityFilter =
+            new org.saiku.service.olap.ai.KAnonymityFilter(0, null);
+
+    public void setKAnonymityFilter(org.saiku.service.olap.ai.KAnonymityFilter f) {
+        this.kAnonymityFilter = f;
+    }
+
+    /**
+     * saiku#905 v1 — apply k-anonymity small-cell suppression to a records
+     * payload using an in-result count measure (a measure column whose caption
+     * contains "count", e.g. Mondrian's "Fact Count"): any row whose count is
+     * below k has all its measure cells masked. No-op when suppression is
+     * disabled, there's no count column, or the payload is empty. The
+     * shadow-count query for cubes that don't surface a count measure is the
+     * saiku#905 follow-up. Package-private so the wiring is unit-testable
+     * without standing up a CellDataSet.
+     */
+    void applyKAnonymity(java.util.List<java.util.Map<String, Object>> records) {
+        if (!kAnonymityFilter.enabled() || records == null || records.isEmpty()) {
+            return;
+        }
+        java.util.LinkedHashSet<String> measureKeys = new java.util.LinkedHashSet<>();
+        for (java.util.Map<String, Object> r : records) {
+            for (java.util.Map.Entry<String, Object> e : r.entrySet()) {
+                if (e.getValue() instanceof org.saiku.service.olap.ai.AiCell) {
+                    measureKeys.add(e.getKey());
+                }
+            }
+        }
+        String countKey = null;
+        for (String k : measureKeys) {
+            if (k.toLowerCase(java.util.Locale.ROOT).contains("count")) {
+                countKey = k;
+                break;
+            }
+        }
+        if (countKey != null) {
+            kAnonymityFilter.applyToRecords(records, countKey, measureKeys);
+        }
+    }
+
     public void setThinQueryService(ThinQueryService tqs) {
         this.thinQueryService = tqs;
     }
@@ -1783,6 +1827,12 @@ public class AiQueryResource {
             List<String> measureNames = new ArrayList<>();
             for (AiQueryMetadata.Caption c : cols) measureNames.add(c.getCaption());
             meta.setMeasures(measureNames);
+
+            // saiku#905: k-anonymity small-cell suppression on the records
+            // payload (mutates cells in place; resp already holds this list).
+            if (!useMatrix) {
+                applyKAnonymity(records);
+            }
         }
         resp.setRuntimeMs(System.currentTimeMillis() - startedAt);
         return resp;

--- a/saiku-core/saiku-web/src/test/java/org/saiku/web/rest/resources/AiQueryResourceKAnonTest.java
+++ b/saiku-core/saiku-web/src/test/java/org/saiku/web/rest/resources/AiQueryResourceKAnonTest.java
@@ -79,4 +79,84 @@ public class AiQueryResourceKAnonTest {
         r.applyKAnonymity(records);
         assertFalse(((AiCell) records.get(0).get("Store Sales")).isSuppressed());
     }
+
+    /* --- #1324 gate: count-detection guard + matrix-gap characterization --- */
+
+    @Test
+    public void discount_alone_is_not_treated_as_the_count_column() {
+        // saiku#905 / SEC+QA #1324 guard: "Discount" merely CONTAINS "count" —
+        // it must NOT be mistaken for the row-count measure. Under the old
+        // contains() heuristic this row (Discount=2 < k, no real count) was
+        // masked off the discount value — suppression silently keyed off the
+        // wrong column. With whole-word detection there is no count column here,
+        // so nothing is suppressed. (Would go RED on the pre-fix heuristic.)
+        AiQueryResource r = new AiQueryResource();
+        r.setKAnonymityFilter(new KAnonymityFilter(5, "null"));
+
+        Map<String, Object> rec = new LinkedHashMap<>();
+        rec.put("Product Family", "Specialty");
+        rec.put("Discount", new AiCell(2.0, "2", null));
+        rec.put("Store Sales", new AiCell(12.0, "$12", null));
+        List<Map<String, Object>> records = new ArrayList<>();
+        records.add(rec);
+
+        r.applyKAnonymity(records);
+
+        assertFalse(
+                "Discount must not be treated as a count column",
+                ((AiCell) records.get(0).get("Store Sales")).isSuppressed());
+        assertFalse(
+                "the Discount cell itself must not be masked",
+                ((AiCell) records.get(0).get("Discount")).isSuppressed());
+    }
+
+    @Test
+    public void real_count_is_chosen_over_a_discount_decoy() {
+        // A genuine "Fact Count" (=9, >= k) means the row is NOT small, even
+        // though a decoy "Discount" (=2) sorts first in the row. The old
+        // contains() pick would seize "Discount" first and wrongly suppress;
+        // whole-word matching skips it and reads the real count → no suppression.
+        AiQueryResource r = new AiQueryResource();
+        r.setKAnonymityFilter(new KAnonymityFilter(5, "null"));
+
+        Map<String, Object> rec = new LinkedHashMap<>();
+        rec.put("Product Family", "Mainline");
+        rec.put("Discount", new AiCell(2.0, "2", null)); // decoy, sorts FIRST
+        rec.put("Fact Count", new AiCell(9.0, "9", null)); // the real count, >= k
+        rec.put("Store Sales", new AiCell(900.0, "$900", null));
+        List<Map<String, Object>> records = new ArrayList<>();
+        records.add(rec);
+
+        r.applyKAnonymity(records);
+
+        assertFalse(
+                "the real Fact Count (9 >= k) must drive the decision, not the Discount decoy",
+                ((AiCell) records.get(0).get("Store Sales")).isSuppressed());
+    }
+
+    @Test
+    public void matrix_output_is_not_suppressed_known_v1_gap() {
+        // saiku#905-B documented v1 known-gap (SEC #1324): the format=matrix
+        // egress path is deliberately NOT k-anon-suppressed. The seam
+        // applyKAnonymity(records, matrix) early-returns on matrix=true; this
+        // locks that contract so the day matrix suppression lands (#905-B) — or
+        // the gate accidentally moves — this test flags it. For contrast, the
+        // SAME small row IS suppressed on the records path (matrix=false).
+        AiQueryResource r = new AiQueryResource();
+        r.setKAnonymityFilter(new KAnonymityFilter(5, "null"));
+
+        List<Map<String, Object>> matrixRows = new ArrayList<>();
+        matrixRows.add(row("Specialty", 2, 12.0)); // count 2 < k
+        r.applyKAnonymity(matrixRows, true);
+        assertFalse(
+                "matrix output is a documented v1 known-gap — NOT suppressed (#905-B)",
+                ((AiCell) matrixRows.get(0).get("Store Sales")).isSuppressed());
+
+        List<Map<String, Object>> recordRows = new ArrayList<>();
+        recordRows.add(row("Specialty", 2, 12.0)); // identical small row
+        r.applyKAnonymity(recordRows, false);
+        assertTrue(
+                "the records path still suppresses the same small row",
+                ((AiCell) recordRows.get(0).get("Store Sales")).isSuppressed());
+    }
 }

--- a/saiku-core/saiku-web/src/test/java/org/saiku/web/rest/resources/AiQueryResourceKAnonTest.java
+++ b/saiku-core/saiku-web/src/test/java/org/saiku/web/rest/resources/AiQueryResourceKAnonTest.java
@@ -1,0 +1,82 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.web.rest.resources;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.Test;
+import org.saiku.service.olap.ai.AiCell;
+import org.saiku.service.olap.ai.KAnonymityFilter;
+
+/**
+ * saiku#905 — call-site (wiring) coverage for {@code AiQueryResource.applyKAnonymity}:
+ * proves the resource detects the in-result count measure ("...count...") and
+ * runs suppression over the records payload, not just that the filter works in
+ * isolation.
+ */
+public class AiQueryResourceKAnonTest {
+
+    private static Map<String, Object> row(String dim, double count, double sales) {
+        Map<String, Object> r = new LinkedHashMap<>();
+        r.put("Product Family", dim);
+        r.put("Fact Count", new AiCell(count, String.valueOf((int) count), null));
+        r.put("Store Sales", new AiCell(sales, "$" + sales, null));
+        return r;
+    }
+
+    @Test
+    public void detects_count_column_and_suppresses_small_rows() {
+        AiQueryResource r = new AiQueryResource();
+        r.setKAnonymityFilter(new KAnonymityFilter(5, "null"));
+
+        List<Map<String, Object>> records = new ArrayList<>();
+        records.add(row("Specialty", 2, 12.0)); // < 5 -> suppressed
+        records.add(row("Mainline", 9, 900.0)); // >= 5 -> kept
+
+        r.applyKAnonymity(records);
+
+        assertTrue(((AiCell) records.get(0).get("Store Sales")).isSuppressed());
+        assertNull(((AiCell) records.get(0).get("Store Sales")).getValue());
+        assertTrue(((AiCell) records.get(0).get("Fact Count")).isSuppressed());
+        assertFalse(((AiCell) records.get(1).get("Store Sales")).isSuppressed());
+        assertEquals(Double.valueOf(900.0), ((AiCell) records.get(1).get("Store Sales")).getValue());
+    }
+
+    @Test
+    public void noop_when_no_count_column_present() {
+        AiQueryResource r = new AiQueryResource();
+        r.setKAnonymityFilter(new KAnonymityFilter(5, "null"));
+
+        List<Map<String, Object>> records = new ArrayList<>();
+        Map<String, Object> rec = new LinkedHashMap<>();
+        rec.put("Product Family", "Specialty");
+        rec.put("Store Sales", new AiCell(12.0, "$12", null)); // no count column
+        records.add(rec);
+
+        r.applyKAnonymity(records);
+
+        assertFalse(
+                "cannot suppress without a count measure",
+                ((AiCell) records.get(0).get("Store Sales")).isSuppressed());
+    }
+
+    @Test
+    public void unwired_filter_defaults_disabled() {
+        // No setKAnonymityFilter() -> default k=0 (disabled) -> no suppression,
+        // preserving existing behaviour until the Spring bean injects the real one.
+        AiQueryResource r = new AiQueryResource();
+        List<Map<String, Object>> records = new ArrayList<>();
+        records.add(row("Specialty", 1, 5.0));
+        r.applyKAnonymity(records);
+        assertFalse(((AiCell) records.get(0).get("Store Sales")).isSuppressed());
+    }
+}

--- a/saiku-webapp/src/main/webapp/WEB-INF/saiku-beans.xml
+++ b/saiku-webapp/src/main/webapp/WEB-INF/saiku-beans.xml
@@ -243,10 +243,15 @@
          and FAILS FAST on an invalid value before the app serves traffic. -->
     <bean id="aiPolicyGuard" class="org.saiku.service.olap.ai.AiPolicyGuard"/>
 
+    <!-- saiku#905: k-anonymity small-cell suppression. Singleton resolving
+         ai.kAnonymity (default 5; 0 disables) + ai.kAnonymity.maskValue at boot. -->
+    <bean id="kAnonymityFilter" class="org.saiku.service.olap.ai.KAnonymityFilter"/>
+
     <bean id="aiQueryResource" scope="request"
           class="org.saiku.web.rest.resources.AiQueryResource">
         <aop:scoped-proxy/>
         <property name="aiPolicyGuard" ref="aiPolicyGuard"/>
+        <property name="kAnonymityFilter" ref="kAnonymityFilter"/>
         <property name="thinQueryService" ref="thinQueryBean"/>
         <property name="cubeMetadataService" ref="aiCubeMetadataServiceBean"/>
         <property name="asyncQueryService" ref="asyncQueryServiceBean"/>


### PR DESCRIPTION
## Summary
Adds k-anonymity small-cell suppression to the AI Query API. When a result row is backed by fewer than `k` underlying facts, its measure cells are masked so the AI surface never leaks values computed from a tiny (re-identifiable) population. This is part 1: the in-result count path — it suppresses using a count measure already present in the result. The shadow-count query for cubes that do not surface a count measure is the #905 follow-up.

## The change
- **`KAnonymityFilter`** (new) — config-driven via `ai.kAnonymity` (default `5`; `0` disables) and `ai.kAnonymity.maskValue` (default `"null"`). Resolves from env (`SAIKU_AI_KANONYMITY`) / system property at boot, fail-safe to `5` on an invalid value, and logs the effective setting. `shouldSuppress(rowCount)` is `enabled && 0 < rowCount < k`. `mask(cell)` nulls the value and sets `formatted` per the mask mode, flagging the cell `suppressed=true`.
- **`AiCell`** — new `suppressed` flag, `@JsonInclude(NON_DEFAULT)` so ordinary cells stay lean on the wire.
- **`AiQueryResource.applyKAnonymity(records)`** — detects the in-result count measure (a column whose caption contains "count", e.g. Mondrian's "Fact Count") and runs suppression over the records payload. No-op when disabled, when there's no count column, or on an empty payload. Wired in `buildResponse` for the records (non-matrix) path.
- **Spring wiring** — `kAnonymityFilter` singleton bean + property injection on `aiQueryResource` in `saiku-beans.xml`. Default (un-wired) construction is `k=0` (disabled) so existing tests / un-wired contexts are unchanged until the bean injects the real config.

## Verified
- `mvn spotless:check test` green locally on JDK 21.
- `KAnonymityFilterTest` (10) — threshold resolution, fail-safe, mask modes, boundary `rowCount==k`.
- `AiQueryResourceKAnonTest` (3) — call-site/wiring: count-column detection + suppression, no-op without a count column, un-wired default disabled.
- `AiQueryResourceTest` (36) regression — unchanged behaviour with the filter at its disabled default.

## Test plan
1. Start the launcher with `-Dai.kAnonymity=5`.
2. `POST /saiku/api/ai/query` for a cube/measure with a count measure on a low-cardinality breakdown; confirm rows whose count `< 5` come back with `suppressed: true` and masked measure cells, while rows `>= 5` are untouched.
3. Restart with `-Dai.kAnonymity=0`; confirm suppression is off.

## Notes
- Follow-ups (separate PRs): (B) shadow-count query for cubes with no in-result count measure; UI render for suppressed cells.
- Rebased onto current `development` (keep-both with #903's `aiPolicyGuard`); both policy and k-anon test suites pass together.
