### PR TITLE
fix(ai): correct drillthrough position error message to col:row (#930)

### DIFF
--- a/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/AiQueryResource.java
+++ b/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/AiQueryResource.java
@@ -1320,7 +1320,8 @@ public class AiQueryResource {
                 AiQueryResponse resp = new AiQueryResponse();
                 resp.setStatus(AiQueryResponse.Status.VALIDATION_ERROR);
                 resp.setError(
-                        "Malformed position '" + position + "'. Expected \"row:col\" cell coordinates, e.g. \"2:1\".");
+                        "Malformed position '" + position
+                                + "'. Expected \"col:row\" cell coordinates (column-axis index then row-axis index), e.g. \"2:1\".");
                 resp.setField("position");
                 return Response.status(Response.Status.BAD_REQUEST)
                         .entity(resp)
@@ -1509,8 +1510,9 @@ public class AiQueryResource {
                 } catch (NumberFormatException nfe) {
                     AiQueryResponse resp = new AiQueryResponse();
                     resp.setStatus(AiQueryResponse.Status.VALIDATION_ERROR);
-                    resp.setError("Malformed position '" + position
-                            + "'. Expected \"row:col\" cell coordinates, e.g. \"2:1\".");
+                    resp.setError(
+                            "Malformed position '" + position
+                                    + "'. Expected \"col:row\" cell coordinates (column-axis index then row-axis index), e.g. \"2:1\".");
                     resp.setField("position");
                     return Response.status(Response.Status.BAD_REQUEST)
                             .entity(resp)

--- a/saiku-core/saiku-web/src/test/java/org/saiku/web/rest/resources/AiQueryResourceTest.java
+++ b/saiku-core/saiku-web/src/test/java/org/saiku/web/rest/resources/AiQueryResourceTest.java
@@ -624,6 +624,13 @@ public class AiQueryResourceTest {
         assertEquals(400, resp.getStatus());
         AiQueryResponse body = (AiQueryResponse) resp.getEntity();
         assertEquals("position", body.getField());
+        // The message must state the real contract — column-axis index first
+        // ("col:row"), matching the javadoc + AI-QUERY-API.md, NOT the inverted
+        // "row:col" the string used to claim (saiku#930 doc/error fix).
+        String err = body.getError();
+        assertNotNull(err);
+        assertTrue("error should state the col:row order", err.contains("col:row"));
+        assertFalse("error must not state the inverted row:col order", err.contains("row:col"));
     }
 
     /* --- #1160 characterization: lock the error-translation branches ----- */


### PR DESCRIPTION
## Summary
Small correctness fix: `AiQueryResource.parseCellPosition` (and the CSV-export variant) rejected a malformed `?position=` with `Expected "row:col" cell coordinates` — but the **actual contract is `col:row`**. `cellPosition[i]` indexes `axes.get(i)`, and axis 0 is the **column** axis, so the order is column-axis-index : row-axis-index. Both method javadocs and `docs/AI-QUERY-API.md` already say `col:row`; the error string was the lone outlier and would mislead an API consumer self-correcting from the message.

## The change
- Both error strings → `Expected "col:row" cell coordinates (column-axis index then row-axis index), e.g. "2:1".`
- Strengthened `AiQueryResourceTest.drillthroughMalformedPositionReturns400` to assert the message contains `col:row` and **not** `row:col` (goes RED if the inversion ever returns).

## Verified
- `mvn -pl saiku-core/saiku-web -am test -Dtest=AiQueryResourceTest` → BUILD SUCCESS; spotless clean.

## Notes
- Found while writing the #1052 AI-QUERY-API docs (PR #1321), which document the correct `col:row` form — this aligns the runtime error message with the docs + javadoc. Behaviour-neutral apart from the message text; no shape/contract change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)