### PR TITLE
security(deps): bump spring 6.2.19 + spring-security 6.5.11 + log4j 2.25.4 (closes Dependabot CVE batch)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,8 +27,8 @@
              dependencyManagement, but a child not importing the BOM would
              otherwise inherit the stale 4.3.30/1.19 values — kept in sync
              with saiku-bom/pom.xml to remove the footgun. -->
-        <spring.version>6.2.8</spring.version>
-        <spring.security.version>6.5.1</spring.security.version>
+        <spring.version>6.2.19</spring.version>
+        <spring.security.version>6.5.11</spring.security.version>
         <slf4j.version>2.0.16</slf4j.version>
         <jersey.version>3.1.9</jersey.version>
         <maven.build.timestamp.format>yyyyMMdd-HHmm</maven.build.timestamp.format>

--- a/saiku-bom/pom.xml
+++ b/saiku-bom/pom.xml
@@ -13,14 +13,15 @@
 
     <properties>
         <!-- Shared third-party versions. Child poms reference these via ${...}. -->
-        <!-- Spring Framework 6.2.x is the latest 6.x GA line (6.2.8 as of 2025-06).
-             6.2.x closes CVE-2025-41242 (path traversal) and CVE-2025-41249
-             (annotation-detection authorization). 7.x is still in milestones. -->
-        <spring.version>6.2.11</spring.version>
-        <!-- Spring Security 6.5.x is the latest GA line (6.5.1 as of 2025-06).
-             Closes CVE-2026-22732 (HTTP-headers-not-written) and CVE-2026-22746
-             (user-attribute enumeration). Pairs with Spring Framework 6.2.x. -->
-        <spring.security.version>6.5.10</spring.security.version>
+        <!-- Spring Framework 6.2.x is the latest 6.x GA line. 6.2.19 carries the
+             backported fixes for the 2026-06-01 advisory (16 CVEs, CVE-2026-41838..41855)
+             AND the older spring-webmvc CVE-2026-22737/22741/22745/22735 — staying on 6.x
+             keeps the XML-wired Spring Security working; 7.x is a separate planned migration. -->
+        <spring.version>6.2.19</spring.version>
+        <!-- Spring Security 6.5.x is the latest GA line paired with Spring Framework 6.2.x.
+             6.5.11 is current hygiene (the 2026-06 CVE batch is in spring-framework, fixed
+             transitively by the 6.2.19 bump above). 7.x deferred to a planned migration. -->
+        <spring.security.version>6.5.11</spring.security.version>
         <!-- slf4j 1.x reached EOL; 2.0.x is the maintained line. API
              (org.slf4j.Logger / LoggerFactory) is binary-compatible for
              the call surface saiku uses. Note: the slf4j → log4j-2 binding
@@ -32,7 +33,7 @@
              namespace (so existing imports keep working) but routes everything
              through log4j-core 2.x. slf4j-log4j12 likewise gets swapped for
              log4j-slf4j-impl, the slf4j-1.x → log4j2 binding. -->
-        <log4j2.version>2.24.3</log4j2.version>
+        <log4j2.version>2.25.4</log4j2.version>
         <!-- Batik 1.8 has CVE-2022-38398/40146/41704/42890/44729/44730. 1.17 fixes them. -->
         <batik.version>1.19</batik.version>
         <jersey.version>3.1.9</jersey.version>


### PR DESCRIPTION
## Summary
Closes the bulk of the open Dependabot **security alerts** with a low-risk minor bump on our current major lines — **no Spring 7 / Jakarta migration**. Tom approved this remediation plan (from the dependency-security review).

- **`spring.version` 6.2.11 → 6.2.19** — backported fixes for the 2026-06-01 advisory (**CVE-2026-41838…41855**, 16 CVEs) **and** the older `spring-webmvc` **CVE-2026-22737/22741/22745/22735**. Staying on 6.2.x keeps the XML-wired Spring Security working.
- **`spring.security.version` 6.5.10 → 6.5.11** — current-line hygiene (the CVE batch is in spring-framework, fixed transitively by the bump above).
- **`log4j2.version` 2.24.3 → 2.25.4** — closes **CVE-2026-34477/34478/34479/34480** + **CVE-2025-68161**.
- Root `pom.xml` shadow props synced to match the BOM (were stale at 6.2.8 / 6.5.1) per the in-file "keep in sync" note.

Batik is already on 1.19 (≥1.17) so **CVE-2022-44730 is already mitigated** — no change needed.

## Supersedes
Dependabot **#1311** (spring → 7.0.8) and **#1310** (spring-security → 7.1.0) — those are major upgrades that **fail CI** (Spring 7 drops the XML-config style we use) and are a separate planned migration, not a security patch. Recommend closing both once this merges.

## Applicability note (SEC)
Most of the 16-CVE Spring batch is architecturally **not reachable** in Saiku (no WebFlux/WebSocket/JMS/JSP; verified no user-input SpEL, no `UriComponentsBuilder`); the one on-classpath item (AntPathMatcher ReDoS) is CVSS-Low and needs an attacker-controlled pattern we don't expose. This bump is taken because it's free and clears the alerts, not because of acute exposure. Full triage in the report shared with Tom.

## Verification
- Local `mvn verify` on JDK 21 with the new versions: **full reactor compiles; all tests pass except two pre-existing Windows-local flake groups** — `MdxEchoGoldenTest`/`SchemaInferrerGoldenTest` (golden-text CRLF) and `SaikuQueryCacheTest` (file-deletion timing). **Both fail identically on clean `development`** (baselined), so this dependency-only change introduces **zero** new failures. They pass on CI's Linux runners.
- Dependency-only diff (2 files, version props); no source changes.

🔐 SEC remediation P1 of the Tom-approved plan. P2 (OpenPDF swap, UI deps incl. jsPDF) and P3 (test/build hygiene) follow as separate single-concern PRs. Handing to LEAD — not self-merging.
