### PR TITLE
security(deps): swap com.lowagie:itext → OpenPDF 1.4.2 (closes CVE-2017-9096 XXE)

### DIFF
--- a/saiku-bom/pom.xml
+++ b/saiku-bom/pom.xml
@@ -336,15 +336,16 @@
                 <artifactId>batik-ext</artifactId>
                 <version>${batik.version}</version>
             </dependency>
-            <!-- iText 4.2.0 under the old "iText:iText" groupId was never on Maven
-                 Central and the original hosting is gone. com.lowagie:itext:2.1.7
-                 is the same artifact (last OSS release before AGPL) published on
-                 Central. Saiku's PDF export code imports com.lowagie.text.* so
-                 the API surface is unchanged — only the coords. -->
+            <!-- OpenPDF 1.4.2 is the maintained fork of the abandoned
+                 com.lowagie:itext:2.1.7. It keeps the same com.lowagie.text.*
+                 package (the rename to org.openpdf is a 2.x change), so Saiku's
+                 PDF export imports are unchanged — only the coords. Closes
+                 CVE-2017-9096 (XXE in iText <= 4.2.2), which com.lowagie:itext
+                 never fixed (no patched release exists). -->
             <dependency>
-                <groupId>com.lowagie</groupId>
-                <artifactId>itext</artifactId>
-                <version>2.1.7</version>
+                <groupId>com.github.librepdf</groupId>
+                <artifactId>openpdf</artifactId>
+                <version>1.4.2</version>
             </dependency>
             <dependency>
                 <groupId>org.saikuanalytics</groupId>

--- a/saiku-core/saiku-web/pom.xml
+++ b/saiku-core/saiku-web/pom.xml
@@ -250,11 +250,11 @@
             <artifactId>xmlgraphics-commons</artifactId>
         </dependency>
 
-        <!-- Inherits version from saiku-bom (com.lowagie:itext:2.1.7,
-             Central-resolvable, same com.lowagie.text.* API). -->
+        <!-- OpenPDF (maintained com.lowagie:itext fork; same com.lowagie.text.*
+             API; fixes CVE-2017-9096). Version from saiku-bom. -->
         <dependency>
-            <groupId>com.lowagie</groupId>
-            <artifactId>itext</artifactId>
+            <groupId>com.github.librepdf</groupId>
+            <artifactId>openpdf</artifactId>
         </dependency>
         <dependency>
             <groupId>net.sourceforge.htmlcleaner</groupId>


### PR DESCRIPTION
## Summary
Replaces the **abandoned, unpatchable** `com.lowagie:itext:2.1.7` with the maintained **OpenPDF 1.4.2** fork (Tom-approved plan, P2a). Closes **CVE-2017-9096** (iText XXE, HIGH) — `com.lowagie:itext` has **no patched release**, so a version bump was impossible; the fix is the library swap.

## Why it's a clean drop-in
OpenPDF 1.4.x keeps the **same `com.lowagie.text.*` package** (the rename to `org.openpdf` is a 2.x change). Saiku's only consumers — `saiku-web/.../export/PdfReport.java` and `.../svg/PdfReport.java` — compile unchanged. This is a coords-only swap in `saiku-bom` (dependencyManagement) + `saiku-web` (dependency).

## Verification
- Full reactor **compiles** against OpenPDF (saiku-web jar builds).
- **saiku-web tests 377/0.**
- `openpdf:1.4.2` resolves from Maven Central; no stray `com.lowagie:itext` remains.

🔐 SEC remediation P2a of the Tom-approved plan. P1 (#1326 spring/log4j) and P2 UI (#1328) are separate PRs; P3 (test/build hygiene: junit, hadoop, plugin PRs) follows. Handing to LEAD — not self-merging.
