### PR TITLE
security(deps): saiku-web junit 4.8.2 → BOM 4.13.2 (closes CVE-2020-15250, test scope)

### DIFF
--- a/saiku-core/saiku-web/pom.xml
+++ b/saiku-core/saiku-web/pom.xml
@@ -270,11 +270,11 @@
         </dependency>
 
 
-        <!-- Test -->
+        <!-- Test — version inherited from saiku-bom (4.13.2); the old hard-pin
+             at 4.8.2 carried CVE-2020-15250 (TemporaryFolder info disclosure). -->
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.8.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
## Summary
Test-only hygiene (Tom-approved plan, P3). `saiku-web` hard-pinned **junit 4.8.2**, overriding the BOM-managed **4.13.2** used by every other module — 4.8.2 carries **CVE-2020-15250** (`TemporaryFolder` information disclosure, test scope). This drops the override so saiku-web inherits 4.13.2.

## Verification
- saiku-web tests **378/0** under junit 4.13.2 (excluding the pre-existing Windows-local flake classes, which are environment-only and pass on CI Linux).

## Items intentionally NOT changed (with rationale)
- **`hadoop-common` (LOW, CVE-2024-23454):** the BOM deliberately pins **2.10.2** for `hive-jdbc:2.3.9` compatibility; the only fix is hadoop **3.4.0**, a major bump that risks the hive JDBC surface. **Accepting the LOW risk** rather than forcing a breaking major for a transitive — flag for a future hive/hadoop modernization.
- **Dependabot #1312 (hamcrest 3.0), #1313 (maven-dependency-plugin), #1314 (maven-antrun-plugin):** build/test tooling, **no CVE**. Tom approved as optional — recommend LEAD merges those Dependabot PRs directly (no need to reopen here).

🔐 SEC remediation P3 of the Tom-approved plan — the final piece. Companion PRs: #1326 (spring/log4j), #1328 (UI: jspdf/sveltekit/vitest), #1329 (OpenPDF swap). Handing to LEAD — not self-merging.
