### PR TITLE
test(ai): lock the drillthrough-CSV malformed-position error message (#930 follow-up)

### DIFF
--- a/saiku-core/saiku-web/src/test/java/org/saiku/web/rest/resources/AiQueryResourceTest.java
+++ b/saiku-core/saiku-web/src/test/java/org/saiku/web/rest/resources/AiQueryResourceTest.java
@@ -633,6 +633,25 @@ public class AiQueryResourceTest {
         assertFalse("error must not state the inverted row:col order", err.contains("row:col"));
     }
 
+    @Test
+    public void drillthroughExportCsvMalformedPositionReturns400() {
+        // saiku#930 sibling-lock to drillthroughMalformedPositionReturns400: the
+        // CSV-export endpoint carries its OWN inline position parse, independent
+        // of parseCellPosition, so its malformed-position 400 message must ALSO
+        // state the real col:row contract — otherwise the two duplicated strings
+        // can silently drift (one fixed, the other reverting). The parse fails
+        // before any query runs, so the setUp StubThinQueryService is enough and
+        // returns=null skips the schema-resolution block.
+        Response resp = resource.drillthroughExportCsv("sync-query-id", 100, null, "abc", null);
+        assertEquals(400, resp.getStatus());
+        AiQueryResponse body = (AiQueryResponse) resp.getEntity();
+        assertEquals("position", body.getField());
+        String err = body.getError();
+        assertNotNull(err);
+        assertTrue("CSV-export error should state the col:row order", err.contains("col:row"));
+        assertFalse("CSV-export error must not state the inverted row:col order", err.contains("row:col"));
+    }
+
     /* --- #1160 characterization: lock the error-translation branches ----- */
 
     /** saiku#783: an unknown queryId leaks an NPE from the internal


### PR DESCRIPTION
Follow-up to #1325. That PR corrected two duplicated `row:col`→`col:row` error strings, but only `parseCellPosition` (via `/drillthrough`) had a test — the second corrected string lives in `drillthroughExportCsv`'s own inline position parse and had zero coverage, so the two could silently drift apart (one fixed, the other reverting unnoticed).

This adds the sibling lock: a malformed `position` to the CSV-export endpoint returns `400` with `field=position` and a message stating the real `col:row` order (not the inverted `row:col`). Same toothful shape as the existing drillthrough test — positive `contains("col:row")` plus a negative `assertFalse(contains("row:col"))` that would have gone red against the old string. The parse fails before any query runs, so the existing `setUp` stub suffices — no new fixtures.

**Test-only.** `AiQueryResourceTest` 37/0; spotless clean. Verified on JDK 21.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
