### PR TITLE
test: make MDX/schema golden compares line-ending-agnostic (kill 7 Windows flakes)

### DIFF
--- a/saiku-core/saiku-service/src/test/java/org/saiku/service/olap/ai/MdxEchoGoldenTest.java
+++ b/saiku-core/saiku-service/src/test/java/org/saiku/service/olap/ai/MdxEchoGoldenTest.java
@@ -110,7 +110,12 @@ public class MdxEchoGoldenTest {
             fail("wrote " + target + " — inspect diff and re-run without -D" + UPDATE_PROPERTY);
         }
 
-        assertEquals("MDX differs from " + expectedResource, expected, actual);
+        // Compare on content, not byte-exact line endings: a golden checked out
+        // with CRLF (git core.autocrlf=true on Windows) must still match the
+        // LF the converter emits — otherwise these goldens flake on every
+        // Windows clone with a spurious \r\n-vs-\n diff (no .gitattributes pins
+        // the fixtures to LF).
+        assertEquals("MDX differs from " + expectedResource, normalizeEol(expected), normalizeEol(actual));
     }
 
     private static String readResource(String resource) throws IOException {
@@ -118,6 +123,11 @@ public class MdxEchoGoldenTest {
             if (in == null) return null;
             return new String(in.readAllBytes(), StandardCharsets.UTF_8);
         }
+    }
+
+    /** Normalise CRLF/CR to LF so golden comparison is line-ending-agnostic. */
+    private static String normalizeEol(String s) {
+        return s == null ? null : s.replace("\r\n", "\n").replace('\r', '\n');
     }
 
     /**

--- a/saiku-core/saiku-service/src/test/java/org/saiku/service/schema/generate/infer/SchemaInferrerGoldenTest.java
+++ b/saiku-core/saiku-service/src/test/java/org/saiku/service/schema/generate/infer/SchemaInferrerGoldenTest.java
@@ -98,7 +98,10 @@ public class SchemaInferrerGoldenTest {
                 continue;
             }
 
-            if (!expected.equals(actual)) {
+            // Content compare, not byte-exact line endings — a golden checked
+            // out with CRLF (git core.autocrlf=true on Windows) must still match
+            // the LF the generator emits, else these flake on every Windows clone.
+            if (!normalizeEol(expected).equals(normalizeEol(actual))) {
                 failures.append("[")
                         .append(fixture)
                         .append("] output differs from ")
@@ -120,6 +123,11 @@ public class SchemaInferrerGoldenTest {
             }
             fail(failures.toString());
         }
+    }
+
+    /** Normalise CRLF/CR to LF so golden comparison is line-ending-agnostic. */
+    private static String normalizeEol(String s) {
+        return s == null ? null : s.replace("\r\n", "\n").replace('\r', '\n');
     }
 
     private static String readResource(String resource) throws IOException {


### PR DESCRIPTION
﻿The `MdxEchoGoldenTest` (6) and `SchemaInferrerGoldenTest` (1) golden tests fail on every Windows clone: git `core.autocrlf=true` checks the `expected.mdx` / `.expected.json` fixtures out with CRLF, but the converter/serializer emit LF, and the golden compare was byte-exact — so it's a spurious `\r\n`-vs-`\n` diff (there's no `.gitattributes` pinning the fixtures to LF). These are the 7 "pre-existing Windows-local flakes" the recent dependency-CVE merges kept having to triage as not-a-regression.

**Fix:** normalize CRLF/CR → LF on both sides before the golden compare, so a content golden asserts content, not byte-exact line endings (which it shouldn't care about). No fixture or production change, and a no-op on already-LF content — so Linux CI (already green) is unaffected.

Reproduced **RED→GREEN** locally: before = `MdxEchoGoldenTest` 6/6 + `SchemaInferrerGoldenTest` 1/1 FAIL on Windows; after = **7/0**.

> Note: a `.gitattributes` pinning text fixtures to `eol=lf` would also fix this at the source — happy to add that as a follow-up if preferred. The test-side normalization makes the goldens robust regardless of any clone's git config. (The other documented local flake — `SaikuQueryCache` file-delete timing, 3 tests — is a separate, non-CRLF issue, left out of scope here.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
