### PR TITLE
chore(deps): bump maven-dependency-plugin 3.6.1 -> 3.11.0 (closes #1313)

### DIFF
--- a/saiku-launcher/pom.xml
+++ b/saiku-launcher/pom.xml
@@ -99,7 +99,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-dependency-plugin</artifactId>
-                <version>3.6.1</version>
+                <version>3.11.0</version>
                 <executions>
                     <execution>
                         <id>copy-war</id>


### PR DESCRIPTION
## Summary
Bumps `maven-dependency-plugin` 3.6.1 → 3.11.0. Re-authored from dependabot #1313 onto current `development` so CI can run with the `GH_PACKAGES_TOKEN` (dependabot PRs don't get repo secrets, so their build fails on GitHub-Packages auth rather than on the change). Closes/supersedes #1313.

## The change
One line in `saiku-launcher/pom.xml`. The plugin's only use is the launcher's `prepare-package` `copy` goal (saiku-webapp WAR → fat jar).

## Verified
- Local: `dependency:3.11.0:copy (copy-war)` runs and the launcher packages — BUILD SUCCESS.
- CI green on this branch (has the packages token, unlike the dependabot PR).

## Notes
The other two open dependabot bumps were reviewed and **declined**, not merged:
- antrun 1.6 → 3.2.0 (#1314): the 1.6 declaration in `saiku-webapp/pom.xml` uses the `<tasks>` element removed in antrun 3.x (and it's a dead, empty `deploy-ui` no-op) — needs that execution removed/migrated first, a separate chore.
- hamcrest-library 2.2 → 3.0 (#1312): the BOM deliberately pins all hamcrest artifacts to 2.2 as backward-compat shims so serenity-bdd/jbehave transitives can't pull old hamcrest onto the classpath; bumping only `hamcrest-library` would mix versions against that pin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
