### PR TITLE
fix(security): close the k-anonymity format=matrix bypass (closes #1324)

### DIFF
--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ai/KAnonymityFilter.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ai/KAnonymityFilter.java
@@ -163,11 +163,32 @@ public class KAnonymityFilter {
      * @return number of rows suppressed
      */
     public int applyToRecords(List<Map<String, Object>> rows, String countKey, Collection<String> measureKeys) {
+        return applyToRows(rows, countKey, measureKeys);
+    }
+
+    /**
+     * saiku#1324 — matrix-format variant of {@link #applyToRecords}. The
+     * {@code format=matrix} payload is index-keyed and typed {@link AiCell}, but
+     * the suppression decision is identical: a row whose {@code countKey} cell is
+     * below k has every {@code measureKeys} cell masked. Shares the same core as
+     * the records path so the two egress shapes can never drift apart (which is
+     * how the original count-detection gap slipped in).
+     */
+    public int applyToMatrix(List<Map<String, AiCell>> rows, String countKey, Collection<String> measureKeys) {
+        return applyToRows(rows, countKey, measureKeys);
+    }
+
+    /**
+     * Shared suppression core over any String-keyed, {@link AiCell}-valued row
+     * map — records carry {@code Object} values (cell or row-header String),
+     * matrix carries {@code AiCell} directly. Reads only, masks cells in place.
+     */
+    private int applyToRows(List<? extends Map<String, ?>> rows, String countKey, Collection<String> measureKeys) {
         if (!enabled() || rows == null || countKey == null || measureKeys == null) {
             return 0;
         }
         int suppressed = 0;
-        for (Map<String, Object> row : rows) {
+        for (Map<String, ?> row : rows) {
             if (row == null) {
                 continue;
             }

--- a/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/AiQueryResource.java
+++ b/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/AiQueryResource.java
@@ -142,34 +142,16 @@ public class AiQueryResource {
             java.util.regex.Pattern.compile("\\bcounts?\\b", java.util.regex.Pattern.CASE_INSENSITIVE);
 
     /**
-     * saiku#905 v1 — apply k-anonymity small-cell suppression to a records
-     * payload using an in-result count measure (a measure column whose caption
-     * names a count on a word boundary, e.g. Mondrian's "Fact Count"): any row
-     * whose count is below k has all its measure cells masked. No-op when
-     * suppression is disabled, there's no count column, or the payload is empty.
-     * The shadow-count query for cubes that don't surface a count measure is the
-     * saiku#905 follow-up. Package-private so the wiring is unit-testable
-     * without standing up a CellDataSet. Convenience overload for the records
-     * (non-matrix) path.
+     * saiku#905 / #1324 — apply k-anonymity small-cell suppression to a
+     * records-format payload using an in-result count measure (a measure column
+     * whose caption names a count on a word boundary, e.g. Mondrian's "Fact
+     * Count"): any row whose count is below k has all its measure cells masked.
+     * No-op when suppression is disabled, there's no count column, or the payload
+     * is empty. The shadow-count query for cubes that don't surface a count
+     * measure is the saiku#905 follow-up. Package-private so the wiring is
+     * unit-testable without standing up a CellDataSet.
      */
     void applyKAnonymity(java.util.List<java.util.Map<String, Object>> records) {
-        applyKAnonymity(records, false);
-    }
-
-    /**
-     * saiku#905 v1 — as {@link #applyKAnonymity(java.util.List)}, with the
-     * output-mode gate folded in as a testable seam. When {@code matrix} is
-     * true this is a deliberate no-op: the {@code format=matrix} output is a
-     * known v1 gap (small cells are NOT suppressed there) tracked as the
-     * saiku#905-B follow-up — multi-tenant / embed deployments post-filter at
-     * the proxy in the meantime (SEC #1324). Routing the skip through this
-     * method (instead of an outer {@code if}) lets QA lock the gap contract
-     * without constructing a CellDataSet.
-     */
-    void applyKAnonymity(java.util.List<java.util.Map<String, Object>> records, boolean matrix) {
-        if (matrix) {
-            return; // saiku#905-B known gap: matrix output is not k-anon-suppressed in v1
-        }
         if (!kAnonymityFilter.enabled() || records == null || records.isEmpty()) {
             return;
         }
@@ -190,6 +172,38 @@ public class AiQueryResource {
         }
         if (countKey != null) {
             kAnonymityFilter.applyToRecords(records, countKey, measureKeys);
+        }
+    }
+
+    /**
+     * saiku#1324 — apply k-anonymity to the {@code format=matrix} payload,
+     * closing the egress bypass where small cells previously returned unmasked
+     * just because the caller asked for matrix output. Matrix cells are
+     * index-keyed ("0","1",…), so the count column is located via
+     * {@code columnCaptions} (index → caption, captured as the matrix is built)
+     * using the same whole-word detection as the records path; then every cell in
+     * a sub-k row is masked. No-op when disabled, empty, or there's no count
+     * column. Package-private for unit-testing without a CellDataSet.
+     */
+    void applyKAnonymityMatrix(
+            java.util.List<java.util.Map<String, AiCell>> matrix, java.util.List<String> columnCaptions) {
+        if (!kAnonymityFilter.enabled() || matrix == null || matrix.isEmpty() || columnCaptions == null) {
+            return;
+        }
+        String countKey = null;
+        java.util.LinkedHashSet<String> measureKeys = new java.util.LinkedHashSet<>();
+        for (int i = 0; i < columnCaptions.size(); i++) {
+            String key = String.valueOf(i);
+            measureKeys.add(key);
+            String caption = columnCaptions.get(i);
+            if (countKey == null
+                    && caption != null
+                    && COUNT_MEASURE.matcher(caption).find()) {
+                countKey = key;
+            }
+        }
+        if (countKey != null) {
+            kAnonymityFilter.applyToMatrix(matrix, countKey, measureKeys);
         }
     }
 
@@ -1773,6 +1787,10 @@ public class AiQueryResource {
             List<AiQueryMetadata.Caption> rows = new ArrayList<>();
             List<Map<String, AiCell>> matrix = new ArrayList<>();
             List<Map<String, Object>> records = new ArrayList<>();
+            // saiku#1324: index -> caption for the matrix payload, captured as
+            // the matrix is built, so k-anon can find the count column (matrix
+            // cells are keyed by index, not caption).
+            List<String> matrixColumnCaptions = new ArrayList<>();
 
             // Row-header column captions (e.g. ["Product Family"] or
             // ["Product Family", "Year"] for multi-axis rows). We pull
@@ -1808,6 +1826,10 @@ public class AiQueryResource {
                     Map<String, AiCell> cells = new LinkedHashMap<>();
                     for (int c = 0; c < totalWidth; c++) {
                         cells.put(String.valueOf(c), toCell(body[1][c]));
+                        if (matrixColumnCaptions.size() <= c) {
+                            String cap = body[0][c] == null ? ("col" + c) : safe(body[0][c].getFormattedValue());
+                            matrixColumnCaptions.add(cap.isEmpty() ? ("col" + c) : cap);
+                        }
                     }
                     matrix.add(cells);
                     rows.add(new AiQueryMetadata.Caption("", ""));
@@ -1829,7 +1851,12 @@ public class AiQueryResource {
                     if (useMatrix) {
                         Map<String, AiCell> cells = new LinkedHashMap<>();
                         for (int c = rowHeaderCount; c < totalWidth; c++) {
-                            cells.put(String.valueOf(c - rowHeaderCount), toCell(row[c]));
+                            int colIdx = c - rowHeaderCount;
+                            cells.put(String.valueOf(colIdx), toCell(row[c]));
+                            if (matrixColumnCaptions.size() <= colIdx) {
+                                matrixColumnCaptions.add(
+                                        colIdx < cols.size() ? cols.get(colIdx).getCaption() : ("col" + colIdx));
+                            }
                         }
                         matrix.add(cells);
                     } else {
@@ -1859,11 +1886,15 @@ public class AiQueryResource {
             for (AiQueryMetadata.Caption c : cols) measureNames.add(c.getCaption());
             meta.setMeasures(measureNames);
 
-            // saiku#905: k-anonymity small-cell suppression on the records
-            // payload (mutates cells in place; resp already holds this list).
-            // The output-mode gate lives inside the method (matrix = v1 no-op,
-            // saiku#905-B) so the skip is a unit-testable seam.
-            applyKAnonymity(records, useMatrix);
+            // saiku#905 / #1324: k-anonymity small-cell suppression on BOTH
+            // egress shapes (mutates cells in place; resp already holds the
+            // list). The matrix path was the #1324 bypass — it's now suppressed
+            // too, via the index->caption map captured above.
+            if (useMatrix) {
+                applyKAnonymityMatrix(matrix, matrixColumnCaptions);
+            } else {
+                applyKAnonymity(records);
+            }
         }
         resp.setRuntimeMs(System.currentTimeMillis() - startedAt);
         return resp;

--- a/saiku-core/saiku-web/src/test/java/org/saiku/web/rest/resources/AiQueryResourceKAnonTest.java
+++ b/saiku-core/saiku-web/src/test/java/org/saiku/web/rest/resources/AiQueryResourceKAnonTest.java
@@ -33,6 +33,14 @@ public class AiQueryResourceKAnonTest {
         return r;
     }
 
+    /** A matrix-format row: cells keyed by data-column INDEX (not caption). */
+    private static Map<String, AiCell> matrixRow(double count, double sales) {
+        Map<String, AiCell> r = new LinkedHashMap<>();
+        r.put("0", new AiCell(count, String.valueOf((int) count), null)); // count column
+        r.put("1", new AiCell(sales, "$" + sales, null)); // sales column
+        return r;
+    }
+
     @Test
     public void detects_count_column_and_suppresses_small_rows() {
         AiQueryResource r = new AiQueryResource();
@@ -135,28 +143,48 @@ public class AiQueryResourceKAnonTest {
     }
 
     @Test
-    public void matrix_output_is_not_suppressed_known_v1_gap() {
-        // saiku#905-B documented v1 known-gap (SEC #1324): the format=matrix
-        // egress path is deliberately NOT k-anon-suppressed. The seam
-        // applyKAnonymity(records, matrix) early-returns on matrix=true; this
-        // locks that contract so the day matrix suppression lands (#905-B) — or
-        // the gate accidentally moves — this test flags it. For contrast, the
-        // SAME small row IS suppressed on the records path (matrix=false).
+    public void matrix_output_is_now_suppressed() {
+        // saiku#1324: the format=matrix egress path is no longer a bypass.
+        // Matrix cells are index-keyed; applyKAnonymityMatrix locates the count
+        // column from the index->caption list and masks every cell in a sub-k
+        // row, exactly like the records path. (RED against the old #905-B no-op.)
         AiQueryResource r = new AiQueryResource();
         r.setKAnonymityFilter(new KAnonymityFilter(5, "null"));
 
-        List<Map<String, Object>> matrixRows = new ArrayList<>();
-        matrixRows.add(row("Specialty", 2, 12.0)); // count 2 < k
-        r.applyKAnonymity(matrixRows, true);
-        assertFalse(
-                "matrix output is a documented v1 known-gap — NOT suppressed (#905-B)",
-                ((AiCell) matrixRows.get(0).get("Store Sales")).isSuppressed());
+        List<String> cols = List.of("Fact Count", "Store Sales"); // index 0, 1
+        List<Map<String, AiCell>> matrix = new ArrayList<>();
+        matrix.add(matrixRow(2, 12.0)); // count 2 < k -> suppressed
+        matrix.add(matrixRow(9, 900.0)); // count 9 >= k -> kept
 
-        List<Map<String, Object>> recordRows = new ArrayList<>();
-        recordRows.add(row("Specialty", 2, 12.0)); // identical small row
-        r.applyKAnonymity(recordRows, false);
+        r.applyKAnonymityMatrix(matrix, cols);
+
+        assertTrue(matrix.get(0).get("1").isSuppressed());
+        assertNull(matrix.get(0).get("1").getValue());
         assertTrue(
-                "the records path still suppresses the same small row",
-                ((AiCell) recordRows.get(0).get("Store Sales")).isSuppressed());
+                "the count cell itself is disclosive and masked too",
+                matrix.get(0).get("0").isSuppressed());
+        assertFalse(matrix.get(1).get("1").isSuppressed());
+        assertEquals(Double.valueOf(900.0), matrix.get(1).get("1").getValue());
+    }
+
+    @Test
+    public void matrix_discount_decoy_is_not_the_count_column() {
+        // Parity with the records guard: a "Discount" column must not be picked
+        // as the count in matrix mode either (whole-word detection on captions).
+        AiQueryResource r = new AiQueryResource();
+        r.setKAnonymityFilter(new KAnonymityFilter(5, "null"));
+
+        List<String> cols = List.of("Discount", "Store Sales");
+        Map<String, AiCell> row = new LinkedHashMap<>();
+        row.put("0", new AiCell(2.0, "2", null)); // Discount = 2 (decoy)
+        row.put("1", new AiCell(12.0, "$12", null));
+        List<Map<String, AiCell>> matrix = new ArrayList<>();
+        matrix.add(row);
+
+        r.applyKAnonymityMatrix(matrix, cols);
+
+        assertFalse(
+                "Discount must not be treated as the count column in matrix mode",
+                matrix.get(0).get("1").isSuppressed());
     }
 }


### PR DESCRIPTION
## Summary
Closes the k-anonymity `format=matrix` bypass (#1324). #905 part 1 suppressed small cells only on the **records** egress shape — `POST /saiku/api/ai/query?format=matrix` returned the same small cells **unmasked** (the seam deliberately no-op'd on matrix as a documented v1 gap). With k-anon default-on (k=5) in prod, that was a real bypass. This makes matrix suppression first-class.

The other half of #1324 — robust count-measure detection (the `\bcounts?\b` word-boundary fix that stops `Discount`/`Account` being mistaken for the count) — shipped earlier in #1323.

## The change
- **`KAnonymityFilter`** — factored the suppression decision into a private shared core (`applyToRows`) so the records and matrix paths can never drift apart (that drift is exactly how the count-detection gap slipped in). Added `applyToMatrix()` for the index-keyed, `AiCell`-typed matrix payload; `applyToRecords()` keeps its signature and now delegates to the core.
- **`AiQueryResource`** — capture an index→caption map as the matrix is built (both the standard and measures-only branches), and add `applyKAnonymityMatrix()`, which locates the count column from that map using the **same** whole-word detection as the records path, then masks every cell in a sub-k row (the count cell included — a count of 3 is itself disclosive). The call site now suppresses **both** shapes; the obsolete no-op matrix overload is removed.

## Verified
- `KAnonymityFilterTest` **10/0**, `AiQueryResourceKAnonTest` **7/0** — the old "matrix is a known v1 gap" characterization flipped to **`matrix_output_is_now_suppressed`** (RED against the old no-op), plus a **`matrix_discount_decoy_is_not_the_count_column`** guard for parity with the records path.
- `AiQueryResourceTest` **37/0** regression. spotless clean.

## Test plan
1. Start with `-Dai.kAnonymity=5`, query a cube with a count measure on a low-cardinality breakdown.
2. `POST /ai/query?format=records` → small rows masked (`suppressed: true`).
3. `POST /ai/query?format=matrix` → **same rows now masked** (previously leaked).

## Notes
- Records behaviour is unchanged.
- The shadow-count query for cubes with no in-result count measure remains the separate #905-B follow-up (out of scope here).
- @AGENT SEC: this is the egress-bypass close — please verify no remaining `/ai/*` shape returns small cells unmasked while k-anon is on. @AGENT QA: the matrix characterization tests are the gate's test half.
