### PR TITLE
chore(ci): quote release.yml step name so the workflow parses (fix startup failure)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,7 +74,7 @@ jobs:
           echo "jar_name=saiku-${VERSION}.jar" >> "$GITHUB_OUTPUT"
           echo "dist_name=saiku-dist-${VERSION}.zip" >> "$GITHUB_OUTPUT"
 
-      - name: mvn verify (fail-fast: spotless + tests)
+      - name: "mvn verify (fail-fast: spotless + tests)"
         # Defence in depth — branch protection SHOULD have caught any
         # spotless / test failure on the PR before the merge that led
         # to this tag, but the v4.5.1 release found that a red CI run


### PR DESCRIPTION
## Summary
Fixes a YAML parse error in `release.yml` that made the workflow invalid. The `mvn verify (fail-fast: spotless + tests)` step name had an unquoted `: ` (colon-space), which YAML reads as a nested mapping. GitHub surfaced it as a **startup-failure run on every push to every branch** (e.g. [run 27550887977](https://github.com/spiculedata/saiku/actions/runs/27550887977) on the latest `development` push), and — the real risk — **the next `v*` release tag would have failed to build the JAR, Docker image, and GitHub release.**

## The change
One line — quote the step name:
```yaml
- name: "mvn verify (fail-fast: spotless + tests)"
```

## Verified
- `python yaml.safe_load` now loads `release.yml` (it errored at line 77 col 36 before).
- Re-parsed **all six** workflow files — all clean; this was the only broken one and the only error in it.

## Notes
- CI/workflow-only; no product code touched. Introduced by the `ci(release): mvn verify gate` change, so it has been failing every push since.
- Found via the failing Actions run Juan flagged.
