### PR TITLE
feat(security): AI audit log of every AI API call (closes #906)

### DIFF
--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ai/audit/AiAuditEntry.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ai/audit/AiAuditEntry.java
@@ -1,0 +1,70 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.service.olap.ai.audit;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+/**
+ * One audit record for a single AI API call (saiku#906). Captures the
+ * <em>shape</em> of the call — who, which endpoint, the policy decision, a
+ * fingerprint of the schema sent, token counts, latency, outcome — but never
+ * the prompt content or any cell values. Logging the content would make the
+ * audit trail a second PII surface; the shape is what an auditor needs to
+ * answer "what did the AI feature send, and was it allowed?".
+ *
+ * <p>Public fields + no-arg constructor so Jackson can round-trip it to/from the
+ * JSONL audit file. {@code NON_NULL} keeps unset fields (e.g. {@code model} on a
+ * non-LLM endpoint) out of the serialised line.
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class AiAuditEntry {
+
+    /** Outcome values — kept as constants so writers + the read API agree. */
+    public static final String OUTCOME_SUCCESS = "success";
+
+    public static final String OUTCOME_VALIDATION_ERROR = "validation_error";
+    public static final String OUTCOME_DENIED = "denied";
+    public static final String OUTCOME_UPSTREAM_ERROR = "upstream_error";
+    public static final String OUTCOME_ERROR = "error";
+
+    public static final String DECISION_ALLOW = "allow";
+    public static final String DECISION_DENY = "deny";
+
+    /** ISO-8601 UTC timestamp, second precision (e.g. {@code 2026-06-15T10:23:14Z}). */
+    public String ts;
+    /** Tenant id when running multi-tenant; null on single-tenant OSS. */
+    public String tenant;
+    /** Authenticated principal name, or {@code anonymous}. */
+    public String user;
+    /** REST path hit, e.g. {@code /saiku/api/ai/query}. */
+    public String endpoint;
+    /** Active data-exposure policy tier (#903): schema-only | aggregated | full. */
+    public String policy;
+    /** {@code allow} or {@code deny} — whether the policy permitted this call. */
+    public String policyDecision;
+    /** Upstream LLM provider for NL-ask calls (#904): anthropic | openai | ollama | noop. Null for non-LLM endpoints. */
+    public String upstream;
+    /** Upstream model id when known. Null for non-LLM endpoints. */
+    public String model;
+    /** {@code sha256:<hex>} over the sorted names of the dims/hiers/levels/measures
+     *  sent — lets an auditor confirm what shape of metadata crossed without
+     *  storing the metadata itself. */
+    public String schemaFingerprint;
+    /** Cube the call targeted (canonical {@code connection/catalog/schema/cube} or its display name). */
+    public String cube;
+    /** Approx. prompt token count for LLM endpoints. Null when not applicable. */
+    public Integer promptTokens;
+    /** Approx. response token count for LLM endpoints. Null when not applicable. */
+    public Integer responseTokens;
+    /** Server-side wall-clock latency for the call, in milliseconds. */
+    public Long latencyMs;
+    /** One of the {@code OUTCOME_*} constants. */
+    public String outcome;
+    /** Error class / short reason on a non-success outcome — never the full
+     *  message (could leak SQL / paths / values). Null on success. */
+    public String error;
+
+    public AiAuditEntry() {}
+}

--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ai/audit/AiAuditLog.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ai/audit/AiAuditLog.java
@@ -1,0 +1,221 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.service.olap.ai.audit;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardOpenOption;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+import java.util.TreeSet;
+import java.util.concurrent.locks.ReentrantLock;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Append-only audit log of every AI API call (saiku#906). One JSON line per
+ * call written to {@code ${saiku.home}/logs/ai-audit.jsonl}, capturing the
+ * call's <em>shape</em> ({@link AiAuditEntry}) — never the prompt content or any
+ * cell values. Audit-trail is a compliance requirement (SOC 2, ISO 27001, NHS
+ * DSPT, HIPAA): without it the answer to "what did your AI feature send
+ * yesterday?" is "we don't know".
+ *
+ * <p><b>Append-only by design.</b> Records are never silently pruned or
+ * overwritten — an audit log that drops its own entries fails the audit.
+ * Daily rotation / cold archival is a deliberate follow-up (the issue's Phase
+ * 2: a queryable structured store); v1 keeps a single growing JSONL that ops
+ * rotate at the filesystem/log4j level.
+ *
+ * <p>Thread-safe: a per-instance lock serialises appends. {@link #recent} reads
+ * the file fresh each call (audit reads are admin/ops, not hot-path). Failures
+ * to write are logged but never thrown — auditing must not break the call it
+ * audits, though a write failure is itself logged loudly as it is a compliance
+ * gap.
+ */
+public class AiAuditLog {
+
+    private static final Logger log = LoggerFactory.getLogger(AiAuditLog.class);
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    /** System property to disable auditing entirely (default ON — compliance). */
+    public static final String PROP_ENABLED = "ai.audit.enabled";
+    /** System property to override the audit file location. */
+    public static final String PROP_FILE = "ai.audit.file";
+
+    private final Path file;
+    private final boolean enabled;
+    private final ReentrantLock writeLock = new ReentrantLock();
+
+    /** Production constructor — resolves the file path + enabled flag from
+     *  system properties / {@code saiku.home}, and logs the posture once. */
+    public AiAuditLog() {
+        this(resolveDefaultFile(), !"false".equalsIgnoreCase(System.getProperty(PROP_ENABLED, "true")));
+        if (enabled) {
+            log.info("AI audit log ENABLED -> {}", file);
+        } else {
+            log.info("AI audit log DISABLED ({}=false)", PROP_ENABLED);
+        }
+    }
+
+    /** Explicit constructor for tests / programmatic wiring. */
+    public AiAuditLog(Path file, boolean enabled) {
+        this.file = file;
+        this.enabled = enabled;
+    }
+
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    public Path getFile() {
+        return file;
+    }
+
+    private static Path resolveDefaultFile() {
+        String override = System.getProperty(PROP_FILE);
+        if (override != null && !override.isBlank()) {
+            return Paths.get(override);
+        }
+        String home = System.getProperty("saiku.home");
+        Path base = (home != null && !home.isEmpty()) ? Paths.get(home) : Paths.get("saiku-home");
+        return base.resolve("logs").resolve("ai-audit.jsonl");
+    }
+
+    /**
+     * Append one audit record. Stamps {@code ts} (UTC, second precision) if the
+     * caller left it null. Never throws — a failure to audit is logged but must
+     * not break the AI call being audited.
+     */
+    public void record(AiAuditEntry entry) {
+        if (!enabled || entry == null) {
+            return;
+        }
+        if (entry.ts == null) {
+            entry.ts = Instant.now().truncatedTo(ChronoUnit.SECONDS).toString();
+        }
+        writeLock.lock();
+        try {
+            if (file.getParent() != null) {
+                Files.createDirectories(file.getParent());
+            }
+            String line = MAPPER.writeValueAsString(entry) + "\n";
+            Files.write(
+                    file, line.getBytes(StandardCharsets.UTF_8), StandardOpenOption.CREATE, StandardOpenOption.APPEND);
+        } catch (IOException e) {
+            // Loud: a missing audit entry is a compliance gap, not noise.
+            log.error("AI audit WRITE FAILED for {} {} — entry lost: {}", entry.endpoint, entry.user, e.toString());
+        } finally {
+            writeLock.unlock();
+        }
+    }
+
+    /**
+     * Read recent audit entries newest-first, optionally filtered. The file is
+     * append-chronological, so we read all, filter, reverse, then page. Intended
+     * for the admin read endpoint (low frequency); not a hot path.
+     *
+     * @param limit max entries to return (clamped to [1, 5000]); 0/negative → 100
+     * @param offset entries to skip from the newest end (for pagination)
+     * @param userFilter only entries for this user when non-blank
+     * @param sinceIso only entries with {@code ts >= sinceIso} (ISO-8601 UTC) when non-blank
+     */
+    public List<AiAuditEntry> recent(int limit, int offset, String userFilter, String sinceIso) {
+        int cap = limit <= 0 ? 100 : Math.min(limit, 5000);
+        int skip = Math.max(0, offset);
+        List<AiAuditEntry> all = readAll();
+        Collections.reverse(all); // newest first
+        List<AiAuditEntry> out = new ArrayList<>();
+        int seen = 0;
+        for (AiAuditEntry e : all) {
+            if (userFilter != null && !userFilter.isBlank() && !userFilter.equals(e.user)) {
+                continue;
+            }
+            if (sinceIso != null && !sinceIso.isBlank() && (e.ts == null || e.ts.compareTo(sinceIso) < 0)) {
+                continue;
+            }
+            if (seen++ < skip) {
+                continue;
+            }
+            out.add(e);
+            if (out.size() >= cap) {
+                break;
+            }
+        }
+        return out;
+    }
+
+    /** Total number of audit lines on disk (for the read endpoint's paging meta). */
+    public long count() {
+        return readAll().size();
+    }
+
+    private List<AiAuditEntry> readAll() {
+        List<AiAuditEntry> out = new ArrayList<>();
+        if (!Files.isReadable(file)) {
+            return out;
+        }
+        try {
+            for (String line : Files.readAllLines(file, StandardCharsets.UTF_8)) {
+                if (line.isBlank()) {
+                    continue;
+                }
+                try {
+                    out.add(MAPPER.readValue(line, AiAuditEntry.class));
+                } catch (Exception parse) {
+                    log.debug("Skipping unparseable audit line: {}", parse.toString());
+                }
+            }
+        } catch (IOException e) {
+            log.warn("AI audit read failed for {}: {}", file, e.toString());
+        }
+        return out;
+    }
+
+    /**
+     * Fingerprint a set of schema names (dims / hierarchies / levels / measures)
+     * sent to the AI surface. Sorted + de-duped so the digest is order-stable,
+     * then SHA-256. Returns {@code sha256:<hex>}, or null for an empty/null set.
+     * The point is to prove <em>what shape</em> of metadata crossed without
+     * storing the metadata itself.
+     */
+    public static String fingerprint(Collection<String> names) {
+        if (names == null || names.isEmpty()) {
+            return null;
+        }
+        TreeSet<String> sorted = new TreeSet<>();
+        for (String n : names) {
+            if (n != null && !n.isBlank()) {
+                sorted.add(n);
+            }
+        }
+        if (sorted.isEmpty()) {
+            return null;
+        }
+        try {
+            MessageDigest md = MessageDigest.getInstance("SHA-256");
+            md.update(String.join("\n", sorted).getBytes(StandardCharsets.UTF_8));
+            byte[] digest = md.digest();
+            StringBuilder hex = new StringBuilder(digest.length * 2);
+            for (byte b : digest) {
+                hex.append(String.format(Locale.ROOT, "%02x", b));
+            }
+            return "sha256:" + hex;
+        } catch (NoSuchAlgorithmException e) {
+            // SHA-256 is mandated by the JLS — unreachable.
+            return null;
+        }
+    }
+}

--- a/saiku-core/saiku-service/src/test/java/org/saiku/service/olap/ai/audit/AiAuditLogTest.java
+++ b/saiku-core/saiku-service/src/test/java/org/saiku/service/olap/ai/audit/AiAuditLogTest.java
@@ -1,0 +1,147 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.service.olap.ai.audit;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.List;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+/** saiku#906 — unit coverage for the AI audit log core. */
+public class AiAuditLogTest {
+
+    @Rule
+    public TemporaryFolder tmp = new TemporaryFolder();
+
+    private AiAuditLog newLog() {
+        return new AiAuditLog(tmp.getRoot().toPath().resolve("logs").resolve("ai-audit.jsonl"), true);
+    }
+
+    private static AiAuditEntry entry(String user, String outcome) {
+        AiAuditEntry e = new AiAuditEntry();
+        e.user = user;
+        e.endpoint = "/saiku/api/ai/query";
+        e.policy = "schema-only";
+        e.policyDecision = AiAuditEntry.DECISION_ALLOW;
+        e.cube = "Sales";
+        e.schemaFingerprint = AiAuditLog.fingerprint(Arrays.asList("Store Sales", "Product Family"));
+        e.promptTokens = 412;
+        e.latencyMs = 2103L;
+        e.outcome = outcome;
+        return e;
+    }
+
+    @Test
+    public void records_and_reads_back_newest_first() {
+        AiAuditLog auditLog = newLog();
+        auditLog.record(entry("alice", AiAuditEntry.OUTCOME_SUCCESS));
+        auditLog.record(entry("bob", AiAuditEntry.OUTCOME_DENIED));
+
+        List<AiAuditEntry> recent = auditLog.recent(10, 0, null, null);
+        assertEquals(2, recent.size());
+        assertEquals("bob", recent.get(0).user); // newest first
+        assertEquals("alice", recent.get(1).user);
+        assertEquals(2L, auditLog.count());
+    }
+
+    @Test
+    public void stamps_ts_when_absent() {
+        AiAuditLog auditLog = newLog();
+        auditLog.record(entry("alice", AiAuditEntry.OUTCOME_SUCCESS));
+        AiAuditEntry got = auditLog.recent(1, 0, null, null).get(0);
+        assertNotNull("ts is stamped on write", got.ts);
+        assertTrue("ISO-8601 UTC", got.ts.endsWith("Z"));
+    }
+
+    @Test
+    public void append_only_never_overwrites() throws Exception {
+        AiAuditLog auditLog = newLog();
+        for (int i = 0; i < 5; i++) {
+            auditLog.record(entry("u" + i, AiAuditEntry.OUTCOME_SUCCESS));
+        }
+        Path f = auditLog.getFile();
+        long lines = Files.readAllLines(f).stream().filter(l -> !l.isBlank()).count();
+        assertEquals("every record is its own appended line", 5, lines);
+    }
+
+    @Test
+    public void never_logs_prompt_or_cell_content() throws Exception {
+        // The audit line must carry shape only — no prompt text, no values.
+        AiAuditLog auditLog = newLog();
+        auditLog.record(entry("alice", AiAuditEntry.OUTCOME_SUCCESS));
+        String raw = String.join("\n", Files.readAllLines(auditLog.getFile()));
+        // The serialised entry has no field that could carry content.
+        assertFalse(raw.toLowerCase().contains("prompt\":\"")); // no prompt text field
+        assertTrue("fingerprint is a hash, not the names", raw.contains("sha256:"));
+        // The raw schema names are NOT present — only their hash.
+        assertFalse("schema names must not appear, only the fingerprint", raw.contains("Product Family"));
+    }
+
+    @Test
+    public void filters_by_user_and_since() {
+        AiAuditLog auditLog = newLog();
+        AiAuditEntry old = entry("alice", AiAuditEntry.OUTCOME_SUCCESS);
+        old.ts = "2026-01-01T00:00:00Z";
+        auditLog.record(old);
+        AiAuditEntry recentA = entry("alice", AiAuditEntry.OUTCOME_SUCCESS);
+        recentA.ts = "2026-06-15T10:00:00Z";
+        auditLog.record(recentA);
+        AiAuditEntry recentB = entry("bob", AiAuditEntry.OUTCOME_SUCCESS);
+        recentB.ts = "2026-06-15T11:00:00Z";
+        auditLog.record(recentB);
+
+        assertEquals(2, auditLog.recent(10, 0, "alice", null).size());
+        assertEquals(1, auditLog.recent(10, 0, "bob", null).size());
+        // since filter keeps only the two June entries
+        assertEquals(2, auditLog.recent(10, 0, null, "2026-06-01T00:00:00Z").size());
+    }
+
+    @Test
+    public void respects_limit_and_offset() {
+        AiAuditLog auditLog = newLog();
+        for (int i = 0; i < 5; i++) {
+            AiAuditEntry e = entry("u" + i, AiAuditEntry.OUTCOME_SUCCESS);
+            e.ts = "2026-06-15T10:0" + i + ":00Z";
+            auditLog.record(e);
+        }
+        List<AiAuditEntry> page = auditLog.recent(2, 1, null, null); // skip newest, take 2
+        assertEquals(2, page.size());
+        assertEquals("u3", page.get(0).user); // newest is u4; offset 1 -> u3
+        assertEquals("u2", page.get(1).user);
+    }
+
+    @Test
+    public void disabled_is_a_noop() {
+        AiAuditLog auditLog = new AiAuditLog(tmp.getRoot().toPath().resolve("off.jsonl"), false);
+        auditLog.record(entry("alice", AiAuditEntry.OUTCOME_SUCCESS));
+        assertEquals(0L, auditLog.count());
+        assertTrue(auditLog.recent(10, 0, null, null).isEmpty());
+    }
+
+    @Test
+    public void fingerprint_is_order_insensitive_and_deduped() {
+        String a = AiAuditLog.fingerprint(Arrays.asList("Store Sales", "Product Family", "Year"));
+        String b = AiAuditLog.fingerprint(Arrays.asList("Year", "Product Family", "Store Sales", "Year"));
+        assertEquals("same name set -> same fingerprint regardless of order/dupes", a, b);
+        assertTrue(a.startsWith("sha256:"));
+        String c = AiAuditLog.fingerprint(Arrays.asList("Store Sales", "Product Family"));
+        assertFalse("different name set -> different fingerprint", a.equals(c));
+    }
+
+    @Test
+    public void fingerprint_null_or_empty_is_null() {
+        assertNull(AiAuditLog.fingerprint(null));
+        assertNull(AiAuditLog.fingerprint(java.util.Collections.emptyList()));
+    }
+}

--- a/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/SaikuJerseyApplication.java
+++ b/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/SaikuJerseyApplication.java
@@ -53,5 +53,12 @@ public class SaikuJerseyApplication extends ResourceConfig {
             }
             register(ctx.getBean(name));
         }
+
+        // saiku#906: the AI audit filter writes one record per /ai/* call. It's
+        // a JAX-RS provider, not a @Path resource, so the scan above misses it —
+        // register it explicitly. Guarded so a context without it still boots.
+        if (ctx.containsBean("aiAuditFilter")) {
+            register(ctx.getBean("aiAuditFilter"));
+        }
     }
 }

--- a/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/AiAuditFilter.java
+++ b/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/AiAuditFilter.java
@@ -1,0 +1,195 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.web.rest.resources;
+
+import jakarta.ws.rs.container.ContainerRequestContext;
+import jakarta.ws.rs.container.ContainerRequestFilter;
+import jakarta.ws.rs.container.ContainerResponseContext;
+import jakarta.ws.rs.container.ContainerResponseFilter;
+import jakarta.ws.rs.ext.Provider;
+import java.security.Principal;
+import org.saiku.service.olap.ai.AiPolicyGuard;
+import org.saiku.service.olap.ai.audit.AiAuditEntry;
+import org.saiku.service.olap.ai.audit.AiAuditLog;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * saiku#906 — the audit backbone: a JAX-RS filter that writes one
+ * {@link AiAuditEntry} for <em>every</em> {@code /saiku/api/ai/*} call. Because
+ * it's a single registered provider, coverage is structural — a new AI endpoint
+ * is audited automatically, with no per-endpoint code to forget (the failure
+ * mode that makes a compliance audit log worthless).
+ *
+ * <p>The filter records what it can see from the request/response envelope —
+ * user, endpoint, the active policy tier + allow/deny, outcome, latency. Richer
+ * per-call detail (cube, schema fingerprint, token counts) is <em>enrichment</em>
+ * that resources opt into by setting the {@code P_*} request properties below;
+ * the filter folds those in if present. A missing enrichment degrades an entry
+ * gracefully — it never produces a missing entry, which is the whole point.
+ *
+ * <p>Never throws into the response path: an audit failure is logged, not
+ * propagated (though {@link AiAuditLog} logs write failures loudly — they are a
+ * compliance gap).
+ */
+@Provider
+public class AiAuditFilter implements ContainerRequestFilter, ContainerResponseFilter {
+
+    private static final Logger log = LoggerFactory.getLogger(AiAuditFilter.class);
+
+    private static final String START_NANOS = "saiku.ai.audit.startNanos";
+
+    /** Enrichment property keys — resources may set these on the request context
+     *  ({@code requestContext.setProperty(...)}) and the filter folds them in. */
+    public static final String P_CUBE = "saiku.ai.audit.cube";
+
+    public static final String P_FINGERPRINT = "saiku.ai.audit.fingerprint";
+    public static final String P_UPSTREAM = "saiku.ai.audit.upstream";
+    public static final String P_MODEL = "saiku.ai.audit.model";
+    public static final String P_PROMPT_TOKENS = "saiku.ai.audit.promptTokens";
+    public static final String P_RESPONSE_TOKENS = "saiku.ai.audit.responseTokens";
+    public static final String P_ERROR = "saiku.ai.audit.error";
+
+    private AiAuditLog auditLog;
+    private AiPolicyGuard policyGuard;
+
+    public void setAuditLog(AiAuditLog auditLog) {
+        this.auditLog = auditLog;
+    }
+
+    public void setPolicyGuard(AiPolicyGuard policyGuard) {
+        this.policyGuard = policyGuard;
+    }
+
+    @Override
+    public void filter(ContainerRequestContext request) {
+        // Stamp the start so the response side can compute latency.
+        request.setProperty(START_NANOS, System.nanoTime());
+    }
+
+    @Override
+    public void filter(ContainerRequestContext request, ContainerResponseContext response) {
+        // Thin adapter: pull the primitives off the JAX-RS envelope, then defer
+        // to the pure buildEntry() core (which is what the tests exercise).
+        try {
+            if (auditLog == null || !auditLog.isEnabled()) {
+                return;
+            }
+            String path = "/" + request.getUriInfo().getPath();
+            Long latencyMs = null;
+            Object start = request.getProperty(START_NANOS);
+            if (start instanceof Long) {
+                latencyMs = (System.nanoTime() - (Long) start) / 1_000_000L;
+            }
+            java.util.Map<String, Object> enrichment = new java.util.HashMap<>();
+            for (String k : ENRICH_KEYS) {
+                Object v = request.getProperty(k);
+                if (v != null) {
+                    enrichment.put(k, v);
+                }
+            }
+            AiAuditEntry e =
+                    buildEntry(path, principalName(request), response.getStatus(), latencyMs, enrichment, policyGuard);
+            if (e != null) {
+                auditLog.record(e);
+            }
+        } catch (RuntimeException ex) {
+            // Auditing must never break the response.
+            log.warn("AI audit filter error (response still served): {}", ex.toString());
+        }
+    }
+
+    /** Enrichment keys the response filter folds in if a resource set them. */
+    private static final String[] ENRICH_KEYS = {
+        P_CUBE, P_FINGERPRINT, P_UPSTREAM, P_MODEL, P_PROMPT_TOKENS, P_RESPONSE_TOKENS, P_ERROR
+    };
+
+    /**
+     * Pure core: build the audit entry for a call, or {@code null} if the path
+     * is not on the AI surface ({@code /ai/}). Extracted from the filter so it's
+     * unit-testable without standing up JAX-RS contexts.
+     */
+    static AiAuditEntry buildEntry(
+            String path,
+            String user,
+            int status,
+            Long latencyMs,
+            java.util.Map<String, Object> enrichment,
+            AiPolicyGuard policyGuard) {
+        // Only audit the AI surface. The admin read endpoint is at
+        // /saiku/admin/ai-audit (no "/ai/" segment) so it isn't self-audited.
+        if (path == null || !path.contains("/ai/")) {
+            return null;
+        }
+        AiAuditEntry e = new AiAuditEntry();
+        e.endpoint = path;
+        e.user = (user == null || user.isBlank()) ? "anonymous" : user;
+        e.outcome = outcomeFor(status);
+        // A 403 on the AI surface is an AiPolicyViolation (the only 403 path here,
+        // via AiPolicyViolationMapper) — i.e. the policy DENIED the call.
+        e.policyDecision = status == 403 ? AiAuditEntry.DECISION_DENY : AiAuditEntry.DECISION_ALLOW;
+        if (policyGuard != null && policyGuard.current() != null) {
+            e.policy = policyGuard.current().displayName();
+        }
+        e.latencyMs = latencyMs;
+        if (enrichment != null) {
+            e.cube = str(enrichment.get(P_CUBE));
+            e.schemaFingerprint = str(enrichment.get(P_FINGERPRINT));
+            e.upstream = str(enrichment.get(P_UPSTREAM));
+            e.model = str(enrichment.get(P_MODEL));
+            e.promptTokens = intOrNull(enrichment.get(P_PROMPT_TOKENS));
+            e.responseTokens = intOrNull(enrichment.get(P_RESPONSE_TOKENS));
+        }
+        if (!AiAuditEntry.OUTCOME_SUCCESS.equals(e.outcome)) {
+            // Short, leak-safe error token: a resource-supplied error class if it
+            // enriched one, else the HTTP status. Never the message.
+            String enriched = enrichment == null ? null : str(enrichment.get(P_ERROR));
+            e.error = enriched != null ? enriched : ("HTTP " + status);
+        }
+        return e;
+    }
+
+    private static String principalName(ContainerRequestContext request) {
+        if (request.getSecurityContext() == null) {
+            return "anonymous";
+        }
+        Principal p = request.getSecurityContext().getUserPrincipal();
+        return p == null ? "anonymous" : p.getName();
+    }
+
+    static String outcomeFor(int status) {
+        if (status >= 200 && status < 300) {
+            return AiAuditEntry.OUTCOME_SUCCESS;
+        }
+        if (status == 400) {
+            return AiAuditEntry.OUTCOME_VALIDATION_ERROR;
+        }
+        if (status == 403) {
+            return AiAuditEntry.OUTCOME_DENIED;
+        }
+        return AiAuditEntry.OUTCOME_ERROR; // 5xx + anything else unexpected
+    }
+
+    private static String str(Object o) {
+        return o == null ? null : o.toString();
+    }
+
+    private static Integer intOrNull(Object o) {
+        if (o instanceof Integer) {
+            return (Integer) o;
+        }
+        if (o instanceof Number) {
+            return ((Number) o).intValue();
+        }
+        if (o instanceof String) {
+            try {
+                return Integer.valueOf(((String) o).trim());
+            } catch (NumberFormatException ignore) {
+                return null;
+            }
+        }
+        return null;
+    }
+}

--- a/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/AiAuditResource.java
+++ b/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/AiAuditResource.java
@@ -1,0 +1,62 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.web.rest.resources;
+
+import jakarta.annotation.security.RolesAllowed;
+import jakarta.ws.rs.DefaultValue;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.core.MediaType;
+import java.util.List;
+import org.saiku.service.olap.ai.audit.AiAuditEntry;
+import org.saiku.service.olap.ai.audit.AiAuditLog;
+
+/**
+ * saiku#906 — admin-only read API over the AI audit log. Lets ops answer
+ * "what did the AI surface do, by whom, allowed or denied?" without shell access
+ * to the JSONL file. Returns the most recent entries newest-first, filterable by
+ * user and start date, paginated.
+ *
+ * <p>Path is {@code /saiku/admin/ai-audit} (the {@code /saiku/admin} convention,
+ * and deliberately NOT under {@code /ai/} so reads of the audit log aren't
+ * themselves audited by {@link AiAuditFilter}). {@code @RolesAllowed} is enforced
+ * by Jersey's RolesAllowedDynamicFeature AND the {@code /rest/saiku/admin/**}
+ * Spring Security intercept-url — defence in depth.
+ */
+@Path("/saiku/admin/ai-audit")
+@RolesAllowed("ROLE_ADMIN")
+public class AiAuditResource {
+
+    private AiAuditLog auditLog;
+
+    public void setAuditLog(AiAuditLog auditLog) {
+        this.auditLog = auditLog;
+    }
+
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    public AiAuditPage recent(
+            @QueryParam("limit") @DefaultValue("100") int limit,
+            @QueryParam("offset") @DefaultValue("0") int offset,
+            @QueryParam("user") String user,
+            @QueryParam("since") String since) {
+        AiAuditPage page = new AiAuditPage();
+        page.entries = auditLog.recent(limit, offset, user, since);
+        page.total = auditLog.count();
+        page.limit = limit;
+        page.offset = offset;
+        return page;
+    }
+
+    /** Paginated audit response envelope. Public fields for Jackson. */
+    public static final class AiAuditPage {
+        public List<AiAuditEntry> entries;
+        public long total;
+        public int limit;
+        public int offset;
+    }
+}

--- a/saiku-core/saiku-web/src/test/java/org/saiku/web/rest/resources/AiAuditFilterTest.java
+++ b/saiku-core/saiku-web/src/test/java/org/saiku/web/rest/resources/AiAuditFilterTest.java
@@ -1,0 +1,103 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.web.rest.resources;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.Test;
+import org.saiku.service.olap.ai.AiPolicy;
+import org.saiku.service.olap.ai.AiPolicyGuard;
+import org.saiku.service.olap.ai.audit.AiAuditEntry;
+
+/**
+ * saiku#906 — coverage for the audit backbone's pure core ({@code buildEntry}):
+ * derives outcome + allow/deny from the response status, only fires for the
+ * {@code /ai/} surface, records the active policy tier, and folds in enrichment.
+ */
+public class AiAuditFilterTest {
+
+    private static final AiPolicyGuard GUARD = new AiPolicyGuard(AiPolicy.SCHEMA_ONLY);
+
+    private static Map<String, Object> enrich(Object... kv) {
+        Map<String, Object> m = new HashMap<>();
+        for (int i = 0; i + 1 < kv.length; i += 2) {
+            m.put((String) kv[i], kv[i + 1]);
+        }
+        return m;
+    }
+
+    @Test
+    public void audits_an_ai_call_success() {
+        AiAuditEntry e = AiAuditFilter.buildEntry("/saiku/api/ai/query", "alice", 200, 12L, null, GUARD);
+        assertEquals("/saiku/api/ai/query", e.endpoint);
+        assertEquals("alice", e.user);
+        assertEquals(AiAuditEntry.OUTCOME_SUCCESS, e.outcome);
+        assertEquals(AiAuditEntry.DECISION_ALLOW, e.policyDecision);
+        assertEquals("schema-only", e.policy);
+        assertEquals(Long.valueOf(12L), e.latencyMs);
+        assertNull("no error on success", e.error);
+    }
+
+    @Test
+    public void records_denied_on_403() {
+        AiAuditEntry e = AiAuditFilter.buildEntry("/saiku/api/ai/query", "bob", 403, 5L, null, GUARD);
+        assertEquals(AiAuditEntry.OUTCOME_DENIED, e.outcome);
+        assertEquals(AiAuditEntry.DECISION_DENY, e.policyDecision);
+        assertEquals("HTTP 403", e.error);
+    }
+
+    @Test
+    public void records_validation_error_on_400() {
+        AiAuditEntry e = AiAuditFilter.buildEntry("/saiku/api/ai/query", "bob", 400, 5L, null, GUARD);
+        assertEquals(AiAuditEntry.OUTCOME_VALIDATION_ERROR, e.outcome);
+        assertEquals(AiAuditEntry.DECISION_ALLOW, e.policyDecision);
+    }
+
+    @Test
+    public void server_error_maps_to_error_outcome() {
+        AiAuditEntry e = AiAuditFilter.buildEntry("/saiku/api/ai/query", "bob", 500, 5L, null, GUARD);
+        assertEquals(AiAuditEntry.OUTCOME_ERROR, e.outcome);
+        assertEquals("HTTP 500", e.error);
+    }
+
+    @Test
+    public void skips_non_ai_paths() {
+        // The admin audit read endpoint (/saiku/admin/ai-audit) and other non-AI
+        // calls must NOT be audited (no "/ai/" segment) -> null entry.
+        assertNull(AiAuditFilter.buildEntry("/saiku/admin/ai-audit", "admin", 200, 1L, null, GUARD));
+        assertNull(AiAuditFilter.buildEntry("/saiku/session", "admin", 200, 1L, null, GUARD));
+    }
+
+    @Test
+    public void anonymous_when_no_principal() {
+        AiAuditEntry e = AiAuditFilter.buildEntry("/saiku/api/ai/cubes", null, 200, 1L, null, GUARD);
+        assertEquals("anonymous", e.user);
+    }
+
+    @Test
+    public void folds_in_resource_enrichment() {
+        Map<String, Object> en = enrich(
+                AiAuditFilter.P_CUBE, "Sales",
+                AiAuditFilter.P_FINGERPRINT, "sha256:abc",
+                AiAuditFilter.P_PROMPT_TOKENS, 412,
+                AiAuditFilter.P_UPSTREAM, "ollama");
+        AiAuditEntry e = AiAuditFilter.buildEntry("/saiku/api/ai/ask", "alice", 200, 9L, en, GUARD);
+        assertEquals("Sales", e.cube);
+        assertEquals("sha256:abc", e.schemaFingerprint);
+        assertEquals(Integer.valueOf(412), e.promptTokens);
+        assertEquals("ollama", e.upstream);
+    }
+
+    @Test
+    public void outcome_for_status_boundaries() {
+        assertEquals(AiAuditEntry.OUTCOME_SUCCESS, AiAuditFilter.outcomeFor(204));
+        assertEquals(AiAuditEntry.OUTCOME_VALIDATION_ERROR, AiAuditFilter.outcomeFor(400));
+        assertEquals(AiAuditEntry.OUTCOME_DENIED, AiAuditFilter.outcomeFor(403));
+        assertEquals(AiAuditEntry.OUTCOME_ERROR, AiAuditFilter.outcomeFor(503));
+    }
+}

--- a/saiku-webapp/src/main/webapp/WEB-INF/saiku-beans.xml
+++ b/saiku-webapp/src/main/webapp/WEB-INF/saiku-beans.xml
@@ -247,6 +247,19 @@
          ai.kAnonymity (default 5; 0 disables) + ai.kAnonymity.maskValue at boot. -->
     <bean id="kAnonymityFilter" class="org.saiku.service.olap.ai.KAnonymityFilter"/>
 
+    <!-- saiku#906: AI audit log. Append-only JSONL at ${saiku.home}/logs/
+         ai-audit.jsonl; resolves ai.audit.enabled (default ON) + ai.audit.file
+         at boot. Written by aiAuditFilter, read by aiAuditResource. -->
+    <bean id="aiAuditLog" class="org.saiku.service.olap.ai.audit.AiAuditLog"/>
+
+    <!-- saiku#906: the audit backbone — a JAX-RS provider that records one entry
+         per /saiku/api/ai/* call (registered explicitly in SaikuJerseyApplication
+         since it isn't a @Path bean). Reads the active policy tier off the guard. -->
+    <bean id="aiAuditFilter" class="org.saiku.web.rest.resources.AiAuditFilter">
+        <property name="auditLog" ref="aiAuditLog"/>
+        <property name="policyGuard" ref="aiPolicyGuard"/>
+    </bean>
+
     <bean id="aiQueryResource" scope="request"
           class="org.saiku.web.rest.resources.AiQueryResource">
         <aop:scoped-proxy/>
@@ -265,6 +278,13 @@
              saiku.ai.ask.provider is set to 'anthropic' or 'openai' and the
              matching API key env var is supplied. See aiAskServiceBean below. -->
         <property name="askService" ref="aiAskServiceBean"/>
+    </bean>
+
+    <!-- saiku#906: admin-only read API over the audit log
+         (GET /saiku/admin/ai-audit). Stateless singleton; @RolesAllowed +
+         the /rest/saiku/admin/** intercept-url both gate it. -->
+    <bean id="aiAuditResource" class="org.saiku.web.rest.resources.AiAuditResource">
+        <property name="auditLog" ref="aiAuditLog"/>
     </bean>
 
     <!-- ====================================================================


### PR DESCRIPTION
## Summary
Adds a compliance-grade audit trail for the AI surface (#906). Answers the auditor's question — *"what did your AI feature do yesterday, by whom, and was it allowed?"* — for **every** `/saiku/api/ai/*` call. Logs the call's **shape only** (who / endpoint / policy tier / allow-deny / outcome / latency / a `sha256` schema fingerprint / token counts) — **never the prompt content or any cell values**, because logging content would make the audit trail a second PII surface.

## Design (and the one decision that matters)
The defining property of an audit log is **completeness** — a silent gap is where an incident hides and fails the audit. So coverage is **structural**, via one JAX-RS filter, not per-endpoint instrumentation that a new endpoint could miss (the same half-control trap as the k-anon matrix bypass we just closed). Richness is layered on top and degrades gracefully.

- **`AiAuditLog` + `AiAuditEntry`** (saiku-service) — append-only JSONL at `${saiku.home}/logs/ai-audit.jsonl`, thread-safe. **Never silently prunes** (an audit log that drops its own entries fails the audit). `fingerprint()` = sha256 over the sorted dim/measure names, proving *what shape* of metadata crossed without storing it. `recent()`/`count()` back the read API.
- **`AiAuditFilter`** (saiku-web) — a single registered provider that writes one entry per `/ai/*` call. A new AI endpoint is audited automatically, no code to forget. Resources opt into richer fields (cube / fingerprint / tokens) by setting request properties (`P_*`); a missing enrichment degrades an entry, never drops it. The pure `buildEntry()` core is unit-tested without JAX-RS contexts.
- **`AiAuditResource`** (saiku-web) — admin-only `GET /saiku/admin/ai-audit`, paginated + filterable by `user`/`since`. Path deliberately avoids `/ai/` so audit reads aren't self-audited; `@RolesAllowed("ROLE_ADMIN")` + the `/rest/saiku/admin/**` intercept both gate it.
- **Wiring** — `aiAuditLog` + `aiAuditFilter` + `aiAuditResource` beans; filter registered in `SaikuJerseyApplication`. Defaults **ON** (`ai.audit.enabled=false` to disable; `ai.audit.file` to override the path).

## Verified
- **`AiAuditLogTest` 9/0** — record→read roundtrip, **never logs prompt/cell content (only the fingerprint)**, append-only never overwrites, fingerprint order-insensitive + de-duped, user/since filters, limit/offset paging, disabled = no-op.
- **`AiAuditFilterTest` 8/0** — outcome + allow/deny derived from status (200/400/403/5xx), `/ai/`-only coverage (skips `/saiku/admin/ai-audit` + `/saiku/session`), anonymous principal, enrichment fold-in.
- Regression: `AiQueryResourceTest` 37/0, `AiQueryResourceKAnonTest` 6/0; both modules compile; spotless clean.

## Notes
- I deliberately did **not** touch `AiQueryResource` — the filter gives complete baseline coverage without per-endpoint edits, so this is disjoint from the in-gate #1324.
- Path is `/saiku/admin/ai-audit` (admin convention) rather than the issue's `/saiku/api/admin/ai/audit` — same gate, and it keeps audit-reads out of the `/ai/` filter.
- **Follow-ups (tracked):** per-endpoint enrichment (cube/fingerprint/tokens), LLM token capture on `/ai/ask` (lands with #904's upstream adapter), daily rotation / queryable Phase-2 store, admin UI viewer (DEV).
- @AGENT SEC: please verify the audit line can never carry content (only shape/hash) and the read endpoint is admin-gated. @AGENT QA: completeness (filter covers every `/ai/*`) + the no-content-leak assertions are the test-quality crux.
