### PR TITLE
chore(release): bump 4.5.2 -> 4.6.0 for the release cut

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <groupId>org.saikuanalytics</groupId>
     <artifactId>saiku</artifactId>
     <packaging>pom</packaging>
-    <version>4.5.2</version>
+    <version>4.6.0</version>
     <name>Saiku Module Project</name>
     <scm>
         <developerConnection>

--- a/saiku-bom/pom.xml
+++ b/saiku-bom/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.saikuanalytics</groupId>
     <artifactId>saiku-bom</artifactId>
-    <version>4.5.2</version>
+    <version>4.6.0</version>
     <packaging>pom</packaging>
     <name>Saiku BOM</name>
     <description>Central dependency-version catalogue for Saiku modules.</description>

--- a/saiku-core/pom.xml
+++ b/saiku-core/pom.xml
@@ -2,14 +2,14 @@
     <parent>
         <artifactId>saiku</artifactId>
         <groupId>org.saikuanalytics</groupId>
-        <version>4.5.2</version>
+        <version>4.6.0</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>
     <artifactId>saiku-core</artifactId>
     <packaging>pom</packaging>
     <name>saiku - core libraries</name>
-    <version>4.5.2</version>
+    <version>4.6.0</version>
 
     <modules>
         <module>saiku-olap-util</module>

--- a/saiku-core/saiku-olap-util/pom.xml
+++ b/saiku-core/saiku-olap-util/pom.xml
@@ -3,11 +3,11 @@
     <parent>
         <artifactId>saiku-core</artifactId>
         <groupId>org.saikuanalytics</groupId>
-        <version>4.5.2</version>
+        <version>4.6.0</version>
     </parent>
 	<artifactId>saiku-olap-util</artifactId>
 	<packaging>jar</packaging>
-	<version>4.5.2</version>
+	<version>4.6.0</version>
 	<name>saiku olap util</name>
 	<properties>
 		<maven.compiler.source>1.8</maven.compiler.source>

--- a/saiku-core/saiku-semantic/pom.xml
+++ b/saiku-core/saiku-semantic/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <artifactId>saiku-core</artifactId>
         <groupId>org.saikuanalytics</groupId>
-        <version>4.5.2</version>
+        <version>4.6.0</version>
     </parent>
 
     <artifactId>saiku-semantic</artifactId>

--- a/saiku-core/saiku-service/pom.xml
+++ b/saiku-core/saiku-service/pom.xml
@@ -2,12 +2,12 @@
     <parent>
         <artifactId>saiku-core</artifactId>
         <groupId>org.saikuanalytics</groupId>
-        <version>4.5.2</version>
+        <version>4.6.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>jar</packaging>
     <artifactId>saiku-service</artifactId>
-    <version>4.5.2</version>
+    <version>4.6.0</version>
     <name>saiku - services</name>
     <build>
         <plugins>

--- a/saiku-core/saiku-web/pom.xml
+++ b/saiku-core/saiku-web/pom.xml
@@ -2,11 +2,11 @@
     <parent>
         <artifactId>saiku-core</artifactId>
         <groupId>org.saikuanalytics</groupId>
-        <version>4.5.2</version>
+        <version>4.6.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>saiku-web</artifactId>
-    <version>4.5.2</version>
+    <version>4.6.0</version>
     <name>saiku - web</name>
     <packaging>jar</packaging>
 

--- a/saiku-launcher/pom.xml
+++ b/saiku-launcher/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.saikuanalytics</groupId>
         <artifactId>saiku</artifactId>
-        <version>4.5.2</version>
+        <version>4.6.0</version>
     </parent>
 
     <artifactId>saiku-launcher</artifactId>

--- a/saiku-webapp/pom.xml
+++ b/saiku-webapp/pom.xml
@@ -2,11 +2,11 @@
     <parent>
         <artifactId>saiku</artifactId>
         <groupId>org.saikuanalytics</groupId>
-        <version>4.5.2</version>
+        <version>4.6.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>saiku-webapp</artifactId>
-    <version>4.5.2</version>
+    <version>4.6.0</version>
     <name>saiku - webapp</name>
     <packaging>war</packaging>
     <build>


### PR DESCRIPTION
## Summary
Bumps all **9 reactor poms** 4.5.2 → 4.6.0 via `mvn versions:set`, prepping the `v4.6.0` tag Tom is about to cut.

**Minor bump** — this release is substantial: AI governance (PII annotations #902, `ai.policy` #903, k-anonymity #905), the `<saiku-embed>` web component (#1301–1304), combo charts (#1089), and a full dependency-CVE remediation (Spring 6.2.19 / Spring Security 6.5.11 / log4j 2.25.4 / OpenPDF / junit).

## Verified
- All 9 poms (root, BOM, saiku-core, olap-util, service, semantic, web, webapp, launcher) at 4.6.0; **no 4.5.2 stragglers**.
- `mvn validate` clean across the reactor (parent + BOM resolve).

## ⚠️ Merge order
**This is the LAST PR before the tag.** Merge it only after the in-flight feature PRs land (#1340 k-anon matrix bypass, #1342 AI audit log) — then Tom tags `v4.6.0` on `development` and `release.yml` builds it. (release.yml itself was just un-broken in #1341.)

## Notes
- `saiku-ui` (independent versioning, 3.18.2) is **not** bumped here — separate cadence; Tom's call if it should move.