### PR TITLE
docs(ai): k-anon now suppresses matrix output too (#1324 follow-up)

### DIFF
--- a/docs/AI-QUERY-API.md
+++ b/docs/AI-QUERY-API.md
@@ -400,21 +400,19 @@ finished the query; `cached` indicates a cache-hit response.
 ### Privacy: k-anonymity small-cell suppression (saiku#905)
 
 When `ai.kAnonymity` is set (default `5`; `0` disables), the server masks
-small-cell measure values before the result crosses the AI boundary. Any
-**records-format** row whose in-result count measure — a column whose caption
-names a count on a word boundary, e.g. Mondrian's `Fact Count` (so `Discount`
-/ `Account` are *not* mistaken for it) — falls below `k` has every measure cell
-in that row masked. A masked cell carries `suppressed: true`, a nulled `value`,
-and a `formatted` of `—` (or the configured `ai.kAnonymity.maskValue`). This is
-the standard statistical small-cell control: a "SUM of salary by department"
-stops disclosing a one-person department's salary.
+small-cell measure values before the result crosses the AI boundary. Any row —
+in **either** `records` **or** `matrix` format — whose in-result count measure (a
+column whose caption names a count on a word boundary, e.g. Mondrian's `Fact
+Count`, so `Discount` / `Account` are *not* mistaken for it) falls below `k` has
+every measure cell in that row masked. A masked cell carries `suppressed: true`,
+a nulled `value`, and a `formatted` of `—` (or the configured
+`ai.kAnonymity.maskValue`). This is the standard statistical small-cell control:
+a "SUM of salary by department" stops disclosing a one-person department's
+salary. Both egress shapes run the same suppression core, so they cannot drift
+apart (the `format=matrix` bypass was closed in saiku#1324).
 
-**v1 limits (the shadow-count follow-up is tracked as saiku#905-B):**
+**v1 limit (the shadow-count follow-up is tracked as saiku#905-B):**
 
-- **`format=matrix` is NOT suppressed.** Small-cell masking applies only to
-  records output; matrix output returns the raw cells. Deployments that expose
-  matrix to untrusted callers should keep post-filtering at the proxy (or use
-  records format) until the follow-up lands.
 - **Only in-result count measures are covered.** A cube whose result carries no
   count measure — and the `/ai/anomaly` / `/ai/forecast` surfaces — are not yet
   suppressed.


### PR DESCRIPTION
﻿My #1332 note in `AI-QUERY-API.md` documented the k-anon `format=matrix` output as a v1 known-gap (*"NOT suppressed... #905-B"*). #1324 (PR #1340) **closes that bypass** — records and matrix now run the same suppression core — so that note is now stale and would ship self-contradictory in 4.6.0.

This updates the note: both egress shapes are suppressed; the only remaining v1 limit is cubes with no in-result count measure (plus the `/ai/anomaly` / `/ai/forecast` surfaces), still tracked as the #905-B shadow-count follow-up.

**Docs-only. Please merge AFTER #1340** (the behaviour change it documents) so docs and code stay in step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
