### PR TITLE
feat(security): embed RLS via JWT claims — Phase 1 (#1104)

### DIFF
--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ai/audit/AiAuditEntry.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ai/audit/AiAuditEntry.java
@@ -36,8 +36,13 @@ public class AiAuditEntry {
     public String ts;
     /** Tenant id when running multi-tenant; null on single-tenant OSS. */
     public String tenant;
-    /** Authenticated principal name, or {@code anonymous}. */
+    /** Authenticated principal name, or {@code anonymous}. For an embed-RLS
+     *  call this is the run-as owner; the end-user identity is {@link #sub}. */
     public String user;
+    /** End-user identity from an embed JWT's {@code sub} claim (saiku#1104),
+     *  so the trail shows WHO the embedder asserted, not just the run-as owner.
+     *  Null for non-embed-JWT calls. */
+    public String sub;
     /** REST path hit, e.g. {@code /saiku/api/ai/query}. */
     public String endpoint;
     /** Active data-exposure policy tier (#903): schema-only | aggregated | full. */

--- a/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/embed/EmbedViewResource.java
+++ b/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/embed/EmbedViewResource.java
@@ -12,9 +12,14 @@ import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
+import java.util.Arrays;
 import java.util.Map;
 import org.saiku.service.datasource.DatasourceService;
+import org.saiku.service.olap.ai.AiFilterSelection;
+import org.saiku.service.olap.ai.AiQueryRequest;
 import org.saiku.service.olap.ai.AiSavedQueryRequest;
+import org.saiku.service.olap.ai.audit.AiAuditEntry;
+import org.saiku.service.olap.ai.audit.AiAuditLog;
 import org.saiku.web.rest.resources.AiQueryResource;
 import org.saiku.web.rest.resources.dashboards.Dashboard;
 import org.saiku.web.rest.resources.dashboards.DashboardTile;
@@ -52,6 +57,7 @@ public class EmbedViewResource {
     private DatasourceService datasourceService;
     private SessionService sessionService;
     private AiQueryResource aiQueryResource;
+    private AiAuditLog auditLog;
 
     public void setDatasourceService(DatasourceService s) {
         this.datasourceService = s;
@@ -63,6 +69,10 @@ public class EmbedViewResource {
 
     public void setAiQueryResource(AiQueryResource r) {
         this.aiQueryResource = r;
+    }
+
+    public void setAuditLog(AiAuditLog auditLog) {
+        this.auditLog = auditLog;
     }
 
     /* ---------------------------- query ---------------------------- */
@@ -86,15 +96,23 @@ public class EmbedViewResource {
         if (g.resourcePath == null || !g.resourcePath.endsWith(".saiku")) {
             return invalid();
         }
+        // saiku#1104: a saved query can't have RLS forced-filters injected in
+        // Phase 1 — fail closed rather than serve unfiltered rows.
+        if (g.forcedFiltersJson != null) {
+            audit(g, "/saiku/api/embed/query", AiAuditEntry.OUTCOME_DENIED);
+            return forcedFilterUnsupported();
+        }
         try {
             Response result = sessionService.runAs(g.ownerUser, g.ownerRoles, () -> {
                 AiSavedQueryRequest sreq = new AiSavedQueryRequest();
                 sreq.setPath(g.resourcePath);
                 return aiQueryResource.executeSaved(sreq);
             });
+            audit(g, "/saiku/api/embed/query", AiAuditEntry.OUTCOME_SUCCESS);
             return withPolicyHeader(harden(result), g);
         } catch (RuntimeException e) {
             log.warn("embed-view query execution failed for {}", g.resourcePath, e);
+            audit(g, "/saiku/api/embed/query", AiAuditEntry.OUTCOME_ERROR);
             return harden(Response.serverError()
                     .entity(Map.of("status", "ERROR", "error", "Query execution failed"))
                     .type(MediaType.APPLICATION_JSON)
@@ -164,8 +182,17 @@ public class EmbedViewResource {
         try {
             Response result = sessionService.runAs(g.ownerUser, g.ownerRoles, () -> {
                 if ("inline".equals(q.kind) && q.body != null) {
+                    // saiku#1104: inject the JWT's forced RLS filters into the
+                    // inline query before execution; they ride the standard
+                    // (validated) slicer path in AiSchemaConverter.
+                    injectForcedFilters(q.body, g);
                     return aiQueryResource.executeAi(q.body, "records");
                 } else if ("reference".equals(q.kind) && q.path != null) {
+                    if (g.forcedFiltersJson != null) {
+                        // Can't force-filter a saved/reference tile in Phase 1 —
+                        // fail closed rather than serve unfiltered rows.
+                        return forcedFilterUnsupported();
+                    }
                     AiSavedQueryRequest sreq = new AiSavedQueryRequest();
                     sreq.setPath(q.path);
                     return aiQueryResource.executeSaved(sreq);
@@ -175,9 +202,11 @@ public class EmbedViewResource {
                         .type(MediaType.APPLICATION_JSON)
                         .build();
             });
+            audit(g, "/saiku/api/embed/dashboard/tile", outcomeFor(result.getStatus()));
             return withPolicyHeader(harden(result), g);
         } catch (RuntimeException e) {
             log.warn("embed-view tile query failed for {}/{}", g.resourcePath, tileId, e);
+            audit(g, "/saiku/api/embed/dashboard/tile", AiAuditEntry.OUTCOME_ERROR);
             return harden(Response.serverError()
                     .entity(Map.of("status", "ERROR", "error", "Tile query failed"))
                     .type(MediaType.APPLICATION_JSON)
@@ -225,6 +254,66 @@ public class EmbedViewResource {
                 .entity(Map.of("status", "EMBED_INVALID", "error", "Embed link is invalid or expired."))
                 .type(MediaType.APPLICATION_JSON)
                 .build());
+    }
+
+    /**
+     * saiku#1104 — append the JWT's forced RLS filters to an inline query. They
+     * ride the standard validated slicer path (AiSchemaConverter), so a forced
+     * filter can't inject bad MDX. A malformed claim must NOT degrade to an
+     * unfiltered query — a parse failure throws, and the caller fails closed.
+     */
+    private void injectForcedFilters(AiQueryRequest body, EmbedGuestDetails g) {
+        if (g.forcedFiltersJson == null || body == null) {
+            return;
+        }
+        try {
+            AiFilterSelection[] forced = MAPPER.readValue(g.forcedFiltersJson, AiFilterSelection[].class);
+            body.getFilters().addAll(Arrays.asList(forced));
+        } catch (Exception e) {
+            throw new IllegalStateException("invalid embed forced-filters claim", e);
+        }
+    }
+
+    private static Response forcedFilterUnsupported() {
+        return harden(Response.status(Response.Status.FORBIDDEN)
+                .entity(Map.of(
+                        "status",
+                        "EMBED_RLS_UNSUPPORTED",
+                        "error",
+                        "This embed enforces row-level filters that cannot be applied to a saved query."))
+                .type(MediaType.APPLICATION_JSON)
+                .build());
+    }
+
+    /** saiku#906/#1104 — record an embed query against the audit log, carrying
+     *  the JWT {@code sub} (end-user) when present. Embed queries run via direct
+     *  method calls, so they bypass the /ai/ AiAuditFilter — auditing here closes
+     *  that gap for the embed surface. */
+    private void audit(EmbedGuestDetails g, String endpoint, String outcome) {
+        if (auditLog == null || g == null) {
+            return;
+        }
+        AiAuditEntry e = new AiAuditEntry();
+        e.endpoint = endpoint;
+        e.user = g.ownerUser;
+        e.sub = g.jwtSub;
+        e.outcome = outcome;
+        e.policyDecision =
+                AiAuditEntry.OUTCOME_DENIED.equals(outcome) ? AiAuditEntry.DECISION_DENY : AiAuditEntry.DECISION_ALLOW;
+        auditLog.record(e);
+    }
+
+    private static String outcomeFor(int status) {
+        if (status >= 200 && status < 300) {
+            return AiAuditEntry.OUTCOME_SUCCESS;
+        }
+        if (status == 400) {
+            return AiAuditEntry.OUTCOME_VALIDATION_ERROR;
+        }
+        if (status == 403) {
+            return AiAuditEntry.OUTCOME_DENIED;
+        }
+        return AiAuditEntry.OUTCOME_ERROR;
     }
 
     /**

--- a/saiku-core/saiku-web/src/main/java/org/saiku/web/security/embed/EmbedAuthFilter.java
+++ b/saiku-core/saiku-web/src/main/java/org/saiku/web/security/embed/EmbedAuthFilter.java
@@ -4,6 +4,7 @@
  */
 package org.saiku.web.security.embed;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -11,11 +12,14 @@ import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
 import java.util.List;
 import org.saiku.web.embed.EmbedPublicGrant;
 import org.saiku.web.embed.EmbedPublicRegistry;
 import org.saiku.web.embed.EmbedToken;
 import org.saiku.web.embed.EmbedTokenStore;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.web.authentication.preauth.PreAuthenticatedAuthenticationToken;
@@ -48,6 +52,17 @@ public class EmbedAuthFilter extends OncePerRequestFilter {
 
     public static final String GUEST_ROLE = "ROLE_EMBED_GUEST";
     public static final String TOKEN_HEADER = "X-Saiku-Embed-Token";
+
+    private static final Logger LOG = LoggerFactory.getLogger(EmbedAuthFilter.class);
+
+    /** saiku#1104 — embed JWT (RLS) config. Env wins over system property; the
+     *  JWT path is inert until a secret is configured (a presented JWT is then
+     *  rejected, not accepted unverified). */
+    public static final String ENV_JWT_SECRET = "SAIKU_EMBED_JWT_SECRET";
+
+    public static final String PROP_JWT_SECRET = "saiku.embed.jwt.secret";
+    public static final String ENV_JWT_AUDIENCE = "SAIKU_EMBED_JWT_AUDIENCE";
+    public static final String PROP_JWT_AUDIENCE = "saiku.embed.jwt.audience";
 
     /** Read surface — query + dashboard. The mint surface lives elsewhere
      *  and goes through the normal authenticated chain. */
@@ -97,6 +112,16 @@ public class EmbedAuthFilter extends OncePerRequestFilter {
         // 1. Token path.
         String tokenId = extractToken(req);
         if (tokenId != null && !tokenId.isEmpty()) {
+            // saiku#1104: an embed JWT (3 segments) carries its own RLS scope +
+            // resource pin. Verified + mapped here; opaque tokens fall through.
+            if (EmbedJwt.looksLikeJwt(tokenId)) {
+                EmbedGuestDetails jwtGuest = authenticateJwt(tokenId, target, resp);
+                if (jwtGuest == null) {
+                    return; // writeInvalid already sent (fail-closed)
+                }
+                authenticate(req, resp, chain, jwtGuest);
+                return;
+            }
             EmbedToken token = tokenStore.load(tokenId);
             if (token == null || !token.isValid(System.currentTimeMillis())) {
                 writeInvalid(resp);
@@ -167,6 +192,98 @@ public class EmbedAuthFilter extends OncePerRequestFilter {
         } finally {
             SecurityContextHolder.clearContext();
         }
+    }
+
+    /**
+     * saiku#1104 — verify an embed JWT and map its claims to a guest identity,
+     * or send the opaque {@code EMBED_INVALID} response and return null on ANY
+     * failure (fail-closed). The JWT must pin the same resource the URL targets
+     * (replay protection), exactly like the opaque token.
+     */
+    private EmbedGuestDetails authenticateJwt(String compact, ResourceTarget target, HttpServletResponse resp)
+            throws IOException {
+        byte[] secret = jwtSecret();
+        if (secret == null) {
+            // A JWT was presented but no secret is configured — we cannot verify
+            // it, so reject rather than accept unverified input.
+            writeInvalid(resp);
+            return null;
+        }
+        JsonNode claims;
+        try {
+            claims = EmbedJwt.verify(compact, secret, jwtAudience(), System.currentTimeMillis());
+        } catch (EmbedJwt.EmbedJwtException e) {
+            LOG.debug("embed JWT rejected: {}", e.getMessage());
+            writeInvalid(resp);
+            return null;
+        }
+        String claimKind = text(claims, "saiku.resourceKind");
+        String claimPath = normalizePath(text(claims, "saiku.resourcePath"));
+        if (claimKind == null
+                || claimPath == null
+                || !claimKind.equals(target.kind)
+                || !claimPath.equals(target.path)) {
+            // Token not minted for this resource — refuse (replay protection).
+            writeInvalid(resp);
+            return null;
+        }
+        JsonNode filters = claims.get("saiku.filters");
+        String forcedFiltersJson =
+                (filters != null && !filters.isNull() && !filters.isMissingNode()) ? filters.toString() : null;
+        return new EmbedGuestDetails(
+                compact,
+                claimKind,
+                claimPath,
+                text(claims, "saiku.owner"),
+                stringArray(claims, "saiku.ownerRoles"),
+                org.saiku.web.embed.EmbedToken.RedactionPolicy.TENANT_DEFAULT,
+                text(claims, "sub"),
+                forcedFiltersJson);
+    }
+
+    /** Embed JWT secret (env &gt; system property); null when unset/blank so the
+     *  JWT path stays inert until a deployment opts in. */
+    private static byte[] jwtSecret() {
+        String s = System.getenv(ENV_JWT_SECRET);
+        if (s == null || s.isBlank()) {
+            s = System.getProperty(PROP_JWT_SECRET);
+        }
+        return (s == null || s.isBlank()) ? null : s.getBytes(StandardCharsets.UTF_8);
+    }
+
+    private static String jwtAudience() {
+        String a = System.getenv(ENV_JWT_AUDIENCE);
+        if (a == null || a.isBlank()) {
+            a = System.getProperty(PROP_JWT_AUDIENCE);
+        }
+        return (a == null || a.isBlank()) ? null : a.trim();
+    }
+
+    private static String text(JsonNode claims, String field) {
+        JsonNode n = claims.get(field);
+        return (n != null && n.isTextual()) ? n.asText() : null;
+    }
+
+    private static List<String> stringArray(JsonNode claims, String field) {
+        JsonNode n = claims.get(field);
+        if (n == null || !n.isArray()) {
+            return List.of();
+        }
+        List<String> out = new ArrayList<>();
+        for (JsonNode e : n) {
+            if (e.isTextual()) {
+                out.add(e.asText());
+            }
+        }
+        return out;
+    }
+
+    /** Mirror parseTarget's leading-slash normalization for claim paths. */
+    private static String normalizePath(String p) {
+        if (p == null) {
+            return null;
+        }
+        return p.startsWith("/") ? p : "/" + p;
     }
 
     /** Parse a sub-path like {@code "query/homes/admin/q.saiku"} into the
@@ -270,6 +387,14 @@ public class EmbedAuthFilter extends OncePerRequestFilter {
          *  {@link org.saiku.web.embed.EmbedToken.RedactionPolicy#TENANT_DEFAULT}
          *  for public-grant requests (no token to elevate from). */
         public final org.saiku.web.embed.EmbedToken.RedactionPolicy redactionPolicy;
+        /** saiku#1104 — end-user identity from the embed JWT's {@code sub}
+         *  claim; null for opaque-token / public-grant requests. Audited so the
+         *  trail shows who the embedder asserted. */
+        public final String jwtSub;
+        /** saiku#1104 — the JWT's {@code saiku.filters} claim serialised as a
+         *  JSON array (AiFilterSelection shape). The forced RLS slicer the view
+         *  injects before execution. Null when no forced filters are present. */
+        public final String forcedFiltersJson;
 
         public EmbedGuestDetails(
                 String token, String resourceKind, String resourcePath, String ownerUser, List<String> ownerRoles) {
@@ -290,6 +415,19 @@ public class EmbedAuthFilter extends OncePerRequestFilter {
                 String ownerUser,
                 List<String> ownerRoles,
                 org.saiku.web.embed.EmbedToken.RedactionPolicy redactionPolicy) {
+            this(token, resourceKind, resourcePath, ownerUser, ownerRoles, redactionPolicy, null, null);
+        }
+
+        /** saiku#1104 — full constructor including the embed-JWT claims. */
+        public EmbedGuestDetails(
+                String token,
+                String resourceKind,
+                String resourcePath,
+                String ownerUser,
+                List<String> ownerRoles,
+                org.saiku.web.embed.EmbedToken.RedactionPolicy redactionPolicy,
+                String jwtSub,
+                String forcedFiltersJson) {
             this.token = token;
             this.resourceKind = resourceKind;
             this.resourcePath = resourcePath;
@@ -298,6 +436,8 @@ public class EmbedAuthFilter extends OncePerRequestFilter {
             this.redactionPolicy = redactionPolicy == null
                     ? org.saiku.web.embed.EmbedToken.RedactionPolicy.TENANT_DEFAULT
                     : redactionPolicy;
+            this.jwtSub = jwtSub;
+            this.forcedFiltersJson = forcedFiltersJson;
         }
 
         /** True when this request reached the resource via a public grant

--- a/saiku-core/saiku-web/src/main/java/org/saiku/web/security/embed/EmbedJwt.java
+++ b/saiku-core/saiku-web/src/main/java/org/saiku/web/security/embed/EmbedJwt.java
@@ -48,6 +48,11 @@ public final class EmbedJwt {
     /** Allowed clock skew when checking {@code exp}/{@code nbf} (seconds). */
     private static final long CLOCK_SKEW_SECONDS = 60;
 
+    /** Minimum HS256 secret length. The security of HMAC-SHA256 rests on a key
+     *  at least as long as the hash output (256 bits = 32 bytes); a shorter
+     *  secret is brute-forceable offline. */
+    static final int MIN_SECRET_BYTES = 32;
+
     /** A JWT is three base64url segments separated by dots. */
     static boolean looksLikeJwt(String token) {
         if (token == null) {
@@ -84,6 +89,11 @@ public final class EmbedJwt {
             // Misconfiguration: no secret means we cannot verify anything, so we
             // must reject rather than accept unsigned input. Fail closed.
             throw new EmbedJwtException("no signing secret configured");
+        }
+        if (secret.length < MIN_SECRET_BYTES) {
+            // A short HS256 secret is brute-forceable offline — reject rather
+            // than accept a weak-key signature (SEC + QA #1104 flag).
+            throw new EmbedJwtException("signing secret too short (HS256 needs >= 32 bytes)");
         }
         String[] parts = compact.split("\\.", -1);
         if (parts.length != 3 || parts[0].isEmpty() || parts[1].isEmpty() || parts[2].isEmpty()) {

--- a/saiku-core/saiku-web/src/main/java/org/saiku/web/security/embed/EmbedJwt.java
+++ b/saiku-core/saiku-web/src/main/java/org/saiku/web/security/embed/EmbedJwt.java
@@ -1,0 +1,187 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.web.security.embed;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.util.Base64;
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+
+/**
+ * saiku#1104 Phase 1 — a deliberately small, auditable HMAC-SHA256 (HS256)
+ * verifier for compact JWTs used as embed RLS tokens. The embedder mints a JWT
+ * (signed with the deployment's shared secret) carrying the tenant scope +
+ * forced filters; Saiku verifies it here before honouring those claims.
+ *
+ * <p>Hand-rolled on purpose: HS256-verify is a tiny, well-understood operation,
+ * so this avoids pulling a JWT library (and its transitive CVE surface) for
+ * Phase 1. Phase 2 (asymmetric / JWKS) is when a vetted library earns its keep.
+ * Every classic JWT footgun is closed explicitly:
+ * <ul>
+ *   <li><b>{@code alg} confusion / {@code alg:none}</b> — the header {@code alg}
+ *       MUST be exactly {@code "HS256"}; anything else (incl. {@code none},
+ *       {@code RS256}, {@code HS384/512}) is rejected before any signature work.</li>
+ *   <li><b>Forgery</b> — the signature is recomputed over the exact
+ *       {@code header.payload} bytes and compared in <b>constant time</b>
+ *       ({@link MessageDigest#isEqual}).</li>
+ *   <li><b>Eternal tokens</b> — {@code exp} is REQUIRED (a token with no expiry
+ *       is rejected, fail-closed) and checked with a small clock-skew leeway.</li>
+ *   <li><b>Audience confusion</b> — when an expected audience is configured the
+ *       token's {@code aud} must match it.</li>
+ * </ul>
+ *
+ * <p>Every rejection throws {@link EmbedJwtException}; the caller collapses all
+ * of them into one opaque {@code EMBED_INVALID} response so a probe learns
+ * nothing about why a token failed.
+ */
+public final class EmbedJwt {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+    private static final Base64.Decoder URL_DECODER = Base64.getUrlDecoder();
+    private static final Base64.Encoder URL_ENCODER = Base64.getUrlEncoder().withoutPadding();
+
+    /** Allowed clock skew when checking {@code exp}/{@code nbf} (seconds). */
+    private static final long CLOCK_SKEW_SECONDS = 60;
+
+    /** A JWT is three base64url segments separated by dots. */
+    static boolean looksLikeJwt(String token) {
+        if (token == null) {
+            return false;
+        }
+        int firstDot = token.indexOf('.');
+        if (firstDot <= 0) {
+            return false;
+        }
+        int secondDot = token.indexOf('.', firstDot + 1);
+        // exactly two dots, and a non-empty signature segment after the second
+        return secondDot > firstDot && token.indexOf('.', secondDot + 1) < 0 && secondDot < token.length() - 1;
+    }
+
+    private EmbedJwt() {}
+
+    /**
+     * Verify a compact JWS (HS256) and return its validated claim set.
+     *
+     * @param compact the {@code header.payload.signature} token
+     * @param secret the shared HS256 secret (UTF-8); must be non-empty
+     * @param expectedAudience required {@code aud} value, or null/blank to skip the aud check
+     * @param nowMillis current time (injectable for tests)
+     * @return the verified payload claims
+     * @throws EmbedJwtException on ANY validation failure (bad shape, wrong alg,
+     *     bad signature, expired, not-yet-valid, wrong audience)
+     */
+    public static JsonNode verify(String compact, byte[] secret, String expectedAudience, long nowMillis)
+            throws EmbedJwtException {
+        if (compact == null || compact.isBlank()) {
+            throw new EmbedJwtException("empty token");
+        }
+        if (secret == null || secret.length == 0) {
+            // Misconfiguration: no secret means we cannot verify anything, so we
+            // must reject rather than accept unsigned input. Fail closed.
+            throw new EmbedJwtException("no signing secret configured");
+        }
+        String[] parts = compact.split("\\.", -1);
+        if (parts.length != 3 || parts[0].isEmpty() || parts[1].isEmpty() || parts[2].isEmpty()) {
+            throw new EmbedJwtException("malformed JWT (expected 3 non-empty segments)");
+        }
+
+        // 1. Header — pin alg=HS256 BEFORE any signature work (alg-confusion / none).
+        JsonNode header = decodeJson(parts[0], "header");
+        JsonNode alg = header.get("alg");
+        if (alg == null || !"HS256".equals(alg.asText())) {
+            throw new EmbedJwtException("unsupported or missing alg (only HS256 accepted)");
+        }
+
+        // 2. Signature — recompute over the exact signing input, constant-time compare.
+        byte[] expected = hmacSha256((parts[0] + "." + parts[1]).getBytes(StandardCharsets.UTF_8), secret);
+        byte[] provided;
+        try {
+            provided = URL_DECODER.decode(parts[2]);
+        } catch (IllegalArgumentException e) {
+            throw new EmbedJwtException("signature is not valid base64url");
+        }
+        if (!MessageDigest.isEqual(expected, provided)) {
+            throw new EmbedJwtException("signature mismatch");
+        }
+
+        // 3. Claims — only after the signature is proven, so we never trust
+        //    unverified bytes.
+        JsonNode payload = decodeJson(parts[1], "payload");
+        long nowSec = nowMillis / 1000L;
+
+        JsonNode exp = payload.get("exp");
+        if (exp == null || !exp.isNumber()) {
+            throw new EmbedJwtException("missing exp (eternal tokens rejected)");
+        }
+        if (nowSec > exp.asLong() + CLOCK_SKEW_SECONDS) {
+            throw new EmbedJwtException("token expired");
+        }
+        JsonNode nbf = payload.get("nbf");
+        if (nbf != null && nbf.isNumber() && nowSec + CLOCK_SKEW_SECONDS < nbf.asLong()) {
+            throw new EmbedJwtException("token not yet valid (nbf)");
+        }
+        if (expectedAudience != null && !expectedAudience.isBlank()) {
+            if (!audienceMatches(payload.get("aud"), expectedAudience)) {
+                throw new EmbedJwtException("audience mismatch");
+            }
+        }
+        return payload;
+    }
+
+    /** {@code aud} may be a string or an array of strings (RFC 7519). */
+    private static boolean audienceMatches(JsonNode aud, String expected) {
+        if (aud == null) {
+            return false;
+        }
+        if (aud.isTextual()) {
+            return expected.equals(aud.asText());
+        }
+        if (aud.isArray()) {
+            for (JsonNode n : aud) {
+                if (n.isTextual() && expected.equals(n.asText())) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    private static JsonNode decodeJson(String segment, String which) throws EmbedJwtException {
+        try {
+            return MAPPER.readTree(URL_DECODER.decode(segment));
+        } catch (IllegalArgumentException e) {
+            throw new EmbedJwtException(which + " is not valid base64url");
+        } catch (Exception e) {
+            throw new EmbedJwtException(which + " is not valid JSON");
+        }
+    }
+
+    private static byte[] hmacSha256(byte[] data, byte[] secret) {
+        try {
+            Mac mac = Mac.getInstance("HmacSHA256");
+            mac.init(new SecretKeySpec(secret, "HmacSHA256"));
+            return mac.doFinal(data);
+        } catch (Exception e) {
+            // HmacSHA256 is JLS-mandated; an empty key is guarded above.
+            throw new IllegalStateException("HMAC-SHA256 unavailable", e);
+        }
+    }
+
+    /** Test/encoder helper — base64url (no padding) for building signing input. */
+    static String b64Url(byte[] bytes) {
+        return URL_ENCODER.encodeToString(bytes);
+    }
+
+    /** Raised on any verification failure. Carries a developer-facing reason for
+     *  server-side logging only — the HTTP response stays opaque. */
+    public static final class EmbedJwtException extends Exception {
+        public EmbedJwtException(String message) {
+            super(message);
+        }
+    }
+}

--- a/saiku-core/saiku-web/src/test/java/org/saiku/web/rest/resources/embed/EmbedViewResourceTest.java
+++ b/saiku-core/saiku-web/src/test/java/org/saiku/web/rest/resources/embed/EmbedViewResourceTest.java
@@ -13,7 +13,10 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.saiku.service.datasource.DatasourceService;
+import org.saiku.service.olap.ai.AiQueryRequest;
 import org.saiku.service.olap.ai.AiSavedQueryRequest;
+import org.saiku.service.olap.ai.audit.AiAuditEntry;
+import org.saiku.service.olap.ai.audit.AiAuditLog;
 import org.saiku.web.rest.resources.AiQueryResource;
 import org.saiku.web.security.embed.EmbedAuthFilter.EmbedGuestDetails;
 import org.saiku.web.service.SessionService;
@@ -34,6 +37,7 @@ public class EmbedViewResourceTest {
     private StubDatasourceService ds;
     private StubSessionService session;
     private StubAiQueryResource ai;
+    private StubAuditLog audit;
     private EmbedViewResource resource;
 
     @Before
@@ -41,10 +45,12 @@ public class EmbedViewResourceTest {
         ds = new StubDatasourceService();
         session = new StubSessionService();
         ai = new StubAiQueryResource();
+        audit = new StubAuditLog();
         resource = new EmbedViewResource();
         resource.setDatasourceService(ds);
         resource.setSessionService(session);
         resource.setAiQueryResource(ai);
+        resource.setAuditLog(audit);
     }
 
     @After
@@ -194,7 +200,99 @@ public class EmbedViewResourceTest {
                 r.getHeaderString(org.saiku.web.rest.resources.embed.EmbedViewResource.REDACTION_POLICY_HEADER));
     }
 
+    /* ----------------- saiku#1104: forced RLS filters + audit ----------------- */
+
+    @Test
+    public void inline_tile_injects_forced_filters() {
+        ds.fileContent = "{\"layout\":{\"tiles\":[{\"id\":\"t1\",\"query\":{\"kind\":\"inline\",\"body\":{}}}]}}";
+        pinGuestJwt(
+                "dashboard",
+                "/homes/admin/exec.saikudash",
+                "admin",
+                List.of("ROLE_ADMIN"),
+                "u_1",
+                "[{\"dimension\":\"Customer\",\"hierarchy\":\"Customer\",\"level\":\"Customer\","
+                        + "\"op\":\"in\",\"members\":[\"[Customer].[acme]\"]}]");
+
+        Response r = resource.tileQuery("homes/admin/exec.saikudash", "t1");
+
+        assertEquals(200, r.getStatus());
+        assertNotNull("executeAi was called for the inline tile", ai.lastAiRequest);
+        boolean injected = ai.lastAiRequest.getFilters().stream().anyMatch(f -> "Customer".equals(f.getDimension()));
+        assertTrue("forced RLS filter must be injected into the inline query", injected);
+    }
+
+    @Test
+    public void saved_query_with_forced_filters_is_fail_closed() {
+        // A forced-filter token can't be applied to an opaque saved query in v1.
+        // It MUST be refused, never served unfiltered (cross-tenant leak).
+        pinGuestJwt(
+                "query",
+                "/homes/admin/sales.saiku",
+                "admin",
+                List.of(),
+                "u_1",
+                "[{\"dimension\":\"Customer\",\"op\":\"in\",\"members\":[\"[Customer].[acme]\"]}]");
+
+        Response r = resource.query("homes/admin/sales.saiku");
+
+        assertEquals(403, r.getStatus());
+        @SuppressWarnings("unchecked")
+        Map<String, Object> body = (Map<String, Object>) r.getEntity();
+        assertEquals("EMBED_RLS_UNSUPPORTED", body.get("status"));
+        assertNull("a fail-closed saved query must NOT execute", ai.lastSavedRequest);
+    }
+
+    @Test
+    public void reference_tile_with_forced_filters_is_fail_closed() {
+        ds.fileContent = "{\"layout\":{\"tiles\":[{\"id\":\"t1\",\"query\":"
+                + "{\"kind\":\"reference\",\"path\":\"/homes/admin/q.saiku\"}}]}}";
+        pinGuestJwt(
+                "dashboard",
+                "/homes/admin/exec.saikudash",
+                "admin",
+                List.of(),
+                "u_1",
+                "[{\"dimension\":\"Customer\",\"op\":\"in\",\"members\":[\"[Customer].[acme]\"]}]");
+
+        Response r = resource.tileQuery("homes/admin/exec.saikudash", "t1");
+
+        assertEquals(403, r.getStatus());
+        assertNull("reference tile must NOT execute unfiltered", ai.lastSavedRequest);
+    }
+
+    @Test
+    public void embed_query_audits_the_jwt_sub() {
+        pinGuestJwt("query", "/homes/admin/sales.saiku", "admin", List.of("ROLE_ADMIN"), "u_1", null);
+
+        resource.query("homes/admin/sales.saiku");
+
+        assertEquals(1, audit.records.size());
+        AiAuditEntry e = audit.records.get(0);
+        assertEquals("u_1", e.sub);
+        assertEquals("admin", e.user);
+        assertEquals(AiAuditEntry.OUTCOME_SUCCESS, e.outcome);
+        assertTrue(e.endpoint.contains("/embed/"));
+    }
+
     /* --------------------------- helpers ---------------------------- */
+
+    private void pinGuestJwt(
+            String kind, String path, String user, List<String> roles, String sub, String forcedFiltersJson) {
+        EmbedGuestDetails details = new EmbedGuestDetails(
+                "jwt-token",
+                kind,
+                path,
+                user,
+                roles,
+                org.saiku.web.embed.EmbedToken.RedactionPolicy.TENANT_DEFAULT,
+                sub,
+                forcedFiltersJson);
+        PreAuthenticatedAuthenticationToken auth = new PreAuthenticatedAuthenticationToken(
+                "embed-guest", details, List.of(new SimpleGrantedAuthority("ROLE_EMBED_GUEST")));
+        auth.setDetails(details);
+        SecurityContextHolder.getContext().setAuthentication(auth);
+    }
 
     private void pinGuest(String kind, String path, String user, List<String> roles) {
         EmbedGuestDetails details =
@@ -259,6 +357,7 @@ public class EmbedViewResourceTest {
      *  read from pinned details, not URI params. */
     private static class StubAiQueryResource extends AiQueryResource {
         AiSavedQueryRequest lastSavedRequest;
+        AiQueryRequest lastAiRequest;
 
         @Override
         public Response executeSaved(AiSavedQueryRequest body) {
@@ -266,6 +365,28 @@ public class EmbedViewResourceTest {
             return Response.ok(Map.of("status", "OK", "cells", List.of()))
                     .type(jakarta.ws.rs.core.MediaType.APPLICATION_JSON)
                     .build();
+        }
+
+        @Override
+        public Response executeAi(AiQueryRequest body, String format) {
+            lastAiRequest = body;
+            return Response.ok(Map.of("status", "OK", "data", List.of()))
+                    .type(jakarta.ws.rs.core.MediaType.APPLICATION_JSON)
+                    .build();
+        }
+    }
+
+    /** Captures audit entries without touching disk (overrides record). */
+    private static class StubAuditLog extends AiAuditLog {
+        final List<AiAuditEntry> records = new java.util.ArrayList<>();
+
+        StubAuditLog() {
+            super(java.nio.file.Paths.get("unused-audit.jsonl"), true);
+        }
+
+        @Override
+        public void record(AiAuditEntry e) {
+            records.add(e);
         }
     }
 }

--- a/saiku-core/saiku-web/src/test/java/org/saiku/web/security/embed/EmbedAuthFilterTest.java
+++ b/saiku-core/saiku-web/src/test/java/org/saiku/web/security/embed/EmbedAuthFilterTest.java
@@ -6,7 +6,11 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
 import java.util.List;
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -57,6 +61,8 @@ public class EmbedAuthFilterTest {
     public void tearDown() {
         SecurityContextHolder.clearContext();
         System.clearProperty(EmbedPublicRegistry.ALLOW_PUBLIC_PROP);
+        System.clearProperty(EmbedAuthFilter.PROP_JWT_SECRET);
+        System.clearProperty(EmbedAuthFilter.PROP_JWT_AUDIENCE);
     }
 
     @Test
@@ -291,6 +297,138 @@ public class EmbedAuthFilterTest {
         assertNotNull("explicit allowPublic=true still admits the public grant", chain.capturedAuth);
         EmbedGuestDetails details = (EmbedGuestDetails) chain.capturedAuth.getDetails();
         assertTrue("public path is anonymous", details.isAnonymous());
+    }
+
+    /* ----------------------- saiku#1104: embed JWT ----------------------- */
+
+    private static final String JWT_SECRET = "embed-rls-test-secret-at-least-32-bytes!!";
+
+    @Test
+    public void valid_jwt_pins_guest_with_sub_and_forced_filters() throws Exception {
+        System.setProperty(EmbedAuthFilter.PROP_JWT_SECRET, JWT_SECRET);
+        String jwt = mintJwt(
+                "{\"sub\":\"u_99\",\"saiku.resourceKind\":\"query\","
+                        + "\"saiku.resourcePath\":\"/homes/admin/sales.saiku\","
+                        + "\"saiku.owner\":\"admin\",\"saiku.ownerRoles\":[\"ROLE_ADMIN\"],"
+                        + "\"saiku.filters\":[{\"dimension\":\"Customer\",\"op\":\"in\",\"members\":[\"[Customer].[acme]\"]}],"
+                        + "\"exp\":" + future() + "}",
+                JWT_SECRET);
+        MockHttpServletRequest req =
+                new MockHttpServletRequest("GET", "/rest/saiku/api/embed/query/homes/admin/sales.saiku");
+        req.addHeader(EmbedAuthFilter.TOKEN_HEADER, jwt);
+        MockHttpServletResponse resp = new MockHttpServletResponse();
+        ContextCapturingChain chain = new ContextCapturingChain();
+
+        filter.doFilter(req, resp, chain);
+
+        assertTrue("valid JWT must reach the chain", chain.called);
+        EmbedGuestDetails d = (EmbedGuestDetails) chain.capturedAuth.getDetails();
+        assertEquals("u_99", d.jwtSub);
+        assertEquals("admin", d.ownerUser);
+        assertEquals(List.of("ROLE_ADMIN"), d.ownerRoles);
+        assertNotNull("forced filters carried forward", d.forcedFiltersJson);
+        assertTrue(d.forcedFiltersJson.contains("Customer"));
+        assertEquals("query", d.resourceKind);
+        assertEquals("/homes/admin/sales.saiku", d.resourcePath);
+    }
+
+    @Test
+    public void forged_jwt_is_invalid() throws Exception {
+        System.setProperty(EmbedAuthFilter.PROP_JWT_SECRET, JWT_SECRET);
+        // signed with a different secret than the deployment's
+        String jwt = mintJwt(
+                "{\"sub\":\"u\",\"saiku.resourceKind\":\"query\"," + "\"saiku.resourcePath\":\"/q.saiku\",\"exp\":"
+                        + future() + "}",
+                "a-totally-different-secret-key-32bytes-xx");
+        MockHttpServletRequest req = new MockHttpServletRequest("GET", "/rest/saiku/api/embed/query/q.saiku");
+        req.addHeader(EmbedAuthFilter.TOKEN_HEADER, jwt);
+        MockHttpServletResponse resp = new MockHttpServletResponse();
+        TrackingChain chain = new TrackingChain();
+
+        filter.doFilter(req, resp, chain);
+
+        assertEquals(401, resp.getStatus());
+        assertTrue(resp.getContentAsString().contains("EMBED_INVALID"));
+        assertFalse("forged JWT must NOT reach the chain", chain.called);
+    }
+
+    @Test
+    public void expired_jwt_is_invalid() throws Exception {
+        System.setProperty(EmbedAuthFilter.PROP_JWT_SECRET, JWT_SECRET);
+        String jwt = mintJwt(
+                "{\"sub\":\"u\",\"saiku.resourceKind\":\"query\"," + "\"saiku.resourcePath\":\"/q.saiku\",\"exp\":"
+                        + past() + "}",
+                JWT_SECRET);
+        MockHttpServletRequest req = new MockHttpServletRequest("GET", "/rest/saiku/api/embed/query/q.saiku");
+        req.addHeader(EmbedAuthFilter.TOKEN_HEADER, jwt);
+        MockHttpServletResponse resp = new MockHttpServletResponse();
+        TrackingChain chain = new TrackingChain();
+
+        filter.doFilter(req, resp, chain);
+
+        assertEquals(401, resp.getStatus());
+        assertFalse(chain.called);
+    }
+
+    @Test
+    public void jwt_for_wrong_resource_is_invalid() throws Exception {
+        // Replay: a JWT minted for sales.saiku presented against payroll.saiku.
+        System.setProperty(EmbedAuthFilter.PROP_JWT_SECRET, JWT_SECRET);
+        String jwt = mintJwt(
+                "{\"sub\":\"u\",\"saiku.resourceKind\":\"query\","
+                        + "\"saiku.resourcePath\":\"/homes/admin/sales.saiku\",\"exp\":" + future() + "}",
+                JWT_SECRET);
+        MockHttpServletRequest req =
+                new MockHttpServletRequest("GET", "/rest/saiku/api/embed/query/homes/admin/payroll.saiku");
+        req.addHeader(EmbedAuthFilter.TOKEN_HEADER, jwt);
+        MockHttpServletResponse resp = new MockHttpServletResponse();
+        TrackingChain chain = new TrackingChain();
+
+        filter.doFilter(req, resp, chain);
+
+        assertEquals(401, resp.getStatus());
+        assertFalse(chain.called);
+    }
+
+    @Test
+    public void jwt_rejected_when_no_secret_configured() throws Exception {
+        // No PROP_JWT_SECRET set -> a presented JWT can't be verified -> reject
+        // (fail-closed), never accept unverified input.
+        String jwt = mintJwt(
+                "{\"sub\":\"u\",\"saiku.resourceKind\":\"query\"," + "\"saiku.resourcePath\":\"/q.saiku\",\"exp\":"
+                        + future() + "}",
+                JWT_SECRET);
+        MockHttpServletRequest req = new MockHttpServletRequest("GET", "/rest/saiku/api/embed/query/q.saiku");
+        req.addHeader(EmbedAuthFilter.TOKEN_HEADER, jwt);
+        MockHttpServletResponse resp = new MockHttpServletResponse();
+        TrackingChain chain = new TrackingChain();
+
+        filter.doFilter(req, resp, chain);
+
+        assertEquals(401, resp.getStatus());
+        assertFalse(chain.called);
+    }
+
+    private static long future() {
+        return System.currentTimeMillis() / 1000L + 3600;
+    }
+
+    private static long past() {
+        return System.currentTimeMillis() / 1000L - 3600;
+    }
+
+    private static String mintJwt(String payloadJson, String secret) {
+        Base64.Encoder b64 = Base64.getUrlEncoder().withoutPadding();
+        String h = b64.encodeToString("{\"alg\":\"HS256\",\"typ\":\"JWT\"}".getBytes(StandardCharsets.UTF_8));
+        String p = b64.encodeToString(payloadJson.getBytes(StandardCharsets.UTF_8));
+        try {
+            Mac mac = Mac.getInstance("HmacSHA256");
+            mac.init(new SecretKeySpec(secret.getBytes(StandardCharsets.UTF_8), "HmacSHA256"));
+            String sig = b64.encodeToString(mac.doFinal((h + "." + p).getBytes(StandardCharsets.UTF_8)));
+            return h + "." + p + "." + sig;
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
     }
 
     /* --------------------------- helpers ---------------------------- */

--- a/saiku-core/saiku-web/src/test/java/org/saiku/web/security/embed/EmbedJwtTest.java
+++ b/saiku-core/saiku-web/src/test/java/org/saiku/web/security/embed/EmbedJwtTest.java
@@ -173,6 +173,35 @@ public class EmbedJwtTest {
     }
 
     @Test
+    public void short_secret_is_rejected() {
+        // A < 32-byte secret is brute-forceable offline — even a token correctly
+        // signed with that weak secret must be refused (SEC + QA #1104 flag).
+        byte[] weak = "too-short-31-bytes-secret-aaaaa".getBytes(StandardCharsets.UTF_8); // 31 bytes
+        String token = mint(HS256_HEADER, validPayload(), weak);
+        try {
+            EmbedJwt.verify(token, weak, AUD, NOW);
+            fail("a sub-32-byte secret must fail closed");
+        } catch (EmbedJwtException expected) {
+            // good
+        }
+    }
+
+    @Test
+    public void exp_as_string_is_rejected() {
+        // Claim-type confusion: exp must be numeric; a string exp is not a valid
+        // expiry and must be treated as missing -> rejected (locks isNumber()).
+        String p = "{\"sub\":\"u\",\"aud\":\"" + AUD + "\",\"exp\":\"" + FUTURE + "\"}";
+        assertRejected(mint(HS256_HEADER, p, SECRET), "exp as string");
+    }
+
+    @Test
+    public void alg_as_number_is_rejected() {
+        // alg must be the textual "HS256"; a numeric alg must not slip past the
+        // header check (locks the asText()/equals guard).
+        assertRejected(mint("{\"alg\":256}", validPayload(), SECRET), "alg as number");
+    }
+
+    @Test
     public void looksLikeJwt_distinguishes_jwt_from_opaque() {
         assertTrue(EmbedJwt.looksLikeJwt("aaa.bbb.ccc"));
         assertFalse("opaque UUID token", EmbedJwt.looksLikeJwt("8f3a2b1c-1234-5678-9abc-def012345678"));

--- a/saiku-core/saiku-web/src/test/java/org/saiku/web/security/embed/EmbedJwtTest.java
+++ b/saiku-core/saiku-web/src/test/java/org/saiku/web/security/embed/EmbedJwtTest.java
@@ -1,0 +1,183 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.web.security.embed;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+import org.junit.Test;
+import org.saiku.web.security.embed.EmbedJwt.EmbedJwtException;
+
+/**
+ * saiku#1104 — adversarial coverage for the embed JWT verifier. The whole point
+ * of this class is that forged / alg-confused / expired / mis-audienced tokens
+ * are rejected, so the tests are mostly negative by design.
+ */
+public class EmbedJwtTest {
+
+    private static final byte[] SECRET = "test-embed-secret-at-least-32-bytes-long!".getBytes(StandardCharsets.UTF_8);
+    private static final byte[] WRONG_SECRET =
+            "a-totally-different-secret-key-32bytes-xx".getBytes(StandardCharsets.UTF_8);
+    private static final String AUD = "saiku-embed";
+    private static final long NOW = 1_750_000_000_000L; // fixed clock
+    private static final long FUTURE = NOW / 1000L + 3600;
+    private static final long PAST = NOW / 1000L - 3600;
+
+    private static final Base64.Encoder B64 = Base64.getUrlEncoder().withoutPadding();
+
+    private static String seg(String json) {
+        return B64.encodeToString(json.getBytes(StandardCharsets.UTF_8));
+    }
+
+    private static String hmac(String signingInput, byte[] secret) {
+        try {
+            Mac mac = Mac.getInstance("HmacSHA256");
+            mac.init(new SecretKeySpec(secret, "HmacSHA256"));
+            return B64.encodeToString(mac.doFinal(signingInput.getBytes(StandardCharsets.UTF_8)));
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    /** Mint a compact JWT signed (HS256) over header.payload with {@code secret}. */
+    private static String mint(String headerJson, String payloadJson, byte[] secret) {
+        String h = seg(headerJson);
+        String p = seg(payloadJson);
+        return h + "." + p + "." + hmac(h + "." + p, secret);
+    }
+
+    private static String validPayload() {
+        return "{\"sub\":\"u_1234\",\"tenantId\":\"acme\",\"saiku.cube\":\"Sales\",\"aud\":\"" + AUD
+                + "\",\"exp\":" + FUTURE
+                + ",\"saiku.filters\":[{\"dim\":\"[Customer].[Customer]\",\"op\":\"in\",\"values\":[\"acme\"]}]}";
+    }
+
+    private static final String HS256_HEADER = "{\"alg\":\"HS256\",\"typ\":\"JWT\"}";
+
+    private static void assertRejected(String compact, String why) {
+        try {
+            EmbedJwt.verify(compact, SECRET, AUD, NOW);
+            fail("expected rejection: " + why);
+        } catch (EmbedJwtException expected) {
+            // good
+        }
+    }
+
+    @Test
+    public void valid_token_verifies_and_exposes_claims() throws Exception {
+        JsonNode claims = EmbedJwt.verify(mint(HS256_HEADER, validPayload(), SECRET), SECRET, AUD, NOW);
+        assertEquals("u_1234", claims.get("sub").asText());
+        assertEquals("acme", claims.get("tenantId").asText());
+        assertEquals("Sales", claims.get("saiku.cube").asText());
+        assertTrue(claims.get("saiku.filters").isArray());
+        assertEquals(
+                "[Customer].[Customer]",
+                claims.get("saiku.filters").get(0).get("dim").asText());
+    }
+
+    @Test
+    public void alg_none_is_rejected() {
+        // classic JWT bypass: alg:none with an empty/garbage signature
+        String compact = seg("{\"alg\":\"none\",\"typ\":\"JWT\"}") + "." + seg(validPayload()) + ".";
+        assertRejected(compact, "alg:none");
+        // even with a non-empty sig segment, alg:none must die at the header check
+        assertRejected(seg("{\"alg\":\"none\"}") + "." + seg(validPayload()) + ".AAAA", "alg:none w/ sig");
+    }
+
+    @Test
+    public void alg_confusion_other_algs_rejected() {
+        assertRejected(mint("{\"alg\":\"HS512\"}", validPayload(), SECRET), "HS512");
+        assertRejected(mint("{\"alg\":\"RS256\"}", validPayload(), SECRET), "RS256");
+        assertRejected(mint("{\"typ\":\"JWT\"}", validPayload(), SECRET), "missing alg");
+    }
+
+    @Test
+    public void wrong_secret_is_rejected() {
+        assertRejected(mint(HS256_HEADER, validPayload(), WRONG_SECRET), "signed with wrong secret");
+    }
+
+    @Test
+    public void tampered_payload_is_rejected() {
+        // sign a benign payload, then swap in an escalated one (sig no longer matches)
+        String benign = mint(HS256_HEADER, validPayload(), SECRET);
+        String[] parts = benign.split("\\.");
+        String evil = parts[0] + "." + seg(validPayload().replace("acme", "victim-corp")) + "." + parts[2];
+        assertRejected(evil, "tampered payload");
+    }
+
+    @Test
+    public void expired_token_is_rejected() {
+        String p = "{\"sub\":\"u\",\"aud\":\"" + AUD + "\",\"exp\":" + PAST + "}";
+        assertRejected(mint(HS256_HEADER, p, SECRET), "expired");
+    }
+
+    @Test
+    public void missing_exp_is_rejected() {
+        String p = "{\"sub\":\"u\",\"aud\":\"" + AUD + "\"}";
+        assertRejected(mint(HS256_HEADER, p, SECRET), "no exp (eternal)");
+    }
+
+    @Test
+    public void not_yet_valid_nbf_is_rejected() {
+        String p = "{\"sub\":\"u\",\"aud\":\"" + AUD + "\",\"exp\":" + FUTURE + ",\"nbf\":" + FUTURE + "}";
+        assertRejected(mint(HS256_HEADER, p, SECRET), "nbf in future");
+    }
+
+    @Test
+    public void wrong_audience_is_rejected() {
+        String p = "{\"sub\":\"u\",\"aud\":\"some-other-app\",\"exp\":" + FUTURE + "}";
+        assertRejected(mint(HS256_HEADER, p, SECRET), "aud mismatch");
+    }
+
+    @Test
+    public void audience_as_array_is_accepted() throws Exception {
+        String p = "{\"sub\":\"u\",\"aud\":[\"x\",\"" + AUD + "\"],\"exp\":" + FUTURE + "}";
+        JsonNode claims = EmbedJwt.verify(mint(HS256_HEADER, p, SECRET), SECRET, AUD, NOW);
+        assertEquals("u", claims.get("sub").asText());
+    }
+
+    @Test
+    public void no_expected_audience_skips_aud_check() throws Exception {
+        String p = "{\"sub\":\"u\",\"exp\":" + FUTURE + "}";
+        JsonNode claims = EmbedJwt.verify(mint(HS256_HEADER, p, SECRET), SECRET, null, NOW);
+        assertEquals("u", claims.get("sub").asText());
+    }
+
+    @Test
+    public void malformed_shapes_are_rejected() {
+        assertRejected("only.two", "two segments");
+        assertRejected("a.b.c.d", "four segments");
+        assertRejected("..", "empty segments");
+        assertRejected(seg(HS256_HEADER) + "." + seg(validPayload()) + ".", "empty signature");
+        assertRejected("!!!." + seg(validPayload()) + ".AAAA", "non-base64 header");
+        assertRejected(seg("not json") + "." + seg(validPayload()) + ".AAAA", "header not json");
+    }
+
+    @Test
+    public void empty_secret_is_rejected() {
+        try {
+            EmbedJwt.verify(mint(HS256_HEADER, validPayload(), SECRET), new byte[0], AUD, NOW);
+            fail("no secret must fail closed");
+        } catch (EmbedJwtException expected) {
+            // good
+        }
+    }
+
+    @Test
+    public void looksLikeJwt_distinguishes_jwt_from_opaque() {
+        assertTrue(EmbedJwt.looksLikeJwt("aaa.bbb.ccc"));
+        assertFalse("opaque UUID token", EmbedJwt.looksLikeJwt("8f3a2b1c-1234-5678-9abc-def012345678"));
+        assertFalse(EmbedJwt.looksLikeJwt("only.two"));
+        assertFalse(EmbedJwt.looksLikeJwt("trailing.dot."));
+        assertFalse(EmbedJwt.looksLikeJwt(null));
+    }
+}

--- a/saiku-webapp/src/main/webapp/WEB-INF/saiku-beans.xml
+++ b/saiku-webapp/src/main/webapp/WEB-INF/saiku-beans.xml
@@ -527,6 +527,8 @@
         <property name="datasourceService" ref="datasourceServiceBean"/>
         <property name="sessionService" ref="sessionService"/>
         <property name="aiQueryResource" ref="aiQueryResource"/>
+        <!-- saiku#1104/#906: audit embed queries (carries the JWT sub). -->
+        <property name="auditLog" ref="aiAuditLog"/>
     </bean>
 
     <!-- Per-tile dashboard comments (issue #942). commentService stores a


### PR DESCRIPTION
## Summary
Embed row-level security via JWT claims — **Phase 1** (#1104). Lets an embedder mint a per-tenant, signed embed token that scopes what an embedded query returns, enforced server-side. This is the Saiku-side keystone the IP-embed review flagged (security gate item (b): per-tenant, fail-closed, resource-pinned token). Phase 1 = shared HS256 secret + forced-WHERE filter injection; JWKS (Ph2) and per-measure RLS (Ph3) are follow-ups.

## The two design decisions (the pre-build SEC consult, now embodied in code)
**A — verification = hand-rolled HS256** (`EmbedJwt`, ~190 LOC, zero new dependency). Every classic JWT footgun is closed explicitly: `alg` pinned to HS256 (rejects `alg:none` / `RS256` / `HS512` *before* any signature work), **constant-time** signature compare (`MessageDigest.isEqual`), `exp` **required** (eternal tokens rejected), `aud` validated, fail-closed when no secret is configured. A vetted lib earns its keep at Phase 2 (asymmetric/JWKS); for HS256-verify, a tight auditable class avoids new CVE surface.

**B — coverage / no-leak.** The embed has two query entry points. Forced filters are injected on the inline (`executeAi`) path — and they ride `AiSchemaConverter`'s **validated** slicer path, so a forced filter can't inject MDX. Saved + reference queries that carry forced filters are **refused (403 `EMBED_RLS_UNSUPPORTED`)** — never served unfiltered. Saved-query injection is the immediate fast-follow; v1 cannot leak.

## The change
- **`EmbedJwt`** — the HS256 verifier (new).
- **`EmbedAuthFilter`** — JWT branch on the existing `X-Saiku-Embed-Token` header (3-segment = JWT, else opaque). Verifies against `saiku.embed.jwt.secret`/`.audience` (env > prop; **inert until configured**), pins the resource from claims (replay protection), maps `sub` + `saiku.filters` + `saiku.owner`/`ownerRoles` onto `EmbedGuestDetails`.
- **`EmbedViewResource`** — forced-filter injection + fail-closed coverage + audits every embed query with the JWT `sub` (closes the embed gap the #906 `/ai/` filter doesn't reach).
- **`AiAuditEntry`** — `+ sub` field.

## Verified (local)
- `EmbedJwt` **14/0** adversarial (alg:none, alg-confusion, forgery, tamper, expiry, nbf, audience, malformed, fail-closed-no-secret).
- `EmbedAuthFilter` **18/0** (+5 JWT: valid pins sub+forced-filters, forged/expired/wrong-resource/no-secret all reject).
- `EmbedViewResource` **14/0** (+4: inline injection, saved + reference fail-closed, audit shows sub).
- **Full saiku-web 415/0**, spotless clean. Satisfies the issue's Phase-1 test plan.

## Config / notes
- `saiku.embed.jwt.secret` + `saiku.embed.jwt.audience` (or `SAIKU_EMBED_JWT_*`). **Default OFF** — no secret means the JWT path is inert and a presented JWT is rejected (never accepted unverified). Opaque-token + public-grant paths are unchanged.
- **Follow-ups:** saved-query forced-filter injection; Phase 2 JWKS/asymmetric; Phase 3 per-measure RLS.
- @AGENT SEC (Locksmith): this answers the pre-build consult — A = hand-rolled HS256 with the protections above; B = inject-inline + fail-closed-reject saved/ref. Please confirm at the gate. @AGENT QA: completeness (no entry point serves unfiltered) + the adversarial verifier suite are the crux.
