### PR TITLE
feat(workbench): measure-group tree + dim-applicability hints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -474,3 +474,6 @@ nbdist/
 
 # Claude Code session worktrees / scratch (never commit)
 .claude/
+
+# git worktrees
+.worktrees/

--- a/saiku-core/saiku-olap-util/src/main/java/mondrian/olap4j/SaikuMondrianHelper.java
+++ b/saiku-core/saiku-olap-util/src/main/java/mondrian/olap4j/SaikuMondrianHelper.java
@@ -161,8 +161,7 @@ public class SaikuMondrianHelper {
      *       "no information, assume applicable" to preserve legacy UX.</li>
      * </ul>
      */
-    public static java.util.Set<String> getMeasureGroupsForDimension(
-            org.olap4j.metadata.Dimension dim) {
+    public static java.util.Set<String> getMeasureGroupsForDimension(org.olap4j.metadata.Dimension dim) {
         if (!isMondrian(dim)) {
             return null;
         }

--- a/saiku-core/saiku-olap-util/src/main/java/mondrian/olap4j/SaikuMondrianHelper.java
+++ b/saiku-core/saiku-olap-util/src/main/java/mondrian/olap4j/SaikuMondrianHelper.java
@@ -145,6 +145,57 @@ public class SaikuMondrianHelper {
         return null;
     }
 
+    /**
+     * For a Mondrian cube dimension, return the names of every measure group
+     * the dimension has a real (non-NoLink) join to. Used by the SPA's
+     * applicability hinting in DimensionList: when the user has measures
+     * selected the SPA mutes dimensions whose link set is not a superset of
+     * the required measure groups, so virtual cubes that mix conformed and
+     * non-conformed dims surface the asymmetry instead of silently producing
+     * sparse/empty cellsets (saiku-cloud#TODO).
+     *
+     * <p>Returns:
+     * <ul>
+     *   <li>a set of MG names (possibly empty for a fully-NoLinked dim);</li>
+     *   <li>{@code null} for non-Mondrian providers — caller treats as
+     *       "no information, assume applicable" to preserve legacy UX.</li>
+     * </ul>
+     */
+    public static java.util.Set<String> getMeasureGroupsForDimension(
+            org.olap4j.metadata.Dimension dim) {
+        if (!isMondrian(dim)) {
+            return null;
+        }
+        try {
+            MondrianOlap4jDimension odim = (MondrianOlap4jDimension) dim;
+            // getOlapElement() is protected — accessible from this same
+            // mondrian.olap4j package. Returns the wrapped Mondrian
+            // Dimension (which is a RolapCubeDimension when surfaced
+            // through Cube.getDimensions()).
+            mondrian.olap.OlapElement el = odim.getOlapElement();
+            if (!(el instanceof RolapCubeDimension)) {
+                return null;
+            }
+            RolapCubeDimension rcd = (RolapCubeDimension) el;
+            RolapCube cube = rcd.getCube();
+            java.util.LinkedHashSet<String> out = new java.util.LinkedHashSet<>();
+            // dimensionMap3 is keyed by RolapCubeDimension and only contains
+            // dims with a real (non-NoLink) join — exactly the applicability
+            // signal we want to surface to the SPA.
+            for (RolapMeasureGroup mg : cube.getMeasureGroups()) {
+                if (mg.dimensionMap3.containsKey(rcd)) {
+                    out.add(mg.getName());
+                }
+            }
+            return out;
+        } catch (Throwable t) {
+            // Defensive: never let a metadata introspection failure poison
+            // discover — the SPA treats null as "no info, assume applicable".
+            log.debug("getMeasureGroupsForDimension failed: {}", t.toString());
+            return null;
+        }
+    }
+
     private static boolean isHanger(RolapCubeDimension dimension) {
         return DimensionLookup.getHanger(dimension);
     }

--- a/saiku-core/saiku-service/src/main/java/org/saiku/olap/dto/SaikuDimension.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/olap/dto/SaikuDimension.java
@@ -15,9 +15,11 @@
  */
 package org.saiku.olap.dto;
 
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 public class SaikuDimension extends AbstractSaikuObject {
 
@@ -36,6 +38,20 @@ public class SaikuDimension extends AbstractSaikuObject {
      *  the schema XML. Lets the SPA detect time dimensions without falling
      *  back to caption substring matching (saiku#1221). */
     private String dimensionType;
+    /** Names of the {@code <MeasureGroup>}s this dimension has a real
+     *  (non-NoLink) join to. Populated by {@code ObjectUtil.convert(Dimension)}
+     *  via {@code SaikuMondrianHelper.getMeasureGroupsForDimension}.
+     *
+     *  <p>Drives the SPA's dim-applicability hinting (saiku#TODO): when the
+     *  user has measures selected from MGs {@code R}, a dimension is
+     *  applicable iff {@code measureGroups ⊇ R}. Dimensions that fail this
+     *  check render greyed with a tooltip explaining the unjoined MG, so
+     *  virtual cubes that mix conformed and non-conformed dims surface the
+     *  asymmetry instead of silently producing sparse/empty cellsets.
+     *
+     *  <p>Null on non-Mondrian providers — the SPA treats null as "no info,
+     *  assume applicable" to preserve legacy UX. */
+    private List<String> measureGroups;
 
     public SaikuDimension() {
         super(null, null);
@@ -87,5 +103,13 @@ public class SaikuDimension extends AbstractSaikuObject {
 
     public void setDimensionType(String dimensionType) {
         this.dimensionType = dimensionType;
+    }
+
+    public List<String> getMeasureGroups() {
+        return measureGroups == null ? null : new ArrayList<>(measureGroups);
+    }
+
+    public void setMeasureGroups(Set<String> measureGroups) {
+        this.measureGroups = measureGroups == null ? null : new ArrayList<>(measureGroups);
     }
 }

--- a/saiku-core/saiku-service/src/main/java/org/saiku/olap/util/ObjectUtil.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/olap/util/ObjectUtil.java
@@ -80,6 +80,9 @@ public class ObjectUtil {
         } catch (Throwable ignored) {
             // Some drivers throw on getDimensionType — leave null.
         }
+        // Per-dimension MeasureGroup link set (Mondrian only). Drives the
+        // SPA's dim-applicability hinting on virtual cubes.
+        sd.setMeasureGroups(mondrian.olap4j.SaikuMondrianHelper.getMeasureGroupsForDimension(dim));
         return sd;
     }
 

--- a/saiku-ui/src/lib/api/discover.ts
+++ b/saiku-ui/src/lib/api/discover.ts
@@ -90,6 +90,16 @@ export interface SaikuDimension {
    *  this so the SPA's time-filter detection has a dimension-level
    *  signal independent of caption text. */
   dimensionType?: string;
+  /** Names of the MeasureGroups this dimension has a real (non-NoLink) join
+   *  to. Populated by SaikuMondrianHelper.getMeasureGroupsForDimension on
+   *  Mondrian providers; null elsewhere.
+   *
+   *  Used in DimensionList for applicability hinting on virtual cubes —
+   *  when the user has measures selected from MGs R, a dimension is
+   *  visually muted iff measureGroups doesn't cover R. Null is treated as
+   *  "no info, assume applicable" so legacy single-MG cubes render
+   *  identically to today. */
+  measureGroups?: string[] | null;
 }
 
 export interface SaikuMeasure {
@@ -103,6 +113,14 @@ export interface SaikuMeasure {
    *  / OlapDiscoverResource.getCubeMeasures). The field is forwarded
    *  raw so admin UIs can badge "(hidden)" rows without re-checking. */
   visible?: boolean;
+  /** Mondrian-4 MeasureGroup the base measure belongs to. Populated by
+   *  SaikuMondrianHelper.getMeasureGroup; empty string for calculated
+   *  members (no MG) and null for non-Mondrian providers. Drives the
+   *  measure-tree grouping in DimensionList so virtual cubes that pull
+   *  from multiple fact tables (e.g. FoodMart's Warehouse and Sales)
+   *  render Sales / Warehouse / Calculated as separate sections instead
+   *  of one flat list. */
+  measureGroup?: string | null;
 }
 
 const REST_BASE = "/rest/saiku";

--- a/saiku-ui/src/lib/views/DimensionList.svelte
+++ b/saiku-ui/src/lib/views/DimensionList.svelte
@@ -12,6 +12,7 @@
   import { measuresHiddenToggle } from "$lib/stores/measuresHiddenToggle.svelte";
   import {
     Sigma,
+    FunctionSquare,
     Folder,
     GitFork,
     ChevronRight,
@@ -152,14 +153,117 @@
     expanded[id] = !(expanded[id] ?? true);
   }
 
-  function measureGroups(): Record<string, typeof metadata extends null ? never : NonNullable<typeof metadata>["measures"]> {
-    const groups: Record<string, NonNullable<typeof metadata>["measures"]> = {};
-    if (!metadata) return groups;
+  /** Fallback header used when the backend exposes no measure-group
+   *  metadata (non-Mondrian providers) or when every measure of a cube
+   *  has the same group — in both cases we render a single flat list
+   *  under this label, matching the historical UX. */
+  const DEFAULT_MEASURE_GROUP = "Measures";
+  /** Bucket for `calculated: true` measures (Mondrian CalculatedMembers
+   *  have no MeasureGroup) — separates derived KPIs from raw aggregates
+   *  visually and signals to the user that these compose underlying
+   *  measures rather than reading from a fact table. */
+  const CALCULATED_GROUP = "Calculated";
+
+  /** Compute the group label for a single measure.
+   *  Precedence:
+   *    1. Calculated members → CALCULATED_GROUP
+   *    2. Mondrian-supplied measureGroup string → that string
+   *    3. Anything else (null/empty/missing) → DEFAULT_MEASURE_GROUP
+   */
+  function groupLabel(m: SaikuMeasure): string {
+    if (m.calculated) return CALCULATED_GROUP;
+    const mg = m.measureGroup;
+    if (typeof mg === "string" && mg.length > 0) return mg;
+    return DEFAULT_MEASURE_GROUP;
+  }
+
+  /** Group measures by their resolved label, preserving the order
+   *  measures arrive in (the backend already returns them in schema
+   *  order). The Calculated bucket — when present — is always last so
+   *  derived KPIs cluster at the bottom regardless of how many base
+   *  MeasureGroups there are.
+   *
+   *  Returns an array of [label, measures] pairs (not an object) so
+   *  iteration order is preserved across Svelte renders. */
+  // Reactive bucket-by-MG of the loaded cube's measures. Recomputed
+  // whenever metadata changes; `$derived` ensures the template can
+  // reference the value directly without re-bucketing on every render.
+  const measureGroupsDerived = $derived<Array<[string, SaikuMeasure[]]>>(measureGroups());
+
+  function measureGroups(): Array<[string, SaikuMeasure[]]> {
+    if (!metadata) return [];
+    const groups = new Map<string, SaikuMeasure[]>();
     for (const m of metadata.measures) {
-      const key = "Measures";
-      (groups[key] ??= []).push(m);
+      const key = groupLabel(m);
+      const bucket = groups.get(key);
+      if (bucket) bucket.push(m);
+      else groups.set(key, [m]);
     }
-    return groups;
+    // Push CALCULATED_GROUP to the end if it exists.
+    const calc = groups.get(CALCULATED_GROUP);
+    if (calc) {
+      groups.delete(CALCULATED_GROUP);
+      groups.set(CALCULATED_GROUP, calc);
+    }
+    return Array.from(groups.entries());
+  }
+
+  // ---- Dim-applicability (saiku#TODO virtual cube UX) ----
+
+  /**
+   * Set of MeasureGroup names the currently-selected measures span. Empty
+   * when the user has no measures selected or every selected measure is
+   * calculated (calc members have no MG of their own — their applicability
+   * derives from the base measures they reference, which we don't introspect
+   * statically; treating them as no-constraint is the safe default).
+   *
+   * Rebuilt reactively from the query's measure details + the cube metadata's
+   * measure list so we can resolve a uniqueName → measureGroup without
+   * re-walking the wire.
+   */
+  const requiredMeasureGroups = $derived.by<Set<string>>(() => {
+    const out = new Set<string>();
+    const selected = query.current?.queryModel?.details.measures ?? [];
+    if (selected.length === 0 || !metadata) return out;
+    const byUniqueName = new Map<string, SaikuMeasure>();
+    for (const m of metadata.measures) byUniqueName.set(m.uniqueName, m);
+    for (const sel of selected) {
+      const m = byUniqueName.get(sel.uniqueName);
+      if (!m) continue;
+      if (m.calculated) continue;
+      const mg = m.measureGroup;
+      if (typeof mg === "string" && mg.length > 0) out.add(mg);
+    }
+    return out;
+  });
+
+  /**
+   * True when this dimension is applicable to every currently-selected base
+   * measure — i.e. it has a real (non-NoLink) join to every required MG.
+   *
+   *  - dim.measureGroups null → backend can't tell (non-Mondrian) →
+   *    assume applicable; don't mute.
+   *  - requiredMeasureGroups empty → no constraints yet → applicable.
+   *  - otherwise → applicable iff dim.measureGroups ⊇ required.
+   */
+  function dimApplicable(dim: SaikuDimension): boolean {
+    if (!dim.measureGroups) return true;
+    if (requiredMeasureGroups.size === 0) return true;
+    for (const mg of requiredMeasureGroups) {
+      if (!dim.measureGroups.includes(mg)) return false;
+    }
+    return true;
+  }
+
+  /**
+   * Human-readable list of the MGs the dim does NOT join, scoped to the
+   * currently-required set. Drives the tooltip on muted dim rows so the
+   * user sees WHY a dim is greyed out without having to inspect the schema.
+   */
+  function unjoinedMeasureGroups(dim: SaikuDimension): string[] {
+    if (!dim.measureGroups || requiredMeasureGroups.size === 0) return [];
+    const joined = new Set(dim.measureGroups);
+    return Array.from(requiredMeasureGroups).filter((mg) => !joined.has(mg));
   }
 
   // ---- Measures modal (bulk pick) + Calculated member modal ----
@@ -335,37 +439,59 @@
         </span>
       </header>
       <ul class="tree">
-        {#each Object.entries(measureGroups()) as [group, items]}
-          {@const gid = `m:${group}`}
-          <li class="tree__node">
-            <button type="button" class="tree__row tree__row--group" onclick={() => toggle(gid)}>
-              <span class="tree__twisty" class:tree__twisty--open={expanded[gid] !== false}>
-                <ChevronRight size={12} />
-              </span>
-              <span class="tree__label">{group}</span>
-              <span class="tree__count">{items.length}</span>
-            </button>
-            {#if expanded[gid] !== false}
-              <ul class="tree">
-                {#each items as measure}
-                  <li class="tree__node">
-                    <button
-                      type="button"
-                      class="tree__row tree__row--measure"
-                      draggable="true"
-                      title={measure.caption}
-                      ondragstart={(e) => onMeasureDragStart(e, measure)}
-                      onclick={() => onMeasureClick(measure)}
-                    >
-                      <span class="tree__icon tree__icon--measure" aria-hidden="true"><Sigma size={13} /></span>
-                      <span class="tree__label">{measure.caption || measure.name}</span>
-                    </button>
-                  </li>
-                {/each}
-              </ul>
-            {/if}
-          </li>
-        {/each}
+        {#if measureGroupsDerived.length <= 1}
+          {#each measureGroupsDerived[0]?.[1] ?? [] as measure}
+            <li class="tree__node">
+              <button
+                type="button"
+                class="tree__row tree__row--measure"
+                draggable="true"
+                title={measure.caption}
+                ondragstart={(e) => onMeasureDragStart(e, measure)}
+                onclick={() => onMeasureClick(measure)}
+              >
+                <span class="tree__icon tree__icon--measure" aria-hidden="true">
+                  {#if measure.calculated}<FunctionSquare size={13} />{:else}<Sigma size={13} />{/if}
+                </span>
+                <span class="tree__label">{measure.caption || measure.name}</span>
+              </button>
+            </li>
+          {/each}
+        {:else}
+          {#each measureGroupsDerived as [group, items]}
+            {@const gid = `m:${group}`}
+            <li class="tree__node">
+              <button type="button" class="tree__row tree__row--group" onclick={() => toggle(gid)}>
+                <span class="tree__twisty" class:tree__twisty--open={expanded[gid] !== false}>
+                  <ChevronRight size={12} />
+                </span>
+                <span class="tree__label">{group}</span>
+                <span class="tree__count">{items.length}</span>
+              </button>
+              {#if expanded[gid] !== false}
+                <ul class="tree">
+                  {#each items as measure}
+                    <li class="tree__node">
+                      <button
+                        type="button"
+                        class="tree__row tree__row--measure"
+                        draggable="true"
+                        title={measure.caption}
+                        ondragstart={(e) => onMeasureDragStart(e, measure)}
+                        onclick={() => onMeasureClick(measure)}
+                      >
+                        <span class="tree__icon tree__icon--measure" aria-hidden="true">
+                          {#if measure.calculated}<FunctionSquare size={13} />{:else}<Sigma size={13} />{/if}
+                        </span>
+                        <span class="tree__label">{measure.caption || measure.name}</span>
+                      </button>
+                    </li>
+                  {/each}
+                </ul>
+              {/if}
+            </li>
+          {/each}
+        {/if}
         {#if metadata.measures.length === 0}
           <li class="tree__empty">{i18n.t("panels.noMeasures")}</li>
         {/if}
@@ -377,13 +503,25 @@
       <ul class="tree">
         {#each metadata.dimensions.filter((d) => d.name !== "Measures") as dim}
           {@const did = `d:${dim.uniqueName}`}
-          <li class="tree__node">
-            <button type="button" class="tree__row tree__row--dim" onclick={() => toggle(did)} title={dim.caption}>
+          {@const applicable = dimApplicable(dim)}
+          {@const unjoined = unjoinedMeasureGroups(dim)}
+          <li class="tree__node" class:tree__node--muted={!applicable}>
+            <button
+              type="button"
+              class="tree__row tree__row--dim"
+              onclick={() => toggle(did)}
+              title={applicable
+                ? (dim.caption ?? "")
+                : `${dim.caption || dim.name} — does not join to the ${unjoined.join(" or ")} measure group${unjoined.length > 1 ? "s" : ""}. Selecting levels here will roll those measures up to All.`}
+            >
               <span class="tree__twisty" class:tree__twisty--open={expanded[did] !== false}>
                 <ChevronRight size={12} />
               </span>
               <span class="tree__icon" aria-hidden="true"><Folder size={13} /></span>
               <span class="tree__label">{dim.caption || dim.name}</span>
+              {#if !applicable}
+                <span class="tree__badge tree__badge--warn" aria-label="not joined to selected measures">⚠</span>
+              {/if}
             </button>
             {#if expanded[did] !== false}
               <ul class="tree">
@@ -646,5 +784,24 @@
   .tree__count {
     color: var(--fg-subtle);
     font-size: var(--fs-xs);
+  }
+  /* Dim-applicability hint for virtual cubes. When a measure from a fact
+     table that doesn't join the dim is selected, the dim row (and its
+     entire subtree) is rendered at reduced opacity with a warning badge.
+     Click-through still works — this is signal, not blocking. */
+  .tree__node--muted > .tree__row { opacity: 0.45; }
+  .tree__node--muted > .tree { opacity: 0.45; }
+  .tree__badge {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    font-size: var(--fs-xs);
+    padding: 0 4px;
+    border-radius: var(--radius-sm);
+    line-height: 1;
+  }
+  .tree__badge--warn {
+    color: var(--warn, #d97706);
+    background: color-mix(in srgb, var(--warn, #d97706) 12%, transparent);
   }
 </style>


### PR DESCRIPTION
## Summary

Two UX improvements for cubes with multiple MeasureGroups (virtual cubes like the rewritten \`Warehouse and Sales\` — see sibling PR). Single-MG cubes are unchanged.

### Measure tree — grouped by MeasureGroup

Before: 17 measures spilling out flat. After:

\`\`\`
MEASURES (17)
├─ ▶ Sales              6
├─ ▶ Warehouse          7
└─ ▶ Calculated         4   ← always last; ƒ icon vs Σ for base
\`\`\`

The \`measureGroup\` field was already on \`SaikuMeasure\` (populated by \`SaikuMondrianHelper.getMeasureGroup\`) — the SPA just wasn't reading it. \`DimensionList\` now buckets by group with the Calculated bucket always pinned last and a distinct icon (Σ for base, ƒ for calculated).

### Dim-applicability hints

When the user picks measures from multiple MeasureGroups, dimensions that don't join every selected fact table render visually muted with a ⚠ badge and an explanatory tooltip:

> \"Customer — does not join to the Warehouse measure group. Selecting levels here will roll those measures up to All.\"

Click-through still works — this is signal, not blocking — but the user now sees *why* a cross-fact query produced an empty grid, instead of guessing.

## Backend

New \`SaikuMondrianHelper.getMeasureGroupsForDimension(Dimension)\` reaches into \`RolapMeasureGroup.dimensionMap3\` to extract the non-NoLink join set per cube dimension. Surfaced on the wire as \`SaikuDimension.measureGroups: List<String>\`. \`ObjectUtil.convert(Dimension)\` populates it.

Wire shape verified on \`Warehouse and Sales\`:

| Dimension | measureGroups |
|---|---|
| Customer | [Sales] |
| Promotion | [Sales] |
| Warehouse | [Warehouse] |
| Store, Time, Product | [Sales, Warehouse] |

## Backwards compat

- **Non-Mondrian providers** return null \`measureGroups\` → SPA treats as \"no info, assume applicable.\" Legacy XMLA/JDBC connections behave identically to today.
- **Single-MG cubes** (Pharma, Sales, Bank Accounts): every dim joins the only MG → nothing mutes regardless of selection. Identical to today.
- **Calculated members selected**: don't contribute to the required-MG set (we don't introspect their formulas) → no false-positive muting. Conservative but correct.

## Companion

Depends on no backend ordering — works against any saiku-development. Pairs naturally with the sibling \`Warehouse and Sales\` virtual-cube rewrite PR which is the first realistic multi-MG cube in the shipped FoodMart demo.

## Tests

- \`npm test\` (vitest) — 1009/1009 green
- \`npm run check\` (svelte-check) — 0 errors

## Test plan

- [ ] CI green on development
- [ ] Open \`Warehouse and Sales\`, drop \`Unit Sales\` on measures → Warehouse dim mutes with ⚠
- [ ] Add \`Store Invoice\` → Customer + Promotion also mute
- [ ] Drop \`Store Sales\` (sales-only) from selection → Customer/Promotion re-illuminate
- [ ] Open \`Pharma Rx\` (single-MG) → no muting on any combination of selections