### PR TITLE
security(deps): align Batik to 1.19, drop batik-script 1.7 pin (closes CVE-2022-44730)

### DIFF
--- a/saiku-bom/pom.xml
+++ b/saiku-bom/pom.xml
@@ -337,6 +337,22 @@
                 <artifactId>batik-ext</artifactId>
                 <version>${batik.version}</version>
             </dependency>
+            <!-- batik-script + batik-extension aren't pulled by the managed
+                 coords above, so without an explicit pin they float to old
+                 transitive versions (batik-script resolved to 1.7 — CVE-2022-44730,
+                 fixed 1.17; batik-extension to 1.18). Pin both to ${batik.version}
+                 so the whole Batik set is aligned at 1.19 and CVE-2022-44730 is
+                 closed. -->
+            <dependency>
+                <groupId>org.apache.xmlgraphics</groupId>
+                <artifactId>batik-script</artifactId>
+                <version>${batik.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.xmlgraphics</groupId>
+                <artifactId>batik-extension</artifactId>
+                <version>${batik.version}</version>
+            </dependency>
             <!-- OpenPDF 1.4.2 is the maintained fork of the abandoned
                  com.lowagie:itext:2.1.7. It keeps the same com.lowagie.text.*
                  package (the rename to org.openpdf is a 2.x change), so Saiku's

--- a/saiku-core/saiku-web/pom.xml
+++ b/saiku-core/saiku-web/pom.xml
@@ -237,7 +237,9 @@
         <dependency>
             <groupId>org.apache.xmlgraphics</groupId>
             <artifactId>batik-script</artifactId>
-            <version>1.7</version>
+            <!-- version inherited from saiku-bom (${batik.version}=1.19); the old
+                 hard-pin to 1.7 was CVE-2022-44730 (XSS, fixed 1.17) and left the
+                 Batik set version-skewed. -->
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.xmlgraphics</groupId>


### PR DESCRIPTION
## Summary
Closes the last actionable Dependabot alert — **CVE-2022-44730** (Batik XSS, `batik-script` < 1.17).

Root cause: `saiku-web/pom.xml` declared `batik-script` **directly at `1.7`**, which overrode the BOM and left the vulnerable version on the classpath while every other Batik artifact was managed at **1.19** — a silent version skew.

## Change
- **`saiku-web`**: drop the hard-pinned `<version>1.7</version>` so `batik-script` inherits the BOM (like the sibling `batik-transcoder`/`codec`/`bridge` deps already do). Exclusion kept.
- **`saiku-bom`**: add managed entries for `batik-script` + `batik-extension` at `${batik.version}` — both were floating to old transitive versions (script→1.7, extension→1.18). Now the whole Batik set is aligned at **1.19**.

## Verification
- `dependency:tree`: `batik-script` and `batik-extension` now both resolve to **1.19** (rest already 1.19).
- **saiku-web 407/0** locally (Maven/JDK21) — PDF/SVG export path unaffected.
- Dependency-only diff (2 poms, +19/-1).

🔐 SEC — final cleanup of the dependency-CVE backlog (started in the 4.6.0 dep batch). Remaining 2 alerts are deferred-by-design: esbuild (dev-only, needs vite 6→7) + hadoop-common LOW (hive-2.3.9 compat). Handing to LEAD — not self-merging.
