### PR TITLE
test(security): lock embed-JWT claim-type guards — exp-as-string + alg-as-number (#1104)

### DIFF
--- a/saiku-core/saiku-web/src/test/java/org/saiku/web/security/embed/EmbedJwtTest.java
+++ b/saiku-core/saiku-web/src/test/java/org/saiku/web/security/embed/EmbedJwtTest.java
@@ -163,6 +163,24 @@ public class EmbedJwtTest {
     }
 
     @Test
+    public void exp_as_a_string_is_rejected() {
+        // exp MUST be a JSON number — the verifier guards with isNumber(). A
+        // string "<future>" must NOT be honoured as an expiry, otherwise a token
+        // could dodge the eternal-token rejection by smuggling exp as text
+        // (TextNode.asLong() would happily parse it if the guard were dropped).
+        String p = "{\"sub\":\"u\",\"aud\":\"" + AUD + "\",\"exp\":\"" + FUTURE + "\"}";
+        assertRejected(mint(HS256_HEADER, p, SECRET), "exp as string (not a number)");
+    }
+
+    @Test
+    public void non_string_alg_is_rejected() {
+        // alg as a non-string must not coerce into "HS256". The header check uses
+        // asText(); a numeric 256 stringifies to "256" != "HS256" -> rejected
+        // before any signature work (defends the asText() comparison).
+        assertRejected(mint("{\"alg\":256}", validPayload(), SECRET), "alg as a number");
+    }
+
+    @Test
     public void empty_secret_is_rejected() {
         try {
             EmbedJwt.verify(mint(HS256_HEADER, validPayload(), SECRET), new byte[0], AUD, NOW);


### PR DESCRIPTION
﻿Two adversarial negatives I flagged in the #1345 QA pass, locking the embed JWT verifier's claim-**type** guards (not just claim values):

- **`exp_as_a_string_is_rejected`** — `exp` must be a JSON number (the `isNumber()` guard). A string must not be honoured as an expiry — without the guard, `TextNode.asLong()` would happily parse a string expiry and a token could dodge the eternal-token rejection.
- **`non_string_alg_is_rejected`** — `alg` as a number must not coerce into `"HS256"` via `asText()`; rejected before any signature work.

**Test-only.** `EmbedJwtTest` 16/0 (14 + 2 new); spotless clean; JDK 21. Stacked on the #1104 branch.

> Re the other follow-up from my QA note (forced-filter *binding*): on investigation it's already covered at the `AiSchemaConverter` level — `multipleFiltersOnSameHierarchyRejected` refuses a forced filter colliding with a conflicting same-hierarchy filter (so it can't be *widened* — the query is refused), and distinct-hierarchy filters crossjoin (AND). No new binding test needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
