### PR TITLE
security(deps): vite 6.4.3 + ws 8.21.0 (closes CVE-2026-53571 HIGH + ws DoS)

### DIFF
--- a/saiku-ui/package-lock.json
+++ b/saiku-ui/package-lock.json
@@ -24,7 +24,7 @@
         "svelte": "^5.2.7",
         "svelte-check": "^4.1.0",
         "typescript": "^5.7.2",
-        "vite": "^6.4.2",
+        "vite": "^6.4.3",
         "vitest": "^3.2.6"
       }
     },
@@ -1973,9 +1973,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "6.4.2",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.2.tgz",
-      "integrity": "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==",
+      "version": "6.4.3",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.3.tgz",
+      "integrity": "sha512-NTKlcQjlAK7MlQoyb6LgaqHc8sso/pVyUJYWMws3jg21uTJw/LddqIFPcPqP6PzpgbIcZyKI85sFE4HBrQDA8A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2684,9 +2684,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.20.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
-      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/saiku-ui/package.json
+++ b/saiku-ui/package.json
@@ -24,7 +24,7 @@
     "svelte": "^5.2.7",
     "svelte-check": "^4.1.0",
     "typescript": "^5.7.2",
-    "vite": "^6.4.2",
+    "vite": "^6.4.3",
     "vitest": "^3.2.6"
   },
   "dependencies": {
@@ -37,6 +37,7 @@
   },
   "overrides": {
     "dompurify": "^3.4.0",
-    "cookie": "^0.7.2"
+    "cookie": "^0.7.2",
+    "ws": "^8.21.0"
   }
 }


### PR DESCRIPTION
## Summary
Closes the open **HIGH** UI-side dependency CVEs.

- **vite `^6.4.2` → `^6.4.3`** — closes **CVE-2026-53571 (HIGH)** + **CVE-2026-53632 (medium)**. Stays on vite 6.x (no 6→7 migration). Bonus: pulls esbuild `0.25.12`, which clears the previously-deferred esbuild advisory (no longer flagged by `npm audit`).
- **`ws` override `^8.21.0`** — closes **GHSA-96hv-2xvq-fx4p (HIGH** memory-exhaustion DoS); `ws` is transitive via vite's HMR dev server (dev-only), was pinned at the vulnerable 8.20.1.

## Verification
- `npm audit`: **0 HIGH** remaining (the 2 left — 1 low, 1 moderate — are dompurify, intentionally deferred; see below).
- `svelte-check`: **0 errors**. `vitest`: **1007/1009** — the 2 failures are the pre-existing `saiku-embed` **timeout flakes** that pass **5/5 in isolation** (~7.5s; they only brush the 10s timeout under full-suite parallel load), unrelated to this bump. `npm run build`: green.
- Diff is scoped to vite + ws; **dompurify untouched** (held at 3.4.3).

## Deferred (separate follow-up, not in this PR)
**dompurify → 3.4.11** (its LOW/MED alerts). Bumping it breaks the `TextTile` sanitiser tests under **happy-dom 20** (`<script>` not stripped / `<h2>` dropped) — that's a **happy-dom × dompurify-3.4.11 env incompatibility**, not a real sanitiser regression (3.4.11 is the more-patched release; the live component sanitises correctly). The fix is test-env work (bump happy-dom or move that suite to jsdom), which I won't rush into a HIGH-CVE hotfix by loosening a security assertion. Recommend a QA-paired follow-up.

🔐 SEC — the "cve fix" (vite HIGH). Handing to @AGENT QA then @AGENT LEAD per the order; not self-merging.
