### PR TITLE
security(deps): jackson 2.18.8 (closes CVE-2026-54512/54513 HIGH + SSRF)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
         <jersey.version>3.1.9</jersey.version>
         <maven.build.timestamp.format>yyyyMMdd-HHmm</maven.build.timestamp.format>
         <saiku-query.version>0.4-SNAPSHOT</saiku-query.version>
-        <jackson.version>2.18.6</jackson.version>
+        <jackson.version>2.18.8</jackson.version>
     </properties>
     <repositories>
         <!-- In-tree Maven file-repo for vendored deps that aren't reachable on

--- a/saiku-bom/pom.xml
+++ b/saiku-bom/pom.xml
@@ -38,7 +38,7 @@
         <batik.version>1.19</batik.version>
         <jersey.version>3.1.9</jersey.version>
         <saiku-query.version>0.4-SNAPSHOT</saiku-query.version>
-        <jackson.version>2.18.6</jackson.version>
+        <jackson.version>2.18.8</jackson.version>
         <arrow.version>18.2.0</arrow.version>
         <caffeine.version>3.2.4</caffeine.version>
         <!-- JSON Schema (draft 2020-12) validator for the AiQueryRequest


### PR DESCRIPTION
## Summary
Closes **2 HIGH** jackson-databind CVEs (+ 1 medium SSRF) via an in-line patch bump **2.18.6 → 2.18.8** (BOM + root-pom shadow; no minor/major change).

| CVE | Sev | What | Fixed |
|---|---|---|---|
| CVE-2026-54512 | **HIGH** | PolymorphicTypeValidator bypass via generic type params → arbitrary class instantiation | 2.18.8 |
| CVE-2026-54513 | **HIGH** | array subtype allowlist bypass in `BasicPolymorphicTypeValidator` (`allowIfSubTypeIsArray`) | 2.18.8 |
| CVE-2026-54514 | medium | `InetSocketAddress` deserialization → eager DNS resolution (SSRF) | 2.18.8 |

## Verification
- **saiku-web 419/0** + saiku-service green with 2.18.8 (Maven/JDK21) — jackson is heaviest in the REST/DTO/AI-serialization layer (saiku-web), all clean.
- Java-only diff (2 poms, version property). 
- *Note:* a full-reactor `verify` hit an unrelated `saiku-webapp` **npm-build SIGABRT (exit 134)** — an environmental Node crash in the UI build step, **not** this Java dependency bump (the UI builds clean standalone, as verified on #1359). CI builds the UI in its own resourced step.

## Deferred (not fixable in-line)
**CVE-2026-54515** (medium — case-insensitive `@JsonIgnoreProperties` bypass) is fixed in **2.18.9**, which **isn't published** (the 2.18.x line tops out at 2.18.8). Deferred until 2.18.9 lands or a planned 2.19+ move — not worth a minor-line jump for one residual medium.

🔐 SEC — both HIGHs closed. Handing to @AGENT QA then @AGENT LEAD per the order; not self-merging.
