### PR TITLE
feat(embed): host-page chart theming via CSS custom properties (#1103)

### DIFF
--- a/saiku-ui/src/embed/EmbedChart.svelte
+++ b/saiku-ui/src/embed/EmbedChart.svelte
@@ -24,6 +24,8 @@
   import { CanvasRenderer } from "echarts/renderers";
   import type { EChartsType, ECBasicOption } from "echarts/types/dist/shared";
   import type { EmbedRow } from "./types";
+  // #1103: host-page chart theming via CSS custom properties.
+  import { readEmbedChartTheme, type EmbedChartTheme } from "./embedChartTheme";
 
   // Register modules once at module scope. ECharts dedupes a repeat
   // `use()` so this is safe across many <saiku-embed> instances.
@@ -69,7 +71,14 @@
    * shifts (e.g. a column appearing / disappearing). */
   $effect(() => {
     if (!chart) return;
-    const opt = buildOption(rows, mode);
+    // #1103: resolve host-set chart theming from CSS vars on this element
+    // (custom properties inherit through the shadow boundary). Unstyled →
+    // empty theme → ECharts defaults (back-compat).
+    const el = container;
+    const theme: EmbedChartTheme = el
+      ? readEmbedChartTheme((n) => getComputedStyle(el).getPropertyValue(n))
+      : { palette: [] };
+    const opt = buildOption(rows, mode, theme);
     chart.setOption(opt, { notMerge: true });
   });
 
@@ -82,10 +91,19 @@
     return true;
   }
 
-  function buildOption(rs: EmbedRow[], chartMode: string): ECBasicOption {
+  function buildOption(rs: EmbedRow[], chartMode: string, theme: EmbedChartTheme): ECBasicOption {
+    const fg = theme.fg;
+    const axisColor = theme.axisLine;
+    // #1103: host-set series palette → ECharts `color` cycle. Spread so an
+    // unstyled embed emits no `color` key (output byte-identical to pre-#1103).
+    const colorOpt: ECBasicOption = theme.palette.length ? { color: theme.palette } : {};
+    const legendOpt = { bottom: 0, ...(fg ? { textStyle: { color: fg } } : {}) };
+    const fgText = fg ? { color: fg } : {};
+    const axisLineOpt = axisColor ? { axisLine: { lineStyle: { color: axisColor } } } : {};
+
     if (rs.length === 0) {
       return {
-        title: { text: "No data", left: "center", top: "middle", textStyle: { fontSize: 12 } },
+        title: { text: "No data", left: "center", top: "middle", textStyle: { fontSize: 12, ...fgText } },
       };
     }
     const cols = Object.keys(rs[0]);
@@ -97,15 +115,16 @@
       // Pie uses the FIRST numeric column only — falls back to a bar
       // chart if there isn't one.
       const valCol = numericCols[0];
-      if (!valCol) return { title: { text: "No numeric series" } };
+      if (!valCol) return { title: { text: "No numeric series", textStyle: { ...fgText } } };
       return {
+        ...colorOpt,
         tooltip: { trigger: "item" },
-        legend: { bottom: 0 },
+        legend: legendOpt,
         series: [
           {
             type: "pie",
             radius: ["40%", "70%"],
-            label: { show: true, formatter: "{b}: {d}%" },
+            label: { show: true, formatter: "{b}: {d}%", ...fgText },
             data: rs.map((r) => ({
               name: r[categoryCol]?.formatted ?? "",
               value: r[valCol]?.value ?? 0,
@@ -116,6 +135,7 @@
     }
 
     return {
+      ...colorOpt,
       tooltip: {
         trigger: "axis",
         // ECharts default tooltip is bare numbers; replace with the
@@ -138,14 +158,20 @@
           return `<b>${cat}</b><br/>${lines}`;
         },
       },
-      legend: { bottom: 0 },
+      legend: legendOpt,
       grid: { left: 40, right: 16, top: 24, bottom: 36, containLabel: true },
       xAxis: {
         type: "category",
         data: categories,
-        axisLabel: { interval: 0, rotate: categories.length > 8 ? -30 : 0 },
+        axisLabel: { interval: 0, rotate: categories.length > 8 ? -30 : 0, ...fgText },
+        ...axisLineOpt,
       },
-      yAxis: { type: "value" },
+      yAxis: {
+        type: "value",
+        ...(fg ? { axisLabel: { color: fg } } : {}),
+        ...axisLineOpt,
+        ...(axisColor ? { splitLine: { lineStyle: { color: axisColor } } } : {}),
+      },
       series: numericCols.map((c) => ({
         name: c,
         type: chartMode === "line" ? ("line" as const) : ("bar" as const),

--- a/saiku-ui/src/embed/EmbedChart.svelte
+++ b/saiku-ui/src/embed/EmbedChart.svelte
@@ -22,10 +22,11 @@
     TooltipComponent,
   } from "echarts/components";
   import { CanvasRenderer } from "echarts/renderers";
-  import type { EChartsType, ECBasicOption } from "echarts/types/dist/shared";
+  import type { EChartsType } from "echarts/types/dist/shared";
   import type { EmbedRow } from "./types";
   // #1103: host-page chart theming via CSS custom properties.
   import { readEmbedChartTheme, type EmbedChartTheme } from "./embedChartTheme";
+  import { buildEmbedChartOption } from "./embedChartOption";
 
   // Register modules once at module scope. ECharts dedupes a repeat
   // `use()` so this is safe across many <saiku-embed> instances.
@@ -78,107 +79,9 @@
     const theme: EmbedChartTheme = el
       ? readEmbedChartTheme((n) => getComputedStyle(el).getPropertyValue(n))
       : { palette: [] };
-    const opt = buildOption(rows, mode, theme);
+    const opt = buildEmbedChartOption(rows, mode, theme);
     chart.setOption(opt, { notMerge: true });
   });
-
-  function isNumericColumn(rs: EmbedRow[], col: string): boolean {
-    for (const r of rs) {
-      const v = r[col]?.value;
-      if (v === null || v === undefined) continue;
-      if (typeof v !== "number" || Number.isNaN(v)) return false;
-    }
-    return true;
-  }
-
-  function buildOption(rs: EmbedRow[], chartMode: string, theme: EmbedChartTheme): ECBasicOption {
-    const fg = theme.fg;
-    const axisColor = theme.axisLine;
-    // #1103: host-set series palette → ECharts `color` cycle. Spread so an
-    // unstyled embed emits no `color` key (output byte-identical to pre-#1103).
-    const colorOpt: ECBasicOption = theme.palette.length ? { color: theme.palette } : {};
-    const legendOpt = { bottom: 0, ...(fg ? { textStyle: { color: fg } } : {}) };
-    const fgText = fg ? { color: fg } : {};
-    const axisLineOpt = axisColor ? { axisLine: { lineStyle: { color: axisColor } } } : {};
-
-    if (rs.length === 0) {
-      return {
-        title: { text: "No data", left: "center", top: "middle", textStyle: { fontSize: 12, ...fgText } },
-      };
-    }
-    const cols = Object.keys(rs[0]);
-    const numericCols = cols.filter((c) => isNumericColumn(rs, c));
-    const categoryCol = cols.find((c) => !isNumericColumn(rs, c)) ?? cols[0];
-    const categories = rs.map((r) => r[categoryCol]?.formatted ?? "");
-
-    if (chartMode === "pie") {
-      // Pie uses the FIRST numeric column only — falls back to a bar
-      // chart if there isn't one.
-      const valCol = numericCols[0];
-      if (!valCol) return { title: { text: "No numeric series", textStyle: { ...fgText } } };
-      return {
-        ...colorOpt,
-        tooltip: { trigger: "item" },
-        legend: legendOpt,
-        series: [
-          {
-            type: "pie",
-            radius: ["40%", "70%"],
-            label: { show: true, formatter: "{b}: {d}%", ...fgText },
-            data: rs.map((r) => ({
-              name: r[categoryCol]?.formatted ?? "",
-              value: r[valCol]?.value ?? 0,
-            })),
-          },
-        ],
-      };
-    }
-
-    return {
-      ...colorOpt,
-      tooltip: {
-        trigger: "axis",
-        // ECharts default tooltip is bare numbers; replace with the
-        // pre-formatted cells from the server so the host page sees
-        // the same caption the workbench would. The trigger fires
-        // once per category with all series, so we walk the params.
-        formatter: (params: unknown) => {
-          const arr = Array.isArray(params) ? params : [params];
-          // arr[0].axisValue is the category caption; per-series .seriesName + .dataIndex
-          const cat = (arr[0] as { axisValue?: string }).axisValue ?? "";
-          const lines = arr
-            .map((p) => {
-              const idx = (p as { dataIndex: number }).dataIndex;
-              const name = (p as { seriesName: string }).seriesName;
-              const cell = rs[idx]?.[name];
-              const disp = cell?.formatted ?? String((p as { value: unknown }).value ?? "");
-              return `${name}: ${disp}`;
-            })
-            .join("<br/>");
-          return `<b>${cat}</b><br/>${lines}`;
-        },
-      },
-      legend: legendOpt,
-      grid: { left: 40, right: 16, top: 24, bottom: 36, containLabel: true },
-      xAxis: {
-        type: "category",
-        data: categories,
-        axisLabel: { interval: 0, rotate: categories.length > 8 ? -30 : 0, ...fgText },
-        ...axisLineOpt,
-      },
-      yAxis: {
-        type: "value",
-        ...(fg ? { axisLabel: { color: fg } } : {}),
-        ...axisLineOpt,
-        ...(axisColor ? { splitLine: { lineStyle: { color: axisColor } } } : {}),
-      },
-      series: numericCols.map((c) => ({
-        name: c,
-        type: chartMode === "line" ? ("line" as const) : ("bar" as const),
-        data: rs.map((r) => r[c]?.value ?? null),
-      })),
-    };
-  }
 </script>
 
 <div bind:this={container} class="chart" role="img" aria-label="Saiku embed chart"></div>

--- a/saiku-ui/src/embed/README.md
+++ b/saiku-ui/src/embed/README.md
@@ -161,6 +161,28 @@ saiku-embed {
 }
 ```
 
+### Theming the chart itself
+
+The variables above style the embed **chrome** (frame, header, table). To brand
+the **chart series + axes**, set these (custom properties inherit through the
+shadow boundary, so the canvas chart picks them up):
+
+```css
+saiku-embed {
+  /* Series colour cycle — set as many as you need, 1..8, contiguously.
+     Any unset → the chart falls back to the built-in palette. */
+  --saiku-embed-chart-1: #2563eb;
+  --saiku-embed-chart-2: #16a34a;
+  --saiku-embed-chart-3: #dc2626;
+  /* …up to --saiku-embed-chart-8 */
+
+  /* Axis labels / legend / titles use --saiku-embed-fg;
+     axis + split lines use --saiku-embed-muted (both shared with the chrome). */
+}
+```
+
+An embed with none of these set renders exactly as before (ECharts defaults).
+
 ## Security model
 
 - **Header-only token transport.** The token travels as

--- a/saiku-ui/src/embed/embedChartOption.test.ts
+++ b/saiku-ui/src/embed/embedChartOption.test.ts
@@ -1,0 +1,84 @@
+/*
+ * #1103 fast-follow — unit coverage for the embed chart's APPLIER
+ * (buildEmbedChartOption), extracted from EmbedChart.svelte. The reader
+ * (embedChartTheme.test.ts) proves the CSS vars parse correctly; this proves
+ * the parsed theme maps onto the ECharts option AND — the crux — that an
+ * unstyled embed emits the same option as pre-#1103 (no color/fg/axisLine
+ * keys). Without this, a future buildOption refactor could silently break the
+ * byte-identical back-compat guarantee with no red test.
+ */
+import { describe, test, expect } from "vitest";
+import { buildEmbedChartOption } from "./embedChartOption";
+import type { EmbedRow } from "./types";
+import type { EmbedChartTheme } from "./embedChartTheme";
+
+// A non-numeric `value` makes the column a category axis (isNumericColumn → false);
+// row-header cells carry the caption. Type it loosely for the fixture.
+const cat = (label: string) => ({ value: label as unknown as number, formatted: label });
+const num = (n: number) => ({ value: n, formatted: String(n) });
+
+const ROWS: EmbedRow[] = [
+  { Country: cat("France"), Sales: num(100), Units: num(5) },
+  { Country: cat("Spain"), Sales: num(200), Units: num(8) },
+];
+
+const UNSTYLED: EmbedChartTheme = { palette: [] };
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+describe("buildEmbedChartOption", () => {
+  test("unstyled (no vars) emits NO color/fg/axisLine keys — byte-identical to pre-#1103", () => {
+    const opt = buildEmbedChartOption(ROWS, "bar", UNSTYLED) as any;
+    expect(opt.color).toBeUndefined(); // no host palette → no `color` key
+    expect(opt.legend.textStyle).toBeUndefined(); // no fg → no legend textStyle
+    expect(opt.xAxis.axisLabel.color).toBeUndefined(); // no fg → no x label colour
+    expect(opt.xAxis.axisLine).toBeUndefined(); // no axisLine theme on x
+    expect(opt.yAxis.axisLabel).toBeUndefined(); // no fg → no y label colour
+    expect(opt.yAxis.axisLine).toBeUndefined();
+    expect(opt.yAxis.splitLine).toBeUndefined();
+  });
+
+  test("each numeric column becomes its own bar series; the non-numeric column is the category axis", () => {
+    const opt = buildEmbedChartOption(ROWS, "bar", UNSTYLED) as any;
+    expect(opt.series.map((s: any) => s.name)).toEqual(["Sales", "Units"]);
+    expect(opt.series.every((s: any) => s.type === "bar")).toBe(true);
+    expect(opt.xAxis.data).toEqual(["France", "Spain"]);
+  });
+
+  test("host palette → ECharts `color` cycle", () => {
+    const opt = buildEmbedChartOption(ROWS, "bar", { palette: ["#2563eb", "#16a34a", "#dc2626"] }) as any;
+    expect(opt.color).toEqual(["#2563eb", "#16a34a", "#dc2626"]);
+  });
+
+  test("fg themes axis labels + legend text", () => {
+    const opt = buildEmbedChartOption(ROWS, "bar", { palette: [], fg: "#ffffff" }) as any;
+    expect(opt.legend.textStyle.color).toBe("#ffffff");
+    expect(opt.xAxis.axisLabel.color).toBe("#ffffff");
+    expect(opt.yAxis.axisLabel.color).toBe("#ffffff");
+  });
+
+  test("axisLine (muted) themes both axis lines + the y splitLine", () => {
+    const opt = buildEmbedChartOption(ROWS, "bar", { palette: [], axisLine: "#cccccc" }) as any;
+    expect(opt.xAxis.axisLine.lineStyle.color).toBe("#cccccc");
+    expect(opt.yAxis.axisLine.lineStyle.color).toBe("#cccccc");
+    expect(opt.yAxis.splitLine.lineStyle.color).toBe("#cccccc");
+  });
+
+  test("line mode → line series", () => {
+    const opt = buildEmbedChartOption(ROWS, "line", UNSTYLED) as any;
+    expect(opt.series.every((s: any) => s.type === "line")).toBe(true);
+  });
+
+  test("pie mode → a single pie series on the first numeric column, honouring the palette", () => {
+    const opt = buildEmbedChartOption(ROWS, "pie", { palette: ["#abc"] }) as any;
+    expect(opt.series).toHaveLength(1);
+    expect(opt.series[0].type).toBe("pie");
+    expect(opt.color).toEqual(["#abc"]); // palette still applies in pie mode
+    expect(opt.series[0].data.map((d: any) => d.value)).toEqual([100, 200]); // first numeric col = Sales
+  });
+
+  test("empty rows → 'No data' title, still no color key when unstyled", () => {
+    const opt = buildEmbedChartOption([], "bar", UNSTYLED) as any;
+    expect(opt.title.text).toBe("No data");
+    expect(opt.color).toBeUndefined();
+  });
+});

--- a/saiku-ui/src/embed/embedChartOption.ts
+++ b/saiku-ui/src/embed/embedChartOption.ts
@@ -1,0 +1,108 @@
+/*
+ * #1103 — the pure records→ECharts option builder for the embed chart,
+ * extracted verbatim from EmbedChart.svelte so the host-theme var→ECharts
+ * mapping (and the "byte-identical when unstyled" back-compat guarantee) is
+ * unit-testable without standing up the Svelte component or a live ECharts
+ * canvas. Behaviour-preserving: EmbedChart.svelte now imports buildEmbedChartOption.
+ */
+import type { ECBasicOption } from "echarts/types/dist/shared";
+import type { EmbedChartTheme } from "./embedChartTheme";
+import type { EmbedRow } from "./types";
+
+function isNumericColumn(rs: EmbedRow[], col: string): boolean {
+  for (const r of rs) {
+    const v = r[col]?.value;
+    if (v === null || v === undefined) continue;
+    if (typeof v !== "number" || Number.isNaN(v)) return false;
+  }
+  return true;
+}
+
+export function buildEmbedChartOption(rs: EmbedRow[], chartMode: string, theme: EmbedChartTheme): ECBasicOption {
+  const fg = theme.fg;
+  const axisColor = theme.axisLine;
+  // #1103: host-set series palette → ECharts `color` cycle. Spread so an
+  // unstyled embed emits no `color` key (output byte-identical to pre-#1103).
+  const colorOpt: ECBasicOption = theme.palette.length ? { color: theme.palette } : {};
+  const legendOpt = { bottom: 0, ...(fg ? { textStyle: { color: fg } } : {}) };
+  const fgText = fg ? { color: fg } : {};
+  const axisLineOpt = axisColor ? { axisLine: { lineStyle: { color: axisColor } } } : {};
+
+  if (rs.length === 0) {
+    return {
+      title: { text: "No data", left: "center", top: "middle", textStyle: { fontSize: 12, ...fgText } },
+    };
+  }
+  const cols = Object.keys(rs[0]);
+  const numericCols = cols.filter((c) => isNumericColumn(rs, c));
+  const categoryCol = cols.find((c) => !isNumericColumn(rs, c)) ?? cols[0];
+  const categories = rs.map((r) => r[categoryCol]?.formatted ?? "");
+
+  if (chartMode === "pie") {
+    // Pie uses the FIRST numeric column only — falls back to a bar
+    // chart if there isn't one.
+    const valCol = numericCols[0];
+    if (!valCol) return { title: { text: "No numeric series", textStyle: { ...fgText } } };
+    return {
+      ...colorOpt,
+      tooltip: { trigger: "item" },
+      legend: legendOpt,
+      series: [
+        {
+          type: "pie",
+          radius: ["40%", "70%"],
+          label: { show: true, formatter: "{b}: {d}%", ...fgText },
+          data: rs.map((r) => ({
+            name: r[categoryCol]?.formatted ?? "",
+            value: r[valCol]?.value ?? 0,
+          })),
+        },
+      ],
+    };
+  }
+
+  return {
+    ...colorOpt,
+    tooltip: {
+      trigger: "axis",
+      // ECharts default tooltip is bare numbers; replace with the
+      // pre-formatted cells from the server so the host page sees
+      // the same caption the workbench would. The trigger fires
+      // once per category with all series, so we walk the params.
+      formatter: (params: unknown) => {
+        const arr = Array.isArray(params) ? params : [params];
+        // arr[0].axisValue is the category caption; per-series .seriesName + .dataIndex
+        const cat = (arr[0] as { axisValue?: string }).axisValue ?? "";
+        const lines = arr
+          .map((p) => {
+            const idx = (p as { dataIndex: number }).dataIndex;
+            const name = (p as { seriesName: string }).seriesName;
+            const cell = rs[idx]?.[name];
+            const disp = cell?.formatted ?? String((p as { value: unknown }).value ?? "");
+            return `${name}: ${disp}`;
+          })
+          .join("<br/>");
+        return `<b>${cat}</b><br/>${lines}`;
+      },
+    },
+    legend: legendOpt,
+    grid: { left: 40, right: 16, top: 24, bottom: 36, containLabel: true },
+    xAxis: {
+      type: "category",
+      data: categories,
+      axisLabel: { interval: 0, rotate: categories.length > 8 ? -30 : 0, ...fgText },
+      ...axisLineOpt,
+    },
+    yAxis: {
+      type: "value",
+      ...(fg ? { axisLabel: { color: fg } } : {}),
+      ...axisLineOpt,
+      ...(axisColor ? { splitLine: { lineStyle: { color: axisColor } } } : {}),
+    },
+    series: numericCols.map((c) => ({
+      name: c,
+      type: chartMode === "line" ? ("line" as const) : ("bar" as const),
+      data: rs.map((r) => r[c]?.value ?? null),
+    })),
+  };
+}

--- a/saiku-ui/src/embed/embedChartTheme.test.ts
+++ b/saiku-ui/src/embed/embedChartTheme.test.ts
@@ -1,0 +1,71 @@
+/*
+ * Unit tests for the #1103 embed chart-theming reader.
+ */
+
+import { describe, test, expect } from "vitest";
+import { readEmbedChartTheme, hasEmbedChartTheme } from "./embedChartTheme";
+
+/** Build a CSS-var getter from a plain map (missing keys → ""). */
+function getter(vars: Record<string, string>): (name: string) => string {
+  return (name) => vars[name] ?? "";
+}
+
+describe("readEmbedChartTheme", () => {
+  test("no vars set → empty palette, no fg/axisLine (unstyled = ECharts default)", () => {
+    const t = readEmbedChartTheme(getter({}));
+    expect(t.palette).toEqual([]);
+    expect(t.fg).toBeUndefined();
+    expect(t.axisLine).toBeUndefined();
+    expect(hasEmbedChartTheme(t)).toBe(false);
+  });
+
+  test("reads a contiguous palette from chart-1..N", () => {
+    const t = readEmbedChartTheme(
+      getter({
+        "--saiku-embed-chart-1": "#2563eb",
+        "--saiku-embed-chart-2": "#16a34a",
+        "--saiku-embed-chart-3": "#dc2626",
+      }),
+    );
+    expect(t.palette).toEqual(["#2563eb", "#16a34a", "#dc2626"]);
+    expect(hasEmbedChartTheme(t)).toBe(true);
+  });
+
+  test("stops at the first gap (a missing index doesn't reorder the cycle)", () => {
+    const t = readEmbedChartTheme(
+      getter({
+        "--saiku-embed-chart-1": "#111",
+        "--saiku-embed-chart-2": "#222",
+        // 3 unset
+        "--saiku-embed-chart-4": "#444",
+      }),
+    );
+    expect(t.palette).toEqual(["#111", "#222"]);
+  });
+
+  test("caps at 8 colours", () => {
+    const vars: Record<string, string> = {};
+    for (let i = 1; i <= 12; i++) vars[`--saiku-embed-chart-${i}`] = `#${i}`;
+    expect(readEmbedChartTheme(getter(vars)).palette).toHaveLength(8);
+  });
+
+  test("trims whitespace; blank var is treated as unset", () => {
+    const t = readEmbedChartTheme(
+      getter({
+        "--saiku-embed-chart-1": "  #abc  ",
+        "--saiku-embed-fg": "  #1f2937 ",
+        "--saiku-embed-muted": "   ",
+      }),
+    );
+    expect(t.palette).toEqual(["#abc"]);
+    expect(t.fg).toBe("#1f2937");
+    expect(t.axisLine).toBeUndefined(); // whitespace-only → unset
+  });
+
+  test("fg / axisLine without a palette still counts as themed", () => {
+    const t = readEmbedChartTheme(getter({ "--saiku-embed-fg": "#fff" }));
+    expect(t.palette).toEqual([]);
+    expect(t.fg).toBe("#fff");
+    expect(hasEmbedChartTheme(t)).toBe(true);
+  });
+});

--- a/saiku-ui/src/embed/embedChartTheme.ts
+++ b/saiku-ui/src/embed/embedChartTheme.ts
@@ -1,0 +1,49 @@
+/*
+ * issue #1103 — host-page chart theming for <saiku-embed>.
+ *
+ * The host page styles the embedded CHART (not just the chrome) via CSS custom
+ * properties on the element:
+ *
+ *   saiku-embed {
+ *     --saiku-embed-chart-1: #2563eb;   ... up to --saiku-embed-chart-8
+ *     --saiku-embed-fg:      #1f2937;    // axis labels / legend / titles
+ *     --saiku-embed-muted:   #9ca3af;    // axis + split lines
+ *   }
+ *
+ * CSS custom properties inherit THROUGH the shadow boundary, so they're
+ * readable via getComputedStyle on any element inside the component. Pure: the
+ * reader takes a `(varName) => value` lookup so it unit-tests without a DOM.
+ */
+
+export interface EmbedChartTheme {
+  /** Series colour cycle, in order. Empty → ECharts' built-in palette (the
+   *  pre-#1103 default, so an unstyled embed is unchanged). */
+  palette: string[];
+  /** Text colour for axis labels, legend and titles (`--saiku-embed-fg`). */
+  fg?: string;
+  /** Colour for axis + split lines (`--saiku-embed-muted`). */
+  axisLine?: string;
+}
+
+/**
+ * Resolve the chart theme from a CSS-var getter. The palette is read
+ * **contiguously** from `--saiku-embed-chart-1` and stops at the first unset
+ * index, so `1,2,3` set → a 3-colour cycle (a gap doesn't silently reorder).
+ */
+export function readEmbedChartTheme(getVar: (name: string) => string): EmbedChartTheme {
+  const palette: string[] = [];
+  for (let i = 1; i <= 8; i++) {
+    const v = (getVar(`--saiku-embed-chart-${i}`) || "").trim();
+    if (!v) break;
+    palette.push(v);
+  }
+  const fg = (getVar("--saiku-embed-fg") || "").trim() || undefined;
+  const axisLine = (getVar("--saiku-embed-muted") || "").trim() || undefined;
+  return { palette, fg, axisLine };
+}
+
+/** Has the host actually set any chart theme var? (Lets the renderer skip
+ *  emitting empty style objects when the embed is unstyled.) */
+export function hasEmbedChartTheme(t: EmbedChartTheme): boolean {
+  return t.palette.length > 0 || !!t.fg || !!t.axisLine;
+}


### PR DESCRIPTION
## Summary
The `<saiku-embed>` chrome was already themeable, but the embedded **chart** rendered with ECharts' default palette and axis colours regardless of the host theme. This adds host-page theming of the chart series + axes via CSS custom properties. Frontend-only, additive, **fully back-compatible**.

## The change
Set these on `saiku-embed` in the host page (custom properties inherit through the shadow boundary, so the canvas chart reads them):
- `--saiku-embed-chart-1..8` — the series colour cycle (read contiguously from 1; any unset → the built-in palette).
- `--saiku-embed-fg` — axis labels / legend / titles; `--saiku-embed-muted` — axis + split lines (both already used for the chrome).

A pure reader (`embedChartTheme.ts`) resolves the vars; `EmbedChart` applies them to the ECharts `color` palette + axis/text colours. An embed with none set renders byte-identical to before.

## Verified
- svelte-check 0 errors, vitest 1015/1015 (incl. 6 new `embedChartTheme` tests: contiguous palette, gap-stop, 8-cap, trim/blank-as-unset, fg/axisLine), embed bundle builds.
- Eyeballed locally: default vs branded charts side-by-side — series, axis text and grid lines recolour to the host palette; an unstyled embed is unchanged.

## Scope
This is the chart-theming half of #1103. The `<saiku-chart>` / `<saiku-dashboard>` tag-split is intentionally skipped — the single `<saiku-embed>` tag already embeds both a query and a dashboard, so splitting it is churn an embedder doesn't need. Closes the "theme tokens reach the chrome but not the chart" gap from the embed review.

## Notes
Touches the published `@concepttocloud/saiku-embed` component, but additively (new optional CSS vars; no API/markup change). README updated with a "Theming the chart itself" section.