### PR TITLE
feat(ai-ask): carve NL ask LLM layer onto development with insight + view-change tools

### DIFF
--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ai/ask/AbstractNlAskProvider.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ai/ask/AbstractNlAskProvider.java
@@ -5,6 +5,7 @@
 package org.saiku.service.olap.ai.ask;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import java.io.IOException;
 import java.net.URI;
@@ -32,11 +33,25 @@ import java.time.Duration;
  */
 abstract class AbstractNlAskProvider implements NlAskProvider {
 
-    /** Name of the structured-output tool/function both providers ask the model to call. */
+    /** Name of the query-building tool. Picks when the user wants new data / a new breakdown. */
     protected static final String TOOL_NAME = "emit_query";
 
     /** Name of the off-topic refusal tool/function — the scope guardrail (security control). */
     protected static final String REFUSAL_TOOL_NAME = "refuse_off_topic";
+
+    /**
+     * Name of the insight tool — picks when the user asks for analysis of the currently-rendered
+     * cellset ("spot trends", "what's interesting", "summarise this"). No query is built; the model
+     * just returns markdown commentary on the cellset digest it was given.
+     */
+    protected static final String INSIGHT_TOOL_NAME = "emit_insight";
+
+    /**
+     * Name of the view-change tool — picks when the user asks to change how the existing cellset is
+     * displayed ("switch to chart", "show this as a bar chart", "back to grid"). No query is built;
+     * the UI applies viewMode + chartType.
+     */
+    protected static final String VIEW_CHANGE_TOOL_NAME = "emit_view_change";
 
     /** Prefix on the degraded reason when the model refuses an off-topic question. */
     protected static final String REFUSAL_REASON_PREFIX = "OFF_TOPIC: ";
@@ -132,5 +147,102 @@ abstract class AbstractNlAskProvider implements NlAskProvider {
             return "";
         }
         return s.length() <= max ? s : s.substring(0, max) + "...";
+    }
+
+    /**
+     * Builds the JSON Schema for the {@code emit_insight} tool's input. Provider-agnostic — both
+     * Anthropic and OpenAI consume the same {@code {"type":"object", "properties":...}} shape under
+     * their respective tool/function definitions.
+     *
+     * <p>Two fields: {@code markdown} (required, the analysis body) and {@code headline} (optional
+     * 1-line summary the drawer can render above the body).
+     */
+    protected static ObjectNode insightInputSchema() {
+        ObjectNode root = MAPPER.createObjectNode();
+        root.put("type", "object");
+        ObjectNode props = root.putObject("properties");
+        ObjectNode markdown = props.putObject("markdown");
+        markdown.put("type", "string");
+        markdown.put(
+                "description",
+                "The analysis itself as markdown — paragraphs, bullets, optional small tables. "
+                        + "Keep it tight: 3-8 sentences for trend questions, 1-2 paragraphs for deeper "
+                        + "asks. Reference specific row/column captions and figures from the cellset "
+                        + "digest provided as context. Do NOT include the user's question back to them, "
+                        + "do NOT prefix with 'Here is an analysis'.");
+        ObjectNode headline = props.putObject("headline");
+        headline.put("type", "string");
+        headline.put(
+                "description",
+                "Optional 1-line headline (<=80 chars) shown above the markdown body in the drawer. "
+                        + "Example: 'Revenue concentrated in Q4; CA leads by 38%.'");
+        root.putArray("required").add("markdown");
+        return root;
+    }
+
+    /**
+     * Builds the JSON Schema for the {@code emit_view_change} tool's input. {@code viewMode} +
+     * {@code chartType} are constrained to the canonical catalog in {@link AiViewChangeCatalog}; the
+     * routing layer rejects any value outside the enum lists.
+     *
+     * <p>The tool description (per-provider, not here) enumerates the chart-type catalog with hints
+     * so the model has enough context to pick well.
+     */
+    protected static ObjectNode viewChangeInputSchema() {
+        ObjectNode root = MAPPER.createObjectNode();
+        root.put("type", "object");
+        ObjectNode props = root.putObject("properties");
+
+        ObjectNode viewMode = props.putObject("viewMode");
+        viewMode.put("type", "string");
+        ArrayNode viewEnum = viewMode.putArray("enum");
+        for (String v : AiViewChangeCatalog.VIEW_MODES) {
+            viewEnum.add(v);
+        }
+        viewMode.put("description", "Target view mode: 'grid' for tabular cellset, 'chart' for a chart render.");
+
+        ObjectNode chartType = props.putObject("chartType");
+        chartType.put("type", "string");
+        ArrayNode chartEnum = chartType.putArray("enum");
+        for (String id : AiViewChangeCatalog.CHART_TYPE_IDS) {
+            chartEnum.add(id);
+        }
+        chartType.put(
+                "description",
+                "Chart-type id. Only meaningful when viewMode='chart'. Pick the one that fits the "
+                        + "cellset shape: line/area for time series, bar/stackedBar for categorical "
+                        + "comparisons, pie/donut/treemap for part-to-whole with few categories, "
+                        + "heatmap for matrix views, map for geo dims. See the per-id hints above.");
+
+        ObjectNode reason = props.putObject("reason");
+        reason.put("type", "string");
+        reason.put(
+                "description",
+                "Optional 1-sentence rationale shown in the drawer "
+                        + "('Time-series → line chart fits best.', 'Few categories → pie.').");
+
+        root.putArray("required").add("viewMode");
+        return root;
+    }
+
+    /**
+     * Build a human-readable enumeration of the chart-type catalog suitable for inclusion in the
+     * tool description. Each line: {@code "- <id> (<label>, <group>): <hint>"}. The LLM reads this
+     * once to learn what each id maps to so it picks sensibly.
+     */
+    protected static String chartTypeCatalogText() {
+        StringBuilder sb = new StringBuilder();
+        for (java.util.Map<String, String> entry : AiViewChangeCatalog.CHART_TYPES) {
+            sb.append("- ")
+                    .append(entry.get("id"))
+                    .append(" (")
+                    .append(entry.get("label"))
+                    .append(", ")
+                    .append(entry.get("group"))
+                    .append("): ")
+                    .append(entry.get("hint"))
+                    .append('\n');
+        }
+        return sb.toString();
     }
 }

--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ai/ask/AiAskApi.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ai/ask/AiAskApi.java
@@ -7,6 +7,7 @@ package org.saiku.service.olap.ai.ask;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import java.util.ArrayList;
 import java.util.List;
+import org.saiku.olap.query2.ThinQueryModel;
 import org.saiku.service.olap.ai.AiCubeRef;
 import org.saiku.service.olap.ai.AiQueryRequest;
 import org.saiku.service.olap.ai.AiQueryResponse;
@@ -26,6 +27,31 @@ public final class AiAskApi {
         private String question;
         private AiCubeRef cube;
         private List<NlAskMessageDto> history;
+        /**
+         * Optional markdown digest of the user's currently-rendered cellset (built client-side from
+         * {@code query.result}). When present, the model can route to the {@code emit_insight} tool
+         * ('spot trends') or pick a sensible chart for {@code emit_view_change}. When absent, only
+         * {@code emit_query} is realistically reachable. Subject to {@code AiPolicyGuard} on the
+         * server — schema-only mode strips the digest before it reaches the LLM.
+         */
+        private String cellsetDigest;
+        /**
+         * Optional override of the model's tool choice. When null/empty (default), the model picks
+         * among all four tools (query / insight / view_change / refusal). When set to "query" /
+         * "insight" / "view_change" the server narrows the tool list to that one + refusal, so the
+         * model can't route to a different intent for this turn. UX: the drawer surfaces this as a
+         * segmented "Auto / Query / Insight / View" picker above the input — Auto leaves this null.
+         */
+        private String forceTool;
+        /**
+         * Optional snapshot of the user's current AiQueryRequest (projected from the live
+         * queryModel client-side). When present, the LLM sees the existing query as context and is
+         * instructed to PRESERVE fields the user didn't ask to change — e.g. "add therapeutic
+         * class to columns" extends the cube view rather than wiping rows / filters / measures
+         * the user already chose. Type is the raw AiQueryRequest wire shape; we deserialize it
+         * back into an AiQueryRequest below before handing to the service.
+         */
+        private AiQueryRequest currentQuery;
 
         public String getQuestion() {
             return question;
@@ -49,6 +75,30 @@ public final class AiAskApi {
 
         public void setHistory(List<NlAskMessageDto> v) {
             this.history = v;
+        }
+
+        public String getCellsetDigest() {
+            return cellsetDigest;
+        }
+
+        public void setCellsetDigest(String v) {
+            this.cellsetDigest = v;
+        }
+
+        public String getForceTool() {
+            return forceTool;
+        }
+
+        public void setForceTool(String v) {
+            this.forceTool = v;
+        }
+
+        public AiQueryRequest getCurrentQuery() {
+            return currentQuery;
+        }
+
+        public void setCurrentQuery(AiQueryRequest v) {
+            this.currentQuery = v;
         }
 
         /** Convert the wire-shape history into the service-layer record list. */
@@ -118,6 +168,25 @@ public final class AiAskApi {
         private AiQueryRequest request;
         private AiQueryResponse response;
         private String generatedMdx;
+        /**
+         * The structured {@link ThinQueryModel} the converter produced for the AI's request — the
+         * same shape the workbench's chip UI manipulates. When present, "edit in canvas" can hydrate
+         * the workspace builder directly (interactive chips) instead of pasting the generated MDX
+         * (which the user can't drag/drop). Absent on degraded paths and on paths where conversion
+         * failed before producing a ThinQuery.
+         */
+        private ThinQueryModel queryModel;
+        /**
+         * Markdown analysis of the user's current cellset. Present when the model picked {@code
+         * emit_insight}. Mutually exclusive with {@link #request} / {@link #queryModel} / {@link
+         * #viewChange} — exactly one is non-null on success.
+         */
+        private AiInsight insight;
+        /**
+         * Target view mode + chart type. Present when the model picked {@code emit_view_change}.
+         * Mutually exclusive with the other intents as above.
+         */
+        private AiViewChange viewChange;
 
         public boolean isDegraded() {
             return degraded;
@@ -165,6 +234,30 @@ public final class AiAskApi {
 
         public void setGeneratedMdx(String v) {
             this.generatedMdx = v;
+        }
+
+        public ThinQueryModel getQueryModel() {
+            return queryModel;
+        }
+
+        public void setQueryModel(ThinQueryModel v) {
+            this.queryModel = v;
+        }
+
+        public AiInsight getInsight() {
+            return insight;
+        }
+
+        public void setInsight(AiInsight v) {
+            this.insight = v;
+        }
+
+        public AiViewChange getViewChange() {
+            return viewChange;
+        }
+
+        public void setViewChange(AiViewChange v) {
+            this.viewChange = v;
         }
     }
 }

--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ai/ask/AiAskService.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ai/ask/AiAskService.java
@@ -155,7 +155,9 @@ public class AiAskService {
             schema = metadataService.getSchema(ref);
         } catch (RuntimeException e) {
             log.warn("Failed to load schema for {} — cannot ask AI", ref, e);
-            return AskOutcome.degraded("failed to load cube schema: " + e.getMessage(), null);
+            // Generic client-facing reason — the exception detail (datasource / JDBC error text)
+            // is logged above, never echoed to the caller (#1282-class info-leak hardening).
+            return AskOutcome.degraded("failed to load cube schema", null);
         }
 
         String schemaJson;
@@ -228,8 +230,9 @@ public class AiAskService {
             return AskOutcome.degraded("provider returned unexpected kind: " + kind, resp.model());
         } catch (JsonProcessingException e) {
             log.warn("Provider returned invalid JSON for kind={}: {}", resp.kind(), e.getMessage());
-            return AskOutcome.degraded(
-                    "provider emitted invalid JSON for " + resp.kind() + ": " + e.getMessage(), resp.model());
+            // Generic client-facing reason — the parser detail is logged above, not echoed
+            // to the caller (#1282-class info-leak hardening). Kind is a safe enum.
+            return AskOutcome.degraded("provider emitted invalid JSON for " + resp.kind(), resp.model());
         }
     }
 

--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ai/ask/AiAskService.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ai/ask/AiAskService.java
@@ -62,26 +62,87 @@ public class AiAskService {
         return provider.isConfigured();
     }
 
-    /** Result of an {@link #ask(AiCubeRef, String, List)} call. */
-    public record AskOutcome(boolean degraded, String reason, AiQueryRequest request, String model) {
+    /**
+     * Result of an {@link #ask(AiCubeRef, String, List)} call.
+     *
+     * <p>Exactly one of {@code request} / {@code insight} / {@code viewChange} is non-null on
+     * success (matched to {@link #kind()}); all are null on degraded.
+     */
+    public record AskOutcome(
+            Kind kind,
+            boolean degraded,
+            String reason,
+            AiQueryRequest request,
+            AiInsight insight,
+            AiViewChange viewChange,
+            String model) {
+
+        public enum Kind {
+            QUERY,
+            INSIGHT,
+            VIEW_CHANGE
+        }
+
         public static AskOutcome ok(AiQueryRequest request, String model) {
-            return new AskOutcome(false, null, request, model);
+            return new AskOutcome(Kind.QUERY, false, null, request, null, null, model);
+        }
+
+        public static AskOutcome okInsight(AiInsight insight, String model) {
+            return new AskOutcome(Kind.INSIGHT, false, null, null, insight, null, model);
+        }
+
+        public static AskOutcome okViewChange(AiViewChange viewChange, String model) {
+            return new AskOutcome(Kind.VIEW_CHANGE, false, null, null, null, viewChange, model);
         }
 
         public static AskOutcome degraded(String reason, String model) {
-            return new AskOutcome(true, reason, null, model);
+            return new AskOutcome(null, true, reason, null, null, null, model);
         }
     }
 
     /**
-     * Translate a natural-language question into an {@link AiQueryRequest} grounded on the cube
-     * pointed to by {@code ref}.
+     * Translate a natural-language question against the cube pointed to by {@code ref}.
      *
      * @param ref cube to target; must be non-null and have a non-null cubeName
      * @param question free-form English question; must be non-blank
      * @param history prior turns; may be null / empty for single-shot asks
      */
     public AskOutcome ask(AiCubeRef ref, String question, List<NlAskMessage> history) {
+        return ask(ref, question, history, null, NlAskRequest.ForceTool.AUTO, null);
+    }
+
+    public AskOutcome ask(AiCubeRef ref, String question, List<NlAskMessage> history, String cellsetDigest) {
+        return ask(ref, question, history, cellsetDigest, NlAskRequest.ForceTool.AUTO, null);
+    }
+
+    public AskOutcome ask(
+            AiCubeRef ref,
+            String question,
+            List<NlAskMessage> history,
+            String cellsetDigest,
+            NlAskRequest.ForceTool forceTool) {
+        return ask(ref, question, history, cellsetDigest, forceTool, null);
+    }
+
+    /**
+     * Same as {@link #ask(AiCubeRef, String, List)} but accepts the user's currently-rendered
+     * cellset as a markdown digest AND a tool-choice override. The digest lets the model pick
+     * {@link AskOutcome.Kind#INSIGHT} (analyse the current data) or {@link
+     * AskOutcome.Kind#VIEW_CHANGE} (pick the right chart) in addition to {@link
+     * AskOutcome.Kind#QUERY}. When {@code cellsetDigest} is null/blank, the model has no data
+     * context and can only build queries.
+     *
+     * <p>{@code forceTool} narrows the provider's tool list when the user explicitly picked an
+     * intent in the drawer's mode picker. Default {@link NlAskRequest.ForceTool#AUTO} leaves all
+     * four tools available so the LLM routes by question shape.
+     */
+    public AskOutcome ask(
+            AiCubeRef ref,
+            String question,
+            List<NlAskMessage> history,
+            String cellsetDigest,
+            NlAskRequest.ForceTool forceTool,
+            AiQueryRequest currentQuery) {
         if (ref == null) {
             return AskOutcome.degraded("cube ref required", null);
         }
@@ -107,20 +168,68 @@ public class AiAskService {
             return AskOutcome.degraded("schema serialisation failed", null);
         }
 
-        NlAskRequest req =
-                new NlAskRequest(ref, question, schemaJson, requestSchemaJson, history == null ? List.of() : history);
+        // Serialise the current query into JSON for the provider to embed in the prompt.
+        // Null/blank when absent — providers omit the "Current query" context block entirely
+        // rather than say "Current query: null", which would just bloat the prompt.
+        String currentQueryJson = null;
+        if (currentQuery != null) {
+            try {
+                currentQueryJson = mapper.writeValueAsString(currentQuery);
+            } catch (JsonProcessingException e) {
+                log.debug("Failed to serialise currentQuery for ask context; omitting", e);
+            }
+        }
+        NlAskRequest req = new NlAskRequest(
+                ref,
+                question,
+                schemaJson,
+                requestSchemaJson,
+                history == null ? List.of() : history,
+                cellsetDigest,
+                forceTool == null ? NlAskRequest.ForceTool.AUTO : forceTool,
+                currentQueryJson);
         NlAskResponse resp = provider.ask(req);
 
         if (resp.degraded()) {
             return AskOutcome.degraded(resp.reason(), resp.model());
         }
 
+        // Route by which tool the provider's model picked.
         try {
-            AiQueryRequest parsed = mapper.readValue(resp.aiQueryRequestJson(), AiQueryRequest.class);
-            return AskOutcome.ok(parsed, resp.model());
+            NlAskResponse.Kind kind = resp.kind();
+            if (kind == NlAskResponse.Kind.QUERY) {
+                AiQueryRequest parsed = mapper.readValue(resp.payloadJson(), AiQueryRequest.class);
+                return AskOutcome.ok(parsed, resp.model());
+            }
+            if (kind == NlAskResponse.Kind.INSIGHT) {
+                AiInsight insight = mapper.readValue(resp.payloadJson(), AiInsight.class);
+                if (insight == null
+                        || insight.getMarkdown() == null
+                        || insight.getMarkdown().isBlank()) {
+                    return AskOutcome.degraded("provider emitted empty insight", resp.model());
+                }
+                return AskOutcome.okInsight(insight, resp.model());
+            }
+            if (kind == NlAskResponse.Kind.VIEW_CHANGE) {
+                AiViewChange vc = mapper.readValue(resp.payloadJson(), AiViewChange.class);
+                if (vc == null
+                        || vc.getViewMode() == null
+                        || !AiViewChangeCatalog.VIEW_MODES.contains(vc.getViewMode())) {
+                    return AskOutcome.degraded("provider emitted invalid viewMode", resp.model());
+                }
+                if (vc.getChartType() != null
+                        && !vc.getChartType().isBlank()
+                        && !AiViewChangeCatalog.CHART_TYPE_IDS.contains(vc.getChartType())) {
+                    return AskOutcome.degraded(
+                            "provider emitted unknown chartType '" + vc.getChartType() + "'", resp.model());
+                }
+                return AskOutcome.okViewChange(vc, resp.model());
+            }
+            return AskOutcome.degraded("provider returned unexpected kind: " + kind, resp.model());
         } catch (JsonProcessingException e) {
-            log.warn("Provider returned non-AiQueryRequest JSON: {}", e.getMessage());
-            return AskOutcome.degraded("provider emitted invalid AiQueryRequest JSON: " + e.getMessage(), resp.model());
+            log.warn("Provider returned invalid JSON for kind={}: {}", resp.kind(), e.getMessage());
+            return AskOutcome.degraded(
+                    "provider emitted invalid JSON for " + resp.kind() + ": " + e.getMessage(), resp.model());
         }
     }
 

--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ai/ask/AiInsight.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ai/ask/AiInsight.java
@@ -1,0 +1,48 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.service.olap.ai.ask;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+/**
+ * Output of the {@code emit_insight} tool — a natural-language analysis the model produced about
+ * the user's current cellset. Returned by {@code POST /saiku/api/ai/ask} when the model picks the
+ * insight intent (e.g. "spot any trends in this data", "what's interesting here").
+ *
+ * <p>Pure-data render contract: the UI renders {@link #markdown} as markdown inside the AI Query
+ * drawer's chat thread. No execution side effects.
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public final class AiInsight {
+
+    /** The analysis itself. Markdown is preferred — the UI renders it as such. */
+    private String markdown;
+
+    /** Optional 1-line headline shown above the markdown body in the drawer. */
+    private String headline;
+
+    public AiInsight() {}
+
+    public AiInsight(String markdown, String headline) {
+        this.markdown = markdown;
+        this.headline = headline;
+    }
+
+    public String getMarkdown() {
+        return markdown;
+    }
+
+    public void setMarkdown(String v) {
+        this.markdown = v;
+    }
+
+    public String getHeadline() {
+        return headline;
+    }
+
+    public void setHeadline(String v) {
+        this.headline = v;
+    }
+}

--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ai/ask/AiViewChange.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ai/ask/AiViewChange.java
@@ -1,0 +1,69 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.service.olap.ai.ask;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+/**
+ * Output of the {@code emit_view_change} tool — instructions for the UI to change how the current
+ * cellset is displayed (grid vs chart, which chart type). Returned by {@code POST
+ * /saiku/api/ai/ask} when the model picks the view-change intent (e.g. "switch to a chart", "show
+ * this as a bar chart").
+ *
+ * <p>The fields below intentionally mirror the workbench's {@code query.viewMode} +
+ * {@code query.chartType} state — the client just assigns them to the store after receiving the
+ * response. No query is re-executed.
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public final class AiViewChange {
+
+    /**
+     * Either {@code "grid"} or {@code "chart"}. Anything else the client will reject. Mirrors the
+     * workbench's {@code ViewMode}.
+     */
+    private String viewMode;
+
+    /**
+     * One of the chart-type ids enumerated in {@link AiViewChangeCatalog#CHART_TYPES} (kept in sync
+     * with the UI's {@code CHART_TYPES} array in {@code chartTypes.ts}). Only meaningful when
+     * {@link #viewMode} is {@code "chart"}.
+     */
+    private String chartType;
+
+    /** Optional 1-sentence rationale shown in the drawer ("Time-series → line chart fits best."). */
+    private String reason;
+
+    public AiViewChange() {}
+
+    public AiViewChange(String viewMode, String chartType, String reason) {
+        this.viewMode = viewMode;
+        this.chartType = chartType;
+        this.reason = reason;
+    }
+
+    public String getViewMode() {
+        return viewMode;
+    }
+
+    public void setViewMode(String v) {
+        this.viewMode = v;
+    }
+
+    public String getChartType() {
+        return chartType;
+    }
+
+    public void setChartType(String v) {
+        this.chartType = v;
+    }
+
+    public String getReason() {
+        return reason;
+    }
+
+    public void setReason(String v) {
+        this.reason = v;
+    }
+}

--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ai/ask/AiViewChangeCatalog.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ai/ask/AiViewChangeCatalog.java
@@ -1,0 +1,181 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.service.olap.ai.ask;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Constants for the {@code emit_view_change} tool's input schema — the catalogue of view modes and
+ * chart types the LLM is allowed to pick from. Kept in sync with the SvelteKit UI's
+ * {@code chartTypes.ts} ({@code CHART_TYPES} array).
+ *
+ * <p>When the UI grows a new chart type, add it here too. The drift-detection lives in
+ * {@code AiViewChangeCatalogParityTest} (UI source-of-truth → server enum match) — if you add a
+ * chart only here, the parity test still passes; the LLM just won't know to emit the new id. If you
+ * add it only on the UI side, the model can never reach it.
+ */
+public final class AiViewChangeCatalog {
+
+    private AiViewChangeCatalog() {}
+
+    public static final List<String> VIEW_MODES = List.of("grid", "chart");
+
+    /**
+     * Catalogue with one entry per supported chart type. {@code group} is the grouping label the UI
+     * shows; {@code hint} is a one-line guide for the model on when this chart fits — fed into the
+     * tool description so the LLM picks sensibly without us having to coach it per question.
+     */
+    public static final List<Map<String, String>> CHART_TYPES = List.of(
+            Map.of(
+                    "id",
+                    "bar",
+                    "label",
+                    "Bar",
+                    "group",
+                    "Bars",
+                    "hint",
+                    "1 measure × N categorical dims; quick comparisons across rows."),
+            Map.of(
+                    "id",
+                    "stackedBar",
+                    "label",
+                    "Stacked bar",
+                    "group",
+                    "Bars",
+                    "hint",
+                    "1 measure × N dims with a secondary categorical breakdown; part-to-whole per category."),
+            Map.of(
+                    "id",
+                    "waterfall",
+                    "label",
+                    "Waterfall",
+                    "group",
+                    "Bars",
+                    "hint",
+                    "Sequential +/- contributions to a running total (P&L, variance bridges)."),
+            Map.of(
+                    "id",
+                    "line",
+                    "label",
+                    "Line",
+                    "group",
+                    "Lines",
+                    "hint",
+                    "1+ measures over an ordered/time dimension; default for time series."),
+            Map.of(
+                    "id",
+                    "stackedLine",
+                    "label",
+                    "Stacked line",
+                    "group",
+                    "Lines",
+                    "hint",
+                    "Multiple series over time with cumulative stacking."),
+            Map.of(
+                    "id",
+                    "area",
+                    "label",
+                    "Area",
+                    "group",
+                    "Lines",
+                    "hint",
+                    "Single series over time emphasising magnitude."),
+            Map.of(
+                    "id",
+                    "stackedArea",
+                    "label",
+                    "Stacked area",
+                    "group",
+                    "Lines",
+                    "hint",
+                    "Multiple series over time with cumulative magnitude (composition)."),
+            Map.of(
+                    "id",
+                    "pie",
+                    "label",
+                    "Pie",
+                    "group",
+                    "Proportional",
+                    "hint",
+                    "Single measure split across <=6 categories; part-to-whole at one point in time."),
+            Map.of(
+                    "id",
+                    "donut",
+                    "label",
+                    "Donut",
+                    "group",
+                    "Proportional",
+                    "hint",
+                    "Same as pie but with center space for a KPI overlay."),
+            Map.of(
+                    "id",
+                    "treemap",
+                    "label",
+                    "Treemap",
+                    "group",
+                    "Proportional",
+                    "hint",
+                    "Hierarchical part-to-whole with many leaf categories (size-encoded)."),
+            Map.of(
+                    "id",
+                    "sunburst",
+                    "label",
+                    "Sunburst",
+                    "group",
+                    "Proportional",
+                    "hint",
+                    "Hierarchical part-to-whole rendered as concentric rings."),
+            Map.of(
+                    "id",
+                    "heatmap",
+                    "label",
+                    "Heatmap",
+                    "group",
+                    "Matrix",
+                    "hint",
+                    "2 categorical dims × 1 measure; spot hotspots in a matrix."),
+            Map.of(
+                    "id",
+                    "radar",
+                    "label",
+                    "Radar",
+                    "group",
+                    "Matrix",
+                    "hint",
+                    "Multiple measures profiled across one categorical axis (KPI radar)."),
+            Map.of(
+                    "id",
+                    "scatter",
+                    "label",
+                    "Scatter",
+                    "group",
+                    "Points",
+                    "hint",
+                    "2 measures plotted as x/y points; correlation / clustering."),
+            Map.of(
+                    "id",
+                    "bubble",
+                    "label",
+                    "Bubble",
+                    "group",
+                    "Points",
+                    "hint",
+                    "3 measures (x, y, size); like scatter with a magnitude dimension."),
+            Map.of(
+                    "id",
+                    "map",
+                    "label",
+                    "Map (choropleth)",
+                    "group",
+                    "Geo",
+                    "hint",
+                    "1 measure × geographic dim (country/state/postcode); regional comparison."));
+
+    /** Fast contains-check used by the routing layer to reject hallucinated ids. */
+    public static final Set<String> CHART_TYPE_IDS =
+            Set.copyOf(CHART_TYPES.stream().map(c -> c.get("id")).toList());
+}

--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ai/ask/AnthropicNlAskProvider.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ai/ask/AnthropicNlAskProvider.java
@@ -34,24 +34,40 @@ public final class AnthropicNlAskProvider extends AbstractNlAskProvider {
     private static final String ENDPOINT = "https://api.anthropic.com/v1/messages";
     private static final String API_VERSION = "2023-06-01";
 
-    private static final String SYSTEM_PROMPT = "You are a Mondrian OLAP query assistant scoped to a "
-            + "single cube. Your job is to translate a user's natural-language question about the "
-            + "cube's data into a single AiQueryRequest by calling the emit_query tool. "
-            + "SCOPE GUARDRAIL: If the user's question is NOT about querying this cube's data — e.g. "
-            + "general knowledge, coding help, weather, math, prose composition, jokes, advice, "
-            + "personal questions, or anything you couldn't answer with measures/dimensions from the "
-            + "schema below — you MUST call the refuse_off_topic tool with a one-sentence reason. "
-            + "Do not attempt to answer off-topic questions with prose, and do not invent a cube "
-            + "query just to satisfy the user. Borderline cases (analytical questions phrased in "
-            + "domain terms that map to the schema) should still call emit_query. "
+    private static final String SYSTEM_PROMPT = "You are a Mondrian OLAP analyst assistant scoped to a "
+            + "single cube. You have FOUR tools — pick exactly one based on the user's intent.\n\n"
+            + "TOOL CHOICE:\n"
+            + "  - emit_query: the user wants new data or a different breakdown of the cube. "
+            + "Translate their question into a single AiQueryRequest matching the schema.\n"
+            + "  - emit_insight: the user wants ANALYSIS of the data currently on screen ('spot trends', "
+            + "'what's interesting', 'summarise this', 'why is X high'). The user's current cellset is "
+            + "provided as a digest below; reason from it. Do NOT build a new query. Return a markdown "
+            + "analysis that references specific row/column captions and figures from the digest.\n"
+            + "  - emit_view_change: the user wants to change HOW the existing data is displayed "
+            + "('switch to chart', 'show this as a bar chart', 'back to grid', 'best chart for this'). "
+            + "Pick viewMode + chartType from the catalog. Do NOT re-query. If the user just says 'chart' "
+            + "or 'best chart', pick the chartType that best fits the cellset shape (time-series → line, "
+            + "few categories → bar/pie, geo → map, two-dim categorical → heatmap, etc).\n"
+            + "  - refuse_off_topic: SCOPE GUARDRAIL. If the question is NOT about this cube's data — e.g. "
+            + "general knowledge, coding help, weather, math, prose composition, jokes, advice, personal "
+            + "questions — call refuse_off_topic with a one-sentence reason. Do not invent cube queries to "
+            + "satisfy off-topic questions.\n\n"
+            + "DISAMBIGUATION RULES:\n"
+            + "  (a) If the cellset digest is absent or empty, you cannot do insight or sensibly route a "
+            + "view change — fall back to emit_query if the question implies a fresh breakdown, otherwise "
+            + "refuse_off_topic.\n"
+            + "  (b) If the user explicitly names a different dimension/measure/filter that's NOT on the "
+            + "current cellset, prefer emit_query even if the phrasing sounds analytical.\n"
+            + "  (c) For ambiguous questions like 'what about by region?' on an existing cellset, prefer "
+            + "emit_query (they want a new breakdown).\n\n"
             + "CRITICAL RULES for emit_query: (1) Every name field MUST refer to a member, measure, "
             + "dimension, hierarchy or level present in the provided cube schema — never invent names. "
             + "(2) Echo the connectionName, catalog, schema and cubeName from the provided cube ref "
             + "exactly. (3) Prefer rows for the dimension the user wants to break down by; use columns "
             + "only when the user explicitly compares across two axes. (4) Put time / region restrictions "
             + "in filters (the slicer). (5) When the user asks for 'top N' or 'bottom N', set both "
-            + "`order` and `limit`. (6) Keep aggregator overrides off unless the user asks for one. "
-            + "Always call exactly one tool — never respond with prose.";
+            + "`order` and `limit`. (6) Keep aggregator overrides off unless the user asks for one.\n\n"
+            + "Always call exactly ONE tool — never respond with prose.";
 
     /** Provider configuration. */
     public record Config(String apiKey, String model, double temperature, int maxTokens, Duration requestTimeout) {
@@ -124,16 +140,76 @@ public final class AnthropicNlAskProvider extends AbstractNlAskProvider {
         root.put("model", config.model());
         root.put("max_tokens", config.maxTokens());
         root.put("temperature", config.temperature());
-        root.put(
-                "system",
-                SYSTEM_PROMPT + "\n\nCube schema:\n" + request.cubeSchemaJson() + "\n\nCube ref to echo: "
-                        + cubeRefJson(request));
+
+        NlAskRequest.ForceTool force = request.forceTool();
+        boolean wantQuery = force == NlAskRequest.ForceTool.AUTO || force == NlAskRequest.ForceTool.QUERY;
+        boolean wantInsight = force == NlAskRequest.ForceTool.AUTO || force == NlAskRequest.ForceTool.INSIGHT;
+        boolean wantViewChange = force == NlAskRequest.ForceTool.AUTO || force == NlAskRequest.ForceTool.VIEW_CHANGE;
+
+        StringBuilder system = new StringBuilder(SYSTEM_PROMPT);
+        system.append("\n\nCube schema:\n").append(request.cubeSchemaJson());
+        system.append("\n\nCube ref to echo: ").append(cubeRefJson(request));
+        // Chart-type catalog only matters for view-change routing. Skipping it on query/insight-only
+        // turns trims ~500 tokens off the prompt and shaves a noticeable chunk off response time.
+        if (wantViewChange) {
+            system.append("\n\nChart-type catalog (for emit_view_change):\n").append(chartTypeCatalogText());
+        }
+        if (request.cellsetDigest() != null && !request.cellsetDigest().isBlank()) {
+            system.append("\n\nUser's current cellset (markdown digest — use for emit_insight / "
+                            + "emit_view_change reasoning):\n")
+                    .append(truncate(request.cellsetDigest(), 8000));
+        } else if (wantInsight || wantViewChange) {
+            system.append("\n\nNo current cellset on screen — emit_insight and emit_view_change are "
+                    + "unavailable for this turn.");
+        }
+        // Current AiQueryRequest snapshot — gives the LLM full context on what's already on screen
+        // so emit_query can EXTEND ('add therapeutic class to columns' should preserve existing
+        // rows/measures/filters) rather than wipe-and-rewrite. Only included when query routing is
+        // possible (forceTool=auto|query) — insight/view-change don't touch the query model.
+        if (wantQuery
+                && request.currentQueryJson() != null
+                && !request.currentQueryJson().isBlank()) {
+            system.append("\n\nUser's CURRENT AiQueryRequest (preserve fields when extending — when the "
+                            + "user says 'add X' or 'also break down by Y', return a query that KEEPS "
+                            + "existing measures/rows/columns/filters and adds the new one. Only drop a "
+                            + "field when the user explicitly asks to remove it):\n")
+                    .append(truncate(request.currentQueryJson(), 4000));
+        }
+        root.put("system", system.toString());
 
         ArrayNode tools = root.putArray("tools");
-        ObjectNode tool = tools.addObject();
-        tool.put("name", TOOL_NAME);
-        tool.put("description", "Emit a structured AiQueryRequest matching the cube schema.");
-        tool.set("input_schema", MAPPER.readTree(request.requestJsonSchema()));
+
+        // wantQuery / wantInsight / wantViewChange are computed at the top of the method (where the
+        // system prompt's tool-specific sections are pruned by the same flags).
+        if (wantQuery) {
+            ObjectNode queryTool = tools.addObject();
+            queryTool.put("name", TOOL_NAME);
+            queryTool.put("description", "Emit a structured AiQueryRequest matching the cube schema.");
+            queryTool.set("input_schema", MAPPER.readTree(request.requestJsonSchema()));
+        }
+
+        if (wantInsight) {
+            ObjectNode insightTool = tools.addObject();
+            insightTool.put("name", INSIGHT_TOOL_NAME);
+            insightTool.put(
+                    "description",
+                    "Analyse the user's CURRENT cellset (provided as a digest in the system prompt) and "
+                            + "return a markdown explanation. Use when the user asks about trends, "
+                            + "comparisons, summaries, or 'what's interesting' about the data already on screen. "
+                            + "Do not propose a new query.");
+            insightTool.set("input_schema", insightInputSchema());
+        }
+
+        if (wantViewChange) {
+            ObjectNode viewTool = tools.addObject();
+            viewTool.put("name", VIEW_CHANGE_TOOL_NAME);
+            viewTool.put(
+                    "description",
+                    "Change how the user's CURRENT cellset is displayed (grid vs chart, chart type). "
+                            + "Use when the user asks to switch view or pick a chart that fits the data. Do "
+                            + "not propose a new query.");
+            viewTool.set("input_schema", viewChangeInputSchema());
+        }
 
         // Refusal path — the model picks this when the user's question isn't
         // about the cube. Stops Saiku's AI key from becoming a free general
@@ -151,9 +227,9 @@ public final class AnthropicNlAskProvider extends AbstractNlAskProvider {
         reasonProp.put("description", "One-sentence explanation of why the question is off-topic.");
         refusalSchema.putArray("required").add("reason");
 
-        // tool_choice "any" — model must call a tool, but picks emit_query OR
-        // refuse_off_topic. Was "tool" (forced emit_query) before; that path
-        // would have the model invent queries for off-topic questions.
+        // tool_choice "any" — model must call a tool, but picks among the four. Was "tool" (forced
+        // emit_query) at the very start of the AI Ask feature; that path would have the model invent
+        // queries for off-topic / analytical / view-change questions.
         ObjectNode toolChoice = root.putObject("tool_choice");
         toolChoice.put("type", "any");
 
@@ -196,15 +272,28 @@ public final class AnthropicNlAskProvider extends AbstractNlAskProvider {
                     continue;
                 }
                 String toolName = block.path("name").asText();
+                JsonNode input = block.path("input");
                 if (TOOL_NAME.equals(toolName)) {
-                    JsonNode input = block.path("input");
                     if (input.isMissingNode() || input.isNull()) {
                         return NlAskResponse.degraded("empty tool_use input", model);
                     }
-                    return NlAskResponse.ok(MAPPER.writeValueAsString(input), model, inputTokens, outputTokens);
+                    return NlAskResponse.okQuery(MAPPER.writeValueAsString(input), model, inputTokens, outputTokens);
+                }
+                if (INSIGHT_TOOL_NAME.equals(toolName)) {
+                    if (input.isMissingNode() || input.isNull()) {
+                        return NlAskResponse.degraded("empty insight tool input", model);
+                    }
+                    return NlAskResponse.okInsight(MAPPER.writeValueAsString(input), model, inputTokens, outputTokens);
+                }
+                if (VIEW_CHANGE_TOOL_NAME.equals(toolName)) {
+                    if (input.isMissingNode() || input.isNull()) {
+                        return NlAskResponse.degraded("empty view_change tool input", model);
+                    }
+                    return NlAskResponse.okViewChange(
+                            MAPPER.writeValueAsString(input), model, inputTokens, outputTokens);
                 }
                 if (REFUSAL_TOOL_NAME.equals(toolName)) {
-                    String reason = block.path("input").path("reason").asText("Question is not about the cube.");
+                    String reason = input.path("reason").asText("Question is not about the cube.");
                     return NlAskResponse.degraded(REFUSAL_REASON_PREFIX + reason, model);
                 }
             }

--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ai/ask/NlAskRequest.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ai/ask/NlAskRequest.java
@@ -26,6 +26,12 @@ import org.saiku.service.olap.ai.AiCubeRef;
  *       shape.
  *   <li>{@code history} — prior {@code (user, assistant)} turns for multi-turn follow-ups. May be
  *       empty for a single-shot ask.
+ *   <li>{@code cellsetDigest} — optional markdown / text digest of the user's currently-rendered
+ *       cellset. Only set when the user already has results on screen and the AI policy permits
+ *       data passthrough. Lets the model see the data shape so it can route to the {@code
+ *       emit_insight} or {@code emit_view_change} tools (trend analysis / "switch to chart"). When
+ *       {@code null}, the model can still produce queries from the schema alone but can't do
+ *       insight or sensibly route view changes.
  * </ul>
  *
  * <p>Implementations MUST NOT mutate any field; the record is intentionally immutable.
@@ -35,7 +41,26 @@ public record NlAskRequest(
         String question,
         String cubeSchemaJson,
         String requestJsonSchema,
-        List<NlAskMessage> history) {
+        List<NlAskMessage> history,
+        String cellsetDigest,
+        ForceTool forceTool,
+        String currentQueryJson) {
+
+    /**
+     * Optional override for the tool the LLM is allowed to call. Default (null/{@code AUTO}) leaves
+     * the full four-tool picker on. Setting one of {@link #QUERY}/{@link #INSIGHT}/{@link
+     * #VIEW_CHANGE} narrows the provider's tool list to just that one + the refusal tool, so the
+     * model is forced into the user-chosen intent and can't auto-route to a different one.
+     *
+     * <p>Refusal stays available whichever mode is picked — even an explicitly-forced "query" turn
+     * should be able to refuse if the question is off-topic.
+     */
+    public enum ForceTool {
+        AUTO,
+        QUERY,
+        INSIGHT,
+        VIEW_CHANGE
+    }
 
     public NlAskRequest {
         Objects.requireNonNull(cubeRef, "cubeRef");
@@ -46,5 +71,42 @@ public record NlAskRequest(
         Objects.requireNonNull(cubeSchemaJson, "cubeSchemaJson");
         Objects.requireNonNull(requestJsonSchema, "requestJsonSchema");
         history = history == null ? List.of() : List.copyOf(history);
+        if (forceTool == null) forceTool = ForceTool.AUTO;
+    }
+
+    /** Pre-forceTool ctor — kept for callers that don't need the override. */
+    public NlAskRequest(
+            AiCubeRef cubeRef,
+            String question,
+            String cubeSchemaJson,
+            String requestJsonSchema,
+            List<NlAskMessage> history,
+            String cellsetDigest) {
+        this(cubeRef, question, cubeSchemaJson, requestJsonSchema, history, cellsetDigest, ForceTool.AUTO, null);
+    }
+
+    /** Pre-currentQueryJson ctor — for callers that don't have a current-query snapshot. */
+    public NlAskRequest(
+            AiCubeRef cubeRef,
+            String question,
+            String cubeSchemaJson,
+            String requestJsonSchema,
+            List<NlAskMessage> history,
+            String cellsetDigest,
+            ForceTool forceTool) {
+        this(cubeRef, question, cubeSchemaJson, requestJsonSchema, history, cellsetDigest, forceTool, null);
+    }
+
+    /**
+     * Pre-multi-tool ctor — kept so call sites that don't have a cellset digest stay terse. New
+     * code passing a digest should use the 6- or 7-arg canonical ctor.
+     */
+    public NlAskRequest(
+            AiCubeRef cubeRef,
+            String question,
+            String cubeSchemaJson,
+            String requestJsonSchema,
+            List<NlAskMessage> history) {
+        this(cubeRef, question, cubeSchemaJson, requestJsonSchema, history, null, ForceTool.AUTO, null);
     }
 }

--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ai/ask/NlAskResponse.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ai/ask/NlAskResponse.java
@@ -7,10 +7,22 @@ package org.saiku.service.olap.ai.ask;
 /**
  * Output of {@link NlAskProvider#ask(NlAskRequest)}.
  *
- * <p>The provider returns the raw {@link org.saiku.service.olap.ai.AiQueryRequest} JSON emitted by
- * the model. Validation against the live cube happens in the existing {@code /ai/query} converter
- * — keeping this contract narrow (parse + emit) means a misbehaving provider can be diagnosed
- * without coupling it to the converter.
+ * <p>The provider returns the raw JSON the model emitted, plus a {@link Kind} discriminator
+ * identifying which tool the model picked. Three intents are routed by {@link AiAskService}:
+ *
+ * <ul>
+ *   <li>{@link Kind#QUERY} — an {@code AiQueryRequest} the converter will execute.
+ *   <li>{@link Kind#INSIGHT} — an {@code AiInsight} (markdown analysis of the user's current
+ *       cellset). No execution.
+ *   <li>{@link Kind#VIEW_CHANGE} — an {@code AiViewChange} (target viewMode + chartType). No
+ *       execution.
+ *   <li>{@link Kind#REFUSAL} — the model called the refusal tool (off-topic question). Surface
+ *       {@link #reason()} verbatim to the user.
+ * </ul>
+ *
+ * <p>Validation against the live cube happens in the existing {@code /ai/query} converter for the
+ * QUERY kind only — keeping this contract narrow (parse + emit) means a misbehaving provider can be
+ * diagnosed without coupling it to the converter or the cellset.
  *
  * <p>Degradation modes (return this rather than throw):
  *
@@ -21,10 +33,13 @@ package org.saiku.service.olap.ai.ask;
  *   <li>Parse failure — {@code degraded=true, reason="parse error: ..."}.
  * </ul>
  *
- * @param aiQueryRequestJson the structured request emitted by the model; {@code null} when
- *     {@code degraded}
- * @param degraded {@code true} iff the provider could not return a usable request
- * @param reason short, human-readable explanation when {@code degraded}; empty otherwise
+ * @param kind which intent the model picked; {@code null} when {@code degraded}
+ * @param payloadJson the raw JSON the model emitted for the picked tool; {@code null} when {@code
+ *     degraded}
+ * @param degraded {@code true} iff the provider could not return a usable payload
+ * @param reason short, human-readable explanation when {@code degraded}; empty otherwise. Also used
+ *     to carry the refusal sentence when {@code kind == REFUSAL} (in which case {@code degraded} is
+ *     false but {@code reason} carries the message).
  * @param model echo of the model id the provider used (for audit / telemetry); {@code null} when
  *     not applicable (noop)
  * @param inputTokens prompt token count when reported by the provider; {@code -1} when unknown
@@ -32,21 +47,65 @@ package org.saiku.service.olap.ai.ask;
  *     unknown
  */
 public record NlAskResponse(
-        String aiQueryRequestJson, boolean degraded, String reason, String model, int inputTokens, int outputTokens) {
+        Kind kind,
+        String payloadJson,
+        boolean degraded,
+        String reason,
+        String model,
+        int inputTokens,
+        int outputTokens) {
+
+    public enum Kind {
+        QUERY,
+        INSIGHT,
+        VIEW_CHANGE,
+        REFUSAL
+    }
 
     public NlAskResponse {
         reason = reason == null ? "" : reason;
     }
 
-    public static NlAskResponse ok(String json, String model, int inputTokens, int outputTokens) {
-        return new NlAskResponse(json, false, "", model, inputTokens, outputTokens);
+    public static NlAskResponse okQuery(String json, String model, int inputTokens, int outputTokens) {
+        return new NlAskResponse(Kind.QUERY, json, false, "", model, inputTokens, outputTokens);
+    }
+
+    public static NlAskResponse okInsight(String json, String model, int inputTokens, int outputTokens) {
+        return new NlAskResponse(Kind.INSIGHT, json, false, "", model, inputTokens, outputTokens);
+    }
+
+    public static NlAskResponse okViewChange(String json, String model, int inputTokens, int outputTokens) {
+        return new NlAskResponse(Kind.VIEW_CHANGE, json, false, "", model, inputTokens, outputTokens);
+    }
+
+    public static NlAskResponse refusal(String reason, String model, int inputTokens, int outputTokens) {
+        return new NlAskResponse(Kind.REFUSAL, null, false, reason, model, inputTokens, outputTokens);
     }
 
     public static NlAskResponse degraded(String reason) {
-        return new NlAskResponse(null, true, reason, null, -1, -1);
+        return new NlAskResponse(null, null, true, reason, null, -1, -1);
     }
 
     public static NlAskResponse degraded(String reason, String model) {
-        return new NlAskResponse(null, true, reason, model, -1, -1);
+        return new NlAskResponse(null, null, true, reason, model, -1, -1);
+    }
+
+    /**
+     * @deprecated Pre-multi-tool alias for {@link #okQuery(String, String, int, int)}. Kept so the
+     *     existing provider tests don't churn. New code should use the kind-explicit factories.
+     */
+    @Deprecated
+    public static NlAskResponse ok(String json, String model, int inputTokens, int outputTokens) {
+        return okQuery(json, model, inputTokens, outputTokens);
+    }
+
+    /**
+     * @return the payload JSON when {@link #kind()} is {@link Kind#QUERY}; {@code null} otherwise.
+     * @deprecated Pre-multi-tool alias for {@link #payloadJson()}. Same churn-avoidance as {@link
+     *     #ok(String, String, int, int)}.
+     */
+    @Deprecated
+    public String aiQueryRequestJson() {
+        return kind == Kind.QUERY ? payloadJson : null;
     }
 }

--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ai/ask/OpenAINlAskProvider.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ai/ask/OpenAINlAskProvider.java
@@ -36,24 +36,38 @@ public final class OpenAINlAskProvider extends AbstractNlAskProvider {
     /** Default endpoint. Override via {@link Config#endpoint()} for OpenAI-compatible servers. */
     public static final String DEFAULT_ENDPOINT = "https://api.openai.com/v1/chat/completions";
 
-    private static final String SYSTEM_PROMPT = "You are a Mondrian OLAP query assistant scoped to a "
-            + "single cube. Your job is to translate a user's natural-language question about the "
-            + "cube's data into a single AiQueryRequest by calling the emit_query function. "
-            + "SCOPE GUARDRAIL: If the user's question is NOT about querying this cube's data — e.g. "
-            + "general knowledge, coding help, weather, math, prose composition, jokes, advice, "
-            + "personal questions, or anything you couldn't answer with measures/dimensions from the "
-            + "schema below — you MUST call the refuse_off_topic function with a one-sentence reason. "
-            + "Do not attempt to answer off-topic questions with prose, and do not invent a cube "
-            + "query just to satisfy the user. Borderline cases (analytical questions phrased in "
-            + "domain terms that map to the schema) should still call emit_query. "
+    private static final String SYSTEM_PROMPT = "You are a Mondrian OLAP analyst assistant scoped to a "
+            + "single cube. You have FOUR functions — pick exactly one based on the user's intent.\n\n"
+            + "FUNCTION CHOICE:\n"
+            + "  - emit_query: the user wants new data or a different breakdown of the cube. "
+            + "Translate their question into a single AiQueryRequest matching the schema.\n"
+            + "  - emit_insight: the user wants ANALYSIS of the data currently on screen ('spot trends', "
+            + "'what's interesting', 'summarise this', 'why is X high'). The user's current cellset is "
+            + "provided as a digest below; reason from it. Do NOT build a new query. Return a markdown "
+            + "analysis that references specific row/column captions and figures from the digest.\n"
+            + "  - emit_view_change: the user wants to change HOW the existing data is displayed "
+            + "('switch to chart', 'show this as a bar chart', 'back to grid', 'best chart for this'). "
+            + "Pick viewMode + chartType from the catalog. Do NOT re-query. If the user just says 'chart' "
+            + "or 'best chart', pick the chartType that best fits the cellset shape (time-series → line, "
+            + "few categories → bar/pie, geo → map, two-dim categorical → heatmap, etc).\n"
+            + "  - refuse_off_topic: SCOPE GUARDRAIL. If the question is NOT about this cube's data, call "
+            + "refuse_off_topic with a one-sentence reason. Do not invent cube queries to satisfy "
+            + "off-topic questions.\n\n"
+            + "DISAMBIGUATION RULES:\n"
+            + "  (a) If the cellset digest is absent or empty, you cannot do insight or sensibly route a "
+            + "view change — fall back to emit_query if the question implies a fresh breakdown, otherwise "
+            + "refuse_off_topic.\n"
+            + "  (b) If the user explicitly names a different dimension/measure/filter that's NOT on the "
+            + "current cellset, prefer emit_query.\n"
+            + "  (c) For ambiguous 'what about by region?' on an existing cellset, prefer emit_query.\n\n"
             + "CRITICAL RULES for emit_query: (1) Every name field MUST refer to a member, measure, "
             + "dimension, hierarchy or level present in the provided cube schema — never invent names. "
             + "(2) Echo the connectionName, catalog, schema and cubeName from the provided cube ref "
             + "exactly. (3) Prefer rows for the dimension the user wants to break down by; use columns "
             + "only when the user explicitly compares across two axes. (4) Put time / region restrictions "
             + "in filters (the slicer). (5) When the user asks for 'top N' or 'bottom N', set both "
-            + "`order` and `limit`. (6) Keep aggregator overrides off unless the user asks for one. "
-            + "Always call exactly one function — never respond with prose.";
+            + "`order` and `limit`. (6) Keep aggregator overrides off unless the user asks for one.\n\n"
+            + "Always call exactly ONE function — never respond with prose.";
 
     /** Provider configuration. */
     public record Config(
@@ -131,13 +145,51 @@ public final class OpenAINlAskProvider extends AbstractNlAskProvider {
         root.put("max_tokens", config.maxTokens());
         root.put("temperature", config.temperature());
 
+        // Mode picker — Auto leaves all three intents available; an explicit pick narrows the
+        // tool list (+ refusal, always available) so the LLM can't auto-route to a different
+        // intent. Same flags also drive the system-prompt pruning below for speed.
+        NlAskRequest.ForceTool force = request.forceTool();
+        boolean wantQuery = force == NlAskRequest.ForceTool.AUTO || force == NlAskRequest.ForceTool.QUERY;
+        boolean wantInsight = force == NlAskRequest.ForceTool.AUTO || force == NlAskRequest.ForceTool.INSIGHT;
+        boolean wantViewChange = force == NlAskRequest.ForceTool.AUTO || force == NlAskRequest.ForceTool.VIEW_CHANGE;
+
         ArrayNode tools = root.putArray("tools");
-        ObjectNode tool = tools.addObject();
-        tool.put("type", "function");
-        ObjectNode fn = tool.putObject("function");
-        fn.put("name", TOOL_NAME);
-        fn.put("description", "Emit a structured AiQueryRequest matching the cube schema.");
-        fn.set("parameters", MAPPER.readTree(request.requestJsonSchema()));
+
+        if (wantQuery) {
+            ObjectNode tool = tools.addObject();
+            tool.put("type", "function");
+            ObjectNode fn = tool.putObject("function");
+            fn.put("name", TOOL_NAME);
+            fn.put("description", "Emit a structured AiQueryRequest matching the cube schema.");
+            fn.set("parameters", MAPPER.readTree(request.requestJsonSchema()));
+        }
+
+        if (wantInsight) {
+            ObjectNode insightTool = tools.addObject();
+            insightTool.put("type", "function");
+            ObjectNode insightFn = insightTool.putObject("function");
+            insightFn.put("name", INSIGHT_TOOL_NAME);
+            insightFn.put(
+                    "description",
+                    "Analyse the user's CURRENT cellset (provided as a digest in the system prompt) and "
+                            + "return a markdown explanation. Use when the user asks about trends, "
+                            + "comparisons, summaries, or 'what's interesting' about the data already on screen. "
+                            + "Do not propose a new query.");
+            insightFn.set("parameters", insightInputSchema());
+        }
+
+        if (wantViewChange) {
+            ObjectNode viewTool = tools.addObject();
+            viewTool.put("type", "function");
+            ObjectNode viewFn = viewTool.putObject("function");
+            viewFn.put("name", VIEW_CHANGE_TOOL_NAME);
+            viewFn.put(
+                    "description",
+                    "Change how the user's CURRENT cellset is displayed (grid vs chart, chart type). "
+                            + "Use when the user asks to switch view or pick a chart that fits the data. Do "
+                            + "not propose a new query.");
+            viewFn.set("parameters", viewChangeInputSchema());
+        }
 
         // Refusal path — model picks this when the user's question isn't
         // about the cube. Stops the AI key becoming a free general LLM proxy.
@@ -156,18 +208,37 @@ public final class OpenAINlAskProvider extends AbstractNlAskProvider {
         reasonProp.put("description", "One-sentence explanation of why the question is off-topic.");
         refusalParams.putArray("required").add("reason");
 
-        // tool_choice "required" — model must call a function, picks emit_query
-        // OR refuse_off_topic. Was forced-emit_query before; that would have
-        // the model invent queries for off-topic questions.
+        // tool_choice "required" — model must call exactly one function, but is free to choose
+        // among the four. Forced-emit_query (the very first iteration of this feature) would have
+        // the model invent queries for off-topic / analytical / view-change questions.
         root.put("tool_choice", "required");
 
         ArrayNode messages = root.putArray("messages");
         ObjectNode system = messages.addObject();
         system.put("role", "system");
-        system.put(
-                "content",
-                SYSTEM_PROMPT + "\n\nCube schema:\n" + request.cubeSchemaJson() + "\n\nCube ref to echo: "
-                        + cubeRefJson(request));
+        StringBuilder sys = new StringBuilder(SYSTEM_PROMPT);
+        sys.append("\n\nCube schema:\n").append(request.cubeSchemaJson());
+        sys.append("\n\nCube ref to echo: ").append(cubeRefJson(request));
+        if (wantViewChange) {
+            sys.append("\n\nChart-type catalog (for emit_view_change):\n").append(chartTypeCatalogText());
+        }
+        if (request.cellsetDigest() != null && !request.cellsetDigest().isBlank()) {
+            sys.append("\n\nUser's current cellset (markdown digest — use for emit_insight / "
+                            + "emit_view_change reasoning):\n")
+                    .append(truncate(request.cellsetDigest(), 8000));
+        } else if (wantInsight || wantViewChange) {
+            sys.append("\n\nNo current cellset on screen — emit_insight and emit_view_change are "
+                    + "unavailable for this turn.");
+        }
+        if (wantQuery
+                && request.currentQueryJson() != null
+                && !request.currentQueryJson().isBlank()) {
+            sys.append("\n\nUser's CURRENT AiQueryRequest (preserve fields when extending — 'add X' or "
+                            + "'also break down by Y' should KEEP existing measures/rows/columns/filters "
+                            + "and add the new one; only drop a field when the user asks to remove it):\n")
+                    .append(truncate(request.currentQueryJson(), 4000));
+        }
+        system.put("content", sys.toString());
 
         for (NlAskMessage m : request.history()) {
             ObjectNode mNode = messages.addObject();
@@ -211,24 +282,36 @@ public final class OpenAINlAskProvider extends AbstractNlAskProvider {
         for (JsonNode call : toolCalls) {
             JsonNode function = call.path("function");
             String fnName = function.path("name").asText();
+            String arguments = function.path("arguments").asText(null);
+            // OpenAI returns the function arguments as a JSON-encoded STRING (not a nested object)
+            // — so the value here is itself JSON ready for re-parse by the routing layer.
             if (TOOL_NAME.equals(fnName)) {
-                String arguments = function.path("arguments").asText(null);
                 if (arguments == null || arguments.isBlank()) {
                     return NlAskResponse.degraded("empty tool_call arguments", model);
                 }
-                // arguments is itself JSON-encoded as a string per the OpenAI contract — return as-is.
-                return NlAskResponse.ok(arguments, model, inputTokens, outputTokens);
+                return NlAskResponse.okQuery(arguments, model, inputTokens, outputTokens);
+            }
+            if (INSIGHT_TOOL_NAME.equals(fnName)) {
+                if (arguments == null || arguments.isBlank()) {
+                    return NlAskResponse.degraded("empty insight tool arguments", model);
+                }
+                return NlAskResponse.okInsight(arguments, model, inputTokens, outputTokens);
+            }
+            if (VIEW_CHANGE_TOOL_NAME.equals(fnName)) {
+                if (arguments == null || arguments.isBlank()) {
+                    return NlAskResponse.degraded("empty view_change tool arguments", model);
+                }
+                return NlAskResponse.okViewChange(arguments, model, inputTokens, outputTokens);
             }
             if (REFUSAL_TOOL_NAME.equals(fnName)) {
                 String reason = "Question is not about the cube.";
-                String argsStr = function.path("arguments").asText("");
-                if (!argsStr.isBlank()) {
-                    JsonNode args = MAPPER.readTree(argsStr);
+                if (arguments != null && !arguments.isBlank()) {
+                    JsonNode args = MAPPER.readTree(arguments);
                     reason = args.path("reason").asText(reason);
                 }
                 return NlAskResponse.degraded(REFUSAL_REASON_PREFIX + reason, model);
             }
         }
-        return NlAskResponse.degraded("tool_calls did not include emit_query", model);
+        return NlAskResponse.degraded("tool_calls did not include a recognised tool", model);
     }
 }

--- a/saiku-core/saiku-service/src/test/java/org/saiku/service/olap/ai/ask/AiAskServiceTest.java
+++ b/saiku-core/saiku-service/src/test/java/org/saiku/service/olap/ai/ask/AiAskServiceTest.java
@@ -47,7 +47,10 @@ public class AiAskServiceTest {
                 stub(NlAskResponse.ok("{}", "m", 0, 0)));
         AiAskService.AskOutcome out = svc.ask(CUBE, "show sales", List.of());
         assertTrue(out.degraded());
-        assertTrue(out.reason().contains("cube not found"));
+        // #1282-class hardening: the client-facing reason is generic; the raw exception detail
+        // ("cube not found", which can carry datasource / JDBC text) is logged server-side only.
+        assertTrue(out.reason().contains("failed to load cube schema"));
+        assertFalse(out.reason().contains("cube not found"));
     }
 
     @Test

--- a/saiku-core/saiku-service/src/test/java/org/saiku/service/olap/ai/ask/AiAskServiceTest.java
+++ b/saiku-core/saiku-service/src/test/java/org/saiku/service/olap/ai/ask/AiAskServiceTest.java
@@ -66,7 +66,7 @@ public class AiAskServiceTest {
                 fixedSchemaService(emptySchema()), stub(NlAskResponse.ok("not-valid-json", "claude-x", 1, 1)));
         AiAskService.AskOutcome out = svc.ask(CUBE, "show sales", List.of());
         assertTrue(out.degraded());
-        assertTrue(out.reason().contains("invalid AiQueryRequest JSON"));
+        assertTrue(out.reason().contains("provider emitted invalid JSON"));
         assertEquals("claude-x", out.model());
     }
 

--- a/saiku-core/saiku-service/src/test/java/org/saiku/service/olap/ai/ask/AnthropicNlAskProviderTest.java
+++ b/saiku-core/saiku-service/src/test/java/org/saiku/service/olap/ai/ask/AnthropicNlAskProviderTest.java
@@ -44,18 +44,20 @@ public class AnthropicNlAskProviderTest {
 
         assertEquals("claude-x", root.get("model").asText());
         assertEquals(1024, root.get("max_tokens").asInt());
-        // tool_choice "any" lets the model pick emit_query OR refuse_off_topic.
+        // tool_choice "any" lets the model pick among the four scoped tools.
         assertEquals("any", root.get("tool_choice").get("type").asText());
 
+        // AUTO routing exposes all four tools: emit_query, emit_insight, emit_view_change,
+        // and the refuse_off_topic scope guardrail (always appended last).
         JsonNode tools = root.get("tools");
-        assertEquals(2, tools.size());
+        assertEquals(4, tools.size());
         assertEquals("emit_query", tools.get(0).get("name").asText());
         assertEquals("object", tools.get(0).get("input_schema").get("type").asText());
-        assertEquals("refuse_off_topic", tools.get(1).get("name").asText());
+        JsonNode refusal = tools.get(tools.size() - 1);
+        assertEquals("refuse_off_topic", refusal.get("name").asText());
         assertEquals(
                 "string",
-                tools.get(1)
-                        .get("input_schema")
+                refusal.get("input_schema")
                         .get("properties")
                         .get("reason")
                         .get("type")
@@ -217,7 +219,8 @@ public class AnthropicNlAskProviderTest {
                 provider.buildRequestBody(new NlAskRequest(CUBE, "q", SCHEMA, REQUEST_SCHEMA, List.of())));
 
         assertEquals("any", root.get("tool_choice").get("type").asText());
-        JsonNode refusal = root.get("tools").get(1);
+        JsonNode tools = root.get("tools");
+        JsonNode refusal = tools.get(tools.size() - 1);
         assertEquals("refuse_off_topic", refusal.get("name").asText());
         assertEquals(
                 "reason", refusal.get("input_schema").get("required").get(0).asText());
@@ -232,8 +235,9 @@ public class AnthropicNlAskProviderTest {
                         provider.buildRequestBody(new NlAskRequest(CUBE, "q", SCHEMA, REQUEST_SCHEMA, List.of())))
                 .get("system")
                 .asText();
-        assertTrue(system.contains("you MUST call the refuse_off_topic tool"));
-        assertTrue(system.contains("Always call exactly one tool"));
+        assertTrue(system.contains("SCOPE GUARDRAIL"));
+        assertTrue(system.contains("call refuse_off_topic with a one-sentence reason"));
+        assertTrue(system.contains("Always call exactly ONE tool"));
     }
 
     /** Refusal with no reason field falls back to the canonical OFF_TOPIC default reason. */

--- a/saiku-core/saiku-service/src/test/java/org/saiku/service/olap/ai/ask/OpenAINlAskProviderTest.java
+++ b/saiku-core/saiku-service/src/test/java/org/saiku/service/olap/ai/ask/OpenAINlAskProviderTest.java
@@ -44,19 +44,21 @@ public class OpenAINlAskProviderTest {
 
         assertEquals("gpt-x", root.get("model").asText());
         assertEquals(1024, root.get("max_tokens").asInt());
-        // tool_choice "required" — model must call a function, picks emit_query OR refuse_off_topic.
+        // tool_choice "required" — model must call a function, picks among the four scoped functions.
         assertEquals("required", root.get("tool_choice").asText());
 
+        // AUTO routing exposes all four functions: emit_query, emit_insight, emit_view_change,
+        // and the refuse_off_topic scope guardrail (always appended last).
         JsonNode tools = root.get("tools");
-        assertEquals(2, tools.size());
+        assertEquals(4, tools.size());
         assertEquals("function", tools.get(0).get("type").asText());
         assertEquals("emit_query", tools.get(0).get("function").get("name").asText());
         assertEquals(
                 "object",
                 tools.get(0).get("function").get("parameters").get("type").asText());
-        assertEquals("function", tools.get(1).get("type").asText());
-        assertEquals(
-                "refuse_off_topic", tools.get(1).get("function").get("name").asText());
+        JsonNode refusal = tools.get(tools.size() - 1);
+        assertEquals("function", refusal.get("type").asText());
+        assertEquals("refuse_off_topic", refusal.get("function").get("name").asText());
 
         // System message embeds the cube schema
         JsonNode messages = root.get("messages");
@@ -160,7 +162,7 @@ public class OpenAINlAskProviderTest {
                 + "\"arguments\":\"{}\"}}]}}]}";
         NlAskResponse resp = OpenAINlAskProvider.parseToolResponse(body, "gpt-x");
         assertTrue(resp.degraded());
-        assertEquals("tool_calls did not include emit_query", resp.reason());
+        assertEquals("tool_calls did not include a recognised tool", resp.reason());
     }
 
     // ---------- characterization: security invariants (issue #1159) ----------
@@ -200,7 +202,8 @@ public class OpenAINlAskProviderTest {
                 provider.buildRequestBody(new NlAskRequest(CUBE, "q", SCHEMA, REQUEST_SCHEMA, List.of())));
 
         assertEquals("required", root.get("tool_choice").asText());
-        JsonNode refusal = root.get("tools").get(1).get("function");
+        JsonNode tools = root.get("tools");
+        JsonNode refusal = tools.get(tools.size() - 1).get("function");
         assertEquals("refuse_off_topic", refusal.get("name").asText());
         assertEquals("reason", refusal.get("parameters").get("required").get(0).asText());
     }
@@ -216,8 +219,9 @@ public class OpenAINlAskProviderTest {
                 .get(0)
                 .get("content")
                 .asText();
-        assertTrue(system.contains("you MUST call the refuse_off_topic function"));
-        assertTrue(system.contains("Always call exactly one function"));
+        assertTrue(system.contains("SCOPE GUARDRAIL"));
+        assertTrue(system.contains("call refuse_off_topic with a one-sentence reason"));
+        assertTrue(system.contains("Always call exactly ONE function"));
     }
 
     @Test

--- a/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/AiQueryResource.java
+++ b/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/AiQueryResource.java
@@ -762,7 +762,25 @@ public class AiQueryResource {
                     .build();
         }
 
-        AiAskService.AskOutcome outcome = askService.ask(body.getCube(), body.getQuestion(), body.historyAsMessages());
+        // Translate the wire-shape forceTool string into the service enum. Unknown / null → AUTO so
+        // a bad client value silently degrades to auto-routing rather than 400ing the whole turn.
+        org.saiku.service.olap.ai.ask.NlAskRequest.ForceTool force =
+                org.saiku.service.olap.ai.ask.NlAskRequest.ForceTool.AUTO;
+        if (body.getForceTool() != null) {
+            try {
+                force = org.saiku.service.olap.ai.ask.NlAskRequest.ForceTool.valueOf(
+                        body.getForceTool().toUpperCase());
+            } catch (IllegalArgumentException ignored) {
+                // unknown — keep AUTO
+            }
+        }
+        AiAskService.AskOutcome outcome = askService.ask(
+                body.getCube(),
+                body.getQuestion(),
+                body.historyAsMessages(),
+                body.getCellsetDigest(),
+                force,
+                body.getCurrentQuery());
         if (outcome.degraded()) {
             AiAskApi.AskResponse out = new AiAskApi.AskResponse();
             out.setDegraded(true);
@@ -777,10 +795,24 @@ public class AiQueryResource {
                     .build();
         }
 
-        AiQueryRequest req = outcome.request();
         AiAskApi.AskResponse out = new AiAskApi.AskResponse();
         out.setDegraded(false);
         out.setModel(outcome.model());
+
+        // Insight and view-change intents skip the converter / execution entirely — the model already
+        // produced the final artefact (markdown analysis / view target). Return immediately so the
+        // drawer can render the result without going through ThinQuery → MDX → backend round-trip.
+        if (outcome.kind() == AiAskService.AskOutcome.Kind.INSIGHT) {
+            out.setInsight(outcome.insight());
+            return Response.ok(out).type(MediaType.APPLICATION_JSON).build();
+        }
+        if (outcome.kind() == AiAskService.AskOutcome.Kind.VIEW_CHANGE) {
+            out.setViewChange(outcome.viewChange());
+            return Response.ok(out).type(MediaType.APPLICATION_JSON).build();
+        }
+
+        // Default branch: QUERY intent — convert + execute as before.
+        AiQueryRequest req = outcome.request();
         out.setRequest(req);
 
         // Execute the produced request through the same path /ai/query uses. Errors are translated
@@ -792,6 +824,10 @@ public class AiQueryResource {
             schemaValidator.assertValid(MAPPER.valueToTree(req));
             AiSchema schema = cubeMetadataService.getSchema(req.getCube());
             ThinQuery tq = converter.convert(req, schema);
+            // Surface the converted ThinQueryModel so the UI's "edit in canvas" can hydrate the
+            // workbench's chip builder directly (interactive query) instead of pasting MDX (opaque
+            // to the chip UI — user can't drag/drop). Same shape the workspace builder manipulates.
+            out.setQueryModel(tq.getQueryModel());
             CellDataSet cds = thinQueryService.execute(tq);
             AiQueryResponse aiResp = buildResponse(tq, cds, start, "records");
             out.setResponse(aiResp);

--- a/saiku-core/saiku-web/src/test/java/org/saiku/web/rest/resources/AiQueryResourceAskTest.java
+++ b/saiku-core/saiku-web/src/test/java/org/saiku/web/rest/resources/AiQueryResourceAskTest.java
@@ -28,6 +28,7 @@ import org.saiku.service.olap.ai.ask.AiAskApi;
 import org.saiku.service.olap.ai.ask.AiAskService;
 import org.saiku.service.olap.ai.ask.NlAskMessage;
 import org.saiku.service.olap.ai.ask.NlAskProvider;
+import org.saiku.service.olap.ai.ask.NlAskRequest;
 import org.saiku.service.olap.ai.ask.NlAskResponse;
 
 /** Resource-level tests for {@code POST /saiku/api/ai/ask}. No network. */
@@ -71,8 +72,17 @@ public class AiQueryResourceAskTest {
     /** Wire a fake askService that returns a fixed outcome. */
     private void wireAskService(AiAskService.AskOutcome outcome) {
         resource.setAskService(new AiAskService(ref -> schema, stubProvider("")) {
+            // The resource calls the six-arg overload (cellset digest + tool-choice + current
+            // query); the narrower overloads all delegate to it, so overriding this one catches
+            // every code path the resource can take.
             @Override
-            public AskOutcome ask(AiCubeRef ref, String question, List<NlAskMessage> history) {
+            public AskOutcome ask(
+                    AiCubeRef ref,
+                    String question,
+                    List<NlAskMessage> history,
+                    String cellsetDigest,
+                    NlAskRequest.ForceTool forceTool,
+                    AiQueryRequest currentQuery) {
                 return outcome;
             }
         });


### PR DESCRIPTION
## Summary

Splits the AI Ask natural-language layer — the LLM-egress surface — out of the #1362 SvelteKit port so it can land and be security-reviewed on its own, on top of current `development`. This is the backend half only; the UI wiring is deferred (see below).

Adds two tools beyond `emit_query`:
- `emit_insight` — analyse the cellset currently on screen, no re-query
- `emit_view_change` — switch grid/chart and pick a chart type from the catalog

## The change

- `saiku-service` `olap/ai/ask/`: Anthropic + OpenAI providers now expose the four-tool surface; `AiAskService` routes by which tool the model picked; new `AiInsight` / `AiViewChange` / `AiViewChangeCatalog`.
- `saiku-web` `AiQueryResource`: insight / view-change / force-tool endpoints.
- The eight provider/service guardrail tests are updated to the new four-tool shape.

## Scope guardrail is unchanged

The 2→4 tool extension does not weaken the egress guardrail. The tests now lock these invariants against the new shape rather than the old 2-tool layout:
- `refuse_off_topic` is always present (asserted as the always-last tool)
- `tool_choice` still forces a single tool call (`any` for Anthropic, `required` for OpenAI)
- the system prompt keeps the `SCOPE GUARDRAIL` wording
- unrecognised tool calls degrade instead of turning the key into a free general-purpose LLM proxy

No assertion was removed or relaxed — only re-pointed at the new tool order and the evolved (still-strict) prompt wording.

## UI is intentionally out of scope

The ask drawer and the workspace view-change handlers are coupled on #1362 to the Tailwind migration and the undo/redo work, so pulling them in here would drag both into this PR. Keeping this PR to the backend egress matches our small single-concern split (BE / tests / UI) and isolates the security-relevant surface. The UI lands separately.

## Verified locally

- saiku-service AI-ask suite: 50/50
- saiku-web `AiAskRateLimitAndSizeTest`: green
- `npm run check` (svelte-check): 0 errors
- `aiAsk` vitest: 7/7
- spotless: clean

Backend test-only change (no runnable UI surface), so the suite is the verification.

## Review gate

SEC first (LLM egress + guardrail tests), then QA, then LEAD to merge. Please do not merge before both stamps.