### PR TITLE
test(embed): extract + unit-test buildEmbedChartOption (#1103 byte-identical lock)

### DIFF
--- a/saiku-ui/src/embed/EmbedChart.svelte
+++ b/saiku-ui/src/embed/EmbedChart.svelte
@@ -22,10 +22,11 @@
     TooltipComponent,
   } from "echarts/components";
   import { CanvasRenderer } from "echarts/renderers";
-  import type { EChartsType, ECBasicOption } from "echarts/types/dist/shared";
+  import type { EChartsType } from "echarts/types/dist/shared";
   import type { EmbedRow } from "./types";
   // #1103: host-page chart theming via CSS custom properties.
   import { readEmbedChartTheme, type EmbedChartTheme } from "./embedChartTheme";
+  import { buildEmbedChartOption } from "./embedChartOption";
 
   // Register modules once at module scope. ECharts dedupes a repeat
   // `use()` so this is safe across many <saiku-embed> instances.
@@ -78,107 +79,9 @@
     const theme: EmbedChartTheme = el
       ? readEmbedChartTheme((n) => getComputedStyle(el).getPropertyValue(n))
       : { palette: [] };
-    const opt = buildOption(rows, mode, theme);
+    const opt = buildEmbedChartOption(rows, mode, theme);
     chart.setOption(opt, { notMerge: true });
   });
-
-  function isNumericColumn(rs: EmbedRow[], col: string): boolean {
-    for (const r of rs) {
-      const v = r[col]?.value;
-      if (v === null || v === undefined) continue;
-      if (typeof v !== "number" || Number.isNaN(v)) return false;
-    }
-    return true;
-  }
-
-  function buildOption(rs: EmbedRow[], chartMode: string, theme: EmbedChartTheme): ECBasicOption {
-    const fg = theme.fg;
-    const axisColor = theme.axisLine;
-    // #1103: host-set series palette → ECharts `color` cycle. Spread so an
-    // unstyled embed emits no `color` key (output byte-identical to pre-#1103).
-    const colorOpt: ECBasicOption = theme.palette.length ? { color: theme.palette } : {};
-    const legendOpt = { bottom: 0, ...(fg ? { textStyle: { color: fg } } : {}) };
-    const fgText = fg ? { color: fg } : {};
-    const axisLineOpt = axisColor ? { axisLine: { lineStyle: { color: axisColor } } } : {};
-
-    if (rs.length === 0) {
-      return {
-        title: { text: "No data", left: "center", top: "middle", textStyle: { fontSize: 12, ...fgText } },
-      };
-    }
-    const cols = Object.keys(rs[0]);
-    const numericCols = cols.filter((c) => isNumericColumn(rs, c));
-    const categoryCol = cols.find((c) => !isNumericColumn(rs, c)) ?? cols[0];
-    const categories = rs.map((r) => r[categoryCol]?.formatted ?? "");
-
-    if (chartMode === "pie") {
-      // Pie uses the FIRST numeric column only — falls back to a bar
-      // chart if there isn't one.
-      const valCol = numericCols[0];
-      if (!valCol) return { title: { text: "No numeric series", textStyle: { ...fgText } } };
-      return {
-        ...colorOpt,
-        tooltip: { trigger: "item" },
-        legend: legendOpt,
-        series: [
-          {
-            type: "pie",
-            radius: ["40%", "70%"],
-            label: { show: true, formatter: "{b}: {d}%", ...fgText },
-            data: rs.map((r) => ({
-              name: r[categoryCol]?.formatted ?? "",
-              value: r[valCol]?.value ?? 0,
-            })),
-          },
-        ],
-      };
-    }
-
-    return {
-      ...colorOpt,
-      tooltip: {
-        trigger: "axis",
-        // ECharts default tooltip is bare numbers; replace with the
-        // pre-formatted cells from the server so the host page sees
-        // the same caption the workbench would. The trigger fires
-        // once per category with all series, so we walk the params.
-        formatter: (params: unknown) => {
-          const arr = Array.isArray(params) ? params : [params];
-          // arr[0].axisValue is the category caption; per-series .seriesName + .dataIndex
-          const cat = (arr[0] as { axisValue?: string }).axisValue ?? "";
-          const lines = arr
-            .map((p) => {
-              const idx = (p as { dataIndex: number }).dataIndex;
-              const name = (p as { seriesName: string }).seriesName;
-              const cell = rs[idx]?.[name];
-              const disp = cell?.formatted ?? String((p as { value: unknown }).value ?? "");
-              return `${name}: ${disp}`;
-            })
-            .join("<br/>");
-          return `<b>${cat}</b><br/>${lines}`;
-        },
-      },
-      legend: legendOpt,
-      grid: { left: 40, right: 16, top: 24, bottom: 36, containLabel: true },
-      xAxis: {
-        type: "category",
-        data: categories,
-        axisLabel: { interval: 0, rotate: categories.length > 8 ? -30 : 0, ...fgText },
-        ...axisLineOpt,
-      },
-      yAxis: {
-        type: "value",
-        ...(fg ? { axisLabel: { color: fg } } : {}),
-        ...axisLineOpt,
-        ...(axisColor ? { splitLine: { lineStyle: { color: axisColor } } } : {}),
-      },
-      series: numericCols.map((c) => ({
-        name: c,
-        type: chartMode === "line" ? ("line" as const) : ("bar" as const),
-        data: rs.map((r) => r[c]?.value ?? null),
-      })),
-    };
-  }
 </script>
 
 <div bind:this={container} class="chart" role="img" aria-label="Saiku embed chart"></div>

--- a/saiku-ui/src/embed/embedChartOption.test.ts
+++ b/saiku-ui/src/embed/embedChartOption.test.ts
@@ -1,0 +1,84 @@
+/*
+ * #1103 fast-follow — unit coverage for the embed chart's APPLIER
+ * (buildEmbedChartOption), extracted from EmbedChart.svelte. The reader
+ * (embedChartTheme.test.ts) proves the CSS vars parse correctly; this proves
+ * the parsed theme maps onto the ECharts option AND — the crux — that an
+ * unstyled embed emits the same option as pre-#1103 (no color/fg/axisLine
+ * keys). Without this, a future buildOption refactor could silently break the
+ * byte-identical back-compat guarantee with no red test.
+ */
+import { describe, test, expect } from "vitest";
+import { buildEmbedChartOption } from "./embedChartOption";
+import type { EmbedRow } from "./types";
+import type { EmbedChartTheme } from "./embedChartTheme";
+
+// A non-numeric `value` makes the column a category axis (isNumericColumn → false);
+// row-header cells carry the caption. Type it loosely for the fixture.
+const cat = (label: string) => ({ value: label as unknown as number, formatted: label });
+const num = (n: number) => ({ value: n, formatted: String(n) });
+
+const ROWS: EmbedRow[] = [
+  { Country: cat("France"), Sales: num(100), Units: num(5) },
+  { Country: cat("Spain"), Sales: num(200), Units: num(8) },
+];
+
+const UNSTYLED: EmbedChartTheme = { palette: [] };
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+describe("buildEmbedChartOption", () => {
+  test("unstyled (no vars) emits NO color/fg/axisLine keys — byte-identical to pre-#1103", () => {
+    const opt = buildEmbedChartOption(ROWS, "bar", UNSTYLED) as any;
+    expect(opt.color).toBeUndefined(); // no host palette → no `color` key
+    expect(opt.legend.textStyle).toBeUndefined(); // no fg → no legend textStyle
+    expect(opt.xAxis.axisLabel.color).toBeUndefined(); // no fg → no x label colour
+    expect(opt.xAxis.axisLine).toBeUndefined(); // no axisLine theme on x
+    expect(opt.yAxis.axisLabel).toBeUndefined(); // no fg → no y label colour
+    expect(opt.yAxis.axisLine).toBeUndefined();
+    expect(opt.yAxis.splitLine).toBeUndefined();
+  });
+
+  test("each numeric column becomes its own bar series; the non-numeric column is the category axis", () => {
+    const opt = buildEmbedChartOption(ROWS, "bar", UNSTYLED) as any;
+    expect(opt.series.map((s: any) => s.name)).toEqual(["Sales", "Units"]);
+    expect(opt.series.every((s: any) => s.type === "bar")).toBe(true);
+    expect(opt.xAxis.data).toEqual(["France", "Spain"]);
+  });
+
+  test("host palette → ECharts `color` cycle", () => {
+    const opt = buildEmbedChartOption(ROWS, "bar", { palette: ["#2563eb", "#16a34a", "#dc2626"] }) as any;
+    expect(opt.color).toEqual(["#2563eb", "#16a34a", "#dc2626"]);
+  });
+
+  test("fg themes axis labels + legend text", () => {
+    const opt = buildEmbedChartOption(ROWS, "bar", { palette: [], fg: "#ffffff" }) as any;
+    expect(opt.legend.textStyle.color).toBe("#ffffff");
+    expect(opt.xAxis.axisLabel.color).toBe("#ffffff");
+    expect(opt.yAxis.axisLabel.color).toBe("#ffffff");
+  });
+
+  test("axisLine (muted) themes both axis lines + the y splitLine", () => {
+    const opt = buildEmbedChartOption(ROWS, "bar", { palette: [], axisLine: "#cccccc" }) as any;
+    expect(opt.xAxis.axisLine.lineStyle.color).toBe("#cccccc");
+    expect(opt.yAxis.axisLine.lineStyle.color).toBe("#cccccc");
+    expect(opt.yAxis.splitLine.lineStyle.color).toBe("#cccccc");
+  });
+
+  test("line mode → line series", () => {
+    const opt = buildEmbedChartOption(ROWS, "line", UNSTYLED) as any;
+    expect(opt.series.every((s: any) => s.type === "line")).toBe(true);
+  });
+
+  test("pie mode → a single pie series on the first numeric column, honouring the palette", () => {
+    const opt = buildEmbedChartOption(ROWS, "pie", { palette: ["#abc"] }) as any;
+    expect(opt.series).toHaveLength(1);
+    expect(opt.series[0].type).toBe("pie");
+    expect(opt.color).toEqual(["#abc"]); // palette still applies in pie mode
+    expect(opt.series[0].data.map((d: any) => d.value)).toEqual([100, 200]); // first numeric col = Sales
+  });
+
+  test("empty rows → 'No data' title, still no color key when unstyled", () => {
+    const opt = buildEmbedChartOption([], "bar", UNSTYLED) as any;
+    expect(opt.title.text).toBe("No data");
+    expect(opt.color).toBeUndefined();
+  });
+});

--- a/saiku-ui/src/embed/embedChartOption.ts
+++ b/saiku-ui/src/embed/embedChartOption.ts
@@ -1,0 +1,108 @@
+/*
+ * #1103 — the pure records→ECharts option builder for the embed chart,
+ * extracted verbatim from EmbedChart.svelte so the host-theme var→ECharts
+ * mapping (and the "byte-identical when unstyled" back-compat guarantee) is
+ * unit-testable without standing up the Svelte component or a live ECharts
+ * canvas. Behaviour-preserving: EmbedChart.svelte now imports buildEmbedChartOption.
+ */
+import type { ECBasicOption } from "echarts/types/dist/shared";
+import type { EmbedChartTheme } from "./embedChartTheme";
+import type { EmbedRow } from "./types";
+
+function isNumericColumn(rs: EmbedRow[], col: string): boolean {
+  for (const r of rs) {
+    const v = r[col]?.value;
+    if (v === null || v === undefined) continue;
+    if (typeof v !== "number" || Number.isNaN(v)) return false;
+  }
+  return true;
+}
+
+export function buildEmbedChartOption(rs: EmbedRow[], chartMode: string, theme: EmbedChartTheme): ECBasicOption {
+  const fg = theme.fg;
+  const axisColor = theme.axisLine;
+  // #1103: host-set series palette → ECharts `color` cycle. Spread so an
+  // unstyled embed emits no `color` key (output byte-identical to pre-#1103).
+  const colorOpt: ECBasicOption = theme.palette.length ? { color: theme.palette } : {};
+  const legendOpt = { bottom: 0, ...(fg ? { textStyle: { color: fg } } : {}) };
+  const fgText = fg ? { color: fg } : {};
+  const axisLineOpt = axisColor ? { axisLine: { lineStyle: { color: axisColor } } } : {};
+
+  if (rs.length === 0) {
+    return {
+      title: { text: "No data", left: "center", top: "middle", textStyle: { fontSize: 12, ...fgText } },
+    };
+  }
+  const cols = Object.keys(rs[0]);
+  const numericCols = cols.filter((c) => isNumericColumn(rs, c));
+  const categoryCol = cols.find((c) => !isNumericColumn(rs, c)) ?? cols[0];
+  const categories = rs.map((r) => r[categoryCol]?.formatted ?? "");
+
+  if (chartMode === "pie") {
+    // Pie uses the FIRST numeric column only — falls back to a bar
+    // chart if there isn't one.
+    const valCol = numericCols[0];
+    if (!valCol) return { title: { text: "No numeric series", textStyle: { ...fgText } } };
+    return {
+      ...colorOpt,
+      tooltip: { trigger: "item" },
+      legend: legendOpt,
+      series: [
+        {
+          type: "pie",
+          radius: ["40%", "70%"],
+          label: { show: true, formatter: "{b}: {d}%", ...fgText },
+          data: rs.map((r) => ({
+            name: r[categoryCol]?.formatted ?? "",
+            value: r[valCol]?.value ?? 0,
+          })),
+        },
+      ],
+    };
+  }
+
+  return {
+    ...colorOpt,
+    tooltip: {
+      trigger: "axis",
+      // ECharts default tooltip is bare numbers; replace with the
+      // pre-formatted cells from the server so the host page sees
+      // the same caption the workbench would. The trigger fires
+      // once per category with all series, so we walk the params.
+      formatter: (params: unknown) => {
+        const arr = Array.isArray(params) ? params : [params];
+        // arr[0].axisValue is the category caption; per-series .seriesName + .dataIndex
+        const cat = (arr[0] as { axisValue?: string }).axisValue ?? "";
+        const lines = arr
+          .map((p) => {
+            const idx = (p as { dataIndex: number }).dataIndex;
+            const name = (p as { seriesName: string }).seriesName;
+            const cell = rs[idx]?.[name];
+            const disp = cell?.formatted ?? String((p as { value: unknown }).value ?? "");
+            return `${name}: ${disp}`;
+          })
+          .join("<br/>");
+        return `<b>${cat}</b><br/>${lines}`;
+      },
+    },
+    legend: legendOpt,
+    grid: { left: 40, right: 16, top: 24, bottom: 36, containLabel: true },
+    xAxis: {
+      type: "category",
+      data: categories,
+      axisLabel: { interval: 0, rotate: categories.length > 8 ? -30 : 0, ...fgText },
+      ...axisLineOpt,
+    },
+    yAxis: {
+      type: "value",
+      ...(fg ? { axisLabel: { color: fg } } : {}),
+      ...axisLineOpt,
+      ...(axisColor ? { splitLine: { lineStyle: { color: axisColor } } } : {}),
+    },
+    series: numericCols.map((c) => ({
+      name: c,
+      type: chartMode === "line" ? ("line" as const) : ("bar" as const),
+      data: rs.map((r) => r[c]?.value ?? null),
+    })),
+  };
+}


### PR DESCRIPTION
﻿Fast-follow to #1364 — the coverage gap I flagged in my QA pass. The reader (`embedChartTheme.ts`) was unit-tested, but the **applier** (`buildOption` inside `EmbedChart.svelte` — the var→ECharts palette/axis mapping + the "byte-identical when unstyled" back-compat guarantee) wasn't directly tested. It was correct-by-construction only, so a future `buildOption` refactor could silently break it with no red test.

- **Extracted** `buildOption` (+ `isNumericColumn`) **verbatim** from `EmbedChart.svelte` into a pure `embedChartOption.ts` (`buildEmbedChartOption`); the component now imports it. Behaviour-preserving — the existing **1015** vitest tests still pass unchanged.
- **Added** `embedChartOption.test.ts` (8 tests): unstyled emits **no** `color`/`fg`/`axisLine` keys (the byte-identical lock), palette→`color` cycle, fg→axis+legend text, axisLine→axis lines + y `splitLine`, bar/line/pie series shaping, empty-rows "No data".

`svelte-check` 0 errors, **vitest 1023/1023** (1015 + 8 new), embed bundle builds. Verified on Node (8 GB heap). Stacked on the #1103 branch so it folds in with the feature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
