### PR TITLE
test(ai): lock the view-change allowlist guardrail (#1365 follow-up)

### DIFF
--- a/saiku-core/saiku-service/src/test/java/org/saiku/service/olap/ai/ask/AiAskServiceTest.java
+++ b/saiku-core/saiku-service/src/test/java/org/saiku/service/olap/ai/ask/AiAskServiceTest.java
@@ -114,6 +114,47 @@ public class AiAskServiceTest {
         assertTrue(captured.requestJsonSchema().contains("AiQueryRequest"));
     }
 
+    /* ---- saiku#1365 view-change allowlist (the LLM can't inject an arbitrary view) ---- */
+
+    @Test
+    public void acceptsAViewChangeWithAnAllowlistedChartType() {
+        // A view-change whose chartType is in AiViewChangeCatalog.CHART_TYPE_IDS is
+        // accepted (not degraded) and surfaced for the UI to apply.
+        String json = "{\"viewMode\":\"chart\",\"chartType\":\"bar\",\"reason\":\"trend over time\"}";
+        AiAskService svc = new AiAskService(
+                fixedSchemaService(emptySchema()), stub(NlAskResponse.okViewChange(json, "claude-x", 1, 1)));
+        AiAskService.AskOutcome out = svc.ask(CUBE, "make it a bar chart", List.of());
+        assertFalse(out.degraded());
+        assertNotNull(out.viewChange());
+        assertEquals("chart", out.viewChange().getViewMode());
+        assertEquals("bar", out.viewChange().getChartType());
+    }
+
+    @Test
+    public void rejectsAHallucinatedChartType() {
+        // The guardrail: anything outside the chartType allowlist is rejected
+        // (degraded), so a hallucinated id can never reach the UI render path.
+        // RED if the !CHART_TYPE_IDS.contains() guard at AiAskService were dropped.
+        String json = "{\"viewMode\":\"chart\",\"chartType\":\"totally-made-up-3d-globe\"}";
+        AiAskService svc = new AiAskService(
+                fixedSchemaService(emptySchema()), stub(NlAskResponse.okViewChange(json, "claude-x", 1, 1)));
+        AiAskService.AskOutcome out = svc.ask(CUBE, "switch view", List.of());
+        assertTrue(out.degraded());
+        assertTrue(out.reason().contains("unknown chartType"));
+        assertNull("a rejected view-change must not surface to the UI", out.viewChange());
+    }
+
+    @Test
+    public void rejectsAnInvalidViewMode() {
+        // viewMode is likewise allowlisted (grid | chart) — a bogus mode degrades.
+        String json = "{\"viewMode\":\"hologram\",\"chartType\":\"bar\"}";
+        AiAskService svc = new AiAskService(
+                fixedSchemaService(emptySchema()), stub(NlAskResponse.okViewChange(json, "claude-x", 1, 1)));
+        AiAskService.AskOutcome out = svc.ask(CUBE, "switch view", List.of());
+        assertTrue(out.degraded());
+        assertTrue(out.reason().contains("invalid viewMode"));
+    }
+
     // ---------- helpers ----------
 
     private static AiCubeMetadataService fixedSchemaService(AiSchema schema) {


### PR DESCRIPTION
﻿Fast-follow to #1365 — the test gap from my QA pass. The AI-ask layer rejects a view-change whose `viewMode` ∉ `VIEW_MODES` or whose `chartType` ∉ `AiViewChangeCatalog.CHART_TYPE_IDS` (in `AiAskService`) — the guardrail that stops the LLM injecting an **arbitrary view-change** into the UI render path. SEC code-verified it, but nothing exercised the rejection. Three tests:

- **`acceptsAViewChangeWithAnAllowlistedChartType`** — `chart`/`bar` → `okViewChange` (not degraded).
- **`rejectsAHallucinatedChartType`** — a chartType outside the allowlist → degraded `"unknown chartType"`, never surfaced (`viewChange()` null). **RED if the `contains()` guard is dropped.**
- **`rejectsAnInvalidViewMode`** — viewMode outside `grid`|`chart` → degraded.

`AiAskServiceTest` **10/0** (7 + 3 new); spotless clean; JDK 21. Stacked on the #1365 branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
