### PR TITLE
test(olap)+fix(ui): #1362 dedupe NPE-guard test + cross-platform check-tokens

### DIFF
--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ThinQueryService.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ThinQueryService.java
@@ -575,7 +575,10 @@ public class ThinQueryService implements Serializable {
         return old;
     }
 
-    private ThinQuery removeDupSelections(ThinQuery old) {
+    // Package-private + static (uses only its argument, no instance state) so the
+    // null-selection guard below is unit-testable without standing up the bean
+    // (saiku#1362 — the AI edit-in-canvas NPE regression).
+    static ThinQuery removeDupSelections(ThinQuery old) {
         // Pure-MDX queries (e.g. those built by AiSchemaConverter) carry no
         // queryModel — there are no model-side selections to deduplicate.
         if (old == null || old.getQueryModel() == null) return old;

--- a/saiku-core/saiku-service/src/test/java/org/saiku/service/olap/ThinQueryServiceDedupeTest.java
+++ b/saiku-core/saiku-service/src/test/java/org/saiku/service/olap/ThinQueryServiceDedupeTest.java
@@ -1,0 +1,113 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.service.olap;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.Test;
+import org.olap4j.impl.NamedListImpl;
+import org.olap4j.metadata.NamedList;
+import org.saiku.olap.query2.ThinAxis;
+import org.saiku.olap.query2.ThinHierarchy;
+import org.saiku.olap.query2.ThinLevel;
+import org.saiku.olap.query2.ThinMember;
+import org.saiku.olap.query2.ThinQuery;
+import org.saiku.olap.query2.ThinQueryModel;
+import org.saiku.olap.query2.ThinQueryModel.AxisLocation;
+import org.saiku.olap.query2.ThinSelection;
+
+/**
+ * saiku#1362 — locks the {@code removeDupSelections} null-selection guard. The
+ * AI Ask "edit in canvas" path re-executes an AI-built queryModel client-side;
+ * those models carry levels with a NULL selection (the converter only sets one
+ * when the request names members), and the dedupe pass used to NPE on
+ * {@code getSelection().getMembers()}. The guard skips them — these tests pin
+ * that (and that the actual dedupe still works on real selections).
+ */
+public class ThinQueryServiceDedupeTest {
+
+    private static ThinMember m(String unique) {
+        return new ThinMember(unique, unique, unique);
+    }
+
+    /** A hierarchy carrying one level with the given (possibly null) selection. */
+    private static ThinHierarchy hier(String hierUnique, String dim, String levelName, ThinSelection sel) {
+        ThinLevel lvl = new ThinLevel(levelName, levelName, sel, new ArrayList<>());
+        Map<String, ThinLevel> levels = new LinkedHashMap<>();
+        levels.put(levelName, lvl);
+        return new ThinHierarchy(hierUnique, hierUnique, dim, levels);
+    }
+
+    private static ThinQuery modelWith(AxisLocation loc, ThinHierarchy... hiers) {
+        ThinQuery tq = new ThinQuery();
+        tq.setName("t");
+        tq.setQueryModel(new ThinQueryModel());
+        NamedList<ThinHierarchy> nl = new NamedListImpl<>();
+        Collections.addAll(nl, hiers);
+        tq.getQueryModel().getAxes().put(loc, new ThinAxis(loc, nl, false, new ArrayList<>()));
+        return tq;
+    }
+
+    private static ThinSelection inclusion(ThinMember... members) {
+        return new ThinSelection(ThinSelection.Type.INCLUSION, new ArrayList<>(List.of(members)));
+    }
+
+    private static ThinSelection selectionOf(ThinQuery tq, int hierIndex, String level) {
+        return tq.getQueryModel()
+                .getAxis(AxisLocation.ROWS)
+                .getHierarchies()
+                .get(hierIndex)
+                .getLevels()
+                .get(level)
+                .getSelection();
+    }
+
+    @Test
+    public void skipsLevelsWithNullSelection_noNpe() {
+        // The regression: a level with a null selection must NOT NPE the dedupe.
+        // RED before the `if (selection == null) continue` guard.
+        ThinQuery tq = modelWith(AxisLocation.ROWS, hier("[Date].[Date]", "Date", "All", null));
+
+        ThinQuery out = ThinQueryService.removeDupSelections(tq); // must not throw
+
+        assertNotNull(out);
+        assertNull("a null-selection level is left untouched", selectionOf(tq, 0, "All"));
+    }
+
+    @Test
+    public void dedupesDuplicateMembersOnARealSelection() {
+        // Sanity: the actual dedupe still works on a level that DOES carry a selection.
+        ThinSelection sel = inclusion(m("[P].[Drink]"), m("[P].[Drink]"), m("[P].[Food]"));
+        ThinQuery tq = modelWith(AxisLocation.ROWS, hier("[P].[P]", "P", "Family", sel));
+
+        ThinQueryService.removeDupSelections(tq);
+
+        List<String> names = selectionOf(tq, 0, "Family").getMembers().stream()
+                .map(ThinMember::getUniqueName)
+                .toList();
+        assertEquals(List.of("[P].[Drink]", "[P].[Food]"), names);
+    }
+
+    @Test
+    public void mixedNullAndRealSelections_dedupesRealLeavesNullAlone_noNpe() {
+        // The real edit-in-canvas shape: one AI axis-only level (null selection)
+        // alongside one with duplicate members. No NPE; the real one is deduped.
+        ThinHierarchy nullLvl = hier("[Date].[Date]", "Date", "All", null);
+        ThinHierarchy dupLvl = hier("[Time].[Time]", "Time", "Year", inclusion(m("[T].[1997]"), m("[T].[1997]")));
+        ThinQuery tq = modelWith(AxisLocation.ROWS, nullLvl, dupLvl);
+
+        ThinQueryService.removeDupSelections(tq); // no NPE despite the null-selection level
+
+        assertNull(selectionOf(tq, 0, "All"));
+        assertEquals(1, selectionOf(tq, 1, "Year").getMembers().size());
+    }
+}

--- a/saiku-ui/scripts/check-tokens.mjs
+++ b/saiku-ui/scripts/check-tokens.mjs
@@ -18,9 +18,8 @@
  *   - src/lib/design-system/   — definition site of TONE_CLASSES
  */
 
-import { execSync } from 'node:child_process';
-import { existsSync } from 'node:fs';
-import { join, resolve } from 'node:path';
+import { existsSync, readdirSync, readFileSync } from 'node:fs';
+import { join, resolve, relative, sep } from 'node:path';
 
 const here = resolve(import.meta.dirname, '..');
 process.chdir(here);
@@ -37,30 +36,37 @@ function isExempt(path) {
 	return EXEMPT.some((e) => path === e || path.startsWith(e));
 }
 
-const pattern = `\\b(text|bg|border|hover:bg|hover:text)-(${FORBIDDEN_TONES.join('|')})-[0-9]+`;
-const includes = ['*.svelte', '*.ts'].map((p) => `--include=${p}`).join(' ');
-const dirs = SEARCH_DIRS.filter((d) => existsSync(join(here, d))).join(' ');
+const pattern = new RegExp(`\\b(text|bg|border|hover:bg|hover:text)-(${FORBIDDEN_TONES.join('|')})-[0-9]+`);
+const EXTENSIONS = ['.svelte', '.ts'];
 
-let raw;
-try {
-	raw = execSync(`grep -rnE '${pattern}' ${dirs} ${includes}`, {
-		encoding: 'utf8',
-		stdio: ['ignore', 'pipe', 'ignore']
-	});
-} catch (e) {
-	// grep exits 1 when no matches. That's the success case for this check.
-	if (e.status === 1) {
-		console.log('✓ No raw status-tone Tailwind utilities found.');
-		process.exit(0);
+// Node-native recursive scan — no shell-out to `grep`, so the check runs the
+// same on Windows / macOS / Linux (the old execSync(`grep …`) crashed on
+// Windows where grep isn't a command; saiku#1362 follow-up). Emits the same
+// `relPath:lineNo:lineText` shape grep -rnE produced, so the logic below is
+// unchanged.
+function scan(dir, out) {
+	for (const entry of readdirSync(dir, { withFileTypes: true })) {
+		if (entry.name === 'node_modules' || entry.name.startsWith('.')) continue;
+		const full = join(dir, entry.name);
+		if (entry.isDirectory()) {
+			scan(full, out);
+		} else if (EXTENSIONS.some((e) => entry.name.endsWith(e))) {
+			const rel = relative(here, full).split(sep).join('/'); // posix-style for isExempt
+			const fileLines = readFileSync(full, 'utf8').split(/\r?\n/);
+			fileLines.forEach((text, i) => {
+				if (pattern.test(text)) out.push(`${rel}:${i + 1}:${text}`);
+			});
+		}
 	}
-	throw e;
 }
 
-const lines = raw.trim().split('\n');
-const violations = lines.filter((line) => {
-	const path = line.split(':')[0];
-	return !isExempt(path);
-});
+const matches = [];
+for (const d of SEARCH_DIRS) {
+	const abs = join(here, d);
+	if (existsSync(abs)) scan(abs, matches);
+}
+
+const violations = matches.filter((line) => !isExempt(line.split(':')[0]));
 
 if (violations.length === 0) {
 	console.log('✓ No raw status-tone Tailwind utilities found outside allowed paths.');


### PR DESCRIPTION
﻿Two follow-ups to my #1362 QA pass.

**1. Lock the dedupe NPE-guard (Finding 1).** `ThinQueryService.removeDupSelections` skips levels with a null selection — AI-built queryModels (the "edit in canvas" path) carry those, and the dedupe used to NPE on `getSelection().getMembers()`. Widened the method to package-private `static` (it uses only its argument, no instance state) + added `ThinQueryServiceDedupeTest` (3): null-selection level skipped (**no NPE — RED before the guard**), real selections still deduped, and the mixed real+null shape.

**2. Make `check-tokens.mjs` cross-platform (Finding 3 / DEV's flag b).** The token-guard `execSync`'d `grep`, which doesn't exist on Windows — so `npm run lint:tokens` (and `npm run lint`) **crashed on every Windows dev box** (it even tanked `npm test`'s exit code). Rewrote the scan in pure Node (recursive fs walk + regex), emitting the same `relPath:lineNo:text` shape, **no shell-out**. Verified on Windows: passes, exit 0, and still excludes the exempt `design-system/` definition site (so the guard keeps its teeth).

`saiku-service` compiles + `ThinQueryServiceDedupeTest` 3/0; `check-tokens.mjs` runs clean cross-platform. Stacked on the #1362 branch so both fold in with the port.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
