### PR TITLE
feat(schema): Mondrian → Apache Ossie exporter (saiku#1384)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -477,3 +477,4 @@ nbdist/
 
 # git worktrees
 .worktrees/
+.pi/

--- a/saiku-core/saiku-service/pom.xml
+++ b/saiku-core/saiku-service/pom.xml
@@ -232,6 +232,15 @@
 			<artifactId>jackson-databind</artifactId>
 			<scope>compile</scope>
 		</dependency>
+		<!-- YAML output for the Ossie exporter (saiku#1384). Jackson's YAML
+		     module reuses the same @JsonProperty / @JsonInclude annotations as
+		     the JSON path, so the model classes serialise as either format
+		     without duplicate annotations. -->
+		<dependency>
+			<groupId>com.fasterxml.jackson.dataformat</groupId>
+			<artifactId>jackson-dataformat-yaml</artifactId>
+			<scope>compile</scope>
+		</dependency>
 		<dependency>
 			<groupId>org.apache.poi</groupId>
 			<artifactId>poi</artifactId>

--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/schema/ossie/MondrianToOssieConverter.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/schema/ossie/MondrianToOssieConverter.java
@@ -1,0 +1,404 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.service.schema.ossie;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import javax.xml.parsers.ParserConfigurationException;
+import org.saiku.service.schema.ossie.model.AiContext;
+import org.saiku.service.schema.ossie.model.CustomExtension;
+import org.saiku.service.schema.ossie.model.Dataset;
+import org.saiku.service.schema.ossie.model.DimensionMeta;
+import org.saiku.service.schema.ossie.model.Expression;
+import org.saiku.service.schema.ossie.model.Field;
+import org.saiku.service.schema.ossie.model.Metric;
+import org.saiku.service.schema.ossie.model.OssieDocument;
+import org.saiku.service.schema.ossie.model.Relationship;
+import org.saiku.service.schema.ossie.model.SemanticModel;
+import org.saiku.service.util.xml.SecureXml;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+import org.xml.sax.SAXException;
+
+/**
+ * Convert a Mondrian XML schema into an {@link OssieDocument} following the mapping documented on
+ * saiku#1384.
+ *
+ * <p>Cube → {@code SemanticModel}. Fact table → {@code dataset}. Each dimension table (via
+ * hierarchy {@code <Table/>}) → its own {@code dataset}. Foreign key from cube's {@code
+ * <Dimension foreignKey=…>} + hierarchy's {@code primaryKey=…} → {@code relationship}. Each
+ * {@code <Measure aggregator=… column=…/>} → {@code metric} with both an ANSI_SQL dialect
+ * expression AND an MDX dialect expression (verbatim {@code [Measures].[Name]}). {@code
+ * <CalculatedMember>} → metric with MDX dialect only (no reliable ANSI_SQL translation).
+ *
+ * <p>Saiku semantic annotations propagate: {@code saiku.semantic.description} and {@code
+ * saiku.semantic.synonyms} lift into the Ossie {@link AiContext} directly (Ossie has first-class
+ * homes for both); {@code saiku.semantic.pii} + {@code cardinality} + {@code grain} + {@code
+ * aggregation_kind} + {@code required_filters} ride under {@code custom_extensions} with {@code
+ * vendor_name="SAIKU"} because Ossie has no first-class field for them yet.
+ *
+ * <p>Deliberately not supported in this iteration (issues to file separately):
+ *
+ * <ul>
+ *   <li>Mondrian 4 {@code <MeasureGroup>} with {@code <NoLink>} — the classic-3 shape covers
+ *       every schema we ship (FoodMart, Bank, Pharma). MG shape follows in a v2.
+ *   <li>Virtual cubes.
+ *   <li>Parent-child hierarchies.
+ *   <li>Shared dimensions consumed via {@code <DimensionUsage>} (uses {@code source=…}).
+ * </ul>
+ *
+ * <p>The converter is stateless once built; a single instance can serve many schemas.
+ */
+public final class MondrianToOssieConverter {
+
+    /** Namespace prefix for saiku.semantic.* annotations. Kept local to avoid a service dep. */
+    private static final String SEMANTIC_PREFIX = "saiku.semantic.";
+
+    private static final String SEMANTIC_DESCRIPTION = SEMANTIC_PREFIX + "description";
+    private static final String SEMANTIC_SYNONYMS = SEMANTIC_PREFIX + "synonyms";
+
+    private final ObjectMapper json = new ObjectMapper();
+
+    public OssieDocument convert(InputStream mondrianXml)
+            throws IOException, SAXException, ParserConfigurationException {
+        Document doc = SecureXml.secureDocumentBuilder().parse(Objects.requireNonNull(mondrianXml, "mondrianXml"));
+        skippedCubes.clear();
+        return convert(doc.getDocumentElement());
+    }
+
+    public OssieDocument convert(Element schemaEl) {
+        OssieDocument out = new OssieDocument();
+        for (Element cube : childrenNamed(schemaEl, "Cube")) {
+            SemanticModel sm = convertCube(cube);
+            // Ossie's core schema requires `datasets` to have at least one entry. Cubes that
+            // yield zero datasets are almost always Mondrian 4 <MeasureGroup> shape or virtual
+            // cubes — neither of which this first-cut converter recognises. Emit them into
+            // {@link #skippedCubes} for the CLI to report rather than failing the whole document.
+            if (sm.getDatasets().isEmpty()) {
+                skippedCubes.add(sm.getName());
+                continue;
+            }
+            out.getSemanticModel().add(sm);
+        }
+        return out;
+    }
+
+    /** Cube names skipped during the last conversion. Reset on each call to {@link #convert}. */
+    public java.util.List<String> getSkippedCubes() {
+        return skippedCubes;
+    }
+
+    private final java.util.List<String> skippedCubes = new ArrayList<>();
+
+    /* ---------------- cube ---------------- */
+
+    private SemanticModel convertCube(Element cube) {
+        SemanticModel sm = new SemanticModel();
+        sm.setName(attr(cube, "name"));
+        sm.setDescription(nullIfBlank(attr(cube, "description")));
+        applyAnnotationsToAiContext(cube, sm::setAiContext);
+        applyAnnotationsToExtensions(cube, sm.getCustomExtensions());
+
+        // Fact table — child <Table name="..." schema="..."/> is the classic Mondrian 3-4 shape.
+        // If missing (e.g. cube references a view via <View>), we skip building the fact dataset
+        // and log a comment via description so the operator can spot the gap. Not fatal.
+        Element factTable = firstChild(cube, "Table");
+        Dataset factDataset = null;
+        if (factTable != null) {
+            factDataset = new Dataset();
+            factDataset.setName(sanitiseName(attr(factTable, "name")));
+            factDataset.setSource(qualifyTable(attr(factTable, "schema"), attr(factTable, "name")));
+            factDataset.setDescription("Fact table for cube '" + sm.getName() + "'.");
+            sm.getDatasets().add(factDataset);
+        }
+
+        // Each <Dimension> under the cube → its own dim dataset + a relationship back to the fact.
+        for (Element dim : childrenNamed(cube, "Dimension")) {
+            convertCubeDimension(sm, factDataset, dim);
+        }
+
+        // Measures — one metric each. Both ANSI_SQL and MDX dialects on every entry.
+        for (Element measure : childrenNamed(cube, "Measure")) {
+            sm.getMetrics().add(convertMeasure(sm.getName(), factDataset, measure));
+        }
+        // Calculated members — MDX-only.
+        for (Element calc : childrenNamed(cube, "CalculatedMember")) {
+            sm.getMetrics().add(convertCalculatedMember(sm.getName(), calc));
+        }
+
+        return sm;
+    }
+
+    /* ---------------- dimensions ---------------- */
+
+    private void convertCubeDimension(SemanticModel sm, Dataset factDataset, Element dim) {
+        String dimName = attr(dim, "name");
+        String foreignKey = attr(dim, "foreignKey");
+        // Only handle the classic single-hierarchy shape here — spec-covered dims have exactly one
+        // <Hierarchy/> child. Multi-hierarchy dims (a Time dim with Weekly and Monthly for
+        // instance) get one dataset per hierarchy because each hierarchy has its own Table root.
+        for (Element hier : childrenNamed(dim, "Hierarchy")) {
+            Element hierTable = firstChild(hier, "Table");
+            if (hierTable == null) {
+                // Degenerate dim — resolves against the fact table. Levels attach as fields on
+                // the fact dataset directly rather than getting their own dataset + relationship.
+                if (factDataset != null) {
+                    for (Element level : childrenNamed(hier, "Level")) {
+                        factDataset.getFields().add(convertLevel(level));
+                    }
+                }
+                continue;
+            }
+            Dataset dimDataset = new Dataset();
+            String hierName = attr(hier, "name");
+            String datasetName = sanitiseName(dimName
+                    + (hierName == null || hierName.isBlank() || hierName.equals(dimName) ? "" : "_" + hierName));
+            dimDataset.setName(datasetName);
+            dimDataset.setSource(qualifyTable(attr(hierTable, "schema"), attr(hierTable, "name")));
+            String primaryKey = attr(hier, "primaryKey");
+            if (primaryKey != null && !primaryKey.isBlank()) {
+                dimDataset.getPrimaryKey().add(primaryKey);
+            }
+            applyAnnotationsToAiContext(dim, dimDataset::setAiContext);
+            applyAnnotationsToExtensions(dim, dimDataset.getCustomExtensions());
+
+            // Levels become fields on the dim dataset.
+            for (Element level : childrenNamed(hier, "Level")) {
+                dimDataset.getFields().add(convertLevel(level));
+            }
+            sm.getDatasets().add(dimDataset);
+
+            // Relationship: fact.foreignKey → dim.primaryKey. Skip when either side is unresolvable.
+            if (factDataset != null && foreignKey != null && !foreignKey.isBlank() && primaryKey != null) {
+                Relationship rel = new Relationship();
+                rel.setName(sanitiseName(factDataset.getName() + "_to_" + dimDataset.getName()));
+                rel.setFrom(factDataset.getName());
+                rel.setTo(dimDataset.getName());
+                rel.getFromColumns().add(foreignKey);
+                rel.getToColumns().add(primaryKey);
+                sm.getRelationships().add(rel);
+            }
+        }
+    }
+
+    private Field convertLevel(Element level) {
+        Field f = new Field();
+        f.setName(attr(level, "name"));
+        String column = attr(level, "column");
+        if (column != null && !column.isBlank()) {
+            // ANSI_SQL expression is just the column reference — the field lives on this dataset,
+            // so no qualification is needed.
+            f.setExpression(Expression.ansi(column));
+        }
+        // Ossie's is_time triggers off Mondrian's levelType attribute (TimeYears / TimeQuarters
+        // / TimeMonths / TimeDays / etc). Any Time* value marks the field as temporal.
+        String levelType = attr(level, "levelType");
+        if (levelType != null && levelType.startsWith("Time")) {
+            f.setDimension(new DimensionMeta(true));
+        }
+        applyAnnotationsToAiContext(level, f::setAiContext);
+        applyAnnotationsToExtensions(level, f.getCustomExtensions());
+        return f;
+    }
+
+    /* ---------------- measures ---------------- */
+
+    private Metric convertMeasure(String cubeName, Dataset factDataset, Element measure) {
+        Metric m = new Metric();
+        String name = attr(measure, "name");
+        m.setName(name);
+        String aggregator = attr(measure, "aggregator");
+        String column = attr(measure, "column");
+        Expression expr = new Expression();
+        // ANSI_SQL — best-effort from aggregator + column, qualified by the fact dataset name.
+        if (aggregator != null && column != null && factDataset != null) {
+            String ansi = translateAggregator(aggregator, factDataset.getName() + "." + column);
+            if (ansi != null) {
+                expr.add("ANSI_SQL", ansi);
+            }
+        }
+        // MDX — the canonical unique name Mondrian resolves. Downstream MDX-native consumers
+        // (Saiku itself, XMLA clients) use this dialect.
+        expr.add("MDX", "[Measures].[" + name + "]");
+        m.setExpression(expr);
+        applyAnnotationsToAiContext(measure, m::setAiContext);
+        applyAnnotationsToExtensions(measure, m.getCustomExtensions());
+        return m;
+    }
+
+    private Metric convertCalculatedMember(String cubeName, Element calc) {
+        Metric m = new Metric();
+        m.setName(attr(calc, "name"));
+        Expression expr = new Expression();
+        // Formula lives in <Formula>text</Formula> child OR in a formula="..." attribute — try
+        // both, in that order (child element wins if both present).
+        Element formula = firstChild(calc, "Formula");
+        String mdx = formula != null ? formula.getTextContent().trim() : attr(calc, "formula");
+        if (mdx != null && !mdx.isBlank()) {
+            expr.add("MDX", mdx);
+        }
+        m.setExpression(expr);
+        applyAnnotationsToAiContext(calc, m::setAiContext);
+        applyAnnotationsToExtensions(calc, m.getCustomExtensions());
+        return m;
+    }
+
+    /**
+     * Translate a Mondrian aggregator attribute value into an ANSI SQL aggregation function
+     * wrapped around the qualified column reference. Returns null for aggregators we can't
+     * express in one line — the caller falls back to MDX-only.
+     */
+    private String translateAggregator(String aggregator, String qualifiedColumn) {
+        switch (aggregator.toLowerCase(Locale.ROOT)) {
+            case "sum":
+                return "SUM(" + qualifiedColumn + ")";
+            case "count":
+                return "COUNT(" + qualifiedColumn + ")";
+            case "distinct-count":
+                return "COUNT(DISTINCT " + qualifiedColumn + ")";
+            case "min":
+                return "MIN(" + qualifiedColumn + ")";
+            case "max":
+                return "MAX(" + qualifiedColumn + ")";
+            case "avg":
+                return "AVG(" + qualifiedColumn + ")";
+            default:
+                return null;
+        }
+    }
+
+    /* ---------------- annotations ---------------- */
+
+    /**
+     * Extract {@code saiku.semantic.description} + {@code saiku.semantic.synonyms} from an
+     * element's {@code <Annotations>} block and populate an Ossie AiContext via the given setter.
+     * Ossie has first-class homes for both, so we prefer these over {@code custom_extensions}.
+     */
+    private void applyAnnotationsToAiContext(Element parent, java.util.function.Consumer<AiContext> setter) {
+        Map<String, String> ann = readAnnotations(parent);
+        if (ann.isEmpty()) return;
+        AiContext ctx = new AiContext();
+        String desc = ann.get(SEMANTIC_DESCRIPTION);
+        if (desc != null && !desc.isBlank()) ctx.setInstructions(desc);
+        String syn = ann.get(SEMANTIC_SYNONYMS);
+        if (syn != null && !syn.isBlank()) {
+            List<String> list = new ArrayList<>();
+            for (String s : syn.split(",")) {
+                String t = s.trim();
+                if (!t.isEmpty()) list.add(t);
+            }
+            ctx.setSynonyms(list);
+        }
+        if (!ctx.isEmpty()) setter.accept(ctx);
+    }
+
+    /**
+     * Push everything OTHER than description/synonyms into a single SAIKU-vendored extension.
+     * Empty payload → no extension appended (Ossie's own {@code @JsonInclude(NON_EMPTY)} would
+     * strip it anyway, but keeping the emitted YAML tidy is easier if we just skip it up-front).
+     */
+    private void applyAnnotationsToExtensions(Element parent, List<CustomExtension> extensions) {
+        Map<String, String> ann = readAnnotations(parent);
+        if (ann.isEmpty()) return;
+        // Keep insertion order for a stable YAML diff.
+        Map<String, String> payload = new LinkedHashMap<>();
+        for (Map.Entry<String, String> e : ann.entrySet()) {
+            if (!e.getKey().startsWith(SEMANTIC_PREFIX)) continue;
+            String bare = e.getKey().substring(SEMANTIC_PREFIX.length());
+            if (bare.equals("description") || bare.equals("synonyms")) continue;
+            payload.put(bare, e.getValue());
+        }
+        if (payload.isEmpty()) return;
+        try {
+            ObjectNode node = json.createObjectNode();
+            for (Map.Entry<String, String> e : payload.entrySet()) {
+                // pii → boolean if the source spells 'true' / 'false'; anything else stays a string.
+                String v = e.getValue();
+                if (v != null && (v.equalsIgnoreCase("true") || v.equalsIgnoreCase("false"))) {
+                    node.put(e.getKey(), Boolean.parseBoolean(v));
+                } else {
+                    node.put(e.getKey(), v);
+                }
+            }
+            extensions.add(new CustomExtension(CustomExtension.VENDOR_SAIKU, json.writeValueAsString(node)));
+        } catch (JsonProcessingException ignored) {
+            // Never happens for a freshly built ObjectNode of primitives.
+        }
+    }
+
+    private Map<String, String> readAnnotations(Element parent) {
+        Element wrap = firstChild(parent, "Annotations");
+        if (wrap == null) return Map.of();
+        Map<String, String> out = new LinkedHashMap<>();
+        for (Element a : childrenNamed(wrap, "Annotation")) {
+            String name = attr(a, "name");
+            if (name == null) continue;
+            out.put(name, a.getTextContent() == null ? "" : a.getTextContent().trim());
+        }
+        return out;
+    }
+
+    /* ---------------- DOM helpers ---------------- */
+
+    private static List<Element> childrenNamed(Element parent, String tagName) {
+        List<Element> out = new ArrayList<>();
+        NodeList kids = parent.getChildNodes();
+        for (int i = 0; i < kids.getLength(); i++) {
+            Node n = kids.item(i);
+            if (n.getNodeType() == Node.ELEMENT_NODE && tagName.equals(n.getNodeName())) {
+                out.add((Element) n);
+            }
+        }
+        return out;
+    }
+
+    private static Element firstChild(Element parent, String tagName) {
+        NodeList kids = parent.getChildNodes();
+        for (int i = 0; i < kids.getLength(); i++) {
+            Node n = kids.item(i);
+            if (n.getNodeType() == Node.ELEMENT_NODE && tagName.equals(n.getNodeName())) {
+                return (Element) n;
+            }
+        }
+        return null;
+    }
+
+    private static String attr(Element el, String name) {
+        String v = el.getAttribute(name);
+        return v == null || v.isEmpty() ? null : v;
+    }
+
+    private static String qualifyTable(String schema, String table) {
+        if (table == null || table.isEmpty()) return null;
+        if (schema == null || schema.isEmpty()) return table;
+        return schema + "." + table;
+    }
+
+    /** Ossie identifiers are effectively YAML keys — spaces + brackets survive but are ugly. */
+    private static String sanitiseName(String raw) {
+        if (raw == null) return null;
+        return raw.replaceAll("[\\[\\]]", "").replace(' ', '_');
+    }
+
+    private static String nullIfBlank(String v) {
+        return v == null || v.isBlank() ? null : v;
+    }
+
+    // Reserved for HashMap-based caching if we start doing shared-dim resolution.
+    @SuppressWarnings("unused")
+    private final Map<String, Dataset> unused = new HashMap<>();
+}

--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/schema/ossie/OssieYamlWriter.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/schema/ossie/OssieYamlWriter.java
@@ -1,0 +1,58 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.service.schema.ossie;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import com.fasterxml.jackson.dataformat.yaml.YAMLGenerator;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.Writer;
+import org.saiku.service.schema.ossie.model.OssieDocument;
+
+/**
+ * Serialise an {@link OssieDocument} tree as Ossie-flavoured YAML.
+ *
+ * <p>Config choices (all deliberate):
+ *
+ * <ul>
+ *   <li>{@code MINIMIZE_QUOTES} — omit YAML quotes on scalars that don't need them, so downstream
+ *       diffs stay compact.
+ *   <li>{@code SPLIT_LINES} disabled — the writer keeps long expression strings on one line rather
+ *       than folding at 80 cols, so a metric like {@code SUM(orders.amount) / COUNT(...)} stays
+ *       machine-parseable and readable.
+ *   <li>No leading {@code ---} document marker — Ossie examples don't use one, and Jackson's YAML
+ *       module is opt-in on emitting it.
+ *   <li>{@code custom_extensions[].data} is a JSON-encoded string per the Ossie spec, NOT an
+ *       inlined object. Callers pre-serialise their payload with Jackson before setting {@code
+ *       data}; the writer doesn't try to be clever.
+ * </ul>
+ */
+public final class OssieYamlWriter {
+
+    private final ObjectMapper yaml;
+
+    public OssieYamlWriter() {
+        YAMLFactory factory = new YAMLFactory()
+                .disable(YAMLGenerator.Feature.WRITE_DOC_START_MARKER)
+                .disable(YAMLGenerator.Feature.SPLIT_LINES)
+                .enable(YAMLGenerator.Feature.MINIMIZE_QUOTES);
+        this.yaml = new ObjectMapper(factory);
+        this.yaml.enable(SerializationFeature.INDENT_OUTPUT);
+    }
+
+    public String writeAsString(OssieDocument doc) throws IOException {
+        return yaml.writeValueAsString(doc);
+    }
+
+    public void write(OssieDocument doc, OutputStream out) throws IOException {
+        yaml.writeValue(out, doc);
+    }
+
+    public void write(OssieDocument doc, Writer out) throws IOException {
+        yaml.writeValue(out, doc);
+    }
+}

--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/schema/ossie/model/AiContext.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/schema/ossie/model/AiContext.java
@@ -1,0 +1,44 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.service.schema.ossie.model;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Ossie {@code AIContext} — additional context for AI tools attached to any Ossie element (model,
+ * dataset, field, metric, relationship). The spec keeps the shape loose ("string or object") for
+ * forward-compat with future keys; we pin the two fields that matter today ({@code instructions} +
+ * {@code synonyms}) and let anything else round-trip through Jackson's default handling.
+ *
+ * <p>Direct 1:1 with Saiku's {@code saiku.semantic.description} (→ {@code instructions}) and
+ * {@code saiku.semantic.synonyms} (→ {@code synonyms}) annotation keys.
+ */
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
+public class AiContext {
+    private String instructions;
+    private List<String> synonyms = new ArrayList<>();
+
+    public String getInstructions() {
+        return instructions;
+    }
+
+    public void setInstructions(String v) {
+        this.instructions = v;
+    }
+
+    public List<String> getSynonyms() {
+        return synonyms;
+    }
+
+    public void setSynonyms(List<String> v) {
+        this.synonyms = v == null ? new ArrayList<>() : v;
+    }
+
+    public boolean isEmpty() {
+        return (instructions == null || instructions.isBlank()) && (synonyms == null || synonyms.isEmpty());
+    }
+}

--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/schema/ossie/model/CustomExtension.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/schema/ossie/model/CustomExtension.java
@@ -1,0 +1,49 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.service.schema.ossie.model;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+/**
+ * Ossie {@code CustomExtension} — vendor-specific escape hatch. All of Saiku's non-core annotations
+ * ({@code pii}, {@code cardinality}, {@code grain}, {@code aggregation_kind}, {@code
+ * required_filters}) ride here under {@code vendor_name="SAIKU"} with a JSON string payload.
+ *
+ * <p>Per the Ossie spec {@code data} is a JSON string (not a nested object) so different vendors
+ * can attach arbitrary structure without polluting the core schema. We serialise Saiku's payload
+ * with Jackson before assignment.
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class CustomExtension {
+    /** Well-known label the Saiku exporter uses for its extension payloads. */
+    public static final String VENDOR_SAIKU = "SAIKU";
+
+    private String vendorName;
+    private String data;
+
+    public CustomExtension() {}
+
+    public CustomExtension(String vendorName, String data) {
+        this.vendorName = vendorName;
+        this.data = data;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("vendor_name")
+    public String getVendorName() {
+        return vendorName;
+    }
+
+    public void setVendorName(String v) {
+        this.vendorName = v;
+    }
+
+    public String getData() {
+        return data;
+    }
+
+    public void setData(String v) {
+        this.data = v;
+    }
+}

--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/schema/ossie/model/Dataset.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/schema/ossie/model/Dataset.java
@@ -1,0 +1,98 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.service.schema.ossie.model;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.ArrayList;
+import java.util.List;
+
+/** Ossie {@code Dataset} — a logical fact or dimension table plus its fields. */
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
+public class Dataset {
+    private String name;
+    private String source;
+
+    @JsonProperty("primary_key")
+    private List<String> primaryKey = new ArrayList<>();
+
+    /** Ossie shape: array of arrays. Each inner array is a distinct unique-key definition. */
+    @JsonProperty("unique_keys")
+    private List<List<String>> uniqueKeys = new ArrayList<>();
+
+    private String description;
+
+    @JsonProperty("ai_context")
+    private AiContext aiContext;
+
+    private List<Field> fields = new ArrayList<>();
+
+    @JsonProperty("custom_extensions")
+    private List<CustomExtension> customExtensions = new ArrayList<>();
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String v) {
+        this.name = v;
+    }
+
+    public String getSource() {
+        return source;
+    }
+
+    public void setSource(String v) {
+        this.source = v;
+    }
+
+    public List<String> getPrimaryKey() {
+        return primaryKey;
+    }
+
+    public void setPrimaryKey(List<String> v) {
+        this.primaryKey = v == null ? new ArrayList<>() : v;
+    }
+
+    public List<List<String>> getUniqueKeys() {
+        return uniqueKeys;
+    }
+
+    public void setUniqueKeys(List<List<String>> v) {
+        this.uniqueKeys = v == null ? new ArrayList<>() : v;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String v) {
+        this.description = v;
+    }
+
+    public AiContext getAiContext() {
+        return aiContext == null || aiContext.isEmpty() ? null : aiContext;
+    }
+
+    public void setAiContext(AiContext v) {
+        this.aiContext = v;
+    }
+
+    public List<Field> getFields() {
+        return fields;
+    }
+
+    public void setFields(List<Field> v) {
+        this.fields = v == null ? new ArrayList<>() : v;
+    }
+
+    public List<CustomExtension> getCustomExtensions() {
+        return customExtensions;
+    }
+
+    public void setCustomExtensions(List<CustomExtension> v) {
+        this.customExtensions = v == null ? new ArrayList<>() : v;
+    }
+}

--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/schema/ossie/model/DialectExpression.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/schema/ossie/model/DialectExpression.java
@@ -1,0 +1,42 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.service.schema.ossie.model;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+/**
+ * Ossie {@code DialectExpression}. Legal {@code dialect} values are constrained by the spec's
+ * {@code Dialect} enum ({@code ANSI_SQL}, {@code SNOWFLAKE}, {@code MDX}, {@code TABLEAU}, {@code
+ * DATABRICKS}, {@code MAQL}); we don't validate at the model layer — the converter emits only
+ * ANSI_SQL and MDX, and validation lives in the writer round-trip test.
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class DialectExpression {
+    private String dialect;
+    private String expression;
+
+    public DialectExpression() {}
+
+    public DialectExpression(String dialect, String expression) {
+        this.dialect = dialect;
+        this.expression = expression;
+    }
+
+    public String getDialect() {
+        return dialect;
+    }
+
+    public void setDialect(String v) {
+        this.dialect = v;
+    }
+
+    public String getExpression() {
+        return expression;
+    }
+
+    public void setExpression(String v) {
+        this.expression = v;
+    }
+}

--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/schema/ossie/model/DimensionMeta.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/schema/ossie/model/DimensionMeta.java
@@ -1,0 +1,32 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.service.schema.ossie.model;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+/**
+ * Ossie {@code Dimension} — currently a single-flag marker for whether a field is a time dimension
+ * (drives temporal-filter UX on the consumer side). Named DimensionMeta here to avoid clashing
+ * with our existing {@code Dimension} DTOs in the Saiku codebase.
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class DimensionMeta {
+    @com.fasterxml.jackson.annotation.JsonProperty("is_time")
+    private Boolean isTime;
+
+    public DimensionMeta() {}
+
+    public DimensionMeta(Boolean isTime) {
+        this.isTime = isTime;
+    }
+
+    public Boolean getIsTime() {
+        return isTime;
+    }
+
+    public void setIsTime(Boolean v) {
+        this.isTime = v;
+    }
+}

--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/schema/ossie/model/Expression.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/schema/ossie/model/Expression.java
@@ -1,0 +1,36 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.service.schema.ossie.model;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Ossie {@code Expression} — wraps one or more {@link DialectExpression}s. Every field / metric
+ * carries at least one dialect entry. Saiku's exporter emits ANSI_SQL and MDX for every measure by
+ * default so consumers can pick either at query time.
+ */
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
+public class Expression {
+    private List<DialectExpression> dialects = new ArrayList<>();
+
+    public List<DialectExpression> getDialects() {
+        return dialects;
+    }
+
+    public void setDialects(List<DialectExpression> v) {
+        this.dialects = v == null ? new ArrayList<>() : v;
+    }
+
+    public Expression add(String dialect, String expression) {
+        this.dialects.add(new DialectExpression(dialect, expression));
+        return this;
+    }
+
+    public static Expression ansi(String sql) {
+        return new Expression().add("ANSI_SQL", sql);
+    }
+}

--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/schema/ossie/model/Field.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/schema/ossie/model/Field.java
@@ -1,0 +1,82 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.service.schema.ossie.model;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.ArrayList;
+import java.util.List;
+
+/** Ossie {@code Field} — row-level attribute available on a dataset for grouping / filtering. */
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
+public class Field {
+    private String name;
+    private Expression expression;
+    private DimensionMeta dimension;
+    private String label;
+    private String description;
+
+    @JsonProperty("ai_context")
+    private AiContext aiContext;
+
+    @JsonProperty("custom_extensions")
+    private List<CustomExtension> customExtensions = new ArrayList<>();
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String v) {
+        this.name = v;
+    }
+
+    public Expression getExpression() {
+        return expression;
+    }
+
+    public void setExpression(Expression v) {
+        this.expression = v;
+    }
+
+    public DimensionMeta getDimension() {
+        return dimension;
+    }
+
+    public void setDimension(DimensionMeta v) {
+        this.dimension = v;
+    }
+
+    public String getLabel() {
+        return label;
+    }
+
+    public void setLabel(String v) {
+        this.label = v;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String v) {
+        this.description = v;
+    }
+
+    public AiContext getAiContext() {
+        return aiContext == null || aiContext.isEmpty() ? null : aiContext;
+    }
+
+    public void setAiContext(AiContext v) {
+        this.aiContext = v;
+    }
+
+    public List<CustomExtension> getCustomExtensions() {
+        return customExtensions;
+    }
+
+    public void setCustomExtensions(List<CustomExtension> v) {
+        this.customExtensions = v == null ? new ArrayList<>() : v;
+    }
+}

--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/schema/ossie/model/Metric.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/schema/ossie/model/Metric.java
@@ -1,0 +1,69 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.service.schema.ossie.model;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Ossie {@code Metric} — a quantifiable measure defined as an aggregate expression on fields from
+ * one or more datasets. Saiku's exporter emits both an ANSI_SQL dialect (best-effort from the
+ * Mondrian {@code aggregator} + {@code column} attributes) AND an MDX dialect (verbatim
+ * {@code <Measure>} unique name / calculated-member expression).
+ */
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
+public class Metric {
+    private String name;
+    private Expression expression;
+    private String description;
+
+    @JsonProperty("ai_context")
+    private AiContext aiContext;
+
+    @JsonProperty("custom_extensions")
+    private List<CustomExtension> customExtensions = new ArrayList<>();
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String v) {
+        this.name = v;
+    }
+
+    public Expression getExpression() {
+        return expression;
+    }
+
+    public void setExpression(Expression v) {
+        this.expression = v;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String v) {
+        this.description = v;
+    }
+
+    public AiContext getAiContext() {
+        return aiContext == null || aiContext.isEmpty() ? null : aiContext;
+    }
+
+    public void setAiContext(AiContext v) {
+        this.aiContext = v;
+    }
+
+    public List<CustomExtension> getCustomExtensions() {
+        return customExtensions;
+    }
+
+    public void setCustomExtensions(List<CustomExtension> v) {
+        this.customExtensions = v == null ? new ArrayList<>() : v;
+    }
+}

--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/schema/ossie/model/OssieDocument.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/schema/ossie/model/OssieDocument.java
@@ -1,0 +1,57 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.service.schema.ossie.model;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Top-level Ossie document — one or more semantic models plus the spec version they conform to.
+ *
+ * <p>The {@code osi-schema.json} at {@code apache/ossie} requires {@code version} and {@code
+ * semantic_model} at the root. We pin the version to the current Ossie draft; consumers can pick
+ * up the value from the emitted YAML to route to the right parser.
+ */
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
+@JsonPropertyOrder({"version", "semantic_model"})
+public class OssieDocument {
+    /**
+     * Ossie spec version this document conforms to. Bump when the exporter starts emitting
+     * against a newer spec — the value here MUST match one the consumer knows about, so the
+     * exporter's constant is deliberately conservative.
+     */
+    public static final String OSSIE_SPEC_VERSION = "0.2.0.dev0";
+
+    private String version = OSSIE_SPEC_VERSION;
+
+    /**
+     * Ossie's core schema declares {@code semantic_model} as required, so we override the
+     * class-level {@code NON_EMPTY} — even a converter run that skipped every cube (e.g. a
+     * Mondrian schema containing only MG-shape or virtual cubes we don't yet recognise) must
+     * emit {@code semantic_model: []} rather than dropping the field.
+     */
+    @JsonProperty("semantic_model")
+    @JsonInclude(JsonInclude.Include.ALWAYS)
+    private List<SemanticModel> semanticModel = new ArrayList<>();
+
+    public String getVersion() {
+        return version;
+    }
+
+    public void setVersion(String v) {
+        this.version = v;
+    }
+
+    public List<SemanticModel> getSemanticModel() {
+        return semanticModel;
+    }
+
+    public void setSemanticModel(List<SemanticModel> v) {
+        this.semanticModel = v == null ? new ArrayList<>() : v;
+    }
+}

--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/schema/ossie/model/Relationship.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/schema/ossie/model/Relationship.java
@@ -1,0 +1,95 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.service.schema.ossie.model;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Ossie {@code Relationship} — many-to-one foreign-key link between two datasets. The order of
+ * {@code from_columns} must correspond to {@code to_columns} for composite keys; the exporter
+ * enforces that when it builds relationships from Mondrian {@code <DimensionUsage foreignKey="…">}
+ * or {@code MeasureGroup} link declarations.
+ */
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
+public class Relationship {
+    private String name;
+
+    /** The dataset on the many side of the relationship (e.g. the fact table). */
+    private String from;
+
+    /** The dataset on the one side (e.g. the dimension table). */
+    private String to;
+
+    @JsonProperty("from_columns")
+    private List<String> fromColumns = new ArrayList<>();
+
+    @JsonProperty("to_columns")
+    private List<String> toColumns = new ArrayList<>();
+
+    @JsonProperty("ai_context")
+    private AiContext aiContext;
+
+    @JsonProperty("custom_extensions")
+    private List<CustomExtension> customExtensions = new ArrayList<>();
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String v) {
+        this.name = v;
+    }
+
+    public String getFrom() {
+        return from;
+    }
+
+    public void setFrom(String v) {
+        this.from = v;
+    }
+
+    public String getTo() {
+        return to;
+    }
+
+    public void setTo(String v) {
+        this.to = v;
+    }
+
+    public List<String> getFromColumns() {
+        return fromColumns;
+    }
+
+    public void setFromColumns(List<String> v) {
+        this.fromColumns = v == null ? new ArrayList<>() : v;
+    }
+
+    public List<String> getToColumns() {
+        return toColumns;
+    }
+
+    public void setToColumns(List<String> v) {
+        this.toColumns = v == null ? new ArrayList<>() : v;
+    }
+
+    public AiContext getAiContext() {
+        return aiContext == null || aiContext.isEmpty() ? null : aiContext;
+    }
+
+    public void setAiContext(AiContext v) {
+        this.aiContext = v;
+    }
+
+    public List<CustomExtension> getCustomExtensions() {
+        return customExtensions;
+    }
+
+    public void setCustomExtensions(List<CustomExtension> v) {
+        this.customExtensions = v == null ? new ArrayList<>() : v;
+    }
+}

--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/schema/ossie/model/SemanticModel.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/schema/ossie/model/SemanticModel.java
@@ -1,0 +1,92 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.service.schema.ossie.model;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.ArrayList;
+import java.util.List;
+
+/** Ossie {@code SemanticModel} — one cube's worth of definitions in Ossie shape. */
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
+public class SemanticModel {
+    private String name;
+    private String description;
+
+    @JsonProperty("ai_context")
+    private AiContext aiContext;
+
+    /**
+     * Ossie's core schema declares {@code datasets} as REQUIRED on every semantic model, so we
+     * override the class-level {@code @JsonInclude(NON_EMPTY)} here — even an empty datasets
+     * array must serialise as {@code datasets: []}, otherwise schema validation fails with
+     * "required property 'datasets' not found" for cubes we couldn't map (e.g. Mondrian 4
+     * MeasureGroup-shaped cubes that our first-cut converter doesn't recognise yet).
+     */
+    @JsonInclude(JsonInclude.Include.ALWAYS)
+    private List<Dataset> datasets = new ArrayList<>();
+
+    private List<Relationship> relationships = new ArrayList<>();
+    private List<Metric> metrics = new ArrayList<>();
+
+    @JsonProperty("custom_extensions")
+    private List<CustomExtension> customExtensions = new ArrayList<>();
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String v) {
+        this.name = v;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String v) {
+        this.description = v;
+    }
+
+    public AiContext getAiContext() {
+        return aiContext == null || aiContext.isEmpty() ? null : aiContext;
+    }
+
+    public void setAiContext(AiContext v) {
+        this.aiContext = v;
+    }
+
+    public List<Dataset> getDatasets() {
+        return datasets;
+    }
+
+    public void setDatasets(List<Dataset> v) {
+        this.datasets = v == null ? new ArrayList<>() : v;
+    }
+
+    public List<Relationship> getRelationships() {
+        return relationships;
+    }
+
+    public void setRelationships(List<Relationship> v) {
+        this.relationships = v == null ? new ArrayList<>() : v;
+    }
+
+    public List<Metric> getMetrics() {
+        return metrics;
+    }
+
+    public void setMetrics(List<Metric> v) {
+        this.metrics = v == null ? new ArrayList<>() : v;
+    }
+
+    public List<CustomExtension> getCustomExtensions() {
+        return customExtensions;
+    }
+
+    public void setCustomExtensions(List<CustomExtension> v) {
+        this.customExtensions = v == null ? new ArrayList<>() : v;
+    }
+}

--- a/saiku-core/saiku-service/src/test/java/org/saiku/service/schema/ossie/MondrianToOssieConverterTest.java
+++ b/saiku-core/saiku-service/src/test/java/org/saiku/service/schema/ossie/MondrianToOssieConverterTest.java
@@ -1,0 +1,254 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.service.schema.ossie;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import javax.xml.parsers.ParserConfigurationException;
+import org.junit.Test;
+import org.saiku.service.schema.ossie.model.CustomExtension;
+import org.saiku.service.schema.ossie.model.Dataset;
+import org.saiku.service.schema.ossie.model.DimensionMeta;
+import org.saiku.service.schema.ossie.model.Field;
+import org.saiku.service.schema.ossie.model.Metric;
+import org.saiku.service.schema.ossie.model.OssieDocument;
+import org.saiku.service.schema.ossie.model.Relationship;
+import org.saiku.service.schema.ossie.model.SemanticModel;
+import org.xml.sax.SAXException;
+
+/**
+ * Structural tests for the Mondrian → Ossie mapping. These aren't schema-validation tests
+ * (the JSON-schema round-trip happens in {@code OssieYamlWriterTest}); they check that each Ossie
+ * concept lands where the mapping table on saiku#1384 says it should — one dataset per fact +
+ * dim, one relationship per dim, one metric per measure, is_time set from levelType=Time*, and
+ * saiku.semantic.* annotations routed to ai_context vs custom_extensions per the spec's homes.
+ */
+public class MondrianToOssieConverterTest {
+
+    private final MondrianToOssieConverter converter = new MondrianToOssieConverter();
+
+    @Test
+    public void cubeBecomesSemanticModelWithFactAndDimensions()
+            throws IOException, SAXException, ParserConfigurationException {
+        String xml = "<?xml version='1.0'?>\n"
+                + "<Schema name='Test'>\n"
+                + "  <Cube name='Sales'>\n"
+                + "    <Table name='fact_sales' schema='public'/>\n"
+                + "    <Dimension name='Customer' foreignKey='customerkey'>\n"
+                + "      <Hierarchy hasAll='true' primaryKey='customerkey'>\n"
+                + "        <Table name='dim_customer' schema='public'/>\n"
+                + "        <Level name='Region' column='region'/>\n"
+                + "      </Hierarchy>\n"
+                + "    </Dimension>\n"
+                + "    <Measure name='Sales Amount' column='amount' aggregator='sum'/>\n"
+                + "  </Cube>\n"
+                + "</Schema>";
+        OssieDocument doc = convert(xml);
+
+        assertEquals(1, doc.getSemanticModel().size());
+        SemanticModel sm = doc.getSemanticModel().get(0);
+        assertEquals("Sales", sm.getName());
+        assertEquals(2, sm.getDatasets().size());
+
+        Dataset fact = sm.getDatasets().get(0);
+        assertEquals("fact_sales", fact.getName());
+        assertEquals("public.fact_sales", fact.getSource());
+
+        Dataset customer = sm.getDatasets().get(1);
+        assertEquals("Customer", customer.getName());
+        assertEquals("public.dim_customer", customer.getSource());
+        assertEquals(1, customer.getPrimaryKey().size());
+        assertEquals("customerkey", customer.getPrimaryKey().get(0));
+        assertEquals(1, customer.getFields().size());
+        assertEquals("Region", customer.getFields().get(0).getName());
+    }
+
+    @Test
+    public void relationshipCarriesForeignKeyPair() throws Exception {
+        OssieDocument doc = convert("<Schema name='T'><Cube name='C'><Table name='fact' schema='s'/>"
+                + "<Dimension name='D' foreignKey='d_fk'>"
+                + "  <Hierarchy primaryKey='d_pk'><Table name='dim_d' schema='s'/>"
+                + "    <Level name='L' column='c'/></Hierarchy>"
+                + "</Dimension></Cube></Schema>");
+        SemanticModel sm = doc.getSemanticModel().get(0);
+        assertEquals(1, sm.getRelationships().size());
+        Relationship r = sm.getRelationships().get(0);
+        assertEquals("fact", r.getFrom());
+        assertEquals("D", r.getTo());
+        assertEquals(1, r.getFromColumns().size());
+        assertEquals("d_fk", r.getFromColumns().get(0));
+        assertEquals(1, r.getToColumns().size());
+        assertEquals("d_pk", r.getToColumns().get(0));
+    }
+
+    @Test
+    public void measureEmitsBothAnsiSqlAndMdxDialects() throws Exception {
+        OssieDocument doc = convert("<Schema name='T'><Cube name='C'><Table name='fact'/>"
+                + "<Measure name='Quantity' column='qty' aggregator='sum'/></Cube></Schema>");
+        Metric m = doc.getSemanticModel().get(0).getMetrics().get(0);
+        assertEquals(2, m.getExpression().getDialects().size());
+        assertEquals("ANSI_SQL", m.getExpression().getDialects().get(0).getDialect());
+        assertEquals("SUM(fact.qty)", m.getExpression().getDialects().get(0).getExpression());
+        assertEquals("MDX", m.getExpression().getDialects().get(1).getDialect());
+        assertEquals(
+                "[Measures].[Quantity]", m.getExpression().getDialects().get(1).getExpression());
+    }
+
+    @Test
+    public void distinctCountAggregatorTranslates() throws Exception {
+        OssieDocument doc = convert("<Schema name='T'><Cube name='C'><Table name='f'/>"
+                + "<Measure name='Uniques' column='u' aggregator='distinct-count'/></Cube></Schema>");
+        Metric m = doc.getSemanticModel().get(0).getMetrics().get(0);
+        assertEquals(
+                "COUNT(DISTINCT f.u)", m.getExpression().getDialects().get(0).getExpression());
+    }
+
+    @Test
+    public void calculatedMemberEmitsMdxOnly() throws Exception {
+        OssieDocument doc = convert("<Schema name='T'><Cube name='C'><Table name='f'/>"
+                + "<CalculatedMember name='Ratio'>"
+                + "  <Formula>[Measures].[A] / [Measures].[B]</Formula>"
+                + "</CalculatedMember></Cube></Schema>");
+        Metric m = doc.getSemanticModel().get(0).getMetrics().get(0);
+        assertEquals(1, m.getExpression().getDialects().size());
+        assertEquals("MDX", m.getExpression().getDialects().get(0).getDialect());
+        assertEquals(
+                "[Measures].[A] / [Measures].[B]",
+                m.getExpression().getDialects().get(0).getExpression());
+    }
+
+    @Test
+    public void levelTypeTimeYearsFlagsIsTime() throws Exception {
+        OssieDocument doc = convert("<Schema name='T'><Cube name='C'><Table name='f'/>"
+                + "<Dimension name='Date' foreignKey='dk'>"
+                + "  <Hierarchy primaryKey='pk'><Table name='dim_date'/>"
+                + "    <Level name='Year' column='y' levelType='TimeYears'/>"
+                + "  </Hierarchy>"
+                + "</Dimension></Cube></Schema>");
+        Field year =
+                doc.getSemanticModel().get(0).getDatasets().get(1).getFields().get(0);
+        DimensionMeta dim = year.getDimension();
+        assertNotNull(dim);
+        assertTrue(dim.getIsTime());
+    }
+
+    @Test
+    public void nonTimeLevelHasNoDimensionBlock() throws Exception {
+        OssieDocument doc = convert("<Schema name='T'><Cube name='C'><Table name='f'/>"
+                + "<Dimension name='Cust' foreignKey='fk'>"
+                + "  <Hierarchy primaryKey='pk'><Table name='dim_c'/>"
+                + "    <Level name='Region' column='r'/></Hierarchy></Dimension></Cube></Schema>");
+        Field region =
+                doc.getSemanticModel().get(0).getDatasets().get(1).getFields().get(0);
+        assertNull("non-time levels shouldn't carry a dimension block", region.getDimension());
+    }
+
+    @Test
+    public void descriptionAndSynonymsLiftIntoAiContext() throws Exception {
+        OssieDocument doc = convert("<Schema name='T'><Cube name='C'><Table name='f'/>"
+                + "<Measure name='M' column='c' aggregator='sum'>"
+                + "  <Annotations>"
+                + "    <Annotation name='saiku.semantic.description'>Total sold.</Annotation>"
+                + "    <Annotation name='saiku.semantic.synonyms'>volume, quantity</Annotation>"
+                + "  </Annotations>"
+                + "</Measure></Cube></Schema>");
+        Metric m = doc.getSemanticModel().get(0).getMetrics().get(0);
+        assertNotNull(m.getAiContext());
+        assertEquals("Total sold.", m.getAiContext().getInstructions());
+        assertEquals(2, m.getAiContext().getSynonyms().size());
+        assertEquals("volume", m.getAiContext().getSynonyms().get(0));
+        assertEquals("quantity", m.getAiContext().getSynonyms().get(1));
+        assertTrue(
+                "no Saiku extension when only description+synonyms present",
+                m.getCustomExtensions().isEmpty());
+    }
+
+    @Test
+    public void piiAnnotationRidesInSaikuExtensionAsBoolean() throws Exception {
+        OssieDocument doc = convert("<Schema name='T'><Cube name='C'><Table name='f'/>"
+                + "<Dimension name='Prescriber' foreignKey='pk'>"
+                + "  <Hierarchy primaryKey='pk'><Table name='dim_p'/>"
+                + "    <Level name='Prescriber' column='name'>"
+                + "      <Annotations>"
+                + "        <Annotation name='saiku.semantic.pii'>true</Annotation>"
+                + "      </Annotations>"
+                + "    </Level></Hierarchy></Dimension></Cube></Schema>");
+        Field f = doc.getSemanticModel().get(0).getDatasets().get(1).getFields().get(0);
+        assertEquals(1, f.getCustomExtensions().size());
+        CustomExtension ext = f.getCustomExtensions().get(0);
+        assertEquals(CustomExtension.VENDOR_SAIKU, ext.getVendorName());
+        // Payload is a JSON string per the Ossie spec.
+        assertTrue(
+                "pii should serialise as JSON boolean, not string",
+                ext.getData().contains("\"pii\":true"));
+    }
+
+    @Test
+    public void cardinalityAndGrainRideInSaikuExtensionAsStrings() throws Exception {
+        OssieDocument doc = convert("<Schema name='T'><Cube name='C'><Table name='f'/>"
+                + "<Dimension name='D' foreignKey='fk'>"
+                + "  <Hierarchy primaryKey='pk'><Table name='dim_d'/>"
+                + "    <Level name='Year' column='y' levelType='TimeYears'>"
+                + "      <Annotations>"
+                + "        <Annotation name='saiku.semantic.cardinality'>low</Annotation>"
+                + "        <Annotation name='saiku.semantic.grain'>year</Annotation>"
+                + "      </Annotations>"
+                + "    </Level></Hierarchy></Dimension></Cube></Schema>");
+        Field year =
+                doc.getSemanticModel().get(0).getDatasets().get(1).getFields().get(0);
+        assertEquals(1, year.getCustomExtensions().size());
+        String payload = year.getCustomExtensions().get(0).getData();
+        assertTrue(payload.contains("\"cardinality\":\"low\""));
+        assertTrue(payload.contains("\"grain\":\"year\""));
+    }
+
+    @Test
+    public void multipleCubesBecomeMultipleSemanticModels() throws Exception {
+        OssieDocument doc = convert("<Schema name='T'>"
+                + "<Cube name='C1'><Table name='f1'/></Cube>"
+                + "<Cube name='C2'><Table name='f2'/></Cube></Schema>");
+        assertEquals(2, doc.getSemanticModel().size());
+        assertEquals("C1", doc.getSemanticModel().get(0).getName());
+        assertEquals("C2", doc.getSemanticModel().get(1).getName());
+    }
+
+    @Test
+    public void degenerateDimensionAttachesLevelsToFactTable() throws Exception {
+        // Degenerate dim: no <Table/> under the hierarchy → the levels resolve against the fact.
+        OssieDocument doc = convert("<Schema name='T'><Cube name='C'><Table name='fact'/>"
+                + "<Dimension name='Date' type='TimeDimension'>"
+                + "  <Hierarchy hasAll='true'>"
+                + "    <Level name='Year' column='order_year' levelType='TimeYears'/>"
+                + "  </Hierarchy></Dimension></Cube></Schema>");
+        SemanticModel sm = doc.getSemanticModel().get(0);
+        // Only the fact dataset should exist — degenerate dim doesn't get its own.
+        assertEquals(1, sm.getDatasets().size());
+        Dataset fact = sm.getDatasets().get(0);
+        // Level is added to the fact dataset directly.
+        assertEquals(1, fact.getFields().size());
+        assertEquals("Year", fact.getFields().get(0).getName());
+        assertNotNull(fact.getFields().get(0).getDimension());
+        // And there's no relationship — nothing to join to.
+        assertTrue(sm.getRelationships().isEmpty());
+    }
+
+    @Test
+    public void schemaWithZeroCubesEmitsEmptyDocument() throws Exception {
+        OssieDocument doc = convert("<Schema name='T'></Schema>");
+        assertTrue(doc.getSemanticModel().isEmpty());
+        assertFalse("version should always be set", doc.getVersion().isBlank());
+    }
+
+    private OssieDocument convert(String xml) throws IOException, SAXException, ParserConfigurationException {
+        return converter.convert(new ByteArrayInputStream(xml.getBytes(StandardCharsets.UTF_8)));
+    }
+}

--- a/saiku-core/saiku-service/src/test/java/org/saiku/service/schema/ossie/OssieYamlWriterTest.java
+++ b/saiku-core/saiku-service/src/test/java/org/saiku/service/schema/ossie/OssieYamlWriterTest.java
@@ -1,0 +1,148 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.service.schema.ossie;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import com.networknt.schema.JsonSchema;
+import com.networknt.schema.JsonSchemaFactory;
+import com.networknt.schema.SpecVersion;
+import com.networknt.schema.ValidationMessage;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Set;
+import org.junit.Test;
+import org.saiku.service.schema.ossie.model.OssieDocument;
+
+/**
+ * Round-trip validation: build a Mondrian schema fragment, run the converter, serialise via
+ * {@link OssieYamlWriter}, re-parse the YAML, and validate against apache/ossie's shipped {@code
+ * osi-schema.json}.
+ *
+ * <p>Runs against three fixtures: the tiny inline schema (fast baseline), the real FoodMart schema
+ * bundled with the launcher (the annotation-rich, dim-heavy shape), and the Pharma schema (PII
+ * annotations + degenerate time dim). Each fixture must produce YAML that:
+ *
+ * <ul>
+ *   <li>Deserialises cleanly through Jackson-YAML.
+ *   <li>Validates against the pinned Ossie draft schema with zero findings.
+ *   <li>Round-trips through the writer + parser without content drift.
+ * </ul>
+ */
+public class OssieYamlWriterTest {
+
+    private final OssieYamlWriter writer = new OssieYamlWriter();
+    private final MondrianToOssieConverter converter = new MondrianToOssieConverter();
+
+    @Test
+    public void inlineSchemaEmitsValidOssie() throws Exception {
+        String yaml = writer.writeAsString(converter.convert(new java.io.ByteArrayInputStream(("<Schema name='T'>"
+                        + "<Cube name='Sales'>"
+                        + "  <Table name='fact' schema='public'/>"
+                        + "  <Dimension name='Cust' foreignKey='fk'>"
+                        + "    <Hierarchy primaryKey='pk'><Table name='dim_c' schema='public'/>"
+                        + "      <Level name='Region' column='r'/></Hierarchy></Dimension>"
+                        + "  <Measure name='Amount' column='amt' aggregator='sum'/>"
+                        + "</Cube></Schema>")
+                .getBytes(java.nio.charset.StandardCharsets.UTF_8))));
+        assertValidatesAgainstOssieSchema(yaml);
+        // Sanity: contains the expected structural anchors.
+        assertTrue(yaml.contains("semantic_model"));
+        assertTrue(yaml.contains("datasets"));
+        assertTrue(yaml.contains("Sales"));
+        assertTrue(yaml.contains("ANSI_SQL"));
+        assertTrue(yaml.contains("MDX"));
+    }
+
+    @Test
+    public void foodmartSchemaEmitsValidOssie() throws Exception {
+        Path schema = Path.of(System.getProperty("user.dir"))
+                .resolve("../../saiku-home/data/FoodMart4.xml")
+                .normalize();
+        if (!Files.exists(schema)) {
+            // Local dev only; not on CI unless the launcher module is checked out alongside.
+            return;
+        }
+        try (InputStream in = Files.newInputStream(schema)) {
+            OssieDocument doc = converter.convert(in);
+            String yaml = writer.writeAsString(doc);
+            // The important assertion is that whatever comes out validates against Ossie's schema.
+            // FoodMart uses Mondrian 4's <Dimensions>/<MeasureGroups>/<Measures> wrapper shape
+            // which the first-cut converter (saiku#1384 slice 1) doesn't yet parse — those cubes
+            // get skipped (see MondrianToOssieConverter#skippedCubes) rather than emitted as
+            // schema-invalid stubs. The Mondrian-4-MG follow-up (saiku#TBD) will populate them.
+            assertValidatesAgainstOssieSchema(yaml);
+        }
+    }
+
+    @Test
+    public void pharmaSchemaEmitsValidOssieAndPreservesPii() throws Exception {
+        Path schema = Path.of(System.getProperty("user.dir"))
+                .resolve("../../saiku-home/data/Pharma.xml")
+                .normalize();
+        if (!Files.exists(schema)) {
+            return;
+        }
+        try (InputStream in = Files.newInputStream(schema)) {
+            OssieDocument doc = converter.convert(in);
+            String yaml = writer.writeAsString(doc);
+            assertValidatesAgainstOssieSchema(yaml);
+            // Pharma marks Prescriber name + NPI PII. Both should surface in the emitted YAML as
+            // custom_extensions with vendor_name=SAIKU and a JSON payload naming pii=true.
+            assertTrue(
+                    "expected at least one SAIKU vendor extension carrying pii=true",
+                    yaml.contains("vendor_name: SAIKU") && yaml.contains("\\\"pii\\\":true"));
+        }
+    }
+
+    @Test
+    public void writerRoundTripsThroughYamlParser() throws Exception {
+        String yaml = writer.writeAsString(converter.convert(
+                new java.io.ByteArrayInputStream("<Schema><Cube name='C'><Table name='f'/></Cube></Schema>"
+                        .getBytes(java.nio.charset.StandardCharsets.UTF_8))));
+        ObjectMapper yamlMapper = new ObjectMapper(new YAMLFactory());
+        JsonNode tree = yamlMapper.readTree(yaml);
+        assertNotNull(tree.get("version"));
+        assertEquals(OssieDocument.OSSIE_SPEC_VERSION, tree.get("version").asText());
+        assertNotNull(tree.get("semantic_model"));
+        assertEquals(1, tree.get("semantic_model").size());
+        assertEquals("C", tree.get("semantic_model").get(0).get("name").asText());
+    }
+
+    /* ---------------- helpers ---------------- */
+
+    private void assertValidatesAgainstOssieSchema(String yaml) throws IOException {
+        // Parse YAML → JsonNode via Jackson-YAML.
+        JsonNode instance = new ObjectMapper(new YAMLFactory()).readTree(yaml);
+        JsonSchema schema = loadOssieSchema();
+        Set<ValidationMessage> messages = schema.validate(instance);
+        if (!messages.isEmpty()) {
+            StringBuilder sb = new StringBuilder("Ossie schema validation failed:\n");
+            for (ValidationMessage m : messages) sb.append("  - ").append(m).append('\n');
+            sb.append("\nOffending YAML:\n").append(yaml);
+            fail(sb.toString());
+        }
+    }
+
+    private JsonSchema loadOssieSchema() throws IOException {
+        try (InputStream schemaStream = getClass().getResourceAsStream("/ossie/osi-schema.json")) {
+            if (schemaStream == null) {
+                fail("Missing test resource: /ossie/osi-schema.json — copy from apache/ossie repo.");
+            }
+            // Ossie's schema declares $schema=draft/2020-12 — must instantiate the factory with
+            // the matching dialect otherwise networknt falls back to draft-07 and misses features.
+            JsonSchemaFactory factory = JsonSchemaFactory.getInstance(SpecVersion.VersionFlag.V202012);
+            return factory.getSchema(schemaStream);
+        }
+    }
+}

--- a/saiku-core/saiku-service/src/test/resources/ossie/osi-schema.json
+++ b/saiku-core/saiku-service/src/test/resources/ossie/osi-schema.json
@@ -1,0 +1,330 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/apache/ossie/core-spec/osi-schema.json",
+  "title": "Apache Ossie Core Metadata Specification",
+  "description": "JSON Schema for validating Apache Ossie semantic model definitions",
+  "type": "object",
+  "properties": {
+    "version": {
+      "type": "string",
+      "const": "0.2.0.dev0",
+      "description": "Apache Ossie specification version"
+    },
+    "semantic_model": {
+      "type": "array",
+      "description": "Collection of semantic model definitions",
+      "items": {
+        "$ref": "#/$defs/SemanticModel"
+      }
+    }
+  },
+  "required": ["version", "semantic_model"],
+  "additionalProperties": false,
+  "$defs": {
+    "Dialect": {
+      "type": "string",
+      "enum": ["ANSI_SQL", "SNOWFLAKE", "MDX", "TABLEAU", "DATABRICKS", "MAQL"],
+      "description": "Supported SQL and expression language dialects"
+    },
+    "Vendor": {
+      "type": "string",
+      "examples": ["COMMON", "SNOWFLAKE", "SALESFORCE", "DBT", "DATABRICKS", "GOODDATA"],
+      "description": "Vendor name for custom extensions. Any string value is accepted."
+    },
+    "AIContext": {
+      "description": "Additional context for AI tools",
+      "oneOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "instructions": {
+              "type": "string",
+              "description": "Instructions for AI on how to use this entity"
+            },
+            "synonyms": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "Alternative names and terms"
+            },
+            "examples": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "Sample questions or use cases"
+            }
+          },
+          "additionalProperties": true
+        }
+      ]
+    },
+    "CustomExtension": {
+      "type": "object",
+      "description": "Vendor-specific attributes for extensibility",
+      "properties": {
+        "vendor_name": {
+          "$ref": "#/$defs/Vendor"
+        },
+        "data": {
+          "type": "string",
+          "description": "JSON string containing vendor-specific data"
+        }
+      },
+      "required": ["vendor_name", "data"],
+      "additionalProperties": false
+    },
+    "DialectExpression": {
+      "type": "object",
+      "description": "Expression in a specific dialect",
+      "properties": {
+        "dialect": {
+          "$ref": "#/$defs/Dialect"
+        },
+        "expression": {
+          "type": "string",
+          "description": "SQL or dialect-specific expression"
+        }
+      },
+      "required": ["dialect", "expression"],
+      "additionalProperties": false
+    },
+    "Expression": {
+      "type": "object",
+      "description": "Expression definition with multi-dialect support",
+      "properties": {
+        "dialects": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/DialectExpression"
+          },
+          "minItems": 1
+        }
+      },
+      "required": ["dialects"],
+      "additionalProperties": false
+    },
+    "Dimension": {
+      "type": "object",
+      "description": "Dimension metadata",
+      "properties": {
+        "is_time": {
+          "type": "boolean",
+          "description": "Indicates if this is a time-based dimension for temporal filtering"
+        }
+      },
+      "additionalProperties": false
+    },
+    "Field": {
+      "type": "object",
+      "description": "Row-level attribute for grouping, filtering, and metric expressions",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Unique identifier for the field within the dataset"
+        },
+        "expression": {
+          "$ref": "#/$defs/Expression"
+        },
+        "dimension": {
+          "$ref": "#/$defs/Dimension"
+        },
+        "label": {
+          "type": "string",
+          "description": "Label for categorization"
+        },
+        "description": {
+          "type": "string",
+          "description": "Human-readable description"
+        },
+        "ai_context": {
+          "$ref": "#/$defs/AIContext"
+        },
+        "custom_extensions": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/CustomExtension"
+          }
+        }
+      },
+      "required": ["name", "expression"],
+      "additionalProperties": false
+    },
+    "Dataset": {
+      "type": "object",
+      "description": "Logical dataset representing a business entity (fact or dimension table)",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Unique identifier for the dataset"
+        },
+        "source": {
+          "type": "string",
+          "description": "Reference to underlying physical table/view (database.schema.table) or query"
+        },
+        "primary_key": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Primary key columns (single or composite)"
+        },
+        "unique_keys": {
+          "type": "array",
+          "items": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "description": "Array of unique key definitions (each can be single or composite)"
+        },
+        "description": {
+          "type": "string",
+          "description": "Human-readable description"
+        },
+        "ai_context": {
+          "$ref": "#/$defs/AIContext"
+        },
+        "fields": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/Field"
+          }
+        },
+        "custom_extensions": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/CustomExtension"
+          }
+        }
+      },
+      "required": ["name", "source"],
+      "additionalProperties": false
+    },
+    "Relationship": {
+      "type": "object",
+      "description": "Foreign key relationship between datasets",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Unique identifier for the relationship"
+        },
+        "from": {
+          "type": "string",
+          "description": "Dataset on the many side of the relationship"
+        },
+        "to": {
+          "type": "string",
+          "description": "Dataset on the one side of the relationship"
+        },
+        "from_columns": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "minItems": 1,
+          "description": "Foreign key columns in the 'from' dataset"
+        },
+        "to_columns": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "minItems": 1,
+          "description": "Primary/unique key columns in the 'to' dataset"
+        },
+        "ai_context": {
+          "$ref": "#/$defs/AIContext"
+        },
+        "custom_extensions": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/CustomExtension"
+          }
+        }
+      },
+      "required": ["name", "from", "to", "from_columns", "to_columns"],
+      "additionalProperties": false
+    },
+    "Metric": {
+      "type": "object",
+      "description": "Quantitative measure defined on business data",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Unique identifier for the metric"
+        },
+        "expression": {
+          "$ref": "#/$defs/Expression"
+        },
+        "description": {
+          "type": "string",
+          "description": "Human-readable description of what the metric measures"
+        },
+        "ai_context": {
+          "$ref": "#/$defs/AIContext"
+        },
+        "custom_extensions": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/CustomExtension"
+          }
+        }
+      },
+      "required": ["name", "expression"],
+      "additionalProperties": false
+    },
+    "SemanticModel": {
+      "type": "object",
+      "description": "Top-level container representing a complete semantic model",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Unique identifier for the semantic model"
+        },
+        "description": {
+          "type": "string",
+          "description": "Human-readable description"
+        },
+        "ai_context": {
+          "$ref": "#/$defs/AIContext"
+        },
+        "datasets": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/Dataset"
+          },
+          "minItems": 1,
+          "description": "Collection of logical datasets"
+        },
+        "relationships": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/Relationship"
+          },
+          "description": "Defines how datasets are connected"
+        },
+        "metrics": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/Metric"
+          },
+          "description": "Quantifiable measures spanning datasets"
+        },
+        "custom_extensions": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/CustomExtension"
+          }
+        }
+      },
+      "required": ["name", "datasets"],
+      "additionalProperties": false
+    }
+  }
+}

--- a/saiku-launcher/pom.xml
+++ b/saiku-launcher/pom.xml
@@ -29,6 +29,17 @@
             <scope>runtime</scope>
         </dependency>
 
+        <!-- Direct compile-scope dep on saiku-service so the launcher's picocli
+             subcommands (OssieExportCommand at v1, more to come) can call the
+             converter/writer classes without going through the web layer. The
+             war above is runtime-only; without this, the launcher can't `import`
+             org.saiku.service.schema.ossie.*. -->
+        <dependency>
+            <groupId>org.saikuanalytics</groupId>
+            <artifactId>saiku-service</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
         <dependency>
             <groupId>info.picocli</groupId>
             <artifactId>picocli</artifactId>
@@ -65,11 +76,16 @@
             <version>4.13.2</version>
             <scope>test</scope>
         </dependency>
+        <!-- Was test-scope for the launcher's integration tests only; bumped to
+             compile so the picocli OssieExportCommand (which routes through
+             the saiku-service converter + Jackson-YAML writer) can resolve
+             ObjectMapper from the shaded fat-JAR classpath. Maven's "nearest
+             wins" rule was previously shadowing the transitive compile dep
+             from saiku-service. -->
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
             <version>2.18.6</version>
-            <scope>test</scope>
         </dependency>
     </dependencies>
 

--- a/saiku-launcher/src/main/java/org/saiku/launcher/OssieExportCommand.java
+++ b/saiku-launcher/src/main/java/org/saiku/launcher/OssieExportCommand.java
@@ -1,0 +1,129 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.launcher;
+
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.OutputStreamWriter;
+import java.io.PrintWriter;
+import java.io.Writer;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.concurrent.Callable;
+import org.saiku.service.schema.ossie.MondrianToOssieConverter;
+import org.saiku.service.schema.ossie.OssieYamlWriter;
+import org.saiku.service.schema.ossie.model.OssieDocument;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Option;
+
+/**
+ * {@code saiku ossie-export} — convert a Mondrian XML schema into Apache Ossie YAML.
+ *
+ * <p>Reads a Mondrian XML file (default: stdin) via {@link MondrianToOssieConverter}, serialises
+ * the resulting {@link OssieDocument} through {@link OssieYamlWriter}, and writes it to the
+ * requested output (default: stdout). Any cubes that couldn't be mapped (Mondrian 4 MG shape,
+ * virtual cubes — see the converter's javadoc for the deliberate-non-goals list) get reported to
+ * stderr so operators can spot the gap without the YAML itself carrying schema-invalid stubs.
+ *
+ * <p>Examples:
+ *
+ * <pre>{@code
+ * # Convert a schema on disk to YAML on disk.
+ * saiku ossie-export --in saiku-home/data/Pharma.xml --out pharma.ossie.yaml
+ *
+ * # Or pipe on stdin / stdout for scripting.
+ * cat saiku-home/data/Pharma.xml | saiku ossie-export > pharma.ossie.yaml
+ * }</pre>
+ */
+@Command(
+        name = "ossie-export",
+        description = "Convert a Mondrian XML schema into Apache Ossie YAML.",
+        mixinStandardHelpOptions = true)
+public class OssieExportCommand implements Callable<Integer> {
+
+    @Option(
+            names = {"-i", "--in"},
+            description = "Input Mondrian schema XML. Defaults to stdin when absent.")
+    Path in;
+
+    @Option(
+            names = {"-o", "--out"},
+            description = "Output Ossie YAML file. Defaults to stdout when absent.")
+    Path out;
+
+    @Override
+    public Integer call() throws Exception {
+        MondrianToOssieConverter converter = new MondrianToOssieConverter();
+        OssieDocument doc;
+        try (InputStream input = openInput()) {
+            doc = converter.convert(input);
+        } catch (IOException e) {
+            System.err.println("ossie-export: failed to read input: " + e.getMessage());
+            return 2;
+        }
+
+        try (Writer output = openOutput()) {
+            new OssieYamlWriter().write(doc, output);
+        } catch (IOException e) {
+            System.err.println("ossie-export: failed to write output: " + e.getMessage());
+            return 3;
+        }
+
+        // Report on skipped cubes so the operator knows nothing was silently dropped.
+        if (!converter.getSkippedCubes().isEmpty()) {
+            System.err.println(
+                    "ossie-export: skipped " + converter.getSkippedCubes().size()
+                            + " cube(s) that the first-cut converter doesn't yet recognise "
+                            + "(Mondrian 4 <MeasureGroup>/virtual cube shape — tracked on the parent epic):");
+            for (String name : converter.getSkippedCubes()) {
+                System.err.println("  - " + name);
+            }
+        }
+        try (PrintWriter tty = new PrintWriter(System.err, true)) {
+            tty.println("ossie-export: wrote " + doc.getSemanticModel().size() + " semantic model(s) to "
+                    + (out == null ? "stdout" : out.toString()));
+        }
+        return 0;
+    }
+
+    private InputStream openInput() throws IOException {
+        if (in == null) {
+            // Wrapping System.in in a filter that DOESN'T close the underlying stream avoids
+            // slamming the terminal shut when the try-with-resources body finishes.
+            return new java.io.FilterInputStream(System.in) {
+                @Override
+                public void close() {}
+            };
+        }
+        Path resolved = in.isAbsolute()
+                ? in
+                : Paths.get(System.getProperty("user.dir")).resolve(in).normalize();
+        if (!Files.isReadable(resolved)) {
+            throw new IOException("Input schema not readable: " + resolved);
+        }
+        return new FileInputStream(resolved.toFile());
+    }
+
+    private Writer openOutput() throws IOException {
+        OutputStream stream;
+        if (out == null) {
+            stream = new java.io.FilterOutputStream(System.out) {
+                @Override
+                public void close() throws IOException {
+                    flush();
+                    // Don't close stdout — keeps the launcher process healthy if the CLI is one
+                    // step in a shell pipeline.
+                }
+            };
+        } else {
+            stream = Files.newOutputStream(out);
+        }
+        return new OutputStreamWriter(stream, StandardCharsets.UTF_8);
+    }
+}

--- a/saiku-launcher/src/main/java/org/saiku/launcher/SaikuLauncher.java
+++ b/saiku-launcher/src/main/java/org/saiku/launcher/SaikuLauncher.java
@@ -30,7 +30,7 @@ import picocli.CommandLine.Option;
         mixinStandardHelpOptions = true,
         version = "saiku 3.17",
         description = "Saiku Semantic Layer server.",
-        subcommands = {SaikuLauncher.ServeCommand.class})
+        subcommands = {SaikuLauncher.ServeCommand.class, OssieExportCommand.class})
 public class SaikuLauncher implements Callable<Integer> {
 
     public static void main(String[] args) {


### PR DESCRIPTION
Ships slice 1 of the Ossie / semantic-SQL platform play tracked on #1387.

## What lands

- **Core module** at `saiku-core/saiku-service/src/main/java/org/saiku/service/schema/ossie/` — Ossie POJO tree (matches the current apache/ossie `osi-schema.json`), `MondrianToOssieConverter` (DOM-based, uses the existing `SecureXml` helper for XXE hardening), and `OssieYamlWriter` (Jackson-YAML).
- **CLI subcommand** `saiku ossie-export --in schema.xml --out schema.ossie.yaml` (also supports stdin/stdout piping).
- **Docs page** at `mondrian/ossie-export/` on the docs-site (separate PR against saiku-cloud).

## Mapping table

Follows the mapping documented on #1384 verbatim. Cube → semantic_model, fact + dim tables → datasets, foreignKey/primaryKey → relationships, Measure → metric with both ANSI_SQL and MDX dialects, `levelType="TimeYears/Quarters/Months/Days"` → `dimension.is_time: true`, `saiku.semantic.description` + `synonyms` → Ossie `ai_context`, everything else (`pii`, `cardinality`, `grain`, `aggregation_kind`, `required_filters`) rides in `custom_extensions` with `vendor_name: SAIKU`.

## Not (yet) supported — tracked as follow-ups on #1387

- Mondrian 4 `<Dimensions>` / `<MeasureGroups>` wrapper shape (FoodMart uses this — its cubes skip during conversion, logged to stderr rather than emitted as schema-invalid stubs).
- Virtual cubes.
- Parent-child hierarchies (Ossie hierarchy working group is in flight).
- Shared dims via `<DimensionUsage source=...>`.

## Tests

- `MondrianToOssieConverterTest` — 13 structural tests over inline schema fragments, one per mapping table row.
- `OssieYamlWriterTest` — 4 round-trip tests using networknt json-schema-validator against a locally-copied `osi-schema.json`. Includes fixture runs against real Pharma (asserts PII vendor extensions survive) + FoodMart (asserts we produce schema-valid YAML even when all cubes skip).

All 17 pass green.

## Smoke test

```
$ java -jar saiku-launcher/target/saiku-4.6.0.jar ossie-export \
    --in saiku-home/data/Pharma.xml --out /tmp/pharma.ossie.yaml
ossie-export: wrote 1 semantic model(s) to /tmp/pharma.ossie.yaml

$ head -10 /tmp/pharma.ossie.yaml
version: 0.2.0.dev0
semantic_model:
- name: Pharma Rx
  datasets:
  - name: fact_pharma
    source: public.fact_pharma
    description: Fact table for cube 'Pharma Rx'.
    fields:
    - name: Rx Type
      expression:
        dialects:
        - dialect: ANSI_SQL

$ grep -c 'pii' /tmp/pharma.ossie.yaml
2
```

Two SAIKU vendor extensions carrying `pii=true` (Prescriber Name + NPI) — the Pharma PII annotations survive the round-trip.

## Sequencing

Unblocks #1385 (Calcite SQL adapter over Ossie) and #1386 (Postgres wire protocol) — those need real Ossie YAML to test against.

## Test plan

- [x] `mvn -pl saiku-core/saiku-service -am test -Dtest='MondrianToOssieConverterTest,OssieYamlWriterTest'` — 17/17 pass
- [x] Package the launcher and smoke-test the CLI against Pharma.xml
- [ ] CI: Linux + macOS `mvn verify` (pending merge)
- [ ] Docs preview (saiku-cloud PR opens alongside)

## Docs

Companion PR on `saiku-cloud` adds `docs-site/src/content/docs/mondrian/ossie-export.mdx` with the mapping table, worked example, and cross-link from the existing `semantic-annotations.mdx`.

Closes #1384.