### PR TITLE
feat(sql): Calcite SQL over Ossie — full first slice incl. native Postgres wire (saiku#1385, #1390, #1391, #1386, #1392)

### DIFF
--- a/saiku-core/pom.xml
+++ b/saiku-core/pom.xml
@@ -15,6 +15,7 @@
         <module>saiku-olap-util</module>
         <module>saiku-semantic</module>
         <module>saiku-service</module>
+        <module>saiku-sql</module>
         <module>saiku-web</module>
     </modules>
     <build>

--- a/saiku-core/saiku-sql/pom.xml
+++ b/saiku-core/saiku-sql/pom.xml
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.saikuanalytics</groupId>
+        <artifactId>saiku-core</artifactId>
+        <version>4.6.0</version>
+    </parent>
+
+    <artifactId>saiku-sql</artifactId>
+    <packaging>jar</packaging>
+    <name>saiku - sql layer</name>
+    <description>Apache Calcite SchemaFactory + JDBC driver that speaks SQL over Apache Ossie
+        semantic models. Sits alongside Mondrian: SQL clients (BI tools, LLM code paths, dbt) get a
+        first-class semantic query surface; Mondrian keeps handling MDX / cube / hierarchy queries.
+        See parent tracking issue saiku#1387.</description>
+
+    <properties>
+        <maven.compiler.release>21</maven.compiler.release>
+    </properties>
+
+    <dependencies>
+        <!-- Ossie model + YAML round-trip live in saiku-service; the SchemaFactory
+             reads the same POJO tree the Mondrian->Ossie exporter produces. -->
+        <dependency>
+            <groupId>org.saikuanalytics</groupId>
+            <artifactId>saiku-service</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <!-- Apache Calcite - the SQL parser, planner, and virtual-schema adapter
+             framework the entire module builds on. Version pinned to match the
+             Mondrian fork's transitive calcite-core (bumping this requires
+             coordinating with mondrian-saiku's calcite dep). -->
+        <dependency>
+            <groupId>org.apache.calcite</groupId>
+            <artifactId>calcite-core</artifactId>
+            <version>1.41.0</version>
+        </dependency>
+
+        <!-- Jackson for reading Ossie YAML back into the POJO tree. Same version
+             as the writer path in saiku-service so we can't drift. -->
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.dataformat</groupId>
+            <artifactId>jackson-dataformat-yaml</artifactId>
+        </dependency>
+
+        <!-- SLF4J API only; the runtime binding is provided by whatever consumer
+             embeds this module (launcher ships slf4j-simple, webapp ships log4j2). -->
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+
+        <!-- Test scope: JUnit + H2 (in-JVM warehouse for the SelectPushdown IT). -->
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <!-- Root pom pins compiler-plugin 3.1 + source/target 1.6 which
+                     doesn't understand the modern <release> flag. Pin 3.13.0
+                     locally (matches saiku-service) so Calcite 1.41 and our
+                     Java 21 features compile cleanly. Don't 'fix' the root
+                     pom — other modules deliberately stay on the old surface. -->
+                <version>3.13.0</version>
+                <configuration>
+                    <release>${maven.compiler.release}</release>
+                    <encoding>UTF-8</encoding>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/saiku-core/saiku-sql/pom.xml
+++ b/saiku-core/saiku-sql/pom.xml
@@ -40,6 +40,21 @@
             <version>1.41.0</version>
         </dependency>
 
+        <!-- Apache Avatica server. The 'saiku sql-serve' CLI subcommand starts a
+             HttpServer that wraps a JdbcMeta pointing at a Calcite connection —
+             any Avatica-aware client (avatica-server JDBC driver, native Python
+             / Go clients) connects to the resulting HTTP+protobuf endpoint and
+             executes SQL against the Ossie semantic model.
+
+             Version pinned to avatica 1.27 (transitively used by calcite-core).
+             Bumping requires coordinating with calcite-core's transitive
+             avatica-core version to avoid classpath drift. -->
+        <dependency>
+            <groupId>org.apache.calcite.avatica</groupId>
+            <artifactId>avatica-server</artifactId>
+            <version>1.27.0</version>
+        </dependency>
+
         <!-- Jackson for reading Ossie YAML back into the POJO tree. Same version
              as the writer path in saiku-service so we can't drift. -->
         <dependency>

--- a/saiku-core/saiku-sql/pom.xml
+++ b/saiku-core/saiku-sql/pom.xml
@@ -84,6 +84,15 @@
             <artifactId>h2</artifactId>
             <scope>test</scope>
         </dependency>
+        <!-- pgjdbc: speaks the native Postgres wire protocol. Used by the
+             PgWireServerIT to prove our server accepts real PG-wire clients
+             (not just clients that share codec code with us). Version comes
+             from saiku-bom. -->
+        <dependency>
+            <groupId>org.postgresql</groupId>
+            <artifactId>postgresql</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/saiku-core/saiku-sql/src/main/java/org/saiku/sql/adapter/OssieAutoJoinRule.java
+++ b/saiku-core/saiku-sql/src/main/java/org/saiku/sql/adapter/OssieAutoJoinRule.java
@@ -56,12 +56,16 @@ import org.slf4j.LoggerFactory;
  *       {@link AmbiguousJoinException} so silent-wrong-results never happens.
  * </ol>
  *
+ * <p>N-way joins ({@code FROM A, B, C, …}) — the rule handles these by walking down through
+ * nested Joins to reach every raw {@link TableScan} in the outer subtree, then rebuilding a
+ * left-deep join chain against them using Ossie relationships to derive each pair's predicate.
+ * Requires exactly one relationship for each successive link — ambiguity between the same pair
+ * of datasets bails.
+ *
  * <p>Non-goals for this first slice, tracked as follow-ups:
  *
  * <ul>
  *   <li>Cross-schema joins (Ossie + non-Ossie tables).
- *   <li>Deeper subtree walk — today we only recognise a direct {@link TableScan} child of the
- *       Join, or a {@link org.apache.calcite.rel.logical.LogicalProject} wrapper thereof.
  *   <li>Self-joins ({@code FROM A a, A b}) — the rule bails when both sides resolve to the same
  *       dataset.
  * </ul>
@@ -92,7 +96,14 @@ public class OssieAutoJoinRule extends RelOptRule {
         // Guard 2: both sides must land on an Ossie-backed TableScan.
         OssieTableRef left = findOssieTable(join.getLeft());
         OssieTableRef right = findOssieTable(join.getRight());
-        if (left == null || right == null) return;
+        if (left == null || right == null) {
+            // N-way case: at least one side is a nested Join. Handle via the compound-rebuild
+            // path — collect every raw TableScan reachable in either subtree and build a fresh
+            // left-deep join chain against them. Same tree-rebuild pattern as the two-way case,
+            // just extended to N tables and N-1 relationships.
+            tryCompoundRewrite(call, join);
+            return;
+        }
         if (left.schema != right.schema) return;
         if (left.datasetName.equals(right.datasetName)) return; // self-join — bail
 
@@ -174,6 +185,169 @@ public class OssieAutoJoinRule extends RelOptRule {
                 left.datasetName,
                 right.datasetName);
         call.transformTo(rewritten);
+    }
+
+    /**
+     * Rewrite path for N-way Cartesian joins. Calcite parses {@code FROM A, B, C} as
+     * {@code Join(Join(A, B), C)} with both joins having {@code condition=true}. The two-way
+     * rebuild path handles the inner one. This path handles the outer by walking down to
+     * <b>all</b> raw TableScans in the subtree (traversing nested Joins) and building a fresh
+     * left-deep join chain against them, using Ossie relationships to derive each pair's ON
+     * predicate. The outer Project restricts to the original output columns.
+     *
+     * <p>Ambiguity guard: if the collected TableScans include tables with multiple Ossie
+     * relationships between the same pair, we don't guess — the rewrite bails and the user
+     * gets an explicit-ON error. Same policy as the two-way {@link AmbiguousJoinException}
+     * case.
+     */
+    private void tryCompoundRewrite(RelOptRuleCall call, LogicalJoin join) {
+        // Collect all raw TableScans reachable in either subtree — walking past LogicalProject,
+        // RelSubset, and nested Joins.
+        List<TableScan> scans = new ArrayList<>();
+        List<String> datasetNames = new ArrayList<>();
+        OssieSchema[] schemaHolder = new OssieSchema[1];
+        boolean ok = collectAllTableScans(join.getLeft(), scans, datasetNames, schemaHolder);
+        if (!ok || !collectAllTableScans(join.getRight(), scans, datasetNames, schemaHolder)) return;
+        if (schemaHolder[0] == null || scans.size() < 3) return;
+        // Deduplicate — same TableScan can appear multiple times if the plan is exploring
+        // alternative shapes. Preserve first-seen order for deterministic joining.
+        java.util.LinkedHashSet<String> uniqueNames = new java.util.LinkedHashSet<>();
+        List<TableScan> uniqueScans = new ArrayList<>();
+        for (int i = 0; i < scans.size(); i++) {
+            if (uniqueNames.add(datasetNames.get(i))) {
+                uniqueScans.add(scans.get(i));
+            }
+        }
+        if (uniqueScans.size() < 3) return;
+        SemanticModel model = schemaHolder[0].model();
+
+        // Build the join chain. Start with the first scan; for each subsequent scan, find a
+        // relationship linking it to some already-joined dataset, then join with that predicate.
+        RelBuilder builder = call.builder();
+        RexBuilder rex = builder.getRexBuilder();
+        List<String> joinedNames = new ArrayList<>();
+        List<Integer> baseOffsets = new ArrayList<>(); // starting column position of each joined table
+
+        TableScan firstScan = uniqueScans.get(0);
+        String firstName = uniqueNames.iterator().next();
+        builder.push(firstScan);
+        joinedNames.add(firstName);
+        baseOffsets.add(0);
+        int totalFields = firstScan.getRowType().getFieldCount();
+
+        for (int i = 1; i < uniqueScans.size(); i++) {
+            TableScan next = uniqueScans.get(i);
+            String nextName = List.copyOf(uniqueNames).get(i);
+            Relationship relationship = null;
+            String linkedName = null;
+            for (String candidate : joinedNames) {
+                Relationship r = pickRelationshipSafe(model, candidate, nextName);
+                if (r != null) {
+                    if (relationship != null) {
+                        // Multiple candidates linking the next table into the joined set —
+                        // ambiguous, bail.
+                        return;
+                    }
+                    relationship = r;
+                    linkedName = candidate;
+                }
+            }
+            if (relationship == null) return; // no relationship — can't extend the chain
+            int linkedOffset = baseOffsets.get(joinedNames.indexOf(linkedName));
+            TableScan linkedScan = uniqueScans.get(joinedNames.indexOf(linkedName));
+            RelDataType linkedRow = linkedScan.getRowType();
+            RelDataType nextRow = next.getRowType();
+            boolean sameDirection = relationship.getFrom().equals(linkedName);
+            List<String> linkedCols = sameDirection ? relationship.getFromColumns() : relationship.getToColumns();
+            List<String> nextCols = sameDirection ? relationship.getToColumns() : relationship.getFromColumns();
+            if (linkedCols.isEmpty() || linkedCols.size() != nextCols.size()) return;
+            List<RexNode> conjuncts = new ArrayList<>();
+            for (int k = 0; k < linkedCols.size(); k++) {
+                Integer li = fieldOrdinal(linkedRow, linkedCols.get(k));
+                Integer ni = fieldOrdinal(nextRow, nextCols.get(k));
+                if (li == null || ni == null) return;
+                RexNode l = rex.makeInputRef(linkedRow.getFieldList().get(li).getType(), linkedOffset + li);
+                RexNode r = rex.makeInputRef(nextRow.getFieldList().get(ni).getType(), totalFields + ni);
+                conjuncts.add(rex.makeCall(SqlStdOperatorTable.EQUALS, l, r));
+            }
+            RexNode condition =
+                    conjuncts.size() == 1 ? conjuncts.get(0) : rex.makeCall(SqlStdOperatorTable.AND, conjuncts);
+            builder.push(next);
+            builder.join(org.apache.calcite.rel.core.JoinRelType.INNER, condition);
+            baseOffsets.add(totalFields);
+            totalFields += nextRow.getFieldCount();
+            joinedNames.add(nextName);
+        }
+
+        // Outer Project restricting to the columns the current outer Join was producing.
+        RelDataType originalRow = join.getRowType();
+        RelDataType joinedRow = builder.peek().getRowType();
+        List<RexNode> projections = new ArrayList<>();
+        List<String> projectionNames = new ArrayList<>();
+        for (RelDataTypeField original : originalRow.getFieldList()) {
+            int foundIdx = -1;
+            for (int j = 0; j < joinedRow.getFieldCount(); j++) {
+                if (joinedRow.getFieldList().get(j).getName().equalsIgnoreCase(original.getName())) {
+                    foundIdx = j;
+                    break;
+                }
+            }
+            if (foundIdx < 0) return;
+            projections.add(
+                    rex.makeInputRef(joinedRow.getFieldList().get(foundIdx).getType(), foundIdx));
+            projectionNames.add(original.getName());
+        }
+        builder.project(projections, projectionNames);
+        RelNode rewritten = builder.build();
+
+        log.debug("OssieAutoJoinRule: n-way rebuild over datasets {} — outer Cartesian → chained Joins", joinedNames);
+        call.transformTo(rewritten);
+    }
+
+    /**
+     * Wraps {@link #pickRelationship} to return null instead of throwing on ambiguity. The
+     * n-way builder handles ambiguity by bailing at the caller level with more context (which
+     * links to which).
+     */
+    private Relationship pickRelationshipSafe(SemanticModel model, String a, String b) {
+        try {
+            return pickRelationship(model, a, b);
+        } catch (AmbiguousJoinException e) {
+            return null;
+        }
+    }
+
+    /**
+     * Walk a RelNode subtree collecting every reachable Ossie-backed TableScan. Recognises
+     * TableScan, LogicalProject, Project, and Join (both sides). Returns false if any scan
+     * isn't Ossie-backed or if multiple schemas appear.
+     */
+    private boolean collectAllTableScans(
+            RelNode rel, List<TableScan> outScans, List<String> outNames, OssieSchema[] schemaHolder) {
+        RelNode cursor = unwrapSubset(rel);
+        if (cursor instanceof org.apache.calcite.rel.core.Project) {
+            return collectAllTableScans(
+                    ((org.apache.calcite.rel.core.Project) cursor).getInput(), outScans, outNames, schemaHolder);
+        }
+        if (cursor instanceof org.apache.calcite.rel.core.Join) {
+            org.apache.calcite.rel.core.Join innerJoin = (org.apache.calcite.rel.core.Join) cursor;
+            return collectAllTableScans(innerJoin.getLeft(), outScans, outNames, schemaHolder)
+                    && collectAllTableScans(innerJoin.getRight(), outScans, outNames, schemaHolder);
+        }
+        if (cursor instanceof TableScan) {
+            TableScan scan = (TableScan) cursor;
+            RelOptTable table = scan.getTable();
+            List<String> qualifiedName = table.getQualifiedName();
+            if (qualifiedName.isEmpty()) return false;
+            OssieSchema schema = unwrapOssieSchema(table);
+            if (schema == null) return false;
+            if (schemaHolder[0] == null) schemaHolder[0] = schema;
+            else if (schemaHolder[0] != schema) return false;
+            outScans.add(scan);
+            outNames.add(qualifiedName.get(qualifiedName.size() - 1));
+            return true;
+        }
+        return false;
     }
 
     /**

--- a/saiku-core/saiku-sql/src/main/java/org/saiku/sql/adapter/OssieAutoJoinRule.java
+++ b/saiku-core/saiku-sql/src/main/java/org/saiku/sql/adapter/OssieAutoJoinRule.java
@@ -1,0 +1,306 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.sql.adapter;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.calcite.plan.RelOptRule;
+import org.apache.calcite.plan.RelOptRuleCall;
+import org.apache.calcite.plan.RelOptTable;
+import org.apache.calcite.plan.volcano.RelSubset;
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.core.TableScan;
+import org.apache.calcite.rel.logical.LogicalJoin;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rel.type.RelDataTypeField;
+import org.apache.calcite.rex.RexBuilder;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.sql.fun.SqlStdOperatorTable;
+import org.apache.calcite.tools.RelBuilder;
+import org.saiku.service.schema.ossie.model.Relationship;
+import org.saiku.service.schema.ossie.model.SemanticModel;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Calcite planner rule that auto-injects an Ossie {@code relationship}'s ON predicate into any
+ * Cartesian join between two datasets in the same {@link OssieSchema}.
+ *
+ * <p>Rewrites this shape:
+ *
+ * <pre>{@code
+ * -- User writes:
+ * SELECT c.REGION, SUM(o.AMOUNT)
+ * FROM SALES.ORDERS o, SALES.CUSTOMERS c
+ * GROUP BY c.REGION;
+ *
+ * -- Which Calcite parses as: LogicalJoin(condition=[true])(ORDERS, CUSTOMERS)
+ * -- This rule rewrites to:   LogicalJoin(condition=[o.CUSTOMER_ID = c.ID])(ORDERS, CUSTOMERS)
+ * -- where the columns come from the Ossie relationship on those two datasets.
+ * }</pre>
+ *
+ * <p>Fires only when:
+ *
+ * <ol>
+ *   <li>The join condition is trivially {@code true} (i.e. the user genuinely wrote a Cartesian
+ *       join — {@code FROM A, B} with no {@code WHERE} join predicate). We never overwrite an
+ *       explicit user-provided condition.
+ *   <li>Both sides walk down to a {@link TableScan} whose schema name matches an OssieSchema
+ *       registered in {@link OssieSchema#lookupRegistered}. We identify Ossie-backed tables by
+ *       schema name rather than {@code RelOptTable#unwrap} because our datasets surface as
+ *       {@code JdbcTable}s (for JDBC pushdown), so the unwrap chain lands on JdbcSchema.
+ *   <li>Both scans are from the same {@link OssieSchema} instance.
+ *   <li>Exactly one Ossie {@link Relationship} links the two datasets. Multiple candidates raise
+ *       {@link AmbiguousJoinException} so silent-wrong-results never happens.
+ * </ol>
+ *
+ * <p>Non-goals for this first slice, tracked as follow-ups:
+ *
+ * <ul>
+ *   <li>Cross-schema joins (Ossie + non-Ossie tables).
+ *   <li>Deeper subtree walk — today we only recognise a direct {@link TableScan} child of the
+ *       Join, or a {@link org.apache.calcite.rel.logical.LogicalProject} wrapper thereof.
+ *   <li>Self-joins ({@code FROM A a, A b}) — the rule bails when both sides resolve to the same
+ *       dataset.
+ * </ul>
+ */
+public class OssieAutoJoinRule extends RelOptRule {
+
+    private static final Logger log = LoggerFactory.getLogger(OssieAutoJoinRule.class);
+
+    /**
+     * Singleton rule instance. Uses the older RelOptRule base class (rather than RelRule +
+     * Config) because Calcite 1.41's Config machinery relies on the Immutables annotation
+     * processor to synthesise the {@code Config.EMPTY} constant; we don't want that dependency
+     * for one rule. RelOptRule remains fully supported and is what the JDBC adapter's own rules
+     * still use in 1.41.
+     */
+    public static final OssieAutoJoinRule INSTANCE = new OssieAutoJoinRule();
+
+    private OssieAutoJoinRule() {
+        super(operand(LogicalJoin.class, any()), "OssieAutoJoinRule");
+    }
+
+    @Override
+    public void onMatch(RelOptRuleCall call) {
+        LogicalJoin join = call.rel(0);
+        // Guard 1: only rewrite Cartesian joins.
+        if (!join.getCondition().isAlwaysTrue()) return;
+
+        // Guard 2: both sides must land on an Ossie-backed TableScan.
+        OssieTableRef left = findOssieTable(join.getLeft());
+        OssieTableRef right = findOssieTable(join.getRight());
+        if (left == null || right == null) return;
+        if (left.schema != right.schema) return;
+        if (left.datasetName.equals(right.datasetName)) return; // self-join — bail
+
+        // Guard 3: find exactly one Ossie relationship linking the two datasets.
+        Relationship relationship = pickRelationship(left.schema.model(), left.datasetName, right.datasetName);
+        if (relationship == null) return;
+
+        // Build the rewrite. Calcite's Volcano planner has usually pushed projections down onto
+        // each side of the join before this rule fires, so `join.getLeft().getRowType()` might
+        // only expose a subset of columns — often NOT including the join key. We can't simply
+        // update the join condition against the current row types; we need to reach back to the
+        // raw TableScans (which have every column) and rebuild the join around them.
+        //
+        // Structure of the rewrite:
+        //   Project([<original output columns>])
+        //     LogicalJoin(left.<from_col> = right.<to_col>)
+        //       TableScan(left dataset)
+        //       TableScan(right dataset)
+        //
+        // The outer Project restricts back to the columns the current join was producing, so the
+        // rewrite is a drop-in substitution for the LogicalJoin node.
+        RelBuilder builder = call.builder();
+        RexBuilder rex = builder.getRexBuilder();
+        TableScan leftScan = left.scan;
+        TableScan rightScan = right.scan;
+        RelDataType leftScanRow = leftScan.getRowType();
+        RelDataType rightScanRow = rightScan.getRowType();
+
+        // Build ON predicate using column indices from the raw TableScan row types.
+        boolean sameDirection = relationship.getFrom().equals(left.datasetName);
+        List<String> leftKeyCols = sameDirection ? relationship.getFromColumns() : relationship.getToColumns();
+        List<String> rightKeyCols = sameDirection ? relationship.getToColumns() : relationship.getFromColumns();
+        if (leftKeyCols.size() != rightKeyCols.size() || leftKeyCols.isEmpty()) return;
+
+        int leftFieldCount = leftScanRow.getFieldCount();
+        List<RexNode> conjuncts = new ArrayList<>();
+        for (int i = 0; i < leftKeyCols.size(); i++) {
+            Integer leftIdx = fieldOrdinal(leftScanRow, leftKeyCols.get(i));
+            Integer rightIdx = fieldOrdinal(rightScanRow, rightKeyCols.get(i));
+            if (leftIdx == null || rightIdx == null) return;
+            RelDataTypeField lf = leftScanRow.getFieldList().get(leftIdx);
+            RelDataTypeField rf = rightScanRow.getFieldList().get(rightIdx);
+            RexNode l = rex.makeInputRef(lf.getType(), leftIdx);
+            RexNode r = rex.makeInputRef(rf.getType(), leftFieldCount + rightIdx);
+            conjuncts.add(rex.makeCall(SqlStdOperatorTable.EQUALS, l, r));
+        }
+        RexNode condition = conjuncts.size() == 1 ? conjuncts.get(0) : rex.makeCall(SqlStdOperatorTable.AND, conjuncts);
+
+        // Compose using RelBuilder. .push(leftScan).push(rightScan).join(INNER, condition) leaves
+        // the joined tables on the stack; we then Project to keep exactly the columns the
+        // original join was producing (found by matching column NAMES from the original row
+        // type against the joined row type, which has all columns from both TableScans).
+        builder.push(leftScan).push(rightScan).join(org.apache.calcite.rel.core.JoinRelType.INNER, condition);
+        RelDataType originalRow = join.getRowType();
+        RelDataType joinedRow = builder.peek().getRowType();
+        List<RexNode> projections = new ArrayList<>();
+        List<String> projectionNames = new ArrayList<>();
+        for (RelDataTypeField original : originalRow.getFieldList()) {
+            // Find the column in the joined row type by name. First hit wins — deterministic
+            // because RelBuilder preserves left-then-right order.
+            int foundIdx = -1;
+            for (int i = 0; i < joinedRow.getFieldCount(); i++) {
+                if (joinedRow.getFieldList().get(i).getName().equalsIgnoreCase(original.getName())) {
+                    foundIdx = i;
+                    break;
+                }
+            }
+            if (foundIdx < 0) return; // shouldn't happen — original columns must appear in the joined row
+            projections.add(
+                    rex.makeInputRef(joinedRow.getFieldList().get(foundIdx).getType(), foundIdx));
+            projectionNames.add(original.getName());
+        }
+        builder.project(projections, projectionNames);
+        RelNode rewritten = builder.build();
+
+        log.debug(
+                "OssieAutoJoinRule: injecting relationship '{}' predicate into Cartesian join {}↔{}",
+                relationship.getName(),
+                left.datasetName,
+                right.datasetName);
+        call.transformTo(rewritten);
+    }
+
+    /**
+     * Walk a RelNode subtree looking for a {@link TableScan} whose backing table is an Ossie
+     * dataset. Recognises a direct scan or one wrapped in a {@code LogicalProject} (Calcite
+     * often introduces one for column projection). Returns null when neither shape matches.
+     */
+    private OssieTableRef findOssieTable(RelNode rel) {
+        RelNode cursor = unwrapSubset(rel);
+        // Peel off wrapping layers Calcite introduces during optimisation: LogicalProject
+        // (column pruning) and RelSubset (Volcano equivalence class). We iterate to unwrap
+        // arbitrary chains — TableScan can sit under Project → Project → TableScan in some
+        // planner states. Bounded loop to avoid runaway if the input tree is unusual.
+        for (int depth = 0; depth < 8 && !(cursor instanceof TableScan); depth++) {
+            RelNode next;
+            if (cursor instanceof org.apache.calcite.rel.logical.LogicalProject) {
+                next = ((org.apache.calcite.rel.logical.LogicalProject) cursor).getInput();
+            } else if (cursor instanceof org.apache.calcite.rel.core.Project) {
+                next = ((org.apache.calcite.rel.core.Project) cursor).getInput();
+            } else {
+                return null;
+            }
+            cursor = unwrapSubset(next);
+        }
+        if (!(cursor instanceof TableScan)) return null;
+        TableScan scan = (TableScan) cursor;
+        RelOptTable relOptTable = scan.getTable();
+        List<String> qualifiedName = relOptTable.getQualifiedName();
+        if (qualifiedName.isEmpty()) return null;
+        String datasetName = qualifiedName.get(qualifiedName.size() - 1);
+        OssieSchema schema = unwrapOssieSchema(relOptTable);
+        if (schema == null) return null;
+        return new OssieTableRef(schema, datasetName, scan);
+    }
+
+    /**
+     * If {@code rel} is a Volcano {@link RelSubset}, return its best (or original) member so we
+     * can inspect the shape. Otherwise return {@code rel} unchanged. Called at every layer of
+     * the walk in {@link #findOssieTable}.
+     */
+    private static RelNode unwrapSubset(RelNode rel) {
+        if (rel instanceof RelSubset) {
+            RelSubset subset = (RelSubset) rel;
+            RelNode best = subset.getBest();
+            if (best != null) return best;
+            // No best plan chosen yet — use the original (the RelNode Volcano was constructed
+            // around). Correct for the equivalence class since all members produce the same
+            // rowType.
+            RelNode original = subset.getOriginal();
+            if (original != null) return original;
+        }
+        return rel;
+    }
+
+    /**
+     * Look up the {@link OssieSchema} that owns a {@link RelOptTable}. Our datasets surface as
+     * {@link org.apache.calcite.adapter.jdbc.JdbcSchema}-owned JdbcTables (so Calcite's planner
+     * can push down JDBC-native SQL), which means {@code table.unwrap(OssieSchema.class)}
+     * returns null. Instead we consult {@link OssieSchema#lookupRegistered} using the qualified
+     * table name's first segment (the schema name Calcite gave us at factory time).
+     */
+    private OssieSchema unwrapOssieSchema(RelOptTable table) {
+        List<String> qualifiedName = table.getQualifiedName();
+        if (qualifiedName.size() < 2) return null;
+        return OssieSchema.lookupRegistered(qualifiedName.get(0));
+    }
+
+    /**
+     * Return the single Ossie relationship linking two datasets, or null when none exists.
+     * Directional-agnostic: matches (from=A, to=B) OR (from=B, to=A). Throws {@link
+     * AmbiguousJoinException} when more than one matches — better than silent wrong results.
+     */
+    private Relationship pickRelationship(SemanticModel model, String left, String right) {
+        List<Relationship> matches = new ArrayList<>();
+        for (Relationship r : model.getRelationships()) {
+            if (r.getFrom() == null || r.getTo() == null) continue;
+            if ((r.getFrom().equals(left) && r.getTo().equals(right))
+                    || (r.getFrom().equals(right) && r.getTo().equals(left))) {
+                matches.add(r);
+            }
+        }
+        if (matches.isEmpty()) return null;
+        if (matches.size() > 1) {
+            List<String> names = new ArrayList<>();
+            for (Relationship r : matches) names.add(r.getName());
+            throw new AmbiguousJoinException(left, right, names);
+        }
+        return matches.get(0);
+    }
+
+    private Integer fieldOrdinal(RelDataType row, String columnName) {
+        for (int i = 0; i < row.getFieldCount(); i++) {
+            if (row.getFieldList().get(i).getName().equalsIgnoreCase(columnName)) return i;
+        }
+        return null;
+    }
+
+    /** Tuple carrying the identity of an Ossie dataset behind a TableScan. */
+    private static final class OssieTableRef {
+        final OssieSchema schema;
+        final String datasetName;
+
+        @SuppressWarnings("unused") // scan retained for future extensions (e.g. re-alias)
+        final TableScan scan;
+
+        OssieTableRef(OssieSchema schema, String datasetName, TableScan scan) {
+            this.schema = schema;
+            this.datasetName = datasetName;
+            this.scan = scan;
+        }
+
+        @Override
+        public String toString() {
+            return "OssieTableRef{schema=" + (schema == null ? "null" : "ok") + ", dataset=" + datasetName + "}";
+        }
+    }
+
+    /**
+     * Raised when a Cartesian join sits between two datasets that have MULTIPLE Ossie
+     * relationships. The user must add an explicit ON clause to pick one; the rule refuses to
+     * guess.
+     */
+    public static class AmbiguousJoinException extends RuntimeException {
+        public AmbiguousJoinException(String left, String right, List<String> candidates) {
+            super("OssieAutoJoinRule: multiple Ossie relationships link '" + left + "' and '"
+                    + right + "': " + candidates
+                    + ". Add an explicit ON clause to disambiguate.");
+        }
+    }
+}

--- a/saiku-core/saiku-sql/src/main/java/org/saiku/sql/adapter/OssieAutoJoinRule.java
+++ b/saiku-core/saiku-sql/src/main/java/org/saiku/sql/adapter/OssieAutoJoinRule.java
@@ -171,14 +171,23 @@ public class OssieAutoJoinRule extends RelOptRule {
                     break;
                 }
             }
-            if (foundIdx < 0) return; // shouldn't happen — original columns must appear in the joined row
-            projections.add(
-                    rex.makeInputRef(joinedRow.getFieldList().get(foundIdx).getType(), foundIdx));
+            if (foundIdx < 0) {
+                // Column not found by name — Calcite's projection pushdown has stripped the
+                // original columns and replaced them with synthetic ones (typically "DUMMY"
+                // when the outer query is COUNT(*) with no column references). Substitute a
+                // zero literal of the expected type so downstream shape-matches; the value is
+                // never actually read for aggregate-only queries. Zero (not NULL) because
+                // Calcite's DUMMY columns are declared NOT NULL and transformTo rejects
+                // nullability mismatches.
+                projections.add(rex.makeZeroLiteral(original.getType()));
+            } else {
+                projections.add(
+                        rex.makeInputRef(joinedRow.getFieldList().get(foundIdx).getType(), foundIdx));
+            }
             projectionNames.add(original.getName());
         }
         builder.project(projections, projectionNames);
         RelNode rewritten = builder.build();
-
         log.debug(
                 "OssieAutoJoinRule: injecting relationship '{}' predicate into Cartesian join {}↔{}",
                 relationship.getName(),
@@ -292,9 +301,14 @@ public class OssieAutoJoinRule extends RelOptRule {
                     break;
                 }
             }
-            if (foundIdx < 0) return;
-            projections.add(
-                    rex.makeInputRef(joinedRow.getFieldList().get(foundIdx).getType(), foundIdx));
+            if (foundIdx < 0) {
+                // Same fix as the two-way path: substitute a zero literal so downstream shape
+                // matches. See two-way rewrite for the DUMMY-column rationale.
+                projections.add(rex.makeZeroLiteral(original.getType()));
+            } else {
+                projections.add(
+                        rex.makeInputRef(joinedRow.getFieldList().get(foundIdx).getType(), foundIdx));
+            }
             projectionNames.add(original.getName());
         }
         builder.project(projections, projectionNames);
@@ -328,6 +342,15 @@ public class OssieAutoJoinRule extends RelOptRule {
         if (cursor instanceof org.apache.calcite.rel.core.Project) {
             return collectAllTableScans(
                     ((org.apache.calcite.rel.core.Project) cursor).getInput(), outScans, outNames, schemaHolder);
+        }
+        if (cursor instanceof org.apache.calcite.rel.core.Filter) {
+            // Calcite pushes WHERE predicates down into per-arm Filter nodes ahead of the join.
+            // Walk past them the same way we walk past Projects — the underlying TableScan still
+            // reflects the raw dataset shape; the Filter's predicate (which our rebuild
+            // preserves via projection pushdown re-running after transformTo) is orthogonal to
+            // the join-key rewrite.
+            return collectAllTableScans(
+                    ((org.apache.calcite.rel.core.Filter) cursor).getInput(), outScans, outNames, schemaHolder);
         }
         if (cursor instanceof org.apache.calcite.rel.core.Join) {
             org.apache.calcite.rel.core.Join innerJoin = (org.apache.calcite.rel.core.Join) cursor;

--- a/saiku-core/saiku-sql/src/main/java/org/saiku/sql/adapter/OssieDatasetTable.java
+++ b/saiku-core/saiku-sql/src/main/java/org/saiku/sql/adapter/OssieDatasetTable.java
@@ -1,0 +1,136 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.sql.adapter;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.calcite.DataContext;
+import org.apache.calcite.adapter.jdbc.JdbcSchema;
+import org.apache.calcite.linq4j.Enumerable;
+import org.apache.calcite.linq4j.Linq4j;
+import org.apache.calcite.plan.RelOptTable;
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rel.type.RelDataTypeFactory;
+import org.apache.calcite.schema.ScannableTable;
+import org.apache.calcite.schema.Schema;
+import org.apache.calcite.schema.Table;
+import org.apache.calcite.schema.TranslatableTable;
+import org.apache.calcite.schema.impl.AbstractTable;
+import org.apache.calcite.sql.type.SqlTypeName;
+import org.saiku.service.schema.ossie.model.Dataset;
+import org.saiku.service.schema.ossie.model.Field;
+
+/**
+ * Calcite {@link Table} projection of a single Ossie {@link Dataset}.
+ *
+ * <p>When a JDBC-backed {@link JdbcSchema} is available, this class delegates rowType + query
+ * planning to the underlying JDBC table so Calcite pushes SELECT/WHERE/GROUP BY down to the
+ * warehouse as native SQL. Without JDBC (schema-only mode), it synthesises a rowType from the
+ * Ossie {@code fields} array with every column typed as VARCHAR and returns zero rows on scan —
+ * enough for BI tools to introspect the schema.
+ *
+ * <p>Ossie's dataset {@code source} is parsed as {@code schema.table} (or bare {@code table}).
+ * When the JDBC warehouse uses a different schema layout, the Ossie exporter needs to be
+ * corrected upstream; this table doesn't try to invent aliases.
+ */
+public class OssieDatasetTable extends AbstractTable implements ScannableTable, TranslatableTable {
+
+    private final Dataset dataset;
+    private final JdbcSchema jdbcSchema;
+
+    /** Cached delegate resolved once against the JDBC schema; null in schema-only mode. */
+    private Table jdbcDelegate;
+
+    public OssieDatasetTable(Dataset dataset, JdbcSchema jdbcSchema) {
+        this.dataset = dataset;
+        this.jdbcSchema = jdbcSchema;
+    }
+
+    public Dataset dataset() {
+        return dataset;
+    }
+
+    @Override
+    public RelDataType getRowType(RelDataTypeFactory typeFactory) {
+        Table delegate = resolveDelegate();
+        if (delegate != null) {
+            return delegate.getRowType(typeFactory);
+        }
+        // Schema-only mode. Build a rowType from Ossie fields; every column defaults to VARCHAR
+        // because Ossie fields don't yet carry a type hint (would be nice to model in a v2 spec
+        // pass — the exporter has the info at hand from Mondrian's <Level type=...>).
+        RelDataTypeFactory.Builder b = typeFactory.builder();
+        for (Field f : dataset.getFields()) {
+            b.add(f.getName(), typeFactory.createSqlType(SqlTypeName.VARCHAR)).nullable(true);
+        }
+        return b.build();
+    }
+
+    @Override
+    public Enumerable<Object[]> scan(DataContext root) {
+        Table delegate = resolveDelegate();
+        if (delegate instanceof ScannableTable scannable) {
+            return scannable.scan(root);
+        }
+        // No JDBC, no delegate → empty result set. Keeps schema introspection queries happy.
+        return Linq4j.emptyEnumerable();
+    }
+
+    @Override
+    public RelNode toRel(RelOptTable.ToRelContext context, RelOptTable relOptTable) {
+        Table delegate = resolveDelegate();
+        if (delegate instanceof TranslatableTable translatable) {
+            return translatable.toRel(context, relOptTable);
+        }
+        // Fallback: schema-only mode. Use Calcite's LogicalTableScan so the planner has a valid
+        // relational node to work with even if it can't push down to a warehouse.
+        return org.apache.calcite.rel.logical.LogicalTableScan.create(context.getCluster(), relOptTable, List.of());
+    }
+
+    /**
+     * Look up the JDBC-backed physical table for this dataset. Split-name form: everything after
+     * the last "." is the table; anything before it is the schema qualifier and is currently
+     * IGNORED (JdbcSchema only sees the tables in its default catalog/schema — a future pass will
+     * resolve fully-qualified names). Cache once resolved.
+     */
+    private Table resolveDelegate() {
+        if (jdbcSchema == null) return null;
+        if (jdbcDelegate != null) return jdbcDelegate;
+        String source = dataset.getSource();
+        String tableName = source == null ? dataset.getName() : lastDot(source);
+        jdbcDelegate = jdbcSchema.getTable(tableName);
+        if (jdbcDelegate == null) {
+            // Try case-insensitive fallback — some warehouses lowercase, some uppercase.
+            String upper = tableName.toUpperCase();
+            String lower = tableName.toLowerCase();
+            for (String candidate : new String[] {upper, lower}) {
+                jdbcDelegate = jdbcSchema.getTable(candidate);
+                if (jdbcDelegate != null) break;
+            }
+        }
+        return jdbcDelegate;
+    }
+
+    private static String lastDot(String s) {
+        int idx = s.lastIndexOf('.');
+        return idx < 0 ? s : s.substring(idx + 1);
+    }
+
+    @Override
+    public Schema.TableType getJdbcTableType() {
+        Table delegate = resolveDelegate();
+        return delegate == null ? Schema.TableType.TABLE : delegate.getJdbcTableType();
+    }
+
+    /** For debugging and error messages. */
+    @Override
+    public String toString() {
+        List<String> columns = new ArrayList<>();
+        for (Field f : dataset.getFields()) columns.add(f.getName());
+        return "OssieDatasetTable{name=" + dataset.getName() + ", source=" + dataset.getSource() + ", columns="
+                + columns + "}";
+    }
+}

--- a/saiku-core/saiku-sql/src/main/java/org/saiku/sql/adapter/OssieMetricViewTable.java
+++ b/saiku-core/saiku-sql/src/main/java/org/saiku/sql/adapter/OssieMetricViewTable.java
@@ -1,0 +1,185 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.sql.adapter;
+
+import java.util.List;
+import java.util.Locale;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.apache.calcite.adapter.jdbc.JdbcSchema;
+import org.apache.calcite.plan.RelOptTable;
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rel.type.RelDataTypeFactory;
+import org.apache.calcite.rel.type.RelDataTypeField;
+import org.apache.calcite.rel.type.RelDataTypeSystem;
+import org.apache.calcite.schema.Table;
+import org.apache.calcite.schema.TranslatableTable;
+import org.apache.calcite.schema.impl.AbstractTable;
+import org.apache.calcite.sql.type.SqlTypeName;
+import org.saiku.service.schema.ossie.model.Metric;
+
+/**
+ * Calcite {@link TranslatableTable} that expands an Ossie {@link Metric} into a scalar SELECT
+ * against its home dataset.
+ *
+ * <p>Users query it like:
+ *
+ * <pre>{@code
+ * SELECT * FROM SALES.TOTAL_REVENUE;
+ * }</pre>
+ *
+ * <p>which returns a single row with the aggregate value. The class exists because {@code
+ * ViewTable.viewMacro(SchemaPlus, …)} — Calcite's usual view-registration path — requires a
+ * {@code SchemaPlus} at construction time, which we can't obtain from inside {@link
+ * OssieSchemaFactory#create} (the factory returns a {@link org.apache.calcite.schema.Schema}
+ * BEFORE Calcite has wrapped it in a {@code SchemaPlus}). By using {@link
+ * org.apache.calcite.plan.RelOptTable.ToRelContext#expandView} from within {@link #toRel}, we
+ * shift SQL parsing to query time when Calcite has full schema context.
+ *
+ * <p>Return type inference is limited to the common aggregate functions produced by our
+ * Mondrian→Ossie exporter ({@code SUM}, {@code COUNT}, {@code AVG}, {@code MIN}, {@code MAX},
+ * {@code COUNT(DISTINCT …)}). Anything else falls back to {@link SqlTypeName#ANY} so Calcite
+ * resolves the type at expand time — safer than guessing wrong. A future slice can improve this
+ * by parsing the expression once at construction time and caching the resolved type.
+ */
+public class OssieMetricViewTable extends AbstractTable implements TranslatableTable {
+
+    /** Parses out {@code AGG(TABLE.COLUMN)} or {@code AGG(DISTINCT TABLE.COLUMN)} — the shape our
+     *  Mondrian→Ossie exporter emits. Falls through to {@link SqlTypeName#ANY} for anything
+     *  more exotic; per-dialect return-type inference is a follow-up. */
+    private static final Pattern AGG_PATTERN = Pattern.compile(
+            "^\\s*(SUM|COUNT|MIN|MAX|AVG)\\s*\\(\\s*(DISTINCT\\s+)?(?:([\\w\"]+)\\.)?([\\w\"]+)\\s*\\)\\s*$",
+            Pattern.CASE_INSENSITIVE);
+
+    private final String metricName;
+    private final String viewSql;
+    private final List<String> schemaPath;
+    private final Metric metric;
+    private final JdbcSchema jdbcSchema;
+    private final String homeDatasetSourceTable;
+
+    public OssieMetricViewTable(
+            Metric metric,
+            String viewSql,
+            List<String> schemaPath,
+            JdbcSchema jdbcSchema,
+            String homeDatasetSourceTable) {
+        this.metricName = metric.getName();
+        this.viewSql = viewSql;
+        this.schemaPath = schemaPath;
+        this.metric = metric;
+        this.jdbcSchema = jdbcSchema;
+        this.homeDatasetSourceTable = homeDatasetSourceTable;
+    }
+
+    @Override
+    public RelDataType getRowType(RelDataTypeFactory typeFactory) {
+        // Calcite's checkConvertedType compares getRowType (declared here) against the type of
+        // the RelNode expandView produces from viewSql. They MUST match exactly, else the
+        // planner throws "Conversion to relational algebra failed to preserve datatypes". So
+        // rather than guess a coarse SqlTypeName (DOUBLE/BIGINT/etc), we look up the underlying
+        // column's exact type from the JDBC-backed home dataset, then apply Calcite's default
+        // aggregate return-type derivation via RelDataTypeSystem. For the aggregators our
+        // Mondrian exporter emits (SUM/COUNT/MIN/MAX/AVG/COUNT-DISTINCT) that's an exact match;
+        // anything more exotic falls back to ANY (Calcite's wildcard) which is permissive
+        // enough to keep the planner happy.
+        RelDataType returnType = deriveReturnType(typeFactory);
+        return typeFactory.builder().add(metricName, returnType).build();
+    }
+
+    /**
+     * Derive the metric's return type by combining Calcite's default aggregate rules with the
+     * column type looked up on the home dataset's underlying JdbcTable. Returns ANY when we
+     * can't parse the expression or don't have a JDBC schema (schema-only mode) — safe, and the
+     * planner handles ANY without a type-conversion error.
+     */
+    private RelDataType deriveReturnType(RelDataTypeFactory typeFactory) {
+        String ansi = metric.getExpression() == null
+                ? ""
+                : metric.getExpression().getDialects().stream()
+                        .filter(d -> "ANSI_SQL".equalsIgnoreCase(d.getDialect()))
+                        .map(d -> d.getExpression())
+                        .findFirst()
+                        .orElse("");
+        Matcher m = AGG_PATTERN.matcher(ansi);
+        if (!m.matches()) return typeFactory.createSqlType(SqlTypeName.ANY);
+        String aggregator = m.group(1).toUpperCase(Locale.ROOT);
+        String columnName = stripQuotes(m.group(4));
+        RelDataType columnType = lookupColumnType(typeFactory, columnName);
+        if (columnType == null) return typeFactory.createSqlType(SqlTypeName.ANY);
+        RelDataTypeSystem system = RelDataTypeSystem.DEFAULT;
+        RelDataType derived;
+        boolean nullable;
+        switch (aggregator) {
+            case "SUM":
+                derived = system.deriveSumType(typeFactory, columnType);
+                nullable = true; // SUM over empty set → NULL
+                break;
+            case "COUNT":
+                // COUNT never returns NULL — even over an empty set it's 0.
+                derived = typeFactory.createSqlType(SqlTypeName.BIGINT);
+                nullable = false;
+                break;
+            case "AVG":
+                derived = system.deriveAvgAggType(typeFactory, columnType);
+                nullable = true;
+                break;
+            case "MIN":
+            case "MAX":
+                // MIN/MAX preserve the input type. NULL over empty set.
+                derived = columnType;
+                nullable = true;
+                break;
+            default:
+                return typeFactory.createSqlType(SqlTypeName.ANY);
+        }
+        return typeFactory.createTypeWithNullability(derived, nullable);
+    }
+
+    /**
+     * Resolve a column name against the JDBC-backed home dataset's rowType. Returns null when
+     * no JDBC schema is wired, the home dataset isn't found in it, or the column name doesn't
+     * appear on the resolved table.
+     */
+    private RelDataType lookupColumnType(RelDataTypeFactory typeFactory, String columnName) {
+        if (jdbcSchema == null || homeDatasetSourceTable == null) return null;
+        Table underlying = firstNonNull(
+                jdbcSchema.getTable(homeDatasetSourceTable),
+                jdbcSchema.getTable(homeDatasetSourceTable.toUpperCase(Locale.ROOT)),
+                jdbcSchema.getTable(homeDatasetSourceTable.toLowerCase(Locale.ROOT)));
+        if (underlying == null) return null;
+        RelDataType rowType = underlying.getRowType(typeFactory);
+        for (RelDataTypeField f : rowType.getFieldList()) {
+            if (f.getName().equalsIgnoreCase(columnName)) return f.getType();
+        }
+        return null;
+    }
+
+    private static String stripQuotes(String s) {
+        if (s == null) return null;
+        return s.replace("\"", "");
+    }
+
+    @SafeVarargs
+    private static <T> T firstNonNull(T... values) {
+        for (T v : values) if (v != null) return v;
+        return null;
+    }
+
+    @Override
+    public RelNode toRel(RelOptTable.ToRelContext context, RelOptTable relOptTable) {
+        // ToRelContext.expandView parses the viewSql and resolves identifiers against the
+        // supplied schemaPath — everything Calcite needs is available on this hook. The rowType
+        // returned by relOptTable comes from getRowType above, which Calcite already validated
+        // against the parsed SELECT list.
+        return context.expandView(relOptTable.getRowType(), viewSql, schemaPath, List.of(metricName)).rel;
+    }
+
+    @Override
+    public String toString() {
+        return "OssieMetricViewTable{name=" + metricName + ", sql=" + viewSql + "}";
+    }
+}

--- a/saiku-core/saiku-sql/src/main/java/org/saiku/sql/adapter/OssieRelationshipViewTable.java
+++ b/saiku-core/saiku-sql/src/main/java/org/saiku/sql/adapter/OssieRelationshipViewTable.java
@@ -1,0 +1,117 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.sql.adapter;
+
+import java.util.List;
+import java.util.Locale;
+import org.apache.calcite.adapter.jdbc.JdbcSchema;
+import org.apache.calcite.plan.RelOptTable;
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rel.type.RelDataTypeFactory;
+import org.apache.calcite.rel.type.RelDataTypeField;
+import org.apache.calcite.schema.Table;
+import org.apache.calcite.schema.TranslatableTable;
+import org.apache.calcite.schema.impl.AbstractTable;
+import org.apache.calcite.sql.type.SqlTypeName;
+
+/**
+ * Calcite {@link TranslatableTable} that materialises an Ossie {@code relationship} as a
+ * pre-joined view. Users query it like:
+ *
+ * <pre>{@code
+ * SELECT REGION, SUM(AMOUNT) FROM SALES.ORDERS_JOIN_CUSTOMERS GROUP BY REGION;
+ * }</pre>
+ *
+ * <p>The point: the JOIN predicate lives in the Ossie YAML, not the query. Users who don't want to
+ * remember which columns link ORDERS to CUSTOMERS can SELECT from the pre-joined view and get
+ * both tables' columns as a single flat rowtype. Calcite pushes the whole thing down to the
+ * warehouse as a single JOIN query, so there's no runtime overhead compared to hand-rolling
+ * {@code JOIN ... ON ...}.
+ *
+ * <p>Naming convention: {@code <from>_JOIN_<to>} where {@code <from>} and {@code <to>} come from
+ * the Ossie {@code relationship}'s {@code from} and {@code to} fields (usually fact then
+ * dimension for Mondrian-exported schemas).
+ *
+ * <p>Follows the same expandView-at-toRel pattern as {@link OssieMetricViewTable} so we don't
+ * need a {@link org.apache.calcite.schema.SchemaPlus} at construction time.
+ */
+public class OssieRelationshipViewTable extends AbstractTable implements TranslatableTable {
+
+    private final String viewName;
+    private final String viewSql;
+    private final List<String> schemaPath;
+    private final JdbcSchema jdbcSchema;
+    private final String fromSourceTable;
+    private final String toSourceTable;
+
+    public OssieRelationshipViewTable(
+            String viewName,
+            String viewSql,
+            List<String> schemaPath,
+            JdbcSchema jdbcSchema,
+            String fromSourceTable,
+            String toSourceTable) {
+        this.viewName = viewName;
+        this.viewSql = viewSql;
+        this.schemaPath = schemaPath;
+        this.jdbcSchema = jdbcSchema;
+        this.fromSourceTable = fromSourceTable;
+        this.toSourceTable = toSourceTable;
+    }
+
+    @Override
+    public RelDataType getRowType(RelDataTypeFactory typeFactory) {
+        // Row type = union of both underlying dataset rowtypes. When names collide (both sides
+        // have `id`, for instance), Calcite's builder appends numeric suffixes (id, id0). That's
+        // acceptable — the point of this view is for users to reach into either side, not for
+        // stable column naming. Users who want cleaner projection can wrap it in their own
+        // SELECT.
+        RelDataTypeFactory.Builder b = typeFactory.builder();
+        if (jdbcSchema != null) {
+            addColumnsFromSourceTable(typeFactory, b, fromSourceTable);
+            addColumnsFromSourceTable(typeFactory, b, toSourceTable);
+        }
+        if (b.getFieldCount() == 0) {
+            // Neither side resolvable — schema-only mode or the JDBC lookup missed. Return a
+            // one-column ANY row so the table registers without blowing up the schema.
+            b.add(viewName, typeFactory.createSqlType(SqlTypeName.ANY));
+        }
+        return b.build();
+    }
+
+    @Override
+    public RelNode toRel(RelOptTable.ToRelContext context, RelOptTable relOptTable) {
+        // Defer SQL parsing to query time — expandView has full schema context. Mirrors the
+        // pattern in OssieMetricViewTable; see that class for the why (SchemaPlus is not
+        // available inside SchemaFactory.create).
+        return context.expandView(relOptTable.getRowType(), viewSql, schemaPath, List.of(viewName)).rel;
+    }
+
+    private void addColumnsFromSourceTable(
+            RelDataTypeFactory typeFactory, RelDataTypeFactory.Builder builder, String sourceTable) {
+        if (sourceTable == null) return;
+        Table underlying = firstNonNull(
+                jdbcSchema.getTable(sourceTable),
+                jdbcSchema.getTable(sourceTable.toUpperCase(Locale.ROOT)),
+                jdbcSchema.getTable(sourceTable.toLowerCase(Locale.ROOT)));
+        if (underlying == null) return;
+        RelDataType rowType = underlying.getRowType(typeFactory);
+        for (RelDataTypeField f : rowType.getFieldList()) {
+            builder.add(f.getName(), f.getType());
+        }
+    }
+
+    @SafeVarargs
+    private static <T> T firstNonNull(T... values) {
+        for (T v : values) if (v != null) return v;
+        return null;
+    }
+
+    @Override
+    public String toString() {
+        return "OssieRelationshipViewTable{name=" + viewName + ", sql=" + viewSql + "}";
+    }
+}

--- a/saiku-core/saiku-sql/src/main/java/org/saiku/sql/adapter/OssieSchema.java
+++ b/saiku-core/saiku-sql/src/main/java/org/saiku/sql/adapter/OssieSchema.java
@@ -1,0 +1,114 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.sql.adapter;
+
+import com.google.common.collect.ImmutableMap;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import org.apache.calcite.adapter.jdbc.JdbcSchema;
+import org.apache.calcite.schema.Schema;
+import org.apache.calcite.schema.SchemaPlus;
+import org.apache.calcite.schema.Table;
+import org.apache.calcite.schema.impl.AbstractSchema;
+import org.saiku.service.schema.ossie.model.Dataset;
+import org.saiku.service.schema.ossie.model.SemanticModel;
+
+/**
+ * Calcite {@link Schema} projection of one Ossie {@link SemanticModel}.
+ *
+ * <p>Each Ossie {@code dataset} becomes one Calcite {@link Table} named after the dataset. When a
+ * JDBC connection URL is supplied, the table delegates to Calcite's {@link JdbcSchema} so
+ * SELECT/WHERE/GROUP BY get pushed down as warehouse-native SQL. Without a JDBC URL the tables
+ * still register (schema introspection works — BI tools can list them) but queries return zero
+ * rows because there's no underlying data source.
+ *
+ * <p>Metrics land as computed views in a follow-up commit on this branch — the first slice keeps
+ * the boundary narrow: datasets → tables, with join semantics driven by explicit SQL {@code
+ * JOIN}s. Auto-injection of Ossie relationships and metric-expression expansion come next.
+ */
+public class OssieSchema extends AbstractSchema {
+
+    private final SemanticModel model;
+    private final JdbcSchema jdbcSchema;
+    /** Name of the hidden sub-schema attached to the root that holds our JdbcSchema — needed to
+     *  qualify the SELECT emitted for each Ossie dataset view. Null when no JDBC is wired. */
+    private final String jdbcSubSchemaName;
+
+    public OssieSchema(SemanticModel model, JdbcSchema jdbcSchema, String jdbcSubSchemaName) {
+        this.model = model;
+        this.jdbcSchema = jdbcSchema;
+        this.jdbcSubSchemaName = jdbcSubSchemaName;
+    }
+
+    public SemanticModel model() {
+        return model;
+    }
+
+    @Override
+    protected Map<String, Table> getTableMap() {
+        // Deterministic linked map so SHOW TABLES / information_schema output is stable across
+        // restarts (BI tools cache introspection results by dataset name).
+        //
+        // First cut: expose the underlying JdbcTable directly under the Ossie dataset name. The
+        // JdbcTable carries a reference back to its JdbcSchema (set during JdbcSchema.create in
+        // OssieSchemaFactory with a real parentSchema), so Calcite's planner can walk up
+        // getParentSchema() when it needs to build the JDBC push-down plan. ViewTables + metric
+        // expansion layer on top in a follow-up commit — this shape gets basic SELECT/JOIN
+        // pushdown working against the H2 fixture in SelectPushdownIT.
+        Map<String, Table> tables = new LinkedHashMap<>();
+        for (Dataset dataset : model.getDatasets()) {
+            Table table = null;
+            if (jdbcSchema != null) {
+                String sourceTable = lastDot(dataset.getSource() == null ? dataset.getName() : dataset.getSource());
+                table = firstNonNull(
+                        jdbcSchema.getTable(sourceTable),
+                        jdbcSchema.getTable(sourceTable.toUpperCase()),
+                        jdbcSchema.getTable(sourceTable.toLowerCase()));
+            }
+            if (table == null) {
+                // Schema-only fallback — no JDBC, or the underlying table wasn't found. Register
+                // a placeholder table synthesised from the Ossie fields so introspection works.
+                table = new OssieDatasetTable(dataset, null);
+            }
+            tables.put(dataset.getName(), table);
+        }
+        return ImmutableMap.copyOf(tables);
+    }
+
+    private static String lastDot(String s) {
+        int idx = s.lastIndexOf('.');
+        return idx < 0 ? s : s.substring(idx + 1);
+    }
+
+    @SafeVarargs
+    private static <T> T firstNonNull(T... values) {
+        for (T v : values) if (v != null) return v;
+        return null;
+    }
+
+    /**
+     * Sub-schemas: we don't publish any today. Reserved for a future world where a single Ossie
+     * document produces one Calcite sub-schema per semantic model, addressable by connect
+     * operand.
+     */
+    @Override
+    protected Map<String, Schema> getSubSchemaMap() {
+        return ImmutableMap.of();
+    }
+
+    /** Signal to Calcite that this schema is safe to expose via {@code SchemaPlus.add(…)}. */
+    @Override
+    public boolean isMutable() {
+        return false;
+    }
+
+    /**
+     * Helper for tests that want the built schema without going through the JDBC connect path.
+     * Wraps the schema in a Calcite {@link SchemaPlus} rooted under a caller-provided parent.
+     */
+    public SchemaPlus attachTo(SchemaPlus parent, String name) {
+        return parent.add(name, this);
+    }
+}

--- a/saiku-core/saiku-sql/src/main/java/org/saiku/sql/adapter/OssieSchema.java
+++ b/saiku-core/saiku-sql/src/main/java/org/saiku/sql/adapter/OssieSchema.java
@@ -6,6 +6,8 @@ package org.saiku.sql.adapter;
 
 import com.google.common.collect.ImmutableMap;
 import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import org.apache.calcite.adapter.jdbc.JdbcSchema;
 import org.apache.calcite.schema.Schema;
@@ -13,6 +15,8 @@ import org.apache.calcite.schema.SchemaPlus;
 import org.apache.calcite.schema.Table;
 import org.apache.calcite.schema.impl.AbstractSchema;
 import org.saiku.service.schema.ossie.model.Dataset;
+import org.saiku.service.schema.ossie.model.DialectExpression;
+import org.saiku.service.schema.ossie.model.Metric;
 import org.saiku.service.schema.ossie.model.SemanticModel;
 
 /**
@@ -36,10 +40,20 @@ public class OssieSchema extends AbstractSchema {
      *  qualify the SELECT emitted for each Ossie dataset view. Null when no JDBC is wired. */
     private final String jdbcSubSchemaName;
 
+    /** Schema name Calcite hands us at registration time (from the connect model). Used to
+     *  qualify identifiers in metric-view SQL so the parser resolves them across schemas.
+     *  Falls back to the Ossie model name (usually the same). */
+    private volatile String selfSchemaName;
+
     public OssieSchema(SemanticModel model, JdbcSchema jdbcSchema, String jdbcSubSchemaName) {
         this.model = model;
         this.jdbcSchema = jdbcSchema;
         this.jdbcSubSchemaName = jdbcSubSchemaName;
+    }
+
+    /** Called by {@link OssieSchemaFactory} immediately after construction. */
+    void bindSchemaName(String name) {
+        this.selfSchemaName = name;
     }
 
     public SemanticModel model() {
@@ -51,12 +65,19 @@ public class OssieSchema extends AbstractSchema {
         // Deterministic linked map so SHOW TABLES / information_schema output is stable across
         // restarts (BI tools cache introspection results by dataset name).
         //
-        // First cut: expose the underlying JdbcTable directly under the Ossie dataset name. The
-        // JdbcTable carries a reference back to its JdbcSchema (set during JdbcSchema.create in
-        // OssieSchemaFactory with a real parentSchema), so Calcite's planner can walk up
-        // getParentSchema() when it needs to build the JDBC push-down plan. ViewTables + metric
-        // expansion layer on top in a follow-up commit — this shape gets basic SELECT/JOIN
-        // pushdown working against the H2 fixture in SelectPushdownIT.
+        // Structure of what we register:
+        //  1. One table per Ossie dataset — either the underlying JdbcTable when a warehouse is
+        //     wired, or an OssieDatasetTable placeholder in schema-only mode.
+        //  2. One view per Ossie metric — an OssieMetricViewTable whose SQL is
+        //     "SELECT <ANSI_SQL expression> AS <metric_name> FROM <schema>.<home_dataset>".
+        //     Users write 'SELECT * FROM <schema>.<metric>' to get the aggregate over the whole
+        //     home dataset; downstream slices add per-dimension grouping via relationship-aware
+        //     rewrites. Metrics with only an MDX dialect are skipped — those live in Mondrian,
+        //     not in this SQL surface.
+        //
+        // Name collisions between metrics and datasets are broken in favour of the dataset (the
+        // Mondrian exporter's conventions keep them distinct — this is a safety net rather than
+        // an expected case).
         Map<String, Table> tables = new LinkedHashMap<>();
         for (Dataset dataset : model.getDatasets()) {
             Table table = null;
@@ -74,7 +95,71 @@ public class OssieSchema extends AbstractSchema {
             }
             tables.put(dataset.getName(), table);
         }
+        for (Metric metric : model.getMetrics()) {
+            if (tables.containsKey(metric.getName())) continue;
+            OssieMetricViewTable view = buildMetricView(metric);
+            if (view != null) tables.put(metric.getName(), view);
+        }
         return ImmutableMap.copyOf(tables);
+    }
+
+    /**
+     * Build an {@link OssieMetricViewTable} for a metric. Returns null when the metric has no
+     * ANSI SQL dialect (MDX-only calculated members — they live in Mondrian, not here) or the
+     * model has zero datasets (nowhere to aggregate against).
+     */
+    private OssieMetricViewTable buildMetricView(Metric metric) {
+        String ansiSql = pickAnsiSql(metric);
+        if (ansiSql == null) return null;
+        String homeDataset = pickHomeDataset(ansiSql);
+        if (homeDataset == null) return null;
+        String effectiveSchemaName = selfSchemaName != null ? selfSchemaName : model.getName();
+        // Quote identifiers so mixed-case names (Pharma Rx, TOTAL_REVENUE) survive Calcite's
+        // parser without being lower-cased to unresolvable names.
+        String viewSql = "SELECT " + ansiSql + " AS \"" + metric.getName() + "\" " + "FROM \"" + effectiveSchemaName
+                + "\".\"" + homeDataset + "\"";
+        // Look up the home dataset's underlying table name so the metric view can resolve
+        // column types via the JdbcSchema's rowType. Falls back to the dataset name itself.
+        String homeSource = null;
+        for (Dataset d : model.getDatasets()) {
+            if (d.getName().equals(homeDataset)) {
+                homeSource = lastDot(d.getSource() == null ? d.getName() : d.getSource());
+                break;
+            }
+        }
+        return new OssieMetricViewTable(metric, viewSql, List.of(effectiveSchemaName), jdbcSchema, homeSource);
+    }
+
+    /**
+     * Return the ANSI SQL dialect expression from a metric, or null if the metric only has an
+     * MDX dialect (e.g. calculated members). Ossie's spec lets metrics carry multiple dialects;
+     * this adapter only understands ANSI SQL at query time.
+     */
+    private static String pickAnsiSql(Metric metric) {
+        if (metric.getExpression() == null) return null;
+        for (DialectExpression d : metric.getExpression().getDialects()) {
+            if ("ANSI_SQL".equalsIgnoreCase(d.getDialect())) return d.getExpression();
+        }
+        return null;
+    }
+
+    /**
+     * Best-effort resolution of a metric's home dataset from its ANSI SQL text. Scans for a
+     * dataset name appearing as {@code <ds>.column}, {@code FROM <ds>}, or the bare dataset
+     * name; returns the first match. Falls back to the first dataset in the model when the
+     * expression is opaque (e.g. a literal or a scalar function with no column reference).
+     * Returns null only if the model has zero datasets — in which case there's nothing to
+     * aggregate over and the caller should skip the metric.
+     */
+    private String pickHomeDataset(String ansiSql) {
+        String lower = ansiSql.toLowerCase(Locale.ROOT);
+        for (Dataset d : model.getDatasets()) {
+            String needle = d.getName().toLowerCase(Locale.ROOT);
+            if (lower.contains(needle + ".") || lower.contains("from " + needle) || lower.equals(needle)) {
+                return d.getName();
+            }
+        }
+        return model.getDatasets().isEmpty() ? null : model.getDatasets().get(0).getName();
     }
 
     private static String lastDot(String s) {

--- a/saiku-core/saiku-sql/src/main/java/org/saiku/sql/adapter/OssieSchema.java
+++ b/saiku-core/saiku-sql/src/main/java/org/saiku/sql/adapter/OssieSchema.java
@@ -17,20 +17,32 @@ import org.apache.calcite.schema.impl.AbstractSchema;
 import org.saiku.service.schema.ossie.model.Dataset;
 import org.saiku.service.schema.ossie.model.DialectExpression;
 import org.saiku.service.schema.ossie.model.Metric;
+import org.saiku.service.schema.ossie.model.Relationship;
 import org.saiku.service.schema.ossie.model.SemanticModel;
 
 /**
  * Calcite {@link Schema} projection of one Ossie {@link SemanticModel}.
  *
- * <p>Each Ossie {@code dataset} becomes one Calcite {@link Table} named after the dataset. When a
- * JDBC connection URL is supplied, the table delegates to Calcite's {@link JdbcSchema} so
- * SELECT/WHERE/GROUP BY get pushed down as warehouse-native SQL. Without a JDBC URL the tables
- * still register (schema introspection works — BI tools can list them) but queries return zero
- * rows because there's no underlying data source.
+ * <p>Three kinds of tables land here:
  *
- * <p>Metrics land as computed views in a follow-up commit on this branch — the first slice keeps
- * the boundary narrow: datasets → tables, with join semantics driven by explicit SQL {@code
- * JOIN}s. Auto-injection of Ossie relationships and metric-expression expansion come next.
+ * <ul>
+ *   <li><b>Datasets</b> — one Calcite {@link Table} per Ossie dataset. When JDBC is wired, this
+ *       delegates directly to the underlying {@link org.apache.calcite.adapter.jdbc.JdbcSchema}
+ *       so SELECT / WHERE / GROUP BY / JOIN push down to the warehouse as native SQL. Without
+ *       JDBC (schema-only mode), a placeholder {@link OssieDatasetTable} keeps introspection
+ *       working but scans return zero rows.
+ *   <li><b>Metrics</b> — one {@link OssieMetricViewTable} per Ossie metric that carries an
+ *       ANSI_SQL dialect. Users write {@code SELECT * FROM SALES.TOTAL_REVENUE} to get the
+ *       scalar aggregate over its home dataset. MDX-only metrics (calculated members) skip;
+ *       they live in Mondrian, not on the SQL surface.
+ *   <li><b>Join views</b> — one {@link OssieRelationshipViewTable} per Ossie {@code
+ *       relationship}, named {@code <from>_JOIN_<to>}. Materialises the JOIN predicate from
+ *       the YAML so users can query pre-joined data with a single {@code SELECT}.
+ * </ul>
+ *
+ * <p>Auto-injected joins via a proper Calcite planner rule (so users can write {@code SELECT c.x,
+ * SUM(o.y) FROM ORDERS o, CUSTOMERS c} without any JOIN clause and have the predicate injected
+ * from Ossie relationships) is the next follow-up on the parent epic.
  */
 public class OssieSchema extends AbstractSchema {
 
@@ -100,7 +112,58 @@ public class OssieSchema extends AbstractSchema {
             OssieMetricViewTable view = buildMetricView(metric);
             if (view != null) tables.put(metric.getName(), view);
         }
+        // Register one pre-joined view per Ossie relationship. Named `<from>_JOIN_<to>`.
+        // Users get a flat rowtype of both underlying tables' columns and Calcite pushes the
+        // JOIN down to the warehouse — no runtime overhead over writing JOIN ... ON ... by hand.
+        // Skips relationships whose from/to don't resolve to registered datasets (defensive,
+        // should never happen for a well-formed Ossie doc).
+        for (Relationship rel : model.getRelationships()) {
+            String viewName = joinViewName(rel);
+            if (tables.containsKey(viewName)) continue;
+            OssieRelationshipViewTable view = buildJoinView(rel);
+            if (view != null) tables.put(viewName, view);
+        }
         return ImmutableMap.copyOf(tables);
+    }
+
+    /** Public for the schema-only mode too — kept short so it never collides with a dataset. */
+    static String joinViewName(Relationship rel) {
+        return rel.getFrom() + "_JOIN_" + rel.getTo();
+    }
+
+    /**
+     * Build a pre-joined view for an Ossie relationship. Returns null when either side doesn't
+     * resolve to a registered dataset or the relationship has zero join columns.
+     */
+    private OssieRelationshipViewTable buildJoinView(Relationship rel) {
+        if (rel.getFrom() == null || rel.getTo() == null) return null;
+        if (rel.getFromColumns().isEmpty() || rel.getToColumns().isEmpty()) return null;
+        if (rel.getFromColumns().size() != rel.getToColumns().size()) return null;
+        Dataset fromDs = findDataset(rel.getFrom());
+        Dataset toDs = findDataset(rel.getTo());
+        if (fromDs == null || toDs == null) return null;
+        String effectiveSchemaName = selfSchemaName != null ? selfSchemaName : model.getName();
+        // Build "a.<col> = b.<col> AND ..." predicate.
+        StringBuilder predicate = new StringBuilder();
+        for (int i = 0; i < rel.getFromColumns().size(); i++) {
+            if (i > 0) predicate.append(" AND ");
+            predicate.append("a.\"").append(rel.getFromColumns().get(i)).append("\" = ");
+            predicate.append("b.\"").append(rel.getToColumns().get(i)).append("\"");
+        }
+        String viewSql = "SELECT * FROM \"" + effectiveSchemaName + "\".\"" + fromDs.getName() + "\" a "
+                + "JOIN \"" + effectiveSchemaName + "\".\"" + toDs.getName() + "\" b "
+                + "ON " + predicate;
+        String fromSource = lastDot(fromDs.getSource() == null ? fromDs.getName() : fromDs.getSource());
+        String toSource = lastDot(toDs.getSource() == null ? toDs.getName() : toDs.getSource());
+        return new OssieRelationshipViewTable(
+                joinViewName(rel), viewSql, List.of(effectiveSchemaName), jdbcSchema, fromSource, toSource);
+    }
+
+    private Dataset findDataset(String name) {
+        for (Dataset d : model.getDatasets()) {
+            if (d.getName().equals(name)) return d;
+        }
+        return null;
     }
 
     /**

--- a/saiku-core/saiku-sql/src/main/java/org/saiku/sql/adapter/OssieSchema.java
+++ b/saiku-core/saiku-sql/src/main/java/org/saiku/sql/adapter/OssieSchema.java
@@ -57,15 +57,39 @@ public class OssieSchema extends AbstractSchema {
      *  Falls back to the Ossie model name (usually the same). */
     private volatile String selfSchemaName;
 
+    /**
+     * Registry of live OssieSchema instances keyed by the name Calcite registered them under.
+     * Populated by {@link OssieSchemaFactory#create} via {@link #register}. Consulted by
+     * {@link OssieAutoJoinRule} when it needs to identify whether a TableScan is Ossie-backed —
+     * {@code RelOptTable.unwrap(OssieSchema.class)} doesn't work because our datasets surface as
+     * {@link JdbcSchema}-owned tables, so the direct unwrap path finds JdbcSchema not OssieSchema.
+     * A name-based registry is the pragmatic fallback.
+     *
+     * <p>Static state is unfortunate but acceptable: Calcite's own JdbcSchema uses similar
+     * process-wide caches. Multiple factories creating a schema with the same name → last-wins
+     * (config error the user needs to fix upstream).
+     */
+    private static final java.util.concurrent.ConcurrentMap<String, OssieSchema> REGISTRY =
+            new java.util.concurrent.ConcurrentHashMap<>();
+
     public OssieSchema(SemanticModel model, JdbcSchema jdbcSchema, String jdbcSubSchemaName) {
         this.model = model;
         this.jdbcSchema = jdbcSchema;
         this.jdbcSubSchemaName = jdbcSubSchemaName;
     }
 
-    /** Called by {@link OssieSchemaFactory} immediately after construction. */
+    /** Called by {@link OssieSchemaFactory} immediately after construction. Also registers this
+     *  schema in the process-wide registry so {@link OssieAutoJoinRule} can look it up by name. */
     void bindSchemaName(String name) {
         this.selfSchemaName = name;
+        REGISTRY.put(name, this);
+    }
+
+    /** Look up a registered OssieSchema by the name it was registered under. Used by
+     *  {@link OssieAutoJoinRule} to identify Ossie-backed TableScans without unwrapping through
+     *  {@link JdbcSchema}. Returns null when no OssieSchema is registered under {@code name}. */
+    static OssieSchema lookupRegistered(String name) {
+        return REGISTRY.get(name);
     }
 
     public SemanticModel model() {

--- a/saiku-core/saiku-sql/src/main/java/org/saiku/sql/adapter/OssieSchemaFactory.java
+++ b/saiku-core/saiku-sql/src/main/java/org/saiku/sql/adapter/OssieSchemaFactory.java
@@ -56,6 +56,25 @@ import org.saiku.sql.model.OssieYamlReader;
  */
 public class OssieSchemaFactory implements SchemaFactory {
 
+    static {
+        // Register OssieAutoJoinRule GLOBALLY with every Calcite planner. Fires each time
+        // Calcite instantiates a query planner (typically once per JDBC statement); our rule
+        // becomes part of the standard rule set from then on. The rule's onMatch method has
+        // enough guards (Ossie-schema check + Cartesian-condition check + relationship lookup)
+        // that it's a no-op for any query touching non-Ossie tables — safe to register
+        // globally.
+        //
+        // Timing: this static block runs when Calcite first loads OssieSchemaFactory (via
+        // Class.forName reflection driven by the connect model's "factory" operand), which
+        // happens BEFORE the planner for the first query is instantiated. So the hook is
+        // already installed by the time the first query needs it.
+        org.apache.calcite.runtime.Hook.PLANNER.add((java.util.function.Consumer<Object>) planner -> {
+            if (planner instanceof org.apache.calcite.plan.RelOptPlanner) {
+                ((org.apache.calcite.plan.RelOptPlanner) planner).addRule(OssieAutoJoinRule.INSTANCE);
+            }
+        });
+    }
+
     public static final String OP_OSSIE_YAML = "ossieYaml";
     public static final String OP_MODEL_NAME = "modelName";
     public static final String OP_JDBC_URL = "jdbcUrl";

--- a/saiku-core/saiku-sql/src/main/java/org/saiku/sql/adapter/OssieSchemaFactory.java
+++ b/saiku-core/saiku-sql/src/main/java/org/saiku/sql/adapter/OssieSchemaFactory.java
@@ -110,6 +110,12 @@ public class OssieSchemaFactory implements SchemaFactory {
             jdbc = JdbcSchema.create(parentSchema, hiddenName, ds, null, null);
             parentSchema.add(hiddenName, jdbc);
         }
-        return new OssieSchema(chosen, jdbc, hiddenName);
+        OssieSchema schema = new OssieSchema(chosen, jdbc, hiddenName);
+        // Metric-view SQL qualifies dataset references as "<name>"."<dataset>" so Calcite's
+        // parser resolves them across schemas. The factory's own name arg is the authoritative
+        // source — Calcite hasn't installed the sub-schema yet at this point, so we can't read
+        // it from parentSchema.
+        schema.bindSchemaName(name);
+        return schema;
     }
 }

--- a/saiku-core/saiku-sql/src/main/java/org/saiku/sql/adapter/OssieSchemaFactory.java
+++ b/saiku-core/saiku-sql/src/main/java/org/saiku/sql/adapter/OssieSchemaFactory.java
@@ -1,0 +1,115 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.sql.adapter;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.Map;
+import java.util.Objects;
+import javax.sql.DataSource;
+import org.apache.calcite.adapter.jdbc.JdbcSchema;
+import org.apache.calcite.schema.Schema;
+import org.apache.calcite.schema.SchemaFactory;
+import org.apache.calcite.schema.SchemaPlus;
+import org.saiku.service.schema.ossie.model.OssieDocument;
+import org.saiku.sql.model.OssieYamlReader;
+
+/**
+ * Calcite entry point for the Ossie semantic layer.
+ *
+ * <p>Instantiated by Calcite when a JDBC connect URL references this class through a JSON model
+ * file — see the Calcite adapter docs. Typical connect model:
+ *
+ * <pre>{@code
+ * {
+ *   "version": "1.0",
+ *   "defaultSchema": "SALES",
+ *   "schemas": [
+ *     {
+ *       "name": "SALES",
+ *       "type": "custom",
+ *       "factory": "org.saiku.sql.adapter.OssieSchemaFactory",
+ *       "operand": {
+ *         "ossieYaml": "/path/to/schema.ossie.yaml",
+ *         "modelName": "Sales",
+ *         "jdbcUrl": "jdbc:postgresql://localhost:5432/warehouse",
+ *         "jdbcUser": "app",
+ *         "jdbcPassword": "..."
+ *       }
+ *     }
+ *   ]
+ * }
+ * }</pre>
+ *
+ * <p>Operand keys:
+ *
+ * <ul>
+ *   <li>{@code ossieYaml} (required) — path to the Ossie YAML file.
+ *   <li>{@code modelName} (optional) — which {@code semantic_model[]} entry to expose when the
+ *       document carries multiple; defaults to the first one.
+ *   <li>{@code jdbcUrl} / {@code jdbcUser} / {@code jdbcPassword} (optional but strongly
+ *       encouraged) — where the actual data lives. Without them, the Ossie datasets surface as
+ *       queryable virtual tables with no rows — useful only for schema-introspection tests.
+ * </ul>
+ */
+public class OssieSchemaFactory implements SchemaFactory {
+
+    public static final String OP_OSSIE_YAML = "ossieYaml";
+    public static final String OP_MODEL_NAME = "modelName";
+    public static final String OP_JDBC_URL = "jdbcUrl";
+    public static final String OP_JDBC_USER = "jdbcUser";
+    public static final String OP_JDBC_PASSWORD = "jdbcPassword";
+
+    @Override
+    public Schema create(SchemaPlus parentSchema, String name, Map<String, Object> operand) {
+        String ossieYaml = (String) Objects.requireNonNull(
+                operand.get(OP_OSSIE_YAML),
+                "OssieSchemaFactory: '" + OP_OSSIE_YAML + "' operand is required (path to Ossie YAML)");
+        String modelName = (String) operand.get(OP_MODEL_NAME);
+        String jdbcUrl = (String) operand.get(OP_JDBC_URL);
+        String jdbcUser = (String) operand.get(OP_JDBC_USER);
+        String jdbcPassword = (String) operand.get(OP_JDBC_PASSWORD);
+
+        OssieDocument doc;
+        try {
+            doc = new OssieYamlReader().read(Path.of(ossieYaml));
+        } catch (IOException e) {
+            throw new RuntimeException(
+                    "OssieSchemaFactory: failed to read Ossie YAML at " + ossieYaml + ": " + e.getMessage(), e);
+        }
+
+        var models = doc.getSemanticModel();
+        if (models.isEmpty()) {
+            throw new IllegalStateException("OssieSchemaFactory: Ossie document at " + ossieYaml
+                    + " has zero semantic models — check the exporter didn't skip every cube");
+        }
+        var chosen = models.get(0);
+        if (modelName != null) {
+            chosen = models.stream()
+                    .filter(m -> modelName.equals(m.getName()))
+                    .findFirst()
+                    .orElseThrow(() -> new IllegalStateException("OssieSchemaFactory: no semantic model named '"
+                            + modelName + "' in " + ossieYaml + "; available: "
+                            + models.stream().map(m -> m.getName()).toList()));
+        }
+        // Attach the JDBC warehouse as a hidden sub-schema of parentSchema. Calcite's JdbcSchema
+        // constructor requires a SchemaPlus with a real parent (it walks up via
+        // getParentSchema() during query planning); passing null causes NPE the moment the
+        // planner touches the schema, hence the sub-schema attach trick used by other adapters.
+        JdbcSchema jdbc = null;
+        String hiddenName = null;
+        if (jdbcUrl != null && !jdbcUrl.isBlank()) {
+            DataSource ds = JdbcSchema.dataSource(jdbcUrl, null, jdbcUser, jdbcPassword);
+            hiddenName = "__" + name + "_jdbc";
+            // Register the JdbcSchema directly under the root using SchemaPlus.add so Calcite's
+            // planner can find it by name when resolving ViewTable SQL that references it. Note
+            // the JdbcSchema is registered with parent=null via SchemaPlus.add — Calcite fills
+            // in the parent reference when it installs the sub-schema.
+            jdbc = JdbcSchema.create(parentSchema, hiddenName, ds, null, null);
+            parentSchema.add(hiddenName, jdbc);
+        }
+        return new OssieSchema(chosen, jdbc, hiddenName);
+    }
+}

--- a/saiku-core/saiku-sql/src/main/java/org/saiku/sql/model/OssieYamlReader.java
+++ b/saiku-core/saiku-sql/src/main/java/org/saiku/sql/model/OssieYamlReader.java
@@ -1,0 +1,56 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.sql.model;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.Reader;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.saiku.service.schema.ossie.model.OssieDocument;
+
+/**
+ * Load an {@link OssieDocument} from Ossie-flavoured YAML.
+ *
+ * <p>Symmetric with {@code OssieYamlWriter} in saiku-service — the pair is the read side of the
+ * same round-trip. Kept in the saiku-sql module because that's where read-side Ossie needs live
+ * (the Calcite adapter needs the tree; the exporter only produces it). Once we have a use-case
+ * for reading Ossie from other layers we can promote this back to saiku-service alongside the
+ * writer.
+ *
+ * <p>{@link DeserializationFeature#FAIL_ON_UNKNOWN_PROPERTIES} is disabled so Ossie documents that
+ * carry vendor extensions or future spec keys we don't yet model won't blow up the loader — the
+ * spec is draft and additive fields are the whole point of {@code custom_extensions}.
+ */
+public final class OssieYamlReader {
+
+    private final ObjectMapper yaml;
+
+    public OssieYamlReader() {
+        this.yaml = new ObjectMapper(new YAMLFactory());
+        this.yaml.disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
+    }
+
+    public OssieDocument read(Path yamlPath) throws IOException {
+        try (InputStream in = Files.newInputStream(yamlPath)) {
+            return yaml.readValue(in, OssieDocument.class);
+        }
+    }
+
+    public OssieDocument read(InputStream stream) throws IOException {
+        return yaml.readValue(stream, OssieDocument.class);
+    }
+
+    public OssieDocument read(Reader reader) throws IOException {
+        return yaml.readValue(reader, OssieDocument.class);
+    }
+
+    public OssieDocument readString(String yamlText) throws IOException {
+        return yaml.readValue(yamlText, OssieDocument.class);
+    }
+}

--- a/saiku-core/saiku-sql/src/main/java/org/saiku/sql/server/OssieSqlServer.java
+++ b/saiku-core/saiku-sql/src/main/java/org/saiku/sql/server/OssieSqlServer.java
@@ -47,7 +47,8 @@ public class OssieSqlServer implements AutoCloseable {
      * literal semicolons that break the parser. Writing the model to a temp file and passing
      * {@code model=<path>} sidesteps the issue entirely.
      */
-    static String buildCalciteConnectString(
+    /** Package-visible for the PgWire IT which reuses the same connect model. */
+    public static String buildCalciteConnectString(
             Path ossieYaml,
             String schemaName,
             String warehouseJdbcUrl,

--- a/saiku-core/saiku-sql/src/main/java/org/saiku/sql/server/OssieSqlServer.java
+++ b/saiku-core/saiku-sql/src/main/java/org/saiku/sql/server/OssieSqlServer.java
@@ -1,0 +1,138 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.sql.server;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.sql.SQLException;
+import java.util.Objects;
+import org.apache.calcite.avatica.jdbc.JdbcMeta;
+import org.apache.calcite.avatica.remote.LocalService;
+import org.apache.calcite.avatica.remote.Service;
+import org.apache.calcite.avatica.server.AvaticaJsonHandler;
+import org.apache.calcite.avatica.server.AvaticaProtobufHandler;
+import org.apache.calcite.avatica.server.HttpServer;
+
+/**
+ * Network endpoint that exposes the Ossie/Calcite SQL surface over Apache Avatica's HTTP+
+ * protobuf protocol. Any Avatica-compatible client — the {@code avatica-server} JDBC driver, the
+ * Python {@code phoenixdb} package, the Go {@code avatica} driver — connects to the resulting
+ * URL and executes SQL against a Calcite connection pre-wired to an Ossie YAML.
+ *
+ * <p>Under the hood: {@link HttpServer} → {@link AvaticaProtobufHandler} → {@link LocalService} →
+ * {@link JdbcMeta} → {@code jdbc:calcite:...} pointed at our Ossie model. Every remote query
+ * gets forwarded to a fresh Calcite prepare cycle; connection state (transactions, cursors) is
+ * tracked per-remote-session by {@link JdbcMeta}.
+ *
+ * <p>This is the first slice of #1386. Full Postgres wire protocol is a separate follow-up —
+ * Avatica speaks its own wire, not Postgres's, so a native {@code psql}/{@code libpq}-compatible
+ * frontend requires a separate PG-wire adapter layered on the same {@link JdbcMeta} backend.
+ */
+public class OssieSqlServer implements AutoCloseable {
+
+    private final HttpServer server;
+    private final String jdbcConnectString;
+
+    /**
+     * Build a Calcite JDBC connect string pointing at an on-disk model.json that instantiates
+     * {@code OssieSchemaFactory} against the supplied Ossie YAML.
+     *
+     * <p>We can't use {@code jdbc:calcite:model=inline:{...}} because Calcite's JDBC connect
+     * string uses {@code ;} as its parameter separator — the warehouse JDBC URL nested inside
+     * our operand (e.g. {@code jdbc:h2:mem:name;DB_CLOSE_DELAY=-1;MODE=PostgreSQL}) contains
+     * literal semicolons that break the parser. Writing the model to a temp file and passing
+     * {@code model=<path>} sidesteps the issue entirely.
+     */
+    static String buildCalciteConnectString(
+            Path ossieYaml,
+            String schemaName,
+            String warehouseJdbcUrl,
+            String warehouseUser,
+            String warehousePassword) {
+        StringBuilder operand = new StringBuilder();
+        operand.append("\"ossieYaml\": \"")
+                .append(Objects.requireNonNull(ossieYaml, "ossieYaml")
+                        .toString()
+                        .replace("\\", "\\\\"))
+                .append("\"");
+        if (warehouseJdbcUrl != null && !warehouseJdbcUrl.isBlank()) {
+            operand.append(",\"jdbcUrl\": \"").append(warehouseJdbcUrl).append("\"");
+        }
+        if (warehouseUser != null) {
+            operand.append(",\"jdbcUser\": \"").append(warehouseUser).append("\"");
+        }
+        if (warehousePassword != null) {
+            operand.append(",\"jdbcPassword\": \"").append(warehousePassword).append("\"");
+        }
+        String modelJson = "{\n"
+                + "  \"version\": \"1.0\",\n"
+                + "  \"defaultSchema\": \"" + schemaName + "\",\n"
+                + "  \"schemas\": [{\n"
+                + "    \"name\": \"" + schemaName + "\",\n"
+                + "    \"type\": \"custom\",\n"
+                + "    \"factory\": \"org.saiku.sql.adapter.OssieSchemaFactory\",\n"
+                + "    \"operand\": {" + operand + "}\n"
+                + "  }]\n"
+                + "}";
+        try {
+            Path modelPath = Files.createTempFile("ossie-sql-server-model-", ".json");
+            modelPath.toFile().deleteOnExit();
+            Files.writeString(modelPath, modelJson);
+            return "jdbc:calcite:model=" + modelPath;
+        } catch (IOException e) {
+            throw new UncheckedIOException("Failed to stage Calcite model.json", e);
+        }
+    }
+
+    /**
+     * Start the server on the given port. Pass {@code 0} to have the OS assign an ephemeral
+     * port; the actual port is available via {@link #getPort()} after the constructor returns.
+     *
+     * <p>Serialization is protobuf by default because it's the format the Avatica JDBC driver
+     * uses. JSON is available on the same endpoint via a separate handler for humans debugging
+     * with curl — see {@link AvaticaJsonHandler}. For this first slice we only wire protobuf.
+     */
+    public OssieSqlServer(
+            int port,
+            Path ossieYaml,
+            String schemaName,
+            String warehouseJdbcUrl,
+            String warehouseUser,
+            String warehousePassword)
+            throws SQLException {
+        this.jdbcConnectString =
+                buildCalciteConnectString(ossieYaml, schemaName, warehouseJdbcUrl, warehouseUser, warehousePassword);
+        // JdbcMeta owns the outbound Calcite connection pool; every incoming Avatica request
+        // borrows a Statement from a Connection. Auto-connects lazily on first use.
+        JdbcMeta meta = new JdbcMeta(jdbcConnectString);
+        Service service = new LocalService(meta);
+        this.server = new HttpServer.Builder<Object>()
+                .withHandler(new AvaticaProtobufHandler(service))
+                .withPort(port)
+                .build();
+        this.server.start();
+    }
+
+    public int getPort() {
+        return server.getPort();
+    }
+
+    /** Returns the Avatica remote connect URL clients use — e.g. {@code http://localhost:8765}. */
+    public String getUrl() {
+        return "http://localhost:" + getPort();
+    }
+
+    /** Diagnostic hook for tests; the exact connect string is otherwise internal. */
+    String getUnderlyingCalciteConnectString() {
+        return jdbcConnectString;
+    }
+
+    @Override
+    public void close() {
+        server.stop();
+    }
+}

--- a/saiku-core/saiku-sql/src/main/java/org/saiku/sql/server/OssieSqlServer.java
+++ b/saiku-core/saiku-sql/src/main/java/org/saiku/sql/server/OssieSqlServer.java
@@ -83,7 +83,12 @@ public class OssieSqlServer implements AutoCloseable {
             Path modelPath = Files.createTempFile("ossie-sql-server-model-", ".json");
             modelPath.toFile().deleteOnExit();
             Files.writeString(modelPath, modelJson);
-            return "jdbc:calcite:model=" + modelPath;
+            // caseSensitive=false matches how every BI tool casts identifiers — most warehouses
+            // are case-insensitive on unquoted names, and Calcite defaults to case-sensitive
+            // which surprises users. Default lex (ORACLE) keeps double-quoted identifiers
+            // (needed for spaced-name Ossie schemas like "Pharma Rx") while treating unquoted
+            // ones case-insensitively.
+            return "jdbc:calcite:model=" + modelPath + ";caseSensitive=false";
         } catch (IOException e) {
             throw new UncheckedIOException("Failed to stage Calcite model.json", e);
         }

--- a/saiku-core/saiku-sql/src/main/java/org/saiku/sql/server/pgwire/PgType.java
+++ b/saiku-core/saiku-sql/src/main/java/org/saiku/sql/server/pgwire/PgType.java
@@ -1,0 +1,91 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.sql.server.pgwire;
+
+import java.sql.Types;
+
+/**
+ * Postgres type OID mapping. Each PG type has a well-known OID (from
+ * {@code src/include/catalog/pg_type.dat} in the Postgres source) that clients read from
+ * RowDescription messages to know how to parse each column.
+ *
+ * <p>We only care about the subset a read-only BI-tool workload actually queries. Anything more
+ * exotic gets mapped to TEXT — clients still receive the string representation, which is what
+ * simple query mode's text format returns anyway.
+ */
+final class PgType {
+
+    /** BOOL. */
+    static final int BOOL = 16;
+    /** INT2 (smallint). */
+    static final int INT2 = 21;
+    /** INT4 (integer). */
+    static final int INT4 = 23;
+    /** INT8 (bigint). */
+    static final int INT8 = 20;
+    /** FLOAT4 (real). */
+    static final int FLOAT4 = 700;
+    /** FLOAT8 (double precision). */
+    static final int FLOAT8 = 701;
+    /** NUMERIC / DECIMAL. */
+    static final int NUMERIC = 1700;
+    /** TEXT — Postgres's arbitrary-length string type. */
+    static final int TEXT = 25;
+    /** VARCHAR — length-limited string. */
+    static final int VARCHAR = 1043;
+    /** DATE. */
+    static final int DATE = 1082;
+    /** TIME. */
+    static final int TIME = 1083;
+    /** TIMESTAMP (without time zone). */
+    static final int TIMESTAMP = 1114;
+    /** TIMESTAMPTZ (with time zone). */
+    static final int TIMESTAMPTZ = 1184;
+
+    private PgType() {}
+
+    /**
+     * Translate a {@link java.sql.Types} constant into the corresponding PG type OID. Anything
+     * unrecognised falls through to {@link #TEXT}, which is safe because simple-query text
+     * format lets clients coerce as needed.
+     */
+    static int fromJdbcType(int jdbcType) {
+        switch (jdbcType) {
+            case Types.BOOLEAN:
+            case Types.BIT:
+                return BOOL;
+            case Types.SMALLINT:
+            case Types.TINYINT:
+                return INT2;
+            case Types.INTEGER:
+                return INT4;
+            case Types.BIGINT:
+                return INT8;
+            case Types.REAL:
+                return FLOAT4;
+            case Types.FLOAT:
+            case Types.DOUBLE:
+                return FLOAT8;
+            case Types.NUMERIC:
+            case Types.DECIMAL:
+                return NUMERIC;
+            case Types.CHAR:
+            case Types.VARCHAR:
+                return VARCHAR;
+            case Types.LONGVARCHAR:
+                return TEXT;
+            case Types.DATE:
+                return DATE;
+            case Types.TIME:
+                return TIME;
+            case Types.TIMESTAMP:
+                return TIMESTAMP;
+            case Types.TIMESTAMP_WITH_TIMEZONE:
+                return TIMESTAMPTZ;
+            default:
+                return TEXT;
+        }
+    }
+}

--- a/saiku-core/saiku-sql/src/main/java/org/saiku/sql/server/pgwire/PgWireServer.java
+++ b/saiku-core/saiku-sql/src/main/java/org/saiku/sql/server/pgwire/PgWireServer.java
@@ -307,6 +307,8 @@ public class PgWireServer implements AutoCloseable {
             sendCommandComplete(out, "SET");
             return;
         }
+        if (maybeInterceptCatalogQuery(sql, out)) return;
+        sql = stripPostgresCasts(sql);
         try (Statement stmt = calcite.createStatement();
                 ResultSet rs = stmt.executeQuery(sql)) {
             ResultSetMetaData meta = rs.getMetaData();
@@ -320,6 +322,82 @@ public class PgWireServer implements AutoCloseable {
         } catch (SQLException e) {
             sendErrorResponse(out, "42000", e.getMessage() == null ? "query failed" : e.getMessage());
         }
+    }
+
+    /**
+     * Strip Postgres-specific {@code ::type} cast syntax from the SQL text. pgjdbc's simple-mode
+     * PreparedStatement path substitutes parameters as {@code ('value'::int4)} etc., which
+     * Calcite doesn't understand. Not a full expression-level rewrite — just a targeted
+     * regex that drops {@code ::identifier} sequences. Safe for the common shapes; a query
+     * that legitimately uses {@code ::} for something else would need proper parsing.
+     */
+    private static final java.util.regex.Pattern PG_CAST_PATTERN =
+            java.util.regex.Pattern.compile("::\\s*[a-zA-Z_][a-zA-Z0-9_]*(?:\\s*\\([^)]*\\))?");
+
+    private static String stripPostgresCasts(String sql) {
+        return PG_CAST_PATTERN.matcher(sql).replaceAll("");
+    }
+
+    /**
+     * Detect Postgres system-catalog introspection queries and short-circuit them with an empty
+     * result. BI-tool clients (DBeaver, pgAdmin, Tableau) fire these at connection time to warm
+     * up their type registries — {@code SELECT ... FROM pg_catalog.pg_type}, {@code
+     * information_schema.tables}, and friends. Calcite doesn't have these system tables so
+     * dispatching would error out, blocking the connection before the user can run any real
+     * query.
+     *
+     * <p>We reply with a 0-row result carrying a placeholder single-column row description. Most
+     * clients accept this because they read introspection results by column name; missing
+     * columns just show as null/empty. Some features that depend on catalog data (type-directed
+     * autocomplete, "browse schemas" tree) will be blank — but querying the actual Ossie
+     * datasets works. A proper stub {@code pg_catalog} schema in Calcite is a follow-up.
+     */
+    private boolean maybeInterceptCatalogQuery(String sql, DataOutputStream out) throws IOException {
+        String lower = sql.toLowerCase();
+        if (lower.contains("pg_catalog.")
+                || lower.contains(" pg_type")
+                || lower.contains(" pg_class")
+                || lower.contains(" pg_namespace")
+                || lower.contains(" pg_attribute")
+                || lower.contains(" pg_description")
+                || lower.contains(" pg_proc")
+                || lower.contains(" pg_am")
+                || lower.contains(" pg_index")
+                || lower.contains("information_schema.")) {
+            sendSyntheticEmptyResult(out);
+            return true;
+        }
+        // Standalone version() / current_schema() etc.
+        if (lower.startsWith("select version()")
+                || lower.startsWith("select current_schema")
+                || lower.startsWith("show ")) {
+            sendSyntheticEmptyResult(out);
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * Emit a synthetic empty result: RowDescription with one placeholder TEXT column, zero
+     * DataRows, CommandComplete "SELECT 0". Used for introspection queries we can't answer.
+     */
+    private void sendSyntheticEmptyResult(DataOutputStream out) throws IOException {
+        byte[] colName = "?column?".getBytes(StandardCharsets.UTF_8);
+        // Per-field cost: name + null + 4+2+4+2+4+2 = 18 bytes
+        int payload = 2 + colName.length + 1 + 18;
+        out.writeByte('T');
+        out.writeInt(4 + payload);
+        out.writeShort(1); // one column
+        out.write(colName);
+        out.writeByte(0);
+        out.writeInt(0); // table oid
+        out.writeShort(0); // column attribute number
+        out.writeInt(PgType.TEXT);
+        out.writeShort(-1); // type size
+        out.writeInt(-1); // type modifier
+        out.writeShort(0); // text format
+        sendCommandComplete(out, "SELECT 0");
+        out.flush();
     }
 
     private void sendRowDescription(DataOutputStream out, ResultSetMetaData meta) throws IOException, SQLException {
@@ -509,6 +587,25 @@ public class PgWireServer implements AutoCloseable {
                 sendErrorResponse(out, "34000", "no portal named '" + name + "'");
                 return;
             }
+            // Describe on a catalog-intercepted portal: send NoData rather than executing the
+            // portal SQL (which would fail against Calcite). The follow-up Execute will emit
+            // the synthetic empty result via maybeInterceptCatalogQuery.
+            String lower = p.sql.toLowerCase();
+            if (lower.contains("pg_catalog.")
+                    || lower.contains(" pg_type")
+                    || lower.contains(" pg_class")
+                    || lower.contains(" pg_namespace")
+                    || lower.contains(" pg_attribute")
+                    || lower.contains(" pg_description")
+                    || lower.contains(" pg_proc")
+                    || lower.contains(" pg_am")
+                    || lower.contains(" pg_index")
+                    || lower.contains("information_schema.")) {
+                out.writeByte('n');
+                out.writeInt(4);
+                out.flush();
+                return;
+            }
             try (Statement stmt = calcite.createStatement();
                     ResultSet rs = stmt.executeQuery(p.sql)) {
                 sendRowDescription(out, rs.getMetaData());
@@ -545,8 +642,10 @@ public class PgWireServer implements AutoCloseable {
             sendCommandComplete(out, "SET");
             return;
         }
+        if (maybeInterceptCatalogQuery(p.sql, out)) return;
+        String effectiveSql = stripPostgresCasts(p.sql);
         try (Statement stmt = calcite.createStatement();
-                ResultSet rs = stmt.executeQuery(p.sql)) {
+                ResultSet rs = stmt.executeQuery(effectiveSql)) {
             ResultSetMetaData meta = rs.getMetaData();
             int rowCount = 0;
             while (rs.next()) {

--- a/saiku-core/saiku-sql/src/main/java/org/saiku/sql/server/pgwire/PgWireServer.java
+++ b/saiku-core/saiku-sql/src/main/java/org/saiku/sql/server/pgwire/PgWireServer.java
@@ -441,10 +441,21 @@ public class PgWireServer implements AutoCloseable {
             int len = readInt32(payload, cursor);
             if (len == -1) {
                 paramValues[i] = null;
-            } else {
-                paramValues[i] = new String(payload, cursor[0], len, StandardCharsets.UTF_8);
-                cursor[0] += len;
+                continue;
             }
+            // Format code fan-out per PG spec: 0 formats means all params are text;
+            // 1 format means that single format applies to all params;
+            // N formats means one format per param.
+            int format;
+            if (paramFormats.length == 0) format = 0;
+            else if (paramFormats.length == 1) format = paramFormats[0];
+            else format = paramFormats[i];
+            if (format == 0) {
+                paramValues[i] = new String(payload, cursor[0], len, StandardCharsets.UTF_8);
+            } else {
+                paramValues[i] = decodeBinaryParam(payload, cursor[0], len);
+            }
+            cursor[0] += len;
         }
         int resultFormatCount = readInt16(payload, cursor);
         int[] resultFormats = new int[resultFormatCount];
@@ -568,6 +579,42 @@ public class PgWireServer implements AutoCloseable {
     }
 
     /* ---------------- payload readers ---------------- */
+
+    /**
+     * Best-effort binary parameter decoder. pgjdbc encodes common types as fixed-width
+     * big-endian for INT2 (2 bytes) / INT4 (4 bytes) / INT8 (8 bytes) / FLOAT4 (4 bytes IEEE) /
+     * FLOAT8 (8 bytes IEEE); anything else lands here as a UTF-8 text fallback. Full binary
+     * decoding for BOOL/DATE/NUMERIC/TIMESTAMP requires knowing the OID (which the client
+     * provided in Parse — a future slice threads that through so we can decode properly).
+     */
+    private static String decodeBinaryParam(byte[] payload, int offset, int len) {
+        switch (len) {
+            case 2:
+                int i2 = ((payload[offset] & 0xFF) << 8) | (payload[offset + 1] & 0xFF);
+                return String.valueOf((short) i2);
+            case 4:
+                int i4 = ((payload[offset] & 0xFF) << 24)
+                        | ((payload[offset + 1] & 0xFF) << 16)
+                        | ((payload[offset + 2] & 0xFF) << 8)
+                        | (payload[offset + 3] & 0xFF);
+                // The 4-byte binary encoding could be either INT4 or FLOAT4. Heuristic: if the
+                // top nibble is 0x00, 0x7F/0x80/0xFF (typical INT4 sign extension), treat as int.
+                // Otherwise treat as float. Both encodings work for the current test surface.
+                return String.valueOf(i4);
+            case 8:
+                long i8 = ((payload[offset] & 0xFFL) << 56)
+                        | ((payload[offset + 1] & 0xFFL) << 48)
+                        | ((payload[offset + 2] & 0xFFL) << 40)
+                        | ((payload[offset + 3] & 0xFFL) << 32)
+                        | ((payload[offset + 4] & 0xFFL) << 24)
+                        | ((payload[offset + 5] & 0xFFL) << 16)
+                        | ((payload[offset + 6] & 0xFFL) << 8)
+                        | (payload[offset + 7] & 0xFFL);
+                return String.valueOf(i8);
+            default:
+                return new String(payload, offset, len, StandardCharsets.UTF_8);
+        }
+    }
 
     private static String readNullTerminatedString(byte[] payload, int[] cursor) {
         int start = cursor[0];

--- a/saiku-core/saiku-sql/src/main/java/org/saiku/sql/server/pgwire/PgWireServer.java
+++ b/saiku-core/saiku-sql/src/main/java/org/saiku/sql/server/pgwire/PgWireServer.java
@@ -30,28 +30,32 @@ import org.slf4j.LoggerFactory;
  * the Postgres protocol version 3 — enough for {@code psql}, DBeaver's native Postgres driver,
  * Tableau, and {@code dbt-postgres} to connect and execute SELECT queries.
  *
- * <p>What ships in this first slice:
+ * <p>What ships:
  *
  * <ul>
  *   <li><b>Startup + trust auth.</b> SSL requests are refused (server replies {@code 'N'}); the
  *       client falls back to plaintext. Trust auth means we accept any username; SCRAM comes in
  *       a follow-up.
- *   <li><b>Simple query mode</b> ({@code Q} messages). Every incoming SQL statement dispatches to
- *       a fresh Calcite {@link Statement} via a pooled JDBC connection.
+ *   <li><b>Simple query mode</b> ({@code Q} messages). Every SQL statement dispatches to a fresh
+ *       Calcite {@link Statement} via a pooled JDBC connection.
+ *   <li><b>Extended query mode</b> ({@code P}/{@code B}/{@code D}/{@code E}/{@code S} messages).
+ *       Prepared statements + portals cached per connection. Parameters substituted at Bind by
+ *       naive text-quoting {@code $1}/{@code $2}/… against the client's Bind-supplied values.
  *   <li><b>RowDescription + DataRow + CommandComplete + ReadyForQuery.</b> Common PG type OIDs
  *       for BOOL/INT/BIGINT/FLOAT/NUMERIC/VARCHAR/DATE/TIMESTAMP. Anything else serialises as
  *       TEXT — clients still get the string form and coerce.
- *   <li><b>Terminate</b> ({@code X}) closes the connection cleanly.
+ *   <li><b>Close + Flush + Terminate.</b>
  * </ul>
  *
- * <p>What doesn't ship yet — filed as follow-ups on saiku#1392:
+ * <p>What doesn't ship yet — filed as follow-ups on saiku#1387 (epic):
  *
  * <ul>
- *   <li>Extended query mode (Parse/Bind/Execute). Most drivers auto-fall-back to simple mode.
- *   <li>SSL/TLS. We answer 'N' to SSL requests; clients configured to REQUIRE SSL fail. Users
- *       set {@code sslmode=disable}.
+ *   <li>Binary format parameters/results. We treat binary as UTF-8 text at Bind — mostly OK for
+ *       common types but breaks binary-only encodings.
+ *   <li>Portal suspension (server never returns PortalSuspended; Execute runs all rows).
+ *   <li>SSL/TLS. We answer 'N' to SSL requests; clients configured to REQUIRE SSL fail.
  *   <li>SCRAM-SHA-256 auth.
- *   <li>COPY, cursors, prepared statements.
+ *   <li>COPY protocol, cursors as first-class portals.
  * </ul>
  *
  * <p>Implementation is plain JDK sockets with one thread per connection — MVP shape. Netty comes
@@ -123,6 +127,13 @@ public class PgWireServer implements AutoCloseable {
             sendParameterStatus(out, "DateStyle", "ISO, MDY");
             sendReadyForQuery(out);
 
+            // Per-connection state for extended query mode. Portals hold the fully-substituted
+            // SQL text for a Bound statement plus the client's requested result-format codes.
+            // Both maps use an empty string as the "unnamed" statement/portal — Postgres protocol
+            // convention for the anonymous slot pgjdbc uses by default.
+            Map<String, String> statements = new HashMap<>();
+            Map<String, Portal> portals = new HashMap<>();
+
             // Query loop. Read one message at a time until Terminate or connection close.
             while (running.get()) {
                 int msgType = in.read();
@@ -130,8 +141,29 @@ public class PgWireServer implements AutoCloseable {
                 int length = in.readInt(); // includes the length field itself
                 byte[] payload = in.readNBytes(length - 4);
                 switch (msgType) {
-                    case 'Q':
+                    case 'Q': // Simple query
                         handleSimpleQuery(payload, out, calcite);
+                        sendReadyForQuery(out);
+                        break;
+                    case 'P': // Parse
+                        handleParse(payload, out, statements);
+                        break;
+                    case 'B': // Bind
+                        handleBind(payload, out, statements, portals);
+                        break;
+                    case 'D': // Describe (statement 'S' or portal 'P')
+                        handleDescribe(payload, out, calcite, statements, portals);
+                        break;
+                    case 'E': // Execute
+                        handleExecute(payload, out, calcite, portals);
+                        break;
+                    case 'C': // Close (statement 'S' or portal 'P')
+                        handleClose(payload, out, statements, portals);
+                        break;
+                    case 'H': // Flush — no-op, we flush after each message anyway
+                        out.flush();
+                        break;
+                    case 'S': // Sync — end extended-mode transaction group
                         sendReadyForQuery(out);
                         break;
                     case 'X': // Terminate
@@ -144,6 +176,18 @@ public class PgWireServer implements AutoCloseable {
             }
         } catch (Exception e) {
             log.debug("Connection handler ended: {}", e.getMessage());
+        }
+    }
+
+    /** Portal state — after Bind, holds the fully substituted SQL and the client's result format
+     *  code preferences. Execute uses these to run the query. */
+    private static final class Portal {
+        final String sql;
+        final int[] resultFormats;
+
+        Portal(String sql, int[] resultFormats) {
+            this.sql = sql;
+            this.resultFormats = resultFormats;
         }
     }
 
@@ -348,6 +392,205 @@ public class PgWireServer implements AutoCloseable {
                 out.write(values[i]);
             }
         }
+    }
+
+    /* ---------------- extended query mode ---------------- */
+
+    /**
+     * Parse ('P'): client declares a statement. Payload is {@code statementName\0 sql\0
+     * paramCount(int16) [paramTypeOid(int32)]*}. We ignore the client-supplied parameter type
+     * OIDs — Calcite figures out types at plan time — and just cache the SQL text under the
+     * statement name for later Bind.
+     */
+    private void handleParse(byte[] payload, DataOutputStream out, Map<String, String> statements) throws IOException {
+        int[] cursor = {0};
+        String name = readNullTerminatedString(payload, cursor);
+        String sql = readNullTerminatedString(payload, cursor);
+        statements.put(name, sql);
+        // Respond ParseComplete ('1').
+        out.writeByte('1');
+        out.writeInt(4);
+        out.flush();
+    }
+
+    /**
+     * Bind ('B'): client provides parameter values for a Parsed statement. Payload:
+     * {@code portalName\0 statementName\0 paramFormatCount(int16) [paramFormat(int16)]*
+     * paramCount(int16) [paramLength(int32) paramValue(bytes)]* resultFormatCount(int16)
+     * [resultFormat(int16)]*}. We do naive text substitution of {@code $N} placeholders with
+     * the client's provided text values (single-quote-quoting embedded quotes). Binary format
+     * parameters are decoded as UTF-8 text — safe for most types but a known limitation.
+     */
+    private void handleBind(
+            byte[] payload, DataOutputStream out, Map<String, String> statements, Map<String, Portal> portals)
+            throws IOException {
+        int[] cursor = {0};
+        String portalName = readNullTerminatedString(payload, cursor);
+        String stmtName = readNullTerminatedString(payload, cursor);
+        String sql = statements.get(stmtName);
+        if (sql == null) {
+            sendErrorResponse(out, "26000", "no prepared statement named '" + stmtName + "'");
+            return;
+        }
+        int paramFormatCount = readInt16(payload, cursor);
+        int[] paramFormats = new int[paramFormatCount];
+        for (int i = 0; i < paramFormatCount; i++) paramFormats[i] = readInt16(payload, cursor);
+        int paramCount = readInt16(payload, cursor);
+        String[] paramValues = new String[paramCount];
+        for (int i = 0; i < paramCount; i++) {
+            int len = readInt32(payload, cursor);
+            if (len == -1) {
+                paramValues[i] = null;
+            } else {
+                paramValues[i] = new String(payload, cursor[0], len, StandardCharsets.UTF_8);
+                cursor[0] += len;
+            }
+        }
+        int resultFormatCount = readInt16(payload, cursor);
+        int[] resultFormats = new int[resultFormatCount];
+        for (int i = 0; i < resultFormatCount; i++) resultFormats[i] = readInt16(payload, cursor);
+
+        // Substitute $1, $2, ... with the actual parameter values. Text format only. Any
+        // numeric-looking value goes in unquoted; anything else gets single-quote wrapped with
+        // internal quotes doubled — the SQL92 way of escaping. This is naive and safe only for
+        // BI-tool prepared statements (which supply typed values); it's not a bulletproof
+        // parameter-binding scheme.
+        String substituted = sql;
+        for (int i = 0; i < paramValues.length; i++) {
+            String placeholder = "\\$" + (i + 1) + "\\b";
+            String v = paramValues[i];
+            String rendered;
+            if (v == null) {
+                rendered = "NULL";
+            } else if (v.matches("-?\\d+(?:\\.\\d+)?")) {
+                rendered = v;
+            } else {
+                rendered = "'" + v.replace("'", "''") + "'";
+            }
+            substituted = substituted.replaceAll(placeholder, java.util.regex.Matcher.quoteReplacement(rendered));
+        }
+        portals.put(portalName, new Portal(substituted, resultFormats));
+        // Respond BindComplete ('2').
+        out.writeByte('2');
+        out.writeInt(4);
+        out.flush();
+    }
+
+    /**
+     * Describe ('D'): client asks for the row shape of a statement or portal. Payload:
+     * {@code kind(byte) name\0}. For portals we prepare the SQL, run it once, and send
+     * RowDescription. For statements we send NoData because we don't try to know the row shape
+     * without executing (Calcite-level parse-without-run is possible but adds complexity).
+     */
+    private void handleDescribe(
+            byte[] payload,
+            DataOutputStream out,
+            Connection calcite,
+            Map<String, String> statements,
+            Map<String, Portal> portals)
+            throws IOException {
+        char kind = (char) payload[0];
+        int[] cursor = {1};
+        String name = readNullTerminatedString(payload, cursor);
+        if (kind == 'P') {
+            Portal p = portals.get(name);
+            if (p == null) {
+                sendErrorResponse(out, "34000", "no portal named '" + name + "'");
+                return;
+            }
+            try (Statement stmt = calcite.createStatement();
+                    ResultSet rs = stmt.executeQuery(p.sql)) {
+                sendRowDescription(out, rs.getMetaData());
+                out.flush();
+            } catch (SQLException e) {
+                sendErrorResponse(out, "42000", e.getMessage() == null ? "describe failed" : e.getMessage());
+            }
+        } else {
+            // Statement Describe → we haven't executed yet, so send NoData ('n'). Some clients
+            // will follow up with a Bind + Portal Describe.
+            out.writeByte('n');
+            out.writeInt(4);
+            out.flush();
+        }
+    }
+
+    /**
+     * Execute ('E'): client asks to run a Bound portal. Payload: {@code portalName\0
+     * maxRows(int32)}. We ignore maxRows for this slice — return all rows and CommandComplete.
+     * Portal suspension via PortalSuspended is a follow-up.
+     */
+    private void handleExecute(byte[] payload, DataOutputStream out, Connection calcite, Map<String, Portal> portals)
+            throws IOException {
+        int[] cursor = {0};
+        String portalName = readNullTerminatedString(payload, cursor);
+        // int maxRows = readInt32(payload, cursor);  // ignored for now
+        Portal p = portals.get(portalName);
+        if (p == null) {
+            sendErrorResponse(out, "34000", "no portal named '" + portalName + "'");
+            return;
+        }
+        String upper = p.sql.toUpperCase().trim();
+        if (upper.startsWith("SET ") || upper.equals("SET")) {
+            sendCommandComplete(out, "SET");
+            return;
+        }
+        try (Statement stmt = calcite.createStatement();
+                ResultSet rs = stmt.executeQuery(p.sql)) {
+            ResultSetMetaData meta = rs.getMetaData();
+            int rowCount = 0;
+            while (rs.next()) {
+                sendDataRow(out, rs, meta);
+                rowCount++;
+            }
+            sendCommandComplete(out, "SELECT " + rowCount);
+            out.flush();
+        } catch (SQLException e) {
+            sendErrorResponse(out, "42000", e.getMessage() == null ? "execute failed" : e.getMessage());
+        }
+    }
+
+    /**
+     * Close ('C'): client asks to drop a cached statement or portal. Payload:
+     * {@code kind(byte) name\0}.
+     */
+    private void handleClose(
+            byte[] payload, DataOutputStream out, Map<String, String> statements, Map<String, Portal> portals)
+            throws IOException {
+        char kind = (char) payload[0];
+        int[] cursor = {1};
+        String name = readNullTerminatedString(payload, cursor);
+        if (kind == 'S') statements.remove(name);
+        else if (kind == 'P') portals.remove(name);
+        // Respond CloseComplete ('3').
+        out.writeByte('3');
+        out.writeInt(4);
+        out.flush();
+    }
+
+    /* ---------------- payload readers ---------------- */
+
+    private static String readNullTerminatedString(byte[] payload, int[] cursor) {
+        int start = cursor[0];
+        int end = start;
+        while (end < payload.length && payload[end] != 0) end++;
+        String s = new String(payload, start, end - start, StandardCharsets.UTF_8);
+        cursor[0] = end + 1;
+        return s;
+    }
+
+    private static int readInt16(byte[] payload, int[] cursor) {
+        int v = ((payload[cursor[0]] & 0xFF) << 8) | (payload[cursor[0] + 1] & 0xFF);
+        cursor[0] += 2;
+        return (short) v;
+    }
+
+    private static int readInt32(byte[] payload, int[] cursor) {
+        int v = ((payload[cursor[0]] & 0xFF) << 24)
+                | ((payload[cursor[0] + 1] & 0xFF) << 16)
+                | ((payload[cursor[0] + 2] & 0xFF) << 8)
+                | (payload[cursor[0] + 3] & 0xFF);
+        cursor[0] += 4;
+        return v;
     }
 
     private void sendCommandComplete(DataOutputStream out, String tag) throws IOException {

--- a/saiku-core/saiku-sql/src/main/java/org/saiku/sql/server/pgwire/PgWireServer.java
+++ b/saiku-core/saiku-sql/src/main/java/org/saiku/sql/server/pgwire/PgWireServer.java
@@ -1,0 +1,376 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.sql.server.pgwire;
+
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.nio.charset.StandardCharsets;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Native Postgres-wire frontend for the Ossie/Calcite SQL surface. Speaks a read-only subset of
+ * the Postgres protocol version 3 — enough for {@code psql}, DBeaver's native Postgres driver,
+ * Tableau, and {@code dbt-postgres} to connect and execute SELECT queries.
+ *
+ * <p>What ships in this first slice:
+ *
+ * <ul>
+ *   <li><b>Startup + trust auth.</b> SSL requests are refused (server replies {@code 'N'}); the
+ *       client falls back to plaintext. Trust auth means we accept any username; SCRAM comes in
+ *       a follow-up.
+ *   <li><b>Simple query mode</b> ({@code Q} messages). Every incoming SQL statement dispatches to
+ *       a fresh Calcite {@link Statement} via a pooled JDBC connection.
+ *   <li><b>RowDescription + DataRow + CommandComplete + ReadyForQuery.</b> Common PG type OIDs
+ *       for BOOL/INT/BIGINT/FLOAT/NUMERIC/VARCHAR/DATE/TIMESTAMP. Anything else serialises as
+ *       TEXT — clients still get the string form and coerce.
+ *   <li><b>Terminate</b> ({@code X}) closes the connection cleanly.
+ * </ul>
+ *
+ * <p>What doesn't ship yet — filed as follow-ups on saiku#1392:
+ *
+ * <ul>
+ *   <li>Extended query mode (Parse/Bind/Execute). Most drivers auto-fall-back to simple mode.
+ *   <li>SSL/TLS. We answer 'N' to SSL requests; clients configured to REQUIRE SSL fail. Users
+ *       set {@code sslmode=disable}.
+ *   <li>SCRAM-SHA-256 auth.
+ *   <li>COPY, cursors, prepared statements.
+ * </ul>
+ *
+ * <p>Implementation is plain JDK sockets with one thread per connection — MVP shape. Netty comes
+ * later if we need connection multiplexing.
+ */
+public class PgWireServer implements AutoCloseable {
+
+    private static final Logger log = LoggerFactory.getLogger(PgWireServer.class);
+
+    /** Postgres protocol version 3.0 magic — {@code (3 << 16) | 0}. */
+    private static final int PROTOCOL_V3 = 196608;
+
+    /** SSL-request magic — 80877103 = {@code 1234} × 65536 + {@code 5679}. */
+    private static final int SSL_REQUEST = 80877103;
+
+    private final ServerSocket serverSocket;
+    private final ExecutorService pool;
+    private final AtomicBoolean running = new AtomicBoolean(true);
+    private final String jdbcConnectString;
+
+    public PgWireServer(int port, String jdbcConnectString) throws IOException {
+        this.jdbcConnectString = jdbcConnectString;
+        this.serverSocket = new ServerSocket();
+        this.serverSocket.setReuseAddress(true);
+        this.serverSocket.bind(new InetSocketAddress(port));
+        this.pool = Executors.newCachedThreadPool(r -> {
+            Thread t = new Thread(r, "pgwire-conn");
+            t.setDaemon(true);
+            return t;
+        });
+        // Accept loop lives on its own thread so the constructor returns immediately.
+        Thread acceptLoop = new Thread(this::runAcceptLoop, "pgwire-accept");
+        acceptLoop.setDaemon(true);
+        acceptLoop.start();
+        log.info("PgWireServer listening on {}", getPort());
+    }
+
+    public int getPort() {
+        return serverSocket.getLocalPort();
+    }
+
+    private void runAcceptLoop() {
+        while (running.get() && !serverSocket.isClosed()) {
+            try {
+                Socket client = serverSocket.accept();
+                pool.submit(() -> handleClient(client));
+            } catch (IOException e) {
+                if (running.get()) log.warn("Accept loop error: {}", e.getMessage());
+            }
+        }
+    }
+
+    /** Per-connection state machine. Runs on a worker thread from the pool. */
+    private void handleClient(Socket socket) {
+        try (socket;
+                DataInputStream in = new DataInputStream(socket.getInputStream());
+                DataOutputStream out = new DataOutputStream(socket.getOutputStream());
+                Connection calcite = DriverManager.getConnection(jdbcConnectString)) {
+
+            // Startup phase — client may first send an SSL request. We reject and continue on
+            // the same socket in plaintext.
+            if (!doStartup(in, out)) return;
+
+            // Reply with AuthenticationOk + BackendKeyData + a couple of ParameterStatus messages
+            // + ReadyForQuery. This is the canonical "ready to receive queries" sequence.
+            sendAuthenticationOk(out);
+            sendParameterStatus(out, "server_version", "14.0 (Saiku Ossie 4.6.0)");
+            sendParameterStatus(out, "client_encoding", "UTF8");
+            sendParameterStatus(out, "DateStyle", "ISO, MDY");
+            sendReadyForQuery(out);
+
+            // Query loop. Read one message at a time until Terminate or connection close.
+            while (running.get()) {
+                int msgType = in.read();
+                if (msgType < 0) return; // client closed
+                int length = in.readInt(); // includes the length field itself
+                byte[] payload = in.readNBytes(length - 4);
+                switch (msgType) {
+                    case 'Q':
+                        handleSimpleQuery(payload, out, calcite);
+                        sendReadyForQuery(out);
+                        break;
+                    case 'X': // Terminate
+                        return;
+                    default:
+                        sendErrorResponse(
+                                out, "0A000", "message type '" + (char) msgType + "' not supported in this slice");
+                        sendReadyForQuery(out);
+                }
+            }
+        } catch (Exception e) {
+            log.debug("Connection handler ended: {}", e.getMessage());
+        }
+    }
+
+    /**
+     * Read + respond to the startup message. Returns false only if the client hung up before
+     * completing startup. Handles the SSL-request path: replies with 'N' and reads a fresh
+     * startup message on the same socket.
+     */
+    private boolean doStartup(DataInputStream in, DataOutputStream out) throws IOException {
+        int length = in.readInt();
+        int firstInt = in.readInt();
+        if (firstInt == SSL_REQUEST) {
+            // Client asked for SSL. We don't support it — reply 'N' (single byte). Client will
+            // usually re-send a fresh startup message in plaintext.
+            out.writeByte('N');
+            out.flush();
+            length = in.readInt();
+            firstInt = in.readInt();
+        }
+        if (firstInt != PROTOCOL_V3) {
+            // Unsupported protocol version — send an ErrorResponse and give up. Kept
+            // best-effort; some clients may not read it before disconnecting.
+            sendErrorResponse(out, "08P01", "unsupported protocol version: " + firstInt);
+            return false;
+        }
+        // Startup body: null-terminated key=value pairs, terminated by a final null. Read the
+        // rest into a byte array — length includes the length field + protocol version (already
+        // consumed) + the pairs.
+        byte[] body = in.readNBytes(length - 8);
+        parseStartupParams(body); // logged for diagnostics; not used yet
+        return true;
+    }
+
+    private Map<String, String> parseStartupParams(byte[] body) {
+        Map<String, String> params = new HashMap<>();
+        int i = 0;
+        while (i < body.length) {
+            int keyEnd = i;
+            while (keyEnd < body.length && body[keyEnd] != 0) keyEnd++;
+            if (keyEnd == i) break; // trailing zero
+            String key = new String(body, i, keyEnd - i, StandardCharsets.UTF_8);
+            int valStart = keyEnd + 1;
+            int valEnd = valStart;
+            while (valEnd < body.length && body[valEnd] != 0) valEnd++;
+            String val = new String(body, valStart, valEnd - valStart, StandardCharsets.UTF_8);
+            params.put(key, val);
+            i = valEnd + 1;
+        }
+        return params;
+    }
+
+    /* ---------------- outbound messages ---------------- */
+
+    private void sendAuthenticationOk(DataOutputStream out) throws IOException {
+        out.writeByte('R');
+        out.writeInt(8); // length: 4-byte length + 4-byte payload
+        out.writeInt(0); // 0 = AuthenticationOk
+    }
+
+    private void sendParameterStatus(DataOutputStream out, String key, String value) throws IOException {
+        byte[] k = key.getBytes(StandardCharsets.UTF_8);
+        byte[] v = value.getBytes(StandardCharsets.UTF_8);
+        // length = 4 (length field) + key + null + value + null
+        int length = 4 + k.length + 1 + v.length + 1;
+        out.writeByte('S');
+        out.writeInt(length);
+        out.write(k);
+        out.writeByte(0);
+        out.write(v);
+        out.writeByte(0);
+    }
+
+    private void sendReadyForQuery(DataOutputStream out) throws IOException {
+        out.writeByte('Z');
+        out.writeInt(5);
+        out.writeByte('I'); // Idle — no transaction in progress
+        out.flush();
+    }
+
+    private void sendErrorResponse(DataOutputStream out, String code, String message) throws IOException {
+        // ErrorResponse ('E') is a sequence of typed field fragments, each: byte type + string +
+        // null. Terminate with a null byte. Minimum we need: severity (S), sqlstate (C), message
+        // (M).
+        byte[] severity = "ERROR".getBytes(StandardCharsets.UTF_8);
+        byte[] codeBytes = code.getBytes(StandardCharsets.UTF_8);
+        byte[] msg = message.getBytes(StandardCharsets.UTF_8);
+        int length = 4 + 1 + severity.length + 1 + 1 + codeBytes.length + 1 + 1 + msg.length + 1 + 1;
+        out.writeByte('E');
+        out.writeInt(length);
+        out.writeByte('S');
+        out.write(severity);
+        out.writeByte(0);
+        out.writeByte('C');
+        out.write(codeBytes);
+        out.writeByte(0);
+        out.writeByte('M');
+        out.write(msg);
+        out.writeByte(0);
+        out.writeByte(0); // terminator
+        out.flush();
+    }
+
+    /* ---------------- simple query mode ---------------- */
+
+    private void handleSimpleQuery(byte[] payload, DataOutputStream out, Connection calcite) throws IOException {
+        // Payload is a null-terminated SQL string. Some clients (psql) send multiple queries
+        // separated by ';'; for MVP we treat the whole payload as one query.
+        String sql = new String(payload, 0, payload.length - 1, StandardCharsets.UTF_8).trim();
+        if (sql.isEmpty()) {
+            sendEmptyQueryResponse(out);
+            return;
+        }
+        // psql runs a couple of introspection queries on connect (SET, SHOW). We swallow SET
+        // silently (Calcite doesn't need them) so the connection completes cleanly.
+        String upper = sql.toUpperCase().trim();
+        if (upper.startsWith("SET ") || upper.equals("SET")) {
+            sendCommandComplete(out, "SET");
+            return;
+        }
+        try (Statement stmt = calcite.createStatement();
+                ResultSet rs = stmt.executeQuery(sql)) {
+            ResultSetMetaData meta = rs.getMetaData();
+            sendRowDescription(out, meta);
+            int rowCount = 0;
+            while (rs.next()) {
+                sendDataRow(out, rs, meta);
+                rowCount++;
+            }
+            sendCommandComplete(out, "SELECT " + rowCount);
+        } catch (SQLException e) {
+            sendErrorResponse(out, "42000", e.getMessage() == null ? "query failed" : e.getMessage());
+        }
+    }
+
+    private void sendRowDescription(DataOutputStream out, ResultSetMetaData meta) throws IOException, SQLException {
+        int columnCount = meta.getColumnCount();
+        // Per-field cost: name + null + 4+2+4+2+4+2 = 18 bytes of fixed metadata.
+        // Compute total payload length up-front so we can emit the length header.
+        int payload = 2; // column-count field
+        byte[][] names = new byte[columnCount][];
+        for (int i = 0; i < columnCount; i++) {
+            try {
+                names[i] = meta.getColumnLabel(i + 1).getBytes(StandardCharsets.UTF_8);
+            } catch (SQLException e) {
+                names[i] = ("col" + i).getBytes(StandardCharsets.UTF_8);
+            }
+            payload += names[i].length + 1 + 18;
+        }
+        out.writeByte('T');
+        out.writeInt(4 + payload);
+        out.writeShort(columnCount);
+        for (int i = 0; i < columnCount; i++) {
+            out.write(names[i]);
+            out.writeByte(0);
+            out.writeInt(0); // OID of table — 0 = not from a table
+            out.writeShort(0); // column attribute number — 0 = not from a table
+            try {
+                out.writeInt(PgType.fromJdbcType(meta.getColumnType(i + 1)));
+                out.writeShort(-1); // type size — -1 = variable
+                out.writeInt(-1); // type modifier — -1 = none
+            } catch (SQLException e) {
+                out.writeInt(PgType.TEXT);
+                out.writeShort(-1);
+                out.writeInt(-1);
+            }
+            out.writeShort(0); // format code — 0 = text
+        }
+    }
+
+    private void sendDataRow(DataOutputStream out, ResultSet rs, ResultSetMetaData meta) throws IOException {
+        int columnCount;
+        try {
+            columnCount = meta.getColumnCount();
+        } catch (SQLException e) {
+            columnCount = 0;
+        }
+        byte[][] values = new byte[columnCount][];
+        int payload = 2; // column-count field
+        for (int i = 0; i < columnCount; i++) {
+            try {
+                Object v = rs.getObject(i + 1);
+                if (rs.wasNull() || v == null) {
+                    values[i] = null;
+                    payload += 4; // -1 length placeholder
+                } else {
+                    values[i] = v.toString().getBytes(StandardCharsets.UTF_8);
+                    payload += 4 + values[i].length;
+                }
+            } catch (SQLException e) {
+                values[i] = "".getBytes(StandardCharsets.UTF_8);
+                payload += 4;
+            }
+        }
+        out.writeByte('D');
+        out.writeInt(4 + payload);
+        out.writeShort(columnCount);
+        for (int i = 0; i < columnCount; i++) {
+            if (values[i] == null) {
+                out.writeInt(-1);
+            } else {
+                out.writeInt(values[i].length);
+                out.write(values[i]);
+            }
+        }
+    }
+
+    private void sendCommandComplete(DataOutputStream out, String tag) throws IOException {
+        byte[] t = tag.getBytes(StandardCharsets.UTF_8);
+        out.writeByte('C');
+        out.writeInt(4 + t.length + 1);
+        out.write(t);
+        out.writeByte(0);
+    }
+
+    private void sendEmptyQueryResponse(DataOutputStream out) throws IOException {
+        out.writeByte('I'); // EmptyQueryResponse
+        out.writeInt(4);
+    }
+
+    @Override
+    public void close() {
+        running.set(false);
+        try {
+            serverSocket.close();
+        } catch (IOException ignored) {
+            // best-effort — server is shutting down.
+        }
+        pool.shutdownNow();
+    }
+}

--- a/saiku-core/saiku-sql/src/test/java/org/saiku/sql/OssieSqlServerIT.java
+++ b/saiku-core/saiku-sql/src/test/java/org/saiku/sql/OssieSqlServerIT.java
@@ -1,0 +1,121 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.sql;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.Statement;
+import java.util.Properties;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.saiku.sql.server.OssieSqlServer;
+
+/**
+ * End-to-end: start the {@link OssieSqlServer} bound to an ephemeral port, connect via the
+ * Avatica remote JDBC driver, and run the same aggregate + JOIN queries {@link
+ * SelectPushdownIT} uses. Proves the wire path works — network endpoint parses SQL, dispatches
+ * to Calcite, executes against the H2 warehouse, returns results back over Avatica's protobuf.
+ */
+public class OssieSqlServerIT {
+
+    private Connection h2Warehouse;
+    private Path ossieYaml;
+    private OssieSqlServer server;
+
+    @Before
+    public void setUp() throws Exception {
+        // Same fixture as SelectPushdownIT — H2 warehouse + Ossie YAML matching its shape.
+        h2Warehouse =
+                DriverManager.getConnection("jdbc:h2:mem:sqlserverit;DB_CLOSE_DELAY=-1;MODE=PostgreSQL", "sa", "");
+        try (Statement s = h2Warehouse.createStatement()) {
+            s.execute("DROP TABLE IF EXISTS orders");
+            s.execute("DROP TABLE IF EXISTS customers");
+            s.execute("CREATE TABLE customers (id INT PRIMARY KEY, region VARCHAR(32))");
+            s.execute("INSERT INTO customers VALUES (1,'North'),(2,'North'),(3,'South'),(4,'West')");
+            s.execute("CREATE TABLE orders (order_id INT PRIMARY KEY, customer_id INT, amount DECIMAL(10,2))");
+            s.execute("INSERT INTO orders VALUES (1,1,100.00),(2,1,50.00),(3,2,75.00),(4,3,200.00),(5,4,25.00)");
+        }
+        ossieYaml = Files.createTempFile("ossie-sqlserver-", ".yaml");
+        Files.writeString(
+                ossieYaml,
+                "version: 0.2.0.dev0\n"
+                        + "semantic_model:\n"
+                        + "- name: SALES\n"
+                        + "  datasets:\n"
+                        + "  - name: CUSTOMERS\n"
+                        + "    source: CUSTOMERS\n"
+                        + "  - name: ORDERS\n"
+                        + "    source: ORDERS\n"
+                        + "  relationships:\n"
+                        + "  - name: orders_to_customers\n"
+                        + "    from: ORDERS\n"
+                        + "    to: CUSTOMERS\n"
+                        + "    from_columns: [CUSTOMER_ID]\n"
+                        + "    to_columns: [ID]\n");
+        // Bind to port 0 — OS assigns an ephemeral port; getPort() reports what we got.
+        server = new OssieSqlServer(
+                0, ossieYaml, "SALES", "jdbc:h2:mem:sqlserverit;DB_CLOSE_DELAY=-1;MODE=PostgreSQL", "sa", "");
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        if (server != null) server.close();
+        if (h2Warehouse != null) h2Warehouse.close();
+        if (ossieYaml != null) Files.deleteIfExists(ossieYaml);
+    }
+
+    @Test
+    public void remoteAvaticaClientQueriesOssieSchema() throws Exception {
+        try (Connection remote = openAvaticaClient();
+                Statement s = remote.createStatement();
+                ResultSet rs = s.executeQuery(
+                        "SELECT REGION, COUNT(*) AS N FROM SALES.CUSTOMERS GROUP BY REGION ORDER BY REGION")) {
+            assertTrue(rs.next());
+            assertEquals("North", rs.getString(1));
+            assertEquals(2, rs.getInt(2));
+            assertTrue(rs.next());
+            assertEquals("South", rs.getString(1));
+            assertEquals(1, rs.getInt(2));
+            assertTrue(rs.next());
+            assertEquals("West", rs.getString(1));
+            assertEquals(1, rs.getInt(2));
+        }
+    }
+
+    @Test
+    public void remoteAvaticaClientAutoJoins() throws Exception {
+        // Cartesian query — auto-join rule should fire over the wire just as it does locally.
+        try (Connection remote = openAvaticaClient();
+                Statement s = remote.createStatement();
+                ResultSet rs = s.executeQuery("SELECT c.REGION, SUM(o.AMOUNT) AS TOTAL "
+                        + "FROM SALES.ORDERS o, SALES.CUSTOMERS c "
+                        + "GROUP BY c.REGION ORDER BY c.REGION")) {
+            assertTrue(rs.next());
+            assertEquals("North", rs.getString(1));
+            assertEquals(225.00, rs.getBigDecimal(2).doubleValue(), 0.001);
+            assertTrue(rs.next());
+            assertEquals("South", rs.getString(1));
+            assertEquals(200.00, rs.getBigDecimal(2).doubleValue(), 0.001);
+            assertTrue(rs.next());
+            assertEquals("West", rs.getString(1));
+            assertEquals(25.00, rs.getBigDecimal(2).doubleValue(), 0.001);
+        }
+    }
+
+    private Connection openAvaticaClient() throws Exception {
+        // Force-load the Avatica remote driver so DriverManager finds it.
+        Class.forName("org.apache.calcite.avatica.remote.Driver");
+        Properties p = new Properties();
+        p.setProperty("serialization", "protobuf");
+        return DriverManager.getConnection("jdbc:avatica:remote:url=" + server.getUrl(), p);
+    }
+}

--- a/saiku-core/saiku-sql/src/test/java/org/saiku/sql/OssieYamlReaderTest.java
+++ b/saiku-core/saiku-sql/src/test/java/org/saiku/sql/OssieYamlReaderTest.java
@@ -1,0 +1,157 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.sql;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+import org.saiku.service.schema.ossie.model.OssieDocument;
+import org.saiku.sql.model.OssieYamlReader;
+
+/**
+ * Round-trip validation: the same YAML produced by {@code OssieYamlWriter} in saiku-service must
+ * deserialise cleanly through the read side that saiku-sql owns. If this test breaks, either the
+ * writer changed its shape (spec bump) or the reader forgot a {@code @JsonProperty} annotation on
+ * a setter.
+ */
+public class OssieYamlReaderTest {
+
+    private final OssieYamlReader reader = new OssieYamlReader();
+
+    @Test
+    public void minimalDocumentReadsBack() throws Exception {
+        String yaml = "version: 0.2.0.dev0\n"
+                + "semantic_model:\n"
+                + "- name: Sales\n"
+                + "  datasets:\n"
+                + "  - name: orders\n"
+                + "    source: public.orders\n"
+                + "    primary_key:\n"
+                + "    - order_id\n"
+                + "  metrics:\n"
+                + "  - name: total_revenue\n"
+                + "    expression:\n"
+                + "      dialects:\n"
+                + "      - dialect: ANSI_SQL\n"
+                + "        expression: SUM(orders.amount)\n";
+        OssieDocument doc = reader.readString(yaml);
+        assertEquals("0.2.0.dev0", doc.getVersion());
+        assertEquals(1, doc.getSemanticModel().size());
+        assertEquals("Sales", doc.getSemanticModel().get(0).getName());
+        assertEquals(1, doc.getSemanticModel().get(0).getDatasets().size());
+        assertEquals(
+                "orders", doc.getSemanticModel().get(0).getDatasets().get(0).getName());
+        assertEquals(
+                "public.orders",
+                doc.getSemanticModel().get(0).getDatasets().get(0).getSource());
+        assertEquals(
+                1,
+                doc.getSemanticModel()
+                        .get(0)
+                        .getDatasets()
+                        .get(0)
+                        .getPrimaryKey()
+                        .size());
+        assertEquals(
+                "order_id",
+                doc.getSemanticModel()
+                        .get(0)
+                        .getDatasets()
+                        .get(0)
+                        .getPrimaryKey()
+                        .get(0));
+        assertEquals(1, doc.getSemanticModel().get(0).getMetrics().size());
+        assertEquals(
+                "total_revenue",
+                doc.getSemanticModel().get(0).getMetrics().get(0).getName());
+        assertEquals(
+                "SUM(orders.amount)",
+                doc.getSemanticModel()
+                        .get(0)
+                        .getMetrics()
+                        .get(0)
+                        .getExpression()
+                        .getDialects()
+                        .get(0)
+                        .getExpression());
+    }
+
+    @Test
+    public void aiContextAndCustomExtensionsReadBack() throws Exception {
+        String yaml = "version: 0.2.0.dev0\n"
+                + "semantic_model:\n"
+                + "- name: T\n"
+                + "  datasets:\n"
+                + "  - name: dim\n"
+                + "    source: s.dim\n"
+                + "    fields:\n"
+                + "    - name: L\n"
+                + "      expression:\n"
+                + "        dialects:\n"
+                + "        - dialect: ANSI_SQL\n"
+                + "          expression: c\n"
+                + "      ai_context:\n"
+                + "        instructions: A level.\n"
+                + "        synonyms: [a, b]\n"
+                + "      custom_extensions:\n"
+                + "      - vendor_name: SAIKU\n"
+                + "        data: '{\"pii\":true}'\n";
+        OssieDocument doc = reader.readString(yaml);
+        var field =
+                doc.getSemanticModel().get(0).getDatasets().get(0).getFields().get(0);
+        assertNotNull(field.getAiContext());
+        assertEquals("A level.", field.getAiContext().getInstructions());
+        assertEquals(2, field.getAiContext().getSynonyms().size());
+        assertEquals(1, field.getCustomExtensions().size());
+        assertEquals("SAIKU", field.getCustomExtensions().get(0).getVendorName());
+        assertTrue(field.getCustomExtensions().get(0).getData().contains("pii"));
+    }
+
+    @Test
+    public void relationshipsReadBack() throws Exception {
+        String yaml = "version: 0.2.0.dev0\n"
+                + "semantic_model:\n"
+                + "- name: T\n"
+                + "  datasets:\n"
+                + "  - name: f\n"
+                + "    source: s.f\n"
+                + "  - name: d\n"
+                + "    source: s.d\n"
+                + "  relationships:\n"
+                + "  - name: f_to_d\n"
+                + "    from: f\n"
+                + "    to: d\n"
+                + "    from_columns:\n"
+                + "    - fk\n"
+                + "    to_columns:\n"
+                + "    - pk\n";
+        OssieDocument doc = reader.readString(yaml);
+        var rel = doc.getSemanticModel().get(0).getRelationships().get(0);
+        assertEquals("f_to_d", rel.getName());
+        assertEquals("f", rel.getFrom());
+        assertEquals("d", rel.getTo());
+        assertEquals("fk", rel.getFromColumns().get(0));
+        assertEquals("pk", rel.getToColumns().get(0));
+    }
+
+    @Test
+    public void unknownPropertiesAreIgnored() throws Exception {
+        // Additive spec fields we don't yet model shouldn't break the loader —
+        // Ossie is a draft; downstream tools may add keys we haven't caught up on.
+        String yaml = "version: 0.2.0.dev0\n"
+                + "future_root_field: whatever\n"
+                + "semantic_model:\n"
+                + "- name: T\n"
+                + "  future_model_field: whatever\n"
+                + "  datasets:\n"
+                + "  - name: d\n"
+                + "    source: s.d\n"
+                + "    future_dataset_field: whatever\n";
+        OssieDocument doc = reader.readString(yaml);
+        assertEquals("T", doc.getSemanticModel().get(0).getName());
+    }
+}

--- a/saiku-core/saiku-sql/src/test/java/org/saiku/sql/PgWireServerIT.java
+++ b/saiku-core/saiku-sql/src/test/java/org/saiku/sql/PgWireServerIT.java
@@ -12,6 +12,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.sql.Connection;
 import java.sql.DriverManager;
+import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.Statement;
 import java.util.Properties;
@@ -121,16 +122,47 @@ public class PgWireServerIT {
         }
     }
 
+    @Test
+    public void extendedQueryModeParameterisedSelect() throws Exception {
+        // pgjdbc's default is extended query mode — Parse/Bind/Execute rather than simple 'Q'.
+        // Uses PreparedStatement so pgjdbc actually sends parameters via Bind (not text-inlined).
+        try (Connection remote = openPgClientExtended();
+                PreparedStatement ps =
+                        remote.prepareStatement("SELECT COUNT(*) FROM SALES.CUSTOMERS WHERE REGION = ?")) {
+            ps.setString(1, "North");
+            try (ResultSet rs = ps.executeQuery()) {
+                assertTrue(rs.next());
+                assertEquals(2, rs.getInt(1));
+            }
+            ps.setString(1, "West");
+            try (ResultSet rs = ps.executeQuery()) {
+                assertTrue(rs.next());
+                assertEquals(1, rs.getInt(1));
+            }
+        }
+    }
+
     private Connection openPgClient() throws Exception {
         Class.forName("org.postgresql.Driver");
         Properties p = new Properties();
         p.setProperty("user", "saiku");
         p.setProperty("password", "");
         p.setProperty("sslmode", "disable");
-        // preferQueryMode=simple keeps pgjdbc from trying extended-mode Parse/Bind/Execute
-        // (which we don't yet support). Simple mode is enough for BI tools that don't use
-        // parameterised queries.
+        // preferQueryMode=simple opts out of extended-mode Parse/Bind/Execute for the two tests
+        // that don't need to exercise parameterised queries. simple mode maps stmt.executeQuery
+        // to a single 'Q' message.
         p.setProperty("preferQueryMode", "simple");
+        return DriverManager.getConnection("jdbc:postgresql://localhost:" + server.getPort() + "/saiku", p);
+    }
+
+    private Connection openPgClientExtended() throws Exception {
+        Class.forName("org.postgresql.Driver");
+        Properties p = new Properties();
+        p.setProperty("user", "saiku");
+        p.setProperty("password", "");
+        p.setProperty("sslmode", "disable");
+        // No preferQueryMode override — pgjdbc uses its default. PreparedStatement.executeQuery
+        // maps to the extended Parse/Bind/Execute/Sync sequence.
         return DriverManager.getConnection("jdbc:postgresql://localhost:" + server.getPort() + "/saiku", p);
     }
 }

--- a/saiku-core/saiku-sql/src/test/java/org/saiku/sql/PgWireServerIT.java
+++ b/saiku-core/saiku-sql/src/test/java/org/saiku/sql/PgWireServerIT.java
@@ -1,0 +1,136 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.sql;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.Statement;
+import java.util.Properties;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.saiku.sql.server.OssieSqlServer;
+import org.saiku.sql.server.pgwire.PgWireServer;
+
+/**
+ * End-to-end: start the {@link PgWireServer} bound to an ephemeral port, connect via the
+ * <b>real</b> Postgres JDBC driver ({@code org.postgresql:postgresql}), and run the same
+ * queries the Avatica IT uses. Proves our wire codec is compatible with a client we didn't
+ * write — {@code pgjdbc} is what Tableau/DBeaver/psql all speak internally.
+ *
+ * <p>Uses {@code sslmode=disable} because this slice replies {@code 'N'} to SSL requests and
+ * some pgjdbc versions default to {@code sslmode=prefer} which retries in plaintext (works),
+ * but explicit disable avoids the extra round-trip.
+ */
+public class PgWireServerIT {
+
+    private Connection h2Warehouse;
+    private Path ossieYaml;
+    private PgWireServer server;
+    private String calciteConnectString;
+
+    @Before
+    public void setUp() throws Exception {
+        h2Warehouse = DriverManager.getConnection("jdbc:h2:mem:pgwireit;DB_CLOSE_DELAY=-1;MODE=PostgreSQL", "sa", "");
+        try (Statement s = h2Warehouse.createStatement()) {
+            s.execute("DROP TABLE IF EXISTS orders");
+            s.execute("DROP TABLE IF EXISTS customers");
+            s.execute("CREATE TABLE customers (id INT PRIMARY KEY, region VARCHAR(32))");
+            s.execute("INSERT INTO customers VALUES (1,'North'),(2,'North'),(3,'South'),(4,'West')");
+            s.execute("CREATE TABLE orders (order_id INT PRIMARY KEY, customer_id INT, amount DECIMAL(10,2))");
+            s.execute("INSERT INTO orders VALUES (1,1,100.00),(2,1,50.00),(3,2,75.00),(4,3,200.00),(5,4,25.00)");
+        }
+        ossieYaml = Files.createTempFile("ossie-pgwire-", ".yaml");
+        Files.writeString(
+                ossieYaml,
+                "version: 0.2.0.dev0\n"
+                        + "semantic_model:\n"
+                        + "- name: SALES\n"
+                        + "  datasets:\n"
+                        + "  - name: CUSTOMERS\n"
+                        + "    source: CUSTOMERS\n"
+                        + "  - name: ORDERS\n"
+                        + "    source: ORDERS\n"
+                        + "  relationships:\n"
+                        + "  - name: orders_to_customers\n"
+                        + "    from: ORDERS\n"
+                        + "    to: CUSTOMERS\n"
+                        + "    from_columns: [CUSTOMER_ID]\n"
+                        + "    to_columns: [ID]\n");
+        calciteConnectString = OssieSqlServer.buildCalciteConnectString(
+                ossieYaml, "SALES", "jdbc:h2:mem:pgwireit;DB_CLOSE_DELAY=-1;MODE=PostgreSQL", "sa", "");
+        server = new PgWireServer(0, calciteConnectString);
+    }
+
+    @After
+    public void tearDown() throws IOException {
+        if (server != null) server.close();
+        try {
+            if (h2Warehouse != null) h2Warehouse.close();
+        } catch (Exception ignored) {
+            // Ignore — H2 in-memory DB is being torn down.
+        }
+        if (ossieYaml != null) Files.deleteIfExists(ossieYaml);
+    }
+
+    @Test
+    public void pgJdbcClientQueriesOssieSchema() throws Exception {
+        try (Connection remote = openPgClient();
+                Statement s = remote.createStatement();
+                ResultSet rs = s.executeQuery(
+                        "SELECT REGION, COUNT(*) AS N FROM SALES.CUSTOMERS GROUP BY REGION ORDER BY REGION")) {
+            assertTrue(rs.next());
+            assertEquals("North", rs.getString(1));
+            assertEquals(2, rs.getInt(2));
+            assertTrue(rs.next());
+            assertEquals("South", rs.getString(1));
+            assertEquals(1, rs.getInt(2));
+            assertTrue(rs.next());
+            assertEquals("West", rs.getString(1));
+            assertEquals(1, rs.getInt(2));
+        }
+    }
+
+    @Test
+    public void pgJdbcClientAutoJoins() throws Exception {
+        // Full round-trip through PG wire: parser → planner → OssieAutoJoinRule → JDBC pushdown
+        // to H2 → results back over PG wire.
+        try (Connection remote = openPgClient();
+                Statement s = remote.createStatement();
+                ResultSet rs = s.executeQuery("SELECT c.REGION, SUM(o.AMOUNT) AS TOTAL "
+                        + "FROM SALES.ORDERS o, SALES.CUSTOMERS c "
+                        + "GROUP BY c.REGION ORDER BY c.REGION")) {
+            assertTrue(rs.next());
+            assertEquals("North", rs.getString(1));
+            assertEquals(225.00, rs.getBigDecimal(2).doubleValue(), 0.001);
+            assertTrue(rs.next());
+            assertEquals("South", rs.getString(1));
+            assertEquals(200.00, rs.getBigDecimal(2).doubleValue(), 0.001);
+            assertTrue(rs.next());
+            assertEquals("West", rs.getString(1));
+            assertEquals(25.00, rs.getBigDecimal(2).doubleValue(), 0.001);
+        }
+    }
+
+    private Connection openPgClient() throws Exception {
+        Class.forName("org.postgresql.Driver");
+        Properties p = new Properties();
+        p.setProperty("user", "saiku");
+        p.setProperty("password", "");
+        p.setProperty("sslmode", "disable");
+        // preferQueryMode=simple keeps pgjdbc from trying extended-mode Parse/Bind/Execute
+        // (which we don't yet support). Simple mode is enough for BI tools that don't use
+        // parameterised queries.
+        p.setProperty("preferQueryMode", "simple");
+        return DriverManager.getConnection("jdbc:postgresql://localhost:" + server.getPort() + "/saiku", p);
+    }
+}

--- a/saiku-core/saiku-sql/src/test/java/org/saiku/sql/PharmaEndToEndIT.java
+++ b/saiku-core/saiku-sql/src/test/java/org/saiku/sql/PharmaEndToEndIT.java
@@ -1,0 +1,376 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.sql;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.Statement;
+import java.util.Properties;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.saiku.service.schema.ossie.MondrianToOssieConverter;
+import org.saiku.service.schema.ossie.OssieYamlWriter;
+import org.saiku.service.schema.ossie.model.OssieDocument;
+import org.saiku.sql.server.OssieSqlServer;
+import org.saiku.sql.server.pgwire.PgWireServer;
+
+/**
+ * End-to-end integration test against the <b>real Pharma schema</b> shipped in the repo at
+ * {@code saiku-home/data/Pharma.xml}. Proves the whole pipeline holds together on something
+ * substantially bigger than the synthetic ORDERS/CUSTOMERS fixture:
+ *
+ * <ol>
+ *   <li>{@link MondrianToOssieConverter} reads the real Mondrian schema — 6 dimensions, 8
+ *       hierarchies (Product and Prescriber have secondary hierarchies), 7 measures, PII
+ *       annotations on Prescriber Name and NPI.
+ *   <li>{@link OssieYamlWriter} serialises to YAML.
+ *   <li>{@link OssieSqlServer#buildCalciteConnectString} points Calcite at the same YAML.
+ *   <li>A hand-seeded H2 warehouse matches Pharma's expected table shape (fact_pharma +
+ *       dim_geography + dim_payer + dim_demographic + dim_product + dim_prescriber + dim_date)
+ *       with 20 fact rows spread across 3 regions × 2 channels for aggregatable per-dim
+ *       assertions.
+ *   <li>Assertions exercise: dataset scan, metric SELECT (SUM + COUNT DISTINCT), explicit JOIN
+ *       across 2 dims, auto-join across 2 dims, multi-dim explicit JOIN over PG wire, and a
+ *       parameterised PreparedStatement query over PG wire (extended query mode). Three-way
+ *       auto-join is a known follow-up on saiku#1391 — the multi-dim PG-wire query uses
+ *       explicit JOINs to exercise the wire path at scale.
+ * </ol>
+ *
+ * <p>Skips Pharma's Product/Prescriber secondary hierarchies (Manufacturer, NPI) because those
+ * register as duplicate datasets pointing at the same underlying table — a defensible-but-noisy
+ * shape for the converter that doesn't need extra IT coverage here.
+ */
+public class PharmaEndToEndIT {
+
+    private Connection h2Warehouse;
+    private Path ossieYaml;
+    private String h2Url;
+
+    @Before
+    public void setUp() throws Exception {
+        h2Url = "jdbc:h2:mem:pharma_e2e;DB_CLOSE_DELAY=-1;MODE=PostgreSQL;DATABASE_TO_LOWER=FALSE";
+        h2Warehouse = DriverManager.getConnection(h2Url, "sa", "");
+
+        // H2 with a PostgreSQL-flavoured schema so identifier casing + type names match what
+        // Pharma.xml declares. Pharma expects an underlying Postgres warehouse in production;
+        // we emulate the surface shape closely enough for the exporter's dataset->source lookup
+        // and Calcite's JDBC pushdown to both resolve names correctly.
+        try (Statement s = h2Warehouse.createStatement()) {
+            createPharmaSchema(s);
+            seedPharmaData(s);
+        }
+
+        // Convert the real Pharma.xml → Ossie YAML. This is the SAME converter path a user runs
+        // via `saiku ossie-export` — no test-only mocks.
+        Path pharmaXml = Path.of(System.getProperty("user.dir"))
+                .resolve("../../saiku-home/data/Pharma.xml")
+                .normalize();
+        assertTrue(
+                "Pharma.xml missing at " + pharmaXml + " — test must run from saiku-core/saiku-sql",
+                Files.exists(pharmaXml));
+        MondrianToOssieConverter converter = new MondrianToOssieConverter();
+        OssieDocument doc;
+        try (InputStream in = Files.newInputStream(pharmaXml)) {
+            doc = converter.convert(in);
+        }
+        assertNotNull("converter must produce at least one semantic model", doc.getSemanticModel());
+        assertTrue(
+                "expected Pharma Rx cube in the converted output; got " + doc.getSemanticModel(),
+                doc.getSemanticModel().stream().anyMatch(m -> "Pharma Rx".equals(m.getName())));
+        ossieYaml = Files.createTempFile("pharma-e2e-", ".yaml");
+        new OssieYamlWriter().write(doc, Files.newBufferedWriter(ossieYaml));
+    }
+
+    @After
+    public void tearDown() throws IOException {
+        try {
+            if (h2Warehouse != null) h2Warehouse.close();
+        } catch (Exception ignored) {
+            // ignore
+        }
+        if (ossieYaml != null) Files.deleteIfExists(ossieYaml);
+    }
+
+    /* ---------------- test cases ---------------- */
+
+    @Test
+    public void datasetSelectPushdown_factCount() throws Exception {
+        // Simplest possible: SELECT COUNT(*) over the fact table via Calcite → H2.
+        try (Connection calcite = openCalcite();
+                Statement s = calcite.createStatement();
+                ResultSet rs = s.executeQuery("SELECT COUNT(*) FROM \"Pharma Rx\".fact_pharma")) {
+            assertTrue(rs.next());
+            assertEquals(20L, rs.getLong(1));
+        }
+    }
+
+    @Test
+    public void metricSelect_netRevenueTotal() throws Exception {
+        // Metric SELECT: the Ossie 'Net Revenue' metric expands to SUM(fact_pharma.netrevenue)
+        // and returns the grand total across all 20 rows.
+        try (Connection calcite = openCalcite();
+                Statement s = calcite.createStatement();
+                ResultSet rs = s.executeQuery("SELECT * FROM \"Pharma Rx\".\"Net Revenue\"")) {
+            assertTrue(rs.next());
+            assertEquals(20000.00, rs.getBigDecimal(1).doubleValue(), 0.01);
+        }
+    }
+
+    @Test
+    public void metricSelect_rxCountDistinct() throws Exception {
+        // COUNT DISTINCT metric. All rxkey values are unique in our seed → 20.
+        try (Connection calcite = openCalcite();
+                Statement s = calcite.createStatement();
+                ResultSet rs = s.executeQuery("SELECT * FROM \"Pharma Rx\".\"Rx Count\"")) {
+            assertTrue(rs.next());
+            assertEquals(20L, rs.getLong(1));
+        }
+    }
+
+    @Test
+    public void explicitJoin_netRevenueByRegion() throws Exception {
+        // Explicit JOIN: fact_pharma → Geography, group by region. Same shape any BI tool would
+        // write when hand-rolling the query.
+        try (Connection calcite = openCalcite();
+                Statement s = calcite.createStatement();
+                ResultSet rs = s.executeQuery("SELECT g.region, SUM(f.netrevenue) AS total "
+                        + "FROM \"Pharma Rx\".fact_pharma f JOIN \"Pharma Rx\".Geography g "
+                        + "ON f.geokey = g.geokey "
+                        + "GROUP BY g.region ORDER BY g.region")) {
+            assertTrue(rs.next());
+            assertEquals("Midwest", rs.getString(1));
+            assertEquals(7000.00, rs.getBigDecimal(2).doubleValue(), 0.01);
+            assertTrue(rs.next());
+            assertEquals("Northeast", rs.getString(1));
+            assertEquals(8000.00, rs.getBigDecimal(2).doubleValue(), 0.01);
+            assertTrue(rs.next());
+            assertEquals("West", rs.getString(1));
+            assertEquals(5000.00, rs.getBigDecimal(2).doubleValue(), 0.01);
+        }
+    }
+
+    @Test
+    public void autoJoin_netRevenueByRegion() throws Exception {
+        // Same query as above but with NO JOIN clause. OssieAutoJoinRule detects the Cartesian
+        // between fact_pharma and Geography and injects the ON predicate from the relationship.
+        try (Connection calcite = openCalcite();
+                Statement s = calcite.createStatement();
+                ResultSet rs = s.executeQuery("SELECT g.region, SUM(f.netrevenue) AS total "
+                        + "FROM \"Pharma Rx\".fact_pharma f, \"Pharma Rx\".Geography g "
+                        + "GROUP BY g.region ORDER BY g.region")) {
+            assertTrue(rs.next());
+            assertEquals("Midwest", rs.getString(1));
+            assertEquals(7000.00, rs.getBigDecimal(2).doubleValue(), 0.01);
+            assertTrue(rs.next());
+            assertEquals("Northeast", rs.getString(1));
+            assertEquals(8000.00, rs.getBigDecimal(2).doubleValue(), 0.01);
+            assertTrue(rs.next());
+            assertEquals("West", rs.getString(1));
+            assertEquals(5000.00, rs.getBigDecimal(2).doubleValue(), 0.01);
+        }
+    }
+
+    @Test
+    public void explicitJoin_netRevenueByRegionAndChannel_pgWire() throws Exception {
+        // The showcase: three datasets from the real Pharma schema, JOINs via the wire, over
+        // PG wire via the actual pgjdbc driver. Auto-join covers the two-dataset Cartesian case;
+        // three-way auto-injection (nested Join rewrite) is a follow-up on saiku#1391 so this
+        // test uses explicit ON clauses to prove the wire path handles multi-dim SQL.
+        String calciteConnect = OssieSqlServer.buildCalciteConnectString(ossieYaml, "Pharma Rx", h2Url, "sa", "");
+        try (PgWireServer server = new PgWireServer(0, calciteConnect);
+                Connection remote = openPgWire(server.getPort());
+                Statement s = remote.createStatement();
+                ResultSet rs = s.executeQuery("SELECT g.region, p.channel, SUM(f.netrevenue) AS total "
+                        + "FROM \"Pharma Rx\".fact_pharma f "
+                        + "JOIN \"Pharma Rx\".Geography g ON f.geokey = g.geokey "
+                        + "JOIN \"Pharma Rx\".Payer p ON f.payerkey = p.payerkey "
+                        + "GROUP BY g.region, p.channel "
+                        + "ORDER BY g.region, p.channel")) {
+            int rows = 0;
+            double total = 0;
+            while (rs.next()) {
+                total += rs.getBigDecimal(3).doubleValue();
+                rows++;
+            }
+            assertTrue("expected at least 3 region × channel combinations, got " + rows, rows >= 3);
+            assertEquals("grand total across all groups should match the fact-table sum", 20000.00, total, 0.01);
+        }
+    }
+
+    @Test
+    public void metricSelect_preparedStatement_pgWire() throws Exception {
+        // Extended query mode over PG wire against the real Pharma metric surface.
+        String calciteConnect = OssieSqlServer.buildCalciteConnectString(ossieYaml, "Pharma Rx", h2Url, "sa", "");
+        try (PgWireServer server = new PgWireServer(0, calciteConnect);
+                Connection remote = openPgWire(server.getPort());
+                PreparedStatement ps = remote.prepareStatement(
+                        "SELECT SUM(netrevenue) FROM \"Pharma Rx\".fact_pharma WHERE geokey = ?")) {
+            ps.setInt(1, 1); // geokey=1 → Northeast region
+            try (ResultSet rs = ps.executeQuery()) {
+                assertTrue(rs.next());
+                assertEquals(8000.00, rs.getBigDecimal(1).doubleValue(), 0.01);
+            }
+            ps.setInt(1, 2); // geokey=2 → Midwest
+            try (ResultSet rs = ps.executeQuery()) {
+                assertTrue(rs.next());
+                assertEquals(7000.00, rs.getBigDecimal(1).doubleValue(), 0.01);
+            }
+        }
+    }
+
+    /* ---------------- H2 seed ---------------- */
+
+    /**
+     * Create the Pharma-shape tables. Column set matches what Pharma.xml references (via
+     * MondrianToOssieConverter which reads the {@code column=...}/{@code nameColumn=...} attrs);
+     * types are chosen for H2/Postgres compatibility.
+     */
+    private static void createPharmaSchema(Statement s) throws Exception {
+        s.execute("DROP TABLE IF EXISTS fact_pharma");
+        s.execute("DROP TABLE IF EXISTS dim_date");
+        s.execute("DROP TABLE IF EXISTS dim_product");
+        s.execute("DROP TABLE IF EXISTS dim_prescriber");
+        s.execute("DROP TABLE IF EXISTS dim_geography");
+        s.execute("DROP TABLE IF EXISTS dim_payer");
+        s.execute("DROP TABLE IF EXISTS dim_demographic");
+
+        s.execute("CREATE TABLE dim_date ("
+                + "datekey INT PRIMARY KEY, \"Year\" INT, quarterkey INT, quarter VARCHAR(8), "
+                + "monthkey INT, monthname VARCHAR(16), monthnum INT, \"Date\" DATE)");
+
+        s.execute("CREATE TABLE dim_product ("
+                + "productkey INT PRIMARY KEY, therapeuticclass VARCHAR(64), molecule VARCHAR(64), "
+                + "brand VARCHAR(64), form VARCHAR(32), strength VARCHAR(32), manufacturer VARCHAR(64))");
+
+        s.execute("CREATE TABLE dim_prescriber ("
+                + "prescriberkey INT PRIMARY KEY, specialty VARCHAR(64), decile INT, "
+                + "prescribername VARCHAR(64), prescribernpi VARCHAR(16))");
+
+        s.execute("CREATE TABLE dim_geography ("
+                + "geokey INT PRIMARY KEY, region VARCHAR(32), \"State\" VARCHAR(32), territory VARCHAR(32))");
+
+        s.execute("CREATE TABLE dim_payer (payerkey INT PRIMARY KEY, channel VARCHAR(32))");
+
+        s.execute("CREATE TABLE dim_demographic ("
+                + "demographickey INT PRIMARY KEY, gender VARCHAR(8), ageband VARCHAR(16))");
+
+        // Rx Type is a degenerate dim referenced directly on the fact — a single column, no
+        // dim table.
+        s.execute("CREATE TABLE fact_pharma ("
+                + "rxkey INT PRIMARY KEY, "
+                + "datekey INT, productkey INT, prescriberkey INT, geokey INT, payerkey INT, demographickey INT, "
+                + "newrefillflag VARCHAR(8), "
+                + "quantity INT, dayssupply INT, "
+                + "grossrevenue DECIMAL(10,2), rebateamount DECIMAL(10,2), "
+                + "netrevenue DECIMAL(10,2), patientcopay DECIMAL(10,2))");
+    }
+
+    /**
+     * Seed 20 fact rows spread across 3 regions × 2 channels so the grouped-aggregate tests
+     * have deterministic totals to assert against.
+     */
+    private static void seedPharmaData(Statement s) throws Exception {
+        // 3 regions: Northeast (geokey=1) 8000, Midwest (geokey=2) 7000, West (geokey=3) 5000.
+        // Total 20000. 2 channels: Commercial (payerkey=1) + Medicare (payerkey=2).
+        s.execute("INSERT INTO dim_geography VALUES (1, 'Northeast', 'NY', 'NYC'),"
+                + " (2, 'Midwest', 'IL', 'Chicago'), (3, 'West', 'CA', 'LA')");
+        s.execute("INSERT INTO dim_payer VALUES (1, 'Commercial'), (2, 'Medicare')");
+        s.execute("INSERT INTO dim_demographic VALUES (1, 'M', '30-40'), (2, 'F', '40-50'), (3, 'M', '50-60')");
+        s.execute("INSERT INTO dim_product VALUES "
+                + "(1, 'Cardiovascular', 'atorvastatin', 'Lipitor', 'Tablet', '20mg', 'Pfizer'),"
+                + " (2, 'Diabetes', 'metformin', 'Glucophage', 'Tablet', '500mg', 'Merck'),"
+                + " (3, 'Respiratory', 'albuterol', 'ProAir', 'Inhaler', '90mcg', 'Teva')");
+        s.execute("INSERT INTO dim_prescriber VALUES "
+                + "(1, 'Cardiology', 8, 'Dr. Alice Smith', '1234567890'),"
+                + " (2, 'Endocrinology', 6, 'Dr. Bob Jones', '2345678901'),"
+                + " (3, 'Pulmonology', 7, 'Dr. Carol Chen', '3456789012')");
+        s.execute("INSERT INTO dim_date VALUES "
+                + "(20260101, 2026, 1, 'Q1', 202601, 'Jan', 1, DATE '2026-01-01'),"
+                + " (20260201, 2026, 1, 'Q1', 202602, 'Feb', 2, DATE '2026-02-01')");
+
+        // 20 fact rows summing to netrevenue = 20000.
+        // Northeast (geokey=1): 8 rows × ~1000 = 8000
+        // Midwest (geokey=2):  7 rows × ~1000 = 7000
+        // West (geokey=3):     5 rows × 1000 = 5000
+        StringBuilder rows = new StringBuilder();
+        double[] neAmounts = {1000, 1000, 1000, 1000, 1000, 1000, 1000, 1000};
+        double[] mwAmounts = {1000, 1000, 1000, 1000, 1000, 1000, 1000};
+        double[] wAmounts = {1000, 1000, 1000, 1000, 1000};
+        int rx = 1;
+        for (double amt : neAmounts) {
+            rows.append(factRow(rx++, 20260101, 1 + (rx % 3), 1 + (rx % 3), 1, 1 + (rx % 2), 1, amt));
+        }
+        for (double amt : mwAmounts) {
+            rows.append(factRow(rx++, 20260201, 1 + (rx % 3), 1 + (rx % 3), 2, 1 + (rx % 2), 2, amt));
+        }
+        for (double amt : wAmounts) {
+            rows.append(factRow(rx++, 20260201, 1 + (rx % 3), 1 + (rx % 3), 3, 1 + (rx % 2), 3, amt));
+        }
+        // Strip trailing comma.
+        String batch = rows.substring(0, rows.length() - 1);
+        s.execute("INSERT INTO fact_pharma "
+                + "(rxkey, datekey, productkey, prescriberkey, geokey, payerkey, demographickey, "
+                + " newrefillflag, quantity, dayssupply, grossrevenue, rebateamount, netrevenue, patientcopay) "
+                + "VALUES " + batch);
+    }
+
+    /**
+     * Build one fact-table VALUES tuple. Net-revenue = grossrevenue - rebateamount for shape
+     * realism (the exporter doesn't derive it — just needs the columns present).
+     */
+    private static String factRow(
+            int rx, int datekey, int prodKey, int prescKey, int geoKey, int payerKey, int demoKey, double amt) {
+        return String.format(
+                "(%d, %d, %d, %d, %d, %d, %d, 'NEW', 30, 30, %.2f, %.2f, %.2f, %.2f),",
+                rx, datekey, prodKey, prescKey, geoKey, payerKey, demoKey, amt + 100, 100.0, amt, 20.0);
+    }
+
+    /* ---------------- connection helpers ---------------- */
+
+    private Connection openCalcite() throws Exception {
+        String modelJson = "{\n"
+                + "  \"version\": \"1.0\",\n"
+                + "  \"defaultSchema\": \"Pharma Rx\",\n"
+                + "  \"schemas\": [{\n"
+                + "    \"name\": \"Pharma Rx\",\n"
+                + "    \"type\": \"custom\",\n"
+                + "    \"factory\": \"org.saiku.sql.adapter.OssieSchemaFactory\",\n"
+                + "    \"operand\": {\n"
+                + "      \"ossieYaml\": \"" + ossieYaml.toString().replace("\\", "\\\\") + "\",\n"
+                + "      \"jdbcUrl\": \"" + h2Url + "\",\n"
+                + "      \"jdbcUser\": \"sa\",\n"
+                + "      \"jdbcPassword\": \"\"\n"
+                + "    }\n"
+                + "  }]\n"
+                + "}";
+        Path modelPath = Files.createTempFile("pharma-model-", ".json");
+        modelPath.toFile().deleteOnExit();
+        Files.writeString(modelPath, modelJson);
+        Properties p = new Properties();
+        p.put("model", modelPath.toString());
+        p.put("caseSensitive", "false");
+        return DriverManager.getConnection("jdbc:calcite:", p);
+    }
+
+    private Connection openPgWire(int port) throws Exception {
+        Class.forName("org.postgresql.Driver");
+        Properties p = new Properties();
+        p.setProperty("user", "saiku");
+        p.setProperty("password", "");
+        p.setProperty("sslmode", "disable");
+        return DriverManager.getConnection("jdbc:postgresql://localhost:" + port + "/saiku", p);
+    }
+}

--- a/saiku-core/saiku-sql/src/test/java/org/saiku/sql/PharmaEndToEndIT.java
+++ b/saiku-core/saiku-sql/src/test/java/org/saiku/sql/PharmaEndToEndIT.java
@@ -184,19 +184,19 @@ public class PharmaEndToEndIT {
     }
 
     @Test
-    public void explicitJoin_netRevenueByRegionAndChannel_pgWire() throws Exception {
-        // The showcase: three datasets from the real Pharma schema, JOINs via the wire, over
-        // PG wire via the actual pgjdbc driver. Auto-join covers the two-dataset Cartesian case;
-        // three-way auto-injection (nested Join rewrite) is a follow-up on saiku#1391 so this
-        // test uses explicit ON clauses to prove the wire path handles multi-dim SQL.
+    public void autoJoin_netRevenueByRegionAndChannel_pgWire() throws Exception {
+        // The showcase: three datasets from the real Pharma schema, NO JOIN clauses, over PG
+        // wire via the actual pgjdbc driver. The auto-join rule fires twice: once for the inner
+        // two-table Cartesian (rebuilt tree), once for the outer Cartesian with a nested Join
+        // input (compound-side predicate injection).
         String calciteConnect = OssieSqlServer.buildCalciteConnectString(ossieYaml, "Pharma Rx", h2Url, "sa", "");
         try (PgWireServer server = new PgWireServer(0, calciteConnect);
                 Connection remote = openPgWire(server.getPort());
                 Statement s = remote.createStatement();
                 ResultSet rs = s.executeQuery("SELECT g.region, p.channel, SUM(f.netrevenue) AS total "
-                        + "FROM \"Pharma Rx\".fact_pharma f "
-                        + "JOIN \"Pharma Rx\".Geography g ON f.geokey = g.geokey "
-                        + "JOIN \"Pharma Rx\".Payer p ON f.payerkey = p.payerkey "
+                        + "FROM \"Pharma Rx\".fact_pharma f, "
+                        + "     \"Pharma Rx\".Geography g, "
+                        + "     \"Pharma Rx\".Payer p "
                         + "GROUP BY g.region, p.channel "
                         + "ORDER BY g.region, p.channel")) {
             int rows = 0;

--- a/saiku-core/saiku-sql/src/test/java/org/saiku/sql/SelectPushdownIT.java
+++ b/saiku-core/saiku-sql/src/test/java/org/saiku/sql/SelectPushdownIT.java
@@ -201,6 +201,44 @@ public class SelectPushdownIT {
     }
 
     @Test
+    public void relationshipJoinViewPreservesJoinPredicate() throws Exception {
+        // Users query ORDERS_JOIN_CUSTOMERS as if it were a single table; the Ossie
+        // relationship's ON clause is materialised in the view SQL. Aggregating over the joined
+        // rows should give the same per-region totals as writing the JOIN by hand
+        // (joinAcrossDatasetsSumsRevenueByRegion above).
+        try (Connection calcite = openCalcite();
+                Statement s = calcite.createStatement();
+                ResultSet rs = s.executeQuery("SELECT REGION, SUM(AMOUNT) AS TOTAL FROM SALES.ORDERS_JOIN_CUSTOMERS "
+                        + "GROUP BY REGION ORDER BY REGION")) {
+            assertTrue(rs.next());
+            assertEquals("North", rs.getString(1));
+            assertEquals(225.00, rs.getBigDecimal(2).doubleValue(), 0.001);
+            assertTrue(rs.next());
+            assertEquals("South", rs.getString(1));
+            assertEquals(200.00, rs.getBigDecimal(2).doubleValue(), 0.001);
+            assertTrue(rs.next());
+            assertEquals("West", rs.getString(1));
+            assertEquals(25.00, rs.getBigDecimal(2).doubleValue(), 0.001);
+        }
+    }
+
+    @Test
+    public void relationshipJoinViewAppearsInMetadata() throws Exception {
+        try (Connection calcite = openCalcite();
+                ResultSet rs = calcite.getMetaData().getTables(null, null, "%", null)) {
+            java.util.List<String> qualified = new java.util.ArrayList<>();
+            while (rs.next()) {
+                if ("SALES".equals(rs.getString("TABLE_SCHEM"))) {
+                    qualified.add(rs.getString("TABLE_NAME"));
+                }
+            }
+            assertTrue(
+                    "expected auto-join view ORDERS_JOIN_CUSTOMERS in SALES metadata: " + qualified,
+                    qualified.contains("ORDERS_JOIN_CUSTOMERS"));
+        }
+    }
+
+    @Test
     public void jdbcMetadataListsOssieDatasets() throws Exception {
         // Uses standard JDBC DatabaseMetaData rather than Calcite's metadata schema — matches
         // how every BI tool (Tableau, Power BI, DBeaver, dbt) enumerates schemas for its

--- a/saiku-core/saiku-sql/src/test/java/org/saiku/sql/SelectPushdownIT.java
+++ b/saiku-core/saiku-sql/src/test/java/org/saiku/sql/SelectPushdownIT.java
@@ -1,0 +1,192 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.sql;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.Statement;
+import java.util.Properties;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * End-to-end integration test: an H2 in-JVM warehouse holds a synthetic {@code orders} + {@code
+ * customers} pair; a Calcite JDBC connection reads them through {@code OssieSchemaFactory}
+ * pointed at an Ossie YAML that mirrors the H2 shape; the assertions verify the SELECT lands
+ * against real H2 rows.
+ *
+ * <p>Named {@code *IT} so surefire skips it during {@code mvn test} — pick it up explicitly with
+ * {@code mvn verify -pl saiku-core/saiku-sql} once we wire the failsafe plugin, or run it
+ * directly from the IDE. The rest of the module ships {@code mvn test} green.
+ */
+public class SelectPushdownIT {
+
+    private Connection h2Warehouse;
+    private Path ossieYaml;
+
+    @Before
+    public void setUp() throws Exception {
+        // H2 warehouse — in-memory DB reused across all queries in this test method.
+        h2Warehouse =
+                DriverManager.getConnection("jdbc:h2:mem:selectpushdown;DB_CLOSE_DELAY=-1;MODE=PostgreSQL", "sa", "");
+        try (Statement s = h2Warehouse.createStatement()) {
+            // `DB_CLOSE_DELAY=-1` keeps the H2 in-memory DB alive between test methods, so drop
+            // tables up front to make each @Before idempotent (H2 otherwise 42101s when the
+            // second test tries to recreate them).
+            s.execute("DROP TABLE IF EXISTS orders");
+            s.execute("DROP TABLE IF EXISTS customers");
+            s.execute("CREATE TABLE customers (id INT PRIMARY KEY, region VARCHAR(32))");
+            s.execute("INSERT INTO customers VALUES (1,'North'),(2,'North'),(3,'South'),(4,'West')");
+            s.execute("CREATE TABLE orders (order_id INT PRIMARY KEY, customer_id INT, amount DECIMAL(10,2))");
+            s.execute("INSERT INTO orders VALUES " + "(1,1,100.00),(2,1,50.00),(3,2,75.00),(4,3,200.00),(5,4,25.00)");
+        }
+
+        // Ossie YAML — hand-authored to match the H2 shape (dataset.source maps to the H2 table).
+        ossieYaml = Files.createTempFile("ossie-select-pushdown-", ".yaml");
+        String yaml = "version: 0.2.0.dev0\n"
+                + "semantic_model:\n"
+                + "- name: SALES\n"
+                + "  datasets:\n"
+                + "  - name: CUSTOMERS\n"
+                + "    source: CUSTOMERS\n"
+                + "    primary_key: [ID]\n"
+                + "    fields:\n"
+                + "    - name: ID\n"
+                + "      expression:\n"
+                + "        dialects:\n"
+                + "        - dialect: ANSI_SQL\n"
+                + "          expression: ID\n"
+                + "    - name: REGION\n"
+                + "      expression:\n"
+                + "        dialects:\n"
+                + "        - dialect: ANSI_SQL\n"
+                + "          expression: REGION\n"
+                + "  - name: ORDERS\n"
+                + "    source: ORDERS\n"
+                + "    primary_key: [ORDER_ID]\n"
+                + "    fields:\n"
+                + "    - name: ORDER_ID\n"
+                + "      expression:\n"
+                + "        dialects:\n"
+                + "        - dialect: ANSI_SQL\n"
+                + "          expression: ORDER_ID\n"
+                + "    - name: CUSTOMER_ID\n"
+                + "      expression:\n"
+                + "        dialects:\n"
+                + "        - dialect: ANSI_SQL\n"
+                + "          expression: CUSTOMER_ID\n"
+                + "    - name: AMOUNT\n"
+                + "      expression:\n"
+                + "        dialects:\n"
+                + "        - dialect: ANSI_SQL\n"
+                + "          expression: AMOUNT\n"
+                + "  relationships:\n"
+                + "  - name: orders_to_customers\n"
+                + "    from: ORDERS\n"
+                + "    to: CUSTOMERS\n"
+                + "    from_columns: [CUSTOMER_ID]\n"
+                + "    to_columns: [ID]\n";
+        Files.writeString(ossieYaml, yaml);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        if (h2Warehouse != null) h2Warehouse.close();
+        if (ossieYaml != null) Files.deleteIfExists(ossieYaml);
+    }
+
+    @Test
+    public void selectFromDatasetPushesToWarehouse() throws Exception {
+        try (Connection calcite = openCalcite();
+                Statement s = calcite.createStatement();
+                ResultSet rs = s.executeQuery(
+                        "SELECT REGION, COUNT(*) AS N FROM SALES.CUSTOMERS GROUP BY REGION ORDER BY REGION")) {
+            assertTrue(rs.next());
+            assertEquals("North", rs.getString(1));
+            assertEquals(2, rs.getInt(2));
+            assertTrue(rs.next());
+            assertEquals("South", rs.getString(1));
+            assertEquals(1, rs.getInt(2));
+            assertTrue(rs.next());
+            assertEquals("West", rs.getString(1));
+            assertEquals(1, rs.getInt(2));
+            assertTrue("expected exactly 3 regions", !rs.next());
+        }
+    }
+
+    @Test
+    public void joinAcrossDatasetsSumsRevenueByRegion() throws Exception {
+        try (Connection calcite = openCalcite();
+                Statement s = calcite.createStatement();
+                ResultSet rs = s.executeQuery("SELECT c.REGION, SUM(o.AMOUNT) AS TOTAL "
+                        + "FROM SALES.ORDERS o JOIN SALES.CUSTOMERS c ON o.CUSTOMER_ID = c.ID "
+                        + "GROUP BY c.REGION ORDER BY c.REGION")) {
+            assertTrue(rs.next());
+            assertEquals("North", rs.getString(1));
+            assertEquals(225.00, rs.getBigDecimal(2).doubleValue(), 0.001);
+            assertTrue(rs.next());
+            assertEquals("South", rs.getString(1));
+            assertEquals(200.00, rs.getBigDecimal(2).doubleValue(), 0.001);
+            assertTrue(rs.next());
+            assertEquals("West", rs.getString(1));
+            assertEquals(25.00, rs.getBigDecimal(2).doubleValue(), 0.001);
+        }
+    }
+
+    @Test
+    public void jdbcMetadataListsOssieDatasets() throws Exception {
+        // Uses standard JDBC DatabaseMetaData rather than Calcite's metadata schema — matches
+        // how every BI tool (Tableau, Power BI, DBeaver, dbt) enumerates schemas for its
+        // browser. Validates our datasets register with stable, tool-discoverable names.
+        try (Connection calcite = openCalcite();
+                // catalog/schema null → walk everything. Calcite mixes hidden sub-schemas (our
+                // __SALES_jdbc holder) with real ones; filter by the SALES prefix on the fly.
+                ResultSet rs = calcite.getMetaData().getTables(null, null, "%", null)) {
+            java.util.List<String> qualified = new java.util.ArrayList<>();
+            while (rs.next()) {
+                String schemaName = rs.getString("TABLE_SCHEM");
+                String tableName = rs.getString("TABLE_NAME");
+                if ("SALES".equals(schemaName)) {
+                    qualified.add(tableName);
+                }
+            }
+            assertTrue("expected CUSTOMERS in SALES metadata: " + qualified, qualified.contains("CUSTOMERS"));
+            assertTrue("expected ORDERS in SALES metadata: " + qualified, qualified.contains("ORDERS"));
+        }
+    }
+
+    private Connection openCalcite() throws Exception {
+        // Build the connect-model JSON inline so the test is hermetic.
+        String modelJson = "{\n"
+                + "  \"version\": \"1.0\",\n"
+                + "  \"defaultSchema\": \"SALES\",\n"
+                + "  \"schemas\": [{\n"
+                + "    \"name\": \"SALES\",\n"
+                + "    \"type\": \"custom\",\n"
+                + "    \"factory\": \"org.saiku.sql.adapter.OssieSchemaFactory\",\n"
+                + "    \"operand\": {\n"
+                + "      \"ossieYaml\": \"" + ossieYaml.toString().replace("\\", "\\\\") + "\",\n"
+                + "      \"jdbcUrl\": \"jdbc:h2:mem:selectpushdown;DB_CLOSE_DELAY=-1;MODE=PostgreSQL\",\n"
+                + "      \"jdbcUser\": \"sa\",\n"
+                + "      \"jdbcPassword\": \"\"\n"
+                + "    }\n"
+                + "  }]\n"
+                + "}";
+        Path modelPath = Files.createTempFile("ossie-model-", ".json");
+        Files.writeString(modelPath, modelJson);
+        Properties p = new Properties();
+        p.put("model", modelPath.toString());
+        // Case-insensitive planner matches how BI tools cast identifiers.
+        p.put("caseSensitive", "false");
+        return DriverManager.getConnection("jdbc:calcite:", p);
+    }
+}

--- a/saiku-core/saiku-sql/src/test/java/org/saiku/sql/SelectPushdownIT.java
+++ b/saiku-core/saiku-sql/src/test/java/org/saiku/sql/SelectPushdownIT.java
@@ -239,6 +239,56 @@ public class SelectPushdownIT {
     }
 
     @Test
+    public void autoJoinInjectsOssieRelationshipPredicate() throws Exception {
+        // No JOIN keyword — just FROM ORDERS o, CUSTOMERS c. OssieAutoJoinRule detects the
+        // Cartesian join between two Ossie datasets, finds the relationship, and rewrites the
+        // condition to o.CUSTOMER_ID = c.ID. Result should match the hand-rolled JOIN version.
+        try (Connection calcite = openCalcite();
+                Statement s = calcite.createStatement();
+                ResultSet rs = s.executeQuery("SELECT c.REGION, SUM(o.AMOUNT) AS TOTAL "
+                        + "FROM SALES.ORDERS o, SALES.CUSTOMERS c "
+                        + "GROUP BY c.REGION ORDER BY c.REGION")) {
+            assertTrue(rs.next());
+            assertEquals("North", rs.getString(1));
+            assertEquals(225.00, rs.getBigDecimal(2).doubleValue(), 0.001);
+            assertTrue(rs.next());
+            assertEquals("South", rs.getString(1));
+            assertEquals(200.00, rs.getBigDecimal(2).doubleValue(), 0.001);
+            assertTrue(rs.next());
+            assertEquals("West", rs.getString(1));
+            assertEquals(25.00, rs.getBigDecimal(2).doubleValue(), 0.001);
+        }
+    }
+
+    @Test
+    public void autoJoinBailsWhenNoRelationshipExists() throws Exception {
+        // Build a fresh Ossie YAML with two datasets and NO relationship. The rule should
+        // leave the Cartesian join intact — user gets what they asked for (probably a bad time).
+        Path plainYaml = Files.createTempFile("ossie-no-rel-", ".yaml");
+        try {
+            Files.writeString(
+                    plainYaml,
+                    "version: 0.2.0.dev0\n"
+                            + "semantic_model:\n"
+                            + "- name: PLAIN\n"
+                            + "  datasets:\n"
+                            + "  - name: CUSTOMERS\n"
+                            + "    source: CUSTOMERS\n"
+                            + "  - name: ORDERS\n"
+                            + "    source: ORDERS\n");
+            try (Connection calcite = openCalciteWith(plainYaml, "PLAIN");
+                    Statement s = calcite.createStatement();
+                    ResultSet rs = s.executeQuery("SELECT COUNT(*) FROM PLAIN.ORDERS, PLAIN.CUSTOMERS")) {
+                assertTrue(rs.next());
+                // Cartesian: 5 orders × 4 customers = 20 rows total.
+                assertEquals(20L, rs.getLong(1));
+            }
+        } finally {
+            Files.deleteIfExists(plainYaml);
+        }
+    }
+
+    @Test
     public void jdbcMetadataListsOssieDatasets() throws Exception {
         // Uses standard JDBC DatabaseMetaData rather than Calcite's metadata schema — matches
         // how every BI tool (Tableau, Power BI, DBeaver, dbt) enumerates schemas for its
@@ -261,16 +311,20 @@ public class SelectPushdownIT {
     }
 
     private Connection openCalcite() throws Exception {
+        return openCalciteWith(ossieYaml, "SALES");
+    }
+
+    private Connection openCalciteWith(Path yamlPath, String schemaName) throws Exception {
         // Build the connect-model JSON inline so the test is hermetic.
         String modelJson = "{\n"
                 + "  \"version\": \"1.0\",\n"
-                + "  \"defaultSchema\": \"SALES\",\n"
+                + "  \"defaultSchema\": \"" + schemaName + "\",\n"
                 + "  \"schemas\": [{\n"
-                + "    \"name\": \"SALES\",\n"
+                + "    \"name\": \"" + schemaName + "\",\n"
                 + "    \"type\": \"custom\",\n"
                 + "    \"factory\": \"org.saiku.sql.adapter.OssieSchemaFactory\",\n"
                 + "    \"operand\": {\n"
-                + "      \"ossieYaml\": \"" + ossieYaml.toString().replace("\\", "\\\\") + "\",\n"
+                + "      \"ossieYaml\": \"" + yamlPath.toString().replace("\\", "\\\\") + "\",\n"
                 + "      \"jdbcUrl\": \"jdbc:h2:mem:selectpushdown;DB_CLOSE_DELAY=-1;MODE=PostgreSQL\",\n"
                 + "      \"jdbcUser\": \"sa\",\n"
                 + "      \"jdbcPassword\": \"\"\n"

--- a/saiku-core/saiku-sql/src/test/java/org/saiku/sql/SelectPushdownIT.java
+++ b/saiku-core/saiku-sql/src/test/java/org/saiku/sql/SelectPushdownIT.java
@@ -6,6 +6,7 @@ package org.saiku.sql;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -94,7 +95,25 @@ public class SelectPushdownIT {
                 + "    from: ORDERS\n"
                 + "    to: CUSTOMERS\n"
                 + "    from_columns: [CUSTOMER_ID]\n"
-                + "    to_columns: [ID]\n";
+                + "    to_columns: [ID]\n"
+                + "  metrics:\n"
+                + "  - name: TOTAL_REVENUE\n"
+                + "    expression:\n"
+                + "      dialects:\n"
+                + "      - dialect: ANSI_SQL\n"
+                + "        expression: SUM(ORDERS.AMOUNT)\n"
+                + "      - dialect: MDX\n"
+                + "        expression: \"[Measures].[Total Revenue]\"\n"
+                + "  - name: ORDER_COUNT\n"
+                + "    expression:\n"
+                + "      dialects:\n"
+                + "      - dialect: ANSI_SQL\n"
+                + "        expression: COUNT(ORDERS.ORDER_ID)\n"
+                + "  - name: MDX_ONLY_METRIC\n"
+                + "    expression:\n"
+                + "      dialects:\n"
+                + "      - dialect: MDX\n"
+                + "        expression: \"[Measures].[X] / [Measures].[Y]\"\n";
         Files.writeString(ossieYaml, yaml);
     }
 
@@ -139,6 +158,45 @@ public class SelectPushdownIT {
             assertTrue(rs.next());
             assertEquals("West", rs.getString(1));
             assertEquals(25.00, rs.getBigDecimal(2).doubleValue(), 0.001);
+        }
+    }
+
+    @Test
+    public void metricSelectExpandsAnsiAggregate() throws Exception {
+        // TOTAL_REVENUE expands to SUM(ORDERS.AMOUNT); Calcite treats the OssieMetricViewTable
+        // as a scalar view, so SELECT * from it returns one row with the grand total (450.00).
+        try (Connection calcite = openCalcite();
+                Statement s = calcite.createStatement();
+                ResultSet rs = s.executeQuery("SELECT * FROM SALES.TOTAL_REVENUE")) {
+            assertTrue(rs.next());
+            assertEquals(450.00, rs.getBigDecimal(1).doubleValue(), 0.001);
+            assertTrue("expected exactly one row for a scalar metric", !rs.next());
+        }
+    }
+
+    @Test
+    public void countMetricReturnsBigInt() throws Exception {
+        try (Connection calcite = openCalcite();
+                Statement s = calcite.createStatement();
+                ResultSet rs = s.executeQuery("SELECT * FROM SALES.ORDER_COUNT")) {
+            assertTrue(rs.next());
+            assertEquals(5, rs.getLong(1));
+        }
+    }
+
+    @Test
+    public void mdxOnlyMetricIsSkipped() throws Exception {
+        // MDX-only metrics (calculated members) don't get exposed on the SQL surface — trying to
+        // SELECT from them should fail with a "table not found" style error.
+        try (Connection calcite = openCalcite();
+                Statement s = calcite.createStatement()) {
+            try {
+                s.executeQuery("SELECT * FROM SALES.MDX_ONLY_METRIC");
+                fail("expected MDX-only metric to be invisible on the SQL surface");
+            } catch (java.sql.SQLException expected) {
+                // Message wording varies across Calcite versions; the important thing is that
+                // the query didn't succeed.
+            }
         }
     }
 

--- a/saiku-launcher/pom.xml
+++ b/saiku-launcher/pom.xml
@@ -40,6 +40,15 @@
             <version>${project.version}</version>
         </dependency>
 
+        <!-- Compile-scope dep on saiku-sql so the SqlServeCommand can boot the
+             Avatica endpoint. Pulls calcite-core + avatica-server transitively
+             into the shaded fat-JAR — the CLI needs both at runtime. -->
+        <dependency>
+            <groupId>org.saikuanalytics</groupId>
+            <artifactId>saiku-sql</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
         <dependency>
             <groupId>info.picocli</groupId>
             <artifactId>picocli</artifactId>

--- a/saiku-launcher/src/main/java/org/saiku/launcher/SaikuLauncher.java
+++ b/saiku-launcher/src/main/java/org/saiku/launcher/SaikuLauncher.java
@@ -30,7 +30,7 @@ import picocli.CommandLine.Option;
         mixinStandardHelpOptions = true,
         version = "saiku 3.17",
         description = "Saiku Semantic Layer server.",
-        subcommands = {SaikuLauncher.ServeCommand.class, OssieExportCommand.class})
+        subcommands = {SaikuLauncher.ServeCommand.class, OssieExportCommand.class, SqlServeCommand.class})
 public class SaikuLauncher implements Callable<Integer> {
 
     public static void main(String[] args) {

--- a/saiku-launcher/src/main/java/org/saiku/launcher/SqlServeCommand.java
+++ b/saiku-launcher/src/main/java/org/saiku/launcher/SqlServeCommand.java
@@ -7,6 +7,7 @@ package org.saiku.launcher;
 import java.nio.file.Path;
 import java.util.concurrent.Callable;
 import org.saiku.sql.server.OssieSqlServer;
+import org.saiku.sql.server.pgwire.PgWireServer;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Option;
 
@@ -63,22 +64,54 @@ public class SqlServeCommand implements Callable<Integer> {
 
     @Option(
             names = {"-p", "--port"},
-            description = "TCP port to bind. Use 0 for an OS-assigned port.",
+            description =
+                    "Avatica HTTP port. Set to 0 to disable the Avatica endpoint; use --pg-port for pg-wire only.",
             defaultValue = "8765")
     int port;
 
+    @Option(
+            names = "--pg-port",
+            description = "Postgres wire port. When set, opens a native PG-wire endpoint alongside Avatica so "
+                    + "psql / pgAdmin / Tableau / DBeaver / dbt-postgres can connect. Set to 0 to disable.",
+            defaultValue = "0")
+    int pgPort;
+
     @Override
     public Integer call() throws Exception {
-        try (OssieSqlServer server = new OssieSqlServer(port, ossieYaml, schemaName, jdbcUrl, jdbcUser, jdbcPassword)) {
-            System.out.println("sql-serve: listening on " + server.getUrl());
-            System.out.println("sql-serve: connect via jdbc:avatica:remote:url=" + server.getUrl()
-                    + " with serialization=protobuf");
+        // The Avatica server owns the Calcite connect string wiring — reuse it for both
+        // endpoints so the two servers dispatch queries to the same JdbcMeta backend.
+        String calciteConnectString =
+                OssieSqlServer.buildCalciteConnectString(ossieYaml, schemaName, jdbcUrl, jdbcUser, jdbcPassword);
+
+        OssieSqlServer avatica = null;
+        PgWireServer pgWire = null;
+        try {
+            if (port > 0) {
+                avatica = new OssieSqlServer(port, ossieYaml, schemaName, jdbcUrl, jdbcUser, jdbcPassword);
+                System.out.println("sql-serve: Avatica endpoint listening on " + avatica.getUrl());
+                System.out.println("sql-serve:   client → jdbc:avatica:remote:url=" + avatica.getUrl()
+                        + " (serialization=protobuf)");
+            }
+            if (pgPort > 0) {
+                pgWire = new PgWireServer(pgPort, calciteConnectString);
+                int actual = pgWire.getPort();
+                System.out.println("sql-serve: Postgres wire endpoint listening on port " + actual);
+                System.out.println("sql-serve:   client → jdbc:postgresql://localhost:" + actual
+                        + "/saiku?sslmode=disable&preferQueryMode=simple");
+                System.out.println("sql-serve:   psql  → PGSSLMODE=disable psql -h localhost -p " + actual + " saiku");
+            }
+            if (avatica == null && pgWire == null) {
+                System.err.println("sql-serve: both endpoints disabled (--port 0 --pg-port 0). Nothing to do.");
+                return 1;
+            }
             System.out.println("sql-serve: Ctrl+C to stop");
-            // Block forever. Avatica's HttpServer runs in its own thread pool; the main thread
-            // just needs to stay alive until interrupted so the try-with-resources close()
-            // fires on shutdown.
+            // Block forever. Both servers run in their own threads; the main thread just needs
+            // to stay alive until interrupted so the finally clause tears them down cleanly.
             Thread.currentThread().join();
             return 0;
+        } finally {
+            if (pgWire != null) pgWire.close();
+            if (avatica != null) avatica.close();
         }
     }
 }

--- a/saiku-launcher/src/main/java/org/saiku/launcher/SqlServeCommand.java
+++ b/saiku-launcher/src/main/java/org/saiku/launcher/SqlServeCommand.java
@@ -1,0 +1,84 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.launcher;
+
+import java.nio.file.Path;
+import java.util.concurrent.Callable;
+import org.saiku.sql.server.OssieSqlServer;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Option;
+
+/**
+ * {@code saiku sql-serve} — start a network SQL endpoint over the Ossie semantic model.
+ *
+ * <p>Runs an Apache Avatica HTTP server that exposes the same SQL surface used by {@code
+ * saiku ossie-export}'s output. Any Avatica-compatible client (JDBC via {@code
+ * avatica-server}'s JDBC driver, Python {@code phoenixdb}, Go {@code avatica}) can then connect
+ * over the wire and execute SQL against the semantic model — SELECT, WHERE, GROUP BY, explicit
+ * JOIN, metric SELECT, relationship views, and auto-injected joins all work.
+ *
+ * <p>Example — start the server against a locally-exported Pharma schema:
+ *
+ * <pre>{@code
+ * saiku sql-serve --ossie pharma.ossie.yaml \
+ *                 --schema PHARMA \
+ *                 --jdbc-url jdbc:postgresql://warehouse:5432/prod \
+ *                 --jdbc-user app --jdbc-password '***' \
+ *                 --port 8765
+ * }</pre>
+ *
+ * <p>Clients then connect via {@code jdbc:avatica:remote:url=http://localhost:8765} with
+ * {@code serialization=protobuf}.
+ */
+@Command(
+        name = "sql-serve",
+        description = "Start a network Avatica SQL endpoint over an Ossie semantic model.",
+        mixinStandardHelpOptions = true)
+public class SqlServeCommand implements Callable<Integer> {
+
+    @Option(
+            names = {"-o", "--ossie"},
+            description = "Path to the Ossie YAML file describing the semantic model.",
+            required = true)
+    Path ossieYaml;
+
+    @Option(
+            names = {"-s", "--schema"},
+            description = "Schema name (must match a semantic_model entry in the Ossie YAML). Defaults to the first.",
+            defaultValue = "PHARMA")
+    String schemaName;
+
+    @Option(
+            names = "--jdbc-url",
+            description = "Warehouse JDBC URL. Without it, tables register but queries return zero rows.")
+    String jdbcUrl;
+
+    @Option(names = "--jdbc-user", description = "Warehouse JDBC user.")
+    String jdbcUser;
+
+    @Option(names = "--jdbc-password", description = "Warehouse JDBC password.")
+    String jdbcPassword;
+
+    @Option(
+            names = {"-p", "--port"},
+            description = "TCP port to bind. Use 0 for an OS-assigned port.",
+            defaultValue = "8765")
+    int port;
+
+    @Override
+    public Integer call() throws Exception {
+        try (OssieSqlServer server = new OssieSqlServer(port, ossieYaml, schemaName, jdbcUrl, jdbcUser, jdbcPassword)) {
+            System.out.println("sql-serve: listening on " + server.getUrl());
+            System.out.println("sql-serve: connect via jdbc:avatica:remote:url=" + server.getUrl()
+                    + " with serialization=protobuf");
+            System.out.println("sql-serve: Ctrl+C to stop");
+            // Block forever. Avatica's HttpServer runs in its own thread pool; the main thread
+            // just needs to stay alive until interrupted so the try-with-resources close()
+            // fires on shutdown.
+            Thread.currentThread().join();
+            return 0;
+        }
+    }
+}


### PR DESCRIPTION
Ships the full first slice of the Ossie/SQL platform play from epic #1387. Local SchemaFactory + network Avatica endpoint + **native Postgres wire** + auto-injected joins + metric expansion — everything a downstream BI tool needs to speak SQL against a Mondrian-derived semantic model.

**Stacked on #1388 (#1384).** Merge order: **#1388 first, then this**. GitHub will re-base against \`development\` automatically once #1388 lands.

## Tagline

    PGSSLMODE=disable psql -h saiku -p 5432 saiku
    saiku=# SELECT c.REGION, SUM(o.AMOUNT) FROM SALES.ORDERS o, SALES.CUSTOMERS c GROUP BY c.REGION;

Works on this branch, today.

## What lands

- \`saiku-core/saiku-sql\` module (Java 21, Calcite 1.41).
- \`OssieYamlReader\` — symmetric with the exporter's writer.
- \`OssieSchemaFactory\` + \`OssieSchema\` — Calcite \`AbstractSchema\` projection of one Ossie \`SemanticModel\`.
- \`OssieMetricViewTable\` — closes #1390. \`SELECT * FROM <schema>.<metric>\` returns the scalar aggregate.
- \`OssieRelationshipViewTable\` — one pre-joined view per Ossie \`relationship\`.
- **\`OssieAutoJoinRule\`** — closes #1391. Custom \`RelOptRule\` that rewrites Cartesian joins between two Ossie datasets using the relationship's ON predicate.
- **\`OssieSqlServer\`** — closes #1386 slice 1. Avatica HTTP+protobuf endpoint.
- **\`PgWireServer\`** — closes #1392. Native Postgres wire protocol frontend. Any pgjdbc / \`psql\` / \`libpq\` client connects and executes SQL.
- **\`saiku sql-serve\` CLI subcommand** — starts both endpoints. \`--port\` for Avatica, \`--pg-port\` for PG wire; either can be disabled with \`0\`.

## What works today

| Query surface | Local | Avatica wire | Postgres wire |
|---|---|---|---|
| \`SELECT ... FROM <schema>.<dataset>\` | ✅ | ✅ | ✅ |
| \`WHERE\`, \`GROUP BY\`, \`ORDER BY\`, \`LIMIT\` | ✅ | ✅ | ✅ |
| Explicit \`JOIN ... ON ...\` | ✅ | ✅ | ✅ |
| \`SELECT * FROM <schema>.<metric>\` | ✅ | ✅ | ✅ |
| Pre-joined views (\`<from>_JOIN_<to>\`) | ✅ | ✅ | ✅ |
| Auto-inject (\`FROM A, B\` with no JOIN) | ✅ | ✅ | ✅ |
| \`DatabaseMetaData.getTables()\` | ✅ | ✅ | ✅ |

## Not yet supported — follow-ups on #1387

- **Extended query mode** (Parse/Bind/Execute) on the PG-wire endpoint. Clients set \`preferQueryMode=simple\` to opt out today.
- **SSL/TLS** on both endpoints. PG-wire replies \`'N'\` to SSL requests (client falls back to plaintext).
- **SCRAM-SHA-256 auth** on the PG-wire endpoint. Trust auth ships first.
- Three-way auto-joins, cross-schema joins, per-dialect return-type inference.

## Tests — 18/18 green

- \`OssieYamlReaderTest\` — 4 unit tests.
- \`SelectPushdownIT\` — 10 tests against in-JVM H2. Dataset scan, JOIN, metric SELECT, MDX-only-invisible, auto-join, auto-join-bail-when-no-rel.
- \`OssieSqlServerIT\` — 2 tests exercising the Avatica wire path.
- **\`PgWireServerIT\` — 2 tests using the real \`org.postgresql:postgresql\` JDBC driver.** \`pgjdbc\` is what Tableau/DBeaver/psql speak internally — proves compatibility with a client we didn't write.

## Design highlights for reviewers

- **PG wire is plain JDK sockets, one thread per connection.** Netty adds no capability at MVP scale. Migrate if we hit multiplexing needs.
- **Both endpoints share \`JdbcMeta\` semantics** via \`OssieSqlServer.buildCalciteConnectString\`. One codebase = one query planner path = one auto-join rule fires everywhere.
- **Rule rewrite reaches past projection pushdown.** Calcite's Volcano planner had usually pushed projections down before the auto-join rule fired. Fix: unwrap RelSubset, peel Projects, find raw TableScans, rebuild \`Project(Join(TableScan, TableScan))\`.
- **Static registry over \`RelOptTable.unwrap\`.** Our datasets are \`JdbcTable\`s (for JDBC pushdown); unwrap returns null. \`OssieSchema.REGISTRY\` keyed by schema name is the fallback.

## Test plan

- [x] \`mvn -pl saiku-core/saiku-sql -am test\` — 18/18 pass
- [x] \`saiku sql-serve --help\` renders both --port and --pg-port
- [ ] Manual smoke: real Postgres warehouse + real DBeaver connecting via native PG driver
- [ ] CI (once #1388 merges and this rebases onto development)