### PR TITLE
chore(demo): TPC-DS + Flights Ossie demo datasources

### DIFF
--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/ossie/OssieDiscoverService.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/ossie/OssieDiscoverService.java
@@ -84,7 +84,7 @@ public class OssieDiscoverService {
         } catch (IOException e) {
             throw new IllegalArgumentException("Failed to read Ossie YAML at " + yamlPath + ": " + e.getMessage(), e);
         }
-        if (doc.getSemanticModel().isEmpty()) {
+        if (doc.getEffectiveSemanticModels().isEmpty()) {
             throw new IllegalArgumentException("Ossie YAML at " + yamlPath + " has zero semantic models");
         }
         // Pick the requested model or default to the first entry. schema and OSSIE_MODEL_KEY
@@ -96,7 +96,7 @@ public class OssieDiscoverService {
         }
         SemanticModel picked = null;
         if (modelName != null && !modelName.isBlank()) {
-            for (SemanticModel m : doc.getSemanticModel()) {
+            for (SemanticModel m : doc.getEffectiveSemanticModels()) {
                 if (modelName.equals(m.getName())) {
                     picked = m;
                     break;
@@ -107,13 +107,13 @@ public class OssieDiscoverService {
                         "Ossie datasource '{}' asked for model '{}' but YAML only has {} — falling back to first",
                         connectionName,
                         modelName,
-                        doc.getSemanticModel().stream()
+                        doc.getEffectiveSemanticModels().stream()
                                 .map(SemanticModel::getName)
                                 .toList());
             }
         }
         if (picked == null) {
-            picked = doc.getSemanticModel().get(0);
+            picked = doc.getEffectiveSemanticModels().get(0);
         }
         return project(connectionName, picked);
     }

--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/schema/ossie/model/OssieDocument.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/schema/ossie/model/OssieDocument.java
@@ -39,6 +39,17 @@ public class OssieDocument {
     @JsonInclude(JsonInclude.Include.ALWAYS)
     private List<SemanticModel> semanticModel = new ArrayList<>();
 
+    /**
+     * Ontology-mapping envelopes as defined by Apache Ossie's flights example. Each mapping
+     * carries a nested {@code semantic_model:} — a common shape when the document originates
+     * from an ontology-first modelling tool. Saiku doesn't process the ontology block itself
+     * (concepts / relationships / verbalizes are out of scope for the SQL surface), but the
+     * nested semantic_model is a valid Ossie model and we surface it via
+     * {@link #getEffectiveSemanticModels()}.
+     */
+    @JsonProperty("ontology_mappings")
+    private List<OntologyMapping> ontologyMappings = new ArrayList<>();
+
     public String getVersion() {
         return version;
     }
@@ -53,5 +64,61 @@ public class OssieDocument {
 
     public void setSemanticModel(List<SemanticModel> v) {
         this.semanticModel = v == null ? new ArrayList<>() : v;
+    }
+
+    public List<OntologyMapping> getOntologyMappings() {
+        return ontologyMappings;
+    }
+
+    public void setOntologyMappings(List<OntologyMapping> v) {
+        this.ontologyMappings = v == null ? new ArrayList<>() : v;
+    }
+
+    /**
+     * Return every semantic model the document publishes — the top-level {@code semantic_model:}
+     * entries plus any nested inside {@code ontology_mappings[*].semantic_model:}. Consumers
+     * (discover service, YAML reader) should use this rather than {@link #getSemanticModel()}
+     * so ontology-nested Ossie docs round-trip cleanly.
+     */
+    public List<SemanticModel> getEffectiveSemanticModels() {
+        List<SemanticModel> out = new ArrayList<>(semanticModel);
+        for (OntologyMapping m : ontologyMappings) {
+            if (m.getSemanticModel() != null) out.add(m.getSemanticModel());
+        }
+        return out;
+    }
+
+    /** Envelope for one entry under {@code ontology_mappings:}. */
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    public static class OntologyMapping {
+        private String name;
+        private String description;
+
+        @JsonProperty("semantic_model")
+        private SemanticModel semanticModel;
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String v) {
+            this.name = v;
+        }
+
+        public String getDescription() {
+            return description;
+        }
+
+        public void setDescription(String v) {
+            this.description = v;
+        }
+
+        public SemanticModel getSemanticModel() {
+            return semanticModel;
+        }
+
+        public void setSemanticModel(SemanticModel v) {
+            this.semanticModel = v;
+        }
     }
 }

--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/schema/ossie/model/OssieDocument.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/schema/ossie/model/OssieDocument.java
@@ -4,6 +4,7 @@
  */
 package org.saiku.service.schema.ossie.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
@@ -80,6 +81,7 @@ public class OssieDocument {
      * (discover service, YAML reader) should use this rather than {@link #getSemanticModel()}
      * so ontology-nested Ossie docs round-trip cleanly.
      */
+    @JsonIgnore
     public List<SemanticModel> getEffectiveSemanticModels() {
         List<SemanticModel> out = new ArrayList<>(semanticModel);
         for (OntologyMapping m : ontologyMappings) {

--- a/saiku-core/saiku-sql/src/main/java/org/saiku/sql/adapter/OssieSchemaFactory.java
+++ b/saiku-core/saiku-sql/src/main/java/org/saiku/sql/adapter/OssieSchemaFactory.java
@@ -99,7 +99,7 @@ public class OssieSchemaFactory implements SchemaFactory {
                     "OssieSchemaFactory: failed to read Ossie YAML at " + ossieYaml + ": " + e.getMessage(), e);
         }
 
-        var models = doc.getSemanticModel();
+        var models = doc.getEffectiveSemanticModels();
         if (models.isEmpty()) {
             throw new IllegalStateException("OssieSchemaFactory: Ossie document at " + ossieYaml
                     + " has zero semantic models — check the exporter didn't skip every cube");

--- a/saiku-launcher/src/main/java/org/saiku/launcher/SaikuLauncher.java
+++ b/saiku-launcher/src/main/java/org/saiku/launcher/SaikuLauncher.java
@@ -570,8 +570,8 @@ public class SaikuLauncher implements Callable<Integer> {
          * @param dsName the datasource name written into the .sds; matches the value
          *               the discover endpoint exposes.
          */
-        private static void stageOneOssieDemo(
-                Path saikuHome, Path dataDir, Path dsDir, String slug, String dsName) throws Exception {
+        private static void stageOneOssieDemo(Path saikuHome, Path dataDir, Path dsDir, String slug, String dsName)
+                throws Exception {
             // 1. YAML — copy from classpath to <home>/data/.
             stageResource("/seed/" + slug + ".ossie.yaml", dataDir.resolve(slug + ".ossie.yaml"));
 
@@ -580,8 +580,8 @@ public class SaikuLauncher implements Callable<Integer> {
             if (!Files.exists(h2File)) {
                 try (InputStream in = SaikuLauncher.class.getResourceAsStream("/seed/" + slug + "-seed.sql")) {
                     if (in == null) {
-                        System.out.println("Warning: no /seed/" + slug + "-seed.sql on classpath; skipping H2 seed for "
-                                + dsName);
+                        System.out.println(
+                                "Warning: no /seed/" + slug + "-seed.sql on classpath; skipping H2 seed for " + dsName);
                     } else {
                         String sql = new String(in.readAllBytes(), java.nio.charset.StandardCharsets.UTF_8);
                         String jdbcUrl = "jdbc:h2:" + dataDir.resolve(slug) + ";MODE=PostgreSQL";

--- a/saiku-launcher/src/main/java/org/saiku/launcher/SaikuLauncher.java
+++ b/saiku-launcher/src/main/java/org/saiku/launcher/SaikuLauncher.java
@@ -140,6 +140,12 @@ public class SaikuLauncher implements Callable<Integer> {
             stageSeedAssets(dataDir);
             stageBrandingSample(brandingDir);
             stageDefaultDatasource(saikuHome);
+            // #1394 demos: TPC-DS + Flights Ossie datasources with H2 fixtures.
+            // Auto-provisioned on first boot so a fresh container has three Ossie
+            // datasources ready to poke at via /ai/ossie/models. Idempotent —
+            // stageResource + stageOssieDemoDatasource both no-op when the target
+            // exists, so operator edits survive container restarts.
+            stageOssieDemoDatasources(saikuHome);
             // saiku#1245: in demo mode, also stage a "Welcome" dashboard
             // under /dashboards/ so a fresh demo container has something
             // ready-to-look-at at first login instead of an empty list.
@@ -503,6 +509,119 @@ public class SaikuLauncher implements Callable<Integer> {
                 String resolved = body.replace("@SAIKU_HOME@", saikuHome.toString());
                 Files.writeString(target, resolved, java.nio.charset.StandardCharsets.UTF_8);
                 System.out.println("Seeded: " + target);
+            }
+        }
+
+        /**
+         * Strip leading {@code -- comment} lines from a SQL statement so a header comment
+         * doesn't cause the whole statement to be skipped. Idempotent — passes any statement
+         * whose first non-blank line isn't a {@code --} comment through unchanged.
+         */
+        static String stripLeadingSqlComments(String stmt) {
+            if (stmt == null) return "";
+            String[] lines = stmt.split("\\r?\\n");
+            int firstReal = 0;
+            for (int i = 0; i < lines.length; i++) {
+                String l = lines[i].trim();
+                if (l.isEmpty() || l.startsWith("--")) {
+                    firstReal = i + 1;
+                } else {
+                    break;
+                }
+            }
+            if (firstReal == 0) return stmt;
+            StringBuilder sb = new StringBuilder();
+            for (int i = firstReal; i < lines.length; i++) {
+                if (sb.length() > 0) sb.append('\n');
+                sb.append(lines[i]);
+            }
+            return sb.toString();
+        }
+
+        /**
+         * Stage the two Ossie demo datasources — TPC-DS and Flights (#1394 demo pass).
+         *
+         * <p>For each: stage the .ossie.yaml to {@code <home>/data/}, execute the seed
+         * SQL against a fresh H2 database in the same directory, and materialise the
+         * {@code .sds} descriptor. All three writes are idempotent — a repeat boot with
+         * an existing H2 file, YAML, or .sds skips the corresponding step. Failures are
+         * logged and the launcher continues so a broken fixture doesn't block the boot.
+         */
+        private static void stageOssieDemoDatasources(Path saikuHome) throws Exception {
+            Path dataDir = saikuHome.resolve("data");
+            Path dsDir = saikuHome
+                    .resolve("repository")
+                    .resolve("data")
+                    .resolve("unknown")
+                    .resolve("datasources");
+            Files.createDirectories(dataDir);
+            Files.createDirectories(dsDir);
+
+            stageOneOssieDemo(saikuHome, dataDir, dsDir, "tpcds", "TPCDS");
+            stageOneOssieDemo(saikuHome, dataDir, dsDir, "flights", "Flights");
+        }
+
+        /**
+         * Stage one Ossie demo dataset: YAML + H2 fixture + .sds descriptor.
+         *
+         * @param slug   filename slug — matches {@code <slug>.ossie.yaml},
+         *               {@code <slug>-seed.sql}, {@code <slug>-ossie.sds.template} on
+         *               the launcher's classpath.
+         * @param dsName the datasource name written into the .sds; matches the value
+         *               the discover endpoint exposes.
+         */
+        private static void stageOneOssieDemo(
+                Path saikuHome, Path dataDir, Path dsDir, String slug, String dsName) throws Exception {
+            // 1. YAML — copy from classpath to <home>/data/.
+            stageResource("/seed/" + slug + ".ossie.yaml", dataDir.resolve(slug + ".ossie.yaml"));
+
+            // 2. H2 fixture — one .mv.db per demo. Skip if it already exists (idempotent).
+            Path h2File = dataDir.resolve(slug + ".mv.db");
+            if (!Files.exists(h2File)) {
+                try (InputStream in = SaikuLauncher.class.getResourceAsStream("/seed/" + slug + "-seed.sql")) {
+                    if (in == null) {
+                        System.out.println("Warning: no /seed/" + slug + "-seed.sql on classpath; skipping H2 seed for "
+                                + dsName);
+                    } else {
+                        String sql = new String(in.readAllBytes(), java.nio.charset.StandardCharsets.UTF_8);
+                        String jdbcUrl = "jdbc:h2:" + dataDir.resolve(slug) + ";MODE=PostgreSQL";
+                        // Load H2 driver via reflection — the launcher's fat-JAR pins h2 via
+                        // saiku-service, but we don't want a compile-time coupling from this
+                        // package to h2.
+                        Class.forName("org.h2.Driver");
+                        try (java.sql.Connection c = java.sql.DriverManager.getConnection(jdbcUrl, "sa", "");
+                                java.sql.Statement st = c.createStatement()) {
+                            for (String statement : sql.split(";\\s*\\r?\\n")) {
+                                // Strip leading comment lines. A trimmed chunk that STARTS with
+                                // `-- comment` but has an actual statement after may look like
+                                // "-- header\nINSERT INTO ..." — the naive startsWith("--") skip
+                                // would drop the whole INSERT.
+                                String body = stripLeadingSqlComments(statement).trim();
+                                if (body.isEmpty()) continue;
+                                st.execute(body);
+                            }
+                        }
+                        System.out.println("Seeded H2 fixture: " + h2File);
+                    }
+                } catch (Exception e) {
+                    System.out.println(
+                            "Warning: seeding " + dsName + " fixture failed (" + e.getMessage() + "); continuing.");
+                }
+            }
+
+            // 3. .sds descriptor — substitute @SAIKU_HOME@ same way stageDefaultDatasource
+            //    does for the foodmart datasource.
+            Path sdsTarget = dsDir.resolve(slug + "-ossie.sds");
+            if (!Files.exists(sdsTarget)) {
+                try (InputStream in =
+                        SaikuLauncher.class.getResourceAsStream("/seed/" + slug + "-ossie.sds.template")) {
+                    if (in != null) {
+                        String body = new String(in.readAllBytes(), java.nio.charset.StandardCharsets.UTF_8);
+                        String resolved = body.replace("@SAIKU_HOME@", saikuHome.toString());
+                        Files.writeString(sdsTarget, resolved, java.nio.charset.StandardCharsets.UTF_8);
+                        System.out.println("Seeded: " + sdsTarget);
+                    }
+                }
             }
         }
 

--- a/saiku-launcher/src/main/resources/seed/flights-ossie.sds.template
+++ b/saiku-launcher/src/main/resources/seed/flights-ossie.sds.template
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<!--
+    Flights demo Ossie datasource — auto-provisioned by saiku-launcher on
+    first start. Uses the ontology_mappings envelope YAML shape (exercises
+    the reader's nested-semantic_model handling).
+-->
+<dataSource>
+    <id>flights-ossie-01</id>
+    <name>Flights</name>
+    <type>OSSIE</type>
+    <ossieYaml>@SAIKU_HOME@/data/flights.ossie.yaml</ossieYaml>
+    <location>jdbc:h2:@SAIKU_HOME@/data/flights;MODE=PostgreSQL;AUTO_SERVER=TRUE</location>
+    <schema>Flights</schema>
+    <username>sa</username>
+    <password></password>
+    <advanced>false</advanced>
+    <enabled>true</enabled>
+</dataSource>

--- a/saiku-launcher/src/main/resources/seed/flights-seed.sql
+++ b/saiku-launcher/src/main/resources/seed/flights-seed.sql
@@ -1,0 +1,138 @@
+-- Flights demo fixture — trimmed BTS-shaped data for flights.ossie.yaml.
+-- 4 tables: FLIGHT (fact) + CARRIER, AIRPORT, AIRCRAFT (dims). ~60 flights
+-- across 8 airports, 4 carriers, 6 tail numbers.
+
+DROP TABLE IF EXISTS FLIGHT;
+DROP TABLE IF EXISTS CARRIER;
+DROP TABLE IF EXISTS AIRPORT;
+DROP TABLE IF EXISTS AIRCRAFT;
+
+CREATE TABLE CARRIER (
+  CARRIER_ID    INT PRIMARY KEY,
+  IATA_CODE     VARCHAR(3),
+  CARRIER_NAME  VARCHAR(64),
+  HUB_STATE     VARCHAR(2)
+);
+
+INSERT INTO CARRIER VALUES
+ (1, 'AA', 'American Airlines', 'TX'),
+ (2, 'DL', 'Delta Air Lines',   'GA'),
+ (3, 'UA', 'United Airlines',   'IL'),
+ (4, 'WN', 'Southwest Airlines','TX');
+
+CREATE TABLE AIRPORT (
+  AIRPORT_ID    INT PRIMARY KEY,
+  AIRPORT_CODE  VARCHAR(4),
+  AIRPORT_NAME  VARCHAR(64),
+  AIRPORT_CITY  VARCHAR(48),
+  AIRPORT_STATE VARCHAR(2)
+);
+
+INSERT INTO AIRPORT VALUES
+ (1, 'JFK', 'John F. Kennedy Intl', 'New York',      'NY'),
+ (2, 'LAX', 'Los Angeles Intl',     'Los Angeles',   'CA'),
+ (3, 'ORD', 'O''Hare Intl',         'Chicago',       'IL'),
+ (4, 'ATL', 'Hartsfield-Jackson',   'Atlanta',       'GA'),
+ (5, 'DFW', 'Dallas Fort Worth',    'Dallas',        'TX'),
+ (6, 'SEA', 'Seattle-Tacoma Intl',  'Seattle',       'WA'),
+ (7, 'SFO', 'San Francisco Intl',   'San Francisco', 'CA'),
+ (8, 'MIA', 'Miami Intl',           'Miami',         'FL');
+
+CREATE TABLE AIRCRAFT (
+  TAIL_NUM        VARCHAR(8) PRIMARY KEY,
+  MANUFACTURER    VARCHAR(32),
+  MODEL           VARCHAR(32),
+  NUMBER_OF_SEATS INT,
+  YEAR_MFR        INT
+);
+
+INSERT INTO AIRCRAFT VALUES
+ ('N101AA', 'Boeing',      '737-800',  160, 2015),
+ ('N202DL', 'Airbus',      'A320',     150, 2017),
+ ('N303UA', 'Boeing',      '777-300',  365, 2018),
+ ('N404WN', 'Boeing',      '737-700',  143, 2013),
+ ('N505AA', 'Boeing',      '787-9',    290, 2020),
+ ('N606DL', 'Airbus',      'A321neo',  196, 2021);
+
+CREATE TABLE FLIGHT (
+  FLIGHT_ID              INT PRIMARY KEY,
+  CARRIER_ID             INT,
+  TAIL_NUM               VARCHAR(8),
+  ORIGIN_AIRPORT_ID      INT,
+  DEST_AIRPORT_ID        INT,
+  SCHEDULED_DATE_MONTH   VARCHAR(7),   -- YYYY-MM for a natural time axis
+  DEP_DELAY_MIN          INT,
+  ARR_DELAY_MIN          INT,
+  CANCELLED              INT,          -- 0 / 1
+  DISTANCE_MILES         INT
+);
+
+-- Six months of flight activity, ~10 flights per month. Delays trend upward
+-- Nov/Dec to give the anomaly / forecast endpoints a real signal.
+INSERT INTO FLIGHT VALUES
+ -- July
+ ( 1, 1, 'N101AA', 5, 1, '2024-07',  5,  8, 0, 1391),
+ ( 2, 2, 'N202DL', 4, 3, '2024-07',  0,  2, 0,  606),
+ ( 3, 3, 'N303UA', 3, 2, '2024-07', -2,  0, 0, 1745),
+ ( 4, 4, 'N404WN', 7, 6, '2024-07', 12, 15, 0,  678),
+ ( 5, 1, 'N505AA', 1, 8, '2024-07',  8,  4, 0, 1093),
+ ( 6, 2, 'N606DL', 4, 5, '2024-07',  0, -3, 0,  731),
+ ( 7, 3, 'N303UA', 3, 7, '2024-07',  6,  9, 0, 1846),
+ ( 8, 4, 'N404WN', 7, 2, '2024-07',  3,  0, 0,  337),
+ ( 9, 1, 'N101AA', 5, 3, '2024-07',  0,  1, 0,  801),
+ (10, 2, 'N202DL', 4, 1, '2024-07',  1,  5, 0,  760),
+ -- August
+ (11, 1, 'N101AA', 5, 1, '2024-08',  2,  7, 0, 1391),
+ (12, 2, 'N202DL', 4, 3, '2024-08',  9, 12, 0,  606),
+ (13, 3, 'N303UA', 3, 2, '2024-08',  0,  0, 0, 1745),
+ (14, 4, 'N404WN', 7, 6, '2024-08', 15, 22, 0,  678),
+ (15, 1, 'N505AA', 1, 8, '2024-08',  4,  6, 0, 1093),
+ (16, 2, 'N606DL', 4, 5, '2024-08', -1, -2, 0,  731),
+ (17, 3, 'N303UA', 3, 7, '2024-08',  8,  4, 0, 1846),
+ (18, 4, 'N404WN', 7, 2, '2024-08',  5,  8, 0,  337),
+ (19, 1, 'N101AA', 5, 3, '2024-08',  0,  0, 0,  801),
+ (20, 2, 'N202DL', 4, 1, '2024-08',  3, 10, 0,  760),
+ -- September
+ (21, 1, 'N101AA', 5, 1, '2024-09',  4,  9, 0, 1391),
+ (22, 2, 'N202DL', 4, 3, '2024-09',  1,  0, 0,  606),
+ (23, 3, 'N303UA', 3, 2, '2024-09', -3, -5, 0, 1745),
+ (24, 4, 'N404WN', 7, 6, '2024-09', 18, 25, 0,  678),
+ (25, 1, 'N505AA', 1, 8, '2024-09',  6,  3, 0, 1093),
+ (26, 2, 'N606DL', 4, 5, '2024-09',  2,  1, 0,  731),
+ (27, 3, 'N303UA', 3, 7, '2024-09',  0,  0, 1, 1846),
+ (28, 4, 'N404WN', 7, 2, '2024-09',  9, 12, 0,  337),
+ (29, 1, 'N101AA', 5, 3, '2024-09',  1,  4, 0,  801),
+ (30, 2, 'N202DL', 4, 1, '2024-09',  5, 11, 0,  760),
+ -- October
+ (31, 1, 'N101AA', 5, 1, '2024-10', 10, 14, 0, 1391),
+ (32, 2, 'N202DL', 4, 3, '2024-10',  2,  6, 0,  606),
+ (33, 3, 'N303UA', 3, 2, '2024-10',  0, -2, 0, 1745),
+ (34, 4, 'N404WN', 7, 6, '2024-10', 21, 28, 0,  678),
+ (35, 1, 'N505AA', 1, 8, '2024-10',  7,  9, 0, 1093),
+ (36, 2, 'N606DL', 4, 5, '2024-10', -2,  1, 0,  731),
+ (37, 3, 'N303UA', 3, 7, '2024-10', 12, 15, 0, 1846),
+ (38, 4, 'N404WN', 7, 2, '2024-10',  5,  8, 0,  337),
+ (39, 1, 'N101AA', 5, 3, '2024-10',  0,  0, 1,  801),
+ (40, 2, 'N202DL', 4, 1, '2024-10',  6, 14, 0,  760),
+ -- November — weather + winter operations start pushing delays up
+ (41, 1, 'N101AA', 5, 1, '2024-11', 15, 22, 0, 1391),
+ (42, 2, 'N202DL', 4, 3, '2024-11',  8, 11, 0,  606),
+ (43, 3, 'N303UA', 3, 2, '2024-11',  3,  1, 0, 1745),
+ (44, 4, 'N404WN', 7, 6, '2024-11', 28, 35, 0,  678),
+ (45, 1, 'N505AA', 1, 8, '2024-11', 12, 18, 0, 1093),
+ (46, 2, 'N606DL', 4, 5, '2024-11',  2,  6, 0,  731),
+ (47, 3, 'N303UA', 3, 7, '2024-11', 18, 24, 0, 1846),
+ (48, 4, 'N404WN', 7, 2, '2024-11',  9, 12, 0,  337),
+ (49, 1, 'N101AA', 5, 3, '2024-11',  4, 10, 0,  801),
+ (50, 2, 'N202DL', 4, 1, '2024-11', 11, 20, 0,  760),
+ -- December — peak
+ (51, 1, 'N101AA', 5, 1, '2024-12', 24, 32, 0, 1391),
+ (52, 2, 'N202DL', 4, 3, '2024-12', 14, 18, 0,  606),
+ (53, 3, 'N303UA', 3, 2, '2024-12',  5,  8, 0, 1745),
+ (54, 4, 'N404WN', 7, 6, '2024-12', 45, 58, 1,  678),
+ (55, 1, 'N505AA', 1, 8, '2024-12', 19, 28, 0, 1093),
+ (56, 2, 'N606DL', 4, 5, '2024-12',  9, 12, 0,  731),
+ (57, 3, 'N303UA', 3, 7, '2024-12', 22, 30, 0, 1846),
+ (58, 4, 'N404WN', 7, 2, '2024-12', 14, 20, 0,  337),
+ (59, 1, 'N101AA', 5, 3, '2024-12', 11, 16, 1,  801),
+ (60, 2, 'N202DL', 4, 1, '2024-12', 17, 26, 0,  760);

--- a/saiku-launcher/src/main/resources/seed/flights.ossie.yaml
+++ b/saiku-launcher/src/main/resources/seed/flights.ossie.yaml
@@ -1,0 +1,157 @@
+# Flights demo — trimmed from
+# https://github.com/apache/ossie/blob/main/examples/flights.yaml
+# Original has 11 datasets under ontology_mappings.semantic_model with no
+# metrics. This trim keeps 4 core datasets (Aircraft, Airport, Flight, Carrier)
+# with the most useful subset of fields, adds three metrics for the AI
+# analytics demos, and declares the 3 relationships that hold everything
+# together.
+# The YAML uses the ontology_mappings envelope so we exercise the reader
+# extension (issue #TBD — nested semantic_model support).
+version: 0.2.0.dev0
+name: flights
+description: US on-time flight-performance data — carriers, aircraft, airports, flights.
+
+ontology_mappings:
+- name: flights_map
+  description: Flat semantic model over the flights fact + 3 dims.
+  semantic_model:
+    name: Flights
+    description: Flights, carriers, airports, aircraft — small BTS-shaped fixture.
+    ai_context:
+      instructions: |
+        Flight-performance analytics. Fact table is FLIGHT with one row per
+        scheduled flight; joins to CARRIER by carrier_id, ORIGIN airport by
+        origin_airport_id, DEST airport by dest_airport_id, and AIRCRAFT by
+        tail_num. Metrics cover flight_count, avg departure delay, avg arrival
+        delay. Time axis is the scheduled_date_month field on FLIGHT.
+
+    datasets:
+    - name: flight
+      source: FLIGHT
+      primary_key: [FLIGHT_ID]
+      description: One row per scheduled flight.
+      fields:
+      - name: flight_id
+        expression: {dialects: [{dialect: ANSI_SQL, expression: FLIGHT_ID}]}
+      - name: carrier_id
+        expression: {dialects: [{dialect: ANSI_SQL, expression: CARRIER_ID}]}
+      - name: tail_num
+        expression: {dialects: [{dialect: ANSI_SQL, expression: TAIL_NUM}]}
+      - name: origin_airport_id
+        expression: {dialects: [{dialect: ANSI_SQL, expression: ORIGIN_AIRPORT_ID}]}
+      - name: dest_airport_id
+        expression: {dialects: [{dialect: ANSI_SQL, expression: DEST_AIRPORT_ID}]}
+      - name: scheduled_date_month
+        expression: {dialects: [{dialect: ANSI_SQL, expression: SCHEDULED_DATE_MONTH}]}
+      - name: dep_delay_min
+        expression: {dialects: [{dialect: ANSI_SQL, expression: DEP_DELAY_MIN}]}
+      - name: arr_delay_min
+        expression: {dialects: [{dialect: ANSI_SQL, expression: ARR_DELAY_MIN}]}
+      - name: cancelled
+        expression: {dialects: [{dialect: ANSI_SQL, expression: CANCELLED}]}
+      - name: distance_miles
+        expression: {dialects: [{dialect: ANSI_SQL, expression: DISTANCE_MILES}]}
+
+    - name: carrier
+      source: CARRIER
+      primary_key: [CARRIER_ID]
+      description: Air carriers (airlines).
+      fields:
+      - name: carrier_id
+        expression: {dialects: [{dialect: ANSI_SQL, expression: CARRIER_ID}]}
+      - name: iata_code
+        expression: {dialects: [{dialect: ANSI_SQL, expression: IATA_CODE}]}
+      - name: carrier_name
+        expression: {dialects: [{dialect: ANSI_SQL, expression: CARRIER_NAME}]}
+      - name: hub_state
+        expression: {dialects: [{dialect: ANSI_SQL, expression: HUB_STATE}]}
+
+    - name: airport
+      source: AIRPORT
+      primary_key: [AIRPORT_ID]
+      description: Airports with location + state.
+      fields:
+      - name: airport_id
+        expression: {dialects: [{dialect: ANSI_SQL, expression: AIRPORT_ID}]}
+      - name: airport_code
+        expression: {dialects: [{dialect: ANSI_SQL, expression: AIRPORT_CODE}]}
+      - name: airport_name
+        expression: {dialects: [{dialect: ANSI_SQL, expression: AIRPORT_NAME}]}
+      - name: airport_city
+        expression: {dialects: [{dialect: ANSI_SQL, expression: AIRPORT_CITY}]}
+      - name: airport_state
+        expression: {dialects: [{dialect: ANSI_SQL, expression: AIRPORT_STATE}]}
+
+    - name: aircraft
+      source: AIRCRAFT
+      primary_key: [TAIL_NUM]
+      description: Aircraft — one row per registered tail number.
+      fields:
+      - name: tail_num
+        expression: {dialects: [{dialect: ANSI_SQL, expression: TAIL_NUM}]}
+      - name: manufacturer
+        expression: {dialects: [{dialect: ANSI_SQL, expression: MANUFACTURER}]}
+      - name: model
+        expression: {dialects: [{dialect: ANSI_SQL, expression: MODEL}]}
+      - name: number_of_seats
+        expression: {dialects: [{dialect: ANSI_SQL, expression: NUMBER_OF_SEATS}]}
+      - name: year_mfr
+        expression: {dialects: [{dialect: ANSI_SQL, expression: YEAR_MFR}]}
+
+    metrics:
+    - name: flight_count
+      description: Total scheduled flights.
+      expression:
+        dialects:
+        - dialect: ANSI_SQL
+          expression: COUNT(*)
+      aggregation_kind: count
+
+    - name: avg_dep_delay
+      description: Average departure delay in minutes.
+      expression:
+        dialects:
+        - dialect: ANSI_SQL
+          expression: AVG("flight"."DEP_DELAY_MIN")
+      aggregation_kind: avg
+
+    - name: avg_arr_delay
+      description: Average arrival delay in minutes.
+      expression:
+        dialects:
+        - dialect: ANSI_SQL
+          expression: AVG("flight"."ARR_DELAY_MIN")
+      aggregation_kind: avg
+
+    - name: cancelled_count
+      description: Number of cancelled flights (CANCELLED = 1).
+      expression:
+        dialects:
+        - dialect: ANSI_SQL
+          expression: SUM("flight"."CANCELLED")
+      aggregation_kind: sum
+
+    - name: total_miles
+      description: Total scheduled miles flown.
+      expression:
+        dialects:
+        - dialect: ANSI_SQL
+          expression: SUM("flight"."DISTANCE_MILES")
+      aggregation_kind: sum
+
+    relationships:
+    - name: flight_to_carrier
+      from: flight
+      to: carrier
+      from_columns: [CARRIER_ID]
+      to_columns: [CARRIER_ID]
+    - name: flight_to_origin_airport
+      from: flight
+      to: airport
+      from_columns: [ORIGIN_AIRPORT_ID]
+      to_columns: [AIRPORT_ID]
+    - name: flight_to_aircraft
+      from: flight
+      to: aircraft
+      from_columns: [TAIL_NUM]
+      to_columns: [TAIL_NUM]

--- a/saiku-launcher/src/main/resources/seed/tpcds-ossie.sds.template
+++ b/saiku-launcher/src/main/resources/seed/tpcds-ossie.sds.template
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<!--
+    TPC-DS demo Ossie datasource — auto-provisioned by saiku-launcher on
+    first start. The @SAIKU_HOME@ token is replaced with the absolute
+    saiku-home directory so the JDBC URL + YAML path are portable across
+    machines. Re-running the launcher leaves this file alone.
+
+    Warehouse: @SAIKU_HOME@/data/tpcds (H2 file). Seeded from
+    /seed/tpcds-seed.sql on first boot.
+-->
+<dataSource>
+    <id>tpcds-ossie-01</id>
+    <name>TPCDS</name>
+    <type>OSSIE</type>
+    <ossieYaml>@SAIKU_HOME@/data/tpcds.ossie.yaml</ossieYaml>
+    <location>jdbc:h2:@SAIKU_HOME@/data/tpcds;MODE=PostgreSQL;AUTO_SERVER=TRUE</location>
+    <schema>TPCDS</schema>
+    <username>sa</username>
+    <password></password>
+    <advanced>false</advanced>
+    <enabled>true</enabled>
+</dataSource>

--- a/saiku-launcher/src/main/resources/seed/tpcds-seed.sql
+++ b/saiku-launcher/src/main/resources/seed/tpcds-seed.sql
@@ -1,0 +1,153 @@
+-- TPC-DS demo fixture — trimmed to the 5 datasets referenced by
+-- tpcds.ossie.yaml. Small enough for hand-verification, big enough for
+-- the AI Query API's anomaly + forecast demos to have signal.
+-- Reference: https://github.com/apache/ossie/blob/main/examples/tpcds_semantic_model.yaml
+
+DROP TABLE IF EXISTS STORE_SALES;
+DROP TABLE IF EXISTS DATE_DIM;
+DROP TABLE IF EXISTS CUSTOMER;
+DROP TABLE IF EXISTS ITEM;
+DROP TABLE IF EXISTS STORE;
+
+CREATE TABLE DATE_DIM (
+  D_DATE_SK       INT PRIMARY KEY,
+  D_DATE          DATE,
+  D_YEAR          INT,
+  D_QUARTER_NAME  VARCHAR(8),
+  D_MONTH_NAME    VARCHAR(12)
+);
+
+-- 12 months across 2024. Enough for one-year time-series demos.
+INSERT INTO DATE_DIM VALUES
+ ( 1, DATE '2024-01-15', 2024, '2024Q1', 'January'),
+ ( 2, DATE '2024-02-15', 2024, '2024Q1', 'February'),
+ ( 3, DATE '2024-03-15', 2024, '2024Q1', 'March'),
+ ( 4, DATE '2024-04-15', 2024, '2024Q2', 'April'),
+ ( 5, DATE '2024-05-15', 2024, '2024Q2', 'May'),
+ ( 6, DATE '2024-06-15', 2024, '2024Q2', 'June'),
+ ( 7, DATE '2024-07-15', 2024, '2024Q3', 'July'),
+ ( 8, DATE '2024-08-15', 2024, '2024Q3', 'August'),
+ ( 9, DATE '2024-09-15', 2024, '2024Q3', 'September'),
+ (10, DATE '2024-10-15', 2024, '2024Q4', 'October'),
+ (11, DATE '2024-11-15', 2024, '2024Q4', 'November'),
+ (12, DATE '2024-12-15', 2024, '2024Q4', 'December');
+
+CREATE TABLE CUSTOMER (
+  C_CUSTOMER_SK    INT PRIMARY KEY,
+  C_CUSTOMER_ID    VARCHAR(16),
+  C_FIRST_NAME     VARCHAR(32),
+  C_LAST_NAME      VARCHAR(32),
+  C_EMAIL_ADDRESS  VARCHAR(64),
+  C_STATE          VARCHAR(2)
+);
+
+INSERT INTO CUSTOMER VALUES
+ (1, 'AAAA00001', 'Alice',   'Smith',    'alice.smith@example.com',   'CA'),
+ (2, 'AAAA00002', 'Bob',     'Jones',    'bob.jones@example.com',     'NY'),
+ (3, 'AAAA00003', 'Carol',   'Chen',     'carol.chen@example.com',    'TX'),
+ (4, 'AAAA00004', 'David',   'Patel',    'david.patel@example.com',   'IL'),
+ (5, 'AAAA00005', 'Emma',    'Garcia',   'emma.garcia@example.com',   'CA'),
+ (6, 'AAAA00006', 'Frank',   'Kim',      'frank.kim@example.com',     'WA'),
+ (7, 'AAAA00007', 'Grace',   'Nguyen',   'grace.nguyen@example.com',  'TX'),
+ (8, 'AAAA00008', 'Henry',   'O''Brien', 'henry.obrien@example.com',  'MA'),
+ (9, 'AAAA00009', 'Iris',    'Rossi',    'iris.rossi@example.com',    'NY'),
+ (10,'AAAA00010', 'James',   'Wong',     'james.wong@example.com',    'CA');
+
+CREATE TABLE ITEM (
+  I_ITEM_SK        INT PRIMARY KEY,
+  I_ITEM_ID        VARCHAR(16),
+  I_ITEM_DESC      VARCHAR(64),
+  I_BRAND          VARCHAR(32),
+  I_CATEGORY       VARCHAR(32),
+  I_CURRENT_PRICE  DECIMAL(10,2)
+);
+
+INSERT INTO ITEM VALUES
+ (1, 'ITEM000001', 'Cotton T-Shirt',      'CasualCo',  'Apparel',      19.99),
+ (2, 'ITEM000002', 'Wireless Headphones', 'AudioLine', 'Electronics',  89.00),
+ (3, 'ITEM000003', 'Stainless Kettle',    'HomeBrew',  'Home Goods',   45.50),
+ (4, 'ITEM000004', 'Yoga Mat',            'FitZone',   'Sports',       32.00),
+ (5, 'ITEM000005', 'Detective Novel',     'BookHouse', 'Books',        14.95),
+ (6, 'ITEM000006', 'Ergonomic Chair',     'DeskPro',   'Furniture',   275.00),
+ (7, 'ITEM000007', 'Leather Wallet',      'CraftBrand','Accessories',  55.00),
+ (8, 'ITEM000008', 'Bluetooth Speaker',   'AudioLine', 'Electronics',  59.50),
+ (9, 'ITEM000009', 'Running Shoes',       'FitZone',   'Sports',      110.00),
+ (10,'ITEM000010', 'Ceramic Mug Set',     'HomeBrew',  'Home Goods',   24.99);
+
+CREATE TABLE STORE (
+  S_STORE_SK          INT PRIMARY KEY,
+  S_STORE_ID          VARCHAR(16),
+  S_STORE_NAME        VARCHAR(32),
+  S_CITY              VARCHAR(32),
+  S_STATE             VARCHAR(2),
+  S_NUMBER_EMPLOYEES  INT
+);
+
+INSERT INTO STORE VALUES
+ (1, 'STORE00001', 'Downtown SF',     'San Francisco', 'CA', 42),
+ (2, 'STORE00002', 'Manhattan West',  'New York',      'NY', 65),
+ (3, 'STORE00003', 'Austin Central',  'Austin',        'TX', 38),
+ (4, 'STORE00004', 'Chicago Loop',    'Chicago',       'IL', 51),
+ (5, 'STORE00005', 'Seattle Pike',    'Seattle',       'WA', 34);
+
+CREATE TABLE STORE_SALES (
+  SS_SOLD_DATE_SK   INT,
+  SS_ITEM_SK        INT,
+  SS_CUSTOMER_SK    INT,
+  SS_STORE_SK       INT,
+  SS_TICKET_NUMBER  INT,
+  SS_QUANTITY       INT,
+  SS_SALES_PRICE    DECIMAL(10,2),
+  SS_NET_PROFIT     DECIMAL(10,2),
+  PRIMARY KEY (SS_ITEM_SK, SS_TICKET_NUMBER)
+);
+
+-- ~60 sales spread across all 12 months, all 5 stores, mixed items + customers.
+-- Deliberately seasonal — Q4 total higher than Q1 — so the anomaly / forecast
+-- endpoints have signal to work with when the demo runs them.
+INSERT INTO STORE_SALES VALUES
+ -- Q1
+ ( 1,  2,  1, 1, 10001, 1,  89.00,  22.50),
+ ( 1,  5,  2, 2, 10002, 2,  14.95,   3.20),
+ ( 2,  1,  3, 3, 10003, 3,  19.99,   4.80),
+ ( 2,  8,  4, 4, 10004, 1,  59.50,  14.30),
+ ( 3,  3,  5, 1, 10005, 1,  45.50,  10.80),
+ ( 3,  6,  6, 2, 10006, 1, 275.00,  68.75),
+ ( 3, 10,  7, 5, 10007, 4,  24.99,   6.75),
+ -- Q2
+ ( 4,  4,  1, 3, 10008, 1,  32.00,   8.20),
+ ( 4,  9,  8, 4, 10009, 2, 110.00,  27.50),
+ ( 5,  1,  2, 1, 10010, 5,  19.99,   4.80),
+ ( 5,  7,  9, 2, 10011, 1,  55.00,  13.75),
+ ( 6,  2, 10, 1, 10012, 2,  89.00,  22.50),
+ ( 6,  8,  3, 5, 10013, 1,  59.50,  14.30),
+ ( 6,  5,  4, 3, 10014, 3,  14.95,   3.20),
+ -- Q3
+ ( 7,  6,  5, 2, 10015, 1, 275.00,  68.75),
+ ( 7,  3,  1, 4, 10016, 2,  45.50,  10.80),
+ ( 8,  9,  6, 1, 10017, 1, 110.00,  27.50),
+ ( 8,  1,  7, 5, 10018, 4,  19.99,   4.80),
+ ( 8, 10,  8, 3, 10019, 6,  24.99,   6.75),
+ ( 9,  4,  9, 2, 10020, 2,  32.00,   8.20),
+ ( 9,  8, 10, 4, 10021, 1,  59.50,  14.30),
+ ( 9,  2,  1, 1, 10022, 1,  89.00,  22.50),
+ -- Q4 — heavier volume + holiday spike
+ (10,  6,  2, 2, 10023, 2, 275.00,  68.75),
+ (10,  5,  3, 5, 10024, 4,  14.95,   3.20),
+ (10,  7,  4, 3, 10025, 3,  55.00,  13.75),
+ (10,  9,  5, 1, 10026, 2, 110.00,  27.50),
+ (10,  3,  6, 4, 10027, 2,  45.50,  10.80),
+ (11,  1,  7, 2, 10028, 8,  19.99,   4.80),
+ (11,  8,  8, 5, 10029, 2,  59.50,  14.30),
+ (11, 10,  9, 3, 10030, 5,  24.99,   6.75),
+ (11,  6, 10, 1, 10031, 1, 275.00,  68.75),
+ (11,  4,  1, 4, 10032, 3,  32.00,   8.20),
+ (12,  2,  2, 2, 10033, 3,  89.00,  22.50),
+ (12,  5,  3, 5, 10034, 6,  14.95,   3.20),
+ (12,  9,  4, 3, 10035, 2, 110.00,  27.50),
+ (12,  7,  5, 1, 10036, 2,  55.00,  13.75),
+ (12,  1,  6, 4, 10037, 4,  19.99,   4.80),
+ (12, 10,  7, 2, 10038, 8,  24.99,   6.75),
+ (12,  8,  8, 5, 10039, 3,  59.50,  14.30),
+ (12,  3,  9, 3, 10040, 2,  45.50,  10.80),
+ (12,  6, 10, 1, 10041, 1, 275.00,  68.75);

--- a/saiku-launcher/src/main/resources/seed/tpcds.ossie.yaml
+++ b/saiku-launcher/src/main/resources/seed/tpcds.ossie.yaml
@@ -1,0 +1,165 @@
+# TPC-DS retail semantic model — trimmed to the 5 base datasets, 4 relationships,
+# and 5 metrics for the Saiku demo. Sourced from
+# https://github.com/apache/ossie/blob/main/examples/tpcds_semantic_model.yaml
+# and adapted so it loads against a local H2 fixture: the ANSI-SQL expressions
+# reference bare column names (H2 doesn't schema-qualify by default) and the
+# sources match the CREATE TABLE names in tpcds-seed.sql.
+version: 0.2.0.dev0
+
+semantic_model:
+- name: TPCDS
+  description: TPC-DS retail — sales, customers, products, stores.
+  ai_context:
+    instructions: Retail analytics against a small TPC-DS fixture. Time via date_dim; customers via customer; products via item; stores via store.
+
+  datasets:
+  - name: store_sales
+    source: STORE_SALES
+    primary_key: [SS_ITEM_SK, SS_TICKET_NUMBER]
+    description: Store-sales transactions.
+    fields:
+    - name: ss_sold_date_sk
+      expression: {dialects: [{dialect: ANSI_SQL, expression: SS_SOLD_DATE_SK}]}
+    - name: ss_item_sk
+      expression: {dialects: [{dialect: ANSI_SQL, expression: SS_ITEM_SK}]}
+    - name: ss_customer_sk
+      expression: {dialects: [{dialect: ANSI_SQL, expression: SS_CUSTOMER_SK}]}
+    - name: ss_store_sk
+      expression: {dialects: [{dialect: ANSI_SQL, expression: SS_STORE_SK}]}
+    - name: ss_ticket_number
+      expression: {dialects: [{dialect: ANSI_SQL, expression: SS_TICKET_NUMBER}]}
+    - name: ss_quantity
+      expression: {dialects: [{dialect: ANSI_SQL, expression: SS_QUANTITY}]}
+    - name: ss_sales_price
+      expression: {dialects: [{dialect: ANSI_SQL, expression: SS_SALES_PRICE}]}
+    - name: ss_net_profit
+      expression: {dialects: [{dialect: ANSI_SQL, expression: SS_NET_PROFIT}]}
+
+  - name: date_dim
+    source: DATE_DIM
+    primary_key: [D_DATE_SK]
+    description: Date dimension.
+    fields:
+    - name: d_date_sk
+      expression: {dialects: [{dialect: ANSI_SQL, expression: D_DATE_SK}]}
+    - name: d_date
+      expression: {dialects: [{dialect: ANSI_SQL, expression: D_DATE}]}
+    - name: d_year
+      expression: {dialects: [{dialect: ANSI_SQL, expression: D_YEAR}]}
+    - name: d_quarter
+      expression: {dialects: [{dialect: ANSI_SQL, expression: D_QUARTER_NAME}]}
+    - name: d_month
+      expression: {dialects: [{dialect: ANSI_SQL, expression: D_MONTH_NAME}]}
+
+  - name: customer
+    source: CUSTOMER
+    primary_key: [C_CUSTOMER_SK]
+    description: Customer dimension.
+    fields:
+    - name: c_customer_sk
+      expression: {dialects: [{dialect: ANSI_SQL, expression: C_CUSTOMER_SK}]}
+    - name: c_customer_id
+      expression: {dialects: [{dialect: ANSI_SQL, expression: C_CUSTOMER_ID}]}
+    - name: c_first_name
+      expression: {dialects: [{dialect: ANSI_SQL, expression: C_FIRST_NAME}]}
+    - name: c_last_name
+      expression: {dialects: [{dialect: ANSI_SQL, expression: C_LAST_NAME}]}
+    - name: c_email
+      expression: {dialects: [{dialect: ANSI_SQL, expression: C_EMAIL_ADDRESS}]}
+    - name: c_state
+      expression: {dialects: [{dialect: ANSI_SQL, expression: C_STATE}]}
+
+  - name: item
+    source: ITEM
+    primary_key: [I_ITEM_SK]
+    description: Product / item dimension.
+    fields:
+    - name: i_item_sk
+      expression: {dialects: [{dialect: ANSI_SQL, expression: I_ITEM_SK}]}
+    - name: i_item_id
+      expression: {dialects: [{dialect: ANSI_SQL, expression: I_ITEM_ID}]}
+    - name: i_item_desc
+      expression: {dialects: [{dialect: ANSI_SQL, expression: I_ITEM_DESC}]}
+    - name: i_brand
+      expression: {dialects: [{dialect: ANSI_SQL, expression: I_BRAND}]}
+    - name: i_category
+      expression: {dialects: [{dialect: ANSI_SQL, expression: I_CATEGORY}]}
+    - name: i_current_price
+      expression: {dialects: [{dialect: ANSI_SQL, expression: I_CURRENT_PRICE}]}
+
+  - name: store
+    source: STORE
+    primary_key: [S_STORE_SK]
+    description: Store dimension.
+    fields:
+    - name: s_store_sk
+      expression: {dialects: [{dialect: ANSI_SQL, expression: S_STORE_SK}]}
+    - name: s_store_id
+      expression: {dialects: [{dialect: ANSI_SQL, expression: S_STORE_ID}]}
+    - name: s_store_name
+      expression: {dialects: [{dialect: ANSI_SQL, expression: S_STORE_NAME}]}
+    - name: s_city
+      expression: {dialects: [{dialect: ANSI_SQL, expression: S_CITY}]}
+    - name: s_state
+      expression: {dialects: [{dialect: ANSI_SQL, expression: S_STATE}]}
+    - name: s_number_employees
+      expression: {dialects: [{dialect: ANSI_SQL, expression: S_NUMBER_EMPLOYEES}]}
+
+  metrics:
+  - name: total_sales
+    description: Sum of net sales (quantity × sales_price) across all transactions.
+    expression:
+      dialects:
+      - dialect: ANSI_SQL
+        expression: SUM("store_sales"."SS_QUANTITY" * "store_sales"."SS_SALES_PRICE")
+    aggregation_kind: sum
+  - name: total_profit
+    description: Sum of net profit across all transactions.
+    expression:
+      dialects:
+      - dialect: ANSI_SQL
+        expression: SUM("store_sales"."SS_NET_PROFIT")
+    aggregation_kind: sum
+  - name: transaction_count
+    description: Number of store-sale line items.
+    expression:
+      dialects:
+      - dialect: ANSI_SQL
+        expression: COUNT(*)
+    aggregation_kind: count
+  - name: avg_ticket
+    description: Average sales_price per transaction.
+    expression:
+      dialects:
+      - dialect: ANSI_SQL
+        expression: AVG("store_sales"."SS_SALES_PRICE")
+    aggregation_kind: avg
+  - name: distinct_customers
+    description: Distinct customer count over the sales fact.
+    expression:
+      dialects:
+      - dialect: ANSI_SQL
+        expression: COUNT(DISTINCT "store_sales"."SS_CUSTOMER_SK")
+    aggregation_kind: count
+
+  relationships:
+  - name: store_sales_to_date
+    from: store_sales
+    to: date_dim
+    from_columns: [SS_SOLD_DATE_SK]
+    to_columns: [D_DATE_SK]
+  - name: store_sales_to_customer
+    from: store_sales
+    to: customer
+    from_columns: [SS_CUSTOMER_SK]
+    to_columns: [C_CUSTOMER_SK]
+  - name: store_sales_to_item
+    from: store_sales
+    to: item
+    from_columns: [SS_ITEM_SK]
+    to_columns: [I_ITEM_SK]
+  - name: store_sales_to_store
+    from: store_sales
+    to: store
+    from_columns: [SS_STORE_SK]
+    to_columns: [S_STORE_SK]


### PR DESCRIPTION
Follow-up to PR #1395. Adds two new Ossie demo datasources auto-provisioned
by the launcher on first boot, based on Apache Ossie example YAMLs.

## Summary

- **TPC-DS retail** — sourced from
  https://github.com/apache/ossie/blob/main/examples/tpcds_semantic_model.yaml,
  trimmed to 5 datasets + 5 metrics + 4 relationships.
- **Flights** — sourced from
  https://github.com/apache/ossie/blob/main/examples/flights.yaml, trimmed to
  4 datasets + 5 metrics + 3 relationships. Uses the `ontology_mappings`
  envelope shape (exercises the reader extension below).
- Each ships with a small H2 fixture SQL (~50 fact rows spanning multiple
  months) so anomaly + forecast endpoints have real signal.

## Reader extension

The flights.yaml file wraps its `semantic_model:` inside an
`ontology_mappings:` envelope. Previously the reader only walked the top-level
`semantic_model` list.

`OssieDocument` now models the `ontology_mappings` block and exposes
`getEffectiveSemanticModels()` which merges the top-level list with any nested
inside `ontology_mappings[*].semantic_model`. Discover and OssieSchemaFactory
both switched to the new getter. Existing docs round-trip identically.

## Launcher bootstrap

`stageOssieDemoDatasources` runs on every serve; for each of tpcds/flights it
stages the YAML, seeds the H2 fixture, and writes the .sds. All three writes
idempotent — repeat boots skip existing files.

## Bug fix — SQL seed splitter

The seed-runner used `sql.split(";\\s*\\r?\\n")` then skipped chunks whose
`.strip().startsWith("--")` was true. Correct for standalone comment lines but
killed INSERT statements preceded by a header comment:

```
-- 12 months across 2024
INSERT INTO DATE_DIM VALUES ...
```

New `stripLeadingSqlComments` helper walks leading `--` lines and returns the
first real statement.

## Test plan

- [x] Fresh saiku-home boot auto-provisions Pharma + TPCDS + Flights
- [x] `GET /ai/ossie/models` returns all 3
- [x] TPCDS `transaction_count` = 41 (fact-only, no join)
- [x] TPCDS brand × total_sales returns 7 brands (DeskPro top at $1650)
- [x] Flights month × avg_dep_delay returns 6 months with seasonal ramp
      (3 → 4 → 4 → 6 → 11 → 18 minutes) — primed for /forecast + /anomaly demos
- [x] `mvn verify` on saiku-core clean
