### PR TITLE
feat(ossie/ai): expose field.label in schema + response columns

### DIFF
--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/ossie/ai/OssieAiSchema.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/ossie/ai/OssieAiSchema.java
@@ -195,6 +195,12 @@ public class OssieAiSchema {
     @JsonInclude(JsonInclude.Include.NON_NULL)
     public static class Field {
         private String name;
+        /**
+         * Human-readable label from Ossie {@code field.label} (spec 0.2.0.dev0). Nullable —
+         * consumers fall back to {@link #name}. Surfaces "Net Revenue" alongside {@code NETREVENUE}.
+         */
+        private String label;
+
         private String type;
         private String description;
         private String unit;
@@ -214,6 +220,14 @@ public class OssieAiSchema {
 
         public void setName(String v) {
             this.name = v;
+        }
+
+        public String getLabel() {
+            return label;
+        }
+
+        public void setLabel(String v) {
+            this.label = v;
         }
 
         public String getType() {

--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/ossie/ai/OssieAiSchemaProjector.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/ossie/ai/OssieAiSchemaProjector.java
@@ -109,6 +109,7 @@ public final class OssieAiSchemaProjector {
                 if (f.isPii()) continue; // saiku#902 parity — PII fields never enter the AI view.
                 OssieAiSchema.Field out_field = new OssieAiSchema.Field();
                 out_field.setName(f.getName());
+                out_field.setLabel(f.getLabel());
                 out_field.setDescription(f.getDescription());
                 // Type + samples come from the warehouse. Best-effort: swallow failures so
                 // the schema still projects when the warehouse is offline (agent still sees

--- a/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/AiOssieResource.java
+++ b/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/AiOssieResource.java
@@ -1018,13 +1018,13 @@ public class AiOssieResource {
         int dimIdx = 0;
         for (OssieAiQueryRequest.FieldRef r : req.getRows()) {
             OssieAiQueryResponse.Column col = new OssieAiQueryResponse.Column(
-                    r.getDataset() + "." + r.getField(), headerLabel(header, dimIdx, r.getField()), "dimension");
+                    r.getDataset() + "." + r.getField(), dimensionLabel(schema, r, header, dimIdx), "dimension");
             out.getColumns().add(col);
             dimIdx++;
         }
         for (OssieAiQueryRequest.FieldRef c : req.getColumns()) {
             OssieAiQueryResponse.Column col = new OssieAiQueryResponse.Column(
-                    c.getDataset() + "." + c.getField(), headerLabel(header, dimIdx, c.getField()), "dimension");
+                    c.getDataset() + "." + c.getField(), dimensionLabel(schema, c, header, dimIdx), "dimension");
             out.getColumns().add(col);
             dimIdx++;
         }
@@ -1223,6 +1223,25 @@ public class AiOssieResource {
             sup.put("reason", "k-anonymity threshold k=" + kAnonymityFilter.threshold());
             body.put("suppressed", sup);
         }
+    }
+
+    /**
+     * Column label for a dimension: prefers the field's Ossie {@code label} (spec 0.2.0.dev0
+     * — surfaces "Net Revenue" alongside {@code NETREVENUE}), else the CellDataSet header, else
+     * the raw field name. Same fallback chain the MDX AI response uses.
+     */
+    private String dimensionLabel(
+            OssieAiSchema schema, OssieAiQueryRequest.FieldRef ref, AbstractBaseCell[] header, int idx) {
+        OssieAiSchema.Dataset ds = schema.getDatasets()
+                .get(ref.getDataset() == null ? "" : ref.getDataset().toLowerCase(java.util.Locale.ROOT));
+        if (ds != null) {
+            OssieAiSchema.Field f = ds.getFields()
+                    .get(ref.getField() == null ? "" : ref.getField().toLowerCase(java.util.Locale.ROOT));
+            if (f != null && f.getLabel() != null && !f.getLabel().isBlank()) {
+                return f.getLabel();
+            }
+        }
+        return headerLabel(header, idx, ref.getField());
     }
 
     private String headerLabel(AbstractBaseCell[] header, int idx, String fallback) {

--- a/saiku-launcher/src/main/resources/seed/flights.ossie.yaml
+++ b/saiku-launcher/src/main/resources/seed/flights.ossie.yaml
@@ -42,14 +42,19 @@ ontology_mappings:
       - name: dest_airport_id
         expression: {dialects: [{dialect: ANSI_SQL, expression: DEST_AIRPORT_ID}]}
       - name: scheduled_date_month
+        label: Month
         expression: {dialects: [{dialect: ANSI_SQL, expression: SCHEDULED_DATE_MONTH}]}
       - name: dep_delay_min
+        label: Departure delay (min)
         expression: {dialects: [{dialect: ANSI_SQL, expression: DEP_DELAY_MIN}]}
       - name: arr_delay_min
+        label: Arrival delay (min)
         expression: {dialects: [{dialect: ANSI_SQL, expression: ARR_DELAY_MIN}]}
       - name: cancelled
+        label: Cancelled
         expression: {dialects: [{dialect: ANSI_SQL, expression: CANCELLED}]}
       - name: distance_miles
+        label: Distance (miles)
         expression: {dialects: [{dialect: ANSI_SQL, expression: DISTANCE_MILES}]}
 
     - name: carrier
@@ -60,10 +65,13 @@ ontology_mappings:
       - name: carrier_id
         expression: {dialects: [{dialect: ANSI_SQL, expression: CARRIER_ID}]}
       - name: iata_code
+        label: IATA code
         expression: {dialects: [{dialect: ANSI_SQL, expression: IATA_CODE}]}
       - name: carrier_name
+        label: Carrier
         expression: {dialects: [{dialect: ANSI_SQL, expression: CARRIER_NAME}]}
       - name: hub_state
+        label: Hub state
         expression: {dialects: [{dialect: ANSI_SQL, expression: HUB_STATE}]}
 
     - name: airport
@@ -74,12 +82,16 @@ ontology_mappings:
       - name: airport_id
         expression: {dialects: [{dialect: ANSI_SQL, expression: AIRPORT_ID}]}
       - name: airport_code
+        label: Airport code
         expression: {dialects: [{dialect: ANSI_SQL, expression: AIRPORT_CODE}]}
       - name: airport_name
+        label: Airport
         expression: {dialects: [{dialect: ANSI_SQL, expression: AIRPORT_NAME}]}
       - name: airport_city
+        label: City
         expression: {dialects: [{dialect: ANSI_SQL, expression: AIRPORT_CITY}]}
       - name: airport_state
+        label: State
         expression: {dialects: [{dialect: ANSI_SQL, expression: AIRPORT_STATE}]}
 
     - name: aircraft
@@ -90,12 +102,16 @@ ontology_mappings:
       - name: tail_num
         expression: {dialects: [{dialect: ANSI_SQL, expression: TAIL_NUM}]}
       - name: manufacturer
+        label: Manufacturer
         expression: {dialects: [{dialect: ANSI_SQL, expression: MANUFACTURER}]}
       - name: model
+        label: Model
         expression: {dialects: [{dialect: ANSI_SQL, expression: MODEL}]}
       - name: number_of_seats
+        label: Seats
         expression: {dialects: [{dialect: ANSI_SQL, expression: NUMBER_OF_SEATS}]}
       - name: year_mfr
+        label: Year built
         expression: {dialects: [{dialect: ANSI_SQL, expression: YEAR_MFR}]}
 
     metrics:

--- a/saiku-launcher/src/main/resources/seed/tpcds.ossie.yaml
+++ b/saiku-launcher/src/main/resources/seed/tpcds.ossie.yaml
@@ -45,10 +45,13 @@ semantic_model:
     - name: d_date
       expression: {dialects: [{dialect: ANSI_SQL, expression: D_DATE}]}
     - name: d_year
+      label: Year
       expression: {dialects: [{dialect: ANSI_SQL, expression: D_YEAR}]}
     - name: d_quarter
+      label: Quarter
       expression: {dialects: [{dialect: ANSI_SQL, expression: D_QUARTER_NAME}]}
     - name: d_month
+      label: Month
       expression: {dialects: [{dialect: ANSI_SQL, expression: D_MONTH_NAME}]}
 
   - name: customer
@@ -61,12 +64,16 @@ semantic_model:
     - name: c_customer_id
       expression: {dialects: [{dialect: ANSI_SQL, expression: C_CUSTOMER_ID}]}
     - name: c_first_name
+      label: First name
       expression: {dialects: [{dialect: ANSI_SQL, expression: C_FIRST_NAME}]}
     - name: c_last_name
+      label: Last name
       expression: {dialects: [{dialect: ANSI_SQL, expression: C_LAST_NAME}]}
     - name: c_email
+      label: Email address
       expression: {dialects: [{dialect: ANSI_SQL, expression: C_EMAIL_ADDRESS}]}
     - name: c_state
+      label: State
       expression: {dialects: [{dialect: ANSI_SQL, expression: C_STATE}]}
 
   - name: item
@@ -79,12 +86,16 @@ semantic_model:
     - name: i_item_id
       expression: {dialects: [{dialect: ANSI_SQL, expression: I_ITEM_ID}]}
     - name: i_item_desc
+      label: Description
       expression: {dialects: [{dialect: ANSI_SQL, expression: I_ITEM_DESC}]}
     - name: i_brand
+      label: Brand
       expression: {dialects: [{dialect: ANSI_SQL, expression: I_BRAND}]}
     - name: i_category
+      label: Category
       expression: {dialects: [{dialect: ANSI_SQL, expression: I_CATEGORY}]}
     - name: i_current_price
+      label: Current price
       expression: {dialects: [{dialect: ANSI_SQL, expression: I_CURRENT_PRICE}]}
 
   - name: store
@@ -97,12 +108,16 @@ semantic_model:
     - name: s_store_id
       expression: {dialects: [{dialect: ANSI_SQL, expression: S_STORE_ID}]}
     - name: s_store_name
+      label: Store name
       expression: {dialects: [{dialect: ANSI_SQL, expression: S_STORE_NAME}]}
     - name: s_city
+      label: City
       expression: {dialects: [{dialect: ANSI_SQL, expression: S_CITY}]}
     - name: s_state
+      label: State
       expression: {dialects: [{dialect: ANSI_SQL, expression: S_STATE}]}
     - name: s_number_employees
+      label: Employees
       expression: {dialects: [{dialect: ANSI_SQL, expression: S_NUMBER_EMPLOYEES}]}
 
   metrics:


### PR DESCRIPTION
Small follow-up to PR #1406. Surfaces Ossie's `field.label` (spec
0.2.0.dev0) through the AI schema and the response columns.

## Summary

- `OssieAiSchema.Field` gets a `label` property; `OssieAiSchemaProjector`
  copies `f.getLabel()` so `GET /ai/ossie/schema/{c}/{m}` publishes "Net
  Revenue" alongside `netrevenue`.
- `AiOssieResource.toRecordsResponse` — dimension columns pick the field
  label first, fall back to the CellDataSet header, then to the raw field
  name. Metric columns unchanged (metric labels aren't in the Ossie spec
  yet).
- TPC-DS and Flights demo YAMLs get labels on their dimension fields so
  the affordance is visible immediately — Brand / Category / Airport /
  Carrier / etc.

## Not in this PR

Dataset and metric labels aren't in the Ossie spec at 0.2.0.dev0. When
there's demand, file upstream against `apache/ossie` and add
`dataset.label` / `metric.label` here too.

## Test plan

- [x] `mvn -pl saiku-core/saiku-service test -Dtest='OssieAi*'` green
- [x] `mvn -pl saiku-core/saiku-web -am compile` clean
- [x] Live smoke on local launcher: `GET /schema/unknown_TPCDS/TPCDS`
      returns e.g. `{"i_brand": {"name": "i_brand", "label": "Brand", ...}}`
- [x] `POST /query` with rows=[{dataset:item,field:i_brand}] returns
      column with `label: "Brand"` instead of `label: "i_brand"`
