### PR TITLE
feat(ossie/dbt): MetricFlow → Ossie converter + translator field-expression fix

### DIFF
--- a/docs/dbt-hookup/README.md
+++ b/docs/dbt-hookup/README.md
@@ -1,0 +1,148 @@
+# dbt / MetricFlow → Saiku hookup
+
+Point Saiku at your existing dbt project's semantic model. The
+converter here reads MetricFlow YAML (the shape dbt has used since
+1.7) and emits [Apache Ossie](https://github.com/apache/ossie) YAML
+that Saiku loads through its normal datasource registration.
+
+Once wired, everything Saiku exposes over its Ossie model — the
+workbench, `/rest/saiku/api/ai/ossie/*` REST surface, the 5 MCP tools,
+the `/ai/ossie/ask` natural-language layer, anomaly + forecast
+endpoints — works against your dbt semantic layer with zero
+re-modelling.
+
+## Why not `dbt --osi` directly?
+
+dbt Core v1.12 will emit OSI JSON natively via
+[`target/osi_document.json`](https://docs.getdbt.com/docs/build/osi-semantic-models),
+but v1.12 hasn't shipped to PyPI yet (as of July 2026 the latest
+release is 1.11.12). Meanwhile most dbt projects in the wild have
+MetricFlow semantic models today, and dbt has been emitting OSI
+v0.1.x — Saiku follows v0.2.0.dev0 (the current draft). Either way,
+a version-adapter is a real need — this converter is that adapter.
+
+Once dbt 1.12 ships and stabilises on the same spec version as
+Saiku, this converter becomes a thin CLI over "read the JSON dbt
+already wrote."
+
+## Ingredients
+
+- `orders_semantic.yml` — a sample MetricFlow YAML (semantic_models +
+  metrics)
+- `metricflow_to_ossie.py` — the converter (~200 lines, pure Python +
+  pyyaml)
+- `orders-seed.sql` — an H2 fixture that mirrors what the dbt project's
+  `fct_orders` / `dim_customers` / `dim_locations` models would produce
+
+## One-shot walkthrough
+
+```bash
+# 1. Convert MetricFlow YAML → Ossie YAML.
+cd docs/dbt-hookup
+pip install pyyaml
+python3 metricflow_to_ossie.py orders_semantic.yml \
+  --model-name Orders \
+  --description "Orders demo from dbt MetricFlow" \
+  > orders.ossie.yaml
+
+# 2. Seed the warehouse — H2 for the local smoke; swap for your real
+#    warehouse's JDBC URL when running for keeps.
+H2_JAR=$(find ~/.m2 -name 'h2-2.3.232.jar' | head -1)
+java -cp "$H2_JAR" org.h2.tools.RunScript \
+  -url "jdbc:h2:$PWD/orders;MODE=PostgreSQL" \
+  -user sa -password '' \
+  -script orders-seed.sql
+
+# 3. Register with Saiku. Drop this .sds template into
+#    saiku-home/repository/data/unknown/datasources/ with @SAIKU_HOME@
+#    substituted (same shape as tpcds-ossie.sds / flights-ossie.sds).
+cat > /tmp/orders-ossie.sds <<EOF
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<dataSource>
+    <id>orders-ossie-01</id>
+    <name>Orders</name>
+    <type>OSSIE</type>
+    <ossieYaml>${PWD}/orders.ossie.yaml</ossieYaml>
+    <location>jdbc:h2:${PWD}/orders;MODE=PostgreSQL;AUTO_SERVER=TRUE</location>
+    <schema>Orders</schema>
+    <username>sa</username>
+    <password></password>
+    <advanced>false</advanced>
+    <enabled>true</enabled>
+</dataSource>
+EOF
+
+# 4. Point Saiku at it (either by copying the .sds file into your
+#    running launcher's saiku-home/repository/data/unknown/datasources/
+#    or via the admin API), then verify:
+curl -s http://localhost:8080/rest/saiku/api/ai/ossie/models \
+    -b /tmp/saiku-cookies.txt | jq '.[] | select(.modelName == "Orders")'
+```
+
+Expected output:
+
+```json
+{
+  "connectionName": "unknown_Orders",
+  "modelName": "Orders",
+  "description": "Orders demo from dbt MetricFlow",
+  "factDataset": "orders",
+  "datasetCount": 3,
+  "metricCount": 3
+}
+```
+
+## What the converter maps
+
+| MetricFlow shape | Ossie shape |
+| --- | --- |
+| `semantic_models[*]` | `datasets[*]` (name + description + fields + primary_key) |
+| `.model: ref('fct_orders')` | `dataset.source: FCT_ORDERS` |
+| `.entities[type=primary]` | `dataset.primary_key` |
+| `.entities[type=foreign]` | Ossie `relationships` (matched to primary entities on other datasets by name) |
+| `.dimensions[*]` (label + expr) | `dataset.fields[*]` — label field, ANSI expression |
+| `.measures[*]` | Building blocks for metrics — not surfaced directly (matches Ossie's shape) |
+| `metrics[type=simple]` | `metrics[*]` — expression composed from `agg(expr)` on the source dataset |
+| `metrics[type=ratio]` | `metrics[*]` — expression `(SUM(num)) / NULLIF(SUM(denom), 0)` |
+| `metrics[type=cumulative]` | Warning + skip (out of scope; file an issue if you need it) |
+| `metrics[type=derived]` | Warning + skip (same) |
+
+## What you get on the Saiku side
+
+Same surface as any other Ossie model:
+
+- **Workbench UI** — drag-drop shelves, undo/redo, sort/limit,
+  aggregation override, right-click filter, crosstab pivot, chart view
+- **AI Query API** at `/rest/saiku/api/ai/ossie/*` — /models, /schema,
+  /query, /query/preview, /values/search, /query/execute-async,
+  /anomaly, /forecast, /row-detail, /ask (see
+  [`AI-OSSIE-API.md`](../AI-OSSIE-API.md))
+- **MCP tools** at `/rest/saiku/api/mcp` — `list_ossie_models`,
+  `describe_ossie_model`, `search_field_values`, `run_ossie_query`,
+  `preview_ossie_query`
+- **k-anonymity + PII redaction** — configure at the launcher, applies
+  to all Ossie models uniformly
+
+## What's not translated (yet)
+
+- **`metrics[type=cumulative]`** — MetricFlow's rolling / period-to-date
+  metrics need Ossie window-function support that we don't emit today.
+- **`metrics[type=derived]`** — arbitrary expressions over other
+  metrics. Doable, but the R1 converter only walks one level for
+  ratios; deeper nesting would need iteration.
+- **Custom aggregations** — `median`, `percentile_cont`, etc. work
+  when the underlying warehouse supports them (Postgres, DuckDB,
+  Snowflake, BigQuery all do; H2 depends on version). No behaviour
+  difference from any other Ossie metric expression — the converter
+  just spells them out.
+- **`agg_time_dimension` inference** — MetricFlow uses it to auto-add
+  time filters; Ossie leaves that to the caller. Set `timeAxis`
+  explicitly on `/anomaly` + `/forecast` requests.
+
+## Feedback + issues
+
+Improvements to the converter live under the parent tracker
+[#1394](https://github.com/spiculedata/saiku/issues/1394). If dbt v1.12
+lands before we drop this shim, we'll switch to reading
+`target/osi_document.json` directly and this file becomes a fallback
+for older dbt projects.

--- a/docs/dbt-hookup/metricflow_to_ossie.py
+++ b/docs/dbt-hookup/metricflow_to_ossie.py
@@ -1,0 +1,340 @@
+#!/usr/bin/env python3
+"""
+metricflow_to_ossie — translate a dbt MetricFlow YAML into an Ossie
+(v0.2.0.dev0) YAML that Saiku can load as an Ossie datasource.
+
+Rationale
+---------
+dbt Core v1.12 will consume/emit OSI documents natively, but as of
+July 2026 v1.12 hasn't shipped to PyPI (1.11.12 is latest). Meanwhile
+most dbt projects in the wild have MetricFlow semantic models today.
+
+This script bridges the gap: it reads MetricFlow YAML (the shape dbt
+projects have been using since dbt 1.7) and emits Ossie YAML. The
+mapping is deterministic — both formats describe the same thing.
+
+MetricFlow → Ossie mapping
+--------------------------
+| MetricFlow                 | Ossie                                    |
+| -------------------------- | ---------------------------------------- |
+| semantic_models[*].name    | semantic_model.datasets[*].name          |
+| semantic_models[*].model   | dataset.source (ref('x') → x uppercased) |
+| .entities[type=primary]    | dataset.primary_key                      |
+| .entities[type=foreign]    | Ossie relationships (see below)          |
+| .dimensions[*]             | dataset.fields[*] (label + expr copy)    |
+| .measures[*]               | (not surfaced — MetricFlow uses these    |
+|                            |  as building blocks for metrics)         |
+| metrics[type=simple]       | metrics[*] (measure's agg + expr)        |
+| metrics[type=ratio]        | metrics[*] with SUM(num)/SUM(denom) SQL  |
+
+Relationships
+-------------
+MetricFlow doesn't declare joins directly — it infers them from
+matching entity names across semantic models. If dataset A has a
+foreign entity `customer_id` and dataset B has a primary entity
+`customer_id`, MetricFlow joins A → B on that column.
+
+This converter replays the same rule: every foreign entity gets a
+relationship to whichever other semantic model exposes the same
+entity as primary.
+
+Usage
+-----
+    python3 metricflow_to_ossie.py orders_semantic.yml > orders.ossie.yaml
+
+Then drop the output into your Saiku launcher's saiku-home/data/ and
+register a .sds datasource pointing at the warehouse. See README.md.
+"""
+from __future__ import annotations
+
+import argparse
+import sys
+from typing import Any
+
+try:
+    import yaml
+except ImportError:
+    print("This script needs pyyaml: pip install pyyaml", file=sys.stderr)
+    sys.exit(2)
+
+
+AGG_FUNCS = {
+    "sum": "SUM",
+    "count": "COUNT",
+    "count_distinct": "COUNT",  # will wrap in DISTINCT below
+    "avg": "AVG",
+    "average": "AVG",
+    "min": "MIN",
+    "max": "MAX",
+    "median": "MEDIAN",
+    "percentile": "PERCENTILE_CONT",
+}
+
+
+def measure_expression(dataset_name: str, measure: dict) -> str:
+    """Compose the ANSI-SQL expression a Simple metric emits.
+
+    MetricFlow measures have shape {name, agg, expr}. `expr` defaults to
+    the measure's own name — Ossie's ANSI dialect wants a fully-qualified
+    aggregate call. So `agg: sum, expr: order_total` on dataset `orders`
+    becomes `SUM("orders"."order_total")`.
+
+    COUNT with `expr: 1` — MetricFlow's canonical "count of rows" idiom —
+    collapses to `COUNT(*)`. COUNT DISTINCT wraps the target expression.
+    """
+    agg = str(measure.get("agg", "sum")).lower()
+    expr = str(measure.get("expr", measure["name"]))
+    sql_func = AGG_FUNCS.get(agg, "SUM")
+    if agg == "count" and expr.strip() == "1":
+        return "COUNT(*)"
+    ref = f'"{dataset_name}"."{expr}"'
+    if agg == "count_distinct":
+        return f"COUNT(DISTINCT {ref})"
+    return f"{sql_func}({ref})"
+
+
+def build_datasets(semantic_models: list[dict]) -> list[dict]:
+    """MetricFlow's semantic_models[*] → Ossie datasets[*].
+
+    We drop measures — those become metrics later. Dimensions become
+    Ossie fields; labels + expressions carry across 1:1. Primary
+    entities populate the dataset's primary_key.
+    """
+    out = []
+    for sm in semantic_models:
+        name = sm["name"]
+        # ref('fct_orders') → FCT_ORDERS. Fallback to the sm.name if no model.
+        source = _extract_ref(sm.get("model", name))
+        primary_key = []
+        for e in sm.get("entities", []):
+            if e.get("type") == "primary":
+                primary_key.append(e.get("expr", e["name"]).upper())
+        fields = []
+        for d in sm.get("dimensions", []):
+            f = {
+                "name": d["name"],
+                "expression": {
+                    "dialects": [
+                        {
+                            "dialect": "ANSI_SQL",
+                            "expression": str(d.get("expr", d["name"])).upper(),
+                        }
+                    ]
+                },
+            }
+            if d.get("label"):
+                f["label"] = d["label"]
+            if d.get("description"):
+                f["description"] = d["description"]
+            fields.append(f)
+        # Add primary-key columns as fields too, so agents can filter on them.
+        for e in sm.get("entities", []):
+            col = str(e.get("expr", e["name"])).upper()
+            if any(fld["name"].upper() == col.lower().upper() for fld in fields):
+                continue
+            fields.append(
+                {
+                    "name": e["name"],
+                    "expression": {
+                        "dialects": [{"dialect": "ANSI_SQL", "expression": col}]
+                    },
+                }
+            )
+        ds = {
+            "name": name,
+            "source": source,
+            "fields": fields,
+        }
+        if primary_key:
+            ds["primary_key"] = primary_key
+        if sm.get("description"):
+            ds["description"] = sm["description"]
+        out.append(ds)
+    return out
+
+
+def build_metrics(metrics: list[dict], semantic_models: list[dict]) -> list[dict]:
+    """MetricFlow metrics[*] → Ossie metrics[*].
+
+    Simple metrics reference a measure; we look the measure up in the
+    semantic_models to compose the aggregate expression. Ratio metrics
+    become `SUM(numerator) / NULLIF(SUM(denominator), 0)` — safe against
+    the zero-denominator case.
+    """
+    # Build a measure lookup: measure_name → (dataset_name, measure dict)
+    measure_index: dict[str, tuple[str, dict]] = {}
+    for sm in semantic_models:
+        for m in sm.get("measures", []):
+            measure_index[m["name"]] = (sm["name"], m)
+
+    # And a metric lookup for ratio-composition.
+    metric_index: dict[str, dict] = {m["name"]: m for m in metrics}
+    out = []
+    for m in metrics:
+        mtype = m.get("type", "simple")
+        expr = None
+        agg_kind = None
+        if mtype == "simple":
+            measure_name = m.get("type_params", {}).get("measure")
+            if not measure_name or measure_name not in measure_index:
+                print(
+                    f"warning: metric '{m['name']}' references unknown measure "
+                    f"'{measure_name}'; skipping",
+                    file=sys.stderr,
+                )
+                continue
+            ds_name, measure = measure_index[measure_name]
+            expr = measure_expression(ds_name, measure)
+            agg_kind = str(measure.get("agg", "sum")).lower()
+        elif mtype == "ratio":
+            tp = m.get("type_params", {})
+            num_name = tp.get("numerator")
+            denom_name = tp.get("denominator")
+            num_expr = _resolve_metric_expr(num_name, metric_index, measure_index)
+            denom_expr = _resolve_metric_expr(denom_name, metric_index, measure_index)
+            if num_expr and denom_expr:
+                expr = f"({num_expr}) / NULLIF({denom_expr}, 0)"
+                agg_kind = "ratio"
+            else:
+                print(
+                    f"warning: ratio metric '{m['name']}' unresolvable; skipping",
+                    file=sys.stderr,
+                )
+                continue
+        else:
+            # cumulative, derived — out of scope for the R1 converter.
+            print(
+                f"warning: metric type '{mtype}' on '{m['name']}' not translated; "
+                "skipping (file an issue if you need it)",
+                file=sys.stderr,
+            )
+            continue
+
+        ossie_m = {
+            "name": m["name"],
+            "expression": {"dialects": [{"dialect": "ANSI_SQL", "expression": expr}]},
+        }
+        if agg_kind:
+            ossie_m["aggregation_kind"] = agg_kind
+        if m.get("description"):
+            ossie_m["description"] = m["description"]
+        out.append(ossie_m)
+    return out
+
+
+def build_relationships(semantic_models: list[dict]) -> list[dict]:
+    """Infer relationships from matching entity names across semantic models.
+
+    MetricFlow's join semantics: dataset A's `type: foreign` entity joins
+    to dataset B's `type: primary` entity when the entity names match.
+    We replay that here, producing Ossie relationships that the auto-join
+    rule can act on at query time.
+    """
+    # Index each primary entity: name → (dataset_name, column_expr)
+    primaries: dict[str, tuple[str, str]] = {}
+    for sm in semantic_models:
+        for e in sm.get("entities", []):
+            if e.get("type") == "primary":
+                primaries[e["name"]] = (
+                    sm["name"],
+                    str(e.get("expr", e["name"])).upper(),
+                )
+    rels = []
+    seen = set()
+    for sm in semantic_models:
+        for e in sm.get("entities", []):
+            if e.get("type") != "foreign":
+                continue
+            if e["name"] not in primaries:
+                continue
+            src_col = str(e.get("expr", e["name"])).upper()
+            to_ds, to_col = primaries[e["name"]]
+            rel_name = f"{sm['name']}_to_{to_ds}"
+            key = (sm["name"], to_ds, src_col, to_col)
+            if key in seen:
+                continue
+            seen.add(key)
+            rels.append(
+                {
+                    "name": rel_name,
+                    "from": sm["name"],
+                    "to": to_ds,
+                    "from_columns": [src_col],
+                    "to_columns": [to_col],
+                }
+            )
+    return rels
+
+
+def convert(source: dict, model_name: str, description: str | None = None) -> dict:
+    """Assemble a full Ossie document from the parsed MetricFlow YAML."""
+    semantic_models = source.get("semantic_models", [])
+    metrics = source.get("metrics", [])
+    ossie_model: dict[str, Any] = {"name": model_name}
+    if description:
+        ossie_model["description"] = description
+    ossie_model["datasets"] = build_datasets(semantic_models)
+    metric_defs = build_metrics(metrics, semantic_models)
+    if metric_defs:
+        ossie_model["metrics"] = metric_defs
+    rels = build_relationships(semantic_models)
+    if rels:
+        ossie_model["relationships"] = rels
+    return {"version": "0.2.0.dev0", "semantic_model": [ossie_model]}
+
+
+def _extract_ref(model_expr: str) -> str:
+    """`ref('fct_orders')` → `FCT_ORDERS`. Bare strings pass through."""
+    s = model_expr.strip()
+    if s.startswith("ref(") and s.endswith(")"):
+        inner = s[4:-1].strip().strip("'\"")
+        return inner.upper()
+    return s.upper()
+
+
+def _resolve_metric_expr(
+    name: str | None,
+    metric_index: dict[str, dict],
+    measure_index: dict[str, tuple[str, dict]],
+) -> str | None:
+    """Resolve a metric-name reference (from ratio numerator/denominator)
+    to a concrete SQL expression by walking through the metric+measure
+    indices. One level deep only — nested ratios need iteration."""
+    if not name:
+        return None
+    if name in metric_index:
+        m = metric_index[name]
+        if m.get("type") == "simple":
+            measure_name = m.get("type_params", {}).get("measure")
+            if measure_name in measure_index:
+                ds_name, measure = measure_index[measure_name]
+                return measure_expression(ds_name, measure)
+    if name in measure_index:
+        ds_name, measure = measure_index[name]
+        return measure_expression(ds_name, measure)
+    return None
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__.strip().splitlines()[0])
+    ap.add_argument("source", help="Path to MetricFlow YAML.")
+    ap.add_argument(
+        "--model-name",
+        default="Model",
+        help="Name to give the emitted Ossie semantic_model. Default: Model.",
+    )
+    ap.add_argument(
+        "--description",
+        default=None,
+        help="Optional description written to semantic_model.description.",
+    )
+    args = ap.parse_args()
+    with open(args.source) as f:
+        src = yaml.safe_load(f)
+    out = convert(src, args.model_name, args.description)
+    yaml.safe_dump(out, sys.stdout, sort_keys=False, default_flow_style=False)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/docs/dbt-hookup/orders-seed.sql
+++ b/docs/dbt-hookup/orders-seed.sql
@@ -1,0 +1,76 @@
+-- Warehouse fixture that mirrors what the dbt project's `fct_orders`,
+-- `dim_customers`, `dim_locations` models would produce. Small enough
+-- to inspect; big enough to power the analytics demos.
+
+DROP TABLE IF EXISTS FCT_ORDERS;
+DROP TABLE IF EXISTS DIM_CUSTOMERS;
+DROP TABLE IF EXISTS DIM_LOCATIONS;
+
+CREATE TABLE DIM_CUSTOMERS (
+  ID              INT PRIMARY KEY,
+  CUSTOMER_TYPE   VARCHAR(16),
+  COUNTRY         VARCHAR(2)
+);
+
+INSERT INTO DIM_CUSTOMERS VALUES
+ (1, 'individual', 'US'),
+ (2, 'business',   'US'),
+ (3, 'individual', 'GB'),
+ (4, 'business',   'GB'),
+ (5, 'individual', 'CA'),
+ (6, 'business',   'DE');
+
+CREATE TABLE DIM_LOCATIONS (
+  ID     INT PRIMARY KEY,
+  NAME   VARCHAR(32),
+  REGION VARCHAR(16)
+);
+
+INSERT INTO DIM_LOCATIONS VALUES
+ (1, 'Downtown SF',  'West'),
+ (2, 'Times Square', 'East'),
+ (3, 'Camden Town',  'UK'),
+ (4, 'Berlin Mitte', 'DACH');
+
+CREATE TABLE FCT_ORDERS (
+  ID             INT PRIMARY KEY,
+  CUSTOMER_ID    INT,
+  LOCATION_ID    INT,
+  ORDERED_AT     VARCHAR(10),
+  IS_FOOD_ORDER  INT,
+  STATUS         VARCHAR(16),
+  ORDER_TOTAL    DECIMAL(10,2)
+);
+
+-- 30 orders across 4 locations, 6 customers, 6 months.
+INSERT INTO FCT_ORDERS VALUES
+ ( 1, 1, 1, '2024-07-05', 1, 'completed', 42.50),
+ ( 2, 2, 2, '2024-07-12', 0, 'completed', 155.00),
+ ( 3, 3, 3, '2024-07-19', 1, 'completed', 18.75),
+ ( 4, 4, 4, '2024-07-26', 0, 'completed', 220.00),
+ ( 5, 5, 1, '2024-08-02', 1, 'completed', 36.00),
+ ( 6, 6, 2, '2024-08-09', 0, 'cancelled', 89.50),
+ ( 7, 1, 3, '2024-08-16', 1, 'completed', 24.25),
+ ( 8, 2, 4, '2024-08-23', 0, 'completed', 175.75),
+ ( 9, 3, 1, '2024-09-01', 1, 'completed', 51.00),
+ (10, 4, 2, '2024-09-08', 0, 'refunded',  95.00),
+ (11, 5, 3, '2024-09-15', 1, 'completed', 33.50),
+ (12, 6, 4, '2024-09-22', 0, 'completed', 210.00),
+ (13, 1, 1, '2024-10-05', 1, 'completed', 47.25),
+ (14, 2, 2, '2024-10-12', 0, 'completed', 165.00),
+ (15, 3, 3, '2024-10-19', 1, 'completed', 22.00),
+ (16, 4, 4, '2024-10-26', 0, 'cancelled', 305.00),
+ (17, 5, 1, '2024-11-02', 1, 'completed', 41.75),
+ (18, 6, 2, '2024-11-09', 0, 'completed', 145.50),
+ (19, 1, 3, '2024-11-16', 1, 'completed', 28.00),
+ (20, 2, 4, '2024-11-23', 0, 'completed', 195.00),
+ (21, 3, 1, '2024-12-05', 1, 'completed', 55.25),
+ (22, 4, 2, '2024-12-12', 0, 'completed', 240.00),
+ (23, 5, 3, '2024-12-19', 1, 'completed', 32.75),
+ (24, 6, 4, '2024-12-26', 0, 'completed', 275.00),
+ (25, 1, 1, '2024-12-31', 1, 'completed', 62.50),
+ (26, 2, 2, '2024-07-04', 0, 'completed', 190.00),
+ (27, 3, 3, '2024-08-04', 1, 'completed', 19.50),
+ (28, 4, 4, '2024-09-04', 0, 'completed', 285.00),
+ (29, 5, 1, '2024-10-04', 1, 'completed', 44.00),
+ (30, 6, 2, '2024-11-04', 0, 'completed', 155.75);

--- a/docs/dbt-hookup/orders.ossie.yaml
+++ b/docs/dbt-hookup/orders.ossie.yaml
@@ -1,0 +1,126 @@
+version: 0.2.0.dev0
+semantic_model:
+- name: Orders
+  description: "Orders demo \u2014 converted from dbt MetricFlow YAML"
+  datasets:
+  - name: orders
+    source: FCT_ORDERS
+    fields:
+    - name: ordered_at
+      expression:
+        dialects:
+        - dialect: ANSI_SQL
+          expression: ORDERED_AT
+    - name: is_food_order
+      expression:
+        dialects:
+        - dialect: ANSI_SQL
+          expression: IS_FOOD_ORDER
+      label: Food order
+    - name: order_status
+      expression:
+        dialects:
+        - dialect: ANSI_SQL
+          expression: STATUS
+      label: Status
+    - name: order_id
+      expression:
+        dialects:
+        - dialect: ANSI_SQL
+          expression: ID
+    - name: customer_id
+      expression:
+        dialects:
+        - dialect: ANSI_SQL
+          expression: CUSTOMER_ID
+    - name: location_id
+      expression:
+        dialects:
+        - dialect: ANSI_SQL
+          expression: LOCATION_ID
+    primary_key:
+    - ID
+    description: "One row per completed order \u2014 the fact table."
+  - name: customers
+    source: DIM_CUSTOMERS
+    fields:
+    - name: customer_type
+      expression:
+        dialects:
+        - dialect: ANSI_SQL
+          expression: CUSTOMER_TYPE
+      label: Customer type
+    - name: customer_country
+      expression:
+        dialects:
+        - dialect: ANSI_SQL
+          expression: COUNTRY
+      label: Country
+    - name: customer_id
+      expression:
+        dialects:
+        - dialect: ANSI_SQL
+          expression: ID
+    primary_key:
+    - ID
+    description: Customer dimension.
+  - name: locations
+    source: DIM_LOCATIONS
+    fields:
+    - name: location_name
+      expression:
+        dialects:
+        - dialect: ANSI_SQL
+          expression: NAME
+      label: Location
+    - name: location_region
+      expression:
+        dialects:
+        - dialect: ANSI_SQL
+          expression: REGION
+      label: Region
+    - name: location_id
+      expression:
+        dialects:
+        - dialect: ANSI_SQL
+          expression: ID
+    primary_key:
+    - ID
+    description: Store locations.
+  metrics:
+  - name: total_revenue
+    expression:
+      dialects:
+      - dialect: ANSI_SQL
+        expression: SUM("orders"."order_total")
+    aggregation_kind: sum
+    description: Sum of order totals across the fact table.
+  - name: order_count
+    expression:
+      dialects:
+      - dialect: ANSI_SQL
+        expression: COUNT(*)
+    aggregation_kind: count
+    description: Number of orders.
+  - name: avg_order_value
+    expression:
+      dialects:
+      - dialect: ANSI_SQL
+        expression: (SUM("orders"."order_total")) / NULLIF(COUNT(*), 0)
+    aggregation_kind: ratio
+    description: Average order total (total_revenue / order_count).
+  relationships:
+  - name: orders_to_customers
+    from: orders
+    to: customers
+    from_columns:
+    - CUSTOMER_ID
+    to_columns:
+    - ID
+  - name: orders_to_locations
+    from: orders
+    to: locations
+    from_columns:
+    - LOCATION_ID
+    to_columns:
+    - ID

--- a/docs/dbt-hookup/orders_semantic.yml
+++ b/docs/dbt-hookup/orders_semantic.yml
@@ -1,0 +1,110 @@
+# Sample dbt MetricFlow semantic model + metrics. This is the shape a real
+# dbt project would emit in its models/ directory. Referenced by the
+# metricflow_to_ossie.py converter that produces an Ossie-format YAML the
+# Saiku launcher can register as a datasource.
+#
+# Docs: https://docs.getdbt.com/docs/build/semantic-models
+
+semantic_models:
+  - name: orders
+    description: "One row per completed order — the fact table."
+    model: ref('fct_orders')
+    defaults:
+      agg_time_dimension: ordered_at
+
+    entities:
+      - name: order_id
+        type: primary
+        expr: id
+      - name: customer_id
+        type: foreign
+        expr: customer_id
+      - name: location_id
+        type: foreign
+        expr: location_id
+
+    dimensions:
+      - name: ordered_at
+        type: time
+        expr: ordered_at
+        type_params:
+          time_granularity: day
+      - name: is_food_order
+        type: categorical
+        expr: is_food_order
+        label: "Food order"
+      - name: order_status
+        type: categorical
+        expr: status
+        label: "Status"
+
+    measures:
+      - name: order_total
+        description: "Sum of order totals in USD."
+        agg: sum
+        expr: order_total
+      - name: order_count
+        description: "Count of orders."
+        agg: count
+        expr: 1
+
+  - name: customers
+    description: "Customer dimension."
+    model: ref('dim_customers')
+
+    entities:
+      - name: customer_id
+        type: primary
+        expr: id
+
+    dimensions:
+      - name: customer_type
+        type: categorical
+        expr: customer_type
+        label: "Customer type"
+      - name: customer_country
+        type: categorical
+        expr: country
+        label: "Country"
+
+  - name: locations
+    description: "Store locations."
+    model: ref('dim_locations')
+
+    entities:
+      - name: location_id
+        type: primary
+        expr: id
+
+    dimensions:
+      - name: location_name
+        type: categorical
+        expr: name
+        label: "Location"
+      - name: location_region
+        type: categorical
+        expr: region
+        label: "Region"
+
+metrics:
+  - name: total_revenue
+    description: "Sum of order totals across the fact table."
+    type: simple
+    label: "Total revenue"
+    type_params:
+      measure: order_total
+
+  - name: order_count
+    description: "Number of orders."
+    type: simple
+    label: "Order count"
+    type_params:
+      measure: order_count
+
+  - name: avg_order_value
+    description: "Average order total (total_revenue / order_count)."
+    type: ratio
+    label: "Avg order value"
+    type_params:
+      numerator: total_revenue
+      denominator: order_count

--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/ossie/OssieShelfSqlTranslator.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/ossie/OssieShelfSqlTranslator.java
@@ -59,12 +59,12 @@ public final class OssieShelfSqlTranslator {
         List<String> selectCols = new ArrayList<>();
         List<String> groupByCols = new ArrayList<>();
         for (OssieQueryModel.FieldRef f : model.getRows()) {
-            String qref = qualifiedField(f);
+            String qref = qualifiedField(f, semantic);
             selectCols.add(qref + " AS " + quoteAlias(f.getDataset() + "." + f.getField()));
             groupByCols.add(qref);
         }
         for (OssieQueryModel.FieldRef f : model.getColumns()) {
-            String qref = qualifiedField(f);
+            String qref = qualifiedField(f, semantic);
             selectCols.add(qref + " AS " + quoteAlias(f.getDataset() + "." + f.getField()));
             groupByCols.add(qref);
         }
@@ -99,7 +99,7 @@ public final class OssieShelfSqlTranslator {
         // --- WHERE ---
         List<String> whereClauses = new ArrayList<>();
         for (OssieQueryModel.FilterExpr f : model.getFilters()) {
-            whereClauses.add(filterToSql(f));
+            whereClauses.add(filterToSql(f, semantic));
         }
         if (!whereClauses.isEmpty()) {
             sql.append(" WHERE ").append(String.join(" AND ", whereClauses));
@@ -119,7 +119,9 @@ public final class OssieShelfSqlTranslator {
                     // Aggregate columns can be referenced by alias in ORDER BY (Calcite handles this).
                     ref = quoteRef(s.getMetric());
                 } else {
-                    ref = quoteRef(s.getDataset()) + "." + quoteRef(s.getField());
+                    String colExpr = lookupFieldExpression(semantic, s.getDataset(), s.getField());
+                    String col = (colExpr != null && !colExpr.isBlank()) ? quoteRef(colExpr) : quoteRef(s.getField());
+                    ref = quoteRef(s.getDataset()) + "." + col;
                 }
                 orderCols.add(ref + " " + normalizedDirection(s.getDirection()));
             }
@@ -178,11 +180,36 @@ public final class OssieShelfSqlTranslator {
         return override + "(" + inner + ")";
     }
 
-    private String qualifiedField(OssieQueryModel.FieldRef f) {
+    /**
+     * Resolve a shelf {@link OssieQueryModel.FieldRef} to its qualified SQL expression.
+     *
+     * <p>When the model declares an ANSI_SQL expression on the field, we use it — this covers
+     * converters like the dbt/MetricFlow bridge that give fields agent-friendly names
+     * ({@code customer_country}) mapped to raw columns ({@code COUNTRY}). When no expression
+     * is declared, fall back to the field's name itself; that's the shape our Pharma / TPCDS /
+     * Flights demo YAMLs use where the field name IS the underlying column.
+     */
+    private String qualifiedField(OssieQueryModel.FieldRef f, OssieModelDto semantic) {
         if (f.getDataset() == null || f.getField() == null) {
             throw new IllegalArgumentException("FieldRef requires both dataset and field");
         }
-        return quoteRef(f.getDataset()) + "." + quoteRef(f.getField());
+        String columnExpr = lookupFieldExpression(semantic, f.getDataset(), f.getField());
+        String col = (columnExpr != null && !columnExpr.isBlank()) ? quoteRef(columnExpr) : quoteRef(f.getField());
+        return quoteRef(f.getDataset()) + "." + col;
+    }
+
+    /** Walk the semantic model for a field's ANSI_SQL expression. Returns null when absent. */
+    private String lookupFieldExpression(OssieModelDto semantic, String datasetName, String fieldName) {
+        if (semantic == null || datasetName == null || fieldName == null) return null;
+        for (OssieModelDto.Dataset ds : semantic.getDatasets()) {
+            if (!datasetName.equalsIgnoreCase(ds.getName())) continue;
+            for (OssieModelDto.Field field : ds.getFields()) {
+                if (fieldName.equalsIgnoreCase(field.getName())) {
+                    return field.getExpression();
+                }
+            }
+        }
+        return null;
     }
 
     /**
@@ -203,10 +230,12 @@ public final class OssieShelfSqlTranslator {
                 "Ossie metric '" + metricName + "' not found in semantic model '" + semantic.getName() + "'");
     }
 
-    private String filterToSql(OssieQueryModel.FilterExpr f) {
+    private String filterToSql(OssieQueryModel.FilterExpr f, OssieModelDto semantic) {
         String col;
         if (f.getDataset() != null && !f.getDataset().isBlank()) {
-            col = quoteRef(f.getDataset()) + "." + quoteRef(f.getField());
+            String colExpr = lookupFieldExpression(semantic, f.getDataset(), f.getField());
+            String colName = (colExpr != null && !colExpr.isBlank()) ? colExpr : f.getField();
+            col = quoteRef(f.getDataset()) + "." + quoteRef(colName);
         } else {
             col = quoteRef(f.getField());
         }


### PR DESCRIPTION
See commit message. Adds docs/dbt-hookup/ + fixes OssieShelfSqlTranslator to use each field's declared ANSI_SQL expression (bug surfaced by the dbt converter demo, real fix that helps every converter-emitted YAML).