### PR TITLE
feat(ossie/ai): synonym resolution + custom_extensions passthrough (#1408, #1409)

### DIFF
--- a/docs/AI-OSSIE-API.md
+++ b/docs/AI-OSSIE-API.md
@@ -305,6 +305,49 @@ Fields marked `pii: true` in the Ossie YAML are stripped entirely
 from the schema view. Callers can't reference them; a query that does
 returns `VALIDATION_ERROR` naming the field as "unknown".
 
+### AI-context synonyms (#1408)
+
+Every dataset, field, and metric in the Ossie YAML can declare
+`ai_context.synonyms`. Those synonyms are surfaced on the schema view
+as three lowercased-alias → canonical-name maps:
+
+```jsonc
+{
+  "fieldAliases":   { "state": "customers.region", "geo": "customers.region" },
+  "metricAliases":  { "revenue": "net_revenue", "turnover": "net_revenue", "top-line": "net_revenue" },
+  "datasetAliases": { "clients": "customers", "buyers": "customers" }
+}
+```
+
+At request time, the validator resolves synonyms before rejecting a
+name. A `POST /query` with `values: [{metric: "revenue"}]` gets
+rewritten in place to `values: [{metric: "net_revenue"}]`; the executor
++ SQL translator never see the alias. Cross-dataset field synonyms are
+deliberately not auto-rewritten — a request for `customers.geo` where
+`geo` aliases `stores.state` returns `VALIDATION_ERROR` rather than
+silently pointing at the wrong dataset.
+
+### Custom extensions passthrough (#1409)
+
+The Ossie `custom_extensions[]` list on any dataset, field, or metric
+carries through to the schema view as `customExtensions[]` on the
+matching AI schema element. Data payloads are parsed once into JSON so
+consumers don't re-parse.
+
+Extensions whose data payload declares `"visibility": "internal"` are
+filtered out entirely — that flag is the standard escape hatch for
+tooling-private metadata (Saiku's own internal annotations, dbt's
+tool-only bookkeeping, etc.) that shouldn't reach an agent-facing view.
+
+```yaml
+# In the YAML
+custom_extensions:
+- vendor_name: PUBLIC         # ← passes through
+  data: '{"note":"visible"}'
+- vendor_name: INTERNAL       # ← filtered, never reaches the AI view
+  data: '{"visibility":"internal","secret":true}'
+```
+
 ---
 
 ## Step 4 — validation: how the API teaches the agent

--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/ossie/CustomExtensionDto.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/ossie/CustomExtensionDto.java
@@ -1,0 +1,41 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.service.ossie;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.JsonNode;
+
+/**
+ * Client-facing slice of an OSI {@code custom_extensions[]} entry.
+ *
+ * <p>The library ({@link bi.saiku.ossie.model.CustomExtension}) keeps the {@code data} payload as a
+ * raw JSON string; here we parse it into a {@link JsonNode} so the workbench + AI schema can walk
+ * the structure without a second parse. Extensions marked {@code visibility: internal} in their
+ * data payload are stripped by {@link OssieDiscoverService} before this DTO is built, so anything
+ * that lands here is safe to render.
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class CustomExtensionDto {
+    private String vendorName;
+    private JsonNode data;
+
+    @JsonProperty("vendor_name")
+    public String getVendorName() {
+        return vendorName;
+    }
+
+    public void setVendorName(String v) {
+        this.vendorName = v;
+    }
+
+    public JsonNode getData() {
+        return data;
+    }
+
+    public void setData(JsonNode v) {
+        this.data = v;
+    }
+}

--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/ossie/OssieDiscoverService.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/ossie/OssieDiscoverService.java
@@ -4,6 +4,7 @@
  */
 package org.saiku.service.ossie;
 
+import bi.saiku.ossie.OssieSynonymIndex;
 import bi.saiku.ossie.OssieYamlReader;
 import bi.saiku.ossie.model.CustomExtension;
 import bi.saiku.ossie.model.Dataset;
@@ -13,6 +14,7 @@ import bi.saiku.ossie.model.Metric;
 import bi.saiku.ossie.model.OssieDocument;
 import bi.saiku.ossie.model.Relationship;
 import bi.saiku.ossie.model.SemanticModel;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import java.io.IOException;
@@ -132,6 +134,13 @@ public class OssieDiscoverService {
         for (Relationship r : src.getRelationships()) {
             out.getRelationships().add(projectRelationship(r));
         }
+        // Synonym indices come from bi.saiku.ossie:ossie-core so every consumer of the AI schema
+        // (agents, validators, workbench "did you mean" hints) reads canonicalisation off the DTO
+        // rather than rewalking the source. Populated once at DTO-build time — cheap enough that
+        // an empty synonyms case doesn't need a fast path.
+        out.setFieldAliases(OssieSynonymIndex.buildFieldIndex(src));
+        out.setMetricAliases(OssieSynonymIndex.buildMetricIndex(src));
+        out.setDatasetAliases(OssieSynonymIndex.buildDatasetIndex(src));
         return out;
     }
 
@@ -141,6 +150,7 @@ public class OssieDiscoverService {
         d.setSource(src.getSource());
         d.setDescription(src.getDescription());
         d.setPrimaryKey(new ArrayList<>(src.getPrimaryKey()));
+        d.setCustomExtensions(projectCustomExtensions(src.getCustomExtensions()));
         for (Field f : src.getFields()) {
             d.getFields().add(projectField(f));
         }
@@ -157,6 +167,7 @@ public class OssieDiscoverService {
         f.setTime(src.getDimension() != null
                 && Boolean.TRUE.equals(src.getDimension().getIsTime()));
         f.setPii(readPii(src.getCustomExtensions()));
+        f.setCustomExtensions(projectCustomExtensions(src.getCustomExtensions()));
         return f;
     }
 
@@ -167,7 +178,47 @@ public class OssieDiscoverService {
                 src.getExpression() == null ? List.of() : src.getExpression().getDialects()));
         m.setDescription(src.getDescription());
         m.setAggregationKind(readAggregationKind(src.getCustomExtensions()));
+        m.setCustomExtensions(projectCustomExtensions(src.getCustomExtensions()));
         return m;
+    }
+
+    /**
+     * Copy an OSI {@code custom_extensions[]} list into the DTO shape, parsing each entry's opaque
+     * JSON {@code data} into a {@link JsonNode} so downstream consumers walk it structurally
+     * without re-parsing.
+     *
+     * <p>Extensions whose payload declares {@code "visibility":"internal"} are dropped — that flag
+     * is the standard escape hatch for tooling-private metadata that shouldn't reach an
+     * agent-facing view (saiku#1409). Vendor-private extensions that omit the flag stay in.
+     */
+    private List<CustomExtensionDto> projectCustomExtensions(List<CustomExtension> src) {
+        List<CustomExtensionDto> out = new ArrayList<>();
+        if (src == null) return out;
+        for (CustomExtension ext : src) {
+            if (ext == null) continue;
+            CustomExtensionDto dto = new CustomExtensionDto();
+            dto.setVendorName(ext.getVendorName());
+            JsonNode data = null;
+            if (ext.getData() != null && !ext.getData().isBlank()) {
+                try {
+                    data = json.readTree(ext.getData());
+                } catch (IOException e) {
+                    log.debug(
+                            "custom_extensions[{}].data is not valid JSON — dropping to null on the DTO: {}",
+                            ext.getVendorName(),
+                            e.getMessage());
+                }
+            }
+            if (data != null) {
+                JsonNode visibility = data.get("visibility");
+                if (visibility != null && visibility.isTextual() && "internal".equals(visibility.asText())) {
+                    continue;
+                }
+                dto.setData(data);
+            }
+            out.add(dto);
+        }
+        return out;
     }
 
     private OssieModelDto.Relationship projectRelationship(Relationship src) {

--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/ossie/OssieModelDto.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/ossie/OssieModelDto.java
@@ -4,18 +4,25 @@
  */
 package org.saiku.service.ossie;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 
 /**
  * Client-facing view of one Ossie {@code semantic_model} — the tree the analytics workbench
  * renders in the schema browser and drags fields/metrics from.
  *
  * <p>Structurally a slimmed-down projection of {@link bi.saiku.ossie.model.SemanticModel}:
- * we drop {@code ai_context}, {@code custom_extensions.data} payloads, and any dialect other
+ * we drop {@code ai_context.instructions}, {@code custom_extensions.data} payloads, and any dialect other
  * than the primary ANSI SQL one so the on-wire JSON stays small. The write-side (metric
  * annotations, PII vendor extensions) still lives in the YAML — the workbench only needs enough
  * to power drag-drop + display.
+ *
+ * <p>Synonym maps ({@link #getFieldAliases()} etc.) are pre-computed at DTO-build time via
+ * {@code bi.saiku.ossie.OssieSynonymIndex} so downstream consumers (the AI schema projector,
+ * validators) don't rewalk the source tree.
  */
 public class OssieModelDto {
 
@@ -25,6 +32,15 @@ public class OssieModelDto {
     private List<Dataset> datasets = new ArrayList<>();
     private List<Metric> metrics = new ArrayList<>();
     private List<Relationship> relationships = new ArrayList<>();
+
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    private Map<String, String> fieldAliases = new LinkedHashMap<>();
+
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    private Map<String, String> metricAliases = new LinkedHashMap<>();
+
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    private Map<String, String> datasetAliases = new LinkedHashMap<>();
 
     public String getConnection() {
         return connection;
@@ -74,6 +90,30 @@ public class OssieModelDto {
         this.relationships = v == null ? new ArrayList<>() : v;
     }
 
+    public Map<String, String> getFieldAliases() {
+        return fieldAliases;
+    }
+
+    public void setFieldAliases(Map<String, String> v) {
+        this.fieldAliases = v == null ? new LinkedHashMap<>() : v;
+    }
+
+    public Map<String, String> getMetricAliases() {
+        return metricAliases;
+    }
+
+    public void setMetricAliases(Map<String, String> v) {
+        this.metricAliases = v == null ? new LinkedHashMap<>() : v;
+    }
+
+    public Map<String, String> getDatasetAliases() {
+        return datasetAliases;
+    }
+
+    public void setDatasetAliases(Map<String, String> v) {
+        this.datasetAliases = v == null ? new LinkedHashMap<>() : v;
+    }
+
     /** One Ossie dataset — a queryable table. */
     public static class Dataset {
         private String name;
@@ -81,6 +121,17 @@ public class OssieModelDto {
         private String description;
         private List<Field> fields = new ArrayList<>();
         private List<String> primaryKey = new ArrayList<>();
+
+        @JsonInclude(JsonInclude.Include.NON_EMPTY)
+        private List<CustomExtensionDto> customExtensions = new ArrayList<>();
+
+        public List<CustomExtensionDto> getCustomExtensions() {
+            return customExtensions;
+        }
+
+        public void setCustomExtensions(List<CustomExtensionDto> v) {
+            this.customExtensions = v == null ? new ArrayList<>() : v;
+        }
 
         public String getName() {
             return name;
@@ -131,6 +182,17 @@ public class OssieModelDto {
         private String description;
         private boolean isTime;
         private boolean pii;
+
+        @JsonInclude(JsonInclude.Include.NON_EMPTY)
+        private List<CustomExtensionDto> customExtensions = new ArrayList<>();
+
+        public List<CustomExtensionDto> getCustomExtensions() {
+            return customExtensions;
+        }
+
+        public void setCustomExtensions(List<CustomExtensionDto> v) {
+            this.customExtensions = v == null ? new ArrayList<>() : v;
+        }
 
         public String getName() {
             return name;
@@ -187,6 +249,17 @@ public class OssieModelDto {
         private String expression;
         private String description;
         private String aggregationKind;
+
+        @JsonInclude(JsonInclude.Include.NON_EMPTY)
+        private List<CustomExtensionDto> customExtensions = new ArrayList<>();
+
+        public List<CustomExtensionDto> getCustomExtensions() {
+            return customExtensions;
+        }
+
+        public void setCustomExtensions(List<CustomExtensionDto> v) {
+            this.customExtensions = v == null ? new ArrayList<>() : v;
+        }
 
         public String getName() {
             return name;

--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/ossie/ai/OssieAiSchema.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/ossie/ai/OssieAiSchema.java
@@ -184,6 +184,22 @@ public class OssieAiSchema {
         /** Fields keyed by lower-case field name. */
         private Map<String, Field> fields = new LinkedHashMap<>();
 
+        /**
+         * Passed-through Ossie {@code custom_extensions[]}. Populated from the DTO layer; anything
+         * with {@code visibility: internal} is filtered upstream. Empty for datasets without
+         * extensions.
+         */
+        @JsonInclude(JsonInclude.Include.NON_EMPTY)
+        private List<org.saiku.service.ossie.CustomExtensionDto> customExtensions = new ArrayList<>();
+
+        public List<org.saiku.service.ossie.CustomExtensionDto> getCustomExtensions() {
+            return customExtensions;
+        }
+
+        public void setCustomExtensions(List<org.saiku.service.ossie.CustomExtensionDto> v) {
+            this.customExtensions = v == null ? new ArrayList<>() : v;
+        }
+
         public String getName() {
             return name;
         }
@@ -246,6 +262,21 @@ public class OssieAiSchema {
         private Long estimatedDistinct;
 
         private List<String> sampleValues = new ArrayList<>();
+
+        /**
+         * Passed-through Ossie {@code custom_extensions[]}. See
+         * {@link Dataset#getCustomExtensions()}.
+         */
+        @JsonInclude(JsonInclude.Include.NON_EMPTY)
+        private List<org.saiku.service.ossie.CustomExtensionDto> customExtensions = new ArrayList<>();
+
+        public List<org.saiku.service.ossie.CustomExtensionDto> getCustomExtensions() {
+            return customExtensions;
+        }
+
+        public void setCustomExtensions(List<org.saiku.service.ossie.CustomExtensionDto> v) {
+            this.customExtensions = v == null ? new ArrayList<>() : v;
+        }
 
         public String getName() {
             return name;
@@ -329,6 +360,21 @@ public class OssieAiSchema {
         private String aggregationKind;
         private String unit;
         private List<String> supportedOverrides = new ArrayList<>();
+
+        /**
+         * Passed-through Ossie {@code custom_extensions[]}. See
+         * {@link Dataset#getCustomExtensions()}.
+         */
+        @JsonInclude(JsonInclude.Include.NON_EMPTY)
+        private List<org.saiku.service.ossie.CustomExtensionDto> customExtensions = new ArrayList<>();
+
+        public List<org.saiku.service.ossie.CustomExtensionDto> getCustomExtensions() {
+            return customExtensions;
+        }
+
+        public void setCustomExtensions(List<org.saiku.service.ossie.CustomExtensionDto> v) {
+            this.customExtensions = v == null ? new ArrayList<>() : v;
+        }
 
         public String getName() {
             return name;

--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/ossie/ai/OssieAiSchemaProjector.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/ossie/ai/OssieAiSchemaProjector.java
@@ -97,6 +97,12 @@ public final class OssieAiSchemaProjector {
         out.setDescription(semantic.getDescription());
         out.setModelId(connectionName + "/" + semantic.getName());
 
+        // Alias maps are pre-computed by OssieDiscoverService via bi.saiku.ossie.OssieSynonymIndex.
+        // Copying them straight across preserves case-normalisation + first-declared-wins semantics.
+        out.setFieldAliases(semantic.getFieldAliases());
+        out.setMetricAliases(semantic.getMetricAliases());
+        out.setDatasetAliases(semantic.getDatasetAliases());
+
         // ---- Datasets + fields ----
         String factCandidate = null;
         for (OssieModelDto.Dataset ds : semantic.getDatasets()) {
@@ -105,12 +111,14 @@ public final class OssieAiSchemaProjector {
             out_ds.setSource(ds.getSource());
             out_ds.setDescription(ds.getDescription());
             out_ds.setPrimaryKey(new ArrayList<>(ds.getPrimaryKey()));
+            out_ds.setCustomExtensions(new ArrayList<>(ds.getCustomExtensions()));
             for (OssieModelDto.Field f : ds.getFields()) {
                 if (f.isPii()) continue; // saiku#902 parity — PII fields never enter the AI view.
                 OssieAiSchema.Field out_field = new OssieAiSchema.Field();
                 out_field.setName(f.getName());
                 out_field.setLabel(f.getLabel());
                 out_field.setDescription(f.getDescription());
+                out_field.setCustomExtensions(new ArrayList<>(f.getCustomExtensions()));
                 // Type + samples come from the warehouse. Best-effort: swallow failures so
                 // the schema still projects when the warehouse is offline (agent still sees
                 // field names, just without samples).
@@ -141,6 +149,7 @@ public final class OssieAiSchemaProjector {
             out_m.setExpression(m.getExpression());
             out_m.setAggregationKind(deriveAggregationKind(m));
             out_m.setSupportedOverrides(deriveSupportedOverrides(m));
+            out_m.setCustomExtensions(new ArrayList<>(m.getCustomExtensions()));
             out.getMetrics().put(m.getName(), out_m);
         }
 

--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/ossie/ai/OssieAiValidator.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/ossie/ai/OssieAiValidator.java
@@ -92,7 +92,15 @@ public final class OssieAiValidator {
                     "dataset is required",
                     new ArrayList<>(schema.getDatasets().keySet()));
         }
-        OssieAiSchema.Dataset ds = schema.getDatasets().get(ref.getDataset().toLowerCase(Locale.ROOT));
+        // Dataset synonyms — rewrite the request to the canonical name before lookup so downstream
+        // code (translator, sample generation) sees canonical names only.
+        String datasetKey = ref.getDataset().toLowerCase(Locale.ROOT);
+        String datasetAlias = schema.getDatasetAliases().get(datasetKey);
+        if (datasetAlias != null) {
+            ref.setDataset(datasetAlias);
+            datasetKey = datasetAlias.toLowerCase(Locale.ROOT);
+        }
+        OssieAiSchema.Dataset ds = schema.getDatasets().get(datasetKey);
         if (ds == null) {
             throw new OssieAiValidationException(
                     path + ".dataset",
@@ -104,6 +112,19 @@ public final class OssieAiValidator {
                     path + ".field",
                     "field is required",
                     new ArrayList<>(ds.getFields().keySet()));
+        }
+        // Field synonyms — index values are "<dataset>.<field>" so we only accept an alias if it
+        // resolves to a field on the SAME dataset the caller asked for. Cross-dataset synonym hits
+        // are ambiguous ("state" could be customers.state or stores.state) so we reject rather
+        // than guess.
+        if (!ds.getFields().containsKey(ref.getField().toLowerCase(Locale.ROOT))) {
+            String fieldAlias = schema.getFieldAliases().get(ref.getField().toLowerCase(Locale.ROOT));
+            if (fieldAlias != null) {
+                int dot = fieldAlias.indexOf('.');
+                if (dot > 0 && ds.getName().equalsIgnoreCase(fieldAlias.substring(0, dot))) {
+                    ref.setField(fieldAlias.substring(dot + 1));
+                }
+            }
         }
         if (!ds.getFields().containsKey(ref.getField().toLowerCase(Locale.ROOT))) {
             throw new OssieAiValidationException(
@@ -123,7 +144,16 @@ public final class OssieAiValidator {
                     "metric is required",
                     new ArrayList<>(schema.getMetrics().keySet()));
         }
+        // Metric synonyms — same rewrite pattern as datasets. Rewritten to canonical so the
+        // executor sees the metric name declared in the YAML.
         OssieAiSchema.Metric metric = schema.getMetrics().get(ref.getMetric());
+        if (metric == null) {
+            String metricAlias = schema.getMetricAliases().get(ref.getMetric().toLowerCase(Locale.ROOT));
+            if (metricAlias != null) {
+                ref.setMetric(metricAlias);
+                metric = schema.getMetrics().get(metricAlias);
+            }
+        }
         if (metric == null) {
             throw new OssieAiValidationException(
                     path + ".metric",

--- a/saiku-core/saiku-service/src/test/java/org/saiku/service/ossie/OssieDiscoverServiceTest.java
+++ b/saiku-core/saiku-service/src/test/java/org/saiku/service/ossie/OssieDiscoverServiceTest.java
@@ -164,6 +164,83 @@ public class OssieDiscoverServiceTest {
         service.getModel("SALES");
     }
 
+    // ---- synonym + custom_extensions passthrough (#1408 / #1409) ----
+
+    @Test
+    public void synonymAliasesPopulatedFromAiContext() throws Exception {
+        Path yamlWithSynonyms = Files.createTempFile("ossie-syn-", ".yaml");
+        Files.writeString(
+                yamlWithSynonyms,
+                "version: 0.2.0.dev0\n"
+                        + "semantic_model:\n"
+                        + "- name: T\n"
+                        + "  datasets:\n"
+                        + "  - name: customers\n"
+                        + "    source: s.c\n"
+                        + "    ai_context:\n"
+                        + "      synonyms: [clients, buyers]\n"
+                        + "    fields:\n"
+                        + "    - name: region\n"
+                        + "      expression:\n"
+                        + "        dialects: [{dialect: ANSI_SQL, expression: r}]\n"
+                        + "      ai_context:\n"
+                        + "        synonyms: [state, geo]\n"
+                        + "  metrics:\n"
+                        + "  - name: net_revenue\n"
+                        + "    expression:\n"
+                        + "      dialects: [{dialect: ANSI_SQL, expression: SUM(x)}]\n"
+                        + "    ai_context:\n"
+                        + "      synonyms: [revenue, turnover, top-line]\n");
+        try {
+            datasourceManager.put(
+                    "T", ossieDatasource("T", propsOf(ISaikuConnection.OSSIE_YAML_KEY, yamlWithSynonyms.toString())));
+            OssieModelDto dto = service.getModel("T");
+            assertEquals("net_revenue", dto.getMetricAliases().get("revenue"));
+            assertEquals("net_revenue", dto.getMetricAliases().get("turnover"));
+            assertEquals("net_revenue", dto.getMetricAliases().get("top-line"));
+            assertEquals("customers", dto.getDatasetAliases().get("clients"));
+            assertEquals("customers.region", dto.getFieldAliases().get("state"));
+            assertEquals("customers.region", dto.getFieldAliases().get("geo"));
+        } finally {
+            Files.deleteIfExists(yamlWithSynonyms);
+        }
+    }
+
+    @Test
+    public void internalVisibilityExtensionsGetFiltered() throws Exception {
+        Path yamlWithInternal = Files.createTempFile("ossie-ext-", ".yaml");
+        Files.writeString(
+                yamlWithInternal,
+                "version: 0.2.0.dev0\n"
+                        + "semantic_model:\n"
+                        + "- name: T\n"
+                        + "  datasets:\n"
+                        + "  - name: d\n"
+                        + "    source: s.d\n"
+                        + "    fields:\n"
+                        + "    - name: f\n"
+                        + "      expression:\n"
+                        + "        dialects: [{dialect: ANSI_SQL, expression: c}]\n"
+                        + "      custom_extensions:\n"
+                        + "      - vendor_name: PUBLIC\n"
+                        + "        data: '{\"note\":\"visible\"}'\n"
+                        + "      - vendor_name: INTERNAL\n"
+                        + "        data: '{\"visibility\":\"internal\",\"secret\":true}'\n");
+        try {
+            datasourceManager.put(
+                    "T", ossieDatasource("T", propsOf(ISaikuConnection.OSSIE_YAML_KEY, yamlWithInternal.toString())));
+            OssieModelDto dto = service.getModel("T");
+            var ext = dto.getDatasets().get(0).getFields().get(0).getCustomExtensions();
+            // INTERNAL extension filtered out; PUBLIC remains.
+            assertEquals(1, ext.size());
+            assertEquals("PUBLIC", ext.get(0).getVendorName());
+            assertNotNull(ext.get(0).getData());
+            assertEquals("visible", ext.get(0).getData().get("note").asText());
+        } finally {
+            Files.deleteIfExists(yamlWithInternal);
+        }
+    }
+
     @Test
     public void descriptionsSurviveProjection() {
         // Belt-and-braces regression guard: a field with a description but no PII extension

--- a/saiku-core/saiku-service/src/test/java/org/saiku/service/ossie/ai/OssieAiSchemaProjectorTest.java
+++ b/saiku-core/saiku-service/src/test/java/org/saiku/service/ossie/ai/OssieAiSchemaProjectorTest.java
@@ -85,6 +85,58 @@ public class OssieAiSchemaProjectorTest {
         assertFalse(simple.getValues().isEmpty());
     }
 
+    // ---- alias map + custom_extensions passthrough (#1408 / #1409) ----
+
+    @Test
+    public void aliasMapsCarryThroughFromDto() {
+        OssieModelDto semantic = buildFixture();
+        semantic.getFieldAliases().put("state", "customers.region");
+        semantic.getMetricAliases().put("revenue", "net_revenue");
+        semantic.getDatasetAliases().put("clients", "customers");
+
+        OssieAiSchema schema = new OssieAiSchemaProjector().project("Pharma", semantic, null);
+        assertEquals("customers.region", schema.getFieldAliases().get("state"));
+        assertEquals("net_revenue", schema.getMetricAliases().get("revenue"));
+        assertEquals("customers", schema.getDatasetAliases().get("clients"));
+    }
+
+    @Test
+    public void customExtensionsCarryThroughOnField() {
+        OssieModelDto semantic = buildFixture();
+        // Attach an ext to the fact_pharma.NETREVENUE field.
+        org.saiku.service.ossie.CustomExtensionDto ext = new org.saiku.service.ossie.CustomExtensionDto();
+        ext.setVendorName("SAIKU");
+        semantic.getDatasets().get(0).getFields().get(0).getCustomExtensions().add(ext);
+
+        OssieAiSchema schema = new OssieAiSchemaProjector().project("Pharma", semantic, null);
+        var field = schema.getDatasets().get("fact_pharma").getFields().get("netrevenue");
+        assertEquals(1, field.getCustomExtensions().size());
+        assertEquals("SAIKU", field.getCustomExtensions().get(0).getVendorName());
+    }
+
+    @Test
+    public void customExtensionsCarryThroughOnDatasetAndMetric() {
+        OssieModelDto semantic = buildFixture();
+        org.saiku.service.ossie.CustomExtensionDto dsExt = new org.saiku.service.ossie.CustomExtensionDto();
+        dsExt.setVendorName("SAIKU");
+        semantic.getDatasets().get(0).getCustomExtensions().add(dsExt);
+
+        org.saiku.service.ossie.CustomExtensionDto mExt = new org.saiku.service.ossie.CustomExtensionDto();
+        mExt.setVendorName("DBT");
+        semantic.getMetrics().get(0).getCustomExtensions().add(mExt);
+
+        OssieAiSchema schema = new OssieAiSchemaProjector().project("Pharma", semantic, null);
+        assertEquals(
+                1, schema.getDatasets().get("fact_pharma").getCustomExtensions().size());
+        assertEquals(
+                "DBT",
+                schema.getMetrics()
+                        .get("net_revenue")
+                        .getCustomExtensions()
+                        .get(0)
+                        .getVendorName());
+    }
+
     private OssieModelDto buildFixture() {
         OssieModelDto semantic = new OssieModelDto();
         semantic.setName("Pharma");

--- a/saiku-core/saiku-service/src/test/java/org/saiku/service/ossie/ai/OssieAiValidatorTest.java
+++ b/saiku-core/saiku-service/src/test/java/org/saiku/service/ossie/ai/OssieAiValidatorTest.java
@@ -219,6 +219,81 @@ public class OssieAiValidatorTest {
         validator.validateTimeAxis("customers.region", req, schema);
     }
 
+    // ---- synonym resolution (#1408) ----
+
+    @Test
+    public void metricSynonymRewrittenToCanonical() {
+        // Declare "revenue" and "turnover" as synonyms for net_revenue via the alias map.
+        schema.getMetricAliases().put("revenue", "net_revenue");
+        schema.getMetricAliases().put("turnover", "net_revenue");
+
+        OssieAiQueryRequest req = new OssieAiQueryRequest();
+        req.setModel("Pharma");
+        req.getRows().add(fieldRef("customers", "region"));
+        OssieAiQueryRequest.MetricRef mref = metricRef("revenue", null);
+        req.getValues().add(mref);
+
+        validator.validate(req, schema);
+
+        // Validator MUST rewrite the request to canonical so the executor sees a real name.
+        assertEquals("net_revenue", mref.getMetric());
+    }
+
+    @Test
+    public void datasetSynonymRewrittenToCanonical() {
+        schema.getDatasetAliases().put("clients", "customers");
+
+        OssieAiQueryRequest req = new OssieAiQueryRequest();
+        req.setModel("Pharma");
+        OssieAiQueryRequest.FieldRef fref = fieldRef("clients", "region");
+        req.getRows().add(fref);
+        req.getValues().add(metricRef("net_revenue", null));
+
+        validator.validate(req, schema);
+        assertEquals("customers", fref.getDataset());
+    }
+
+    @Test
+    public void fieldSynonymRewrittenWhenDatasetMatches() {
+        // "state" already exists on customers. Add a synonym "geo" → customers.region.
+        schema.getFieldAliases().put("geo", "customers.region");
+
+        OssieAiQueryRequest req = new OssieAiQueryRequest();
+        req.setModel("Pharma");
+        OssieAiQueryRequest.FieldRef fref = fieldRef("customers", "geo");
+        req.getRows().add(fref);
+        req.getValues().add(metricRef("net_revenue", null));
+
+        validator.validate(req, schema);
+        assertEquals("region", fref.getField());
+    }
+
+    @Test
+    public void fieldSynonymIgnoredWhenDatasetDoesNotMatch() {
+        // "geo" is a synonym for stores.state — but the caller asked for customers.geo.
+        // Cross-dataset synonym should NOT silently rewrite (ambiguous).
+        OssieAiSchema.Dataset stores = new OssieAiSchema.Dataset();
+        stores.setName("stores");
+        OssieAiSchema.Field storesState = new OssieAiSchema.Field();
+        storesState.setName("state");
+        stores.getFields().put("state", storesState);
+        schema.getDatasets().put("stores", stores);
+        schema.getFieldAliases().put("geo", "stores.state");
+
+        OssieAiQueryRequest req = new OssieAiQueryRequest();
+        req.setModel("Pharma");
+        // Look up "geo" against `customers` which has no such field. Should reject.
+        req.getRows().add(fieldRef("customers", "geo"));
+        req.getValues().add(metricRef("net_revenue", null));
+        try {
+            validator.validate(req, schema);
+            fail("expected validation error — cross-dataset synonym should not rewrite");
+        } catch (OssieAiValidationException e) {
+            assertEquals("rows[0].field", e.getField());
+            assertTrue(e.getMessage().contains("unknown field 'geo'"));
+        }
+    }
+
     private static OssieAiQueryRequest.FieldRef fieldRef(String dataset, String field) {
         OssieAiQueryRequest.FieldRef f = new OssieAiQueryRequest.FieldRef();
         f.setDataset(dataset);


### PR DESCRIPTION
Wires the OSI ai_context.synonyms and custom_extensions[] blocks
through the DTO layer, the AI schema view, and the query validator so
agents can refer to entities by synonym and consumer-side tooling can
carry vendor annotations without dropping them.

## saiku#1408 — synonyms

- OssieModelDto gains fieldAliases / metricAliases / datasetAliases
  maps. OssieDiscoverService populates them via the library's
  bi.saiku.ossie.OssieSynonymIndex — dogfooding the ossie-core helper
  we shipped in spiculedata/ossie#4.
- OssieAiSchemaProjector copies the alias maps to the AI schema view
  so they surface on GET /ai/ossie/schema.
- OssieAiValidator resolves synonyms before rejecting names on
  POST /ai/ossie/query:
  - Dataset synonyms rewrite ref.dataset in place; downstream code sees
    the canonical name only.
  - Metric synonyms rewrite ref.metric similarly.
  - Field synonyms only rewrite when the alias resolves to a field on
    the SAME dataset the caller asked for — cross-dataset synonyms
    (ambiguous by design) get rejected instead of silently misrouting.

## saiku#1409 — custom_extensions

- New CustomExtensionDto in org.saiku.service.ossie — thin wire model
  carrying vendor_name + parsed JSON data.
- OssieModelDto.Field / Dataset / Metric gain customExtensions lists;
  discover service parses each extension's opaque data string into a
  JsonNode once so consumers walk it structurally.
- 'visibility: internal' filter: any extension whose parsed data
  declares visibility=internal is dropped at the discover-service
  boundary. That's the standard escape hatch for tooling-private
  metadata (Saiku's own annotations, dbt's tool-only bookkeeping)
  that shouldn't reach an agent-facing view.
- OssieAiSchema.Field / Dataset / Metric gain customExtensions
  passthrough; projector copies straight across.

## Verification

- Full reactor tests: BUILD SUCCESS
- saiku-service: 769/769 (was 760; +9 new tests)
  - OssieAiValidatorTest: +4 synonym-resolution cases (metric alias
    rewrite, dataset alias rewrite, field alias rewrite when dataset
    matches, field alias IGNORED when cross-dataset)
  - OssieAiSchemaProjectorTest: +3 (alias maps carry through, custom
    extensions carry through on field, on dataset + metric)
  - OssieDiscoverServiceTest: +2 (synonym aliases populated from
    ai_context, visibility:internal extensions filtered)
- saiku-sql: SaikuOssieConnectionTest still 2/2
- Zero behavioural regressions on existing tests

## Docs

docs/AI-OSSIE-API.md gains two new subsections under Step 2:
- "AI-context synonyms (#1408)" — shows fieldAliases/metricAliases/
  datasetAliases shape + describes the request-rewriting behaviour +
  documents the cross-dataset ambiguity guard
- "Custom extensions passthrough (#1409)" — shows the customExtensions
  shape + the visibility:internal filter with a YAML example