### PR TITLE
feat(ossie/ai): ontology endpoint + describe_ossie_ontology MCP tool (#1410)

### DIFF
--- a/docs/AI-OSSIE-API.md
+++ b/docs/AI-OSSIE-API.md
@@ -381,6 +381,58 @@ The same shape covers:
 
 ---
 
+## Step 4b — inspect the ontology block (#1410)
+
+Some OSI documents carry a top-level `ontology:` block alongside the
+SQL-adjacent `semantic_model:` — a knowledge-graph view of the
+entities (concepts) in the domain and the relationships between them
+(attributes, associations, derived relationships). See the [Apache
+Ossie flights example](https://github.com/apache/ossie/blob/main/examples/flights.yaml)
+for the canonical shape.
+
+```http
+GET /rest/saiku/api/ai/ossie/ontology/{connection}/{model}
+```
+
+Response body:
+
+```json
+{
+  "connection": "unknown_Flights",
+  "model": "Flights",
+  "ontology": [
+    {
+      "concept": {
+        "name": "Example_Runway",
+        "type": "EntityType",
+        "identify_by": ["id"]
+      },
+      "relationships": [
+        {"name": "id",
+         "roles": [{"concept": "String"}],
+         "verbalizes": ["{Example_Runway} id {String}"],
+         "multiplicity": "ManyToOne"},
+        {"name": "airports",
+         "roles": [{"concept": "Example_Airport"}],
+         "verbalizes": ["{Example_Runway} airports {Example_Airport}"],
+         "multiplicity": "ManyToOne",
+         "derived_by": ["Example_Runway.airportid == Example_Airport.airportid"]}
+      ]
+    }
+  ]
+}
+```
+
+Documents without an ontology block return `{"ontology": []}`. Same
+authentication + connection-validation semantics as the other
+endpoints.
+
+Use the same shape as the input to a `describe_ossie_ontology` MCP
+call (see [MCP integration](#mcp-integration) below) — the tool
+wraps this endpoint.
+
+---
+
 ## Step 5 — preview
 
 ```http
@@ -663,13 +715,14 @@ narration attached.
 
 ## MCP integration
 
-The five Ossie tools are exposed via `POST /saiku/api/mcp` alongside
+The six Ossie tools are exposed via `POST /saiku/api/mcp` alongside
 the six MDX tools. Each wraps the corresponding REST endpoint:
 
 | MCP tool | REST equivalent |
 | --- | --- |
 | `list_ossie_models` | `GET /ai/ossie/models` |
 | `describe_ossie_model` | `GET /ai/ossie/schema/{c}/{m}` |
+| `describe_ossie_ontology` | `GET /ai/ossie/ontology/{c}/{m}` |
 | `search_field_values` | `GET /ai/ossie/values/search` |
 | `run_ossie_query` | `POST /ai/ossie/query` |
 | `preview_ossie_query` | `POST /ai/ossie/query/preview` |

--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/ossie/OssieDiscoverService.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/ossie/OssieDiscoverService.java
@@ -59,10 +59,23 @@ public class OssieDiscoverService {
     }
 
     /**
-     * Return the Ossie model tree for a connection. Throws {@link IllegalArgumentException} if
-     * the connection isn't OSSIE-typed or the YAML file is missing / unreadable.
+     * Return the ontology block from the Ossie document associated with a connection. Empty when
+     * the document has no {@code ontology:} section. Same connection-validation rules as
+     * {@link #getModel(String)} — throws {@link IllegalArgumentException} on unknown / non-Ossie
+     * datasources or missing YAML.
      */
-    public OssieModelDto getModel(String connectionName) {
+    public List<bi.saiku.ossie.model.ontology.OntologyEntry> getOntology(String connectionName) {
+        OssieDocument doc = readDocument(connectionName);
+        return doc.getOntology();
+    }
+
+    /**
+     * Load and parse the underlying {@link OssieDocument} for a connection. Kept package-private
+     * because callers should prefer the projected {@link OssieModelDto} — direct document access
+     * exists for the ontology surface (which has no OssieModelDto equivalent) and future spec
+     * blocks that don't fit the semantic-model projection.
+     */
+    OssieDocument readDocument(String connectionName) {
         SaikuDatasource ds = datasourceManager.getDatasource(connectionName);
         if (ds == null) {
             throw new IllegalArgumentException("No datasource named '" + connectionName + "'");
@@ -80,15 +93,23 @@ public class OssieDiscoverService {
         if (!Files.isReadable(yaml)) {
             throw new IllegalArgumentException("Ossie YAML not readable at " + yamlPath);
         }
-        OssieDocument doc;
         try {
-            doc = new OssieYamlReader().read(yaml);
+            return new OssieYamlReader().read(yaml);
         } catch (IOException e) {
             throw new IllegalArgumentException("Failed to read Ossie YAML at " + yamlPath + ": " + e.getMessage(), e);
         }
+    }
+
+    /**
+     * Return the Ossie model tree for a connection. Throws {@link IllegalArgumentException} if
+     * the connection isn't OSSIE-typed or the YAML file is missing / unreadable.
+     */
+    public OssieModelDto getModel(String connectionName) {
+        OssieDocument doc = readDocument(connectionName);
         if (doc.getEffectiveSemanticModels().isEmpty()) {
-            throw new IllegalArgumentException("Ossie YAML at " + yamlPath + " has zero semantic models");
+            throw new IllegalArgumentException("Ossie YAML for '" + connectionName + "' has zero semantic models");
         }
+        SaikuDatasource ds = datasourceManager.getDatasource(connectionName);
         // Pick the requested model or default to the first entry. schema and OSSIE_MODEL_KEY
         // both mean "which semantic_model[] to pick"; schema is what the .sds writes, the
         // constant is the wire-level property key.

--- a/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/AiOssieResource.java
+++ b/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/AiOssieResource.java
@@ -218,6 +218,51 @@ public class AiOssieResource {
     }
 
     // -------------------------------------------------------------------
+    // GET /ontology
+    // -------------------------------------------------------------------
+
+    /**
+     * Return the OSI {@code ontology:} block for a connection's document — the knowledge-graph
+     * shape (concepts + relationships) that some Ossie documents declare alongside the
+     * SQL-adjacent {@code semantic_model:}. Empty response body {@code {"ontology": []}} when
+     * the document has none.
+     *
+     * <p>Same shape agents get through the {@code describe_ossie_ontology} MCP tool — the tool
+     * wraps this endpoint.
+     */
+    @GET
+    @Path("/ontology/{connection}/{model}")
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response getOntology(@PathParam("connection") String connectionName, @PathParam("model") String modelName) {
+        if (ossieDiscoverService == null) {
+            return error("Ossie discover not wired");
+        }
+        try {
+            // modelName is currently informational — the ontology block sits at the document
+            // level, not the semantic-model level. Kept as a path param for parity with /schema
+            // and to leave room for future spec revisions that scope ontologies per model.
+            OssieModelDto semantic = ossieDiscoverService.getModel(connectionName);
+            if (semantic.getName() == null || !semantic.getName().equalsIgnoreCase(modelName)) {
+                return badRequest(
+                        "model",
+                        "model '" + modelName + "' not found on connection '" + connectionName + "'",
+                        List.of(semantic.getName()));
+            }
+            var ontology = ossieDiscoverService.getOntology(connectionName);
+            Map<String, Object> body = new LinkedHashMap<>();
+            body.put("connection", connectionName);
+            body.put("model", modelName);
+            body.put("ontology", ontology);
+            return Response.ok(body).type(MediaType.APPLICATION_JSON).build();
+        } catch (IllegalArgumentException e) {
+            return badRequest("connection", e.getMessage(), List.of());
+        } catch (Exception e) {
+            log.error("Ossie ontology fetch failed for {}/{}", connectionName, modelName, e);
+            return error("ontology fetch failed");
+        }
+    }
+
+    // -------------------------------------------------------------------
     // POST /query
     // -------------------------------------------------------------------
 

--- a/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/mcp/McpResource.java
+++ b/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/mcp/McpResource.java
@@ -251,6 +251,12 @@ public class McpResource {
                 String model = requiredString(args, "model");
                 return unwrap(aiOssieResource.getSchema(connection, model, null));
             }
+            case "describe_ossie_ontology": {
+                requireOssie();
+                String connection = requiredString(args, "connection");
+                String model = requiredString(args, "model");
+                return unwrap(aiOssieResource.getOntology(connection, model));
+            }
             case "search_field_values": {
                 requireOssie();
                 String connection = requiredString(args, "connection");
@@ -397,6 +403,8 @@ public class McpResource {
             + "\"description\":\"Semantic-model name from list_ossie_models.\"}"
             + "},\"additionalProperties\":false}";
 
+    private static final String DESCRIBE_OSSIE_ONTOLOGY_SCHEMA = DESCRIBE_OSSIE_MODEL_SCHEMA;
+
     private static final String SEARCH_FIELD_VALUES_SCHEMA = "{\"type\":\"object\","
             + "\"required\":[\"connection\",\"dataset\",\"field\"],"
             + "\"properties\":{"
@@ -522,6 +530,14 @@ public class McpResource {
                             + "know which names resolve. Includes ready-made example bodies (simpleGroupBy, crosstab, "
                             + "topN) you can copy directly.",
                     DESCRIBE_OSSIE_MODEL_SCHEMA));
+            tools.add(tool(
+                    "describe_ossie_ontology",
+                    "Get the OSI ontology block for an Ossie model — a knowledge-graph view of the entities "
+                            + "(concepts) and the relationships between them (attributes, associations, derived). Use "
+                            + "when the user asks about the model at the entity level (\"what concepts exist?\", "
+                            + "\"what's connected to Airport?\") rather than the SQL-adjacent dataset level. Empty "
+                            + "{ontology:[]} when the document doesn't declare one.",
+                    DESCRIBE_OSSIE_ONTOLOGY_SCHEMA));
             tools.add(tool(
                     "search_field_values",
                     "Find distinct values of an Ossie field by substring match. Use when describe_ossie_model's "

--- a/saiku-core/saiku-web/src/test/java/org/saiku/web/rest/resources/mcp/McpResourceTest.java
+++ b/saiku-core/saiku-web/src/test/java/org/saiku/web/rest/resources/mcp/McpResourceTest.java
@@ -251,6 +251,66 @@ public class McpResourceTest {
     }
 
     /** Minimal stub — captures arguments and returns canned responses. */
+    /* --------------------- Ossie tools (saiku#1410) -------------------- */
+
+    @Test
+    public void ossieOntologyToolAdvertisedWhenResourceWired() throws Exception {
+        StubAiOssieResource stubOssie = new StubAiOssieResource();
+        resource.setAiOssieResource(stubOssie);
+        String sid = openSession();
+        Response list = resource.handle(rpc("tools/list", 2, MAPPER.createObjectNode()), sid);
+        JsonNode listBody = MAPPER.valueToTree(list.getEntity());
+        List<String> toolNames = new java.util.ArrayList<>();
+        listBody.path("result")
+                .path("tools")
+                .forEach(t -> toolNames.add(t.path("name").asText()));
+        // 6 OLAP tools + 6 Ossie tools (list, describe, describe_ontology, search, run, preview)
+        assertEquals(12, toolNames.size());
+        assertTrue("describe_ossie_ontology should be advertised", toolNames.contains("describe_ossie_ontology"));
+    }
+
+    @Test
+    public void describeOssieOntologyDelegatesToResource() throws Exception {
+        StubAiOssieResource stubOssie = new StubAiOssieResource();
+        stubOssie.ontologyResponse =
+                Response.ok(java.util.Map.of("ontology", List.of())).build();
+        resource.setAiOssieResource(stubOssie);
+        String sid = openSession();
+        ObjectNode args = MAPPER.createObjectNode();
+        args.put("connection", "Pharma");
+        args.put("model", "Pharma");
+        Response resp = resource.handle(rpc("tools/call", 3, callParams("describe_ossie_ontology", args)), sid);
+        assertEquals(200, resp.getStatus());
+        assertEquals("Pharma", stubOssie.ontologyConnection.get());
+        assertEquals("Pharma", stubOssie.ontologyModel.get());
+    }
+
+    private String openSession() throws Exception {
+        Response init = resource.handle(rpc("initialize", 1, MAPPER.createObjectNode()), null);
+        return init.getHeaderString(SESSION_HEADER);
+    }
+
+    private ObjectNode callParams(String tool, ObjectNode args) {
+        ObjectNode params = MAPPER.createObjectNode();
+        params.put("name", tool);
+        params.set("arguments", args);
+        return params;
+    }
+
+    private static final class StubAiOssieResource extends org.saiku.web.rest.resources.AiOssieResource {
+        Response ontologyResponse =
+                Response.ok(java.util.Map.of("ontology", List.of())).build();
+        final AtomicReference<String> ontologyConnection = new AtomicReference<>();
+        final AtomicReference<String> ontologyModel = new AtomicReference<>();
+
+        @Override
+        public Response getOntology(String connection, String model) {
+            ontologyConnection.set(connection);
+            ontologyModel.set(model);
+            return ontologyResponse;
+        }
+    }
+
     private static final class StubAiQueryResource extends AiQueryResource {
         Response cubesResponse = Response.ok(List.of()).build();
         Response executeResponse = Response.ok(new AiQueryResponse()).build();


### PR DESCRIPTION
Exposes the OSI ontology block through the AI Query API + the MCP
surface. Consumes the OntologyEntry / OntologyConcept /
OntologyRelationship / OntologyRole DTOs published from
bi.saiku.ossie:ossie-core:0.1.0-SNAPSHOT (spiculedata/ossie#5).

## What's new

### REST endpoint

    GET /rest/saiku/api/ai/ossie/ontology/{connection}/{model}

Returns:
- {"connection": "...", "model": "...", "ontology": [OntologyEntry]}
- Empty list when the underlying document has no ontology block
- Same validation shape as /schema — unknown connection returns
  VALIDATION_ERROR with candidate list

### MCP tool

- describe_ossie_ontology, same operand schema as describe_ossie_model
  (connection + model). Wraps the REST endpoint via
  AiOssieResource.getOntology.
- Only advertised in tools/list when AiOssieResource is wired
  (matches existing Ossie-tool gating pattern).

### OssieDiscoverService

- New public getOntology(connectionName) returning List<OntologyEntry>
- Refactored: extracted a package-private readDocument helper so
  getModel + getOntology share connection-validation + YAML-read code
  paths. Zero behavioural change on getModel.

## Tests

- McpResourceTest: +2 cases (ontology tool advertised on tools/list
  when Ossie is wired, describe_ossie_ontology dispatches to
  getOntology on the resource). 14/14 total.
- Full saiku-service + saiku-web reactor: green.

## Docs

docs/AI-OSSIE-API.md gains a new "Step 4b — inspect the ontology
block" section between validation and preview. Table of MCP tools
updated to 6.

Closes saiku#1410. Ontology-block DTOs are pure passthrough; consumers
that want to reason over the graph (subsumption, transitive closure,
concept-based navigation) build on top.