### PR TITLE
docs: governance + roadmap + security + code-of-conduct + refreshed contributing

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,138 @@
+# Contributor Covenant Code of Conduct
+
+## Our pledge
+
+We as members, contributors, and leaders pledge to make participation
+in our community a harassment-free experience for everyone, regardless
+of age, body size, visible or invisible disability, ethnicity, sex
+characteristics, gender identity and expression, level of experience,
+education, socio-economic status, nationality, personal appearance,
+race, caste, colour, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open,
+welcoming, diverse, inclusive, and healthy community.
+
+## Our standards
+
+Examples of behaviour that contributes to a positive environment:
+
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologising to those affected by our
+  mistakes, and learning from the experience
+- Focusing on what is best not just for us as individuals but for
+  the overall community
+
+Examples of unacceptable behaviour:
+
+- The use of sexualised language or imagery, and sexual attention
+  or advances of any kind
+- Trolling, insulting or derogatory comments, and personal or
+  political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or
+  email address, without their explicit permission
+- Other conduct which could reasonably be considered inappropriate
+  in a professional setting
+
+## Enforcement responsibilities
+
+The primary maintainer (Tom Barber) is responsible for clarifying
+and enforcing our standards of acceptable behaviour and will take
+appropriate and fair corrective action in response to any behaviour
+they deem inappropriate, threatening, offensive, or harmful.
+
+The maintainer has the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other
+contributions that are not aligned to this Code of Conduct, and
+will communicate reasons for moderation decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also
+applies when an individual is officially representing the community
+in public spaces. Examples of representing our community include
+using an official email address, posting via an official social
+media account, or acting as an appointed representative at an
+online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behaviour
+may be reported to the primary maintainer at
+[tom@spicule.co.uk](mailto:tom@spicule.co.uk).
+
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and
+security of the reporter of any incident.
+
+## Enforcement guidelines
+
+Community leaders will follow these Community Impact Guidelines in
+determining the consequences for any action they deem in violation
+of this Code of Conduct:
+
+### 1. Correction
+
+**Community impact:** Use of inappropriate language or other
+behaviour deemed unprofessional or unwelcome.
+
+**Consequence:** A private, written warning from community leaders,
+providing clarity around the nature of the violation and an
+explanation of why the behaviour was inappropriate. A public apology
+may be requested.
+
+### 2. Warning
+
+**Community impact:** A violation through a single incident or
+series of actions.
+
+**Consequence:** A warning with consequences for continued behaviour.
+No interaction with the people involved, including unsolicited
+interaction with those enforcing the Code of Conduct, for a specified
+period of time. This includes avoiding interactions in community
+spaces as well as external channels like social media. Violating
+these terms may lead to a temporary or permanent ban.
+
+### 3. Temporary ban
+
+**Community impact:** A serious violation of community standards,
+including sustained inappropriate behaviour.
+
+**Consequence:** A temporary ban from any sort of interaction or
+public communication with the community for a specified period of
+time. No public or private interaction with the people involved,
+including unsolicited interaction with those enforcing the Code of
+Conduct, is allowed during this period. Violating these terms may
+lead to a permanent ban.
+
+### 4. Permanent ban
+
+**Community impact:** Demonstrating a pattern of violation of
+community standards, including sustained inappropriate behaviour,
+harassment of an individual, or aggression toward or disparagement
+of classes of individuals.
+
+**Consequence:** A permanent ban from any sort of public interaction
+within the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the
+FAQ at [https://www.contributor-covenant.org/faq][FAQ]. Translations
+are available at [https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,63 +1,195 @@
-## We love community submissions!
+# Contributing to Saiku
 
-To get started, please [sign the Contributor License Agreement](https://www.clahub.com/agreements/OSBI/saiku) so we can accept your pull requests.
+Thanks for wanting to help. This document covers everything from a
+one-line typo fix to a whole feature — pick the depth you need.
 
-Follow the standards of [**Style Guide**](https://github.com/OSBI/saiku-styleguide) Saiku :metal:
+For the human side of the project (who decides what, how commit
+rights work, licensing posture), see [`GOVERNANCE.md`](./GOVERNANCE.md).
 
-### Commit Messages
+## Quickstart for contributors
 
-Please try and make sure there is a relevant [issue ticket](https://github.com/OSBI/saiku/issues) available to commit against, this helps us track issues and the code committed to fix the issue/enhancement.
+The whole loop is: fork → clone → branch → change → PR.
 
-When committing please format your commit message with an issue reference and comment for example:
+```bash
+# 1. Fork spiculedata/saiku on GitHub, then clone your fork
+git clone git@github.com:YOUR_USERNAME/saiku.git
+cd saiku
 
-```sh
-git commit -a -m "#1234 - Fix bug x by doing y"
+# 2. Track our upstream so you can pull in main-branch updates
+git remote add upstream https://github.com/spiculedata/saiku.git
+git fetch upstream
+
+# 3. Branch off development, NOT main / master
+git checkout -b feature/short-descriptive-name upstream/development
+
+# 4. Build once so you know your machine is set up
+mvn verify   # requires JDK 21 + Maven 3.9+
+
+# 5. Make your change. Write tests. Run `mvn spotless:apply` before
+#    committing to satisfy the style-check.
+
+# 6. Open a PR against `development` (NOT `main`)
 ```
 
-Where `#1234` represents the issue number.
+Every PR against `development` triggers CI on Ubuntu and macOS with
+JDK 21. Green CI + one maintainer approval merges the PR.
 
-### Git Flow
+## Development setup
 
-We develop using the git flow framework, please develop against the [development](https://github.com/OSBI/saiku/tree/development) branch, although how you develop against your own fork is up to you, pull requests against **master** will no longer be accepted.
+**Prerequisites:**
 
-For people developing directly in our repository please create feature branches, hot fix branches, and release branches, you can do this manually but we have a maven plugin to make life easier:
+- JDK 21 (Temurin recommended). Older JDKs won't compile the reactor.
+- Maven 3.9+.
+- Node.js 20+ (only if you're touching `saiku-ui/`).
+- Docker (only for the launcher integration tests and end-to-end
+  UI runs).
 
-#### Feature Branches
+**One-time setup:**
 
-##### Create a feature branch:
-
-```sh
-mvn jgitflow:feature-start
+```bash
+./scripts/install-hooks.sh   # installs the pre-commit spotless hook
 ```
 
-#### Hot Fix Branches
+**Common commands:**
 
-Hot fixes are releases forked from the latest release branch and merged back into master and development. After you have completed a hotfix a new release should be issued.
-
-##### Create a hot fix:
-
-```sh
-mvn jgitflow:hotfix-start
+```bash
+mvn verify                                              # full build + tests + spotless-check (CI's gate)
+mvn -pl saiku-core/saiku-service -am test               # one module's tests
+mvn -pl saiku-core/saiku-service test -Dtest=MyTest     # single test class
+mvn -pl saiku-launcher -am -Dmaven.test.skip=true package   # build the runnable fat-JAR
+mvn spotless:apply                                      # auto-format Java (Palantir style)
 ```
 
-##### Finish a hot fix:
+Full build environment details — including the GitHub Packages auth
+gotcha for Mondrian dependencies — live in
+[`CLAUDE.md`](./CLAUDE.md) at the repo root.
 
-```sh
-mvn jgitflow:hotfix-finish -DkeepBranch -DnoHotfixBuild
+## Branching
+
+We use **Gitflow**. In practice:
+
+- All feature work goes on a `feature/<name>` branch off `development`.
+- Hotfixes branch off `main` as `hotfix/<name>` and merge back to
+  both `main` and `development`.
+- Release prep happens on `release/<version>` branches off
+  `development`, which then merge to `main` (tagged) and back to
+  `development`.
+- Never push directly to `main` or `development` — always PR.
+- Chores and refactors that don't fit `feature/` use `chore/<name>`.
+
+## Commit messages
+
+Format:
+
+```
+#<issue> - <short description>
+
+Optional longer body explaining why (not what — the diff shows the
+what). Wrap at 72 columns.
 ```
 
-#### Release Branches
+- Reference an issue number when the change fixes one. If no issue
+  exists, that's fine for small changes; open one first for anything
+  substantial.
+- Types we use in commit prefixes when helpful: `feat`, `fix`,
+  `docs`, `chore`, `refactor`, `test`, `perf`, `ci`.
+- Attribution is set up globally; don't add `Co-Authored-By` unless
+  it's a genuine pair-programmed change.
 
-Release branches are created when the development branch is feature complete, if not bug free. Once a release branch has been created you are still free to fix bugs within the release branch.
+## Testing expectations
 
-##### Create Release Branch:
+We aim for **80%+ test coverage** on new code. Tests come in three
+flavors:
 
-```sh
-mvn jgitflow:release-start
-```
+- **Unit tests** — individual functions, DTOs, services. Fast, no
+  network. Live under `src/test/java`.
+- **Integration tests** (`*IT.java`) — spin up a real database (H2
+  in-process), exercise the SQL adapter or query paths. Live
+  alongside the code they test.
+- **End-to-end tests** — the launcher IT harness in
+  [`saiku-launcher/test-*-live.sh`](./saiku-launcher/) drives a
+  live server over HTTP.
 
-##### Finish Release:
+Bugfixes come with a regression test. New features come with
+enough coverage that a future refactor can trust the tests. Ask
+in the PR if you're unsure how much is enough — happy to discuss.
 
-```sh
-mvn jgitflow:release-finish -DnoReleaseBuild
-```
+## Code style
+
+- **Palantir Java Format** enforced via
+  [Spotless](https://github.com/diffplug/spotless). `mvn spotless:apply`
+  formats. The pre-commit hook installed by
+  `scripts/install-hooks.sh` runs it automatically.
+- **Spring XML wiring**, not JavaConfig. Webapp beans live in
+  `applicationContext-*.xml`; new beans go there.
+- **JAX-RS 3 (Jersey)**, not Spring MVC. REST resources are
+  `@Path`-annotated Jersey resources.
+- **Prefer immutability** at the DTO layer. New DTOs should have
+  final fields where practical.
+
+The `.spotless` config is authoritative on formatting; the human
+guide is short: read the surrounding code and match it.
+
+## Reporting bugs
+
+1. Search [existing issues](https://github.com/spiculedata/saiku/issues)
+   first — chances are it's already logged.
+2. If not, open a new issue with:
+   - Saiku version (`docker inspect ghcr.io/spiculedata/saiku` or
+     the launcher log's first line)
+   - What you expected to happen
+   - What actually happened, with the log excerpt if there was one
+   - Steps to reproduce that a stranger could follow
+3. If it's a **security issue**, don't open a public issue — see
+   [`SECURITY.md`](./SECURITY.md) for the disclosure process.
+
+## Requesting features
+
+Open a GitHub issue tagged `enhancement`. Explain the use case
+first, the implementation second — knowing why matters more than
+knowing how. If it's a big directional ask, please raise it on
+[GitHub Discussions](https://github.com/spiculedata/saiku/discussions)
+before committing time to a large PR.
+
+For roadmap-level changes, see the "How to propose a change" section
+of [`ROADMAP.md`](./ROADMAP.md).
+
+## PR review
+
+- One maintainer approval + green CI is enough to merge routine
+  changes.
+- Substantive changes (breaking APIs, licensing implications,
+  cross-module refactors) get more eyes — expect discussion, and
+  give reviewers time.
+- If a review sits idle for more than a week, ping the PR politely.
+  We're a small team; things fall through.
+
+Reviews are meant to be a conversation, not a gate. If a reviewer
+asks for a change you disagree with, push back with reasoning —
+the review usually improves for it. If we can't reach agreement,
+the primary maintainer has the final call, but that's rare.
+
+## Code of conduct
+
+We follow the [Contributor Covenant](./CODE_OF_CONDUCT.md).
+Violations get reported to Tom Barber at
+[tom@spicule.co.uk](mailto:tom@spicule.co.uk); serious ones lose
+project access.
+
+## Licensing
+
+By opening a PR you affirm that you have the right to contribute
+the code and agree to license it under Apache 2.0 + EPL 1.0 (the
+Saiku licence). No CLA click-through required — a plain
+`Signed-off-by:` trailer on your commit, per
+[Developer Certificate of Origin 1.1](https://developercertificate.org/),
+is sufficient.
+
+Add it with `git commit -s`.
+
+## Thank you
+
+The project has gone through eras with different amounts of
+external maintenance. Every PR from an external contributor is
+what keeps it a real open-source project rather than a company's
+public artifact. Thank you for spending the time.

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,0 +1,127 @@
+# Saiku project governance
+
+_Last reviewed: 2026-07-10_
+
+This document explains how Saiku is governed: who decides what,
+how decisions get made, who has commit rights, and how those
+rights are gained and lost. Enterprise buyers evaluating Saiku for
+production regularly ask for this document. Contributors reading
+it will find the process transparent and light-touch.
+
+## Structure
+
+Saiku is stewarded by **Spicule Ltd**, the maintaining company. Day-
+to-day maintenance, release management, and roadmap curation happen
+inside Spicule. External contributors are welcome and their work
+lands in mainline releases.
+
+- **Maintaining organization:** [Spicule Ltd](https://spicule.co.uk),
+  incorporated in England & Wales.
+- **Primary maintainer:** Tom Barber ([tom@spicule.co.uk](mailto:tom@spicule.co.uk)).
+- **Commercial product:** [Saiku Cloud](https://cloud.saiku.bi) — the
+  same binary self-hosted operators run, plus operational plumbing.
+  Cloud revenue funds the open-source work.
+
+## Decision-making
+
+Saiku uses a **lazy consensus** model for day-to-day changes.
+
+- A pull request is deemed accepted when a maintainer approves it
+  and CI is green. No formal quorum required for routine work.
+- **Substantive changes** (breaking API changes, licensing changes,
+  removing a shipped feature, cutting a major release) require
+  explicit discussion on a GitHub issue with at least 72 hours for
+  community response before merge.
+- **Roadmap changes** (adding or removing items from
+  [`ROADMAP.md`](./ROADMAP.md)) require the same 72-hour window.
+- **Security decisions** — see [`SECURITY.md`](./SECURITY.md) — go
+  through a private disclosure process and aren't debated in the
+  open until a fix has shipped.
+
+Where consensus can't be reached, the primary maintainer has the
+final call. That happens rarely; in practice most disagreements
+resolve in the PR conversation.
+
+## Commit rights
+
+Three tiers of GitHub access:
+
+- **Contributor** — anyone who's opened a PR. No repo permissions;
+  work lands via PR review.
+- **Committer** — write access to the repo. Granted by consensus of
+  existing committers after sustained quality contribution
+  (typically 5+ merged PRs across the codebase). Committers can
+  merge PRs (their own excluded), triage issues, and approve
+  routine changes.
+- **Maintainer** — admin access. Currently: Tom Barber. Additional
+  maintainers are added by unanimous agreement of existing
+  maintainers when the load or the bus factor demands it.
+
+Rights are removed for demonstrated bad-faith behavior (violating
+the [Code of Conduct](./CODE_OF_CONDUCT.md), knowingly landing
+malicious code) or on request. Inactive committers keep their
+rights unless they ask to be removed.
+
+Current committers are listed at [MAINTAINERS.md](./MAINTAINERS.md)
+when we have more than one; today the maintainer list is `Tom
+Barber` alone.
+
+## The bus factor honesty
+
+Saiku's daily contribution graph today is dominated by one person
+(`Tom Barber`). We're aware; it's not a state we want to stay in.
+Steps we're actively taking:
+
+- **Library extraction.** The load-bearing Ossie / OSI parser and
+  Calcite adapter were split into
+  [`bi.saiku.ossie:ossie-core`](https://github.com/spiculedata/ossie)
+  and `bi.saiku.ossie:ossie-sql` — Apache 2.0, in their own
+  repository, independently maintainable by any JVM contributor
+  without touching the main Saiku codebase.
+- **Public roadmap.** [`ROADMAP.md`](./ROADMAP.md) makes the
+  direction of travel visible so external contributors can plan
+  around it.
+- **Onboarding.** [`CONTRIBUTING.md`](./CONTRIBUTING.md) is
+  refreshed so a new contributor can go from clone to merged PR
+  without asking for hand-holding.
+- **Pentaho community.** The natural pool of external maintainers
+  is the Pentaho / Mondrian community that Saiku already serves.
+  We reach out actively when someone contributes and shows
+  interest.
+
+Enterprise buyers who need a stronger continuity guarantee can
+purchase [Saiku Cloud](https://cloud.saiku.bi) or an
+[Enterprise support contract](https://saiku.bi/#pricing), both of
+which are backed by Spicule Ltd under commercial terms.
+
+## Licensing
+
+Saiku ships under **Apache License 2.0 with EPL 1.0 exemptions**
+(the same dual license Mondrian has used since Pentaho). Any
+change to the licence would go through the 72-hour substantive-
+change process AND would require explicit sign-off from every
+copyright holder whose contributions materially remain in the
+codebase.
+
+The published pledge — the version of Saiku you self-host is the
+version Spicule runs in Cloud — is a governance commitment, not
+just marketing copy. Relicensing to a source-available or
+commercial-only licence in the future would violate that pledge and
+isn't on any roadmap.
+
+## Relationship with the Ossie project
+
+Saiku is a reference consumer of the Apache Ossie / Open Semantic
+Interchange specification. Saiku engineers who submit changes to
+the Apache Ossie project do so as individual contributors under
+the Apache CLA — they don't act as agents of Spicule. This
+separation lets Ossie remain a genuinely vendor-neutral standard
+even while Saiku is a large consumer.
+
+## Contact
+
+- **Governance questions:** [tom@spicule.co.uk](mailto:tom@spicule.co.uk)
+- **Security disclosures:** see [`SECURITY.md`](./SECURITY.md)
+- **Code of conduct violations:** see
+  [`CODE_OF_CONDUCT.md`](./CODE_OF_CONDUCT.md)
+- **Commercial:** [hello@spicule.co.uk](mailto:hello@spicule.co.uk)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,124 @@
+# Saiku roadmap
+
+_Last reviewed: 2026-07-10_
+
+This roadmap captures the direction of travel for Saiku over the
+next 6-12 months. Priorities move; that's the whole point of a
+roadmap that's kept honest. See the
+[GOVERNANCE](./GOVERNANCE.md) doc for how changes to this file get
+proposed.
+
+Everything below is public work in the open-source repository.
+Cloud-only operational features (multi-tenant billing, SSO
+integrations with SLAs, region deployment) are tracked separately
+and don't appear here.
+
+## Currently shipping (Q3 2026)
+
+Features that are landing in the current milestone, referenced by
+GitHub issue where one exists.
+
+- **Ossie / Open Semantic Interchange, end-to-end.** DTOs +
+  YAML/JSON reader, Calcite adapter, shelf-state query engine, AI
+  Query API, MCP tools, natural-language ask. Shipped in July
+  2026 as [`bi.saiku.ossie:ossie-core`](https://github.com/spiculedata/ossie)
+  + `bi.saiku.ossie:ossie-sql`. Saiku consumes it as an external
+  library.
+- **AI Query API for both OLAP and Ossie surfaces.** Records +
+  matrix formats, async execute, anomaly detection, forecasting,
+  natural-language ask. See [`docs/AI-QUERY-API.md`](./docs/AI-QUERY-API.md)
+  and [`docs/AI-OSSIE-API.md`](./docs/AI-OSSIE-API.md).
+- **dbt / MetricFlow integration.** dbt Core 1.12's
+  `target/osi_document.json` is consumed directly. Older dbt
+  versions use the MetricFlow-to-Ossie converter in
+  [`docs/dbt-hookup/`](./docs/dbt-hookup/).
+- **Synonym resolution, custom_extensions passthrough, ontology
+  block.** Every OSI spec surface the flights + tpcds reference
+  examples exercise now round-trips through Saiku
+  ([#1408](https://github.com/spiculedata/saiku/issues/1408),
+  [#1409](https://github.com/spiculedata/saiku/issues/1409),
+  [#1410](https://github.com/spiculedata/saiku/issues/1410)).
+
+## Next up (Q4 2026)
+
+Features prioritized but not yet actively in flight. Order below
+reflects current thinking; order will shift as we learn.
+
+- **Roles-based security for Ossie models
+  ([#1393](https://github.com/spiculedata/saiku/issues/1393)).**
+  Mondrian-parity per-role WHERE-clause injection driven by
+  Spring Security authorities. Load-bearing for any enterprise
+  procurement conversation where "the CFO's row-level security
+  applies to AI queries too" is a requirement. Design phase
+  first (YAML shape, translator hook points, k-anonymity
+  interaction), then implementation.
+- **Extract the Ossie shelf translator to `bi.saiku.ossie:ossie-sql`
+  (saiku#1396 Path 2).** Path 1 (adapter classes) already
+  landed. Path 2 disentangles the shelf translator from Saiku-
+  specific bindings (`OssieQueryModel`, k-anon filter, PII
+  redaction) so the library becomes the reference translator
+  for JVM consumers. Real design work.
+- **GraphQL API.** Wraps the existing typed AI Query API. Table-
+  stakes for embedded and SaaS evaluators. Deferred until an
+  actual embedded evaluator asks — we don't want to spend a week
+  building it against no user requests.
+- **Cube feature-tracker comparison page on saiku.bi.** Mechanical
+  content asset for "cube open source alternative" search
+  traffic. Not code, but tracked here for planning.
+
+## Investigating (H1 2027)
+
+Directions we've committed to explore but not to build.
+
+- **Ontology-driven schema navigation UI.** The OSI ontology block
+  ships knowledge-graph shape (concepts, relationships,
+  verbalizations, derived_by). Rendering it as a first-class
+  navigation surface alongside the dataset tree would give agents
+  and humans an entity-level model view no BI tool has today.
+  Depends on a real design pass — not just "render the block."
+- **`bi.saiku.ossie:ossie-mondrian` — Mondrian → Ossie adapter
+  as a standalone library.** Currently
+  [`MondrianToOssieConverter`](./saiku-core/saiku-service/src/main/java/org/saiku/service/schema/ossie/MondrianToOssieConverter.java)
+  lives in Saiku because it depends on Mondrian. Extracting it
+  would let non-Saiku tools convert Mondrian schemas to OSI
+  YAML.
+- **Broader warehouse dialect coverage.** Calcite handles many
+  dialects; native dialect maps exist for Postgres, H2, HSQLDB,
+  MSSQL, MySQL/MariaDB, Oracle. Redshift and Databricks are the
+  two most-requested additions.
+
+## Not on the roadmap
+
+Being explicit about what we're deliberately not building matters
+as much as what we are.
+
+- **Per-seat pricing.** Flat pricing is a competitive weapon; we
+  keep it.
+- **Gating existing OSS features behind a Cloud paywall.** The
+  no-rug-pull pledge is a governance commitment; see
+  [`GOVERNANCE.md`](./GOVERNANCE.md).
+- **DAX API.** Power BI is served through SQL / DirectQuery; a
+  parallel DAX API is a wrong investment for the audience Saiku
+  serves.
+- **FedRAMP compliance.** Not the market we serve. Enterprise
+  procurement asks for it are politely declined.
+- **Chat-driven data-app builder (Cube D3 equivalent).** Cube's
+  D3 is a $47M-of-VC product surface. We don't out-Cube Cube on
+  chat UX; we serve teams for whom Excel + governed cubes + MCP
+  is the right shape.
+
+## How to propose a change
+
+- **Small addition / adjustment:** open a GitHub issue tagged
+  `roadmap` describing the ask and the audience. Discussion
+  happens on the issue; if consensus favors it we PR it into this
+  file.
+- **Big directional shift** (removing a whole tier above, changing
+  our not-on-roadmap stance): raise it on
+  [GitHub Discussions](https://github.com/spiculedata/saiku/discussions)
+  first. 72-hour open discussion window per
+  [`GOVERNANCE.md`](./GOVERNANCE.md) before any file change.
+- **Enterprise-specific ask:** email
+  [hello@spicule.co.uk](mailto:hello@spicule.co.uk) with the use
+  case. Cloud enterprise contracts can influence prioritization
+  transparently; we'll say yes or no in writing.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,84 @@
+# Security policy
+
+## Reporting a vulnerability
+
+**Do not open a public GitHub issue for security-sensitive reports.**
+
+Email [security@saiku.bi](mailto:security@saiku.bi) with:
+
+- A description of the vulnerability
+- The Saiku version(s) affected
+- Steps to reproduce, ideally with a minimal proof of concept
+- Any known impact assessment
+
+We acknowledge receipt within 48 hours (usually same day during UK
+business hours) and share our first triage assessment within seven
+days. If the finding is confirmed, we agree a disclosure timeline
+with you — typically 30-90 days from acknowledgement, longer for
+deep-cutting fixes, shorter for actively-exploited issues.
+
+If your finding lands within scope, we're happy to credit you
+publicly in the fix's release notes and CVE record. We don't
+currently run a paid bug bounty program.
+
+## What's in scope
+
+- The current major version (Saiku 4.x) of the open-source build
+- [Saiku Cloud](https://cloud.saiku.bi) production endpoints
+- The AI Query API surfaces (`/rest/saiku/api/ai/*`)
+- The MCP endpoint (`/rest/saiku/api/mcp`)
+- The Ossie library
+  ([`bi.saiku.ossie:ossie-core`](https://github.com/spiculedata/ossie),
+  `bi.saiku.ossie:ossie-sql`)
+
+Reports against the following are welcomed but a lower priority:
+
+- Saiku 3.x — no longer maintained
+- Third-party dependencies with issues fixed upstream — we bump
+  those on our normal cadence
+- Demo instance (`demo.saiku.bi`) findings that don't affect a
+  hardened production deployment
+
+## What's not in scope
+
+- Social engineering against Spicule staff
+- Denial-of-service against `demo.saiku.bi` (it's a demo; running
+  it at rope's end doesn't tell us anything about production)
+- Findings that require an attacker who already has admin
+  credentials
+- Missing security headers on cloud-hosted marketing pages
+  (`saiku.bi`) — reports welcomed but treated as informational
+- Missing rate limits on obviously-throttleable endpoints — please
+  suggest a reasonable limit rather than flooding the endpoint to
+  make the point
+
+## PGP
+
+If you need to encrypt your report, ask for our PGP key in a first
+short email and we'll reply with it.
+
+## What we do on our side
+
+- **Dependency scanning:** Snyk on every push to `development`;
+  OWASP Dependency-Check via `mvn -P security verify` on release
+  builds. Findings above CVSS 7.0 block release.
+- **Secrets scanning:** GitHub secret scanning enabled repo-wide;
+  commit hooks reject common credential patterns.
+- **Fail-closed defaults.** Non-obvious ones: the AI policy guard
+  defaults to `SCHEMA_ONLY` in production so AI endpoints don't
+  return aggregated data or raw rows without explicit operator
+  opt-in; the launcher refuses to serve in production while the
+  default admin password (`admin/admin`) is unchanged; observability
+  is opt-in so no data leaves the box unless configured.
+- **Vulnerability triage.** Findings are logged internally with a
+  planned fix window; the fix + disclosure ship together per the
+  agreed timeline.
+
+Full production security posture is at
+[docs.saiku.bi/security/posture](https://docs.saiku.bi/security/posture/).
+
+## Contact
+
+- **Security disclosures:** [security@saiku.bi](mailto:security@saiku.bi)
+- **General inquiries:** [hello@saiku.bi](mailto:hello@saiku.bi)
+- **Governance questions:** [tom@spicule.co.uk](mailto:tom@spicule.co.uk)


### PR DESCRIPTION
Five files at the repo root that enterprise buyers grep for before
they'll open a conversation. Report flagged the bus-factor + docs
gaps at P1.

## Added

- **`GOVERNANCE.md`** — how Saiku is governed. Structure (Spicule +
  primary maintainer), lazy consensus + 72-hour substantive change
  window, three-tier commit-rights model (Contributor / Committer /
  Maintainer), honest bus-factor section naming the steps we're
  actively taking (library extraction, roadmap, onboarding, Pentaho
  community outreach), licensing pledge (no rug-pull is a governance
  commitment not just marketing), Ossie relationship, contacts.
- **`ROADMAP.md`** — current shipping (Q3 2026: Ossie end-to-end, AI
  Query API, dbt hookup, spec follow-ups), next up (Q4 2026: roles
  security saiku#1393, translator extraction Path 2 saiku#1396,
  GraphQL when asked, Cube feature-tracker page), investigating
  (H1 2027: ontology-driven navigation, ossie-mondrian library,
  Redshift + Databricks dialects), and explicit "not on the roadmap"
  list (no per-seat, no OSS paywall, no DAX API, no FedRAMP, no D3
  equivalent). Includes how-to-propose-a-change section.
- **`SECURITY.md`** — vulnerability reporting to security@saiku.bi
  with 48h acknowledgement + 30-90 day disclosure timeline. Scope
  table (current 4.x + Cloud + AI APIs + Ossie library IN; 3.x +
  social + credentials-required OUT). What we do on our side
  (Snyk, OWASP dep-check, secrets scanning, fail-closed defaults —
  named the AiPolicy schema-only production default that just came
  up in the demo tile fix).
- **`CODE_OF_CONDUCT.md`** — Contributor Covenant 2.1 unchanged,
  enforcement routed to tom@spicule.co.uk.
- **`CONTRIBUTING.md`** (rewrite) — the existing file referenced OSBI
  (old org), clahub.com (dead service), old repo URLs. Replaced
  with: current fork/clone/branch/PR loop, prereqs (JDK 21 + Maven
  3.9), one-time setup (install-hooks.sh), common commands, Gitflow
  branch model, commit message format, testing expectations (80%+
  target), code style (Palantir Java Format via Spotless, Spring
  XML wiring, JAX-RS 3), bug + feature reporting, PR review model,
  DCO-style Signed-off-by attestation.

## Not changed

- No behaviour changes. Documentation-only PR.
- Existing PRs in flight unaffected.

## Impact

Enterprise procurement conversations that stall on "who's behind
this? what happens if they're hit by a bus?" now have a real page
to point at. The report specifically called out this being the
answer the "you can't hire your way to Cube's headcount" objection
needs.
