### PR TITLE
#1409 feat(ossie): well-known SAIKU extensions (display / roles / graded pii)

### DIFF
--- a/docs/AI-OSSIE-API.md
+++ b/docs/AI-OSSIE-API.md
@@ -348,6 +348,100 @@ custom_extensions:
   data: '{"visibility":"internal","secret":true}'
 ```
 
+### Well-known Saiku extensions (#1409)
+
+The `vendor_name: SAIKU` blob is the reserved namespace for Saiku's own
+well-known keys. Three are defined in v4.7; the namespace is
+deliberately extensible — unknown keys under the SAIKU vendor
+round-trip untouched so future well-knowns don't require a coordinated
+release.
+
+#### `saiku.display` — presentation overrides
+
+```yaml
+custom_extensions:
+- vendor_name: SAIKU
+  data: |
+    {
+      "display": {
+        "caption": "Net Revenue",
+        "format": "$#,##0.00",
+        "unit": "USD",
+        "hidden": false
+      }
+    }
+```
+
+- **`caption`** overrides the field / metric label in the AI schema
+  response. Wins over any Phase-3 `<datasource>.generated.json` rename
+  for the same object.
+- **`format`** is a number-format pattern (`DecimalFormat` syntax) the
+  workbench applies when rendering values.
+- **`unit`** is free text (`"USD"`, `"hours"`, `"%"`) — same field the
+  legacy MDX schema exposes.
+- **`hidden: true`** strips the field / metric from the AI schema
+  response entirely. Different from `pii` — hidden means the operator
+  doesn't want the AI to see it at all; PII means the data is sensitive
+  and the value gets redacted at query time.
+
+#### `saiku.roles` — role-based visibility
+
+```yaml
+custom_extensions:
+- vendor_name: SAIKU
+  data: |
+    {
+      "roles": {
+        "allow": ["ROLE_SALES", "ROLE_ANALYST"],
+        "deny": ["ROLE_EMBED_GUEST"]
+      }
+    }
+```
+
+- Empty / missing **`allow`** = allow all callers.
+- Non-empty **`allow`** = caller must have at least one matching role.
+- **`deny`** overrides `allow`.
+- Full enforcement (filtering the schema + query response against the
+  caller's Spring Security authorities) is tracked with the Ossie RLS
+  work in [saiku#1393](https://github.com/spiculedata/saiku/issues/1393).
+  This slice defines the annotation and exposes it on the projected
+  DTO; the runtime filter lands with #1393.
+
+#### `saiku.pii` — graded PII
+
+```yaml
+custom_extensions:
+- vendor_name: SAIKU
+  data: |
+    {
+      "pii": {"level": "hash"}
+    }
+```
+
+Extends the legacy `"pii": true` boolean into a graded shape. Three
+levels:
+
+| Level     | Behaviour                                                                            |
+|-----------|--------------------------------------------------------------------------------------|
+| `redact`  | Value is `null` on the wire. Same as the legacy `"pii": true` boolean.               |
+| `mask`    | Value is replaced with a fixed mask token (e.g. `"***"`) preserving row shape.        |
+| `hash`    | Value is replaced with a deterministic keyed-hash hex prefix, preserving joinability. |
+
+The legacy boolean form stays supported — `"pii": true` and
+`"pii": {"level": "redact"}` are equivalent.
+
+### Extension namespace convention
+
+`saiku.*` (nested under `vendor_name: SAIKU`) is reserved for
+Saiku-authored well-knowns. Third-party integrators SHOULD use their
+own vendor name (`vendor_name: DBT`, `vendor_name: PREFECT`, etc.);
+unknown vendor names round-trip unchanged through the AI schema so
+downstream consumers can read them without a coordinated release.
+
+Within the SAIKU blob, unknown keys are ignored (not rejected) — a
+future well-known key can be authored by a newer exporter without
+breaking older consumers.
+
 ---
 
 ## Step 4 — validation: how the API teaches the agent

--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/ossie/OssieDiscoverService.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/ossie/OssieDiscoverService.java
@@ -189,6 +189,7 @@ public class OssieDiscoverService {
                 && Boolean.TRUE.equals(src.getDimension().getIsTime()));
         f.setPii(readPii(src.getCustomExtensions()));
         f.setCustomExtensions(projectCustomExtensions(src.getCustomExtensions()));
+        applyWellKnownExtensionsToField(f, src.getCustomExtensions());
         return f;
     }
 
@@ -200,7 +201,48 @@ public class OssieDiscoverService {
         m.setDescription(src.getDescription());
         m.setAggregationKind(readAggregationKind(src.getCustomExtensions()));
         m.setCustomExtensions(projectCustomExtensions(src.getCustomExtensions()));
+        applyWellKnownExtensionsToMetric(m, src.getCustomExtensions());
         return m;
+    }
+
+    /**
+     * Overlay the {@code saiku.display}, {@code saiku.roles}, and {@code saiku.pii} well-knowns
+     * (saiku#1409) onto a projected field. Absent extensions leave the field unchanged.
+     */
+    private static void applyWellKnownExtensionsToField(OssieModelDto.Field f, List<CustomExtension> src) {
+        SaikuWellKnownExtensions.Parsed w = SaikuWellKnownExtensions.read(src);
+        if (w.isEmpty()) return;
+        if (w.display() != null) {
+            f.setDisplayCaption(w.display().caption());
+            f.setDisplayFormat(w.display().format());
+            f.setDisplayUnit(w.display().unit());
+            f.setDisplayHidden(w.display().hidden());
+        }
+        if (w.roles() != null) {
+            f.setAllowRoles(new ArrayList<>(w.roles().allow()));
+            f.setDenyRoles(new ArrayList<>(w.roles().deny()));
+        }
+        if (w.pii() != null) {
+            f.setPiiLevel(w.pii().name());
+            // The legacy `pii` boolean stays true for any level — the graded form is additive.
+            if (!f.isPii()) f.setPii(true);
+        }
+    }
+
+    /** Same overlay for metrics. Metrics don't carry a pii boolean, so the pii level lands nowhere. */
+    private static void applyWellKnownExtensionsToMetric(OssieModelDto.Metric m, List<CustomExtension> src) {
+        SaikuWellKnownExtensions.Parsed w = SaikuWellKnownExtensions.read(src);
+        if (w.isEmpty()) return;
+        if (w.display() != null) {
+            m.setDisplayCaption(w.display().caption());
+            m.setDisplayFormat(w.display().format());
+            m.setDisplayUnit(w.display().unit());
+            m.setDisplayHidden(w.display().hidden());
+        }
+        if (w.roles() != null) {
+            m.setAllowRoles(new ArrayList<>(w.roles().allow()));
+            m.setDenyRoles(new ArrayList<>(w.roles().deny()));
+        }
     }
 
     /**

--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/ossie/OssieModelDto.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/ossie/OssieModelDto.java
@@ -183,6 +183,28 @@ public class OssieModelDto {
         private boolean isTime;
         private boolean pii;
 
+        // saiku#1409 well-known extensions. All null when the operator hasn't authored one.
+        @JsonInclude(JsonInclude.Include.NON_NULL)
+        private String displayCaption;
+
+        @JsonInclude(JsonInclude.Include.NON_NULL)
+        private String displayFormat;
+
+        @JsonInclude(JsonInclude.Include.NON_NULL)
+        private String displayUnit;
+
+        @JsonInclude(JsonInclude.Include.NON_DEFAULT)
+        private boolean displayHidden;
+
+        @JsonInclude(JsonInclude.Include.NON_EMPTY)
+        private List<String> allowRoles = new ArrayList<>();
+
+        @JsonInclude(JsonInclude.Include.NON_EMPTY)
+        private List<String> denyRoles = new ArrayList<>();
+
+        @JsonInclude(JsonInclude.Include.NON_NULL)
+        private String piiLevel;
+
         @JsonInclude(JsonInclude.Include.NON_EMPTY)
         private List<CustomExtensionDto> customExtensions = new ArrayList<>();
 
@@ -241,6 +263,62 @@ public class OssieModelDto {
         public void setPii(boolean v) {
             this.pii = v;
         }
+
+        public String getDisplayCaption() {
+            return displayCaption;
+        }
+
+        public void setDisplayCaption(String v) {
+            this.displayCaption = v;
+        }
+
+        public String getDisplayFormat() {
+            return displayFormat;
+        }
+
+        public void setDisplayFormat(String v) {
+            this.displayFormat = v;
+        }
+
+        public String getDisplayUnit() {
+            return displayUnit;
+        }
+
+        public void setDisplayUnit(String v) {
+            this.displayUnit = v;
+        }
+
+        public boolean isDisplayHidden() {
+            return displayHidden;
+        }
+
+        public void setDisplayHidden(boolean v) {
+            this.displayHidden = v;
+        }
+
+        public List<String> getAllowRoles() {
+            return allowRoles;
+        }
+
+        public void setAllowRoles(List<String> v) {
+            this.allowRoles = v == null ? new ArrayList<>() : v;
+        }
+
+        public List<String> getDenyRoles() {
+            return denyRoles;
+        }
+
+        public void setDenyRoles(List<String> v) {
+            this.denyRoles = v == null ? new ArrayList<>() : v;
+        }
+
+        public String getPiiLevel() {
+            return piiLevel;
+        }
+
+        public void setPiiLevel(String v) {
+            this.piiLevel = v;
+        }
     }
 
     /** Ossie metric — expands to an aggregate expression at query time. */
@@ -249,6 +327,25 @@ public class OssieModelDto {
         private String expression;
         private String description;
         private String aggregationKind;
+
+        // saiku#1409 well-known extensions — same shape as Field.
+        @JsonInclude(JsonInclude.Include.NON_NULL)
+        private String displayCaption;
+
+        @JsonInclude(JsonInclude.Include.NON_NULL)
+        private String displayFormat;
+
+        @JsonInclude(JsonInclude.Include.NON_NULL)
+        private String displayUnit;
+
+        @JsonInclude(JsonInclude.Include.NON_DEFAULT)
+        private boolean displayHidden;
+
+        @JsonInclude(JsonInclude.Include.NON_EMPTY)
+        private List<String> allowRoles = new ArrayList<>();
+
+        @JsonInclude(JsonInclude.Include.NON_EMPTY)
+        private List<String> denyRoles = new ArrayList<>();
 
         @JsonInclude(JsonInclude.Include.NON_EMPTY)
         private List<CustomExtensionDto> customExtensions = new ArrayList<>();
@@ -291,6 +388,54 @@ public class OssieModelDto {
 
         public void setAggregationKind(String v) {
             this.aggregationKind = v;
+        }
+
+        public String getDisplayCaption() {
+            return displayCaption;
+        }
+
+        public void setDisplayCaption(String v) {
+            this.displayCaption = v;
+        }
+
+        public String getDisplayFormat() {
+            return displayFormat;
+        }
+
+        public void setDisplayFormat(String v) {
+            this.displayFormat = v;
+        }
+
+        public String getDisplayUnit() {
+            return displayUnit;
+        }
+
+        public void setDisplayUnit(String v) {
+            this.displayUnit = v;
+        }
+
+        public boolean isDisplayHidden() {
+            return displayHidden;
+        }
+
+        public void setDisplayHidden(boolean v) {
+            this.displayHidden = v;
+        }
+
+        public List<String> getAllowRoles() {
+            return allowRoles;
+        }
+
+        public void setAllowRoles(List<String> v) {
+            this.allowRoles = v == null ? new ArrayList<>() : v;
+        }
+
+        public List<String> getDenyRoles() {
+            return denyRoles;
+        }
+
+        public void setDenyRoles(List<String> v) {
+            this.denyRoles = v == null ? new ArrayList<>() : v;
         }
     }
 

--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/ossie/SaikuWellKnownExtensions.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/ossie/SaikuWellKnownExtensions.java
@@ -1,0 +1,254 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.service.ossie;
+
+import bi.saiku.ossie.model.CustomExtension;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * Well-known extension keys under the {@code SAIKU} vendor namespace on OSI {@code
+ * custom_extensions[]} entries (saiku#1409).
+ *
+ * <p>Ossie's OSI-spec {@code custom_extensions} field carries free-form vendor metadata. Saiku has
+ * traditionally scattered its consumption of that blob (there's a dedicated {@code readPii()} and a
+ * {@code readAggregationKind()} on the discover service, each hand-coding one field). This class
+ * pulls the parsing together so every consumer sees the same typed view, and so operators have
+ * exactly one place to look for what's supported.
+ *
+ * <p>Three well-knowns land in this slice; more can be added as needed. All live under
+ * {@code vendor_name: SAIKU}:
+ *
+ * <ul>
+ *   <li>{@code display} — caption / format / unit / hidden. Overlays field/metric presentation and
+ *       gates whether the entry surfaces in the AI schema response at all.
+ *   <li>{@code roles} — {@code allow} / {@code deny} role lists that filter which fields/metrics
+ *       are visible to a given user. Enforcement lives with the Ossie RLS work (saiku#1393); this
+ *       class just parses the annotation.
+ *   <li>{@code pii} — extends the legacy {@code "pii": true} boolean into a graded {@code {level:
+ *       "redact" | "mask" | "hash"}} shape. Backwards compatible: {@code true} keeps meaning
+ *       {@code REDACT}.
+ * </ul>
+ *
+ * <p>Everything else (unknown keys inside the SAIKU blob, other vendor names) round-trips
+ * unchanged through {@link CustomExtensionDto} — this class is additive, never destructive.
+ */
+public final class SaikuWellKnownExtensions {
+
+    /** The canonical vendor name for Saiku's well-known keys. */
+    public static final String VENDOR_SAIKU = "SAIKU";
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    private SaikuWellKnownExtensions() {}
+
+    /**
+     * Read the SAIKU vendor blob out of {@code extensions} and return a typed view. Returns an
+     * empty {@link Parsed} record when no SAIKU extension is present, when the blob is empty, or
+     * when the JSON is malformed.
+     *
+     * <p>Deliberately swallows parse errors — a bad extension blob mustn't break discover. The
+     * discover service already logs at debug when {@link CustomExtensionDto} parsing fails; this
+     * layer is even more of a best-effort read.
+     */
+    public static Parsed read(List<CustomExtension> extensions) {
+        if (extensions == null || extensions.isEmpty()) {
+            return Parsed.EMPTY;
+        }
+        for (CustomExtension ext : extensions) {
+            if (ext == null || !VENDOR_SAIKU.equals(ext.getVendorName())) continue;
+            String data = ext.getData();
+            if (data == null || data.isBlank()) continue;
+            try {
+                JsonNode node = MAPPER.readTree(data);
+                if (node.isObject()) {
+                    return parse(node);
+                }
+            } catch (IOException ignored) {
+                // best-effort: skip and try the next SAIKU entry.
+            }
+        }
+        return Parsed.EMPTY;
+    }
+
+    /**
+     * Same as {@link #read(List)} but operates on the already-projected {@link CustomExtensionDto}
+     * shape used downstream. Handy for consumers past the discover boundary.
+     */
+    public static Parsed readFromDtos(List<CustomExtensionDto> dtos) {
+        if (dtos == null || dtos.isEmpty()) {
+            return Parsed.EMPTY;
+        }
+        for (CustomExtensionDto dto : dtos) {
+            if (dto == null || !VENDOR_SAIKU.equals(dto.getVendorName())) continue;
+            JsonNode data = dto.getData();
+            if (data == null || !data.isObject()) continue;
+            return parse(data);
+        }
+        return Parsed.EMPTY;
+    }
+
+    private static Parsed parse(JsonNode node) {
+        return new Parsed(readDisplay(node.get("display")), readRoles(node.get("roles")), readPii(node.get("pii")));
+    }
+
+    private static Display readDisplay(JsonNode d) {
+        if (d == null || !d.isObject()) return null;
+        String caption = readTextField(d, "caption");
+        String format = readTextField(d, "format");
+        String unit = readTextField(d, "unit");
+        boolean hidden = d.has("hidden") && d.get("hidden").asBoolean(false);
+        // A display block that only carries `hidden:false` (i.e. the default) is functionally
+        // absent — return null so consumers don't allocate an empty overlay.
+        if (caption == null && format == null && unit == null && !hidden) return null;
+        return new Display(caption, format, unit, hidden);
+    }
+
+    private static Roles readRoles(JsonNode r) {
+        if (r == null || !r.isObject()) return null;
+        Set<String> allow = readStringSet(r.get("allow"));
+        Set<String> deny = readStringSet(r.get("deny"));
+        if (allow.isEmpty() && deny.isEmpty()) return null;
+        return new Roles(allow, deny);
+    }
+
+    private static PiiLevel readPii(JsonNode p) {
+        if (p == null || p.isNull()) return null;
+        if (p.isBoolean()) {
+            return p.asBoolean(false) ? PiiLevel.REDACT : null;
+        }
+        if (p.isObject()) {
+            JsonNode level = p.get("level");
+            if (level == null || !level.isTextual()) return null;
+            String v = level.asText().toUpperCase(Locale.ROOT);
+            return switch (v) {
+                case "REDACT" -> PiiLevel.REDACT;
+                case "MASK" -> PiiLevel.MASK;
+                case "HASH" -> PiiLevel.HASH;
+                default -> null;
+            };
+        }
+        return null;
+    }
+
+    private static String readTextField(JsonNode node, String field) {
+        JsonNode v = node.get(field);
+        if (v == null || !v.isTextual()) return null;
+        String s = v.asText();
+        return s.isBlank() ? null : s;
+    }
+
+    private static Set<String> readStringSet(JsonNode arr) {
+        if (arr == null || !arr.isArray()) return Set.of();
+        Set<String> out = new LinkedHashSet<>();
+        for (JsonNode e : arr) {
+            if (!e.isTextual()) continue;
+            String s = e.asText();
+            if (s != null && !s.isBlank()) out.add(s);
+        }
+        return Collections.unmodifiableSet(out);
+    }
+
+    /** Typed view of the SAIKU vendor blob on one field / metric / dataset. All three well-knowns are optional. */
+    public record Parsed(Display display, Roles roles, PiiLevel pii) {
+
+        public static final Parsed EMPTY = new Parsed(null, null, null);
+
+        /** True when every well-known is absent. Callers use this to short-circuit downstream overlays. */
+        public boolean isEmpty() {
+            return display == null && roles == null && pii == null;
+        }
+    }
+
+    /**
+     * {@code saiku.display} — cosmetic overrides that flow into the schema response so the workbench
+     * (and any AI-schema consumer) renders the field/metric the way the operator intended.
+     *
+     * <p>{@code caption} overrides any Phase-3 {@code <datasource>.generated.json} rename for the
+     * same object; the display extension is authoritative when both are present. {@code format} is a
+     * number-format pattern (Java {@code DecimalFormat} syntax); {@code unit} is free-form ({@code
+     * "USD"}, {@code "hours"}, {@code "%"}); {@code hidden} = true removes the entry from
+     * agent-facing schema responses.
+     */
+    public record Display(String caption, String format, String unit, boolean hidden) {
+
+        public boolean hasOverride() {
+            return caption != null || format != null || unit != null || hidden;
+        }
+    }
+
+    /**
+     * {@code saiku.roles} — role allow/deny lists. Enforcement (filtering schema + query responses
+     * against the current user's roles) lives with the Ossie RLS work in saiku#1393; this record is
+     * the shared parse target so the annotation lands in the DTO layer today.
+     *
+     * <p>Semantics: {@code allow} empty = allow all; a non-empty {@code allow} requires the caller
+     * to have at least one matching role. {@code deny} overrides {@code allow}.
+     */
+    public record Roles(Set<String> allow, Set<String> deny) {
+
+        public Roles {
+            allow = allow == null ? Set.of() : Collections.unmodifiableSet(new LinkedHashSet<>(allow));
+            deny = deny == null ? Set.of() : Collections.unmodifiableSet(new LinkedHashSet<>(deny));
+        }
+
+        /**
+         * Whether a caller with the given {@code callerRoles} can see the annotated field/metric.
+         * {@code null} or empty {@code callerRoles} is treated as "no roles" and matches only when
+         * {@code allow} is empty and {@code deny} doesn't hit.
+         */
+        public boolean permits(Set<String> callerRoles) {
+            Set<String> caller = callerRoles == null ? Set.of() : callerRoles;
+            for (String d : deny) {
+                if (caller.contains(d)) return false;
+            }
+            if (allow.isEmpty()) return true;
+            for (String a : allow) {
+                if (caller.contains(a)) return true;
+            }
+            return false;
+        }
+    }
+
+    /**
+     * {@code saiku.pii} — how sensitive values should be masked when they land in a response.
+     *
+     * <p>Legacy {@code "pii": true} maps to {@link #REDACT}. The graded form {@code {"level":
+     * "mask"}} or {@code {"level": "hash"}} covers cases where the value must be present but
+     * obscured. Enforcement of the level (the actual redaction) is a downstream concern — this
+     * class just names the intent.
+     */
+    public enum PiiLevel {
+        /** Value is null on the wire. Behaviour of the existing {@code pii: true} boolean. */
+        REDACT,
+        /** Value is replaced with a fixed mask token (e.g. {@code "***"}) preserving row shape. */
+        MASK,
+        /** Value is replaced with a deterministic hex prefix of a keyed hash, preserving joinability. */
+        HASH
+    }
+
+    /** Convenience: are any well-knowns set on {@code extensions}? Runs in one pass. */
+    public static boolean isAnyWellKnownPresent(List<CustomExtension> extensions) {
+        return !Objects.equals(read(extensions), Parsed.EMPTY);
+    }
+
+    /** Convenience: same, over the DTO shape. */
+    public static boolean isAnyWellKnownPresentDto(List<CustomExtensionDto> dtos) {
+        return !readFromDtos(dtos).isEmpty();
+    }
+
+    /** Non-null empty list wrapping {@code extensions}, for callers that guard on null before iterating. */
+    public static List<CustomExtension> emptyIfNull(List<CustomExtension> extensions) {
+        return extensions == null ? new ArrayList<>() : extensions;
+    }
+}

--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/ossie/ai/OssieAiSchemaProjector.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/ossie/ai/OssieAiSchemaProjector.java
@@ -114,10 +114,21 @@ public final class OssieAiSchemaProjector {
             out_ds.setCustomExtensions(new ArrayList<>(ds.getCustomExtensions()));
             for (OssieModelDto.Field f : ds.getFields()) {
                 if (f.isPii()) continue; // saiku#902 parity — PII fields never enter the AI view.
+                // saiku#1409 — `saiku.display.hidden: true` strips the field from the AI schema
+                // response too. Different from PII (PII strips because it's sensitive; hidden
+                // strips because the operator doesn't want the AI to see it).
+                if (f.isDisplayHidden()) continue;
                 OssieAiSchema.Field out_field = new OssieAiSchema.Field();
                 out_field.setName(f.getName());
-                out_field.setLabel(f.getLabel());
+                // saiku#1409 display caption overrides the raw label. Operators write
+                // `saiku.display.caption` to give the AI a business-friendly name;
+                // the label falls through when no caption is set.
+                out_field.setLabel(f.getDisplayCaption() != null ? f.getDisplayCaption() : f.getLabel());
                 out_field.setDescription(f.getDescription());
+                // saiku#1409 unit overlay — the display extension overrides any type-inferred unit.
+                if (f.getDisplayUnit() != null) {
+                    out_field.setUnit(f.getDisplayUnit());
+                }
                 out_field.setCustomExtensions(new ArrayList<>(f.getCustomExtensions()));
                 // Type + samples come from the warehouse. Best-effort: swallow failures so
                 // the schema still projects when the warehouse is offline (agent still sees
@@ -143,12 +154,24 @@ public final class OssieAiSchemaProjector {
 
         // ---- Metrics ----
         for (OssieModelDto.Metric m : semantic.getMetrics()) {
+            // saiku#1409 — `saiku.display.hidden: true` strips the metric from the AI schema.
+            if (m.isDisplayHidden()) continue;
             OssieAiSchema.Metric out_m = new OssieAiSchema.Metric();
             out_m.setName(m.getName());
+            // saiku#1409 display caption overrides the raw name as the displayName; the schema
+            // response has `name` (the canonical key the AI uses in a query body) and
+            // `displayName` (what the AI can echo back to the user).
+            if (m.getDisplayCaption() != null) {
+                out_m.setDisplayName(m.getDisplayCaption());
+            }
             out_m.setDescription(m.getDescription());
             out_m.setExpression(m.getExpression());
             out_m.setAggregationKind(deriveAggregationKind(m));
             out_m.setSupportedOverrides(deriveSupportedOverrides(m));
+            // saiku#1409 unit overlay for metrics.
+            if (m.getDisplayUnit() != null) {
+                out_m.setUnit(m.getDisplayUnit());
+            }
             out_m.setCustomExtensions(new ArrayList<>(m.getCustomExtensions()));
             out.getMetrics().put(m.getName(), out_m);
         }

--- a/saiku-core/saiku-service/src/test/java/org/saiku/service/ossie/OssieDiscoverServiceTest.java
+++ b/saiku-core/saiku-service/src/test/java/org/saiku/service/ossie/OssieDiscoverServiceTest.java
@@ -256,6 +256,92 @@ public class OssieDiscoverServiceTest {
         assertEquals("Sales region", region.getDescription());
     }
 
+    // ---- well-known extensions (saiku#1409): display, roles, graded pii ----
+
+    @Test
+    public void wellKnownExtensionsProjectOntoFields() throws Exception {
+        Path wkYaml = Files.createTempFile("ossie-wk-", ".yaml");
+        Files.writeString(
+                wkYaml,
+                "version: 0.2.0.dev0\n"
+                        + "semantic_model:\n"
+                        + "- name: T\n"
+                        + "  datasets:\n"
+                        + "  - name: d\n"
+                        + "    source: s.d\n"
+                        + "    fields:\n"
+                        + "    - name: revenue\n"
+                        + "      expression:\n"
+                        + "        dialects: [{dialect: ANSI_SQL, expression: r}]\n"
+                        + "      custom_extensions:\n"
+                        + "      - vendor_name: SAIKU\n"
+                        + "        data: '{\"display\":{\"caption\":\"Net Revenue\",\"format\":\"$#,##0.00\",\"unit\":\"USD\"}}'\n"
+                        + "    - name: ssn\n"
+                        + "      expression:\n"
+                        + "        dialects: [{dialect: ANSI_SQL, expression: ssn}]\n"
+                        + "      custom_extensions:\n"
+                        + "      - vendor_name: SAIKU\n"
+                        + "        data: '{\"pii\":{\"level\":\"hash\"}}'\n"
+                        + "    - name: internal_flag\n"
+                        + "      expression:\n"
+                        + "        dialects: [{dialect: ANSI_SQL, expression: f}]\n"
+                        + "      custom_extensions:\n"
+                        + "      - vendor_name: SAIKU\n"
+                        + "        data: '{\"display\":{\"hidden\":true},\"roles\":{\"allow\":[\"ROLE_ADMIN\"]}}'\n");
+        try {
+            datasourceManager.put(
+                    "T", ossieDatasource("T", propsOf(ISaikuConnection.OSSIE_YAML_KEY, wkYaml.toString())));
+            OssieModelDto dto = service.getModel("T");
+
+            OssieModelDto.Field revenue = dto.getDatasets().get(0).getFields().get(0);
+            assertEquals("Net Revenue", revenue.getDisplayCaption());
+            assertEquals("$#,##0.00", revenue.getDisplayFormat());
+            assertEquals("USD", revenue.getDisplayUnit());
+            assertFalse("no hidden flag", revenue.isDisplayHidden());
+
+            OssieModelDto.Field ssn = dto.getDatasets().get(0).getFields().get(1);
+            assertEquals("HASH", ssn.getPiiLevel());
+            assertTrue("graded pii still flips the legacy boolean", ssn.isPii());
+
+            OssieModelDto.Field internal = dto.getDatasets().get(0).getFields().get(2);
+            assertTrue("hidden flag survives", internal.isDisplayHidden());
+            assertEquals(List.of("ROLE_ADMIN"), internal.getAllowRoles());
+            assertTrue("no deny roles set", internal.getDenyRoles().isEmpty());
+        } finally {
+            Files.deleteIfExists(wkYaml);
+        }
+    }
+
+    @Test
+    public void wellKnownExtensionsProjectOntoMetrics() throws Exception {
+        Path wkYaml = Files.createTempFile("ossie-wk-m-", ".yaml");
+        Files.writeString(
+                wkYaml,
+                "version: 0.2.0.dev0\n"
+                        + "semantic_model:\n"
+                        + "- name: T\n"
+                        + "  datasets: [{name: d, source: s.d, fields: []}]\n"
+                        + "  metrics:\n"
+                        + "  - name: revenue\n"
+                        + "    expression:\n"
+                        + "      dialects: [{dialect: ANSI_SQL, expression: SUM(x)}]\n"
+                        + "    custom_extensions:\n"
+                        + "    - vendor_name: SAIKU\n"
+                        + "      data: '{\"display\":{\"caption\":\"Net Revenue\",\"unit\":\"USD\"},\"roles\":{\"deny\":[\"ROLE_EMBED_GUEST\"]}}'\n");
+        try {
+            datasourceManager.put(
+                    "T", ossieDatasource("T", propsOf(ISaikuConnection.OSSIE_YAML_KEY, wkYaml.toString())));
+            OssieModelDto dto = service.getModel("T");
+            OssieModelDto.Metric revenue = dto.getMetrics().get(0);
+            assertEquals("Net Revenue", revenue.getDisplayCaption());
+            assertEquals("USD", revenue.getDisplayUnit());
+            assertTrue("no allow roles set", revenue.getAllowRoles().isEmpty());
+            assertEquals(List.of("ROLE_EMBED_GUEST"), revenue.getDenyRoles());
+        } finally {
+            Files.deleteIfExists(wkYaml);
+        }
+    }
+
     private static SaikuDatasource ossieDatasource(String name, Properties props) {
         return new SaikuDatasource(name, SaikuDatasource.Type.OSSIE, props);
     }

--- a/saiku-core/saiku-service/src/test/java/org/saiku/service/ossie/SaikuWellKnownExtensionsTest.java
+++ b/saiku-core/saiku-service/src/test/java/org/saiku/service/ossie/SaikuWellKnownExtensionsTest.java
@@ -1,0 +1,184 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.service.ossie;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import bi.saiku.ossie.model.CustomExtension;
+import java.util.List;
+import java.util.Set;
+import org.junit.Test;
+
+/**
+ * Parsing behaviour + backward-compatibility guarantees for the SAIKU vendor well-knowns
+ * (saiku#1409): {@code display}, {@code roles}, and the graded {@code pii} shape.
+ */
+public class SaikuWellKnownExtensionsTest {
+
+    @Test
+    public void nullOrEmptyReturnsEmpty() {
+        assertTrue(SaikuWellKnownExtensions.read(null).isEmpty());
+        assertTrue(SaikuWellKnownExtensions.read(List.of()).isEmpty());
+    }
+
+    @Test
+    public void nonSaikuVendorReturnsEmpty() {
+        SaikuWellKnownExtensions.Parsed w =
+                SaikuWellKnownExtensions.read(List.of(saiku("BIRST", "{\"display\":{\"caption\":\"X\"}}")));
+        assertTrue(w.isEmpty());
+    }
+
+    @Test
+    public void malformedJsonReturnsEmpty() {
+        SaikuWellKnownExtensions.Parsed w = SaikuWellKnownExtensions.read(List.of(saiku("SAIKU", "not json at all")));
+        assertTrue(w.isEmpty());
+    }
+
+    @Test
+    public void parsesDisplay() {
+        SaikuWellKnownExtensions.Parsed w = SaikuWellKnownExtensions.read(
+                List.of(
+                        saiku(
+                                "SAIKU",
+                                "{\"display\":{\"caption\":\"Net Revenue\",\"format\":\"$#,##0.00\",\"unit\":\"USD\",\"hidden\":false}}")));
+        assertNotNull(w.display());
+        assertEquals("Net Revenue", w.display().caption());
+        assertEquals("$#,##0.00", w.display().format());
+        assertEquals("USD", w.display().unit());
+        assertFalse(w.display().hidden());
+    }
+
+    @Test
+    public void parsesHiddenOnly() {
+        SaikuWellKnownExtensions.Parsed w =
+                SaikuWellKnownExtensions.read(List.of(saiku("SAIKU", "{\"display\":{\"hidden\":true}}")));
+        assertNotNull(w.display());
+        assertTrue(w.display().hidden());
+        assertNull(w.display().caption());
+    }
+
+    @Test
+    public void displayWithOnlyDefaultsReturnsNull() {
+        // `hidden:false` with no other fields is functionally empty — no overlay to apply.
+        SaikuWellKnownExtensions.Parsed w =
+                SaikuWellKnownExtensions.read(List.of(saiku("SAIKU", "{\"display\":{\"hidden\":false}}")));
+        assertNull(w.display());
+    }
+
+    @Test
+    public void parsesRoles() {
+        SaikuWellKnownExtensions.Parsed w = SaikuWellKnownExtensions.read(List.of(
+                saiku("SAIKU", "{\"roles\":{\"allow\":[\"ROLE_SALES\",\"ROLE_ANALYST\"],\"deny\":[\"ROLE_EMBED\"]}}")));
+        assertNotNull(w.roles());
+        assertEquals(Set.of("ROLE_SALES", "ROLE_ANALYST"), w.roles().allow());
+        assertEquals(Set.of("ROLE_EMBED"), w.roles().deny());
+    }
+
+    @Test
+    public void rolesEmptyBothReturnsNull() {
+        SaikuWellKnownExtensions.Parsed w =
+                SaikuWellKnownExtensions.read(List.of(saiku("SAIKU", "{\"roles\":{\"allow\":[],\"deny\":[]}}")));
+        assertNull(w.roles());
+    }
+
+    @Test
+    public void rolesPermits() {
+        SaikuWellKnownExtensions.Roles r =
+                new SaikuWellKnownExtensions.Roles(Set.of("ROLE_SALES", "ROLE_ANALYST"), Set.of("ROLE_EMBED"));
+
+        assertTrue(r.permits(Set.of("ROLE_SALES")));
+        assertTrue(r.permits(Set.of("ROLE_ANALYST", "ROLE_ADMIN")));
+        assertFalse("no allowed role", r.permits(Set.of("ROLE_ADMIN")));
+        assertFalse("deny overrides allow", r.permits(Set.of("ROLE_SALES", "ROLE_EMBED")));
+        assertFalse("null caller = no roles", r.permits(null));
+    }
+
+    @Test
+    public void emptyAllowMeansAllowAll() {
+        SaikuWellKnownExtensions.Roles r = new SaikuWellKnownExtensions.Roles(Set.of(), Set.of("ROLE_EMBED"));
+        assertTrue(r.permits(Set.of("ROLE_ANYTHING")));
+        assertTrue(r.permits(Set.of()));
+        assertFalse(r.permits(Set.of("ROLE_EMBED", "ROLE_OTHER")));
+    }
+
+    @Test
+    public void parsesLegacyPiiBoolean() {
+        // Backwards compat: `pii: true` still means REDACT.
+        SaikuWellKnownExtensions.Parsed w = SaikuWellKnownExtensions.read(List.of(saiku("SAIKU", "{\"pii\":true}")));
+        assertEquals(SaikuWellKnownExtensions.PiiLevel.REDACT, w.pii());
+    }
+
+    @Test
+    public void piiFalseMeansAbsent() {
+        SaikuWellKnownExtensions.Parsed w = SaikuWellKnownExtensions.read(List.of(saiku("SAIKU", "{\"pii\":false}")));
+        assertNull(w.pii());
+    }
+
+    @Test
+    public void parsesGradedPiiLevel() {
+        assertEquals(
+                SaikuWellKnownExtensions.PiiLevel.MASK,
+                SaikuWellKnownExtensions.read(List.of(saiku("SAIKU", "{\"pii\":{\"level\":\"mask\"}}")))
+                        .pii());
+        assertEquals(
+                SaikuWellKnownExtensions.PiiLevel.HASH,
+                SaikuWellKnownExtensions.read(List.of(saiku("SAIKU", "{\"pii\":{\"level\":\"HASH\"}}")))
+                        .pii());
+        assertEquals(
+                SaikuWellKnownExtensions.PiiLevel.REDACT,
+                SaikuWellKnownExtensions.read(List.of(saiku("SAIKU", "{\"pii\":{\"level\":\"redact\"}}")))
+                        .pii());
+    }
+
+    @Test
+    public void unknownPiiLevelReturnsNull() {
+        assertNull(SaikuWellKnownExtensions.read(List.of(saiku("SAIKU", "{\"pii\":{\"level\":\"invisible\"}}")))
+                .pii());
+    }
+
+    @Test
+    public void allThreeWellKnownsCoexist() {
+        SaikuWellKnownExtensions.Parsed w = SaikuWellKnownExtensions.read(List.of(saiku(
+                "SAIKU",
+                "{\"display\":{\"caption\":\"Rev\"},"
+                        + "\"roles\":{\"allow\":[\"ROLE_A\"]},"
+                        + "\"pii\":{\"level\":\"mask\"}}")));
+        assertNotNull(w.display());
+        assertNotNull(w.roles());
+        assertNotNull(w.pii());
+        assertFalse(w.isEmpty());
+    }
+
+    @Test
+    public void firstSaikuEntryWins() {
+        // Two SAIKU entries — the first one is authoritative. Downstream code doesn't need to
+        // merge across entries; that would create ordering ambiguity.
+        SaikuWellKnownExtensions.Parsed w = SaikuWellKnownExtensions.read(List.of(
+                saiku("SAIKU", "{\"display\":{\"caption\":\"First\"}}"),
+                saiku("SAIKU", "{\"display\":{\"caption\":\"Second\"}}")));
+        assertEquals("First", w.display().caption());
+    }
+
+    @Test
+    public void unknownKeysInSaikuBlobAreIgnored() {
+        // Unknown keys under SAIKU shouldn't crash parsing — the annotation namespace is
+        // deliberately extensible.
+        SaikuWellKnownExtensions.Parsed w = SaikuWellKnownExtensions.read(
+                List.of(saiku("SAIKU", "{\"display\":{\"caption\":\"X\"},\"future_extension\":42}")));
+        assertNotNull(w.display());
+        assertEquals("X", w.display().caption());
+    }
+
+    private static CustomExtension saiku(String vendor, String data) {
+        CustomExtension ext = new CustomExtension();
+        ext.setVendorName(vendor);
+        ext.setData(data);
+        return ext;
+    }
+}

--- a/saiku-core/saiku-service/src/test/java/org/saiku/service/ossie/ai/OssieAiSchemaProjectorTest.java
+++ b/saiku-core/saiku-service/src/test/java/org/saiku/service/ossie/ai/OssieAiSchemaProjectorTest.java
@@ -114,6 +114,78 @@ public class OssieAiSchemaProjectorTest {
         assertEquals("SAIKU", field.getCustomExtensions().get(0).getVendorName());
     }
 
+    // ---- saiku#1409 well-known display extensions on the AI schema ----
+
+    @Test
+    public void hiddenFieldStrippedFromAiSchema() {
+        OssieModelDto semantic = buildFixture();
+        OssieModelDto.Field region = semantic.getDatasets().get(1).getFields().get(0);
+        region.setDisplayHidden(true);
+
+        OssieAiSchema schema = new OssieAiSchemaProjector().project("Pharma", semantic, null);
+
+        // `region` is the only non-PII field on the `customers` dataset; hidden strips it
+        // just like PII does — the dataset ends up with no queryable fields.
+        assertNull(
+                "region should not appear on the AI schema when hidden",
+                schema.getDatasets().get("customers").getFields().get("region"));
+    }
+
+    @Test
+    public void hiddenMetricStrippedFromAiSchema() {
+        OssieModelDto semantic = buildFixture();
+        semantic.getMetrics().get(1).setDisplayHidden(true); // line_count
+
+        OssieAiSchema schema = new OssieAiSchemaProjector().project("Pharma", semantic, null);
+
+        assertNotNull("net_revenue survives", schema.getMetrics().get("net_revenue"));
+        assertNull(
+                "line_count is hidden and shouldn't project",
+                schema.getMetrics().get("line_count"));
+    }
+
+    @Test
+    public void displayCaptionOverridesFieldLabel() {
+        OssieModelDto semantic = buildFixture();
+        OssieModelDto.Field netrev = semantic.getDatasets().get(0).getFields().get(0);
+        netrev.setLabel("Net Revenue (raw)");
+        netrev.setDisplayCaption("Net Revenue");
+
+        OssieAiSchema schema = new OssieAiSchemaProjector().project("Pharma", semantic, null);
+        assertEquals(
+                "display caption wins over the raw label",
+                "Net Revenue",
+                schema.getDatasets()
+                        .get("fact_pharma")
+                        .getFields()
+                        .get("netrevenue")
+                        .getLabel());
+    }
+
+    @Test
+    public void displayCaptionOverridesMetricDisplayName() {
+        OssieModelDto semantic = buildFixture();
+        semantic.getMetrics().get(0).setDisplayCaption("Net Revenue $");
+
+        OssieAiSchema schema = new OssieAiSchemaProjector().project("Pharma", semantic, null);
+        assertEquals("Net Revenue $", schema.getMetrics().get("net_revenue").getDisplayName());
+    }
+
+    @Test
+    public void displayUnitOverlaidOnAiField() {
+        OssieModelDto semantic = buildFixture();
+        semantic.getDatasets().get(0).getFields().get(0).setDisplayUnit("USD");
+
+        OssieAiSchema schema = new OssieAiSchemaProjector().project("Pharma", semantic, null);
+        assertEquals(
+                "USD",
+                schema.getDatasets()
+                        .get("fact_pharma")
+                        .getFields()
+                        .get("netrevenue")
+                        .getUnit());
+    }
+
     @Test
     public void customExtensionsCarryThroughOnDatasetAndMetric() {
         OssieModelDto semantic = buildFixture();


### PR DESCRIPTION
Closes the "well-known extensions" side of #1409. Independent of the skills/spaces PR stack — targets `development` directly.

## Summary

Defines the SAIKU vendor namespace on OSI `custom_extensions[]` as a first-class annotation surface with three well-knowns. Field/metric authors set them in the YAML; consumers (workbench, AI schema, future RLS) read them from a typed accessor.

## The three well-knowns

### `saiku.display` — presentation overrides

```yaml
custom_extensions:
- vendor_name: SAIKU
  data: |
    { "display": { "caption": "Net Revenue", "format": "$#,##0.00", "unit": "USD", "hidden": false } }
```

- `caption` overrides field label / metric displayName in the AI schema response (wins over Phase-3 `<datasource>.generated.json` renames).
- `unit` overlays the AI schema unit.
- `hidden: true` **strips the field / metric from the AI schema entirely** — different from PII: hidden means "don't show the AI this exists at all", PII means "the AI can see the name but the value is redacted".
- `format` (DecimalFormat pattern) carries through the DTO for the workbench to consume.

### `saiku.roles` — role-based visibility

```yaml
custom_extensions:
- vendor_name: SAIKU
  data: |
    { "roles": { "allow": ["ROLE_SALES", "ROLE_ANALYST"], "deny": ["ROLE_EMBED_GUEST"] } }
```

- Parsed and exposed on the projected DTO for downstream filters.
- Semantics locked: `deny` overrides `allow`; empty `allow` = all callers permitted.
- **Runtime enforcement (filtering AI schema + query responses against Spring Security authorities) is intentionally deferred to #1393 (Ossie RLS)** — same annotation shape, expanded to `row_predicates` there.

### `saiku.pii` — graded PII

```yaml
custom_extensions:
- vendor_name: SAIKU
  data: '{"pii":{"level":"hash"}}'
```

- Three levels: `redact` (null the value), `mask` (fixed token, preserves row shape), `hash` (keyed hex prefix, preserves joinability).
- **Backwards compatible:** legacy `"pii": true` still parses as `REDACT`.
- Level exposed on the DTO; existing PII scanner still fires on any truthy shape. Level-aware redaction is a follow-up.

## Extensibility

- Unknown keys within the SAIKU blob **round-trip unchanged** — new well-knowns can ship without a coordinated release.
- Non-SAIKU vendors round-trip unchanged (existing behavior).
- First SAIKU entry wins if a YAML has multiple — no cross-entry merge, which would create ordering ambiguity.

Convention documented: `vendor_name: SAIKU` is reserved for Saiku well-knowns; third-party integrators use their own vendor names.

## Wired consumers

- `OssieDiscoverService.projectField/Metric` — overlays display + roles + pii level onto `OssieModelDto`.
- `OssieAiSchemaProjector` — strips hidden fields/metrics, applies display caption over label/displayName, layers display unit.

## Tests

- **SaikuWellKnownExtensionsTest** — 17 tests for every parsed shape + backward-compat guarantees + role-filter semantics
- **OssieDiscoverServiceTest** — 2 new tests for display/roles/pii projection onto field + metric DTOs
- **OssieAiSchemaProjectorTest** — 5 new tests for hidden filter + caption/unit overlay on both field and metric

Full service suite: **803 tests, 0 failures**, 1 skipped (Anthropic env-var gate). Spotless clean.

## Test plan

- [ ] Author a `saiku.display.hidden: true` extension on a Pharma field → confirm `GET /ai/ossie/schema/…` omits it
- [ ] Author `saiku.display.caption: "Custom"` → confirm the AI schema label reflects it
- [ ] Author `saiku.pii: {level: hash}` → confirm the DTO `piiLevel` field is set and `isPii` stays true
- [ ] Author `saiku.roles: {allow: [ROLE_ADMIN]}` → confirm the annotation lands on the DTO's `allowRoles` (runtime filter behavior stays with #1393)
- [ ] Legacy `saiku.pii: true` still hides the field from the AI schema (existing behavior)

## Related

- Feature ticket: #1409
- Extension enforcement follow-up: #1393 (Ossie RLS) — `saiku.roles` runtime filter lives there
- Docs page on the public site: separate PR (to be stacked on the skills docs PR chain)