### PR TITLE
#1429 feat(observability): pre-baked bundles for Datadog / Grafana Cloud / New Relic / CloudWatch

### DIFF
--- a/docs/observability.md
+++ b/docs/observability.md
@@ -125,6 +125,28 @@ can correlate logs ↔ traces:
 2026-06-03T12:34:56.789 INFO  [ThinQueryService] [trace_id=4bf92f3577b34da6a3ce929d0e0e4736 span_id=00f067aa0ba902b7] Executing MDX …
 ```
 
+## Provider bundles (saiku#1429)
+
+Four pre-baked provider integrations ship under
+[`observability/`](../observability/) — each with a copy-paste
+quickstart, a Docker Compose bundle (or env template), and a Grafana
+starter dashboard everyone reuses.
+
+| Provider              | Path                                                | Pipeline                                        |
+|-----------------------|-----------------------------------------------------|-------------------------------------------------|
+| **Datadog**           | [`observability/datadog/`](../observability/datadog/)         | Datadog Agent (OTLP receiver) → Datadog SaaS    |
+| **Grafana Cloud**     | [`observability/grafana-cloud/`](../observability/grafana-cloud/) | Direct OTLP → Grafana Cloud                     |
+| **New Relic**         | [`observability/new-relic/`](../observability/new-relic/)     | Direct OTLP → New Relic                         |
+| **AWS CloudWatch**    | [`observability/cloudwatch/`](../observability/cloudwatch/)   | ADOT collector → CloudWatch / X-Ray             |
+
+The [`observability/dashboards/grafana/saiku-overview.json`](../observability/dashboards/grafana/saiku-overview.json)
+dashboard covers HTTP request rate + latency, Mondrian JDBC statement
+rate + p95, JVM heap, GC pause, JVM threads, DBCP2 pool utilization,
+and outbound HTTP calls to AI providers. Import via Grafana →
+Dashboards → Import → Upload JSON. The PromQL queries are compatible
+with any Prometheus-speaking data source (Grafana Cloud Mimir, self-
+hosted Prometheus, Datadog's Prometheus API, etc.).
+
 ## What this doesn't cover
 
 Tier 1 stops at framework-level auto-instrumentation. The following

--- a/observability/README.md
+++ b/observability/README.md
@@ -1,0 +1,61 @@
+# Observability adaptor bundles
+
+Pre-baked configurations for pointing Saiku's OpenTelemetry instrumentation
+at named observability providers. Saiku's [OTel plumbing](../docs/observability.md)
+is provider-neutral — every bundle here is a thin envelope around the same
+`OTEL_EXPORTER_OTLP_*` environment variables the OTel SDK reads directly.
+
+## Providers
+
+| Provider              | Path                       | Ships to                                                                    | Auth        |
+|-----------------------|----------------------------|-----------------------------------------------------------------------------|-------------|
+| **Datadog**           | [datadog/](datadog/)               | Datadog Agent (OTLP receiver) → Datadog                                     | API key     |
+| **Grafana Cloud**     | [grafana-cloud/](grafana-cloud/)   | Direct OTLP → Grafana Cloud                                                 | Instance token |
+| **New Relic**         | [new-relic/](new-relic/)           | Direct OTLP → New Relic                                                     | License key |
+| **AWS CloudWatch**    | [cloudwatch/](cloudwatch/)         | ADOT collector → CloudWatch Metrics + X-Ray traces + CloudWatch Logs        | IAM role    |
+| **Self-hosted OTel Collector** | (see [docs/observability.md](../docs/observability.md)) | Any of the above via the standard OpenTelemetry Collector | Depends on downstream |
+
+Each subdirectory has a `README.md` with a copy-paste quickstart and a
+`docker-compose.yml` (or `env.example`) that boots the pipeline.
+
+## Dashboards
+
+- [dashboards/grafana/saiku-overview.json](dashboards/grafana/saiku-overview.json)
+  — Grafana starter dashboard covering HTTP request rate + latency,
+  Mondrian SQL emission, JVM heap, DBCP2 pool utilization, and the AI
+  Query token-usage tiles. Import via Grafana → Dashboards → Import →
+  Upload JSON.
+
+## Which bundle should I pick?
+
+- **You're already paying for Datadog / New Relic / Grafana Cloud** — use
+  that provider's bundle. The pipeline is one collector + your existing
+  auth; there's nothing to build.
+- **You're on AWS and don't want another vendor** — use the CloudWatch
+  bundle. ADOT emits into CloudWatch Metrics + X-Ray natively.
+- **You run your own Prometheus / Tempo / Loki stack** — you don't need
+  a bundle. Point `OTEL_EXPORTER_OTLP_ENDPOINT` at your existing OTel
+  Collector and follow [docs/observability.md](../docs/observability.md).
+- **You just want to poke around locally** — the parent doc has a
+  ten-second `docker run otel/opentelemetry-collector` snippet that
+  logs received spans to stdout. No account required.
+
+## What Saiku already emits
+
+Auto-instrumented by the OTel Java agent (Tier 1, always on when the
+agent is attached):
+
+- **HTTP request spans** for every `/rest/**` endpoint — method, route,
+  status code, latency.
+- **JDBC child spans** for every SQL statement Mondrian generates —
+  `db.system`, `db.statement`, duration. The big win: every slow MDX
+  query is decomposed into its SQL.
+- **`java.net.http.HttpClient` outbound spans** — Anthropic / OpenAI /
+  any downstream HTTP call appears as a child of the parent request.
+- **JVM metrics** — heap, GC pause, thread count, class loading.
+- **DBCP2 pool metrics** — active / idle connections, wait times.
+- **Log records** with `trace_id` / `span_id` in MDC — every log line
+  correlates back to a trace.
+
+Custom domain spans (per-MDX-query attribution, per-ai-ask token usage)
+are Tier 2 and ship in a follow-up.

--- a/observability/cloudwatch/README.md
+++ b/observability/cloudwatch/README.md
@@ -1,0 +1,106 @@
+# Saiku → AWS CloudWatch
+
+Route Saiku's OpenTelemetry signals into AWS CloudWatch via the **AWS
+Distro for OpenTelemetry (ADOT) collector**. Metrics land in CloudWatch
+Metrics, traces in AWS X-Ray, and logs in CloudWatch Logs — all with
+IAM role authentication, no long-lived keys required if you're running
+on EC2 / ECS / EKS.
+
+## Quickstart
+
+```bash
+docker compose up -d
+```
+
+The compose bundle spins up:
+
+- The **ADOT collector** with receivers for OTLP (gRPC 4317, HTTP 4318)
+  and exporters for CloudWatch EMF (metrics), AWS X-Ray (traces), and
+  CloudWatch Logs.
+- **Saiku** pointed at the collector.
+
+## Prerequisites
+
+The ADOT collector needs AWS credentials to write to CloudWatch and
+X-Ray. Best options in order of preference:
+
+- **EC2 / ECS / EKS with instance role** — leave the compose bundle
+  alone; ADOT picks up the ambient credentials.
+- **AWS Vault / short-lived session** — mount your creds:
+  ```bash
+  aws-vault exec my-profile -- docker compose up -d
+  ```
+- **Explicit access keys** — set `AWS_ACCESS_KEY_ID` +
+  `AWS_SECRET_ACCESS_KEY` + `AWS_REGION` in the environment before
+  running compose. Not recommended for production.
+
+The IAM policy needs:
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "cloudwatch:PutMetricData",
+        "logs:CreateLogGroup",
+        "logs:CreateLogStream",
+        "logs:PutLogEvents",
+        "logs:DescribeLogStreams",
+        "logs:DescribeLogGroups",
+        "xray:PutTraceSegments",
+        "xray:PutTelemetryRecords",
+        "xray:GetSamplingRules",
+        "xray:GetSamplingTargets",
+        "xray:GetSamplingStatisticSummaries"
+      ],
+      "Resource": "*"
+    }
+  ]
+}
+```
+
+## Where things show up in AWS
+
+| Signal  | AWS service           | How to find it                                                                     |
+|---------|-----------------------|------------------------------------------------------------------------------------|
+| Metrics | CloudWatch → Metrics  | Namespace `Saiku` (override via `AWS_EMF_NAMESPACE`). Filter by `service=saiku`.    |
+| Traces  | X-Ray → Traces        | Service `saiku`. The service map lights up automatically.                          |
+| Logs    | CloudWatch → Log groups | `/aws/otel/saiku/logs` (configurable in `otel-collector-config.yaml`).           |
+| SQL     | X-Ray → subsegments   | Every Mondrian-emitted SQL statement is a `db.statement`-annotated subsegment.     |
+
+## Sampling
+
+X-Ray charges per trace. Configure sampling with X-Ray's central rule
+manager, OR at the OTel SDK level:
+
+```yaml
+environment:
+  OTEL_TRACES_SAMPLER: parentbased_traceidratio
+  OTEL_TRACES_SAMPLER_ARG: "0.05"
+```
+
+## Verifying it works
+
+1. `docker compose up -d`.
+2. Query Saiku: `curl -u admin:admin http://localhost:8080/rest/saiku/info`.
+3. In AWS Console → X-Ray → Traces, `saiku` should appear within a
+   couple of minutes.
+4. In CloudWatch → Metrics → Custom namespaces, `Saiku` should be
+   listed with JVM / DBCP / HTTP series populating.
+
+If nothing shows up, tail the collector:
+
+```bash
+docker compose logs otel-collector | tail
+```
+
+You want to see `CloudWatchLogsExporter`, `AWSXRayExporter`, and
+`AWSEMFExporter` all reporting successful exports.
+
+## Reference
+
+- [AWS Distro for OpenTelemetry](https://aws-otel.github.io/)
+- [ADOT collector config reference](https://aws-otel.github.io/docs/setup/build-collector-with-scripts)
+- [Saiku observability overview](../../docs/observability.md)

--- a/observability/cloudwatch/docker-compose.yml
+++ b/observability/cloudwatch/docker-compose.yml
@@ -1,0 +1,43 @@
+# Saiku → ADOT collector → CloudWatch / X-Ray / CloudWatch Logs.
+#
+# The AWS Distro for OpenTelemetry (ADOT) collector wraps the standard
+# OpenTelemetry Collector with pre-configured AWS exporters. IAM
+# authentication happens transparently — either via the EC2 / ECS /
+# EKS instance role, or via mounted credentials.
+services:
+  otel-collector:
+    image: public.ecr.aws/aws-observability/aws-otel-collector:latest
+    container_name: saiku-adot-collector
+    command: ["--config=/etc/otel-collector-config.yaml"]
+    environment:
+      AWS_REGION: ${AWS_REGION:-us-east-1}
+      # If you're passing static creds (not recommended), uncomment:
+      # AWS_ACCESS_KEY_ID: ${AWS_ACCESS_KEY_ID}
+      # AWS_SECRET_ACCESS_KEY: ${AWS_SECRET_ACCESS_KEY}
+      # AWS_SESSION_TOKEN: ${AWS_SESSION_TOKEN}
+    volumes:
+      - ./otel-collector-config.yaml:/etc/otel-collector-config.yaml:ro
+      # Mount ~/.aws when running under aws-vault or dev machines.
+      - ${HOME}/.aws:/root/.aws:ro
+    ports:
+      - "127.0.0.1:4317:4317"
+      - "127.0.0.1:4318:4318"
+
+  saiku:
+    image: ghcr.io/spiculedata/saiku:latest
+    container_name: saiku
+    depends_on:
+      - otel-collector
+    environment:
+      OTEL_EXPORTER_OTLP_ENDPOINT: "http://otel-collector:4318"
+      OTEL_EXPORTER_OTLP_PROTOCOL: "http/protobuf"
+      OTEL_SERVICE_NAME: "saiku"
+      OTEL_RESOURCE_ATTRIBUTES: "deployment.environment=demo,service.version=4.6.0"
+      OTEL_TRACES_SAMPLER: "parentbased_always_on"
+    ports:
+      - "8080:8080"
+    volumes:
+      - saiku-home:/app/saiku-home
+
+volumes:
+  saiku-home: {}

--- a/observability/cloudwatch/otel-collector-config.yaml
+++ b/observability/cloudwatch/otel-collector-config.yaml
@@ -1,0 +1,52 @@
+# ADOT collector config for Saiku:
+#   receive OTLP from Saiku → export metrics to CloudWatch (EMF), traces
+#   to X-Ray, logs to CloudWatch Logs.
+
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:4317
+      http:
+        endpoint: 0.0.0.0:4318
+
+processors:
+  batch:
+    timeout: 5s
+    send_batch_size: 512
+
+  # X-Ray requires trace IDs in its own format. This processor is a
+  # no-op on payloads that already carry compatible IDs (ADOT SDK) and
+  # the necessary rewrite otherwise (vanilla OTel SDK, which is what
+  # Saiku uses).
+  resourcedetection:
+    detectors: [ec2, ecs, eks, env]
+    override: false
+
+exporters:
+  awsemf:
+    namespace: Saiku
+    log_group_name: "/aws/otel/saiku/metrics"
+    dimension_rollup_option: NoDimensionRollup
+
+  awsxray:
+    # No config needed — uses ambient AWS creds + region.
+
+  awscloudwatchlogs:
+    log_group_name: "/aws/otel/saiku/logs"
+    log_stream_name: "otlp"
+
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [resourcedetection, batch]
+      exporters: [awsxray]
+    metrics:
+      receivers: [otlp]
+      processors: [resourcedetection, batch]
+      exporters: [awsemf]
+    logs:
+      receivers: [otlp]
+      processors: [resourcedetection, batch]
+      exporters: [awscloudwatchlogs]

--- a/observability/dashboards/grafana/saiku-overview.json
+++ b/observability/dashboards/grafana/saiku-overview.json
@@ -1,0 +1,360 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "datasource",
+          "uid": "grafana"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "description": "Saiku Analytics — Tier 1 auto-instrumentation overview. Traffic, JDBC / Mondrian SQL emission, JVM health, DBCP2 pool, and outbound AI-provider calls. Ships in observability/dashboards/grafana/.",
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "collapsed": false,
+      "gridPos": {"h": 1, "w": 24, "x": 0, "y": 0},
+      "id": 100,
+      "panels": [],
+      "title": "HTTP traffic",
+      "type": "row"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "$DS_PROMETHEUS"},
+      "description": "Request rate per HTTP method + route, from the OTel Jetty instrumentation.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "palette-classic"},
+          "custom": {
+            "axisLabel": "req/s",
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "showPoints": "never",
+            "spanNulls": false
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 1},
+      "id": 1,
+      "options": {"legend": {"displayMode": "table", "placement": "bottom", "showLegend": true, "calcs": ["mean", "max"]}, "tooltip": {"mode": "multi"}},
+      "targets": [
+        {
+          "expr": "sum by (http_route, http_request_method) (rate(http_server_request_duration_seconds_count{service_name=~\"$service\"}[5m]))",
+          "legendFormat": "{{http_request_method}} {{http_route}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Request rate",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "$DS_PROMETHEUS"},
+      "description": "p50, p95, p99 request latency across all routes.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "palette-classic"},
+          "custom": {
+            "axisLabel": "seconds",
+            "drawStyle": "line",
+            "fillOpacity": 5,
+            "lineWidth": 2,
+            "showPoints": "never"
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 1},
+      "id": 2,
+      "options": {"legend": {"displayMode": "table", "placement": "bottom", "showLegend": true, "calcs": ["mean", "max"]}, "tooltip": {"mode": "multi"}},
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.50, sum by (le) (rate(http_server_request_duration_seconds_bucket{service_name=~\"$service\"}[5m])))",
+          "legendFormat": "p50",
+          "refId": "A"
+        },
+        {
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(http_server_request_duration_seconds_bucket{service_name=~\"$service\"}[5m])))",
+          "legendFormat": "p95",
+          "refId": "B"
+        },
+        {
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(http_server_request_duration_seconds_bucket{service_name=~\"$service\"}[5m])))",
+          "legendFormat": "p99",
+          "refId": "C"
+        }
+      ],
+      "title": "Request latency percentiles",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {"h": 1, "w": 24, "x": 0, "y": 9},
+      "id": 101,
+      "panels": [],
+      "title": "Mondrian → JDBC",
+      "type": "row"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "$DS_PROMETHEUS"},
+      "description": "SQL statement rate — every Mondrian-emitted query lands as a JDBC span, and the auto-instrumentation counts them.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "palette-classic"},
+          "custom": {
+            "axisLabel": "stmt/s",
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 2,
+            "showPoints": "never"
+          },
+          "unit": "reqps"
+        }
+      },
+      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 10},
+      "id": 3,
+      "options": {"legend": {"displayMode": "table", "placement": "bottom", "calcs": ["mean", "max"]}, "tooltip": {"mode": "multi"}},
+      "targets": [
+        {
+          "expr": "sum by (db_system) (rate(db_client_operation_duration_seconds_count{service_name=~\"$service\"}[5m]))",
+          "legendFormat": "{{db_system}}",
+          "refId": "A"
+        }
+      ],
+      "title": "JDBC statement rate",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "$DS_PROMETHEUS"},
+      "description": "Per-statement JDBC latency — p95 tail is the leading indicator of slow Mondrian queries.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "palette-classic"},
+          "custom": {
+            "axisLabel": "seconds",
+            "drawStyle": "line",
+            "fillOpacity": 5,
+            "lineWidth": 2,
+            "showPoints": "never"
+          },
+          "unit": "s"
+        }
+      },
+      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 10},
+      "id": 4,
+      "options": {"legend": {"displayMode": "table", "placement": "bottom", "calcs": ["mean", "max"]}, "tooltip": {"mode": "multi"}},
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.95, sum by (le, db_system) (rate(db_client_operation_duration_seconds_bucket{service_name=~\"$service\"}[5m])))",
+          "legendFormat": "p95 {{db_system}}",
+          "refId": "A"
+        }
+      ],
+      "title": "JDBC statement latency (p95)",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {"h": 1, "w": 24, "x": 0, "y": 18},
+      "id": 102,
+      "panels": [],
+      "title": "JVM health",
+      "type": "row"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "$DS_PROMETHEUS"},
+      "description": "Heap used vs heap max — the primary GC-pressure signal.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "palette-classic"},
+          "custom": {"drawStyle": "line", "fillOpacity": 10, "lineWidth": 2},
+          "unit": "bytes"
+        }
+      },
+      "gridPos": {"h": 8, "w": 8, "x": 0, "y": 19},
+      "id": 5,
+      "options": {"legend": {"displayMode": "table", "placement": "bottom", "calcs": ["mean", "max"]}, "tooltip": {"mode": "multi"}},
+      "targets": [
+        {
+          "expr": "sum(jvm_memory_used_bytes{service_name=~\"$service\", jvm_memory_type=\"heap\"})",
+          "legendFormat": "heap used",
+          "refId": "A"
+        },
+        {
+          "expr": "sum(jvm_memory_committed_bytes{service_name=~\"$service\", jvm_memory_type=\"heap\"})",
+          "legendFormat": "heap committed",
+          "refId": "B"
+        }
+      ],
+      "title": "JVM heap",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "$DS_PROMETHEUS"},
+      "description": "GC pause time per collection cycle. Sustained p99 above ~200ms is the first sign your heap is undersized.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "palette-classic"},
+          "custom": {"drawStyle": "line", "fillOpacity": 5, "lineWidth": 2},
+          "unit": "s"
+        }
+      },
+      "gridPos": {"h": 8, "w": 8, "x": 8, "y": 19},
+      "id": 6,
+      "options": {"legend": {"displayMode": "table", "placement": "bottom", "calcs": ["mean", "max"]}, "tooltip": {"mode": "multi"}},
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.95, sum by (le, jvm_gc_name) (rate(jvm_gc_duration_seconds_bucket{service_name=~\"$service\"}[5m])))",
+          "legendFormat": "p95 {{jvm_gc_name}}",
+          "refId": "A"
+        }
+      ],
+      "title": "GC pause p95",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "$DS_PROMETHEUS"},
+      "description": "Total live JVM threads — spikes correlate with request-handler saturation.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "palette-classic"},
+          "custom": {"drawStyle": "line", "fillOpacity": 10, "lineWidth": 2},
+          "unit": "short"
+        }
+      },
+      "gridPos": {"h": 8, "w": 8, "x": 16, "y": 19},
+      "id": 7,
+      "options": {"legend": {"displayMode": "table", "placement": "bottom", "calcs": ["mean", "max"]}, "tooltip": {"mode": "multi"}},
+      "targets": [
+        {
+          "expr": "sum(jvm_threads_count{service_name=~\"$service\"})",
+          "legendFormat": "threads",
+          "refId": "A"
+        }
+      ],
+      "title": "JVM threads",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {"h": 1, "w": 24, "x": 0, "y": 27},
+      "id": 103,
+      "panels": [],
+      "title": "DBCP2 pool + outbound HTTP",
+      "type": "row"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "$DS_PROMETHEUS"},
+      "description": "Warehouse connection pool utilization. Sustained saturation → warehouse-side query starvation is imminent.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "palette-classic"},
+          "custom": {"drawStyle": "line", "fillOpacity": 10, "lineWidth": 2},
+          "unit": "short"
+        }
+      },
+      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 28},
+      "id": 8,
+      "options": {"legend": {"displayMode": "table", "placement": "bottom", "calcs": ["mean", "max"]}, "tooltip": {"mode": "multi"}},
+      "targets": [
+        {
+          "expr": "sum by (pool) (db_client_connections_usage{service_name=~\"$service\", state=\"used\"})",
+          "legendFormat": "{{pool}} — in use",
+          "refId": "A"
+        },
+        {
+          "expr": "sum by (pool) (db_client_connections_usage{service_name=~\"$service\", state=\"idle\"})",
+          "legendFormat": "{{pool}} — idle",
+          "refId": "B"
+        }
+      ],
+      "title": "DBCP2 connections",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "$DS_PROMETHEUS"},
+      "description": "Outbound HTTP client calls — Anthropic, OpenAI, and any downstream HTTP service the AI ask flow hits.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "palette-classic"},
+          "custom": {"drawStyle": "line", "fillOpacity": 5, "lineWidth": 2},
+          "unit": "reqps"
+        }
+      },
+      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 28},
+      "id": 9,
+      "options": {"legend": {"displayMode": "table", "placement": "bottom", "calcs": ["mean", "max"]}, "tooltip": {"mode": "multi"}},
+      "targets": [
+        {
+          "expr": "sum by (server_address) (rate(http_client_request_duration_seconds_count{service_name=~\"$service\"}[5m]))",
+          "legendFormat": "{{server_address}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Outbound HTTP rate (AI providers etc.)",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 39,
+  "style": "dark",
+  "tags": ["saiku", "opentelemetry"],
+  "templating": {
+    "list": [
+      {
+        "current": {"selected": true, "text": "Prometheus", "value": "Prometheus"},
+        "hide": 0,
+        "includeAll": false,
+        "label": "Data source",
+        "multi": false,
+        "name": "DS_PROMETHEUS",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      },
+      {
+        "current": {"selected": true, "text": "saiku", "value": "saiku"},
+        "datasource": {"type": "prometheus", "uid": "$DS_PROMETHEUS"},
+        "definition": "label_values(http_server_request_duration_seconds_count, service_name)",
+        "hide": 0,
+        "includeAll": false,
+        "label": "Service",
+        "multi": false,
+        "name": "service",
+        "options": [],
+        "query": {"query": "label_values(http_server_request_duration_seconds_count, service_name)", "refId": "PrometheusVariableQueryEditor-VariableQuery"},
+        "refresh": 2,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "type": "query"
+      }
+    ]
+  },
+  "time": {"from": "now-1h", "to": "now"},
+  "timepicker": {},
+  "timezone": "",
+  "title": "Saiku overview (OpenTelemetry)",
+  "uid": "saiku-overview",
+  "version": 1,
+  "weekStart": ""
+}

--- a/observability/datadog/README.md
+++ b/observability/datadog/README.md
@@ -1,0 +1,82 @@
+# Saiku → Datadog
+
+Route Saiku's OpenTelemetry traces, metrics, and logs into Datadog via
+the Datadog Agent's built-in OTLP receiver. No separate OTel Collector
+required — the Datadog Agent speaks OTLP natively.
+
+## Quickstart
+
+Set your Datadog API key and pull down the compose bundle:
+
+```bash
+export DD_API_KEY=<your-datadog-api-key>
+export DD_SITE=datadoghq.com     # datadoghq.eu / us3.datadoghq.com / etc.
+docker compose up -d
+```
+
+## What this deploys
+
+- **Datadog Agent** with the OTLP receiver enabled on ports 4317 (gRPC)
+  and 4318 (HTTP/protobuf). The agent forwards traces to APM, metrics
+  to the Metrics API, and logs to the Logs Ingestion pipeline.
+- **Saiku** with the OTel Java agent attached and the OTLP endpoint
+  pointed at the Datadog Agent container.
+
+## Where things show up in Datadog
+
+| Signal  | Datadog product                   | How to find it                                                            |
+|---------|-----------------------------------|---------------------------------------------------------------------------|
+| Traces  | APM → Service Map                 | Service name `saiku` (override with `OTEL_SERVICE_NAME`).                 |
+| Metrics | Metrics → Explorer                | Filter by `service:saiku`. Every JVM / DBCP2 / HTTP metric surfaces here. |
+| Logs    | Logs → Live Tail                  | `service:saiku` — each log line is trace-correlated via `trace_id`.        |
+| SQL     | APM → Database Monitoring (via JDBC spans) | Filter APM spans by `span.type:sql`; the auto-instrumented JDBC layer exposes every Mondrian-emitted statement. |
+
+## Sampling
+
+The default `parentbased_always_on` sampler in `docker-compose.yml`
+captures every trace — fine for the demo, not production. Under real
+load flip to:
+
+```yaml
+environment:
+  OTEL_TRACES_SAMPLER: parentbased_traceidratio
+  OTEL_TRACES_SAMPLER_ARG: "0.05"   # 5% root traces
+```
+
+Datadog APM's usage-based billing rewards low sampling ratios — 1-5%
+is typical.
+
+## Overriding the target Datadog site
+
+`DD_SITE` picks the Datadog region:
+
+- `datadoghq.com` — US1 (default)
+- `datadoghq.eu` — EU1
+- `us3.datadoghq.com` — US3
+- `us5.datadoghq.com` — US5
+- `ap1.datadoghq.com` — AP1
+- `ddog-gov.com` — US1-FED
+
+## Verifying it works
+
+1. Boot the stack: `docker compose up -d`.
+2. Wait ~30 seconds for the first traces to flush.
+3. Query Saiku: `curl -u admin:admin http://localhost:8080/rest/saiku/info`.
+4. In Datadog → APM → Service Map, `saiku` should appear as a service
+   with an inbound edge from the HTTP `GET /rest/saiku/info` route.
+
+If nothing shows up, check the Datadog Agent's logs:
+
+```bash
+docker compose logs datadog-agent | grep -i otlp
+```
+
+You want to see the OTLP receiver bound on `:4317` and `:4318`.
+
+## Reference
+
+- [Datadog: OpenTelemetry with the Datadog Agent](https://docs.datadoghq.com/opentelemetry/collector_exporter/otlp_receiver/)
+- [Saiku observability overview](../../docs/observability.md)
+- [Grafana starter dashboard](../dashboards/grafana/saiku-overview.json)
+  — the same metrics render in Datadog too; the dashboard JSON is a
+  reference for which series to build widgets from.

--- a/observability/datadog/docker-compose.yml
+++ b/observability/datadog/docker-compose.yml
@@ -1,0 +1,47 @@
+# Saiku → Datadog Agent (OTLP receiver) → Datadog SaaS.
+#
+# The Datadog Agent's OTLP receiver runs on 4317 (gRPC) and 4318 (HTTP).
+# Saiku emits to the HTTP endpoint by default because it's the simplest to
+# proxy through service meshes if you later put one in front.
+#
+# Required: DD_API_KEY. Optional: DD_SITE (defaults to US1).
+services:
+  datadog-agent:
+    image: gcr.io/datadoghq/agent:7
+    container_name: saiku-dd-agent
+    environment:
+      DD_API_KEY: ${DD_API_KEY:?DD_API_KEY must be set}
+      DD_SITE: ${DD_SITE:-datadoghq.com}
+      # Enable the OTLP receiver on both protocols. Saiku picks HTTP by
+      # default; leaving gRPC on lets you point other services at it too.
+      DD_OTLP_CONFIG_RECEIVER_PROTOCOLS_GRPC_ENDPOINT: "0.0.0.0:4317"
+      DD_OTLP_CONFIG_RECEIVER_PROTOCOLS_HTTP_ENDPOINT: "0.0.0.0:4318"
+      DD_APM_ENABLED: "true"
+      DD_LOGS_ENABLED: "true"
+      DD_HOSTNAME: "saiku-host"
+    ports:
+      # Only exposed on localhost; if you're running the agent on a
+      # dedicated observability node, drop these binds.
+      - "127.0.0.1:4318:4318"
+      - "127.0.0.1:4317:4317"
+
+  saiku:
+    image: ghcr.io/spiculedata/saiku:latest
+    container_name: saiku
+    depends_on:
+      - datadog-agent
+    environment:
+      OTEL_EXPORTER_OTLP_ENDPOINT: "http://datadog-agent:4318"
+      OTEL_EXPORTER_OTLP_PROTOCOL: "http/protobuf"
+      OTEL_SERVICE_NAME: "saiku"
+      OTEL_RESOURCE_ATTRIBUTES: "deployment.environment=demo,service.version=4.6.0"
+      # Sensible-default sampler for the demo. Flip to
+      # parentbased_traceidratio for production.
+      OTEL_TRACES_SAMPLER: "parentbased_always_on"
+    ports:
+      - "8080:8080"
+    volumes:
+      - saiku-home:/app/saiku-home
+
+volumes:
+  saiku-home: {}

--- a/observability/grafana-cloud/README.md
+++ b/observability/grafana-cloud/README.md
@@ -1,0 +1,74 @@
+# Saiku → Grafana Cloud
+
+Route Saiku's OpenTelemetry signals into Grafana Cloud via its **direct
+OTLP endpoint**. Grafana Cloud accepts OTLP natively, so no collector is
+required — Saiku's built-in OTel Java agent talks straight to the cloud.
+
+## Quickstart
+
+Grab an OTLP instance token from Grafana Cloud → **Connections → Data
+sources → OpenTelemetry (OTLP)** — it renders the endpoint URL and the
+`Authorization: Basic <base64>` header you'll paste below.
+
+```bash
+export OTEL_EXPORTER_OTLP_ENDPOINT="https://otlp-gateway-<region>.grafana.net/otlp"
+export OTEL_EXPORTER_OTLP_PROTOCOL="http/protobuf"
+export OTEL_EXPORTER_OTLP_HEADERS="Authorization=Basic <the-base64-token>"
+export OTEL_SERVICE_NAME=saiku
+export OTEL_RESOURCE_ATTRIBUTES="deployment.environment=production,service.version=4.6.0"
+
+docker run -d --name saiku \
+  -p 8080:8080 \
+  -e OTEL_EXPORTER_OTLP_ENDPOINT \
+  -e OTEL_EXPORTER_OTLP_PROTOCOL \
+  -e OTEL_EXPORTER_OTLP_HEADERS \
+  -e OTEL_SERVICE_NAME \
+  -e OTEL_RESOURCE_ATTRIBUTES \
+  ghcr.io/spiculedata/saiku:latest
+```
+
+The full env-var block is in [env.example](env.example). Copy it to
+`.env` and edit the values.
+
+## Where things show up in Grafana Cloud
+
+| Signal  | Grafana Cloud product | How to find it                                                                     |
+|---------|-----------------------|------------------------------------------------------------------------------------|
+| Traces  | Grafana Cloud Traces (Tempo) | Explore → Tempo → Service `saiku`.                                          |
+| Metrics | Grafana Cloud Metrics (Mimir) | Explore → Prometheus → `service=saiku`.                                      |
+| Logs    | Grafana Cloud Logs (Loki)    | Explore → Loki → `{service="saiku"}` — every log line carries `trace_id`.     |
+
+## Starter dashboard
+
+Import the [Saiku overview dashboard](../dashboards/grafana/saiku-overview.json):
+
+1. Grafana → Dashboards → **Import**.
+2. Upload `dashboards/grafana/saiku-overview.json`.
+3. Pick the Grafana Cloud Prometheus data source when prompted.
+
+The dashboard uses PromQL-compatible queries (Mimir speaks Prometheus)
+so no rewriting is required.
+
+## Sampling
+
+Grafana Cloud Traces is priced by ingested trace volume. For anything
+above demo scale, flip the sampler:
+
+```bash
+export OTEL_TRACES_SAMPLER=parentbased_traceidratio
+export OTEL_TRACES_SAMPLER_ARG=0.05   # 5% root traces
+```
+
+## Verifying it works
+
+1. Start Saiku with the env vars set.
+2. Run a couple of queries: `curl -u admin:admin http://localhost:8080/rest/saiku/info`.
+3. In Grafana Cloud → Explore → Tempo, search for service `saiku`. First
+   spans should appear within 30 seconds.
+4. Check the Saiku container logs for `OpenTelemetry SDK exporter` lines
+   — they'll surface any auth failures.
+
+## Reference
+
+- [Grafana Cloud OTLP endpoint docs](https://grafana.com/docs/grafana-cloud/send-data/otlp/)
+- [Saiku observability overview](../../docs/observability.md)

--- a/observability/grafana-cloud/env.example
+++ b/observability/grafana-cloud/env.example
@@ -1,0 +1,24 @@
+# Grafana Cloud OTLP env template.
+# Copy to .env and fill in the values from Grafana Cloud → Connections →
+# Data sources → OpenTelemetry (OTLP).
+
+# The OTLP gateway URL for your Grafana Cloud stack. Includes the
+# `/otlp` path suffix; the OTel SDK appends /v1/traces, /v1/metrics,
+# /v1/logs automatically.
+OTEL_EXPORTER_OTLP_ENDPOINT=https://otlp-gateway-prod-eu-west-2.grafana.net/otlp
+
+# HTTP/protobuf is the recommended protocol for Grafana Cloud.
+OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
+
+# Base64-encoded "instance-id:token" from the Grafana Cloud UI.
+# Uses the standard OTLP headers env var — comma-separated key=value pairs.
+OTEL_EXPORTER_OTLP_HEADERS=Authorization=Basic REPLACE_ME_WITH_BASE64
+
+# Identifies this deployment in Grafana Cloud dashboards + traces.
+OTEL_SERVICE_NAME=saiku
+OTEL_RESOURCE_ATTRIBUTES=deployment.environment=production,service.version=4.6.0
+
+# Sampling. `parentbased_always_on` captures every trace — flip to
+# `parentbased_traceidratio` + a ratio for production.
+OTEL_TRACES_SAMPLER=parentbased_always_on
+# OTEL_TRACES_SAMPLER_ARG=0.05

--- a/observability/new-relic/README.md
+++ b/observability/new-relic/README.md
@@ -1,0 +1,68 @@
+# Saiku → New Relic
+
+Route Saiku's OpenTelemetry signals into New Relic via its **direct OTLP
+endpoint**. New Relic accepts OTLP natively — no collector required.
+
+## Quickstart
+
+Grab a New Relic **ingest license key** from
+account.newrelic.com → API keys → **INGEST - LICENSE**. This is the key
+Data ingestion uses; it's distinct from the User API key.
+
+```bash
+export OTEL_EXPORTER_OTLP_ENDPOINT="https://otlp.nr-data.net"
+export OTEL_EXPORTER_OTLP_PROTOCOL="grpc"
+export OTEL_EXPORTER_OTLP_HEADERS="api-key=<your-license-key>"
+export OTEL_SERVICE_NAME=saiku
+export OTEL_RESOURCE_ATTRIBUTES="deployment.environment=production,service.version=4.6.0"
+
+docker run -d --name saiku \
+  -p 8080:8080 \
+  -e OTEL_EXPORTER_OTLP_ENDPOINT \
+  -e OTEL_EXPORTER_OTLP_PROTOCOL \
+  -e OTEL_EXPORTER_OTLP_HEADERS \
+  -e OTEL_SERVICE_NAME \
+  -e OTEL_RESOURCE_ATTRIBUTES \
+  ghcr.io/spiculedata/saiku:latest
+```
+
+## US vs EU endpoint
+
+Pick the endpoint that matches your New Relic account's data region:
+
+- **US:** `https://otlp.nr-data.net`
+- **EU:** `https://otlp.eu01.nr-data.net`
+
+Wrong endpoint → data is silently dropped. Check the container log for
+`403 Forbidden` OTLP export lines if traces don't appear.
+
+## Where things show up in New Relic
+
+| Signal  | New Relic product           | Query                                                                    |
+|---------|-----------------------------|--------------------------------------------------------------------------|
+| Traces  | APM & Services              | Service `saiku` — Distributed Tracing view lights up automatically.       |
+| Metrics | Metrics Explorer / NRQL     | `FROM Metric SELECT * WHERE service.name = 'saiku'`.                     |
+| Logs    | Logs UI                     | `service.name:saiku` — trace-correlated via `trace.id`.                   |
+| SQL     | Databases (via JDBC spans)  | Every Mondrian-emitted SQL statement appears as a database span.         |
+
+## Sampling
+
+New Relic APM data is priced by ingested GB. Real deployments should
+sample:
+
+```bash
+export OTEL_TRACES_SAMPLER=parentbased_traceidratio
+export OTEL_TRACES_SAMPLER_ARG=0.05
+```
+
+## Verifying it works
+
+1. Start the container with the env vars set.
+2. Query Saiku: `curl -u admin:admin http://localhost:8080/rest/saiku/info`.
+3. In New Relic → APM & Services, `saiku` should appear as a service.
+   First spans typically show up within a minute.
+
+## Reference
+
+- [New Relic: OpenTelemetry OTLP configuration](https://docs.newrelic.com/docs/opentelemetry/best-practices/opentelemetry-otlp/)
+- [Saiku observability overview](../../docs/observability.md)

--- a/observability/new-relic/env.example
+++ b/observability/new-relic/env.example
@@ -1,0 +1,20 @@
+# New Relic OTLP env template. Copy to .env and fill in the values.
+
+# US region default. EU accounts: https://otlp.eu01.nr-data.net
+OTEL_EXPORTER_OTLP_ENDPOINT=https://otlp.nr-data.net
+
+# grpc is New Relic's default. http/protobuf works too if you pin the
+# endpoint to https://otlp.nr-data.net:4318 explicitly.
+OTEL_EXPORTER_OTLP_PROTOCOL=grpc
+
+# INGEST - LICENSE key from https://one.newrelic.com/api-keys
+OTEL_EXPORTER_OTLP_HEADERS=api-key=REPLACE_ME_WITH_LICENSE_KEY
+
+# Identifies the service in APM. Anything more specific than "saiku" is
+# fine — e.g. "saiku-us-east-1" for regional deployments.
+OTEL_SERVICE_NAME=saiku
+OTEL_RESOURCE_ATTRIBUTES=deployment.environment=production,service.version=4.6.0
+
+# Sampling. Flip to parentbased_traceidratio in production.
+OTEL_TRACES_SAMPLER=parentbased_always_on
+# OTEL_TRACES_SAMPLER_ARG=0.05


### PR DESCRIPTION
Closes #1429. Independent of the skills/spaces/well-knowns stack — targets `development` directly.

## Summary

Enterprise buyers scan RFP rows for their vendor's name. "Bring your own OpenTelemetry" scores partial when it should score full. This PR ships four named-provider bundles that flip that row from partial to full without touching a line of Java.

Four bundles under `observability/`:

| Provider              | Path                                                | Pipeline                                        |
|-----------------------|-----------------------------------------------------|-------------------------------------------------|
| **Datadog**           | `observability/datadog/`         | Datadog Agent (OTLP receiver) → Datadog SaaS    |
| **Grafana Cloud**     | `observability/grafana-cloud/`   | Direct OTLP → Grafana Cloud                     |
| **New Relic**         | `observability/new-relic/`       | Direct OTLP → New Relic                         |
| **AWS CloudWatch**    | `observability/cloudwatch/`      | ADOT collector → CloudWatch / X-Ray             |

Each ships a copy-paste README quickstart (endpoint URLs per region, auth model, IAM policy for CloudWatch), a `docker-compose.yml` or `env.example`, and a pointer to the shared starter Grafana dashboard.

## Grafana starter dashboard

`observability/dashboards/grafana/saiku-overview.json` — a single dashboard covering:

- **HTTP** — request rate + p50/p95/p99 latency (per-route)
- **Mondrian / JDBC** — SQL statement rate + p95 latency (the load-bearing view for slow-query diagnosis)
- **JVM** — heap used / committed, GC pause p95, thread count
- **DBCP2 pool** — connections in-use / idle per pool
- **Outbound HTTP** — request rate keyed by `server_address` so Anthropic / OpenAI calls are visible next to warehouse traffic

PromQL-compatible queries, so it works on any Prometheus-speaking data source: Grafana Cloud Mimir, self-hosted Prometheus, Datadog's Prometheus API, ADOT's CloudWatch Metrics via Metric Insights.

## What's here

- 12 new files: 4 provider READMEs + 4 configs (compose or env) + 1 collector config + 1 dashboard JSON + 1 top-level README + docs/observability.md update
- **Zero code changes.** Everything rides the OTel plumbing that landed in the initial observability slice; the bundles are configuration + docs.

## Docs

- `observability/README.md` — landing page with a "which bundle should I pick?" section
- Per-provider READMEs with region-specific endpoints, auth setup, sampling guidance, verification steps
- `docs/observability.md` gains a "Provider bundles" section pointing at all four + the dashboard

## Test plan

- [ ] `DD_API_KEY=test docker compose -f observability/datadog/docker-compose.yml config -q` — no errors
- [ ] `docker compose -f observability/cloudwatch/docker-compose.yml config -q` — no errors
- [ ] `observability/dashboards/grafana/saiku-overview.json` valid JSON (verified — `python3 -c 'import json; json.load(open(...))'` passes)
- [ ] Import the dashboard into a fresh Grafana → renders (needs a live Saiku emitting to a Prometheus source)
- [ ] Live-test one provider end-to-end (Grafana Cloud is easiest — needs only an instance token)

## Non-goals for this slice

- **S3 audit-log export** — mentioned in the original ticket; deferred as a separate bundle (needs an OTel Collector `awss3` exporter which is a different plumbing surface).
- **Provider-specific dashboards** — the starter Grafana dashboard covers 80% of what operators need across all providers. Datadog / New Relic dashboards can ship in follow-ups once we know which panels get customized in the wild.
- **Public docs site page** — separate PR (same pattern as skills/spaces/well-knowns).

## Related

- Feature ticket: #1429
- Existing OTel plumbing: `docs/observability.md`, `docker/saiku-entrypoint`