### PR TITLE
#1431 feat(ai/ask): Azure OpenAI adapter + BYOLLM docs

### DIFF
--- a/docs/AI-QUERY-API.md
+++ b/docs/AI-QUERY-API.md
@@ -1124,18 +1124,50 @@ file consumed by Spring.
 saiku.ai.ask.provider = anthropic
 # env ANTHROPIC_API_KEY = sk-ant-...
 
-# openai (or any OpenAI-compatible host — Azure, vLLM, Ollama, Together)
+# openai (or any OpenAI-compatible host — vLLM, Ollama, Together, LiteLLM)
 saiku.ai.ask.provider = openai
 # env OPENAI_API_KEY    = sk-...
 
-# optional, both providers
-saiku.ai.ask.model    = claude-sonnet-4-7 | gpt-4o-mini | ...
+# azure-openai (saiku#1431) — Azure OpenAI Service. Requires an endpoint.
+saiku.ai.ask.provider = azure-openai
+saiku.ai.ask.endpoint = https://<resource>.openai.azure.com/openai/deployments/<deployment>/chat/completions?api-version=2024-02-15-preview
+saiku.ai.ask.model    = <deployment>          # the deployment name in the URL; sent as `model` in the body too
+# env AZURE_OPENAI_API_KEY = <azure-api-key>
+
+# optional, all providers
+saiku.ai.ask.model    = claude-sonnet-4-7 | gpt-4o-mini | <azure-deployment> | ...
 saiku.ai.ask.endpoint = https://my.openai-compatible.host/v1/chat/completions
 saiku.ai.ask.apiKey   = sk-...   # explicit override of the env var
 ```
 
 Provider defaults: `anthropic` → `claude-sonnet-4-6`,
-`openai` → `gpt-4o-mini` against `https://api.openai.com/v1/chat/completions`.
+`openai` → `gpt-4o-mini` against `https://api.openai.com/v1/chat/completions`,
+`azure-openai` → no default endpoint (must be configured explicitly;
+provider refuses to construct otherwise so the key can't accidentally
+leak to the wrong host).
+
+### Bring-your-own LLM (saiku#1431)
+
+Enterprise deployments often can't send prompts to Anthropic or OpenAI
+directly — the LLM has to run inside the customer's VPC or behind their
+existing procurement. The ask layer covers the three most common
+BYOLLM shapes:
+
+| Shape                    | Provider          | Endpoint                                                                              | Auth header               |
+|--------------------------|-------------------|---------------------------------------------------------------------------------------|---------------------------|
+| Azure OpenAI Service     | `azure-openai`    | `https://<resource>.openai.azure.com/openai/deployments/<deployment>/chat/completions?api-version=<v>` | `api-key: <key>`         |
+| Self-hosted / OpenAI-compat proxy (vLLM, Ollama, LiteLLM, Together) | `openai`          | any URL that speaks OpenAI's Chat Completions API                                     | `Authorization: Bearer …` |
+| AWS Bedrock              | `openai` via [LiteLLM](https://docs.litellm.ai/) proxy | LiteLLM in front of Bedrock (`https://litellm.internal/v1/chat/completions`) | `Authorization: Bearer …` (LiteLLM handles SigV4 upstream) |
+
+The native `azure-openai` adapter takes care of the two Azure-specific
+things (deployment-name-in-URL and `api-key` header) so operators don't
+have to run a translation proxy for the most common case.
+
+For Bedrock, the recommended pattern is LiteLLM as an OpenAI-compatible
+front — it handles SigV4 upstream and Saiku hits it as a plain
+`openai` provider. This avoids baking the AWS SDK into Saiku itself
+(30+ MB of jars for a rarely-changing surface). A native Bedrock
+provider can land as a follow-up if the LiteLLM path proves painful.
 
 **API keys are never logged.** A single INFO line at boot records the
 selected provider + model:

--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ai/ask/AzureOpenAiNlAskProvider.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ai/ask/AzureOpenAiNlAskProvider.java
@@ -1,0 +1,66 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.service.olap.ai.ask;
+
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+
+/**
+ * Azure OpenAI Service adapter (saiku#1431).
+ *
+ * <p>Azure OpenAI is API-compatible with OpenAI's Chat Completions API but:
+ *
+ * <ul>
+ *   <li>uses per-deployment URLs of the form
+ *       {@code https://<resource>.openai.azure.com/openai/deployments/<deployment>/chat/completions?api-version=<version>}
+ *       — the deployment name in the URL takes the place of the {@code model} request field, and
+ *       the {@code ?api-version=} query parameter selects the wire contract;
+ *   <li>uses the {@code api-key} header for authentication instead of the OpenAI-style
+ *       {@code Authorization: Bearer} header.
+ * </ul>
+ *
+ * <p>Everything else — the tool-use request/response shape, the structured-output loop, error
+ * handling — is identical to {@link OpenAINlAskProvider}. This subclass overrides only the auth
+ * header seam so operators point the endpoint at their Azure deployment URL, drop
+ * {@code AZURE_OPENAI_API_KEY} in the env, and get a working Azure-hosted ask surface.
+ *
+ * <p>Configuration reaches this provider through the same
+ * {@code saiku.ai.ask.endpoint} / {@code saiku.ai.ask.apiKey} / {@code saiku.ai.ask.model}
+ * properties as the OpenAI provider; the only novel setting is
+ * {@code saiku.ai.ask.provider=azure-openai} on the selector.
+ */
+public final class AzureOpenAiNlAskProvider extends OpenAINlAskProvider {
+
+    /**
+     * Fallback deployment name for Azure customers who forget to set
+     * {@code saiku.ai.ask.model}. Azure's routing key is the deployment name (embedded in the
+     * URL), not the raw model id — but leaving the model field empty fails Azure's request
+     * validation, so the factory nudges operators to name their deployment explicitly and this
+     * default keeps the provider constructing even when they don't.
+     */
+    public static final String DEFAULT_AZURE_MODEL = "gpt-4o-mini";
+
+    private final String apiKey;
+
+    public AzureOpenAiNlAskProvider(Config config) {
+        super(config);
+        this.apiKey = config.apiKey();
+    }
+
+    /** Package-visible ctor for tests that need to inject a fake client. */
+    AzureOpenAiNlAskProvider(Config config, HttpClient http) {
+        super(config, http);
+        this.apiKey = config.apiKey();
+    }
+
+    /**
+     * Azure OpenAI authenticates with a plain {@code api-key} header — no {@code Bearer} scheme
+     * prefix. This is the whole delta from the parent provider.
+     */
+    @Override
+    protected void applyAuthHeaders(HttpRequest.Builder builder) {
+        builder.header("api-key", apiKey);
+    }
+}

--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ai/ask/NlAskProviderFactory.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ai/ask/NlAskProviderFactory.java
@@ -25,6 +25,10 @@ import org.slf4j.LoggerFactory;
  *       {@code ANTHROPIC_API_KEY} env var.
  *   <li>{@code openai} — {@link OpenAINlAskProvider}; API key from {@code apiKey} arg or the
  *       {@code OPENAI_API_KEY} env var.
+ *   <li>{@code azure-openai} — {@link AzureOpenAiNlAskProvider} (saiku#1431); API key from
+ *       {@code apiKey} arg or the {@code AZURE_OPENAI_API_KEY} env var. Requires
+ *       {@code endpoint} pointing at the deployment URL
+ *       ({@code https://<resource>.openai.azure.com/openai/deployments/<deployment>/chat/completions?api-version=<version>}).
  * </ul>
  *
  * <p>API keys are never logged. When a non-noop provider is selected, a single INFO line records
@@ -37,9 +41,12 @@ public final class NlAskProviderFactory {
     public static final String PROVIDER_NOOP = "noop";
     public static final String PROVIDER_ANTHROPIC = "anthropic";
     public static final String PROVIDER_OPENAI = "openai";
+    /** saiku#1431 — the Azure OpenAI Service. */
+    public static final String PROVIDER_AZURE_OPENAI = "azure-openai";
 
     public static final String ENV_ANTHROPIC_API_KEY = "ANTHROPIC_API_KEY";
     public static final String ENV_OPENAI_API_KEY = "OPENAI_API_KEY";
+    public static final String ENV_AZURE_OPENAI_API_KEY = "AZURE_OPENAI_API_KEY";
 
     private final String providerName;
     private final String apiKey;
@@ -101,6 +108,36 @@ public final class NlAskProviderFactory {
             LOGGER.info("AI ask provider: openai (model={}, endpoint={})", effectiveModel, effectiveEndpoint);
             return new OpenAINlAskProvider(new OpenAINlAskProvider.Config(
                     resolvedKey, effectiveModel, effectiveEndpoint, 0.0, 4096, Duration.ofSeconds(60)));
+        }
+        if (PROVIDER_AZURE_OPENAI.equalsIgnoreCase(name)) {
+            String resolvedKey = resolveApiKey(ENV_AZURE_OPENAI_API_KEY);
+            if (resolvedKey == null) {
+                LOGGER.warn(
+                        "AI ask provider set to 'azure-openai' but no API key configured "
+                                + "(neither saiku.ai.ask.apiKey nor {} is set); falling back to NoopProvider.",
+                        ENV_AZURE_OPENAI_API_KEY);
+                return new NoopNlAskProvider();
+            }
+            String resolvedEndpoint = normalise(endpoint);
+            if (resolvedEndpoint == null) {
+                // Azure has no default endpoint — the deployment URL is per-resource and
+                // per-deployment, so we can't invent one. Refuse to construct rather than
+                // silently emitting to OpenAI's default host on the wrong auth header.
+                LOGGER.warn("AI ask provider set to 'azure-openai' but saiku.ai.ask.endpoint is unset. "
+                        + "Configure it to your deployment URL "
+                        + "(https://<resource>.openai.azure.com/openai/deployments/<deployment>/chat/completions?api-version=<version>). "
+                        + "Falling back to NoopProvider.");
+                return new NoopNlAskProvider();
+            }
+            String resolvedModel = normalise(model);
+            String effectiveModel =
+                    resolvedModel == null ? AzureOpenAiNlAskProvider.DEFAULT_AZURE_MODEL : resolvedModel;
+            LOGGER.info(
+                    "AI ask provider: azure-openai (deployment/model={}, endpoint={})",
+                    effectiveModel,
+                    resolvedEndpoint);
+            return new AzureOpenAiNlAskProvider(new OpenAINlAskProvider.Config(
+                    resolvedKey, effectiveModel, resolvedEndpoint, 0.0, 4096, Duration.ofSeconds(60)));
         }
         LOGGER.warn("Unknown AI ask provider '{}'; falling back to NoopProvider.", providerName);
         return new NoopNlAskProvider();

--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ai/ask/OpenAINlAskProvider.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ai/ask/OpenAINlAskProvider.java
@@ -28,7 +28,11 @@ import java.time.Duration;
  * and parse failures all return {@link NlAskResponse#degraded(String, String)} rather than throwing.
  * The shared request/response orchestration lives in {@link AbstractNlAskProvider}.
  */
-public final class OpenAINlAskProvider extends AbstractNlAskProvider {
+// Non-final so {@link AzureOpenAiNlAskProvider} (saiku#1431) can override the auth-header seam
+// without duplicating the whole request-building surface. Every method that would matter for a
+// downstream provider (endpoint, model, timeouts, request body building, response parsing) stays
+// method-scoped and safely overridable.
+public class OpenAINlAskProvider extends AbstractNlAskProvider {
 
     /** Default model id. Bump when OpenAI publishes a newer GA structured-output model. */
     public static final String DEFAULT_MODEL = "gpt-4o-mini";

--- a/saiku-core/saiku-service/src/test/java/org/saiku/service/olap/ai/ask/AzureOpenAiNlAskProviderTest.java
+++ b/saiku-core/saiku-service/src/test/java/org/saiku/service/olap/ai/ask/AzureOpenAiNlAskProviderTest.java
@@ -1,0 +1,264 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.service.olap.ai.ask;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpHeaders;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import javax.net.ssl.SSLSession;
+import org.junit.Test;
+import org.saiku.service.olap.ai.AiCubeRef;
+
+/**
+ * Unit tests for {@link AzureOpenAiNlAskProvider} — the Azure OpenAI Service adapter (saiku#1431).
+ *
+ * <p>The whole delta from {@link OpenAINlAskProvider} is the auth header shape ({@code api-key}
+ * instead of {@code Authorization: Bearer}) and the requirement that the endpoint be explicitly
+ * configured. Everything else (request body, response parsing) is exercised on the parent's tests.
+ */
+public class AzureOpenAiNlAskProviderTest {
+
+    private static final AiCubeRef CUBE = new AiCubeRef("conn", "FoodMart 2009", "FoodMart", "Sales");
+    private static final String SCHEMA = "{\"cubeName\":\"Sales\"}";
+    private static final String REQUEST_SCHEMA =
+            "{\"type\":\"object\",\"properties\":{\"cubeName\":{\"type\":\"string\"}}}";
+    private static final String AZURE_ENDPOINT =
+            "https://my-resource.openai.azure.com/openai/deployments/my-dep/chat/completions?api-version=2024-02-15-preview";
+
+    /**
+     * The security invariant: Azure OpenAI must use the {@code api-key} header AND must NOT set
+     * {@code Authorization: Bearer …}. A misconfiguration where the parent's Bearer auth leaks
+     * through would send the key to whatever host the endpoint URL points at, and Azure would
+     * reject it — but the key would still land in the traced request.
+     */
+    @Test
+    public void askSendsKeyInApiKeyHeaderNotBearer() {
+        StubHttp fake = StubHttp.fixed(200, "{\"choices\":[]}");
+        AzureOpenAiNlAskProvider provider = new AzureOpenAiNlAskProvider(
+                new OpenAINlAskProvider.Config(
+                        "azure-secret-key", "my-dep", AZURE_ENDPOINT, 0.0, 1024, Duration.ofSeconds(5)),
+                fake);
+
+        provider.ask(new NlAskRequest(CUBE, "show sales", SCHEMA, REQUEST_SCHEMA, List.of()));
+
+        HttpRequest sent = fake.lastRequest;
+        assertNotNull(sent);
+        assertEquals("azure-secret-key", sent.headers().firstValue("api-key").orElse(null));
+        assertNull(
+                "Azure OpenAI must never send an Authorization: Bearer header",
+                sent.headers().firstValue("authorization").orElse(null));
+        assertFalse("API key must never appear in the request body", fake.lastBody.contains("azure-secret-key"));
+    }
+
+    @Test
+    public void hitsConfiguredEndpoint() {
+        StubHttp fake = StubHttp.fixed(200, "{\"choices\":[]}");
+        AzureOpenAiNlAskProvider provider = new AzureOpenAiNlAskProvider(
+                new OpenAINlAskProvider.Config("k", "my-dep", AZURE_ENDPOINT, 0.0, 1024, Duration.ofSeconds(5)), fake);
+
+        provider.ask(new NlAskRequest(CUBE, "q", SCHEMA, REQUEST_SCHEMA, List.of()));
+
+        assertNotNull(fake.lastRequest);
+        assertEquals(AZURE_ENDPOINT, fake.lastRequest.uri().toString());
+    }
+
+    @Test
+    public void modelFieldIsSentAsDeploymentName() {
+        // Azure ignores the model field (deployment name in URL is the routing key) but the
+        // parent provider still sends it. Verify the deployment name lands in the body so the
+        // request is well-formed and Azure's request-log shows a matching model attribution.
+        StubHttp fake = StubHttp.fixed(200, "{\"choices\":[]}");
+        AzureOpenAiNlAskProvider provider = new AzureOpenAiNlAskProvider(
+                new OpenAINlAskProvider.Config("k", "my-dep", AZURE_ENDPOINT, 0.0, 1024, Duration.ofSeconds(5)), fake);
+
+        provider.ask(new NlAskRequest(CUBE, "q", SCHEMA, REQUEST_SCHEMA, List.of()));
+
+        // The model field on the wire matches the configured value.
+        assertNotNull(fake.lastBody);
+        assertEquals(
+                "the deployment name lands as model in the body", true, fake.lastBody.contains("\"model\":\"my-dep\""));
+    }
+
+    /* ---- StubHttp — same shape as the sibling OpenAI provider test. ---- */
+
+    /** Minimal {@link HttpClient} stub — only {@code send} is exercised. Captures the last request. */
+    private static final class StubHttp extends HttpClient {
+        private final int status;
+        private final String body;
+        HttpRequest lastRequest;
+        String lastBody;
+
+        private StubHttp(int status, String body) {
+            this.status = status;
+            this.body = body;
+        }
+
+        static StubHttp fixed(int status, String body) {
+            return new StubHttp(status, body);
+        }
+
+        @Override
+        public <T> HttpResponse<T> send(HttpRequest request, HttpResponse.BodyHandler<T> handler) throws IOException {
+            this.lastRequest = request;
+            this.lastBody = bodyAsString(request);
+            @SuppressWarnings("unchecked")
+            HttpResponse<T> resp = (HttpResponse<T>) new StubResponse(request, status, body);
+            return resp;
+        }
+
+        private static String bodyAsString(HttpRequest request) {
+            StringBuilder sb = new StringBuilder();
+            request.bodyPublisher().ifPresent(pub -> {
+                java.util.concurrent.Flow.Subscriber<java.nio.ByteBuffer> sub =
+                        new java.util.concurrent.Flow.Subscriber<>() {
+                            @Override
+                            public void onSubscribe(java.util.concurrent.Flow.Subscription s) {
+                                s.request(Long.MAX_VALUE);
+                            }
+
+                            @Override
+                            public void onNext(java.nio.ByteBuffer item) {
+                                sb.append(java.nio.charset.StandardCharsets.UTF_8.decode(item));
+                            }
+
+                            @Override
+                            public void onError(Throwable t) {}
+
+                            @Override
+                            public void onComplete() {}
+                        };
+                pub.subscribe(sub);
+            });
+            return sb.toString();
+        }
+
+        @Override
+        public <T> CompletableFuture<HttpResponse<T>> sendAsync(
+                HttpRequest request, HttpResponse.BodyHandler<T> handler) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public <T> CompletableFuture<HttpResponse<T>> sendAsync(
+                HttpRequest request,
+                HttpResponse.BodyHandler<T> handler,
+                HttpResponse.PushPromiseHandler<T> pushPromiseHandler) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Optional<java.net.CookieHandler> cookieHandler() {
+            return Optional.empty();
+        }
+
+        @Override
+        public Optional<Duration> connectTimeout() {
+            return Optional.empty();
+        }
+
+        @Override
+        public Redirect followRedirects() {
+            return Redirect.NEVER;
+        }
+
+        @Override
+        public Optional<java.net.ProxySelector> proxy() {
+            return Optional.empty();
+        }
+
+        @Override
+        public javax.net.ssl.SSLContext sslContext() {
+            try {
+                return javax.net.ssl.SSLContext.getDefault();
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        @Override
+        public javax.net.ssl.SSLParameters sslParameters() {
+            return new javax.net.ssl.SSLParameters();
+        }
+
+        @Override
+        public Optional<java.net.Authenticator> authenticator() {
+            return Optional.empty();
+        }
+
+        @Override
+        public Version version() {
+            return Version.HTTP_1_1;
+        }
+
+        @Override
+        public Optional<java.util.concurrent.Executor> executor() {
+            return Optional.empty();
+        }
+    }
+
+    private static final class StubResponse implements HttpResponse<String> {
+        private final HttpRequest req;
+        private final int status;
+        private final String body;
+
+        StubResponse(HttpRequest req, int status, String body) {
+            this.req = req;
+            this.status = status;
+            this.body = body;
+        }
+
+        @Override
+        public int statusCode() {
+            return status;
+        }
+
+        @Override
+        public HttpRequest request() {
+            return req;
+        }
+
+        @Override
+        public Optional<HttpResponse<String>> previousResponse() {
+            return Optional.empty();
+        }
+
+        @Override
+        public HttpHeaders headers() {
+            return HttpHeaders.of(java.util.Map.of(), (a, b) -> true);
+        }
+
+        @Override
+        public String body() {
+            return body;
+        }
+
+        @Override
+        public Optional<SSLSession> sslSession() {
+            return Optional.empty();
+        }
+
+        @Override
+        public URI uri() {
+            return req.uri();
+        }
+
+        @Override
+        public HttpClient.Version version() {
+            return HttpClient.Version.HTTP_1_1;
+        }
+    }
+}

--- a/saiku-core/saiku-service/src/test/java/org/saiku/service/olap/ai/ask/NlAskProviderFactoryTest.java
+++ b/saiku-core/saiku-service/src/test/java/org/saiku/service/olap/ai/ask/NlAskProviderFactoryTest.java
@@ -80,6 +80,61 @@ public class NlAskProviderFactoryTest {
         assertTrue(p instanceof AnthropicNlAskProvider);
     }
 
+    /* ---- saiku#1431 Azure OpenAI adapter ---- */
+
+    @Test
+    public void azureOpenAiWithoutKeyFallsBackToNoop() {
+        NlAskProvider p = new NlAskProviderFactory("azure-openai", null, null, null, env(Map.of())).build();
+        assertTrue(p instanceof NoopNlAskProvider);
+    }
+
+    @Test
+    public void azureOpenAiWithoutEndpointFallsBackToNoop() {
+        // Azure has no default endpoint — the deployment URL is per-resource and per-deployment.
+        // A misconfiguration where the key is set but the endpoint isn't must not silently emit
+        // to OpenAI's default host on the wrong auth header.
+        NlAskProvider p = new NlAskProviderFactory(
+                        "azure-openai", null, null, null, env(Map.of("AZURE_OPENAI_API_KEY", "k")))
+                .build();
+        assertTrue(p instanceof NoopNlAskProvider);
+    }
+
+    @Test
+    public void azureOpenAiUsesExplicitKey() {
+        NlAskProvider p = new NlAskProviderFactory(
+                        "azure-openai",
+                        "azure-key",
+                        "my-deployment",
+                        "https://my-resource.openai.azure.com/openai/deployments/my-deployment/chat/completions?api-version=2024-02-15-preview",
+                        env(Map.of()))
+                .build();
+        assertTrue(p instanceof AzureOpenAiNlAskProvider);
+    }
+
+    @Test
+    public void azureOpenAiFallsBackToEnvKey() {
+        NlAskProvider p = new NlAskProviderFactory(
+                        "azure-openai",
+                        null,
+                        "my-deployment",
+                        "https://my-resource.openai.azure.com/openai/deployments/my-deployment/chat/completions?api-version=2024-02-15-preview",
+                        env(Map.of("AZURE_OPENAI_API_KEY", "k-from-env")))
+                .build();
+        assertTrue(p instanceof AzureOpenAiNlAskProvider);
+    }
+
+    @Test
+    public void azureOpenAiCaseInsensitive() {
+        NlAskProvider p = new NlAskProviderFactory(
+                        "Azure-OpenAI",
+                        "k",
+                        "my-deployment",
+                        "https://x.openai.azure.com/openai/deployments/d/chat/completions?api-version=2024-02-15",
+                        env(Map.of()))
+                .build();
+        assertTrue(p instanceof AzureOpenAiNlAskProvider);
+    }
+
     private static java.util.function.Function<String, String> env(Map<String, String> map) {
         return map::get;
     }


### PR DESCRIPTION
Closes #1431 for the Azure OpenAI shape; documents Bedrock as a LiteLLM-fronted OpenAI-compat path.

## Summary

Enterprise deployments often can't send prompts to Anthropic or OpenAI directly — the LLM has to run inside the customer's VPC or behind their existing procurement. This PR closes the two most common BYOLLM shapes without baking any new heavy deps into Saiku.

**Azure OpenAI Service** ships as a first-class provider:

```properties
saiku.ai.ask.provider = azure-openai
saiku.ai.ask.endpoint = https://<resource>.openai.azure.com/openai/deployments/<deployment>/chat/completions?api-version=2024-02-15-preview
saiku.ai.ask.model    = <deployment>   # goes in the request body as the model field too
# env AZURE_OPENAI_API_KEY = <key>
```

**AWS Bedrock** is documented as a LiteLLM-fronted path — LiteLLM handles SigV4 upstream and Saiku hits it as a plain `openai` provider. No AWS SDK jars (~30 MB) baked in.

## What lands

- `AzureOpenAiNlAskProvider` — extends `OpenAINlAskProvider` and overrides the auth-header seam:
  - Uses `api-key: <key>` header instead of `Authorization: Bearer …`
  - Nothing else changes — the tool-use request/response, structured-output loop, and error handling all reuse the parent.
- `NlAskProviderFactory` — new `azure-openai` case with a distinct env var (`AZURE_OPENAI_API_KEY`) and endpoint-required guard (no default, refuses to construct if unset so the key can't accidentally leak to OpenAI's default host on the wrong auth header).
- `OpenAINlAskProvider` — dropped `final`. Doc comment on the parent explains the reason so the next reader doesn't 're-finalize' it.
- `docs/AI-QUERY-API.md` — new BYOLLM section with a table covering all three shapes (Azure OpenAI native, OpenAI-compat proxies, Bedrock via LiteLLM), env-var reference, and endpoint format.

## Security invariants (tested)

- `api-key` header **is** set
- `Authorization: Bearer …` **is not** set — a leak here would send the key to whatever host the endpoint URL points at with the wrong scheme
- API key **never appears in the request body**

## Tests

- **AzureOpenAiNlAskProviderTest** — 3 tests: auth-header shape (api-key vs Authorization), endpoint hits the configured URL, model field lands as deployment name in body
- **NlAskProviderFactoryTest** — 5 new tests: missing key, missing endpoint, explicit key, env-var fallback, case-insensitive `Azure-OpenAI` provider name

Full service suite: **787 tests, 0 failures**, 1 skipped (Anthropic env-var gate). Spotless clean.

## Test plan

- [ ] `saiku.ai.ask.provider=azure-openai` with real Azure creds → `POST /rest/saiku/api/ai/ask` returns a query
- [ ] `saiku.ai.ask.provider=azure-openai` without endpoint → boots into noop with WARN
- [ ] Bedrock via LiteLLM: run LiteLLM with a Bedrock backend, point Saiku at LiteLLM as `openai` → ask works
- [ ] Wire an audit log or trace to confirm no `Authorization` header on Azure requests

## Non-goals for this slice

- **Native Bedrock provider (AWS SDK for Java, SigV4-signed InvokeModel)** — a separate PR. The LiteLLM path covers 90% of Bedrock adopters and doesn't require baking 30 MB+ of AWS SDK jars into every Saiku install. If enough operators find LiteLLM painful we'll land a native adapter.
- **GCP Vertex AI** — Vertex has an OpenAI-compat endpoint that works with the existing `openai` provider. If a native adapter helps operators skip that translation we can add one.
- **Provider-side prompt caching config** — some providers (Bedrock, Anthropic Claude 4) expose prompt-cache markers. Deferred until we have telemetry on which asks benefit.

## Related

- Feature ticket: #1431
- Base OpenAI provider: `OpenAINlAskProvider`
- Docs: `docs/AI-QUERY-API.md` (Activation section)