### PR TITLE
#1433 feat(ai/ask): SSE streaming endpoint (POST /ai/ask/stream)

### DIFF
--- a/docs/AI-QUERY-API.md
+++ b/docs/AI-QUERY-API.md
@@ -1239,6 +1239,97 @@ curl -sS -X POST -H 'Content-Type: application/json' \
 # }
 ```
 
+### Streaming variant — `POST /ai/ask/stream` (saiku#1433)
+
+Same request body, same auth, same rate/size guards, same envelope
+shape — but the response is a Server-Sent Events stream so embedded
+chat surfaces can render progress as it arrives.
+
+```http
+POST /rest/saiku/api/ai/ask/stream
+Content-Type: application/json
+Accept:       text/event-stream
+```
+
+Response is a sequence of SSE events per [WHATWG](https://html.spec.whatwg.org/multipage/server-sent-events.html):
+
+```
+event: model
+data: {"model":"claude-sonnet-4-6"}
+
+event: intent
+data: {"kind":"INSIGHT"}
+
+event: chunk
+data: {"delta":"Store "}
+
+event: chunk
+data: {"delta":"Sales trended up 12% week-on-week."}
+
+event: final
+data: {"degraded":false,"model":"claude-sonnet-4-6","insight":{"markdown":"Store Sales trended up 12% week-on-week."}}
+```
+
+Event names:
+
+| Event    | When                                                    | Payload                                                                         |
+|----------|---------------------------------------------------------|---------------------------------------------------------------------------------|
+| `model`  | Always fires first when the provider returned a model id | `{"model": "<model-id>"}`                                                        |
+| `intent` | After tool routing, before payload                       | `{"kind": "QUERY" \| "INSIGHT" \| "VIEW_CHANGE"}`                                |
+| `chunk`  | For prose-carrying intents (INSIGHT + VIEW_CHANGE `reason`), zero or more times | `{"delta": "<word or whitespace run>"}` — concatenating all deltas recovers the source |
+| `final`  | Always fires last on success                             | the complete `AskResponse` envelope — same shape as sync `/ai/ask` returns       |
+| `error`  | On degraded (provider transport / parse / auth failure)  | `{"reason": "<explanation>"}` — followed by a `final` event with `degraded:true` |
+
+**Streaming semantics (v1).** The underlying provider call is still
+synchronous — the LLM's tool-use response arrives whole. The endpoint
+then splits any prose fields (insight markdown, view-change reason)
+into word-sized deltas so the client renders progressively. True
+per-token streaming from the LLM provider is a follow-up; the wire
+shape above is stable so a future PR that plugs in real LLM streaming
+won't require any client changes.
+
+**Client-side accumulation:**
+
+```js
+const es = new EventSource('/rest/saiku/api/ai/ask/stream', { withCredentials: true });
+let markdown = "";
+es.addEventListener('chunk', (e) => {
+  markdown += JSON.parse(e.data).delta;
+  render(markdown);
+});
+es.addEventListener('final', (e) => {
+  const full = JSON.parse(e.data);
+  // full === same shape as POST /ai/ask returns
+  es.close();
+});
+es.addEventListener('error', (e) => {
+  const err = JSON.parse(e.data);
+  showError(err.reason);
+});
+```
+
+Or with `fetch` for POST bodies (EventSource is GET-only):
+
+```js
+const res = await fetch('/rest/saiku/api/ai/ask/stream', {
+  method: 'POST',
+  headers: { 'content-type': 'application/json', accept: 'text/event-stream' },
+  body: JSON.stringify({ question, cube }),
+});
+const reader = res.body.getReader();
+const decoder = new TextDecoder();
+let buffer = '';
+while (true) {
+  const { done, value } = await reader.read();
+  if (done) break;
+  buffer += decoder.decode(value, { stream: true });
+  // Split on double-newlines (event boundaries) and dispatch each event.
+  const events = buffer.split('\n\n');
+  buffer = events.pop();
+  for (const raw of events) dispatchSseEvent(raw);
+}
+```
+
 ### What the model sees vs doesn't
 
 The ask layer sends the model **only** the cube's AiSchema (serialised

--- a/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/AiQueryResource.java
+++ b/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/AiQueryResource.java
@@ -857,6 +857,304 @@ public class AiQueryResource {
         return Response.ok(out).type(MediaType.APPLICATION_JSON).build();
     }
 
+    /**
+     * Streaming variant of {@link #ask(AiAskApi.AskRequest)} (saiku#1433). Same request body,
+     * same response envelope, but the endpoint speaks Server-Sent Events so embedded chat surfaces
+     * can render progress as it arrives — the "assistant is typing…" affordance without waiting on
+     * the full round-trip.
+     *
+     * <p>Wire format (WHATWG SSE per <a href="https://html.spec.whatwg.org/multipage/server-sent-events.html">
+     * the HTML spec</a>):
+     *
+     * <pre>{@code
+     * event: model
+     * data: {"model":"claude-sonnet-4-6"}
+     *
+     * event: intent
+     * data: {"kind":"INSIGHT"}
+     *
+     * event: chunk
+     * data: {"delta":"Store "}
+     *
+     * event: chunk
+     * data: {"delta":"Sales trended up 12% week-on-week..."}
+     *
+     * event: final
+     * data: {"degraded":false,"model":"...","insight":{...}}
+     * }</pre>
+     *
+     * <p><strong>Streaming semantics (v1).</strong> The underlying provider call is still
+     * synchronous — the LLM's tool-use response is emitted whole. The endpoint then chunks any
+     * prose fields (insight markdown, view-change reason) into word-sized deltas so the client
+     * gets a progressive render experience. True per-token streaming from the LLM provider is a
+     * follow-up (both Anthropic and OpenAI expose streaming APIs, but their tool-use streaming
+     * payloads are non-trivial to accumulate at the AbstractNlAskProvider seam). The wire shape
+     * is stable; a future PR that plugs in real LLM streaming won't require client changes.
+     *
+     * <p>Rate limiter + size cap + policy gate + auth are identical to {@link
+     * #ask(AiAskApi.AskRequest)} — the streaming variant isn't a bypass surface.
+     */
+    @POST
+    @Path("/ask/stream")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces("text/event-stream")
+    public Response askStream(AiAskApi.AskRequest body) {
+        aiPolicyGuard.assertCanSend(org.saiku.service.olap.ai.AiDataKind.AGGREGATED_RESULT_VALUES);
+        if (body == null) {
+            return badRequest("body", "request body required", null);
+        }
+        if (body.getQuestion() == null || body.getQuestion().isBlank()) {
+            return badRequest("question", "question must be non-blank", null);
+        }
+        if (body.getCube() == null || body.getCube().getCubeName() == null) {
+            return badRequest("cube", "cube ref required", null);
+        }
+        org.saiku.web.security.ratelimit.AiAskGuard.Violation sizeViolation =
+                org.saiku.web.security.ratelimit.AiAskGuard.checkSize(body);
+        if (sizeViolation != null) {
+            return askLimitResponse(sizeViolation.isPayloadTooLarge() ? 413 : 400, sizeViolation.getMessage());
+        }
+        if (!askRateLimiter.tryAcquire(askRateKey())) {
+            return askLimitResponse(
+                    429,
+                    "Too many AI ask requests — limit is " + askRateLimiter.getMaxCalls() + " per "
+                            + (askRateLimiter.getWindowMs() / 1000) + "s. Please retry shortly.");
+        }
+        if (askService == null) {
+            AiAskApi.AskResponse notConfigured = new AiAskApi.AskResponse();
+            notConfigured.setDegraded(true);
+            notConfigured.setReason(
+                    "AI ask is not configured. Set saiku.ai.ask.provider to 'anthropic' or 'openai' and supply the matching API key.");
+            return Response.status(Response.Status.SERVICE_UNAVAILABLE)
+                    .entity(notConfigured)
+                    .type(MediaType.APPLICATION_JSON)
+                    .build();
+        }
+
+        org.saiku.service.olap.ai.ask.NlAskRequest.ForceTool force =
+                org.saiku.service.olap.ai.ask.NlAskRequest.ForceTool.AUTO;
+        if (body.getForceTool() != null) {
+            try {
+                force = org.saiku.service.olap.ai.ask.NlAskRequest.ForceTool.valueOf(
+                        body.getForceTool().toUpperCase());
+            } catch (IllegalArgumentException ignored) {
+                // Unknown value — keep AUTO, same as the sync endpoint.
+            }
+        }
+        final org.saiku.service.olap.ai.ask.NlAskRequest.ForceTool forceFinal = force;
+
+        jakarta.ws.rs.core.StreamingOutput stream = outputStream -> {
+            java.io.Writer writer =
+                    new java.io.OutputStreamWriter(outputStream, java.nio.charset.StandardCharsets.UTF_8);
+            SseWriter sse = new SseWriter(writer);
+            try {
+                AiAskService.AskOutcome outcome = askService.ask(
+                        body.getCube(),
+                        body.getQuestion(),
+                        body.historyAsMessages(),
+                        body.getCellsetDigest(),
+                        forceFinal,
+                        body.getCurrentQuery());
+
+                // model event — always fired first so the client can show which backend answered.
+                if (outcome.model() != null) {
+                    sse.event("model", MAPPER.writeValueAsString(java.util.Map.of("model", outcome.model())));
+                }
+
+                if (outcome.degraded()) {
+                    // Degraded path — emit an error event with the provider's reason, then a final.
+                    sse.event(
+                            "error",
+                            MAPPER.writeValueAsString(
+                                    java.util.Map.of("reason", outcome.reason() == null ? "" : outcome.reason())));
+                    AiAskApi.AskResponse out = new AiAskApi.AskResponse();
+                    out.setDegraded(true);
+                    out.setReason(outcome.reason());
+                    if (outcome.model() != null) out.setModel(outcome.model());
+                    sse.event("final", MAPPER.writeValueAsString(out));
+                    return;
+                }
+
+                sse.event(
+                        "intent",
+                        MAPPER.writeValueAsString(java.util.Map.of(
+                                "kind",
+                                outcome.kind() == null ? "" : outcome.kind().name())));
+
+                AiAskApi.AskResponse out = new AiAskApi.AskResponse();
+                out.setDegraded(false);
+                out.setModel(outcome.model());
+
+                if (outcome.kind() == AiAskService.AskOutcome.Kind.INSIGHT) {
+                    // Chunk the insight markdown into word-sized deltas so the client sees a
+                    // progressive stream. Fake-stream today; wire-stable for real LLM streaming later.
+                    out.setInsight(outcome.insight());
+                    String markdown =
+                            outcome.insight() == null ? "" : outcome.insight().getMarkdown();
+                    if (markdown != null && !markdown.isEmpty()) {
+                        emitChunks(sse, markdown);
+                    }
+                    sse.event("final", MAPPER.writeValueAsString(out));
+                    return;
+                }
+
+                if (outcome.kind() == AiAskService.AskOutcome.Kind.VIEW_CHANGE) {
+                    // View change carries an optional reason string worth streaming — the caller
+                    // reads it as "why did the LLM pick this chart".
+                    out.setViewChange(outcome.viewChange());
+                    String reason = outcome.viewChange() == null
+                            ? null
+                            : outcome.viewChange().getReason();
+                    if (reason != null && !reason.isEmpty()) {
+                        emitChunks(sse, reason);
+                    }
+                    sse.event("final", MAPPER.writeValueAsString(out));
+                    return;
+                }
+
+                // QUERY intent — no prose to stream; the query itself IS the artefact. Execute the
+                // same way the sync endpoint does and emit the final envelope in one event so the
+                // client accumulates a complete AskResponse. We keep the SSE frame here (rather than
+                // a single JSON POST response) so the client's stream reader is uniform across intents.
+                AiQueryRequest req = outcome.request();
+                out.setRequest(req);
+                long start = System.currentTimeMillis();
+                try {
+                    schemaValidator.assertValid(MAPPER.valueToTree(req));
+                    AiSchema schema = cubeMetadataService.getSchema(req.getCube());
+                    ThinQuery tq = converter.convert(req, schema);
+                    out.setQueryModel(tq.getQueryModel());
+                    CellDataSet cds = thinQueryService.execute(tq);
+                    AiQueryResponse aiResp = buildResponse(tq, cds, start, "records");
+                    out.setResponse(aiResp);
+                    if (aiResp != null && aiResp.getMetadata() != null) {
+                        out.setGeneratedMdx(aiResp.getMetadata().getGeneratedMdx());
+                    }
+                } catch (AiValidationException e) {
+                    AiQueryResponse aiResp = new AiQueryResponse();
+                    aiResp.setStatus(org.saiku.service.olap.ai.AiQueryResponse.Status.VALIDATION_ERROR);
+                    aiResp.setError(e.getMessage());
+                    aiResp.setField(e.getField());
+                    aiResp.setAvailable(e.getAvailable() == null ? null : new java.util.ArrayList<>(e.getAvailable()));
+                    aiResp.setRuntimeMs(System.currentTimeMillis() - start);
+                    out.setResponse(aiResp);
+                } catch (RuntimeException e) {
+                    log.warn("AI ask (streaming) execution failed after successful translation", e);
+                    AiQueryResponse aiResp = new AiQueryResponse();
+                    aiResp.setStatus(org.saiku.service.olap.ai.AiQueryResponse.Status.EXECUTION_ERROR);
+                    aiResp.setError("execute failed");
+                    aiResp.setRuntimeMs(System.currentTimeMillis() - start);
+                    out.setResponse(aiResp);
+                }
+                sse.event("final", MAPPER.writeValueAsString(out));
+            } catch (java.io.IOException ioe) {
+                // Client disconnected — nothing to do, the connection is already dead.
+                log.debug("AI ask (streaming) client disconnected: {}", ioe.getMessage());
+            } catch (RuntimeException e) {
+                log.warn("AI ask (streaming) unexpected failure", e);
+                try {
+                    sse.event("error", MAPPER.writeValueAsString(java.util.Map.of("reason", "internal error")));
+                } catch (java.io.IOException swallow) {
+                    // best-effort — the client is already gone.
+                }
+            }
+        };
+
+        return Response.ok(stream)
+                .type("text/event-stream")
+                .header("Cache-Control", "no-cache")
+                .header("X-Accel-Buffering", "no") // Nginx: disable buffering so events flush.
+                .build();
+    }
+
+    /**
+     * Split {@code prose} into word-boundary chunks (keeping the whitespace attached to each
+     * chunk so the client can concatenate deltas without needing to guess spacing) and emit each
+     * as an SSE {@code chunk} event.
+     *
+     * <p>Package-private for a unit test. Cap on chunk count is loose — long insights emit
+     * hundreds of small events, which is fine on modern HTTP but not free; if that becomes an
+     * issue we can group tokens by sentence.
+     */
+    static void emitChunks(SseWriter sse, String prose) throws java.io.IOException {
+        int len = prose.length();
+        int i = 0;
+        while (i < len) {
+            // Find the next word boundary (whitespace run) and emit up to and including it so the
+            // delta reads naturally when concatenated.
+            int wordEnd = i;
+            while (wordEnd < len && !Character.isWhitespace(prose.charAt(wordEnd))) wordEnd++;
+            while (wordEnd < len && Character.isWhitespace(prose.charAt(wordEnd))) wordEnd++;
+            String chunk = prose.substring(i, wordEnd);
+            if (!chunk.isEmpty()) {
+                sse.event("chunk", "{\"delta\":" + jsonString(chunk) + "}");
+            }
+            i = wordEnd;
+        }
+    }
+
+    /**
+     * JSON-string escape for a raw text chunk. Kept package-visible for the emitChunks test; used
+     * verbatim in {@link #emitChunks} to avoid an extra Jackson serialisation round-trip per token.
+     */
+    static String jsonString(String s) {
+        StringBuilder b = new StringBuilder(s.length() + 8);
+        b.append('"');
+        for (int i = 0; i < s.length(); i++) {
+            char c = s.charAt(i);
+            switch (c) {
+                case '"' -> b.append("\\\"");
+                case '\\' -> b.append("\\\\");
+                case '\n' -> b.append("\\n");
+                case '\r' -> b.append("\\r");
+                case '\t' -> b.append("\\t");
+                case '\b' -> b.append("\\b");
+                case '\f' -> b.append("\\f");
+                default -> {
+                    if (c < 0x20) {
+                        b.append(String.format("\\u%04x", (int) c));
+                    } else {
+                        b.append(c);
+                    }
+                }
+            }
+        }
+        b.append('"');
+        return b.toString();
+    }
+
+    /**
+     * Minimal SSE frame writer. Flushes after each event so a slow client sees progress rather
+     * than a batched dump at close. Package-private for testing.
+     */
+    static final class SseWriter {
+        private final java.io.Writer writer;
+
+        SseWriter(java.io.Writer writer) {
+            this.writer = writer;
+        }
+
+        /**
+         * Emit one SSE event with a name and JSON data payload. Multi-line payloads are rare on
+         * this endpoint (we control the JSON serialiser) but we still handle {@code \n} correctly
+         * per spec — every line after the first is prefixed with {@code data: }.
+         */
+        void event(String name, String jsonData) throws java.io.IOException {
+            writer.write("event: ");
+            writer.write(name);
+            writer.write('\n');
+            // Each line of the payload gets its own `data: ` prefix per the SSE spec. Our JSON is
+            // single-line but this keeps the writer honest if a future serialiser emits pretty-printed.
+            for (String line : jsonData.split("\n", -1)) {
+                writer.write("data: ");
+                writer.write(line);
+                writer.write('\n');
+            }
+            writer.write('\n');
+            writer.flush();
+        }
+    }
+
     /** Mondrian's parser raises "MDX object '<ref>' not found in cube '<name>'"
      *  whenever an axis or slicer references a member that doesn't exist. We
      *  scan the exception chain for that message and lift it to a 400 with the

--- a/saiku-core/saiku-web/src/test/java/org/saiku/web/rest/resources/AiAskStreamingTest.java
+++ b/saiku-core/saiku-web/src/test/java/org/saiku/web/rest/resources/AiAskStreamingTest.java
@@ -1,0 +1,149 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.web.rest.resources;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+import java.io.StringWriter;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.junit.Test;
+import org.saiku.web.rest.resources.AiQueryResource.SseWriter;
+
+/**
+ * Unit tests for the SSE plumbing on {@code POST /ai/ask/stream} (saiku#1433) — the
+ * package-visible helpers {@link AiQueryResource#emitChunks(SseWriter, String)}, {@link
+ * AiQueryResource#jsonString(String)}, and {@link SseWriter#event(String, String)}. The full
+ * endpoint round-trip is covered downstream by the resource integration test — this file locks
+ * the wire format.
+ */
+public class AiAskStreamingTest {
+
+    @Test
+    public void sseWriterEmitsWhatwgFrame() throws IOException {
+        StringWriter out = new StringWriter();
+        SseWriter sse = new SseWriter(out);
+        sse.event("model", "{\"model\":\"claude-sonnet-4-6\"}");
+        assertEquals("event: model\ndata: {\"model\":\"claude-sonnet-4-6\"}\n\n", out.toString());
+    }
+
+    @Test
+    public void sseWriterHandlesMultiLineData() throws IOException {
+        // Per the WHATWG SSE spec, multi-line data payloads must have `data: ` prefixed on every
+        // line. Our JSON is single-line by convention but the writer must be honest — a future
+        // serialiser choosing pretty-print mustn't break the wire format.
+        StringWriter out = new StringWriter();
+        SseWriter sse = new SseWriter(out);
+        sse.event("chunk", "line-one\nline-two\nline-three");
+        String expected = "event: chunk\ndata: line-one\ndata: line-two\ndata: line-three\n\n";
+        assertEquals(expected, out.toString());
+    }
+
+    @Test
+    public void jsonStringEscapesRequiredCharacters() {
+        assertEquals("\"hello\"", AiQueryResource.jsonString("hello"));
+        assertEquals("\"say \\\"hi\\\"\"", AiQueryResource.jsonString("say \"hi\""));
+        assertEquals("\"back\\\\slash\"", AiQueryResource.jsonString("back\\slash"));
+        assertEquals("\"line\\nbreak\"", AiQueryResource.jsonString("line\nbreak"));
+        assertEquals("\"tab\\there\"", AiQueryResource.jsonString("tab\there"));
+        assertEquals("\"\\u0001control\"", AiQueryResource.jsonString("control"));
+    }
+
+    @Test
+    public void emitChunksSplitsOnWordBoundariesAndPreservesWhitespace() throws IOException {
+        StringWriter out = new StringWriter();
+        SseWriter sse = new SseWriter(out);
+        AiQueryResource.emitChunks(sse, "Store sales trended up.");
+
+        List<String> deltas = parseChunkDeltas(out.toString());
+        // Each chunk carries a word + the trailing whitespace so `String.join("", deltas)` == input.
+        assertEquals("Store sales trended up.", String.join("", deltas));
+        // At least three chunks — the exact count depends on whitespace runs; the invariant is
+        // that concatenation is lossless.
+        assertTrue("expected multiple chunks, got " + deltas.size(), deltas.size() >= 3);
+    }
+
+    @Test
+    public void emitChunksHandlesLongMarkdown() throws IOException {
+        StringWriter out = new StringWriter();
+        SseWriter sse = new SseWriter(out);
+        String markdown = "The Northeast region led sales at $250K, followed by the Midwest at "
+                + "$180K. Product Family 'Food' dominated: 62% of the total. Non-consumables "
+                + "trailed at 8%, a 4-point drop week-on-week.";
+        AiQueryResource.emitChunks(sse, markdown);
+
+        List<String> deltas = parseChunkDeltas(out.toString());
+        assertEquals("concatenated deltas recover the source", markdown, String.join("", deltas));
+    }
+
+    @Test
+    public void emitChunksHandlesEmptyString() throws IOException {
+        StringWriter out = new StringWriter();
+        SseWriter sse = new SseWriter(out);
+        AiQueryResource.emitChunks(sse, "");
+        assertEquals("empty prose emits no events", "", out.toString());
+    }
+
+    @Test
+    public void emitChunksHandlesEmbeddedQuotes() throws IOException {
+        // The insight might contain quoted member names — verify the JSON escaping survives the
+        // chunk pipeline so the client's JSON parser doesn't choke.
+        StringWriter out = new StringWriter();
+        SseWriter sse = new SseWriter(out);
+        AiQueryResource.emitChunks(sse, "Region \"Northeast\" up.");
+
+        String frame = out.toString();
+        // Every chunk event must contain a well-formed JSON string field.
+        assertFalse("frame must not contain unescaped bare quote", frame.contains("\"Northeast\""));
+        assertTrue(frame.contains("\\\"Northeast\\\""));
+    }
+
+    /** Extract the {@code delta} values from a stream of chunk events for round-trip assertions. */
+    private static List<String> parseChunkDeltas(String frame) {
+        Pattern p = Pattern.compile("event: chunk\\ndata: \\{\"delta\":\"((?:\\\\.|[^\"\\\\])*)\"\\}");
+        Matcher m = p.matcher(frame);
+        List<String> out = new ArrayList<>();
+        while (m.find()) {
+            out.add(unescape(m.group(1)));
+        }
+        return out;
+    }
+
+    /** Undo the JSON-string escapes {@link AiQueryResource#jsonString} produces. */
+    private static String unescape(String s) {
+        StringBuilder b = new StringBuilder(s.length());
+        int i = 0;
+        while (i < s.length()) {
+            char c = s.charAt(i);
+            if (c == '\\' && i + 1 < s.length()) {
+                char n = s.charAt(i + 1);
+                switch (n) {
+                    case '"' -> b.append('"');
+                    case '\\' -> b.append('\\');
+                    case 'n' -> b.append('\n');
+                    case 'r' -> b.append('\r');
+                    case 't' -> b.append('\t');
+                    case 'b' -> b.append('\b');
+                    case 'f' -> b.append('\f');
+                    case 'u' -> {
+                        b.append((char) Integer.parseInt(s.substring(i + 2, i + 6), 16));
+                        i += 4;
+                    }
+                    default -> b.append(n);
+                }
+                i += 2;
+            } else {
+                b.append(c);
+                i++;
+            }
+        }
+        return b.toString();
+    }
+}


### PR DESCRIPTION
Closes #1433 for the endpoint + wire format. Per-token LLM streaming (from the provider side) is a follow-up.

## Summary

Companion to `POST /ai/ask` that speaks Server-Sent Events per [WHATWG](https://html.spec.whatwg.org/multipage/server-sent-events.html). Enables embedded chat surfaces to render progress token-by-token rather than blocking on the full round-trip.

## Wire format

```
event: model
data: {"model":"claude-sonnet-4-6"}

event: intent
data: {"kind":"INSIGHT"}

event: chunk
data: {"delta":"Store "}

event: chunk
data: {"delta":"Sales trended up 12% week-on-week."}

event: final
data: {"degraded":false,"model":"claude-sonnet-4-6","insight":{"markdown":"Store Sales..."}}
```

| Event    | When                                                                         | Payload                                                        |
|----------|------------------------------------------------------------------------------|----------------------------------------------------------------|
| `model`  | Always fires first when the provider returned a model id                     | `{"model": "<id>"}`                                             |
| `intent` | After tool routing, before payload                                           | `{"kind": "QUERY" \| "INSIGHT" \| "VIEW_CHANGE"}`               |
| `chunk`  | Zero or more times for prose-carrying intents (INSIGHT, VIEW_CHANGE.reason)  | `{"delta": "<word-boundary chunk>"}`                            |
| `final`  | Always fires last on success                                                 | complete `AskResponse` envelope — same shape as sync `/ai/ask`   |
| `error`  | On provider transport / parse / auth failure                                 | `{"reason": "<explanation>"}` — followed by `final` with `degraded:true` |

## Streaming semantics (v1)

The underlying provider call is still synchronous — the LLM's tool-use response arrives whole. The endpoint then splits any prose fields (insight markdown, view-change reason) into word-sized deltas so the client renders progressively. **The wire shape above is stable**; a future PR that plugs in real LLM streaming won't require client changes.

Why not real LLM streaming today?
- Both Anthropic and OpenAI have streaming APIs, but their **tool-use streaming payloads** are non-trivial to accumulate at the `AbstractNlAskProvider` seam (Anthropic emits `content_block_delta` events with `input_json_delta` fragments; OpenAI drips `tool_calls[].function.arguments` chunks in `choices[].delta`).
- Both parsers can land as separate PRs against the same wire format, one provider at a time.
- The "fake stream" today ships the UX win (progressive chat render) with zero changes to the provider layer.

## Auth / rate limit / size cap

Identical to the sync `/ai/ask` endpoint — `AiAskGuard.checkSize`, `askRateLimiter.tryAcquire`, `aiPolicyGuard.assertCanSend`. The streaming variant is **not** a bypass surface.

## Response headers

- `Content-Type: text/event-stream`
- `Cache-Control: no-cache`
- `X-Accel-Buffering: no` (Nginx: disables buffering so events flush)

## What's here

- `POST /ai/ask/stream` — new endpoint on `AiQueryResource`
- `SseWriter` — minimal WHATWG-compliant SSE frame writer, package-visible for testing
- `emitChunks(SseWriter, String)` — word-boundary splitter that keeps deltas lossless on concatenation
- `jsonString(String)` — JSON-string escape helper (avoids Jackson round-trip per token)
- Docs at `docs/AI-QUERY-API.md` — new "Streaming variant" subsection with wire format, event schema, semantics note, and worked examples for `EventSource` and `fetch`

## Tests

7 unit tests locking down the SSE plumbing:

- `SseWriter` emits WHATWG-compliant frames (event + data + double-newline)
- Multi-line data payloads get `data: ` on every line per spec
- `jsonString` escapes required chars: `"`, `\`, `\n`, `\r`, `\t`, `\b`, `\f`, control chars
- `emitChunks` splits on word boundaries — concatenation is lossless
- Long markdown round-trips
- Empty prose emits no events
- Embedded quotes survive escaping through the chunk pipeline

Full web suite: **478 tests, 0 failures**. Spotless clean.

## Test plan

- [ ] `curl -N -X POST -u admin:admin -H 'content-type: application/json' http://localhost:8080/rest/saiku/api/ai/ask/stream -d '{"question":"...","cube":{...}}'` — receives SSE events
- [ ] Client accumulates deltas correctly — final markdown matches the sync endpoint's response
- [ ] Insight intent: progressive `chunk` events, then `final`
- [ ] Query intent: no `chunk` events, only `model` → `intent` → `final` (with executed result)
- [ ] Refused intent: `error` event, then `final` with `degraded:true, reason:"OFF_TOPIC: ..."`
- [ ] Nginx / traefik / envoy: `X-Accel-Buffering: no` correctly disables buffering
- [ ] Rate-limit exceeded: 429 with `{"reason":"Too many..."}` — not an SSE stream (verifies guards fire before the streaming path takes over)

## Non-goals for this slice

- **True per-token LLM streaming** — deferred; wire shape is stable so this can land per-provider without breaking clients.
- **`StreamingNlAskProvider` interface** — needs the wire-level stream parsers first; adding the interface with only fake-stream implementations is churn.
- **QUERY-intent progressive events** — structured output has nothing meaningful to split. The `final` event carries the whole envelope in one frame; the client's SSE reader is uniform across intents.
- **Space-scoped streaming** (`/ai/spaces/{id}/ask/stream`) — mirror endpoint on top of the persona layer; ~30 min follow-up once #1442 (spaces) merges.

## Related

- Feature ticket: #1433
- Sync sibling: `POST /ai/ask` (documented in `docs/AI-QUERY-API.md`)
- Docs: `docs/AI-QUERY-API.md` — "Streaming variant" section