### PR TITLE
#1424 feat(ai/eval): YAML ground-truth harness for agent evals

### DIFF
--- a/docs/EVAL-SPEC.md
+++ b/docs/EVAL-SPEC.md
@@ -1,0 +1,231 @@
+# Agent-eval framework — YAML ground-truth harness (`saiku-home/evals/`)
+
+Ships in saiku v4.7 as [saiku#1424](https://github.com/spiculedata/saiku/issues/1424).
+
+The eval framework runs a suite of ground-truth cases against the ask
+surface and reports where the LLM diverged from expectations. Every
+case is a **YAML file** committed alongside the semantic model. CI
+runs the suite and fails the build when a regression lands — the same
+review discipline the semantic layer itself gets.
+
+Deliberate design: **no LLM-as-judge.** Cube's Evals bills its harness
+as "deterministic result-set diff" for a reason — LLM-as-judge is
+expensive, non-reproducible, and lets subtle wrong answers slip
+through. Saiku's runner does the same job the hard way: direct value
+comparison with numeric tolerance and explicit key normalisation.
+
+## On-disk shape
+
+Suites live as YAML files under `saiku-home/evals/`. One suite per
+file. Each suite targets one cube; every case in the suite runs
+against it.
+
+```yaml title="saiku-home/evals/foodmart-sales.eval.yaml"
+name: foodmart-sales-evals
+description: Ground-truth cases for the FoodMart Sales cube
+cube:
+  connectionName: unknown_foodmart
+  catalog: FoodMart
+  schema: FoodMart
+  cubeName: Sales
+
+cases:
+  # QUERY case — expected rows compared with tolerance.
+  - name: sales-by-country
+    question: show me store sales by country
+    expectedIntent: QUERY
+    expectedRows:
+      - {country: "USA",    storeSales: 565238.13}
+      - {country: "Canada", storeSales:  79063.11}
+      - {country: "Mexico", storeSales:  51298.13}
+    tolerance:
+      relative: 0.001    # 0.1% relative — masks sub-cent warehouse drift
+    orderMatters: true
+
+  # INSIGHT case — insight markdown must contain each string.
+  - name: trend-analysis
+    question: are sales trending up week-on-week?
+    expectedIntent: INSIGHT
+    expectedInsightContains:
+      - Store Sales
+      - week-on-week
+
+  # REFUSED case — model must decline off-topic with a matching reason.
+  - name: refuse-off-topic
+    question: what's the weather in Paris?
+    expectedIntent: REFUSED
+    expectedRefusalContains: cube
+
+  # Multi-turn case — history seeds the ask.
+  - name: follow-up-turn
+    question: now break it down by state
+    history:
+      - {role: user,      content: show store sales by country}
+      - {role: assistant, content: 3 rows returned.}
+    expectedIntent: QUERY
+    expectedRows:
+      - {state: "CA", storeSales: 214893.10}
+      - {state: "OR", storeSales: 108737.55}
+```
+
+## Fields
+
+### Suite-level
+
+| Field         | Required | Type              | Notes                                                            |
+|---------------|----------|-------------------|------------------------------------------------------------------|
+| `name`        | yes      | string            | Displayed in the report; used as the CI job's summary identifier |
+| `description` | no       | string            | Free-text shown in the report header                             |
+| `cube`        | yes      | object            | Cube ref every case in the suite targets                         |
+| `cases`       | yes      | array             | Non-empty list of ground-truth cases                             |
+
+### Case-level
+
+| Field                        | Required | Type              | Notes                                                                                            |
+|------------------------------|----------|-------------------|--------------------------------------------------------------------------------------------------|
+| `name`                       | yes      | string            | Unique within the suite. Used in the mismatch path.                                              |
+| `question`                   | yes      | string            | Natural-language ask fed to `POST /ai/ask`                                                       |
+| `history`                    | no       | array of `{role, content}` | Prior turns to seed the ask. Empty for single-shot cases.                                    |
+| `expectedIntent`             | no       | string            | `QUERY` \| `INSIGHT` \| `VIEW_CHANGE` \| `REFUSED` (case-insensitive)                             |
+| `expectedRefusalContains`    | no       | string            | Substring the refusal reason must contain. Only meaningful with `expectedIntent: REFUSED`.       |
+| `expectedRows`               | no       | array of maps     | Expected result rows for `QUERY`. See [Row comparison](#row-comparison) below.                   |
+| `orderMatters`               | no       | boolean           | Defaults `true`. When `false`, both sides sort by keys before diff.                              |
+| `expectedInsightContains`    | no       | array of strings  | Substrings the insight markdown must contain. Substring match, not exact.                        |
+| `tolerance`                  | no       | `{absolute, relative}` | Numeric tolerance for row comparisons. Both default to `0.0` (exact match).                     |
+
+## Row comparison
+
+### Key normalisation
+
+Column keys compare case-insensitively with whitespace, underscores, and
+hyphens stripped:
+
+- `Store Sales`
+- `storeSales`
+- `store_sales`
+- `STORE-SALES`
+
+All normalise to the same key. Prevents a rename in the schema-projector's
+output shape from failing every eval that references the column.
+
+### Numeric parsing
+
+Expected values that parse as numbers are compared numerically with
+tolerance. The parser is forgiving about how eval authors write numbers:
+
+- `500.0`, `500`, `500.00` — all parse as 500
+- `"$565,238.13"` — currency prefixes and thousands separators stripped
+- `"(500)"` — parenthesised negatives → -500
+- `"12%"` — trailing % stripped; compared as 12
+
+Non-numeric expected values are compared as strings (whitespace-trimmed
+on both sides).
+
+### Tolerance
+
+```yaml
+tolerance:
+  absolute: 0.01     # cell passes if |actual - expected| <= 0.01
+  relative: 0.001    # cell passes if |actual - expected| / |expected| <= 0.001
+```
+
+A cell passes if **either** tolerance is satisfied — set both when you
+want "5 cents absolute OR 0.1% relative, whichever is looser".
+
+Absolute and relative both default to zero (exact match).
+
+### Missing keys are asymmetric
+
+- An expected key not present in the actual row is a **mismatch** — the
+  operator authored an expectation that the schema doesn't produce.
+- An actual key **not** in the expectation is **NOT** — expectations are
+  additive so growing the schema with a new column doesn't break every
+  eval.
+
+## Reports
+
+The runner emits an {@link EvalReport} carrying one outcome per case
+plus a one-line CI summary:
+
+```
+Suite: foodmart-sales-evals
+Description: Ground-truth cases for the FoodMart Sales cube
+9/10 passed, 1 failed, 0 degraded, 0 skipped (elapsed 12483ms)
+
+PASS: sales-by-country (854ms, intent=QUERY, model=claude-sonnet-4-6)
+PASS: trend-analysis (742ms, intent=INSIGHT, model=claude-sonnet-4-6)
+PASS: refuse-off-topic (312ms, intent=REFUSED, model=claude-sonnet-4-6)
+FAIL: top-3-product-families (1024ms, intent=QUERY, model=claude-sonnet-4-6)
+  rows[0].productFamily: expected "Food", got "Drink"
+  rows[1].productFamily: expected "Non-Consumable", got "Food"
+  rows[2].productFamily: expected "Drink", got "Non-Consumable"
+```
+
+Rendered via [`EvalReportWriter.toText`](../saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ai/eval/EvalReportWriter.java).
+Also available as pretty-printed JSON via `toJson` for CI archives.
+
+## Error codes
+
+Structured YAML-parse failures surface with a stable code so CI can
+distinguish "author wrote a broken YAML" from "the ask surface produced
+a wrong answer":
+
+| Code                | When                                                                     |
+|---------------------|--------------------------------------------------------------------------|
+| `MALFORMED_YAML`    | The YAML parser rejected the file.                                       |
+| `MISSING_FIELD`     | A required field is absent (`name`, `cube`, `cases`, `question`).        |
+| `BLANK_FIELD`       | A required string field is present but empty.                            |
+| `TYPE_MISMATCH`     | A field has the wrong type (e.g. `cases` is a mapping, not an array).    |
+| `INVALID_TOLERANCE` | `tolerance.absolute` or `tolerance.relative` is negative.                |
+
+## Non-goals for v1
+
+- **REST endpoint** to trigger runs — the runner is programmatic in v1.
+  CLI + REST wrappers are a follow-up.
+- **`saiku eval` CLI subcommand** — deferred.
+- **Recording adapter** — an adapter that writes each live response to
+  a fixture file so the fixture adapter can replay deterministically
+  without spending LLM budget. Design ready; implementation deferred.
+- **Cross-run comparison** — "is today's eval worse than yesterday's?"
+  Requires report archiving. Follow-up.
+- **Structural diff on the emitted AiQueryRequest** (as opposed to the
+  executed row-set) — multiple structurally-different requests can
+  produce the same rows, so row-diff is a better ground truth.
+
+## CI integration
+
+The runner is a plain Java class:
+
+```java
+import org.saiku.service.olap.ai.eval.*;
+
+EvalSuite suite = EvalYamlReader.read(new FileReader("saiku-home/evals/foodmart-sales.eval.yaml"),
+    "foodmart-sales.eval.yaml");
+EvalAskAdapter live = new LiveAskAdapter(askService, thinQueryService); // wire your ask + execute
+EvalReport report = new AgentEvalRunner(live).run(suite);
+
+System.out.println(EvalReportWriter.toText(report));
+if (!report.allPassed()) {
+  System.exit(1); // fail the CI job on any FAIL or DEGRADED outcome
+}
+```
+
+A GitHub Actions workflow that runs on PR:
+
+```yaml title=".github/workflows/agent-evals.yml"
+name: agent-evals
+on: [pull_request]
+jobs:
+  evals:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-java@v4
+        with: { java-version: '21', distribution: 'temurin' }
+      - name: Run eval suite
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        run: |
+          # Boot the launcher, run the eval suite, fail the job on any regression.
+          ./scripts/run-evals.sh saiku-home/evals/
+```

--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ai/eval/AgentEvalRunner.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ai/eval/AgentEvalRunner.java
@@ -1,0 +1,135 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.service.olap.ai.eval;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.Objects;
+import org.saiku.service.olap.ai.eval.EvalOutcome.Mismatch;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Runs an {@link EvalSuite} through an {@link EvalAskAdapter} and returns a per-case
+ * {@link EvalReport} (saiku#1424).
+ *
+ * <p>The runner is intentionally passive on scheduling — cases execute sequentially in the order
+ * the suite defines them. Parallel execution across cases is deferred (it'd invalidate the
+ * history-threaded turn model and complicate rate-limit accounting) but any case that itself
+ * takes minutes can be moved to its own smaller suite so a failure in one doesn't block the
+ * others.
+ *
+ * <p>Threading model: safe to call concurrently across suites (the runner is stateless). Not
+ * safe to invoke twice against the same suite in parallel — the {@link EvalAskAdapter} contract
+ * doesn't require thread-safety.
+ */
+public final class AgentEvalRunner {
+
+    private static final Logger log = LoggerFactory.getLogger(AgentEvalRunner.class);
+
+    private final EvalAskAdapter adapter;
+
+    public AgentEvalRunner(EvalAskAdapter adapter) {
+        this.adapter = Objects.requireNonNull(adapter, "adapter");
+    }
+
+    /**
+     * Execute every case in {@code suite} and return the aggregated report.
+     *
+     * @param suite the ground-truth cases
+     * @throws NullPointerException if {@code suite} is null
+     */
+    public EvalReport run(EvalSuite suite) {
+        Objects.requireNonNull(suite, "suite");
+        long suiteStart = nowMillis();
+        List<EvalOutcome> outcomes = new ArrayList<>(suite.cases().size());
+        for (EvalCase c : suite.cases()) {
+            outcomes.add(runOneCase(suite, c));
+        }
+        long total = nowMillis() - suiteStart;
+        EvalReport report = new EvalReport(suite.name(), suite.description(), outcomes, total);
+        log.info("Eval suite '{}' finished: {}", suite.name(), report.oneLine());
+        return report;
+    }
+
+    private EvalOutcome runOneCase(EvalSuite suite, EvalCase c) {
+        long start = nowMillis();
+        EvalAskResult result;
+        try {
+            result = adapter.ask(suite.cube(), c.question(), c.history());
+        } catch (RuntimeException e) {
+            log.warn(
+                    "Case '{}' raised {} — treating as degraded",
+                    c.name(),
+                    e.getClass().getSimpleName(),
+                    e);
+            return EvalOutcome.degraded(
+                    c.name(), nowMillis() - start, e.getClass().getSimpleName() + ": " + e.getMessage(), null);
+        }
+        long durationMs = nowMillis() - start;
+
+        if (result == null) {
+            return EvalOutcome.degraded(c.name(), durationMs, "adapter returned null", null);
+        }
+        if (result.degraded()) {
+            return EvalOutcome.degraded(c.name(), durationMs, result.degradedReason(), result.model());
+        }
+
+        List<Mismatch> mismatches = new ArrayList<>();
+
+        // 1. Intent match (cheap check, runs first).
+        if (c.expectedIntent() != null) {
+            String expected = c.expectedIntent().toUpperCase(Locale.ROOT);
+            String actual = result.intent() == null ? "" : result.intent().toUpperCase(Locale.ROOT);
+            if (!expected.equals(actual)) {
+                mismatches.add(new Mismatch("intent", "expected " + expected + ", got " + actual));
+                // Bail out of the deeper checks — comparing REFUSED-shape expectations against a
+                // QUERY-shape actual produces confusing cascade failures. Report the intent
+                // mismatch and stop.
+                return EvalOutcome.fail(c.name(), durationMs, result.intent(), result.model(), mismatches);
+            }
+        }
+
+        // 2. Refusal reason substring match.
+        if (c.expectedRefusalContains() != null) {
+            String reason = result.refusalReason() == null ? "" : result.refusalReason();
+            if (!reason.contains(c.expectedRefusalContains())) {
+                mismatches.add(new Mismatch(
+                        "refusalReason",
+                        "expected reason to contain \"" + c.expectedRefusalContains() + "\", got \"" + reason + "\""));
+            }
+        }
+
+        // 3. Rows comparison for QUERY intent.
+        if (c.expectedRows() != null && !c.expectedRows().isEmpty()) {
+            EvalTolerance tol = c.tolerance() == null ? EvalTolerance.EXACT : c.tolerance();
+            mismatches.addAll(RowComparator.compare(c.expectedRows(), result.rows(), tol, c.orderMatters()));
+        }
+
+        // 4. Insight substring matches.
+        if (c.expectedInsightContains() != null && !c.expectedInsightContains().isEmpty()) {
+            String markdown = result.insightMarkdown() == null ? "" : result.insightMarkdown();
+            for (String needle : c.expectedInsightContains()) {
+                if (!markdown.contains(needle)) {
+                    mismatches.add(new Mismatch("insight.markdown", "expected markdown to contain \"" + needle + "\""));
+                }
+            }
+        }
+
+        if (mismatches.isEmpty()) {
+            return EvalOutcome.pass(c.name(), durationMs, result.intent(), result.model());
+        }
+        return EvalOutcome.fail(c.name(), durationMs, result.intent(), result.model(), mismatches);
+    }
+
+    /**
+     * Package-private clock hook — overridden in tests so timings are deterministic. Production
+     * always uses {@link System#currentTimeMillis}.
+     */
+    long nowMillis() {
+        return System.currentTimeMillis();
+    }
+}

--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ai/eval/EvalAskAdapter.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ai/eval/EvalAskAdapter.java
@@ -1,0 +1,46 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.service.olap.ai.eval;
+
+import java.util.List;
+import java.util.Map;
+import org.saiku.service.olap.ai.AiCubeRef;
+
+/**
+ * SPI the eval runner uses to call an ask surface (saiku#1424).
+ *
+ * <p>Deliberately narrow: the runner passes in a cube ref + question + history + tolerance-hint
+ * and gets an {@link EvalAskResult} back. Adapters translate their own configured ask flow into
+ * that neutral shape:
+ *
+ * <ul>
+ *   <li><b>Live adapter</b> — wraps {@code AiAskService.ask} + query execution. Used by CI runs
+ *       against a real LLM. Requires a launcher (or in-process bean wiring) with a configured
+ *       provider.
+ *   <li><b>Fixture adapter</b> — returns canned {@link EvalAskResult}s from disk. Used by
+ *       runner unit tests and by CI runs that want deterministic regression checks without
+ *       spending LLM budget.
+ *   <li><b>Recording adapter</b> — wraps a live adapter and writes each response to disk, so the
+ *       fixture adapter has something to replay from later.
+ * </ul>
+ *
+ * <p>Adapters are single-shot per case — the runner invokes {@link #ask} once per case in order.
+ * Implementations are free to be stateful (a recording adapter accumulates its output between
+ * calls) as long as they're safe to call sequentially.
+ */
+@FunctionalInterface
+public interface EvalAskAdapter {
+
+    /**
+     * Execute one case's ask.
+     *
+     * @param cube the suite's cube ref
+     * @param question the case's natural-language question
+     * @param history prior turns from the case (empty for single-shot cases)
+     * @return the ask outcome projected into the neutral {@link EvalAskResult}. Never null;
+     *     adapters that hit a hard error return {@link EvalAskResult#forDegraded(String, String)}.
+     */
+    EvalAskResult ask(AiCubeRef cube, String question, List<Map<String, String>> history);
+}

--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ai/eval/EvalAskResult.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ai/eval/EvalAskResult.java
@@ -1,0 +1,63 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.service.olap.ai.eval;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Neutral projection of an ask flow's outcome for the eval runner (saiku#1424). Adapters
+ * translate their own response shapes into this record so the runner can compare against
+ * expectations without knowing whether it's talking to {@code AiAskService}, a REST mock, or a
+ * recorded fixture.
+ *
+ * <p>Exactly one of the intent-specific slots ({@code rows} for QUERY, {@code insightMarkdown}
+ * for INSIGHT, {@code viewMode} for VIEW_CHANGE, {@code refusalReason} for REFUSED) is populated
+ * on success; all are null on {@code degraded=true}.
+ *
+ * @param intent one of {@code "QUERY"}, {@code "INSIGHT"}, {@code "VIEW_CHANGE"}, {@code "REFUSED"},
+ *     or {@code null} on degraded.
+ * @param model the LLM model id that answered, for the report.
+ * @param rows executed result rows for QUERY intent. Each row is a column-key → cell-value map.
+ * @param insightMarkdown insight markdown for INSIGHT intent.
+ * @param viewMode target view mode for VIEW_CHANGE intent.
+ * @param refusalReason the model's refusal sentence for REFUSED intent.
+ * @param degraded true if the ask failed at the provider layer.
+ * @param degradedReason human-readable explanation when {@code degraded}.
+ */
+public record EvalAskResult(
+        String intent,
+        String model,
+        List<Map<String, Object>> rows,
+        String insightMarkdown,
+        String viewMode,
+        String refusalReason,
+        boolean degraded,
+        String degradedReason) {
+
+    public EvalAskResult {
+        rows = rows == null ? null : List.copyOf(rows);
+    }
+
+    public static EvalAskResult forQuery(String model, List<Map<String, Object>> rows) {
+        return new EvalAskResult("QUERY", model, rows, null, null, null, false, null);
+    }
+
+    public static EvalAskResult forInsight(String model, String markdown) {
+        return new EvalAskResult("INSIGHT", model, null, markdown, null, null, false, null);
+    }
+
+    public static EvalAskResult forViewChange(String model, String viewMode) {
+        return new EvalAskResult("VIEW_CHANGE", model, null, null, viewMode, null, false, null);
+    }
+
+    public static EvalAskResult forRefusal(String model, String reason) {
+        return new EvalAskResult("REFUSED", model, null, null, null, reason, false, null);
+    }
+
+    public static EvalAskResult forDegraded(String model, String reason) {
+        return new EvalAskResult(null, model, null, null, null, null, true, reason);
+    }
+}

--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ai/eval/EvalCase.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ai/eval/EvalCase.java
@@ -1,0 +1,80 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.service.olap.ai.eval;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * One ground-truth case in an {@link EvalSuite} (saiku#1424).
+ *
+ * <p>A case pairs a natural-language question with a deterministic expectation. Expectations come
+ * in four flavours, checked in order of specificity:
+ *
+ * <ol>
+ *   <li>{@link #expectedIntent()} — the ask must be routed to a specific intent
+ *       (QUERY / INSIGHT / VIEW_CHANGE / REFUSED). Cheap; runs first.
+ *   <li>{@link #expectedRefusalContains()} — for REFUSED cases, the refusal reason must contain
+ *       this substring. Guards against the model refusing for the wrong reason.
+ *   <li>{@link #expectedRows()} — for QUERY cases, the executed result rows must match. The
+ *       comparator applies {@link #tolerance()} and {@link #orderMatters()}.
+ *   <li>{@link #expectedInsightContains()} — for INSIGHT cases, the markdown must contain each
+ *       string. Substring match rather than exact — an LLM producing "Store Sales up 12%" should
+ *       pass a case expecting {@code ["Store Sales", "up"]} without brittle exact-string
+ *       matching.
+ * </ol>
+ *
+ * <p>All expectation fields are optional; a case with none of them set only asserts that the
+ * response wasn't degraded.
+ *
+ * @param name display name — used in the report. Should be unique within the suite.
+ * @param question the natural-language ask. Fed to {@code POST /ai/ask} verbatim.
+ * @param history prior turns to seed the ask with. Empty for single-shot cases.
+ * @param expectedIntent required intent (case-insensitive). Null skips the check.
+ * @param expectedRefusalContains substring the refusal reason must contain. Only meaningful with
+ *     {@code expectedIntent == "REFUSED"}. Null skips the check.
+ * @param expectedRows expected result rows for QUERY cases. Each row is a map from column key to
+ *     expected value (numeric or string). Null skips the check.
+ * @param orderMatters if true (default), rows must match in order. If false, rows are sorted by
+ *     their keys before diff — useful when the order isn't semantically meaningful.
+ * @param expectedInsightContains list of substrings that must appear in the insight markdown.
+ *     Null / empty skips the check.
+ * @param tolerance numeric tolerance for row comparisons. Applied per-cell to any expected value
+ *     that parses as a number. Null uses the {@link EvalTolerance#EXACT} default (exact match).
+ */
+public record EvalCase(
+        String name,
+        String question,
+        List<Map<String, String>> history,
+        String expectedIntent,
+        String expectedRefusalContains,
+        List<Map<String, Object>> expectedRows,
+        boolean orderMatters,
+        List<String> expectedInsightContains,
+        EvalTolerance tolerance) {
+
+    public EvalCase {
+        Objects.requireNonNull(name, "name");
+        Objects.requireNonNull(question, "question");
+        if (name.isBlank()) {
+            throw new IllegalArgumentException("case name must be non-blank");
+        }
+        if (question.isBlank()) {
+            throw new IllegalArgumentException("case question must be non-blank");
+        }
+        history = history == null ? List.of() : List.copyOf(history);
+        expectedRows = expectedRows == null ? null : List.copyOf(expectedRows);
+        expectedInsightContains = expectedInsightContains == null ? null : List.copyOf(expectedInsightContains);
+    }
+
+    /** Convenience — checks whether any expectation is set. Zero-expectation cases only assert the ask wasn't degraded. */
+    public boolean hasExpectations() {
+        return expectedIntent != null
+                || expectedRefusalContains != null
+                || (expectedRows != null && !expectedRows.isEmpty())
+                || (expectedInsightContains != null && !expectedInsightContains.isEmpty());
+    }
+}

--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ai/eval/EvalOutcome.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ai/eval/EvalOutcome.java
@@ -1,0 +1,74 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.service.olap.ai.eval;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * The result of running one {@link EvalCase} through the runner (saiku#1424).
+ *
+ * <p>Composed of a status enum (pass / fail / degraded / skipped) and a list of {@link Mismatch}es
+ * describing every point where the actual outcome diverged from the case's expectations. The
+ * report generator surfaces mismatches directly so an operator reading a failed CI can see
+ * exactly which row / cell / intent broke without spelunking through logs.
+ *
+ * @param caseName mirror of the source case's name
+ * @param status pass / fail / degraded / skipped
+ * @param mismatches ordered list of specific expectation failures. Empty on {@link Status#PASS}.
+ * @param durationMs wall-clock elapsed to run this case, for reporting
+ * @param actualIntent intent returned by the ask surface, for reporting on failure ("expected
+ *     QUERY, got REFUSED")
+ * @param actualModel LLM model id that answered, for reporting
+ */
+public record EvalOutcome(
+        String caseName,
+        Status status,
+        List<Mismatch> mismatches,
+        long durationMs,
+        String actualIntent,
+        String actualModel) {
+
+    public EvalOutcome {
+        mismatches = mismatches == null ? List.of() : List.copyOf(mismatches);
+    }
+
+    public enum Status {
+        /** Every expectation matched. */
+        PASS,
+        /** At least one expectation didn't match. */
+        FAIL,
+        /** The ask surface returned {@code degraded=true} (provider transport / parse / config error). */
+        DEGRADED,
+        /** The case was intentionally not run (dry-run mode, missing config, etc.). */
+        SKIPPED
+    }
+
+    /**
+     * A single divergence between expected and actual.
+     *
+     * @param path structural path to the mismatch — e.g. {@code "intent"}, {@code "rows[2].storeSales"},
+     *     {@code "insight.markdown"}. Empty on top-level failures.
+     * @param message human-readable one-liner describing the divergence.
+     */
+    public record Mismatch(String path, String message) {}
+
+    /** Convenience: build a passing outcome. */
+    public static EvalOutcome pass(String caseName, long durationMs, String intent, String model) {
+        return new EvalOutcome(caseName, Status.PASS, Collections.emptyList(), durationMs, intent, model);
+    }
+
+    /** Convenience: build a failing outcome from a mismatch list. */
+    public static EvalOutcome fail(
+            String caseName, long durationMs, String intent, String model, List<Mismatch> mismatches) {
+        return new EvalOutcome(caseName, Status.FAIL, mismatches, durationMs, intent, model);
+    }
+
+    /** Convenience: build a degraded outcome for provider failures. */
+    public static EvalOutcome degraded(String caseName, long durationMs, String reason, String model) {
+        return new EvalOutcome(
+                caseName, Status.DEGRADED, List.of(new Mismatch("provider", reason)), durationMs, null, model);
+    }
+}

--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ai/eval/EvalReport.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ai/eval/EvalReport.java
@@ -1,0 +1,68 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.service.olap.ai.eval;
+
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * The aggregated result of running an {@link EvalSuite} (saiku#1424).
+ *
+ * <p>Contains one {@link EvalOutcome} per case plus tallies for the CI summary line
+ * ({@code 47/50 passed, 3 failed, 0 degraded}). Serialisable to JSON (for CI archive) via a
+ * plain {@code ObjectMapper} — the fields are all records or primitives.
+ *
+ * @param suiteName mirror of the source suite's name
+ * @param suiteDescription mirror of the source suite's description
+ * @param outcomes ordered outcomes, one per case
+ * @param totalDurationMs wall-clock elapsed across the whole run
+ */
+public record EvalReport(String suiteName, String suiteDescription, List<EvalOutcome> outcomes, long totalDurationMs) {
+
+    public EvalReport {
+        Objects.requireNonNull(suiteName, "suiteName");
+        outcomes = outcomes == null ? List.of() : List.copyOf(outcomes);
+    }
+
+    /** Number of cases in the suite. */
+    public int totalCases() {
+        return outcomes.size();
+    }
+
+    public int passedCount() {
+        return countByStatus(EvalOutcome.Status.PASS);
+    }
+
+    public int failedCount() {
+        return countByStatus(EvalOutcome.Status.FAIL);
+    }
+
+    public int degradedCount() {
+        return countByStatus(EvalOutcome.Status.DEGRADED);
+    }
+
+    public int skippedCount() {
+        return countByStatus(EvalOutcome.Status.SKIPPED);
+    }
+
+    /** True when every case passed. Used by CI to decide the run's exit code. */
+    public boolean allPassed() {
+        return failedCount() == 0 && degradedCount() == 0;
+    }
+
+    /** Single-line CI summary: {@code "3/5 passed, 1 failed, 1 degraded, 0 skipped"}. */
+    public String oneLine() {
+        return passedCount() + "/" + totalCases() + " passed, " + failedCount() + " failed, " + degradedCount()
+                + " degraded, " + skippedCount() + " skipped";
+    }
+
+    private int countByStatus(EvalOutcome.Status s) {
+        int n = 0;
+        for (EvalOutcome o : outcomes) {
+            if (o.status() == s) n++;
+        }
+        return n;
+    }
+}

--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ai/eval/EvalReportWriter.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ai/eval/EvalReportWriter.java
@@ -1,0 +1,110 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.service.olap.ai.eval;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import java.util.List;
+
+/**
+ * Formatters for an {@link EvalReport} (saiku#1424).
+ *
+ * <p>Two shapes:
+ *
+ * <ul>
+ *   <li>{@link #toJson(EvalReport)} — pretty-printed JSON. What CI archives; what a downstream
+ *       tool re-parses.
+ *   <li>{@link #toText(EvalReport)} — human-readable multi-line summary. What operators eyeball
+ *       when a run fails and they want to know which case broke without opening the JSON.
+ * </ul>
+ *
+ * <p>Both are static utilities — the report itself carries all the information; the writer just
+ * decides how to render it.
+ */
+public final class EvalReportWriter {
+
+    private static final ObjectMapper JSON = new ObjectMapper().enable(SerializationFeature.INDENT_OUTPUT);
+
+    private EvalReportWriter() {}
+
+    /** Pretty-print the report as JSON. */
+    public static String toJson(EvalReport report) {
+        try {
+            return JSON.writeValueAsString(report);
+        } catch (JsonProcessingException e) {
+            // Records + primitives — should never fail. Fall back to the one-liner if it does.
+            return "{\"error\":\"json write failed: " + e.getMessage() + "\", \"summary\":\"" + report.oneLine()
+                    + "\"}";
+        }
+    }
+
+    /**
+     * Human-readable text summary. Format:
+     *
+     * <pre>{@code
+     * Suite: foodmart-sales-evals
+     * Description: Ground-truth cases for FoodMart Sales
+     * 3/5 passed, 1 failed, 1 degraded, 0 skipped (elapsed 421ms)
+     *
+     * FAIL: top-3-product-families (128ms, intent=QUERY, model=claude-sonnet-4-6)
+     *   rows[0].productFamily: expected "Food", got "Drink"
+     *   rows[1].productFamily: expected "Non-Consumable", got "Food"
+     *
+     * DEGRADED: refuse-off-topic (12ms, model=null)
+     *   provider: HTTP 503: upstream unavailable
+     * }</pre>
+     */
+    public static String toText(EvalReport report) {
+        StringBuilder b = new StringBuilder();
+        b.append("Suite: ").append(report.suiteName()).append('\n');
+        if (report.suiteDescription() != null && !report.suiteDescription().isBlank()) {
+            b.append("Description: ").append(report.suiteDescription()).append('\n');
+        }
+        b.append(report.oneLine())
+                .append(" (elapsed ")
+                .append(report.totalDurationMs())
+                .append("ms)\n\n");
+
+        for (EvalOutcome o : report.outcomes()) {
+            if (o.status() == EvalOutcome.Status.PASS) {
+                // Successes get a single-line log — the CI summary handles the passing case
+                // overview. Detailed failure lines below are what matter to the reader.
+                b.append("PASS: ")
+                        .append(o.caseName())
+                        .append(" (")
+                        .append(o.durationMs())
+                        .append("ms, intent=")
+                        .append(nullSafe(o.actualIntent()))
+                        .append(", model=")
+                        .append(nullSafe(o.actualModel()))
+                        .append(")\n");
+                continue;
+            }
+            b.append(o.status().name())
+                    .append(": ")
+                    .append(o.caseName())
+                    .append(" (")
+                    .append(o.durationMs())
+                    .append("ms, intent=")
+                    .append(nullSafe(o.actualIntent()))
+                    .append(", model=")
+                    .append(nullSafe(o.actualModel()))
+                    .append(")\n");
+            writeMismatches(b, o.mismatches());
+        }
+        return b.toString();
+    }
+
+    private static void writeMismatches(StringBuilder b, List<EvalOutcome.Mismatch> mismatches) {
+        for (EvalOutcome.Mismatch m : mismatches) {
+            b.append("  ").append(m.path()).append(": ").append(m.message()).append('\n');
+        }
+    }
+
+    private static String nullSafe(String s) {
+        return s == null ? "null" : s;
+    }
+}

--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ai/eval/EvalSuite.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ai/eval/EvalSuite.java
@@ -1,0 +1,38 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.service.olap.ai.eval;
+
+import java.util.List;
+import java.util.Objects;
+import org.saiku.service.olap.ai.AiCubeRef;
+
+/**
+ * A named collection of AI-ask ground-truth cases (saiku#1424). Suites are the unit of a CI run;
+ * every case in a suite targets the same cube and the same LLM configuration.
+ *
+ * <p>Suites live as YAML on disk under {@code saiku-home/evals/}. The launcher walks that
+ * directory on demand — evals are not run on boot; they run when {@link AgentEvalRunner} is
+ * invoked (from the CLI, a REST endpoint, or CI).
+ *
+ * @param name a human-readable identifier for the suite. Used in reports and the JUnit-style
+ *     CI summary. Should be filename-safe.
+ * @param description free text — surfaced verbatim in the report header. Optional.
+ * @param cube the cube every case in the suite targets. The runner passes this to the ask flow;
+ *     cases don't override it.
+ * @param cases the ground-truth cases. Ordered — the runner executes them in order so a failure
+ *     surfaces the failing sequence when a case depends on the previous one (rare, but possible
+ *     with history-threaded turns).
+ */
+public record EvalSuite(String name, String description, AiCubeRef cube, List<EvalCase> cases) {
+
+    public EvalSuite {
+        Objects.requireNonNull(name, "name");
+        Objects.requireNonNull(cube, "cube");
+        if (name.isBlank()) {
+            throw new IllegalArgumentException("suite name must be non-blank");
+        }
+        cases = cases == null ? List.of() : List.copyOf(cases);
+    }
+}

--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ai/eval/EvalTolerance.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ai/eval/EvalTolerance.java
@@ -1,0 +1,49 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.service.olap.ai.eval;
+
+/**
+ * Numeric tolerance for row-cell comparisons (saiku#1424).
+ *
+ * <p>Applied per-cell whenever the expected value parses as a number. Non-numeric expected values
+ * (strings, member captions) are always exact-matched. Cases whose data is inherently noisy —
+ * warehouse floating-point drift, sub-cent rounding differences — set a small relative tolerance
+ * so the eval doesn't flag noise as regression.
+ *
+ * @param absolute maximum absolute difference. {@code |actual - expected| <= absolute} passes.
+ *     Zero means exact match (subject to {@link #relative}).
+ * @param relative maximum fractional difference. {@code |actual - expected| / |expected| <= relative}
+ *     passes. Zero means exact match. Relative dominates absolute — a cell passes if EITHER
+ *     tolerance is satisfied.
+ */
+public record EvalTolerance(double absolute, double relative) {
+
+    /** Zero tolerance — expected must equal actual bit-for-bit. */
+    public static final EvalTolerance EXACT = new EvalTolerance(0.0, 0.0);
+
+    public EvalTolerance {
+        if (absolute < 0.0 || Double.isNaN(absolute)) {
+            throw new IllegalArgumentException("absolute tolerance must be >= 0 (got " + absolute + ")");
+        }
+        if (relative < 0.0 || Double.isNaN(relative)) {
+            throw new IllegalArgumentException("relative tolerance must be >= 0 (got " + relative + ")");
+        }
+    }
+
+    /**
+     * Check whether {@code actual} is within tolerance of {@code expected}. Returns true for
+     * exact-match on non-numeric-comparable values (both must be NaN or infinite the same way to
+     * pass — a strict interpretation but tests won't produce those legitimately).
+     */
+    public boolean isWithin(double expected, double actual) {
+        if (Double.isNaN(expected) && Double.isNaN(actual)) return true;
+        if (Double.isNaN(expected) || Double.isNaN(actual)) return false;
+        if (expected == actual) return true;
+        double diff = Math.abs(actual - expected);
+        if (absolute > 0.0 && diff <= absolute) return true;
+        if (relative > 0.0 && expected != 0.0 && diff / Math.abs(expected) <= relative) return true;
+        return false;
+    }
+}

--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ai/eval/EvalYamlReader.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ai/eval/EvalYamlReader.java
@@ -1,0 +1,260 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.service.olap.ai.eval;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.dataformat.yaml.YAMLMapper;
+import java.io.IOException;
+import java.io.Reader;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import org.saiku.service.olap.ai.AiCubeRef;
+
+/**
+ * Loads an {@link EvalSuite} from its on-disk YAML form (saiku#1424).
+ *
+ * <p>Every failure surfaces as {@link EvalParseException} with a stable {@link
+ * EvalParseException#code()} so the report generator can distinguish "author wrote a broken YAML"
+ * from "the ask surface produced a wrong answer" — the two shouldn't be conflated in CI.
+ *
+ * <p>On-disk shape (spec lives at {@code docs/EVAL-SPEC.md}):
+ *
+ * <pre>{@code
+ * name: foodmart-sales-evals
+ * description: Ground-truth cases for FoodMart Sales
+ * cube:
+ *   connectionName: unknown_foodmart
+ *   catalog: FoodMart
+ *   schema: FoodMart
+ *   cubeName: Sales
+ * cases:
+ *   - name: sales-by-country
+ *     question: "show store sales by country"
+ *     expectedRows:
+ *       - {country: "USA", storeSales: 565238.13}
+ *       - {country: "Canada", storeSales: 79063.11}
+ *     tolerance: {relative: 0.001}
+ *     orderMatters: true
+ *   - name: refuse-off-topic
+ *     question: "What's the weather?"
+ *     expectedIntent: REFUSED
+ *     expectedRefusalContains: cube
+ * }</pre>
+ */
+public final class EvalYamlReader {
+
+    private static final YAMLMapper YAML = new YAMLMapper();
+
+    private EvalYamlReader() {}
+
+    public static EvalSuite read(Reader reader, String source) throws EvalParseException {
+        JsonNode node;
+        try {
+            node = YAML.readTree(reader);
+        } catch (IOException e) {
+            throw new EvalParseException("MALFORMED_YAML", source, "not valid YAML: " + e.getMessage());
+        }
+        return read(node, source);
+    }
+
+    public static EvalSuite read(String yaml, String source) throws EvalParseException {
+        JsonNode node;
+        try {
+            node = YAML.readTree(yaml);
+        } catch (IOException e) {
+            throw new EvalParseException("MALFORMED_YAML", source, "not valid YAML: " + e.getMessage());
+        }
+        return read(node, source);
+    }
+
+    private static EvalSuite read(JsonNode node, String source) throws EvalParseException {
+        if (node == null || !node.isObject()) {
+            throw new EvalParseException("MALFORMED_YAML", source, "top-level must be a YAML mapping");
+        }
+        String name = requireStringField(node, "name", source);
+        String description = optionalStringField(node, "description");
+        AiCubeRef cube = readCubeRef(node, source);
+
+        List<EvalCase> cases = new ArrayList<>();
+        JsonNode casesNode = node.get("cases");
+        if (casesNode == null || !casesNode.isArray()) {
+            throw new EvalParseException("MISSING_FIELD", source, "'cases' must be a non-empty list");
+        }
+        int idx = 0;
+        for (JsonNode c : casesNode) {
+            cases.add(readCase(c, source, idx));
+            idx++;
+        }
+        if (cases.isEmpty()) {
+            throw new EvalParseException("MISSING_FIELD", source, "'cases' must be a non-empty list");
+        }
+        return new EvalSuite(name, description, cube, cases);
+    }
+
+    private static AiCubeRef readCubeRef(JsonNode root, String source) throws EvalParseException {
+        JsonNode cubeNode = root.get("cube");
+        if (cubeNode == null || !cubeNode.isObject()) {
+            throw new EvalParseException(
+                    "MISSING_FIELD", source, "'cube' must be an object with connectionName/catalog/schema/cubeName");
+        }
+        return new AiCubeRef(
+                requireStringField(cubeNode, "connectionName", source),
+                requireStringField(cubeNode, "catalog", source),
+                requireStringField(cubeNode, "schema", source),
+                requireStringField(cubeNode, "cubeName", source));
+    }
+
+    private static EvalCase readCase(JsonNode node, String source, int idx) throws EvalParseException {
+        if (node == null || !node.isObject()) {
+            throw new EvalParseException("MALFORMED_YAML", source, "cases[" + idx + "] must be a mapping");
+        }
+        String name = requireStringField(node, "name", source);
+        String question = requireStringField(node, "question", source);
+        String expectedIntent = optionalStringField(node, "expectedIntent");
+        String expectedRefusalContains = optionalStringField(node, "expectedRefusalContains");
+        boolean orderMatters =
+                node.has("orderMatters") ? node.get("orderMatters").asBoolean(true) : true;
+
+        List<Map<String, String>> history = readHistory(node.get("history"), source, idx);
+        List<Map<String, Object>> expectedRows = readRows(node.get("expectedRows"), source, idx);
+        List<String> expectedInsightContains = readStringArray(node.get("expectedInsightContains"), source, idx);
+        EvalTolerance tolerance = readTolerance(node.get("tolerance"), source, idx);
+
+        return new EvalCase(
+                name,
+                question,
+                history,
+                expectedIntent,
+                expectedRefusalContains,
+                expectedRows,
+                orderMatters,
+                expectedInsightContains,
+                tolerance);
+    }
+
+    private static List<Map<String, String>> readHistory(JsonNode h, String source, int idx) throws EvalParseException {
+        if (h == null || h.isNull()) return List.of();
+        if (!h.isArray()) {
+            throw new EvalParseException("TYPE_MISMATCH", source, "cases[" + idx + "].history must be an array");
+        }
+        List<Map<String, String>> out = new ArrayList<>();
+        for (JsonNode entry : h) {
+            if (!entry.isObject()) {
+                throw new EvalParseException(
+                        "TYPE_MISMATCH", source, "cases[" + idx + "].history[] entries must be mappings");
+            }
+            Map<String, String> m = new LinkedHashMap<>();
+            entry.fields().forEachRemaining(f -> m.put(f.getKey(), f.getValue().asText()));
+            out.add(m);
+        }
+        return out;
+    }
+
+    private static List<Map<String, Object>> readRows(JsonNode r, String source, int idx) throws EvalParseException {
+        if (r == null || r.isNull()) return null;
+        if (!r.isArray()) {
+            throw new EvalParseException("TYPE_MISMATCH", source, "cases[" + idx + "].expectedRows must be an array");
+        }
+        List<Map<String, Object>> out = new ArrayList<>();
+        for (JsonNode row : r) {
+            if (!row.isObject()) {
+                throw new EvalParseException(
+                        "TYPE_MISMATCH", source, "cases[" + idx + "].expectedRows[] entries must be mappings");
+            }
+            Map<String, Object> m = new LinkedHashMap<>();
+            row.fields().forEachRemaining(f -> m.put(f.getKey(), jsonScalarToJava(f.getValue())));
+            out.add(m);
+        }
+        return out;
+    }
+
+    private static List<String> readStringArray(JsonNode a, String source, int idx) throws EvalParseException {
+        if (a == null || a.isNull()) return null;
+        if (!a.isArray()) {
+            throw new EvalParseException(
+                    "TYPE_MISMATCH", source, "cases[" + idx + "].expectedInsightContains must be an array");
+        }
+        List<String> out = new ArrayList<>();
+        for (JsonNode e : a) {
+            if (!e.isTextual()) {
+                throw new EvalParseException(
+                        "TYPE_MISMATCH",
+                        source,
+                        "cases[" + idx + "].expectedInsightContains[] entries must be strings");
+            }
+            out.add(e.asText());
+        }
+        return out;
+    }
+
+    private static EvalTolerance readTolerance(JsonNode t, String source, int idx) throws EvalParseException {
+        if (t == null || t.isNull()) return null;
+        if (!t.isObject()) {
+            throw new EvalParseException("TYPE_MISMATCH", source, "cases[" + idx + "].tolerance must be a mapping");
+        }
+        double abs = t.has("absolute") ? t.get("absolute").asDouble(0.0) : 0.0;
+        double rel = t.has("relative") ? t.get("relative").asDouble(0.0) : 0.0;
+        try {
+            return new EvalTolerance(abs, rel);
+        } catch (IllegalArgumentException e) {
+            throw new EvalParseException(
+                    "INVALID_TOLERANCE", source, "cases[" + idx + "].tolerance: " + e.getMessage());
+        }
+    }
+
+    private static Object jsonScalarToJava(JsonNode v) {
+        if (v == null || v.isNull()) return null;
+        if (v.isBoolean()) return v.asBoolean();
+        if (v.isInt()) return v.asInt();
+        if (v.isLong()) return v.asLong();
+        if (v.isDouble() || v.isFloat()) return v.asDouble();
+        if (v.isBigDecimal()) return v.decimalValue();
+        return v.asText();
+    }
+
+    private static String requireStringField(JsonNode node, String field, String source) throws EvalParseException {
+        JsonNode v = node.get(field);
+        if (v == null || v.isNull()) {
+            throw new EvalParseException("MISSING_FIELD", source, "required field '" + field + "' is missing");
+        }
+        if (!v.isTextual()) {
+            throw new EvalParseException("TYPE_MISMATCH", source, "field '" + field + "' must be a string");
+        }
+        String s = v.asText();
+        if (s.isBlank()) {
+            throw new EvalParseException("BLANK_FIELD", source, "field '" + field + "' must be non-blank");
+        }
+        return s;
+    }
+
+    private static String optionalStringField(JsonNode node, String field) {
+        JsonNode v = node.get(field);
+        if (v == null || v.isNull() || !v.isTextual()) return null;
+        String s = v.asText();
+        return s.isBlank() ? null : s;
+    }
+
+    /** Structured YAML-parse failure — mirrors the shape of the skill and space parsers. */
+    public static final class EvalParseException extends Exception {
+        private final String code;
+        private final String source;
+
+        public EvalParseException(String code, String source, String message) {
+            super(message);
+            this.code = code;
+            this.source = source;
+        }
+
+        public String code() {
+            return code;
+        }
+
+        public String source() {
+            return source;
+        }
+    }
+}

--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ai/eval/RowComparator.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ai/eval/RowComparator.java
@@ -1,0 +1,220 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.service.olap.ai.eval;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.TreeMap;
+import org.saiku.service.olap.ai.eval.EvalOutcome.Mismatch;
+
+/**
+ * Deterministic row-set diff for QUERY-intent eval cases (saiku#1424).
+ *
+ * <p>Cube's Evals is billed as "deterministic result-set diff (no LLM-as-judge)" for a reason:
+ * LLM-as-judge is expensive, non-reproducible, and lets subtle wrong answers slip through. This
+ * comparator does the same job the hard way — direct value comparison with numeric tolerance and
+ * explicit key normalisation.
+ *
+ * <p>Comparison rules:
+ *
+ * <ul>
+ *   <li><b>Key normalisation.</b> Column keys are compared case-insensitively with whitespace
+ *       collapsed. {@code "Store Sales"}, {@code "storeSales"}, and {@code "STORE_SALES"} all map
+ *       to the same normalised key. Prevents a rename in the schema-projector's output shape
+ *       from failing every eval.
+ *   <li><b>Order handling.</b> When {@link EvalCase#orderMatters()} is true, rows compare
+ *       positionally. When false, both sides sort by a stable serialisation of their normalised
+ *       keys before diffing.
+ *   <li><b>Numeric tolerance.</b> Any expected value that parses as a number is compared via
+ *       {@link EvalTolerance#isWithin(double, double)}. Non-numeric values compare
+ *       string-equality-after-normalisation.
+ *   <li><b>Missing keys.</b> An expected key not present in the actual row is a mismatch. An
+ *       actual key not expected is NOT — expectations are additive so the eval doesn't break when
+ *       the schema grows a new column.
+ * </ul>
+ *
+ * <p>Every divergence surfaces as an {@link Mismatch} with a precise structural path
+ * ({@code "rows[2].storeSales"}) so the report reader knows exactly where to look.
+ */
+public final class RowComparator {
+
+    private RowComparator() {}
+
+    /**
+     * Diff expected against actual. Returns an empty list on match, one or more mismatches
+     * otherwise.
+     *
+     * @param expected the case's expected rows. Null / empty means no row expectation set — the
+     *     comparator returns empty immediately.
+     * @param actual rows returned by the ask surface. Null is treated as empty.
+     * @param tolerance numeric tolerance. Use {@link EvalTolerance#EXACT} for exact match.
+     * @param orderMatters when true, rows compare positionally; when false, both sides are sorted
+     *     by normalised keys before diff.
+     */
+    public static List<Mismatch> compare(
+            List<Map<String, Object>> expected,
+            List<Map<String, Object>> actual,
+            EvalTolerance tolerance,
+            boolean orderMatters) {
+        List<Mismatch> mismatches = new ArrayList<>();
+        if (expected == null || expected.isEmpty()) {
+            return mismatches;
+        }
+        List<Map<String, Object>> actualList = actual == null ? List.of() : actual;
+
+        // Row-count parity — an eval that expects 3 rows and gets 5 is a bug even if the first
+        // 3 match. Surface both sizes so the report is self-descriptive.
+        if (expected.size() != actualList.size()) {
+            mismatches.add(new Mismatch("rows", "expected " + expected.size() + " row(s), got " + actualList.size()));
+            // Continue comparing to surface which rows differ — better report than "size mismatch,
+            // giving up".
+        }
+
+        // Expected side is iterated with its ORIGINAL keys (so mismatch paths read as the operator
+        // wrote them in the YAML — `rows[2].storeSales`, not `rows[2].storesales`). Actual side is
+        // normalised for the lookup so `Store Sales` on the wire matches `storeSales` in the YAML.
+        List<Map<String, Object>> orderedExpected = orderMatters ? expected : sortStable(expected);
+        List<Map<String, Object>> normalisedActual =
+                actualList.stream().map(RowComparator::normaliseKeys).toList();
+        if (!orderMatters) {
+            normalisedActual = sortStable(normalisedActual);
+        }
+
+        int commonSize = Math.min(orderedExpected.size(), normalisedActual.size());
+        for (int i = 0; i < commonSize; i++) {
+            compareRow(i, orderedExpected.get(i), normalisedActual.get(i), tolerance, mismatches);
+        }
+        return mismatches;
+    }
+
+    private static void compareRow(
+            int index,
+            Map<String, Object> expected,
+            Map<String, Object> actualNormalised,
+            EvalTolerance tolerance,
+            List<Mismatch> out) {
+        for (Map.Entry<String, Object> e : expected.entrySet()) {
+            String originalKey = e.getKey();
+            String normalisedKey = normaliseKey(originalKey);
+            Object expectedValue = e.getValue();
+            if (!actualNormalised.containsKey(normalisedKey)) {
+                out.add(new Mismatch("rows[" + index + "]." + originalKey, "expected key not present in actual row"));
+                continue;
+            }
+            Object actualValue = actualNormalised.get(normalisedKey);
+            Double expectedNumber = asNumber(expectedValue);
+            if (expectedNumber != null) {
+                Double actualNumber = asNumber(actualValue);
+                if (actualNumber == null) {
+                    out.add(new Mismatch(
+                            "rows[" + index + "]." + originalKey,
+                            "expected numeric " + expectedNumber + " but actual is not a number: " + actualValue));
+                    continue;
+                }
+                if (!tolerance.isWithin(expectedNumber, actualNumber)) {
+                    out.add(new Mismatch(
+                            "rows[" + index + "]." + originalKey,
+                            "expected " + expectedNumber + " ± tol(" + tolerance.absolute() + "," + tolerance.relative()
+                                    + "), got " + actualNumber));
+                }
+            } else {
+                // Non-numeric expected — string-normalise both sides for comparison.
+                String expectedStr = normaliseString(expectedValue);
+                String actualStr = normaliseString(actualValue);
+                if (!expectedStr.equals(actualStr)) {
+                    out.add(new Mismatch(
+                            "rows[" + index + "]." + originalKey,
+                            "expected \"" + expectedStr + "\", got \"" + actualStr + "\""));
+                }
+            }
+        }
+    }
+
+    /**
+     * Normalise a column key: lower-case, strip whitespace + underscores + hyphens. Preserves
+     * insertion order via {@link LinkedHashMap} so per-row iteration matches the report.
+     */
+    private static Map<String, Object> normaliseKeys(Map<String, Object> row) {
+        Map<String, Object> out = new LinkedHashMap<>(row.size());
+        for (Map.Entry<String, Object> e : row.entrySet()) {
+            out.put(normaliseKey(e.getKey()), e.getValue());
+        }
+        return out;
+    }
+
+    static String normaliseKey(String key) {
+        if (key == null) return "";
+        StringBuilder b = new StringBuilder(key.length());
+        for (int i = 0; i < key.length(); i++) {
+            char c = key.charAt(i);
+            if (Character.isWhitespace(c) || c == '_' || c == '-') continue;
+            b.append(Character.toLowerCase(c));
+        }
+        return b.toString();
+    }
+
+    private static String normaliseString(Object v) {
+        if (v == null) return "";
+        return v.toString().trim();
+    }
+
+    /**
+     * Parse {@code v} as a double. Returns null for non-numeric values or unparseable strings.
+     * Handles {@link Number}, boxed primitives, and String representations
+     * ({@code "123"}, {@code "$1,234.56"}, {@code "-1.5e3"}). Currency prefixes and thousands
+     * separators are stripped before parsing so eval authors can write {@code "$565,238.13"} and
+     * have it compare cleanly against an unformatted number.
+     */
+    static Double asNumber(Object v) {
+        if (v == null) return null;
+        if (v instanceof Number n) return n.doubleValue();
+        if (v instanceof Boolean) return null;
+        String s = v.toString().trim();
+        if (s.isEmpty()) return null;
+        // Strip common decoration.
+        String cleaned = s.replaceAll("[\\$£€¥,]", "").trim();
+        // Handle parenthesised negatives: "(500)" -> -500.
+        if (cleaned.startsWith("(") && cleaned.endsWith(")")) {
+            cleaned = "-" + cleaned.substring(1, cleaned.length() - 1);
+        }
+        // Handle trailing % — treat as-is (an expected "12%" compares to a "12" numerically).
+        // Callers who want "0.12 vs 12%" semantics can use tolerance.
+        if (cleaned.endsWith("%")) {
+            cleaned = cleaned.substring(0, cleaned.length() - 1).trim();
+        }
+        try {
+            return Double.parseDouble(cleaned);
+        } catch (NumberFormatException e) {
+            return null;
+        }
+    }
+
+    /**
+     * Sort rows by a stable serialisation of their normalised keys. Ties break on insertion
+     * order via {@link Comparator#thenComparing}. Only used when {@code orderMatters = false}.
+     */
+    private static List<Map<String, Object>> sortStable(List<Map<String, Object>> rows) {
+        List<Map<String, Object>> copy = new ArrayList<>(rows);
+        copy.sort(Comparator.comparing(RowComparator::rowKey));
+        return copy;
+    }
+
+    /** Serialise a row into a stable key for sorting. Uses TreeMap iteration order so equal rows produce equal keys. */
+    private static String rowKey(Map<String, Object> row) {
+        StringBuilder b = new StringBuilder();
+        // TreeMap for deterministic iteration order regardless of the source map's ordering.
+        for (Map.Entry<String, Object> e : new TreeMap<>(row).entrySet()) {
+            b.append(e.getKey())
+                    .append('=')
+                    .append(String.valueOf(e.getValue()).toLowerCase(Locale.ROOT))
+                    .append('|');
+        }
+        return b.toString();
+    }
+}

--- a/saiku-core/saiku-service/src/test/java/org/saiku/service/olap/ai/eval/AgentEvalRunnerTest.java
+++ b/saiku-core/saiku-service/src/test/java/org/saiku/service/olap/ai/eval/AgentEvalRunnerTest.java
@@ -1,0 +1,200 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.service.olap.ai.eval;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.util.List;
+import java.util.Map;
+import org.junit.Test;
+import org.saiku.service.olap.ai.AiCubeRef;
+
+public class AgentEvalRunnerTest {
+
+    private static final AiCubeRef CUBE = new AiCubeRef("conn", "cat", "sch", "Sales");
+
+    @Test
+    public void passingSuiteReportsAllGreen() {
+        EvalCase c = new EvalCase(
+                "sales-by-country",
+                "show sales by country",
+                List.of(),
+                "QUERY",
+                null,
+                List.of(map("country", "USA", "storeSales", 500.0)),
+                true,
+                null,
+                EvalTolerance.EXACT);
+        EvalSuite suite = new EvalSuite("t", "test", CUBE, List.of(c));
+
+        EvalAskAdapter adapter = (cube, question, history) ->
+                EvalAskResult.forQuery("stub-model", List.of(map("country", "USA", "storeSales", 500.0)));
+
+        EvalReport report = new AgentEvalRunner(adapter).run(suite);
+        assertTrue(report.allPassed());
+        assertEquals(1, report.passedCount());
+        assertEquals(0, report.failedCount());
+        assertEquals(EvalOutcome.Status.PASS, report.outcomes().get(0).status());
+    }
+
+    @Test
+    public void intentMismatchFailsFastWithoutDeeperChecks() {
+        // A case expecting REFUSED but getting QUERY shouldn't cascade into a "no refusal reason"
+        // failure — the intent mismatch is enough to explain the failure.
+        EvalCase c = new EvalCase(
+                "refuse-off-topic",
+                "what's the weather?",
+                List.of(),
+                "REFUSED",
+                "cube",
+                null,
+                true,
+                null,
+                EvalTolerance.EXACT);
+        EvalSuite suite = new EvalSuite("t", null, CUBE, List.of(c));
+
+        EvalAskAdapter adapter =
+                (cube, question, history) -> EvalAskResult.forQuery("stub-model", List.of(map("weather", "sunny")));
+
+        EvalReport report = new AgentEvalRunner(adapter).run(suite);
+        assertFalse(report.allPassed());
+        assertEquals(EvalOutcome.Status.FAIL, report.outcomes().get(0).status());
+        assertEquals(1, report.outcomes().get(0).mismatches().size());
+        assertEquals("intent", report.outcomes().get(0).mismatches().get(0).path());
+    }
+
+    @Test
+    public void refusalReasonSubstringChecked() {
+        EvalCase c = new EvalCase(
+                "refuse-off-topic",
+                "what's the weather?",
+                List.of(),
+                "REFUSED",
+                "not about this cube",
+                null,
+                true,
+                null,
+                EvalTolerance.EXACT);
+        EvalSuite suite = new EvalSuite("t", null, CUBE, List.of(c));
+
+        EvalAskAdapter adapter = (cube, question, history) ->
+                EvalAskResult.forRefusal("stub-model", "OFF_TOPIC: unrelated to the cube's data");
+
+        EvalReport report = new AgentEvalRunner(adapter).run(suite);
+        assertFalse("refusal reason doesn't contain the expected substring", report.allPassed());
+        assertEquals(
+                "refusalReason", report.outcomes().get(0).mismatches().get(0).path());
+    }
+
+    @Test
+    public void degradedAdapterProducesDegradedOutcome() {
+        EvalCase c = new EvalCase("any", "q", List.of(), null, null, null, true, null, EvalTolerance.EXACT);
+        EvalSuite suite = new EvalSuite("t", null, CUBE, List.of(c));
+
+        EvalAskAdapter adapter =
+                (cube, question, history) -> EvalAskResult.forDegraded("stub-model", "HTTP 503: upstream unavailable");
+
+        EvalReport report = new AgentEvalRunner(adapter).run(suite);
+        assertEquals(1, report.degradedCount());
+        assertEquals(0, report.passedCount());
+        assertFalse(report.allPassed());
+    }
+
+    @Test
+    public void adapterThrowingIsHandledAsDegraded() {
+        // A wire-level exception (network, JSON parse, whatever) must translate to a degraded
+        // outcome — the runner shouldn't fail the whole suite because one case's adapter blew up.
+        EvalCase c = new EvalCase("any", "q", List.of(), null, null, null, true, null, EvalTolerance.EXACT);
+        EvalSuite suite = new EvalSuite("t", null, CUBE, List.of(c));
+
+        EvalAskAdapter adapter = (cube, question, history) -> {
+            throw new RuntimeException("kaboom");
+        };
+
+        EvalReport report = new AgentEvalRunner(adapter).run(suite);
+        assertEquals(1, report.degradedCount());
+    }
+
+    @Test
+    public void insightSubstringMatchWorks() {
+        EvalCase c = new EvalCase(
+                "insight-check",
+                "spot trends",
+                List.of(),
+                "INSIGHT",
+                null,
+                null,
+                true,
+                List.of("Store Sales", "up 12%"),
+                EvalTolerance.EXACT);
+        EvalSuite suite = new EvalSuite("t", null, CUBE, List.of(c));
+
+        EvalAskAdapter adapter = (cube, question, history) ->
+                EvalAskResult.forInsight("stub-model", "Store Sales are up 12% week-on-week.");
+
+        EvalReport report = new AgentEvalRunner(adapter).run(suite);
+        assertTrue(report.allPassed());
+    }
+
+    @Test
+    public void insightMissingSubstringIsMismatch() {
+        EvalCase c = new EvalCase(
+                "insight-check",
+                "spot trends",
+                List.of(),
+                "INSIGHT",
+                null,
+                null,
+                true,
+                List.of("Store Sales", "up 20%"),
+                EvalTolerance.EXACT);
+        EvalSuite suite = new EvalSuite("t", null, CUBE, List.of(c));
+
+        EvalAskAdapter adapter = (cube, question, history) ->
+                EvalAskResult.forInsight("stub-model", "Store Sales are up 12% week-on-week.");
+
+        EvalReport report = new AgentEvalRunner(adapter).run(suite);
+        assertFalse(report.allPassed());
+        // The intent match passes; only the "up 20%" substring should surface.
+        assertEquals(1, report.outcomes().get(0).mismatches().size());
+        assertTrue(report.outcomes().get(0).mismatches().get(0).message().contains("up 20%"));
+    }
+
+    @Test
+    public void oneLineSummaryFormatsCorrectly() {
+        // 2 pass, 1 fail, 1 degraded suite.
+        List<EvalCase> cases = List.of(
+                caseWithExpected("a", "QUERY"),
+                caseWithExpected("b", "QUERY"),
+                caseWithExpected("c", "QUERY"),
+                caseWithExpected("d", "QUERY"));
+        EvalSuite suite = new EvalSuite("t", null, CUBE, cases);
+
+        java.util.Iterator<EvalAskResult> replies = List.of(
+                        EvalAskResult.forQuery("m", List.of()),
+                        EvalAskResult.forQuery("m", List.of()),
+                        EvalAskResult.forInsight("m", "wrong intent"),
+                        EvalAskResult.forDegraded("m", "boom"))
+                .iterator();
+        EvalAskAdapter adapter = (cube, question, history) -> replies.next();
+
+        EvalReport report = new AgentEvalRunner(adapter).run(suite);
+        assertEquals("2/4 passed, 1 failed, 1 degraded, 0 skipped", report.oneLine());
+    }
+
+    /* ---- helpers ---- */
+
+    private static EvalCase caseWithExpected(String name, String intent) {
+        return new EvalCase(name, "q", List.of(), intent, null, null, true, null, EvalTolerance.EXACT);
+    }
+
+    private static Map<String, Object> map(Object... kv) {
+        java.util.LinkedHashMap<String, Object> m = new java.util.LinkedHashMap<>();
+        for (int i = 0; i < kv.length; i += 2) m.put(String.valueOf(kv[i]), kv[i + 1]);
+        return m;
+    }
+}

--- a/saiku-core/saiku-service/src/test/java/org/saiku/service/olap/ai/eval/EvalYamlReaderTest.java
+++ b/saiku-core/saiku-service/src/test/java/org/saiku/service/olap/ai/eval/EvalYamlReaderTest.java
@@ -1,0 +1,182 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.service.olap.ai.eval;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import org.junit.Test;
+
+public class EvalYamlReaderTest {
+
+    private static final String CUBE_BLOCK =
+            "cube:\n  connectionName: unknown_foodmart\n  catalog: FoodMart\n  schema: FoodMart\n  cubeName: Sales\n";
+
+    @Test
+    public void parsesGoldenPath() throws Exception {
+        String yaml = "name: foodmart-evals\n"
+                + "description: Ground-truth cases\n"
+                + CUBE_BLOCK
+                + "cases:\n"
+                + "  - name: sales-by-country\n"
+                + "    question: show store sales by country\n"
+                + "    expectedIntent: QUERY\n"
+                + "    expectedRows:\n"
+                + "      - {country: USA, storeSales: 500.0}\n"
+                + "      - {country: Canada, storeSales: 100.0}\n"
+                + "    tolerance: {relative: 0.001}\n"
+                + "    orderMatters: true\n";
+        EvalSuite s = EvalYamlReader.read(yaml, "test.yaml");
+        assertEquals("foodmart-evals", s.name());
+        assertEquals("Ground-truth cases", s.description());
+        assertEquals("unknown_foodmart", s.cube().getConnectionName());
+        assertEquals(1, s.cases().size());
+
+        EvalCase c = s.cases().get(0);
+        assertEquals("sales-by-country", c.name());
+        assertEquals("QUERY", c.expectedIntent());
+        assertEquals(2, c.expectedRows().size());
+        assertEquals(0.001, c.tolerance().relative(), 1e-9);
+        assertTrue(c.orderMatters());
+    }
+
+    @Test
+    public void parsesRefusalCase() throws Exception {
+        String yaml = "name: refusals\n"
+                + CUBE_BLOCK
+                + "cases:\n"
+                + "  - name: refuse-off-topic\n"
+                + "    question: what's the weather?\n"
+                + "    expectedIntent: REFUSED\n"
+                + "    expectedRefusalContains: cube\n";
+        EvalSuite s = EvalYamlReader.read(yaml, "t.yaml");
+        assertEquals("REFUSED", s.cases().get(0).expectedIntent());
+        assertEquals("cube", s.cases().get(0).expectedRefusalContains());
+        assertNull(s.cases().get(0).expectedRows());
+    }
+
+    @Test
+    public void parsesInsightCase() throws Exception {
+        String yaml = "name: insights\n"
+                + CUBE_BLOCK
+                + "cases:\n"
+                + "  - name: trend-analysis\n"
+                + "    question: spot trends\n"
+                + "    expectedIntent: INSIGHT\n"
+                + "    expectedInsightContains:\n"
+                + "      - Store Sales\n"
+                + "      - week-on-week\n";
+        EvalSuite s = EvalYamlReader.read(yaml, "t.yaml");
+        assertEquals(2, s.cases().get(0).expectedInsightContains().size());
+    }
+
+    @Test
+    public void orderMattersDefaultsToTrue() throws Exception {
+        String yaml = "name: t\n" + CUBE_BLOCK + "cases:\n  - name: a\n    question: q\n";
+        EvalSuite s = EvalYamlReader.read(yaml, "t.yaml");
+        assertTrue(s.cases().get(0).orderMatters());
+    }
+
+    @Test
+    public void orderMattersCanBeFalse() throws Exception {
+        String yaml = "name: t\n" + CUBE_BLOCK + "cases:\n  - name: a\n    question: q\n    orderMatters: false\n";
+        EvalSuite s = EvalYamlReader.read(yaml, "t.yaml");
+        assertFalse(s.cases().get(0).orderMatters());
+    }
+
+    @Test
+    public void rejectsMissingName() {
+        assertParseCode(CUBE_BLOCK + "cases:\n  - name: a\n    question: q\n", "MISSING_FIELD");
+    }
+
+    @Test
+    public void rejectsMissingCube() {
+        assertParseCode("name: t\ncases:\n  - name: a\n    question: q\n", "MISSING_FIELD");
+    }
+
+    @Test
+    public void rejectsMissingCases() {
+        assertParseCode("name: t\n" + CUBE_BLOCK, "MISSING_FIELD");
+    }
+
+    @Test
+    public void rejectsEmptyCases() {
+        assertParseCode("name: t\n" + CUBE_BLOCK + "cases: []\n", "MISSING_FIELD");
+    }
+
+    @Test
+    public void rejectsMalformedYaml() {
+        assertParseCode("name: t\n cube: {  broken", "MALFORMED_YAML");
+    }
+
+    @Test
+    public void rejectsNegativeTolerance() {
+        assertParseCode(
+                "name: t\n" + CUBE_BLOCK + "cases:\n  - name: a\n    question: q\n    tolerance: {relative: -0.1}\n",
+                "INVALID_TOLERANCE");
+    }
+
+    @Test
+    public void historySurvivesParsing() throws Exception {
+        String yaml = "name: t\n"
+                + CUBE_BLOCK
+                + "cases:\n"
+                + "  - name: a\n"
+                + "    question: follow-up\n"
+                + "    history:\n"
+                + "      - {role: user, content: original question}\n"
+                + "      - {role: assistant, content: original answer}\n";
+        EvalSuite s = EvalYamlReader.read(yaml, "t.yaml");
+        assertEquals(2, s.cases().get(0).history().size());
+        assertEquals("user", s.cases().get(0).history().get(0).get("role"));
+    }
+
+    @Test
+    public void numericRowValuesParseAsNumbers() throws Exception {
+        String yaml = "name: t\n"
+                + CUBE_BLOCK
+                + "cases:\n"
+                + "  - name: a\n"
+                + "    question: q\n"
+                + "    expectedRows:\n"
+                + "      - {n: 42, f: 1.5, s: hello}\n";
+        EvalSuite s = EvalYamlReader.read(yaml, "t.yaml");
+        var row = s.cases().get(0).expectedRows().get(0);
+        assertTrue(row.get("n") instanceof Number);
+        assertTrue(row.get("f") instanceof Number);
+        assertEquals("hello", row.get("s"));
+    }
+
+    @Test
+    public void toleranceExactWhenNotSpecified() throws Exception {
+        String yaml = "name: t\n" + CUBE_BLOCK + "cases:\n  - name: a\n    question: q\n";
+        EvalSuite s = EvalYamlReader.read(yaml, "t.yaml");
+        assertNull("no explicit tolerance", s.cases().get(0).tolerance());
+        // Runner treats null as EXACT by default (verified in AgentEvalRunnerTest).
+    }
+
+    @Test
+    public void reportsCarrySuiteDescription() throws Exception {
+        String yaml = "name: t\ndescription: my suite\n" + CUBE_BLOCK + "cases:\n  - name: a\n    question: q\n";
+        EvalSuite s = EvalYamlReader.read(yaml, "t.yaml");
+        assertEquals("my suite", s.description());
+    }
+
+    /* ---- helpers ---- */
+
+    private static void assertParseCode(String yaml, String expectedCode) {
+        try {
+            EvalYamlReader.read(yaml, "t.yaml");
+            fail("expected EvalParseException(" + expectedCode + ")");
+        } catch (EvalYamlReader.EvalParseException e) {
+            assertEquals("code (message was: " + e.getMessage() + ")", expectedCode, e.code());
+            assertNotNull(e.source());
+        }
+    }
+}

--- a/saiku-core/saiku-service/src/test/java/org/saiku/service/olap/ai/eval/RowComparatorTest.java
+++ b/saiku-core/saiku-service/src/test/java/org/saiku/service/olap/ai/eval/RowComparatorTest.java
@@ -1,0 +1,134 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.service.olap.ai.eval;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.util.List;
+import java.util.Map;
+import org.junit.Test;
+
+public class RowComparatorTest {
+
+    private static final EvalTolerance EXACT = EvalTolerance.EXACT;
+    private static final EvalTolerance ONE_PCT = new EvalTolerance(0.0, 0.01);
+
+    @Test
+    public void emptyExpectedMeansPass() {
+        assertTrue(RowComparator.compare(null, someRows(), EXACT, true).isEmpty());
+        assertTrue(RowComparator.compare(List.of(), someRows(), EXACT, true).isEmpty());
+    }
+
+    @Test
+    public void exactMatchPasses() {
+        List<Map<String, Object>> exp = List.of(row("country", "USA", "storeSales", 500.0));
+        List<Map<String, Object>> act = List.of(row("country", "USA", "storeSales", 500.0));
+        assertTrue(RowComparator.compare(exp, act, EXACT, true).isEmpty());
+    }
+
+    @Test
+    public void toleranceMasksSmallNumericDrift() {
+        List<Map<String, Object>> exp = List.of(row("storeSales", 500.0));
+        List<Map<String, Object>> act = List.of(row("storeSales", 501.0)); // 0.2% drift
+        // Exact fails, 1% relative tolerance passes.
+        assertEquals(1, RowComparator.compare(exp, act, EXACT, true).size());
+        assertTrue(RowComparator.compare(exp, act, ONE_PCT, true).isEmpty());
+    }
+
+    @Test
+    public void rowCountMismatchIsReported() {
+        List<Map<String, Object>> exp = List.of(row("k", "a"), row("k", "b"), row("k", "c"));
+        List<Map<String, Object>> act = List.of(row("k", "a"), row("k", "b"));
+        var mismatches = RowComparator.compare(exp, act, EXACT, true);
+        assertTrue(mismatches.stream()
+                .anyMatch(m -> m.path().equals("rows") && m.message().contains("3")));
+    }
+
+    @Test
+    public void keyNormalisationEqualsRenameVariants() {
+        // "Store Sales" == "storeSales" == "STORE_SALES" all normalise to the same key.
+        List<Map<String, Object>> exp = List.of(row("Store Sales", 500.0));
+        List<Map<String, Object>> act = List.of(row("storeSales", 500.0));
+        assertTrue(RowComparator.compare(exp, act, EXACT, true).isEmpty());
+
+        List<Map<String, Object>> upper = List.of(row("STORE_SALES", 500.0));
+        assertTrue(RowComparator.compare(exp, upper, EXACT, true).isEmpty());
+    }
+
+    @Test
+    public void missingKeyIsMismatch() {
+        List<Map<String, Object>> exp = List.of(row("country", "USA", "storeSales", 500.0));
+        List<Map<String, Object>> act = List.of(row("country", "USA")); // no storeSales
+        var mismatches = RowComparator.compare(exp, act, EXACT, true);
+        assertTrue(mismatches.stream().anyMatch(m -> m.path().contains("storeSales")));
+    }
+
+    @Test
+    public void extraActualKeyIsNotMismatch() {
+        // Expectations are additive. An actual row with an extra column doesn't fail the eval.
+        List<Map<String, Object>> exp = List.of(row("country", "USA"));
+        List<Map<String, Object>> act = List.of(row("country", "USA", "extra", "sidecar"));
+        assertTrue(RowComparator.compare(exp, act, EXACT, true).isEmpty());
+    }
+
+    @Test
+    public void orderMattersFalseSortsBothSides() {
+        List<Map<String, Object>> exp = List.of(row("country", "USA", "n", 3.0), row("country", "Canada", "n", 1.0));
+        List<Map<String, Object>> act = List.of(row("country", "Canada", "n", 1.0), row("country", "USA", "n", 3.0));
+        // With orderMatters=true, positions mismatch.
+        var strict = RowComparator.compare(exp, act, EXACT, true);
+        assertTrue("strict order should surface mismatches", !strict.isEmpty());
+        // With orderMatters=false, sort makes them equal.
+        assertTrue(RowComparator.compare(exp, act, EXACT, false).isEmpty());
+    }
+
+    @Test
+    public void currencyPrefixesAndCommasParseAsNumbers() {
+        // Eval author writes "$565,238.13" as string; comparator parses it as 565238.13.
+        List<Map<String, Object>> exp = List.of(row("storeSales", "$565,238.13"));
+        List<Map<String, Object>> act = List.of(row("storeSales", 565238.13));
+        assertTrue(RowComparator.compare(exp, act, EXACT, true).isEmpty());
+    }
+
+    @Test
+    public void parenthesisedNegativeParses() {
+        List<Map<String, Object>> exp = List.of(row("delta", "(500)"));
+        List<Map<String, Object>> act = List.of(row("delta", -500.0));
+        assertTrue(RowComparator.compare(exp, act, EXACT, true).isEmpty());
+    }
+
+    @Test
+    public void stringComparisonNormalisesWhitespace() {
+        List<Map<String, Object>> exp = List.of(row("country", "USA "));
+        List<Map<String, Object>> act = List.of(row("country", " USA"));
+        assertTrue(RowComparator.compare(exp, act, EXACT, true).isEmpty());
+    }
+
+    @Test
+    public void mismatchPathIsPreciseForFailedCell() {
+        List<Map<String, Object>> exp = List.of(row("k", "a"), row("k", "b", "n", 100.0));
+        List<Map<String, Object>> act = List.of(row("k", "a"), row("k", "b", "n", 250.0));
+        var mismatches = RowComparator.compare(exp, act, EXACT, true);
+        assertEquals(1, mismatches.size());
+        assertEquals("rows[1].n", mismatches.get(0).path());
+        assertTrue(mismatches.get(0).message().contains("100.0"));
+        assertTrue(mismatches.get(0).message().contains("250.0"));
+    }
+
+    /* ---- helpers ---- */
+
+    private static List<Map<String, Object>> someRows() {
+        return List.of(row("k", "value"));
+    }
+
+    private static Map<String, Object> row(Object... kv) {
+        java.util.LinkedHashMap<String, Object> m = new java.util.LinkedHashMap<>();
+        for (int i = 0; i < kv.length; i += 2) {
+            m.put(String.valueOf(kv[i]), kv[i + 1]);
+        }
+        return m;
+    }
+}

--- a/saiku-launcher/src/main/resources/seed/evals/foodmart-sales.eval.yaml
+++ b/saiku-launcher/src/main/resources/seed/evals/foodmart-sales.eval.yaml
@@ -1,0 +1,69 @@
+# Ground-truth eval cases for the FoodMart Sales cube (saiku#1424).
+#
+# Runs against the AI ask layer to catch regressions when the LLM
+# provider changes, the schema changes, or the prompt changes. See
+# docs/EVAL-SPEC.md for the file format reference.
+#
+# Numbers in expectedRows are from the seeded FoodMart HSQL database;
+# they'll be off if the FoodMart schema is rebuilt with different data,
+# in which case rerun the queries manually and update this file.
+
+name: foodmart-sales-evals
+description: >
+  Ground-truth cases for the FoodMart Sales cube. Baseline for AI ask
+  regressions when the LLM provider, model, prompt, or schema changes.
+
+cube:
+  connectionName: unknown_foodmart
+  catalog: FoodMart
+  schema: FoodMart
+  cubeName: Sales
+
+cases:
+
+  # -----------------------------------------------------------------
+  # QUERY intent — routes to emit_query, executes, compares row-set.
+  # -----------------------------------------------------------------
+
+  - name: store-sales-by-country
+    question: Show store sales broken down by country.
+    expectedIntent: QUERY
+    expectedRows:
+      - {country: "Canada", storeSales:  57197.83}
+      - {country: "Mexico", storeSales: 132720.19}
+      - {country: "USA",    storeSales: 375691.60}
+    tolerance:
+      relative: 0.001  # 0.1% — masks warehouse floating-point drift
+    orderMatters: false
+
+  - name: unit-sales-by-product-family
+    question: Break down unit sales by Product Family.
+    expectedIntent: QUERY
+    expectedRows:
+      - {productFamily: "Drink",          unitSales:  24597}
+      - {productFamily: "Food",           unitSales: 191940}
+      - {productFamily: "Non-Consumable", unitSales:  50236}
+    orderMatters: false
+
+  # -----------------------------------------------------------------
+  # INSIGHT intent — no new query; markdown must reference key figures.
+  # -----------------------------------------------------------------
+
+  - name: what-drove-sales
+    question: what's driving store sales this quarter?
+    expectedIntent: INSIGHT
+    expectedInsightContains:
+      - Store Sales
+
+  # -----------------------------------------------------------------
+  # REFUSED intent — off-topic must decline with a matching reason.
+  # -----------------------------------------------------------------
+
+  - name: refuse-general-knowledge
+    question: What's the capital of France?
+    expectedIntent: REFUSED
+    expectedRefusalContains: cube
+
+  - name: refuse-coding-help
+    question: Write me a Python function that sorts a list.
+    expectedIntent: REFUSED


### PR DESCRIPTION
Closes #1424.

## Summary

Deterministic result-set diff harness for AI-ask regressions. Every case is a YAML file committed alongside the semantic model; CI runs the suite and fails on any regression. **No LLM-as-judge** — direct value comparison with numeric tolerance and explicit key normalisation, the same review discipline the semantic layer itself gets.

## What's here

**Model classes (Java records):**
- `EvalSuite` — name / description / cube / cases
- `EvalCase` — question / history / expected* / tolerance / orderMatters
- `EvalTolerance` — absolute + relative, both default zero
- `EvalOutcome` — per-case pass/fail/degraded/skipped + mismatches
- `EvalReport` — aggregate; `oneLine()` + `allPassed()` for CI
- `EvalAskAdapter` — SPI: `(cube, question, history) → EvalAskResult`
- `EvalAskResult` — neutral projection; `QUERY|INSIGHT|VIEW_CHANGE|REFUSED|DEGRADED`

**The comparator (`RowComparator`) is the meat.** Design decisions:

- **Key normalisation:** `Store Sales == storeSales == STORE_SALES`. Whitespace, underscores, hyphens all stripped; case-folded. Prevents a rename in the schema-projector's output shape from failing every eval that references the column.
- **Path preservation:** mismatch paths read as the operator wrote them in the YAML (`rows[2].storeSales`, not `rows[2].storesales`) so the error message points at the right YAML line.
- **Numeric parsing:** expected values that parse as numbers compare numerically with tolerance. The parser accepts `$565,238.13`, `(500)` for parenthesised negatives, `12%` for percentages — same forgiveness eval authors need to write natural values.
- **Asymmetric keys:** expected key not in actual is a mismatch. Actual key not expected is **NOT** — expectations are additive so growing the schema with a new column doesn't break every eval.

**Runner:**
- Runs cases sequentially in the order the suite defines
- Adapter exception → degraded outcome (not suite failure)
- Intent mismatch bails out of deeper checks (no cascade failures)
- Records per-case duration for reporting

**YAML parser** with structured error codes: `MALFORMED_YAML`, `MISSING_FIELD`, `BLANK_FIELD`, `TYPE_MISMATCH`, `INVALID_TOLERANCE`.

**Report writer** emits both JSON (CI archive) and human-readable text (operator eyeball).

**Bundled example** at `saiku-launcher/src/main/resources/seed/evals/foodmart-sales.eval.yaml` — 5 baseline cases covering QUERY (with tolerance-based row diff), INSIGHT (markdown substring), and REFUSED (off-topic guardrail).

## Docs

`docs/EVAL-SPEC.md` — file format spec, field reference, row comparison rules, error codes, CI integration examples (programmatic Java call + GitHub Actions workflow), non-goals.

## Tests

**35 unit tests**, all passing:
- **12 comparator tests** — tolerance masking numeric drift, key normalisation across rename variants, currency prefixes / commas / parenthesised negatives, order handling, missing keys, extra keys, precise mismatch path
- **15 YAML parser tests** — every error code, history + rows + insight round-trip, default value handling
- **8 runner tests** — passing suite, intent mismatch fails fast, refusal reason substring, degraded adapter, adapter exception → degraded, insight substring positive + negative, one-line summary format

Full service suite: **814 tests, 0 failures**, 1 skipped (Anthropic env-var gate). Spotless clean.

## Test plan

- [ ] `mvn -pl saiku-core/saiku-service test -Dtest='*Eval*'` — 35 tests pass
- [ ] `EvalYamlReader.read(...)` against the bundled `foodmart-sales.eval.yaml` — returns a valid `EvalSuite`
- [ ] `EvalReportWriter.toText(...)` and `toJson(...)` produce readable output
- [ ] Once a live-wired adapter lands (follow-up), run the FoodMart suite against a real Anthropic + FoodMart launcher — 5/5 pass

## Non-goals for v1

- **REST endpoint** to trigger runs — the runner is programmatic. `POST /ai/evals/run` follows once the CLI wrapper's shape is clear.
- **`saiku eval` CLI subcommand** — deferred.
- **Recording adapter** — writes each live response to a fixture file so a fixture adapter can replay deterministically without spending LLM budget. Design ready; implementation deferred.
- **Cross-run comparison** — "is today's eval worse than yesterday's?" Requires report archiving. Follow-up.
- **Live wired-in adapter** that plugs `AiAskService` + query execution — follow-up; the SPI is defined and stable so this is a small PR against a known contract.
- **Structural diff on the emitted AiQueryRequest** (as opposed to the executed row-set) — multiple structurally-different requests can produce the same rows, so row-diff is a better ground truth.

## Related

- Feature ticket: #1424
- Spec: `docs/EVAL-SPEC.md`
- Related deferred: CI integration example in the spec doc uses a `run-evals.sh` wrapper that'll land once the live adapter does