### PR TITLE
#1424 feat(ai/eval): LiveEvalAskAdapter — production SPI implementation

### DIFF
--- a/docs/EVAL-SPEC.md
+++ b/docs/EVAL-SPEC.md
@@ -191,17 +191,32 @@ a wrong answer":
 - **Structural diff on the emitted AiQueryRequest** (as opposed to the
   executed row-set) — multiple structurally-different requests can
   produce the same rows, so row-diff is a better ground truth.
+- **Matrix-mode + measures-only cellset extraction in the live adapter.**
+  The current flattening handles the records-with-row-headers shape
+  every real query produces; two edge cases from the resource's
+  `buildResponse` (matrix mode; single-row measures-only queries) are
+  deliberately skipped as v1 scope. Follow-up if a real suite hits
+  either shape.
 
 ## CI integration
 
-The runner is a plain Java class:
+The runner is a plain Java class. The production adapter that plugs
+into `AiAskService` + query execution ships as
+[`LiveEvalAskAdapter`](../saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ai/eval/LiveEvalAskAdapter.java):
 
 ```java
 import org.saiku.service.olap.ai.eval.*;
 
 EvalSuite suite = EvalYamlReader.read(new FileReader("saiku-home/evals/foodmart-sales.eval.yaml"),
     "foodmart-sales.eval.yaml");
-EvalAskAdapter live = new LiveAskAdapter(askService, thinQueryService); // wire your ask + execute
+
+// Production adapter — call AiAskService, execute any produced query, flatten to records.
+EvalAskAdapter live = new LiveEvalAskAdapter(
+    askService,          // org.saiku.service.olap.ai.ask.AiAskService
+    metadataService,     // org.saiku.service.olap.ai.AiCubeMetadataService
+    converter,           // org.saiku.service.olap.ai.AiSchemaConverter
+    thinQueryService);   // org.saiku.service.olap.ThinQueryService
+
 EvalReport report = new AgentEvalRunner(live).run(suite);
 
 System.out.println(EvalReportWriter.toText(report));
@@ -209,6 +224,21 @@ if (!report.allPassed()) {
   System.exit(1); // fail the CI job on any FAIL or DEGRADED outcome
 }
 ```
+
+The adapter routes each intent to the right output:
+
+| Intent | What lands in `EvalAskResult`                                                                     |
+|-------|-----------------------------------------------------------------------------------------------------|
+| QUERY | Ask → convert → execute → flatten cellset to `List<Map<String, Object>>` for the row comparator.    |
+| INSIGHT | Ask outcome's `insight.markdown` as-is for substring match.                                        |
+| VIEW_CHANGE | Ask outcome's `viewChange.viewMode`.                                                            |
+| REFUSED | `OFF_TOPIC:` reason mapped back to `EvalAskResult.forRefusal(...)`.                                 |
+| DEGRADED | Provider failures + adapter-thrown exceptions surface as degraded outcomes; the run continues.     |
+
+The cellset → records flattening deliberately skips the resource's
+matrix mode + measures-only special case + k-anonymity suppression —
+the eval framework wants the raw ground truth, and k-anonymity is a
+response-shaping concern for user-facing responses, not eval CI.
 
 A GitHub Actions workflow that runs on PR:
 

--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ai/eval/LiveEvalAskAdapter.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ai/eval/LiveEvalAskAdapter.java
@@ -1,0 +1,267 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.service.olap.ai.eval;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import org.saiku.olap.dto.resultset.AbstractBaseCell;
+import org.saiku.olap.dto.resultset.CellDataSet;
+import org.saiku.olap.dto.resultset.DataCell;
+import org.saiku.olap.dto.resultset.MemberCell;
+import org.saiku.olap.query2.ThinQuery;
+import org.saiku.service.olap.ThinQueryService;
+import org.saiku.service.olap.ai.AiCubeMetadataService;
+import org.saiku.service.olap.ai.AiCubeRef;
+import org.saiku.service.olap.ai.AiQueryRequest;
+import org.saiku.service.olap.ai.AiSchema;
+import org.saiku.service.olap.ai.AiSchemaConverter;
+import org.saiku.service.olap.ai.ask.AiAskService;
+import org.saiku.service.olap.ai.ask.NlAskMessage;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * The production {@link EvalAskAdapter} — plugs {@link AiAskService} plus the query executor into
+ * the eval runner so CI can run a suite against a real launcher with a real LLM provider
+ * (saiku#1424 follow-up).
+ *
+ * <p>Given a case's cube ref + question + history, the adapter:
+ *
+ * <ol>
+ *   <li>Calls {@link AiAskService#ask} to route the ask and get the LLM's structured output.
+ *   <li>For {@link AiAskService.AskOutcome.Kind#QUERY} — converts the {@link AiQueryRequest} via
+ *       {@link AiSchemaConverter}, executes through {@link ThinQueryService}, and flattens the
+ *       resulting {@link CellDataSet} into the neutral {@code List<Map<String, Object>>} the
+ *       {@link RowComparator} expects.
+ *   <li>For INSIGHT / VIEW_CHANGE / REFUSED — projects the outcome directly onto the neutral
+ *       {@link EvalAskResult} without hitting the query executor.
+ * </ol>
+ *
+ * <p>Records-format flattening is deliberately simpler than the resource's {@code buildResponse}
+ * (~200 lines with matrix support, measures-only shape, and k-anonymity suppression). The
+ * comparator does key normalisation, so this class doesn't repeat the resource's caption-caching
+ * logic; every row is projected as {@code {rowHeaderCaption: memberString, dataColCaption: number}}
+ * which is exactly what the eval framework compares. Follow-up work can extract {@code
+ * buildResponse} into a shared helper if a subtle behavioural difference between the AI ask
+ * response and the eval extractor surfaces in practice.
+ */
+public final class LiveEvalAskAdapter implements EvalAskAdapter {
+
+    private static final Logger log = LoggerFactory.getLogger(LiveEvalAskAdapter.class);
+
+    private final AiAskService askService;
+    private final AiCubeMetadataService metadataService;
+    private final AiSchemaConverter converter;
+    private final ThinQueryService thinQueryService;
+
+    public LiveEvalAskAdapter(
+            AiAskService askService,
+            AiCubeMetadataService metadataService,
+            AiSchemaConverter converter,
+            ThinQueryService thinQueryService) {
+        this.askService = Objects.requireNonNull(askService, "askService");
+        this.metadataService = Objects.requireNonNull(metadataService, "metadataService");
+        this.converter = Objects.requireNonNull(converter, "converter");
+        this.thinQueryService = Objects.requireNonNull(thinQueryService, "thinQueryService");
+    }
+
+    @Override
+    public EvalAskResult ask(AiCubeRef cube, String question, List<Map<String, String>> history) {
+        List<NlAskMessage> nlHistory = toNlHistory(history);
+        AiAskService.AskOutcome outcome;
+        try {
+            outcome = askService.ask(cube, question, nlHistory);
+        } catch (RuntimeException e) {
+            log.warn("live eval adapter: ask failed for cube {}", cube, e);
+            return EvalAskResult.forDegraded(
+                    null, "ask failure: " + e.getClass().getSimpleName() + ": " + e.getMessage());
+        }
+
+        if (outcome.degraded()) {
+            String reason = outcome.reason() == null ? "provider degraded" : outcome.reason();
+            // Refusal is a routed intent, not a real degradation — the tool-choice picked
+            // `refuse_off_topic` and the ask service surfaces that with an `OFF_TOPIC: ...`
+            // reason prefix. Map it back to REFUSED so the eval framework's expectedIntent match
+            // works cleanly.
+            if (reason.startsWith("OFF_TOPIC:")) {
+                return EvalAskResult.forRefusal(
+                        outcome.model(), reason.substring("OFF_TOPIC:".length()).trim());
+            }
+            return EvalAskResult.forDegraded(outcome.model(), reason);
+        }
+
+        AiAskService.AskOutcome.Kind kind = outcome.kind();
+        if (kind == null) {
+            return EvalAskResult.forDegraded(outcome.model(), "provider returned no intent");
+        }
+
+        return switch (kind) {
+            case QUERY -> handleQuery(outcome);
+            case INSIGHT -> EvalAskResult.forInsight(
+                    outcome.model(),
+                    outcome.insight() == null ? "" : outcome.insight().getMarkdown());
+            case VIEW_CHANGE -> EvalAskResult.forViewChange(
+                    outcome.model(),
+                    outcome.viewChange() == null ? "" : outcome.viewChange().getViewMode());
+        };
+    }
+
+    private EvalAskResult handleQuery(AiAskService.AskOutcome outcome) {
+        AiQueryRequest req = outcome.request();
+        if (req == null) {
+            return EvalAskResult.forDegraded(outcome.model(), "QUERY outcome missing request payload");
+        }
+        try {
+            AiSchema schema = metadataService.getSchema(req.getCube());
+            ThinQuery tq = converter.convert(req, schema);
+            CellDataSet cds = thinQueryService.execute(tq);
+            List<Map<String, Object>> rows = flattenToRecords(cds);
+            return EvalAskResult.forQuery(outcome.model(), rows);
+        } catch (RuntimeException e) {
+            log.warn("live eval adapter: QUERY execution failed after successful translation", e);
+            return EvalAskResult.forDegraded(
+                    outcome.model(), "execute failed: " + e.getClass().getSimpleName() + ": " + e.getMessage());
+        }
+    }
+
+    /**
+     * Flatten a {@link CellDataSet} into records format — one map per body row, keyed by column
+     * caption. Row-header columns land as their formatted-value string; data columns land as the
+     * numeric {@link DataCell#getRawNumber()} when the cell carries a raw value, falling back to
+     * the formatted string otherwise. This mirrors what the eval comparator's numeric parser
+     * expects — a numeric value if the schema knows one, else a display string it can compare as
+     * text.
+     *
+     * <p>Simpler than the resource's {@code buildResponse} — no matrix mode, no measures-only
+     * flattening, no k-anonymity. Package-visible so a targeted test can exercise the cellset →
+     * records shape without spinning up an ask service.
+     */
+    static List<Map<String, Object>> flattenToRecords(CellDataSet cds) {
+        if (cds == null) return List.of();
+        AbstractBaseCell[][] headers = cds.getCellSetHeaders();
+        AbstractBaseCell[][] body = cds.getCellSetBody();
+        if (body == null || body.length == 0) return List.of();
+
+        int totalWidth = body[0] == null ? 0 : body[0].length;
+        int rowHeaderCount = countRowHeaderColumns(body);
+
+        List<String> columnCaptions = extractColumnCaptions(headers, rowHeaderCount, totalWidth);
+        List<String> rowHeaderCaptions = extractRowHeaderCaptions(headers, rowHeaderCount);
+
+        List<Map<String, Object>> records = new ArrayList<>(body.length);
+        for (AbstractBaseCell[] row : body) {
+            if (row == null) continue;
+            Map<String, Object> record = new LinkedHashMap<>();
+            // Row-header columns first — kept as their formatted string.
+            for (int c = 0; c < rowHeaderCount && c < row.length; c++) {
+                String key = c < rowHeaderCaptions.size() ? rowHeaderCaptions.get(c) : ("row" + c);
+                record.put(key, row[c] == null ? "" : safeText(row[c].getFormattedValue()));
+            }
+            // Data cells — prefer the numeric raw value; fall back to the formatted string.
+            for (int c = rowHeaderCount; c < totalWidth && c < row.length; c++) {
+                int colIdx = c - rowHeaderCount;
+                String colKey = colIdx < columnCaptions.size() ? columnCaptions.get(colIdx) : ("col" + colIdx);
+                Object value = cellToValue(row[c]);
+                record.put(colKey, value);
+            }
+            records.add(record);
+        }
+        return records;
+    }
+
+    /**
+     * Pull a comparable value out of a body cell. Data cells with a raw {@link Number} preserve
+     * their type; text-only rows fall back to the formatted string.
+     */
+    private static Object cellToValue(AbstractBaseCell cell) {
+        if (cell == null) return "";
+        if (cell instanceof DataCell dc) {
+            Number raw = dc.getRawNumber();
+            if (raw != null) return raw;
+            return safeText(dc.getFormattedValue());
+        }
+        return safeText(cell.getFormattedValue());
+    }
+
+    /**
+     * Count the row-header columns — the leftmost columns whose entire body column is
+     * {@link MemberCell}. Handles cubes with no rows axis (all body columns are data) by returning
+     * zero.
+     */
+    private static int countRowHeaderColumns(AbstractBaseCell[][] body) {
+        if (body == null || body.length == 0 || body[0] == null) return 0;
+        int width = body[0].length;
+        int count = 0;
+        for (int c = 0; c < width; c++) {
+            boolean allMembers = true;
+            for (AbstractBaseCell[] row : body) {
+                if (row == null || c >= row.length) continue;
+                if (!(row[c] instanceof MemberCell)) {
+                    allMembers = false;
+                    break;
+                }
+            }
+            if (allMembers) count++;
+            else break;
+        }
+        return count;
+    }
+
+    private static List<String> extractColumnCaptions(
+            AbstractBaseCell[][] headers, int rowHeaderCount, int totalWidth) {
+        List<String> out = new ArrayList<>();
+        if (headers == null || headers.length == 0 || totalWidth == 0) return out;
+        AbstractBaseCell[] lastHeader = headers[headers.length - 1];
+        for (int c = rowHeaderCount; c < totalWidth; c++) {
+            String caption =
+                    c < lastHeader.length && lastHeader[c] != null ? safeText(lastHeader[c].getFormattedValue()) : "";
+            if (caption.isEmpty()) caption = "col" + (c - rowHeaderCount);
+            out.add(caption);
+        }
+        return out;
+    }
+
+    private static List<String> extractRowHeaderCaptions(AbstractBaseCell[][] headers, int rowHeaderCount) {
+        List<String> out = new ArrayList<>();
+        if (headers == null || headers.length == 0) return out;
+        AbstractBaseCell[] lastHeader = headers[headers.length - 1];
+        for (int c = 0; c < rowHeaderCount && c < lastHeader.length; c++) {
+            String cap = lastHeader[c] == null ? "" : safeText(lastHeader[c].getFormattedValue());
+            if (cap.isEmpty()) cap = "row" + c;
+            out.add(cap);
+        }
+        return out;
+    }
+
+    private static String safeText(String s) {
+        return s == null ? "" : s;
+    }
+
+    /**
+     * Convert the case's {@code List<Map<String, String>>} history (YAML shape — string / string)
+     * into {@link NlAskMessage}s the ask service consumes. Skips entries missing {@code role} or
+     * {@code content} rather than throwing — an eval case with a garbled history block should
+     * degrade cleanly, not crash the run.
+     */
+    private static List<NlAskMessage> toNlHistory(List<Map<String, String>> history) {
+        if (history == null || history.isEmpty()) return List.of();
+        List<NlAskMessage> out = new ArrayList<>();
+        for (Map<String, String> entry : history) {
+            if (entry == null) continue;
+            String role = entry.get("role");
+            String content = entry.get("content");
+            if (role == null || content == null) continue;
+            String lc = role.toLowerCase(Locale.ROOT);
+            if ("user".equals(lc)) out.add(NlAskMessage.user(content));
+            else if ("assistant".equals(lc)) out.add(NlAskMessage.assistant(content));
+            // Ignore unknown roles ("system", garbage) — the ask service only handles the two.
+        }
+        return out;
+    }
+}

--- a/saiku-core/saiku-service/src/test/java/org/saiku/service/olap/ai/eval/LiveEvalAskAdapterTest.java
+++ b/saiku-core/saiku-service/src/test/java/org/saiku/service/olap/ai/eval/LiveEvalAskAdapterTest.java
@@ -1,0 +1,152 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.service.olap.ai.eval;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.util.List;
+import java.util.Map;
+import org.junit.Test;
+import org.saiku.olap.dto.resultset.AbstractBaseCell;
+import org.saiku.olap.dto.resultset.CellDataSet;
+import org.saiku.olap.dto.resultset.DataCell;
+import org.saiku.olap.dto.resultset.MemberCell;
+
+/**
+ * Unit tests for the cellset → records flattening in {@link LiveEvalAskAdapter}. The full
+ * ask/convert/execute pipeline is covered by the resource-level integration path — this focuses on
+ * the extraction that turns Mondrian's cellset shape into the neutral {@code List<Map<String,
+ * Object>>} the eval framework compares.
+ */
+public class LiveEvalAskAdapterTest {
+
+    @Test
+    public void nullCellsetProducesEmptyList() {
+        assertTrue(LiveEvalAskAdapter.flattenToRecords(null).isEmpty());
+    }
+
+    @Test
+    public void emptyBodyProducesEmptyList() {
+        CellDataSet cds = new CellDataSet();
+        cds.setCellSetBody(new AbstractBaseCell[0][0]);
+        assertTrue(LiveEvalAskAdapter.flattenToRecords(cds).isEmpty());
+    }
+
+    @Test
+    public void flattensSingleAxisQueryToRecords() {
+        // "Show store sales by country" — 1 row-header column (Country) + 1 data column (Store Sales).
+        CellDataSet cds = buildCellset(new String[][] {{"Country", "Store Sales"}}, new Cell[][] {
+            {member("USA"), data("$565,238.13", 565238.13)},
+            {member("Canada"), data("$79,063.11", 79063.11)},
+            {member("Mexico"), data("$51,298.13", 51298.13)}
+        });
+
+        List<Map<String, Object>> rows = LiveEvalAskAdapter.flattenToRecords(cds);
+        assertEquals(3, rows.size());
+
+        assertEquals("USA", rows.get(0).get("Country"));
+        assertEquals(565238.13, ((Number) rows.get(0).get("Store Sales")).doubleValue(), 1e-9);
+
+        assertEquals("Canada", rows.get(1).get("Country"));
+        assertEquals(79063.11, ((Number) rows.get(1).get("Store Sales")).doubleValue(), 1e-9);
+    }
+
+    @Test
+    public void preservesNumericRawValueWhenAvailable() {
+        // Data cells with a raw number should preserve their numeric type — the comparator's
+        // tolerance math needs doubles, not strings, or every eval degrades to string-eq mode.
+        CellDataSet cds = buildCellset(
+                new String[][] {{"Country", "Unit Sales"}}, new Cell[][] {{member("USA"), data("266,773", 266773)}});
+        Map<String, Object> row = LiveEvalAskAdapter.flattenToRecords(cds).get(0);
+        assertTrue("data column value must be numeric", row.get("Unit Sales") instanceof Number);
+    }
+
+    @Test
+    public void fallsBackToFormattedStringWhenRawIsNull() {
+        // Text-only data cell (no raw number available) — falls back to the formatted string.
+        CellDataSet cds = buildCellset(
+                new String[][] {{"Country", "Comment"}}, new Cell[][] {{member("USA"), data("north-american", null)}});
+        Map<String, Object> row = LiveEvalAskAdapter.flattenToRecords(cds).get(0);
+        assertEquals("north-american", row.get("Comment"));
+    }
+
+    @Test
+    public void handlesMultipleRowHeaderColumns() {
+        // Two dims on rows (Country × Year), one measure column.
+        CellDataSet cds = buildCellset(new String[][] {{"Country", "Year", "Store Sales"}}, new Cell[][] {
+            {member("USA"), member("1997"), data("$200K", 200000.0)},
+            {member("USA"), member("1998"), data("$225K", 225000.0)}
+        });
+
+        List<Map<String, Object>> rows = LiveEvalAskAdapter.flattenToRecords(cds);
+        assertEquals(2, rows.size());
+        assertEquals("USA", rows.get(0).get("Country"));
+        assertEquals("1997", rows.get(0).get("Year"));
+        assertNotNull(rows.get(0).get("Store Sales"));
+    }
+
+    @Test
+    public void generatesSyntheticCaptionsWhenHeadersMissing() {
+        // Body-only cellset (e.g. tests that don't bother building headers). The extractor
+        // shouldn't crash — it uses synthetic row0/col0 keys.
+        CellDataSet cds = new CellDataSet();
+        cds.setCellSetHeaders(new AbstractBaseCell[0][0]);
+        cds.setCellSetBody(new AbstractBaseCell[][] {
+            {member("Row").cell(), data("100", 100).cell()}
+        });
+        List<Map<String, Object>> rows = LiveEvalAskAdapter.flattenToRecords(cds);
+        assertEquals(1, rows.size());
+        // No row-header captions were provided → the extractor treats every column as a data column
+        // (rowHeaderCount = 0 when the body's leftmost column contains a MemberCell but there are
+        // no headers to name it). Just verify we produced a row without crashing.
+        assertNotNull(rows.get(0));
+    }
+
+    /* ---------- test-cellset builder ---------- */
+
+    /** Sugar wrapper for a body cell — either a member (row header) or a data cell. */
+    private record Cell(AbstractBaseCell cell) {}
+
+    private static Cell member(String caption) {
+        MemberCell m = new MemberCell();
+        m.setFormattedValue(caption);
+        return new Cell(m);
+    }
+
+    private static Cell data(String formatted, Number raw) {
+        DataCell d = new DataCell();
+        d.setFormattedValue(formatted);
+        if (raw != null) d.setRawNumber(raw.doubleValue());
+        return new Cell(d);
+    }
+
+    private static CellDataSet buildCellset(String[][] headerCaptions, Cell[][] body) {
+        CellDataSet cds = new CellDataSet();
+        // Header rows: one row per level, one column per body column. Populate every cell as a
+        // MemberCell so the extractor sees a proper header shape.
+        AbstractBaseCell[][] headers = new AbstractBaseCell[headerCaptions.length][];
+        for (int r = 0; r < headerCaptions.length; r++) {
+            headers[r] = new AbstractBaseCell[headerCaptions[r].length];
+            for (int c = 0; c < headerCaptions[r].length; c++) {
+                MemberCell m = new MemberCell();
+                m.setFormattedValue(headerCaptions[r][c]);
+                headers[r][c] = m;
+            }
+        }
+        cds.setCellSetHeaders(headers);
+
+        AbstractBaseCell[][] bodyCells = new AbstractBaseCell[body.length][];
+        for (int r = 0; r < body.length; r++) {
+            bodyCells[r] = new AbstractBaseCell[body[r].length];
+            for (int c = 0; c < body[r].length; c++) {
+                bodyCells[r][c] = body[r][c].cell();
+            }
+        }
+        cds.setCellSetBody(bodyCells);
+        return cds;
+    }
+}


### PR DESCRIPTION
Follow-up to #1448. Turns the eval framework from "programmatic library" into "runnable against a real launcher" by shipping the production adapter that wires `AiAskService` + query execution behind the SPI.

**Stacked on #1448** — merges into that branch, or rebase onto `development` once #1448 lands.

## Summary

Given a case's `AiCubeRef` + question + history, the adapter:

1. Calls `AiAskService.ask()` to route the ask and get the LLM's structured output.
2. For `QUERY` intent — converts the `AiQueryRequest` via `AiSchemaConverter`, executes through `ThinQueryService`, and flattens the resulting `CellDataSet` into records format for the `RowComparator` to diff.
3. For `INSIGHT` / `VIEW_CHANGE` / `REFUSED` — projects directly onto the neutral `EvalAskResult` without hitting the query executor.
4. Provider degraded outcomes with `OFF_TOPIC:` prefix are correctly mapped back to `REFUSED` (the tool-choice picked `refuse_off_topic` and the ask service surfaces that as a degraded reason string).

## Simplified flattening

The records extractor deliberately skips three edge cases from `AiQueryResource.buildResponse` (~200 lines):

| Feature                | Why skipped                                                                                       |
|------------------------|---------------------------------------------------------------------------------------------------|
| Matrix mode            | Records format is what the eval comparator wants. Matrix cases extract to records anyway.          |
| Measures-only shape    | Real dimension-by-measure queries all fit the standard row-header + data-cell shape. Follow-up.    |
| k-anonymity suppression | The eval framework wants ground truth. k-anon is a response-shaping concern for user-facing egress. |

Data cells preserve numeric raw values via `DataCell.getRawNumber()`, falling back to the formatted string when raw is null. The comparator does numeric tolerance math — needs doubles, not strings.

## Tests

7 new unit tests covering flattening in isolation with a hand-rolled cellset builder:

- Null / empty cellsets → empty list
- Single-axis query (Country × Store Sales) → 3 flattened records with numeric values
- Numeric raw preservation → `getRawNumber()` values survive as `Number`, not string
- Text-only fallback → `null` raw drops to formatted string
- Multi-dim row headers (Country × Year) → both dims land in the row map
- Synthetic captions when headers array is missing → doesn't crash

Full service suite: **821 tests, 0 failures**, 1 skipped. Spotless clean.

## Docs

`docs/EVAL-SPEC.md` updated:
- CI-integration example replaces the placeholder `LiveAskAdapter` reference with the real constructor signature
- Intent → `EvalAskResult` mapping table added
- Skipped-shape non-goals documented (matrix mode + measures-only)

## Test plan

- [x] `mvn -pl saiku-core/saiku-service test -Dtest=LiveEvalAskAdapterTest` → 7/7 pass
- [ ] Wire the adapter behind a REST endpoint (`POST /ai/evals/run`) or CLI subcommand — separate PR
- [ ] Boot a launcher with Anthropic configured + FoodMart seeded, run the bundled `foodmart-sales.eval.yaml` suite through the adapter → 5/5 pass (once wired to a CLI / endpoint)

## Non-goals for this slice

- **REST endpoint / CLI subcommand** — the adapter is the SPI-side production piece. Wiring it to `POST /ai/evals/run` or a `saiku eval` command is a follow-up (small, well-scoped).
- **Matrix-mode extraction** — deferred; the records format handles every dimensional query the eval framework's row-comparator was designed for.
- **Measures-only cellset flattening** — deferred; specialised shape from AiQueryResource that's rare in eval-style questions.

## Related

- Base PR: #1448
- Feature ticket: #1424
- Docs: `docs/EVAL-SPEC.md`