### PR TITLE
#1424 feat(ai/eval): REST endpoints for suite discovery + running

### DIFF
--- a/docs/EVAL-SPEC.md
+++ b/docs/EVAL-SPEC.md
@@ -178,11 +178,48 @@ a wrong answer":
 | `TYPE_MISMATCH`     | A field has the wrong type (e.g. `cases` is a mapping, not an array).    |
 | `INVALID_TOLERANCE` | `tolerance.absolute` or `tolerance.relative` is negative.                |
 
+## REST surface
+
+The eval framework ships four endpoints on the standard `/saiku/api/ai` base:
+
+- `GET  /rest/saiku/api/ai/evals/suites[?errors=true]` — catalogue: `[{name, description, caseCount, cube}]`
+- `GET  /rest/saiku/api/ai/evals/suites/{name}` — one suite's parsed structure (admin UI)
+- `POST /rest/saiku/api/ai/evals/suites/refresh` — force-rescan the catalogue
+- `POST /rest/saiku/api/ai/evals/run` — run a suite, return the JSON report
+
+The run endpoint accepts either shape:
+
+```jsonc
+// Look up by name in saiku-home/evals/
+{ "suiteName": "foodmart-sales-evals" }
+
+// Or inline YAML — CI dynamically builds a suite and doesn't want to write to disk first
+{ "suiteYaml": "name: adhoc\ncube: {...}\ncases: [...]" }
+```
+
+Response is the full JSON `EvalReport`. HTTP `200` is returned regardless of pass/fail — the
+caller inspects `failedCount` / `degradedCount` to decide CI status.
+
+```bash
+# Run the bundled FoodMart suite against a running launcher.
+curl -sS -X POST -u admin:admin \
+  -H 'content-type: application/json' \
+  http://localhost:8080/rest/saiku/api/ai/evals/run \
+  -d '{"suiteName": "foodmart-sales-evals"}' | jq '{
+    summary: .oneLine,
+    passed: .passedCount,
+    failed: .failedCount,
+    outcomes: [.outcomes[] | {caseName, status, mismatches}]
+  }'
+```
+
+The launcher stages the bundled FoodMart suite to `saiku-home/evals/foodmart-sales.eval.yaml`
+on first boot — a fresh install can run the endpoint immediately as a smoke check.
+
 ## Non-goals for v1
 
-- **REST endpoint** to trigger runs — the runner is programmatic in v1.
-  CLI + REST wrappers are a follow-up.
-- **`saiku eval` CLI subcommand** — deferred.
+- **`saiku eval` CLI subcommand** — deferred. The REST endpoint above is the load-bearing
+  surface; a CLI wrapper is a thin HTTP client that pretty-prints the report. Small follow-up.
 - **Recording adapter** — an adapter that writes each live response to
   a fixture file so the fixture adapter can replay deterministically
   without spending LLM budget. Design ready; implementation deferred.

--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ai/eval/EvalSuiteRegistry.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ai/eval/EvalSuiteRegistry.java
@@ -1,0 +1,172 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.service.olap.ai.eval;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Stream;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Catalogue of {@link EvalSuite}s discovered under a scan root (saiku#1424).
+ *
+ * <p>Same discovery model as {@link org.saiku.service.olap.ai.ask.AgentSkillRegistry} and {@link
+ * org.saiku.service.olap.ai.ask.AgentSpaceRegistry}: mtime-based signature check on every read,
+ * atomic snapshot swap on refresh, structured parse errors surfaced via {@link #errors()} so an
+ * operator can fix a broken YAML without reading server logs.
+ *
+ * <p>Scans {@code *.yaml} and {@code *.yml} under the root. Suite name (from the file's YAML)
+ * is the unique key — two files declaring the same {@code name} produce a {@link
+ * SuiteError} of code {@code DUPLICATE_NAME} on the second one.
+ */
+public final class EvalSuiteRegistry {
+
+    private static final Logger log = LoggerFactory.getLogger(EvalSuiteRegistry.class);
+
+    private final Path root;
+    private final AtomicReference<Snapshot> snapshot = new AtomicReference<>(Snapshot.empty());
+
+    public EvalSuiteRegistry(Path root) {
+        this.root = Objects.requireNonNull(root, "root");
+    }
+
+    /** String-arg convenience so Spring XML wiring stays terse. */
+    public EvalSuiteRegistry(String root) {
+        this(Path.of(Objects.requireNonNull(root, "root")));
+    }
+
+    /** Ordered by suite name. */
+    public List<EvalSuite> list() {
+        return refresh().suites;
+    }
+
+    /** Look up by suite name — the {@code name:} field from the YAML, not the filename. */
+    public Optional<EvalSuite> get(String name) {
+        if (name == null || name.isBlank()) return Optional.empty();
+        return Optional.ofNullable(refresh().byName.get(name));
+    }
+
+    /** Structured parse errors from the last scan, keyed by relative file path. */
+    public List<SuiteError> errors() {
+        return refresh().errors;
+    }
+
+    /** Force a rescan (bypasses the signature check). */
+    public void forceRefresh() {
+        snapshot.set(scan());
+    }
+
+    private Snapshot refresh() {
+        Snapshot current = snapshot.get();
+        long sig = signature();
+        if (current.signature == sig) return current;
+        Snapshot next = scan();
+        snapshot.set(next);
+        return next;
+    }
+
+    private long signature() {
+        if (!Files.isDirectory(root)) return -1L;
+        long count = 0;
+        long maxMtime = 0;
+        long totalSize = 0;
+        try (Stream<Path> stream = Files.walk(root)) {
+            for (Path p : (Iterable<Path>) stream::iterator) {
+                if (!Files.isRegularFile(p)) continue;
+                if (!isYamlExtension(p)) continue;
+                BasicFileAttributes attrs = Files.readAttributes(p, BasicFileAttributes.class);
+                count++;
+                maxMtime = Math.max(maxMtime, attrs.lastModifiedTime().toMillis());
+                totalSize += attrs.size();
+            }
+        } catch (IOException e) {
+            log.debug("eval-suite signature scan failed under {}", root, e);
+            return -1L;
+        }
+        long sig = 1125899906842597L;
+        sig = sig * 31 + count;
+        sig = sig * 31 + maxMtime;
+        sig = sig * 31 + totalSize;
+        return sig;
+    }
+
+    private Snapshot scan() {
+        if (!Files.isDirectory(root)) {
+            log.debug("eval-suite root {} does not exist — empty catalogue", root);
+            return Snapshot.empty();
+        }
+        List<EvalSuite> suites = new ArrayList<>();
+        List<SuiteError> errors = new ArrayList<>();
+        try (Stream<Path> stream = Files.walk(root)) {
+            for (Path p : (Iterable<Path>) stream::iterator) {
+                if (!Files.isRegularFile(p)) continue;
+                if (!isYamlExtension(p)) continue;
+                String relPath = root.relativize(p).toString();
+                try {
+                    String content = Files.readString(p, StandardCharsets.UTF_8);
+                    suites.add(EvalYamlReader.read(content, relPath));
+                } catch (EvalYamlReader.EvalParseException e) {
+                    log.warn("eval suite {} rejected: {} ({})", relPath, e.getMessage(), e.code());
+                    errors.add(new SuiteError(relPath, e.code(), e.getMessage()));
+                } catch (IOException e) {
+                    log.warn("eval suite {} could not be read", relPath, e);
+                    errors.add(new SuiteError(relPath, "IO_ERROR", e.getMessage()));
+                }
+            }
+        } catch (IOException e) {
+            log.warn("eval-suite scan under {} failed", root, e);
+        }
+        suites.sort(Comparator.comparing(EvalSuite::name));
+
+        Map<String, EvalSuite> byName = new HashMap<>();
+        List<EvalSuite> deduped = new ArrayList<>(suites.size());
+        for (EvalSuite s : suites) {
+            EvalSuite prior = byName.put(s.name(), s);
+            if (prior != null) {
+                errors.add(new SuiteError(
+                        "(duplicate)",
+                        "DUPLICATE_NAME",
+                        "another file already declared suite name '" + s.name() + "'"));
+            } else {
+                deduped.add(s);
+            }
+        }
+        long sig = signature();
+        return new Snapshot(
+                sig,
+                Collections.unmodifiableList(deduped),
+                Collections.unmodifiableMap(new LinkedHashMap<>(byName)),
+                Collections.unmodifiableList(errors));
+    }
+
+    private static boolean isYamlExtension(Path p) {
+        String name = p.getFileName().toString().toLowerCase();
+        return name.endsWith(".yaml") || name.endsWith(".yml");
+    }
+
+    /** Structured error entry for files that failed to parse. */
+    public record SuiteError(String path, String code, String message) {}
+
+    private record Snapshot(
+            long signature, List<EvalSuite> suites, Map<String, EvalSuite> byName, List<SuiteError> errors) {
+        static Snapshot empty() {
+            return new Snapshot(0L, List.of(), Map.of(), List.of());
+        }
+    }
+}

--- a/saiku-core/saiku-service/src/test/java/org/saiku/service/olap/ai/eval/EvalSuiteRegistryTest.java
+++ b/saiku-core/saiku-service/src/test/java/org/saiku/service/olap/ai/eval/EvalSuiteRegistryTest.java
@@ -1,0 +1,108 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.service.olap.ai.eval;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+public class EvalSuiteRegistryTest {
+
+    @Rule
+    public TemporaryFolder tmp = new TemporaryFolder();
+
+    private static final String CUBE_BLOCK =
+            "cube:\n  connectionName: c\n  catalog: cat\n  schema: s\n  cubeName: Sales\n";
+
+    private static String suiteYaml(String name) {
+        return "name: " + name + "\n" + CUBE_BLOCK + "cases:\n  - name: a\n    question: q\n";
+    }
+
+    @Test
+    public void emptyRootYieldsEmpty() throws Exception {
+        Path root = tmp.newFolder("evals").toPath();
+        EvalSuiteRegistry reg = new EvalSuiteRegistry(root);
+        assertTrue(reg.list().isEmpty());
+        assertTrue(reg.errors().isEmpty());
+    }
+
+    @Test
+    public void missingRootYieldsEmpty() {
+        EvalSuiteRegistry reg = new EvalSuiteRegistry(tmp.getRoot().toPath().resolve("nope"));
+        assertTrue(reg.list().isEmpty());
+    }
+
+    @Test
+    public void scansYamlAndYmlFiles() throws Exception {
+        Path root = tmp.newFolder("evals").toPath();
+        write(root.resolve("a.yaml"), suiteYaml("suite-a"));
+        write(root.resolve("b.yml"), suiteYaml("suite-b"));
+        write(root.resolve("README.txt"), "irrelevant");
+        EvalSuiteRegistry reg = new EvalSuiteRegistry(root);
+        assertEquals(2, reg.list().size());
+    }
+
+    @Test
+    public void surfacesErrorsForBadFiles() throws Exception {
+        Path root = tmp.newFolder("evals").toPath();
+        write(root.resolve("ok.yaml"), suiteYaml("ok"));
+        write(root.resolve("bad.yaml"), "not: valid: yaml: at: all: :\n  broken");
+        EvalSuiteRegistry reg = new EvalSuiteRegistry(root);
+        assertEquals(1, reg.list().size());
+        assertEquals(1, reg.errors().size());
+        assertNotNull(reg.errors().get(0).code());
+    }
+
+    @Test
+    public void dedupesOnSuiteName() throws Exception {
+        Path root = tmp.newFolder("evals").toPath();
+        write(root.resolve("first.yaml"), suiteYaml("dup"));
+        write(root.resolve("second.yaml"), suiteYaml("dup"));
+        EvalSuiteRegistry reg = new EvalSuiteRegistry(root);
+        assertEquals(1, reg.list().size());
+        assertTrue(reg.errors().stream().anyMatch(e -> "DUPLICATE_NAME".equals(e.code())));
+    }
+
+    @Test
+    public void refreshesOnFileAdd() throws Exception {
+        Path root = tmp.newFolder("evals").toPath();
+        write(root.resolve("a.yaml"), suiteYaml("a"));
+        EvalSuiteRegistry reg = new EvalSuiteRegistry(root);
+        assertEquals(1, reg.list().size());
+        write(root.resolve("b.yaml"), suiteYaml("b"));
+        assertEquals(2, reg.list().size());
+    }
+
+    @Test
+    public void getByName() throws Exception {
+        Path root = tmp.newFolder("evals").toPath();
+        write(root.resolve("a.yaml"), suiteYaml("suite-a"));
+        EvalSuiteRegistry reg = new EvalSuiteRegistry(root);
+        assertTrue(reg.get("suite-a").isPresent());
+        assertFalse(reg.get("nope").isPresent());
+        assertFalse(reg.get("").isPresent());
+        assertFalse(reg.get(null).isPresent());
+    }
+
+    @Test
+    public void stringPathCtor() {
+        EvalSuiteRegistry reg =
+                new EvalSuiteRegistry(tmp.getRoot().toPath().resolve("evals").toString());
+        assertNotNull(reg);
+        assertTrue(reg.list().isEmpty());
+    }
+
+    private static void write(Path p, String content) throws Exception {
+        Files.writeString(p, content, StandardCharsets.UTF_8);
+    }
+}

--- a/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/AiQueryResource.java
+++ b/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/AiQueryResource.java
@@ -89,6 +89,23 @@ public class AiQueryResource {
     }
 
     /**
+     * Eval framework wiring (saiku#1424 REST endpoint slice). Both fields are optional — when
+     * either is null the eval endpoints degrade to structured 503 responses rather than throwing,
+     * so the resource stays boot-safe on instances that haven't opted in.
+     */
+    private org.saiku.service.olap.ai.eval.EvalSuiteRegistry evalSuiteRegistry;
+
+    private org.saiku.service.olap.ai.eval.EvalAskAdapter evalAskAdapter;
+
+    public void setEvalSuiteRegistry(org.saiku.service.olap.ai.eval.EvalSuiteRegistry r) {
+        this.evalSuiteRegistry = r;
+    }
+
+    public void setEvalAskAdapter(org.saiku.service.olap.ai.eval.EvalAskAdapter a) {
+        this.evalAskAdapter = a;
+    }
+
+    /**
      * saiku#1151: per-caller call-rate cap on the cost-bearing ask endpoint.
      * Default budget; replace via {@link #setAskRateLimiter} (Spring wiring or
      * tests). Size caps live in {@code AiAskGuard}.
@@ -946,6 +963,165 @@ public class AiQueryResource {
         out.setModel(outcome.model());
         out.setRequest(outcome.request());
         return Response.ok(out).type(MediaType.APPLICATION_JSON).build();
+    }
+
+    /* ============================================================================
+     * Agent-eval framework REST surface (saiku#1424 follow-up)
+     *
+     * Three endpoints so operators + CI can run YAML ground-truth suites without
+     * writing Java:
+     *
+     *   GET  /ai/evals/suites[?errors=true]      — list catalogued suites
+     *   GET  /ai/evals/suites/{name}              — one suite's parsed structure
+     *   POST /ai/evals/run                        — execute a suite, get the report
+     *
+     * Both the registry (for GETs) and the ask-adapter (for run) are optional
+     * beans — when either is null the endpoints return 503 with a structured
+     * "not configured" body rather than 500ing.
+     * ============================================================================ */
+
+    /**
+     * List catalogued eval suites. Pass {@code ?errors=true} to also include parse errors so
+     * operators can fix a broken YAML without reading server logs.
+     */
+    @GET
+    @Path("/evals/suites")
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response listEvalSuites(@QueryParam("errors") @DefaultValue("false") boolean includeErrors) {
+        if (evalSuiteRegistry == null) {
+            return Response.ok(java.util.Map.of("suites", List.of()))
+                    .type(MediaType.APPLICATION_JSON)
+                    .build();
+        }
+        java.util.Map<String, Object> body = new java.util.LinkedHashMap<>();
+        List<Object> out = new ArrayList<>();
+        for (var suite : evalSuiteRegistry.list()) {
+            out.add(java.util.Map.of(
+                    "name", suite.name(),
+                    "description", suite.description() == null ? "" : suite.description(),
+                    "caseCount", suite.cases().size(),
+                    "cube",
+                            java.util.Map.of(
+                                    "connectionName", suite.cube().getConnectionName(),
+                                    "catalog", suite.cube().getCatalog(),
+                                    "schema", suite.cube().getSchema(),
+                                    "cubeName", suite.cube().getCubeName())));
+        }
+        body.put("suites", out);
+        if (includeErrors) {
+            body.put("errors", evalSuiteRegistry.errors());
+        }
+        return Response.ok(body).type(MediaType.APPLICATION_JSON).build();
+    }
+
+    /** Return one suite's parsed structure. */
+    @GET
+    @Path("/evals/suites/{name}")
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response getEvalSuite(@PathParam("name") String name) {
+        if (evalSuiteRegistry == null) {
+            return Response.status(Response.Status.NOT_FOUND)
+                    .entity(java.util.Map.of("error", "eval registry not configured"))
+                    .type(MediaType.APPLICATION_JSON)
+                    .build();
+        }
+        return evalSuiteRegistry
+                .get(name)
+                .<Response>map(suite ->
+                        Response.ok(suite).type(MediaType.APPLICATION_JSON).build())
+                .orElseGet(() -> Response.status(Response.Status.NOT_FOUND)
+                        .entity(java.util.Map.of("error", "suite '" + name + "' not found"))
+                        .type(MediaType.APPLICATION_JSON)
+                        .build());
+    }
+
+    /** Force-refresh the suite catalogue. */
+    @POST
+    @Path("/evals/suites/refresh")
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response refreshEvalSuites() {
+        if (evalSuiteRegistry == null) {
+            return Response.ok(java.util.Map.of("suites", 0, "errors", 0))
+                    .type(MediaType.APPLICATION_JSON)
+                    .build();
+        }
+        evalSuiteRegistry.forceRefresh();
+        return Response.ok(java.util.Map.of(
+                        "suites", evalSuiteRegistry.list().size(),
+                        "errors", evalSuiteRegistry.errors().size()))
+                .type(MediaType.APPLICATION_JSON)
+                .build();
+    }
+
+    /**
+     * Run an eval suite and return the JSON report.
+     *
+     * <p>Two invocation shapes accepted in the request body:
+     *
+     * <ul>
+     *   <li>{@code {"suiteName": "foodmart-sales-evals"}} — looks the suite up in the registry.
+     *   <li>{@code {"suiteYaml": "name: ...\ncube: ..."}} — parses the YAML directly. Handy for
+     *       CI runs that build a suite dynamically and don't want to write to disk first.
+     * </ul>
+     *
+     * <p>Response is the pretty-printed {@link org.saiku.service.olap.ai.eval.EvalReport} JSON.
+     * HTTP {@code 200} when the report was produced regardless of pass/fail — the caller inspects
+     * {@code failedCount} / {@code degradedCount} to decide CI status. {@code 4xx} on missing
+     * suite / malformed body; {@code 503} when the ask adapter isn't wired.
+     */
+    @POST
+    @Path("/evals/run")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response runEvalSuite(java.util.Map<String, String> body) {
+        if (evalAskAdapter == null) {
+            return Response.status(Response.Status.SERVICE_UNAVAILABLE)
+                    .entity(
+                            java.util.Map.of(
+                                    "error",
+                                    "eval runner not configured — check that the AI ask provider is set (saiku.ai.ask.provider) and the launcher has a wired liveEvalAskAdapterBean"))
+                    .type(MediaType.APPLICATION_JSON)
+                    .build();
+        }
+        if (body == null || (body.get("suiteName") == null && body.get("suiteYaml") == null)) {
+            return badRequest("body", "request body must carry either 'suiteName' or 'suiteYaml'", null);
+        }
+
+        org.saiku.service.olap.ai.eval.EvalSuite suite;
+        try {
+            if (body.get("suiteName") != null) {
+                if (evalSuiteRegistry == null) {
+                    return Response.status(Response.Status.NOT_FOUND)
+                            .entity(java.util.Map.of(
+                                    "error", "eval registry not configured — pass 'suiteYaml' instead"))
+                            .type(MediaType.APPLICATION_JSON)
+                            .build();
+                }
+                var maybe = evalSuiteRegistry.get(body.get("suiteName"));
+                if (maybe.isEmpty()) {
+                    return Response.status(Response.Status.NOT_FOUND)
+                            .entity(java.util.Map.of(
+                                    "error", "suite '" + body.get("suiteName") + "' not found in registry"))
+                            .type(MediaType.APPLICATION_JSON)
+                            .build();
+                }
+                suite = maybe.get();
+            } else {
+                suite = org.saiku.service.olap.ai.eval.EvalYamlReader.read(body.get("suiteYaml"), "inline");
+            }
+        } catch (org.saiku.service.olap.ai.eval.EvalYamlReader.EvalParseException e) {
+            return Response.status(Response.Status.BAD_REQUEST)
+                    .entity(java.util.Map.of(
+                            "error", "invalid suite YAML",
+                            "code", e.code(),
+                            "message", e.getMessage()))
+                    .type(MediaType.APPLICATION_JSON)
+                    .build();
+        }
+
+        org.saiku.service.olap.ai.eval.EvalReport report =
+                new org.saiku.service.olap.ai.eval.AgentEvalRunner(evalAskAdapter).run(suite);
+        return Response.ok(report).type(MediaType.APPLICATION_JSON).build();
     }
 
     @POST

--- a/saiku-launcher/src/main/java/org/saiku/launcher/SaikuLauncher.java
+++ b/saiku-launcher/src/main/java/org/saiku/launcher/SaikuLauncher.java
@@ -721,6 +721,14 @@ public class SaikuLauncher implements Callable<Integer> {
             stageResource(
                     "/seed/agent-spaces/foodmart-finance-ops.json",
                     spacesDir.resolve("foodmart-finance-ops.json"));
+
+            // Seed the eval-suite catalogue (saiku#1424) with the FoodMart baseline —
+            // 5 cases covering QUERY / INSIGHT / REFUSED that a fresh install can run
+            // through POST /ai/evals/run as a smoke check.
+            Path evalsDir = saikuHome.resolve("evals");
+            Files.createDirectories(evalsDir);
+            stageResource(
+                    "/seed/evals/foodmart-sales.eval.yaml", evalsDir.resolve("foodmart-sales.eval.yaml"));
         }
 
         /**

--- a/saiku-webapp/src/main/webapp/WEB-INF/saiku-beans.xml
+++ b/saiku-webapp/src/main/webapp/WEB-INF/saiku-beans.xml
@@ -294,6 +294,11 @@
              saiku.ai.ask.provider is set to 'anthropic' or 'openai' and the
              matching API key env var is supplied. See aiAskServiceBean below. -->
         <property name="askService" ref="aiAskServiceBean"/>
+        <!-- Eval framework wiring (saiku#1424). Both properties are optional — the
+             /ai/evals/* endpoints return 404-shaped responses when either bean isn't
+             wired, so the resource stays boot-safe if evals aren't configured. -->
+        <property name="evalSuiteRegistry" ref="evalSuiteRegistryBean"/>
+        <property name="evalAskAdapter" ref="liveEvalAskAdapterBean"/>
     </bean>
 
     <!-- Ossie AI Query API (#1394) — parallel to aiQueryResource but for semantic-YAML
@@ -410,6 +415,27 @@
     <bean id="agentSpaceRegistryBean"
           class="org.saiku.service.olap.ai.ask.AgentSpaceRegistry">
         <constructor-arg type="java.lang.String" value="${saiku.home:./saiku-home}/agent-spaces"/>
+    </bean>
+
+    <!-- Eval suite catalogue (saiku#1424). YAML ground-truth cases under
+         saiku-home/evals/ scanned on demand. Consumed by the /ai/evals/*
+         REST surface. -->
+    <bean id="evalSuiteRegistryBean"
+          class="org.saiku.service.olap.ai.eval.EvalSuiteRegistry">
+        <constructor-arg type="java.lang.String" value="${saiku.home:./saiku-home}/evals"/>
+    </bean>
+
+    <!-- Production ask-adapter used by AgentEvalRunner (saiku#1424). Wires
+         AiAskService + AiCubeMetadataService + AiSchemaConverter + ThinQueryService
+         so the runner has the same execution pipeline as the /ai/ask endpoint. -->
+    <bean id="aiSchemaConverterBean" class="org.saiku.service.olap.ai.AiSchemaConverter"/>
+
+    <bean id="liveEvalAskAdapterBean"
+          class="org.saiku.service.olap.ai.eval.LiveEvalAskAdapter">
+        <constructor-arg ref="aiAskServiceBean"/>
+        <constructor-arg ref="aiCubeMetadataServiceBean"/>
+        <constructor-arg ref="aiSchemaConverterBean"/>
+        <constructor-arg ref="thinQueryBean"/>
     </bean>
 
     <!-- ====================================================================


### PR DESCRIPTION
Follow-up to the merged #1448 + #1449 (eval framework + live adapter). Turns the eval framework from "programmatic library" into "runnable via curl / CI / admin UI".

## Summary

Four endpoints on the standard `/saiku/api/ai` base:

- `GET  /ai/evals/suites[?errors=true]` — catalogue + optional parse errors
- `GET  /ai/evals/suites/{name}` — one suite's parsed structure (for admin UI)
- `POST /ai/evals/suites/refresh` — force-rescan the catalogue
- `POST /ai/evals/run` — execute a suite, return the JSON report

The run endpoint accepts two shapes:

```jsonc
// Look up in saiku-home/evals/
{ "suiteName": "foodmart-sales-evals" }

// Or inline YAML — CI dynamically builds a suite
{ "suiteYaml": "name: adhoc\ncube: {...}\ncases: [...]" }
```

Response is `200` with the full `EvalReport` regardless of pass/fail — the caller inspects `failedCount` / `degradedCount` to decide CI status. `400` on malformed body / missing suite; `503` when the ask adapter isn't wired.

## What's here

- **`EvalSuiteRegistry`** — parallels the skill + space registries. Scans `*.yaml` + `*.yml` under `saiku-home/evals/`, mtime-signature refresh, structured parse errors, duplicate-suite-name detection.
- **Spring wiring** (`saiku-beans.xml`):
  - `evalSuiteRegistryBean` — root at `${saiku.home}/evals`
  - `aiSchemaConverterBean` — new bean for the shared converter
  - `liveEvalAskAdapterBean` — wraps `AiAskService` + `AiCubeMetadataService` + `AiSchemaConverter` + `ThinQueryService`
  - Both injected into `aiQueryResource` as optional properties
- **Launcher staging** — bundled `foodmart-sales.eval.yaml` lands in `saiku-home/evals/` on first boot so a fresh install can run the endpoint immediately as a smoke check
- **Docs** — `docs/EVAL-SPEC.md` gains a `REST surface` section with all four endpoints + a curl example that pipes through `jq` to produce a compact CI summary

## Tests

**8 new `EvalSuiteRegistry` tests:**
- Empty root, missing root
- `.yaml` + `.yml` extension handling; non-YAML files ignored
- Structured errors on bad YAML
- Duplicate suite-name detection
- Add-file mtime refresh
- `get(name)` null safety
- `String`-path convenience ctor

Full service suite: **918 tests, 0 failures**. Full web suite: **478 tests, 0 failures**. Spotless clean.

## Test plan

- [ ] Fresh launcher boot → `GET /rest/saiku/api/ai/evals/suites` returns the seeded FoodMart suite
- [ ] `POST /rest/saiku/api/ai/evals/run` with `{"suiteName": "foodmart-sales-evals"}` and Anthropic configured → runs the 5 cases, returns a report
- [ ] `POST /rest/saiku/api/ai/evals/run` with `{"suiteYaml": "..."}` inline → parses + runs
- [ ] `POST /rest/saiku/api/ai/evals/run` with a bad YAML in `suiteYaml` → 400 with structured `{code, message}`
- [ ] `POST /rest/saiku/api/ai/evals/run` with no provider configured → 503 with clear message
- [ ] Break a YAML file → `/ai/evals/suites?errors=true` surfaces the parse error, other suites still list

## Non-goals for this slice

- **`saiku eval` CLI subcommand** — deferred. The REST endpoint is the load-bearing surface; a CLI wrapper is a thin HTTP client that pretty-prints the report. Small follow-up.
- **Recording adapter** for fixture replay without spending LLM budget — SPI is stable, follow-up.
- **Cross-run comparison** — requires report archiving. Follow-up.

## Related

- Base PRs (already merged): #1448 (framework) + #1449 (live adapter)
- Feature ticket: #1424