### PR TITLE
#1424 feat(eval): saiku eval CLI subcommand

### DIFF
--- a/docs/EVAL-SPEC.md
+++ b/docs/EVAL-SPEC.md
@@ -216,10 +216,45 @@ curl -sS -X POST -u admin:admin \
 The launcher stages the bundled FoodMart suite to `saiku-home/evals/foodmart-sales.eval.yaml`
 on first boot — a fresh install can run the endpoint immediately as a smoke check.
 
+## `saiku eval` CLI
+
+The launcher's `eval` subcommand wraps the REST endpoint so CI doesn't have to embed curl + jq:
+
+```bash
+# Registered suite name (looked up server-side against saiku-home/evals/)
+saiku eval foodmart-sales-evals \
+  --server http://localhost:8080 \
+  --user admin --password admin
+
+# Or a local YAML file — sent inline as suiteYaml
+saiku eval ./ci/regression.eval.yaml \
+  --server https://saiku.internal
+```
+
+The positional `SUITE` arg is treated as a filesystem path if it resolves to a
+readable file, otherwise as a registered suite name. Handy for CI jobs that build
+suites dynamically.
+
+**Options:**
+
+| Flag | Default | Purpose |
+|------|---------|---------|
+| `-s, --server` | `http://localhost:8080` | Launcher URL |
+| `-u, --user` | `admin` | HTTP Basic username |
+| `-P, --password` | `admin` | Basic password. **Prefer `SAIKU_EVAL_PASSWORD` env var** for CI — command-line args show up in process listings |
+| `--format` | `text` | Output shape: `text` (human-readable summary) or `json` (raw report) |
+| `--timeout` | `300` | Server request timeout in seconds |
+| `--fail-on-degraded` / `--no-fail-on-degraded` | `true` | Whether degraded outcomes count as failures for the exit code |
+
+**Exit codes:**
+
+- `0` — every case passed (and no degraded when the flag is on)
+- `1` — at least one case failed / degraded
+- `2` — HTTP error (network, auth, 4xx, 5xx) — server response echoed to stderr
+- `3` — argument error (missing suite, unreadable file, bad flag)
+
 ## Non-goals for v1
 
-- **`saiku eval` CLI subcommand** — deferred. The REST endpoint above is the load-bearing
-  surface; a CLI wrapper is a thin HTTP client that pretty-prints the report. Small follow-up.
 - **Recording adapter** — an adapter that writes each live response to
   a fixture file so the fixture adapter can replay deterministically
   without spending LLM budget. Design ready; implementation deferred.

--- a/saiku-launcher/src/main/java/org/saiku/launcher/EvalCommand.java
+++ b/saiku-launcher/src/main/java/org/saiku/launcher/EvalCommand.java
@@ -1,0 +1,236 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.launcher;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.Base64;
+import java.util.concurrent.Callable;
+import picocli.CommandLine;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Option;
+import picocli.CommandLine.Parameters;
+
+/**
+ * {@code saiku eval} — run an agent-eval suite against a running launcher (saiku#1424 follow-up).
+ *
+ * <p>Wraps the {@code POST /rest/saiku/api/ai/evals/run} endpoint so operators + CI can invoke
+ * a suite without wiring curl + jq into every job:
+ *
+ * <pre>{@code
+ * saiku eval foodmart-sales-evals \
+ *   --server http://localhost:8080 \
+ *   --user admin --password admin
+ * }</pre>
+ *
+ * <p>The positional {@code SUITE} arg is either a registered suite name (looked up server-side
+ * against {@code saiku-home/evals/}) or a path to a YAML file on the local filesystem. The
+ * distinguishing test is simple: if the arg exists as a readable file, it's treated as a path
+ * and the YAML is posted inline; otherwise it's treated as a suite name.
+ *
+ * <p>Exit codes:
+ *
+ * <ul>
+ *   <li>{@code 0} — every case passed.
+ *   <li>{@code 1} — at least one case failed or degraded. The report is still printed.
+ *   <li>{@code 2} — HTTP error (network / auth / 4xx / 5xx). Server response printed to stderr.
+ *   <li>{@code 3} — argument error (missing suite arg, unreadable file, bad flag).
+ * </ul>
+ *
+ * <p>This command is a pure HTTP client — no Spring context, no in-process launcher. The server
+ * must already be running (typically via {@code saiku serve}).
+ */
+@Command(name = "eval", description = "Run an agent-eval suite against a running launcher.")
+public class EvalCommand implements Callable<Integer> {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    @Parameters(
+            index = "0",
+            paramLabel = "SUITE",
+            description = "Suite name (registered on the server) OR path to a local YAML file.")
+    String suite;
+
+    @Option(
+            names = {"-s", "--server"},
+            description = "Launcher URL (default: http://localhost:8080).",
+            defaultValue = "http://localhost:8080")
+    String server;
+
+    @Option(
+            names = {"-u", "--user"},
+            description = "Username for HTTP Basic auth (default: admin).",
+            defaultValue = "admin")
+    String user;
+
+    @Option(
+            names = {"-P", "--password"},
+            description = "Password for HTTP Basic auth (default: admin). "
+                    + "Prefer setting SAIKU_EVAL_PASSWORD in the environment instead.",
+            defaultValue = "admin")
+    String password;
+
+    @Option(
+            names = {"--format"},
+            description = "Output format: text (default) or json.",
+            defaultValue = "text")
+    String format;
+
+    @Option(
+            names = {"--timeout"},
+            description = "Server request timeout in seconds (default 300 — evals can take minutes).",
+            defaultValue = "300")
+    int timeoutSeconds;
+
+    @Option(
+            names = {"--fail-on-degraded"},
+            description = "Exit non-zero when any case degrades (default: true).",
+            defaultValue = "true",
+            negatable = true)
+    boolean failOnDegraded;
+
+    @Override
+    public Integer call() {
+        // Pull password from env if set — SAIKU_EVAL_PASSWORD beats the --password default so CI
+        // doesn't have to pass the password on argv (visible in process listings).
+        String envPassword = System.getenv("SAIKU_EVAL_PASSWORD");
+        if (envPassword != null && !envPassword.isBlank()) {
+            password = envPassword;
+        }
+
+        if (suite == null || suite.isBlank()) {
+            System.err.println("saiku eval: SUITE argument is required");
+            return 3;
+        }
+        if (!"text".equalsIgnoreCase(format) && !"json".equalsIgnoreCase(format)) {
+            System.err.println("saiku eval: --format must be 'text' or 'json' (got '" + format + "')");
+            return 3;
+        }
+
+        String requestBody;
+        try {
+            requestBody = buildRequestBody(suite);
+        } catch (IOException e) {
+            System.err.println("saiku eval: cannot read suite file '" + suite + "': " + e.getMessage());
+            return 3;
+        }
+
+        String url = server.replaceAll("/+$", "") + "/rest/saiku/api/ai/evals/run";
+        String auth =
+                "Basic " + Base64.getEncoder().encodeToString((user + ":" + password).getBytes(StandardCharsets.UTF_8));
+
+        HttpClient http =
+                HttpClient.newBuilder().connectTimeout(Duration.ofSeconds(30)).build();
+        HttpRequest req = HttpRequest.newBuilder()
+                .uri(URI.create(url))
+                .timeout(Duration.ofSeconds(timeoutSeconds))
+                .header("content-type", "application/json")
+                .header("accept", "application/json")
+                .header("authorization", auth)
+                .POST(HttpRequest.BodyPublishers.ofString(requestBody, StandardCharsets.UTF_8))
+                .build();
+
+        HttpResponse<String> res;
+        try {
+            res = http.send(req, HttpResponse.BodyHandlers.ofString());
+        } catch (IOException | InterruptedException e) {
+            if (e instanceof InterruptedException) Thread.currentThread().interrupt();
+            System.err.println("saiku eval: transport error hitting " + url + ": " + e.getMessage());
+            return 2;
+        }
+
+        if (res.statusCode() / 100 != 2) {
+            System.err.println("saiku eval: HTTP " + res.statusCode() + " from " + url);
+            System.err.println(res.body());
+            return 2;
+        }
+
+        JsonNode report;
+        try {
+            report = MAPPER.readTree(res.body());
+        } catch (IOException e) {
+            System.err.println("saiku eval: cannot parse server response as JSON: " + e.getMessage());
+            System.err.println(res.body());
+            return 2;
+        }
+
+        if ("json".equalsIgnoreCase(format)) {
+            System.out.println(res.body());
+        } else {
+            printText(report);
+        }
+
+        int failed = report.path("failedCount").asInt(0);
+        int degraded = report.path("degradedCount").asInt(0);
+        if (failed > 0) return 1;
+        if (failOnDegraded && degraded > 0) return 1;
+        return 0;
+    }
+
+    /**
+     * Build the request body. If {@code suite} points at a readable file, post it inline as
+     * {@code suiteYaml}; otherwise treat as a registered {@code suiteName}.
+     */
+    String buildRequestBody(String suite) throws IOException {
+        Path p = Path.of(suite);
+        if (Files.isReadable(p)) {
+            String yaml = Files.readString(p, StandardCharsets.UTF_8);
+            return MAPPER.writeValueAsString(java.util.Map.of("suiteYaml", yaml));
+        }
+        return MAPPER.writeValueAsString(java.util.Map.of("suiteName", suite));
+    }
+
+    /**
+     * Render an {@code EvalReport} JSON node as a human-readable text summary. Mirrors the
+     * {@code EvalReportWriter.toText} format that the service module produces — kept in sync by
+     * hand rather than a shared library so the CLI doesn't need the whole {@code saiku-service}
+     * classpath.
+     */
+    static void printText(JsonNode report) {
+        String suiteName = report.path("suiteName").asText("(unnamed)");
+        String description = report.path("suiteDescription").asText("");
+        System.out.println("Suite: " + suiteName);
+        if (!description.isEmpty()) {
+            System.out.println("Description: " + description);
+        }
+        int total = report.path("outcomes").isArray() ? report.path("outcomes").size() : 0;
+        int passed = report.path("passedCount").asInt(0);
+        int failed = report.path("failedCount").asInt(0);
+        int degraded = report.path("degradedCount").asInt(0);
+        int skipped = report.path("skippedCount").asInt(0);
+        long duration = report.path("totalDurationMs").asLong(0);
+        System.out.println(passed + "/" + total + " passed, " + failed + " failed, " + degraded + " degraded, "
+                + skipped + " skipped (elapsed " + duration + "ms)");
+        System.out.println();
+
+        for (JsonNode outcome : report.path("outcomes")) {
+            String status = outcome.path("status").asText("?");
+            String caseName = outcome.path("caseName").asText("(unnamed)");
+            long caseDuration = outcome.path("durationMs").asLong(0);
+            String intent = outcome.path("actualIntent").asText("null");
+            String model = outcome.path("actualModel").asText("null");
+            System.out.println(
+                    status + ": " + caseName + " (" + caseDuration + "ms, intent=" + intent + ", model=" + model + ")");
+            for (JsonNode mismatch : outcome.path("mismatches")) {
+                System.out.println("  " + mismatch.path("path").asText("") + ": "
+                        + mismatch.path("message").asText(""));
+            }
+        }
+    }
+
+    /** For tests that want to invoke the command with a pre-built HttpClient shim. */
+    public static int runWith(String[] args) {
+        return new CommandLine(new EvalCommand()).execute(args);
+    }
+}

--- a/saiku-launcher/src/main/java/org/saiku/launcher/SaikuLauncher.java
+++ b/saiku-launcher/src/main/java/org/saiku/launcher/SaikuLauncher.java
@@ -30,7 +30,12 @@ import picocli.CommandLine.Option;
         mixinStandardHelpOptions = true,
         version = "saiku 3.17",
         description = "Saiku Semantic Layer server.",
-        subcommands = {SaikuLauncher.ServeCommand.class, OssieExportCommand.class, SqlServeCommand.class})
+        subcommands = {
+            SaikuLauncher.ServeCommand.class,
+            OssieExportCommand.class,
+            SqlServeCommand.class,
+            EvalCommand.class
+        })
 public class SaikuLauncher implements Callable<Integer> {
 
     public static void main(String[] args) {
@@ -716,19 +721,16 @@ public class SaikuLauncher implements Callable<Integer> {
             Path spacesDir = saikuHome.resolve("agent-spaces");
             Files.createDirectories(spacesDir);
             stageResource(
-                    "/seed/agent-spaces/foodmart-sales-analyst.json",
-                    spacesDir.resolve("foodmart-sales-analyst.json"));
+                    "/seed/agent-spaces/foodmart-sales-analyst.json", spacesDir.resolve("foodmart-sales-analyst.json"));
             stageResource(
-                    "/seed/agent-spaces/foodmart-finance-ops.json",
-                    spacesDir.resolve("foodmart-finance-ops.json"));
+                    "/seed/agent-spaces/foodmart-finance-ops.json", spacesDir.resolve("foodmart-finance-ops.json"));
 
             // Seed the eval-suite catalogue (saiku#1424) with the FoodMart baseline —
             // 5 cases covering QUERY / INSIGHT / REFUSED that a fresh install can run
             // through POST /ai/evals/run as a smoke check.
             Path evalsDir = saikuHome.resolve("evals");
             Files.createDirectories(evalsDir);
-            stageResource(
-                    "/seed/evals/foodmart-sales.eval.yaml", evalsDir.resolve("foodmart-sales.eval.yaml"));
+            stageResource("/seed/evals/foodmart-sales.eval.yaml", evalsDir.resolve("foodmart-sales.eval.yaml"));
         }
 
         /**

--- a/saiku-launcher/src/test/java/org/saiku/launcher/EvalCommandTest.java
+++ b/saiku-launcher/src/test/java/org/saiku/launcher/EvalCommandTest.java
@@ -1,0 +1,115 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.launcher;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+/**
+ * Unit tests for the {@link EvalCommand} — argument parsing, path-vs-name detection, and text
+ * report formatting. The HTTP round-trip is exercised by a live-integration test path (deferred);
+ * this file focuses on the client-side logic that's easy to test in isolation.
+ */
+public class EvalCommandTest {
+
+    private static final ObjectMapper JSON = new ObjectMapper();
+
+    @Rule
+    public TemporaryFolder tmp = new TemporaryFolder();
+
+    @Test
+    public void suiteNameProducesSuiteNameBody() throws Exception {
+        EvalCommand cmd = new EvalCommand();
+        String body = cmd.buildRequestBody("foodmart-sales-evals");
+        JsonNode node = JSON.readTree(body);
+        assertEquals("foodmart-sales-evals", node.path("suiteName").asText());
+        assertTrue("must not carry a suiteYaml payload", node.path("suiteYaml").isMissingNode());
+    }
+
+    @Test
+    public void existingFilePathProducesSuiteYamlBody() throws Exception {
+        Path yaml = tmp.newFile("adhoc.eval.yaml").toPath();
+        String yamlContent = "name: adhoc-suite\ncube:\n  connectionName: c\n  catalog: cat\n"
+                + "  schema: s\n  cubeName: Sales\ncases:\n  - name: a\n    question: q\n";
+        Files.writeString(yaml, yamlContent, StandardCharsets.UTF_8);
+
+        EvalCommand cmd = new EvalCommand();
+        String body = cmd.buildRequestBody(yaml.toString());
+        JsonNode node = JSON.readTree(body);
+        assertTrue("must carry a suiteYaml payload", node.has("suiteYaml"));
+        assertEquals(yamlContent, node.path("suiteYaml").asText());
+        assertTrue("must not carry a suiteName", node.path("suiteName").isMissingNode());
+    }
+
+    @Test
+    public void missingFilePathFallsBackToSuiteName() throws Exception {
+        // A path-shaped arg that doesn't exist as a file: the CLI treats it as a suite name and
+        // lets the server-side registry lookup decide. This keeps "typo in filename" from silently
+        // becoming an inline-YAML post with garbage content.
+        EvalCommand cmd = new EvalCommand();
+        String body = cmd.buildRequestBody("/nonexistent/path/foo.yaml");
+        JsonNode node = JSON.readTree(body);
+        assertEquals("/nonexistent/path/foo.yaml", node.path("suiteName").asText());
+        assertTrue(node.path("suiteYaml").isMissingNode());
+    }
+
+    @Test
+    public void textFormatPrintsSummary() throws Exception {
+        JsonNode report = JSON.readTree("{\"suiteName\":\"my-suite\","
+                + "\"suiteDescription\":\"the description\","
+                + "\"passedCount\":2,\"failedCount\":1,\"degradedCount\":0,\"skippedCount\":0,"
+                + "\"totalDurationMs\":1234,"
+                + "\"outcomes\":["
+                + "{\"caseName\":\"case-a\",\"status\":\"PASS\",\"durationMs\":100,"
+                + "\"actualIntent\":\"QUERY\",\"actualModel\":\"claude-x\",\"mismatches\":[]},"
+                + "{\"caseName\":\"case-b\",\"status\":\"FAIL\",\"durationMs\":200,"
+                + "\"actualIntent\":\"QUERY\",\"actualModel\":\"claude-x\","
+                + "\"mismatches\":[{\"path\":\"rows[0].country\",\"message\":\"expected USA got Mexico\"}]}"
+                + "]}");
+
+        String output = captureStdout(() -> EvalCommand.printText(report));
+        assertTrue("summary line", output.contains("2/2 passed, 1 failed, 0 degraded"));
+        assertTrue("suite name", output.contains("Suite: my-suite"));
+        assertTrue("description", output.contains("Description: the description"));
+        assertTrue("elapsed", output.contains("elapsed 1234ms"));
+        assertTrue("pass line", output.contains("PASS: case-a"));
+        assertTrue("fail line", output.contains("FAIL: case-b"));
+        assertTrue("mismatch surfaced", output.contains("rows[0].country: expected USA got Mexico"));
+    }
+
+    @Test
+    public void textFormatOmitsEmptyDescription() throws Exception {
+        JsonNode report = JSON.readTree("{\"suiteName\":\"n\",\"suiteDescription\":\"\","
+                + "\"passedCount\":1,\"failedCount\":0,\"degradedCount\":0,\"skippedCount\":0,"
+                + "\"totalDurationMs\":0,\"outcomes\":[]}");
+        String output = captureStdout(() -> EvalCommand.printText(report));
+        assertTrue("no Description: prefix when empty", !output.contains("Description:"));
+    }
+
+    /* ---- helpers ---- */
+
+    private static String captureStdout(Runnable body) {
+        PrintStream original = System.out;
+        ByteArrayOutputStream buf = new ByteArrayOutputStream();
+        try {
+            System.setOut(new PrintStream(buf, true, StandardCharsets.UTF_8));
+            body.run();
+        } finally {
+            System.setOut(original);
+        }
+        return buf.toString(StandardCharsets.UTF_8);
+    }
+}


### PR DESCRIPTION
Stacked on #1450 (REST endpoint). Wraps the `/ai/evals/run` endpoint in a Picocli subcommand so CI + operators can invoke a suite without embedding curl + jq.

## Usage

```bash
# Registered suite name (looked up server-side against saiku-home/evals/)
saiku eval foodmart-sales-evals \
  --server http://localhost:8080 \
  --user admin --password admin

# Or a local YAML file — sent inline as suiteYaml
saiku eval ./ci/regression.eval.yaml --server https://saiku.internal
```

The positional `SUITE` arg is treated as a filesystem path if it resolves to a readable file, otherwise as a registered suite name — handy for CI jobs that build suites dynamically.

## Options

| Flag | Default | Purpose |
|------|---------|---------|
| `-s, --server` | `http://localhost:8080` | Launcher URL |
| `-u, --user` | `admin` | HTTP Basic username |
| `-P, --password` | `admin` | Basic password. **Prefer `SAIKU_EVAL_PASSWORD` env var** for CI |
| `--format` | `text` | `text` (human summary) or `json` (raw report) |
| `--timeout` | `300` | Server request timeout in seconds |
| `--fail-on-degraded` / `--no-fail-on-degraded` | `true` | Whether degraded counts as failure |

## Exit codes

- `0` — every case passed (and no degraded when the flag is on)
- `1` — at least one case failed / degraded
- `2` — HTTP error (network, auth, 4xx, 5xx) — server response echoed to stderr
- `3` — argument error (missing suite, unreadable file, bad flag)

## Tests

5 unit tests:
- Suite name → `{suiteName}` body
- Existing file path → `{suiteYaml}` body with the file's content
- Missing file path falls back to `suiteName` (protects against typo-becomes-inline-garbage)
- Text formatter renders every field correctly (summary, pass/fail lines, mismatches)
- Empty description skips the `Description:` prefix

Full launcher suite: 24 tests, 0 failures. Spotless clean.

## Related

- Base PR (must merge first): #1450
- Feature ticket: #1424
- Docs: `docs/EVAL-SPEC.md` — `saiku eval CLI` section