### PR TITLE
#1440 feat(ai/spaces): space-scoped SSE streaming (POST /ai/spaces/{id}/ask/stream)

### DIFF
--- a/docs/AGENT-SPACES-SPEC.md
+++ b/docs/AGENT-SPACES-SPEC.md
@@ -103,7 +103,14 @@ Parse failures surface via `GET /rest/saiku/api/ai/spaces?errors=true`:
   admin UI when editing a persona.
 - `POST /rest/saiku/api/ai/spaces/{id}/ask` — space-scoped ask. Body
   shape mirrors `/ai/ask` but `cube` is optional (falls back to the
-  space default).
+  space default). A cube ref outside the allowlist returns `403`; an
+  unknown space returns `404`.
+- `POST /rest/saiku/api/ai/spaces/{id}/ask/stream` — SSE streaming
+  variant of the above (saiku#1440 + #1433). Same event schema as
+  [`/ai/ask/stream`](AI-QUERY-API.md) (`model` → `intent` → `chunk` →
+  `final`) with the persona scoping applied. The scope pre-flight runs
+  before the stream opens, so a denied ask returns a real `403`/`404`
+  rather than a `200` carrying an in-band error event.
 - `POST /rest/saiku/api/ai/spaces/refresh` — force a rescan.
 
 ## Bundled examples

--- a/docs/AI-QUERY-API.md
+++ b/docs/AI-QUERY-API.md
@@ -1511,6 +1511,11 @@ falls through as a raw ask.
   UI when editing a persona).
 - `POST /rest/saiku/api/ai/spaces/{id}/ask` — space-scoped ask. Body
   shape mirrors `/ai/ask` but `cube` is optional.
+- `POST /rest/saiku/api/ai/spaces/{id}/ask/stream` — SSE streaming
+  variant. Same event schema as [`/ai/ask/stream`](#streaming-variant--post-aiaskstream-saiku1433)
+  (`model` → `intent` → `chunk` → `final`), but the persona scoping
+  from the space applies — the client sees identical wire events
+  whether they hit `/ai/ask/stream` or the space-scoped mirror.
 - `POST /rest/saiku/api/ai/spaces/refresh` — force a rescan.
 
 ### Bundled examples

--- a/docs/AI-QUERY-API.md
+++ b/docs/AI-QUERY-API.md
@@ -1471,7 +1471,11 @@ Two things make a space genuinely enforce scope:
 
 - **Cube allowlist.** `POST /ai/spaces/{id}/ask` refuses any cube ref
   outside the allowlist with a 403 `FORBIDDEN`. When the body omits
-  `cube`, the space's first allowlisted ref is used as the default.
+  `cube`, the space's first allowlisted ref is used as the default. The
+  check runs twice: on the caller-supplied ref before the model call,
+  and again on the cube the model emits in its generated query — so a
+  prompt-injected cross-cube query can't escape the persona's scope
+  (saiku#1453).
 - **System prompt injection.** The space's `systemPrompt` is prepended
   to the built-in `SYSTEM_PROMPT` on the provider side. Users can't
   override it through `history` or `question`.
@@ -1515,7 +1519,10 @@ falls through as a raw ask.
   variant. Same event schema as [`/ai/ask/stream`](#streaming-variant--post-aiaskstream-saiku1433)
   (`model` → `intent` → `chunk` → `final`), but the persona scoping
   from the space applies — the client sees identical wire events
-  whether they hit `/ai/ask/stream` or the space-scoped mirror.
+  whether they hit `/ai/ask/stream` or the space-scoped mirror. The
+  scope check is a pre-flight: a cube outside the allowlist returns a
+  real `403` (an unknown space `404`) *before* the event-stream opens,
+  not a `200` carrying an in-band error event.
 - `POST /rest/saiku/api/ai/spaces/refresh` — force a rescan.
 
 ### Bundled examples

--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ai/ask/AiAskService.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ai/ask/AiAskService.java
@@ -111,7 +111,8 @@ public class AiAskService {
             AiQueryRequest request,
             AiInsight insight,
             AiViewChange viewChange,
-            String model) {
+            String model,
+            SpaceAccess denial) {
 
         public enum Kind {
             QUERY,
@@ -120,19 +121,28 @@ public class AiAskService {
         }
 
         public static AskOutcome ok(AiQueryRequest request, String model) {
-            return new AskOutcome(Kind.QUERY, false, null, request, null, null, model);
+            return new AskOutcome(Kind.QUERY, false, null, request, null, null, model, SpaceAccess.OK);
         }
 
         public static AskOutcome okInsight(AiInsight insight, String model) {
-            return new AskOutcome(Kind.INSIGHT, false, null, null, insight, null, model);
+            return new AskOutcome(Kind.INSIGHT, false, null, null, insight, null, model, SpaceAccess.OK);
         }
 
         public static AskOutcome okViewChange(AiViewChange viewChange, String model) {
-            return new AskOutcome(Kind.VIEW_CHANGE, false, null, null, null, viewChange, model);
+            return new AskOutcome(Kind.VIEW_CHANGE, false, null, null, null, viewChange, model, SpaceAccess.OK);
         }
 
+        /** Provider-side degrade (transport/parse/refusal) — carries no space-scope denial. */
         public static AskOutcome degraded(String reason, String model) {
-            return new AskOutcome(null, true, reason, null, null, null, model);
+            return new AskOutcome(null, true, reason, null, null, null, model, SpaceAccess.OK);
+        }
+
+        /**
+         * Space-scope denial (saiku#1465). The {@code denial} code lets the web layer map to a real
+         * HTTP status without prose-prefix matching on {@link #reason()}.
+         */
+        public static AskOutcome degraded(String reason, String model, SpaceAccess denial) {
+            return new AskOutcome(null, true, reason, null, null, null, model, denial);
         }
     }
 
@@ -202,19 +212,20 @@ public class AiAskService {
             NlAskRequest.ForceTool forceTool,
             AiQueryRequest currentQuery) {
         if (spaces == null) {
-            return AskOutcome.degraded("agent spaces are not configured on this instance", null);
+            return AskOutcome.degraded(
+                    "agent spaces are not configured on this instance", null, SpaceAccess.SPACES_NOT_CONFIGURED);
         }
         if (spaceId == null || spaceId.isBlank()) {
-            return AskOutcome.degraded("space id required", null);
+            return AskOutcome.degraded("space id required", null, SpaceAccess.SPACE_NOT_FOUND);
         }
         java.util.Optional<AgentSpace> maybe = spaces.get(spaceId);
         if (maybe.isEmpty()) {
-            return AskOutcome.degraded("space not found: " + spaceId, null);
+            return AskOutcome.degraded("space not found: " + spaceId, null, SpaceAccess.SPACE_NOT_FOUND);
         }
         AgentSpace space = maybe.get();
         AiCubeRef effectiveRef = ref != null ? ref : space.defaultCube();
         if (effectiveRef == null) {
-            return AskOutcome.degraded("space has no cubes in its allowlist", null);
+            return AskOutcome.degraded("space has no cubes in its allowlist", null, SpaceAccess.FORBIDDEN);
         }
         if (!space.allowsCube(effectiveRef)) {
             // Persona guardrail — the caller tried to point the space at a cube outside its
@@ -222,7 +233,8 @@ public class AiAskService {
             // us a stale cube ref should get corrected, not silently reinterpreted.
             return AskOutcome.degraded(
                     "FORBIDDEN: cube " + effectiveRef.getCubeName() + " is not in space '" + spaceId + "' allowlist",
-                    null);
+                    null,
+                    SpaceAccess.FORBIDDEN);
         }
         return askInternal(effectiveRef, question, history, cellsetDigest, forceTool, currentQuery, space);
     }
@@ -376,7 +388,8 @@ public class AiAskService {
                             cubeName);
                     return AskOutcome.degraded(
                             "FORBIDDEN: cube " + cubeName + " is not in space '" + space.id() + "' allowlist",
-                            resp.model());
+                            resp.model(),
+                            SpaceAccess.FORBIDDEN);
                 }
                 return AskOutcome.ok(parsed, resp.model());
             }

--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ai/ask/AiAskService.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ai/ask/AiAskService.java
@@ -321,6 +321,24 @@ public class AiAskService {
             NlAskResponse.Kind kind = resp.kind();
             if (kind == NlAskResponse.Kind.QUERY) {
                 AiQueryRequest parsed = mapper.readValue(resp.payloadJson(), AiQueryRequest.class);
+                // Persona guardrail (saiku#1453/#1463): the pre-LLM check at askInSpace validated
+                // only the INPUT ref. The model's emitted query names its own cube, which a
+                // prompt-injected question can push outside the allowlist. Re-validate the executed
+                // cube here — this is the only place it can live, because AskOutcome carries no
+                // space context, so a downstream resource (e.g. the streaming endpoint that
+                // executes the query) cannot re-check it.
+                if (space != null && !space.allowsCube(parsed.getCube())) {
+                    String cubeName = parsed.getCube() == null
+                            ? "(none)"
+                            : parsed.getCube().getCubeName();
+                    log.warn(
+                            "Space '{}' scope violation: model emitted a query against non-allowlisted cube {}",
+                            space.id(),
+                            cubeName);
+                    return AskOutcome.degraded(
+                            "FORBIDDEN: cube " + cubeName + " is not in space '" + space.id() + "' allowlist",
+                            resp.model());
+                }
                 return AskOutcome.ok(parsed, resp.model());
             }
             if (kind == NlAskResponse.Kind.INSIGHT) {

--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ai/ask/AiAskService.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ai/ask/AiAskService.java
@@ -227,6 +227,45 @@ public class AiAskService {
         return askInternal(effectiveRef, question, history, cellsetDigest, forceTool, currentQuery, space);
     }
 
+    /**
+     * Result of a synchronous space-access pre-flight — the input-side scope decision, made
+     * without calling the LLM. Lets a streaming endpoint map a scope denial to a real HTTP status
+     * (403 / 404 / 503) <em>before</em> it commits to a 200 event-stream, instead of burying the
+     * denial in an in-band SSE error event (saiku#1454). The post-LLM re-check of the model's
+     * emitted cube (saiku#1453) still runs inside {@link #askInSpace}; this only covers the
+     * caller-supplied ref.
+     */
+    public enum SpaceAccess {
+        OK,
+        SPACES_NOT_CONFIGURED,
+        SPACE_NOT_FOUND,
+        FORBIDDEN
+    }
+
+    /**
+     * Pre-flight the caller-supplied cube ref against the space's allowlist without invoking the
+     * provider. Mirrors the guard sequence at the top of {@link #askInSpace} so the two agree on
+     * what a scope denial is. Cheap (registry lookup only) — safe to call before streaming starts.
+     */
+    public SpaceAccess checkSpaceAccess(String spaceId, AiCubeRef ref) {
+        if (spaces == null) {
+            return SpaceAccess.SPACES_NOT_CONFIGURED;
+        }
+        if (spaceId == null || spaceId.isBlank()) {
+            return SpaceAccess.SPACE_NOT_FOUND;
+        }
+        java.util.Optional<AgentSpace> maybe = spaces.get(spaceId);
+        if (maybe.isEmpty()) {
+            return SpaceAccess.SPACE_NOT_FOUND;
+        }
+        AgentSpace space = maybe.get();
+        AiCubeRef effectiveRef = ref != null ? ref : space.defaultCube();
+        if (effectiveRef == null || !space.allowsCube(effectiveRef)) {
+            return SpaceAccess.FORBIDDEN;
+        }
+        return SpaceAccess.OK;
+    }
+
     private AskOutcome askInternal(
             AiCubeRef ref,
             String question,

--- a/saiku-core/saiku-service/src/test/java/org/saiku/service/olap/ai/ask/AiAskServiceTest.java
+++ b/saiku-core/saiku-service/src/test/java/org/saiku/service/olap/ai/ask/AiAskServiceTest.java
@@ -264,9 +264,16 @@ public class AiAskServiceTest {
     @Test
     public void spaceScopedAskEnforcesAllowlist() throws Exception {
         AtomicReference<NlAskRequest> seen = new AtomicReference<>();
+        // Emit the full 4-coordinate cube the real model returns (AiRequestJsonSchema marks all
+        // four required) so the post-LLM allowlist re-check (saiku#1453) sees an allowlisted cube.
         NlAskProvider capturing = req -> {
             seen.set(req);
-            return NlAskResponse.ok("{\"cube\":{\"cubeName\":\"Sales\"},\"measures\":[]}", "m", 0, 0);
+            return NlAskResponse.ok(
+                    "{\"cube\":{\"connectionName\":\"conn\",\"catalog\":\"cat\",\"schema\":\"sch\",\"cubeName\":\"Sales\"},"
+                            + "\"measures\":[]}",
+                    "m",
+                    0,
+                    0);
         };
         AiAskService svc = new AiAskService(fixedSchemaService(emptySchema()), capturing);
         java.nio.file.Path tmp = java.nio.file.Files.createTempDirectory("spaces");
@@ -295,11 +302,76 @@ public class AiAskServiceTest {
     }
 
     @Test
+    public void spaceScopedAskRejectsLlmQueryAgainstNonAllowlistedCube() throws Exception {
+        // saiku#1453/#1463 — the input ref is allowlisted (passes the pre-LLM check), but the
+        // provider's emitted QUERY names a DIFFERENT cube outside the allowlist (as a prompt
+        // injection would coax it to). The executed cube must be re-validated: the outcome has to
+        // degrade FORBIDDEN, not surface a query the streaming endpoint would then execute against
+        // the foreign cube.
+        String foreignCubeJson = "{"
+                + "\"cube\":{\"connectionName\":\"conn\",\"catalog\":\"cat\",\"schema\":\"sch\",\"cubeName\":\"HR\"},"
+                + "\"measures\":[{\"name\":\"Salary\"}]"
+                + "}";
+        AiAskService svc = new AiAskService(
+                fixedSchemaService(emptySchema()), stub(NlAskResponse.ok(foreignCubeJson, "claude-x", 10, 5)));
+        java.nio.file.Path tmp = java.nio.file.Files.createTempDirectory("spaces");
+        java.nio.file.Files.writeString(
+                tmp.resolve("sales.json"),
+                "{\"id\":\"sales-analyst\",\"name\":\"Sales Analyst\","
+                        + "\"cubeAllowlist\":["
+                        + "{\"connectionName\":\"conn\",\"catalog\":\"cat\",\"schema\":\"sch\",\"cubeName\":\"Sales\"}"
+                        + "]}");
+        svc.setSpaces(new AgentSpaceRegistry(tmp));
+
+        // CUBE (Sales) is allowlisted, so the pre-LLM check passes; the model then emits an HR query.
+        AiAskService.AskOutcome out =
+                svc.askInSpace("sales-analyst", CUBE, "show sales", List.of(), null, NlAskRequest.ForceTool.AUTO, null);
+
+        assertTrue("LLM-chosen cube outside the allowlist must be refused", out.degraded());
+        assertTrue(
+                "denial must carry the FORBIDDEN prefix so the 403 mapping applies: " + out.reason(),
+                out.reason().startsWith("FORBIDDEN"));
+        assertNull("a forbidden cross-cube query must not surface an executable request", out.request());
+    }
+
+    @Test
+    public void spaceScopedAskAllowsLlmQueryAgainstAllowlistedCube() throws Exception {
+        // Companion to the bypass test: when the emitted QUERY names an allowlisted cube, the
+        // re-check is transparent — the request surfaces normally.
+        String allowedCubeJson = "{"
+                + "\"cube\":{\"connectionName\":\"conn\",\"catalog\":\"cat\",\"schema\":\"sch\",\"cubeName\":\"Sales\"},"
+                + "\"measures\":[{\"name\":\"Store Sales\"}]"
+                + "}";
+        AiAskService svc = new AiAskService(
+                fixedSchemaService(emptySchema()), stub(NlAskResponse.ok(allowedCubeJson, "claude-x", 10, 5)));
+        java.nio.file.Path tmp = java.nio.file.Files.createTempDirectory("spaces");
+        java.nio.file.Files.writeString(
+                tmp.resolve("sales.json"),
+                "{\"id\":\"sales-analyst\",\"name\":\"Sales Analyst\","
+                        + "\"cubeAllowlist\":["
+                        + "{\"connectionName\":\"conn\",\"catalog\":\"cat\",\"schema\":\"sch\",\"cubeName\":\"Sales\"}"
+                        + "]}");
+        svc.setSpaces(new AgentSpaceRegistry(tmp));
+
+        AiAskService.AskOutcome out =
+                svc.askInSpace("sales-analyst", CUBE, "show sales", List.of(), null, NlAskRequest.ForceTool.AUTO, null);
+
+        assertFalse(out.degraded());
+        assertNotNull(out.request());
+        assertEquals("Sales", out.request().getCube().getCubeName());
+    }
+
+    @Test
     public void spaceScopedAskUsesDefaultCubeWhenAbsent() throws Exception {
         AtomicReference<NlAskRequest> seen = new AtomicReference<>();
         NlAskProvider capturing = req -> {
             seen.set(req);
-            return NlAskResponse.ok("{\"cube\":{\"cubeName\":\"Sales\"},\"measures\":[]}", "m", 0, 0);
+            return NlAskResponse.ok(
+                    "{\"cube\":{\"connectionName\":\"conn\",\"catalog\":\"cat\",\"schema\":\"sch\",\"cubeName\":\"Sales\"},"
+                            + "\"measures\":[]}",
+                    "m",
+                    0,
+                    0);
         };
         AiAskService svc = new AiAskService(fixedSchemaService(emptySchema()), capturing);
         java.nio.file.Path tmp = java.nio.file.Files.createTempDirectory("spaces");

--- a/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/AiOssieResource.java
+++ b/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/AiOssieResource.java
@@ -119,6 +119,59 @@ public class AiOssieResource {
         this.askService = s;
     }
 
+    /**
+     * saiku#1459: the same cost-DoS + policy guards the MDX ask endpoints carry. Without these the
+     * Ossie {@code /ask} was a bypass surface — a client 429'd or 413'd on {@code /ai/ask} could
+     * switch to {@code /ai/ossie/ask} and reach the paid LLM provider unbounded. Defaults mirror
+     * {@link AiQueryResource} so the guard is on even before Spring wires the shared beans.
+     */
+    private org.saiku.service.olap.ai.AiPolicyGuard aiPolicyGuard =
+            new org.saiku.service.olap.ai.AiPolicyGuard(org.saiku.service.olap.ai.AiPolicy.FULL);
+
+    private org.saiku.web.security.ratelimit.AiRateLimiter askRateLimiter =
+            new org.saiku.web.security.ratelimit.AiRateLimiter();
+
+    public void setAiPolicyGuard(org.saiku.service.olap.ai.AiPolicyGuard g) {
+        this.aiPolicyGuard = g;
+    }
+
+    public void setAskRateLimiter(org.saiku.web.security.ratelimit.AiRateLimiter l) {
+        this.askRateLimiter = l;
+    }
+
+    /** A degraded JSON error at the given status (413 oversize, 400 bad shape, 429 rate). */
+    private Response askLimitResponse(int status, String reason) {
+        String code = status == 429 ? "RATE_LIMITED" : status == 413 ? "REQUEST_TOO_LARGE" : "BAD_REQUEST";
+        return Response.status(status)
+                .entity(Map.of("error", code, "message", reason))
+                .type(MediaType.APPLICATION_JSON)
+                .build();
+    }
+
+    /**
+     * Rate-limit identity = caller principal + client IP, matching {@link AiQueryResource} so a
+     * client's spend across the MDX and Ossie ask endpoints shares one budget when the same
+     * limiter bean is wired into both. Falls back to a constant when no request is bound (tests).
+     */
+    private String askRateKey() {
+        jakarta.servlet.http.HttpServletRequest req = null;
+        org.springframework.web.context.request.RequestAttributes attrs =
+                org.springframework.web.context.request.RequestContextHolder.getRequestAttributes();
+        if (attrs instanceof org.springframework.web.context.request.ServletRequestAttributes) {
+            req = ((org.springframework.web.context.request.ServletRequestAttributes) attrs).getRequest();
+        }
+        String user = null;
+        String ip = null;
+        if (req != null) {
+            user = req.getRemoteUser();
+            if (user == null && req.getUserPrincipal() != null) {
+                user = req.getUserPrincipal().getName();
+            }
+            ip = req.getRemoteAddr();
+        }
+        return (user == null ? "anon" : user) + ":" + (ip == null ? "unknown" : ip);
+    }
+
     // -------------------------------------------------------------------
     // GET /models
     // -------------------------------------------------------------------
@@ -360,6 +413,9 @@ public class AiOssieResource {
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.APPLICATION_JSON)
     public Response ask(Map<String, Object> body) {
+        // saiku#1459: same policy gate the MDX ask endpoints carry — this reaches the same paid LLM
+        // provider and must not be a bypass surface for the AGGREGATED_RESULT_VALUES data policy.
+        aiPolicyGuard.assertCanSend(org.saiku.service.olap.ai.AiDataKind.AGGREGATED_RESULT_VALUES);
         if (askService == null || !askService.isConfigured()) {
             return Response.status(Response.Status.SERVICE_UNAVAILABLE)
                     .entity(
@@ -377,6 +433,30 @@ public class AiOssieResource {
         String question = strOr(body.get("question"));
         if (connection == null) return badRequest("connection", "connection is required", List.of());
         if (question == null) return badRequest("question", "question is required", List.of());
+
+        // saiku#1459: cap request size + call rate before reaching the paid LLM provider, same as
+        // /ai/ask. Extract the history contents up front so an oversize payload is rejected before
+        // any model call.
+        List<String> historyContents = new ArrayList<>();
+        Object rawHistoryForSize = body.get("history");
+        if (rawHistoryForSize instanceof List<?> hlist) {
+            for (Object h : hlist) {
+                if (h instanceof Map<?, ?> hmap) {
+                    historyContents.add(strOr(hmap.get("content")));
+                }
+            }
+        }
+        org.saiku.web.security.ratelimit.AiAskGuard.Violation sizeViolation =
+                org.saiku.web.security.ratelimit.AiAskGuard.checkSize(question, historyContents);
+        if (sizeViolation != null) {
+            return askLimitResponse(sizeViolation.isPayloadTooLarge() ? 413 : 400, sizeViolation.getMessage());
+        }
+        if (!askRateLimiter.tryAcquire(askRateKey())) {
+            return askLimitResponse(
+                    429,
+                    "Too many AI ask requests — limit is " + askRateLimiter.getMaxCalls() + " per "
+                            + (askRateLimiter.getWindowMs() / 1000) + "s. Please retry shortly.");
+        }
         try {
             OssieModelDto semantic = ossieDiscoverService.getModel(connection);
             if (modelName == null || modelName.isBlank()) modelName = semantic.getName();

--- a/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/AiQueryResource.java
+++ b/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/AiQueryResource.java
@@ -891,21 +891,19 @@ public class AiQueryResource {
                 parseForceTool(body.getForceTool()),
                 body.getCurrentQuery());
         if (outcome.degraded()) {
+            // Map scope denials by the outcome's typed denial code (saiku#1465) rather than by
+            // prefix-matching the prose reason — a wording change in the service can no longer
+            // silently downgrade a 403 to a 200. A plain provider degrade (denial == OK) falls
+            // through to a 200 with degraded:true, same as the classic /ask.
+            Response denial = mapSpaceAccessDenial(outcome.denial(), spaceId);
+            if (denial != null) {
+                return denial;
+            }
             AiAskApi.AskResponse out = new AiAskApi.AskResponse();
             out.setDegraded(true);
             out.setReason(outcome.reason());
-            // FORBIDDEN / space-not-found → 403; provider degrade → 200 with degraded:true (same
-            // as classic /ask).
-            String reason = outcome.reason() == null ? "" : outcome.reason();
-            int status = reason.startsWith("FORBIDDEN")
-                            || reason.startsWith("space not found")
-                            || reason.startsWith("space has no cubes")
-                    ? 403
-                    : 200;
-            return Response.status(status)
-                    .entity(out)
-                    .type(MediaType.APPLICATION_JSON)
-                    .build();
+            out.setModel(outcome.model());
+            return Response.ok(out).type(MediaType.APPLICATION_JSON).build();
         }
         // Mirror the classic /ai/ask success handling (saiku#1455): branch on the outcome kind so
         // INSIGHT / VIEW_CHANGE surface their artefact and QUERY is actually executed — previously

--- a/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/AiQueryResource.java
+++ b/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/AiQueryResource.java
@@ -878,44 +878,9 @@ public class AiQueryResource {
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.APPLICATION_JSON)
     public Response askInSpace(@PathParam("id") String spaceId, AiAskApi.AskRequest body) {
-        aiPolicyGuard.assertCanSend(org.saiku.service.olap.ai.AiDataKind.AGGREGATED_RESULT_VALUES);
-        if (body == null) {
-            return badRequest("body", "request body required", null);
-        }
-        if (body.getQuestion() == null || body.getQuestion().isBlank()) {
-            return badRequest("question", "question must be non-blank", null);
-        }
-        // Same size + rate guard as /ask — the space endpoint routes to the same LLM provider, so
-        // it has to carry the same cost-DoS protection.
-        org.saiku.web.security.ratelimit.AiAskGuard.Violation sizeViolation =
-                org.saiku.web.security.ratelimit.AiAskGuard.checkSize(body);
-        if (sizeViolation != null) {
-            return askLimitResponse(sizeViolation.isPayloadTooLarge() ? 413 : 400, sizeViolation.getMessage());
-        }
-        if (!askRateLimiter.tryAcquire(askRateKey())) {
-            return askLimitResponse(
-                    429,
-                    "Too many AI ask requests — limit is " + askRateLimiter.getMaxCalls() + " per "
-                            + (askRateLimiter.getWindowMs() / 1000) + "s. Please retry shortly.");
-        }
-        if (askService == null) {
-            AiAskApi.AskResponse out = new AiAskApi.AskResponse();
-            out.setDegraded(true);
-            out.setReason("AI ask is not configured. Set saiku.ai.ask.provider to enable the feature.");
-            return Response.status(Response.Status.SERVICE_UNAVAILABLE)
-                    .entity(out)
-                    .type(MediaType.APPLICATION_JSON)
-                    .build();
-        }
-        org.saiku.service.olap.ai.ask.NlAskRequest.ForceTool force =
-                org.saiku.service.olap.ai.ask.NlAskRequest.ForceTool.AUTO;
-        if (body.getForceTool() != null) {
-            try {
-                force = org.saiku.service.olap.ai.ask.NlAskRequest.ForceTool.valueOf(
-                        body.getForceTool().toUpperCase());
-            } catch (IllegalArgumentException ignored) {
-                // unknown value — keep AUTO
-            }
+        Response pre = validateAskPreamble(body, false);
+        if (pre != null) {
+            return pre;
         }
         AiAskService.AskOutcome outcome = askService.askInSpace(
                 spaceId,
@@ -923,7 +888,7 @@ public class AiQueryResource {
                 body.getQuestion(),
                 body.historyAsMessages(),
                 body.getCellsetDigest(),
-                force,
+                parseForceTool(body.getForceTool()),
                 body.getCurrentQuery());
         if (outcome.degraded()) {
             AiAskApi.AskResponse out = new AiAskApi.AskResponse();
@@ -953,62 +918,16 @@ public class AiQueryResource {
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.APPLICATION_JSON)
     public Response ask(AiAskApi.AskRequest body) {
-        aiPolicyGuard.assertCanSend(org.saiku.service.olap.ai.AiDataKind.AGGREGATED_RESULT_VALUES);
-        if (body == null) {
-            return badRequest("body", "request body required", null);
-        }
-        if (body.getQuestion() == null || body.getQuestion().isBlank()) {
-            return badRequest("question", "question must be non-blank", null);
-        }
-        if (body.getCube() == null || body.getCube().getCubeName() == null) {
-            return badRequest("cube", "cube ref required", null);
-        }
-        // saiku#1151: cap request size + call rate before reaching the paid LLM
-        // provider. Oversize questions/histories inflate per-call token spend;
-        // unbounded call frequency is a cost-DoS. The logic lives in AiAskGuard /
-        // AiRateLimiter so it stays unit-testable and this resource keeps a thin
-        // touch.
-        org.saiku.web.security.ratelimit.AiAskGuard.Violation sizeViolation =
-                org.saiku.web.security.ratelimit.AiAskGuard.checkSize(body);
-        if (sizeViolation != null) {
-            return askLimitResponse(sizeViolation.isPayloadTooLarge() ? 413 : 400, sizeViolation.getMessage());
-        }
-        if (!askRateLimiter.tryAcquire(askRateKey())) {
-            return askLimitResponse(
-                    429,
-                    "Too many AI ask requests — limit is " + askRateLimiter.getMaxCalls() + " per "
-                            + (askRateLimiter.getWindowMs() / 1000) + "s. Please retry shortly.");
-        }
-        if (askService == null) {
-            AiAskApi.AskResponse out = new AiAskApi.AskResponse();
-            out.setDegraded(true);
-            out.setReason("AI ask is not configured. Set saiku.ai.ask.provider to 'anthropic' "
-                    + "or 'openai' and supply the matching API key (env: ANTHROPIC_API_KEY or "
-                    + "OPENAI_API_KEY) to enable the feature.");
-            return Response.status(Response.Status.SERVICE_UNAVAILABLE)
-                    .entity(out)
-                    .type(MediaType.APPLICATION_JSON)
-                    .build();
-        }
-
-        // Translate the wire-shape forceTool string into the service enum. Unknown / null → AUTO so
-        // a bad client value silently degrades to auto-routing rather than 400ing the whole turn.
-        org.saiku.service.olap.ai.ask.NlAskRequest.ForceTool force =
-                org.saiku.service.olap.ai.ask.NlAskRequest.ForceTool.AUTO;
-        if (body.getForceTool() != null) {
-            try {
-                force = org.saiku.service.olap.ai.ask.NlAskRequest.ForceTool.valueOf(
-                        body.getForceTool().toUpperCase());
-            } catch (IllegalArgumentException ignored) {
-                // unknown — keep AUTO
-            }
+        Response pre = validateAskPreamble(body, true);
+        if (pre != null) {
+            return pre;
         }
         AiAskService.AskOutcome outcome = askService.ask(
                 body.getCube(),
                 body.getQuestion(),
                 body.historyAsMessages(),
                 body.getCellsetDigest(),
-                force,
+                parseForceTool(body.getForceTool()),
                 body.getCurrentQuery());
         if (outcome.degraded()) {
             AiAskApi.AskResponse out = new AiAskApi.AskResponse();
@@ -1126,82 +1045,20 @@ public class AiQueryResource {
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces("text/event-stream")
     public Response askStream(AiAskApi.AskRequest body) {
-        aiPolicyGuard.assertCanSend(org.saiku.service.olap.ai.AiDataKind.AGGREGATED_RESULT_VALUES);
-        if (body == null) {
-            return badRequest("body", "request body required", null);
+        Response pre = validateAskPreamble(body, true);
+        if (pre != null) {
+            return pre;
         }
-        if (body.getQuestion() == null || body.getQuestion().isBlank()) {
-            return badRequest("question", "question must be non-blank", null);
-        }
-        if (body.getCube() == null || body.getCube().getCubeName() == null) {
-            return badRequest("cube", "cube ref required", null);
-        }
-        org.saiku.web.security.ratelimit.AiAskGuard.Violation sizeViolation =
-                org.saiku.web.security.ratelimit.AiAskGuard.checkSize(body);
-        if (sizeViolation != null) {
-            return askLimitResponse(sizeViolation.isPayloadTooLarge() ? 413 : 400, sizeViolation.getMessage());
-        }
-        if (!askRateLimiter.tryAcquire(askRateKey())) {
-            return askLimitResponse(
-                    429,
-                    "Too many AI ask requests — limit is " + askRateLimiter.getMaxCalls() + " per "
-                            + (askRateLimiter.getWindowMs() / 1000) + "s. Please retry shortly.");
-        }
-        if (askService == null) {
-            AiAskApi.AskResponse notConfigured = new AiAskApi.AskResponse();
-            notConfigured.setDegraded(true);
-            notConfigured.setReason(
-                    "AI ask is not configured. Set saiku.ai.ask.provider to 'anthropic' or 'openai' and supply the matching API key.");
-            return Response.status(Response.Status.SERVICE_UNAVAILABLE)
-                    .entity(notConfigured)
-                    .type(MediaType.APPLICATION_JSON)
-                    .build();
-        }
-
-        org.saiku.service.olap.ai.ask.NlAskRequest.ForceTool force =
-                org.saiku.service.olap.ai.ask.NlAskRequest.ForceTool.AUTO;
-        if (body.getForceTool() != null) {
-            try {
-                force = org.saiku.service.olap.ai.ask.NlAskRequest.ForceTool.valueOf(
-                        body.getForceTool().toUpperCase());
-            } catch (IllegalArgumentException ignored) {
-                // Unknown value — keep AUTO, same as the sync endpoint.
-            }
-        }
-        final org.saiku.service.olap.ai.ask.NlAskRequest.ForceTool forceFinal = force;
-
-        final AiAskApi.AskRequest bodyFinal = body;
-        jakarta.ws.rs.core.StreamingOutput stream = outputStream -> {
-            java.io.Writer writer =
-                    new java.io.OutputStreamWriter(outputStream, java.nio.charset.StandardCharsets.UTF_8);
-            SseWriter sse = new SseWriter(writer);
-            try {
-                AiAskService.AskOutcome outcome = askService.ask(
-                        bodyFinal.getCube(),
-                        bodyFinal.getQuestion(),
-                        bodyFinal.historyAsMessages(),
-                        bodyFinal.getCellsetDigest(),
-                        forceFinal,
-                        bodyFinal.getCurrentQuery());
-                streamOutcomeAsSse(outcome, sse);
-            } catch (java.io.IOException ioe) {
-                // Client disconnected — nothing to do, the connection is already dead.
-                log.debug("AI ask (streaming) client disconnected: {}", ioe.getMessage());
-            } catch (RuntimeException e) {
-                log.warn("AI ask (streaming) unexpected failure", e);
-                try {
-                    sse.event("error", MAPPER.writeValueAsString(java.util.Map.of("reason", "internal error")));
-                } catch (java.io.IOException swallow) {
-                    // best-effort — the client is already gone.
-                }
-            }
-        };
-
-        return Response.ok(stream)
-                .type("text/event-stream")
-                .header("Cache-Control", "no-cache")
-                .header("X-Accel-Buffering", "no") // Nginx: disable buffering so events flush.
-                .build();
+        org.saiku.service.olap.ai.ask.NlAskRequest.ForceTool force = parseForceTool(body.getForceTool());
+        return streamAsk(
+                () -> askService.ask(
+                        body.getCube(),
+                        body.getQuestion(),
+                        body.historyAsMessages(),
+                        body.getCellsetDigest(),
+                        force,
+                        body.getCurrentQuery()),
+                "AI ask (streaming)");
     }
 
     /**
@@ -1221,78 +1078,28 @@ public class AiQueryResource {
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces("text/event-stream")
     public Response askInSpaceStream(@PathParam("id") String spaceId, AiAskApi.AskRequest body) {
-        aiPolicyGuard.assertCanSend(org.saiku.service.olap.ai.AiDataKind.AGGREGATED_RESULT_VALUES);
-        if (body == null) {
-            return badRequest("body", "request body required", null);
+        Response pre = validateAskPreamble(body, false);
+        if (pre != null) {
+            return pre;
         }
-        if (body.getQuestion() == null || body.getQuestion().isBlank()) {
-            return badRequest("question", "question must be non-blank", null);
+        // Pre-flight the persona scope BEFORE committing to a 200 event-stream, so a scope denial
+        // maps to a real 403/404/503 rather than a 200 carrying an in-band SSE error (saiku#1454).
+        // The post-LLM re-check of the model's emitted cube (saiku#1453) still runs in askInSpace.
+        Response scopeDenial = mapSpaceAccessDenial(askService.checkSpaceAccess(spaceId, body.getCube()), spaceId);
+        if (scopeDenial != null) {
+            return scopeDenial;
         }
-        org.saiku.web.security.ratelimit.AiAskGuard.Violation sizeViolation =
-                org.saiku.web.security.ratelimit.AiAskGuard.checkSize(body);
-        if (sizeViolation != null) {
-            return askLimitResponse(sizeViolation.isPayloadTooLarge() ? 413 : 400, sizeViolation.getMessage());
-        }
-        if (!askRateLimiter.tryAcquire(askRateKey())) {
-            return askLimitResponse(
-                    429,
-                    "Too many AI ask requests — limit is " + askRateLimiter.getMaxCalls() + " per "
-                            + (askRateLimiter.getWindowMs() / 1000) + "s. Please retry shortly.");
-        }
-        if (askService == null) {
-            AiAskApi.AskResponse notConfigured = new AiAskApi.AskResponse();
-            notConfigured.setDegraded(true);
-            notConfigured.setReason("AI ask is not configured.");
-            return Response.status(Response.Status.SERVICE_UNAVAILABLE)
-                    .entity(notConfigured)
-                    .type(MediaType.APPLICATION_JSON)
-                    .build();
-        }
-
-        org.saiku.service.olap.ai.ask.NlAskRequest.ForceTool force =
-                org.saiku.service.olap.ai.ask.NlAskRequest.ForceTool.AUTO;
-        if (body.getForceTool() != null) {
-            try {
-                force = org.saiku.service.olap.ai.ask.NlAskRequest.ForceTool.valueOf(
-                        body.getForceTool().toUpperCase());
-            } catch (IllegalArgumentException ignored) {
-                // unknown value — keep AUTO
-            }
-        }
-        final org.saiku.service.olap.ai.ask.NlAskRequest.ForceTool forceFinal = force;
-        final AiAskApi.AskRequest bodyFinal = body;
-
-        jakarta.ws.rs.core.StreamingOutput stream = outputStream -> {
-            java.io.Writer writer =
-                    new java.io.OutputStreamWriter(outputStream, java.nio.charset.StandardCharsets.UTF_8);
-            SseWriter sse = new SseWriter(writer);
-            try {
-                AiAskService.AskOutcome outcome = askService.askInSpace(
+        org.saiku.service.olap.ai.ask.NlAskRequest.ForceTool force = parseForceTool(body.getForceTool());
+        return streamAsk(
+                () -> askService.askInSpace(
                         spaceId,
-                        bodyFinal.getCube(),
-                        bodyFinal.getQuestion(),
-                        bodyFinal.historyAsMessages(),
-                        bodyFinal.getCellsetDigest(),
-                        forceFinal,
-                        bodyFinal.getCurrentQuery());
-                streamOutcomeAsSse(outcome, sse);
-            } catch (java.io.IOException ioe) {
-                log.debug("AI ask-in-space (streaming) client disconnected: {}", ioe.getMessage());
-            } catch (RuntimeException e) {
-                log.warn("AI ask-in-space (streaming) unexpected failure", e);
-                try {
-                    sse.event("error", MAPPER.writeValueAsString(java.util.Map.of("reason", "internal error")));
-                } catch (java.io.IOException swallow) {
-                    // best-effort
-                }
-            }
-        };
-
-        return Response.ok(stream)
-                .type("text/event-stream")
-                .header("Cache-Control", "no-cache")
-                .header("X-Accel-Buffering", "no")
-                .build();
+                        body.getCube(),
+                        body.getQuestion(),
+                        body.historyAsMessages(),
+                        body.getCellsetDigest(),
+                        force,
+                        body.getCurrentQuery()),
+                "AI ask-in-space (streaming)");
     }
 
     /**
@@ -2728,6 +2535,158 @@ public class AiQueryResource {
                 .entity(out)
                 .type(MediaType.APPLICATION_JSON)
                 .build();
+    }
+
+    /** Standard client-facing reason for a 503 when no LLM provider is wired. */
+    private static final String ASK_NOT_CONFIGURED_REASON =
+            "AI ask is not configured. Set saiku.ai.ask.provider to 'anthropic' or 'openai' and "
+                    + "supply the matching API key (env: ANTHROPIC_API_KEY or OPENAI_API_KEY) to "
+                    + "enable the feature.";
+
+    /**
+     * Shared validation preamble for every ask endpoint (sync + streaming, classic + space).
+     * Runs the policy gate, shape checks, size cap, rate limit and provider-configured check in
+     * one place so a guard change can't drift across the four copies (saiku#1460). Returns a
+     * ready-to-send error {@link Response} to short-circuit, or {@code null} when the request may
+     * proceed.
+     *
+     * @param requireCube true for the classic endpoints (cube ref mandatory); false for space
+     *     endpoints, where the cube is optional and defaults to the persona's default cube.
+     */
+    private Response validateAskPreamble(AiAskApi.AskRequest body, boolean requireCube) {
+        aiPolicyGuard.assertCanSend(org.saiku.service.olap.ai.AiDataKind.AGGREGATED_RESULT_VALUES);
+        if (body == null) {
+            return badRequest("body", "request body required", null);
+        }
+        if (body.getQuestion() == null || body.getQuestion().isBlank()) {
+            return badRequest("question", "question must be non-blank", null);
+        }
+        if (requireCube && (body.getCube() == null || body.getCube().getCubeName() == null)) {
+            return badRequest("cube", "cube ref required", null);
+        }
+        // saiku#1151: cap request size + call rate before reaching the paid LLM provider. Oversize
+        // questions/histories inflate per-call token spend; unbounded call frequency is a cost-DoS.
+        org.saiku.web.security.ratelimit.AiAskGuard.Violation sizeViolation =
+                org.saiku.web.security.ratelimit.AiAskGuard.checkSize(body);
+        if (sizeViolation != null) {
+            return askLimitResponse(sizeViolation.isPayloadTooLarge() ? 413 : 400, sizeViolation.getMessage());
+        }
+        if (!askRateLimiter.tryAcquire(askRateKey())) {
+            return askLimitResponse(
+                    429,
+                    "Too many AI ask requests — limit is " + askRateLimiter.getMaxCalls() + " per "
+                            + (askRateLimiter.getWindowMs() / 1000) + "s. Please retry shortly.");
+        }
+        if (askService == null) {
+            AiAskApi.AskResponse notConfigured = new AiAskApi.AskResponse();
+            notConfigured.setDegraded(true);
+            notConfigured.setReason(ASK_NOT_CONFIGURED_REASON);
+            return Response.status(Response.Status.SERVICE_UNAVAILABLE)
+                    .entity(notConfigured)
+                    .type(MediaType.APPLICATION_JSON)
+                    .build();
+        }
+        return null;
+    }
+
+    /**
+     * Translate the wire-shape {@code forceTool} string into the service enum. Unknown / null →
+     * {@link org.saiku.service.olap.ai.ask.NlAskRequest.ForceTool#AUTO} so a bad client value
+     * silently degrades to auto-routing rather than 400ing the whole turn. Uses {@link Locale#ROOT}
+     * so the uppercase is locale-independent — a tr-TR JVM must not turn {@code "insight"} into
+     * {@code "İNSİGHT"} and drop the user's explicit pick (saiku#1458).
+     */
+    static org.saiku.service.olap.ai.ask.NlAskRequest.ForceTool parseForceTool(String raw) {
+        if (raw == null) {
+            return org.saiku.service.olap.ai.ask.NlAskRequest.ForceTool.AUTO;
+        }
+        try {
+            return org.saiku.service.olap.ai.ask.NlAskRequest.ForceTool.valueOf(raw.toUpperCase(java.util.Locale.ROOT));
+        } catch (IllegalArgumentException ignored) {
+            return org.saiku.service.olap.ai.ask.NlAskRequest.ForceTool.AUTO;
+        }
+    }
+
+    /**
+     * Map a space-access pre-flight (saiku#1454) to an HTTP error {@link Response}, or {@code null}
+     * when access is granted. Lets the streaming space endpoint return a real 403/404/503
+     * <em>before</em> it commits to a 200 event-stream, honouring the documented "cube refs outside
+     * the allowlist return 403 FORBIDDEN" contract instead of burying the denial in an SSE event.
+     */
+    private Response mapSpaceAccessDenial(AiAskService.SpaceAccess access, String spaceId) {
+        switch (access) {
+            case OK:
+                return null;
+            case SPACES_NOT_CONFIGURED:
+                return askLimitResponse(503, "agent spaces are not configured on this instance");
+            case SPACE_NOT_FOUND:
+                return askLimitResponse(404, "space not found: " + spaceId);
+            case FORBIDDEN:
+                return askLimitResponse(403, "FORBIDDEN: requested cube is not in space '" + spaceId + "' allowlist");
+            default:
+                return null;
+        }
+    }
+
+    /**
+     * Shared SSE runner for the streaming ask endpoints (saiku#1460). Builds the WHATWG SSE stream,
+     * invokes {@code outcomeSupplier} to produce the outcome (the only thing that differs between
+     * {@link #askStream} and {@link #askInSpaceStream}), and pipes it through {@link
+     * #streamOutcomeAsSse}. Centralises the failure handling so both endpoints get identical,
+     * correct behaviour:
+     *
+     * <ul>
+     *   <li>{@link com.fasterxml.jackson.core.JsonProcessingException} (a serialisation failure of
+     *       the outcome payload) is caught <em>before</em> the {@link java.io.IOException} branch —
+     *       it is NOT a client disconnect, so it must surface as an error to the still-connected
+     *       client, not vanish at DEBUG (saiku#1457).
+     *   <li>Every error path emits an {@code error} event <em>followed by</em> a terminal degraded
+     *       {@code final} event, matching the documented wire contract (saiku#1456).
+     * </ul>
+     */
+    private Response streamAsk(java.util.function.Supplier<AiAskService.AskOutcome> outcomeSupplier, String logLabel) {
+        jakarta.ws.rs.core.StreamingOutput stream = outputStream -> {
+            java.io.Writer writer =
+                    new java.io.OutputStreamWriter(outputStream, java.nio.charset.StandardCharsets.UTF_8);
+            SseWriter sse = new SseWriter(writer);
+            try {
+                streamOutcomeAsSse(outcomeSupplier.get(), sse);
+            } catch (com.fasterxml.jackson.core.JsonProcessingException jpe) {
+                // Serialising the outcome failed — the client is still connected. Surface an error
+                // (NOT the disconnect branch below, which JsonProcessingException would fall into
+                // as an IOException subclass) so the turn terminates visibly. (saiku#1457)
+                log.warn("{}: failed to serialise SSE payload", logLabel, jpe);
+                emitStreamError(sse);
+            } catch (java.io.IOException ioe) {
+                // Genuine client disconnect — the connection is already dead, nothing to emit.
+                log.debug("{}: client disconnected: {}", logLabel, ioe.getMessage());
+            } catch (RuntimeException e) {
+                log.warn("{}: unexpected failure", logLabel, e);
+                emitStreamError(sse);
+            }
+        };
+        return Response.ok(stream)
+                .type("text/event-stream")
+                .header("Cache-Control", "no-cache")
+                .header("X-Accel-Buffering", "no") // Nginx: disable buffering so events flush.
+                .build();
+    }
+
+    /**
+     * Emit the terminal error pair — an {@code error} event followed by a degraded {@code final} —
+     * so a client keying completion on {@code final} (per the documented contract) never hangs
+     * (saiku#1456). Best-effort: if even this write fails the client is already gone.
+     */
+    private static void emitStreamError(SseWriter sse) {
+        try {
+            sse.event("error", MAPPER.writeValueAsString(java.util.Map.of("reason", "internal error")));
+            AiAskApi.AskResponse out = new AiAskApi.AskResponse();
+            out.setDegraded(true);
+            out.setReason("internal error");
+            sse.event("final", MAPPER.writeValueAsString(out));
+        } catch (java.io.IOException swallow) {
+            // best-effort — the client is already gone.
+        }
     }
 
     /**

--- a/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/AiQueryResource.java
+++ b/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/AiQueryResource.java
@@ -907,10 +907,10 @@ public class AiQueryResource {
                     .type(MediaType.APPLICATION_JSON)
                     .build();
         }
-        AiAskApi.AskResponse out = new AiAskApi.AskResponse();
-        out.setModel(outcome.model());
-        out.setRequest(outcome.request());
-        return Response.ok(out).type(MediaType.APPLICATION_JSON).build();
+        // Mirror the classic /ai/ask success handling (saiku#1455): branch on the outcome kind so
+        // INSIGHT / VIEW_CHANGE surface their artefact and QUERY is actually executed — previously
+        // this path echoed only {model, request} and silently dropped insight/view-change answers.
+        return buildAskSuccessResponse(outcome);
     }
 
     @POST
@@ -943,64 +943,7 @@ public class AiQueryResource {
                     .build();
         }
 
-        AiAskApi.AskResponse out = new AiAskApi.AskResponse();
-        out.setDegraded(false);
-        out.setModel(outcome.model());
-
-        // Insight and view-change intents skip the converter / execution entirely — the model already
-        // produced the final artefact (markdown analysis / view target). Return immediately so the
-        // drawer can render the result without going through ThinQuery → MDX → backend round-trip.
-        if (outcome.kind() == AiAskService.AskOutcome.Kind.INSIGHT) {
-            out.setInsight(outcome.insight());
-            return Response.ok(out).type(MediaType.APPLICATION_JSON).build();
-        }
-        if (outcome.kind() == AiAskService.AskOutcome.Kind.VIEW_CHANGE) {
-            out.setViewChange(outcome.viewChange());
-            return Response.ok(out).type(MediaType.APPLICATION_JSON).build();
-        }
-
-        // Default branch: QUERY intent — convert + execute as before.
-        AiQueryRequest req = outcome.request();
-        out.setRequest(req);
-
-        // Execute the produced request through the same path /ai/query uses. Errors are translated
-        // back into a 200 with the {request, model} echoed so the UI can still show "the model
-        // proposed this, but it failed at <stage>" — much more useful than a 500.
-        long start = System.currentTimeMillis();
-        try {
-            // Phase 2 shape-validate before the converter sees the request — same as /ai/query.
-            schemaValidator.assertValid(MAPPER.valueToTree(req));
-            AiSchema schema = cubeMetadataService.getSchema(req.getCube());
-            ThinQuery tq = converter.convert(req, schema);
-            // Surface the converted ThinQueryModel so the UI's "edit in canvas" can hydrate the
-            // workbench's chip builder directly (interactive query) instead of pasting MDX (opaque
-            // to the chip UI — user can't drag/drop). Same shape the workspace builder manipulates.
-            out.setQueryModel(tq.getQueryModel());
-            CellDataSet cds = thinQueryService.execute(tq);
-            AiQueryResponse aiResp = buildResponse(tq, cds, start, "records");
-            out.setResponse(aiResp);
-            if (aiResp != null && aiResp.getMetadata() != null) {
-                out.setGeneratedMdx(aiResp.getMetadata().getGeneratedMdx());
-            }
-        } catch (AiValidationException e) {
-            // Surface the converter's structured validation as the response envelope so the UI
-            // can render candidate-list suggestions just like a direct /ai/query call would.
-            AiQueryResponse aiResp = new AiQueryResponse();
-            aiResp.setStatus(org.saiku.service.olap.ai.AiQueryResponse.Status.VALIDATION_ERROR);
-            aiResp.setError(e.getMessage());
-            aiResp.setField(e.getField());
-            aiResp.setAvailable(e.getAvailable() == null ? null : new java.util.ArrayList<>(e.getAvailable()));
-            aiResp.setRuntimeMs(System.currentTimeMillis() - start);
-            out.setResponse(aiResp);
-        } catch (RuntimeException e) {
-            log.warn("AI ask execution failed after successful translation", e);
-            AiQueryResponse aiResp = new AiQueryResponse();
-            aiResp.setStatus(org.saiku.service.olap.ai.AiQueryResponse.Status.EXECUTION_ERROR);
-            aiResp.setError("execute failed");
-            aiResp.setRuntimeMs(System.currentTimeMillis() - start);
-            out.setResponse(aiResp);
-        }
-        return Response.ok(out).type(MediaType.APPLICATION_JSON).build();
+        return buildAskSuccessResponse(outcome);
     }
 
     /**
@@ -1161,39 +1104,11 @@ public class AiQueryResource {
             return;
         }
 
-        // QUERY intent — no prose to stream; the query itself IS the artefact. Execute the same
-        // way the sync endpoint does and emit the final envelope in one event so the client
-        // accumulates a complete AskResponse.
-        AiQueryRequest req = outcome.request();
-        out.setRequest(req);
-        long start = System.currentTimeMillis();
-        try {
-            schemaValidator.assertValid(MAPPER.valueToTree(req));
-            AiSchema schema = cubeMetadataService.getSchema(req.getCube());
-            ThinQuery tq = converter.convert(req, schema);
-            out.setQueryModel(tq.getQueryModel());
-            CellDataSet cds = thinQueryService.execute(tq);
-            AiQueryResponse aiResp = buildResponse(tq, cds, start, "records");
-            out.setResponse(aiResp);
-            if (aiResp != null && aiResp.getMetadata() != null) {
-                out.setGeneratedMdx(aiResp.getMetadata().getGeneratedMdx());
-            }
-        } catch (AiValidationException e) {
-            AiQueryResponse aiResp = new AiQueryResponse();
-            aiResp.setStatus(org.saiku.service.olap.ai.AiQueryResponse.Status.VALIDATION_ERROR);
-            aiResp.setError(e.getMessage());
-            aiResp.setField(e.getField());
-            aiResp.setAvailable(e.getAvailable() == null ? null : new java.util.ArrayList<>(e.getAvailable()));
-            aiResp.setRuntimeMs(System.currentTimeMillis() - start);
-            out.setResponse(aiResp);
-        } catch (RuntimeException e) {
-            log.warn("AI ask (streaming) execution failed after successful translation", e);
-            AiQueryResponse aiResp = new AiQueryResponse();
-            aiResp.setStatus(org.saiku.service.olap.ai.AiQueryResponse.Status.EXECUTION_ERROR);
-            aiResp.setError("execute failed");
-            aiResp.setRuntimeMs(System.currentTimeMillis() - start);
-            out.setResponse(aiResp);
-        }
+        // QUERY intent — no prose to stream; the query itself IS the artefact. Execute the same way
+        // the sync endpoint does (shared helper — saiku#1455/#1460) and emit the final envelope in
+        // one event so the client accumulates a complete AskResponse.
+        out.setRequest(outcome.request());
+        executeQueryIntoResponse(out, outcome.request());
         sse.event("final", MAPPER.writeValueAsString(out));
     }
 
@@ -2587,6 +2502,78 @@ public class AiQueryResource {
                     .build();
         }
         return null;
+    }
+
+    /**
+     * Build the success response envelope for a non-degraded ask outcome, shared by the sync
+     * classic ({@link #ask}) and space ({@link #askInSpace}) endpoints so every ask surface returns
+     * the same shape (saiku#1455). INSIGHT and VIEW_CHANGE short-circuit with the model's artefact;
+     * QUERY is converted + executed the same way {@code /ai/query} does.
+     */
+    private Response buildAskSuccessResponse(AiAskService.AskOutcome outcome) {
+        AiAskApi.AskResponse out = new AiAskApi.AskResponse();
+        out.setDegraded(false);
+        out.setModel(outcome.model());
+
+        // Insight and view-change intents skip the converter / execution entirely — the model
+        // already produced the final artefact (markdown analysis / view target).
+        if (outcome.kind() == AiAskService.AskOutcome.Kind.INSIGHT) {
+            out.setInsight(outcome.insight());
+            return Response.ok(out).type(MediaType.APPLICATION_JSON).build();
+        }
+        if (outcome.kind() == AiAskService.AskOutcome.Kind.VIEW_CHANGE) {
+            out.setViewChange(outcome.viewChange());
+            return Response.ok(out).type(MediaType.APPLICATION_JSON).build();
+        }
+
+        // QUERY intent — convert + execute.
+        out.setRequest(outcome.request());
+        executeQueryIntoResponse(out, outcome.request());
+        return Response.ok(out).type(MediaType.APPLICATION_JSON).build();
+    }
+
+    /**
+     * Convert + execute the model's {@link AiQueryRequest} through the same path {@code /ai/query}
+     * uses, folding the result (or a structured validation / execution error) into {@code out}.
+     * Shared by the sync success path ({@link #buildAskSuccessResponse}) and the streaming QUERY
+     * branch ({@link #streamOutcomeAsSse}) so the two can't diverge. Errors are captured into the
+     * response envelope rather than thrown, so the UI can show "the model proposed this, but it
+     * failed at &lt;stage&gt;" instead of a 500.
+     */
+    private void executeQueryIntoResponse(AiAskApi.AskResponse out, AiQueryRequest req) {
+        long start = System.currentTimeMillis();
+        try {
+            // Phase 2 shape-validate before the converter sees the request — same as /ai/query.
+            schemaValidator.assertValid(MAPPER.valueToTree(req));
+            AiSchema schema = cubeMetadataService.getSchema(req.getCube());
+            ThinQuery tq = converter.convert(req, schema);
+            // Surface the converted ThinQueryModel so the UI's "edit in canvas" can hydrate the
+            // workbench's chip builder directly instead of pasting opaque MDX.
+            out.setQueryModel(tq.getQueryModel());
+            CellDataSet cds = thinQueryService.execute(tq);
+            AiQueryResponse aiResp = buildResponse(tq, cds, start, "records");
+            out.setResponse(aiResp);
+            if (aiResp != null && aiResp.getMetadata() != null) {
+                out.setGeneratedMdx(aiResp.getMetadata().getGeneratedMdx());
+            }
+        } catch (AiValidationException e) {
+            // Surface the converter's structured validation as the response envelope so the UI can
+            // render candidate-list suggestions just like a direct /ai/query call would.
+            AiQueryResponse aiResp = new AiQueryResponse();
+            aiResp.setStatus(org.saiku.service.olap.ai.AiQueryResponse.Status.VALIDATION_ERROR);
+            aiResp.setError(e.getMessage());
+            aiResp.setField(e.getField());
+            aiResp.setAvailable(e.getAvailable() == null ? null : new java.util.ArrayList<>(e.getAvailable()));
+            aiResp.setRuntimeMs(System.currentTimeMillis() - start);
+            out.setResponse(aiResp);
+        } catch (RuntimeException e) {
+            log.warn("AI ask execution failed after successful translation", e);
+            AiQueryResponse aiResp = new AiQueryResponse();
+            aiResp.setStatus(org.saiku.service.olap.ai.AiQueryResponse.Status.EXECUTION_ERROR);
+            aiResp.setError("execute failed");
+            aiResp.setRuntimeMs(System.currentTimeMillis() - start);
+            out.setResponse(aiResp);
+        }
     }
 
     /**

--- a/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/AiQueryResource.java
+++ b/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/AiQueryResource.java
@@ -1170,110 +1170,20 @@ public class AiQueryResource {
         }
         final org.saiku.service.olap.ai.ask.NlAskRequest.ForceTool forceFinal = force;
 
+        final AiAskApi.AskRequest bodyFinal = body;
         jakarta.ws.rs.core.StreamingOutput stream = outputStream -> {
             java.io.Writer writer =
                     new java.io.OutputStreamWriter(outputStream, java.nio.charset.StandardCharsets.UTF_8);
             SseWriter sse = new SseWriter(writer);
             try {
                 AiAskService.AskOutcome outcome = askService.ask(
-                        body.getCube(),
-                        body.getQuestion(),
-                        body.historyAsMessages(),
-                        body.getCellsetDigest(),
+                        bodyFinal.getCube(),
+                        bodyFinal.getQuestion(),
+                        bodyFinal.historyAsMessages(),
+                        bodyFinal.getCellsetDigest(),
                         forceFinal,
-                        body.getCurrentQuery());
-
-                // model event — always fired first so the client can show which backend answered.
-                if (outcome.model() != null) {
-                    sse.event("model", MAPPER.writeValueAsString(java.util.Map.of("model", outcome.model())));
-                }
-
-                if (outcome.degraded()) {
-                    // Degraded path — emit an error event with the provider's reason, then a final.
-                    sse.event(
-                            "error",
-                            MAPPER.writeValueAsString(
-                                    java.util.Map.of("reason", outcome.reason() == null ? "" : outcome.reason())));
-                    AiAskApi.AskResponse out = new AiAskApi.AskResponse();
-                    out.setDegraded(true);
-                    out.setReason(outcome.reason());
-                    if (outcome.model() != null) out.setModel(outcome.model());
-                    sse.event("final", MAPPER.writeValueAsString(out));
-                    return;
-                }
-
-                sse.event(
-                        "intent",
-                        MAPPER.writeValueAsString(java.util.Map.of(
-                                "kind",
-                                outcome.kind() == null ? "" : outcome.kind().name())));
-
-                AiAskApi.AskResponse out = new AiAskApi.AskResponse();
-                out.setDegraded(false);
-                out.setModel(outcome.model());
-
-                if (outcome.kind() == AiAskService.AskOutcome.Kind.INSIGHT) {
-                    // Chunk the insight markdown into word-sized deltas so the client sees a
-                    // progressive stream. Fake-stream today; wire-stable for real LLM streaming later.
-                    out.setInsight(outcome.insight());
-                    String markdown =
-                            outcome.insight() == null ? "" : outcome.insight().getMarkdown();
-                    if (markdown != null && !markdown.isEmpty()) {
-                        emitChunks(sse, markdown);
-                    }
-                    sse.event("final", MAPPER.writeValueAsString(out));
-                    return;
-                }
-
-                if (outcome.kind() == AiAskService.AskOutcome.Kind.VIEW_CHANGE) {
-                    // View change carries an optional reason string worth streaming — the caller
-                    // reads it as "why did the LLM pick this chart".
-                    out.setViewChange(outcome.viewChange());
-                    String reason = outcome.viewChange() == null
-                            ? null
-                            : outcome.viewChange().getReason();
-                    if (reason != null && !reason.isEmpty()) {
-                        emitChunks(sse, reason);
-                    }
-                    sse.event("final", MAPPER.writeValueAsString(out));
-                    return;
-                }
-
-                // QUERY intent — no prose to stream; the query itself IS the artefact. Execute the
-                // same way the sync endpoint does and emit the final envelope in one event so the
-                // client accumulates a complete AskResponse. We keep the SSE frame here (rather than
-                // a single JSON POST response) so the client's stream reader is uniform across intents.
-                AiQueryRequest req = outcome.request();
-                out.setRequest(req);
-                long start = System.currentTimeMillis();
-                try {
-                    schemaValidator.assertValid(MAPPER.valueToTree(req));
-                    AiSchema schema = cubeMetadataService.getSchema(req.getCube());
-                    ThinQuery tq = converter.convert(req, schema);
-                    out.setQueryModel(tq.getQueryModel());
-                    CellDataSet cds = thinQueryService.execute(tq);
-                    AiQueryResponse aiResp = buildResponse(tq, cds, start, "records");
-                    out.setResponse(aiResp);
-                    if (aiResp != null && aiResp.getMetadata() != null) {
-                        out.setGeneratedMdx(aiResp.getMetadata().getGeneratedMdx());
-                    }
-                } catch (AiValidationException e) {
-                    AiQueryResponse aiResp = new AiQueryResponse();
-                    aiResp.setStatus(org.saiku.service.olap.ai.AiQueryResponse.Status.VALIDATION_ERROR);
-                    aiResp.setError(e.getMessage());
-                    aiResp.setField(e.getField());
-                    aiResp.setAvailable(e.getAvailable() == null ? null : new java.util.ArrayList<>(e.getAvailable()));
-                    aiResp.setRuntimeMs(System.currentTimeMillis() - start);
-                    out.setResponse(aiResp);
-                } catch (RuntimeException e) {
-                    log.warn("AI ask (streaming) execution failed after successful translation", e);
-                    AiQueryResponse aiResp = new AiQueryResponse();
-                    aiResp.setStatus(org.saiku.service.olap.ai.AiQueryResponse.Status.EXECUTION_ERROR);
-                    aiResp.setError("execute failed");
-                    aiResp.setRuntimeMs(System.currentTimeMillis() - start);
-                    out.setResponse(aiResp);
-                }
-                sse.event("final", MAPPER.writeValueAsString(out));
+                        bodyFinal.getCurrentQuery());
+                streamOutcomeAsSse(outcome, sse);
             } catch (java.io.IOException ioe) {
                 // Client disconnected — nothing to do, the connection is already dead.
                 log.debug("AI ask (streaming) client disconnected: {}", ioe.getMessage());
@@ -1292,6 +1202,192 @@ public class AiQueryResource {
                 .header("Cache-Control", "no-cache")
                 .header("X-Accel-Buffering", "no") // Nginx: disable buffering so events flush.
                 .build();
+    }
+
+    /**
+     * Space-scoped streaming ask (saiku#1440 + #1433). Same wire format as {@link
+     * #askStream(AiAskApi.AskRequest)} — the events are indistinguishable to the client — but
+     * routes through {@link AiAskService#askInSpace} so the persona's system prompt, cube
+     * allowlist, and skill filter apply. A caller who wants both space scoping AND progressive
+     * chat UX uses this endpoint; the two features were always meant to compose.
+     *
+     * <p>Same rate limit + size cap + policy gate + auth as the classic {@code
+     * /spaces/{id}/ask}. Space-not-found + FORBIDDEN outcomes surface as {@code error} events
+     * followed by a degraded {@code final} — the client sees the same SSE shape regardless of
+     * whether the failure was provider-side or scope-side.
+     */
+    @POST
+    @Path("/spaces/{id}/ask/stream")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces("text/event-stream")
+    public Response askInSpaceStream(@PathParam("id") String spaceId, AiAskApi.AskRequest body) {
+        aiPolicyGuard.assertCanSend(org.saiku.service.olap.ai.AiDataKind.AGGREGATED_RESULT_VALUES);
+        if (body == null) {
+            return badRequest("body", "request body required", null);
+        }
+        if (body.getQuestion() == null || body.getQuestion().isBlank()) {
+            return badRequest("question", "question must be non-blank", null);
+        }
+        org.saiku.web.security.ratelimit.AiAskGuard.Violation sizeViolation =
+                org.saiku.web.security.ratelimit.AiAskGuard.checkSize(body);
+        if (sizeViolation != null) {
+            return askLimitResponse(sizeViolation.isPayloadTooLarge() ? 413 : 400, sizeViolation.getMessage());
+        }
+        if (!askRateLimiter.tryAcquire(askRateKey())) {
+            return askLimitResponse(
+                    429,
+                    "Too many AI ask requests — limit is " + askRateLimiter.getMaxCalls() + " per "
+                            + (askRateLimiter.getWindowMs() / 1000) + "s. Please retry shortly.");
+        }
+        if (askService == null) {
+            AiAskApi.AskResponse notConfigured = new AiAskApi.AskResponse();
+            notConfigured.setDegraded(true);
+            notConfigured.setReason("AI ask is not configured.");
+            return Response.status(Response.Status.SERVICE_UNAVAILABLE)
+                    .entity(notConfigured)
+                    .type(MediaType.APPLICATION_JSON)
+                    .build();
+        }
+
+        org.saiku.service.olap.ai.ask.NlAskRequest.ForceTool force =
+                org.saiku.service.olap.ai.ask.NlAskRequest.ForceTool.AUTO;
+        if (body.getForceTool() != null) {
+            try {
+                force = org.saiku.service.olap.ai.ask.NlAskRequest.ForceTool.valueOf(
+                        body.getForceTool().toUpperCase());
+            } catch (IllegalArgumentException ignored) {
+                // unknown value — keep AUTO
+            }
+        }
+        final org.saiku.service.olap.ai.ask.NlAskRequest.ForceTool forceFinal = force;
+        final AiAskApi.AskRequest bodyFinal = body;
+
+        jakarta.ws.rs.core.StreamingOutput stream = outputStream -> {
+            java.io.Writer writer =
+                    new java.io.OutputStreamWriter(outputStream, java.nio.charset.StandardCharsets.UTF_8);
+            SseWriter sse = new SseWriter(writer);
+            try {
+                AiAskService.AskOutcome outcome = askService.askInSpace(
+                        spaceId,
+                        bodyFinal.getCube(),
+                        bodyFinal.getQuestion(),
+                        bodyFinal.historyAsMessages(),
+                        bodyFinal.getCellsetDigest(),
+                        forceFinal,
+                        bodyFinal.getCurrentQuery());
+                streamOutcomeAsSse(outcome, sse);
+            } catch (java.io.IOException ioe) {
+                log.debug("AI ask-in-space (streaming) client disconnected: {}", ioe.getMessage());
+            } catch (RuntimeException e) {
+                log.warn("AI ask-in-space (streaming) unexpected failure", e);
+                try {
+                    sse.event("error", MAPPER.writeValueAsString(java.util.Map.of("reason", "internal error")));
+                } catch (java.io.IOException swallow) {
+                    // best-effort
+                }
+            }
+        };
+
+        return Response.ok(stream)
+                .type("text/event-stream")
+                .header("Cache-Control", "no-cache")
+                .header("X-Accel-Buffering", "no")
+                .build();
+    }
+
+    /**
+     * Translate one ask outcome into the SSE event sequence documented on {@link
+     * #askStream(AiAskApi.AskRequest)}: {@code model} → {@code intent} → 0+ {@code chunk} → {@code
+     * final}, or {@code model} → {@code error} → degraded-{@code final} when the provider failed.
+     *
+     * <p>Package-visible for unit testing. Called by both {@link #askStream} and {@link
+     * #askInSpaceStream}; the two endpoints differ only in which {@code AiAskService} entry
+     * point they invoke.
+     */
+    void streamOutcomeAsSse(AiAskService.AskOutcome outcome, SseWriter sse) throws java.io.IOException {
+        // model event — always fired first so the client can show which backend answered.
+        if (outcome.model() != null) {
+            sse.event("model", MAPPER.writeValueAsString(java.util.Map.of("model", outcome.model())));
+        }
+
+        if (outcome.degraded()) {
+            // Degraded path — emit an error event with the provider's reason, then a final.
+            sse.event(
+                    "error",
+                    MAPPER.writeValueAsString(
+                            java.util.Map.of("reason", outcome.reason() == null ? "" : outcome.reason())));
+            AiAskApi.AskResponse out = new AiAskApi.AskResponse();
+            out.setDegraded(true);
+            out.setReason(outcome.reason());
+            if (outcome.model() != null) out.setModel(outcome.model());
+            sse.event("final", MAPPER.writeValueAsString(out));
+            return;
+        }
+
+        sse.event(
+                "intent",
+                MAPPER.writeValueAsString(java.util.Map.of(
+                        "kind", outcome.kind() == null ? "" : outcome.kind().name())));
+
+        AiAskApi.AskResponse out = new AiAskApi.AskResponse();
+        out.setDegraded(false);
+        out.setModel(outcome.model());
+
+        if (outcome.kind() == AiAskService.AskOutcome.Kind.INSIGHT) {
+            out.setInsight(outcome.insight());
+            String markdown = outcome.insight() == null ? "" : outcome.insight().getMarkdown();
+            if (markdown != null && !markdown.isEmpty()) {
+                emitChunks(sse, markdown);
+            }
+            sse.event("final", MAPPER.writeValueAsString(out));
+            return;
+        }
+
+        if (outcome.kind() == AiAskService.AskOutcome.Kind.VIEW_CHANGE) {
+            out.setViewChange(outcome.viewChange());
+            String reason =
+                    outcome.viewChange() == null ? null : outcome.viewChange().getReason();
+            if (reason != null && !reason.isEmpty()) {
+                emitChunks(sse, reason);
+            }
+            sse.event("final", MAPPER.writeValueAsString(out));
+            return;
+        }
+
+        // QUERY intent — no prose to stream; the query itself IS the artefact. Execute the same
+        // way the sync endpoint does and emit the final envelope in one event so the client
+        // accumulates a complete AskResponse.
+        AiQueryRequest req = outcome.request();
+        out.setRequest(req);
+        long start = System.currentTimeMillis();
+        try {
+            schemaValidator.assertValid(MAPPER.valueToTree(req));
+            AiSchema schema = cubeMetadataService.getSchema(req.getCube());
+            ThinQuery tq = converter.convert(req, schema);
+            out.setQueryModel(tq.getQueryModel());
+            CellDataSet cds = thinQueryService.execute(tq);
+            AiQueryResponse aiResp = buildResponse(tq, cds, start, "records");
+            out.setResponse(aiResp);
+            if (aiResp != null && aiResp.getMetadata() != null) {
+                out.setGeneratedMdx(aiResp.getMetadata().getGeneratedMdx());
+            }
+        } catch (AiValidationException e) {
+            AiQueryResponse aiResp = new AiQueryResponse();
+            aiResp.setStatus(org.saiku.service.olap.ai.AiQueryResponse.Status.VALIDATION_ERROR);
+            aiResp.setError(e.getMessage());
+            aiResp.setField(e.getField());
+            aiResp.setAvailable(e.getAvailable() == null ? null : new java.util.ArrayList<>(e.getAvailable()));
+            aiResp.setRuntimeMs(System.currentTimeMillis() - start);
+            out.setResponse(aiResp);
+        } catch (RuntimeException e) {
+            log.warn("AI ask (streaming) execution failed after successful translation", e);
+            AiQueryResponse aiResp = new AiQueryResponse();
+            aiResp.setStatus(org.saiku.service.olap.ai.AiQueryResponse.Status.EXECUTION_ERROR);
+            aiResp.setError("execute failed");
+            aiResp.setRuntimeMs(System.currentTimeMillis() - start);
+            out.setResponse(aiResp);
+        }
+        sse.event("final", MAPPER.writeValueAsString(out));
     }
 
     /**

--- a/saiku-core/saiku-web/src/main/java/org/saiku/web/security/ratelimit/AiAskGuard.java
+++ b/saiku-core/saiku-web/src/main/java/org/saiku/web/security/ratelimit/AiAskGuard.java
@@ -42,8 +42,25 @@ public final class AiAskGuard {
      */
     public static Violation checkSize(AiAskApi.AskRequest body) {
         if (body == null) return null;
+        List<String> historyContents = new java.util.ArrayList<>();
+        if (body.getHistory() != null) {
+            for (AiAskApi.NlAskMessageDto m : body.getHistory()) {
+                historyContents.add(m == null ? null : m.getContent());
+            }
+        }
+        return checkSize(body.getQuestion(), historyContents);
+    }
 
-        String question = body.getQuestion();
+    /**
+     * Primitive size check shared by the MDX ask endpoints (via {@link #checkSize(AiAskApi.AskRequest)})
+     * and the Ossie ask endpoint (saiku#1459), which carries its question + history as raw strings
+     * rather than an {@link AiAskApi.AskRequest}. A {@code null} question / history is treated as
+     * in-bounds — the caller rejects an absent question with its own 400.
+     *
+     * @param question the free-form ask text
+     * @param historyContents the {@code content} of each prior turn (nulls tolerated)
+     */
+    public static Violation checkSize(String question, List<String> historyContents) {
         long total = question == null ? 0 : question.length();
         if (question != null && question.length() > MAX_QUESTION_CHARS) {
             return new Violation(
@@ -52,25 +69,25 @@ public final class AiAskGuard {
                     true);
         }
 
-        List<AiAskApi.NlAskMessageDto> history = body.getHistory();
-        if (history != null) {
-            if (history.size() > MAX_HISTORY_MESSAGES) {
+        if (historyContents != null) {
+            if (historyContents.size() > MAX_HISTORY_MESSAGES) {
                 // Count overflow is a malformed/abusive request shape, not an
                 // oversize payload — surface as 400 so the client trims turns.
                 return new Violation(
                         "history",
-                        "history exceeds the " + MAX_HISTORY_MESSAGES + "-message limit (" + history.size() + ").",
+                        "history exceeds the " + MAX_HISTORY_MESSAGES + "-message limit (" + historyContents.size()
+                                + ").",
                         false);
             }
-            for (AiAskApi.NlAskMessageDto m : history) {
-                if (m == null || m.getContent() == null) continue;
-                if (m.getContent().length() > MAX_MESSAGE_CHARS) {
+            for (String content : historyContents) {
+                if (content == null) continue;
+                if (content.length() > MAX_MESSAGE_CHARS) {
                     return new Violation(
                             "history",
                             "a history message exceeds the " + MAX_MESSAGE_CHARS + "-character limit.",
                             true);
                 }
-                total += m.getContent().length();
+                total += content.length();
             }
         }
 

--- a/saiku-core/saiku-web/src/test/java/org/saiku/web/rest/resources/AiAskSpaceStreamTest.java
+++ b/saiku-core/saiku-web/src/test/java/org/saiku/web/rest/resources/AiAskSpaceStreamTest.java
@@ -1,0 +1,182 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.web.rest.resources;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.StreamingOutput;
+import java.io.ByteArrayOutputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Locale;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.saiku.service.olap.ai.AiCubeRef;
+import org.saiku.service.olap.ai.AiSchema;
+import org.saiku.service.olap.ai.ask.AgentSpaceRegistry;
+import org.saiku.service.olap.ai.ask.AiAskApi;
+import org.saiku.service.olap.ai.ask.AiAskService;
+import org.saiku.service.olap.ai.ask.NlAskMessage;
+import org.saiku.service.olap.ai.ask.NlAskProvider;
+import org.saiku.service.olap.ai.ask.NlAskRequest;
+import org.saiku.service.olap.ai.ask.NlAskResponse;
+
+/**
+ * Resource-level tests for the space-scoped streaming endpoint {@code POST
+ * /ai/spaces/{id}/ask/stream} and the shared ask helpers extracted in saiku#1460. Covers the
+ * behavioural fixes folded into that extraction: the 403 scope pre-flight (#1454), the terminal
+ * {@code final} event on failure (#1456), and locale-safe {@code forceTool} parsing (#1458).
+ */
+public class AiAskSpaceStreamTest {
+
+    private static final AiCubeRef ALLOWED = new AiCubeRef("foodmart", "FoodMart", "FoodMart", "Sales");
+    private static final AiCubeRef FORBIDDEN = new AiCubeRef("foodmart", "FoodMart", "FoodMart", "HR");
+
+    private AiQueryResource resource;
+    private AiSchema schema;
+    private Locale defaultLocale;
+
+    @Before
+    public void setUp() {
+        defaultLocale = Locale.getDefault();
+        schema = new AiSchema("foodmart/FoodMart/FoodMart/Sales", "Sales", "[FoodMart].[Sales]");
+        resource = new AiQueryResource();
+        resource.setCubeMetadataService(ref -> schema);
+    }
+
+    @After
+    public void tearDown() {
+        Locale.setDefault(defaultLocale);
+    }
+
+    /** Wire an askService with a real space registry (Sales allowlisted) + a fixed provider. */
+    private void wireSpaceService(NlAskProvider provider) throws Exception {
+        Path tmp = Files.createTempDirectory("spaces");
+        Files.writeString(
+                tmp.resolve("sales.json"),
+                "{\"id\":\"sales-analyst\",\"name\":\"Sales Analyst\","
+                        + "\"cubeAllowlist\":["
+                        + "{\"connectionName\":\"foodmart\",\"catalog\":\"FoodMart\",\"schema\":\"FoodMart\",\"cubeName\":\"Sales\"}"
+                        + "]}");
+        AiAskService svc = new AiAskService(ref -> schema, provider);
+        svc.setSpaces(new AgentSpaceRegistry(tmp));
+        resource.setAskService(svc);
+    }
+
+    private AiAskApi.AskRequest body(AiCubeRef cube) {
+        AiAskApi.AskRequest b = new AiAskApi.AskRequest();
+        b.setQuestion("show sales");
+        b.setCube(cube);
+        return b;
+    }
+
+    private static String drain(Response resp) throws Exception {
+        assertTrue("streaming endpoints return a StreamingOutput entity", resp.getEntity() instanceof StreamingOutput);
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        ((StreamingOutput) resp.getEntity()).write(out);
+        return out.toString(StandardCharsets.UTF_8);
+    }
+
+    // ---- saiku#1454: scope denial maps to a real HTTP status, not a 200 event-stream ----
+
+    @Test
+    public void streamingSpaceEndpointReturns403ForCubeOutsideAllowlist() throws Exception {
+        wireSpaceService(req -> NlAskResponse.degraded("should not be reached"));
+        Response resp = resource.askInSpaceStream("sales-analyst", body(FORBIDDEN));
+        assertEquals(
+                "a cube outside the persona allowlist must be a real 403, not a 200 SSE error", 403, resp.getStatus());
+    }
+
+    @Test
+    public void streamingSpaceEndpointReturns404ForMissingSpace() throws Exception {
+        wireSpaceService(req -> NlAskResponse.degraded("should not be reached"));
+        Response resp = resource.askInSpaceStream("does-not-exist", body(ALLOWED));
+        assertEquals(404, resp.getStatus());
+    }
+
+    @Test
+    public void streamingSpaceEndpointStreams200ForAllowlistedCube() throws Exception {
+        wireSpaceService(req -> NlAskResponse.okViewChange(
+                "{\"viewMode\":\"chart\",\"chartType\":\"bar\",\"reason\":\"trend\"}", "claude-x", 1, 1));
+        Response resp = resource.askInSpaceStream("sales-analyst", body(ALLOWED));
+        assertEquals(200, resp.getStatus());
+        String frame = drain(resp);
+        assertTrue("model event first: " + frame, frame.contains("event: model"));
+        assertTrue("intent event present: " + frame, frame.contains("event: intent"));
+        assertTrue("terminal final event present: " + frame, frame.contains("event: final"));
+    }
+
+    // ---- saiku#1456: an unexpected failure mid-stream still terminates with a final event ----
+
+    @Test
+    public void streamingEmitsTerminalFinalWhenOutcomeSupplierThrows() throws Exception {
+        Path tmp = Files.createTempDirectory("spaces");
+        Files.writeString(
+                tmp.resolve("sales.json"),
+                "{\"id\":\"sales-analyst\",\"name\":\"Sales Analyst\","
+                        + "\"cubeAllowlist\":["
+                        + "{\"connectionName\":\"foodmart\",\"catalog\":\"FoodMart\",\"schema\":\"FoodMart\",\"cubeName\":\"Sales\"}"
+                        + "]}");
+        // askInSpace passes the pre-flight (Sales is allowlisted) but blows up while producing the
+        // outcome — the client must still see an error AND a terminating final, never a truncated
+        // stream that hangs a client keying completion on `final`.
+        AiAskService svc = new AiAskService(ref -> schema, req -> NlAskResponse.degraded("x")) {
+            @Override
+            public AskOutcome askInSpace(
+                    String spaceId,
+                    AiCubeRef ref,
+                    String question,
+                    List<NlAskMessage> history,
+                    String cellsetDigest,
+                    NlAskRequest.ForceTool forceTool,
+                    org.saiku.service.olap.ai.AiQueryRequest currentQuery) {
+                throw new IllegalStateException("boom");
+            }
+        };
+        svc.setSpaces(new AgentSpaceRegistry(tmp));
+        resource.setAskService(svc);
+
+        Response resp = resource.askInSpaceStream("sales-analyst", body(ALLOWED));
+        assertEquals(200, resp.getStatus());
+        String frame = drain(resp);
+        assertTrue("error event emitted on failure: " + frame, frame.contains("event: error"));
+        assertTrue("terminal final event must follow error: " + frame, frame.contains("event: final"));
+        assertTrue(
+                "final must come after error in the stream",
+                frame.indexOf("event: final") > frame.indexOf("event: error"));
+    }
+
+    // ---- saiku#1458: forceTool parsing is locale-independent ----
+
+    @Test
+    public void parseForceToolIsLocaleIndependent() {
+        // On a tr-TR JVM, "insight".toUpperCase() is "İNSİGHT" (dotted capital I) and valueOf fails.
+        // parseForceTool must use Locale.ROOT so the user's explicit pick survives.
+        Locale.setDefault(Locale.forLanguageTag("tr-TR"));
+        assertEquals(NlAskRequest.ForceTool.INSIGHT, AiQueryResource.parseForceTool("insight"));
+        assertEquals(NlAskRequest.ForceTool.QUERY, AiQueryResource.parseForceTool("query"));
+        assertEquals(NlAskRequest.ForceTool.VIEW_CHANGE, AiQueryResource.parseForceTool("view_change"));
+    }
+
+    @Test
+    public void parseForceToolFallsBackToAutoOnUnknownOrNull() {
+        assertEquals(NlAskRequest.ForceTool.AUTO, AiQueryResource.parseForceTool(null));
+        assertEquals(NlAskRequest.ForceTool.AUTO, AiQueryResource.parseForceTool("bogus"));
+    }
+
+    @Test
+    public void parseForceToolNotConfiguredWhenAskServiceNull() {
+        // Sanity: a null askService still returns 503 (preamble short-circuits before scope check).
+        Response resp = resource.askInSpaceStream("sales-analyst", body(ALLOWED));
+        assertEquals(503, resp.getStatus());
+        assertNotNull(resp.getEntity());
+    }
+}

--- a/saiku-core/saiku-web/src/test/java/org/saiku/web/rest/resources/AiAskSpaceStreamTest.java
+++ b/saiku-core/saiku-web/src/test/java/org/saiku/web/rest/resources/AiAskSpaceStreamTest.java
@@ -154,6 +154,56 @@ public class AiAskSpaceStreamTest {
                 frame.indexOf("event: final") > frame.indexOf("event: error"));
     }
 
+    // ---- saiku#1461: direct coverage of streamOutcomeAsSse (the "package-visible for testing" seam) ----
+
+    private String streamOutcome(AiAskService.AskOutcome outcome) throws Exception {
+        java.io.StringWriter sw = new java.io.StringWriter();
+        AiQueryResource.SseWriter sse = new AiQueryResource.SseWriter(sw);
+        resource.streamOutcomeAsSse(outcome, sse);
+        return sw.toString();
+    }
+
+    @Test
+    public void streamOutcomeAsSseEmitsModelIntentFinalForInsight() throws Exception {
+        org.saiku.service.olap.ai.ask.AiInsight insight =
+                new org.saiku.service.olap.ai.ask.AiInsight("Store sales trended up.", "Sales up");
+        String frame = streamOutcome(AiAskService.AskOutcome.okInsight(insight, "claude-x"));
+        assertTrue(frame.contains("event: model"));
+        assertTrue(frame.contains("event: intent"));
+        assertTrue("INSIGHT intent surfaced: " + frame, frame.contains("INSIGHT"));
+        assertTrue("prose chunked: " + frame, frame.contains("event: chunk"));
+        assertTrue(frame.contains("event: final"));
+        assertTrue("model precedes final", frame.indexOf("event: model") < frame.indexOf("event: final"));
+    }
+
+    @Test
+    public void streamOutcomeAsSseEmitsErrorThenFinalForDegraded() throws Exception {
+        String frame = streamOutcome(AiAskService.AskOutcome.degraded("HTTP 503: upstream offline", "claude-x"));
+        assertTrue("error event on degrade: " + frame, frame.contains("event: error"));
+        assertTrue("terminal final still fires: " + frame, frame.contains("event: final"));
+        assertTrue(frame.indexOf("event: final") > frame.indexOf("event: error"));
+    }
+
+    @Test
+    public void streamOutcomeAsSseExecutesQueryBranch() throws Exception {
+        resource.setThinQueryService(new org.saiku.service.olap.ThinQueryService() {
+            @Override
+            public org.saiku.olap.dto.resultset.CellDataSet execute(org.saiku.olap.query2.ThinQuery tq) {
+                return AiQueryResourceTest.buildStubCellDataSet();
+            }
+        });
+        org.saiku.service.olap.ai.AiQueryRequest req = new org.saiku.service.olap.ai.AiQueryRequest();
+        req.setCube(ALLOWED);
+        req.setMeasures(java.util.List.of(new org.saiku.service.olap.ai.AiMeasureSelection("Store Sales")));
+        // schema needs the measure so validation passes
+        schema.measures.put(
+                AiSchema.key("Store Sales"), new AiSchema.Measure("Store Sales", "[Measures].[Store Sales]"));
+
+        String frame = streamOutcome(AiAskService.AskOutcome.ok(req, "claude-x"));
+        assertTrue("QUERY intent surfaced: " + frame, frame.contains("QUERY"));
+        assertTrue("final envelope emitted after execution: " + frame, frame.contains("event: final"));
+    }
+
     // ---- saiku#1458: forceTool parsing is locale-independent ----
 
     @Test

--- a/saiku-core/saiku-web/src/test/java/org/saiku/web/rest/resources/AiOssieAskGuardTest.java
+++ b/saiku-core/saiku-web/src/test/java/org/saiku/web/rest/resources/AiOssieAskGuardTest.java
@@ -1,0 +1,76 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.web.rest.resources;
+
+import static org.junit.Assert.assertEquals;
+
+import jakarta.ws.rs.core.Response;
+import java.util.List;
+import java.util.Map;
+import org.junit.Before;
+import org.junit.Test;
+import org.saiku.service.ossie.ai.OssieAiAskService;
+import org.saiku.web.security.ratelimit.AiRateLimiter;
+
+/**
+ * saiku#1459: the Ossie NL ask endpoint must carry the same cost-DoS guards as {@code /ai/ask}
+ * (size cap + rate limit), so a client blocked on the MDX endpoint can't switch to
+ * {@code /ai/ossie/ask} and reach the paid LLM provider unbounded. These guards fire before any
+ * model call, so a configured-but-unwired askService is enough to exercise them.
+ */
+public class AiOssieAskGuardTest {
+
+    private AiOssieResource resource;
+
+    @Before
+    public void setUp() {
+        resource = new AiOssieResource();
+        // A "configured" ask service so the endpoint gets past the 503 gate and reaches the guards.
+        resource.setAskService(new OssieAiAskService() {
+            @Override
+            public boolean isConfigured() {
+                return true;
+            }
+        });
+    }
+
+    private static Map<String, Object> body(String question) {
+        return Map.of("connection", "sales", "model", "sales", "question", question);
+    }
+
+    @Test
+    public void oversizeQuestionIsRejectedWith413BeforeTheLlmCall() {
+        String huge = "x".repeat(9_000); // > MAX_QUESTION_CHARS (8_000)
+        Response resp = resource.ask(body(huge));
+        assertEquals(413, resp.getStatus());
+    }
+
+    @Test
+    public void exhaustedRateLimitIsRejectedWith429() {
+        // A limiter that always denies — the very first ask is rate-limited.
+        resource.setAskRateLimiter(new AiRateLimiter() {
+            @Override
+            public boolean tryAcquire(String key) {
+                return false;
+            }
+        });
+        Response resp = resource.ask(body("show sales by region"));
+        assertEquals(429, resp.getStatus());
+    }
+
+    @Test
+    public void oversizeHistoryMessageIsRejected() {
+        String hugeContent = "y".repeat(9_000); // > MAX_MESSAGE_CHARS (8_000)
+        Map<String, Object> b = Map.of(
+                "connection",
+                "sales",
+                "question",
+                "and by channel?",
+                "history",
+                List.of(Map.of("role", "user", "content", hugeContent)));
+        Response resp = resource.ask(b);
+        assertEquals(413, resp.getStatus());
+    }
+}

--- a/saiku-core/saiku-web/src/test/java/org/saiku/web/rest/resources/AiQueryResourceAskTest.java
+++ b/saiku-core/saiku-web/src/test/java/org/saiku/web/rest/resources/AiQueryResourceAskTest.java
@@ -219,6 +219,27 @@ public class AiQueryResourceAskTest {
     }
 
     @Test
+    public void spaceSyncMapsForbiddenDenialTo403RegardlessOfReasonWording() {
+        // saiku#1465: the 403 mapping keys off the typed denial code, not a reason prefix. A
+        // FORBIDDEN outcome whose reason does NOT start with "FORBIDDEN" must still be a 403 —
+        // RED against the old reason.startsWith("FORBIDDEN") logic, which would have returned 200.
+        wireSpaceAskService(AiAskService.AskOutcome.degraded(
+                "Cube not permitted for this persona", null, AiAskService.SpaceAccess.FORBIDDEN));
+        Response resp = resource.askInSpace("sales-analyst", validBody());
+        assertEquals(403, resp.getStatus());
+    }
+
+    @Test
+    public void spaceSyncMapsProviderDegradeTo200() {
+        wireSpaceAskService(AiAskService.AskOutcome.degraded("HTTP 503: upstream offline", "claude-x"));
+        Response resp = resource.askInSpace("sales-analyst", validBody());
+        assertEquals(200, resp.getStatus());
+        AiAskApi.AskResponse body = (AiAskApi.AskResponse) resp.getEntity();
+        assertTrue(body.isDegraded());
+        assertEquals("HTTP 503: upstream offline", body.getReason());
+    }
+
+    @Test
     public void spaceSyncSurfacesInsightOutcome() {
         org.saiku.service.olap.ai.ask.AiInsight insight =
                 new org.saiku.service.olap.ai.ask.AiInsight("Store sales trended up 12%.", "Sales up");

--- a/saiku-core/saiku-web/src/test/java/org/saiku/web/rest/resources/AiQueryResourceAskTest.java
+++ b/saiku-core/saiku-web/src/test/java/org/saiku/web/rest/resources/AiQueryResourceAskTest.java
@@ -184,6 +184,55 @@ public class AiQueryResourceAskTest {
                 body.getResponse().getField().startsWith("measures"));
     }
 
+    /* ---- saiku#1455: sync /spaces/{id}/ask must return the full answer, not just {model,request} ---- */
+
+    /** Wire a fake askService whose {@code askInSpace} returns a fixed outcome. */
+    private void wireSpaceAskService(AiAskService.AskOutcome outcome) {
+        resource.setAskService(new AiAskService(ref -> schema, stubProvider("")) {
+            @Override
+            public AskOutcome askInSpace(
+                    String spaceId,
+                    AiCubeRef ref,
+                    String question,
+                    List<NlAskMessage> history,
+                    String cellsetDigest,
+                    NlAskRequest.ForceTool forceTool,
+                    AiQueryRequest currentQuery) {
+                return outcome;
+            }
+        });
+    }
+
+    @Test
+    public void spaceSyncExecutesQueryOutcome() {
+        wireSpaceAskService(AiAskService.AskOutcome.ok(baseEmittedRequest(), "claude-x"));
+
+        Response resp = resource.askInSpace("sales-analyst", validBody());
+        assertEquals(200, resp.getStatus());
+
+        AiAskApi.AskResponse body = (AiAskApi.AskResponse) resp.getEntity();
+        assertFalse(body.isDegraded());
+        assertNotNull("QUERY outcome must be executed on the sync space endpoint, not just echoed", body.getResponse());
+        assertEquals(AiQueryResponse.Status.SUCCESS, body.getResponse().getStatus());
+        assertNotNull("generated MDX surfaced like the classic /ai/ask", body.getGeneratedMdx());
+        assertTrue(body.getGeneratedMdx().contains("FROM [Sales]"));
+    }
+
+    @Test
+    public void spaceSyncSurfacesInsightOutcome() {
+        org.saiku.service.olap.ai.ask.AiInsight insight =
+                new org.saiku.service.olap.ai.ask.AiInsight("Store sales trended up 12%.", "Sales up");
+        wireSpaceAskService(AiAskService.AskOutcome.okInsight(insight, "claude-x"));
+
+        Response resp = resource.askInSpace("sales-analyst", validBody());
+        assertEquals(200, resp.getStatus());
+
+        AiAskApi.AskResponse body = (AiAskApi.AskResponse) resp.getEntity();
+        assertFalse(body.isDegraded());
+        assertNotNull("INSIGHT answer must not be dropped on the sync space endpoint", body.getInsight());
+        assertEquals("Store sales trended up 12%.", body.getInsight().getMarkdown());
+    }
+
     // ---------- stubs ----------
 
     private static NlAskProvider stubProvider(String emittedJson) {

--- a/saiku-launcher/src/main/java/org/saiku/launcher/SaikuLauncher.java
+++ b/saiku-launcher/src/main/java/org/saiku/launcher/SaikuLauncher.java
@@ -716,11 +716,9 @@ public class SaikuLauncher implements Callable<Integer> {
             Path spacesDir = saikuHome.resolve("agent-spaces");
             Files.createDirectories(spacesDir);
             stageResource(
-                    "/seed/agent-spaces/foodmart-sales-analyst.json",
-                    spacesDir.resolve("foodmart-sales-analyst.json"));
+                    "/seed/agent-spaces/foodmart-sales-analyst.json", spacesDir.resolve("foodmart-sales-analyst.json"));
             stageResource(
-                    "/seed/agent-spaces/foodmart-finance-ops.json",
-                    spacesDir.resolve("foodmart-finance-ops.json"));
+                    "/seed/agent-spaces/foodmart-finance-ops.json", spacesDir.resolve("foodmart-finance-ops.json"));
         }
 
         /**


### PR DESCRIPTION
Extends the SSE streaming variant (#1447 merged) to the space-scoped ask surface (#1442 merged). Same wire format, same event ordering, same 'fake stream today, wire-stable later' semantics.

## Summary

The two features were always meant to compose — a caller who wants both persona scoping AND progressive chat UX now has one endpoint that does both. Client's SSE reader is identical:

```
event: model
data: {"model":"claude-sonnet-4-6"}

event: intent
data: {"kind":"INSIGHT"}

event: chunk
data: {"delta":"Store "}

event: chunk
data: {"delta":"Sales trended up 12% week-on-week."}

event: final
data: {"degraded":false,"model":"...","insight":{...}}
```

Space-not-found + FORBIDDEN cube outcomes surface as `error` events followed by a degraded `final` — the SSE reader on the client sees the same shape whether the failure came from the provider or from space-scope enforcement.

## Refactor: shared outcome-to-SSE plumbing

Extracted `streamOutcomeAsSse(outcome, sse)` from the existing `askStream()`. Both `askStream()` and the new `askInSpaceStream()` build their outcome (via `askService.ask` vs `askService.askInSpace`) and then call the shared helper. The two endpoints differ **only** in the outcome-producing call — everything after is identical.

Behaviour-preserving for the existing `/ai/ask/stream` endpoint — the 7 `AiAskStreamingTest` tests continue to pass unchanged.

## Auth + guards

Same rate limit + size cap + policy gate + auth as the classic `/spaces/{id}/ask` endpoint. Not a bypass surface.

## Tests

Full web suite: **478 tests, 0 failures**. Spotless clean. Existing SSE plumbing tests (`SseWriter`, `emitChunks`, `jsonString`) cover the new endpoint too since it goes through the same helper.

## Docs

`docs/AI-QUERY-API.md` — Agent Spaces REST-surface list gains the new endpoint with a pointer to the streaming variant section (event schema already documented there; no duplication).

## Test plan

- [ ] `curl -N -X POST -u admin:admin http://localhost:8080/rest/saiku/api/ai/spaces/foodmart-sales-analyst/ask/stream` → SSE events, persona prompt injected server-side
- [ ] Same body, cube ref outside the space's allowlist → `error` event with `FORBIDDEN`, then degraded `final`
- [ ] Same body, unknown space id → `error` with `space not found`, then degraded `final`
- [ ] Space-scoped INSIGHT ask → chunk events reflect the persona voice (Sales Analyst's brief, numbers-first tone)

## Related

- Base features (both merged): #1447 (SSE streaming) + #1442 (spaces)
- Feature tickets: #1440 + #1433
- Docs: `docs/AI-QUERY-API.md`

---

## Follow-up hardening (code review + security review)

A multi-agent code review and a focused security review of this branch surfaced a cluster of issues in the ask surface. All are fixed in this PR (5 additional commits, full TDD, `mvn verify` green — service 912 tests, web 495):

**Security (High):**
- **Cube-allowlist bypass** — the space allowlist was enforced only on the caller-supplied cube ref, not the cube the LLM emits in its generated query, so a prompt-injected cross-cube query could execute against a non-allowlisted cube. `AiAskService` now re-validates the emitted cube after the model call. This supersedes the old "FORBIDDEN surfaces as SSE error" behaviour below.

**Correctness:**
- Streaming space endpoint now pre-flights the persona scope and returns a real **403** (unknown space **404**) *before* the event-stream opens, instead of a 200 carrying an in-band error.
- Every SSE error path now emits a terminal `final` event (was `error` only), so clients keying completion on `final` can't hang.
- `JsonProcessingException` is caught before the client-disconnect branch (was misrouted to DEBUG-only, silent truncation).
- Sync `/spaces/{id}/ask` now executes QUERY outcomes and surfaces INSIGHT/VIEW_CHANGE answers (was echoing only `{model, request}`).
- `forceTool` parsing is locale-independent (`Locale.ROOT`).
- `/ai/ossie/ask` now carries the same policy gate + size cap + rate limiter as `/ai/ask` (was an unguarded bypass surface).

**Maintainability / coverage / docs:**
- Extracted the ~40-line ask preamble + SSE runner shared by all four endpoints (was a 4th verbatim copy, already drifting).
- Space-denial → HTTP status now maps off a typed code, not a reason-string prefix.
- Restored the 503 remediation guidance; removed the redundant `bodyFinal` aliases.
- Added direct coverage for `streamOutcomeAsSse` + `askInSpaceStream` (was zero); synced `AGENT-SPACES-SPEC.md`.

Updated test-plan expectations (superseding the SSE-error items above):
- [ ] Cube ref outside the space allowlist → **HTTP 403** before the stream opens
- [ ] Unknown space id → **HTTP 404**
- [ ] Prompt-injected query naming a non-allowlisted cube → refused (degraded FORBIDDEN), not executed

Closes #1453
Closes #1454
Closes #1455
Closes #1456
Closes #1457
Closes #1458
Closes #1459
Closes #1460
Closes #1461
Closes #1462
Closes #1463
Closes #1464
Closes #1465
Closes #1466
