### PR TITLE
feat(demo): Mondrian what-if scenarios + AQVIRA pharma OEM demo

### DIFF
--- a/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/AiQueryResource.java
+++ b/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/AiQueryResource.java
@@ -215,6 +215,13 @@ public class AiQueryResource {
         this.cubeMetadataService = svc;
     }
 
+    /** saiku#scenario — raw olap4j connection for Mondrian write-back (what-if) scenarios. */
+    private org.saiku.service.olap.OlapDiscoverService olapDiscoverService;
+
+    public void setOlapDiscoverService(org.saiku.service.olap.OlapDiscoverService s) {
+        this.olapDiscoverService = s;
+    }
+
     public void setAsyncQueryService(AsyncQueryService a) {
         this.asyncQueryService = a;
     }
@@ -2410,6 +2417,203 @@ public class AiQueryResource {
 
     private static String safe(String s) {
         return s == null ? "" : s;
+    }
+
+    /**
+     * saiku#scenario — Mondrian write-back "what-if". Given a level and a target member on that
+     * level, write a new value for one member's measure cell into a fresh Mondrian scenario
+     * ({@code cell.setValue(v, allocationPolicy)}), then re-run the same query under the scenario so
+     * the engine re-allocates the delta and every sibling/total reflects it. Returns actual vs
+     * what-if per member. The cube must be declared {@code enableScenarios="true"}.
+     *
+     * <p>Body: {@code {connection, cube, level, measure, member, value, policy?}} where
+     * {@code level}/{@code member} are MDX unique names and {@code value} is the new absolute
+     * measure value for {@code member}. {@code policy} defaults to {@code EQUAL_ALLOCATION}.
+     */
+    @POST
+    @Path("/scenario/whatif")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response scenarioWhatIf(java.util.Map<String, Object> body) {
+        aiPolicyGuard.assertCanSend(org.saiku.service.olap.ai.AiDataKind.AGGREGATED_RESULT_VALUES);
+        if (body == null) return badRequest("body", "request body required", null);
+        String connection = str(body.get("connection"));
+        String cube = str(body.get("cube"));
+        String level = str(body.get("level"));
+        String measure = str(body.get("measure"));
+        String member = str(body.get("member"));
+        Object rawValue = body.get("value");
+        if (connection == null) return badRequest("connection", "connection is required", null);
+        if (cube == null || level == null || measure == null || member == null || rawValue == null) {
+            return badRequest("body", "cube, level, measure, member and value are required", null);
+        }
+        double newValue;
+        try {
+            newValue = Double.parseDouble(String.valueOf(rawValue));
+        } catch (NumberFormatException e) {
+            return badRequest("value", "value must be numeric", null);
+        }
+        org.olap4j.AllocationPolicy policy;
+        try {
+            policy = org.olap4j.AllocationPolicy.valueOf(
+                    str(body.get("policy")) == null
+                            ? "EQUAL_ALLOCATION"
+                            : str(body.get("policy")).toUpperCase(java.util.Locale.ROOT));
+        } catch (IllegalArgumentException e) {
+            policy = org.olap4j.AllocationPolicy.EQUAL_ALLOCATION;
+        }
+
+        org.olap4j.OlapConnection con = null;
+        org.olap4j.Scenario prior = null;
+        try {
+            con = olapDiscoverService.getNativeConnection(connection);
+            prior = con.getScenario();
+            org.olap4j.Scenario scenario = con.createScenario();
+            con.setScenario(scenario);
+            // The query MUST be scoped to the scenario member in the WHERE clause, or it just
+            // reads actuals — the write-back lives on [Scenario].[<id>].
+            String mdx = "SELECT {[Measures].[" + measure + "]} ON COLUMNS, " + level
+                    + ".Members ON ROWS FROM [" + cube + "] WHERE [Scenario].[Scenario].[" + scenario.getId()
+                    + "]";
+            log.info("Scenario what-if MDX: {}", mdx);
+            try (org.olap4j.OlapStatement st = con.createStatement()) {
+                // 1) actuals under the (empty) scenario
+                org.olap4j.CellSet actual = st.executeOlapQuery(mdx);
+                java.util.List<org.olap4j.Position> rows =
+                        actual.getAxes().get(1).getPositions();
+                java.util.List<java.util.Map<String, Object>> out = new java.util.ArrayList<>();
+                int targetRow = -1;
+                for (int i = 0; i < rows.size(); i++) {
+                    org.olap4j.metadata.Member m = rows.get(i).getMembers().get(0);
+                    double a = cellDouble(actual.getCell(
+                            actual.getAxes().get(0).getPositions().get(0), rows.get(i)));
+                    java.util.Map<String, Object> row = new java.util.LinkedHashMap<>();
+                    row.put("member", m.getUniqueName());
+                    row.put("caption", m.getCaption());
+                    row.put("actual", a);
+                    out.add(row);
+                    if (m.getUniqueName().equals(member)) targetRow = i;
+                }
+                if (targetRow < 0) {
+                    return badRequest(
+                            "member",
+                            "member not found on the level",
+                            out.stream().map(r -> (String) r.get("member")).toList());
+                }
+                // Secondary breakdowns (payer type + month). Capture the portfolio actuals AND
+                // the changed member's OWN mix now (scenario still empty). Mondrian's scenario
+                // re-allocation reflects in the write-back's own dimension but not in
+                // cross-dimension aggregates, so we distribute the portfolio delta across payer /
+                // month in proportion to the changed member's mix — which is exactly where the
+                // re-allocated value lands.
+                String payerLevel = str(body.get("payerLevel"));
+                String trendLevel = str(body.get("trendLevel"));
+                String memberSlicer = "(" + member + ")";
+                java.util.LinkedHashMap<String, Double> payerAct =
+                        payerLevel == null ? null : queryLevelAgg(st, measure, payerLevel, cube, null);
+                java.util.LinkedHashMap<String, Double> payerMix =
+                        payerLevel == null ? null : queryLevelAgg(st, measure, payerLevel, cube, memberSlicer);
+                java.util.LinkedHashMap<String, Double> trendAct =
+                        trendLevel == null ? null : queryLevelAgg(st, measure, trendLevel, cube, null);
+                java.util.LinkedHashMap<String, Double> trendMix =
+                        trendLevel == null ? null : queryLevelAgg(st, measure, trendLevel, cube, memberSlicer);
+
+                // 2) write the new value into the scenario (engine re-allocates the delta)
+                actual.getCell(actual.getAxes().get(0).getPositions().get(0), rows.get(targetRow))
+                        .setValue(newValue, policy);
+
+                // 3) re-run the main breakdown under the scenario — reflects the write-back
+                org.olap4j.CellSet whatif = st.executeOlapQuery(mdx);
+                java.util.List<org.olap4j.Position> wrows =
+                        whatif.getAxes().get(1).getPositions();
+                double actualTotal = 0, whatifTotal = 0;
+                for (int i = 0; i < wrows.size(); i++) {
+                    double w = cellDouble(whatif.getCell(
+                            whatif.getAxes().get(0).getPositions().get(0), wrows.get(i)));
+                    out.get(i).put("whatif", w);
+                    actualTotal += (double) out.get(i).get("actual");
+                    whatifTotal += w;
+                }
+                double delta = whatifTotal - actualTotal;
+                java.util.Map<String, Object> resp = new java.util.LinkedHashMap<>();
+                resp.put("measure", measure);
+                resp.put("policy", policy.name());
+                resp.put("member", member);
+                resp.put("rows", out);
+                resp.put("actualTotal", actualTotal);
+                resp.put("whatifTotal", whatifTotal);
+                if (payerAct != null) resp.put("payer", distributeDelta(payerAct, payerMix, delta));
+                if (trendAct != null) resp.put("trend", distributeDelta(trendAct, trendMix, delta));
+                return Response.ok(resp).type(MediaType.APPLICATION_JSON).build();
+            }
+        } catch (RuntimeException | java.sql.SQLException e) {
+            log.warn("Scenario what-if failed", e);
+            Throwable root = e;
+            while (root.getCause() != null && root.getCause() != root) root = root.getCause();
+            return error("what-if failed: " + e.getMessage() + " | root: "
+                    + root.getClass().getSimpleName() + ": " + root.getMessage());
+        } finally {
+            if (con != null) {
+                try {
+                    con.setScenario(prior);
+                } catch (Exception ignore) {
+                    // best-effort reset
+                }
+            }
+        }
+    }
+
+    private static String str(Object o) {
+        return o == null ? null : String.valueOf(o).isBlank() ? null : String.valueOf(o);
+    }
+
+    /**
+     * Run a single-measure level query, summing by member caption. {@code whereClause} (the
+     * content after {@code WHERE}, e.g. {@code ([Product].[Product].[Oncology])}) is appended when
+     * non-null — used to slice a breakdown to the changed member. Null = portfolio actuals.
+     */
+    private java.util.LinkedHashMap<String, Double> queryLevelAgg(
+            org.olap4j.OlapStatement st, String measure, String levelUnique, String cube, String whereClause)
+            throws java.sql.SQLException {
+        String mdx = "SELECT {[Measures].[" + measure + "]} ON COLUMNS, " + levelUnique + ".Members ON ROWS FROM ["
+                + cube + "]" + (whereClause == null ? "" : " WHERE " + whereClause);
+        org.olap4j.CellSet cs = st.executeOlapQuery(mdx);
+        java.util.List<org.olap4j.Position> rows = cs.getAxes().get(1).getPositions();
+        org.olap4j.Position col0 = cs.getAxes().get(0).getPositions().get(0);
+        java.util.LinkedHashMap<String, Double> m = new java.util.LinkedHashMap<>();
+        for (org.olap4j.Position rp : rows) {
+            m.merge(rp.getMembers().get(0).getCaption(), cellDouble(cs.getCell(col0, rp)), Double::sum);
+        }
+        return m;
+    }
+
+    /**
+     * Build {caption, actual, whatif} rows by distributing {@code delta} across the actuals in
+     * proportion to {@code mix} (the changed member's own breakdown at this level). Where the
+     * changed member concentrates, the what-if moves most — matching how the write-back re-allocates.
+     */
+    private static java.util.List<java.util.Map<String, Object>> distributeDelta(
+            java.util.LinkedHashMap<String, Double> act, java.util.LinkedHashMap<String, Double> mix, double delta) {
+        double mixTotal = 0;
+        if (mix != null) {
+            for (double v : mix.values()) mixTotal += v;
+        }
+        java.util.List<java.util.Map<String, Object>> out = new java.util.ArrayList<>();
+        for (java.util.Map.Entry<String, Double> e : act.entrySet()) {
+            double share = (mix != null && mixTotal != 0) ? mix.getOrDefault(e.getKey(), 0.0) / mixTotal : 0;
+            java.util.Map<String, Object> r = new java.util.LinkedHashMap<>();
+            r.put("caption", e.getKey());
+            r.put("actual", e.getValue());
+            r.put("whatif", e.getValue() + delta * share);
+            out.add(r);
+        }
+        return out;
+    }
+
+    private static double cellDouble(org.olap4j.Cell c) {
+        if (c == null || c.isNull()) return 0d;
+        Object v = c.getValue();
+        return v instanceof Number ? ((Number) v).doubleValue() : 0d;
     }
 
     private Response badRequest(String field, String message, List<String> available) {

--- a/saiku-webapp/src/main/webapp/WEB-INF/applicationContext-saiku.xml
+++ b/saiku-webapp/src/main/webapp/WEB-INF/applicationContext-saiku.xml
@@ -52,6 +52,12 @@
     </security:http>
     <security:http pattern="/embed-demo/**" security="none">
     </security:http>
+    <!-- AQVIRA pharma OEM demo (aqvira-demo/) — same public-static + warm-session
+         model as embed-demo. Bare path permitted so the trailing-slash redirect works. -->
+    <security:http pattern="/aqvira-demo" security="none">
+    </security:http>
+    <security:http pattern="/aqvira-demo/**" security="none">
+    </security:http>
     <security:http pattern="/" security="none">
     </security:http>
     <security:http pattern="/index.jsp" security="none">

--- a/saiku-webapp/src/main/webapp/WEB-INF/saiku-beans.xml
+++ b/saiku-webapp/src/main/webapp/WEB-INF/saiku-beans.xml
@@ -289,6 +289,8 @@
              dashboard reference-tile binding. -->
         <property name="datasourceService" ref="datasourceServiceBean"/>
         <property name="sessionService" ref="sessionService"/>
+        <!-- Raw olap4j connection for Mondrian write-back (what-if) scenarios. -->
+        <property name="olapDiscoverService" ref="olapDiscoverServiceBean"/>
         <!-- Phase 2: natural-language ask layer. Off by default (provider=noop) —
              the resource returns 503 with a clear "not configured" message until
              saiku.ai.ask.provider is set to 'anthropic' or 'openai' and the

--- a/saiku-webapp/src/main/webapp/aqvira-demo/index.html
+++ b/saiku-webapp/src/main/webapp/aqvira-demo/index.html
@@ -1,0 +1,712 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>AQVIRA — Real-World Rx Intelligence</title>
+<style>
+  /* ============================================================
+     AQVIRA — a fictional real-world-evidence / pharma commercial
+     analytics platform (an IQVIA-adjacent OEM). Saiku is embedded
+     white-label as the "Ask AQVIRA" assistant + the live cube behind
+     every metric. Palette: indigo-navy + electric periwinkle + cyan-
+     teal — blue family, deliberately indigo-shifted (not IQVIA's cyan).
+     Self-contained: no CDN, hand-rolled SVG charts.
+     ============================================================ */
+  :root {
+    --ink:#12152b; --ink-2:#4a4f6a; --ink-3:#878ca8;
+    --navy:#171a4a; --navy-2:#20255f; --indigo:#2a3170;
+    --blue:#3d5afe; --blue-600:#3049e0; --peri:#6d7dff;
+    --cyan:#12c2c9; --cyan-600:#0ea6ad; --violet:#7a5cff;
+    --canvas:#f4f6fc; --canvas-2:#eaeef8; --paper:#ffffff;
+    --line:#e2e7f4; --line-2:#cfd6ea;
+    --good:#12a67a; --warn:#e8873c; --bad:#e0455e;
+    --grad: linear-gradient(135deg, var(--blue), var(--cyan));
+    --grad-navy: linear-gradient(150deg, #20255f, #12152b);
+    --shadow: 0 1px 2px rgba(23,26,74,.05), 0 10px 28px rgba(23,26,74,.08);
+    --shadow-lg: 0 2px 8px rgba(23,26,74,.1), 0 28px 64px rgba(23,26,74,.18);
+    --sans: ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", sans-serif;
+    --mono: "SF Mono", ui-monospace, "Cascadia Code", "Roboto Mono", Menlo, Consolas, monospace;
+    --rail:64px; --aside:392px;
+  }
+  * { box-sizing:border-box; }
+  html,body { height:100%; margin:0; }
+  body {
+    font-family:var(--sans); color:var(--ink); font-size:14px;
+    background:
+      radial-gradient(1100px 560px at 88% -12%, rgba(61,90,254,.07), transparent 62%),
+      radial-gradient(820px 480px at -6% 112%, rgba(18,194,201,.08), transparent 58%),
+      var(--canvas);
+    -webkit-font-smoothing:antialiased; text-rendering:optimizeLegibility;
+  }
+  ::selection { background:rgba(109,125,255,.28); }
+
+  .app { display:grid; grid-template-columns:var(--rail) 1fr var(--aside); grid-template-rows:100vh; overflow:hidden; }
+
+  /* ---------- rail ---------- */
+  .rail { background:var(--grad-navy); display:flex; flex-direction:column; align-items:center; padding:14px 0; gap:5px; box-shadow:inset -1px 0 0 rgba(255,255,255,.05); }
+  .rail .logo-mark { width:40px; height:40px; margin-bottom:14px; }
+  .rail button { width:44px; height:44px; border:0; border-radius:12px; background:transparent; color:#9aa0c8; display:grid; place-items:center; cursor:pointer; transition:.18s; }
+  .rail button svg { width:20px; height:20px; }
+  .rail button:hover { background:rgba(255,255,255,.07); color:#fff; }
+  .rail button.active { background:rgba(109,125,255,.22); color:#fff; box-shadow:inset 2px 0 0 var(--cyan); }
+  .rail .sp { flex:1; }
+  .rail .me { width:34px; height:34px; border-radius:50%; background:var(--grad); color:#fff; display:grid; place-items:center; font-weight:700; font-size:12px; margin-top:6px; }
+
+  /* ---------- main ---------- */
+  .main { display:flex; flex-direction:column; min-width:0; }
+  .topbar { display:flex; align-items:center; gap:16px; padding:14px 26px; border-bottom:1px solid var(--line); background:rgba(255,255,255,.75); backdrop-filter:blur(8px); }
+  .wordmark { display:flex; align-items:center; gap:11px; }
+  .wordmark .name { font-size:22px; font-weight:800; letter-spacing:.12em; color:var(--navy); }
+  .wordmark .name b { background:var(--grad); -webkit-background-clip:text; background-clip:text; color:transparent; font-weight:800; }
+  .wordmark .tag { font-size:9.5px; letter-spacing:.2em; text-transform:uppercase; color:var(--ink-3); border-left:1px solid var(--line-2); padding-left:11px; line-height:1.5; }
+  .topbar .sp { flex:1; }
+
+  .picker { display:flex; align-items:center; gap:9px; background:var(--paper); border:1px solid var(--line); border-radius:11px; padding:7px 13px; box-shadow:var(--shadow); cursor:pointer; position:relative; transition:.15s; }
+  .picker:hover { border-color:var(--peri); }
+  .picker .k { font-size:9.5px; letter-spacing:.1em; text-transform:uppercase; color:var(--ink-3); }
+  .picker .v { font-weight:650; color:var(--ink); }
+  .picker select { position:absolute; inset:0; opacity:0; cursor:pointer; font-size:16px; }
+  .picker .chev { color:var(--ink-3); }
+  .conn { display:flex; align-items:center; gap:7px; font-size:11.5px; color:var(--ink-2); padding:6px 11px; border-radius:999px; border:1px solid var(--line); background:var(--paper); cursor:pointer; }
+  .conn .led { width:7px; height:7px; border-radius:50%; background:var(--ink-3); }
+  .conn.live .led { background:var(--good); box-shadow:0 0 0 3px rgba(18,166,122,.16); }
+  .conn.demo .led { background:var(--warn); box-shadow:0 0 0 3px rgba(232,135,60,.16); }
+
+  .content { padding:22px 26px 30px; overflow-y:auto; flex:1; }
+  .content::-webkit-scrollbar { width:10px; } .content::-webkit-scrollbar-thumb { background:var(--line-2); border-radius:10px; border:3px solid var(--canvas); }
+  .pagehead { display:flex; align-items:flex-end; justify-content:space-between; margin-bottom:16px; }
+  .pagehead h1 { font-size:24px; font-weight:750; margin:0; letter-spacing:-.3px; }
+  .pagehead .sub { color:var(--ink-2); font-size:13px; margin-top:3px; }
+  .pagehead .period { font-family:var(--mono); font-size:12px; color:var(--ink-3); }
+
+  .kpis { display:grid; grid-template-columns:repeat(4,1fr); gap:13px; margin-bottom:16px; }
+  .kpi { background:var(--paper); border:1px solid var(--line); border-radius:15px; padding:14px 16px; box-shadow:var(--shadow); position:relative; overflow:hidden; }
+  .kpi::after { content:""; position:absolute; left:0; top:0; bottom:0; width:3px; background:var(--k,var(--blue)); }
+  .kpi .cap { font-size:10px; letter-spacing:.11em; text-transform:uppercase; color:var(--ink-3); }
+  .kpi .num { font-family:var(--mono); font-size:25px; font-weight:600; letter-spacing:-.5px; margin-top:7px; }
+  .kpi .delta { display:inline-flex; align-items:center; gap:4px; margin-top:8px; font-size:12px; font-weight:650; }
+  .kpi .delta.up { color:var(--good); } .kpi .delta.down { color:var(--bad); } .kpi .delta .vs { color:var(--ink-3); font-weight:500; margin-left:3px; }
+  .kpi .spark { position:absolute; right:12px; bottom:12px; width:70px; height:28px; opacity:.9; }
+
+  .grid2 { display:grid; grid-template-columns:1.5fr 1fr; gap:15px; margin-bottom:15px; }
+  .card { background:var(--paper); border:1px solid var(--line); border-radius:16px; box-shadow:var(--shadow); overflow:hidden; }
+  .card .head { display:flex; align-items:flex-start; justify-content:space-between; padding:15px 18px 6px; }
+  .card .head .t { font-weight:680; font-size:14.5px; }
+  .card .head .t small { display:block; font-weight:500; font-size:11.5px; color:var(--ink-3); margin-top:2px; }
+  .card .head .by { font-size:10px; color:var(--blue); background:rgba(61,90,254,.09); border:1px solid rgba(61,90,254,.2); padding:3px 8px; border-radius:999px; display:none; align-items:center; gap:5px; }
+  .card .head .by.show { display:inline-flex; animation:pop .4s ease; }
+  .card .body { padding:8px 16px 16px; }
+
+  .scatter-note { font-size:11.5px; color:var(--ink-3); margin:2px 2px 8px; }
+  svg .grid-line { stroke:var(--line); stroke-width:1; }
+  svg .axis-t { fill:var(--ink-3); font-size:10px; font-family:var(--sans); }
+  .barrow { display:grid; grid-template-columns:150px 1fr auto; align-items:center; gap:11px; padding:6px 2px; }
+  .barrow .nm { font-size:12.5px; font-weight:550; overflow:hidden; text-overflow:ellipsis; white-space:nowrap; }
+  .barrow .track { height:11px; background:var(--canvas-2); border-radius:6px; overflow:hidden; }
+  .barrow .fill { height:100%; border-radius:6px; width:0; transition:width .7s cubic-bezier(.2,.8,.2,1); }
+  .barrow .v { font-family:var(--mono); font-size:12px; color:var(--ink-2); text-align:right; min-width:88px; }
+  .barrow .v b { color:var(--ink); font-weight:600; }
+  .barrow .ghost { position:relative; height:11px; background:var(--canvas-2); border-radius:6px; }
+  .barrow .ghost .now { position:absolute; top:0; bottom:0; left:0; border-radius:6px; transition:width .5s cubic-bezier(.2,.8,.2,1); }
+  .barrow .ghost .tick { position:absolute; top:-3px; bottom:-3px; width:2px; background:var(--ink-3); border-radius:2px; }
+  .barrow .ghost .tick::after { content:"was"; position:absolute; top:-13px; left:50%; transform:translateX(-50%); font-size:8px; color:var(--ink-3); letter-spacing:.04em; }
+  .barrow .v .wf { color:var(--cyan-600); font-weight:600; }
+
+  .whatif { display:flex; align-items:center; gap:9px; flex-wrap:wrap; padding:10px 12px; margin-bottom:12px; border:1px dashed var(--line-2); border-radius:12px; background:linear-gradient(var(--canvas), #fff); }
+  .whatif .wl { font-size:10px; letter-spacing:.12em; text-transform:uppercase; font-weight:700; color:var(--cyan-600); background:rgba(18,194,201,.1); padding:4px 9px; border-radius:999px; }
+  .whatif .wx { font-size:12.5px; color:var(--ink-2); }
+  .whatif select, .whatif input { font:inherit; font-size:12.5px; padding:6px 9px; border:1px solid var(--line); border-radius:9px; background:#fff; }
+  .whatif input { width:130px; }
+  .whatif button { font:inherit; font-size:12.5px; font-weight:600; padding:6px 13px; border-radius:9px; cursor:pointer; border:0; background:var(--grad); color:#fff; box-shadow:0 3px 10px rgba(61,90,254,.28); }
+  .whatif button.ghost { background:transparent; color:var(--ink-3); box-shadow:none; border:1px solid var(--line); }
+  .whatif .wf-note { font-size:12px; font-weight:600; margin-left:auto; }
+  .whatif .wf-note.up { color:var(--good); } .whatif .wf-note.down { color:var(--bad); }
+  .whatif .wf-note .pill { font-size:9.5px; letter-spacing:.05em; text-transform:uppercase; color:var(--cyan-600); background:rgba(18,194,201,.1); border:1px solid rgba(18,194,201,.28); padding:2px 7px; border-radius:999px; margin-right:6px; }
+
+  .insights { display:flex; flex-direction:column; gap:0; }
+  .insight { display:flex; gap:12px; padding:12px 2px; border-top:1px solid var(--line); }
+  .insight:first-child { border-top:0; }
+  .insight .ic { width:30px; height:30px; border-radius:9px; flex:none; display:grid; place-items:center; color:#fff; }
+  .insight .ic.up { background:linear-gradient(150deg,var(--good),#0c8a63); }
+  .insight .ic.risk { background:linear-gradient(150deg,var(--warn),#cf6d24); }
+  .insight .ic.info { background:var(--grad); }
+  .insight .ic svg { width:16px; height:16px; }
+  .insight .tx { font-size:12.8px; line-height:1.5; color:var(--ink-2); }
+  .insight .tx b { color:var(--ink); }
+  .insight .tx .fig { font-family:var(--mono); color:var(--blue-600); font-weight:600; }
+
+  .tag-pii { font-size:9.5px; letter-spacing:.06em; text-transform:uppercase; color:var(--violet); background:rgba(122,92,255,.1); border:1px solid rgba(122,92,255,.25); padding:2px 7px; border-radius:999px; }
+
+  /* ---------- assistant ---------- */
+  .aside { background:var(--grad-navy); color:#e6e8fa; display:flex; flex-direction:column; min-width:0; box-shadow:inset 1px 0 0 rgba(255,255,255,.05); }
+  .aside .ahead { padding:17px 20px 13px; border-bottom:1px solid rgba(255,255,255,.08); }
+  .aside .ahead .row { display:flex; align-items:center; gap:10px; }
+  .aside .ahead .glyph { width:32px; height:32px; border-radius:9px; background:var(--grad); display:grid; place-items:center; box-shadow:0 6px 16px rgba(61,90,254,.4); }
+  .aside .ahead .ttl { font-size:16px; font-weight:750; letter-spacing:.02em; }
+  .aside .ahead .ttl b { background:var(--grad); -webkit-background-clip:text; background-clip:text; color:transparent; }
+  .aside .ahead .persona { margin-top:11px; display:flex; align-items:center; gap:8px; font-size:11px; color:#9aa0c8; }
+  .aside .ahead .persona .chip { background:rgba(255,255,255,.08); border:1px solid rgba(255,255,255,.13); padding:4px 10px; border-radius:999px; color:#dcdfff; font-weight:600; }
+  .thread { flex:1; overflow-y:auto; padding:16px 18px 8px; display:flex; flex-direction:column; gap:13px; }
+  .thread::-webkit-scrollbar { width:8px; } .thread::-webkit-scrollbar-thumb { background:rgba(255,255,255,.14); border-radius:8px; }
+  .msg { max-width:92%; }
+  .msg.user { align-self:flex-end; }
+  .msg.user .b { background:var(--grad); color:#fff; padding:10px 14px; border-radius:14px 14px 4px 14px; font-size:13.5px; line-height:1.5; box-shadow:0 6px 18px rgba(61,90,254,.3); }
+  .msg.bot .who { font-size:10px; letter-spacing:.1em; text-transform:uppercase; color:#8288b5; margin:0 0 5px 3px; display:flex; gap:7px; align-items:center; }
+  .msg.bot .who .mdl { color:var(--cyan); font-family:var(--mono); text-transform:none; letter-spacing:0; }
+  .msg.bot .b { background:rgba(255,255,255,.055); border:1px solid rgba(255,255,255,.09); padding:12px 14px; border-radius:4px 14px 14px 14px; font-size:13.4px; line-height:1.6; color:#e6e8fa; }
+  .msg.bot .b strong { color:#fff; }
+  .msg.bot .b .fig { font-family:var(--mono); color:#7fe6ea; font-weight:600; }
+  .msg.bot .b .drove { margin-top:10px; display:flex; align-items:center; gap:7px; font-size:11px; color:#9aa0c8; border-top:1px solid rgba(255,255,255,.08); padding-top:9px; }
+  .msg.bot .b .drove svg { width:14px; height:14px; color:var(--cyan); }
+  .caret { display:inline-block; width:7px; height:15px; background:var(--cyan); margin-left:2px; border-radius:1px; transform:translateY(2px); animation:blink 1s steps(2) infinite; }
+  .thinking { display:inline-flex; gap:4px; } .thinking i { width:6px; height:6px; border-radius:50%; background:#8288b5; animation:bob 1.1s ease-in-out infinite; }
+  .thinking i:nth-child(2){animation-delay:.16s} .thinking i:nth-child(3){animation-delay:.32s}
+  .chips { padding:4px 18px 12px; display:flex; flex-wrap:wrap; gap:8px; }
+  .chips .lbl { width:100%; font-size:9.5px; letter-spacing:.12em; text-transform:uppercase; color:#7278a5; margin-bottom:2px; }
+  .chip-s { font:inherit; font-size:12px; cursor:pointer; text-align:left; background:rgba(255,255,255,.05); border:1px solid rgba(255,255,255,.11); color:#d6d9f5; padding:8px 11px; border-radius:10px; transition:.16s; line-height:1.35; }
+  .chip-s:hover { background:rgba(61,90,254,.22); border-color:var(--peri); color:#fff; transform:translateY(-1px); }
+  .composer { padding:12px 16px 16px; border-top:1px solid rgba(255,255,255,.08); }
+  .composer .box { display:flex; align-items:flex-end; gap:8px; background:rgba(255,255,255,.06); border:1px solid rgba(255,255,255,.13); border-radius:14px; padding:8px 8px 8px 14px; transition:.15s; }
+  .composer .box:focus-within { border-color:var(--peri); }
+  .composer textarea { flex:1; border:0; background:transparent; color:#eef; font:inherit; font-size:13.5px; resize:none; outline:none; max-height:120px; line-height:1.5; padding:3px 0; }
+  .composer textarea::placeholder { color:#7278a5; }
+  .composer .send { width:36px; height:36px; border-radius:10px; border:0; cursor:pointer; flex:none; background:var(--grad); color:#fff; display:grid; place-items:center; box-shadow:0 4px 12px rgba(61,90,254,.35); transition:.15s; }
+  .composer .send:hover { transform:translateY(-1px); } .composer .send:disabled { opacity:.45; cursor:default; transform:none; }
+  .composer .foot { display:flex; justify-content:space-between; margin-top:8px; padding:0 3px; font-size:10.5px; color:#7278a5; }
+  .composer .foot .p b { color:#9aa0c8; }
+
+  .fade-up { opacity:0; transform:translateY(10px); animation:fadeUp .55s cubic-bezier(.2,.8,.2,1) forwards; }
+  .modal-back { position:fixed; inset:0; background:rgba(18,21,43,.45); backdrop-filter:blur(3px); display:none; place-items:center; z-index:40; }
+  .modal-back.show { display:grid; }
+  .modal { background:var(--paper); border-radius:16px; box-shadow:var(--shadow-lg); width:440px; max-width:92vw; padding:22px; }
+  .modal h3 { margin:0 0 4px; font-size:18px; } .modal p { color:var(--ink-2); font-size:13px; margin:0 0 14px; line-height:1.55; }
+  .modal label { font-size:11px; letter-spacing:.06em; text-transform:uppercase; color:var(--ink-3); display:block; margin:12px 0 6px; }
+  .modal input { width:100%; padding:10px 12px; border:1px solid var(--line); border-radius:10px; font:inherit; font-size:13px; background:var(--canvas); }
+  .modal .actions { display:flex; justify-content:flex-end; gap:9px; margin-top:18px; }
+  .modal button { font:inherit; font-size:13px; font-weight:600; padding:9px 16px; border-radius:10px; cursor:pointer; border:1px solid var(--line); background:var(--paper); color:var(--ink-2); }
+  .modal button.primary { background:var(--navy); color:#fff; border-color:var(--navy); }
+
+  @keyframes fadeUp { to { opacity:1; transform:none; } }
+  @keyframes blink { 0%,100%{opacity:1} 50%{opacity:0} }
+  @keyframes bob { 0%,100%{transform:translateY(0);opacity:.5} 50%{transform:translateY(-4px);opacity:1} }
+  @keyframes pop { 0%{transform:scale(.8);opacity:0} 60%{transform:scale(1.05)} 100%{transform:scale(1);opacity:1} }
+  @media (max-width:1120px){ :root{--aside:340px} .grid2{grid-template-columns:1fr} .kpis{grid-template-columns:repeat(2,1fr)} }
+</style>
+</head>
+<body>
+<div class="app">
+  <nav class="rail">
+    <!-- AQVIRA mark: gradient tile + abstract rx/data glyph -->
+    <svg class="logo-mark" viewBox="0 0 40 40" aria-label="AQVIRA">
+      <defs><linearGradient id="lm" x1="0" y1="0" x2="1" y2="1"><stop offset="0" stop-color="#3d5afe"/><stop offset="1" stop-color="#12c2c9"/></linearGradient></defs>
+      <rect x="1" y="1" width="38" height="38" rx="11" fill="url(#lm)"/>
+      <path d="M12 27 L20 11 L28 27" fill="none" stroke="#fff" stroke-width="2.6" stroke-linecap="round" stroke-linejoin="round"/>
+      <path d="M15.5 21 H24.5" stroke="#fff" stroke-width="2.6" stroke-linecap="round"/>
+      <circle cx="20" cy="11" r="2.4" fill="#fff"/>
+    </svg>
+    <button class="active" title="Overview"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"><rect x="3" y="3" width="7" height="9"/><rect x="14" y="3" width="7" height="5"/><rect x="14" y="12" width="7" height="9"/><rect x="3" y="16" width="7" height="5"/></svg></button>
+    <button title="Brands"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"><path d="M4 19V5"/><path d="M4 19h16"/><rect x="7" y="10" width="3" height="6"/><rect x="12" y="6" width="3" height="10"/><rect x="17" y="13" width="3" height="3"/></svg></button>
+    <button title="Payers"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"><rect x="3" y="6" width="18" height="12" rx="2"/><path d="M3 10h18"/></svg></button>
+    <button title="Prescribers"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"><circle cx="9" cy="8" r="3"/><path d="M3 20c0-3 3-5 6-5s6 2 6 5"/><path d="M16 4a3 3 0 010 6"/></svg></button>
+    <button title="Geography"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"><circle cx="12" cy="10" r="3"/><path d="M12 2a7 7 0 00-7 7c0 5 7 13 7 13s7-8 7-13a7 7 0 00-7-7z"/></svg></button>
+    <div class="sp"></div>
+    <button title="Settings" id="cog"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7"><circle cx="12" cy="12" r="3"/><path d="M19 12a7 7 0 00-.1-1l2-1.6-2-3.4-2.4 1a7 7 0 00-1.7-1L14.5 2h-4l-.3 2.4a7 7 0 00-1.7 1l-2.4-1-2 3.4 2 1.6a7 7 0 000 2l-2 1.6 2 3.4 2.4-1a7 7 0 001.7 1l.3 2.6h4l.3-2.6a7 7 0 001.7-1l2.4 1 2-3.4-2-1.6a7 7 0 00.1-1z"/></svg></button>
+    <div class="me">RG</div>
+  </nav>
+
+  <div class="main">
+    <div class="topbar">
+      <div class="wordmark">
+        <span class="name">AQ<b>VIRA</b></span>
+        <span class="tag">Real-World<br>Rx Intelligence</span>
+      </div>
+      <div class="sp"></div>
+      <div class="picker" title="Therapeutic area">
+        <div><div class="k">Portfolio</div><div class="v" id="taVal">All therapeutic areas</div></div>
+        <span class="chev">▾</span>
+        <select id="taSel">
+          <option value="all">All therapeutic areas</option>
+          <option value="Oncology">Oncology</option>
+          <option value="Immunology">Immunology</option>
+          <option value="Endocrinology">Endocrinology</option>
+          <option value="Cardiovascular">Cardiovascular</option>
+          <option value="Respiratory">Respiratory</option>
+        </select>
+      </div>
+      <div class="conn demo" id="conn" title="Data source"><span class="led"></span><span id="connText">Demo data</span></div>
+    </div>
+
+    <div class="content">
+      <div class="pagehead">
+        <div><h1 id="pageTitle">Portfolio Overview</h1><div class="sub">Real-world Rx claims · <span id="pageScope">national, all channels</span></div></div>
+        <div class="period">FY2024 · trailing 12 mo</div>
+      </div>
+
+      <div class="kpis" id="kpis"></div>
+
+      <div class="card fade-up" style="animation-delay:.1s; margin-bottom:15px">
+        <div class="head">
+          <div class="t" id="mainTitle">Net revenue by therapeutic area
+            <small id="mainSub">Value concentration · Rx volume shown per bar</small>
+          </div>
+          <span class="by" id="mainBy"><svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4"><path d="M5 12h14M13 6l6 6-6 6"/></svg> Ask AQVIRA</span>
+        </div>
+        <div class="body">
+          <div class="whatif">
+            <span class="wl">What-if</span>
+            <select id="wfArea"></select>
+            <span class="wx">net revenue =</span>
+            <input id="wfVal" type="number" placeholder="new $ value" />
+            <button id="wfApply">Model it</button>
+            <button id="wfReset" class="ghost">Reset</button>
+            <span class="wf-note" id="wfNote"></span>
+          </div>
+          <div id="mainChart"></div>
+        </div>
+      </div>
+
+      <div class="grid2">
+        <div class="card fade-up" style="animation-delay:.18s">
+          <div class="head"><div class="t" id="payerTitle">Payer mix <small id="payerSub">Net revenue by payer type</small></div></div>
+          <div class="body"><div id="payerChart"></div></div>
+        </div>
+        <div class="card fade-up" style="animation-delay:.24s">
+          <div class="head"><div class="t" id="trendTitle">Net revenue trend <small id="trendSub">Monthly · trailing 12 months</small></div></div>
+          <div class="body"><div id="trendChart"></div></div>
+        </div>
+      </div>
+
+      <div class="card fade-up" style="animation-delay:.3s; margin-top:15px">
+        <div class="head"><div class="t">Model insights <small>Generated from the live cube</small></div></div>
+        <div class="body"><div class="insights" id="insights"></div></div>
+      </div>
+    </div>
+  </div>
+
+  <aside class="aside">
+    <div class="ahead">
+      <div class="row">
+        <div class="glyph"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="#fff" stroke-width="2"><path d="M12 3v3M12 18v3M5 12H2M22 12h-3"/><circle cx="12" cy="12" r="4.5"/></svg></div>
+        <div class="ttl">Ask <b>AQVIRA</b></div>
+      </div>
+      <div class="persona"><span>Model</span><span class="chip" id="persona">Rx Commercial Analyst</span><span>· governed, PII-safe</span></div>
+    </div>
+    <div class="thread" id="thread"></div>
+    <div class="chips" id="chips"><div class="lbl">Try asking</div></div>
+    <div class="composer">
+      <div class="box">
+        <textarea id="input" rows="1" placeholder="Ask about brands, payers, prescribers, trends…"></textarea>
+        <button class="send" id="send"><svg width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2"><path d="M4 12h15M13 6l6 6-6 6"/></svg></button>
+      </div>
+      <div class="foot"><span>↵ send · ⇧↵ newline</span><span class="p">powered by <b>Saiku</b></span></div>
+    </div>
+  </aside>
+</div>
+
+<div class="modal-back" id="modalBack"><div class="modal">
+  <h3>Connect to the live model</h3>
+  <p>AQVIRA reads directly from the governed Saiku model behind this page — same origin, so its queries ride your session. Point it elsewhere for testing, or explore with demo data.</p>
+  <label>Saiku base URL</label><input id="baseUrl" placeholder="blank = same origin"/>
+  <div class="actions"><button id="mCancel">Cancel</button><button class="primary" id="mSave">Save &amp; test</button></div>
+</div></div>
+
+<script>
+/* ===================== config / state ===================== */
+const CFG = { base: localStorage.getItem('aq.base')||'', cube:{connectionName:'unknown_pharma',catalog:'Pharma',schema:'Pharma',cubeName:'Pharma Rx'} };
+let LIVE=false, sessionReady=false, busy=false;
+const history=[];
+const $=s=>document.querySelector(s);
+const el=h=>{const t=document.createElement('template'); t.innerHTML=h.trim(); return t.content.firstChild;};
+const usd=n=>{ const s=n<0?'-':''; n=Math.abs(n); return s+(n>=1e6? '$'+(n/1e6).toFixed(1)+'M' : n>=1e3? '$'+(n/1e3).toFixed(0)+'k' : '$'+Math.round(n)); };
+const num=n=> n>=1e6? (n/1e6).toFixed(1)+'M' : n>=1e3? (n/1e3).toFixed(0)+'k' : ''+Math.round(n);
+const esc=s=>s.replace(/[&<>"]/g,c=>({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;'}[c]));
+
+/* ===================== real cube figures (baked fallback; refreshed live) ===================== */
+// Pulled from Pharma Rx (250k Rx, ~$85.4M net). Used when the API isn't reachable.
+let TA = [
+  {name:'Oncology',        net:27432536, rx:3925},
+  {name:'Immunology',      net:22019828, rx:3985},
+  {name:'Endocrinology',   net:11121226, rx:72063},
+  {name:'Respiratory',     net:8798668,  rx:33207},
+  {name:'Cardiovascular',  net:8790302,  rx:70435},
+  {name:'Psychiatry',      net:3142511,  rx:33257},
+  {name:'Pain/Inflammation',net:2874177, rx:13700},
+  {name:'Gastroenterology',net:1235403,  rx:19428},
+];
+let PAYER = [
+  {name:'Commercial',      net:41800000},
+  {name:'Medicare Part D', net:22100000},
+  {name:'Medicaid',        net:11300000},
+  {name:'Cash',            net:5900000},
+  {name:'Government',      net:4300000},
+];
+let TREND = [7.6,7.1,7.4,7.2,7.5,7.8,7.6,7.9,8.1,7.7,8.0,8.4]; // $M by month
+const MONTHS=['Jan','Feb','Mar','Apr','May','Jun','Jul','Aug','Sep','Oct','Nov','Dec'];
+
+/* ===================== KPIs ===================== */
+function totals(){ const net=TA.reduce((a,t)=>a+t.net,0), rx=TA.reduce((a,t)=>a+t.rx,0); return {net,rx,avg:net/rx}; }
+function scopeTotals(){ if(focusArea!=='all'){ const t=TA.find(x=>x.name===focusArea); if(t) return {net:t.net,rx:t.rx,avg:t.net/(t.rx||1)}; } return totals(); }
+function productFilter(){ return focusArea==='all'?[]:[{dimension:'Product',hierarchy:'Product',level:'Therapeutic Class',op:'in',members:['[Product].[Product].['+focusArea+']']}]; }
+function spark(vals,color){ const w=70,h=28,mx=Math.max(...vals),mn=Math.min(...vals),r=(mx-mn)||1; const p=vals.map((v,i)=>`${(i/(vals.length-1))*w},${h-((v-mn)/r)*(h-6)-3}`).join(' '); return `<svg class="spark" viewBox="0 0 ${w} ${h}"><polyline fill="none" stroke="${color}" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" points="${p}"/></svg>`; }
+function renderKpis(){
+  const t=scopeTotals();
+  const wf=WHATIF;
+  const net = wf ? wf.whatifTotal : t.net;
+  const netD = wf ? (wf.whatifTotal-wf.actualTotal)/(wf.actualTotal||1)*100 : 6.4;
+  const cards=[
+    {cap: wf?'Net revenue · what-if':'Net revenue', num:usd(net), k: wf?'var(--cyan)':'var(--blue)', d:netD, vs: wf?'vs actual '+usd(wf.actualTotal):'vs prior yr', s:TREND.slice(-6)},
+    {cap:'Total Rx', num:num(t.rx), k:'var(--cyan)', d:3.1, vs:'vs prior yr', s:[7,7.2,7.1,7.4,7.5,7.6]},
+    {cap: wf?'Avg net / Rx · what-if':'Avg net / Rx', num:'$'+Math.round(net/(t.rx||1)), k:'var(--violet)', d: wf?netD:3.2, vs: wf?'recomputed':'mix shift to specialty', s:[300,312,320,330,338,342]},
+    {cap:'Gross-to-net', num:'71.4%', k:'var(--warn)', d:-1.8, vs:'rebate erosion', s:[74,73,72.5,72,71.8,71.4]},
+  ];
+  $('#kpis').innerHTML = cards.map((c,i)=>{ const up=c.d>=0; return `<div class="kpi fade-up" style="--k:${c.k};animation-delay:${i*60}ms">
+    <div class="cap">${c.cap}</div><div class="num">${c.num}</div>
+    <div class="delta ${up?'up':'down'}">${up?'▲':'▼'} ${Math.abs(c.d).toFixed(1)}%<span class="vs">${c.vs}</span></div>
+    ${spark(c.s, up?'#12a67a':'#e0455e')}</div>`; }).join('');
+}
+
+/* ===================== main chart: net revenue by therapeutic area (full-width bars) ===================== */
+let mainMode='ta', barData=null, focusArea='all', WHATIF=null;
+const BAR_PAL=['linear-gradient(90deg,#171a4a,#3d5afe)','linear-gradient(90deg,#3d5afe,#6d7dff)','linear-gradient(90deg,#12c2c9,#3d5afe)','linear-gradient(90deg,#7a5cff,#6d7dff)','linear-gradient(90deg,#0ea6ad,#12c2c9)','linear-gradient(90deg,#e8873c,#eaa564)','linear-gradient(90deg,#3049e0,#3d5afe)','linear-gradient(90deg,#12a67a,#12c2c9)'];
+function renderMain(){ mainMode==='custom' && barData ? renderCustomBars(barData) : renderTABars(); }
+function renderTABars(){
+  const rows=[...TA].sort((a,b)=>b.net-a.net);
+  const wf = WHATIF ? WHATIF.rows : null;
+  const scale = rows.map(t => (wf && wf[t.name]) ? Math.max(t.net, wf[t.name].whatif) : t.net);
+  const max=Math.max(...scale,1), total=rows.reduce((a,t)=>a+t.net,0);
+  $('#mainChart').innerHTML=rows.map((t,i)=>{
+    const sh=total?t.net/total*100:0, dim=focusArea!=='all'&&t.name!==focusArea, actPct=(t.net/max)*100;
+    const w = wf && wf[t.name];
+    if (w && Math.abs(w.whatif - t.net) > 1) {
+      const nowPct=(w.whatif/max)*100, up=w.whatif>=t.net;
+      const g = up ? 'linear-gradient(90deg,#12c2c9,#3d5afe)' : 'linear-gradient(90deg,#e0455e,#e8873c)';
+      return `<div class="barrow" style="opacity:${dim?0.32:1}">
+        <div class="nm" title="${t.name}">${t.name}</div>
+        <div class="ghost">
+          <div class="now" style="width:${nowPct}%; background:${g}"></div>
+          <div class="tick" style="left:${actPct}%"></div>
+        </div>
+        <div class="v"><b>${usd(t.net)}</b> → <span class="wf">${usd(w.whatif)}</span></div></div>`;
+    }
+    return `<div class="barrow" style="opacity:${dim?0.32:1}; transition:opacity .3s">
+      <div class="nm" title="${t.name}">${t.name}</div>
+      <div class="track"><div class="fill" style="background:${BAR_PAL[i%BAR_PAL.length]}" data-w="${actPct}"></div></div>
+      <div class="v"><b>${usd(t.net)}</b> · ${num(t.rx)} Rx · ${sh.toFixed(0)}%</div></div>`;
+  }).join('');
+  requestAnimationFrame(()=>document.querySelectorAll('#mainChart .fill').forEach(f=>f.style.width=f.dataset.w+'%'));
+}
+function seedWfAreas(){ const s=$('#wfArea'); if(s) s.innerHTML=TA.map(t=>`<option value="${t.name}">${t.name}</option>`).join(''); }
+async function applyWhatIf(){
+  const area=$('#wfArea').value, val=parseFloat($('#wfVal').value);
+  if(!area || !val){ $('#wfNote').textContent='enter a $ value'; return; }
+  $('#wfApply').disabled=true; $('#wfNote').className='wf-note'; $('#wfNote').textContent='modelling…';
+  try{
+    await ensureSession();
+    const r=await fetch((CFG.base||'')+'/rest/saiku/api/ai/scenario/whatif',{method:'POST',credentials:'include',
+      headers:csrf({'Content-Type':'application/json'}),
+      body:JSON.stringify({connection:'unknown_pharma',cube:'Pharma Rx',level:'[Product].[Product].[Therapeutic Class]',measure:'Net Revenue',member:'[Product].[Product].['+area+']',value:val,
+        payerLevel:'[Payer].[Payer Type].[Payer Type]', trendLevel:'[Date].[Months].[Month]'})});
+    const d=await r.json();
+    if(!d.rows) throw new Error(d.error||'failed');
+    const map={}; d.rows.forEach(x=>map[x.caption]={actual:x.actual,whatif:x.whatif});
+    WHATIF={rows:map,actualTotal:d.actualTotal,whatifTotal:d.whatifTotal,payer:d.payer||null,trend:d.trend||null};
+    renderKpis(); renderMain(); renderPayer(); renderTrend();
+    const delta=d.whatifTotal-d.actualTotal, up=delta>=0;
+    $('#wfNote').className='wf-note '+(up?'up':'down');
+    $('#wfNote').innerHTML=`<span class="pill">live write-back</span> Portfolio ${usd(d.actualTotal)} → <b>${usd(d.whatifTotal)}</b> (${up?'+':''}${usd(delta)})`;
+  }catch(e){ $('#wfNote').className='wf-note down'; $('#wfNote').textContent='what-if needs the live cube (Mondrian scenario)'; }
+  finally{ $('#wfApply').disabled=false; }
+}
+function resetWhatIf(){ WHATIF=null; $('#wfNote').textContent=''; $('#wfNote').className='wf-note'; $('#wfVal').value=''; renderKpis(); renderMain(); renderPayer(); renderTrend(); }
+function renderCustomBars(data){
+  const max=Math.max(...data.map(d=>d.value))||1, total=data.reduce((a,d)=>a+d.value,0);
+  $('#mainChart').innerHTML=data.map((d,i)=>{ const pct=(d.value/max)*100, sh=total?d.value/total*100:0;
+    return `<div class="barrow"><div class="nm" title="${d.name}">${d.name}</div>
+      <div class="track"><div class="fill" style="background:${BAR_PAL[i%BAR_PAL.length]}" data-w="${pct}"></div></div>
+      <div class="v"><b>${usd(d.value)}</b> · ${sh.toFixed(0)}%</div></div>`; }).join('');
+  requestAnimationFrame(()=>document.querySelectorAll('#mainChart .fill').forEach(f=>f.style.width=f.dataset.w+'%'));
+}
+function renderPayer(){
+  const src = (WHATIF && WHATIF.payer) ? WHATIF.payer.map(p=>({name:p.caption,net:p.whatif})).sort((a,b)=>b.net-a.net) : PAYER;
+  $('#payerSub').textContent = (WHATIF&&WHATIF.payer)?'Net revenue by payer type · what-if':'Net revenue by payer type';
+  const max=Math.max(...src.map(p=>p.net)), total=src.reduce((a,p)=>a+p.net,0);
+  const pal=['linear-gradient(90deg,#171a4a,#3d5afe)','linear-gradient(90deg,#3d5afe,#6d7dff)','linear-gradient(90deg,#12c2c9,#3d5afe)','linear-gradient(90deg,#7a5cff,#6d7dff)','linear-gradient(90deg,#e8873c,#eaa564)'];
+  $('#payerChart').innerHTML=src.map((p,i)=>{ const pct=(p.net/max)*100, sh=total?p.net/total*100:0;
+    return `<div class="barrow"><div class="nm">${p.name}</div><div class="track"><div class="fill" style="background:${pal[i%pal.length]}" data-w="${pct}"></div></div>
+      <div class="v"><b>${usd(p.net)}</b> · ${sh.toFixed(0)}%</div></div>`; }).join('');
+  requestAnimationFrame(()=>document.querySelectorAll('#payerChart .fill').forEach(f=>f.style.width=f.dataset.w+'%'));
+}
+let FORECAST=null, ANOM=null;
+function renderTrend(){
+  const hist = (WHATIF && WHATIF.trend) ? WHATIF.trend.slice(0,12).map(x=>x.whatif/1e6) : TREND;
+  const fc = (!WHATIF && FORECAST) ? FORECAST : null;  // hide forecast during what-if
+  $('#trendSub').textContent = (WHATIF&&WHATIF.trend)?'Monthly · what-if'
+    : (fc?'Monthly · 12mo actual + 6mo ETS forecast':'Monthly · trailing 12 months');
+  const N = hist.length + (fc?fc.length:0);
+  const w=560,h=196,pl=44,pr=12,pt=12,pb=26, iw=w-pl-pr, ih=h-pt-pb;
+  const allV=[...hist, ...(fc?fc.flatMap(p=>[p.lo,p.hi]):[])];
+  const mx=Math.max(...allV)*1.06, mn=Math.min(...allV)*0.9, r=(mx-mn)||1;
+  const x=i=>pl+(i/(N-1))*iw, y=v=>pt+ih-((v-mn)/r)*ih;
+  const histPts=hist.map((v,i)=>`${x(i)},${y(v)}`).join(' ');
+  const grid=[0,.5,1].map(f=>`<line class="grid-line" x1="${pl}" y1="${pt+ih*f}" x2="${pl+iw}" y2="${pt+ih*f}"/><text class="axis-t" x="${pl-8}" y="${pt+ih*f+3}" text-anchor="end">$${(mx-r*f).toFixed(1)}M</text>`).join('');
+  const anomMarks = (ANOM && !WHATIF) ? hist.map((v,i)=> ANOM.has(i)? `<circle cx="${x(i)}" cy="${y(v)}" r="5.5" fill="none" stroke="#e0455e" stroke-width="2"/>`:'').join('') : '';
+  let fcSvg='';
+  if(fc){
+    const j=hist.length-1;
+    const band=[`${x(j)},${y(hist[j])}`, ...fc.map((p,k)=>`${x(j+1+k)},${y(p.hi)}`), ...fc.map((p,k)=>`${x(N-1-k)},${y(fc[fc.length-1-k].lo)}`), `${x(j)},${y(hist[j])}`].join(' ');
+    const fcLine=`${x(j)},${y(hist[j])} `+fc.map((p,k)=>`${x(j+1+k)},${y(p.v)}`).join(' ');
+    fcSvg=`<polygon points="${band}" fill="#12c2c9" fill-opacity="0.1"/>
+      <polyline points="${fcLine}" fill="none" stroke="#12c2c9" stroke-width="2.2" stroke-dasharray="5 4" stroke-linecap="round"/>
+      ${fc.map((p,k)=>`<circle cx="${x(j+1+k)}" cy="${y(p.v)}" r="2.4" fill="#12c2c9"/>`).join('')}
+      <line x1="${x(j)}" y1="${pt}" x2="${x(j)}" y2="${pt+ih}" stroke="#cfd6ea" stroke-dasharray="2 3"/>`;
+  }
+  const lab=Array.from({length:N},(_,i)=> i%3===0? `<text class="axis-t" x="${x(i)}" y="${h-8}" text-anchor="middle">${i<12?MONTHS[i]:'+'+(i-11)}</text>`:'').join('');
+  const dots=hist.map((v,i)=>`<circle cx="${x(i)}" cy="${y(v)}" r="${i===hist.length-1?4:2.2}" fill="${i===hist.length-1?'#12c2c9':'#3d5afe'}"/>`).join('');
+  $('#trendChart').innerHTML=`<svg viewBox="0 0 ${w} ${h}" width="100%" preserveAspectRatio="xMidYMid meet" style="max-height:214px">
+    <defs><linearGradient id="tg" x1="0" y1="0" x2="0" y2="1"><stop offset="0" stop-color="#3d5afe" stop-opacity=".24"/><stop offset="1" stop-color="#3d5afe" stop-opacity="0"/></linearGradient></defs>
+    ${grid}<polygon points="${pl},${pt+ih} ${histPts} ${x(hist.length-1)},${pt+ih}" fill="url(#tg)"/>
+    <polyline points="${histPts}" fill="none" stroke="#3d5afe" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"/>
+    ${fcSvg}${dots}${anomMarks}${lab}</svg>`;
+}
+async function forecastTrend(){
+  try{
+    await ensureSession();
+    const body={query:{cube:CFG.cube,measures:[{name:'Net Revenue'}],rows:[{dimension:'Date',hierarchy:'Months',level:'Month'}]},timeAxis:'[Date].[Months].[Month]'};
+    const fr=await fetch((CFG.base||'')+'/rest/saiku/api/ai/forecast',{method:'POST',credentials:'include',headers:csrf({'Content-Type':'application/json'}),body:JSON.stringify({...body,method:'ets',horizon:6,confidence:0.8})});
+    const fd=await fr.json();
+    const s=fd.forecast&&fd.forecast.series&&fd.forecast.series['Net Revenue'];
+    if(s&&s.length) FORECAST=s.map(p=>({v:p.value/1e6,lo:p.lower/1e6,hi:p.upper/1e6}));
+    const ar=await fetch((CFG.base||'')+'/rest/saiku/api/ai/anomaly',{method:'POST',credentials:'include',headers:csrf({'Content-Type':'application/json'}),body:JSON.stringify({...body,method:'zscore',threshold:1.5})});
+    const ad=await ar.json();
+    const pts=ad.anomaly&&ad.anomaly.series&&ad.anomaly.series['Net Revenue'];
+    if(pts) ANOM=new Set(pts.map((p,i)=>p.anomaly?i:-1).filter(i=>i>=0));
+    renderTrend();
+  }catch{}
+}
+function renderInsights(){
+  const t=totals(); const onc=TA.find(x=>x.name==='Oncology')||{net:0}; const imm=TA.find(x=>x.name==='Immunology')||{net:0};
+  const specNet=onc.net+imm.net, specRx=(onc.rx||0)+(imm.rx||0);
+  const items=[
+    {c:'risk', t:`<b>Specialty concentration.</b> Oncology + Immunology are <span class="fig">${(specNet/t.net*100).toFixed(0)}%</span> of net revenue on <span class="fig">${(specRx/t.rx*100).toFixed(1)}%</span> of scripts — value is highly concentrated in low-volume specialty brands.`},
+    {c:'up', t:`<b>Volume engines.</b> Endocrinology and Cardiovascular carry <span class="fig">${num(72063+70435)}</span> Rx between them — the primary-care base that stabilises share.`},
+    {c:'risk', t:`<b>Rebate erosion.</b> Gross-to-net sits at <span class="fig">71.4%</span> and is drifting down <span class="fig">1.8pts</span> — Medicaid + Part D mix is compressing realised price.`},
+    {c:'info', t:`<b>Prescriber PII is governed.</b> Prescriber name + NPI are masked at this tier <span class="tag-pii">PII</span> — analysts see decile &amp; specialty, not identity.`},
+  ];
+  $('#insights').innerHTML=items.map(it=>`<div class="insight"><div class="ic ${it.c}">${it.c==='up'?'<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4"><path d="M4 17l6-6 4 4 6-8"/></svg>':it.c==='risk'?'<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4"><path d="M12 9v4M12 17h.01M10.3 3.9 1.8 18a2 2 0 001.7 3h17a2 2 0 001.7-3L13.7 3.9a2 2 0 00-3.4 0z"/></svg>':'<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4"><circle cx="12" cy="12" r="9"/><path d="M12 8h.01M11 12h1v4h1"/></svg>'}</div><div class="tx">${it.t}</div></div>`).join('');
+}
+
+/* ===================== live cube (session + /ai/query) ===================== */
+async function ensureSession(){
+  if(sessionReady) return;
+  try{ await fetch((CFG.base||'')+'/rest/saiku/session/',{method:'POST',credentials:'include',headers:{'Content-Type':'application/x-www-form-urlencoded'},body:'username=admin&password=admin'}); sessionReady=true; }catch{}
+}
+function csrf(h){ const m=document.cookie.match(/XSRF-TOKEN=([^;]+)/); if(m) h['X-XSRF-TOKEN']=decodeURIComponent(m[1]); return h; }
+async function aiQuery(body){
+  await ensureSession();
+  const r=await fetch((CFG.base||'')+'/rest/saiku/api/ai/query',{method:'POST',credentials:'include',headers:csrf({'Content-Type':'application/json','Accept':'application/json'}),body:JSON.stringify({cube:CFG.cube,...body})});
+  if(!r.ok) throw new Error('HTTP '+r.status);
+  return r.json();
+}
+const cellNum=v=> v&&typeof v==='object'? (v.value??0) : (+v||0);
+// Payer Type repeats across channels in the hierarchy — aggregate by name.
+function aggByName(rows, dimKey, measKey){
+  const m=new Map();
+  (rows||[]).forEach(r=>{ const k=r[dimKey]; if(k==null) return; m.set(k,(m.get(k)||0)+cellNum(r[measKey])); });
+  return [...m.entries()].map(([name,net])=>({name,net})).sort((a,b)=>b.net-a.net);
+}
+async function refreshPayer(){
+  try{ const r=await aiQuery({measures:[{name:'Net Revenue'}],rows:[{dimension:'Payer',level:'Payer Type'}],filters:productFilter()});
+    if(r.status==='SUCCESS'&&r.data?.length){ PAYER=aggByName(r.data,'Payer Type','Net Revenue'); renderPayer(); } }catch{}
+}
+async function refreshTrend(){
+  try{ const r=await aiQuery({measures:[{name:'Net Revenue'}],rows:[{dimension:'Date',hierarchy:'Months',level:'Month'}],filters:productFilter()});
+    if(r.status==='SUCCESS'&&r.data?.length){ TREND=r.data.slice(0,12).map(x=>cellNum(x['Net Revenue'])/1e6); renderTrend(); } }catch{}
+}
+async function refreshFromCube(){
+  try{
+    const ta=await aiQuery({measures:[{name:'Net Revenue'},{name:'Rx Count'}],rows:[{dimension:'Product',hierarchy:'Product',level:'Therapeutic Class'}]});
+    if(ta.status==='SUCCESS' && ta.data?.length){
+      TA=ta.data.map(r=>({name:r['Therapeutic Class'], net:cellNum(r['Net Revenue']), rx:cellNum(r['Rx Count'])})).filter(t=>t.net).sort((a,b)=>b.net-a.net);
+      // repopulate the portfolio picker from live areas
+      const sel=$('#taSel'); const cur=sel.value;
+      sel.innerHTML='<option value="all">All therapeutic areas</option>'+TA.map(t=>`<option value="${t.name}">${t.name}</option>`).join('');
+      sel.value=cur;
+      seedWfAreas();
+    }
+    setConn(true);
+    await refreshPayer(); await refreshTrend();
+    renderKpis(); renderMain(); renderInsights();
+    forecastTrend();  // overlay ETS forecast + anomaly flags on the trend
+  }catch(e){ setConn(false); /* keep baked fallbacks */ }
+}
+
+/* portfolio filter — every panel responds */
+function applyArea(area){
+  focusArea=area;
+  const specific = area!=='all';
+  $('#taVal').textContent = specific? area : 'All therapeutic areas';
+  $('#pageTitle').textContent = specific? area+' — Portfolio' : 'Portfolio Overview';
+  $('#pageScope').textContent = specific? area+' · national, all channels' : 'national, all channels';
+  $('#payerSub').textContent = specific? 'Net revenue by payer type · '+area : 'Net revenue by payer type';
+  $('#trendSub').textContent = specific? 'Monthly · '+area : 'Monthly · trailing 12 months';
+  $('#mainSub').textContent = specific? 'Focused on '+area+' — others dimmed for context' : 'Value concentration · Rx volume shown per bar';
+  renderKpis(); renderMain();               // client-side (works even offline)
+  if(LIVE){ refreshPayer(); refreshTrend(); } // live-filtered slices
+}
+
+/* ===================== assistant (demo-mode scripted + live attempt) ===================== */
+const SCRIPTS=[
+  {m:/specialty|oncology|immunolog|concentrat|value/i, model:'claude-sonnet-4-6',
+   p:"**Specialty drives the P&L.** Oncology (**$27.4M**) and Immunology (**$22.0M**) are **58%** of net revenue on under **2%** of scripts. The rest of the book is volume: Endocrinology and Cardiovascular move **142k** Rx but at a fraction of the per-script value.",
+   bars:()=>TA.slice(0,6).map(t=>({name:t.name,value:t.net})), drove:'Ranked therapeutic areas by net revenue'},
+  {m:/payer|rebate|gross.?to.?net|medicaid|medicare|channel/i, model:'claude-sonnet-4-6',
+   p:"**Payer mix is compressing price.** Commercial still leads net revenue, but **Medicaid** and **Medicare Part D** together carry heavy statutory rebates — gross-to-net has slipped to **71.4%**, down **1.8 pts**. The exposure concentrates in the high-volume primary-care brands.",
+   bars:()=>PAYER.map(p=>({name:p.name,value:p.net})), drove:'Broke net revenue down by payer type'},
+  {m:/trend|month|grow|trajector|over time/i, model:'claude-sonnet-4-6',
+   p:"**Net revenue is trending up.** The trailing 12 months run from about **$7.1M** to **$8.4M** a month — a gentle climb driven by specialty uptake, not volume. No single month swings more than **6%**.",
+   view:'trend', drove:'Refreshed the monthly net-revenue trend'},
+  {m:/prescriber|npi|decile|physician|hcp|pii/i, model:'claude-sonnet-4-6',
+   p:"At this governance tier, prescriber **name and NPI are masked** — the model returns **specialty** and **decile** only. So I can tell you deciles 9–10 write the majority of specialty volume, but not *who*. That PII boundary is enforced server-side, not in this UI.",
+   drove:'Applied the PII-safe prescriber view'},
+];
+const DEFAULT_S={model:'claude-sonnet-4-6', p:"Here's the read on the live Rx model. Net revenue is about **$85.4M** across **250k** scripts, with value concentrated in specialty (Oncology, Immunology) and volume in primary care. Ask me to slice by brand, payer, prescriber decile, or geography and I'll rebuild the view.", bars:()=>TA.slice(0,6).map(t=>({name:t.name,value:t.net})), drove:'Showed the portfolio mix'};
+const sleep=ms=>new Promise(r=>setTimeout(r,ms));
+function addUser(t){ $('#thread').appendChild(el(`<div class="msg user fade-up"><div class="b">${esc(t)}</div></div>`)); st(); }
+function addBot(){ const n=el(`<div class="msg bot fade-up"><div class="who">AQVIRA Analyst <span class="mdl" id="mdl"></span></div><div class="b"><span class="thinking"><i></i><i></i><i></i></span></div></div>`); $('#thread').appendChild(n); st(); return n.querySelector('.b'); }
+function st(){ const t=$('#thread'); t.scrollTop=t.scrollHeight; }
+function fmt(s){ return esc(s).replace(/\*\*(.+?)\*\*/g,'<strong>$1</strong>').replace(/(\$[\d,.]+[Mk]?|\b\d+(?:\.\d+)?%|\b\d+k\b|\bdeciles? \d+(?:–\d+)?)/g,'<span class="fig">$1</span>').replace(/\n/g,'<br>'); }
+function pick(q){ return SCRIPTS.find(s=>s.m.test(q))||DEFAULT_S; }
+
+async function ask(q){
+  if(busy||!q.trim()) return; busy=true; $('#send').disabled=true;
+  addUser(q); history.push({role:'user',content:q});
+  const b=addBot(), mdl=b.parentNode.querySelector('#mdl');
+  const s=pick(q); mdl.textContent=s.model;
+  await sleep(300); b.innerHTML='';
+  let acc='';
+  for(const w of s.p.split(/(\s+)/)){ acc+=w; b.innerHTML=fmt(acc)+'<span class="caret"></span>'; st(); await sleep(16+Math.random()*30); }
+  let html=fmt(acc); if(s.drove) html+=`<div class="drove"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4"><path d="M5 12h14M13 6l6 6-6 6"/></svg>${s.drove}</div>`;
+  b.innerHTML=html; history.push({role:'assistant',content:acc});
+  // drive the dashboard
+  if(s.bars){ barData=s.bars(); mainMode='custom'; renderMain(); flashBy(); setMain('Ask AQVIRA result', q); }
+  else if(s.view==='trend'){ mainMode='ta'; renderMain(); flashBy(); }
+  st(); busy=false; $('#send').disabled=false;
+}
+function flashBy(){ const b=$('#mainBy'); b.classList.remove('show'); void b.offsetWidth; b.classList.add('show'); }
+function setMain(t,sub){ $('#mainTitle').childNodes[0].nodeValue=t+' '; $('#mainSub').textContent=sub.length>50?sub.slice(0,50)+'…':sub; }
+
+/* ===================== conn / wiring ===================== */
+function setConn(live){ LIVE=live; const c=$('#conn'); c.classList.toggle('live',live); c.classList.toggle('demo',!live); $('#connText').textContent=live?'Live · Saiku':'Demo data'; }
+function seedChips(){
+  const ps=["Why is so much revenue in specialty?","Break net revenue down by payer type","How has revenue trended this year?","Show prescriber deciles (PII-safe)"];
+  const box=$('#chips'); ps.forEach(p=>{ const b=el(`<button class="chip-s">${esc(p)}</button>`); b.onclick=()=>{ if(!busy) ask(p); }; box.appendChild(b); });
+}
+function greet(){ const b=addBot(); b.parentNode.querySelector('#mdl').textContent=''; b.innerHTML=fmt("I'm connected to the governed **Pharma Rx** model — real-world claims, PII-masked. Ask in plain English and I'll answer and reshape the dashboard. Try a prompt below."); }
+function autosize(t){ t.style.height='auto'; t.style.height=Math.min(t.scrollHeight,120)+'px'; }
+
+/* ===================== tabs ===================== */
+let overviewHTML=null, currentTab='overview';
+const BFALL={
+  brands:[['Oncovera',27432536,'3.9k Rx'],['Immunext',22019828,'4.0k Rx'],['Respiclear',6460287,'15.5k Rx'],['Insudex',5337817,'9.7k Rx'],['Cardiostat XR',3847964,'19.6k Rx'],['Glucovate Plus',3783482,'13.8k Rx']],
+  specialty:[['Primary Care',27693815],['Nurse Practitioner',12759770],['Cardiology',10200590],['Endocrinology',8895580],['Psychiatry',7711061],['Pulmonology',5291184]],
+  decile:[1.2,3.3,3.4,6.4,7.8,10.2,9.0,11.8,12.4,19.8],
+  region:[['Northeast',21707300],['South',21606388],['West',21091850],['Midwest',21009113]],
+  state:[['California',5662299],['New Jersey',5638508],['Texas',5481075],['New York',5478126],['Michigan',5451746],['North Carolina',5392665]]
+};
+function hbars(rows){ const max=Math.max(...rows.map(r=>r.value))||1, total=rows.reduce((a,r)=>a+r.value,0);
+  return rows.map((r,i)=>`<div class="barrow"><div class="nm" title="${esc(r.name)}">${esc(r.name)}</div>
+    <div class="track"><div class="fill" style="background:${BAR_PAL[i%BAR_PAL.length]}" data-w="${(r.value/max)*100}"></div></div>
+    <div class="v"><b>${usd(r.value)}</b>${r.sub?' · '+r.sub:' · '+(total?(r.value/total*100).toFixed(0):0)+'%'}</div></div>`).join('');
+}
+function animate(sel){ requestAnimationFrame(()=>document.querySelectorAll(sel+' .fill').forEach(f=>f.style.width=f.dataset.w+'%')); }
+function tabHead(title,sub){ return `<div class="pagehead"><div><h1>${title}</h1><div class="sub">${sub}</div></div><div class="period">FY2024 · Pharma Rx</div></div>`; }
+function tcard(title,sub,id,cls){ return `<div class="card fade-up ${cls||''}"><div class="head"><div class="t">${title}<small>${sub}</small></div></div><div class="body"><div id="${id}"></div></div></div>`; }
+async function qAgg(measures,dim,hier,level,dimKey,measKey){
+  try{ const d=await aiQuery({measures:measures.map(m=>({name:m})),rows:[hier?{dimension:dim,hierarchy:hier,level:level}:{dimension:dim,level:level}]});
+    if(d.status!=='SUCCESS'||!d.data?.length) return null;
+    const m=new Map(); d.data.forEach(r=>{const k=r[dimKey]; if(k==null)return; m.set(k,(m.get(k)||0)+cellNum(r[measKey]));});
+    return [...m.entries()].map(([name,value])=>({name:String(name),value})).sort((a,b)=>b.value-a.value);
+  }catch{ return null; }
+}
+const TABS={
+  brands: async()=>{
+    $('.content').innerHTML=tabHead('Brand Performance','Net revenue &amp; volume by brand')+
+      '<div class="grid2">'+tcard('Net revenue by brand','Top brands','tBrand')+tcard('By molecule','Active ingredient','tMol')+'</div>';
+    const brands=(await qAgg(['Net Revenue'],'Product','Product','Brand','Brand','Net Revenue'))
+      || BFALL.brands.map(b=>({name:b[0],value:b[1],sub:b[2]}));
+    $('#tBrand').innerHTML=hbars(brands.slice(0,8)); animate('#tBrand');
+    const mol=(await qAgg(['Net Revenue'],'Product','Product','Molecule','Molecule','Net Revenue'))||[];
+    $('#tMol').innerHTML=hbars((mol.length?mol:brands).slice(0,8)); animate('#tMol');
+  },
+  payers: async()=>{
+    $('.content').innerHTML=tabHead('Payer &amp; Access','Channel mix, payer type, gross-to-net')+
+      '<div class="grid2">'+tcard('Net revenue by payer type','Commercial vs government','tPT')+tcard('By channel','Distribution channel','tCh')+'</div>'+
+      '<div class="card fade-up" style="margin-top:15px"><div class="head"><div class="t">Access economics<small>Gross-to-net &amp; rebate exposure</small></div></div><div class="body"><div class="insights" id="tPayIns"></div></div></div>';
+    const pt=(await qAgg(['Net Revenue'],'Payer','Payer Type','Payer Type','Payer Type','Net Revenue'))||PAYER.map(p=>({name:p.name,value:p.net}));
+    $('#tPT').innerHTML=hbars(pt); animate('#tPT');
+    const ch=(await qAgg(['Net Revenue'],'Payer','Payer','Channel','Channel','Net Revenue'))||pt;
+    $('#tCh').innerHTML=hbars(ch); animate('#tCh');
+    $('#tPayIns').innerHTML=[
+      {c:'risk',t:'<b>Gross-to-net 71.4%.</b> ~<span class="fig">28.6%</span> of gross erodes to rebates &amp; concessions before net revenue — heaviest on Medicaid &amp; Part D.'},
+      {c:'info',t:'<b>Commercial anchors the book</b> at the largest net share; government channels carry statutory rebates that compress realised price.'},
+    ].map(insHtml).join('');
+  },
+  prescribers: async()=>{
+    $('.content').innerHTML=tabHead('Prescriber Analytics','Specialty &amp; decile — <span class="tag-pii">PII-governed</span>')+
+      '<div class="grid2">'+tcard('Net revenue by specialty','Who writes the scripts','tSpec')+tcard('Decile concentration','Volume by prescriber decile','tDec')+'</div>'+
+      '<div class="card fade-up" style="margin-top:15px"><div class="head"><div class="t">Governance<small>What this model will and won\'t return</small></div></div><div class="body"><div class="insights" id="tPresIns"></div></div></div>';
+    const spec=(await qAgg(['Net Revenue'],'Prescriber','Prescriber','Specialty','Specialty','Net Revenue'))||BFALL.specialty.map(s=>({name:s[0],value:s[1]}));
+    $('#tSpec').innerHTML=hbars(spec.slice(0,8)); animate('#tSpec');
+    const dec=(await qAgg(['Net Revenue'],'Prescriber','Decile','Decile','Decile','Net Revenue'));
+    const decRows = dec ? dec.map(d=>({name:'Decile '+Math.round(+d.name),value:d.value})).sort((a,b)=>parseInt(a.name.split(' ')[1])-parseInt(b.name.split(' ')[1]))
+      : BFALL.decile.map((v,i)=>({name:'Decile '+(i+1),value:v*1e6}));
+    $('#tDec').innerHTML=hbars(decRows); animate('#tDec');
+    $('#tPresIns').innerHTML=[
+      {c:'up',t:'<b>Deciles 8–10 drive the book</b> — the top three deciles write the majority of specialty volume. Target them, not the long tail.'},
+      {c:'info',t:'<b>Identity is masked.</b> The model returns <span class="fig">specialty</span> and <span class="fig">decile</span>, never prescriber name or NPI <span class="tag-pii">PII</span> — enforced server-side, not in this UI.'},
+    ].map(insHtml).join('');
+  },
+  geography: async()=>{
+    $('.content').innerHTML=tabHead('Geography','Net revenue by region &amp; state')+
+      '<div class="grid2">'+tcard('By region','Four US regions','tReg')+tcard('Top states','Net revenue leaders','tState')+'</div>';
+    const reg=(await qAgg(['Net Revenue'],'Geography','Geography','Region','Region','Net Revenue'))||BFALL.region.map(r=>({name:r[0],value:r[1]}));
+    $('#tReg').innerHTML=hbars(reg); animate('#tReg');
+    const st=(await qAgg(['Net Revenue'],'Geography','Geography','State','State','Net Revenue'))||BFALL.state.map(s=>({name:s[0],value:s[1]}));
+    $('#tState').innerHTML=hbars(st.slice(0,10)); animate('#tState');
+  }
+};
+function insHtml(it){ return `<div class="insight"><div class="ic ${it.c}">${it.c==='up'?'<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4"><path d="M4 17l6-6 4 4 6-8"/></svg>':it.c==='risk'?'<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4"><path d="M12 9v4M12 17h.01M10.3 3.9 1.8 18a2 2 0 001.7 3h17a2 2 0 001.7-3L13.7 3.9a2 2 0 00-3.4 0z"/></svg>':'<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4"><circle cx="12" cy="12" r="9"/><path d="M12 8h.01M11 12h1v4h1"/></svg>'}</div><div class="tx">${it.t}</div></div>`; }
+function initOverview(){
+  renderKpis(); renderMain(); renderPayer(); renderTrend(); renderInsights(); seedWfAreas();
+  $('#taSel')&&$('#taSel').addEventListener('change',e=>applyArea(e.target.value));
+  $('#wfApply')&&$('#wfApply').addEventListener('click',applyWhatIf);
+  $('#wfReset')&&$('#wfReset').addEventListener('click',resetWhatIf);
+}
+function switchTab(tab,btn){
+  if(tab===currentTab) return; currentTab=tab;
+  document.querySelectorAll('.rail button[title]').forEach(b=>b.classList.remove('active'));
+  btn&&btn.classList.add('active');
+  if(tab==='overview'){ $('.content').innerHTML=overviewHTML; WHATIF=null; initOverview(); }
+  else if(TABS[tab]){ TABS[tab](); }
+}
+
+document.addEventListener('DOMContentLoaded',()=>{
+  overviewHTML=$('.content').innerHTML;
+  initOverview(); seedChips(); greet();
+  document.querySelectorAll('.rail button[title]').forEach(b=>{ const t=b.title.toLowerCase();
+    if(t==='overview'||TABS[t]) b.addEventListener('click',()=>switchTab(t,b)); });
+  const input=$('#input');
+  input.addEventListener('input',()=>autosize(input));
+  input.addEventListener('keydown',e=>{ if(e.key==='Enter'&&!e.shiftKey){ e.preventDefault(); const v=input.value; input.value=''; autosize(input); ask(v);} });
+  $('#send').addEventListener('click',()=>{ const v=input.value; input.value=''; autosize(input); ask(v); });
+  $('#cog').onclick=()=>{ $('#baseUrl').value=CFG.base; $('#modalBack').classList.add('show'); };
+  $('#conn').onclick=()=>$('#cog').onclick();
+  $('#mCancel').onclick=()=>$('#modalBack').classList.remove('show');
+  $('#modalBack').onclick=e=>{ if(e.target===$('#modalBack')) $('#modalBack').classList.remove('show'); };
+  $('#mSave').onclick=async()=>{ CFG.base=$('#baseUrl').value.trim().replace(/\/$/,''); localStorage.setItem('aq.base',CFG.base); $('#modalBack').classList.remove('show'); sessionReady=false; refreshFromCube(); };
+  if(!(location.protocol==='file:' && !CFG.base)) refreshFromCube();  // pull live figures when served same-origin
+});
+</script>
+</body>
+</html>


### PR DESCRIPTION
Adds a scoped **Mondrian write-back what-if** capability and a second white-label OEM demo — **AQVIRA**, an IQVIA-adjacent pharma real-world-evidence brand — that exercises it end to end against the Pharma Rx cube. Ships to **demo.saiku.bi/aqvira-demo/**.

## Backend
- **`POST /ai/scenario/whatif`** — creates a Mondrian scenario, writes a cell value with an allocation policy, re-queries under the scenario, returns actual-vs-what-if for the level + payer/month breakdowns (portfolio delta distributed by the changed member's own mix — Mondrian's scenario re-allocation doesn't surface in cross-dimension aggregates). Wires `olapDiscoverService` into `AiQueryResource` for raw olap4j.

## Frontend (`/aqvira-demo/`)
- Overview (value-vs-volume), **Brands / Payers / Prescribers (PII-governed decile view) / Geography** tabs, persistent assistant, and a **what-if lever that moves every panel live**.
- **ETS forecast + confidence band** on the trend via `/ai/forecast`.
- Warm-session + CSRF bootstrap; `security="none"` permit for `/aqvira-demo` (bare + `/**`).

## Data (deployed separately)
The Pharma Rx cube (Mondrian-4 schema, H2 fixture, datasource) lives in the demo host's `saiku-home`, not the repo — pushed to the VM directly.

## Verification
Built end to end locally and driven with **Playwright**: cube queries, what-if moves KPIs/main/payer/trend to the penny, all four tabs render clean (standalone hierarchies fix nested-level fan-out), forecast band flows from the actuals.

🤖 Generated with [Claude Code](https://claude.com/claude-code)