### PR TITLE
feat(demo): make AQVIRA pharma demo mobile-ready

### DIFF
--- a/saiku-webapp/src/main/webapp/aqvira-demo/index.html
+++ b/saiku-webapp/src/main/webapp/aqvira-demo/index.html
@@ -140,7 +140,7 @@
 
   /* ---------- assistant ---------- */
   .aside { background:var(--grad-navy); color:#e6e8fa; display:flex; flex-direction:column; min-width:0; box-shadow:inset 1px 0 0 rgba(255,255,255,.05); }
-  .aside .ahead { padding:17px 20px 13px; border-bottom:1px solid rgba(255,255,255,.08); }
+  .aside .ahead { position:relative; padding:17px 20px 13px; border-bottom:1px solid rgba(255,255,255,.08); }
   .aside .ahead .row { display:flex; align-items:center; gap:10px; }
   .aside .ahead .glyph { width:32px; height:32px; border-radius:9px; background:var(--grad); display:grid; place-items:center; box-shadow:0 6px 16px rgba(61,90,254,.4); }
   .aside .ahead .ttl { font-size:16px; font-weight:750; letter-spacing:.02em; }
@@ -176,6 +176,13 @@
   .composer .foot { display:flex; justify-content:space-between; margin-top:8px; padding:0 3px; font-size:10.5px; color:#7278a5; }
   .composer .foot .p b { color:#9aa0c8; }
 
+  /* ---------- mobile-only controls (hidden on desktop) ---------- */
+  .fab { display:none; position:fixed; right:16px; bottom:74px; width:56px; height:56px; border-radius:50%; border:0; background:var(--grad); color:#fff; box-shadow:var(--shadow-lg); z-index:38; cursor:pointer; place-items:center; }
+  .fab svg { width:24px; height:24px; }
+  .fab .dot { position:absolute; top:11px; right:11px; width:9px; height:9px; border-radius:50%; background:var(--cyan); box-shadow:0 0 0 2px var(--navy); }
+  .aclose { display:none; position:absolute; top:14px; right:16px; width:32px; height:32px; border-radius:9px; border:1px solid rgba(255,255,255,.14); background:rgba(255,255,255,.06); color:#cdd2f5; cursor:pointer; align-items:center; justify-content:center; font-size:17px; line-height:1; }
+  .aclose:hover { background:rgba(255,255,255,.12); color:#fff; }
+
   .fade-up { opacity:0; transform:translateY(10px); animation:fadeUp .55s cubic-bezier(.2,.8,.2,1) forwards; }
   .modal-back { position:fixed; inset:0; background:rgba(18,21,43,.45); backdrop-filter:blur(3px); display:none; place-items:center; z-index:40; }
   .modal-back.show { display:grid; }
@@ -192,6 +199,50 @@
   @keyframes bob { 0%,100%{transform:translateY(0);opacity:.5} 50%{transform:translateY(-4px);opacity:1} }
   @keyframes pop { 0%{transform:scale(.8);opacity:0} 60%{transform:scale(1.05)} 100%{transform:scale(1);opacity:1} }
   @media (max-width:1120px){ :root{--aside:340px} .grid2{grid-template-columns:1fr} .kpis{grid-template-columns:repeat(2,1fr)} }
+
+  /* ============================ mobile / tablet ============================ */
+  @media (max-width:820px){
+    /* three-column grid → natural document flow, whole page scrolls */
+    .app { display:block; height:auto; overflow:visible; }
+
+    /* rail → fixed bottom tab bar */
+    .rail { position:fixed; left:0; right:0; bottom:0; z-index:30; height:58px; flex-direction:row;
+            align-items:center; justify-content:space-around; padding:5px 4px; gap:2px;
+            box-shadow:0 -1px 0 rgba(255,255,255,.06), 0 -10px 26px rgba(18,21,43,.3); }
+    .rail .logo-mark, .rail .me, .rail .sp { display:none; }
+    .rail button { width:46px; height:46px; }
+    .rail button.active { box-shadow:inset 0 -2px 0 var(--cyan); }
+
+    /* main column full width */
+    .main { height:auto; min-width:0; }
+    .topbar { position:sticky; top:0; z-index:20; padding:11px 16px; gap:10px; flex-wrap:wrap; }
+    .wordmark .tag { display:none; }
+    .wordmark .name { font-size:19px; }
+    .topbar .sp { flex-basis:100%; height:0; order:2; }
+    .picker, .conn { order:3; }
+    .content { height:auto; overflow:visible; padding:16px 16px calc(58px + 26px); }
+    .pagehead { flex-wrap:wrap; gap:6px; }
+    .pagehead h1 { font-size:20px; }
+    .pagehead .period { display:none; }
+
+    .kpi .num { font-size:22px; }
+    .barrow { grid-template-columns:92px 1fr auto; gap:8px; }
+    .barrow .nm { font-size:12px; }
+    .barrow .v { min-width:0; font-size:11px; }
+    .whatif input { width:108px; }
+
+    /* assistant → off-canvas bottom sheet, opened by the FAB */
+    .aside { position:fixed; inset:0; z-index:40; box-shadow:none;
+             transform:translateY(100%); transition:transform .32s cubic-bezier(.2,.8,.2,1); }
+    .aside.open { transform:none; }
+    .aclose { display:flex; }
+    .fab { display:grid; }
+  }
+  @media (max-width:430px){
+    .kpis { grid-template-columns:1fr 1fr; }
+    .picker .k { display:none; }
+    .whatif { gap:7px; }
+  }
 </style>
 </head>
 <body>
@@ -286,6 +337,7 @@
 
   <aside class="aside">
     <div class="ahead">
+      <button class="aclose" id="asideClose" aria-label="Close assistant">✕</button>
       <div class="row">
         <div class="glyph"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="#fff" stroke-width="2"><path d="M12 3v3M12 18v3M5 12H2M22 12h-3"/><circle cx="12" cy="12" r="4.5"/></svg></div>
         <div class="ttl">Ask <b>AQVIRA</b></div>
@@ -303,6 +355,12 @@
     </div>
   </aside>
 </div>
+
+<!-- mobile: floating "Ask AQVIRA" button that opens the assistant sheet -->
+<button class="fab" id="fab" aria-label="Ask AQVIRA">
+  <span class="dot"></span>
+  <svg viewBox="0 0 24 24" fill="none" stroke="#fff" stroke-width="2"><path d="M12 3v3M12 18v3M5 12H2M22 12h-3"/><circle cx="12" cy="12" r="4.5"/></svg>
+</button>
 
 <div class="modal-back" id="modalBack"><div class="modal">
   <h3>Connect to the live model</h3>
@@ -589,9 +647,15 @@ async function ask(q){
   let html=fmt(acc); if(s.drove) html+=`<div class="drove"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4"><path d="M5 12h14M13 6l6 6-6 6"/></svg>${s.drove}</div>`;
   b.innerHTML=html; history.push({role:'assistant',content:acc});
   // drive the dashboard
-  if(s.bars){ barData=s.bars(); mainMode='custom'; renderMain(); flashBy(); setMain('Ask AQVIRA result', q); }
-  else if(s.view==='trend'){ mainMode='ta'; renderMain(); flashBy(); }
+  let drove=false;
+  if(s.bars){ barData=s.bars(); mainMode='custom'; renderMain(); flashBy(); setMain('Ask AQVIRA result', q); drove=true; }
+  else if(s.view==='trend'){ mainMode='ta'; renderMain(); flashBy(); drove=true; }
   st(); busy=false; $('#send').disabled=false;
+  // on mobile the sheet covers the dashboard — drop it so the reshaped view is visible
+  if(drove && window.matchMedia('(max-width:820px)').matches){
+    const aside=document.querySelector('.aside');
+    if(aside.classList.contains('open')) setTimeout(()=>{ aside.classList.remove('open'); window.scrollTo({top:0,behavior:'smooth'}); },900);
+  }
 }
 function flashBy(){ const b=$('#mainBy'); b.classList.remove('show'); void b.offsetWidth; b.classList.add('show'); }
 function setMain(t,sub){ $('#mainTitle').childNodes[0].nodeValue=t+' '; $('#mainSub').textContent=sub.length>50?sub.slice(0,50)+'…':sub; }
@@ -700,6 +764,10 @@ document.addEventListener('DOMContentLoaded',()=>{
   input.addEventListener('input',()=>autosize(input));
   input.addEventListener('keydown',e=>{ if(e.key==='Enter'&&!e.shiftKey){ e.preventDefault(); const v=input.value; input.value=''; autosize(input); ask(v);} });
   $('#send').addEventListener('click',()=>{ const v=input.value; input.value=''; autosize(input); ask(v); });
+  // mobile assistant sheet
+  const aside=document.querySelector('.aside');
+  $('#fab')&&$('#fab').addEventListener('click',()=>{ aside.classList.add('open'); setTimeout(st,60); });
+  $('#asideClose')&&$('#asideClose').addEventListener('click',()=>aside.classList.remove('open'));
   $('#cog').onclick=()=>{ $('#baseUrl').value=CFG.base; $('#modalBack').classList.add('show'); };
   $('#conn').onclick=()=>$('#cog').onclick();
   $('#mCancel').onclick=()=>$('#modalBack').classList.remove('show');


### PR DESCRIPTION
## Summary

Makes the AQVIRA pharma OEM demo (`/aqvira-demo/`) fully usable on phones. The page was a fixed three-column grid (`rail | dashboard | assistant`) locked to `100vh` with `overflow:hidden` — unusable below tablet width. This adds a mobile breakpoint that reflows it into a natural single-column, scrollable app.

## Changes (all in `aqvira-demo/index.html`, CSS + a little JS)

Below **820px**:
- **Icon rail → fixed bottom tab bar** — horizontal, thumb-reachable, active tab marked with a cyan underline instead of a side rail.
- **Natural document flow** — the app scrolls as a normal page instead of trapping panes inside `100vh`.
- **Dashboard reflow** — KPIs drop to 2-up, the two-column card grid stacks, bar rows tighten their label column, the topbar wraps (portfolio picker + connection pill move to their own row).
- **Assistant → off-canvas bottom sheet** — the "Ask AQVIRA" panel slides up full-screen from a floating action button, with a close control in its header. After the assistant reshapes the dashboard, the sheet auto-drops so the user sees the result.

Below **430px**: minor tightening (single portfolio label, denser what-if row).

**Desktop is unchanged** — everything lives inside new media queries.

## Test plan
- [x] Verified via Playwright at 390×844 (iPhone-class): overview, bottom-nav tab switching (Payers), and the assistant bottom sheet all render and function.
- [x] Baked-fallback data renders fully offline; live cube path unchanged.
- [ ] Spot-check on demo.saiku.bi after deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)