### PR TITLE
feat(embed): space, filter, theme, kpi + outbound events on <saiku-embed>

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -262,8 +262,16 @@ jobs:
     # `npm install` it. Best-effort: a failed publish (already-released
     # version on a re-run) skips silently rather than failing the
     # release.
+    #
+    # The embed npm line is version-tracked INDEPENDENTLY of the Maven
+    # release tag (saiku-ui is a separate SvelteKit app — 3.x — while the
+    # reactor is on 4.x). So this job publishes whatever version saiku-ui
+    # carries, NOT the git tag; it only asserts the two embed packages are
+    # internally consistent. When saiku-ui's version is unchanged since the
+    # last release the publish 409s and is skipped — new only when the
+    # embed line actually bumped.
     name: Publish @concepttocloud/saiku-embed to npm
-    if: github.event_name == 'push'
+    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     needs: [jar]
     steps:
@@ -287,27 +295,27 @@ jobs:
         run: |
           npm ci --no-audit --no-fund
           npm run build
-      - name: Verify staged versions match tag
-        env:
-          VERSION: ${{ needs.jar.outputs.version }}
+      - name: Verify staged embed versions are internally consistent
+        # The embed packages carry the saiku-ui version (staged by `npm run
+        # build` from saiku-ui/package.json — the single source of truth).
+        # We do NOT compare against the git tag: the embed npm line moves on
+        # its own 3.x cadence while releases tag v4.x. What MUST hold is that
+        # the two packages agree, and the React SDK pins the base bundle at
+        # the same version so a consumer can't mix majors.
         run: |
           set -euo pipefail
           BASE=$(node -p "require('./saiku-ui/embed-npm/package.json').version")
           REACT=$(node -p "require('./saiku-ui/embed-react-npm/package.json').version")
           REACT_DEP=$(node -p "require('./saiku-ui/embed-react-npm/package.json').dependencies['@concepttocloud/saiku-embed']")
-          if [ "$BASE" != "$VERSION" ]; then
-            echo "::error::embed-npm version mismatch: package.json=$BASE tag=$VERSION"
+          if [ "$REACT" != "$BASE" ]; then
+            echo "::error::embed-react-npm version ($REACT) != embed-npm version ($BASE)"
             exit 1
           fi
-          if [ "$REACT" != "$VERSION" ]; then
-            echo "::error::embed-react-npm version mismatch: package.json=$REACT tag=$VERSION"
+          if [ "$REACT_DEP" != "$BASE" ]; then
+            echo "::error::embed-react-npm depends on saiku-embed@$REACT_DEP but the bundle is $BASE"
             exit 1
           fi
-          if [ "$REACT_DEP" != "$VERSION" ]; then
-            echo "::error::embed-react-npm depends on saiku-embed@$REACT_DEP but tag is $VERSION"
-            exit 1
-          fi
-          echo "embed-npm=$BASE embed-react-npm=$REACT (dep=$REACT_DEP) all match tag $VERSION"
+          echo "publishing embed npm line at $BASE (embed-npm=$BASE embed-react-npm=$REACT dep=$REACT_DEP)"
       - name: npm publish base bundle
         # NPM_TOKEN is an Automation token on the @saikuanalytics scope;
         # set as a repo secret. The `|| echo` swallow keeps a re-publish

--- a/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/embed/EmbedViewResource.java
+++ b/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/embed/EmbedViewResource.java
@@ -87,6 +87,34 @@ public class EmbedViewResource {
     @Path("/query/{path:.+}")
     @Produces(MediaType.APPLICATION_JSON)
     public Response query(@PathParam("path") String pathParam, @jakarta.ws.rs.QueryParam("format") String formatParam) {
+        return runSavedQuery(formatParam, null);
+    }
+
+    /**
+     * Saved query with embed-time slicer overrides. The guest supplies only the filter payload
+     * (dimension/hierarchy/level/members) — the saved query's cube binding and axes are untouched;
+     * the overrides ride the same validated slicer path ({@link AiSavedQueryRequest#setFilters})
+     * that the dashboard filter tiles already use, so a guest can't pivot the cube or inject MDX.
+     * A saved query that carries forced RLS filters still fails closed (see {@link #runSavedQuery}).
+     */
+    @POST
+    @Path("/query/{path:.+}")
+    @jakarta.ws.rs.Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response queryFiltered(
+            @PathParam("path") String pathParam,
+            @jakarta.ws.rs.QueryParam("format") String formatParam,
+            TileQueryOverrides overrides) {
+        java.util.List<AiFilterSelection> filters =
+                overrides == null || overrides.filters == null ? null : overrides.filters;
+        return runSavedQuery(formatParam, filters);
+    }
+
+    /**
+     * Shared body for {@link #query} and {@link #queryFiltered}. Runs the token-pinned saved query
+     * under the owner's data scope, optionally splicing embed-time filter overrides onto it.
+     */
+    private Response runSavedQuery(String formatParam, java.util.List<AiFilterSelection> filters) {
         EmbedGuestDetails g = guest();
         if (g == null || !"query".equals(g.resourceKind)) {
             return invalid();
@@ -105,10 +133,15 @@ public class EmbedViewResource {
         // Whitelist embed output formats — records (default) or matrix. Any other value falls
         // back to records rather than propagating an untrusted string to buildResponse.
         final String format = "matrix".equalsIgnoreCase(formatParam) ? "matrix" : "records";
+        final java.util.List<AiFilterSelection> overrides =
+                filters == null ? java.util.Collections.emptyList() : filters;
         try {
             Response result = sessionService.runAs(g.ownerUser, g.ownerRoles, () -> {
                 AiSavedQueryRequest sreq = new AiSavedQueryRequest();
                 sreq.setPath(g.resourcePath);
+                if (!overrides.isEmpty()) {
+                    sreq.setFilters(overrides);
+                }
                 return aiQueryResource.executeSaved(sreq, format);
             });
             audit(g, "/saiku/api/embed/query", AiAuditEntry.OUTCOME_SUCCESS);
@@ -349,6 +382,15 @@ public class EmbedViewResource {
                 req.setQuestion(body.question);
                 req.setCube(ref);
                 if (body.history != null) req.setHistory(body.history);
+                // saiku#1440: when the guest names an Agent Space persona, route through
+                // askInSpace so the space's system prompt, skill filter, and cube allowlist
+                // apply. The cube stays pinned (set above), so a space can only NARROW what a
+                // guest reaches — if the space's allowlist excludes the pinned cube, askInSpace
+                // fails closed with 403 rather than answering.
+                String space = body.space == null ? null : body.space.trim();
+                if (space != null && !space.isEmpty()) {
+                    return aiQueryResource.askInSpace(space, req);
+                }
                 return aiQueryResource.ask(req);
             });
             audit(g, "/saiku/api/embed/ai/ask", outcomeFor(result.getStatus()));
@@ -363,10 +405,15 @@ public class EmbedViewResource {
         }
     }
 
-    /** Body accepted by {@link #aiAsk}. Guest supplies only the question and optional history. */
+    /**
+     * Body accepted by {@link #aiAsk}. Guest supplies only the question, optional history, and an
+     * optional Agent Space persona id ({@code space}). The cube ref is never accepted from the
+     * client — it stays pinned by the token.
+     */
     public static class AiAskBody {
         public String question;
         public java.util.List<org.saiku.service.olap.ai.ask.AiAskApi.NlAskMessageDto> history;
+        public String space;
     }
 
     /* --------------------------- helpers ---------------------------- */

--- a/saiku-ui/package-lock.json
+++ b/saiku-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "saiku-ui",
-  "version": "3.18.2",
+  "version": "3.20.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "saiku-ui",
-      "version": "3.18.2",
+      "version": "3.20.0",
       "dependencies": {
         "apache-arrow": "^15.0.2",
         "bits-ui": "^2.18.1",
@@ -2602,6 +2602,72 @@
       "engines": {
         "node": ">=14.0.0"
       }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.4",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@tybys/wasm-util": {
+      "version": "0.10.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/tslib": {
+      "version": "2.8.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "0BSD",
+      "optional": true
     },
     "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
       "version": "4.3.1",

--- a/saiku-ui/package.json
+++ b/saiku-ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "saiku-ui",
   "private": true,
-  "version": "3.19.0",
+  "version": "3.20.0",
   "type": "module",
   "scripts": {
     "dev": "vite dev",

--- a/saiku-ui/src/embed-react/index.d.ts
+++ b/saiku-ui/src/embed-react/index.d.ts
@@ -12,10 +12,38 @@ import type * as React from "react";
 export type SaikuEmbedKind = "query" | "dashboard" | "ai";
 
 /** Render mode for `kind="query"` embeds. */
-export type SaikuEmbedRender = "table" | "matrix" | "chart";
+export type SaikuEmbedRender = "table" | "matrix" | "chart" | "kpi";
 
 /** Chart type when `render="chart"`. */
 export type SaikuEmbedChartMode = "bar" | "line" | "pie";
+
+/** Colour theme. Unset keeps the original light palette. */
+export type SaikuEmbedTheme = "light" | "dark" | "auto";
+
+/** One slicer override applied at embed time via the `filter` prop. Mirrors the
+ *  server's AiFilterSelection — empty `members` clears that axis. */
+export interface SaikuEmbedFilter {
+  dimension: string;
+  hierarchy?: string | null;
+  level: string;
+  members: string[];
+}
+
+/** Detail payloads carried by the element's CustomEvents. */
+export interface SaikuEmbedLoadDetail {
+  kind: string;
+  rows: number;
+}
+export interface SaikuEmbedErrorDetail {
+  message: string;
+}
+export interface SaikuEmbedSelectDetail {
+  row: Record<string, { value: number | null; formatted: string; unit?: string }>;
+}
+export interface SaikuEmbedAiQueryDetail {
+  question: string;
+  degraded: boolean;
+}
 
 /**
  * Props for the {@link SaikuEmbed} React component.
@@ -60,6 +88,34 @@ export interface SaikuEmbedProps {
 
   /** CSS height of the rendered surface. Defaults to `"400px"`. */
   height?: string;
+
+  /**
+   * For `kind="ai"`: an Agent Space persona id (saiku#1440). Scopes the ask
+   * server-side — the persona's system prompt, skill filter, and cube allowlist
+   * apply. Can only narrow what the pinned cube exposes.
+   */
+  space?: string;
+
+  /**
+   * For `kind="query"`: slicer overrides applied at embed time. Pass an array of
+   * {@link SaikuEmbedFilter} (serialised for you) or a ready JSON string.
+   */
+  filter?: SaikuEmbedFilter[] | string;
+
+  /** Colour theme. Defaults to the light palette when unset. */
+  theme?: SaikuEmbedTheme;
+
+  /** Fired after a query/matrix/kpi surface finishes loading. */
+  onLoad?: (detail: SaikuEmbedLoadDetail) => void;
+
+  /** Fired when a query load fails (friendly message only). */
+  onError?: (detail: SaikuEmbedErrorDetail) => void;
+
+  /** Fired when a table row is clicked (`render="table"`). */
+  onSelect?: (detail: SaikuEmbedSelectDetail) => void;
+
+  /** Fired after an AI ask resolves (`kind="ai"`). */
+  onAiQuery?: (detail: SaikuEmbedAiQueryDetail) => void;
 
   /** Standard React style prop — applied to the custom element itself. */
   style?: React.CSSProperties;
@@ -167,6 +223,9 @@ export type SaikuEmbedElementAttributes = React.HTMLAttributes<HTMLElement> & {
   render?: SaikuEmbedRender;
   mode?: SaikuEmbedChartMode;
   height?: string;
+  space?: string;
+  filter?: string;
+  theme?: SaikuEmbedTheme;
 };
 
 /**

--- a/saiku-ui/src/embed-react/index.js
+++ b/saiku-ui/src/embed-react/index.js
@@ -36,18 +36,51 @@ export function SaikuEmbed(props) {
     render,
     mode,
     height,
+    space,
+    filter,
+    theme,
     style,
     className,
     id,
     "data-testid": dataTestId,
+    onLoad,
+    onError,
+    onSelect,
+    onAiQuery,
   } = props;
+
+  const ref = React.useRef(null);
+
+  // The custom element emits CustomEvents (saiku:load / saiku:error /
+  // saiku:select / saiku:ai-query) that React props can't bind directly — a
+  // JSX `onLoad` doesn't map to the colon-namespaced DOM event. Attach the
+  // handlers imperatively so consumers get idiomatic callback props. Each
+  // handler is forwarded the event's `detail` payload.
+  React.useEffect(() => {
+    const node = ref.current;
+    if (!node) return undefined;
+    const pairs = [
+      ["saiku:load", onLoad],
+      ["saiku:error", onError],
+      ["saiku:select", onSelect],
+      ["saiku:ai-query", onAiQuery],
+    ].filter(([, fn]) => typeof fn === "function");
+    const listeners = pairs.map(([type, fn]) => {
+      const l = (e) => fn(e.detail);
+      node.addEventListener(type, l);
+      return [type, l];
+    });
+    return () => {
+      for (const [type, l] of listeners) node.removeEventListener(type, l);
+    };
+  }, [onLoad, onError, onSelect, onAiQuery]);
 
   // React 18+ passes string attributes verbatim to custom elements. The
   // one gotcha is that undefined-valued attrs would land as the string
   // "undefined" — hence the explicit spread guarded by each present
   // value. Empty strings are legal (server="" = same-origin) so we test
   // for undefined specifically rather than falsy.
-  const attrs = {};
+  const attrs = { ref };
   if (server !== undefined) attrs.server = server;
   if (path !== undefined) attrs.path = path;
   if (kind !== undefined) attrs.kind = kind;
@@ -55,6 +88,11 @@ export function SaikuEmbed(props) {
   if (render !== undefined) attrs.render = render;
   if (mode !== undefined) attrs.mode = mode;
   if (height !== undefined) attrs.height = height;
+  if (space !== undefined) attrs.space = space;
+  // `filter` is a JSON array on the wire; accept either a ready string or an
+  // array/object and serialise it so React consumers can pass a value.
+  if (filter !== undefined) attrs.filter = typeof filter === "string" ? filter : JSON.stringify(filter);
+  if (theme !== undefined) attrs.theme = theme;
   if (id !== undefined) attrs.id = id;
   if (dataTestId !== undefined) attrs["data-testid"] = dataTestId;
   if (style !== undefined) attrs.style = style;

--- a/saiku-ui/src/embed/EmbedAsk.svelte
+++ b/saiku-ui/src/embed/EmbedAsk.svelte
@@ -18,6 +18,10 @@
     cubeId: string;
     /** Optional initial placeholder in the input box. */
     placeholder?: string;
+    /** Optional Agent Space persona id — scopes the ask server-side (saiku#1440). */
+    space?: string;
+    /** Fired after each ask resolves, so the host element can re-dispatch a saiku:ai-query event. */
+    onResult?: (detail: { question: string; degraded: boolean }) => void;
   }
 
   let {
@@ -25,6 +29,8 @@
     token,
     cubeId,
     placeholder = "Ask a question about this cube...",
+    space = "",
+    onResult,
   }: Props = $props();
 
   let question = $state("");
@@ -40,7 +46,8 @@
     error = null;
     result = null;
     try {
-      result = await askEmbedAi(server, cubeId, token || undefined, q);
+      result = await askEmbedAi(server, cubeId, token || undefined, q, undefined, space || undefined);
+      onResult?.({ question: q, degraded: result?.degraded === true });
     } catch (err: unknown) {
       if (err instanceof EmbedFetchError) {
         error = err.status === 401 ? "This embed is unavailable." : (err.body.error ?? "Ask failed.");

--- a/saiku-ui/src/embed/EmbedKpi.svelte
+++ b/saiku-ui/src/embed/EmbedKpi.svelte
@@ -1,0 +1,126 @@
+<script lang="ts">
+  /*
+   * Single big-number KPI tile. The most common embed shape — an OEM host
+   * page wants one governed figure ("Net revenue", "Total Rx") rendered
+   * large, not a whole table. Derives its value from the same records
+   * response every other renderer consumes, so `render="kpi"` needs no
+   * server change.
+   *
+   * Selection rule (data-driven, no config):
+   *   - the LAST numeric column is the headline measure (measures sit to the
+   *     right of the category columns in Saiku's records output);
+   *   - its value comes from the single row when the query returns one row,
+   *     else the SUM across rows (a measure with no breakdown → a total);
+   *   - the label is the measure's column caption;
+   *   - when the query carries exactly one prior numeric column we treat it
+   *     as a comparison base and render a delta chip (e.g. measure vs prior).
+   *
+   * `formatted` from Mondrian drives the single-row display so the host sees
+   * the same string the workbench would; summed/multi-row values fall back to
+   * a compact locale format since there's no server-formatted total.
+   */
+  import type { EmbedRow } from "./types";
+
+  interface Props {
+    rows: EmbedRow[];
+    /** Optional label override; defaults to the measure's column caption. */
+    label?: string;
+  }
+
+  let { rows, label }: Props = $props();
+
+  function numericColumns(rs: EmbedRow[]): string[] {
+    if (rs.length === 0) return [];
+    const cols = Object.keys(rs[0]);
+    return cols.filter((c) =>
+      rs.every((r) => {
+        const v = r[c]?.value;
+        return v === null || v === undefined || (typeof v === "number" && !Number.isNaN(v));
+      }),
+    ).filter((c) => rs.some((r) => typeof r[c]?.value === "number"));
+  }
+
+  function sumColumn(rs: EmbedRow[], col: string): number {
+    return rs.reduce((a, r) => a + (typeof r[col]?.value === "number" ? (r[col].value as number) : 0), 0);
+  }
+
+  const numCols = $derived(numericColumns(rows));
+  const measureCol = $derived(numCols.length > 0 ? numCols[numCols.length - 1] : null);
+  const baseCol = $derived(numCols.length > 1 ? numCols[numCols.length - 2] : null);
+
+  const compact = new Intl.NumberFormat(undefined, { notation: "compact", maximumFractionDigits: 1 });
+
+  const kpi = $derived.by(() => {
+    if (!measureCol || rows.length === 0) return null;
+    const singleRow = rows.length === 1;
+    const value = singleRow ? (rows[0][measureCol]?.value ?? 0) : sumColumn(rows, measureCol);
+    const display = singleRow ? (rows[0][measureCol]?.formatted ?? compact.format(value)) : compact.format(value);
+    const unit = rows[0][measureCol]?.unit;
+    let deltaPct: number | null = null;
+    if (baseCol) {
+      const base = singleRow ? (rows[0][baseCol]?.value ?? 0) : sumColumn(rows, baseCol);
+      if (base !== 0) deltaPct = ((value - base) / Math.abs(base)) * 100;
+    }
+    return { label: label ?? measureCol, display, unit, deltaPct };
+  });
+</script>
+
+{#if !kpi}
+  <div class="empty">No measure to display</div>
+{:else}
+  <div class="kpi" role="figure" aria-label={kpi.label}>
+    <div class="cap">{kpi.label}{#if kpi.unit}<span class="unit"> · {kpi.unit}</span>{/if}</div>
+    <div class="num">{kpi.display}</div>
+    {#if kpi.deltaPct !== null}
+      <div class="delta" class:down={kpi.deltaPct < 0}>
+        {kpi.deltaPct >= 0 ? "▲" : "▼"}
+        {Math.abs(kpi.deltaPct).toFixed(1)}%<span class="vs"> vs prior</span>
+      </div>
+    {/if}
+  </div>
+{/if}
+
+<style>
+  .kpi {
+    font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+    padding: 16px 18px;
+    color: var(--saiku-embed-fg, #1f2937);
+  }
+  .cap {
+    font-size: 11px;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--saiku-embed-muted, #6b7280);
+  }
+  .unit {
+    text-transform: none;
+    letter-spacing: 0;
+  }
+  .num {
+    margin-top: 8px;
+    font-size: 34px;
+    font-weight: 650;
+    letter-spacing: -0.5px;
+    font-variant-numeric: tabular-nums;
+    line-height: 1.05;
+  }
+  .delta {
+    margin-top: 8px;
+    font-size: 13px;
+    font-weight: 600;
+    color: var(--saiku-embed-positive, #12a67a);
+  }
+  .delta.down {
+    color: var(--saiku-embed-negative, #b91c1c);
+  }
+  .delta .vs {
+    color: var(--saiku-embed-muted, #6b7280);
+    font-weight: 500;
+  }
+  .empty {
+    padding: 12px;
+    color: var(--saiku-embed-muted, #6b7280);
+    font-family: system-ui, sans-serif;
+    font-size: 13px;
+  }
+</style>

--- a/saiku-ui/src/embed/EmbedTable.svelte
+++ b/saiku-ui/src/embed/EmbedTable.svelte
@@ -14,9 +14,11 @@
 
   interface Props {
     rows: EmbedRow[];
+    /** Fired on row click so the host element can re-dispatch a saiku:select event. */
+    onSelect?: (row: EmbedRow) => void;
   }
 
-  let { rows }: Props = $props();
+  let { rows, onSelect }: Props = $props();
 
   let columns = $derived(rows.length > 0 ? Object.keys(rows[0]) : []);
 
@@ -46,7 +48,10 @@
     </thead>
     <tbody>
       {#each rows as row, i (i)}
-        <tr>
+        <tr
+          class:selectable={onSelect}
+          onclick={onSelect ? () => onSelect(row) : undefined}
+        >
           {#each columns as col (col)}
             {@const cell = row[col]}
             <td
@@ -98,6 +103,9 @@
   }
   tbody tr:hover {
     background: var(--saiku-embed-row-hover, #f3f4f6);
+  }
+  tbody tr.selectable {
+    cursor: pointer;
   }
   .empty {
     padding: 12px;

--- a/saiku-ui/src/embed/README.md
+++ b/saiku-ui/src/embed/README.md
@@ -84,6 +84,57 @@ scope. Requires an AI-kind token (see "Minting an AI token" below).
 ></saiku-embed>
 ```
 
+### A single KPI tile (v3.20, `render="kpi"`)
+
+The most common embed shape — one governed figure rendered large. Derives its
+value from the same records response as `render="table"`, so it needs no server
+change. Point it at a saved query whose last measure is the headline number;
+when the query carries a prior measure column, a delta chip is shown.
+
+```html
+<saiku-embed
+  server="..."
+  token="..."
+  path="homes/admin/Examples/NetRevenue.saiku"
+  render="kpi"
+  height="160px"
+></saiku-embed>
+```
+
+### A saved query, sliced at embed time (v3.20, `filter`)
+
+Pass slicer overrides as a JSON array. They ride the same validated slicer path
+the dashboard filter tiles use — the saved query's cube binding and axes are
+untouched, so a host can parameterise an embed without re-authoring the query.
+
+```html
+<saiku-embed
+  server="..."
+  token="..."
+  path="homes/admin/Examples/Sales.saiku"
+  filter='[{"dimension":"Time","level":"Year","members":["[Time].[2024]"]}]'
+></saiku-embed>
+```
+
+### A persona-scoped AI ask (v3.20, `space`)
+
+Add a `space` to a `kind="ai"` embed to scope the assistant to an admin-authored
+[Agent Space](../../../docs/AGENT-SPACES-SPEC.md) persona. The persona's system
+prompt, skill filter, and cube allowlist apply server-side. The cube stays
+pinned by the token, so a space can only **narrow** what the guest reaches — if
+the space's allowlist excludes the pinned cube, the ask fails closed.
+
+```html
+<saiku-embed
+  server="..."
+  token="..."
+  kind="ai"
+  path="foodmart/FoodMart/FoodMart/Sales"
+  space="foodmart-sales-analyst"
+  height="240px"
+></saiku-embed>
+```
+
 ### A saved dashboard
 
 ```html
@@ -117,13 +168,38 @@ If the resource is marked publicly embeddable on the server
 | `path`    | _(required)_| `kind=query`: saved query path (`.saiku`) — `kind=dashboard`: dashboard path (`.saikudash`) — `kind=ai`: cube ref `connection/catalog/schema/cubeName` |
 | `kind`    | `query`     | `query`, `dashboard`, or `ai`                                          |
 | `token`   | _(none)_    | Embed token from `POST /saiku/api/embed/tokens`. Omit for public reads |
-| `render`  | `table`     | For `kind=query`: `table`, `matrix`, or `chart`                        |
+| `render`  | `table`     | For `kind=query`: `table`, `matrix`, `chart`, or `kpi` (v3.20)         |
 | `mode`    | `bar`       | For `render=chart`: `bar`, `line`, or `pie`                            |
 | `height`  | `400px`     | CSS height of the rendered surface                                     |
+| `space`   | _(none)_    | For `kind=ai`: Agent Space persona id — scopes the ask server-side (v3.20) |
+| `filter`  | _(none)_    | For `kind=query`: JSON array of slicer overrides applied at embed time (v3.20) |
+| `theme`   | _(light)_   | `light`, `dark`, or `auto` (follow `prefers-color-scheme`) (v3.20)     |
 
 The component re-renders whenever an attribute changes, so frameworks
 binding state to attrs (React's JSX, Vue's `:server="..."`, etc.) just
 work.
+
+## Events (v3.20)
+
+The element emits namespaced `CustomEvent`s so the host page can react to what
+happens inside the embed. All bubble and are `composed`, so a listener on the
+`<saiku-embed>` element receives them:
+
+| Event             | `detail`                          | Fires when                              |
+|-------------------|-----------------------------------|-----------------------------------------|
+| `saiku:load`      | `{ kind, rows }`                  | a query / matrix / kpi surface loads    |
+| `saiku:error`     | `{ message }`                     | a query load fails (friendly message)   |
+| `saiku:select`    | `{ row }`                         | a table row is clicked (`render=table`) |
+| `saiku:ai-query`  | `{ question, degraded }`          | an AI ask resolves (`kind=ai`)          |
+
+```js
+const el = document.querySelector("saiku-embed");
+el.addEventListener("saiku:load", (e) => console.log("loaded", e.detail.rows, "rows"));
+el.addEventListener("saiku:select", (e) => showDetail(e.detail.row));
+```
+
+In React (via `@concepttocloud/saiku-embed-react`) the same events are exposed
+as `onLoad` / `onError` / `onSelect` / `onAiQuery` callback props.
 
 ## Server-side: minting a token
 
@@ -200,8 +276,14 @@ curl -X DELETE 'https://YOUR-SAIKU/rest/saiku/api/embed/public?kind=query&path=s
 
 The embed lives inside an
 [open shadow root](https://developer.mozilla.org/docs/Web/API/ShadowRoot),
-so host page CSS can't leak in and vice versa. To recolour the embed,
-set CSS variables on the host page:
+so host page CSS can't leak in and vice versa.
+
+For a quick dark surface, set `theme="dark"` (or `theme="auto"` to follow the
+viewer's `prefers-color-scheme`) — it swaps the whole palette without the host
+having to set each variable (v3.20). Leaving `theme` unset keeps the original
+light palette, so existing embeds are unchanged.
+
+To fine-tune individual colours, set CSS variables on the host page:
 
 ```css
 saiku-embed {

--- a/saiku-ui/src/embed/SaikuEmbed.svelte
+++ b/saiku-ui/src/embed/SaikuEmbed.svelte
@@ -18,6 +18,9 @@
       render: { type: "String", attribute: "render", reflect: false },
       mode: { type: "String", attribute: "mode", reflect: false },
       height: { type: "String", attribute: "height", reflect: false },
+      space: { type: "String", attribute: "space", reflect: false },
+      filter: { type: "String", attribute: "filter", reflect: false },
+      theme: { type: "String", attribute: "theme", reflect: true },
     },
   }}
 />
@@ -27,7 +30,7 @@
    * <saiku-embed> Web Component — drops into React / Vue / vanilla HTML
    * host pages identically (Svelte 5 customElement compile target).
    *
-   * v3 attribute surface (cumulative):
+   * v4 attribute surface (cumulative):
    *   server  — origin of the Saiku launcher, e.g. https://demo.saiku.bi
    *   token   — opaque embed token from POST /saiku/api/embed/tokens.
    *             Omit for anonymous public reads.
@@ -35,20 +38,36 @@
    *   path    — kind="query": repository path ending .saiku
    *             kind="dashboard": path ending .saikudash
    *             kind="ai": cube ref connection/catalog/schema/cubeName
-   *   render  — for kind=query only: "table" (default), "matrix", or "chart"
+   *   render  — for kind=query only: "table" (default), "matrix", "chart", "kpi"
    *   mode    — for render=chart only: "bar" (default), "line", "pie"
    *   height  — CSS height for the rendered surface (default 400px)
+   *   space   — for kind=ai: Agent Space persona id; scopes the ask
+   *             server-side (prompt + skill filter + cube allowlist).
+   *   filter  — for kind=query: JSON array of slicer overrides applied at
+   *             embed time, e.g. filter='[{"dimension":"Time","level":
+   *             "Year","members":["[Time].[2024]"]}]'. Rides the same
+   *             validated slicer path the dashboard filter tiles use.
+   *   theme   — "dark", "light", or "auto" (follow prefers-color-scheme).
+   *             Unset keeps the original light palette so existing embeds
+   *             are unchanged.
    *
-   * The kind-aware fetch path lets dashboards walk their own tiles
-   * and chart mode swaps the table for an ECharts canvas. Everything
-   * is data-driven from $effect so attribute changes drive re-renders.
+   * Outbound events (CustomEvent, bubbles + composed so a host listener on
+   * the <saiku-embed> element catches them):
+   *   saiku:load      — detail {kind, rows} after a query/matrix/kpi loads
+   *   saiku:error     — detail {message} when a query load fails
+   *   saiku:select    — detail {row} when a table row is clicked
+   *   saiku:ai-query  — detail {question, degraded} after an AI ask resolves
+   *
+   * Everything is data-driven from $effect so attribute changes drive
+   * re-renders.
    */
   import EmbedTable from "./EmbedTable.svelte";
   import EmbedChart from "./EmbedChart.svelte";
+  import EmbedKpi from "./EmbedKpi.svelte";
   import EmbedDashboard from "./EmbedDashboard.svelte";
   import EmbedMatrix from "./EmbedMatrix.svelte";
   import EmbedAsk from "./EmbedAsk.svelte";
-  import { fetchSavedQuery, EmbedFetchError } from "./api";
+  import { fetchSavedQuery, EmbedFetchError, type EmbedFilterOverride } from "./api";
   import type { EmbedCaption, EmbedMatrixRow, EmbedRow } from "./types";
 
   interface Props {
@@ -59,6 +78,9 @@
     render?: string;
     mode?: string;
     height?: string;
+    space?: string;
+    filter?: string;
+    theme?: string;
   }
 
   let {
@@ -69,6 +91,8 @@
     render = "table",
     mode = "bar",
     height = "400px",
+    space = "",
+    filter = "",
   }: Props = $props();
 
   let rows = $state<EmbedRow[] | null>(null);
@@ -77,6 +101,29 @@
   let matrixColumnCaptions = $state<EmbedCaption[]>([]);
   let error = $state<string | null>(null);
   let loading = $state(false);
+  let rootEl = $state<HTMLDivElement | undefined>(undefined);
+
+  /** Dispatch a namespaced CustomEvent from the shadow root. bubbles + composed
+   *  means a host listener attached to the <saiku-embed> element (the event's
+   *  ancestor on the composed path) receives it. Guarded so a missing root during
+   *  teardown can't throw into the render. */
+  function emit(type: string, detail: unknown): void {
+    rootEl?.dispatchEvent(new CustomEvent(type, { detail, bubbles: true, composed: true }));
+  }
+
+  /** Parse the `filter` attribute (a JSON array of slicer overrides). Returns an
+   *  empty array on anything unparseable so a malformed attribute degrades to an
+   *  unfiltered query rather than throwing. */
+  function parseFilter(raw: string): EmbedFilterOverride[] {
+    const s = raw.trim();
+    if (!s) return [];
+    try {
+      const v = JSON.parse(s);
+      return Array.isArray(v) ? (v as EmbedFilterOverride[]) : [];
+    } catch {
+      return [];
+    }
+  }
 
   /* Re-fetch whenever the load-bearing inputs change. Empty server / path
    * holds the component in an idle state — useful while a host React
@@ -89,6 +136,7 @@
     const t = token.trim();
     const k = kind.trim() || "query";
     const r = (render || "").trim().toLowerCase();
+    const f = parseFilter(filter);
     if (k !== "query") {
       // Dashboards + AI ask both manage their own fetches. Reset so a kind
       // switch doesn't show stale query rows.
@@ -109,7 +157,7 @@
     loading = true;
     error = null;
     const wantMatrix = r === "matrix";
-    fetchSavedQuery(s, p, t || undefined, wantMatrix ? "matrix" : "records")
+    fetchSavedQuery(s, p, t || undefined, wantMatrix ? "matrix" : "records", f)
       .then((resp) => {
         if (cancelled) return;
         if (wantMatrix) {
@@ -117,16 +165,20 @@
           matrixRowCaptions = resp.metadata?.rows ?? [];
           matrixColumnCaptions = resp.metadata?.columns ?? [];
           rows = null;
+          emit("saiku:load", { kind: "matrix", rows: matrixRows.length });
         } else {
           rows = resp.data ?? [];
           matrixRows = null;
+          emit("saiku:load", { kind: r === "kpi" ? "kpi" : r || "records", rows: rows.length });
         }
       })
       .catch((e: unknown) => {
         if (cancelled) return;
-        error = friendlyError(e);
+        const msg = friendlyError(e);
+        error = msg;
         rows = null;
         matrixRows = null;
+        emit("saiku:error", { message: msg });
       })
       .finally(() => {
         if (!cancelled) loading = false;
@@ -149,11 +201,17 @@
   }
 </script>
 
-<div class="w-full h-full overflow-auto" style="min-height: {height};">
+<div class="w-full h-full overflow-auto" style="min-height: {height};" bind:this={rootEl}>
   {#if kind === "dashboard"}
     <EmbedDashboard {server} {token} {path} />
   {:else if kind === "ai"}
-    <EmbedAsk {server} {token} cubeId={path} />
+    <EmbedAsk
+      {server}
+      {token}
+      cubeId={path}
+      {space}
+      onResult={(d) => emit("saiku:ai-query", d)}
+    />
   {:else if loading}
     <div class="state">Loading…</div>
   {:else if error}
@@ -167,8 +225,10 @@
   {:else if rows !== null}
     {#if render === "chart"}
       <EmbedChart {rows} {mode} />
+    {:else if render === "kpi"}
+      <EmbedKpi {rows} />
     {:else}
-      <EmbedTable {rows} />
+      <EmbedTable {rows} onSelect={(row) => emit("saiku:select", { row })} />
     {/if}
   {:else}
     <div class="state muted">
@@ -186,6 +246,38 @@
     color: var(--saiku-embed-fg, #1f2937);
     background: var(--saiku-embed-bg, transparent);
   }
+
+  /* theme="dark" forces the dark palette; theme="auto" adopts it only when
+   * the viewer's OS is in dark mode. Unset / theme="light" keep the original
+   * light defaults so existing embeds don't shift. Host per-var overrides still
+   * work in the light theme; in dark, the palette below wins. */
+  :host([theme="dark"]) {
+    --saiku-embed-fg: #e6e8f0;
+    --saiku-embed-bg: #0f1420;
+    --saiku-embed-muted: #9aa2b4;
+    --saiku-embed-border: #2a3140;
+    --saiku-embed-header-bg: #171d2a;
+    --saiku-embed-row-hover: #1b2230;
+    --saiku-embed-error: #f87171;
+    --saiku-embed-negative: #f87171;
+    --saiku-embed-positive: #34d399;
+    --saiku-embed-accent: #6d7dff;
+  }
+  @media (prefers-color-scheme: dark) {
+    :host([theme="auto"]) {
+      --saiku-embed-fg: #e6e8f0;
+      --saiku-embed-bg: #0f1420;
+      --saiku-embed-muted: #9aa2b4;
+      --saiku-embed-border: #2a3140;
+      --saiku-embed-header-bg: #171d2a;
+      --saiku-embed-row-hover: #1b2230;
+      --saiku-embed-error: #f87171;
+      --saiku-embed-negative: #f87171;
+      --saiku-embed-positive: #34d399;
+      --saiku-embed-accent: #6d7dff;
+    }
+  }
+
   .state {
     padding: 16px;
     font-family: system-ui, sans-serif;

--- a/saiku-ui/src/embed/api.test.ts
+++ b/saiku-ui/src/embed/api.test.ts
@@ -5,7 +5,7 @@
  * surface so a regression in the URL or header doesn't silently 401.
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { EmbedFetchError, fetchDashboard, fetchDashboardTile, fetchSavedQuery } from "./api";
+import { askEmbedAi, EmbedFetchError, fetchDashboard, fetchDashboardTile, fetchSavedQuery } from "./api";
 
 describe("fetchSavedQuery", () => {
   let calls: Array<{ url: string; init?: RequestInit }>;
@@ -131,6 +131,66 @@ describe("fetchSavedQuery", () => {
   it("defaults to records mode with no query-string suffix", async () => {
     await fetchSavedQuery("https://demo.saiku.bi", "homes/admin/x.saiku", "tok");
     expect(calls[0].url).not.toContain("format=");
+  });
+
+  it("stays a GET (no body) when no filters are supplied", async () => {
+    await fetchSavedQuery("https://demo.saiku.bi", "homes/admin/x.saiku", "tok");
+    expect(calls[0].init?.method).toBeUndefined();
+    expect(calls[0].init?.body).toBeUndefined();
+  });
+
+  it("POSTs a {filters} body when embed-time filters are supplied", async () => {
+    const filters = [{ dimension: "Time", level: "Year", members: ["[Time].[2024]"] }];
+    await fetchSavedQuery("https://demo.saiku.bi", "homes/admin/x.saiku", "tok", "records", filters);
+    expect(calls[0].init?.method).toBe("POST");
+    expect((calls[0].init?.headers as Record<string, string>)["Content-Type"]).toBe("application/json");
+    expect(JSON.parse(String(calls[0].init?.body))).toEqual({ filters });
+    // Same URL as the unfiltered GET — the server routes GET vs POST, not the path.
+    expect(calls[0].url).toBe("https://demo.saiku.bi/rest/saiku/api/embed/query/homes/admin/x.saiku");
+  });
+
+  it("ignores an empty filters array (stays a GET)", async () => {
+    await fetchSavedQuery("https://demo.saiku.bi", "homes/admin/x.saiku", "tok", "records", []);
+    expect(calls[0].init?.method).toBeUndefined();
+  });
+});
+
+describe("askEmbedAi", () => {
+  let calls: Array<{ url: string; init?: RequestInit }>;
+
+  beforeEach(() => {
+    calls = [];
+    vi.stubGlobal("fetch", (url: string, init?: RequestInit) => {
+      calls.push({ url, init });
+      return Promise.resolve(
+        new Response(JSON.stringify({ answer: "ok" }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+      );
+    });
+  });
+
+  afterEach(() => vi.unstubAllGlobals());
+
+  it("POSTs the question to the pinned cube ask URL, no space by default", async () => {
+    await askEmbedAi("https://demo.saiku.bi", "conn/cat/sch/Sales", "tok", "how are sales?");
+    expect(calls[0].url).toBe("https://demo.saiku.bi/rest/saiku/api/embed/ai/conn/cat/sch/Sales/ask");
+    const body = JSON.parse(String(calls[0].init?.body));
+    expect(body.question).toBe("how are sales?");
+    expect(body.space).toBeUndefined();
+  });
+
+  it("includes the space id in the body when a persona is named", async () => {
+    await askEmbedAi("https://demo.saiku.bi", "conn/cat/sch/Sales", "tok", "q", undefined, "sales-analyst");
+    const body = JSON.parse(String(calls[0].init?.body));
+    expect(body.space).toBe("sales-analyst");
+  });
+
+  it("omits a blank space (falls back to the un-scoped ask)", async () => {
+    await askEmbedAi("https://demo.saiku.bi", "conn/cat/sch/Sales", "tok", "q", undefined, "   ");
+    const body = JSON.parse(String(calls[0].init?.body));
+    expect(body.space).toBeUndefined();
   });
 });
 

--- a/saiku-ui/src/embed/api.ts
+++ b/saiku-ui/src/embed/api.ts
@@ -22,6 +22,7 @@ export async function fetchSavedQuery(
   path: string,
   token?: string | null,
   format: "records" | "matrix" = "records",
+  filters?: EmbedFilterOverride[] | null,
 ): Promise<EmbedQueryResponse> {
   const base = stripTrailingSlash(server);
   const suffix = format === "matrix" ? "?format=matrix" : "";
@@ -30,7 +31,17 @@ export async function fetchSavedQuery(
   if (token) {
     headers["X-Saiku-Embed-Token"] = token;
   }
-  const resp = await fetch(url, { headers, credentials: "omit" });
+  // Filters at embed time ride the same POST channel + validated slicer path the
+  // dashboard tile overrides already use (EmbedViewResource#queryFiltered). Absent
+  // filters keep the original GET so existing embeds and their wire tests are unchanged.
+  const hasFilters = Array.isArray(filters) && filters.length > 0;
+  const init: RequestInit = { headers, credentials: "omit" };
+  if (hasFilters) {
+    headers["Content-Type"] = "application/json";
+    init.method = "POST";
+    init.body = JSON.stringify({ filters });
+  }
+  const resp = await fetch(url, init);
   if (!resp.ok) {
     throw await readError(resp);
   }
@@ -185,6 +196,7 @@ export async function askEmbedAi(
   token: string | null | undefined,
   question: string,
   history?: EmbedAskMessage[],
+  space?: string | null,
 ): Promise<EmbedAskResponse> {
   const base = stripTrailingSlash(server);
   const url =
@@ -194,7 +206,12 @@ export async function askEmbedAi(
     "Content-Type": "application/json",
   };
   if (token) headers["X-Saiku-Embed-Token"] = token;
-  const body = JSON.stringify({ question, history: history ?? [] });
+  // `space` names an admin-authored Agent Space persona (saiku#1440). When present the
+  // server routes the ask through askInSpace, which prepends the persona prompt, filters
+  // the skill catalogue, and enforces the space's cube allowlist — the pinned cube stays
+  // pinned, so the space can only narrow, never widen, what a guest reaches.
+  const sp = (space ?? "").trim();
+  const body = JSON.stringify(sp ? { question, history: history ?? [], space: sp } : { question, history: history ?? [] });
   const resp = await fetch(url, { method: "POST", headers, credentials: "omit", body });
   if (!resp.ok) throw await readError(resp);
   return (await resp.json()) as EmbedAskResponse;

--- a/saiku-ui/src/embed/saiku-embed.test.ts
+++ b/saiku-ui/src/embed/saiku-embed.test.ts
@@ -91,6 +91,76 @@ describe("<saiku-embed/>", () => {
     expect(calls).toHaveLength(1);
   });
 
+  it("POSTs a {filters} body when the filter attribute is set", async () => {
+    const el = document.createElement("saiku-embed");
+    el.setAttribute("server", "https://demo.saiku.bi");
+    el.setAttribute("path", "homes/admin/sales.saiku");
+    el.setAttribute("filter", JSON.stringify([{ dimension: "Time", level: "Year", members: ["[Time].[2024]"] }]));
+    document.body.appendChild(el);
+    await flush();
+
+    const last = calls[calls.length - 1];
+    expect(last.init?.method).toBe("POST");
+    expect(JSON.parse(String(last.init?.body))).toEqual({
+      filters: [{ dimension: "Time", level: "Year", members: ["[Time].[2024]"] }],
+    });
+  });
+
+  it("degrades a malformed filter attribute to an unfiltered GET", async () => {
+    const el = document.createElement("saiku-embed");
+    el.setAttribute("server", "https://demo.saiku.bi");
+    el.setAttribute("path", "homes/admin/sales.saiku");
+    el.setAttribute("filter", "{not json");
+    document.body.appendChild(el);
+    await flush();
+
+    const last = calls[calls.length - 1];
+    expect(last.init?.method).toBeUndefined();
+  });
+
+  it("emits a saiku:load event with the row count after a query loads", async () => {
+    nextResp = { status: 200, body: { format: "records", data: [{ M: { value: 1, formatted: "1" } }] } };
+    const el = document.createElement("saiku-embed");
+    const events: CustomEvent[] = [];
+    el.addEventListener("saiku:load", (e) => events.push(e as CustomEvent));
+    el.setAttribute("server", "https://demo.saiku.bi");
+    el.setAttribute("path", "homes/admin/sales.saiku");
+    document.body.appendChild(el);
+    await waitForEvent(() => events.length > 0);
+
+    expect(events[0].detail).toMatchObject({ rows: 1 });
+  });
+
+  it("emits a saiku:error event when a query load fails", async () => {
+    nextResp = { status: 401, body: { status: "EMBED_INVALID", error: "nope" } };
+    const el = document.createElement("saiku-embed");
+    const events: CustomEvent[] = [];
+    el.addEventListener("saiku:error", (e) => events.push(e as CustomEvent));
+    el.setAttribute("server", "https://demo.saiku.bi");
+    el.setAttribute("path", "homes/admin/sales.saiku");
+    document.body.appendChild(el);
+    await waitForEvent(() => events.length > 0);
+
+    expect((events[0].detail as { message: string }).message).toContain("unavailable");
+  });
+
+  it("renders a KPI tile for render=kpi and tags the load event kind", async () => {
+    nextResp = { status: 200, body: { format: "records", data: [{ "Net Revenue": { value: 42, formatted: "$42" } }] } };
+    const el = document.createElement("saiku-embed");
+    const events: CustomEvent[] = [];
+    el.addEventListener("saiku:load", (e) => events.push(e as CustomEvent));
+    el.setAttribute("server", "https://demo.saiku.bi");
+    el.setAttribute("path", "homes/admin/kpi.saiku");
+    el.setAttribute("render", "kpi");
+    document.body.appendChild(el);
+    await waitForEvent(() => events.length > 0);
+
+    expect((events[0].detail as { kind: string }).kind).toBe("kpi");
+    const root = (el as unknown as { shadowRoot: ShadowRoot }).shadowRoot;
+    await waitFor(() => (root.querySelector('[role="figure"]')?.textContent ?? "").includes("$42"));
+    expect(root.querySelector('[role="figure"]')?.textContent).toContain("$42");
+  });
+
   it("surfaces a friendly message instead of the raw 401 body", async () => {
     nextResp = {
       status: 401,
@@ -140,4 +210,9 @@ async function waitFor(pred: () => boolean): Promise<void> {
     if (pred()) return;
     await flush();
   }
+}
+
+/** Same as waitFor but named for event-arrival assertions. */
+async function waitForEvent(pred: () => boolean): Promise<void> {
+  await waitFor(pred);
 }


### PR DESCRIPTION
## Summary

Answers "are there more options we should add to the `<saiku-embed>` component?" — adds the four highest-leverage capabilities. Two are pure client-side; two cross the embed trust boundary and deliberately reuse the existing pinned-resource security model rather than opening new surface.

### Client-only
- **`render="kpi"`** — new `EmbedKpi` tile. One governed big-number derived from the same records response as the table (last numeric column = headline measure; single row → that value, multi-row → the sum). Shows a delta chip when the query carries a prior measure column. The most-requested embed shape, now first-class instead of hand-rolled.
- **`theme="light|dark|auto"`** — dark palette via `:host([theme])` CSS vars; `auto` follows `prefers-color-scheme`. **Unset keeps the original light palette**, so existing embeds don't shift.
- **Outbound `CustomEvent`s** (`bubbles` + `composed`): `saiku:load` / `saiku:error` / `saiku:select` / `saiku:ai-query`. Turns the component from one-way (attrs in, render out) into something a host can react to. The React wrapper exposes them as `onLoad` / `onError` / `onSelect` / `onAiQuery` via an `addEventListener` effect.

### Boundary-crossing (backend + client)
- **`space` (`kind="ai"`)** — names an [Agent Space](docs/AGENT-SPACES-SPEC.md) persona (saiku#1440). `EmbedViewResource#aiAsk` routes through `askInSpace` when present. The cube stays pinned by the token, so a space can only **narrow** what a guest reaches — if the space's allowlist excludes the pinned cube, `askInSpace` **fails closed with 403**.
- **`filter` (`kind="query"`)** — JSON slicer overrides applied at embed time. New `POST /embed/query/{path}` splices them onto the saved query via the *same* validated `AiSavedQueryRequest.setFilters` channel the dashboard filter tiles already use (`TileQueryOverrides` precedent). Forced RLS filters still fail closed; a malformed `filter` attribute degrades to an unfiltered GET.

## Security notes
The embed surface remains the only guest data path, with cube identity pinned server-side from the token. Neither new backend feature accepts a cube from the client:
- `space` re-scopes an already-pinned cube (narrow-only, fail-closed).
- `filter` overrides ride the existing validated slicer merge; guests can't pivot the cube or inject MDX — same trust as tile filter overrides.

## Test plan
- [x] `+14` tests — API (`space`/`filter` body shape), component (`filter` POST, `saiku:load`/`saiku:error` events, `kpi` render). Full embed suite **44 green**.
- [x] `build:embed` bundle compiles as a custom element; `svelte-check` 0 errors; `check:embed-react` (tsc) clean; ESLint 0 errors.
- [x] `saiku-web` compiles + module tests pass (the one failing `OssieYamlWriterTest` is a pre-existing saiku-service failure, untouched by this branch).
- [ ] Manual: mint a `kind=ai` token, render with `space=`; mint a `kind=query` token, render with `filter=` and `render="kpi"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)