### PR TITLE
feat(ai/eval): result store + directory-sweep scheduler core (Phase 2)

### DIFF
--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ai/eval/EvalResultStore.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ai/eval/EvalResultStore.java
@@ -1,0 +1,226 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.service.olap.ai.eval;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Persists scored eval runs to an embedded H2 database so accuracy can be tracked <em>over time</em>
+ * (saiku#1424 — Phase 2). This is what turns the harness from a one-shot CI gate into a live-accuracy
+ * monitor: every scheduled run appends a row, and the trend queries answer "is the model getting
+ * worse against this cube?".
+ *
+ * <p>House style mirrors {@code Database.java} — a dedicated H2 file under {@code saiku-home/data/}
+ * created with {@code CREATE TABLE IF NOT EXISTS}, accessed via plain JDBC. {@code AUTO_SERVER=TRUE}
+ * lets a separate tool (a REST reader, a CLI) open the same file while the launcher holds it.
+ *
+ * <p>Two tables: {@code eval_run} (one row per suite run, with the pass/fail/degraded tallies) and
+ * {@code eval_case_outcome} (one row per case, carrying the mismatch detail as JSON). The store owns
+ * no connection pool — each call opens and closes its own connection, which is plenty for a
+ * once-an-interval writer and a lightweight reader.
+ */
+public final class EvalResultStore {
+
+    private static final Logger log = LoggerFactory.getLogger(EvalResultStore.class);
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    private final String jdbcUrl;
+
+    /** @param jdbcUrl a full H2 JDBC URL — file-backed in production, {@code jdbc:h2:mem:...} in tests. */
+    public EvalResultStore(String jdbcUrl) {
+        this.jdbcUrl = Objects.requireNonNull(jdbcUrl, "jdbcUrl");
+        init();
+    }
+
+    /** Convenience factory — the launcher's {@code saiku-home/data/eval-results} H2 file. */
+    public static EvalResultStore forSaikuHome(String saikuHome) {
+        String home = saikuHome == null || saikuHome.isBlank() ? "./saiku-home" : saikuHome;
+        return new EvalResultStore("jdbc:h2:file:" + home + "/data/eval-results;AUTO_SERVER=TRUE");
+    }
+
+    private Connection connect() throws SQLException {
+        return DriverManager.getConnection(jdbcUrl);
+    }
+
+    private void init() {
+        try (Connection c = connect();
+                Statement s = c.createStatement()) {
+            s.execute("CREATE TABLE IF NOT EXISTS eval_run ("
+                    + "run_id BIGINT AUTO_INCREMENT PRIMARY KEY, "
+                    + "suite_name VARCHAR(255) NOT NULL, "
+                    + "cube_ref VARCHAR(512), "
+                    + "started_at TIMESTAMP NOT NULL, "
+                    + "elapsed_ms BIGINT, "
+                    + "total INT, passed INT, failed INT, degraded INT, skipped INT)");
+            s.execute("CREATE TABLE IF NOT EXISTS eval_case_outcome ("
+                    + "run_id BIGINT NOT NULL, "
+                    + "case_name VARCHAR(255), "
+                    + "status VARCHAR(16), "
+                    + "intent VARCHAR(32), "
+                    + "model VARCHAR(128), "
+                    + "duration_ms BIGINT, "
+                    + "mismatches CLOB)");
+            s.execute("CREATE INDEX IF NOT EXISTS idx_run_suite_time ON eval_run(suite_name, started_at)");
+        } catch (SQLException e) {
+            throw new EvalStoreException("failed to initialise eval result store at " + jdbcUrl, e);
+        }
+    }
+
+    /**
+     * Persist one scored run. Returns the generated run id.
+     *
+     * @param report the scored suite report
+     * @param cubeRef the suite's cube ref, stringified for the row (e.g. {@code conn/cat/sch/cube})
+     * @param startedAt when the run began (the caller stamps this — the store never reads the clock)
+     */
+    public long save(EvalReport report, String cubeRef, Instant startedAt) {
+        Objects.requireNonNull(report, "report");
+        Objects.requireNonNull(startedAt, "startedAt");
+        try (Connection c = connect()) {
+            long runId = insertRun(c, report, cubeRef, startedAt);
+            insertOutcomes(c, runId, report);
+            return runId;
+        } catch (SQLException e) {
+            throw new EvalStoreException("failed to persist eval run for suite " + report.suiteName(), e);
+        }
+    }
+
+    private static long insertRun(Connection c, EvalReport report, String cubeRef, Instant startedAt)
+            throws SQLException {
+        String sql = "INSERT INTO eval_run "
+                + "(suite_name, cube_ref, started_at, elapsed_ms, total, passed, failed, degraded, skipped) "
+                + "VALUES (?,?,?,?,?,?,?,?,?)";
+        try (PreparedStatement ps = c.prepareStatement(sql, Statement.RETURN_GENERATED_KEYS)) {
+            ps.setString(1, report.suiteName());
+            ps.setString(2, cubeRef);
+            ps.setTimestamp(3, Timestamp.from(startedAt));
+            ps.setLong(4, report.totalDurationMs());
+            ps.setInt(5, report.totalCases());
+            ps.setInt(6, report.passedCount());
+            ps.setInt(7, report.failedCount());
+            ps.setInt(8, report.degradedCount());
+            ps.setInt(9, report.skippedCount());
+            ps.executeUpdate();
+            try (ResultSet keys = ps.getGeneratedKeys()) {
+                keys.next();
+                return keys.getLong(1);
+            }
+        }
+    }
+
+    private static void insertOutcomes(Connection c, long runId, EvalReport report) throws SQLException {
+        String sql = "INSERT INTO eval_case_outcome "
+                + "(run_id, case_name, status, intent, model, duration_ms, mismatches) VALUES (?,?,?,?,?,?,?)";
+        try (PreparedStatement ps = c.prepareStatement(sql)) {
+            for (EvalOutcome o : report.outcomes()) {
+                ps.setLong(1, runId);
+                ps.setString(2, o.caseName());
+                ps.setString(3, o.status().name());
+                ps.setString(4, o.actualIntent());
+                ps.setString(5, o.actualModel());
+                ps.setLong(6, o.durationMs());
+                ps.setString(7, mismatchesJson(o));
+                ps.addBatch();
+            }
+            ps.executeBatch();
+        }
+    }
+
+    private static String mismatchesJson(EvalOutcome o) {
+        try {
+            return MAPPER.writeValueAsString(o.mismatches());
+        } catch (Exception e) {
+            // A serialisation glitch on the detail must not lose the whole outcome row.
+            log.warn("could not serialise mismatches for case {}", o.caseName(), e);
+            return "[]";
+        }
+    }
+
+    /** Most-recent runs for a suite, newest first. */
+    public List<RunSummary> recentRuns(String suiteName, int limit) {
+        String sql = "SELECT run_id, suite_name, cube_ref, started_at, elapsed_ms, total, passed, failed, degraded, "
+                + "skipped FROM eval_run WHERE suite_name = ? ORDER BY started_at DESC, run_id DESC LIMIT ?";
+        List<RunSummary> out = new ArrayList<>();
+        try (Connection c = connect();
+                PreparedStatement ps = c.prepareStatement(sql)) {
+            ps.setString(1, suiteName);
+            ps.setInt(2, Math.max(1, limit));
+            try (ResultSet rs = ps.executeQuery()) {
+                while (rs.next()) {
+                    out.add(new RunSummary(
+                            rs.getLong("run_id"),
+                            rs.getString("suite_name"),
+                            rs.getString("cube_ref"),
+                            rs.getTimestamp("started_at").toInstant(),
+                            rs.getLong("elapsed_ms"),
+                            rs.getInt("total"),
+                            rs.getInt("passed"),
+                            rs.getInt("failed"),
+                            rs.getInt("degraded"),
+                            rs.getInt("skipped")));
+                }
+            }
+        } catch (SQLException e) {
+            throw new EvalStoreException("failed to read recent runs for suite " + suiteName, e);
+        }
+        return out;
+    }
+
+    /**
+     * Pass-rate over time for a suite, oldest first — the series a trend chart plots. Derived from
+     * {@link #recentRuns} so a single query backs both the table and the chart.
+     */
+    public List<TrendPoint> passRateSeries(String suiteName, int limit) {
+        List<RunSummary> runs = recentRuns(suiteName, limit);
+        List<TrendPoint> series = new ArrayList<>(runs.size());
+        // recentRuns is newest-first; a time series reads oldest-first.
+        for (int i = runs.size() - 1; i >= 0; i--) {
+            RunSummary r = runs.get(i);
+            series.add(new TrendPoint(r.startedAt(), r.passRate(), r.total()));
+        }
+        return series;
+    }
+
+    /** One persisted run's tallies. */
+    public record RunSummary(
+            long runId,
+            String suiteName,
+            String cubeRef,
+            Instant startedAt,
+            long elapsedMs,
+            int total,
+            int passed,
+            int failed,
+            int degraded,
+            int skipped) {
+        /** Pass rate in [0,1]; zero when the run had no cases. */
+        public double passRate() {
+            return total == 0 ? 0.0 : (double) passed / total;
+        }
+    }
+
+    /** One point on the accuracy-over-time series. */
+    public record TrendPoint(Instant startedAt, double passRate, int total) {}
+
+    /** Unchecked wrapper so callers don't have to handle {@link SQLException} on every store call. */
+    public static final class EvalStoreException extends RuntimeException {
+        public EvalStoreException(String message, Throwable cause) {
+            super(message, cause);
+        }
+    }
+}

--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ai/eval/ScheduledEvalRunner.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ai/eval/ScheduledEvalRunner.java
@@ -1,0 +1,145 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.service.olap.ai.eval;
+
+import java.io.IOException;
+import java.io.Reader;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Objects;
+import java.util.function.Supplier;
+import java.util.stream.Stream;
+import org.saiku.service.olap.ai.AiCubeRef;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Runs every eval suite in a directory and persists each scored report to the {@link
+ * EvalResultStore} (saiku#1424 — Phase 2b). Wired to a launcher cron so accuracy is sampled on a
+ * schedule against the live model — the difference between a one-shot CI gate and continuous
+ * monitoring.
+ *
+ * <p>Deliberately resilient: one unreadable / malformed / failing suite must not abort the sweep.
+ * A YAML that won't parse and a suite whose run throws are both logged and recorded as a skipped
+ * entry in the returned summary; the remaining suites still run and persist. That way a single bad
+ * file never blinds the whole monitor.
+ *
+ * <p>Stateless apart from its collaborators. The {@code clock} supplier is injectable so tests get
+ * deterministic {@code started_at} stamps; production passes {@link Instant#now}.
+ */
+public final class ScheduledEvalRunner {
+
+    private static final Logger log = LoggerFactory.getLogger(ScheduledEvalRunner.class);
+    private static final String SUITE_SUFFIX = ".eval.yaml";
+
+    private final Path evalsDir;
+    private final EvalAskAdapter adapter;
+    private final EvalResultStore store;
+    private final Supplier<Instant> clock;
+
+    public ScheduledEvalRunner(Path evalsDir, EvalAskAdapter adapter, EvalResultStore store) {
+        this(evalsDir, adapter, store, Instant::now);
+    }
+
+    ScheduledEvalRunner(Path evalsDir, EvalAskAdapter adapter, EvalResultStore store, Supplier<Instant> clock) {
+        this.evalsDir = Objects.requireNonNull(evalsDir, "evalsDir");
+        this.adapter = Objects.requireNonNull(adapter, "adapter");
+        this.store = Objects.requireNonNull(store, "store");
+        this.clock = Objects.requireNonNull(clock, "clock");
+    }
+
+    /**
+     * Cron entry point — Spring calls this on the configured schedule. Swallows everything so a
+     * scheduler thread is never killed by a stray exception; the per-suite detail is in the
+     * returned summary and the log.
+     */
+    public void runScheduled() {
+        try {
+            SweepSummary summary = runAll();
+            log.info(
+                    "Scheduled eval sweep: {} suite(s) run, {} skipped ({})",
+                    summary.results().size(),
+                    summary.skipped().size(),
+                    summary.oneLine());
+        } catch (RuntimeException e) {
+            log.error("Scheduled eval sweep failed", e);
+        }
+    }
+
+    /** Run every {@code *.eval.yaml} in the directory, persist each report, and return a summary. */
+    public SweepSummary runAll() {
+        List<SuiteResult> results = new ArrayList<>();
+        List<SkippedSuite> skipped = new ArrayList<>();
+
+        List<Path> files = listSuiteFiles();
+        for (Path file : files) {
+            EvalSuite suite;
+            try (Reader r = Files.newBufferedReader(file, StandardCharsets.UTF_8)) {
+                suite = EvalYamlReader.read(r, file.getFileName().toString());
+            } catch (EvalYamlReader.EvalParseException e) {
+                log.warn("Skipping unparseable eval suite {}: {} ({})", file, e.getMessage(), e.code());
+                skipped.add(new SkippedSuite(file.getFileName().toString(), e.code() + ": " + e.getMessage()));
+                continue;
+            } catch (IOException e) {
+                log.warn("Skipping unreadable eval suite {}: {}", file, e.getMessage());
+                skipped.add(new SkippedSuite(file.getFileName().toString(), "unreadable: " + e.getMessage()));
+                continue;
+            }
+
+            Instant startedAt = clock.get();
+            try {
+                EvalReport report = new AgentEvalRunner(adapter).run(suite);
+                long runId = store.save(report, cubeRef(suite.cube()), startedAt);
+                results.add(new SuiteResult(
+                        suite.name(), runId, report.passedCount(), report.totalCases(), report.oneLine()));
+            } catch (RuntimeException e) {
+                log.warn("Skipping eval suite {} — run/persist failed: {}", suite.name(), e.getMessage(), e);
+                skipped.add(new SkippedSuite(suite.name(), "run failed: " + e.getMessage()));
+            }
+        }
+        return new SweepSummary(results, skipped);
+    }
+
+    private List<Path> listSuiteFiles() {
+        if (!Files.isDirectory(evalsDir)) {
+            log.debug("Eval dir {} does not exist — nothing to run", evalsDir);
+            return List.of();
+        }
+        try (Stream<Path> paths = Files.list(evalsDir)) {
+            return paths.filter(p -> p.getFileName().toString().endsWith(SUITE_SUFFIX))
+                    .sorted(Comparator.comparing(p -> p.getFileName().toString()))
+                    .toList();
+        } catch (IOException e) {
+            log.warn("Could not list eval dir {}: {}", evalsDir, e.getMessage());
+            return List.of();
+        }
+    }
+
+    static String cubeRef(AiCubeRef c) {
+        if (c == null) return "";
+        return c.getConnectionName() + "/" + c.getCatalog() + "/" + c.getSchema() + "/" + c.getCubeName();
+    }
+
+    /** One suite's persisted outcome from a sweep. */
+    public record SuiteResult(String suiteName, long runId, int passed, int total, String oneLine) {}
+
+    /** A suite that couldn't be run (parse error, unreadable, or a failing run). */
+    public record SkippedSuite(String suiteName, String reason) {}
+
+    /** The aggregate outcome of one directory sweep. */
+    public record SweepSummary(List<SuiteResult> results, List<SkippedSuite> skipped) {
+        public String oneLine() {
+            int pass = results.stream().mapToInt(SuiteResult::passed).sum();
+            int total = results.stream().mapToInt(SuiteResult::total).sum();
+            return pass + "/" + total + " cases passed across " + results.size() + " suite(s), " + skipped.size()
+                    + " skipped";
+        }
+    }
+}

--- a/saiku-core/saiku-service/src/test/java/org/saiku/service/olap/ai/eval/EvalResultStoreTest.java
+++ b/saiku-core/saiku-service/src/test/java/org/saiku/service/olap/ai/eval/EvalResultStoreTest.java
@@ -1,0 +1,91 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.service.olap.ai.eval;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.time.Instant;
+import java.util.List;
+import org.junit.Test;
+
+public class EvalResultStoreTest {
+
+    /** Fresh in-memory H2 per test — DB_CLOSE_DELAY keeps it alive across the store's connections. */
+    private static EvalResultStore memStore(String name) {
+        return new EvalResultStore("jdbc:h2:mem:" + name + ";DB_CLOSE_DELAY=-1");
+    }
+
+    private static EvalReport report(String suite, int pass, int fail, int degraded) {
+        java.util.List<EvalOutcome> outcomes = new java.util.ArrayList<>();
+        for (int i = 0; i < pass; i++) outcomes.add(EvalOutcome.pass("p" + i, 10, "QUERY", "claude-x"));
+        for (int i = 0; i < fail; i++)
+            outcomes.add(EvalOutcome.fail(
+                    "f" + i,
+                    20,
+                    "QUERY",
+                    "claude-x",
+                    List.of(new EvalOutcome.Mismatch("rows[0].x", "expected A got B"))));
+        for (int i = 0; i < degraded; i++) outcomes.add(EvalOutcome.degraded("d" + i, 5, "boom", "claude-x"));
+        return new EvalReport(suite, "desc", outcomes, 123);
+    }
+
+    @Test
+    public void savesAndReadsBackARun() {
+        EvalResultStore store = memStore("roundtrip");
+        long id = store.save(report("s1", 3, 1, 0), "conn/cat/sch/Sales", Instant.parse("2026-07-12T10:00:00Z"));
+        assertTrue(id > 0);
+
+        List<EvalResultStore.RunSummary> runs = store.recentRuns("s1", 10);
+        assertEquals(1, runs.size());
+        EvalResultStore.RunSummary r = runs.get(0);
+        assertEquals("s1", r.suiteName());
+        assertEquals("conn/cat/sch/Sales", r.cubeRef());
+        assertEquals(4, r.total());
+        assertEquals(3, r.passed());
+        assertEquals(1, r.failed());
+        assertEquals(0, r.degraded());
+        assertEquals(0.75, r.passRate(), 1e-9);
+        assertEquals(Instant.parse("2026-07-12T10:00:00Z"), r.startedAt());
+    }
+
+    @Test
+    public void recentRunsAreNewestFirstAndLimited() {
+        EvalResultStore store = memStore("recent");
+        store.save(report("s", 1, 0, 0), "c", Instant.parse("2026-07-10T10:00:00Z"));
+        store.save(report("s", 2, 0, 0), "c", Instant.parse("2026-07-11T10:00:00Z"));
+        store.save(report("s", 3, 0, 0), "c", Instant.parse("2026-07-12T10:00:00Z"));
+
+        List<EvalResultStore.RunSummary> runs = store.recentRuns("s", 2);
+        assertEquals(2, runs.size());
+        // newest first
+        assertEquals(Instant.parse("2026-07-12T10:00:00Z"), runs.get(0).startedAt());
+        assertEquals(Instant.parse("2026-07-11T10:00:00Z"), runs.get(1).startedAt());
+    }
+
+    @Test
+    public void passRateSeriesIsOldestFirst() {
+        EvalResultStore store = memStore("trend");
+        // 100%, then 50%, then 0% — a degrading model.
+        store.save(report("s", 2, 0, 0), "c", Instant.parse("2026-07-10T10:00:00Z"));
+        store.save(report("s", 1, 1, 0), "c", Instant.parse("2026-07-11T10:00:00Z"));
+        store.save(report("s", 0, 2, 0), "c", Instant.parse("2026-07-12T10:00:00Z"));
+
+        List<EvalResultStore.TrendPoint> series = store.passRateSeries("s", 10);
+        assertEquals(3, series.size());
+        assertEquals(1.0, series.get(0).passRate(), 1e-9);
+        assertEquals(0.5, series.get(1).passRate(), 1e-9);
+        assertEquals(0.0, series.get(2).passRate(), 1e-9);
+    }
+
+    @Test
+    public void isolatesRunsBySuite() {
+        EvalResultStore store = memStore("bysuite");
+        store.save(report("alpha", 1, 0, 0), "c", Instant.parse("2026-07-12T10:00:00Z"));
+        store.save(report("beta", 1, 0, 0), "c", Instant.parse("2026-07-12T10:00:00Z"));
+        assertEquals(1, store.recentRuns("alpha", 10).size());
+        assertEquals(0, store.recentRuns("gamma", 10).size());
+    }
+}

--- a/saiku-core/saiku-service/src/test/java/org/saiku/service/olap/ai/eval/ScheduledEvalRunnerTest.java
+++ b/saiku-core/saiku-service/src/test/java/org/saiku/service/olap/ai/eval/ScheduledEvalRunnerTest.java
@@ -1,0 +1,95 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.service.olap.ai.eval;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Instant;
+import java.util.List;
+import org.junit.Test;
+
+public class ScheduledEvalRunnerTest {
+
+    private static final String VALID_SUITE = "name: %s\n"
+            + "cube:\n"
+            + "  connectionName: conn\n"
+            + "  catalog: cat\n"
+            + "  schema: sch\n"
+            + "  cubeName: Sales\n"
+            + "cases:\n"
+            + "  - name: sales-by-country\n"
+            + "    question: show sales by country\n"
+            + "    expectedIntent: QUERY\n"
+            + "    expectedRows:\n"
+            + "      - {country: USA, storeSales: 500.0}\n";
+
+    private static EvalResultStore memStore(String name) {
+        return new EvalResultStore("jdbc:h2:mem:" + name + ";DB_CLOSE_DELAY=-1");
+    }
+
+    // Adapter that always answers with the expected row → cases pass; reference execution unused.
+    private static final EvalAskAdapter PASSING = (cube, q, h) -> {
+        java.util.LinkedHashMap<String, Object> row = new java.util.LinkedHashMap<>();
+        row.put("country", "USA");
+        row.put("storeSales", 500.0);
+        return EvalAskResult.forQuery("claude-x", List.of(row));
+    };
+
+    @Test
+    public void runsEverySuiteAndPersistsEach() throws Exception {
+        Path dir = Files.createTempDirectory("evals-run");
+        Files.writeString(dir.resolve("a.eval.yaml"), String.format(VALID_SUITE, "suite-a"), StandardCharsets.UTF_8);
+        Files.writeString(dir.resolve("b.eval.yaml"), String.format(VALID_SUITE, "suite-b"), StandardCharsets.UTF_8);
+        // A non-suite file in the same dir must be ignored.
+        Files.writeString(dir.resolve("notes.txt"), "ignore me", StandardCharsets.UTF_8);
+
+        EvalResultStore store = memStore("sweep");
+        ScheduledEvalRunner runner =
+                new ScheduledEvalRunner(dir, PASSING, store, () -> Instant.parse("2026-07-12T09:00:00Z"));
+
+        ScheduledEvalRunner.SweepSummary summary = runner.runAll();
+
+        assertEquals(2, summary.results().size());
+        assertEquals(0, summary.skipped().size());
+        // Both suites' runs are queryable in the store.
+        assertEquals(1, store.recentRuns("suite-a", 10).size());
+        assertEquals(1, store.recentRuns("suite-b", 10).size());
+        EvalResultStore.RunSummary a = store.recentRuns("suite-a", 10).get(0);
+        assertEquals(1, a.passed());
+        assertEquals("conn/cat/sch/Sales", a.cubeRef());
+        assertEquals(Instant.parse("2026-07-12T09:00:00Z"), a.startedAt());
+    }
+
+    @Test
+    public void malformedSuiteIsSkippedNotFatal() throws Exception {
+        Path dir = Files.createTempDirectory("evals-bad");
+        Files.writeString(dir.resolve("good.eval.yaml"), String.format(VALID_SUITE, "good"), StandardCharsets.UTF_8);
+        Files.writeString(
+                dir.resolve("broken.eval.yaml"), "name: broken\n# no cube, no cases\n", StandardCharsets.UTF_8);
+
+        EvalResultStore store = memStore("badsweep");
+        ScheduledEvalRunner runner =
+                new ScheduledEvalRunner(dir, PASSING, store, () -> Instant.parse("2026-07-12T09:00:00Z"));
+
+        ScheduledEvalRunner.SweepSummary summary = runner.runAll();
+
+        assertEquals("good suite still runs", 1, summary.results().size());
+        assertEquals(1, summary.skipped().size());
+        assertTrue(summary.skipped().get(0).reason().contains("MISSING_FIELD"));
+    }
+
+    @Test
+    public void missingDirYieldsEmptySweep() throws Exception {
+        Path dir = Files.createTempDirectory("evals-parent").resolve("does-not-exist");
+        ScheduledEvalRunner runner = new ScheduledEvalRunner(dir, PASSING, memStore("empty"));
+        ScheduledEvalRunner.SweepSummary summary = runner.runAll();
+        assertEquals(0, summary.results().size());
+        assertEquals(0, summary.skipped().size());
+    }
+}


### PR DESCRIPTION
Phase 2a of the eval monitoring layer (builds on #1473's drift-proof ground truth). Persists scored runs so accuracy can be tracked **across runs** — the step that makes it a live monitor rather than a one-shot gate.

## `EvalResultStore`
- Embedded **H2** under `saiku-home/data/eval-results` (`AUTO_SERVER=TRUE` so a REST reader / CLI can open it alongside the launcher). Same `CREATE TABLE IF NOT EXISTS` + plain-JDBC house style as `Database.java`.
- Two tables: `eval_run` (per-run tallies) and `eval_case_outcome` (per-case detail, mismatches as JSON).
- API: `save(report, cubeRef, startedAt)` → run id; `recentRuns(suite, limit)` (newest-first); `passRateSeries(suite, limit)` (oldest-first, for a trend chart). The caller stamps the time — the store never reads the clock (keeps it deterministic + testable).
- **+4 tests**: in-mem H2 round-trip, newest-first + limit, a degrading-accuracy trend, suite isolation.

## Roadmap
- **Phase 1** ✅ (#1473) — reference-query ground truth (drift-proof).
- **Phase 2a** ← this — the result store.
- **Phase 2b** — launcher-cron scheduler that runs every suite in `saiku-home/evals` and writes each report here.
- **Phase 3** — REST + dashboard surfacing the trend, tying into the OTel work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)