### PR TITLE
fix(ai/ask): omit temperature for gpt-5/o-series (OpenAI + Azure)

### DIFF
--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ai/ask/NlAskProviderFactory.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ai/ask/NlAskProviderFactory.java
@@ -112,8 +112,15 @@ public final class NlAskProviderFactory {
             String effectiveEndpoint =
                     resolvedEndpoint == null ? OpenAINlAskProvider.DEFAULT_ENDPOINT : resolvedEndpoint;
             LOGGER.info("AI ask provider: openai (model={}, endpoint={})", effectiveModel, effectiveEndpoint);
+            // Omit temperature by default: gpt-5 / o-series reject a custom value, and the forced
+            // function call already pins the structured output so determinism doesn't need it.
             return new OpenAINlAskProvider(new OpenAINlAskProvider.Config(
-                    resolvedKey, effectiveModel, effectiveEndpoint, 0.0, 4096, Duration.ofSeconds(60)));
+                    resolvedKey,
+                    effectiveModel,
+                    effectiveEndpoint,
+                    OpenAINlAskProvider.OMIT_TEMPERATURE,
+                    4096,
+                    Duration.ofSeconds(60)));
         }
         if (PROVIDER_AZURE_OPENAI.equalsIgnoreCase(name)) {
             String resolvedKey = resolveApiKey(ENV_AZURE_OPENAI_API_KEY);
@@ -143,7 +150,12 @@ public final class NlAskProviderFactory {
                     effectiveModel,
                     resolvedEndpoint);
             return new AzureOpenAiNlAskProvider(new OpenAINlAskProvider.Config(
-                    resolvedKey, effectiveModel, resolvedEndpoint, 0.0, 4096, Duration.ofSeconds(60)));
+                    resolvedKey,
+                    effectiveModel,
+                    resolvedEndpoint,
+                    OpenAINlAskProvider.OMIT_TEMPERATURE,
+                    4096,
+                    Duration.ofSeconds(60)));
         }
         LOGGER.warn("Unknown AI ask provider '{}'; falling back to NoopProvider.", providerName);
         return new NoopNlAskProvider();

--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ai/ask/OpenAINlAskProvider.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ai/ask/OpenAINlAskProvider.java
@@ -73,6 +73,16 @@ public class OpenAINlAskProvider extends AbstractNlAskProvider {
             + "`order` and `limit`. (6) Keep aggregator overrides off unless the user asks for one.\n\n"
             + "Always call exactly ONE function — never respond with prose.";
 
+    /**
+     * Sentinel for {@link Config#temperature()}: a negative value means "do not send a
+     * {@code temperature} field at all". Required for gpt-5 / o-series models, which reject a custom
+     * {@code temperature} (only the default is accepted) with a 400. Older models fall back to the
+     * API default — safe because the forced function call already pins the structured output.
+     *
+     * <p>Inherited by {@link AzureOpenAiNlAskProvider}, which reuses this request builder.
+     */
+    public static final double OMIT_TEMPERATURE = -1.0;
+
     /** Provider configuration. */
     public record Config(
             String apiKey, String model, String endpoint, double temperature, int maxTokens, Duration requestTimeout) {
@@ -147,7 +157,13 @@ public class OpenAINlAskProvider extends AbstractNlAskProvider {
         ObjectNode root = MAPPER.createObjectNode();
         root.put("model", config.model());
         root.put("max_tokens", config.maxTokens());
-        root.put("temperature", config.temperature());
+        // Only send temperature when explicitly set (>= 0). gpt-5 / o-series reject a custom value;
+        // see OMIT_TEMPERATURE. The forced function call pins the structured output regardless.
+        // NOTE: gpt-5 / o-series also rename max_tokens -> max_completion_tokens on this endpoint —
+        // tracked separately (saiku#1479) since it needs a model-family check.
+        if (config.temperature() >= 0) {
+            root.put("temperature", config.temperature());
+        }
 
         // Mode picker — Auto leaves all three intents available; an explicit pick narrows the
         // tool list (+ refusal, always available) so the LLM can't auto-route to a different

--- a/saiku-core/saiku-service/src/test/java/org/saiku/service/olap/ai/ask/OpenAINlAskProviderTest.java
+++ b/saiku-core/saiku-service/src/test/java/org/saiku/service/olap/ai/ask/OpenAINlAskProviderTest.java
@@ -73,6 +73,31 @@ public class OpenAINlAskProviderTest {
     }
 
     @Test
+    public void omitsTemperatureWhenSentinelNegative() throws Exception {
+        // OMIT_TEMPERATURE (negative) must drop the `temperature` field — gpt-5 / o-series reject a
+        // custom value with a 400.
+        OpenAINlAskProvider provider = new OpenAINlAskProvider(new OpenAINlAskProvider.Config(
+                "k", "gpt-5", OpenAINlAskProvider.DEFAULT_ENDPOINT, OpenAINlAskProvider.OMIT_TEMPERATURE, 1024, null));
+        NlAskRequest req = new NlAskRequest(CUBE, "show sales", SCHEMA, REQUEST_SCHEMA, List.of());
+
+        JsonNode root = MAPPER.readTree(provider.buildRequestBody(req));
+
+        assertFalse("temperature must be omitted when the sentinel is set", root.has("temperature"));
+    }
+
+    @Test
+    public void includesTemperatureWhenExplicitlySet() throws Exception {
+        OpenAINlAskProvider provider = new OpenAINlAskProvider(
+                new OpenAINlAskProvider.Config("k", "gpt-x", OpenAINlAskProvider.DEFAULT_ENDPOINT, 0.3, 1024, null));
+        NlAskRequest req = new NlAskRequest(CUBE, "show sales", SCHEMA, REQUEST_SCHEMA, List.of());
+
+        JsonNode root = MAPPER.readTree(provider.buildRequestBody(req));
+
+        assertTrue(root.has("temperature"));
+        assertEquals(0.3, root.get("temperature").asDouble(), 1e-9);
+    }
+
+    @Test
     public void requestBodyKeepsHistoryBetweenSystemAndQuestion() throws Exception {
         OpenAINlAskProvider provider = new OpenAINlAskProvider(
                 new OpenAINlAskProvider.Config("k", "gpt-x", OpenAINlAskProvider.DEFAULT_ENDPOINT, 0.0, 1024, null));


### PR DESCRIPTION
Closes #1479. Mirror of the Anthropic `OMIT_TEMPERATURE` fix, applied to the OpenAI-compatible providers.

`OpenAINlAskProvider` (and `AzureOpenAiNlAskProvider`, which reuses its request builder) hardcoded `temperature: 0.0`. **gpt-5 / o-series models reject a custom temperature with a 400** — so those models couldn't answer at all, the same failure mode we hit with Sonnet-5.

- Add `OMIT_TEMPERATURE` (negative sentinel → drop the field); the factory defaults both the `openai` and `azure-openai` paths to omit it.
- The forced function call already pins the structured output, so determinism doesn't depend on `temperature=0`; older models fall back to the API default.
- **+2 tests** (`OpenAINlAskProviderTest` → 16 green; Azure inherits the builder).

> Noted in-code and on #1479: gpt-5/o-series also rename `max_tokens` → `max_completion_tokens` on the chat-completions endpoint — left as a follow-up since it needs a model-family check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)