### PR TITLE
fix(ai/privacy): apply k-anonymity to /ai/anomaly + /ai/forecast (part of #1482)

### DIFF
--- a/docs/AI-QUERY-API.md
+++ b/docs/AI-QUERY-API.md
@@ -414,8 +414,14 @@ apart (the `format=matrix` bypass was closed in saiku#1324).
 **v1 limit (the shadow-count follow-up is tracked as saiku#905-B):**
 
 - **Only in-result count measures are covered.** A cube whose result carries no
-  count measure — and the `/ai/anomaly` / `/ai/forecast` surfaces — are not yet
-  suppressed.
+  count measure is not suppressed (there's nothing to key the small-cell test on
+  — the shadow-count follow-up, saiku#905-B, would inject a hidden count).
+- The `/ai/anomaly` and `/ai/forecast` surfaces **are** now suppressed (saiku#1482):
+  their observed records run through the same filter as `/ai/query` before egress,
+  so a small cell can't leak just because it was requested via the anomaly/forecast
+  path. Detection/forecasting still run on the real values (accurate flags); only
+  the observed cell **values** are masked. Forecast projections are derived
+  aggregates, not raw cells, and are unaffected.
 
 ---
 

--- a/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/AiQueryResource.java
+++ b/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/AiQueryResource.java
@@ -552,6 +552,12 @@ public class AiQueryResource {
             return error("anomaly detection failed");
         }
 
+        // saiku#1482 — the /anomaly surface previously bypassed k-anonymity, leaking small-cell
+        // values /ai/query would have masked. Detection ran on the real values above (accurate
+        // flags); we mask the small-cell values in the observed records before they leave. Reuses
+        // the exact filter /ai/query uses — no-op without a count measure or when disabled.
+        applyKAnonymity(resp.getData());
+
         int anomalyCount = org.saiku.service.olap.ai.anomaly.AnomalyAugmenter.countAnomalies(resp);
         resp.setRuntimeMs(System.currentTimeMillis() - start);
 
@@ -663,6 +669,13 @@ public class AiQueryResource {
             log.error("AI forecast failed", e);
             return error("forecast failed");
         }
+
+        // saiku#1482 — mask small-cell values in the observed records before egress, same as
+        // /ai/query. The forecast projections above were computed on the real series (they're
+        // derived aggregates, not raw cells); this closes the raw small-cell leak on the observed
+        // half of the response. No-op without a count measure or when disabled.
+        applyKAnonymity(resp.getData());
+
         resp.setRuntimeMs(System.currentTimeMillis() - start);
 
         // Echo the typed response plus a sibling forecast block (observed data


### PR DESCRIPTION
Part of #1482. Closes the k-anonymity bypass on the anomaly/forecast surfaces.

## Problem
`/ai/anomaly` and `/ai/forecast` build their observed records via `buildResponse` but **skipped the `applyKAnonymity` step `/ai/query` runs** — so a small cell (< k underlying rows) leaked its raw value just because it was requested through the anomaly/forecast path instead of `/query`. A real privacy hole (`AI-QUERY-API.md` had flagged it as saiku#905-B).

## Fix
Both handlers now run `resp.getData()` through the **same** `applyKAnonymity` filter:
- **after** detection/forecasting — so flags + forecast projections compute on the real series (accuracy preserved);
- **before** egress — so small-cell *values* in the observed records are masked.

Reuses the exact, well-tested suppression (`AiQueryResourceKAnonTest`, 7 tests green) — no-op without a count measure or when disabled, identical semantics to `/ai/query`. Forecast projections are derived aggregates (not raw cells) and are unaffected.

## Remaining on #1482
- Ossie R2 suppression placeholder (renders null/0) — separate.
- Count-less cubes (the saiku#905-B shadow-count) — separate.

Docs (`AI-QUERY-API.md` k-anonymity section) updated to reflect the anomaly/forecast surfaces are now covered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)