### PR TITLE
docs(dashboard): correct stale reference-tile hint (closes #1480)

### DIFF
--- a/saiku-ui/src/lib/views/dashboard/TileEditorModal.svelte
+++ b/saiku-ui/src/lib/views/dashboard/TileEditorModal.svelte
@@ -1068,9 +1068,9 @@
                 {/each}
               </select>
               <span class="hint">
-                Runtime fetch of saved queries lands in a follow-up — the
-                reference is persisted, the tile renderer will pick it up
-                once the resolver endpoint is wired.
+                The tile renders live from the saved query — the resolver
+                (POST /ai/query/saved) loads it, merges any applicable
+                dashboard filters, and runs it on each refresh.
               </span>
             {/if}
           </label>


### PR DESCRIPTION
The audit (#1480) flagged the saved-query/reference tile resolver as unbuilt — but that was a **stale comment**. The resolver already ships end-to-end:

- **Backend:** `AiQueryResource.executeSaved` → `POST /ai/query/saved` loads the saved ThinQuery, merges applicable dashboard filters (`ThinQueryFilterMerge`), runs it.
- **Client:** `executeSavedQuery` in `aiQuery.ts`.
- **Render:** `useTileQuery.svelte.ts` handles `kind === "reference"` — calls `executeSavedQuery`, sets loading/error/response; the tile renders live and re-fetches when filters change.

This PR just corrects the misleading hint in `TileEditorModal.svelte` that still said 'lands in a follow-up ... once the resolver endpoint is wired'. Closes #1480.

🤖 Generated with [Claude Code](https://claude.com/claude-code)