### PR TITLE
fix(mcp): guarantee structuredContent is always a JSON object (closes #878)

### DIFF
--- a/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/mcp/McpResource.java
+++ b/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/mcp/McpResource.java
@@ -580,18 +580,33 @@ public class McpResource {
     /** Wrap a tool body in the MCP {@code CallToolResult} envelope:
      *  the body lands in {@code structuredContent} for agents that read
      *  structured JSON directly, and is also serialised into a single
-     *  {@code text} content block for hosts that only support text content. */
-    private ObjectNode wrapToolResult(JsonNode body) {
+     *  {@code text} content block for hosts that only support text content.
+     *
+     *  <p>saiku#878: MCP's {@code structuredContent} MUST be a JSON object, never a bare array
+     *  (claude.ai's tool-result validator rejects arrays). Individual array-returning tools wrap
+     *  under a meaningful key via {@link #wrapList} ("cubes", "members", "models"); this is the
+     *  belt-and-suspenders guard so a future array-returning tool that forgets can't emit a
+     *  spec-violating array — a bare array is wrapped under {@code items}, a null body becomes an
+     *  empty object. Package-visible for unit testing. */
+    ObjectNode wrapToolResult(JsonNode body) {
+        JsonNode structured;
+        if (body == null) {
+            structured = MAPPER.createObjectNode();
+        } else if (body.isArray()) {
+            structured = MAPPER.createObjectNode().set("items", body);
+        } else {
+            structured = body;
+        }
         ObjectNode result = MAPPER.createObjectNode();
         ArrayNode content = result.putArray("content");
         ObjectNode textBlock = content.addObject();
         textBlock.put("type", "text");
         try {
-            textBlock.put("text", MAPPER.writeValueAsString(body));
+            textBlock.put("text", MAPPER.writeValueAsString(structured));
         } catch (JsonProcessingException e) {
-            textBlock.put("text", String.valueOf(body));
+            textBlock.put("text", String.valueOf(structured));
         }
-        result.set("structuredContent", body);
+        result.set("structuredContent", structured);
         result.put("isError", false);
         return result;
     }

--- a/saiku-core/saiku-web/src/test/java/org/saiku/web/rest/resources/mcp/McpResourceTest.java
+++ b/saiku-core/saiku-web/src/test/java/org/saiku/web/rest/resources/mcp/McpResourceTest.java
@@ -5,6 +5,7 @@
 package org.saiku.web.rest.resources.mcp;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertNull;
@@ -12,6 +13,7 @@ import static org.junit.Assert.assertTrue;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import jakarta.ws.rs.core.Response;
 import java.util.List;
@@ -295,6 +297,38 @@ public class McpResourceTest {
         params.put("name", tool);
         params.set("arguments", args);
         return params;
+    }
+
+    /* -------- saiku#878: structuredContent must always be a JSON object -------- */
+
+    @Test
+    public void wrapToolResult_wrapsBareArrayUnderItems() {
+        ArrayNode arr = MAPPER.createArrayNode();
+        arr.add(MAPPER.createObjectNode().put("name", "Sales"));
+        ObjectNode result = resource.wrapToolResult(arr);
+        JsonNode sc = result.get("structuredContent");
+        assertTrue("structuredContent must be a JSON object, never a bare array", sc.isObject());
+        assertTrue(sc.has("items"));
+        assertTrue(sc.get("items").isArray());
+        assertEquals(1, sc.get("items").size());
+    }
+
+    @Test
+    public void wrapToolResult_leavesObjectBodyUnchanged() {
+        ObjectNode body = MAPPER.createObjectNode();
+        body.put("cube", "Sales");
+        ObjectNode result = resource.wrapToolResult(body);
+        JsonNode sc = result.get("structuredContent");
+        assertTrue(sc.isObject());
+        assertEquals("Sales", sc.get("cube").asText());
+        assertFalse("object bodies are passed through untouched", sc.has("items"));
+    }
+
+    @Test
+    public void wrapToolResult_nullBodyBecomesEmptyObject() {
+        ObjectNode result = resource.wrapToolResult(null);
+        assertTrue(result.get("structuredContent").isObject());
+        assertEquals(0, result.get("structuredContent").size());
     }
 
     private static final class StubAiOssieResource extends org.saiku.web.rest.resources.AiOssieResource {


### PR DESCRIPTION
Closes #878. MCP's `structuredContent` **must** be a JSON object — claude.ai's tool-result validator rejects bare arrays.

Array-returning tools already wrap under a meaningful key via `wrapList` (`cubes` / `members` / `models`), but that relies on each tool *remembering* to. I audited every current tool — all array returns are wrapped and the rest return objects — so there's no live violation. But a future array-returning tool that forgets `wrapList` would emit a spec-violating array.

## Fix
A belt-and-suspenders guard in `wrapToolResult` — the single envelope chokepoint every tool result passes through:
- a **bare array** body is wrapped under `items`,
- a **null** body becomes an empty object,
- **objects** pass through untouched (so the meaningful per-tool keys are preserved).

The `text` content block mirrors the same structured value. `wrapToolResult` made package-visible; **+3 tests** (`McpResourceTest` → 17 green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)