### PR TITLE
feat(ai/eval): out-of-process saiku eval CLI + run endpoint (closes #1478)

### DIFF
--- a/docs/EVAL-SPEC.md
+++ b/docs/EVAL-SPEC.md
@@ -207,6 +207,28 @@ FAIL: top-3-product-families (1024ms, intent=QUERY, model=claude-sonnet-4-6)
 Rendered via [`EvalReportWriter.toText`](../saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ai/eval/EvalReportWriter.java).
 Also available as pretty-printed JSON via `toJson` for CI archives.
 
+## Running a suite: the `saiku eval` CLI (saiku#1478)
+
+The out-of-process runner drives a **running** server so the sweep executes inside
+a real request — where the session-scoped query service resolves and MDX runs
+under the caller's data scope (a background cron thread can't do this). It POSTs
+to `POST /rest/saiku/admin/ai-evals/run` (admin-gated, HTTP Basic), which runs
+every suite in `saiku-home/evals/`, persists each scored run to the H2 result
+store (surfaced by the admin **Agent evals** dashboard), and returns the tallies.
+The CLI prints them and sets its exit code so CI can gate on regressions:
+
+```bash
+# Nightly CI job against a running server:
+java -jar saiku-<version>.jar eval \
+  --server https://saiku.example.com --username admin --password ****
+# exit 0 = all green · 1 = a regression · 2 = couldn't reach / auth / run
+# --no-fail-on-regression for report-only; --timeout-minutes for slow sweeps
+```
+
+The same `POST …/ai-evals/run` endpoint backs a "Run now" action and can be
+`curl`ed from any external scheduler — the sanctioned way to populate accuracy
+history on a cadence without an in-server cron.
+
 ## Error codes
 
 Structured YAML-parse failures surface with a stable code so CI can
@@ -221,16 +243,23 @@ a wrong answer":
 | `TYPE_MISMATCH`     | A field has the wrong type (e.g. `cases` is a mapping, not an array).    |
 | `INVALID_TOLERANCE` | `tolerance.absolute` or `tolerance.relative` is negative.                |
 
+## Shipped since v1
+
+- **REST endpoint to trigger runs** — `POST /rest/saiku/admin/ai-evals/run`
+  (saiku#1478). Runs the sweep in-request and persists to the store.
+- **`saiku eval` CLI subcommand** — the out-of-process runner (see above).
+- **Result store + accuracy dashboard** — H2 (`EvalResultStore`) + the admin
+  **Agent evals** trend view (saiku#1424 Phase 2/3).
+- **Reference-query ground truth** — drift-proof, tracks live data.
+
 ## Non-goals for v1
 
-- **REST endpoint** to trigger runs — the runner is programmatic in v1.
-  CLI + REST wrappers are a follow-up.
-- **`saiku eval` CLI subcommand** — deferred.
 - **Recording adapter** — an adapter that writes each live response to
   a fixture file so the fixture adapter can replay deterministically
   without spending LLM budget. Design ready; implementation deferred.
 - **Cross-run comparison** — "is today's eval worse than yesterday's?"
-  Requires report archiving. Follow-up.
+  The store + trend chart now expose the history; an automated
+  worse-than-baseline gate is still a follow-up.
 - **Structural diff on the emitted AiQueryRequest** (as opposed to the
   executed row-set) — multiple structurally-different requests can
   produce the same rows, so row-diff is a better ground truth.

--- a/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/AiEvalResource.java
+++ b/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/AiEvalResource.java
@@ -7,14 +7,25 @@ package org.saiku.web.rest.resources;
 import jakarta.annotation.security.RolesAllowed;
 import jakarta.ws.rs.DefaultValue;
 import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
+import org.saiku.service.olap.ThinQueryService;
+import org.saiku.service.olap.ai.AiCubeMetadataService;
+import org.saiku.service.olap.ai.AiSchemaConverter;
+import org.saiku.service.olap.ai.ask.AiAskService;
+import org.saiku.service.olap.ai.eval.EvalAskAdapter;
 import org.saiku.service.olap.ai.eval.EvalResultStore;
+import org.saiku.service.olap.ai.eval.LiveEvalAskAdapter;
+import org.saiku.service.olap.ai.eval.ScheduledEvalRunner;
 
 /**
  * saiku#1424 (Phase 3) — admin-only read API over the persisted eval results, so an accuracy
@@ -35,9 +46,89 @@ import org.saiku.service.olap.ai.eval.EvalResultStore;
 public class AiEvalResource {
 
     private EvalResultStore store;
+    private AiAskService askService;
+    private AiCubeMetadataService cubeMetadataService;
+    private ThinQueryService thinQueryService;
+    private String evalsDir = "./saiku-home/evals";
 
     public void setStore(EvalResultStore store) {
         this.store = store;
+    }
+
+    public void setAskService(AiAskService askService) {
+        this.askService = askService;
+    }
+
+    public void setCubeMetadataService(AiCubeMetadataService cubeMetadataService) {
+        this.cubeMetadataService = cubeMetadataService;
+    }
+
+    public void setThinQueryService(ThinQueryService thinQueryService) {
+        this.thinQueryService = thinQueryService;
+    }
+
+    public void setEvalsDir(String evalsDir) {
+        if (evalsDir != null && !evalsDir.isBlank()) {
+            this.evalsDir = evalsDir;
+        }
+    }
+
+    /**
+     * Run every suite in the evals directory against the live model and persist each report, then
+     * return the sweep summary. Executes <em>synchronously in the request thread</em> — this is the
+     * whole point of the out-of-process CLI design (saiku#1478): the sweep runs inside a real
+     * request, so the session-scoped {@code thinQueryService} resolves and queries execute under the
+     * caller's (admin's) data scope. A background cron thread couldn't do this.
+     *
+     * <p>The {@code saiku eval} CLI POSTs here from a separate process and reads the tallies to set
+     * its exit code, so CI can gate on accuracy regressions without an in-server scheduler.
+     */
+    @POST
+    @Path("/run")
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response run() {
+        if (askService == null || cubeMetadataService == null || thinQueryService == null) {
+            return Response.status(Response.Status.SERVICE_UNAVAILABLE)
+                    .entity(Map.of("error", "eval execution is not configured (missing ask/metadata/query service)"))
+                    .type(MediaType.APPLICATION_JSON)
+                    .build();
+        }
+        AiSchemaConverter converter = new AiSchemaConverter();
+        EvalAskAdapter adapter = new LiveEvalAskAdapter(askService, cubeMetadataService, converter, thinQueryService);
+        ScheduledEvalRunner runner = new ScheduledEvalRunner(java.nio.file.Path.of(evalsDir), adapter, store);
+        ScheduledEvalRunner.SweepSummary summary = runner.runAll();
+
+        List<Map<String, Object>> results = new ArrayList<>();
+        int totalCases = 0;
+        int passedCases = 0;
+        for (ScheduledEvalRunner.SuiteResult r : summary.results()) {
+            Map<String, Object> m = new LinkedHashMap<>();
+            m.put("suiteName", r.suiteName());
+            m.put("runId", r.runId());
+            m.put("passed", r.passed());
+            m.put("total", r.total());
+            m.put("oneLine", r.oneLine());
+            results.add(m);
+            totalCases += r.total();
+            passedCases += r.passed();
+        }
+        List<Map<String, Object>> skipped = new ArrayList<>();
+        for (ScheduledEvalRunner.SkippedSuite s : summary.skipped()) {
+            Map<String, Object> m = new LinkedHashMap<>();
+            m.put("suiteName", s.suiteName());
+            m.put("reason", s.reason());
+            skipped.add(m);
+        }
+        Map<String, Object> out = new LinkedHashMap<>();
+        out.put("suites", summary.results().size());
+        out.put("total", totalCases);
+        out.put("passed", passedCases);
+        out.put("results", results);
+        out.put("skipped", skipped);
+        // The CLI keys its exit code off this: any case failure OR any skipped (unrunnable) suite.
+        out.put("hasFailures", passedCases < totalCases || !summary.skipped().isEmpty());
+        out.put("summary", summary.oneLine());
+        return Response.ok(out).type(MediaType.APPLICATION_JSON).build();
     }
 
     /** One card per suite that has ever run — the suite name plus its latest run's tally. */

--- a/saiku-launcher/src/main/java/org/saiku/launcher/EvalCommand.java
+++ b/saiku-launcher/src/main/java/org/saiku/launcher/EvalCommand.java
@@ -1,0 +1,139 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.launcher;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.Base64;
+import java.util.concurrent.Callable;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Option;
+
+/**
+ * {@code saiku eval} — run the agent-eval suites against a RUNNING Saiku server and report accuracy
+ * (saiku#1424 / saiku#1478).
+ *
+ * <p>This is the out-of-process runner: it POSTs to {@code /rest/saiku/admin/ai-evals/run} on a live
+ * server, which executes every suite in {@code saiku-home/evals/} <em>inside a real request</em> (so
+ * the session-scoped query service resolves and queries run under the admin's data scope — a
+ * background cron thread can't), persists each scored run to the H2 result store, and returns the
+ * tallies. The command prints them and exits non-zero when any case failed or a suite couldn't run,
+ * so CI can gate on accuracy regressions:
+ *
+ * <pre>{@code
+ * # Nightly CI job against a running server:
+ * saiku eval --server https://saiku.example.com --username admin --password ****
+ * # exit 0 = all green, exit 1 = a regression, exit 2 = couldn't reach / run
+ * }</pre>
+ *
+ * <p>Auth is HTTP Basic (CSRF-exempt on the REST surface); the account must have {@code ROLE_ADMIN}.
+ */
+@Command(name = "eval", description = "Run the agent-eval suites against a running Saiku server and report accuracy.")
+public class EvalCommand implements Callable<Integer> {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    @Option(
+            names = {"-s", "--server"},
+            description = "Base URL of the running Saiku server (default: ${DEFAULT-VALUE}).")
+    String server = "http://localhost:8080";
+
+    @Option(
+            names = {"-u", "--username"},
+            description = "Admin username (default: ${DEFAULT-VALUE}).")
+    String username = "admin";
+
+    @Option(
+            names = {"-p", "--password"},
+            description = "Admin password (default: ${DEFAULT-VALUE}).")
+    String password = "admin";
+
+    @Option(names = "--no-fail-on-regression", description = "Exit 0 even when a suite has failures (report-only).")
+    boolean noFailOnRegression = false;
+
+    @Option(
+            names = "--timeout-minutes",
+            description = "How long to wait for the sweep — LLM latency × cases (default: ${DEFAULT-VALUE}).")
+    int timeoutMinutes = 15;
+
+    @Override
+    public Integer call() {
+        String base = server.endsWith("/") ? server.substring(0, server.length() - 1) : server;
+        String url = base + "/rest/saiku/admin/ai-evals/run";
+        String auth = "Basic "
+                + Base64.getEncoder().encodeToString((username + ":" + password).getBytes(StandardCharsets.UTF_8));
+
+        HttpResponse<String> resp;
+        try {
+            HttpClient client = HttpClient.newBuilder()
+                    .connectTimeout(Duration.ofSeconds(20))
+                    .build();
+            HttpRequest req = HttpRequest.newBuilder(URI.create(url))
+                    .timeout(Duration.ofMinutes(Math.max(1, timeoutMinutes)))
+                    .header("Authorization", auth)
+                    .header("Accept", "application/json")
+                    .POST(HttpRequest.BodyPublishers.noBody())
+                    .build();
+            resp = client.send(req, HttpResponse.BodyHandlers.ofString());
+        } catch (Exception e) {
+            System.err.println("saiku eval: could not reach " + url + " — " + e.getMessage());
+            return 2;
+        }
+
+        if (resp.statusCode() == 401 || resp.statusCode() == 403) {
+            System.err.println("saiku eval: authentication failed (HTTP " + resp.statusCode()
+                    + ") — check --username/--password and that the account has ROLE_ADMIN.");
+            return 2;
+        }
+        if (resp.statusCode() != 200) {
+            System.err.println("saiku eval: server returned HTTP " + resp.statusCode() + " — " + resp.body());
+            return 2;
+        }
+
+        JsonNode json;
+        try {
+            json = MAPPER.readTree(resp.body());
+        } catch (Exception e) {
+            System.err.println("saiku eval: could not parse response — " + e.getMessage());
+            return 2;
+        }
+
+        return report(json);
+    }
+
+    /** Print the sweep tallies and derive the exit code. Package-visible for unit testing. */
+    Integer report(JsonNode json) {
+        System.out.println("Agent eval sweep — " + json.path("summary").asText(""));
+        for (JsonNode r : json.path("results")) {
+            int passed = r.path("passed").asInt();
+            int total = r.path("total").asInt();
+            String mark = passed >= total ? "PASS" : "FAIL";
+            System.out.printf("  %-5s %-32s %d/%d%n", mark, r.path("suiteName").asText(), passed, total);
+        }
+        for (JsonNode s : json.path("skipped")) {
+            System.out.printf(
+                    "  SKIP  %-32s %s%n",
+                    s.path("suiteName").asText(), s.path("reason").asText());
+        }
+
+        boolean hasFailures = json.path("hasFailures").asBoolean(false);
+        if (!hasFailures) {
+            System.out.println("All suites green.");
+            return 0;
+        }
+        if (noFailOnRegression) {
+            System.out.println("Regressions found (report-only mode — exit 0).");
+            return 0;
+        }
+        System.out.println("Regressions found — failing.");
+        return 1;
+    }
+}

--- a/saiku-launcher/src/main/java/org/saiku/launcher/SaikuLauncher.java
+++ b/saiku-launcher/src/main/java/org/saiku/launcher/SaikuLauncher.java
@@ -30,7 +30,12 @@ import picocli.CommandLine.Option;
         mixinStandardHelpOptions = true,
         version = "saiku 3.17",
         description = "Saiku Semantic Layer server.",
-        subcommands = {SaikuLauncher.ServeCommand.class, OssieExportCommand.class, SqlServeCommand.class})
+        subcommands = {
+            SaikuLauncher.ServeCommand.class,
+            OssieExportCommand.class,
+            SqlServeCommand.class,
+            EvalCommand.class
+        })
 public class SaikuLauncher implements Callable<Integer> {
 
     public static void main(String[] args) {

--- a/saiku-launcher/src/test/java/org/saiku/launcher/EvalCommandTest.java
+++ b/saiku-launcher/src/test/java/org/saiku/launcher/EvalCommandTest.java
@@ -1,0 +1,52 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.launcher;
+
+import static org.junit.Assert.assertEquals;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.Test;
+
+/** Exit-code logic for {@code saiku eval} — the contract CI gates on. */
+public class EvalCommandTest {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    private static JsonNode json(String s) throws Exception {
+        return MAPPER.readTree(s);
+    }
+
+    @Test
+    public void allGreenExitsZero() throws Exception {
+        EvalCommand cmd = new EvalCommand();
+        JsonNode body = json("{\"hasFailures\":false,\"summary\":\"6/6\",\"results\":[],\"skipped\":[]}");
+        assertEquals(Integer.valueOf(0), cmd.report(body));
+    }
+
+    @Test
+    public void regressionExitsOne() throws Exception {
+        EvalCommand cmd = new EvalCommand();
+        JsonNode body = json(
+                "{\"hasFailures\":true,\"summary\":\"5/6\",\"results\":[{\"suiteName\":\"s\",\"passed\":5,\"total\":6}],\"skipped\":[]}");
+        assertEquals(Integer.valueOf(1), cmd.report(body));
+    }
+
+    @Test
+    public void skippedSuiteCountsAsFailure() throws Exception {
+        EvalCommand cmd = new EvalCommand();
+        JsonNode body = json(
+                "{\"hasFailures\":true,\"summary\":\"0 run, 1 skipped\",\"results\":[],\"skipped\":[{\"suiteName\":\"bad\",\"reason\":\"MISSING_FIELD\"}]}");
+        assertEquals(Integer.valueOf(1), cmd.report(body));
+    }
+
+    @Test
+    public void reportOnlyModeExitsZeroDespiteRegression() throws Exception {
+        EvalCommand cmd = new EvalCommand();
+        cmd.noFailOnRegression = true;
+        JsonNode body = json("{\"hasFailures\":true,\"summary\":\"5/6\",\"results\":[],\"skipped\":[]}");
+        assertEquals(Integer.valueOf(0), cmd.report(body));
+    }
+}

--- a/saiku-webapp/src/main/webapp/WEB-INF/saiku-beans.xml
+++ b/saiku-webapp/src/main/webapp/WEB-INF/saiku-beans.xml
@@ -375,8 +375,17 @@
         <constructor-arg value="${saiku.home:./saiku-home}"/>
     </bean>
 
-    <bean id="aiEvalResource" class="org.saiku.web.rest.resources.AiEvalResource">
+    <!-- Request-scoped (like aiQueryResource) so POST /run can resolve the session-scoped
+         thinQueryBean and execute the eval sweep under the admin's data scope. The GET reads
+         just use the singleton store. The out-of-process `saiku eval` CLI (saiku#1478) POSTs
+         to /run and gates CI on the returned tallies. -->
+    <bean id="aiEvalResource" scope="request" class="org.saiku.web.rest.resources.AiEvalResource">
+        <aop:scoped-proxy/>
         <property name="store" ref="evalResultStoreBean"/>
+        <property name="askService" ref="aiAskServiceBean"/>
+        <property name="cubeMetadataService" ref="aiCubeMetadataServiceBean"/>
+        <property name="thinQueryService" ref="thinQueryBean"/>
+        <property name="evalsDir" value="${saiku.home:./saiku-home}/evals"/>
     </bean>
 
     <!-- ====================================================================


### PR DESCRIPTION
Closes #1478. Makes it possible to **populate the eval accuracy store** on demand — the piece that was blocked by the session-scope wall (#1477).

## The problem it solves
The eval sweep executes MDX through the **session-scoped** `thinQueryService`. A background cron thread has no HTTP session, so it can't run the live adapter (that's why #1477's in-server cron was blocked). The out-of-process design sidesteps it: run the sweep **inside a real request**, where the session-scoped bean resolves under the caller's data scope — exactly how `aiQueryResource` already executes queries.

## What ships
- **`POST /rest/saiku/admin/ai-evals/run`** (`AiEvalResource`) — request-scoped (mirrors `aiQueryResource`), builds a `LiveEvalAskAdapter` from the wired ask/metadata/query beans, runs `ScheduledEvalRunner.runAll()` **synchronously in-request**, persists each scored run to the H2 store (surfaced by the admin **Agent evals** dashboard), and returns the tallies + a `hasFailures` flag.
- **`saiku eval` CLI** (launcher subcommand) — an HTTP-Basic client (CSRF-exempt) that POSTs to a running server's `/run`, prints the report, and sets its **exit code**: `0` green · `1` regression · `2` unreachable/auth. Flags: `--server`, `--username`, `--password`, `--no-fail-on-regression`, `--timeout-minutes`. **+4 exit-code tests**.
- The same endpoint can be `curl`ed from any external scheduler — the sanctioned cadence trigger, no in-server cron needed.

```bash
java -jar saiku-<version>.jar eval --server https://saiku.example.com --username admin --password ****
```

## Verification
- Unit: CLI exit-code contract (green / regression / skipped / report-only) — 4 green. Compiles across web + launcher.
- Structural: the run endpoint mirrors `aiQueryResource`'s request-scope + session-scoped `thinQueryService` proxy (resolved at call time, synchronously in the request thread) — the proven query-execution pattern.
- End-to-end (real MDX execution + populated dashboard) verified on demo.saiku.bi after deploy.

Roadmap: Phase 1 (reference-query) ✅ · Phase 2 store+scheduler ✅ · Phase 3 dashboard ✅ · **run trigger/CLI ✅ (this)**. #1477 (auto-cron) can now just curl this on a schedule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)