### PR TITLE
feat(embed): row-level security on saved-query + reference tiles (closes #1104)

### DIFF
--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ai/AiSavedQueryRequest.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ai/AiSavedQueryRequest.java
@@ -20,6 +20,7 @@ public class AiSavedQueryRequest {
 
     private String path;
     private List<AiFilterSelection> filters = new ArrayList<>();
+    private List<AiFilterSelection> forcedFilters = new ArrayList<>();
 
     public AiSavedQueryRequest() {}
 
@@ -37,5 +38,19 @@ public class AiSavedQueryRequest {
 
     public void setFilters(List<AiFilterSelection> filters) {
         this.filters = filters == null ? new ArrayList<>() : filters;
+    }
+
+    /**
+     * Forced RLS filters (saiku#1104). Unlike {@link #getFilters()} (best-effort dashboard chips),
+     * these MUST be applied to the loaded query or the request fails closed — they carry the
+     * row-level-security restriction from the embed token's JWT claims, so silently dropping one
+     * would serve unfiltered rows. Set only by the embed surface; empty for normal saved-query runs.
+     */
+    public List<AiFilterSelection> getForcedFilters() {
+        return forcedFilters;
+    }
+
+    public void setForcedFilters(List<AiFilterSelection> forcedFilters) {
+        this.forcedFilters = forcedFilters == null ? new ArrayList<>() : forcedFilters;
     }
 }

--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ai/ThinQueryFilterMerge.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ai/ThinQueryFilterMerge.java
@@ -55,34 +55,56 @@ public final class ThinQueryFilterMerge {
     private ThinQueryFilterMerge() {}
 
     /**
-     * Apply the supplied dashboard filters to {@code tq} in-place. Safe
-     * to call with null/empty {@code filters} (no-op).
+     * Apply the supplied dashboard filters to {@code tq} in-place. Best-effort: filters that don't
+     * resolve (MDX-mode query, unknown dim/hier/level, empty members) are dropped silently — correct
+     * for optional dashboard chips. Safe to call with null/empty {@code filters} (no-op).
      */
     public static void apply(ThinQuery tq, List<AiFilterSelection> filters, AiSchema schema) {
-        if (tq == null || filters == null || filters.isEmpty() || schema == null) return;
-        if (tq.getType() == ThinQuery.Type.MDX) return;
-        ThinQueryModel model = tq.getQueryModel();
-        if (model == null) return;
+        // Best-effort callers don't care which filters were dropped.
+        applyReportingUnapplied(tq, filters, schema);
+    }
 
+    /**
+     * Strict variant for <em>forced RLS filters</em> (saiku#1104): apply what can be applied and
+     * return the sublist that could NOT be — an MDX-mode query (can't splice a WHERE into hand-written
+     * MDX), a dim/hier/level that doesn't resolve in the cube, or empty members. The caller MUST
+     * <strong>fail closed</strong> when the returned list is non-empty: a forced RLS filter that
+     * didn't apply means the query would run <em>unfiltered</em>, which is exactly the leak RLS
+     * exists to prevent. Behaviour-identical to {@link #apply} for the filters that DO apply.
+     *
+     * @return the filters that were not applied (empty when all applied); never null
+     */
+    public static List<AiFilterSelection> applyReportingUnapplied(
+            ThinQuery tq, List<AiFilterSelection> filters, AiSchema schema) {
+        List<AiFilterSelection> unapplied = new ArrayList<>();
+        if (filters == null || filters.isEmpty()) return unapplied;
+        // MDX-mode or model-less queries can't take a spliced slicer at all — every filter is unapplied.
+        ThinQueryModel model = (tq == null || tq.getType() == ThinQuery.Type.MDX) ? null : tq.getQueryModel();
         for (AiFilterSelection f : filters) {
             if (f == null) continue;
-            if (f.getMembers() == null || f.getMembers().isEmpty()) continue;
-            AiSchema.Hierarchy resolvedHier = resolveHierarchy(schema, f.getDimension(), f.getHierarchy());
-            if (resolvedHier == null) continue;
-            AiSchema.Level resolvedLevel = resolveLevel(resolvedHier, f.getLevel());
-            if (resolvedLevel == null) continue;
-
-            // Try to find the hierarchy on any existing axis and rewrite
-            // its selection in place. The dashboard filter overrides
-            // whatever INCLUSION/EXCLUSION the saved query had.
-            if (rewriteExistingAxisSelection(model, resolvedHier, resolvedLevel, f.getMembers())) {
-                continue;
+            if (schema == null || model == null || !applyOne(model, f, schema)) {
+                unapplied.add(f);
             }
-
-            // Not on any axis — add to FILTER (slicer).
-            ThinAxis filterAxis = ensureFilterAxis(model);
-            replaceOrAppendHierarchy(filterAxis, resolvedHier, resolvedLevel, f.getMembers());
         }
+        return unapplied;
+    }
+
+    /** Apply one filter to the model. Returns true iff it resolved and was spliced onto an axis / the slicer. */
+    private static boolean applyOne(ThinQueryModel model, AiFilterSelection f, AiSchema schema) {
+        if (f.getMembers() == null || f.getMembers().isEmpty()) return false;
+        AiSchema.Hierarchy resolvedHier = resolveHierarchy(schema, f.getDimension(), f.getHierarchy());
+        if (resolvedHier == null) return false;
+        AiSchema.Level resolvedLevel = resolveLevel(resolvedHier, f.getLevel());
+        if (resolvedLevel == null) return false;
+
+        // Try to find the hierarchy on any existing axis and rewrite its selection in place; else
+        // add to the FILTER (slicer) axis.
+        if (rewriteExistingAxisSelection(model, resolvedHier, resolvedLevel, f.getMembers())) {
+            return true;
+        }
+        ThinAxis filterAxis = ensureFilterAxis(model);
+        replaceOrAppendHierarchy(filterAxis, resolvedHier, resolvedLevel, f.getMembers());
+        return true;
     }
 
     /* ---------------------------- resolution ---------------------------- */

--- a/saiku-core/saiku-service/src/test/java/org/saiku/service/olap/ai/ThinQueryFilterMergeTest.java
+++ b/saiku-core/saiku-service/src/test/java/org/saiku/service/olap/ai/ThinQueryFilterMergeTest.java
@@ -177,6 +177,26 @@ public class ThinQueryFilterMergeTest {
     }
 
     @Test
+    public void strict_forcedFilterWinsOverAClientFilterOnSameDim() {
+        // Client filter puts Time.Year = 1997 on the slicer; forced RLS then applies Time.Year = 1998.
+        // Forced applies LAST via the same in-place rewrite, so RLS must OVERRIDE the client members —
+        // a client filter must not be able to loosen the row-level restriction.
+        ThinQuery tq = querymodel();
+        ThinQueryFilterMerge.apply(
+                tq, Collections.singletonList(filter("Time", "Time", "Year", "[Time].[Time].[Year].&[1997]")), schema);
+        List<AiFilterSelection> unapplied = ThinQueryFilterMerge.applyReportingUnapplied(
+                tq, Collections.singletonList(filter("Time", "Time", "Year", "[Time].[Time].[Year].&[1998]")), schema);
+        assertTrue(unapplied.isEmpty());
+        ThinAxis fa = tq.getQueryModel().getAxis(AxisLocation.FILTER);
+        ThinLevel lvl = fa.getHierarchies().get(0).getLevels().get("Year");
+        assertEquals(1, lvl.getSelection().getMembers().size());
+        assertEquals(
+                "RLS member must win over the client filter",
+                "[Time].[Time].[Year].&[1998]",
+                lvl.getSelection().getMembers().get(0).getUniqueName());
+    }
+
+    @Test
     public void newHierarchyLandsOnFilterAxis() {
         ThinQuery tq = querymodel();
         ThinQueryFilterMerge.apply(

--- a/saiku-core/saiku-service/src/test/java/org/saiku/service/olap/ai/ThinQueryFilterMergeTest.java
+++ b/saiku-core/saiku-service/src/test/java/org/saiku/service/olap/ai/ThinQueryFilterMergeTest.java
@@ -118,6 +118,64 @@ public class ThinQueryFilterMergeTest {
         assertNull(tq.getQueryModel());
     }
 
+    /* ---- saiku#1104: strict variant for forced RLS filters (applyReportingUnapplied) ---- */
+
+    @Test
+    public void strict_resolvableFilterAppliesWithNothingUnapplied() {
+        ThinQuery tq = querymodel();
+        List<AiFilterSelection> unapplied = ThinQueryFilterMerge.applyReportingUnapplied(
+                tq, Collections.singletonList(filter("Time", "Time", "Year", "[Time].[Time].[Year].&[1997]")), schema);
+        assertTrue("a resolvable forced filter must apply cleanly", unapplied.isEmpty());
+        assertNotNull("and be spliced onto the FILTER axis", tq.getQueryModel().getAxis(AxisLocation.FILTER));
+    }
+
+    @Test
+    public void strict_mdxModeReportsAllUnapplied() {
+        // MDX-mode saved query can't take a spliced slicer — every forced filter is unapplied, so the
+        // caller MUST fail closed (this is the RLS leak we refuse).
+        ThinQuery tq = new ThinQuery("test", null, "SELECT [Measures].[Unit Sales] ON 0 FROM [Sales]");
+        List<AiFilterSelection> forced =
+                Collections.singletonList(filter("Time", "Time", "Year", "[Time].[Time].[Year].&[1997]"));
+        List<AiFilterSelection> unapplied = ThinQueryFilterMerge.applyReportingUnapplied(tq, forced, schema);
+        assertEquals(1, unapplied.size());
+    }
+
+    @Test
+    public void strict_unknownDimensionIsReportedUnapplied() {
+        ThinQuery tq = querymodel();
+        List<AiFilterSelection> unapplied = ThinQueryFilterMerge.applyReportingUnapplied(
+                tq, Collections.singletonList(filter("Made Up", "Made Up", "Year", "[Made Up].[2026]")), schema);
+        assertEquals("an unresolvable forced filter must be reported, not silently dropped", 1, unapplied.size());
+    }
+
+    @Test
+    public void strict_emptyMembersIsReportedUnapplied() {
+        ThinQuery tq = querymodel();
+        List<AiFilterSelection> unapplied = ThinQueryFilterMerge.applyReportingUnapplied(
+                tq, Collections.singletonList(filter("Time", "Time", "Year")), schema);
+        assertEquals(1, unapplied.size());
+    }
+
+    @Test
+    public void strict_nullSchemaFailsClosedForAll() {
+        ThinQuery tq = querymodel();
+        List<AiFilterSelection> forced =
+                Collections.singletonList(filter("Time", "Time", "Year", "[Time].[Time].[Year].&[1997]"));
+        List<AiFilterSelection> unapplied = ThinQueryFilterMerge.applyReportingUnapplied(tq, forced, null);
+        assertEquals("no schema means nothing can be verified-applied — fail closed", 1, unapplied.size());
+    }
+
+    @Test
+    public void strict_mixedReportsOnlyTheUnappliedOne() {
+        ThinQuery tq = querymodel();
+        List<AiFilterSelection> forced = Arrays.asList(
+                filter("Time", "Time", "Year", "[Time].[Time].[Year].&[1997]"), // resolves
+                filter("Made Up", "Made Up", "Year", "[Made Up].[x]")); // does not
+        List<AiFilterSelection> unapplied = ThinQueryFilterMerge.applyReportingUnapplied(tq, forced, schema);
+        assertEquals(1, unapplied.size());
+        assertEquals("Made Up", unapplied.get(0).getDimension());
+    }
+
     @Test
     public void newHierarchyLandsOnFilterAxis() {
         ThinQuery tq = querymodel();

--- a/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/AiQueryResource.java
+++ b/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/AiQueryResource.java
@@ -327,10 +327,34 @@ public class AiQueryResource {
             tq.setName(java.util.UUID.randomUUID().toString());
         }
 
-        // saiku#1104 — forced RLS filters MUST apply or the request fails closed. Unlike the
-        // best-effort dashboard merge below, a forced filter that can't be spliced (MDX-mode saved
-        // query, unresolvable dimension, schema lookup failure) means the query would run UNFILTERED
-        // — the exact row-level-security bypass we refuse. Only the embed surface sets these.
+        // Merge best-effort dashboard runtime filters FIRST. Skipped silently when the request
+        // carries no filters (the historical path), when the query is MDX-mode (can't splice
+        // safely), or when the cube schema can't be loaded. See ThinQueryFilterMerge for the
+        // precedence + axis-rewrite rules.
+        if (body.getFilters() != null
+                && !body.getFilters().isEmpty()
+                && tq.getType() == ThinQuery.Type.QUERYMODEL
+                && tq.getCube() != null
+                && cubeMetadataService != null) {
+            try {
+                org.saiku.olap.dto.SaikuCube cube = tq.getCube();
+                AiCubeRef ref =
+                        new AiCubeRef(cube.getConnection(), cube.getCatalog(), cube.getSchema(), cube.getName());
+                AiSchema schema = cubeMetadataService.getSchema(ref);
+                org.saiku.service.olap.ai.ThinQueryFilterMerge.apply(tq, body.getFilters(), schema);
+            } catch (RuntimeException ve) {
+                // Schema lookup failures shouldn't poison the saved-query
+                // execution path — fall through with the un-merged query
+                // and let it run as-authored.
+                log.warn("Dashboard filter merge skipped for saved query {}: {}", path, ve.getMessage());
+            }
+        }
+
+        // saiku#1104 — forced RLS filters apply LAST (after any client/dashboard filters) so they
+        // always win: a client filter on the same dimension can't loosen the row-level restriction.
+        // They MUST apply or the request fails closed — a forced filter that can't be spliced
+        // (MDX-mode query, unresolvable dimension, schema lookup failure) means the query would run
+        // UNFILTERED, the exact RLS bypass we refuse. Only the embed surface sets these.
         if (body.getForcedFilters() != null && !body.getForcedFilters().isEmpty()) {
             AiSchema forcedSchema = null;
             if (tq.getCube() != null && cubeMetadataService != null) {
@@ -358,30 +382,6 @@ public class AiQueryResource {
                                 "Row-level security filters could not be applied to this saved query."))
                         .type(MediaType.APPLICATION_JSON)
                         .build();
-            }
-        }
-
-        // Merge dashboard runtime filters onto the loaded ThinQuery before
-        // execution. Skipped silently when the request carries no filters
-        // (the historical path), when the query is MDX-mode (can't splice
-        // safely), or when the cube schema can't be loaded. See
-        // ThinQueryFilterMerge for the precedence + axis-rewrite rules.
-        if (body.getFilters() != null
-                && !body.getFilters().isEmpty()
-                && tq.getType() == ThinQuery.Type.QUERYMODEL
-                && tq.getCube() != null
-                && cubeMetadataService != null) {
-            try {
-                org.saiku.olap.dto.SaikuCube cube = tq.getCube();
-                AiCubeRef ref =
-                        new AiCubeRef(cube.getConnection(), cube.getCatalog(), cube.getSchema(), cube.getName());
-                AiSchema schema = cubeMetadataService.getSchema(ref);
-                org.saiku.service.olap.ai.ThinQueryFilterMerge.apply(tq, body.getFilters(), schema);
-            } catch (RuntimeException ve) {
-                // Schema lookup failures shouldn't poison the saved-query
-                // execution path — fall through with the un-merged query
-                // and let it run as-authored.
-                log.warn("Dashboard filter merge skipped for saved query {}: {}", path, ve.getMessage());
             }
         }
 

--- a/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/AiQueryResource.java
+++ b/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/AiQueryResource.java
@@ -327,6 +327,40 @@ public class AiQueryResource {
             tq.setName(java.util.UUID.randomUUID().toString());
         }
 
+        // saiku#1104 — forced RLS filters MUST apply or the request fails closed. Unlike the
+        // best-effort dashboard merge below, a forced filter that can't be spliced (MDX-mode saved
+        // query, unresolvable dimension, schema lookup failure) means the query would run UNFILTERED
+        // — the exact row-level-security bypass we refuse. Only the embed surface sets these.
+        if (body.getForcedFilters() != null && !body.getForcedFilters().isEmpty()) {
+            AiSchema forcedSchema = null;
+            if (tq.getCube() != null && cubeMetadataService != null) {
+                try {
+                    org.saiku.olap.dto.SaikuCube cube = tq.getCube();
+                    forcedSchema = cubeMetadataService.getSchema(
+                            new AiCubeRef(cube.getConnection(), cube.getCatalog(), cube.getSchema(), cube.getName()));
+                } catch (RuntimeException e) {
+                    log.warn("saved-query {} forced-filter schema lookup failed — failing closed", path, e);
+                }
+            }
+            java.util.List<org.saiku.service.olap.ai.AiFilterSelection> unapplied =
+                    org.saiku.service.olap.ai.ThinQueryFilterMerge.applyReportingUnapplied(
+                            tq, body.getForcedFilters(), forcedSchema);
+            if (!unapplied.isEmpty()) {
+                log.warn(
+                        "saved-query {} refused: {} forced RLS filter(s) could not be applied (fail-closed)",
+                        path,
+                        unapplied.size());
+                return Response.status(Response.Status.FORBIDDEN)
+                        .entity(java.util.Map.of(
+                                "status",
+                                "RLS_UNAPPLIED",
+                                "error",
+                                "Row-level security filters could not be applied to this saved query."))
+                        .type(MediaType.APPLICATION_JSON)
+                        .build();
+            }
+        }
+
         // Merge dashboard runtime filters onto the loaded ThinQuery before
         // execution. Skipped silently when the request carries no filters
         // (the historical path), when the query is MDX-mode (can't splice

--- a/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/embed/EmbedViewResource.java
+++ b/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/embed/EmbedViewResource.java
@@ -124,9 +124,14 @@ public class EmbedViewResource {
         if (g.resourcePath == null || !g.resourcePath.endsWith(".saiku")) {
             return invalid();
         }
-        // saiku#1104: a saved query can't have RLS forced-filters injected in
-        // Phase 1 — fail closed rather than serve unfiltered rows.
-        if (g.forcedFiltersJson != null) {
+        // saiku#1104: forced RLS filters from the token's JWT claims. They ride the saved query's
+        // forcedFilters channel and executeSaved fails closed (RLS_UNAPPLIED 403) if any can't be
+        // spliced — so a QUERYMODEL saved query now runs WITH the RLS restriction instead of being
+        // refused outright, while an MDX-mode / unresolvable case still denies rather than leaks.
+        final java.util.List<AiFilterSelection> forced;
+        try {
+            forced = parseForcedFilters(g);
+        } catch (RuntimeException e) {
             audit(g, "/saiku/api/embed/query", AiAuditEntry.OUTCOME_DENIED);
             return forcedFilterUnsupported();
         }
@@ -142,9 +147,12 @@ public class EmbedViewResource {
                 if (!overrides.isEmpty()) {
                     sreq.setFilters(overrides);
                 }
+                if (!forced.isEmpty()) {
+                    sreq.setForcedFilters(forced);
+                }
                 return aiQueryResource.executeSaved(sreq, format);
             });
-            audit(g, "/saiku/api/embed/query", AiAuditEntry.OUTCOME_SUCCESS);
+            audit(g, "/saiku/api/embed/query", outcomeFor(result.getStatus()));
             return withPolicyHeader(harden(result), g);
         } catch (RuntimeException e) {
             log.warn("embed-view query execution failed for {}", g.resourcePath, e);
@@ -234,17 +242,19 @@ public class EmbedViewResource {
                     mergeFilterOverrides(q.body, filterOverrides);
                     return aiQueryResource.executeAi(q.body, "records");
                 } else if ("reference".equals(q.kind) && q.path != null) {
-                    if (g.forcedFiltersJson != null) {
-                        // Can't force-filter a saved/reference tile in Phase 1 —
-                        // fail closed rather than serve unfiltered rows.
-                        return forcedFilterUnsupported();
-                    }
                     AiSavedQueryRequest sreq = new AiSavedQueryRequest();
                     sreq.setPath(q.path);
                     // Filter-tile overrides ride the AiSavedQueryRequest.filters channel — the
                     // AI query resource merges these via ThinQueryFilterMerge before execute.
                     if (!filterOverrides.isEmpty()) {
                         sreq.setFilters(filterOverrides);
+                    }
+                    // saiku#1104: forced RLS filters ride the forcedFilters channel — executeSaved
+                    // applies them or fails closed (RLS_UNAPPLIED 403), so a QUERYMODEL reference
+                    // tile now runs WITH the restriction instead of being refused outright.
+                    java.util.List<AiFilterSelection> forcedTile = parseForcedFilters(g);
+                    if (!forcedTile.isEmpty()) {
+                        sreq.setForcedFilters(forcedTile);
                     }
                     // Dashboard tiles always render as records — tile renderers consume caption-keyed rows.
                     return aiQueryResource.executeSaved(sreq, "records");
@@ -515,12 +525,24 @@ public class EmbedViewResource {
      * unfiltered query — a parse failure throws, and the caller fails closed.
      */
     private void injectForcedFilters(AiQueryRequest body, EmbedGuestDetails g) {
-        if (g.forcedFiltersJson == null || body == null) {
+        if (body == null) {
             return;
+        }
+        body.getFilters().addAll(parseForcedFilters(g));
+    }
+
+    /**
+     * Parse the token's forced RLS filter claim (saiku#1104) into typed filters. A malformed claim
+     * throws so every caller fails closed — a broken RLS claim must never degrade to an unfiltered
+     * query. Returns an empty list when the token carries no forced filters.
+     */
+    private java.util.List<AiFilterSelection> parseForcedFilters(EmbedGuestDetails g) {
+        if (g == null || g.forcedFiltersJson == null) {
+            return java.util.Collections.emptyList();
         }
         try {
             AiFilterSelection[] forced = MAPPER.readValue(g.forcedFiltersJson, AiFilterSelection[].class);
-            body.getFilters().addAll(Arrays.asList(forced));
+            return Arrays.asList(forced);
         } catch (Exception e) {
             throw new IllegalStateException("invalid embed forced-filters claim", e);
         }

--- a/saiku-core/saiku-web/src/test/java/org/saiku/web/rest/resources/embed/EmbedViewResourceTest.java
+++ b/saiku-core/saiku-web/src/test/java/org/saiku/web/rest/resources/embed/EmbedViewResourceTest.java
@@ -223,28 +223,62 @@ public class EmbedViewResourceTest {
     }
 
     @Test
-    public void saved_query_with_forced_filters_is_fail_closed() {
-        // A forced-filter token can't be applied to an opaque saved query in v1.
-        // It MUST be refused, never served unfiltered (cross-tenant leak).
+    public void saved_query_forwards_forced_filters_to_executeSaved() {
+        // saiku#1104: forced RLS filters now RIDE the saved query's forcedFilters channel — where
+        // executeSaved applies them or fails closed. The embed no longer blanket-refuses; it forwards
+        // the JWT claim so a QUERYMODEL saved query runs WITH the restriction.
         pinGuestJwt(
                 "query",
                 "/homes/admin/sales.saiku",
                 "admin",
                 List.of(),
                 "u_1",
-                "[{\"dimension\":\"Customer\",\"op\":\"in\",\"members\":[\"[Customer].[acme]\"]}]");
+                "[{\"dimension\":\"Customer\",\"level\":\"Customer\",\"members\":[\"[Customer].[acme]\"]}]");
+
+        Response r = resource.query("homes/admin/sales.saiku", null);
+
+        assertEquals(200, r.getStatus());
+        assertNotNull("executeSaved must be invoked with the forced filters", ai.lastSavedRequest);
+        assertEquals(
+                "the JWT forced filter must be forwarded on the forcedFilters channel",
+                1,
+                ai.lastSavedRequest.getForcedFilters().size());
+        assertEquals("Customer", ai.lastSavedRequest.getForcedFilters().get(0).getDimension());
+    }
+
+    @Test
+    public void saved_query_forced_filters_unappliable_passes_through_fail_closed() {
+        // When executeSaved can't apply the RLS filter (MDX-mode / unresolvable dim) it returns
+        // 403 RLS_UNAPPLIED; the embed surfaces that fail-closed status verbatim.
+        ai.savedResponseOverride = Response.status(403)
+                .entity(Map.of("status", "RLS_UNAPPLIED", "error", "x"))
+                .build();
+        pinGuestJwt(
+                "query",
+                "/homes/admin/sales.saiku",
+                "admin",
+                List.of(),
+                "u_1",
+                "[{\"dimension\":\"Customer\",\"level\":\"Customer\",\"members\":[\"[Customer].[acme]\"]}]");
 
         Response r = resource.query("homes/admin/sales.saiku", null);
 
         assertEquals(403, r.getStatus());
-        @SuppressWarnings("unchecked")
-        Map<String, Object> body = (Map<String, Object>) r.getEntity();
-        assertEquals("EMBED_RLS_UNSUPPORTED", body.get("status"));
-        assertNull("a fail-closed saved query must NOT execute", ai.lastSavedRequest);
     }
 
     @Test
-    public void reference_tile_with_forced_filters_is_fail_closed() {
+    public void saved_query_malformed_forced_filter_claim_fails_closed() {
+        // A forced-filter JWT claim that isn't valid filter JSON must fail closed, never execute.
+        pinGuestJwt("query", "/homes/admin/sales.saiku", "admin", List.of(), "u_1", "{not-an-array");
+
+        Response r = resource.query("homes/admin/sales.saiku", null);
+
+        assertEquals(403, r.getStatus());
+        assertNull("a malformed RLS claim must NOT execute", ai.lastSavedRequest);
+    }
+
+    @Test
+    public void reference_tile_forwards_forced_filters_to_executeSaved() {
         ds.fileContent = "{\"layout\":{\"tiles\":[{\"id\":\"t1\",\"query\":"
                 + "{\"kind\":\"reference\",\"path\":\"/homes/admin/q.saiku\"}}]}}";
         pinGuestJwt(
@@ -253,12 +287,13 @@ public class EmbedViewResourceTest {
                 "admin",
                 List.of(),
                 "u_1",
-                "[{\"dimension\":\"Customer\",\"op\":\"in\",\"members\":[\"[Customer].[acme]\"]}]");
+                "[{\"dimension\":\"Customer\",\"level\":\"Customer\",\"members\":[\"[Customer].[acme]\"]}]");
 
         Response r = resource.tileQuery("homes/admin/exec.saikudash", "t1", null);
 
-        assertEquals(403, r.getStatus());
-        assertNull("reference tile must NOT execute unfiltered", ai.lastSavedRequest);
+        assertEquals(200, r.getStatus());
+        assertNotNull("reference tile must forward forced filters to executeSaved", ai.lastSavedRequest);
+        assertEquals(1, ai.lastSavedRequest.getForcedFilters().size());
     }
 
     @Test
@@ -359,11 +394,16 @@ public class EmbedViewResourceTest {
         AiSavedQueryRequest lastSavedRequest;
         String lastSavedFormat;
         AiQueryRequest lastAiRequest;
+        // Override the saved-query response to simulate executeSaved's own RLS fail-closed (403).
+        Response savedResponseOverride;
 
         @Override
         public Response executeSaved(AiSavedQueryRequest body, String format) {
             lastSavedRequest = body;
             lastSavedFormat = format;
+            if (savedResponseOverride != null) {
+                return savedResponseOverride;
+            }
             return Response.ok(Map.of("status", "OK", "cells", List.of(), "format", format))
                     .type(jakarta.ws.rs.core.MediaType.APPLICATION_JSON)
                     .build();


### PR DESCRIPTION
Closes #1104. Forced RLS filters from an embed token's JWT claims now **apply** to saved queries and reference tiles instead of failing closed outright.

## The security problem
The inline-query path already injected forced RLS filters. The **saved-query / reference-tile** paths refused *everything* (`EMBED_RLS_UNSUPPORTED`) because the filter merge that would carry them (`ThinQueryFilterMerge.apply`) is **best-effort and silent** — it no-ops on MDX-mode queries and *drops* filters it can't resolve. Silently dropping a *forced RLS* filter would serve **unfiltered rows** — the exact leak RLS prevents. So fail-closed was the safe-but-blunt Phase-1 answer.

## The fix — a strict merge that can't leak
- **`ThinQueryFilterMerge.applyReportingUnapplied()`** — applies what it can and **returns the filters it couldn't** (MDX-mode query, unresolvable dim/hier/level, empty members, null schema). `apply()` now delegates to it, so best-effort dashboard behaviour is unchanged. **+6 security tests** (the guarantee point).
- **`AiSavedQueryRequest.forcedFilters`** — a separate channel from best-effort `filters`.
- **`executeSaved`** — applies `forcedFilters` strictly; if **any** is unapplied, returns **`403 RLS_UNAPPLIED`** (fail closed) *before* executing.
- **`EmbedViewResource`** — the saved-query + reference-tile paths parse the JWT forced-filter claim and set it on `forcedFilters` (shared `parseForcedFilters`; a malformed claim still fails closed); the 403 is audited as `DENIED`.

## Net behaviour
- **QUERYMODEL** saved query / reference tile + RLS token → runs **with** the restriction ✅
- **MDX-mode** or unresolvable dim → still **denies** (never leaks) ✅
- Inline path → unchanged (already injected).

The invariant — *a forced RLS filter is applied or the request fails closed* — is enforced at the merge layer and tested there (MDX → all unapplied, unknown dim → reported, null schema → fail closed, mixed → only the bad one reported).

🤖 Generated with [Claude Code](https://claude.com/claude-code)