### PR TITLE
feat(admin): Agent Spaces CRUD UI — author personas in the admin panel

### DIFF
--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ai/ask/AgentSpaceRegistry.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ai/ask/AgentSpaceRegistry.java
@@ -4,6 +4,10 @@
  */
 package org.saiku.service.olap.ai.ask;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -19,7 +23,9 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.regex.Pattern;
 import java.util.stream.Stream;
+import org.saiku.service.olap.ai.AiCubeRef;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -70,6 +76,79 @@ public final class AgentSpaceRegistry {
     /** Force a rescan (bypasses the signature check). */
     public void forceRefresh() {
         snapshot.set(scan());
+    }
+
+    /* ----------------------------- write (admin CRUD, saiku#1440) ----------------------------- */
+
+    private static final ObjectMapper WRITE_MAPPER = new ObjectMapper().enable(SerializationFeature.INDENT_OUTPUT);
+    // Space ids double as filenames — restrict to kebab-case so a hostile id can't traverse out of
+    // the agent-spaces directory or collide with a dotfile.
+    private static final Pattern SAFE_ID = Pattern.compile("[a-z0-9][a-z0-9-]*");
+
+    /** True when {@code id} is a safe filename stem (kebab-case). */
+    public static boolean isValidId(String id) {
+        return id != null && SAFE_ID.matcher(id).matches();
+    }
+
+    /**
+     * Persist {@code space} as {@code {root}/{id}.json} and rescan so the change is live immediately.
+     * The id must be kebab-safe; the resolved path is re-checked to stay inside the root (defence in
+     * depth against traversal).
+     */
+    public void save(AgentSpace space) throws IOException {
+        Objects.requireNonNull(space, "space");
+        if (!isValidId(space.id())) {
+            throw new IllegalArgumentException("space id must match [a-z0-9-] (got: " + space.id() + ")");
+        }
+        Files.createDirectories(root);
+        Path file = root.resolve(space.id() + ".json").normalize();
+        if (!file.startsWith(root.normalize())) {
+            throw new IllegalArgumentException("space id escapes the agent-spaces directory");
+        }
+        Files.writeString(file, WRITE_MAPPER.writeValueAsString(toJson(space)), StandardCharsets.UTF_8);
+        forceRefresh();
+    }
+
+    /** Delete {@code {root}/{id}.json} and rescan. Returns true if a file was removed. */
+    public boolean delete(String id) throws IOException {
+        if (!isValidId(id)) {
+            return false;
+        }
+        Path file = root.resolve(id + ".json").normalize();
+        if (!file.startsWith(root.normalize())) {
+            return false;
+        }
+        boolean removed = Files.deleteIfExists(file);
+        if (removed) {
+            forceRefresh();
+        }
+        return removed;
+    }
+
+    /** Serialise a space to the on-disk JSON shape {@link AgentSpaceParser} reads (sourcePath omitted). */
+    private static ObjectNode toJson(AgentSpace space) {
+        ObjectNode node = WRITE_MAPPER.createObjectNode();
+        node.put("id", space.id());
+        node.put("name", space.name());
+        if (space.description() != null) {
+            node.put("description", space.description());
+        }
+        if (space.systemPrompt() != null) {
+            node.put("systemPrompt", space.systemPrompt());
+        }
+        ArrayNode cubes = node.putArray("cubeAllowlist");
+        for (AiCubeRef c : space.cubeAllowlist()) {
+            ObjectNode cn = cubes.addObject();
+            cn.put("connectionName", c.getConnectionName());
+            cn.put("catalog", c.getCatalog());
+            cn.put("schema", c.getSchema());
+            cn.put("cubeName", c.getCubeName());
+        }
+        ArrayNode skills = node.putArray("skillAllowlist");
+        space.skillAllowlist().forEach(skills::add);
+        ArrayNode prompts = node.putArray("suggestedPrompts");
+        space.suggestedPrompts().forEach(prompts::add);
+        return node;
     }
 
     private Snapshot refresh() {

--- a/saiku-core/saiku-service/src/test/java/org/saiku/service/olap/ai/ask/AgentSpaceRegistryTest.java
+++ b/saiku-core/saiku-service/src/test/java/org/saiku/service/olap/ai/ask/AgentSpaceRegistryTest.java
@@ -104,6 +104,70 @@ public class AgentSpaceRegistryTest {
         assertTrue(reg.list().isEmpty());
     }
 
+    /* ---- saiku#1440: admin CRUD (save / delete / id validation) ---- */
+
+    @Test
+    public void saveWritesFileAndRoundTrips() throws Exception {
+        Path root = tmp.newFolder("spaces").toPath();
+        AgentSpaceRegistry reg = new AgentSpaceRegistry(root);
+        AgentSpace s = new AgentSpace(
+                "my-space",
+                "My Space",
+                "desc",
+                "You are a test persona.",
+                List.of(new org.saiku.service.olap.ai.AiCubeRef("c", "cat", "sch", "Cube")),
+                List.of("skill-a"),
+                List.of("try this"),
+                "my-space.json");
+        reg.save(s);
+
+        assertTrue(Files.exists(root.resolve("my-space.json")));
+        List<AgentSpace> spaces = reg.list();
+        assertEquals(1, spaces.size());
+        AgentSpace back = spaces.get(0);
+        assertEquals("My Space", back.name());
+        assertEquals("You are a test persona.", back.systemPrompt());
+        assertEquals(1, back.cubeAllowlist().size());
+        assertEquals("Cube", back.cubeAllowlist().get(0).getCubeName());
+        assertEquals(List.of("skill-a"), back.skillAllowlist());
+        assertEquals(List.of("try this"), back.suggestedPrompts());
+    }
+
+    @Test
+    public void deleteRemovesFileAndRescans() throws Exception {
+        Path root = tmp.newFolder("spaces").toPath();
+        write(root.resolve("gone.json"), String.format(GOLDEN, "gone", "Gone"));
+        AgentSpaceRegistry reg = new AgentSpaceRegistry(root);
+        assertEquals(1, reg.list().size());
+        assertTrue(reg.delete("gone"));
+        assertFalse(Files.exists(root.resolve("gone.json")));
+        assertTrue(reg.list().isEmpty());
+        assertFalse("deleting a missing space returns false", reg.delete("gone"));
+    }
+
+    @Test
+    public void saveRejectsUnsafeId() throws Exception {
+        Path root = tmp.newFolder("spaces").toPath();
+        AgentSpaceRegistry reg = new AgentSpaceRegistry(root);
+        AgentSpace evil = new AgentSpace("../evil", "x", null, null, List.of(), List.of(), List.of(), "x.json");
+        try {
+            reg.save(evil);
+            org.junit.Assert.fail("a traversal id must be rejected, not written");
+        } catch (IllegalArgumentException expected) {
+            // ok
+        }
+    }
+
+    @Test
+    public void idValidationIsKebabOnly() {
+        assertTrue(AgentSpaceRegistry.isValidId("foodmart-sales-analyst"));
+        assertFalse(AgentSpaceRegistry.isValidId("../x"));
+        assertFalse(AgentSpaceRegistry.isValidId("Foo Bar"));
+        assertFalse(AgentSpaceRegistry.isValidId("a/b"));
+        assertFalse(AgentSpaceRegistry.isValidId(""));
+        assertFalse(AgentSpaceRegistry.isValidId(null));
+    }
+
     private static void write(Path p, String content) throws Exception {
         Files.writeString(p, content, StandardCharsets.UTF_8);
     }

--- a/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/AgentSpaceAdminResource.java
+++ b/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/AgentSpaceAdminResource.java
@@ -1,0 +1,182 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.web.rest.resources;
+
+import jakarta.annotation.security.RolesAllowed;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.DELETE;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.PUT;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import org.saiku.service.olap.ai.AiCubeRef;
+import org.saiku.service.olap.ai.ask.AgentSpace;
+import org.saiku.service.olap.ai.ask.AgentSpaceRegistry;
+
+/**
+ * saiku#1440 — admin CRUD over Agent Spaces (personas), so they can be authored in the admin panel
+ * instead of by hand-editing JSON under {@code saiku-home/agent-spaces/}. Reads/writes through the
+ * {@link AgentSpaceRegistry} (which rescans on write, so changes go live immediately).
+ *
+ * <p>Path is {@code /saiku/admin/agent-spaces} — admin-gated (@RolesAllowed + the
+ * {@code /rest/saiku/admin/**} intercept), same posture as the other admin resources. Unlike the
+ * public {@code /ai/spaces} catalogue (which omits the system prompt + cube allowlist so an embed
+ * can't read routing decisions), this admin surface returns the FULL space for editing.
+ */
+@Path("/saiku/admin/agent-spaces")
+@RolesAllowed("ROLE_ADMIN")
+public class AgentSpaceAdminResource {
+
+    private AgentSpaceRegistry registry;
+
+    public void setRegistry(AgentSpaceRegistry registry) {
+        this.registry = registry;
+    }
+
+    /** Full spaces for the admin editor. */
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    public List<SpaceDto> list() {
+        List<SpaceDto> out = new ArrayList<>();
+        for (AgentSpace s : registry.list()) {
+            out.add(toDto(s));
+        }
+        return out;
+    }
+
+    /** Parse errors (malformed JSON files) so the UI can flag them. */
+    @GET
+    @Path("/errors")
+    @Produces(MediaType.APPLICATION_JSON)
+    public List<Map<String, String>> errors() {
+        List<Map<String, String>> out = new ArrayList<>();
+        for (AgentSpaceRegistry.SpaceError e : registry.errors()) {
+            out.add(Map.of("source", e.path(), "code", e.code(), "message", e.message()));
+        }
+        return out;
+    }
+
+    /** Create or replace a space. The path id is authoritative (the body id is ignored). */
+    @PUT
+    @Path("/{id}")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response save(@PathParam("id") String id, SpaceDto body) {
+        if (!AgentSpaceRegistry.isValidId(id)) {
+            return bad("id must be kebab-case ([a-z0-9-])");
+        }
+        if (body == null || body.name == null || body.name.isBlank()) {
+            return bad("name is required");
+        }
+        List<AiCubeRef> cubes = new ArrayList<>();
+        if (body.cubeAllowlist != null) {
+            for (CubeRefDto c : body.cubeAllowlist) {
+                if (c == null || blank(c.connectionName) || blank(c.catalog) || blank(c.schema) || blank(c.cubeName)) {
+                    return bad("each cubeAllowlist entry needs connectionName, catalog, schema and cubeName");
+                }
+                cubes.add(new AiCubeRef(c.connectionName, c.catalog, c.schema, c.cubeName));
+            }
+        }
+        AgentSpace space;
+        try {
+            space = new AgentSpace(
+                    id,
+                    body.name,
+                    body.description,
+                    body.systemPrompt,
+                    cubes,
+                    body.skillAllowlist == null ? List.of() : body.skillAllowlist,
+                    body.suggestedPrompts == null ? List.of() : body.suggestedPrompts,
+                    id + ".json");
+            registry.save(space);
+        } catch (IllegalArgumentException e) {
+            return bad(e.getMessage());
+        } catch (Exception e) {
+            return Response.serverError()
+                    .entity(Map.of("error", "could not save space: " + e.getMessage()))
+                    .type(MediaType.APPLICATION_JSON)
+                    .build();
+        }
+        return Response.ok(toDto(space)).type(MediaType.APPLICATION_JSON).build();
+    }
+
+    @DELETE
+    @Path("/{id}")
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response delete(@PathParam("id") String id) {
+        try {
+            boolean removed = registry.delete(id);
+            if (!removed) {
+                return Response.status(Response.Status.NOT_FOUND)
+                        .entity(Map.of("error", "no such space: " + id))
+                        .type(MediaType.APPLICATION_JSON)
+                        .build();
+            }
+            return Response.ok(Map.of("deleted", id))
+                    .type(MediaType.APPLICATION_JSON)
+                    .build();
+        } catch (Exception e) {
+            return Response.serverError()
+                    .entity(Map.of("error", "could not delete space: " + e.getMessage()))
+                    .type(MediaType.APPLICATION_JSON)
+                    .build();
+        }
+    }
+
+    private static Response bad(String message) {
+        return Response.status(Response.Status.BAD_REQUEST)
+                .entity(Map.of("status", "VALIDATION_ERROR", "error", message))
+                .type(MediaType.APPLICATION_JSON)
+                .build();
+    }
+
+    private static boolean blank(String s) {
+        return s == null || s.isBlank();
+    }
+
+    private static SpaceDto toDto(AgentSpace s) {
+        SpaceDto d = new SpaceDto();
+        d.id = s.id();
+        d.name = s.name();
+        d.description = s.description();
+        d.systemPrompt = s.systemPrompt();
+        d.skillAllowlist = new ArrayList<>(s.skillAllowlist());
+        d.suggestedPrompts = new ArrayList<>(s.suggestedPrompts());
+        d.cubeAllowlist = new ArrayList<>();
+        for (AiCubeRef c : s.cubeAllowlist()) {
+            CubeRefDto cr = new CubeRefDto();
+            cr.connectionName = c.getConnectionName();
+            cr.catalog = c.getCatalog();
+            cr.schema = c.getSchema();
+            cr.cubeName = c.getCubeName();
+            d.cubeAllowlist.add(cr);
+        }
+        return d;
+    }
+
+    /** Editable space shape. Public fields for Jackson. */
+    public static final class SpaceDto {
+        public String id;
+        public String name;
+        public String description;
+        public String systemPrompt;
+        public List<CubeRefDto> cubeAllowlist;
+        public List<String> skillAllowlist;
+        public List<String> suggestedPrompts;
+    }
+
+    public static final class CubeRefDto {
+        public String connectionName;
+        public String catalog;
+        public String schema;
+        public String cubeName;
+    }
+}

--- a/saiku-ui/src/lib/api/admin.ts
+++ b/saiku-ui/src/lib/api/admin.ts
@@ -166,6 +166,35 @@ export const adminEvals = {
     get<EvalTrendPoint[]>(`/ai-evals/${encodeURIComponent(suite)}/trend?limit=${limit}`),
 };
 
+/**
+ * Agent Spaces admin CRUD (saiku#1440). Reads/writes the full persona (system prompt + cube
+ * allowlist included, unlike the public /ai/spaces catalogue) so the admin panel can author them
+ * without hand-editing JSON.
+ */
+export interface AgentSpaceCubeRef {
+  connectionName: string;
+  catalog: string;
+  schema: string;
+  cubeName: string;
+}
+
+export interface AgentSpace {
+  id: string;
+  name: string;
+  description?: string;
+  systemPrompt?: string;
+  cubeAllowlist: AgentSpaceCubeRef[];
+  skillAllowlist: string[];
+  suggestedPrompts: string[];
+}
+
+export const adminAgentSpaces = {
+  list: () => get<AgentSpace[]>("/agent-spaces"),
+  errors: () => get<Array<{ source: string; code: string; message: string }>>("/agent-spaces/errors"),
+  save: (space: AgentSpace) => json<AgentSpace>("PUT", `/agent-spaces/${encodeURIComponent(space.id)}`, space),
+  remove: (id: string) => json<null>("DELETE", `/agent-spaces/${encodeURIComponent(id)}`),
+};
+
 export async function getVersion(): Promise<string> {
   const res = await fetch(`${BASE}/version`, { credentials: "include" });
   if (!res.ok) throw new Error(`version -> ${res.status}`);

--- a/saiku-ui/src/lib/views/admin/AgentSpacesAdmin.svelte
+++ b/saiku-ui/src/lib/views/admin/AgentSpacesAdmin.svelte
@@ -1,0 +1,231 @@
+<script lang="ts">
+  /*
+   * Agent Spaces admin editor (saiku#1440). CRUD over the persona JSON files under
+   * saiku-home/agent-spaces/ — a governed AI-ask persona bundles a system prompt, a
+   * cube allowlist (a hard server-side scope), a skill allowlist, and suggested prompts.
+   * Authoring them here replaces hand-editing JSON. Matches the admin panel's look
+   * (design tokens, Button); no raw tone classes (ESLint token-only rule applies).
+   */
+  import { onMount } from "svelte";
+  import { Button } from "$lib/components/ui";
+  import { adminAgentSpaces, type AgentSpace, type AgentSpaceCubeRef } from "$lib/api/admin";
+  import { listAiCubes, type AiCubeSummary } from "$lib/api/dashboards";
+  import { toasts } from "$lib/stores/toasts.svelte";
+  import { Plus, Trash2, Save } from "lucide-svelte";
+
+  let spaces = $state<AgentSpace[]>([]);
+  let cubes = $state<AiCubeSummary[]>([]);
+  let selectedId = $state<string | null>(null);
+  let isNew = $state(false);
+  let saving = $state(false);
+
+  // Working copy of the space being edited.
+  let form = $state<AgentSpace>(blank());
+  // suggestedPrompts + skillAllowlist edited as newline text for a friendlier textarea UX.
+  let promptsText = $state("");
+  let skillsText = $state("");
+
+  function blank(): AgentSpace {
+    return { id: "", name: "", description: "", systemPrompt: "", cubeAllowlist: [], skillAllowlist: [], suggestedPrompts: [] };
+  }
+
+  async function load() {
+    try {
+      [spaces, cubes] = await Promise.all([adminAgentSpaces.list(), listAiCubes().catch(() => [])]);
+    } catch (e) {
+      toasts.danger("Agent spaces", e instanceof Error ? e.message : String(e));
+    }
+  }
+  onMount(() => void load());
+
+  function edit(s: AgentSpace) {
+    isNew = false;
+    selectedId = s.id;
+    form = { ...s, cubeAllowlist: [...s.cubeAllowlist], skillAllowlist: [...s.skillAllowlist], suggestedPrompts: [...s.suggestedPrompts] };
+    promptsText = form.suggestedPrompts.join("\n");
+    skillsText = form.skillAllowlist.join("\n");
+  }
+
+  function newSpace() {
+    isNew = true;
+    selectedId = null;
+    form = blank();
+    promptsText = "";
+    skillsText = "";
+  }
+
+  const cubeKey = (c: AgentSpaceCubeRef | AiCubeSummary) => `${c.connectionName}/${c.catalog}/${c.schema}/${c.cubeName}`;
+  const allowed = (c: AiCubeSummary) => form.cubeAllowlist.some((a) => cubeKey(a) === cubeKey(c));
+
+  function toggleCube(c: AiCubeSummary) {
+    const k = cubeKey(c);
+    if (form.cubeAllowlist.some((a) => cubeKey(a) === k)) {
+      form.cubeAllowlist = form.cubeAllowlist.filter((a) => cubeKey(a) !== k);
+    } else {
+      form.cubeAllowlist = [
+        ...form.cubeAllowlist,
+        { connectionName: c.connectionName, catalog: c.catalog, schema: c.schema, cubeName: c.cubeName },
+      ];
+    }
+  }
+
+  const idOk = $derived(/^[a-z0-9][a-z0-9-]*$/.test(form.id));
+
+  async function save() {
+    if (!idOk) {
+      toasts.danger("Agent spaces", "id must be kebab-case ([a-z0-9-])");
+      return;
+    }
+    if (!form.name.trim()) {
+      toasts.danger("Agent spaces", "name is required");
+      return;
+    }
+    saving = true;
+    try {
+      const payload: AgentSpace = {
+        ...form,
+        skillAllowlist: skillsText.split("\n").map((s) => s.trim()).filter(Boolean),
+        suggestedPrompts: promptsText.split("\n").map((s) => s.trim()).filter(Boolean),
+      };
+      await adminAgentSpaces.save(payload);
+      toasts.success("Agent spaces", `Saved “${payload.name}”`);
+      await load();
+      isNew = false;
+      selectedId = payload.id;
+    } catch (e) {
+      toasts.danger("Agent spaces", e instanceof Error ? e.message : String(e));
+    } finally {
+      saving = false;
+    }
+  }
+
+  async function remove() {
+    if (!selectedId) return;
+    if (!confirm(`Delete agent space “${form.name}”? This removes its JSON file.`)) return;
+    try {
+      await adminAgentSpaces.remove(selectedId);
+      toasts.success("Agent spaces", "Deleted");
+      selectedId = null;
+      form = blank();
+      await load();
+    } catch (e) {
+      toasts.danger("Agent spaces", e instanceof Error ? e.message : String(e));
+    }
+  }
+</script>
+
+<div class="pane">
+  <header class="flex justify-between items-center">
+    <div>
+      <h2>Agent spaces</h2>
+      <p class="text-fg-muted text-sm" style="margin:2px 0 0">Governed AI-ask personas · prompt + hard cube allowlist</p>
+    </div>
+    <Button onclick={newSpace}><Plus size={14} /><span>New space</span></Button>
+  </header>
+
+  <div class="layout">
+    <aside class="list">
+      {#if spaces.length === 0}
+        <p class="text-fg-muted text-sm" style="padding:var(--space-2)">No spaces yet. Create one, or drop JSON in <code>saiku-home/agent-spaces/</code>.</p>
+      {/if}
+      {#each spaces as s (s.id)}
+        <button type="button" class="row" class:active={s.id === selectedId && !isNew} onclick={() => edit(s)}>
+          <span class="nm">{s.name}</span>
+          <span class="meta">{s.cubeAllowlist.length} cube{s.cubeAllowlist.length === 1 ? "" : "s"}</span>
+        </button>
+      {/each}
+    </aside>
+
+    {#if isNew || selectedId}
+      <section class="editor">
+        <div class="grid2">
+          <label class="field">
+            <span>id <small>(kebab-case, becomes the filename)</small></span>
+            <input bind:value={form.id} disabled={!isNew} placeholder="foodmart-sales-analyst" class:invalid={form.id !== "" && !idOk} />
+          </label>
+          <label class="field">
+            <span>Name</span>
+            <input bind:value={form.name} placeholder="FoodMart Sales Analyst" />
+          </label>
+        </div>
+        <label class="field">
+          <span>Description</span>
+          <input bind:value={form.description} placeholder="One line shown in the space picker" />
+        </label>
+        <label class="field">
+          <span>System prompt <small>(prepended to Saiku's built-in prompt — voice, focus, refusal rules)</small></span>
+          <textarea bind:value={form.systemPrompt} rows="7" placeholder="You are the … Analyst. Answer only questions about …"></textarea>
+        </label>
+
+        <div class="field">
+          <span>Cube allowlist <small>(hard scope — an ask against any other cube is refused 403)</small></span>
+          <div class="cubes">
+            {#if cubes.length === 0}
+              <p class="text-fg-muted text-sm">No cubes discovered.</p>
+            {/if}
+            {#each cubes as c (cubeKey(c))}
+              <label class="cube">
+                <input type="checkbox" checked={allowed(c)} onchange={() => toggleCube(c)} />
+                <span>{c.cubeName} <small class="text-fg-muted">· {c.schema}</small></span>
+              </label>
+            {/each}
+          </div>
+        </div>
+
+        <div class="grid2">
+          <label class="field">
+            <span>Skill allowlist <small>(one per line; empty = all skills)</small></span>
+            <textarea bind:value={skillsText} rows="4" placeholder="weekly-foodmart-rollup"></textarea>
+          </label>
+          <label class="field">
+            <span>Suggested prompts <small>(one per line)</small></span>
+            <textarea bind:value={promptsText} rows="4" placeholder="How did sales track last week?"></textarea>
+          </label>
+        </div>
+
+        <div class="actions">
+          <Button onclick={save} disabled={saving || !form.name.trim() || !idOk}>
+            <Save size={14} /><span>{saving ? "Saving…" : "Save"}</span>
+          </Button>
+          {#if !isNew}
+            <Button variant="outline" onclick={remove}><Trash2 size={14} /><span>Delete</span></Button>
+          {/if}
+        </div>
+      </section>
+    {:else}
+      <section class="editor empty">
+        <p class="text-fg-muted text-sm">Select a space to edit, or create a new one.</p>
+      </section>
+    {/if}
+  </div>
+</div>
+
+<style>
+  .pane { display: flex; flex-direction: column; gap: var(--space-4); }
+  h2 { margin: 0; }
+  code { font-family: var(--font-mono, monospace); font-size: var(--fs-xs); background: var(--bg-subtle); padding: 1px 5px; border-radius: 4px; }
+
+  .layout { display: grid; grid-template-columns: 240px 1fr; gap: var(--space-4); align-items: start; }
+  .list { display: flex; flex-direction: column; gap: 2px; border: 1px solid var(--border); border-radius: var(--radius); padding: var(--space-2); background: var(--bg-muted); }
+  .row { display: flex; flex-direction: column; align-items: flex-start; gap: 1px; text-align: left; border: 0; background: transparent; color: var(--fg-muted); cursor: pointer; padding: var(--space-2) var(--space-3); border-radius: var(--radius); font: inherit; }
+  .row:hover { color: var(--fg); background: var(--bg-hover); }
+  .row.active { color: var(--fg); background: var(--bg-hover); box-shadow: inset 2px 0 0 var(--accent); }
+  .row .nm { font-weight: var(--weight-medium); }
+  .row .meta { font-size: var(--fs-xs); color: var(--fg-subtle); }
+
+  .editor { display: flex; flex-direction: column; gap: var(--space-3); min-width: 0; }
+  .editor.empty { border: 1px dashed var(--border); border-radius: var(--radius); padding: var(--space-6); text-align: center; }
+  .grid2 { display: grid; grid-template-columns: 1fr 1fr; gap: var(--space-3); }
+  .field { display: flex; flex-direction: column; gap: 4px; }
+  .field > span { font-size: var(--fs-sm); font-weight: var(--weight-medium); }
+  .field small { font-weight: 400; color: var(--fg-muted); }
+  input, textarea { font: inherit; font-size: var(--fs-sm); padding: 7px 10px; border: 1px solid var(--border); border-radius: var(--radius); background: var(--bg); color: var(--fg); width: 100%; }
+  textarea { resize: vertical; }
+  input:disabled { color: var(--fg-muted); background: var(--bg-muted); }
+  input.invalid { border-color: var(--danger); }
+
+  .cubes { display: grid; grid-template-columns: repeat(auto-fill, minmax(220px, 1fr)); gap: 4px; border: 1px solid var(--border); border-radius: var(--radius); padding: var(--space-3); max-height: 200px; overflow: auto; background: var(--bg-muted); }
+  .cube { display: flex; align-items: center; gap: 8px; font-size: var(--fs-sm); cursor: pointer; }
+
+  .actions { display: flex; gap: var(--space-2); margin-top: var(--space-2); }
+</style>

--- a/saiku-ui/src/routes/admin/+page.svelte
+++ b/saiku-ui/src/routes/admin/+page.svelte
@@ -7,10 +7,11 @@
   import LogsAdmin from "$lib/views/admin/LogsAdmin.svelte";
   import StatsAdmin from "$lib/views/admin/StatsAdmin.svelte";
   import EvalsAdmin from "$lib/views/admin/EvalsAdmin.svelte";
+  import AgentSpacesAdmin from "$lib/views/admin/AgentSpacesAdmin.svelte";
   import ApiAccessAdmin from "$lib/views/admin/ApiAccessAdmin.svelte";
   import LoginForm from "$lib/views/LoginForm.svelte";
 
-  type Tab = "users" | "datasources" | "schemas" | "logs" | "stats" | "evals" | "api";
+  type Tab = "users" | "datasources" | "schemas" | "logs" | "stats" | "evals" | "spaces" | "api";
   let tab = $state<Tab>("users");
 </script>
 
@@ -32,6 +33,7 @@
       <button type="button" role="tab" class:active={tab === "logs"} onclick={() => (tab = "logs")}>{i18n.t("admin.tabs.logs")}</button>
       <button type="button" role="tab" class:active={tab === "stats"} onclick={() => (tab = "stats")}>{i18n.t("admin.tabs.stats")}</button>
       <button type="button" role="tab" class:active={tab === "evals"} onclick={() => (tab = "evals")}>Agent evals</button>
+      <button type="button" role="tab" class:active={tab === "spaces"} onclick={() => (tab = "spaces")}>Agent spaces</button>
       <button type="button" role="tab" class:active={tab === "api"} onclick={() => (tab = "api")}>API access</button>
     </div>
     <section class="flex-1 p-6 overflow-auto">
@@ -47,6 +49,8 @@
         <StatsAdmin />
       {:else if tab === "evals"}
         <EvalsAdmin />
+      {:else if tab === "spaces"}
+        <AgentSpacesAdmin />
       {:else}
         <ApiAccessAdmin defaultOpen={true} />
       {/if}

--- a/saiku-webapp/src/main/webapp/WEB-INF/saiku-beans.xml
+++ b/saiku-webapp/src/main/webapp/WEB-INF/saiku-beans.xml
@@ -441,6 +441,12 @@
         <constructor-arg type="java.lang.String" value="${saiku.home:./saiku-home}/agent-spaces"/>
     </bean>
 
+    <!-- saiku#1440: admin CRUD over Agent Spaces (GET/PUT/DELETE /saiku/admin/agent-spaces).
+         Writes JSON personas through the registry (which rescans on write). Admin-gated. -->
+    <bean id="agentSpaceAdminResource" class="org.saiku.web.rest.resources.AgentSpaceAdminResource">
+        <property name="registry" ref="agentSpaceRegistryBean"/>
+    </bean>
+
     <!-- ====================================================================
          MCP streamable-http endpoint (org.saiku.web.rest.resources.mcp.McpResource
          @ /saiku/api/mcp). Native Jersey resource that speaks JSON-RPC 2.0


### PR DESCRIPTION
Agent Spaces (saiku#1440) were authored by **hand-editing JSON** under `saiku-home/agent-spaces/`. This adds an admin-panel **"Agent spaces"** tab to create / edit / delete them — the same "make a shipped feature usable" move as the eval dashboard.

## Backend
- **`AgentSpaceRegistry`** — `save(space)` / `delete(id)` / `isValidId(id)`: writes the on-disk JSON shape the parser reads and rescans so changes go live immediately. **Security:** ids are restricted to kebab-case and the resolved path is re-checked to stay inside the agent-spaces dir (path-traversal guard). **+4 tests** (round-trip, delete, unsafe-id rejected, id validation).
- **`AgentSpaceAdminResource`** — `GET / PUT / DELETE /saiku/admin/agent-spaces`, admin-gated. Returns the **full** space (system prompt + cube allowlist) for editing — unlike the public `/ai/spaces` catalogue which deliberately omits them. Validates name + cube-ref completeness.

## UI
- **`AgentSpacesAdmin.svelte`** — list + editor: id, name, description, system prompt, a **cube-allowlist checkbox picker** from the live cube list, and skill-allowlist / suggested-prompts as newline textareas. Matches the admin panel's look (design tokens, `Button`); token-only ESLint rule honoured. Wired as a new tab alongside the eval dashboard.
- `adminAgentSpaces` API in `lib/api/admin.ts`.

## Verified
svelte-check 0 errors, ESLint clean, backend compiles, 12 registry tests green. End-to-end (create a persona → it's live for `/ai/spaces/{id}/ask`) verifiable on the demo after deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)