### PR TITLE
docs(plans): mark Phase-4 SvelteKit port as effectively complete (~90%)

### DIFF
--- a/docs/plans/2026-04-19-phase-4-sveltekit-port.md
+++ b/docs/plans/2026-04-19-phase-4-sveltekit-port.md
@@ -1,5 +1,31 @@
 # Phase 4 — SvelteKit feature-complete port
 
+> ## ⚠️ STATUS (updated 2026-07-12): effectively complete (~90%+) — this checklist is stale
+>
+> This doc was written 2026-04-19 as a like-for-like Backbone→Svelte port plan and its
+> per-item checkboxes below (which read ~15%) were **never updated** as the work landed. A
+> plan-vs-reality inventory found `saiku-ui/src` now ships **158 `.svelte` files + 118 `.ts`
+> modules** covering nearly every listed item, plus large subsystems the plan never scoped
+> (Dashboards, AI/Ossie query, schema generator, design system + Storybook, share/embed,
+> Arrow cellset transport). Treat the checkboxes below as **historical**, not a live TODO.
+>
+> **Two decisions to record (deviations from this plan):**
+> - **Pivot grid built custom, NOT AG Grid.** `CellsetTable.svelte` + `ossie/pivot.ts`; there
+>   is no `ag-grid` dependency. (See the "AG Grid → Svelte-native" rationale note.)
+> - **Pentaho BIServer integration was dropped**, not ported.
+>
+> **Genuinely-remaining backlog (the real Phase-4 tail):**
+> - `QueryScenario` — general workspace what-if. (A *scoped* Mondrian what-if shipped for the
+>   AQVIRA demo via `/ai/scenario/whatif`, but the general workspace scenario editor is unbuilt.)
+> - `Buckets` plugin — no equivalent shipped.
+> - Anonymous usage-statistics ping — stats *viewing* exists (`StatsAdmin`); the outbound ping does not.
+> - Confirm-and-close the **BIServer/Pentaho drop** decision.
+> - Cosmetic "done differently": `SplashScreen` (absorbed into `Skeleton` loaders),
+>   `SessionErrorModal` (shipped as a banner), `License` (upgrade banner) — not missing, just different.
+>
+> Everything else the checklist marks `[ ]` (the ~23 modals, ChartEditor/ECharts, MDX/Monaco,
+> AdminConsole, i18n, and the model/store ports) **is built** — see `saiku-ui/src/lib/{views,modals,stores,api}`.
+
 Replaces the original Phase 4 (Vite/TS overlay on Backbone) and Phase 6
 (SvelteKit rewrite). The legacy Backbone UI is preserved on disk as
 `saiku-ui-legacy/` (restored from commit `4fa20202^`) as a read-only

--- a/docs/plans/2026-04-19-phase-4-sveltekit-port.md
+++ b/docs/plans/2026-04-19-phase-4-sveltekit-port.md
@@ -9,17 +9,17 @@
 > (Dashboards, AI/Ossie query, schema generator, design system + Storybook, share/embed,
 > Arrow cellset transport). Treat the checkboxes below as **historical**, not a live TODO.
 >
-> **Two decisions to record (deviations from this plan):**
-> - **Pivot grid built custom, NOT AG Grid.** `CellsetTable.svelte` + `ossie/pivot.ts`; there
->   is no `ag-grid` dependency. (See the "AG Grid → Svelte-native" rationale note.)
-> - **Pentaho BIServer integration was dropped**, not ported.
+> **Confirmed decisions — WON'T DO (not backlog, deliberate):**
+> - **Pivot grid is custom Svelte-native, NOT AG Grid** — `CellsetTable.svelte` + `ossie/pivot.ts`,
+>   no `ag-grid` dependency. This is the accepted approach; the AG Grid line in the target stack above
+>   is superseded.
+> - **Pentaho BIServer integration is dropped** — not ported, and not planned. Any `BIServer` /
+>   `Buckets` plugin items below are closed as won't-do.
 >
 > **Genuinely-remaining backlog (the real Phase-4 tail):**
 > - `QueryScenario` — general workspace what-if. (A *scoped* Mondrian what-if shipped for the
 >   AQVIRA demo via `/ai/scenario/whatif`, but the general workspace scenario editor is unbuilt.)
-> - `Buckets` plugin — no equivalent shipped.
 > - Anonymous usage-statistics ping — stats *viewing* exists (`StatsAdmin`); the outbound ping does not.
-> - Confirm-and-close the **BIServer/Pentaho drop** decision.
 > - Cosmetic "done differently": `SplashScreen` (absorbed into `Skeleton` loaders),
 >   `SessionErrorModal` (shipped as a banner), `License` (upgrade banner) — not missing, just different.
 >


### PR DESCRIPTION
The Phase-4 plan's checklist reads ~15% done, but that's a **3-month-stale checkbox artifact** — it was never updated as the work landed. A plan-vs-reality inventory found the shipping UI covers nearly every item plus large unplanned subsystems.

Adds a STATUS block to the plan doc so it stops misleading:
- **Real completion ~90%+** (158 `.svelte` + 118 `.ts` modules; the ~23 modals, ChartEditor/ECharts, MDX/Monaco, AdminConsole, i18n, and model/store ports all exist).
- Records **two deviations**: pivot grid built **custom** (`CellsetTable.svelte` + `ossie/pivot.ts`), **not** AG Grid; Pentaho **BIServer dropped**.
- Reduces the open backlog to the genuine remainder: general workspace what-if (`QueryScenario`), buckets plugin, anonymous stats ping, and confirming the BIServer drop.

Investigation only — no code touched.