### PR TITLE
docs: saiku eval CLI in dist README + agent-spaces spec refresh

### DIFF
--- a/dist/README.md
+++ b/dist/README.md
@@ -49,6 +49,44 @@ java -jar saiku-<version>.jar serve --help
 | `--context` | `/` | Context path. |
 | `--home` | `./saiku-home` | Saiku home (data, repository, logs, sessions). |
 
+## Subcommands
+
+The launcher is a Picocli multi-command. `serve` runs the web server; the
+others are operational tools that talk to a *running* server.
+
+```bash
+java -jar saiku-<version>.jar <command> --help
+```
+
+| Command | Purpose |
+|---------|---------|
+| `serve` | Start the Saiku web server (see CLI options above). |
+| `sql-serve` | Serve an Ossie/SQL semantic model without the full OLAP stack. |
+| `eval` | Run the agent-eval accuracy suites against a running server and report pass-rate. Exit `0` = all passed, `1` = a suite regressed, `2` = transport/config error. See `docs/EVAL-SPEC.md`. |
+
+`eval` is the CI/cron entry point for the AI accuracy monitor. It POSTs to
+`/rest/saiku/admin/ai-evals/run` (admin Basic auth) and blocks until the sweep
+finishes:
+
+```bash
+# against a locally-running server with default admin/admin
+java -jar saiku-<version>.jar eval
+
+# against a remote server, report-only (never non-zero exit)
+java -jar saiku-<version>.jar eval \
+  --server https://analytics.example.com \
+  --username admin --password '<secret>' \
+  --no-fail-on-regression
+```
+
+| Flag | Default | Notes |
+|------|---------|-------|
+| `-s`, `--server` | `http://localhost:8080` | Base URL of the running server. |
+| `-u`, `--username` | `admin` | Admin username. |
+| `-p`, `--password` | `admin` | Admin password. |
+| `--no-fail-on-regression` | _(off)_ | Exit `0` even when a suite has failures (report-only). |
+| `--timeout-minutes` | `15` | How long to wait for the sweep (LLM latency × cases). |
+
 ## Saiku home layout (auto-created on first run)
 
 ```

--- a/docs/AGENT-SPACES-SPEC.md
+++ b/docs/AGENT-SPACES-SPEC.md
@@ -123,6 +123,29 @@ Fresh launcher installs stage two working personas:
 Both scope to the FoodMart Sales cube — a fresh demo has personas ready
 to click without any operator authoring.
 
+## Shipped since v1
+
+The following were listed as v1 non-goals and have since landed:
+
+- **Admin CRUD UI.** A Svelte admin tab (**Admin → Agent spaces**,
+  `saiku-ui/src/lib/views/admin/AgentSpacesAdmin.svelte`) authors spaces
+  in the browser — system prompt, a checkbox cube allowlist backed by
+  live cube discovery, skill allowlist, and suggested prompts — without
+  hand-editing JSON. Backed by an admin-gated CRUD surface,
+  `GET/PUT/DELETE /rest/saiku/admin/agent-spaces`
+  (`AgentSpaceAdminResource`), which returns the *full* persona
+  (system prompt + cube allowlist included, unlike the redacted public
+  `/ai/spaces` catalogue). Writes go through
+  `AgentSpaceRegistry.save(...)`, which validates the id
+  (kebab-case, path-traversal guarded) before persisting the JSON file.
+  Operators can still drop JSON into `saiku-home/agent-spaces/` directly.
+- **Embed integration.** `<saiku-embed kind="ai" space="foodmart-sales-analyst">`
+  scopes an embedded assistant to a persona server-side (saiku-ui embed
+  v3.20). See `saiku-ui/src/embed/README.md`.
+- **Streaming.** `POST /ai/spaces/{id}/ask/stream` mirrors the SSE wire
+  format of `/ai/ask/stream` with the persona scope applied
+  (saiku#1440 + #1433).
+
 ## Non-goals for v1
 
 - **Per-user / per-role scoping.** Spaces are per-launcher for v1.
@@ -130,10 +153,8 @@ to click without any operator authoring.
   directories onto a per-workspace registry root — deferred.
 - **Data-scope override.** The proposed shape in
   [saiku#1440](https://github.com/spiculedata/saiku/issues/1440) mentions
-  pinning a role's data-scope filters onto every space-scoped query.
-  Deferred to the RLS follow-up so the annotation lives in one place.
-- **Admin CRUD UI.** The runtime enforcement is complete; a Svelte
-  admin UI for authoring spaces via the browser is a follow-up slice.
-  Operators can author the JSON directly in v1.
-- **Embed integration** (`<saiku-embed kind="ai" path="space:sales-analyst">`).
-  Follow-up — the runtime is ready to consume it.
+  pinning a role's data-scope filters onto every space-scoped query. The
+  embed layer now enforces forced row-level filters
+  (`ThinQueryFilterMerge.applyReportingUnapplied`, apply-or-fail-closed —
+  see the RLS notes in the AI Query API docs); pinning those filters onto
+  *space*-scoped asks specifically is still deferred.


### PR DESCRIPTION
In-repo doc reconciliation for features that shipped this cycle but weren't reflected in the reference docs.

## Changes
- **`dist/README.md`** — new **Subcommands** section. The launcher CLI reference documented only `serve`; it now covers `serve` / `sql-serve` / `eval`, with the `eval` flags (`--server`, `--username`, `--password`, `--no-fail-on-regression`, `--timeout-minutes`), exit codes (0 pass / 1 regression / 2 transport), and CI/cron usage examples.
- **`docs/AGENT-SPACES-SPEC.md`** — the **admin CRUD UI**, **`<saiku-embed kind="ai">` integration**, and **RLS enforcement** were listed as deferred non-goals but all shipped. Moved them into a "Shipped since v1" section; rewrote the remaining data-scope non-goal to reflect embed forced-filter enforcement.

Docs-only; no code changes. The public docs-site equivalents are in spiculedata/saiku-cloud#1061.