### PR TITLE
Release 4.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,18 @@
 All notable changes to Saiku are documented here. This project follows
 [Semantic Versioning](https://semver.org/).
 
+## 4.6.1 — 2026-07-13
+
+Patch release fixing version reporting and install telemetry.
+
+### Fixed
+- **Version reporting** — deployed instances reported their version as `dev` because the
+  fat-JAR manifest never stamped `Implementation-Version`, so `getImplementationVersion()`
+  was always null. This broke the `/info` version, the update check, and install telemetry
+  (every 4.6.0 instance pinged as "dev"). Releases now report their real version.
+- **Install telemetry** — the heartbeat counts real releases only: dev/CI/IDE builds are
+  skipped client-side and excluded server-side, so the active-install count is accurate.
+
 ## 4.6.0 — 2026-07-13
 
 The headline release of the year: **Saiku becomes a semantic layer that AI agents can

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,73 @@
+# Changelog
+
+All notable changes to Saiku are documented here. This project follows
+[Semantic Versioning](https://semver.org/).
+
+## 4.6.0 — 2026-07-13
+
+The headline release of the year: **Saiku becomes a semantic layer that AI agents can
+query directly** — no MDX, no SQL. Alongside that, a full embedding SDK, a
+privacy/governance layer, and a large batch of security hardening. 381 commits since 4.5.2.
+
+### 🧠 The Ossie semantic layer (new)
+One semantic model — datasets, fields, metrics, relationships — served to dashboards,
+Excel, and AI agents at once.
+- **Ossie model support** — describe your data once in a portable YAML/OSI document (or
+  generate it from a Mondrian schema) and query it everywhere.
+- **Calcite-based SQL adapter** — Saiku plans clean SQL for the model against almost any warehouse.
+- **Ontology + AI-context surface** — the model carries synonyms, display names and context
+  so agents understand it.
+- **Graph traversal + signals endpoints** — walk relationships (e.g. ownership chains) and pull
+  risk/screening summaries, not just aggregates.
+- **DuckDB/Quack support** with a dialect fix so filtered queries work correctly.
+
+### 🤖 AI & agents
+- **Ask in plain English** — natural-language questions translate to a validated query and
+  return typed results.
+- **Agent Spaces** — named admin-authored personas that scope an ask (system prompt +
+  cube/skill allowlists), enforced server-side.
+- **Agent Skills** — reusable markdown workflows agents can invoke.
+- **SSE streaming** for ask responses (classic + space-scoped).
+- **Bring-your-own-LLM adapters** (Anthropic, OpenAI, Azure OpenAI).
+- **Agent evaluation framework** — CLI, REST endpoints, a results store and a dashboard for
+  scoring agent answers.
+- **AI audit log** and safer policy defaults, plus MCP structured-content support.
+
+### 🔌 Embedding SDK
+- **React embed SDK**, **web-component embed**, and token-based embedding.
+- **Row-level security** (including JWT-driven RLS) and a **PII gate** for embeds.
+- **Chart theming**, embed options, and a force-on header for locked-down deployments.
+- Embed package renamed to **`@concepttocloud/saiku-embed`** (now on npm).
+
+### 🔒 Privacy & governance
+- **PII annotation** on schema fields, with a per-column inspector.
+- **k-anonymity** enforcement on results (matrix + query paths).
+- AI audit logging and tightened AI data-policy defaults.
+
+### 📊 Charts & UI
+- **Combo charts** and **dual-Y-axis**, measure-group tree with dimension applicability,
+  richer time filters, and numerous chart-affordance fixes.
+
+### 📈 Install analytics (new)
+- **Anonymous, opt-out install telemetry** — counts active installs (not downloads) via a
+  daily heartbeat, backed by a zero-cost Cloudflare collector. Disable with
+  `SAIKU_TELEMETRY=off` / `DO_NOT_TRACK=1`.
+
+### 🔭 Observability
+- Opt-in **OpenTelemetry** bundles (Jetty, Jersey, JDBC, JVM) via the OTel agent.
+
+### 🧪 Demos & content
+- New bundled demos: **TPC-DS**, **Flights**, **Pharma**, **Bank showcase**, and a
+  **FoodMart embed** demo — Ossie datasources ready to poke on first boot.
+
+### 🛡️ Security
+- CVE/dependency fixes across **Jackson**, **Spring + Log4j**, **Vite/DOMPurify**, **Batik**,
+  **OpenPDF** (swapped in for iText), and **jsPDF**.
+
+### ⬆️ Dependencies
+- **Jetty 12.1.10**, **Log4j 2.26.0**, **Caffeine 3.2.4**, Spotless 3.7.0, slf4j 2.0.18, and
+  routine GitHub Actions bumps.
+
+**Artifacts:** fat-jar + dist zip on the [GitHub release](https://github.com/spiculedata/saiku/releases/tag/v4.6.0),
+Docker image at `ghcr.io/spiculedata/saiku:4.6.0`, module jars on GitHub Packages,
+and `@concepttocloud/saiku-embed` on npm.

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <groupId>org.saikuanalytics</groupId>
     <artifactId>saiku</artifactId>
     <packaging>pom</packaging>
-    <version>4.6.0</version>
+    <version>4.6.1</version>
     <name>Saiku Module Project</name>
     <scm>
         <developerConnection>

--- a/saiku-bom/pom.xml
+++ b/saiku-bom/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.saikuanalytics</groupId>
     <artifactId>saiku-bom</artifactId>
-    <version>4.6.0</version>
+    <version>4.6.1</version>
     <packaging>pom</packaging>
     <name>Saiku BOM</name>
     <description>Central dependency-version catalogue for Saiku modules.</description>

--- a/saiku-core/pom.xml
+++ b/saiku-core/pom.xml
@@ -2,14 +2,14 @@
     <parent>
         <artifactId>saiku</artifactId>
         <groupId>org.saikuanalytics</groupId>
-        <version>4.6.0</version>
+        <version>4.6.1</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>
     <artifactId>saiku-core</artifactId>
     <packaging>pom</packaging>
     <name>saiku - core libraries</name>
-    <version>4.6.0</version>
+    <version>4.6.1</version>
 
     <modules>
         <module>saiku-olap-util</module>

--- a/saiku-core/saiku-olap-util/pom.xml
+++ b/saiku-core/saiku-olap-util/pom.xml
@@ -3,11 +3,11 @@
     <parent>
         <artifactId>saiku-core</artifactId>
         <groupId>org.saikuanalytics</groupId>
-        <version>4.6.0</version>
+        <version>4.6.1</version>
     </parent>
 	<artifactId>saiku-olap-util</artifactId>
 	<packaging>jar</packaging>
-	<version>4.6.0</version>
+	<version>4.6.1</version>
 	<name>saiku olap util</name>
 	<properties>
 		<maven.compiler.source>1.8</maven.compiler.source>

--- a/saiku-core/saiku-semantic/pom.xml
+++ b/saiku-core/saiku-semantic/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <artifactId>saiku-core</artifactId>
         <groupId>org.saikuanalytics</groupId>
-        <version>4.6.0</version>
+        <version>4.6.1</version>
     </parent>
 
     <artifactId>saiku-semantic</artifactId>

--- a/saiku-core/saiku-service/pom.xml
+++ b/saiku-core/saiku-service/pom.xml
@@ -2,12 +2,12 @@
     <parent>
         <artifactId>saiku-core</artifactId>
         <groupId>org.saikuanalytics</groupId>
-        <version>4.6.0</version>
+        <version>4.6.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>jar</packaging>
     <artifactId>saiku-service</artifactId>
-    <version>4.6.0</version>
+    <version>4.6.1</version>
     <name>saiku - services</name>
     <build>
         <plugins>

--- a/saiku-core/saiku-sql/pom.xml
+++ b/saiku-core/saiku-sql/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.saikuanalytics</groupId>
         <artifactId>saiku-core</artifactId>
-        <version>4.6.0</version>
+        <version>4.6.1</version>
     </parent>
 
     <artifactId>saiku-sql</artifactId>

--- a/saiku-core/saiku-web/pom.xml
+++ b/saiku-core/saiku-web/pom.xml
@@ -2,11 +2,11 @@
     <parent>
         <artifactId>saiku-core</artifactId>
         <groupId>org.saikuanalytics</groupId>
-        <version>4.6.0</version>
+        <version>4.6.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>saiku-web</artifactId>
-    <version>4.6.0</version>
+    <version>4.6.1</version>
     <name>saiku - web</name>
     <packaging>jar</packaging>
 

--- a/saiku-launcher/pom.xml
+++ b/saiku-launcher/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.saikuanalytics</groupId>
         <artifactId>saiku</artifactId>
-        <version>4.6.0</version>
+        <version>4.6.1</version>
     </parent>
 
     <artifactId>saiku-launcher</artifactId>

--- a/saiku-launcher/pom.xml
+++ b/saiku-launcher/pom.xml
@@ -273,6 +273,13 @@
                                 <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
                                     <mainClass>org.saiku.launcher.SaikuLauncher</mainClass>
                                     <manifestEntries>
+                                        <!-- Stamp the release version into the fat-JAR manifest so
+                                             SaikuLauncher.getPackage().getImplementationVersion() resolves
+                                             it at runtime. Without this, every deployed instance reports
+                                             its version as "dev" — breaking the /info version, the update
+                                             check, and install telemetry. -->
+                                        <Implementation-Title>Saiku</Implementation-Title>
+                                        <Implementation-Version>${project.version}</Implementation-Version>
                                         <Multi-Release>true</Multi-Release>
                                         <!-- Apache Arrow (used by ArrowCellsetWriter) needs reflective
                                              access to java.nio.DirectByteBuffer's "address" field on

--- a/saiku-launcher/src/main/java/org/saiku/launcher/TelemetryService.java
+++ b/saiku-launcher/src/main/java/org/saiku/launcher/TelemetryService.java
@@ -74,8 +74,13 @@ public final class TelemetryService {
                 LOG.log(System.Logger.Level.DEBUG, "Saiku telemetry disabled by configuration");
                 return;
             }
-            String v = (version == null || version.isBlank()) ? "dev" : version;
-            TelemetryService svc = new TelemetryService(saikuHome, v, endpointFromConfig());
+            // No release version means this isn't a deployed instance — it's a dev/IDE run or the
+            // integration-test harness booting a server. Those shouldn't count as installs, so skip.
+            if (version == null || version.isBlank() || "dev".equalsIgnoreCase(version)) {
+                LOG.log(System.Logger.Level.DEBUG, "Saiku telemetry skipped: no release version (dev/test run)");
+                return;
+            }
+            TelemetryService svc = new TelemetryService(saikuHome, version, endpointFromConfig());
             svc.announce();
             svc.schedule();
         } catch (Throwable t) {

--- a/saiku-webapp/pom.xml
+++ b/saiku-webapp/pom.xml
@@ -2,11 +2,11 @@
     <parent>
         <artifactId>saiku</artifactId>
         <groupId>org.saikuanalytics</groupId>
-        <version>4.6.0</version>
+        <version>4.6.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>saiku-webapp</artifactId>
-    <version>4.6.0</version>
+    <version>4.6.1</version>
     <name>saiku - webapp</name>
     <packaging>war</packaging>
     <build>

--- a/telemetry/src/index.ts
+++ b/telemetry/src/index.ts
@@ -99,14 +99,17 @@ export default {
 		// --- public counts (cacheable) ------------------------------------------
 		if (url.pathname === '/v1/stats' && request.method === 'GET') {
 			const cutoff = now - WINDOW_SECONDS;
+			// Count real releases only — exclude non-release builds ('dev', *SNAPSHOT*) that come
+			// from CI, integration tests and IDE runs rather than deployed instances.
+			const RELEASE_ONLY = "version <> 'dev' AND version NOT LIKE '%SNAPSHOT%'";
 			try {
 				const active = await env.DB.prepare(
-					'SELECT count(*) AS n FROM installs WHERE last_seen > ?1'
+					`SELECT count(*) AS n FROM installs WHERE last_seen > ?1 AND ${RELEASE_ONLY}`
 				)
 					.bind(cutoff)
 					.first<{ n: number }>();
 				const byVersion = await env.DB.prepare(
-					'SELECT version, count(*) AS n FROM installs WHERE last_seen > ?1 GROUP BY version ORDER BY n DESC'
+					`SELECT version, count(*) AS n FROM installs WHERE last_seen > ?1 AND ${RELEASE_ONLY} GROUP BY version ORDER BY n DESC`
 				)
 					.bind(cutoff)
 					.all();

--- a/telemetry/wrangler.toml
+++ b/telemetry/wrangler.toml
@@ -6,7 +6,7 @@ workers_dev = true
 # Latest released version, returned to instances as the update-check answer.
 # Bump this one line on each release (or wire it to the GitHub releases API later).
 [vars]
-LATEST_VERSION = "4.6.0"
+LATEST_VERSION = "4.6.1"
 
 # D1 (serverless SQLite). Fill database_id after `npm run db:create`.
 [[d1_databases]]


### PR DESCRIPTION
Patch release.

- **Version reporting fix** — fat-JAR now stamps Implementation-Version, so deployed instances report their real version instead of 'dev' (fixes /info, update check, and install telemetry).
- **Telemetry** — counts real releases only (dev/CI/test skipped).

Follows 4.6.0 (same day). 🤖 Generated with Claude Code