### PR TITLE
Release 4.6.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,18 @@
 All notable changes to Saiku are documented here. This project follows
 [Semantic Versioning](https://semver.org/).
 
+## 4.6.2 — 2026-07-16
+
+Patch release.
+
+### Added
+- **`SAIKU_ADMIN_PASSWORD`** — set the admin password without rebuilding the image.
+  The launcher bcrypt-hashes it into a persisted external `<saiku-home>/users.properties`
+  (or supply that file yourself), so a rotated password boots without
+  `SAIKU_ALLOW_DEFAULT_ADMIN`. Fixes the self-host password-rotation gap — the
+  previously-documented `saiku-rotate-admin` command never existed. See
+  `dist/README.md` for details.
+
 ## 4.6.1 — 2026-07-13
 
 Patch release fixing version reporting and install telemetry.

--- a/dist/README.md
+++ b/dist/README.md
@@ -36,6 +36,39 @@ Open <http://localhost:8080/ui/> and sign in:
 A `foodmart` cube list appears on first query (initial load of the H2
 fixture takes ~30 s — subsequent launches reuse the file).
 
+## Setting the admin password
+
+Saiku ships with `admin` / `admin` and **refuses to start** once it's reachable
+on a network while that default is unchanged (demo mode excepted). Set a real
+password — **no rebuild required**:
+
+```bash
+# Docker
+docker run -e SAIKU_ADMIN_PASSWORD='a-strong-password' ... ghcr.io/spiculedata/saiku:<version>
+
+# dist zip / fat-jar
+SAIKU_ADMIN_PASSWORD='a-strong-password' ./run.sh
+```
+
+On boot Saiku bcrypt-hashes it and writes `<saiku-home>/users.properties`
+(persisted on the volume, so it survives restarts — the env var is only needed
+the first time, though setting it again just re-applies it). To add more users
+or manage roles by hand, edit that file directly:
+
+```properties
+admin={bcrypt}$2y$12$....,ROLE_USER,ROLE_ADMIN
+analyst={bcrypt}$2y$12$....,ROLE_USER
+```
+
+Generate a hash with `htpasswd -nbBC 12 <user> '<password>'` and reformat the
+`user:$2y$...` output as `user={bcrypt}$2y$...,ROLE_USER`.
+
+> **Note:** the bundled auth is an in-memory user store — the admin panel's
+> user-management screens are read-only against it. For real multi-user setups,
+> point Saiku at LDAP / OAuth / SAML via `applicationContext-spring-security-memory.xml`.
+> To boot with the default password anyway (local/dev only), set
+> `SAIKU_ALLOW_DEFAULT_ADMIN=true`.
+
 ## CLI options
 
 ```bash

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <groupId>org.saikuanalytics</groupId>
     <artifactId>saiku</artifactId>
     <packaging>pom</packaging>
-    <version>4.6.1</version>
+    <version>4.6.2</version>
     <name>Saiku Module Project</name>
     <scm>
         <developerConnection>

--- a/saiku-bom/pom.xml
+++ b/saiku-bom/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.saikuanalytics</groupId>
     <artifactId>saiku-bom</artifactId>
-    <version>4.6.1</version>
+    <version>4.6.2</version>
     <packaging>pom</packaging>
     <name>Saiku BOM</name>
     <description>Central dependency-version catalogue for Saiku modules.</description>

--- a/saiku-core/pom.xml
+++ b/saiku-core/pom.xml
@@ -2,14 +2,14 @@
     <parent>
         <artifactId>saiku</artifactId>
         <groupId>org.saikuanalytics</groupId>
-        <version>4.6.1</version>
+        <version>4.6.2</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>
     <artifactId>saiku-core</artifactId>
     <packaging>pom</packaging>
     <name>saiku - core libraries</name>
-    <version>4.6.1</version>
+    <version>4.6.2</version>
 
     <modules>
         <module>saiku-olap-util</module>

--- a/saiku-core/saiku-olap-util/pom.xml
+++ b/saiku-core/saiku-olap-util/pom.xml
@@ -3,11 +3,11 @@
     <parent>
         <artifactId>saiku-core</artifactId>
         <groupId>org.saikuanalytics</groupId>
-        <version>4.6.1</version>
+        <version>4.6.2</version>
     </parent>
 	<artifactId>saiku-olap-util</artifactId>
 	<packaging>jar</packaging>
-	<version>4.6.1</version>
+	<version>4.6.2</version>
 	<name>saiku olap util</name>
 	<properties>
 		<maven.compiler.source>1.8</maven.compiler.source>

--- a/saiku-core/saiku-semantic/pom.xml
+++ b/saiku-core/saiku-semantic/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <artifactId>saiku-core</artifactId>
         <groupId>org.saikuanalytics</groupId>
-        <version>4.6.1</version>
+        <version>4.6.2</version>
     </parent>
 
     <artifactId>saiku-semantic</artifactId>

--- a/saiku-core/saiku-service/pom.xml
+++ b/saiku-core/saiku-service/pom.xml
@@ -2,12 +2,12 @@
     <parent>
         <artifactId>saiku-core</artifactId>
         <groupId>org.saikuanalytics</groupId>
-        <version>4.6.1</version>
+        <version>4.6.2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>jar</packaging>
     <artifactId>saiku-service</artifactId>
-    <version>4.6.1</version>
+    <version>4.6.2</version>
     <name>saiku - services</name>
     <build>
         <plugins>

--- a/saiku-core/saiku-sql/pom.xml
+++ b/saiku-core/saiku-sql/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.saikuanalytics</groupId>
         <artifactId>saiku-core</artifactId>
-        <version>4.6.1</version>
+        <version>4.6.2</version>
     </parent>
 
     <artifactId>saiku-sql</artifactId>

--- a/saiku-core/saiku-web/pom.xml
+++ b/saiku-core/saiku-web/pom.xml
@@ -2,11 +2,11 @@
     <parent>
         <artifactId>saiku-core</artifactId>
         <groupId>org.saikuanalytics</groupId>
-        <version>4.6.1</version>
+        <version>4.6.2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>saiku-web</artifactId>
-    <version>4.6.1</version>
+    <version>4.6.2</version>
     <name>saiku - web</name>
     <packaging>jar</packaging>
 

--- a/saiku-launcher/pom.xml
+++ b/saiku-launcher/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.saikuanalytics</groupId>
         <artifactId>saiku</artifactId>
-        <version>4.6.1</version>
+        <version>4.6.2</version>
     </parent>
 
     <artifactId>saiku-launcher</artifactId>

--- a/saiku-launcher/pom.xml
+++ b/saiku-launcher/pom.xml
@@ -88,6 +88,14 @@
             <version>${picocli.version}</version>
         </dependency>
 
+        <!-- BCrypt hashing for the SAIKU_ADMIN_PASSWORD runtime override in
+             SaikuLauncher (rotate the admin password without rebuilding). -->
+        <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-crypto</artifactId>
+            <version>${spring.security.version}</version>
+        </dependency>
+
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-server</artifactId>

--- a/saiku-launcher/src/main/java/org/saiku/launcher/SaikuLauncher.java
+++ b/saiku-launcher/src/main/java/org/saiku/launcher/SaikuLauncher.java
@@ -7,6 +7,8 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Properties;
 import java.util.concurrent.Callable;
 import java.util.zip.ZipEntry;
@@ -21,6 +23,7 @@ import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.ServerConnector;
 import org.eclipse.jetty.session.DefaultSessionCache;
 import org.eclipse.jetty.session.FileSessionDataStore;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import picocli.CommandLine;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Option;
@@ -171,11 +174,19 @@ public class SaikuLauncher implements Callable<Integer> {
 
             Path warPath = extractWar();
 
+            // saiku#1512: runtime admin-password override so operators can set the
+            // admin password (or supply an external users.properties) WITHOUT
+            // rebuilding the image. Precedence: SAIKU_ADMIN_PASSWORD env /
+            // -Dsaiku.admin.password > <saiku-home>/users.properties > the WAR's
+            // baked default. When an override is in effect, Spring Security reads it
+            // via -Dsaiku.security.usersFile and the policy below checks THAT file.
+            Path usersFile = resolveEffectiveUsersFile(saikuHome, warPath);
+
             // saiku#1153: refuse to serve in production while the shipped default
             // admin password is unchanged. Demo mode (SAIKU_DEMO=true) and an
             // explicit SAIKU_ALLOW_DEFAULT_ADMIN=true both opt out. Throws
             // DefaultCredentialsException, which the CLI turns into a clean exit.
-            enforceDefaultCredentialPolicy(warPath);
+            enforceDefaultCredentialPolicy(usersFile, warPath);
 
             Server server = new Server();
             // saiku#1165 audit-3: harden the HTTP transport.
@@ -289,6 +300,12 @@ public class SaikuLauncher implements Callable<Integer> {
             if (Boolean.parseBoolean(System.getProperty("saiku.security.acknowledged", "false"))) {
                 return;
             }
+            // A rotated admin password (SAIKU_ADMIN_PASSWORD / external users.properties / rebuilt
+            // WAR) is not a default-credentials situation — stay quiet outside demo mode.
+            boolean adminIsDefault = Boolean.parseBoolean(System.getProperty("saiku.security.adminIsDefault", "true"));
+            if (!isDemoModeActive() && !adminIsDefault) {
+                return;
+            }
             String bar = "============================================================";
             System.out.println();
             System.out.println(bar);
@@ -305,10 +322,10 @@ public class SaikuLauncher implements Callable<Integer> {
             } else {
                 System.out.println("  SECURITY: default credentials (admin/admin) are active.");
             }
-            System.out.println("  Rotate them in saiku-webapp's users.properties before");
-            System.out.println("  exposing this instance, or replace the in-memory auth");
-            System.out.println("  config (applicationContext-spring-security-memory.xml)");
-            System.out.println("  with LDAP / OAuth / SAML.");
+            System.out.println("  Set SAIKU_ADMIN_PASSWORD=<strong-password> to rotate the admin");
+            System.out.println("  password before exposing this instance (no rebuild needed), or");
+            System.out.println("  replace the in-memory auth (applicationContext-spring-security-");
+            System.out.println("  memory.xml) with LDAP / OAuth / SAML.");
             System.out.println("  Suppress this warning with -Dsaiku.security.acknowledged=true");
             System.out.println(bar);
             System.out.println();
@@ -387,8 +404,13 @@ public class SaikuLauncher implements Callable<Integer> {
          * @throws DefaultCredentialsException with an operator-facing fix-it
          *     message when the boot should be refused.
          */
-        static void enforceDefaultCredentialPolicy(Path warPath) {
-            if (!shouldRefuse(adminPasswordIsDefault(warPath), isDemoModeRequested(), allowDefaultAdmin())) {
+        static void enforceDefaultCredentialPolicy(Path usersFile, Path warPath) {
+            boolean isDefault = usersFile.equals(warPath)
+                    ? adminPasswordIsDefault(warPath)
+                    : isDefaultAdminValue(readAdminValue(usersFile));
+            // Record it so the post-boot warning doesn't cry "default credentials" once rotated.
+            System.setProperty("saiku.security.adminIsDefault", Boolean.toString(isDefault));
+            if (!shouldRefuse(isDefault, isDemoModeRequested(), allowDefaultAdmin())) {
                 return;
             }
             String bar = "============================================================";
@@ -401,9 +423,11 @@ public class SaikuLauncher implements Callable<Integer> {
                     "  with default credentials is compromised within seconds.",
                     "",
                     "  Fix one of the following, then restart:",
-                    "    * Rotate the admin password in users.properties (bcrypt):",
+                    "    * Set an admin password (no rebuild — recommended):",
+                    "        SAIKU_ADMIN_PASSWORD=<a-strong-password>",
+                    "    * Or rotate it in users.properties (bcrypt):",
                     "        htpasswd -nbBC 12 admin <newpassword>",
-                    "    * Replace the in-memory auth with LDAP / OAuth / SAML",
+                    "    * Or replace the in-memory auth with LDAP / OAuth / SAML",
                     "      (applicationContext-spring-security-memory.xml).",
                     "",
                     "  To start anyway (NOT for a production / exposed host), set:",
@@ -412,6 +436,82 @@ public class SaikuLauncher implements Callable<Integer> {
                     bar,
                     "");
             throw new DefaultCredentialsException(msg);
+        }
+
+        /**
+         * Resolve which users.properties Spring Security should authenticate against, and point it
+         * there via {@code -Dsaiku.security.usersFile} when an override is active. Precedence:
+         * {@code SAIKU_ADMIN_PASSWORD} / {@code -Dsaiku.admin.password} (hashed into an external
+         * file) &gt; an existing {@code <saiku-home>/users.properties} &gt; the WAR's baked default
+         * (returned as {@code warPath}). Never throws — falls back to the bundled file on any I/O error.
+         */
+        static Path resolveEffectiveUsersFile(Path saikuHome, Path warPath) {
+            Path external = saikuHome.resolve("users.properties");
+            String pw = System.getenv("SAIKU_ADMIN_PASSWORD");
+            if (pw == null || pw.isBlank()) pw = System.getProperty("saiku.admin.password");
+            try {
+                if (pw != null && !pw.isBlank()) {
+                    writeAdminUsersFile(external, pw.trim());
+                    System.setProperty(
+                            "saiku.security.usersFile", external.toUri().toString());
+                    System.out.println("Admin password set from SAIKU_ADMIN_PASSWORD (" + external + ").");
+                    return external;
+                }
+                if (Files.isRegularFile(external)) {
+                    System.setProperty(
+                            "saiku.security.usersFile", external.toUri().toString());
+                    System.out.println("Using external users.properties (" + external + ").");
+                    return external;
+                }
+            } catch (IOException e) {
+                System.err.println("Could not write external users.properties (" + e.getMessage()
+                        + "); falling back to the bundled default.");
+            }
+            return warPath;
+        }
+
+        /**
+         * Write an external users.properties with a bcrypt {@code admin} row, preserving any other
+         * (non-admin) rows already present so operator-added users survive a password change.
+         */
+        static void writeAdminUsersFile(Path file, String password) throws IOException {
+            List<String> keep = new ArrayList<>();
+            if (Files.isRegularFile(file)) {
+                for (String line : Files.readAllLines(file)) {
+                    String t = line.trim();
+                    if (t.isEmpty() || t.startsWith("#") || t.startsWith("admin=") || t.startsWith("admin ")) {
+                        continue;
+                    }
+                    keep.add(line);
+                }
+            }
+            String hash = new BCryptPasswordEncoder().encode(password);
+            Files.createDirectories(file.getParent());
+            List<String> out = new ArrayList<>();
+            out.add("# Managed by Saiku: admin row set from SAIKU_ADMIN_PASSWORD. Add more users below.");
+            out.add("admin={bcrypt}" + hash + ",ROLE_USER,ROLE_ADMIN");
+            out.addAll(keep);
+            Files.write(file, out);
+            try {
+                File f = file.toFile();
+                f.setReadable(false, false);
+                f.setReadable(true, true);
+                f.setWritable(false, false);
+                f.setWritable(true, true);
+            } catch (RuntimeException ignore) {
+                // best-effort permission tightening — never fatal
+            }
+        }
+
+        /** Read the {@code admin=} value from an external users.properties, or null on any error. */
+        static String readAdminValue(Path file) {
+            try (InputStream in = Files.newInputStream(file)) {
+                Properties p = new Properties();
+                p.load(in);
+                return p.getProperty("admin");
+            } catch (IOException e) {
+                return null;
+            }
         }
 
         /**

--- a/saiku-webapp/pom.xml
+++ b/saiku-webapp/pom.xml
@@ -2,11 +2,11 @@
     <parent>
         <artifactId>saiku</artifactId>
         <groupId>org.saikuanalytics</groupId>
-        <version>4.6.1</version>
+        <version>4.6.2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>saiku-webapp</artifactId>
-    <version>4.6.1</version>
+    <version>4.6.2</version>
     <name>saiku - webapp</name>
     <packaging>war</packaging>
     <build>

--- a/saiku-webapp/src/main/webapp/WEB-INF/applicationContext-spring-security-memory.xml
+++ b/saiku-webapp/src/main/webapp/WEB-INF/applicationContext-spring-security-memory.xml
@@ -24,7 +24,12 @@
   <beans profile="!demo">
     <security:authentication-manager alias="authenticationManager">
       <security:authentication-provider>
-        <security:user-service id="uds" properties="/WEB-INF/users.properties"/>
+        <!-- saiku#1512: users file is overridable at runtime via
+             -Dsaiku.security.usersFile (the launcher sets it from
+             SAIKU_ADMIN_PASSWORD or an external <saiku-home>/users.properties),
+             so operators can rotate the admin password without rebuilding the
+             WAR. Defaults to the baked-in file. -->
+        <security:user-service id="uds" properties="${saiku.security.usersFile:/WEB-INF/users.properties}"/>
       </security:authentication-provider>
     </security:authentication-manager>
   </beans>
@@ -32,7 +37,12 @@
   <beans profile="demo">
     <security:authentication-manager alias="authenticationManager">
       <security:authentication-provider>
-        <security:user-service id="uds" properties="/WEB-INF/users.properties"/>
+        <!-- saiku#1512: users file is overridable at runtime via
+             -Dsaiku.security.usersFile (the launcher sets it from
+             SAIKU_ADMIN_PASSWORD or an external <saiku-home>/users.properties),
+             so operators can rotate the admin password without rebuilding the
+             WAR. Defaults to the baked-in file. -->
+        <security:user-service id="uds" properties="${saiku.security.usersFile:/WEB-INF/users.properties}"/>
       </security:authentication-provider>
       <security:authentication-provider>
         <security:user-service id="udsDemo" properties="/WEB-INF/users-demo.properties"/>

--- a/telemetry/wrangler.toml
+++ b/telemetry/wrangler.toml
@@ -6,7 +6,7 @@ workers_dev = true
 # Latest released version, returned to instances as the update-check answer.
 # Bump this one line on each release (or wire it to the GitHub releases API later).
 [vars]
-LATEST_VERSION = "4.6.1"
+LATEST_VERSION = "4.6.2"
 
 # D1 (serverless SQLite). Fill database_id after `npm run db:create`.
 [[d1_databases]]


### PR DESCRIPTION
Patch: SAIKU_ADMIN_PASSWORD — rotate the admin password without a rebuild (verified end-to-end). Fixes the self-host password-rotation gap. 🤖 Generated with Claude Code