### PR TITLE
#1501 - document the GitHub Packages classic-PAT requirement in the build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,24 @@ custom spans for `ThinQueryService` etc.).
 
 JDK 21 + Maven 3.9+ required.
 
+**Set up GitHub Packages auth first, or the build fails before it compiles.** Saiku's Mondrian fork, olap4j,
+saiku-query and Ossie artifacts are published to GitHub Packages, which requires an authenticated token **even
+though the packages are public**. Without it you get a bare `401 Unauthorized` on `pentaho:mondrian` that never
+mentions tokens:
+
+1. Create a **classic** personal access token with only the `read:packages` scope
+   ([Tokens (classic)](https://github.com/settings/tokens/new)). It must be classic — [GitHub's Maven registry
+   does not accept fine-grained tokens](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-apache-maven-registry),
+   and the UI defaults to fine-grained. Our packages are public, so no `repo` scope or org membership is needed.
+2. Add five `<server>` entries to `~/.m2/settings.xml` — `github-mondrian-saiku`, `github-olap4j`,
+   `github-olap4j-xmlaserver`, `github-saiku-query`, `github-ossie`. Copy the block from
+   [`.github/workflows/ci.yml`](.github/workflows/ci.yml); one token covers all five.
+
+Still getting a 401? A fine-grained token and a classic token missing `read:packages` produce an identical error,
+so check what the token actually has before minting another —
+`curl -sI -H "Authorization: token $PAT" https://api.github.com/user | grep -i x-oauth-scopes`. A classic token's
+scopes are editable in place, and the value doesn't change, so `settings.xml` needs no edit.
+
 ```sh
 # Compile, unit tests, Spotless format check (CI gate):
 mvn verify


### PR DESCRIPTION
Fixes #1501.

Building from source requires a GitHub PAT, and nothing a new contributor reads says so. `README.md` did mention it — but as a footnote *after* the build commands ("See CLAUDE.md for ... the GitHub Packages auth gotcha"), so the actual sequence is: run `mvn verify`, get a bare 401 that never mentions tokens, then maybe find the pointer. This moves it to a prerequisite, before the commands.

Covers the three things that actually bite:

- **A token is needed even though the packages are public.** Non-obvious, and the error says nothing about it.
- **It must be a _classic_ PAT.** GitHub's Maven registry doesn't accept fine-grained tokens, and the UI now defaults to fine-grained — so the natural path fails.
- **How to tell an under-scoped token from a wrong-type one.** Both produce an identical bare 401 with no mention of scopes. The `x-oauth-scopes` check distinguishes them in one command, and classic scopes are editable in place — no re-minting, no `settings.xml` edit.

Also names all five `<server>` ids explicitly and points at `ci.yml` as the copyable source of truth, rather than restating the list somewhere it can drift. (`CLAUDE.md` currently lists four and omits `github-ossie` — that's #1502.)

This is one of two independent reasons a from-source build fails for anyone outside our own setup; #1500 is the other. Neither is visible in CI. Between them they've already cost us at least one self-hoster on Slack.

Docs only.
