### PR TITLE
#1507 - skip Claude Code Review on bot-authored PRs

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -12,11 +12,10 @@ on:
 
 jobs:
   claude-review:
-    # Optional: Filter by PR author
-    # if: |
-    #   github.event.pull_request.user.login == 'external-contributor' ||
-    #   github.event.pull_request.user.login == 'new-developer' ||
-    #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
+    # Bot-authored PRs (Dependabot et al) can't run this: the action refuses
+    # non-human actors, and bot PRs read from a separate secret store that has
+    # no CLAUDE_CODE_OAUTH_TOKEN in it. Skipping keeps their checks clean.
+    if: github.event.pull_request.user.type != 'Bot'
 
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
Closes #1507.

`Claude Code Review` has failed on every Dependabot PR since the workflow landed — all six open ones are carrying a red X for it right now. The action refuses non-human actors by design:

```
Workflow initiated by non-human actor: dependabot (type: Bot).
```

Real CI is green on all six; this job is the only red.

Skipping it for bot authors rather than allowlisting them: the job log shows `Secret source: Dependabot`, so `CLAUDE_CODE_OAUTH_TOKEN` isn't available on those runs anyway — `allowed_bots` would trade "refused the actor" for "no token". And an LLM review of a version bump isn't worth handing the reviewer bot-authored input.

Keyed on `user.type` rather than the `dependabot[bot]` login so Renovate or anything else is covered too. A skipped job reports as skipped, not failed, so the checks come back clean. Human PRs are untouched.
