### PR TITLE
#1509 - resolve launcher jackson-databind from ${jackson.version}

### DIFF
--- a/saiku-launcher/pom.xml
+++ b/saiku-launcher/pom.xml
@@ -131,11 +131,13 @@
              the saiku-service converter + Jackson-YAML writer) can resolve
              ObjectMapper from the shaded fat-JAR classpath. Maven's "nearest
              wins" rule was previously shadowing the transitive compile dep
-             from saiku-service. -->
+             from saiku-service.
+             Version comes from the parent's ${jackson.version}: this module
+             doesn't import saiku-bom, so a literal here drifts behind it. -->
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.18.6</version>
+            <version>${jackson.version}</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
Closes #1509.

`saiku-launcher` hardcoded `jackson-databind` at **2.18.6** while the rest of the reactor is on **2.18.8**. 2.18.6 is inside the vulnerable range for [GHSA-hgj6-7826-r7m5](https://github.com/advisories/GHSA-hgj6-7826-r7m5) (InetSocketAddress deserialization → eager DNS resolution, SSRF), fixed in 2.18.8 — so this is a live medium alert (#499) shipping in the fat-JAR, not a stale finding.

It drifted because this module doesn't import `saiku-bom`, so the BOM's `dependencyManagement` never reaches it and the version got written by hand. The root pom already keeps `<jackson.version>` in sync for exactly this case — its own comment calls the hand-written literal "the footgun". This just points the dep at the property.

The explicit declaration stays: it's there so Maven's "nearest wins" doesn't let the transitive dep from `saiku-service` shadow it on the shaded classpath. Only the literal goes.

**Verified by CI rather than locally** — a full local `verify` is ~50 minutes and another build is currently using the shared `~/.m2`, which has no lock. `build` and `bundle` cover the resolution and the shaded JAR.

**This does not close jackson out.** 2.18.8 is still exposed to [GHSA-5jmj-h7xm-6q6v](https://github.com/advisories/GHSA-5jmj-h7xm-6q6v) (alerts #496, #500), which has **no patched release in the 2.18.x line at all**. That needs a move to 2.19+ and is a compatibility question — filed separately.
