### PR TITLE
#1514 - correct dist/README on admin panel user management

### DIFF
--- a/dist/README.md
+++ b/dist/README.md
@@ -63,9 +63,16 @@ analyst={bcrypt}$2y$12$....,ROLE_USER
 Generate a hash with `htpasswd -nbBC 12 <user> '<password>'` and reformat the
 `user:$2y$...` output as `user={bcrypt}$2y$...,ROLE_USER`.
 
-> **Note:** the bundled auth is an in-memory user store — the admin panel's
-> user-management screens are read-only against it. For real multi-user setups,
-> point Saiku at LDAP / OAuth / SAML via `applicationContext-spring-security-memory.xml`.
+> **⚠️ Don't manage credentials through the admin panel.** The bundled auth reads
+> `users.properties` (above), but the panel's user-management screens write to a
+> separate store that auth never consults. Adding a user or changing a password
+> there returns success and has **no effect**: a new account can't log in, and a
+> rotated password leaves the old one working. Use `SAIKU_ADMIN_PASSWORD` or edit
+> `users.properties` directly. Tracked in
+> [#1514](https://github.com/spiculedata/saiku/issues/1514).
+>
+> For real multi-user setups, point Saiku at LDAP / OAuth / SAML via
+> `applicationContext-spring-security-memory.xml`.
 > To boot with the default password anyway (local/dev only), set
 > `SAIKU_ALLOW_DEFAULT_ADMIN=true`.
 


### PR DESCRIPTION
Part of #1514 — the docs half, separable from the code fix.

`dist/README.md` told operators the admin panel's user-management screens are **read-only**. They aren't. `UsersAdmin.svelte:72` ships an Add-user button in five locales, and the writes return HTTP 200.

Strictly parsed the old sentence was defensible — writes really don't touch the *in-memory* store — but nobody reads it that way, and the real behaviour is worse than read-only. It's silent failure: a new account persists and can't authenticate, and a password rotation returns 200 while the old credential keeps working.

I was misled by this claim myself and repeated it to a self-hoster as intended behaviour, which is roughly the worst outcome a doc line can have. Replacing it with what actually happens, and pointing at `SAIKU_ADMIN_PASSWORD` / `users.properties` as the paths that work.

Docs-only, so `paths-filter` skips the build jobs and `ci` passes on `skipped`. The code fix is #1514.
