### PR TITLE
#1517 - add npm ecosystem for saiku-ui to dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,3 +12,18 @@ updates:
       interval: weekly
     open-pull-requests-limit: 3
     labels: [dependencies, github-actions]
+  # saiku-ui has its own package.json and is not part of the Maven reactor, so
+  # it needs its own entry — without one it is never scanned at all. Grouped so
+  # a week's worth of SvelteKit churn arrives as a couple of PRs, not a wall.
+  - package-ecosystem: npm
+    directory: /saiku-ui
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    labels: [dependencies, npm]
+    groups:
+      dev-dependencies:
+        dependency-type: development
+      production-minor-patch:
+        dependency-type: production
+        update-types: [minor, patch]


### PR DESCRIPTION
Part of #1517 — the gap. The version fixes are #1518.

`dependabot.yml` declared only `maven` and `github-actions`. `saiku-ui` has its own `package.json` and isn't part of the Maven reactor, so it needs its own entry — without one it was **never scanned**. That's why nine XSS advisories sat open since June 17 with no PR: not a judgement call by Dependabot, just nothing pointing at the directory.

Grouped deliberately. The first scan of a SvelteKit app will find a lot at once, and the maven queue is already sitting at its cap of 5 — an ungrouped npm entry would bury the real signal under a wall of PRs, which is roughly how we got here. Two groups (dev, and production minor/patch) means a normal week arrives as a couple of reviewable PRs.

Production **major** bumps are deliberately left ungrouped so they show up individually and get looked at — same reasoning as leaving #1381 (`docker/login-action` v3→v4) blocked for human eyes rather than merging it with the batch.

Config-only, so `paths-filter` skips the build jobs.

**Expect PRs to appear shortly after this merges** — that's the entry working, not something going wrong. Worth watching the first batch to see whether the limit and grouping are tuned right.
