### PR TITLE
#1529 - fix(admin-ui): datasource save fails with /datasources -> 400

### DIFF
--- a/saiku-ui/src/lib/api/admin.datasources.test.ts
+++ b/saiku-ui/src/lib/api/admin.datasources.test.ts
@@ -1,0 +1,100 @@
+/*
+ * Regression tests for the datasource wire mapping (saiku#1529).
+ *
+ * The bug: the admin UI posted its camelCase AdminDatasource shape verbatim
+ * (`name`, `location`, `schemaName`, `type`), none of which exist on the
+ * server's DataSourceMapper. Jackson's FAIL_ON_UNKNOWN_PROPERTIES tripped and
+ * every create/edit failed with `/datasources -> 400`. These tests lock the
+ * boundary mapping so the wire body only ever carries DataSourceMapper keys.
+ */
+import { describe, expect, test } from "vitest";
+import {
+  toDatasourceWire,
+  fromDatasourceWire,
+  type AdminDatasource,
+} from "./admin";
+
+const uiDatasource: AdminDatasource = {
+  id: "",
+  name: "test",
+  connectionName: "",
+  driver: "org.postgresql.Driver",
+  location: "jdbc:postgresql://postgres:5432/testdb",
+  type: "RELATIONAL",
+  connectiontype: "XMLA",
+  username: "testuser",
+  password: "s3cret",
+  schemaName: "public",
+  ossieYaml: "",
+};
+
+describe("toDatasourceWire", () => {
+  test("maps UI field names onto the server DataSourceMapper contract", () => {
+    const wire = toDatasourceWire(uiDatasource);
+    expect(wire.connectionname).toBe("test");
+    expect(wire.jdbcurl).toBe("jdbc:postgresql://postgres:5432/testdb");
+    expect(wire.schema).toBe("public");
+    expect(wire.connectiontype).toBe("XMLA");
+    expect(wire.driver).toBe("org.postgresql.Driver");
+    expect(wire.username).toBe("testuser");
+    expect(wire.password).toBe("s3cret");
+  });
+
+  test("emits ONLY DataSourceMapper keys — no unknown fields that would 400", () => {
+    const allowed = new Set([
+      "id",
+      "connectionname",
+      "connectiontype",
+      "jdbcurl",
+      "schema",
+      "driver",
+      "username",
+      "password",
+      "ossieYaml",
+    ]);
+    for (const key of Object.keys(toDatasourceWire(uiDatasource))) {
+      expect(allowed.has(key)).toBe(true);
+    }
+    // The offending camelCase keys must never reach the wire.
+    const wire = toDatasourceWire(uiDatasource) as Record<string, unknown>;
+    expect(wire.name).toBeUndefined();
+    expect(wire.location).toBeUndefined();
+    expect(wire.schemaName).toBeUndefined();
+    expect(wire.type).toBeUndefined();
+  });
+
+  test("omits the empty id on create so the server assigns one", () => {
+    expect(toDatasourceWire(uiDatasource).id).toBeUndefined();
+    expect(toDatasourceWire({ ...uiDatasource, id: "abc" }).id).toBe("abc");
+  });
+
+  test("omits a blank password so editing without retyping keeps the stored credential", () => {
+    expect(toDatasourceWire({ ...uiDatasource, password: "" }).password).toBeUndefined();
+    expect(toDatasourceWire({ ...uiDatasource, password: undefined }).password).toBeUndefined();
+  });
+});
+
+describe("fromDatasourceWire", () => {
+  test("maps a server row back onto the UI shape (round-trip of the key fields)", () => {
+    const ds = fromDatasourceWire({
+      id: "ds-1",
+      connectionname: "sales-pg",
+      connectiontype: "MONDRIAN",
+      jdbcurl: "jdbc:postgresql://db:5432/sales",
+      schema: "public",
+      driver: "org.postgresql.Driver",
+      username: "reader",
+    });
+    expect(ds.id).toBe("ds-1");
+    expect(ds.name).toBe("sales-pg");
+    expect(ds.location).toBe("jdbc:postgresql://db:5432/sales");
+    expect(ds.schemaName).toBe("public");
+    expect(ds.type).toBe("OLAP");
+  });
+
+  test("derives the legacy type dropdown from connectiontype", () => {
+    expect(fromDatasourceWire({ connectiontype: "MONDRIAN" }).type).toBe("OLAP");
+    expect(fromDatasourceWire({ connectiontype: "XMLA" }).type).toBe("RELATIONAL");
+    expect(fromDatasourceWire({ connectiontype: "OSSIE" }).type).toBe("OSSIE");
+  });
+});

--- a/saiku-ui/src/lib/api/admin.ts
+++ b/saiku-ui/src/lib/api/admin.ts
@@ -91,12 +91,90 @@ export async function listAllRoles(): Promise<string[]> {
   return Array.from(set).sort();
 }
 
+/**
+ * Raw JSON contract of the server-side `DataSourceMapper` (saiku-web). These are the
+ * field names Jersey/Jackson binds on `POST`/`PUT` and emits on `GET` — deliberately
+ * NOT camelCase. The admin UI works in the friendlier {@link AdminDatasource} shape and
+ * translates at this boundary.
+ *
+ * saiku#1529: the previous code posted `AdminDatasource` verbatim (`name`, `location`,
+ * `schemaName`, `type`, …), none of which exist on `DataSourceMapper`. Jackson's
+ * `FAIL_ON_UNKNOWN_PROPERTIES` tripped on the first unknown key and the global
+ * `JacksonValidationExceptionMapper` turned it into an HTTP 400 — so *every* create/edit
+ * failed with `/datasources -> 400`, and the list showed blank Type/Schema columns
+ * because the reads were reading keys the server never sent.
+ */
+interface DatasourceWire {
+  id?: string;
+  connectionname?: string;
+  connectiontype?: string;
+  jdbcurl?: string;
+  schema?: string;
+  driver?: string;
+  username?: string;
+  password?: string;
+  ossieYaml?: string | null;
+}
+
+/** Derive the UI's legacy `type` dropdown value from the wire discriminator. */
+function typeFromConnectiontype(ct?: string): string {
+  if (ct === "OSSIE") return "OSSIE";
+  if (ct === "XMLA") return "RELATIONAL";
+  return "OLAP";
+}
+
+/** Map the UI datasource shape onto the server `DataSourceMapper` wire contract. */
+export function toDatasourceWire(ds: AdminDatasource): DatasourceWire {
+  return {
+    id: ds.id || undefined,
+    connectionname: ds.name,
+    connectiontype: ds.connectiontype,
+    jdbcurl: ds.location,
+    schema: ds.schemaName ?? undefined,
+    driver: ds.driver,
+    username: ds.username,
+    // Only send a password when the operator actually typed one, so editing a datasource
+    // without touching the password field doesn't blank the stored credential.
+    password: ds.password ? ds.password : undefined,
+    ossieYaml: ds.ossieYaml ?? undefined,
+  };
+}
+
+/** Map a server `DataSourceMapper` JSON row back onto the UI datasource shape. */
+export function fromDatasourceWire(w: DatasourceWire): AdminDatasource {
+  return {
+    id: w.id ?? "",
+    name: w.connectionname ?? "",
+    connectionName: w.connectionname,
+    connectiontype: w.connectiontype,
+    type: typeFromConnectiontype(w.connectiontype),
+    driver: w.driver,
+    location: w.jdbcurl,
+    schemaName: w.schema ?? null,
+    username: w.username,
+    // Server never returns the password (DataSourceMapper marks it WRITE_ONLY).
+    ossieYaml: w.ossieYaml ?? null,
+  };
+}
+
 export const adminDatasources = {
-  list: () => get<AdminDatasource[]>("/datasources"),
-  refresh: (id: string) => json<AdminDatasource>("PUT", `/datasources/${encodeURIComponent(id)}/refresh`),
-  create: (ds: AdminDatasource) => json<AdminDatasource>("POST", "/datasources", ds),
-  update: (ds: AdminDatasource) =>
-    json<AdminDatasource>("PUT", `/datasources/${encodeURIComponent(ds.id)}`, ds),
+  list: async () => (await get<DatasourceWire[]>("/datasources")).map(fromDatasourceWire),
+  refresh: async (id: string) => {
+    const w = await json<DatasourceWire>("PUT", `/datasources/${encodeURIComponent(id)}/refresh`);
+    return w ? fromDatasourceWire(w) : null;
+  },
+  create: async (ds: AdminDatasource) => {
+    const w = await json<DatasourceWire>("POST", "/datasources", toDatasourceWire(ds));
+    return w ? fromDatasourceWire(w) : null;
+  },
+  update: async (ds: AdminDatasource) => {
+    const w = await json<DatasourceWire>(
+      "PUT",
+      `/datasources/${encodeURIComponent(ds.id)}`,
+      toDatasourceWire(ds),
+    );
+    return w ? fromDatasourceWire(w) : null;
+  },
   remove: (id: string) => json<null>("DELETE", `/datasources/${encodeURIComponent(id)}`),
 };
 


### PR DESCRIPTION
Fixes #1529.

## Problem
Adding or editing a datasource in the admin panel fails with `Save failed  /datasources -> 400`; the datasource list also shows blank **Type**/**Schema** columns. Reported by a self-hoster on 4.6.2.

## Root cause
The SvelteKit admin form (`saiku-ui/src/lib/api/admin.ts`) posts its camelCase `AdminDatasource` shape verbatim — `name`, `connectionName`, `location`, `type`, `schemaName`, `properties` — none of which exist on the server-side `DataSourceMapper` (`connectionname`, `jdbcurl`, `schema`, `connectiontype`, …). Jackson's `FAIL_ON_UNKNOWN_PROPERTIES` trips on the first unknown key and the global `JacksonValidationExceptionMapper` turns it into an HTTP 400 before the request reaches `AdminResource.createDatasource`. The blank list columns are the same mismatch on the read path.

Confirmed against the live server: `GET /rest/saiku/admin/datasources` emits `connectionname/jdbcurl/schema/connectiontype/…`, not the UI's camelCase names.

Latent since the SvelteKit admin rewrite — the demo only ever uses the seeded FoodMart datasource, so the create form was never exercised.

## Fix
- `toDatasourceWire` / `fromDatasourceWire` translate `AdminDatasource` ⇄ `DataSourceMapper` at the API boundary. The UI keeps its friendly shape; the wire body carries only `DataSourceMapper` keys.
- Blank password on edit is now omitted from the wire, so editing without retyping doesn't wipe the stored credential.
- New `admin.datasources.test.ts` (6 tests) locks the mapping and asserts no camelCase key ever reaches the wire.

## Verification
- `vitest` admin+api: 90 passed (incl. 6 new)
- `npm run check`: 0 errors
- `eslint` on changed files: clean

## Out of scope
The same reporter's "change password / add-remove accounts fail" is a separate, documented limitation — the bundled in-memory user store is read-only to the admin UI. Not addressed here.