### PR TITLE
#1514 - refuse admin-panel password changes instead of reporting success

### DIFF
--- a/.github/test-floors.json
+++ b/.github/test-floors.json
@@ -2,7 +2,7 @@
   "_": "Per-module test-count floors. CI fails if any module's surefire total drops below its floor — catches accidental test deletions. Bump explicitly when adding tests. Floors set during Phase 4 / saiku#8 with totals from feat/platform-improvements.",
   "modules": {
     "saiku-core/saiku-service": 252,
-    "saiku-core/saiku-web": 330,
+    "saiku-core/saiku-web": 338,
     "saiku-launcher": 32
   }
 }

--- a/dist/README.md
+++ b/dist/README.md
@@ -50,10 +50,20 @@ docker run -d -p 8080:8080 -e SAIKU_ADMIN_PASSWORD='a-strong-password' ghcr.io/s
 SAIKU_ADMIN_PASSWORD='a-strong-password' ./run.sh
 ```
 
-On boot Saiku bcrypt-hashes it and writes `<saiku-home>/users.properties`
-(persisted on the volume, so it survives restarts — the env var is only needed
-the first time, though setting it again just re-applies it). To add more users
-or manage roles by hand, edit that file directly:
+On boot Saiku bcrypt-hashes it and writes `<saiku-home>/users.properties`,
+persisted on the volume. Precedence is **`SAIKU_ADMIN_PASSWORD` > an existing
+`<saiku-home>/users.properties` > the WAR's baked default**, so while the
+variable is set it is enforced on *every* boot: it rewrites the `admin` row and
+overrides whatever that file already contains.
+
+That makes the variable the rotation mechanism — change its value and restart,
+and the old password stops working. It also means that while the variable stays
+set, editing the `admin` row by hand is reverted on the next restart. Unset it
+first if you want to manage that row yourself; the stored hash keeps working
+without it.
+
+To add more users or manage roles by hand, edit that file directly — rows other
+than `admin` survive a rewrite of the `admin` row:
 
 ```properties
 admin={bcrypt}$2y$12$....,ROLE_USER,ROLE_ADMIN
@@ -63,12 +73,14 @@ analyst={bcrypt}$2y$12$....,ROLE_USER
 Generate a hash with `htpasswd -nbBC 12 <user> '<password>'` and reformat the
 `user:$2y$...` output as `user={bcrypt}$2y$...,ROLE_USER`.
 
-> **⚠️ Don't manage credentials through the admin panel.** The bundled auth reads
+> **⚠️ The admin panel can't manage credentials.** The bundled auth reads
 > `users.properties` (above), but the panel's user-management screens write to a
-> separate store that auth never consults. Adding a user or changing a password
-> there returns success and has **no effect**: a new account can't log in, and a
-> rotated password leaves the old one working. Use `SAIKU_ADMIN_PASSWORD` or edit
-> `users.properties` directly. Tracked in
+> separate store that auth never consults. **Changing a password there is refused
+> (HTTP 501)**, with a message pointing back here — rotate with
+> `SAIKU_ADMIN_PASSWORD` or by editing `users.properties` directly. Adding a user
+> still succeeds, but the account is only a directory entry (it's what @-mentions
+> in dashboard comments autocomplete against): it can't sign in until you add it
+> to `users.properties` too. Tracked in
 > [#1514](https://github.com/spiculedata/saiku/issues/1514).
 >
 > For real multi-user setups, point Saiku at LDAP / OAuth / SAML via

--- a/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/AdminResource.java
+++ b/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/AdminResource.java
@@ -62,6 +62,37 @@ public class AdminResource {
     private OlapDiscoverService olapDiscoverService;
     private LogExtractor logExtractor;
 
+    /**
+     * saiku#1514: why a password write here is refused rather than acknowledged.
+     *
+     * <p>Authentication resolves through {@code authenticationManager}, whose only providers are
+     * file-backed {@code <security:user-service properties=.../>} beans
+     * (applicationContext-spring-security-memory.xml:32,45,48). This resource writes to H2 via
+     * {@link UserService} → {@code JdbcUserDAO}. No {@code AuthenticationProvider} reads that store,
+     * so a password set here has never had any effect on who can log in — the endpoint simply
+     * returned 200 and the superseded credential kept working.
+     *
+     * <p>The wording is deliberately the launcher's, taken from the boot-time FATAL banner it
+     * prints on a default-credentials refusal ({@code SaikuLauncher.enforceDefaultCredentialPolicy})
+     * and from dist/README's htpasswd recipe, so operators meet one vocabulary for rotation rather
+     * than two. It cannot be shared as a constant: this module is {@code saiku-web}, and the reactor
+     * runs saiku-core → saiku-webapp → saiku-launcher, so depending on the launcher would invert
+     * that order. If the banner is ever reworded, reword this with it.
+     */
+    private static final String PASSWORD_WRITE_UNSUPPORTED = String.join(
+            "\n",
+            "Saiku's bundled authentication reads users.properties; this panel writes to a",
+            "separate store that authentication never consults, so a password set here would",
+            "have no effect and the superseded one would keep working. Set the password one of",
+            "these ways instead, then restart:",
+            "  * Set an admin password (no rebuild — recommended):",
+            "      SAIKU_ADMIN_PASSWORD=<a-strong-password>",
+            "  * Or rotate it in users.properties (bcrypt):",
+            "      htpasswd -nbBC 12 <user> <newpassword>",
+            "  * Or replace the in-memory auth with LDAP / OAuth / SAML",
+            "    (applicationContext-spring-security-memory.xml).",
+            "See https://github.com/spiculedata/saiku/issues/1514");
+
     public LogExtractor getLogExtractor() {
         return logExtractor;
     }
@@ -490,10 +521,16 @@ public class AdminResource {
 
     /**
      * Update a users user details on the Saiku server.
+     *
+     * <p>Email and roles are updated as before. A password change is refused with 501 — see
+     * {@link #PASSWORD_WRITE_UNSUPPORTED}. The refusal is unconditional and applies to every
+     * user, not just {@code admin}: no deployment mode exists in which a password written here
+     * reaches the authenticator, so there is nothing to detect and nothing to condition on.
+     *
      * @summary Update user details
      * @param jsonString SaikuUser object.
      * @param userName The username for the user to be updated.
-     * @return A response containing a user object.
+     * @return A response containing a user object, or 501 when a password change is requested.
      */
     @PUT
     @Produces({"application/json"})
@@ -510,8 +547,18 @@ public class AdminResource {
                         .entity(userService.updateUser(jsonString, false))
                         .build();
             } else {
-                return Response.ok()
-                        .entity(userService.updateUser(jsonString, true))
+                // saiku#1514: this used to call updateUser(jsonString, true), which bcrypt-hashes
+                // into H2 — a store no AuthenticationProvider reads — and return 200. Refuse
+                // instead, and say how to rotate for real. 501, not 4xx: the request is
+                // well-formed and the caller is a legitimate admin; the capability does not exist
+                // in this server (RFC 9110 §15.6.2).
+                log.warn(
+                        "Refused a password change for user '{}' via /admin/users — the admin panel"
+                                + " cannot rotate credentials (saiku#1514).",
+                        userName);
+                return Response.status(Response.Status.NOT_IMPLEMENTED)
+                        .type(MediaType.TEXT_PLAIN)
+                        .entity(PASSWORD_WRITE_UNSUPPORTED)
                         .build();
             }
         } catch (IllegalArgumentException policy) {
@@ -524,6 +571,18 @@ public class AdminResource {
 
     /**
      * Create user details on the Saiku server.
+     *
+     * <p>saiku#1514: deliberately NOT refused, unlike the password change in
+     * {@link #updateUserDetails}. The created row is inert for authentication — the new account
+     * cannot log in until it exists in users.properties — but it is not useless: it is what
+     * {@code /saiku/api/users} ({@code UsersResource}) lists, which is the @-mention directory for
+     * dashboard comments. Refusing here would remove the only way to add someone to that
+     * directory, and it would have to be a blanket refusal rather than a password-only one:
+     * {@link org.saiku.service.user.UserService#addUser} validates the password policy
+     * unconditionally, so a create carries a mandatory password and there is no password-free
+     * create to fall back to. Creating a user is therefore honest about what it does; only the
+     * implication that the account can sign in is not, and the UI carries that caveat.
+     *
      * @summary Create user details
      * @param jsonString SaikuUser object
      * @return A response containing the user object.

--- a/saiku-core/saiku-web/src/test/java/org/saiku/web/rest/resources/AdminResourceUserPasswordTest.java
+++ b/saiku-core/saiku-web/src/test/java/org/saiku/web/rest/resources/AdminResourceUserPasswordTest.java
@@ -1,0 +1,176 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.web.rest.resources;
+
+import static org.junit.Assert.*;
+
+import jakarta.ws.rs.core.Response;
+import org.junit.Before;
+import org.junit.Test;
+import org.saiku.database.dto.SaikuUser;
+import org.saiku.service.user.UserService;
+
+/**
+ * saiku#1514: the admin panel used to accept a password change, write it to H2, and return 200 —
+ * while authentication kept reading users.properties, so the superseded credential stayed live.
+ * Drives {@link AdminResource} against a stubbed {@link UserService} to pin the honest refusal.
+ *
+ * <p>The load-bearing assertion is {@link #passwordChange_neverReachesTheUserService()}: a 501 that
+ * still wrote to H2 would be a cosmetic fix. The write must not happen at all.
+ */
+public class AdminResourceUserPasswordTest {
+
+    private AdminResource resource;
+    private StubUserService users;
+
+    @Before
+    public void setUp() {
+        users = new StubUserService();
+        resource = new AdminResource();
+        resource.setUserService(users);
+    }
+
+    private static SaikuUser user(String username, String password) {
+        SaikuUser u = new SaikuUser();
+        u.setUsername(username);
+        u.setPassword(password);
+        u.setEmail(username + "@example.com");
+        u.setRoles(new String[] {"ROLE_USER"});
+        return u;
+    }
+
+    /* ------------------------- the refusal ------------------------- */
+
+    @Test
+    public void passwordChange_isRefusedWith501() {
+        Response resp = resource.updateUserDetails(user("admin", "a-new-password"), "admin");
+
+        assertEquals(
+                "a password change must be refused, not acknowledged — 501: the request is"
+                        + " well-formed and the caller is a legitimate admin, the capability is absent",
+                501,
+                resp.getStatus());
+    }
+
+    @Test
+    public void passwordChange_neverReachesTheUserService() {
+        resource.updateUserDetails(user("admin", "a-new-password"), "admin");
+
+        assertEquals(
+                "the refusal must happen before the write — a 501 that still hashed into H2 would"
+                        + " leave the operator's password lying around in a store nothing reads",
+                0,
+                users.updateCalls);
+        assertNull(users.lastUpdatedUser);
+    }
+
+    /**
+     * The refusal is only useful if it teaches. An operator who lands here must leave knowing how
+     * to actually rotate — the wording is the launcher's boot banner (SaikuLauncher.java:426-431).
+     */
+    @Test
+    public void refusal_tellsTheOperatorHowToRotate() {
+        Response resp = resource.updateUserDetails(user("admin", "a-new-password"), "admin");
+        String body = String.valueOf(resp.getEntity());
+
+        assertTrue("must name the recommended mechanism", body.contains("SAIKU_ADMIN_PASSWORD"));
+        assertTrue("must name the file that auth actually reads", body.contains("users.properties"));
+        assertTrue("must give the bcrypt recipe for the by-hand path", body.contains("htpasswd -nbBC 12"));
+        assertTrue("must offer the LDAP / OAuth / SAML escape hatch", body.contains("LDAP / OAuth / SAML"));
+        assertTrue(
+                "must link the issue so the reasoning is reachable",
+                body.contains("github.com/spiculedata/saiku/issues/1514"));
+    }
+
+    /**
+     * Every password written by this panel is inert for authentication, not just the admin row —
+     * no AuthenticationProvider reads H2 at all. Scoping the refusal to "admin" would silently
+     * assert that non-admin rotations work, which is false.
+     */
+    @Test
+    public void refusal_appliesToEveryUserNotJustAdmin() {
+        Response resp = resource.updateUserDetails(user("analyst", "a-new-password"), "analyst");
+
+        assertEquals(501, resp.getStatus());
+        assertEquals(0, users.updateCalls);
+    }
+
+    /* ------------- what must keep working (regression guard) ------------- */
+
+    @Test
+    public void emptyPassword_stillUpdatesProfileAndRoles() {
+        Response resp = resource.updateUserDetails(user("admin", ""), "admin");
+
+        assertEquals("an email/roles edit must be unaffected by the password refusal", 200, resp.getStatus());
+        assertEquals(1, users.updateCalls);
+        assertFalse("an empty password must not be treated as a password change", users.lastUpdatePasswordFlag);
+    }
+
+    @Test
+    public void nullPassword_stillUpdatesProfileAndRoles() {
+        Response resp = resource.updateUserDetails(user("admin", null), "admin");
+
+        assertEquals(200, resp.getStatus());
+        assertEquals(1, users.updateCalls);
+        assertFalse(users.lastUpdatePasswordFlag);
+    }
+
+    /**
+     * saiku#1514 scope boundary. Creating a user is NOT refused: the H2 row is what
+     * {@code /saiku/api/users} lists, which is the @-mention directory for dashboard comments.
+     * A blanket refusal here would remove the only way to add someone to that directory — and it
+     * would have to be blanket, because {@code UserService.addUser} validates the password policy
+     * unconditionally, so there is no password-free create to fall back on. If this test ever
+     * fails, that capability is being removed — make it a deliberate decision, not a tidy-up.
+     */
+    @Test
+    public void createUser_isDeliberatelyNotRefused() {
+        Response resp = resource.createUserDetails(user("newbie", "a-valid-password"));
+
+        assertEquals(200, resp.getStatus());
+        assertEquals(1, users.addCalls);
+    }
+
+    /** The authz gate must still precede the refusal — a non-admin learns nothing from it. */
+    @Test
+    public void nonAdmin_isForbidden_andIsNotToldHowToRotate() {
+        users.admin = false;
+
+        Response resp = resource.updateUserDetails(user("admin", "a-new-password"), "admin");
+
+        assertEquals(403, resp.getStatus());
+        assertNull("the rotation guidance must not leak to a non-admin", resp.getEntity());
+        assertEquals(0, users.updateCalls);
+    }
+
+    /* ------------------------------ stub ------------------------------ */
+
+    private static final class StubUserService extends UserService {
+        boolean admin = true;
+        int updateCalls = 0;
+        int addCalls = 0;
+        SaikuUser lastUpdatedUser = null;
+        boolean lastUpdatePasswordFlag = false;
+
+        @Override
+        public boolean isAdmin() {
+            return admin;
+        }
+
+        @Override
+        public SaikuUser updateUser(SaikuUser u, boolean updatepassword) {
+            updateCalls++;
+            lastUpdatedUser = u;
+            lastUpdatePasswordFlag = updatepassword;
+            return u;
+        }
+
+        @Override
+        public SaikuUser addUser(SaikuUser u) {
+            addCalls++;
+            return u;
+        }
+    }
+}

--- a/saiku-ui/src/lib/api/admin.ts
+++ b/saiku-ui/src/lib/api/admin.ts
@@ -62,8 +62,15 @@ async function json<T>(method: "POST" | "PUT" | "DELETE", path: string, body?: u
     headers: body ? { "Content-Type": "application/json", Accept: "application/json" } : {},
     body: body ? JSON.stringify(body) : undefined,
   });
-  if (!res.ok) throw new Error(`${path} -> ${res.status}`);
   const text = await res.text();
+  if (!res.ok) {
+    // saiku#1514: surface the server's explanation, not just the status. AdminResource sends
+    // operator-facing prose on the paths that matter — the 501 refusing a password change, and
+    // the pre-existing 400 carrying the password-policy rule that was broken — and both were
+    // being discarded here, leaving the user with a bare "/users/admin -> 501".
+    const detail = text.trim();
+    throw new Error(detail ? `${path} -> ${res.status}\n${detail}` : `${path} -> ${res.status}`);
+  }
   return text ? (JSON.parse(text) as T) : null;
 }
 

--- a/saiku-ui/src/lib/views/admin/UsersAdmin.svelte
+++ b/saiku-ui/src/lib/views/admin/UsersAdmin.svelte
@@ -113,8 +113,28 @@
       <input class="field__input" bind:value={editing.email} />
     </label>
     <label class="field">
-      <span class="field__label">{editing.id === 0 ? "Password" : "New password (leave blank to keep current)"}</span>
-      <input class="field__input" type="password" bind:value={editing.password} />
+      <span class="field__label">Password</span>
+      <!-- saiku#1514: the bundled auth reads users.properties; this panel writes a store it
+           never consults. Rotation is therefore impossible here in every deployment mode, so
+           the control is disabled rather than left to fail on submit. The server refuses a
+           password change with 501 regardless — this only stops us inviting the attempt. -->
+      <input
+        class="field__input"
+        type="password"
+        bind:value={editing.password}
+        disabled={editing.id !== 0}
+      />
+      {#if editing.id === 0}
+        <p class="field__hint">
+          Adds the account to the @-mention directory. It cannot sign in until it is added to
+          <code>users.properties</code> — the bundled authentication reads that file, not this panel.
+        </p>
+      {:else}
+        <p class="field__hint">
+          Passwords cannot be changed here. Set <code>SAIKU_ADMIN_PASSWORD</code> and restart, or add a
+          bcrypt row to <code>users.properties</code> (<code>htpasswd -nbBC 12 &lt;user&gt; &lt;newpassword&gt;</code>).
+        </p>
+      {/if}
     </label>
     <fieldset class="field">
       <legend class="field__label">Roles</legend>
@@ -145,4 +165,13 @@
 <style>
 h2 { margin: 0; }
   /* .data-grid / .data-grid__actions / .data-grid__empty come from app.css */
+  /* .field__hint is a local convention rather than a global — mirrors TopBottomCountModal.svelte. */
+  .field__hint {
+    margin: var(--space-1) 0 0;
+    color: var(--fg-subtle);
+    font-size: var(--fs-xs);
+  }
+  .field__hint code {
+    font-size: var(--fs-xs);
+  }
 </style>


### PR DESCRIPTION
Closes #1514.

The admin panel's `PUT /admin/users/admin` returned **200**, left `users.properties` byte-identical, and the old password kept authenticating — it reported success and silently did nothing. Writes go to an H2 store; authentication reads `users.properties`; nothing connects them. This makes the panel **refuse honestly** instead.

### Why refuse rather than make it work

`SAIKU_ADMIN_PASSWORD` is the admin-password authority by design — the launcher rewrites the admin row from it on every boot (see `cd4aed06`, which established the precedence `SAIKU_ADMIN_PASSWORD` > external `users.properties` > baked default). The panel has no rotation role, and there is **no mode** in which a panel password-write takes effect: env set → overwritten next boot; external file → read once at startup, never re-read; LDAP/OAuth/SAML → the panel isn't in the auth path at all. So the refusal is unconditional, and detecting the provider would be worse — it would *permit* the write under LDAP/OAuth and reopen the silent-success bug where it's hardest to see.

### The change

- `PUT /admin/users/admin` with a password → **501 Not Implemented**, `text/plain`, with an operator message pointing at `SAIKU_ADMIN_PASSWORD` / `htpasswd` / LDAP — the same guidance the launcher's banner gives.
- Non-password profile edits (email/roles) via `PUT` still work.
- `POST /admin/users` still returns 200 and creates the user. This is deliberate: that H2 row feeds `/saiku/api/users`, the @-mention autocomplete for dashboard comments. The account can't authenticate (auth reads `users.properties`), and the UI now says so — *"cannot sign in until it is added to users.properties"* — so it's disclosed, not silent.
- `admin.ts` now surfaces the server's response body on error instead of discarding it (a bare `/users/admin -> 501` reached the user before). This also un-swallows the pre-existing password-policy 400, and the datasource-save error message from #1529.
- `dist/README.md`: the misleading *"the env var is only needed the first time"* — the wording that caused this whole issue — is replaced with the real contract (enforced every boot; hand-edits reverted on restart).

### Verification

- **Unit:** `AdminResourceUserPasswordTest` (8 tests). The load-bearing assertion is `updateCalls == 0` — the write must *not happen*, not merely that the status is 501. `saiku-web` 508 tests / 0 failures; floor 330→338.
- **Live (self-built launcher on this branch):** bug reproduced on the released 4.6.3 image (200, password unchanged); fix confirmed end-to-end — `PUT` → 501 with the full message body, old password still valid and new rejected after the 501, profile edits still 200, `POST` creates a user that appears in `/saiku/api/users` but can't log in.

Rebased onto 4.6.3; the admin.ts change merges cleanly with the #1529 datasource work and every consumer treats the error message as opaque text, so nothing downstream breaks.

### Known follow-ups (not blockers)
- The 501 message duplicates the launcher's wording (reactor order forbids a shared constant across `saiku-web`/`saiku-launcher`); the javadoc cross-references it.
- A direct API caller bypassing the UI still gets an optimistic 200 on `POST` for a non-authenticating account — disclosed in the UI, not the API.
