### PR TITLE
Fix production frontend build: load Monaco editor worker without the Vite ?worker suffix

### DIFF
--- a/saiku-ui/src/lib/monaco/worker-env.ts
+++ b/saiku-ui/src/lib/monaco/worker-env.ts
@@ -1,5 +1,3 @@
-import EditorWorker from "monaco-editor/esm/vs/editor/editor.worker?worker";
-
 let configured = false;
 
 export function configureMonacoWorkers(): void {
@@ -9,7 +7,23 @@ export function configureMonacoWorkers(): void {
   // load the JSON / CSS / HTML / TS language services.
   (self as unknown as { MonacoEnvironment?: unknown }).MonacoEnvironment = {
     getWorker(): Worker {
-      return new EditorWorker();
+      // Framework-agnostic Vite worker pattern. We deliberately avoid the
+      // `monaco-editor/...?worker` import: the `?worker` suffix is a Vite
+      // *client*-build feature whose plugin never runs in the SvelteKit
+      // SSR/prerender bundle, so any `?worker` specifier Rollup traverses there
+      // (static or dynamic) fails to resolve and breaks the build (saiku#1550).
+      // `new Worker(new URL(...), { type: "module" })` is understood by Vite in
+      // both bundles and constructs the Worker synchronously, as Monaco
+      // requires. The path is relative rather than a bare `monaco-editor/...`
+      // specifier because Vite's worker-URL resolver does not run bare package
+      // specifiers through node resolution here.
+      return new Worker(
+        new URL(
+          "../../../node_modules/monaco-editor/esm/vs/editor/editor.worker.js",
+          import.meta.url,
+        ),
+        { type: "module" },
+      );
     },
   };
 }


### PR DESCRIPTION
`development` is currently red — `build (mvn verify)` and `bundle (Build launcher fat JAR)` both fail because `vite build` can't resolve `monaco-editor/esm/vs/editor/editor.worker?worker` (imported at the top of `saiku-ui/src/lib/monaco/worker-env.ts`) in the SvelteKit SSR bundle. See #1550.

Load the worker with `new Worker(new URL(".../editor.worker.js", import.meta.url), { type: "module" })` instead — Vite resolves the relative path at build time and emits a same-origin hashed worker chunk that builds in both the SSR and client passes. `getWorker` stays synchronous and is still only reached client-side (MonacoEditor.svelte's onMount).

Verified locally:
- `mvn -pl saiku-launcher -am -Dmaven.test.skip=true package` → BUILD SUCCESS; both vite passes complete; `editor.worker-*.js` client chunk emitted; launcher fat JAR produced.
- Booted the fat JAR: `/ui/` → 200 and the worker chunk served 200 (byte-for-byte match).

Frontend-only change, one file. Fixes #1550.