### PR TITLE
Gate LLM egress of cell data and enforce embed PII inspection

### DIFF
--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ai/AiPolicy.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ai/AiPolicy.java
@@ -48,6 +48,16 @@ public enum AiPolicy {
      * {@code full} case-insensitively.
      */
     public static AiPolicy parse(String raw) {
+        return parse(raw, ENV, PROP);
+    }
+
+    /**
+     * Parse as {@link #parse(String)} but name {@code envKey}/{@code propKey} in
+     * the fail-fast error so a second guard reading different keys (e.g. the
+     * LLM-egress guard on {@code SAIKU_AI_LLM_EGRESS} / {@code ai.llm.egress})
+     * reports the keys the operator actually set.
+     */
+    public static AiPolicy parse(String raw, String envKey, String propKey) {
         if (raw == null || raw.isBlank()) {
             return DEFAULT;
         }
@@ -60,7 +70,7 @@ public enum AiPolicy {
             case "full":
                 return FULL;
             default:
-                throw new IllegalArgumentException("Invalid " + PROP + " / " + ENV + " value '" + raw
+                throw new IllegalArgumentException("Invalid " + propKey + " / " + envKey + " value '" + raw
                         + "' — expected one of: schema-only, aggregated, full");
         }
     }
@@ -72,11 +82,22 @@ public enum AiPolicy {
      * value (fail-fast).
      */
     public static AiPolicy resolve(Function<String, String> env, Function<String, String> prop) {
-        String fromEnv = env.apply(ENV);
+        return resolve(env, prop, ENV, PROP);
+    }
+
+    /**
+     * Resolve from an arbitrary pair of env/property keys — env &gt; property &gt;
+     * default. Lets a second, independent policy (the LLM-egress guard) reuse the
+     * same tier enum + fail-fast parsing while reading its own keys, without
+     * changing the meaning of the data-return {@link #ENV}/{@link #PROP} guard.
+     */
+    public static AiPolicy resolve(
+            Function<String, String> env, Function<String, String> prop, String envKey, String propKey) {
+        String fromEnv = env.apply(envKey);
         if (fromEnv != null && !fromEnv.isBlank()) {
-            return parse(fromEnv);
+            return parse(fromEnv, envKey, propKey);
         }
-        return parse(prop.apply(PROP));
+        return parse(prop.apply(propKey), envKey, propKey);
     }
 
     /** The wire/display form: lowercase, hyphenated (e.g. {@code schema-only}). */

--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ai/AiPolicyGuard.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ai/AiPolicyGuard.java
@@ -24,6 +24,17 @@ public class AiPolicyGuard {
 
     private static final Logger log = LoggerFactory.getLogger(AiPolicyGuard.class);
 
+    /**
+     * Environment variable key for the DEDICATED LLM-egress guard — "may cell
+     * data leave the box to a third-party LLM vendor?" — resolved independently
+     * of the data-return {@link AiPolicy#ENV} guard. Takes precedence over
+     * {@link #LLM_EGRESS_PROP}.
+     */
+    public static final String LLM_EGRESS_ENV = "SAIKU_AI_LLM_EGRESS";
+
+    /** System property key for the LLM-egress guard (see {@link #LLM_EGRESS_ENV}). */
+    public static final String LLM_EGRESS_PROP = "ai.llm.egress";
+
     private final AiPolicy current;
 
     /** Production constructor — resolves from the real environment + system
@@ -46,6 +57,30 @@ public class AiPolicyGuard {
     /** Testable resolution seam (env + property lookups injected). */
     public static AiPolicyGuard from(Function<String, String> env, Function<String, String> prop) {
         return new AiPolicyGuard(AiPolicy.resolve(env, prop));
+    }
+
+    /**
+     * Production factory for the DEDICATED LLM-egress guard. Resolves from
+     * {@link #LLM_EGRESS_ENV} &gt; {@link #LLM_EGRESS_PROP} &gt; default
+     * {@code schema-only}, logs the active egress posture once at boot (mirroring
+     * the data-policy boot log), and throws on an invalid configured value so the
+     * app fails fast at startup. Separate from the data-return {@link AiPolicy}
+     * guard: this answers "may cell data egress to a third-party LLM vendor?"
+     * independently of "may aggregated data return to the authenticated caller?".
+     */
+    public static AiPolicyGuard forLlmEgress() {
+        AiPolicyGuard guard = fromLlmEgress(System::getenv, System::getProperty);
+        log.info(
+                "AI LLM egress policy: {} (set via {} / {}; default schema-only)",
+                guard.current.displayName(),
+                LLM_EGRESS_ENV,
+                LLM_EGRESS_PROP);
+        return guard;
+    }
+
+    /** Testable resolution seam for the LLM-egress guard (env + property injected). */
+    public static AiPolicyGuard fromLlmEgress(Function<String, String> env, Function<String, String> prop) {
+        return new AiPolicyGuard(AiPolicy.resolve(env, prop, LLM_EGRESS_ENV, LLM_EGRESS_PROP));
     }
 
     /** The active policy tier. */

--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ai/ask/AiAskService.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ai/ask/AiAskService.java
@@ -11,6 +11,8 @@ import java.util.List;
 import java.util.Objects;
 import org.saiku.service.olap.ai.AiCubeMetadataService;
 import org.saiku.service.olap.ai.AiCubeRef;
+import org.saiku.service.olap.ai.AiDataKind;
+import org.saiku.service.olap.ai.AiPolicyGuard;
 import org.saiku.service.olap.ai.AiQueryRequest;
 import org.saiku.service.olap.ai.AiRequestJsonSchema;
 import org.saiku.service.olap.ai.AiSchema;
@@ -56,6 +58,16 @@ public class AiAskService {
      */
     private AgentSpaceRegistry spaces;
 
+    /**
+     * Dedicated LLM-egress guard (Option A). Answers "may cell data leave the box to a third-party
+     * LLM vendor?" — resolved from {@code SAIKU_AI_LLM_EGRESS} / {@code ai.llm.egress}, SEPARATE
+     * from the data-return {@link AiPolicyGuard} on {@code SAIKU_AI_POLICY}. Injected via setter so
+     * existing two-arg construction stays unchanged. FAIL-CLOSED: a null (unwired) guard is treated
+     * as "egress not permitted", so an unconfigured instance strips cell data from the prompt rather
+     * than leaking it.
+     */
+    private AiPolicyGuard egressGuard;
+
     public AiAskService(AiCubeMetadataService metadataService, NlAskProvider provider) {
         this(metadataService, provider, defaultMapper());
     }
@@ -87,6 +99,26 @@ public class AiAskService {
     /** Agent-space catalogue, or {@code null} if the operator hasn't configured one. */
     public AgentSpaceRegistry spaces() {
         return spaces;
+    }
+
+    /** Spring setter — wired to {@code aiLlmEgressGuard} in {@code saiku-beans.xml}. */
+    public void setEgressGuard(AiPolicyGuard egressGuard) {
+        this.egressGuard = egressGuard;
+    }
+
+    /** The dedicated LLM-egress guard, or {@code null} if not wired (treated as egress-denied). */
+    public AiPolicyGuard egressGuard() {
+        return egressGuard;
+    }
+
+    /**
+     * Whether cell data (the cellset digest) may egress to the LLM vendor under the active egress
+     * posture. FAIL-CLOSED: a null guard, or a guard that doesn't permit {@link
+     * AiDataKind#AGGREGATED_RESULT_VALUES}, returns {@code false} — the digest is stripped and the
+     * prompt is schema-only.
+     */
+    private boolean egressPermitsCellData() {
+        return egressGuard != null && egressGuard.canSend(AiDataKind.AGGREGATED_RESULT_VALUES);
     }
 
     /**
@@ -306,11 +338,26 @@ public class AiAskService {
         String schemaJson;
         String requestSchemaJson;
         try {
-            schemaJson = mapper.writeValueAsString(schema);
+            // #3: serialise the PII-filtered agent view, never the raw schema. PII-tagged levels /
+            // measures have their captions, sample members, descriptions and synonyms stripped before
+            // the schema crosses the trust boundary to the vendor. Applies at every egress tier —
+            // schema egress is permitted even at schema-only, but must still be PII-filtered.
+            schemaJson = mapper.writeValueAsString(schema.toAgentView());
             requestSchemaJson = mapper.writeValueAsString(AiRequestJsonSchema.forRequest());
         } catch (JsonProcessingException e) {
             log.warn("Failed to serialise schema / request-schema for ask", e);
             return AskOutcome.degraded("schema serialisation failed", null);
+        }
+
+        // #2: LLM-egress gate. When the dedicated egress guard does NOT permit aggregated cell
+        // values to leave the box, STRIP the cellset digest so the prompt is schema-only. The ask
+        // still runs — degraded (ungrounded), never refused. Fail-closed: an unwired guard denies
+        // egress, so any doubt strips.
+        String effectiveDigest = cellsetDigest;
+        if (cellsetDigest != null && !cellsetDigest.isBlank() && !egressPermitsCellData()) {
+            effectiveDigest = null;
+            // No data in the log — just the fact that the digest was withheld by policy.
+            log.debug("Cellset digest withheld from LLM by egress policy; ask proceeds schema-only");
         }
 
         // Serialise the current query into JSON for the provider to embed in the prompt.
@@ -356,7 +403,7 @@ public class AiAskService {
                 schemaJson,
                 requestSchemaJson,
                 history == null ? List.of() : history,
-                cellsetDigest,
+                effectiveDigest,
                 forceTool == null ? NlAskRequest.ForceTool.AUTO : forceTool,
                 currentQueryJson,
                 skillsFragment,

--- a/saiku-core/saiku-service/src/test/java/org/saiku/service/olap/ai/AiPolicyGuardTest.java
+++ b/saiku-core/saiku-service/src/test/java/org/saiku/service/olap/ai/AiPolicyGuardTest.java
@@ -115,4 +115,73 @@ public class AiPolicyGuardTest {
                 AiPolicyGuard.from(map(AiPolicy.ENV, "aggregated"), map()).current());
         assertEquals(AiPolicy.SCHEMA_ONLY, new AiPolicyGuard((AiPolicy) null).current());
     }
+
+    /* ------------------------ LLM-egress guard ----------------------- */
+    // The dedicated egress guard reuses AiPolicy but reads its OWN keys
+    // (SAIKU_AI_LLM_EGRESS / ai.llm.egress), independent of the data-return
+    // SAIKU_AI_POLICY / ai.policy guard.
+
+    @Test
+    public void llmEgress_resolves_env_beats_property_beats_default() {
+        // env wins
+        assertEquals(
+                AiPolicy.FULL,
+                AiPolicyGuard.fromLlmEgress(
+                                map(AiPolicyGuard.LLM_EGRESS_ENV, "full"),
+                                map(AiPolicyGuard.LLM_EGRESS_PROP, "aggregated"))
+                        .current());
+        // property used when env absent
+        assertEquals(
+                AiPolicy.AGGREGATED,
+                AiPolicyGuard.fromLlmEgress(map(), map(AiPolicyGuard.LLM_EGRESS_PROP, "aggregated"))
+                        .current());
+        // default (fail-closed) when neither set
+        assertEquals(
+                AiPolicy.SCHEMA_ONLY, AiPolicyGuard.fromLlmEgress(map(), map()).current());
+        // blank env falls through to property
+        assertEquals(
+                AiPolicy.AGGREGATED,
+                AiPolicyGuard.fromLlmEgress(
+                                map(AiPolicyGuard.LLM_EGRESS_ENV, "  "),
+                                map(AiPolicyGuard.LLM_EGRESS_PROP, "aggregated"))
+                        .current());
+    }
+
+    @Test
+    public void llmEgress_default_is_schema_only_which_denies_cell_data() {
+        // Fail-closed default: schema-only egress does NOT permit aggregated cell
+        // values to reach the vendor — the ask path strips the digest on this.
+        AiPolicyGuard g = AiPolicyGuard.fromLlmEgress(map(), map());
+        assertEquals(AiPolicy.SCHEMA_ONLY, g.current());
+        assertFalse(g.canSend(AiDataKind.AGGREGATED_RESULT_VALUES));
+        assertTrue(g.canSend(AiDataKind.SCHEMA_METADATA));
+    }
+
+    @Test
+    public void llmEgress_aggregated_permits_cell_data() {
+        AiPolicyGuard g = AiPolicyGuard.fromLlmEgress(map(AiPolicyGuard.LLM_EGRESS_ENV, "aggregated"), map());
+        assertTrue(g.canSend(AiDataKind.AGGREGATED_RESULT_VALUES));
+    }
+
+    @Test
+    public void llmEgress_invalid_configured_value_fails_fast() {
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> AiPolicyGuard.fromLlmEgress(map(AiPolicyGuard.LLM_EGRESS_ENV, "leak-everything"), map()));
+    }
+
+    @Test
+    public void llmEgress_keys_are_independent_of_data_policy_keys() {
+        // Setting the DATA-policy keys must NOT move the egress guard, and vice
+        // versa — the two postures are resolved separately.
+        assertEquals(
+                AiPolicy.SCHEMA_ONLY,
+                AiPolicyGuard.fromLlmEgress(map(AiPolicy.ENV, "full"), map(AiPolicy.PROP, "full"))
+                        .current());
+        assertEquals(
+                AiPolicy.SCHEMA_ONLY,
+                AiPolicyGuard.from(
+                                map(AiPolicyGuard.LLM_EGRESS_ENV, "full"), map(AiPolicyGuard.LLM_EGRESS_PROP, "full"))
+                        .current());
+    }
 }

--- a/saiku-core/saiku-service/src/test/java/org/saiku/service/olap/ai/ask/AiAskServiceTest.java
+++ b/saiku-core/saiku-service/src/test/java/org/saiku/service/olap/ai/ask/AiAskServiceTest.java
@@ -15,6 +15,8 @@ import java.util.concurrent.atomic.AtomicReference;
 import org.junit.Test;
 import org.saiku.service.olap.ai.AiCubeMetadataService;
 import org.saiku.service.olap.ai.AiCubeRef;
+import org.saiku.service.olap.ai.AiPolicy;
+import org.saiku.service.olap.ai.AiPolicyGuard;
 import org.saiku.service.olap.ai.AiSchema;
 
 /** Unit tests for {@link AiAskService}. Provider + metadata service are stubbed. */
@@ -424,6 +426,89 @@ public class AiAskServiceTest {
         assertFalse("blocked skill must not surface: " + fragment, fragment.contains("/blocked-skill"));
     }
 
+    /* ---- LLM-egress gate: cellset-digest strip (#2) + PII-filtered schema (#3) ---- */
+
+    @Test
+    public void egressSchemaOnlyStripsCellsetDigestButAskStillSucceeds() {
+        // Egress posture is the fail-closed default (schema-only) → the supplied cellset digest must
+        // be withheld from the provider request, but the ask still runs (degraded/ungrounded, NOT
+        // refused).
+        AtomicReference<NlAskRequest> seen = new AtomicReference<>();
+        NlAskProvider capturing = req -> {
+            seen.set(req);
+            return NlAskResponse.ok("{\"cube\":{\"cubeName\":\"Sales\"},\"measures\":[]}", "m", 0, 0);
+        };
+        AiAskService svc = new AiAskService(fixedSchemaService(emptySchema()), capturing);
+        svc.setEgressGuard(new AiPolicyGuard(AiPolicy.SCHEMA_ONLY));
+
+        AiAskService.AskOutcome out = svc.ask(CUBE, "spot the trend", List.of(), "| Country | Sales |\n| CA | 42 |");
+
+        assertFalse("schema-only egress must degrade to schema-only, not refuse the ask", out.degraded());
+        assertNotNull(seen.get());
+        assertNull(
+                "cellset digest must be stripped under schema-only egress",
+                seen.get().cellsetDigest());
+    }
+
+    @Test
+    public void egressAggregatedPassesCellsetDigestThrough() {
+        AtomicReference<NlAskRequest> seen = new AtomicReference<>();
+        NlAskProvider capturing = req -> {
+            seen.set(req);
+            return NlAskResponse.ok("{\"cube\":{\"cubeName\":\"Sales\"},\"measures\":[]}", "m", 0, 0);
+        };
+        AiAskService svc = new AiAskService(fixedSchemaService(emptySchema()), capturing);
+        svc.setEgressGuard(new AiPolicyGuard(AiPolicy.AGGREGATED));
+
+        String digest = "| Country | Sales |\n| CA | 42 |";
+        svc.ask(CUBE, "spot the trend", List.of(), digest);
+
+        assertNotNull(seen.get());
+        assertEquals(
+                "aggregated egress must pass the digest through",
+                digest,
+                seen.get().cellsetDigest());
+    }
+
+    @Test
+    public void egressGuardUnwiredFailsClosedAndStripsDigest() {
+        // No setEgressGuard() call — the guard is null. Fail-closed: absence of a permit means the
+        // digest is stripped, never leaked.
+        AtomicReference<NlAskRequest> seen = new AtomicReference<>();
+        NlAskProvider capturing = req -> {
+            seen.set(req);
+            return NlAskResponse.ok("{\"cube\":{\"cubeName\":\"Sales\"},\"measures\":[]}", "m", 0, 0);
+        };
+        AiAskService svc = new AiAskService(fixedSchemaService(emptySchema()), capturing);
+
+        svc.ask(CUBE, "spot the trend", List.of(), "| Country | Sales |\n| CA | 42 |");
+
+        assertNotNull(seen.get());
+        assertNull(
+                "an unwired egress guard must fail closed and strip the digest",
+                seen.get().cellsetDigest());
+    }
+
+    @Test
+    public void schemaHandedToProviderIsPiiFilteredAgentView() {
+        // #3: the schema JSON in the provider request must be the agent view — a PII-tagged level's
+        // sample members (and captions) must NOT appear; the [REDACTED] sentinel does.
+        AtomicReference<NlAskRequest> seen = new AtomicReference<>();
+        NlAskProvider capturing = req -> {
+            seen.set(req);
+            return NlAskResponse.ok("{\"cube\":{\"cubeName\":\"Sales\"},\"measures\":[]}", "m", 0, 0);
+        };
+        AiAskService svc = new AiAskService(fixedSchemaService(piiSchema()), capturing);
+
+        svc.ask(CUBE, "show customers", List.of());
+
+        String schemaJson = seen.get().cubeSchemaJson();
+        assertNotNull(schemaJson);
+        assertFalse("PII sample member caption must not egress: " + schemaJson, schemaJson.contains("John Smith"));
+        assertFalse("PII display name must not egress: " + schemaJson, schemaJson.contains("Customer Name"));
+        assertTrue("redaction sentinel must be present: " + schemaJson, schemaJson.contains("[REDACTED]"));
+    }
+
     // ---------- helpers ----------
 
     private static AiCubeMetadataService fixedSchemaService(AiSchema schema) {
@@ -432,6 +517,23 @@ public class AiAskServiceTest {
 
     private static AiSchema emptySchema() {
         return new AiSchema("conn/cat/sch/Sales", "Sales", "[Sales]");
+    }
+
+    /** Schema carrying a PII-tagged level with sensitive sample members, to prove #3 filtering. */
+    private static AiSchema piiSchema() {
+        AiSchema schema = new AiSchema("conn/cat/sch/Sales", "Sales", "[Sales]");
+        AiSchema.Level pii = new AiSchema.Level("CustomerName", "[Customers].[CustomerName]");
+        pii.displayName = "Customer Name";
+        pii.pii = true;
+        pii.sampleMembers = List.of(
+                new AiSchema.MemberSample("John Smith", "[Customers].[USA].[CA].[John Smith]"),
+                new AiSchema.MemberSample("Jane Doe", "[Customers].[USA].[CA].[Jane Doe]"));
+        AiSchema.Dimension d = new AiSchema.Dimension("Customers", "[Customers]");
+        AiSchema.Hierarchy h = new AiSchema.Hierarchy("Customers", "[Customers]");
+        h.levels.put(AiSchema.key("CustomerName"), pii);
+        d.hierarchies.put(AiSchema.key("Customers"), h);
+        schema.dimensions.put(AiSchema.key("Customers"), d);
+        return schema;
     }
 
     private static NlAskProvider stub(NlAskResponse fixed) {

--- a/saiku-core/saiku-web/src/test/java/org/saiku/web/embed/EmbedPiiInspectorTest.java
+++ b/saiku-core/saiku-web/src/test/java/org/saiku/web/embed/EmbedPiiInspectorTest.java
@@ -284,6 +284,65 @@ public class EmbedPiiInspectorTest {
         assertTrue(r.referencesPii);
     }
 
+    // saiku-cloud#949 residual: SEC flagged that a per-column FALSE NEGATIVE
+    // would slip a PII-projecting query past grantPublic (HTTP 400 gate) if
+    // the query→refs extraction (extractRefsFromThinQuery) and the schema PII
+    // lookup (refsHitPii) ever disagreed on key derivation. Both route through
+    // AiSchema.key(...). The next two tests pin that alignment on the COLUMNS
+    // axis (the existing pair above only exercises ROWS) using ONE shared cube
+    // schema: the positive proves a PII level projected on a real axis IS
+    // detected; the same-schema negative proves the check is genuinely
+    // per-column (not cube-wide) — a key-derivation mismatch would flip one.
+
+    @Test
+    public void projectedPiiLevel_isDetected() {
+        // Core guard: a query that PROJECTS a pii=true level (here on COLUMNS)
+        // MUST yield referencesPii=true. If key derivation on the two sides
+        // drifted, the projected Email ref would miss the schema's PII flag
+        // and this would silently go false — the exact false-negative SEC
+        // worried publicly-grants a PII query.
+        ds.put(
+                "/projects-pii.saiku",
+                thinQueryWithAxes(
+                        "COLUMNS",
+                        "conn-1",
+                        "Cat",
+                        "Sch",
+                        "Sales",
+                        List.of(new LevelRef("Customer", "[Customer].[Customers]", "Email")),
+                        List.of("Store Sales")));
+        cubes.putSchema("conn-1/Cat/Sch/Sales", cubeWithPiiEmailLevel());
+
+        EmbedPiiInspector.Result r = inspector.inspect("query", "/projects-pii.saiku", "admin", List.of());
+        assertTrue("PII level projected on COLUMNS must be detected", r.referencesPii);
+    }
+
+    @Test
+    public void onlyNonPiiLevelsProjected_notFlagged() {
+        // Per-column proof on the SAME cube schema as projectedPiiLevel_isDetected:
+        // the cube HAS a pii=true Email level, but this query projects only the
+        // clean Time.Quarter × Product.Family levels. Result must be false —
+        // proving the check is per-column, not cube-wide, AND that the clean
+        // refs' keys align (a misalignment could spuriously match, or fail to
+        // exclude, the PII level).
+        ds.put(
+                "/projects-clean.saiku",
+                thinQueryWithAxes(
+                        "COLUMNS",
+                        "conn-1",
+                        "Cat",
+                        "Sch",
+                        "Sales",
+                        List.of(
+                                new LevelRef("Time", "[Time].[Time]", "Quarter"),
+                                new LevelRef("Product", "[Product].[Product]", "Family")),
+                        List.of("Store Sales")));
+        cubes.putSchema("conn-1/Cat/Sch/Sales", cubeWithPiiEmailLevel());
+
+        EmbedPiiInspector.Result r = inspector.inspect("query", "/projects-clean.saiku", "admin", List.of());
+        assertFalse("only clean levels projected — must NOT be flagged", r.referencesPii);
+    }
+
     @Test
     public void query_with_no_query_model_falls_back_to_cube_level_scan() {
         // No queryModel means we can't enumerate columns — must fall back
@@ -420,6 +479,29 @@ public class EmbedPiiInspectorTest {
         return new AiSchema("c/cat/sch/Cube", "Cube", "[Cube]");
     }
 
+    /**
+     * One cube schema shared by projectedPiiLevel_isDetected /
+     * onlyNonPiiLevelsProjected_notFlagged: a pii=true Email level under
+     * [Customer].[Customers], plus clean Time.Quarter, Product.Family and a
+     * clean Store Sales measure. The SAME schema drives both the positive and
+     * the negative so the pair proves the check is genuinely per-column and
+     * that both sides derive matching keys.
+     */
+    private static AiSchema cubeWithPiiEmailLevel() {
+        AiSchema schema = cleanSchema();
+        AiSchema.Dimension cust = new AiSchema.Dimension("Customer", "[Customer]");
+        AiSchema.Hierarchy custHier = new AiSchema.Hierarchy("Customers", "[Customer].[Customers]");
+        AiSchema.Level email = new AiSchema.Level("Email", "[Customer].[Customers].[Email]");
+        email.pii = true;
+        custHier.levels.put(AiSchema.key("Email"), email);
+        cust.hierarchies.put(AiSchema.key("Customers"), custHier);
+        schema.dimensions.put(AiSchema.key("Customer"), cust);
+        addClean(schema, "Time", "Time", "Quarter");
+        addClean(schema, "Product", "Product", "Family");
+        addCleanMeasure(schema, "Store Sales");
+        return schema;
+    }
+
     private static String thinQueryJson(String conn, String cat, String sch, String cube) {
         return "{\"name\":\"q\",\"type\":\"QUERYMODEL\",\"cube\":{\"connection\":\"" + conn + "\",\"catalog\":\"" + cat
                 + "\",\"schema\":\"" + sch + "\",\"name\":\"" + cube + "\"}}";
@@ -463,6 +545,24 @@ public class EmbedPiiInspectorTest {
      */
     private static String thinQueryWithAxes(
             String conn, String cat, String sch, String cube, List<LevelRef> levels, List<String> measureNames) {
+        return thinQueryWithAxes("ROWS", conn, cat, sch, cube, levels, measureNames);
+    }
+
+    /**
+     * As {@link #thinQueryWithAxes(String, String, String, String, List, List)}
+     * but places the projected hierarchies on the named axis (e.g. "ROWS" or
+     * "COLUMNS"). {@code extractRefsFromThinQuery} walks every axis, so the
+     * per-column PII check must hold regardless of which axis a PII level is
+     * projected on.
+     */
+    private static String thinQueryWithAxes(
+            String axis,
+            String conn,
+            String cat,
+            String sch,
+            String cube,
+            List<LevelRef> levels,
+            List<String> measureNames) {
         StringBuilder sb = new StringBuilder();
         sb.append("{\"name\":\"q\",\"type\":\"QUERYMODEL\",\"cube\":{\"connection\":\"")
                 .append(conn)
@@ -473,7 +573,11 @@ public class EmbedPiiInspectorTest {
                 .append("\",\"name\":\"")
                 .append(cube)
                 .append("\"},\"queryModel\":{");
-        sb.append("\"axes\":{\"ROWS\":{\"location\":\"ROWS\",\"hierarchies\":[");
+        sb.append("\"axes\":{\"")
+                .append(axis)
+                .append("\":{\"location\":\"")
+                .append(axis)
+                .append("\",\"hierarchies\":[");
         for (int i = 0; i < levels.size(); i++) {
             if (i > 0) sb.append(',');
             LevelRef ref = levels.get(i);

--- a/saiku-webapp/src/main/webapp/WEB-INF/saiku-beans.xml
+++ b/saiku-webapp/src/main/webapp/WEB-INF/saiku-beans.xml
@@ -266,6 +266,16 @@
          and FAILS FAST on an invalid value before the app serves traffic. -->
     <bean id="aiPolicyGuard" class="org.saiku.service.olap.ai.AiPolicyGuard"/>
 
+    <!-- Dedicated LLM-egress guard (Option A). Answers "may cell data leave the
+         box to a third-party LLM vendor?" — SEPARATE from aiPolicyGuard (which
+         governs whether aggregated data returns to the authenticated caller).
+         forLlmEgress() resolves SAIKU_AI_LLM_EGRESS / ai.llm.egress (default
+         schema-only), logs the active egress posture once at boot, and FAILS FAST
+         on an invalid value. Consumed by aiAskServiceBean to strip the cellset
+         digest from the LLM prompt when egress isn't permitted. -->
+    <bean id="aiLlmEgressGuard" class="org.saiku.service.olap.ai.AiPolicyGuard"
+          factory-method="forLlmEgress"/>
+
     <!-- saiku#905: k-anonymity small-cell suppression. Singleton resolving
          ai.kAnonymity (default 5; 0 disables) + ai.kAnonymity.maskValue at boot. -->
     <bean id="kAnonymityFilter" class="org.saiku.service.olap.ai.KAnonymityFilter"/>
@@ -430,6 +440,9 @@
         <constructor-arg ref="aiAskProviderBean"/>
         <property name="skills" ref="agentSkillRegistryBean"/>
         <property name="spaces" ref="agentSpaceRegistryBean"/>
+        <!-- LLM-egress gate: strips the cellset digest from the prompt when
+             SAIKU_AI_LLM_EGRESS / ai.llm.egress doesn't permit cell data egress. -->
+        <property name="egressGuard" ref="aiLlmEgressGuard"/>
     </bean>
 
     <!-- Skill catalogue (saiku#1426). Markdown files with YAML frontmatter under

--- a/saiku-webapp/src/main/webapp/WEB-INF/saiku-beans.xml
+++ b/saiku-webapp/src/main/webapp/WEB-INF/saiku-beans.xml
@@ -649,6 +649,19 @@
         <constructor-arg ref="embedPublicRegistry"/>
     </bean>
 
+    <!-- saiku-cloud#940 mint-time PII gate. Resolves a resource's bound cubes
+         and walks their AiSchemas for saiku.semantic.pii=true annotations.
+         Constructor takes (DatasourceService, AiCubeMetadataService) — reusing
+         the same datasourceServiceBean the token resource reads files with and
+         the aiCubeMetadataServiceBean the AI query surface already uses for
+         schema lookups (wired identically at aiQueryResource, above). Without
+         this bean set on embedTokenResource.piiInspector the mint/grant PII
+         gates no-op. -->
+    <bean id="embedPiiInspector" class="org.saiku.web.embed.EmbedPiiInspector">
+        <constructor-arg ref="datasourceServiceBean"/>
+        <constructor-arg ref="aiCubeMetadataServiceBean"/>
+    </bean>
+
     <bean id="embedTokenResource"
           class="org.saiku.web.rest.resources.embed.EmbedTokenResource">
         <property name="tokenStore" ref="embedTokenStore"/>
@@ -656,6 +669,7 @@
         <property name="datasourceService" ref="datasourceServiceBean"/>
         <property name="sessionService" ref="sessionService"/>
         <property name="userService" ref="userServiceBean"/>
+        <property name="piiInspector" ref="embedPiiInspector"/>
     </bean>
 
     <bean id="embedViewResource" scope="request"


### PR DESCRIPTION
First of a series splitting the AI email/dashboard work into reviewable pieces. This one is the data-egress foundation the later AI slices build on.

- Add an egress policy gate on the `/ai/ask` path so cell data only reaches the LLM when the configured policy allows it; it fails closed (schema-only) by default, stripping the cellset digest otherwise.
- Wire `EmbedPiiInspector` so the embed PII gates actually enforce, and add COLUMNS-axis regression tests for per-column PII detection.

Backend only (saiku-service, saiku-web, saiku-webapp wiring). Tests included.