### PR TITLE
Draft an email from a natural-language ask and open the composer

### DIFF
--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ai/ask/AbstractNlAskProvider.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ai/ask/AbstractNlAskProvider.java
@@ -53,6 +53,13 @@ abstract class AbstractNlAskProvider implements NlAskProvider {
      */
     protected static final String VIEW_CHANGE_TOOL_NAME = "emit_view_change";
 
+    /**
+     * Name of the email-draft tool — picks when the user explicitly asks to email / send the
+     * currently-rendered cellset. No query is built; the model returns a short prose summary the app
+     * uses as the pre-filled email body. Draft-only — the AI never sends.
+     */
+    protected static final String EMAIL_DRAFT_TOOL_NAME = "emit_email_draft";
+
     /** Prefix on the degraded reason when the model refuses an off-topic question. */
     protected static final String REFUSAL_REASON_PREFIX = "OFF_TOPIC: ";
 
@@ -177,6 +184,27 @@ abstract class AbstractNlAskProvider implements NlAskProvider {
                 "Optional 1-line headline (<=80 chars) shown above the markdown body in the drawer. "
                         + "Example: 'Revenue concentrated in Q4; CA leads by 38%.'");
         root.putArray("required").add("markdown");
+        return root;
+    }
+
+    /**
+     * Builds the JSON Schema for the {@code emit_email_draft} tool's input. Provider-agnostic — both
+     * Anthropic and OpenAI consume the same {@code {"type":"object", "properties":...}} shape under
+     * their respective tool/function definitions.
+     *
+     * <p>One field: {@code summary} (required, the email body).
+     */
+    protected static ObjectNode emailDraftInputSchema() {
+        ObjectNode root = MAPPER.createObjectNode();
+        root.put("type", "object");
+        ObjectNode props = root.putObject("properties");
+        ObjectNode summary = props.putObject("summary");
+        summary.put("type", "string");
+        summary.put(
+                "description",
+                "The email body: a short plain-prose summary of the CURRENT cellset (2-3 sentences, "
+                        + "reference specific figures from the digest). No greeting, no subject line.");
+        root.putArray("required").add("summary");
         return root;
     }
 

--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ai/ask/AiAskApi.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ai/ask/AiAskApi.java
@@ -187,6 +187,13 @@ public final class AiAskApi {
          * Mutually exclusive with the other intents as above.
          */
         private AiViewChange viewChange;
+        /**
+         * Composed email body. Present when the model picked {@code emit_email_draft} AND mail
+         * delivery is configured on this server. Mutually exclusive with the other intents as
+         * above. Draft-only — the browser opens a composer; sending happens via the existing
+         * {@code /email/self}, never here.
+         */
+        private AiEmailDraft emailDraft;
 
         public boolean isDegraded() {
             return degraded;
@@ -258,6 +265,14 @@ public final class AiAskApi {
 
         public void setViewChange(AiViewChange v) {
             this.viewChange = v;
+        }
+
+        public AiEmailDraft getEmailDraft() {
+            return emailDraft;
+        }
+
+        public void setEmailDraft(AiEmailDraft v) {
+            this.emailDraft = v;
         }
     }
 }

--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ai/ask/AiAskService.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ai/ask/AiAskService.java
@@ -133,8 +133,8 @@ public class AiAskService {
     /**
      * Result of an {@link #ask(AiCubeRef, String, List)} call.
      *
-     * <p>Exactly one of {@code request} / {@code insight} / {@code viewChange} is non-null on
-     * success (matched to {@link #kind()}); all are null on degraded.
+     * <p>Exactly one of {@code request} / {@code insight} / {@code viewChange} / {@code
+     * emailDraft} is non-null on success (matched to {@link #kind()}); all are null on degraded.
      */
     public record AskOutcome(
             Kind kind,
@@ -143,30 +143,36 @@ public class AiAskService {
             AiQueryRequest request,
             AiInsight insight,
             AiViewChange viewChange,
+            AiEmailDraft emailDraft,
             String model,
             SpaceAccess denial) {
 
         public enum Kind {
             QUERY,
             INSIGHT,
-            VIEW_CHANGE
+            VIEW_CHANGE,
+            EMAIL_DRAFT
         }
 
         public static AskOutcome ok(AiQueryRequest request, String model) {
-            return new AskOutcome(Kind.QUERY, false, null, request, null, null, model, SpaceAccess.OK);
+            return new AskOutcome(Kind.QUERY, false, null, request, null, null, null, model, SpaceAccess.OK);
         }
 
         public static AskOutcome okInsight(AiInsight insight, String model) {
-            return new AskOutcome(Kind.INSIGHT, false, null, null, insight, null, model, SpaceAccess.OK);
+            return new AskOutcome(Kind.INSIGHT, false, null, null, insight, null, null, model, SpaceAccess.OK);
         }
 
         public static AskOutcome okViewChange(AiViewChange viewChange, String model) {
-            return new AskOutcome(Kind.VIEW_CHANGE, false, null, null, null, viewChange, model, SpaceAccess.OK);
+            return new AskOutcome(Kind.VIEW_CHANGE, false, null, null, null, viewChange, null, model, SpaceAccess.OK);
+        }
+
+        public static AskOutcome okEmailDraft(AiEmailDraft emailDraft, String model) {
+            return new AskOutcome(Kind.EMAIL_DRAFT, false, null, null, null, null, emailDraft, model, SpaceAccess.OK);
         }
 
         /** Provider-side degrade (transport/parse/refusal) — carries no space-scope denial. */
         public static AskOutcome degraded(String reason, String model) {
-            return new AskOutcome(null, true, reason, null, null, null, model, SpaceAccess.OK);
+            return new AskOutcome(null, true, reason, null, null, null, null, model, SpaceAccess.OK);
         }
 
         /**
@@ -174,7 +180,7 @@ public class AiAskService {
          * HTTP status without prose-prefix matching on {@link #reason()}.
          */
         public static AskOutcome degraded(String reason, String model, SpaceAccess denial) {
-            return new AskOutcome(null, true, reason, null, null, null, model, denial);
+            return new AskOutcome(null, true, reason, null, null, null, null, model, denial);
         }
     }
 
@@ -448,6 +454,15 @@ public class AiAskService {
                     return AskOutcome.degraded("provider emitted empty insight", resp.model());
                 }
                 return AskOutcome.okInsight(insight, resp.model());
+            }
+            if (kind == NlAskResponse.Kind.EMAIL_DRAFT) {
+                AiEmailDraft draft = mapper.readValue(resp.payloadJson(), AiEmailDraft.class);
+                if (draft == null
+                        || draft.getSummary() == null
+                        || draft.getSummary().isBlank()) {
+                    return AskOutcome.degraded("provider emitted empty email draft", resp.model());
+                }
+                return AskOutcome.okEmailDraft(draft, resp.model());
             }
             if (kind == NlAskResponse.Kind.VIEW_CHANGE) {
                 AiViewChange vc = mapper.readValue(resp.payloadJson(), AiViewChange.class);

--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ai/ask/AiAskService.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ai/ask/AiAskService.java
@@ -355,6 +355,13 @@ public class AiAskService {
             return AskOutcome.degraded("schema serialisation failed", null);
         }
 
+        // No-data guard (design §5): capture whether the CLIENT actually sent a digest BEFORE the
+        // egress-policy strip below mutates it. This must not be conflated with the post-strip
+        // value — under schema-only egress a digest that WAS on screen gets nulled for the LLM, but
+        // that's "data present, withheld by policy", not "no analysis on screen". Only the latter
+        // should refuse EMAIL_DRAFT (see the EMAIL_DRAFT routing branch further down).
+        final boolean hadCellsetOnScreen = cellsetDigest != null && !cellsetDigest.isBlank();
+
         // #2: LLM-egress gate. When the dedicated egress guard does NOT permit aggregated cell
         // values to leave the box, STRIP the cellset digest so the prompt is schema-only. The ask
         // still runs — degraded (ungrounded), never refused. Fail-closed: an unwired guard denies
@@ -456,6 +463,11 @@ public class AiAskService {
                 return AskOutcome.okInsight(insight, resp.model());
             }
             if (kind == NlAskResponse.Kind.EMAIL_DRAFT) {
+                if (!hadCellsetOnScreen) {
+                    return AskOutcome.degraded(
+                            "No analysis is on screen to summarise — run a query first, then ask me to email it.",
+                            resp.model());
+                }
                 AiEmailDraft draft = mapper.readValue(resp.payloadJson(), AiEmailDraft.class);
                 if (draft == null
                         || draft.getSummary() == null

--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ai/ask/AiEmailDraft.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ai/ask/AiEmailDraft.java
@@ -1,0 +1,36 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.service.olap.ai.ask;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+/**
+ * Output of the {@code emit_email_draft} tool — an email body the model composed from the user's
+ * current cellset. Returned by {@code POST /saiku/api/ai/ask} when the model picks the email-draft
+ * intent (e.g. "draft an email summarising this for my manager").
+ *
+ * <p>Draft-only: the AI never sends. The UI opens a pre-filled email composer with {@link
+ * #summary} so the human can review and send.
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public final class AiEmailDraft {
+
+    /** The composed email body. */
+    private String summary;
+
+    public AiEmailDraft() {}
+
+    public AiEmailDraft(String summary) {
+        this.summary = summary;
+    }
+
+    public String getSummary() {
+        return summary;
+    }
+
+    public void setSummary(String v) {
+        this.summary = v;
+    }
+}

--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ai/ask/AnthropicNlAskProvider.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ai/ask/AnthropicNlAskProvider.java
@@ -35,7 +35,7 @@ public final class AnthropicNlAskProvider extends AbstractNlAskProvider {
     private static final String API_VERSION = "2023-06-01";
 
     private static final String SYSTEM_PROMPT = "You are a Mondrian OLAP analyst assistant scoped to a "
-            + "single cube. You have FOUR tools — pick exactly one based on the user's intent.\n\n"
+            + "single cube. You have FIVE tools — pick exactly one based on the user's intent.\n\n"
             + "TOOL CHOICE:\n"
             + "  - emit_query: the user wants new data or a different breakdown of the cube. "
             + "Translate their question into a single AiQueryRequest matching the schema.\n"
@@ -43,6 +43,11 @@ public final class AnthropicNlAskProvider extends AbstractNlAskProvider {
             + "'what's interesting', 'summarise this', 'why is X high'). The user's current cellset is "
             + "provided as a digest below; reason from it. Do NOT build a new query. Return a markdown "
             + "analysis that references specific row/column captions and figures from the digest.\n"
+            + "  - emit_email_draft: the user explicitly asks to EMAIL / send / 'email it to me' the current "
+            + "analysis. Compose a short prose summary of the current cellset as the email body (like "
+            + "emit_insight, but the user wants it emailed). Requires data on screen — if the digest is "
+            + "empty, use refuse_off_topic and tell them to run an analysis first. You do NOT send the "
+            + "email; the user reviews and sends it.\n"
             + "  - emit_view_change: the user wants to change HOW the existing data is displayed "
             + "('switch to chart', 'show this as a bar chart', 'back to grid', 'best chart for this'). "
             + "Pick viewMode + chartType from the catalog. Do NOT re-query. If the user just says 'chart' "
@@ -158,6 +163,7 @@ public final class AnthropicNlAskProvider extends AbstractNlAskProvider {
         boolean wantQuery = force == NlAskRequest.ForceTool.AUTO || force == NlAskRequest.ForceTool.QUERY;
         boolean wantInsight = force == NlAskRequest.ForceTool.AUTO || force == NlAskRequest.ForceTool.INSIGHT;
         boolean wantViewChange = force == NlAskRequest.ForceTool.AUTO || force == NlAskRequest.ForceTool.VIEW_CHANGE;
+        boolean wantEmailDraft = force == NlAskRequest.ForceTool.AUTO;
 
         StringBuilder system = new StringBuilder(SYSTEM_PROMPT);
         // Agent-space persona voice (saiku#1440). Prepended before the cube schema so the LLM
@@ -222,6 +228,13 @@ public final class AnthropicNlAskProvider extends AbstractNlAskProvider {
                             + "comparisons, summaries, or 'what's interesting' about the data already on screen. "
                             + "Do not propose a new query.");
             insightTool.set("input_schema", insightInputSchema());
+        }
+
+        if (wantEmailDraft) {
+            ObjectNode emailTool = tools.addObject();
+            emailTool.put("name", EMAIL_DRAFT_TOOL_NAME);
+            emailTool.put("description", "Draft an email of the current analysis for the user to review and send.");
+            emailTool.set("input_schema", emailDraftInputSchema());
         }
 
         if (wantViewChange) {
@@ -308,6 +321,13 @@ public final class AnthropicNlAskProvider extends AbstractNlAskProvider {
                         return NlAskResponse.degraded("empty insight tool input", model);
                     }
                     return NlAskResponse.okInsight(MAPPER.writeValueAsString(input), model, inputTokens, outputTokens);
+                }
+                if (EMAIL_DRAFT_TOOL_NAME.equals(toolName)) {
+                    if (input.isMissingNode() || input.isNull()) {
+                        return NlAskResponse.degraded("empty email draft tool input", model);
+                    }
+                    return NlAskResponse.okEmailDraft(
+                            MAPPER.writeValueAsString(input), model, inputTokens, outputTokens);
                 }
                 if (VIEW_CHANGE_TOOL_NAME.equals(toolName)) {
                     if (input.isMissingNode() || input.isNull()) {

--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ai/ask/NlAskResponse.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ai/ask/NlAskResponse.java
@@ -8,7 +8,7 @@ package org.saiku.service.olap.ai.ask;
  * Output of {@link NlAskProvider#ask(NlAskRequest)}.
  *
  * <p>The provider returns the raw JSON the model emitted, plus a {@link Kind} discriminator
- * identifying which tool the model picked. Three intents are routed by {@link AiAskService}:
+ * identifying which tool the model picked. Four intents are routed by {@link AiAskService}:
  *
  * <ul>
  *   <li>{@link Kind#QUERY} — an {@code AiQueryRequest} the converter will execute.

--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ai/ask/NlAskResponse.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ai/ask/NlAskResponse.java
@@ -16,6 +16,8 @@ package org.saiku.service.olap.ai.ask;
  *       cellset). No execution.
  *   <li>{@link Kind#VIEW_CHANGE} — an {@code AiViewChange} (target viewMode + chartType). No
  *       execution.
+ *   <li>{@link Kind#EMAIL_DRAFT} — an {@code AiEmailDraft} (email body summarising the user's
+ *       current cellset). Draft-only — the AI never sends.
  *   <li>{@link Kind#REFUSAL} — the model called the refusal tool (off-topic question). Surface
  *       {@link #reason()} verbatim to the user.
  * </ul>
@@ -59,6 +61,7 @@ public record NlAskResponse(
         QUERY,
         INSIGHT,
         VIEW_CHANGE,
+        EMAIL_DRAFT,
         REFUSAL
     }
 
@@ -76,6 +79,10 @@ public record NlAskResponse(
 
     public static NlAskResponse okViewChange(String json, String model, int inputTokens, int outputTokens) {
         return new NlAskResponse(Kind.VIEW_CHANGE, json, false, "", model, inputTokens, outputTokens);
+    }
+
+    public static NlAskResponse okEmailDraft(String json, String model, int inputTokens, int outputTokens) {
+        return new NlAskResponse(Kind.EMAIL_DRAFT, json, false, "", model, inputTokens, outputTokens);
     }
 
     public static NlAskResponse refusal(String reason, String model, int inputTokens, int outputTokens) {

--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ai/ask/OpenAINlAskProvider.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ai/ask/OpenAINlAskProvider.java
@@ -41,7 +41,7 @@ public class OpenAINlAskProvider extends AbstractNlAskProvider {
     public static final String DEFAULT_ENDPOINT = "https://api.openai.com/v1/chat/completions";
 
     private static final String SYSTEM_PROMPT = "You are a Mondrian OLAP analyst assistant scoped to a "
-            + "single cube. You have FOUR functions — pick exactly one based on the user's intent.\n\n"
+            + "single cube. You have FIVE functions — pick exactly one based on the user's intent.\n\n"
             + "FUNCTION CHOICE:\n"
             + "  - emit_query: the user wants new data or a different breakdown of the cube. "
             + "Translate their question into a single AiQueryRequest matching the schema.\n"
@@ -49,6 +49,11 @@ public class OpenAINlAskProvider extends AbstractNlAskProvider {
             + "'what's interesting', 'summarise this', 'why is X high'). The user's current cellset is "
             + "provided as a digest below; reason from it. Do NOT build a new query. Return a markdown "
             + "analysis that references specific row/column captions and figures from the digest.\n"
+            + "  - emit_email_draft: the user explicitly asks to EMAIL / send / 'email it to me' the current "
+            + "analysis. Compose a short prose summary of the current cellset as the email body (like "
+            + "emit_insight, but the user wants it emailed). Requires data on screen — if the digest is "
+            + "empty, use refuse_off_topic and tell them to run an analysis first. You do NOT send the "
+            + "email; the user reviews and sends it.\n"
             + "  - emit_view_change: the user wants to change HOW the existing data is displayed "
             + "('switch to chart', 'show this as a bar chart', 'back to grid', 'best chart for this'). "
             + "Pick viewMode + chartType from the catalog. Do NOT re-query. If the user just says 'chart' "
@@ -172,6 +177,7 @@ public class OpenAINlAskProvider extends AbstractNlAskProvider {
         boolean wantQuery = force == NlAskRequest.ForceTool.AUTO || force == NlAskRequest.ForceTool.QUERY;
         boolean wantInsight = force == NlAskRequest.ForceTool.AUTO || force == NlAskRequest.ForceTool.INSIGHT;
         boolean wantViewChange = force == NlAskRequest.ForceTool.AUTO || force == NlAskRequest.ForceTool.VIEW_CHANGE;
+        boolean wantEmailDraft = force == NlAskRequest.ForceTool.AUTO;
 
         ArrayNode tools = root.putArray("tools");
 
@@ -196,6 +202,15 @@ public class OpenAINlAskProvider extends AbstractNlAskProvider {
                             + "comparisons, summaries, or 'what's interesting' about the data already on screen. "
                             + "Do not propose a new query.");
             insightFn.set("parameters", insightInputSchema());
+        }
+
+        if (wantEmailDraft) {
+            ObjectNode emailTool = tools.addObject();
+            emailTool.put("type", "function");
+            ObjectNode emailFn = emailTool.putObject("function");
+            emailFn.put("name", EMAIL_DRAFT_TOOL_NAME);
+            emailFn.put("description", "Draft an email of the current analysis for the user to review and send.");
+            emailFn.set("parameters", emailDraftInputSchema());
         }
 
         if (wantViewChange) {
@@ -327,6 +342,12 @@ public class OpenAINlAskProvider extends AbstractNlAskProvider {
                     return NlAskResponse.degraded("empty insight tool arguments", model);
                 }
                 return NlAskResponse.okInsight(arguments, model, inputTokens, outputTokens);
+            }
+            if (EMAIL_DRAFT_TOOL_NAME.equals(fnName)) {
+                if (arguments == null || arguments.isBlank()) {
+                    return NlAskResponse.degraded("empty email draft tool arguments", model);
+                }
+                return NlAskResponse.okEmailDraft(arguments, model, inputTokens, outputTokens);
             }
             if (VIEW_CHANGE_TOOL_NAME.equals(fnName)) {
                 if (arguments == null || arguments.isBlank()) {

--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ai/eval/LiveEvalAskAdapter.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ai/eval/LiveEvalAskAdapter.java
@@ -109,6 +109,10 @@ public final class LiveEvalAskAdapter implements EvalAskAdapter {
             case VIEW_CHANGE -> EvalAskResult.forViewChange(
                     outcome.model(),
                     outcome.viewChange() == null ? "" : outcome.viewChange().getViewMode());
+                // Not yet exercised by the live-eval harness — surfaced as degraded rather than
+                // silently mis-scoring so a suite run makes the gap visible.
+            case EMAIL_DRAFT -> EvalAskResult.forDegraded(
+                    outcome.model(), "email-draft intent not yet supported by the eval harness");
         };
     }
 

--- a/saiku-core/saiku-service/src/test/java/org/saiku/service/olap/ai/ask/AiAskServiceTest.java
+++ b/saiku-core/saiku-service/src/test/java/org/saiku/service/olap/ai/ask/AiAskServiceTest.java
@@ -157,6 +157,34 @@ public class AiAskServiceTest {
         assertTrue(out.reason().contains("invalid viewMode"));
     }
 
+    /* ---- NL email-draft intent (draft-only — the AI never sends) ---- */
+
+    @Test
+    public void returnsParsedEmailDraftOnSuccess() {
+        AiAskService svc = new AiAskService(
+                fixedSchemaService(emptySchema()),
+                stub(NlAskResponse.okEmailDraft("{\"summary\":\"Large tier leads at 7,000.\"}", "m", 0, 0)));
+
+        AiAskService.AskOutcome out = svc.ask(CUBE, "draft an email summarising this", List.of());
+
+        assertFalse(out.degraded());
+        assertEquals(AiAskService.AskOutcome.Kind.EMAIL_DRAFT, out.kind());
+        assertNotNull(out.emailDraft());
+        assertEquals("Large tier leads at 7,000.", out.emailDraft().getSummary());
+    }
+
+    @Test
+    public void degradesWhenEmailDraftSummaryBlank() {
+        AiAskService svc = new AiAskService(
+                fixedSchemaService(emptySchema()), stub(NlAskResponse.okEmailDraft("{\"summary\":\"\"}", "m", 0, 0)));
+
+        AiAskService.AskOutcome out = svc.ask(CUBE, "draft an email summarising this", List.of());
+
+        assertTrue(out.degraded());
+        assertTrue(out.reason().contains("empty email draft"));
+        assertNull(out.emailDraft());
+    }
+
     /* ---- saiku#1426 skill catalogue + slash-command expansion ---- */
 
     @Test

--- a/saiku-core/saiku-service/src/test/java/org/saiku/service/olap/ai/ask/AiAskServiceTest.java
+++ b/saiku-core/saiku-service/src/test/java/org/saiku/service/olap/ai/ask/AiAskServiceTest.java
@@ -165,7 +165,10 @@ public class AiAskServiceTest {
                 fixedSchemaService(emptySchema()),
                 stub(NlAskResponse.okEmailDraft("{\"summary\":\"Large tier leads at 7,000.\"}", "m", 0, 0)));
 
-        AiAskService.AskOutcome out = svc.ask(CUBE, "draft an email summarising this", List.of());
+        // No-data guard (design §5): EMAIL_DRAFT only succeeds when the client actually sent a
+        // cellset digest (analysis on screen) — exercise the overload that carries one.
+        AiAskService.AskOutcome out =
+                svc.ask(CUBE, "draft an email summarising this", List.of(), "| Tier | Balance |\n| Large | 7,000 |");
 
         assertFalse(out.degraded());
         assertEquals(AiAskService.AskOutcome.Kind.EMAIL_DRAFT, out.kind());
@@ -178,11 +181,51 @@ public class AiAskServiceTest {
         AiAskService svc = new AiAskService(
                 fixedSchemaService(emptySchema()), stub(NlAskResponse.okEmailDraft("{\"summary\":\"\"}", "m", 0, 0)));
 
-        AiAskService.AskOutcome out = svc.ask(CUBE, "draft an email summarising this", List.of());
+        // Non-blank digest so this exercises the empty-summary guard, not the no-data guard.
+        AiAskService.AskOutcome out =
+                svc.ask(CUBE, "draft an email summarising this", List.of(), "| Tier | Balance |\n| Large | 7,000 |");
 
         assertTrue(out.degraded());
         assertTrue(out.reason().contains("empty email draft"));
         assertNull(out.emailDraft());
+    }
+
+    @Test
+    public void refusesEmailDraftWhenNoCellsetOnScreen() {
+        // Design §5 belt-and-braces: the server refuses EMAIL_DRAFT when the client sent no
+        // cellset digest at all (no analysis on screen), BEFORE the egress-strip could otherwise
+        // conflate this with a digest withheld by policy. Checked here regardless of what the
+        // provider stub would return.
+        AiAskService svc = new AiAskService(
+                fixedSchemaService(emptySchema()),
+                stub(NlAskResponse.okEmailDraft("{\"summary\":\"Large tier leads at 7,000.\"}", "m", 0, 0)));
+
+        AiAskService.AskOutcome out = svc.ask(CUBE, "draft an email summarising this", List.of(), null);
+
+        assertTrue(out.degraded());
+        assertTrue(out.reason().contains("run a query first"));
+        assertNull(out.emailDraft());
+    }
+
+    @Test
+    public void draftsEmailWhenDigestPresentButEgressStripped() {
+        // Regression guard for the capture-before-strip invariant: the CLIENT sent a non-blank
+        // digest (there WAS analysis on screen), but schema-only egress strips it before it reaches
+        // the LLM. That must NOT be conflated with "client sent nothing" — hadCellsetOnScreen is
+        // captured before the strip, so EMAIL_DRAFT still succeeds. If someone later moved that
+        // capture to read the post-strip value, this test would fail.
+        AiAskService svc = new AiAskService(
+                fixedSchemaService(emptySchema()),
+                stub(NlAskResponse.okEmailDraft("{\"summary\":\"Large tier leads at 7,000.\"}", "m", 0, 0)));
+        svc.setEgressGuard(new AiPolicyGuard(AiPolicy.SCHEMA_ONLY));
+
+        AiAskService.AskOutcome out =
+                svc.ask(CUBE, "draft an email summarising this", List.of(), "| Tier | Balance |\n| Large | 7,000 |");
+
+        assertFalse(out.degraded());
+        assertEquals(AiAskService.AskOutcome.Kind.EMAIL_DRAFT, out.kind());
+        assertNotNull(out.emailDraft());
+        assertEquals("Large tier leads at 7,000.", out.emailDraft().getSummary());
     }
 
     /* ---- saiku#1426 skill catalogue + slash-command expansion ---- */

--- a/saiku-core/saiku-service/src/test/java/org/saiku/service/olap/ai/ask/AnthropicNlAskProviderTest.java
+++ b/saiku-core/saiku-service/src/test/java/org/saiku/service/olap/ai/ask/AnthropicNlAskProviderTest.java
@@ -44,13 +44,13 @@ public class AnthropicNlAskProviderTest {
 
         assertEquals("claude-x", root.get("model").asText());
         assertEquals(1024, root.get("max_tokens").asInt());
-        // tool_choice "any" lets the model pick among the four scoped tools.
+        // tool_choice "any" lets the model pick among the five scoped tools.
         assertEquals("any", root.get("tool_choice").get("type").asText());
 
-        // AUTO routing exposes all four tools: emit_query, emit_insight, emit_view_change,
-        // and the refuse_off_topic scope guardrail (always appended last).
+        // AUTO routing exposes all five tools: emit_query, emit_insight, emit_email_draft,
+        // emit_view_change, and the refuse_off_topic scope guardrail (always appended last).
         JsonNode tools = root.get("tools");
-        assertEquals(4, tools.size());
+        assertEquals(5, tools.size());
         assertEquals("emit_query", tools.get(0).get("name").asText());
         assertEquals("object", tools.get(0).get("input_schema").get("type").asText());
         JsonNode refusal = tools.get(tools.size() - 1);
@@ -157,6 +157,52 @@ public class AnthropicNlAskProviderTest {
         NlAskResponse resp = AnthropicNlAskProvider.parseToolResponse(body, "claude-x");
         assertTrue(resp.degraded());
         assertEquals("empty tool_use input", resp.reason());
+    }
+
+    /** AUTO routing offers emit_email_draft with a schema requiring `summary`. */
+    @Test
+    public void requestBodyIncludesEmailDraftToolWithRequiredSummary() throws Exception {
+        AnthropicNlAskProvider provider =
+                new AnthropicNlAskProvider(new AnthropicNlAskProvider.Config("k", "claude-x", 0.0, 1024, null));
+        JsonNode root = MAPPER.readTree(
+                provider.buildRequestBody(new NlAskRequest(CUBE, "q", SCHEMA, REQUEST_SCHEMA, List.of())));
+
+        JsonNode tools = root.get("tools");
+        JsonNode emailTool = null;
+        for (JsonNode tool : tools) {
+            if ("emit_email_draft".equals(tool.get("name").asText())) {
+                emailTool = tool;
+            }
+        }
+        assertNotNull("emit_email_draft tool must be present in AUTO mode", emailTool);
+        assertEquals("object", emailTool.get("input_schema").get("type").asText());
+        assertEquals(
+                "summary", emailTool.get("input_schema").get("required").get(0).asText());
+    }
+
+    @Test
+    public void parseToolResponseExtractsEmailDraftInputAsJson() throws Exception {
+        String body = "{\"usage\":{\"input_tokens\":11,\"output_tokens\":5},"
+                + "\"content\":[{\"type\":\"tool_use\",\"name\":\"emit_email_draft\","
+                + "\"input\":{\"summary\":\"Large tier leads at 7,000.\"}}]}";
+
+        NlAskResponse resp = AnthropicNlAskProvider.parseToolResponse(body, "claude-x");
+
+        assertFalse(resp.degraded());
+        assertEquals(NlAskResponse.Kind.EMAIL_DRAFT, resp.kind());
+        assertEquals("claude-x", resp.model());
+        assertEquals(11, resp.inputTokens());
+        assertEquals(5, resp.outputTokens());
+        JsonNode parsed = MAPPER.readTree(resp.payloadJson());
+        assertEquals("Large tier leads at 7,000.", parsed.get("summary").asText());
+    }
+
+    @Test
+    public void parseToolResponseDegradesWhenEmailDraftInputMissing() throws Exception {
+        String body = "{\"content\":[{\"type\":\"tool_use\",\"name\":\"emit_email_draft\"}]}";
+        NlAskResponse resp = AnthropicNlAskProvider.parseToolResponse(body, "claude-x");
+        assertTrue(resp.degraded());
+        assertEquals("empty email draft tool input", resp.reason());
     }
 
     @Test

--- a/saiku-core/saiku-service/src/test/java/org/saiku/service/olap/ai/ask/OpenAINlAskProviderTest.java
+++ b/saiku-core/saiku-service/src/test/java/org/saiku/service/olap/ai/ask/OpenAINlAskProviderTest.java
@@ -44,13 +44,13 @@ public class OpenAINlAskProviderTest {
 
         assertEquals("gpt-x", root.get("model").asText());
         assertEquals(1024, root.get("max_tokens").asInt());
-        // tool_choice "required" — model must call a function, picks among the four scoped functions.
+        // tool_choice "required" — model must call a function, picks among the five scoped functions.
         assertEquals("required", root.get("tool_choice").asText());
 
-        // AUTO routing exposes all four functions: emit_query, emit_insight, emit_view_change,
-        // and the refuse_off_topic scope guardrail (always appended last).
+        // AUTO routing exposes all five functions: emit_query, emit_insight, emit_email_draft,
+        // emit_view_change, and the refuse_off_topic scope guardrail (always appended last).
         JsonNode tools = root.get("tools");
-        assertEquals(4, tools.size());
+        assertEquals(5, tools.size());
         assertEquals("function", tools.get(0).get("type").asText());
         assertEquals("emit_query", tools.get(0).get("function").get("name").asText());
         assertEquals(
@@ -170,6 +170,52 @@ public class OpenAINlAskProviderTest {
         NlAskResponse resp = OpenAINlAskProvider.parseToolResponse(body, "gpt-x");
         assertTrue(resp.degraded());
         assertEquals("empty tool_call arguments", resp.reason());
+    }
+
+    /** AUTO routing offers emit_email_draft with a schema requiring `summary`. */
+    @Test
+    public void requestBodyIncludesEmailDraftFunctionWithRequiredSummary() throws Exception {
+        OpenAINlAskProvider provider = new OpenAINlAskProvider(
+                new OpenAINlAskProvider.Config("k", "gpt-x", OpenAINlAskProvider.DEFAULT_ENDPOINT, 0.0, 1024, null));
+        JsonNode root = MAPPER.readTree(
+                provider.buildRequestBody(new NlAskRequest(CUBE, "q", SCHEMA, REQUEST_SCHEMA, List.of())));
+
+        JsonNode tools = root.get("tools");
+        JsonNode emailFn = null;
+        for (JsonNode tool : tools) {
+            if ("emit_email_draft".equals(tool.get("function").get("name").asText())) {
+                emailFn = tool.get("function");
+            }
+        }
+        assertNotNull("emit_email_draft function must be present in AUTO mode", emailFn);
+        assertEquals("object", emailFn.get("parameters").get("type").asText());
+        assertEquals("summary", emailFn.get("parameters").get("required").get(0).asText());
+    }
+
+    @Test
+    public void parseToolResponseExtractsEmailDraftArgumentsAsJson() throws Exception {
+        String body = "{\"usage\":{\"prompt_tokens\":11,\"completion_tokens\":5},"
+                + "\"choices\":[{\"message\":{\"tool_calls\":[{\"function\":{\"name\":\"emit_email_draft\","
+                + "\"arguments\":\"{\\\"summary\\\":\\\"Large tier leads at 7,000.\\\"}\"}}]}}]}";
+
+        NlAskResponse resp = OpenAINlAskProvider.parseToolResponse(body, "gpt-x");
+
+        assertFalse(resp.degraded());
+        assertEquals(NlAskResponse.Kind.EMAIL_DRAFT, resp.kind());
+        assertEquals("gpt-x", resp.model());
+        assertEquals(11, resp.inputTokens());
+        assertEquals(5, resp.outputTokens());
+        JsonNode parsed = MAPPER.readTree(resp.payloadJson());
+        assertEquals("Large tier leads at 7,000.", parsed.get("summary").asText());
+    }
+
+    @Test
+    public void parseToolResponseDegradesWhenEmailDraftArgumentsBlank() throws Exception {
+        String body = "{\"choices\":[{\"message\":{\"tool_calls\":[{\"function\":{\"name\":\"emit_email_draft\","
+                + "\"arguments\":\"\"}}]}}]}";
+        NlAskResponse resp = OpenAINlAskProvider.parseToolResponse(body, "gpt-x");
+        assertTrue(resp.degraded());
+        assertEquals("empty email draft tool arguments", resp.reason());
     }
 
     @Test

--- a/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/AiQueryResource.java
+++ b/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/AiQueryResource.java
@@ -30,6 +30,7 @@ import org.saiku.olap.util.OlapResultSetUtil;
 import org.saiku.olap.util.SaikuProperties;
 import org.saiku.service.async.AsyncQueryHandle;
 import org.saiku.service.async.AsyncQueryService;
+import org.saiku.service.mail.MailSender;
 import org.saiku.service.olap.ThinQueryService;
 import org.saiku.service.olap.ai.AiCell;
 import org.saiku.service.olap.ai.AiCubeMetadataService;
@@ -86,6 +87,24 @@ public class AiQueryResource {
 
     public void setAskService(AiAskService s) {
         this.askService = s;
+    }
+
+    /**
+     * Task 3 (NL email-draft slice): mail-configured gate for the {@code EMAIL_DRAFT} ask outcome.
+     * Wired to the same {@code mailSender} bean {@link org.saiku.web.email.EmailResource} uses for
+     * its own health check — held as {@code null} when no Spring wiring supplies one, in which
+     * case {@link #mailConfigured()} fails closed (never hands the user an un-sendable draft).
+     */
+    private MailSender mailSender;
+
+    public void setMailSender(MailSender mailSender) {
+        this.mailSender = mailSender;
+    }
+
+    /** True only when a real mail transport is wired and configured — mirrors {@code
+     *  EmailResource#health()}'s check exactly, so the two surfaces can never disagree. */
+    private boolean mailConfigured() {
+        return mailSender != null && mailSender.isConfigured();
     }
 
     /**
@@ -1151,6 +1170,27 @@ public class AiQueryResource {
                     outcome.viewChange() == null ? null : outcome.viewChange().getReason();
             if (reason != null && !reason.isEmpty()) {
                 emitChunks(sse, reason);
+            }
+            sse.event("final", MAPPER.writeValueAsString(out));
+            return;
+        }
+
+        if (outcome.kind() == AiAskService.AskOutcome.Kind.EMAIL_DRAFT) {
+            if (!mailConfigured()) {
+                // Task 3: same honest refusal as the sync path (buildAskSuccessResponse), mirrored
+                // into the streaming wire shape — error event carrying the reason, then a degraded
+                // final so a client keying completion on `final` never hangs.
+                sse.event("error", MAPPER.writeValueAsString(java.util.Map.of("reason", MAIL_NOT_CONFIGURED_REASON)));
+                out.setDegraded(true);
+                out.setReason(MAIL_NOT_CONFIGURED_REASON);
+                sse.event("final", MAPPER.writeValueAsString(out));
+                return;
+            }
+            out.setEmailDraft(outcome.emailDraft());
+            String summary =
+                    outcome.emailDraft() == null ? "" : outcome.emailDraft().getSummary();
+            if (summary != null && !summary.isEmpty()) {
+                emitChunks(sse, summary);
             }
             sse.event("final", MAPPER.writeValueAsString(out));
             return;
@@ -2708,6 +2748,13 @@ public class AiQueryResource {
                     + "enable the feature.";
 
     /**
+     * Task 3 (NL email-draft slice): client-facing reason when the model picked {@code
+     * EMAIL_DRAFT} but this server has no mail transport wired ({@link #mailConfigured()} false).
+     * An honest refusal, not a 503 — the ask itself succeeded, only delivery isn't available.
+     */
+    private static final String MAIL_NOT_CONFIGURED_REASON = "Email isn't set up on this server.";
+
+    /**
      * Shared validation preamble for every ask endpoint (sync + streaming, classic + space).
      * Runs the policy gate, shape checks, size cap, rate limit and provider-configured check in
      * one place so a guard change can't drift across the four copies (saiku#1460). Returns a
@@ -2772,6 +2819,19 @@ public class AiQueryResource {
         }
         if (outcome.kind() == AiAskService.AskOutcome.Kind.VIEW_CHANGE) {
             out.setViewChange(outcome.viewChange());
+            return Response.ok(out).type(MediaType.APPLICATION_JSON).build();
+        }
+        if (outcome.kind() == AiAskService.AskOutcome.Kind.EMAIL_DRAFT) {
+            if (!mailConfigured()) {
+                // Task 3: honest refusal — mail isn't wired on this deployment, so don't hand the
+                // user a draft they have no way to send. Mirrors the classic degraded AskResponse
+                // shape (degraded=true + reason, model already set above) rather than inventing a
+                // new envelope.
+                out.setDegraded(true);
+                out.setReason(MAIL_NOT_CONFIGURED_REASON);
+                return Response.ok(out).type(MediaType.APPLICATION_JSON).build();
+            }
+            out.setEmailDraft(outcome.emailDraft());
             return Response.ok(out).type(MediaType.APPLICATION_JSON).build();
         }
 

--- a/saiku-core/saiku-web/src/test/java/org/saiku/web/rest/resources/AiQueryResourceAskTest.java
+++ b/saiku-core/saiku-web/src/test/java/org/saiku/web/rest/resources/AiQueryResourceAskTest.java
@@ -184,6 +184,73 @@ public class AiQueryResourceAskTest {
                 body.getResponse().getField().startsWith("measures"));
     }
 
+    /* ---- Task 3 (NL email-draft slice): EMAIL_DRAFT routing + mail-configured refusal gate ---- */
+
+    private static org.saiku.service.olap.ai.ask.AiEmailDraft stubDraft(String summary) {
+        return new org.saiku.service.olap.ai.ask.AiEmailDraft(summary);
+    }
+
+    @Test
+    public void emailDraftSurfacedWhenMailConfigured() {
+        resource.setMailSender(new org.saiku.service.mail.MailSender() {
+            @Override
+            public boolean isConfigured() {
+                return true;
+            }
+
+            @Override
+            public void send(org.saiku.service.mail.MailMessage message) {
+                throw new UnsupportedOperationException("not exercised by this test");
+            }
+        });
+        wireAskService(AiAskService.AskOutcome.okEmailDraft(stubDraft("Store sales are up 12%."), "claude-x"));
+
+        Response resp = resource.ask(validBody());
+        assertEquals(200, resp.getStatus());
+
+        AiAskApi.AskResponse body = (AiAskApi.AskResponse) resp.getEntity();
+        assertFalse(body.isDegraded());
+        assertNotNull("emailDraft carried on success", body.getEmailDraft());
+        assertEquals("Store sales are up 12%.", body.getEmailDraft().getSummary());
+    }
+
+    @Test
+    public void emailDraftRefusedWhenMailUnconfigured() {
+        resource.setMailSender(new org.saiku.service.mail.MailSender() {
+            @Override
+            public boolean isConfigured() {
+                return false;
+            }
+
+            @Override
+            public void send(org.saiku.service.mail.MailMessage message) {
+                throw new UnsupportedOperationException("not exercised by this test");
+            }
+        });
+        wireAskService(AiAskService.AskOutcome.okEmailDraft(stubDraft("Store sales are up 12%."), "claude-x"));
+
+        Response resp = resource.ask(validBody());
+        assertEquals(200, resp.getStatus());
+
+        AiAskApi.AskResponse body = (AiAskApi.AskResponse) resp.getEntity();
+        assertTrue("mail-unconfigured must refuse, not hand back an un-sendable draft", body.isDegraded());
+        assertEquals("Email isn't set up on this server.", body.getReason());
+        assertNull("no draft leaks through on refusal", body.getEmailDraft());
+    }
+
+    @Test
+    public void emailDraftRefusedWhenMailSenderNeverWired() {
+        // Default state — no setMailSender() call at all (mirrors an un-wired deployment).
+        wireAskService(AiAskService.AskOutcome.okEmailDraft(stubDraft("Store sales are up 12%."), "claude-x"));
+
+        Response resp = resource.ask(validBody());
+        assertEquals(200, resp.getStatus());
+
+        AiAskApi.AskResponse body = (AiAskApi.AskResponse) resp.getEntity();
+        assertTrue(body.isDegraded());
+        assertEquals("Email isn't set up on this server.", body.getReason());
+    }
+
     /* ---- saiku#1455: sync /spaces/{id}/ask must return the full answer, not just {model,request} ---- */
 
     /** Wire a fake askService whose {@code askInSpace} returns a fixed outcome. */

--- a/saiku-ui/src/lib/api/aiAsk.ts
+++ b/saiku-ui/src/lib/api/aiAsk.ts
@@ -90,6 +90,11 @@ export interface AiInsight {
   headline?: string;
 }
 
+/** Email draft summary the AI emitted when the model picked the email intent. */
+export interface AiEmailDraft {
+  summary: string;
+}
+
 /** View-target the AI emitted when the user asked to change how current data is displayed. */
 export interface AiViewChange {
   viewMode: "grid" | "chart";
@@ -125,6 +130,8 @@ export interface AskResponse {
   insight?: AiInsight;
   /** Set when the model picked the view-change intent. Mutually exclusive with the other intents. */
   viewChange?: AiViewChange;
+  /** Set when the model picked the email intent. Mutually exclusive with the other intents. */
+  emailDraft?: AiEmailDraft;
 }
 
 /** Error thrown only on transport / non-JSON failures. The "not configured"

--- a/saiku-ui/src/lib/i18n/en.json
+++ b/saiku-ui/src/lib/i18n/en.json
@@ -601,6 +601,7 @@
   "workspace.aiQuery.copyMdx": "Copy MDX",
   "workspace.aiQuery.editInCanvas": "Edit in canvas",
   "workspace.aiQuery.viaModel": "via {model}",
+  "workspace.aiQuery.emailDraftOpening": "Opening a draft email for you to review…",
   "workspace.aiQuery.insightLabel": "Insight",
   "workspace.aiQuery.viewChangeLabel": "View change",
   "workspace.aiQuery.modeLabel": "Mode",

--- a/saiku-ui/src/lib/stores/emailComposer.svelte.test.ts
+++ b/saiku-ui/src/lib/stores/emailComposer.svelte.test.ts
@@ -1,0 +1,14 @@
+import { describe, it, expect } from "vitest";
+import { emailComposer } from "./emailComposer.svelte";
+
+describe("emailComposer", () => {
+  it("starts closed and flags a requested open, consumed once", () => {
+    emailComposer.consumeOpen(); // reset any prior state
+    expect(emailComposer.pendingOpen).toBe(false);
+    emailComposer.requestOpen();
+    expect(emailComposer.pendingOpen).toBe(true);
+    expect(emailComposer.consumeOpen()).toBe(true); // consuming returns true once
+    expect(emailComposer.pendingOpen).toBe(false); // and clears it
+    expect(emailComposer.consumeOpen()).toBe(false); // second consume is false
+  });
+});

--- a/saiku-ui/src/lib/stores/emailComposer.svelte.ts
+++ b/saiku-ui/src/lib/stores/emailComposer.svelte.ts
@@ -1,0 +1,22 @@
+/*
+ * One-shot signal: the AI-Ask drawer requests that the Email modal open (pre-filled
+ * from the aiInsight store). The toolbar that hosts EmailMeThisModal consumes the
+ * flag to flip the modal open. Kept tiny + consumable so a single request opens once.
+ */
+
+class EmailComposerStore {
+  pendingOpen = $state(false);
+
+  requestOpen(): void {
+    this.pendingOpen = true;
+  }
+
+  /** Returns true if an open was pending, and clears it. */
+  consumeOpen(): boolean {
+    const was = this.pendingOpen;
+    this.pendingOpen = false;
+    return was;
+  }
+}
+
+export const emailComposer = new EmailComposerStore();

--- a/saiku-ui/src/lib/views/AiQueryDrawer.svelte
+++ b/saiku-ui/src/lib/views/AiQueryDrawer.svelte
@@ -17,6 +17,7 @@
    */
 
   import { aiInsight } from "$lib/stores/aiInsight.svelte";
+  import { emailComposer } from "$lib/stores/emailComposer.svelte";
   import { i18n } from "$lib/stores/i18n.svelte";
   import { selection } from "$lib/stores/selection.svelte";
   import { askAi, AiAskTransportError, type AiInsight, type AiViewChange, type AskResponse, type NlAskMessageDto } from "$lib/api/aiAsk";
@@ -337,6 +338,26 @@
           role: "insight",
           text: resp.insight.headline ?? "",
           insightMarkdown: resp.insight.markdown,
+          model: resp.model,
+        },
+      ];
+      inflight = false;
+      return;
+    }
+
+    // Intent: email draft — model picked the email intent. Hand the summary off to the
+    // "email me this" modal via the shared aiInsight store (same seed path the modal already
+    // reads from) and signal the toolbar to open it. The AI never sends — the human reviews
+    // and clicks Send in the modal.
+    if (resp.emailDraft) {
+      aiInsight.set(resp.emailDraft.summary);
+      emailComposer.requestOpen();
+      turns = [
+        ...turns,
+        {
+          id: nextId(),
+          role: "assistant",
+          text: i18n.t("workspace.aiQuery.emailDraftOpening", "Opening a draft email for you to review…"),
           model: resp.model,
         },
       ];

--- a/saiku-ui/src/lib/views/WorkspaceToolbar.svelte
+++ b/saiku-ui/src/lib/views/WorkspaceToolbar.svelte
@@ -43,6 +43,8 @@
   import { i18n } from "$lib/stores/i18n.svelte";
   import { platform } from "$lib/stores/platform.svelte";
   import { mailHealth } from "$lib/stores/mailHealth.svelte";
+  import { emailComposer } from "$lib/stores/emailComposer.svelte";
+  import { untrack } from "svelte";
 
   interface Props {
     /** Open the AI Query drawer. Owned by Workspace so the drawer can overlay the canvas. */
@@ -341,6 +343,20 @@
       subtitle: String(p["saiku.report.subtitle"] ?? ""),
       notes: String(p["saiku.report.notes"] ?? ""),
     };
+  });
+
+  // AI-Ask drawer handoff: the drawer sets emailComposer.pendingOpen after seeding
+  // aiInsight with an email-intent summary; consume the signal here and flip the
+  // modal open. Wrapped in untrack so consuming the flag (which writes pendingOpen,
+  // a dependency of THIS effect) can't re-queue it — the effect only ever needs to
+  // fire once per requestOpen(), not once again for its own consume-write.
+  $effect(() => {
+    if (emailComposer.pendingOpen) {
+      untrack(() => {
+        emailComposer.consumeOpen();
+        emailModalOpen = true;
+      });
+    }
   });
 </script>
 

--- a/saiku-webapp/src/main/webapp/WEB-INF/saiku-beans.xml
+++ b/saiku-webapp/src/main/webapp/WEB-INF/saiku-beans.xml
@@ -332,6 +332,11 @@
              saiku.ai.ask.provider is set to 'anthropic' or 'openai' and the
              matching API key env var is supplied. See aiAskServiceBean below. -->
         <property name="askService" ref="aiAskServiceBean"/>
+        <!-- NL email-draft slice, Task 3: same mailSender bean emailResource uses for its
+             health check (above), so /ai/ask's EMAIL_DRAFT outcome refuses honestly
+             ("Email isn't set up on this server.") whenever mail delivery isn't configured,
+             instead of handing back an un-sendable draft. -->
+        <property name="mailSender" ref="mailSender"/>
     </bean>
 
     <!-- Ossie AI Query API (#1394) — parallel to aiQueryResource but for semantic-YAML


### PR DESCRIPTION
Sixth email slice: ask the AI to email the current analysis, and it composes a draft for review.

- A new EMAIL_DRAFT intent on `/ai/ask`: the model composes the email body via an `emit_email_draft` tool (Anthropic + OpenAI providers). The service routes it and refuses when mail isn't configured or when no analysis is on screen (fail-closed, checked before egress).
- The drawer opens the existing Email composer pre-filled from the draft; the human reviews and clicks Send — the AI never sends.

Backend (ask providers + service) + drawer/composer wiring. Tests included.