### PR TITLE
Make the chained ask resilient on rate-limited LLM tiers

### DIFF
--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ai/ask/AbstractNlAskProvider.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ai/ask/AbstractNlAskProvider.java
@@ -13,6 +13,9 @@ import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.time.Duration;
+import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
  * Shared machinery for the HTTP-backed {@link NlAskProvider} implementations (Anthropic, OpenAI and
@@ -122,8 +125,11 @@ abstract class AbstractNlAskProvider implements NlAskProvider {
             HttpRequest httpRequest = builder.build();
             HttpResponse<String> response = http.send(httpRequest, HttpResponse.BodyHandlers.ofString());
             if (response.statusCode() / 100 != 2) {
-                return NlAskResponse.degraded(
-                        "HTTP " + response.statusCode() + ": " + truncate(response.body(), 200), model());
+                String reason = "HTTP " + response.statusCode() + ": " + truncate(response.body(), 200);
+                if (response.statusCode() == 429) {
+                    return NlAskResponse.rateLimited(reason, model(), parseRetryAfterMs(response));
+                }
+                return NlAskResponse.degraded(reason, model());
             }
             return doParseToolResponse(response.body(), model());
         } catch (IOException | InterruptedException e) {
@@ -137,6 +143,53 @@ abstract class AbstractNlAskProvider implements NlAskProvider {
     }
 
     // ---------- shared helpers ----------
+
+    /** Matches vendor 429-body wait phrasing, e.g. "try again in 9.512s" / "try again in 2m1.2s". */
+    private static final Pattern TRY_AGAIN_IN =
+            Pattern.compile("try again in (?:([0-9]+)m)?([0-9]+(?:\\.[0-9]+)?)s", Pattern.CASE_INSENSITIVE);
+
+    /**
+     * Best-effort wait hint from a 429: prefer the standard {@code Retry-After} header (seconds,
+     * possibly fractional), else parse the vendor body's "try again in Xs" phrasing, else 0
+     * (unknown).
+     */
+    static long parseRetryAfterMs(HttpResponse<String> response) {
+        return parseRetryAfterMs(response.headers().firstValue("retry-after"), response.body());
+    }
+
+    /**
+     * Parse core for {@link #parseRetryAfterMs(HttpResponse)}, split out so it can be unit-tested
+     * without needing a real {@code HttpResponse<String>}.
+     */
+    static long parseRetryAfterMs(Optional<String> retryAfterHeader, String body) {
+        // 1) Retry-After header — seconds (integer or fractional). (HTTP-date form not expected
+        // from LLM vendors.)
+        if (retryAfterHeader.isPresent()) {
+            try {
+                double secs = Double.parseDouble(retryAfterHeader.get().trim());
+                if (secs >= 0) {
+                    return (long) Math.ceil(secs * 1000);
+                }
+            } catch (NumberFormatException ignore) {
+                // fall through to body parse
+            }
+        }
+        // 2) Body phrasing: "Please try again in 9.512s" / "try again in 2m1.2s" (Groq).
+        if (body != null) {
+            Matcher m = TRY_AGAIN_IN.matcher(body);
+            if (m.find()) {
+                long ms = 0;
+                if (m.group(1) != null) {
+                    ms += Long.parseLong(m.group(1)) * 60_000; // minutes
+                }
+                if (m.group(2) != null) {
+                    ms += (long) Math.ceil(Double.parseDouble(m.group(2)) * 1000); // seconds
+                }
+                return ms;
+            }
+        }
+        return 0L; // rate-limited, no parseable hint → caller uses its default
+    }
 
     /** Serialise the cube ref the model must echo back verbatim. */
     protected static String cubeRefJson(NlAskRequest request) {

--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ai/ask/AbstractNlAskProvider.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ai/ask/AbstractNlAskProvider.java
@@ -129,6 +129,9 @@ abstract class AbstractNlAskProvider implements NlAskProvider {
                 if (response.statusCode() == 429) {
                     return NlAskResponse.rateLimited(reason, model(), parseRetryAfterMs(response));
                 }
+                if (response.statusCode() == 400 && isTransientToolError(response.body())) {
+                    return NlAskResponse.retryableToolError(reason, model());
+                }
                 return NlAskResponse.degraded(reason, model());
             }
             return doParseToolResponse(response.body(), model());
@@ -189,6 +192,15 @@ abstract class AbstractNlAskProvider implements NlAskProvider {
             }
         }
         return 0L; // rate-limited, no parseable hint → caller uses its default
+    }
+
+    /**
+     * A Groq/LLM "the model fumbled the tool-call format" 400 — transient, worth a re-ask. Detected by
+     * the vendor error code {@code tool_use_failed} in the body. Other 400s (genuinely malformed
+     * requests) are NOT transient and must NOT be retried, so they fall through to a plain degrade.
+     */
+    static boolean isTransientToolError(String body) {
+        return body != null && body.contains("tool_use_failed");
     }
 
     /** Serialise the cube ref the model must echo back verbatim. */

--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ai/ask/AiAskService.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ai/ask/AiAskService.java
@@ -414,6 +414,60 @@ public class AiAskService {
     }
 
     /**
+     * Max in-loop retries when the LLM returns a rate-limit (HTTP 429). Default 2; 0 disables paced
+     * retry. Read from env {@code SAIKU_AI_CHAIN_RATELIMIT_RETRIES} first, else system property
+     * {@code saiku.ai.ask.chain.rateLimitRetries}, clamped to [0, 5].
+     */
+    private static int rateLimitRetries() {
+        String v = System.getenv("SAIKU_AI_CHAIN_RATELIMIT_RETRIES");
+        if (v == null || v.isBlank()) v = System.getProperty("saiku.ai.ask.chain.rateLimitRetries");
+        int n = 2;
+        if (v != null && !v.isBlank()) {
+            try {
+                n = Integer.parseInt(v.trim());
+            } catch (NumberFormatException ignore) {
+                // fall through to the default
+            }
+        }
+        return Math.max(0, Math.min(5, n));
+    }
+
+    /**
+     * Hard cap on each rate-limit wait (ms). Default 20000; keeps a slow LLM from pinning the
+     * request thread. Read from env {@code SAIKU_AI_CHAIN_RATELIMIT_MAX_WAIT_MS} first, else system
+     * property {@code saiku.ai.ask.chain.rateLimitMaxWaitMs}, clamped to [0, 60000].
+     */
+    private static long rateLimitMaxWaitMs() {
+        String v = System.getenv("SAIKU_AI_CHAIN_RATELIMIT_MAX_WAIT_MS");
+        if (v == null || v.isBlank()) v = System.getProperty("saiku.ai.ask.chain.rateLimitMaxWaitMs");
+        long n = 20_000L;
+        if (v != null && !v.isBlank()) {
+            try {
+                n = Long.parseLong(v.trim());
+            } catch (NumberFormatException ignore) {
+                // fall through to the default
+            }
+        }
+        return Math.max(0L, Math.min(60_000L, n));
+    }
+
+    /** Used when a 429 gave no usable hint ({@code retryAfterMs == 0}). */
+    private static final long DEFAULT_RATE_LIMIT_WAIT_MS = 5_000L;
+
+    /** Sleep primitive, injectable so tests exercise the paced-retry loop without real waits. */
+    @FunctionalInterface
+    interface Sleeper {
+        void sleep(long ms) throws InterruptedException;
+    }
+
+    private Sleeper sleeper = Thread::sleep;
+
+    /** Package-visible for tests. */
+    void setSleeper(Sleeper sleeper) {
+        this.sleeper = sleeper;
+    }
+
+    /**
      * Bounded server-side agentic loop: the model builds a query, the server executes it, the result
      * is fed back (egress-gated), and the model reports on it — all in one request. Terminal tool, a
      * degrade, or the step cap ends the loop. NO send/save/mutate capability; execution returns data
@@ -507,6 +561,25 @@ public class AiAskService {
                     null,
                     List.copyOf(transcript));
             NlAskResponse resp = provider.ask(req);
+
+            // OPT-3: a rate-limited turn (HTTP 429, resp.retryAfterMs() >= 0) is paced + retried in
+            // place — the SAME request, since a rate limit isn't the model's fault — up to a bounded
+            // retry count. A non-429 degrade (retryAfterMs == -1) never enters this loop.
+            int rlRetries = 0;
+            while (resp.degraded() && resp.retryAfterMs() >= 0 && rlRetries < rateLimitRetries()) {
+                long wait = resp.retryAfterMs() > 0 ? resp.retryAfterMs() : DEFAULT_RATE_LIMIT_WAIT_MS;
+                wait = Math.min(wait, rateLimitMaxWaitMs());
+                try {
+                    sleeper.sleep(wait);
+                } catch (InterruptedException ie) {
+                    Thread.currentThread().interrupt();
+                    break; // stop retrying; fall through to the degraded handling below
+                }
+                rlRetries++;
+                log.info(
+                        "chained ask: LLM rate-limited, waited {}ms, retry {}/{}", wait, rlRetries, rateLimitRetries());
+                resp = provider.ask(req);
+            }
 
             if (resp.degraded()) {
                 steps.add(AskOutcome.degraded(resp.reason(), resp.model()));

--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ai/ask/AiAskService.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ai/ask/AiAskService.java
@@ -402,6 +402,18 @@ public class AiAskService {
     }
 
     /**
+     * When true (default), a chained turn that FOLLOWS an executed query is forced to the report
+     * (emit_insight) tool only — dropping the emit_query schema (~9k tokens) so the loop fits tight
+     * LLM token-per-minute limits. Set false to keep full multi-turn agency (the model may issue
+     * another query mid-chain), e.g. for the dashboard builder.
+     */
+    private static boolean forceReportAfterQuery() {
+        String v = System.getenv("SAIKU_AI_CHAIN_FORCE_REPORT");
+        if (v == null || v.isBlank()) v = System.getProperty("saiku.ai.ask.chain.forceReportAfterQuery");
+        return v == null || v.isBlank() || Boolean.parseBoolean(v.trim()); // default TRUE
+    }
+
+    /**
      * Bounded server-side agentic loop: the model builds a query, the server executes it, the result
      * is fed back (egress-gated), and the model reports on it — all in one request. Terminal tool, a
      * degrade, or the step cap ends the loop. NO send/save/mutate capability; execution returns data
@@ -473,8 +485,15 @@ public class AiAskService {
         String turnDigest = effectiveDigest; // the cellset the model sees THIS turn; starts as on-screen (gated)
         int cap = maxSteps();
         boolean hitStepLimit = false;
+        final boolean forceReport = forceReportAfterQuery();
 
         for (int i = 0; i < cap; i++) {
+            // Continuation turns (a query already executed this chain) are forced to the report tool
+            // when the trim toggle is on — drops the ~9k-token emit_query schema from the request the
+            // provider never uses on that turn. Turn-1 (empty transcript) always uses the caller's ft
+            // so it can still emit_query.
+            NlAskRequest.ForceTool turnForceTool =
+                    (forceReport && !transcript.isEmpty()) ? NlAskRequest.ForceTool.INSIGHT : ft;
             NlAskRequest req = new NlAskRequest(
                     ref,
                     effectiveQuestion,
@@ -482,7 +501,7 @@ public class AiAskService {
                     requestSchemaJson,
                     hist,
                     turnDigest,
-                    ft,
+                    turnForceTool,
                     currentQueryJson,
                     skillsFragment,
                     null,

--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ai/ask/NlAskResponse.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ai/ask/NlAskResponse.java
@@ -51,7 +51,9 @@ package org.saiku.service.olap.ai.ask;
  *     tool_call id); {@code null} for degraded/refusal/insight/view-change responses
  * @param retryAfterMs {@code -1} when not a rate-limit; {@code >= 0} when the provider was rate
  *     limited (HTTP 429) and this is the suggested wait, in ms, before retrying ({@code 0} means
- *     rate-limited but the provider gave no usable hint)
+ *     rate-limited but the provider gave no usable hint). Also {@code >= 0} for {@link
+ *     #retryableToolError(String, String)} — a transient tool-call failure — so both share the
+ *     same paced-retry path in the chained-ask loop.
  */
 public record NlAskResponse(
         Kind kind,
@@ -117,6 +119,20 @@ public record NlAskResponse(
      */
     public static NlAskResponse rateLimited(String reason, String model, long retryAfterMs) {
         return new NlAskResponse(null, null, true, reason, model, -1, -1, null, Math.max(0, retryAfterMs));
+    }
+
+    /** Short backoff for {@link #retryableToolError(String, String)} — the model call itself takes
+     *  seconds, so this only avoids the 429 no-hint 5s default and gives a tiny gap before re-asking. */
+    public static final long TOOL_ERROR_BACKOFF_MS = 500L;
+
+    /**
+     * Provider returned a transient tool-call failure (e.g. Groq HTTP 400 {@code tool_use_failed}):
+     * the model fumbled the tool-call format. Degraded, but retryable — a re-ask usually succeeds —
+     * so it carries a short {@link #TOOL_ERROR_BACKOFF_MS} wait, letting the chained-ask loop retry it
+     * through the same paced-retry path as a rate limit.
+     */
+    public static NlAskResponse retryableToolError(String reason, String model) {
+        return new NlAskResponse(null, null, true, reason, model, -1, -1, null, TOOL_ERROR_BACKOFF_MS);
     }
 
     /**

--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ai/ask/NlAskResponse.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ai/ask/NlAskResponse.java
@@ -49,6 +49,9 @@ package org.saiku.service.olap.ai.ask;
  *     unknown
  * @param toolCallId provider-assigned id for the emitted tool call (Anthropic tool_use id / OpenAI
  *     tool_call id); {@code null} for degraded/refusal/insight/view-change responses
+ * @param retryAfterMs {@code -1} when not a rate-limit; {@code >= 0} when the provider was rate
+ *     limited (HTTP 429) and this is the suggested wait, in ms, before retrying ({@code 0} means
+ *     rate-limited but the provider gave no usable hint)
  */
 public record NlAskResponse(
         Kind kind,
@@ -58,7 +61,8 @@ public record NlAskResponse(
         String model,
         int inputTokens,
         int outputTokens,
-        String toolCallId) {
+        String toolCallId,
+        long retryAfterMs) {
 
     public enum Kind {
         QUERY,
@@ -78,31 +82,41 @@ public record NlAskResponse(
 
     public static NlAskResponse okQuery(
             String json, String model, int inputTokens, int outputTokens, String toolCallId) {
-        return new NlAskResponse(Kind.QUERY, json, false, "", model, inputTokens, outputTokens, toolCallId);
+        return new NlAskResponse(Kind.QUERY, json, false, "", model, inputTokens, outputTokens, toolCallId, -1L);
     }
 
     public static NlAskResponse okInsight(String json, String model, int inputTokens, int outputTokens) {
-        return new NlAskResponse(Kind.INSIGHT, json, false, "", model, inputTokens, outputTokens, null);
+        return new NlAskResponse(Kind.INSIGHT, json, false, "", model, inputTokens, outputTokens, null, -1L);
     }
 
     public static NlAskResponse okViewChange(String json, String model, int inputTokens, int outputTokens) {
-        return new NlAskResponse(Kind.VIEW_CHANGE, json, false, "", model, inputTokens, outputTokens, null);
+        return new NlAskResponse(Kind.VIEW_CHANGE, json, false, "", model, inputTokens, outputTokens, null, -1L);
     }
 
     public static NlAskResponse okEmailDraft(String json, String model, int inputTokens, int outputTokens) {
-        return new NlAskResponse(Kind.EMAIL_DRAFT, json, false, "", model, inputTokens, outputTokens, null);
+        return new NlAskResponse(Kind.EMAIL_DRAFT, json, false, "", model, inputTokens, outputTokens, null, -1L);
     }
 
     public static NlAskResponse refusal(String reason, String model, int inputTokens, int outputTokens) {
-        return new NlAskResponse(Kind.REFUSAL, null, false, reason, model, inputTokens, outputTokens, null);
+        return new NlAskResponse(Kind.REFUSAL, null, false, reason, model, inputTokens, outputTokens, null, -1L);
     }
 
     public static NlAskResponse degraded(String reason) {
-        return new NlAskResponse(null, null, true, reason, null, -1, -1, null);
+        return new NlAskResponse(null, null, true, reason, null, -1, -1, null, -1L);
     }
 
     public static NlAskResponse degraded(String reason, String model) {
-        return new NlAskResponse(null, null, true, reason, model, -1, -1, null);
+        return new NlAskResponse(null, null, true, reason, model, -1, -1, null, -1L);
+    }
+
+    /**
+     * Provider hit a rate limit (HTTP 429). Degraded like any transport failure, but carries the
+     * suggested wait so a caller (the chained-ask loop) can pace + retry rather than give up.
+     *
+     * @param retryAfterMs suggested wait in ms; 0 when the provider gave no hint
+     */
+    public static NlAskResponse rateLimited(String reason, String model, long retryAfterMs) {
+        return new NlAskResponse(null, null, true, reason, model, -1, -1, null, Math.max(0, retryAfterMs));
     }
 
     /**

--- a/saiku-core/saiku-service/src/test/java/org/saiku/service/olap/ai/ask/AbstractNlAskProviderTest.java
+++ b/saiku-core/saiku-service/src/test/java/org/saiku/service/olap/ai/ask/AbstractNlAskProviderTest.java
@@ -5,6 +5,8 @@
 package org.saiku.service.olap.ai.ask;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 import java.util.Optional;
 import org.junit.Test;
@@ -59,5 +61,38 @@ public class AbstractNlAskProviderTest {
         long ms = AbstractNlAskProvider.parseRetryAfterMs(
                 Optional.of("Wed, 21 Oct 2026 07:28:00 GMT"), "try again in 3s");
         assertEquals(3000L, ms);
+    }
+
+    /* ---- OPT-4: transient tool_use_failed 400 detection ---- */
+
+    @Test
+    public void detectsGroqStyleToolUseFailedCode() {
+        assertTrue(AbstractNlAskProvider.isTransientToolError(
+                "{\"error\":{\"message\":\"Failed to call a function.\",\"code\":\"tool_use_failed\"}}"));
+    }
+
+    @Test
+    public void detectsBareToolUseFailedSubstring() {
+        assertTrue(AbstractNlAskProvider.isTransientToolError("some prefix tool_use_failed some suffix"));
+    }
+
+    @Test
+    public void nullBodyIsNotTransientToolError() {
+        assertFalse(AbstractNlAskProvider.isTransientToolError(null));
+    }
+
+    @Test
+    public void emptyBodyIsNotTransientToolError() {
+        assertFalse(AbstractNlAskProvider.isTransientToolError(""));
+    }
+
+    @Test
+    public void genericBadRequestBodyIsNotTransientToolError() {
+        assertFalse(AbstractNlAskProvider.isTransientToolError("{\"error\":{\"code\":\"invalid_request_error\"}}"));
+    }
+
+    @Test
+    public void twoXxLookingBodyIsNotTransientToolError() {
+        assertFalse(AbstractNlAskProvider.isTransientToolError("{\"id\":\"msg_1\",\"type\":\"message\"}"));
     }
 }

--- a/saiku-core/saiku-service/src/test/java/org/saiku/service/olap/ai/ask/AbstractNlAskProviderTest.java
+++ b/saiku-core/saiku-service/src/test/java/org/saiku/service/olap/ai/ask/AbstractNlAskProviderTest.java
@@ -1,0 +1,63 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.service.olap.ai.ask;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.Optional;
+import org.junit.Test;
+
+/**
+ * Unit tests for {@link AbstractNlAskProvider#parseRetryAfterMs(Optional, String)} — the 429
+ * wait-hint parse core. Tested via the {@code (Optional<String>, String)} overload rather than the
+ * {@code HttpResponse} one since building a real {@code HttpResponse<String>} for a unit test is
+ * awkward; the {@code HttpResponse} overload is a one-line delegation to this core.
+ */
+public class AbstractNlAskProviderTest {
+
+    @Test
+    public void headerIntegerSecondsWinsOverBody() {
+        long ms = AbstractNlAskProvider.parseRetryAfterMs(Optional.of("9"), "ignored body");
+        assertEquals(9000L, ms);
+    }
+
+    @Test
+    public void headerFractionalSecondsRoundsUp() {
+        long ms = AbstractNlAskProvider.parseRetryAfterMs(Optional.of("9.5"), null);
+        assertEquals(9500L, ms);
+    }
+
+    @Test
+    public void noHeaderFallsBackToBodySecondsOnlyPhrasing() {
+        long ms = AbstractNlAskProvider.parseRetryAfterMs(
+                Optional.empty(), "Rate limit reached. Please try again in 9.512s.");
+        assertEquals(9512L, ms);
+    }
+
+    @Test
+    public void noHeaderFallsBackToBodyMinutesAndSecondsPhrasing() {
+        long ms = AbstractNlAskProvider.parseRetryAfterMs(Optional.empty(), "try again in 2m1.2s");
+        assertEquals(121200L, ms);
+    }
+
+    @Test
+    public void neitherHeaderNorBodyHintReturnsZero() {
+        long ms = AbstractNlAskProvider.parseRetryAfterMs(Optional.empty(), "no hint here");
+        assertEquals(0L, ms);
+    }
+
+    @Test
+    public void nullBodyAndNoHeaderReturnsZero() {
+        long ms = AbstractNlAskProvider.parseRetryAfterMs(Optional.empty(), null);
+        assertEquals(0L, ms);
+    }
+
+    @Test
+    public void unparseableHeaderFallsBackToBody() {
+        long ms = AbstractNlAskProvider.parseRetryAfterMs(
+                Optional.of("Wed, 21 Oct 2026 07:28:00 GMT"), "try again in 3s");
+        assertEquals(3000L, ms);
+    }
+}

--- a/saiku-core/saiku-service/src/test/java/org/saiku/service/olap/ai/ask/AiAskServiceTest.java
+++ b/saiku-core/saiku-service/src/test/java/org/saiku/service/olap/ai/ask/AiAskServiceTest.java
@@ -644,6 +644,61 @@ public class AiAskServiceTest {
     }
 
     @Test
+    public void chainedAskForcesInsightOnContinuationTurnByDefault() {
+        // OPT-1: the continuation (report) turn is asked with forceTool=INSIGHT so the provider
+        // drops the ~9k-token emit_query schema it never uses on that turn — the trim is on by
+        // default. Turn-1 (empty transcript) must still be asked with the caller's forceTool (AUTO)
+        // so it retains full agency to emit_query.
+        ScriptedProvider provider = new ScriptedProvider(List.of(
+                NlAskResponse.okQuery(fullQueryJson(), "m", 10, 5, "t1"),
+                NlAskResponse.okInsight(insightJson(), "m", 10, 5)));
+        AiAskService svc = new AiAskService(fixedSchemaService(salesSchemaWithMeasure()), provider);
+        svc.setThinQueryService(cannedExecutor(cannedCellDataSet()));
+        svc.setEgressGuard(new AiPolicyGuard(AiPolicy.AGGREGATED));
+
+        AiAskService.AskChain chain = svc.askChained(
+                CUBE, "build the query and report on it", List.of(), null, NlAskRequest.ForceTool.AUTO, null);
+
+        assertFalse(chain.hitStepLimit());
+        assertEquals(2, provider.seen().size());
+        assertEquals(NlAskRequest.ForceTool.AUTO, provider.seen().get(0).forceTool());
+        assertEquals(NlAskRequest.ForceTool.INSIGHT, provider.seen().get(1).forceTool());
+    }
+
+    @Test
+    public void chainedAskToggleOffKeepsFullAgencyOnContinuationTurn() {
+        // Toggle off: the continuation turn keeps the caller's forceTool (AUTO here) instead of
+        // being forced to INSIGHT — full multi-turn agency preserved (e.g. dashboard builder).
+        String savedProp = System.getProperty("saiku.ai.ask.chain.forceReportAfterQuery");
+        System.setProperty("saiku.ai.ask.chain.forceReportAfterQuery", "false");
+        try {
+            ScriptedProvider provider = new ScriptedProvider(List.of(
+                    NlAskResponse.okQuery(fullQueryJson(), "m", 10, 5, "t1"),
+                    NlAskResponse.okInsight(insightJson(), "m", 10, 5)));
+            AiAskService svc = new AiAskService(fixedSchemaService(salesSchemaWithMeasure()), provider);
+            svc.setThinQueryService(cannedExecutor(cannedCellDataSet()));
+            svc.setEgressGuard(new AiPolicyGuard(AiPolicy.AGGREGATED));
+
+            AiAskService.AskChain chain = svc.askChained(
+                    CUBE, "build the query and report on it", List.of(), null, NlAskRequest.ForceTool.AUTO, null);
+
+            assertFalse(chain.hitStepLimit());
+            assertEquals(2, provider.seen().size());
+            assertEquals(NlAskRequest.ForceTool.AUTO, provider.seen().get(0).forceTool());
+            assertEquals(
+                    "toggle off must NOT force INSIGHT — caller's forceTool (AUTO) is preserved",
+                    NlAskRequest.ForceTool.AUTO,
+                    provider.seen().get(1).forceTool());
+        } finally {
+            if (savedProp == null) {
+                System.clearProperty("saiku.ai.ask.chain.forceReportAfterQuery");
+            } else {
+                System.setProperty("saiku.ai.ask.chain.forceReportAfterQuery", savedProp);
+            }
+        }
+    }
+
+    @Test
     public void chainedAskAllowsBuildAndReportWithNoCellsetOnScreen() {
         // Empty-screen build+report is allowed for chaining — deliberate contrast with the
         // EMAIL_DRAFT no-data refusal (design §5).
@@ -726,6 +781,12 @@ public class AiAskServiceTest {
 
     @Test
     public void chainedAskHitsStepCapWhenAlwaysBuildingQueries() {
+        // OPT-1 interaction: with the default trim ON, continuation turns are asked with
+        // forceTool=INSIGHT. This test's ScriptedProvider ignores the incoming request entirely and
+        // always replies okQuery ("always building queries"), so the loop still sees QUERY every
+        // turn and counts to the cap exactly as before — a real provider would honor forceTool and
+        // return an insight instead. No toggle-off needed here: the test exercises the pure
+        // step-cap mechanic, which this stub's behavior doesn't depend on forceTool for.
         String savedProp = System.getProperty("saiku.ai.ask.max-steps");
         System.setProperty("saiku.ai.ask.max-steps", "3");
         try {

--- a/saiku-core/saiku-service/src/test/java/org/saiku/service/olap/ai/ask/AiAskServiceTest.java
+++ b/saiku-core/saiku-service/src/test/java/org/saiku/service/olap/ai/ask/AiAskServiceTest.java
@@ -1014,6 +1014,100 @@ public class AiAskServiceTest {
                 "must not retry — exactly one provider call", 1, provider.seen().size());
     }
 
+    /* ---- OPT-4: transient tool_use_failed 400 rides the OPT-3 paced-retry loop unchanged ---- */
+
+    @Test
+    public void chainedAskRecoversAfterOneTransientToolError() {
+        // turn-1 -> okQuery (executes) -> turn-2 first attempt -> retryableToolError(500) -> (wait,
+        // retry) -> turn-2 second attempt -> okInsight. Recovered, not degraded. Proves the EXISTING
+        // OPT-3 loop (unchanged) retries a transient tool_use_failed exactly like a 429.
+        ScriptedProvider provider = new ScriptedProvider(List.of(
+                NlAskResponse.okQuery(fullQueryJson(), "m", 10, 5, "t1"),
+                NlAskResponse.retryableToolError("HTTP 400: tool_use_failed", "m"),
+                NlAskResponse.okInsight(insightJson(), "m", 10, 5)));
+        AiAskService svc = new AiAskService(fixedSchemaService(salesSchemaWithMeasure()), provider);
+        svc.setThinQueryService(cannedExecutor(cannedCellDataSet()));
+        svc.setEgressGuard(new AiPolicyGuard(AiPolicy.AGGREGATED));
+        List<Long> recorded = new ArrayList<>();
+        svc.setSleeper(recorded::add);
+
+        AiAskService.AskChain chain = svc.askChained(
+                CUBE, "build the query and report on it", List.of(), null, NlAskRequest.ForceTool.AUTO, null);
+
+        assertEquals(List.of(NlAskResponse.TOOL_ERROR_BACKOFF_MS), recorded);
+        assertEquals(2, chain.steps().size());
+        assertEquals(AiAskService.AskOutcome.Kind.QUERY, chain.steps().get(0).kind());
+        assertFalse(chain.steps().get(0).degraded());
+        assertEquals(AiAskService.AskOutcome.Kind.INSIGHT, chain.steps().get(1).kind());
+        assertFalse(chain.steps().get(1).degraded());
+        assertEquals(
+                "1 query + 1 failed insight attempt + 1 retried insight = 3 calls",
+                3,
+                provider.seen().size());
+    }
+
+    @Test
+    public void chainedAskExhaustsRetriesOnRepeatedTransientToolErrorThenDegrades() {
+        String savedProp = System.getProperty("saiku.ai.ask.chain.rateLimitRetries");
+        System.setProperty("saiku.ai.ask.chain.rateLimitRetries", "2"); // default, explicit for clarity
+        try {
+            ScriptedProvider provider = new ScriptedProvider(List.of(
+                    NlAskResponse.okQuery(fullQueryJson(), "m", 10, 5, "t1"),
+                    NlAskResponse.retryableToolError("HTTP 400: tool_use_failed", "m"),
+                    NlAskResponse.retryableToolError("HTTP 400: tool_use_failed", "m"),
+                    NlAskResponse.retryableToolError("HTTP 400: tool_use_failed", "m")));
+            AiAskService svc = new AiAskService(fixedSchemaService(salesSchemaWithMeasure()), provider);
+            svc.setThinQueryService(cannedExecutor(cannedCellDataSet()));
+            svc.setEgressGuard(new AiPolicyGuard(AiPolicy.AGGREGATED));
+            List<Long> recorded = new ArrayList<>();
+            svc.setSleeper(recorded::add);
+
+            AiAskService.AskChain chain = svc.askChained(
+                    CUBE, "build the query and report on it", List.of(), null, NlAskRequest.ForceTool.AUTO, null);
+
+            // rateLimitRetries()==2, so it never loops forever: 2 sleeps, then gives up degraded.
+            assertEquals(List.of(NlAskResponse.TOOL_ERROR_BACKOFF_MS, NlAskResponse.TOOL_ERROR_BACKOFF_MS), recorded);
+            assertEquals(2, chain.steps().size());
+            assertEquals(
+                    AiAskService.AskOutcome.Kind.QUERY, chain.steps().get(0).kind());
+            assertTrue(chain.steps().get(1).degraded());
+            assertTrue(chain.steps().get(1).reason().contains("tool_use_failed"));
+            assertEquals(
+                    "1 query + 1 first attempt + 2 retries = 4 provider calls",
+                    4,
+                    provider.seen().size());
+        } finally {
+            if (savedProp == null) {
+                System.clearProperty("saiku.ai.ask.chain.rateLimitRetries");
+            } else {
+                System.setProperty("saiku.ai.ask.chain.rateLimitRetries", savedProp);
+            }
+        }
+    }
+
+    @Test
+    public void chainedAskNonToolErrorPlainDegradeIsNotRetried() {
+        // A plain 400 that is NOT a transient tool_use_failed (e.g. genuinely malformed request)
+        // degrades via NlAskResponse.degraded(...) — retryAfterMs == -1 — and must never enter the
+        // retry loop, exactly like any other non-429/non-tool-error degrade.
+        ScriptedProvider provider = new ScriptedProvider(
+                List.of(NlAskResponse.degraded("HTTP 400: {\"error\":{\"code\":\"invalid_request_error\"}}", "m")));
+        AiAskService svc = new AiAskService(fixedSchemaService(salesSchemaWithMeasure()), provider);
+        svc.setThinQueryService(new ThinQueryService());
+        List<Long> recorded = new ArrayList<>();
+        svc.setSleeper(recorded::add);
+
+        AiAskService.AskChain chain =
+                svc.askChained(CUBE, "show sales", List.of(), null, NlAskRequest.ForceTool.AUTO, null);
+
+        assertTrue("a non-tool-error 400 degrade must never sleep", recorded.isEmpty());
+        assertEquals(1, chain.steps().size());
+        assertTrue(chain.steps().get(0).degraded());
+        assertTrue(chain.steps().get(0).reason().contains("invalid_request_error"));
+        assertEquals(
+                "must not retry — exactly one provider call", 1, provider.seen().size());
+    }
+
     // ---------- helpers ----------
 
     private static AiCubeMetadataService fixedSchemaService(AiSchema schema) {

--- a/saiku-core/saiku-service/src/test/java/org/saiku/service/olap/ai/ask/AiAskServiceTest.java
+++ b/saiku-core/saiku-service/src/test/java/org/saiku/service/olap/ai/ask/AiAskServiceTest.java
@@ -865,6 +865,155 @@ public class AiAskServiceTest {
         assertFalse(chain.hitStepLimit());
     }
 
+    /* ---- OPT-3: bounded rate-limit paced retry in askChained ---- */
+
+    @Test
+    public void chainedAskRecoversAfterOneRateLimit() {
+        // turn-1 -> okQuery (executes) -> turn-2 first attempt -> rateLimited(8000) -> (wait, retry)
+        // -> turn-2 second attempt -> okInsight. Recovered, not degraded.
+        ScriptedProvider provider = new ScriptedProvider(List.of(
+                NlAskResponse.okQuery(fullQueryJson(), "m", 10, 5, "t1"),
+                NlAskResponse.rateLimited("HTTP 429: rate limited", "m", 8000),
+                NlAskResponse.okInsight(insightJson(), "m", 10, 5)));
+        AiAskService svc = new AiAskService(fixedSchemaService(salesSchemaWithMeasure()), provider);
+        svc.setThinQueryService(cannedExecutor(cannedCellDataSet()));
+        svc.setEgressGuard(new AiPolicyGuard(AiPolicy.AGGREGATED));
+        List<Long> recorded = new ArrayList<>();
+        svc.setSleeper(recorded::add);
+
+        AiAskService.AskChain chain = svc.askChained(
+                CUBE, "build the query and report on it", List.of(), null, NlAskRequest.ForceTool.AUTO, null);
+
+        assertEquals(List.of(8000L), recorded);
+        assertEquals(2, chain.steps().size());
+        assertEquals(AiAskService.AskOutcome.Kind.QUERY, chain.steps().get(0).kind());
+        assertFalse(chain.steps().get(0).degraded());
+        assertEquals(AiAskService.AskOutcome.Kind.INSIGHT, chain.steps().get(1).kind());
+        assertFalse(chain.steps().get(1).degraded());
+        assertEquals(3, provider.seen().size());
+    }
+
+    @Test
+    public void chainedAskUnknownRateLimitHintUsesDefaultWait() {
+        ScriptedProvider provider = new ScriptedProvider(List.of(
+                NlAskResponse.okQuery(fullQueryJson(), "m", 10, 5, "t1"),
+                NlAskResponse.rateLimited("HTTP 429: rate limited", "m", 0),
+                NlAskResponse.okInsight(insightJson(), "m", 10, 5)));
+        AiAskService svc = new AiAskService(fixedSchemaService(salesSchemaWithMeasure()), provider);
+        svc.setThinQueryService(cannedExecutor(cannedCellDataSet()));
+        svc.setEgressGuard(new AiPolicyGuard(AiPolicy.AGGREGATED));
+        List<Long> recorded = new ArrayList<>();
+        svc.setSleeper(recorded::add);
+
+        svc.askChained(CUBE, "build the query and report on it", List.of(), null, NlAskRequest.ForceTool.AUTO, null);
+
+        assertEquals(List.of(5000L), recorded);
+    }
+
+    @Test
+    public void chainedAskCapsExcessiveRateLimitWait() {
+        ScriptedProvider provider = new ScriptedProvider(List.of(
+                NlAskResponse.okQuery(fullQueryJson(), "m", 10, 5, "t1"),
+                NlAskResponse.rateLimited("HTTP 429: rate limited", "m", 999999),
+                NlAskResponse.okInsight(insightJson(), "m", 10, 5)));
+        AiAskService svc = new AiAskService(fixedSchemaService(salesSchemaWithMeasure()), provider);
+        svc.setThinQueryService(cannedExecutor(cannedCellDataSet()));
+        svc.setEgressGuard(new AiPolicyGuard(AiPolicy.AGGREGATED));
+        List<Long> recorded = new ArrayList<>();
+        svc.setSleeper(recorded::add);
+
+        svc.askChained(CUBE, "build the query and report on it", List.of(), null, NlAskRequest.ForceTool.AUTO, null);
+
+        assertEquals(List.of(20000L), recorded);
+    }
+
+    @Test
+    public void chainedAskExhaustsRateLimitRetriesThenDegrades() {
+        String savedProp = System.getProperty("saiku.ai.ask.chain.rateLimitRetries");
+        System.setProperty("saiku.ai.ask.chain.rateLimitRetries", "1");
+        try {
+            ScriptedProvider provider = new ScriptedProvider(List.of(
+                    NlAskResponse.okQuery(fullQueryJson(), "m", 10, 5, "t1"),
+                    NlAskResponse.rateLimited("HTTP 429: rate limited", "m", 1000),
+                    NlAskResponse.rateLimited("HTTP 429: rate limited", "m", 1000)));
+            AiAskService svc = new AiAskService(fixedSchemaService(salesSchemaWithMeasure()), provider);
+            svc.setThinQueryService(cannedExecutor(cannedCellDataSet()));
+            svc.setEgressGuard(new AiPolicyGuard(AiPolicy.AGGREGATED));
+            List<Long> recorded = new ArrayList<>();
+            svc.setSleeper(recorded::add);
+
+            AiAskService.AskChain chain = svc.askChained(
+                    CUBE, "build the query and report on it", List.of(), null, NlAskRequest.ForceTool.AUTO, null);
+
+            assertEquals(1, recorded.size());
+            assertEquals(2, chain.steps().size());
+            assertEquals(
+                    AiAskService.AskOutcome.Kind.QUERY, chain.steps().get(0).kind());
+            assertTrue(chain.steps().get(1).degraded());
+            assertTrue(chain.steps().get(1).reason().contains("429"));
+            assertEquals(
+                    "1 query + 1 first insight attempt + 1 retry = 3 provider calls",
+                    3,
+                    provider.seen().size());
+        } finally {
+            if (savedProp == null) {
+                System.clearProperty("saiku.ai.ask.chain.rateLimitRetries");
+            } else {
+                System.setProperty("saiku.ai.ask.chain.rateLimitRetries", savedProp);
+            }
+        }
+    }
+
+    @Test
+    public void chainedAskRateLimitRetriesZeroDisablesRetry() {
+        String savedProp = System.getProperty("saiku.ai.ask.chain.rateLimitRetries");
+        System.setProperty("saiku.ai.ask.chain.rateLimitRetries", "0");
+        try {
+            ScriptedProvider provider = new ScriptedProvider(List.of(
+                    NlAskResponse.okQuery(fullQueryJson(), "m", 10, 5, "t1"),
+                    NlAskResponse.rateLimited("HTTP 429: rate limited", "m", 1000)));
+            AiAskService svc = new AiAskService(fixedSchemaService(salesSchemaWithMeasure()), provider);
+            svc.setThinQueryService(cannedExecutor(cannedCellDataSet()));
+            svc.setEgressGuard(new AiPolicyGuard(AiPolicy.AGGREGATED));
+            List<Long> recorded = new ArrayList<>();
+            svc.setSleeper(recorded::add);
+
+            AiAskService.AskChain chain = svc.askChained(
+                    CUBE, "build the query and report on it", List.of(), null, NlAskRequest.ForceTool.AUTO, null);
+
+            assertTrue("retries=0 must never sleep", recorded.isEmpty());
+            assertEquals(2, chain.steps().size());
+            assertTrue(chain.steps().get(1).degraded());
+            assertEquals(2, provider.seen().size());
+        } finally {
+            if (savedProp == null) {
+                System.clearProperty("saiku.ai.ask.chain.rateLimitRetries");
+            } else {
+                System.setProperty("saiku.ai.ask.chain.rateLimitRetries", savedProp);
+            }
+        }
+    }
+
+    @Test
+    public void chainedAskNonRateLimitDegradeNeverSleepsOrRetries() {
+        // retryAfterMs == -1 (a plain provider degrade, not a 429) must not enter the retry loop.
+        ScriptedProvider provider = new ScriptedProvider(NlAskResponse.degraded("not configured"));
+        AiAskService svc = new AiAskService(fixedSchemaService(salesSchemaWithMeasure()), provider);
+        svc.setThinQueryService(new ThinQueryService());
+        List<Long> recorded = new ArrayList<>();
+        svc.setSleeper(recorded::add);
+
+        AiAskService.AskChain chain =
+                svc.askChained(CUBE, "show sales", List.of(), null, NlAskRequest.ForceTool.AUTO, null);
+
+        assertTrue("a non-429 degrade must never sleep", recorded.isEmpty());
+        assertEquals(1, chain.steps().size());
+        assertTrue(chain.steps().get(0).degraded());
+        assertEquals("not configured", chain.steps().get(0).reason());
+        assertEquals(
+                "must not retry — exactly one provider call", 1, provider.seen().size());
+    }
+
     // ---------- helpers ----------
 
     private static AiCubeMetadataService fixedSchemaService(AiSchema schema) {

--- a/saiku-core/saiku-service/src/test/java/org/saiku/service/olap/ai/ask/NlAskResponseTest.java
+++ b/saiku-core/saiku-service/src/test/java/org/saiku/service/olap/ai/ask/NlAskResponseTest.java
@@ -75,6 +75,17 @@ public class NlAskResponseTest {
     }
 
     @Test
+    public void retryableToolErrorCarriesShortBackoffAndIsDegraded() {
+        NlAskResponse resp = NlAskResponse.retryableToolError("HTTP 400: tool_use_failed", "m");
+        assertTrue(resp.degraded());
+        assertNull(resp.kind());
+        assertEquals(NlAskResponse.TOOL_ERROR_BACKOFF_MS, resp.retryAfterMs());
+        assertEquals(500L, resp.retryAfterMs());
+        assertEquals("m", resp.model());
+        assertEquals("HTTP 400: tool_use_failed", resp.reason());
+    }
+
+    @Test
     public void everyOtherFactoryDefaultsRetryAfterMsToMinusOne() {
         assertEquals(-1L, NlAskResponse.okQuery("{}", "claude-x", 1, 2).retryAfterMs());
         assertEquals(

--- a/saiku-core/saiku-service/src/test/java/org/saiku/service/olap/ai/ask/NlAskResponseTest.java
+++ b/saiku-core/saiku-service/src/test/java/org/saiku/service/olap/ai/ask/NlAskResponseTest.java
@@ -6,6 +6,7 @@ package org.saiku.service.olap.ai.ask;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 import org.junit.Test;
 
@@ -55,5 +56,35 @@ public class NlAskResponseTest {
 
         NlAskResponse resp2 = NlAskResponse.degraded("parse", "claude-x");
         assertNull(resp2.toolCallId());
+    }
+
+    @Test
+    public void rateLimitedCarriesRetryAfterMsAndIsDegraded() {
+        NlAskResponse resp = NlAskResponse.rateLimited("HTTP 429: x", "m", 9500);
+        assertTrue(resp.degraded());
+        assertEquals(9500L, resp.retryAfterMs());
+        assertNull(resp.kind());
+        assertEquals("m", resp.model());
+        assertEquals("HTTP 429: x", resp.reason());
+    }
+
+    @Test
+    public void rateLimitedFloorsNegativeRetryAfterMsToZero() {
+        NlAskResponse resp = NlAskResponse.rateLimited("HTTP 429: x", "m", -5);
+        assertEquals(0L, resp.retryAfterMs());
+    }
+
+    @Test
+    public void everyOtherFactoryDefaultsRetryAfterMsToMinusOne() {
+        assertEquals(-1L, NlAskResponse.okQuery("{}", "claude-x", 1, 2).retryAfterMs());
+        assertEquals(
+                -1L, NlAskResponse.okQuery("{}", "claude-x", 1, 2, "toolu_abc").retryAfterMs());
+        assertEquals(-1L, NlAskResponse.okInsight("{}", "claude-x", 1, 2).retryAfterMs());
+        assertEquals(-1L, NlAskResponse.okViewChange("{}", "claude-x", 1, 2).retryAfterMs());
+        assertEquals(-1L, NlAskResponse.okEmailDraft("{}", "claude-x", 1, 2).retryAfterMs());
+        assertEquals(-1L, NlAskResponse.refusal("off-topic", "claude-x", 1, 2).retryAfterMs());
+        assertEquals(-1L, NlAskResponse.degraded("transport").retryAfterMs());
+        assertEquals(-1L, NlAskResponse.degraded("parse", "claude-x").retryAfterMs());
+        assertEquals(-1L, NlAskResponse.ok("{}", "claude-x", 1, 2).retryAfterMs());
     }
 }


### PR DESCRIPTION
Follow-up to the chaining loop so it works on tight free-tier LLM limits.

- Trim the continuation turn (drop the large query schema once the report turn is forced), roughly halving the second call's tokens.
- Surface an LLM HTTP 429 as a structured rate-limit signal carrying Retry-After, and pace + retry the chained loop through it (bounded, injectable sleeper).
- Retry a transient tool-call failure (the model fumbling a tool call) through the same bounded path.

All bounded and configurable; the existing gates are untouched. Backend. Tests included.