### PR TITLE
Harden the email path and make the LLM timeout configurable

### DIFF
--- a/saiku-bom/pom.xml
+++ b/saiku-bom/pom.xml
@@ -62,6 +62,11 @@
              scalars we need to type Ossie filter payloads + typed cell values.
              Version tracks the graphql-java major line. -->
         <graphqlJavaExtendedScalars.version>24.0</graphqlJavaExtendedScalars.version>
+        <!-- OWASP Java HTML Sanitizer: allowlist-sanitizes client-supplied
+             summaryHtml before it's assembled into the outbound email body
+             (EmailMessageAssembler). 20240325.1 is the latest published
+             release on Maven Central as of this pin. -->
+        <owasp.html.sanitizer.version>20240325.1</owasp.html.sanitizer.version>
     </properties>
 
     <dependencyManagement>
@@ -802,6 +807,16 @@
                 <groupId>com.icegreen</groupId>
                 <artifactId>greenmail-junit5</artifactId>
                 <version>2.1.3</version>
+            </dependency>
+            <!-- OWASP Java HTML Sanitizer: allowlist policy that strips the
+                 client-supplied summaryHtml down to safe formatting/blocks/
+                 links/tables before EmailMessageAssembler builds the outbound
+                 mail body. Pulls in guava transitively — the guava pin above
+                 (33.4.8-jre, for Calcite) wins via dependencyManagement. -->
+            <dependency>
+                <groupId>com.googlecode.owasp-java-html-sanitizer</groupId>
+                <artifactId>owasp-java-html-sanitizer</artifactId>
+                <version>${owasp.html.sanitizer.version}</version>
             </dependency>
         </dependencies>
 

--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ai/ask/NlAskProviderFactory.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ai/ask/NlAskProviderFactory.java
@@ -91,11 +91,7 @@ public final class NlAskProviderFactory {
             // Omit temperature by default: the Claude-5 family rejects it, and tool_choice already
             // forces the structured tool call so determinism doesn't depend on temperature=0.
             return new AnthropicNlAskProvider(new AnthropicNlAskProvider.Config(
-                    resolvedKey,
-                    effectiveModel,
-                    AnthropicNlAskProvider.OMIT_TEMPERATURE,
-                    4096,
-                    Duration.ofSeconds(60)));
+                    resolvedKey, effectiveModel, AnthropicNlAskProvider.OMIT_TEMPERATURE, 4096, askRequestTimeout()));
         }
         if (PROVIDER_OPENAI.equalsIgnoreCase(name)) {
             String resolvedKey = resolveApiKey(ENV_OPENAI_API_KEY);
@@ -120,7 +116,7 @@ public final class NlAskProviderFactory {
                     effectiveEndpoint,
                     OpenAINlAskProvider.OMIT_TEMPERATURE,
                     4096,
-                    Duration.ofSeconds(60)));
+                    askRequestTimeout()));
         }
         if (PROVIDER_AZURE_OPENAI.equalsIgnoreCase(name)) {
             String resolvedKey = resolveApiKey(ENV_AZURE_OPENAI_API_KEY);
@@ -155,10 +151,31 @@ public final class NlAskProviderFactory {
                     resolvedEndpoint,
                     OpenAINlAskProvider.OMIT_TEMPERATURE,
                     4096,
-                    Duration.ofSeconds(60)));
+                    askRequestTimeout()));
         }
         LOGGER.warn("Unknown AI ask provider '{}'; falling back to NoopProvider.", providerName);
         return new NoopNlAskProvider();
+    }
+
+    /**
+     * Per-request HTTP timeout to the LLM provider, in seconds. Configurable because local/
+     * self-hosted models (e.g. Ollama) can take far longer than a hosted API to evaluate a large
+     * prompt. Env {@code SAIKU_AI_ASK_TIMEOUT_SECONDS}, else system property {@code
+     * saiku.ai.ask.timeoutSeconds}, else 60. Clamped to [5, 900].
+     */
+    static Duration askRequestTimeout() {
+        String v = System.getenv("SAIKU_AI_ASK_TIMEOUT_SECONDS");
+        if (v == null || v.isBlank()) v = System.getProperty("saiku.ai.ask.timeoutSeconds");
+        long secs = 60;
+        if (v != null && !v.isBlank()) {
+            try {
+                secs = Long.parseLong(v.trim());
+            } catch (NumberFormatException ignore) {
+                // fall through to the default
+            }
+        }
+        secs = Math.max(5, Math.min(900, secs));
+        return Duration.ofSeconds(secs);
     }
 
     private String resolveApiKey(String envKey) {

--- a/saiku-core/saiku-service/src/test/java/org/saiku/service/olap/ai/ask/NlAskProviderFactoryTest.java
+++ b/saiku-core/saiku-service/src/test/java/org/saiku/service/olap/ai/ask/NlAskProviderFactoryTest.java
@@ -4,13 +4,85 @@
  */
 package org.saiku.service.olap.ai.ask;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
+import java.time.Duration;
 import java.util.Map;
 import org.junit.Test;
 
 /** Unit tests for {@link NlAskProviderFactory}. */
 public class NlAskProviderFactoryTest {
+
+    private static final String PROP = "saiku.ai.ask.timeoutSeconds";
+
+    /* ---- askRequestTimeout() ----
+     * Note: the env-var path (SAIKU_AI_ASK_TIMEOUT_SECONDS) can't be set per-test from within the
+     * JVM, so only the system-property fallback is exercised here; the property path is
+     * representative of the same parse/clamp logic the env path shares. */
+
+    @Test
+    public void askRequestTimeoutDefaultsTo60sWhenUnset() {
+        String saved = System.getProperty(PROP);
+        System.clearProperty(PROP);
+        try {
+            assertEquals(Duration.ofSeconds(60), NlAskProviderFactory.askRequestTimeout());
+        } finally {
+            restore(saved);
+        }
+    }
+
+    @Test
+    public void askRequestTimeoutUsesSystemProperty() {
+        String saved = System.getProperty(PROP);
+        System.setProperty(PROP, "300");
+        try {
+            assertEquals(Duration.ofSeconds(300), NlAskProviderFactory.askRequestTimeout());
+        } finally {
+            restore(saved);
+        }
+    }
+
+    @Test
+    public void askRequestTimeoutClampsLow() {
+        String saved = System.getProperty(PROP);
+        System.setProperty(PROP, "1");
+        try {
+            assertEquals(Duration.ofSeconds(5), NlAskProviderFactory.askRequestTimeout());
+        } finally {
+            restore(saved);
+        }
+    }
+
+    @Test
+    public void askRequestTimeoutClampsHigh() {
+        String saved = System.getProperty(PROP);
+        System.setProperty(PROP, "99999");
+        try {
+            assertEquals(Duration.ofSeconds(900), NlAskProviderFactory.askRequestTimeout());
+        } finally {
+            restore(saved);
+        }
+    }
+
+    @Test
+    public void askRequestTimeoutFallsBackOnNonNumeric() {
+        String saved = System.getProperty(PROP);
+        System.setProperty(PROP, "abc");
+        try {
+            assertEquals(Duration.ofSeconds(60), NlAskProviderFactory.askRequestTimeout());
+        } finally {
+            restore(saved);
+        }
+    }
+
+    private static void restore(String saved) {
+        if (saved == null) {
+            System.clearProperty(PROP);
+        } else {
+            System.setProperty(PROP, saved);
+        }
+    }
 
     @Test
     public void defaultsToNoopWhenProviderIsNull() {

--- a/saiku-core/saiku-web/pom.xml
+++ b/saiku-core/saiku-web/pom.xml
@@ -279,6 +279,13 @@
             <groupId>net.sourceforge.htmlcleaner</groupId>
             <artifactId>htmlcleaner</artifactId>
         </dependency>
+        <!-- OWASP Java HTML Sanitizer: allowlist-sanitizes client-supplied
+             summaryHtml in EmailMessageAssembler before it's assembled into
+             the outbound email body. Version from saiku-bom. -->
+        <dependency>
+            <groupId>com.googlecode.owasp-java-html-sanitizer</groupId>
+            <artifactId>owasp-java-html-sanitizer</artifactId>
+        </dependency>
         <dependency>
             <groupId>org.mozilla</groupId>
             <artifactId>rhino</artifactId>

--- a/saiku-core/saiku-web/src/main/java/org/saiku/web/email/EmailMessageAssembler.java
+++ b/saiku-core/saiku-web/src/main/java/org/saiku/web/email/EmailMessageAssembler.java
@@ -5,6 +5,8 @@ import jakarta.mail.internet.InternetAddress;
 import java.util.ArrayList;
 import java.util.Base64;
 import java.util.List;
+import org.owasp.html.PolicyFactory;
+import org.owasp.html.Sanitizers;
 import org.saiku.service.mail.Attachment;
 import org.saiku.service.mail.InlineImage;
 import org.saiku.service.mail.MailMessage;
@@ -20,14 +22,26 @@ public class EmailMessageAssembler {
 
     private static final String CHART_CID = "chart";
 
+    /**
+     * Allowlist policy for the client-supplied {@code summaryHtml}: formatting (b/i/strong/em/u/
+     * etc), block structure (p/div/h1-6/ul/ol/li/blockquote/pre), links (restricted to safe
+     * protocols, {@code rel=nofollow} added), and tables. Deliberately NO {@code IMAGES} — the AI
+     * summary must not be able to carry a client {@code <img>} (tracking pixel). The server's own
+     * chart {@code <img cid:chart>} is appended after sanitization and is unaffected. Scripts,
+     * event handlers, and {@code javascript:}/{@code data:} URLs are stripped by default; none of
+     * these policies allow them.
+     */
+    private static final PolicyFactory SUMMARY_POLICY =
+            Sanitizers.FORMATTING.and(Sanitizers.BLOCKS).and(Sanitizers.LINKS).and(Sanitizers.TABLES);
+
     public MailMessage assemble(EmailSelfRequest req, String fromAddress) {
         String to = validateAddress(req.getAddress());
         String subject = stripCrlf(req.getSubject() == null ? "" : req.getSubject());
 
-        StringBuilder html = new StringBuilder(
-                req.getSummaryHtml() == null || req.getSummaryHtml().isBlank()
-                        ? "<p>Your Saiku analysis is attached.</p>"
-                        : req.getSummaryHtml());
+        String summary = req.getSummaryHtml() == null || req.getSummaryHtml().isBlank()
+                ? "<p>Your Saiku analysis is attached.</p>"
+                : SUMMARY_POLICY.sanitize(req.getSummaryHtml());
+        StringBuilder html = new StringBuilder(summary);
 
         List<InlineImage> inline = new ArrayList<>();
         if (notBlank(req.getChartPngBase64())) {

--- a/saiku-core/saiku-web/src/main/java/org/saiku/web/email/EmailResource.java
+++ b/saiku-core/saiku-web/src/main/java/org/saiku/web/email/EmailResource.java
@@ -28,12 +28,27 @@ public class EmailResource {
     private MailConfig mailConfig;
     private final EmailMessageAssembler assembler = new EmailMessageAssembler();
 
+    /**
+     * Per-user send rate limit for the self-send endpoint (SEC-harden slice,
+     * task 2/2). Mirrors {@code AiQueryResource#askRateLimiter}: a direct
+     * {@code new} field + Spring/test setter, keyed by the authenticated
+     * principal so one user's abuse can't exhaust another's budget.
+     */
+    private org.saiku.web.security.ratelimit.AiRateLimiter emailRateLimiter =
+            new org.saiku.web.security.ratelimit.AiRateLimiter(
+                    Integer.getInteger("saiku.email.ratelimit.maxPerMinute", 10), 60_000L);
+
     public void setMailSender(MailSender mailSender) {
         this.mailSender = mailSender;
     }
 
     public void setMailConfig(MailConfig mailConfig) {
         this.mailConfig = mailConfig;
+    }
+
+    /** Spring/test setter to override the per-user send rate limit. */
+    public void setEmailRateLimiter(org.saiku.web.security.ratelimit.AiRateLimiter emailRateLimiter) {
+        this.emailRateLimiter = emailRateLimiter;
     }
 
     @GET
@@ -53,6 +68,14 @@ public class EmailResource {
         if (auth == null || !auth.isAuthenticated() || auth instanceof AnonymousAuthenticationToken) {
             return Response.status(Response.Status.UNAUTHORIZED)
                     .entity(Map.of("error", "authentication required"))
+                    .build();
+        }
+        if (!emailRateLimiter.tryAcquire(auth.getName())) {
+            return Response.status(429)
+                    .entity(java.util.Map.of(
+                            "error",
+                            "Too many emails — limit is " + emailRateLimiter.getMaxCalls() + " per "
+                                    + (emailRateLimiter.getWindowMs() / 1000) + "s. Please retry shortly."))
                     .build();
         }
         if (mailSender == null || !mailSender.isConfigured()) {

--- a/saiku-core/saiku-web/src/test/java/org/saiku/web/email/EmailMessageAssemblerTest.java
+++ b/saiku-core/saiku-web/src/test/java/org/saiku/web/email/EmailMessageAssemblerTest.java
@@ -114,4 +114,61 @@ public class EmailMessageAssemblerTest {
             // expected
         }
     }
+
+    @Test
+    public void summaryHtml_stripsScriptAndEventHandlers() {
+        EmailSelfRequest r = req("me@example.com");
+        r.setSummaryHtml("<p>Hi</p><script>alert(1)</script><img src=x onerror=alert(1)>");
+        MailMessage m = assembler.assemble(r, FROM);
+        assertTrue(m.htmlBody().contains("<p>Hi</p>"));
+        assertFalse(m.htmlBody().contains("<script"));
+        assertFalse(m.htmlBody().contains("onerror"));
+        // Only the server-added chart <img cid:chart> may survive; the client's
+        // tracking <img src=x> must not.
+        assertFalse(m.htmlBody().contains("src=\"x\""));
+        assertFalse(m.htmlBody().contains("src=x"));
+    }
+
+    @Test
+    public void summaryHtml_stripsUnsafeLinkProtocol() {
+        EmailSelfRequest r = req("me@example.com");
+        r.setSummaryHtml("<a href=\"javascript:alert(1)\">x</a>");
+        MailMessage m = assembler.assemble(r, FROM);
+        assertFalse(m.htmlBody().contains("javascript:"));
+    }
+
+    @Test
+    public void summaryHtml_keepsSafeFormattingLinksAndTables() {
+        EmailSelfRequest r = req("me@example.com");
+        r.setSummaryHtml("<h3>Report</h3><ul><li>Small $1,500</li></ul>"
+                + "<a href=\"https://x.com\">link</a><table><tr><td>1</td></tr></table>");
+        MailMessage m = assembler.assemble(r, FROM);
+        String body = m.htmlBody();
+        assertTrue(body.contains("Report"));
+        assertTrue(body.contains("Small $1,500"));
+        assertTrue(body.contains("https://x.com"));
+        assertTrue(body.contains("<table"));
+        assertTrue(body.contains(">1<"));
+    }
+
+    @Test
+    public void nullOrBlankSummary_usesDefault() {
+        EmailSelfRequest r1 = req("me@example.com");
+        r1.setSummaryHtml(null);
+        MailMessage m1 = assembler.assemble(r1, FROM);
+        assertTrue(m1.htmlBody().startsWith("<p>Your Saiku analysis is attached.</p>"));
+
+        EmailSelfRequest r2 = req("me@example.com");
+        r2.setSummaryHtml("   ");
+        MailMessage m2 = assembler.assemble(r2, FROM);
+        assertTrue(m2.htmlBody().startsWith("<p>Your Saiku analysis is attached.</p>"));
+    }
+
+    @Test
+    public void chartImg_stillAppendedAfterSanitizedSummary() {
+        EmailSelfRequest r = req("me@example.com");
+        r.setSummaryHtml("<p>Hi</p><script>alert(1)</script>");
+        MailMessage m = assembler.assemble(r, FROM);
+        assertTrue(m.htmlBody().endsWith("<br><img src=\"cid:chart\" alt=\"chart\">"));
+    }
 }

--- a/saiku-core/saiku-web/src/test/java/org/saiku/web/email/EmailResourceTest.java
+++ b/saiku-core/saiku-web/src/test/java/org/saiku/web/email/EmailResourceTest.java
@@ -1,0 +1,178 @@
+package org.saiku.web.email;
+
+import static org.junit.Assert.*;
+
+import jakarta.ws.rs.core.Response;
+import java.util.Base64;
+import java.util.Collections;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.After;
+import org.junit.Test;
+import org.saiku.service.mail.MailConfig;
+import org.saiku.service.mail.MailException;
+import org.saiku.service.mail.MailMessage;
+import org.saiku.service.mail.MailSender;
+import org.saiku.web.security.ratelimit.AiRateLimiter;
+import org.springframework.security.authentication.AnonymousAuthenticationToken;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+/**
+ * SH-2 — per-user send rate-limit on {@code POST /saiku/api/email/self}, plus the
+ * pre-existing auth/configured/send behaviour it must not disturb.
+ */
+public class EmailResourceTest {
+
+    private static final MailConfig CONFIG =
+            new MailConfig("smtp.example.com", 587, "user", "pass", "saiku@example.com", true, false);
+
+    @After
+    public void clearAuth() {
+        SecurityContextHolder.clearContext();
+    }
+
+    private static void login(String principal) {
+        UsernamePasswordAuthenticationToken auth = new UsernamePasswordAuthenticationToken(
+                principal, "x", Collections.singletonList(new SimpleGrantedAuthority("ROLE_USER")));
+        SecurityContext ctx = SecurityContextHolder.createEmptyContext();
+        ctx.setAuthentication(auth);
+        SecurityContextHolder.setContext(ctx);
+    }
+
+    private static EmailSelfRequest validBody() {
+        EmailSelfRequest r = new EmailSelfRequest();
+        r.setAddress("me@example.com");
+        r.setSubject("Your analysis");
+        r.setSummaryHtml("<p>Here is what changed.</p>");
+        r.setChartPngBase64(Base64.getEncoder().encodeToString(new byte[] {(byte) 0x89, 0x50, 0x4E, 0x47}));
+        r.setPdfBase64(Base64.getEncoder().encodeToString("%PDF-1.4".getBytes()));
+        return r;
+    }
+
+    /** Counts sends; always "succeeds" so the resource's happy path is exercised. */
+    private static final class CountingSender implements MailSender {
+        final AtomicInteger sendCount = new AtomicInteger();
+
+        @Override
+        public boolean isConfigured() {
+            return true;
+        }
+
+        @Override
+        public void send(MailMessage message) throws MailException {
+            sendCount.incrementAndGet();
+        }
+    }
+
+    private static EmailResource resource(MailSender sender) {
+        EmailResource r = new EmailResource();
+        r.setMailSender(sender);
+        r.setMailConfig(CONFIG);
+        return r;
+    }
+
+    // ---------- pre-existing behaviour (must stay green) ----------
+
+    @Test
+    public void anonymousCall_returns401_beforeTouchingMailOrLimiter() {
+        SecurityContextHolder.clearContext();
+        EmailResource r = resource(new CountingSender());
+        Response resp = r.sendSelf(validBody());
+        assertEquals(401, resp.getStatus());
+    }
+
+    @Test
+    public void unauthenticatedAnonymousToken_returns401() {
+        SecurityContext ctx = SecurityContextHolder.createEmptyContext();
+        ctx.setAuthentication(new AnonymousAuthenticationToken(
+                "key", "anonymousUser", Collections.singletonList(new SimpleGrantedAuthority("ROLE_ANONYMOUS"))));
+        SecurityContextHolder.setContext(ctx);
+
+        EmailResource r = resource(new CountingSender());
+        Response resp = r.sendSelf(validBody());
+        assertEquals(401, resp.getStatus());
+    }
+
+    @Test
+    public void authenticatedCall_configuredSender_returns200_andSends() {
+        login("alice");
+        CountingSender sender = new CountingSender();
+        EmailResource r = resource(sender);
+        Response resp = r.sendSelf(validBody());
+        assertEquals(200, resp.getStatus());
+        assertEquals(1, sender.sendCount.get());
+        assertEquals("sent", ((Map<?, ?>) resp.getEntity()).get("status"));
+    }
+
+    @Test
+    public void notConfigured_returns503() {
+        login("alice");
+        EmailResource r = new EmailResource();
+        r.setMailSender(null);
+        r.setMailConfig(CONFIG);
+        Response resp = r.sendSelf(validBody());
+        assertEquals(503, resp.getStatus());
+    }
+
+    // ---------- SH-2: rate limiting ----------
+
+    @Test
+    public void withinLimit_bothCallsSucceed() {
+        login("alice");
+        CountingSender sender = new CountingSender();
+        EmailResource r = resource(sender);
+        r.setEmailRateLimiter(new AiRateLimiter(2, 60_000L));
+
+        assertEquals(200, r.sendSelf(validBody()).getStatus());
+        assertEquals(200, r.sendSelf(validBody()).getStatus());
+        assertEquals(2, sender.sendCount.get());
+    }
+
+    @Test
+    public void overLimit_returns429_andDoesNotSendAgain() {
+        login("alice");
+        CountingSender sender = new CountingSender();
+        EmailResource r = resource(sender);
+        r.setEmailRateLimiter(new AiRateLimiter(1, 60_000L));
+
+        assertEquals(200, r.sendSelf(validBody()).getStatus());
+        Response second = r.sendSelf(validBody());
+        assertEquals(429, second.getStatus());
+        assertEquals(1, sender.sendCount.get());
+        Object error = ((Map<?, ?>) second.getEntity()).get("error");
+        assertNotNull(error);
+        assertTrue(error.toString().contains("limit"));
+    }
+
+    @Test
+    public void perUserBuckets_areIndependent() {
+        CountingSender sender = new CountingSender();
+        EmailResource r = resource(sender);
+        r.setEmailRateLimiter(new AiRateLimiter(1, 60_000L));
+
+        login("alice");
+        assertEquals(200, r.sendSelf(validBody()).getStatus());
+
+        login("bob");
+        assertEquals(200, r.sendSelf(validBody()).getStatus());
+
+        assertEquals(2, sender.sendCount.get());
+    }
+
+    @Test
+    public void rateLimitDoesNotFire_beforeAuthCheck() {
+        SecurityContextHolder.clearContext();
+        CountingSender sender = new CountingSender();
+        EmailResource r = resource(sender);
+        // Exhausted limiter — if the auth check didn't run first, an anonymous
+        // caller would still get 429 instead of 401.
+        r.setEmailRateLimiter(new AiRateLimiter(0, 60_000L));
+
+        Response resp = r.sendSelf(validBody());
+        assertEquals(401, resp.getStatus());
+        assertEquals(0, sender.sendCount.get());
+    }
+}


### PR DESCRIPTION
Security hardening on the email send path plus a small LLM-request config.

- Sanitize the client-supplied summary HTML with an OWASP allowlist policy (formatting/blocks/links/tables, no images) before it goes into the outbound email, so it can't carry scripts, event handlers, or tracking pixels. The server-added chart image is appended after sanitizing.
- Rate-limit the self-send endpoint per authenticated user.
- Make the per-request LLM timeout configurable (local/self-hosted models can take far longer than a hosted API).

Backend. Tests included.