### PR TITLE
Fix the Ask the AI button becoming unreadable on hover

### DIFF
--- a/saiku-ui/src/lib/views/WorkspaceToolbar.svelte
+++ b/saiku-ui/src/lib/views/WorkspaceToolbar.svelte
@@ -681,8 +681,7 @@
     border-color: var(--accent);
   }
   .tb-btn--ai:hover {
-    filter: brightness(1.08);
-    color: var(--bg);
+    color: var(--accent);
   }
   /*
    * saiku-cloud#612 — visual cue that the query shape isn't runnable yet


### PR DESCRIPTION
On hover the Ask the AI button showed white text on a white background — the AI button's hover rule set the text colour to the background token instead of the accent, so the label and icon vanished. Point the hover text at the accent colour so it reads as an accent outline on hover, in both light and dark themes. One-line CSS change.