### PR TITLE
Show the Save dialog name field above the folder browser

### DIFF
--- a/saiku-ui/src/lib/modals/SaveQueryModal.svelte
+++ b/saiku-ui/src/lib/modals/SaveQueryModal.svelte
@@ -43,6 +43,25 @@
   }
 
   const valid = $derived(name.trim().length > 0);
+
+  function save(): void {
+    onSave(normalizeFolder(folder), name.trim());
+  }
+
+  // Focus the Name input as soon as it mounts. The modal body only
+  // renders while `open` is true, so the action runs on every open. A
+  // queueMicrotask defers the focus until after the node is painted,
+  // and — being outside any $effect — it never re-triggers reactivity.
+  function autofocus(node: HTMLInputElement) {
+    queueMicrotask(() => node.focus());
+  }
+
+  function onNameKeydown(e: KeyboardEvent) {
+    if (e.key === "Enter" && valid) {
+      e.preventDefault();
+      save();
+    }
+  }
 </script>
 
 <Modal title={i18n.t("modal.save.title")} {open} size="lg" onClose={onCancel}>
@@ -50,22 +69,31 @@
     {i18n.t("modal.save.intro").replace("{folder}", folder || i18n.t("repo.root"))}
   </p>
 
-  <RepositoryBrowser
-    mode="save"
-    selectedPath={folder}
-    onSelect={(p) => (folder = p)}
-  />
-
-  <label class="field mt-3">
+  <label class="field">
     <span class="field__label">{i18n.t("modal.save.name")}</span>
-    <input class="field__input" bind:value={name} autocomplete="off" required />
+    <input
+      class="field__input"
+      bind:value={name}
+      autocomplete="off"
+      required
+      use:autofocus
+      onkeydown={onNameKeydown}
+    />
   </label>
+
+  <div class="mt-3">
+    <RepositoryBrowser
+      mode="save"
+      selectedPath={folder}
+      onSelect={(p) => (folder = p)}
+    />
+  </div>
 
   {#snippet footer()}
     <Button variant="outline" onclick={onCancel}>{i18n.t("modal.cancel")}</Button>
     <Button
       disabled={!valid}
-      onclick={() => onSave(normalizeFolder(folder), name.trim())}
+      onclick={save}
     >{i18n.t("modal.save")}</Button>
   {/snippet}
 </Modal>

--- a/saiku-ui/src/lib/modals/SaveQueryModal.test.ts
+++ b/saiku-ui/src/lib/modals/SaveQueryModal.test.ts
@@ -1,0 +1,82 @@
+/**
+ * Regression cover for saiku#1570: the Save dialog rendered the tall
+ * folder browser first and pushed the Name input below the fold, so
+ * users thought there was no way to name a query. The fix moves the
+ * Name input to the top of the dialog body (before the folder browser),
+ * auto-focuses it on open, and lets Enter save when valid.
+ *
+ * DOM ordering is asserted against Svelte's server render (the repo has
+ * no client-mount test harness — `svelte`'s client `mount` resolves to
+ * the server build under vitest). The save wiring is asserted against
+ * the component source: every save path (footer button + Enter) routes
+ * through one helper that preserves the onSave(folder, name) contract.
+ */
+import { describe, it, expect, vi } from "vitest";
+import { render } from "svelte/server";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+// Stub the heavy folder browser with a marker-only component so the
+// render doesn't pull in the repository store / fetch machinery.
+vi.mock("$lib/components/RepositoryBrowser.svelte", async () => ({
+  default: (await import("./__stubs__/RepositoryBrowserStub.svelte")).default,
+}));
+
+// i18n: echo the key so assertions are locale-independent.
+vi.mock("$lib/stores/i18n.svelte", () => ({
+  i18n: { t: (key: string) => key },
+}));
+
+import SaveQueryModal from "./SaveQueryModal.svelte";
+
+const SOURCE = readFileSync(
+  fileURLToPath(new URL("./SaveQueryModal.svelte", import.meta.url)),
+  "utf8",
+);
+
+function bodyFor(props: Record<string, unknown>): string {
+  return render(SaveQueryModal, {
+    props: {
+      defaultName: "",
+      defaultFolder: "reports",
+      folders: [],
+      open: true,
+      onSave: vi.fn(),
+      onCancel: vi.fn(),
+      ...props,
+    },
+  }).body;
+}
+
+describe("SaveQueryModal (saiku#1570)", () => {
+  it("renders the Name input before the folder browser in DOM order", () => {
+    const body = bodyFor({ open: true });
+
+    const nameIdx = body.indexOf("field__input");
+    const browserIdx = body.indexOf('data-testid="repo-browser"');
+
+    // Both must be present, and the Name input must come first.
+    expect(nameIdx).toBeGreaterThanOrEqual(0);
+    expect(browserIdx).toBeGreaterThanOrEqual(0);
+    expect(nameIdx).toBeLessThan(browserIdx);
+  });
+
+  it("renders the Name field label and intro", () => {
+    const body = bodyFor({ open: true });
+    expect(body).toContain("modal.save.name");
+    expect(body).toContain("modal.save.intro");
+    expect(body).toContain("field__input");
+  });
+
+  it("routes every save path through a single onSave(folder, name) helper", () => {
+    // The helper preserves the folder + trimmed-name contract.
+    expect(SOURCE).toMatch(
+      /function save\(\)\s*:\s*void\s*\{\s*onSave\(normalizeFolder\(folder\),\s*name\.trim\(\)\);\s*\}/,
+    );
+    // Footer Save button uses the helper.
+    expect(SOURCE).toMatch(/onclick=\{save\}/);
+    // Enter-to-save is wired and gated on `valid`.
+    expect(SOURCE).toMatch(/e\.key === "Enter" && valid/);
+    expect(SOURCE).toMatch(/use:autofocus/);
+  });
+});

--- a/saiku-ui/src/lib/modals/__stubs__/RepositoryBrowserStub.svelte
+++ b/saiku-ui/src/lib/modals/__stubs__/RepositoryBrowserStub.svelte
@@ -1,0 +1,16 @@
+<script lang="ts">
+  // Lightweight stand-in for RepositoryBrowser used by SaveQueryModal
+  // tests. Renders a single marked element so DOM-order assertions can
+  // locate "the folder browser" without pulling in the real component's
+  // repository store / fetch machinery.
+  interface Props {
+    mode?: "load" | "save";
+    fileTypes?: string[];
+    selectedPath?: string;
+    onSelect?: (path: string) => void;
+    onOpen?: (path: string) => void;
+  }
+  let { selectedPath = "" }: Props = $props();
+</script>
+
+<div data-testid="repo-browser">{selectedPath}</div>


### PR DESCRIPTION
Closes #1570. The Name input was below the (tall) folder browser, so it fell below the fold and looked like there was no way to name a query. Move Name to the top of the dialog, auto-focus it on open, and let Enter save. Frontend only; test asserts the Name input renders before the folder browser.