### PR TITLE
#1512 - bump jackson to 2.19.4 to clear GHSA-5jmj-h7xm-6q6v

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
         <jersey.version>3.1.9</jersey.version>
         <maven.build.timestamp.format>yyyyMMdd-HHmm</maven.build.timestamp.format>
         <saiku-query.version>0.4-SNAPSHOT</saiku-query.version>
-        <jackson.version>2.18.8</jackson.version>
+        <jackson.version>2.19.4</jackson.version>
         <!-- bi.saiku.ossie:ossie-core — external Ossie/OSI parser library
              (spiculedata/ossie). Track its releases and bump here. -->
         <ossie.version>0.1.0</ossie.version>

--- a/saiku-bom/pom.xml
+++ b/saiku-bom/pom.xml
@@ -38,13 +38,13 @@
         <batik.version>1.19</batik.version>
         <jersey.version>3.1.9</jersey.version>
         <saiku-query.version>0.4-SNAPSHOT</saiku-query.version>
-        <jackson.version>2.18.8</jackson.version>
+        <jackson.version>2.19.4</jackson.version>
         <arrow.version>18.2.0</arrow.version>
         <caffeine.version>3.2.4</caffeine.version>
         <!-- JSON Schema (draft 2020-12) validator for the AiQueryRequest
              body. Used by AiRequestSchemaValidator to enforce shape errors
              before the converter's domain-resolution layer runs. Apache 2.0,
-             ~200KB, no heavy transitives. Pairs with Jackson 2.18.x. -->
+             ~200KB, no heavy transitives. Pairs with Jackson 2.19.x. -->
         <jsonSchemaValidator.version>1.5.8</jsonSchemaValidator.version>
         <!-- Spring GraphQL 1.4.x is the current release line paired with Spring
              Framework 6.2.x. Provides the GraphQlSource / GraphQlHttpHandler


### PR DESCRIPTION
## What

Bumps the jackson stack from **2.18.8** to **2.19.4** (latest stable 2.19.x GA).

## Why

GHSA-5jmj-h7xm-6q6v surfaced via Dependabot alerts #496 and #500. There is **no fix in the 2.18.x line**, so the whole jackson stack has to move up to 2.19.x to clear it.

## How

Every jackson artifact we use resolves from a single `${jackson.version}` property:

- `jackson-core`, `jackson-databind`, `jackson-annotations`
- `jackson-dataformat-yaml`
- `jackson-jaxrs-json-provider`

The property is defined in `saiku-bom/pom.xml` (the dependencyManagement catalogue) and shadowed defensively in the root `pom.xml`. I bumped both in lockstep, so there is **no mixed 2.18/2.19 state** — all artifacts move together. No `jackson-bom` is imported, and no module hardcodes a jackson version outside the property.

## Verification

Local build on JDK 21 + Maven 3.9.9:

- `mvn -DskipTests -pl saiku-core/saiku-service,saiku-core/saiku-web,saiku-core/saiku-sql,saiku-core/saiku-semantic -am compile` — passed.
- Ran jackson-touching tests (JSON serialization, Ossie YAML writer, AI schema validator, schema snapshot, repository type info, suggestion set) — 21 tests green.

Full reactor verify (incl. `saiku-proptest`, which needs JDK 22) left to CI.

## Notes for review

Jackson 2.19 has a few behavioural changes worth a SEC/QA eye — default `JsonNodeFeature` handling and some coercion defaults shifted between 2.18 and 2.19. Our serialization/YAML tests pass, but the AI query JSON surface and the Ossie YAML round-trip are the areas most worth a second look.

Fixes #1512