### PR TITLE
#1551 - run vite build in the ui CI job so a broken prod build fails fast

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,7 +120,7 @@ jobs:
           exit "$fail"
 
   ui:
-    name: ui (svelte-check + vitest)
+    name: ui (svelte-check + vitest + build)
     needs: changes
     if: needs.changes.outputs.ui == 'true' || github.event_name == 'push'
     runs-on: ubuntu-latest
@@ -141,6 +141,13 @@ jobs:
         run: npm run check
       - name: vitest
         run: npm test -- --run
+      # Run the production build in the fast UI lane so a broken `vite build`
+      # fails here instead of only surfacing later inside the heavier Maven
+      # jobs (saiku-webapp's frontend-maven-plugin runs the same `npm run
+      # build`). Placed after check+test so a build break is clearly the
+      # build's fault, not a type/test failure. (saiku#1551)
+      - name: Production build
+        run: npm run build
 
   dist:
     name: bundle (saiku-dist zip)


### PR DESCRIPTION
Fixes #1551

## Problem

The `ui` job in `.github/workflows/ci.yml` ran `npm run check` (svelte-check) and `npm test -- --run` (vitest) but never `npm run build`. A frontend change that breaks the production `vite build` sailed through the fast `ui` gate green — the real vite build only ran much later, inside the heavier Maven jobs (saiku-webapp's `frontend-maven-plugin`). So a broken prod build failed slow instead of fast.

## Fix

Added a `Production build` step to the existing `ui` job, after check + test, running `npm run build` in the same `saiku-ui` working directory. This is the exact command the Maven frontend plugin already runs, so the fast lane now catches a broken build in seconds instead of deferring it to a ~34-minute Maven phase. Placing it after check + test means a build break is clearly attributed to the build rather than a type/test failure. Also renamed the job to `ui (svelte-check + vitest + build)` to match what it does.

Kept as a step in the existing `ui` job rather than a new job — it reuses the same checkout, Node 20 setup, and `npm ci` install, so a separate job would only duplicate setup and cost a redundant install for no benefit.

No changes to the Maven jobs.

## Verification

Ran `npm ci && npm run build` locally against this branch on current development. All four sub-builds pass clean (`build:app` vite build, `build:embed`, `build:embed-npm`, `build:embed-react-npm`) — confirming development's prod build isn't currently broken. (A Node-24-on-Windows npm-spawns-npm shim quirk means the chained script had to be run per-sub-build locally; CI's Node 20 on ubuntu-latest runs the chained `npm run build` directly.)