### PR TITLE
#1554 - gate AI egress on ossie/ask + schema-gen enrichment

### DIFF
--- a/docs/AI-OSSIE-API.md
+++ b/docs/AI-OSSIE-API.md
@@ -805,6 +805,17 @@ parsing, no fence-stripping. Off-topic questions come back as
 `{"error": "OFF_TOPIC", "message": "…"}` and surface as 400 with the
 narration attached.
 
+### LLM egress posture (#1554)
+
+At the default `schema-only` egress posture, `/ai/ossie/ask` sends the
+model's schema **metadata only** — dataset / field / metric names, types,
+cardinality — and strips the schema's `sampleValues` before the prompt
+reaches the LLM vendor. To include sample values — which improves
+filter-value grounding, e.g. the model seeing example members like
+`Springfield` and spelling filters right on the first try — an operator
+sets `SAIKU_AI_LLM_EGRESS=aggregated` (`ai.llm.egress`) on the launcher.
+The gate fails closed: an unconfigured server withholds sample values.
+
 ### Skills — admin-authored workflows (#1426)
 
 Admin-authored markdown workflows under `saiku-home/skills/` are

--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/ossie/ai/OssieAiAskService.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/ossie/ai/OssieAiAskService.java
@@ -14,6 +14,8 @@ import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.time.Duration;
+import org.saiku.service.olap.ai.AiDataKind;
+import org.saiku.service.olap.ai.AiPolicyGuard;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -100,6 +102,16 @@ public class OssieAiAskService {
 
     private final Config config;
 
+    /**
+     * saiku#1554. Dedicated LLM-egress guard, mirroring {@code AiAskService.egressGuard} on the MDX
+     * side. Answers "may raw column sample VALUES leave the box to a third-party LLM vendor?" —
+     * resolved from {@code SAIKU_AI_LLM_EGRESS} / {@code ai.llm.egress}, SEPARATE from the
+     * data-return {@code AiPolicyGuard} on {@code SAIKU_AI_POLICY}. Injected via setter so existing
+     * construction stays unchanged. FAIL-CLOSED: a null (unwired) guard denies egress, so an
+     * unconfigured instance strips the schema's sample values rather than leaking them.
+     */
+    private AiPolicyGuard egressGuard;
+
     public OssieAiAskService() {
         this(resolveFromEnvAndProps());
     }
@@ -111,6 +123,41 @@ public class OssieAiAskService {
         } else {
             log.info("Ossie AI ask DISABLED (set saiku.ai.ask.provider + API key to enable)");
         }
+    }
+
+    /** Spring setter — wired to {@code aiLlmEgressGuard} in {@code saiku-beans.xml}. */
+    public void setEgressGuard(AiPolicyGuard egressGuard) {
+        this.egressGuard = egressGuard;
+    }
+
+    /** The dedicated LLM-egress guard, or {@code null} if not wired (treated as egress-denied). */
+    public AiPolicyGuard egressGuard() {
+        return egressGuard;
+    }
+
+    /**
+     * Whether the schema's raw column sample VALUES may egress to the LLM vendor under the active
+     * egress posture. FAIL-CLOSED: a null (unwired) guard, or a guard whose posture doesn't permit
+     * the classified tier, returns {@code false} — sample values are stripped and only schema
+     * metadata reaches the vendor.
+     *
+     * <p><b>Classification ({@code AiDataKind}) — flagged for SEC review.</b> The datum here is
+     * {@code OssieAiSchema.Field.sampleValues}: raw distinct column values read straight from the
+     * warehouse. A strict parity argument would classify these as {@link AiDataKind#SAMPLE_MEMBERS}
+     * (floor tier), since the projector already drops {@code pii=true} fields (saiku#902 parity) and
+     * the MDX side sends its PII-filtered sample members at every posture. We deliberately chose the
+     * MORE CONSERVATIVE tier {@link AiDataKind#AGGREGATED_RESULT_VALUES} instead, because: (1) these
+     * are raw warehouse VALUES, not curated captions, and the Ossie layer carries only a coarse
+     * field-level {@code pii} flag — it lacks the per-value PII guarantee the MDX
+     * {@code SAMPLE_MEMBERS} tier documents ("already PII-filtered by saiku#902"); (2) at the higher
+     * tier the safe default posture ({@code schema-only}) strips the raw values and sends
+     * metadata-only, while an operator who trusts the vendor can opt in with
+     * {@code SAIKU_AI_LLM_EGRESS=aggregated} — giving a real, testable gate rather than a no-op at
+     * every wired posture. SEC: downgrade to {@code SAMPLE_MEMBERS} (one-line change) if strict
+     * MDX-schema parity is preferred over this conservative posture.
+     */
+    private boolean egressPermitsSampleValues() {
+        return egressGuard != null && egressGuard.canSend(AiDataKind.AGGREGATED_RESULT_VALUES);
     }
 
     public boolean isConfigured() {
@@ -148,20 +195,12 @@ public class OssieAiAskService {
         if (!config.isConfigured()) {
             return new AskResult(null, null, "provider not configured", null);
         }
-        String schemaJson;
+        String userMessage;
         try {
-            schemaJson = MAPPER.writeValueAsString(schema);
+            userMessage = buildUserMessage(question, schema, connectionName, modelName);
         } catch (Exception e) {
             return new AskResult(null, null, "failed to serialise schema: " + e.getMessage(), null);
         }
-
-        String userMessage = "Connection: " + connectionName + "\nModel: " + modelName
-                + "\n\nSchema (JSON):\n```json\n" + schemaJson
-                + "\n```\n\nQuestion: " + question
-                + "\n\nRespond with a single JSON object (no prose). The object must be a valid "
-                + "OssieAiQueryRequest with fields: connection, model, rows[], columns[], values[], "
-                + "filters[], sorts[], limit. Set connection='" + connectionName + "' and model='"
-                + modelName + "'.";
 
         try {
             String rawJson;
@@ -188,6 +227,30 @@ public class OssieAiAskService {
             log.warn("Ossie ask call failed: {}", e.getMessage());
             return new AskResult(null, null, "provider call failed: " + e.getMessage(), null);
         }
+    }
+
+    /**
+     * Build the user message sent to the LLM, applying the saiku#1554 egress projection to the
+     * schema first. Package-visible so the egress strip can be unit-tested without a live provider /
+     * network round-trip. When the egress guard doesn't permit sample-value egress the schema is
+     * projected to metadata-only ({@link OssieAiSchema#toAgentView(boolean)}) before serialisation,
+     * so raw column values never reach the vendor.
+     */
+    String buildUserMessage(String question, OssieAiSchema schema, String connectionName, String modelName)
+            throws com.fasterxml.jackson.core.JsonProcessingException {
+        boolean includeSamples = egressPermitsSampleValues();
+        if (!includeSamples) {
+            // No data in the log — just the fact that sample values were withheld by policy.
+            log.debug("Ossie schema sample values withheld from LLM by egress policy; ask proceeds metadata-only");
+        }
+        String schemaJson = MAPPER.writeValueAsString(schema.toAgentView(includeSamples));
+        return "Connection: " + connectionName + "\nModel: " + modelName
+                + "\n\nSchema (JSON):\n```json\n" + schemaJson
+                + "\n```\n\nQuestion: " + question
+                + "\n\nRespond with a single JSON object (no prose). The object must be a valid "
+                + "OssieAiQueryRequest with fields: connection, model, rows[], columns[], values[], "
+                + "filters[], sorts[], limit. Set connection='" + connectionName + "' and model='"
+                + modelName + "'.";
     }
 
     /**

--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/ossie/ai/OssieAiSchema.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/ossie/ai/OssieAiSchema.java
@@ -172,6 +172,85 @@ public class OssieAiSchema {
         this.examples = v == null ? new LinkedHashMap<>() : v;
     }
 
+    /**
+     * saiku#1554. Project this schema into an agent-facing view fit to cross the trust boundary to a
+     * third-party LLM vendor, mirroring {@code AiSchema.toAgentView()} on the MDX side.
+     *
+     * <p>PII fields are already dropped upstream by {@code OssieAiSchemaProjector} (saiku#902 parity —
+     * a field with {@code pii=true} never enters this DTO), so the only value-bearing datum left to
+     * project here is {@link Field#getSampleValues()} — the raw distinct column values pulled from the
+     * warehouse. When {@code includeSampleValues} is false, every field's sample values are stripped
+     * so only schema <em>metadata</em> (dataset / field / metric names, types, descriptions,
+     * relationships, aggregation kinds) reaches the vendor; all other fields are preserved.
+     *
+     * <p>Returns a projection-correct copy — the caller's original is untouched. This matters because
+     * the projector caches its sample-value lists and shares those list references across requests, so
+     * the strip MUST copy rather than mutate in place. When {@code includeSampleValues} is true there
+     * is nothing to strip and {@code this} is returned unchanged.
+     */
+    public OssieAiSchema toAgentView(boolean includeSampleValues) {
+        if (includeSampleValues) {
+            return this;
+        }
+        OssieAiSchema view = new OssieAiSchema();
+        view.modelId = this.modelId;
+        view.connectionName = this.connectionName;
+        view.modelName = this.modelName;
+        view.description = this.description;
+        view.factDataset = this.factDataset;
+        // Metrics / relationships / aliases / examples / requestSchema carry no raw column sample
+        // values, so they are reused by reference — nothing to redact there.
+        view.metrics = this.metrics;
+        view.relationships = this.relationships;
+        view.fieldAliases = this.fieldAliases;
+        view.metricAliases = this.metricAliases;
+        view.datasetAliases = this.datasetAliases;
+        view.requestSchema = this.requestSchema;
+        view.examples = this.examples;
+        Map<String, Dataset> redacted = new LinkedHashMap<>();
+        for (Map.Entry<String, Dataset> e : this.datasets.entrySet()) {
+            redacted.put(e.getKey(), redactDatasetSamples(e.getValue()));
+        }
+        view.datasets = redacted;
+        return view;
+    }
+
+    /** Shallow copy of a dataset with every field's sample values stripped. */
+    private static Dataset redactDatasetSamples(Dataset d) {
+        Dataset copy = new Dataset();
+        copy.setName(d.getName());
+        copy.setSource(d.getSource());
+        copy.setDescription(d.getDescription());
+        copy.setPrimaryKey(d.getPrimaryKey());
+        copy.setCustomExtensions(d.getCustomExtensions());
+        Map<String, Field> fields = new LinkedHashMap<>();
+        for (Map.Entry<String, Field> e : d.getFields().entrySet()) {
+            fields.put(e.getKey(), redactFieldSamples(e.getValue()));
+        }
+        copy.setFields(fields);
+        return copy;
+    }
+
+    /**
+     * Shallow copy of a field with {@link Field#getSampleValues()} emptied. Keeps the metadata
+     * (name, label, type, description, unit, currency, cardinality, estimatedDistinct, extensions) —
+     * only the raw sample VALUES are withheld.
+     */
+    private static Field redactFieldSamples(Field f) {
+        Field copy = new Field();
+        copy.setName(f.getName());
+        copy.setLabel(f.getLabel());
+        copy.setType(f.getType());
+        copy.setDescription(f.getDescription());
+        copy.setUnit(f.getUnit());
+        copy.setCurrency(f.getCurrency());
+        copy.setCardinality(f.getCardinality());
+        copy.setEstimatedDistinct(f.getEstimatedDistinct());
+        copy.setCustomExtensions(f.getCustomExtensions());
+        copy.setSampleValues(new ArrayList<>()); // stripped — raw warehouse values withheld from the vendor
+        return copy;
+    }
+
     // ---------------- Nested types ----------------
 
     @JsonInclude(JsonInclude.Include.NON_NULL)

--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/schema/generate/enrich/LlmEnricher.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/schema/generate/enrich/LlmEnricher.java
@@ -3,6 +3,8 @@ package org.saiku.service.schema.generate.enrich;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import org.saiku.service.olap.ai.AiDataKind;
+import org.saiku.service.olap.ai.AiPolicyGuard;
 import org.saiku.service.schema.generate.draft.DraftCube;
 import org.saiku.service.schema.generate.draft.DraftDimension;
 import org.saiku.service.schema.generate.draft.DraftSchema;
@@ -42,6 +44,26 @@ public final class LlmEnricher {
     private final int maxRetries;
     private final LlmProvider fallback = new NoopProvider();
 
+    /**
+     * saiku#1554. Dedicated LLM-egress guard, layered ON TOP of {@link #piiFilter} (defense-in-depth,
+     * consistent posture with the MDX {@code /ai/ask} and Ossie {@code /ai/ossie/ask} paths). The
+     * column samples sent to the vendor are raw warehouse values; when the active egress posture
+     * doesn't permit that tier, ALL samples are withheld so only the draft schema METADATA
+     * (table / column names, aggregators) is sent. Injected via setter so existing constructor wiring
+     * stays unchanged. FAIL-CLOSED: a null (unwired) guard denies egress.
+     *
+     * <p><b>Classification — flagged for SEC review.</b> Column samples map to
+     * {@link AiDataKind#SAMPLE_MEMBERS} on a strict reading, but {@link PiiFilter} here is a
+     * deny-LIST (it only strips known-pattern columns — {@code ssn}, {@code email}, … — and can miss
+     * an un-listed sensitive column such as a free-text note). Because that guarantee is weaker than
+     * the annotation-based saiku#902 filter the {@code SAMPLE_MEMBERS} tier assumes, we gate at the
+     * more conservative {@link AiDataKind#AGGREGATED_RESULT_VALUES}: at the safe default posture
+     * ({@code schema-only}) samples are stripped and only metadata egresses; an operator opts in with
+     * {@code SAIKU_AI_LLM_EGRESS=aggregated}. Kept consistent with the Ossie ask path. SEC may
+     * downgrade to {@code SAMPLE_MEMBERS} if the deny-list is considered sufficient.
+     */
+    private AiPolicyGuard egressGuard;
+
     public LlmEnricher(LlmProvider primary, PiiFilter piiFilter, int maxRetries) {
         this.primary = Objects.requireNonNull(primary, "primary");
         this.piiFilter = Objects.requireNonNull(piiFilter, "piiFilter");
@@ -52,10 +74,35 @@ public final class LlmEnricher {
         this(primary, piiFilter, DEFAULT_MAX_RETRIES);
     }
 
+    /** Spring setter — wired to {@code aiLlmEgressGuard} in {@code saiku-beans.xml} (saiku#1554). */
+    public void setEgressGuard(AiPolicyGuard egressGuard) {
+        this.egressGuard = egressGuard;
+    }
+
+    /** The dedicated LLM-egress guard, or {@code null} if not wired (treated as egress-denied). */
+    public AiPolicyGuard egressGuard() {
+        return egressGuard;
+    }
+
+    /**
+     * Whether raw column sample VALUES may egress to the LLM vendor under the active egress posture.
+     * FAIL-CLOSED: a null (unwired) guard, or a posture that doesn't permit the classified tier,
+     * returns {@code false}. See {@link #egressGuard} for the {@link AiDataKind} rationale.
+     */
+    private boolean egressPermitsColumnSamples() {
+        return egressGuard != null && egressGuard.canSend(AiDataKind.AGGREGATED_RESULT_VALUES);
+    }
+
     /** Run the primary provider over the given draft, chunked per cube, with retry + fallback. */
     public SuggestionSet enrich(DraftSchema draft, Map<String, List<String>> columnSamples) {
         Objects.requireNonNull(draft, "draft");
         Map<String, List<String>> safeSamples = piiFilter.filter(columnSamples);
+        // saiku#1554: LLM-egress gate ON TOP of the PiiFilter (defense-in-depth). When the egress
+        // posture doesn't permit sample-value egress, withhold ALL column samples — only the draft
+        // schema metadata (names, aggregators) reaches the vendor. Fail-closed: unwired guard denies.
+        if (!egressPermitsColumnSamples()) {
+            safeSamples = Map.of();
+        }
 
         SuggestionSet accumulated = new SuggestionSet();
 

--- a/saiku-core/saiku-service/src/test/java/org/saiku/service/ossie/ai/OssieAiAskServiceTest.java
+++ b/saiku-core/saiku-service/src/test/java/org/saiku/service/ossie/ai/OssieAiAskServiceTest.java
@@ -1,0 +1,117 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.service.ossie.ai;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.Test;
+import org.saiku.service.olap.ai.AiPolicy;
+import org.saiku.service.olap.ai.AiPolicyGuard;
+
+/**
+ * saiku#1554 — LLM-egress coverage for the Ossie {@code /ai/ossie/ask} path. Verifies the dedicated
+ * egress guard strips the schema's raw column sample VALUES before they cross to a third-party LLM
+ * vendor, while schema metadata always flows. Mirrors the MDX {@code AiAskServiceTest} egress tests.
+ *
+ * <p>The tests exercise {@code buildUserMessage} + {@link OssieAiSchema#toAgentView(boolean)}
+ * directly, so no live LLM provider / network round-trip is needed.
+ */
+public class OssieAiAskServiceTest {
+
+    /** A one-field schema whose sole field carries two distinct sample values. */
+    private static OssieAiSchema schemaWithSamples() {
+        OssieAiSchema schema = new OssieAiSchema();
+        schema.setConnectionName("conn");
+        schema.setModelName("model");
+
+        OssieAiSchema.Field city = new OssieAiSchema.Field();
+        city.setName("city");
+        city.setType("VARCHAR");
+        city.setSampleValues(new ArrayList<>(Arrays.asList("Springfield", "Shelbyville")));
+
+        OssieAiSchema.Dataset customers = new OssieAiSchema.Dataset();
+        customers.setName("customers");
+        Map<String, OssieAiSchema.Field> fields = new LinkedHashMap<>();
+        fields.put("city", city);
+        customers.setFields(fields);
+
+        Map<String, OssieAiSchema.Dataset> datasets = new LinkedHashMap<>();
+        datasets.put("customers", customers);
+        schema.setDatasets(datasets);
+        return schema;
+    }
+
+    private static String message(OssieAiAskService svc, OssieAiSchema schema) throws Exception {
+        return svc.buildUserMessage("how many by city?", schema, "conn", "model");
+    }
+
+    // ---------------- toAgentView projection ----------------
+
+    @Test
+    public void toAgentViewIncludeReturnsSameInstance() {
+        OssieAiSchema schema = schemaWithSamples();
+        assertSame("include=true is a no-op passthrough", schema, schema.toAgentView(true));
+    }
+
+    @Test
+    public void toAgentViewExcludeStripsSampleValuesWithoutMutatingOriginal() {
+        OssieAiSchema schema = schemaWithSamples();
+        OssieAiSchema view = schema.toAgentView(false);
+
+        List<String> viewSamples =
+                view.getDatasets().get("customers").getFields().get("city").getSampleValues();
+        assertTrue("sample values must be stripped in the projected view", viewSamples.isEmpty());
+
+        // The projector caches + shares sample-value lists across requests — the original must be
+        // left untouched by the projection.
+        List<String> originalSamples =
+                schema.getDatasets().get("customers").getFields().get("city").getSampleValues();
+        assertTrue("original sample values must survive (no in-place mutation)", originalSamples.size() == 2);
+
+        // Metadata (field name) survives the projection.
+        assertTrue(view.getDatasets().get("customers").getFields().containsKey("city"));
+    }
+
+    // ---------------- egress gate through buildUserMessage ----------------
+
+    @Test
+    public void egressUnwiredFailsClosedAndStripsSampleValues() throws Exception {
+        // No setEgressGuard() → guard is null → fail-closed: raw sample values must NOT egress.
+        OssieAiAskService svc = new OssieAiAskService();
+        String msg = message(svc, schemaWithSamples());
+
+        assertFalse("unwired egress guard must fail closed and strip sample values", msg.contains("Springfield"));
+        assertFalse(msg.contains("Shelbyville"));
+        assertTrue("schema metadata (field name) must still flow", msg.contains("city"));
+    }
+
+    @Test
+    public void egressSchemaOnlyStripsSampleValuesButMetadataFlows() throws Exception {
+        OssieAiAskService svc = new OssieAiAskService();
+        svc.setEgressGuard(new AiPolicyGuard(AiPolicy.SCHEMA_ONLY));
+        String msg = message(svc, schemaWithSamples());
+
+        assertFalse("schema-only egress must strip raw sample values", msg.contains("Springfield"));
+        assertTrue("schema metadata must still flow at schema-only", msg.contains("city"));
+    }
+
+    @Test
+    public void egressAggregatedPassesSampleValuesThrough() throws Exception {
+        OssieAiAskService svc = new OssieAiAskService();
+        svc.setEgressGuard(new AiPolicyGuard(AiPolicy.AGGREGATED));
+        String msg = message(svc, schemaWithSamples());
+
+        assertTrue("aggregated egress must pass sample values through", msg.contains("Springfield"));
+        assertTrue(msg.contains("Shelbyville"));
+        assertTrue(msg.contains("city"));
+    }
+}

--- a/saiku-core/saiku-service/src/test/java/org/saiku/service/schema/generate/enrich/LlmEnricherTest.java
+++ b/saiku-core/saiku-service/src/test/java/org/saiku/service/schema/generate/enrich/LlmEnricherTest.java
@@ -11,6 +11,8 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import org.junit.Test;
+import org.saiku.service.olap.ai.AiPolicy;
+import org.saiku.service.olap.ai.AiPolicyGuard;
 import org.saiku.service.schema.generate.draft.DraftCube;
 import org.saiku.service.schema.generate.draft.DraftDimension;
 import org.saiku.service.schema.generate.draft.DraftHierarchy;
@@ -213,6 +215,61 @@ public class LlmEnricherTest {
         SuggestionSet set = enr.enrich(twoCubeSchema(), samples());
         assertFalse(set.degraded());
         assertTrue(p.calls >= 2);
+    }
+
+    /* ---- saiku#1554: LLM-egress gate layered on top of the PiiFilter ---- */
+
+    @Test
+    public void egressUnwiredFailsClosedAndStripsAllColumnSamples() {
+        // No setEgressGuard() → guard is null → fail-closed: NO column samples reach the provider,
+        // even the non-PII ones. Only the draft schema metadata egresses.
+        RecordingProvider rec = new RecordingProvider();
+        LlmEnricher enr = new LlmEnricher(rec, new PiiFilter(), 2);
+        enr.enrich(twoCubeSchema(), samples());
+
+        assertFalse("provider should still be called", rec.seen.isEmpty());
+        for (EnrichRequest req : rec.seen) {
+            assertTrue(
+                    "unwired egress guard must fail closed and strip ALL samples",
+                    req.columnSamples().isEmpty());
+        }
+    }
+
+    @Test
+    public void egressSchemaOnlyStripsAllColumnSamples() {
+        // schema-only egress posture → raw column sample VALUES are withheld (conservative tier).
+        RecordingProvider rec = new RecordingProvider();
+        LlmEnricher enr = new LlmEnricher(rec, new PiiFilter(), 2);
+        enr.setEgressGuard(new AiPolicyGuard(AiPolicy.SCHEMA_ONLY));
+        enr.enrich(twoCubeSchema(), samples());
+
+        assertFalse(rec.seen.isEmpty());
+        for (EnrichRequest req : rec.seen) {
+            assertTrue(
+                    "schema-only egress must strip column samples",
+                    req.columnSamples().isEmpty());
+        }
+    }
+
+    @Test
+    public void egressAggregatedPassesNonPiiColumnSamplesThrough() {
+        // aggregated egress posture → non-PII samples flow (PiiFilter still strips ssn/email).
+        RecordingProvider rec = new RecordingProvider();
+        LlmEnricher enr = new LlmEnricher(rec, new PiiFilter(), 2);
+        enr.setEgressGuard(new AiPolicyGuard(AiPolicy.AGGREGATED));
+        enr.enrich(twoCubeSchema(), samples());
+
+        boolean sawNonPiiSample = false;
+        for (EnrichRequest req : rec.seen) {
+            // PiiFilter still applies underneath the egress gate — the deny-listed columns never leak.
+            assertFalse("ssn must still be filtered", req.columnSamples().containsKey("customers.ssn"));
+            assertFalse("email must still be filtered", req.columnSamples().containsKey("customers.email_address"));
+            if (req.columnSamples().containsKey("customers.customer_name")
+                    || req.columnSamples().containsKey("products.product_name")) {
+                sawNonPiiSample = true;
+            }
+        }
+        assertTrue("aggregated egress must pass non-PII samples through", sawNonPiiSample);
     }
 
     @Test

--- a/saiku-webapp/src/main/webapp/WEB-INF/saiku-beans.xml
+++ b/saiku-webapp/src/main/webapp/WEB-INF/saiku-beans.xml
@@ -359,7 +359,12 @@
     </bean>
     <!-- R5: Ossie natural-language ask. Reads saiku.ai.ask.provider + API key from env/props;
          disabled by default (health returns configured=false; /ask returns 503). -->
-    <bean id="ossieAiAskServiceBean" class="org.saiku.service.ossie.ai.OssieAiAskService"/>
+    <bean id="ossieAiAskServiceBean" class="org.saiku.service.ossie.ai.OssieAiAskService">
+        <!-- saiku#1554: dedicated LLM-egress gate — strips the schema's raw column sample values
+             from the prompt when SAIKU_AI_LLM_EGRESS / ai.llm.egress doesn't permit sample-value
+             egress. Mirrors aiAskServiceBean; fail-closed when unwired. -->
+        <property name="egressGuard" ref="aiLlmEgressGuard"/>
+    </bean>
 
     <!-- ====================================================================
          GraphQL API (POST /saiku/api/graphql + GET /schema.graphql).
@@ -816,6 +821,10 @@
         <constructor-arg ref="llmProvider"/>
         <constructor-arg ref="piiFilter"/>
         <constructor-arg value="2"/>
+        <!-- saiku#1554: LLM-egress gate layered on top of the PiiFilter (defense-in-depth). Strips
+             ALL column sample values from the enrichment prompt when SAIKU_AI_LLM_EGRESS /
+             ai.llm.egress doesn't permit sample-value egress; fail-closed when unwired. -->
+        <property name="egressGuard" ref="aiLlmEgressGuard"/>
     </bean>
 
     <bean id="schemaGenExecutor"


### PR DESCRIPTION
Fixes #1554.

The AI LLM-egress policy previously gated only the MDX `/ai/ask` cellset digest. Two other paths egressed data to third-party LLMs with **no egress-posture gate**. This wires the dedicated `aiLlmEgressGuard` bean (`SAIKU_AI_LLM_EGRESS`) into both, fail-closed, mirroring `AiAskService`.

## What changed

**`/ai/ossie/ask` (`OssieAiAskService`)** — previously serialised the raw `OssieAiSchema`, including each field's raw warehouse **sample values**, straight into the LLM user message.
- Setter-injected `egressGuard` (wired to `aiLlmEgressGuard`), fail-closed.
- New `OssieAiSchema.toAgentView(boolean includeSampleValues)` — the `toAgentView` equivalent for the Ossie schema. PII-flagged fields are already dropped upstream by `OssieAiSchemaProjector` (saiku#902 parity), so the remaining sensitive datum is `Field.sampleValues`; the projection strips them (copy, not in-place — the projector caches/shares those lists) when the posture doesn't permit egress. Metadata always flows.
- Prompt assembly extracted to a package-visible `buildUserMessage` so the strip is unit-testable without a live provider.

**Schema-gen enrichment (`LlmEnricher`)** — sends draft schema + column samples to the vendor. The existing `PiiFilter` is kept; the egress gate is layered **on top** (defense-in-depth): when the posture doesn't permit egress, all column samples are withheld and only schema metadata reaches the vendor.

**Wiring** — `ossieAiAskServiceBean` and `llmEnricher` each get `<property name="egressGuard" ref="aiLlmEgressGuard"/>`.

## Classification (`AiDataKind`)

Both paths' raw sample/column **values** are gated at **`AGGREGATED_RESULT_VALUES`**, the conservative choice. A strict parity reading would classify them as `SAMPLE_MEMBERS` (floor tier), but that tier is documented as "already PII-filtered by saiku#902" — a per-value guarantee neither path fully provides (Ossie has only a coarse field-level `pii` flag; schema-gen's `PiiFilter` is a deny-list that can miss un-listed columns). Gating one tier up means the **safe default `schema-only` posture strips the raw values** and sends metadata only, while an operator can opt in with `SAIKU_AI_LLM_EGRESS=aggregated`. Both call sites carry a code comment flagging this for SEC, with the one-line downgrade to `SAMPLE_MEMBERS` documented. Schema metadata stays `SCHEMA_METADATA` (floor, always flows).

## Tests

- New `OssieAiAskServiceTest`: `toAgentView` strips samples without mutating the original; `buildUserMessage` strips at schema-only, passes through at aggregated, fails closed when the guard is unwired; metadata always present.
- Extended `LlmEnricherTest`: samples stripped at schema-only + when unwired (fail-closed), non-PII samples pass through at aggregated (with `PiiFilter` still stripping ssn/email underneath).

`mvn -o -pl saiku-core/saiku-service test -Dtest=OssieAiAskServiceTest,LlmEnricherTest` → **15 run, 0 failures**. Spotless clean.

Not merging / no auto-merge.