### PR TITLE
#1553 - gate history + currentQuery egress on /ai/ask at send-time

### DIFF
--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ai/ask/AiAskService.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ai/ask/AiAskService.java
@@ -867,8 +867,10 @@ public class AiAskService {
         String requestSchemaJson;
         try {
             // Always the PII-filtered agent view (#3) — schema egress is permitted, but must stay
-            // filtered. This path sends NO cell data, so it isn't gated on the aggregated egress
-            // posture the report path uses.
+            // filtered. The dashboard is authored from the schema alone (no cellset digest, no
+            // currentQuery), but the client-supplied history CAN carry prior assistant turns whose
+            // emit_insight / emit_email_draft markdown replays cell-derived figures — so that history
+            // is send-time re-gated below (#1553), same as the report path.
             schemaJson = mapper.writeValueAsString(schema.toAgentView());
             requestSchemaJson = mapper.writeValueAsString(AiRequestJsonSchema.forRequest());
         } catch (JsonProcessingException e) {
@@ -890,12 +892,22 @@ public class AiAskService {
         }
         String spaceSystemPrompt = space != null ? space.systemPrompt() : null;
 
+        // #1553: send-time re-gate of history. When egress forbids aggregated cell data, drop
+        // assistant-role turns (they replay model-emitted, cell-derived figures) and keep the user's
+        // own words. New list — the caller's history is never mutated. Fail-closed via the same
+        // guard the report path uses. The dashboard carries no cellset digest / currentQuery, so
+        // history is the only cell-derived egress vector on this seam.
+        List<NlAskMessage> effectiveHistory = history == null ? List.of() : history;
+        if (!egressPermitsCellData()) {
+            effectiveHistory = dropAssistantTurns(effectiveHistory);
+        }
+
         NlAskRequest req = new NlAskRequest(
                 ref,
                 effectiveQuestion,
                 schemaJson,
                 requestSchemaJson,
-                history == null ? List.of() : history,
+                effectiveHistory,
                 null, // no cellset digest — the dashboard is authored from the schema alone
                 NlAskRequest.ForceTool.DASHBOARD,
                 null,

--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ai/ask/AiAskService.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ai/ask/AiAskService.java
@@ -16,6 +16,7 @@ import org.saiku.service.olap.ThinQueryService;
 import org.saiku.service.olap.ai.AiCubeMetadataService;
 import org.saiku.service.olap.ai.AiCubeRef;
 import org.saiku.service.olap.ai.AiDataKind;
+import org.saiku.service.olap.ai.AiFilterSelection;
 import org.saiku.service.olap.ai.AiPolicyGuard;
 import org.saiku.service.olap.ai.AiQueryRequest;
 import org.saiku.service.olap.ai.AiRequestJsonSchema;
@@ -174,6 +175,64 @@ public class AiAskService {
      */
     private boolean egressPermitsCellData() {
         return egressGuard != null && egressGuard.canSend(AiDataKind.AGGREGATED_RESULT_VALUES);
+    }
+
+    /**
+     * Send-time re-gate of the conversation {@code history} (saiku#1553). When the active egress
+     * posture forbids aggregated cell data ({@code !egressPermitsCellData()}), DROP every
+     * assistant-role turn and keep only the user's own words. Assistant turns replay the model's
+     * previously emitted figures ({@code emit_insight} / {@code emit_email_draft} markdown carrying
+     * cell-derived values); replaying them back to the LLM would egress that data even at
+     * schema-only — the killer case being a turn-1 {@code aggregated} insight the client re-sends at
+     * a turn-2 {@code schema-only} posture. History is client-supplied and untrusted every turn, so
+     * this send-time gate is the only enforceable control (mirrors the {@code cellsetDigest} strip).
+     *
+     * <p>Returns a NEW list — never mutates the caller-owned {@code history}. Fail-closed at the call
+     * site: this runs whenever egress isn't permitted, including the null/unwired-guard case.
+     */
+    private static List<NlAskMessage> dropAssistantTurns(List<NlAskMessage> history) {
+        if (history == null || history.isEmpty()) {
+            return List.of();
+        }
+        List<NlAskMessage> kept = new ArrayList<>(history.size());
+        for (NlAskMessage m : history) {
+            if (m != null && m.role() == NlAskMessage.Role.USER) {
+                kept.add(m);
+            }
+        }
+        return kept;
+    }
+
+    /**
+     * Send-time re-gate of the {@code currentQuery} snapshot (saiku#1553). When the active egress
+     * posture forbids aggregated cell data ({@code !egressPermitsCellData()}), redact a COPY of the
+     * query whose {@code filters[].members} lists (the MDX member unique names like
+     * {@code [Customers].[John Smith]} — a cell-derived selection) are cleared, while KEEPING the
+     * query structure: measures / rows / columns / cube / filter dimension+hierarchy+level refs. The
+     * model still sees what the query is shaped like without seeing which members were picked.
+     *
+     * <p>Copy-not-mutate (saiku#1553): the redaction is applied to a mapper round-trip copy so the
+     * caller-owned {@code currentQuery} object is never touched. Fail-closed: if the copy can't be
+     * made, returns {@code null} so the current-query context block is omitted entirely rather than
+     * risk leaking members.
+     */
+    private AiQueryRequest redactFilterMembers(AiQueryRequest currentQuery) {
+        if (currentQuery == null) {
+            return null;
+        }
+        AiQueryRequest copy;
+        try {
+            copy = mapper.readValue(mapper.writeValueAsString(currentQuery), AiQueryRequest.class);
+        } catch (JsonProcessingException e) {
+            log.debug("currentQuery member redaction copy failed; omitting current-query context", e);
+            return null;
+        }
+        if (copy.getFilters() != null) {
+            for (AiFilterSelection f : copy.getFilters()) {
+                f.setMembers(new ArrayList<>());
+            }
+        }
+        return copy;
     }
 
     /**
@@ -570,10 +629,17 @@ public class AiAskService {
         String effectiveDigest = cellsetDigest;
         if (hadCellsetOnScreen && !egressPermitsCellData()) effectiveDigest = null;
 
+        // #1553: send-time re-gate of currentQuery — same as askInternal. Redact a COPY (members
+        // cleared, structure kept) when egress forbids aggregated cell data; never mutate the
+        // caller's object; fail-closed on an unwired/denying guard.
+        AiQueryRequest effectiveQuery = currentQuery;
+        if (currentQuery != null && !egressPermitsCellData()) {
+            effectiveQuery = redactFilterMembers(currentQuery);
+        }
         String currentQueryJson = null;
-        if (currentQuery != null) {
+        if (effectiveQuery != null) {
             try {
-                currentQueryJson = mapper.writeValueAsString(currentQuery);
+                currentQueryJson = mapper.writeValueAsString(effectiveQuery);
             } catch (JsonProcessingException e) {
                 log.debug("chained ask: currentQuery serialise failed; omitting", e);
             }
@@ -585,7 +651,14 @@ public class AiAskService {
             if (f != null && !f.isBlank()) skillsFragment = f;
         }
         final NlAskRequest.ForceTool ft = forceTool == null ? NlAskRequest.ForceTool.AUTO : forceTool;
-        final List<NlAskMessage> hist = history == null ? List.of() : history;
+        // #1553: send-time re-gate of history — drop assistant turns (model-emitted, cell-derived)
+        // when egress forbids aggregated cell data, keeping the user's turns. New list, computed
+        // once here and reused on every loop turn; the caller's history is never mutated.
+        List<NlAskMessage> histLocal = history == null ? List.of() : history;
+        if (!egressPermitsCellData()) {
+            histLocal = dropAssistantTurns(histLocal);
+        }
+        final List<NlAskMessage> hist = histLocal;
 
         // --- the loop ---
         List<AskOutcome> steps = new ArrayList<>();
@@ -1022,13 +1095,21 @@ public class AiAskService {
             log.debug("Cellset digest withheld from LLM by egress policy; ask proceeds schema-only");
         }
 
+        // #1553: send-time re-gate of currentQuery. When egress forbids aggregated cell data, redact
+        // a COPY whose filter members are cleared (the picked MDX member unique names are
+        // cell-derived) while keeping the query structure. Copy-not-mutate — the caller's object is
+        // untouched. Fail-closed: an unwired/denying guard strips.
+        AiQueryRequest effectiveQuery = currentQuery;
+        if (currentQuery != null && !egressPermitsCellData()) {
+            effectiveQuery = redactFilterMembers(currentQuery);
+        }
         // Serialise the current query into JSON for the provider to embed in the prompt.
         // Null/blank when absent — providers omit the "Current query" context block entirely
         // rather than say "Current query: null", which would just bloat the prompt.
         String currentQueryJson = null;
-        if (currentQuery != null) {
+        if (effectiveQuery != null) {
             try {
-                currentQueryJson = mapper.writeValueAsString(currentQuery);
+                currentQueryJson = mapper.writeValueAsString(effectiveQuery);
             } catch (JsonProcessingException e) {
                 log.debug("Failed to serialise currentQuery for ask context; omitting", e);
             }
@@ -1059,12 +1140,21 @@ public class AiAskService {
         // rails that make the ask surface safe.
         String spaceSystemPrompt = space != null ? space.systemPrompt() : null;
 
+        // #1553: send-time re-gate of history. When egress forbids aggregated cell data, drop
+        // assistant-role turns (they replay model-emitted, cell-derived figures) and keep the user's
+        // own words. New list — the caller's history is never mutated. Fail-closed via the same
+        // guard as the digest / currentQuery strips.
+        List<NlAskMessage> effectiveHistory = history == null ? List.of() : history;
+        if (!egressPermitsCellData()) {
+            effectiveHistory = dropAssistantTurns(effectiveHistory);
+        }
+
         NlAskRequest req = new NlAskRequest(
                 ref,
                 effectiveQuestion,
                 schemaJson,
                 requestSchemaJson,
-                history == null ? List.of() : history,
+                effectiveHistory,
                 effectiveDigest,
                 forceTool == null ? NlAskRequest.ForceTool.AUTO : forceTool,
                 currentQueryJson,

--- a/saiku-core/saiku-service/src/test/java/org/saiku/service/olap/ai/ask/AiAskServiceTest.java
+++ b/saiku-core/saiku-service/src/test/java/org/saiku/service/olap/ai/ask/AiAskServiceTest.java
@@ -1438,6 +1438,95 @@ public class AiAskServiceTest {
         assertNull(spec.tiles().get(2).chartType());
     }
 
+    /* ---- saiku#1553: the /ai/ask/dashboard seam re-gates client-supplied history too ---- */
+
+    /**
+     * Capturing provider that records the request and returns a minimal valid dashboard so the
+     * build completes. Mirrors the report-path capturing lambdas but for the dashboard tool.
+     */
+    private static NlAskProvider capturingDashboard(AtomicReference<NlAskRequest> seen) {
+        String payload = "{\"title\":\"D\",\"tiles\":[" + "{\"title\":\"Grid\",\"type\":\"table\",\"query\":"
+                + VALID_TILE_QUERY + "}]}";
+        return req -> {
+            seen.set(req);
+            return NlAskResponse.okDashboard(payload, "m", 0, 0);
+        };
+    }
+
+    @Test
+    public void buildDashboardSchemaOnlyDropsAssistantHistoryTurnsButKeepsUserTurns() {
+        // #1553: the dashboard endpoint takes client-supplied history just like the report path. Under
+        // schema-only egress the assistant turns (replaying cell-derived figures) must be dropped
+        // before the request crosses to the LLM; only the user's own words survive.
+        AtomicReference<NlAskRequest> seen = new AtomicReference<>();
+        AiAskService svc = new AiAskService(fixedSchemaService(salesSchemaWithMeasure()), capturingDashboard(seen));
+        svc.setEgressGuard(new AiPolicyGuard(AiPolicy.SCHEMA_ONLY));
+
+        svc.buildDashboard(CUBE, "build me a dashboard", historyWithAssistantFigure(), null);
+
+        NlAskRequest captured = seen.get();
+        assertNotNull(captured);
+        assertEquals(
+                "only the two user turns survive schema-only egress on the dashboard seam",
+                2,
+                captured.history().size());
+        for (NlAskMessage m : captured.history()) {
+            assertEquals(NlAskMessage.Role.USER, m.role());
+        }
+        assertFalse(captured.history().stream().anyMatch(m -> m.content().contains("7,000")));
+    }
+
+    @Test
+    public void buildDashboardEgressUnwiredFailsClosedAndDropsAssistantHistory() {
+        // No setEgressGuard() → null guard → fail-closed: assistant turns dropped on the dashboard seam.
+        AtomicReference<NlAskRequest> seen = new AtomicReference<>();
+        AiAskService svc = new AiAskService(fixedSchemaService(salesSchemaWithMeasure()), capturingDashboard(seen));
+
+        svc.buildDashboard(CUBE, "build me a dashboard", historyWithAssistantFigure(), null);
+
+        NlAskRequest captured = seen.get();
+        assertNotNull(captured);
+        assertEquals(
+                "unwired guard fails closed on the dashboard seam",
+                2,
+                captured.history().size());
+        assertFalse(captured.history().stream().anyMatch(m -> m.content().contains("7,000")));
+    }
+
+    @Test
+    public void buildDashboardAggregatedPassesHistoryThroughUntouched() {
+        // At aggregated egress the assistant turn (and its figure) passes through intact.
+        AtomicReference<NlAskRequest> seen = new AtomicReference<>();
+        AiAskService svc = new AiAskService(fixedSchemaService(salesSchemaWithMeasure()), capturingDashboard(seen));
+        svc.setEgressGuard(new AiPolicyGuard(AiPolicy.AGGREGATED));
+
+        svc.buildDashboard(CUBE, "build me a dashboard", historyWithAssistantFigure(), null);
+
+        NlAskRequest captured = seen.get();
+        assertNotNull(captured);
+        assertEquals(
+                "aggregated egress keeps all turns including assistant on the dashboard seam",
+                3,
+                captured.history().size());
+        assertTrue(
+                "assistant figure passes through at aggregated",
+                captured.history().stream().anyMatch(m -> m.content().contains("7,000")));
+    }
+
+    @Test
+    public void buildDashboardSchemaOnlyDoesNotMutateCallerHistory() {
+        // Copy-not-mutate (#1553): the send-time strip operates on a copy; the caller's list is intact.
+        AiAskService svc = new AiAskService(
+                fixedSchemaService(salesSchemaWithMeasure()), capturingDashboard(new AtomicReference<>()));
+        svc.setEgressGuard(new AiPolicyGuard(AiPolicy.SCHEMA_ONLY));
+
+        List<NlAskMessage> history = historyWithAssistantFigure();
+        svc.buildDashboard(CUBE, "build me a dashboard", history, null);
+
+        assertEquals("caller history must not be mutated", 3, history.size());
+        assertEquals(NlAskMessage.Role.ASSISTANT, history.get(1).role());
+    }
+
     @Test
     public void buildDashboardTruncatesToTileCap() {
         // 20 tiles emitted — must truncate to the default cap (6), never error.

--- a/saiku-core/saiku-service/src/test/java/org/saiku/service/olap/ai/ask/AiAskServiceTest.java
+++ b/saiku-core/saiku-service/src/test/java/org/saiku/service/olap/ai/ask/AiAskServiceTest.java
@@ -28,6 +28,7 @@ import org.saiku.olap.query2.ThinQuery;
 import org.saiku.service.olap.ThinQueryService;
 import org.saiku.service.olap.ai.AiCubeMetadataService;
 import org.saiku.service.olap.ai.AiCubeRef;
+import org.saiku.service.olap.ai.AiFilterSelection;
 import org.saiku.service.olap.ai.AiMeasureSelection;
 import org.saiku.service.olap.ai.AiPolicy;
 import org.saiku.service.olap.ai.AiPolicyGuard;
@@ -119,6 +120,10 @@ public class AiAskServiceTest {
             return NlAskResponse.ok("{\"cube\":{\"cubeName\":\"Sales\"},\"measures\":[]}", "m", 0, 0);
         };
         AiAskService svc = new AiAskService(fixedSchemaService(emptySchema()), capturing);
+        // #1553: unchanged full-history passthrough now requires a posture that permits aggregated
+        // egress. Under the fail-closed default the assistant turn would be dropped (covered by the
+        // dedicated #1553 tests); this test asserts the plumbing forwards the whole history intact.
+        svc.setEgressGuard(new AiPolicyGuard(AiPolicy.AGGREGATED));
 
         svc.ask(CUBE, "show sales by country", List.of(NlAskMessage.user("earlier"), NlAskMessage.assistant("ack")));
 
@@ -594,6 +599,187 @@ public class AiAskServiceTest {
         assertFalse("PII sample member caption must not egress: " + schemaJson, schemaJson.contains("John Smith"));
         assertFalse("PII display name must not egress: " + schemaJson, schemaJson.contains("Customer Name"));
         assertTrue("redaction sentinel must be present: " + schemaJson, schemaJson.contains("[REDACTED]"));
+    }
+
+    /* ---- saiku#1553: send-time re-gate of history + currentQuery egress ---- */
+
+    /** History with a user turn, an assistant turn carrying a cell-derived figure, and a 2nd user turn. */
+    private static List<NlAskMessage> historyWithAssistantFigure() {
+        return List.of(
+                NlAskMessage.user("show sales by tier"),
+                NlAskMessage.assistant("Insight: the Large tier leads at 7,000."),
+                NlAskMessage.user("now email it"));
+    }
+
+    /**
+     * A currentQuery snapshot with a resolvable measure + a slicer filter whose member is a specific
+     * customer's MDX unique name — the cell-derived selection #1553 must strip under schema-only.
+     */
+    private static AiQueryRequest currentQueryWithFilterMember() {
+        AiQueryRequest cq = new AiQueryRequest();
+        cq.setCube(CUBE);
+        cq.setMeasures(new ArrayList<>(List.of(new AiMeasureSelection("Store Sales"))));
+        AiFilterSelection filter = new AiFilterSelection(
+                "Customers", "[Customers]", "[Customers].[Name]", new ArrayList<>(List.of("[Customers].[John Smith]")));
+        cq.setFilters(new ArrayList<>(List.of(filter)));
+        return cq;
+    }
+
+    @Test
+    public void schemaOnlyDropsAssistantHistoryTurnsButKeepsUserTurns() {
+        AtomicReference<NlAskRequest> seen = new AtomicReference<>();
+        NlAskProvider capturing = req -> {
+            seen.set(req);
+            return NlAskResponse.ok("{\"cube\":{\"cubeName\":\"Sales\"},\"measures\":[]}", "m", 0, 0);
+        };
+        AiAskService svc = new AiAskService(fixedSchemaService(emptySchema()), capturing);
+        svc.setEgressGuard(new AiPolicyGuard(AiPolicy.SCHEMA_ONLY));
+
+        svc.ask(CUBE, "follow up", historyWithAssistantFigure(), null, NlAskRequest.ForceTool.AUTO, null);
+
+        NlAskRequest captured = seen.get();
+        assertNotNull(captured);
+        assertEquals(
+                "only the two user turns survive schema-only egress",
+                2,
+                captured.history().size());
+        for (NlAskMessage m : captured.history()) {
+            assertEquals(NlAskMessage.Role.USER, m.role());
+        }
+        // The assistant turn's cell-derived figure must never cross to the LLM.
+        assertFalse(captured.history().stream().anyMatch(m -> m.content().contains("7,000")));
+    }
+
+    @Test
+    public void schemaOnlyStripsCurrentQueryFilterMembersButKeepsStructure() {
+        AtomicReference<NlAskRequest> seen = new AtomicReference<>();
+        NlAskProvider capturing = req -> {
+            seen.set(req);
+            return NlAskResponse.ok("{\"cube\":{\"cubeName\":\"Sales\"},\"measures\":[]}", "m", 0, 0);
+        };
+        AiAskService svc = new AiAskService(fixedSchemaService(emptySchema()), capturing);
+        svc.setEgressGuard(new AiPolicyGuard(AiPolicy.SCHEMA_ONLY));
+
+        svc.ask(CUBE, "spot the trend", List.of(), null, NlAskRequest.ForceTool.AUTO, currentQueryWithFilterMember());
+
+        String cqJson = seen.get().currentQueryJson();
+        assertNotNull("current query still forwarded (structure, not data)", cqJson);
+        assertFalse("filter member unique name must be stripped: " + cqJson, cqJson.contains("John Smith"));
+        // Structure kept: measure, filter dimension + level refs all survive.
+        assertTrue("measure structure retained: " + cqJson, cqJson.contains("Store Sales"));
+        assertTrue("filter dimension retained: " + cqJson, cqJson.contains("Customers"));
+        assertTrue("filter level retained: " + cqJson, cqJson.contains("[Customers].[Name]"));
+    }
+
+    @Test
+    public void egressUnwiredFailsClosedAndDropsHistoryAndStripsMembers() {
+        // No setEgressGuard() → null guard → fail-closed: assistant turns dropped, members stripped.
+        AtomicReference<NlAskRequest> seen = new AtomicReference<>();
+        NlAskProvider capturing = req -> {
+            seen.set(req);
+            return NlAskResponse.ok("{\"cube\":{\"cubeName\":\"Sales\"},\"measures\":[]}", "m", 0, 0);
+        };
+        AiAskService svc = new AiAskService(fixedSchemaService(emptySchema()), capturing);
+
+        svc.ask(
+                CUBE,
+                "follow up",
+                historyWithAssistantFigure(),
+                null,
+                NlAskRequest.ForceTool.AUTO,
+                currentQueryWithFilterMember());
+
+        NlAskRequest captured = seen.get();
+        assertNotNull(captured);
+        assertEquals(
+                "unwired guard fails closed: only user turns survive",
+                2,
+                captured.history().size());
+        assertFalse(captured.history().stream().anyMatch(m -> m.content().contains("7,000")));
+        assertFalse(
+                "unwired guard fails closed: members stripped",
+                captured.currentQueryJson().contains("John Smith"));
+    }
+
+    @Test
+    public void aggregatedPassesHistoryAndCurrentQueryThroughUntouched() {
+        AtomicReference<NlAskRequest> seen = new AtomicReference<>();
+        NlAskProvider capturing = req -> {
+            seen.set(req);
+            return NlAskResponse.ok("{\"cube\":{\"cubeName\":\"Sales\"},\"measures\":[]}", "m", 0, 0);
+        };
+        AiAskService svc = new AiAskService(fixedSchemaService(emptySchema()), capturing);
+        svc.setEgressGuard(new AiPolicyGuard(AiPolicy.AGGREGATED));
+
+        svc.ask(
+                CUBE,
+                "follow up",
+                historyWithAssistantFigure(),
+                null,
+                NlAskRequest.ForceTool.AUTO,
+                currentQueryWithFilterMember());
+
+        NlAskRequest captured = seen.get();
+        assertNotNull(captured);
+        assertEquals(
+                "aggregated egress keeps all turns including assistant",
+                3,
+                captured.history().size());
+        assertTrue(
+                "assistant figure passes through at aggregated",
+                captured.history().stream().anyMatch(m -> m.content().contains("7,000")));
+        assertTrue(
+                "filter member passes through at aggregated",
+                captured.currentQueryJson().contains("John Smith"));
+    }
+
+    @Test
+    public void egressStripDoesNotMutateCallerHistoryOrCurrentQuery() {
+        // Copy-not-mutate invariant (#1553): the send-time strip must operate on copies, leaving the
+        // caller-owned history list + currentQuery object exactly as they were passed in.
+        NlAskProvider capturing =
+                req -> NlAskResponse.ok("{\"cube\":{\"cubeName\":\"Sales\"},\"measures\":[]}", "m", 0, 0);
+        AiAskService svc = new AiAskService(fixedSchemaService(emptySchema()), capturing);
+        svc.setEgressGuard(new AiPolicyGuard(AiPolicy.SCHEMA_ONLY));
+
+        List<NlAskMessage> history = historyWithAssistantFigure();
+        AiQueryRequest currentQuery = currentQueryWithFilterMember();
+
+        svc.ask(CUBE, "follow up", history, null, NlAskRequest.ForceTool.AUTO, currentQuery);
+
+        // Original history untouched — assistant turn still present.
+        assertEquals("caller history must not be mutated", 3, history.size());
+        assertEquals(NlAskMessage.Role.ASSISTANT, history.get(1).role());
+        // Original currentQuery untouched — filter member still present.
+        assertEquals(1, currentQuery.getFilters().size());
+        assertEquals(
+                "caller currentQuery members must not be mutated",
+                List.of("[Customers].[John Smith]"),
+                currentQuery.getFilters().get(0).getMembers());
+    }
+
+    @Test
+    public void chainedAskWithheldToolTranscriptNeverCarriesResultDigestUnderSchemaOnly() {
+        // #1553 toolTranscript confirmation: the server-side loop is the only producer of ToolTurns.
+        // Under schema-only egress it stops after building the query — before executing/digesting —
+        // so NO ToolTurn carrying a real result digest is ever replayed to the LLM. The withheld
+        // path (ToolTurn.resultDigest == null) is the only shape the transcript could take, and here
+        // no populated transcript is ever sent at all. RED if the loop leaked a data-bearing turn.
+        ScriptedProvider provider =
+                new ScriptedProvider(List.of(NlAskResponse.okQuery(fullQueryJson(), "m", 10, 5, "t1")));
+        AiAskService svc = new AiAskService(fixedSchemaService(salesSchemaWithMeasure()), provider);
+        svc.setThinQueryService(cannedExecutor(cannedCellDataSet()));
+        svc.setEgressGuard(new AiPolicyGuard(AiPolicy.SCHEMA_ONLY));
+
+        svc.askChained(CUBE, "build and report", List.of(), null, NlAskRequest.ForceTool.AUTO, null);
+
+        for (NlAskRequest req : provider.seen()) {
+            for (ToolTurn turn : req.toolTranscript()) {
+                assertNull(
+                        "no tool turn may carry a result digest under schema-only egress: " + turn.resultDigest(),
+                        turn.resultDigest());
+            }
+        }
     }
 
     /* ---- Task 5: chained-ask wiring (converter + setter-injected ThinQueryService) ---- */


### PR DESCRIPTION
Fixes #1553.

## Problem
The `/ai/ask` egress gate (#1554) stripped only the `cellsetDigest`. `history` and `currentQuery` still reached the LLM ungated, so cell-derived data leaked even at `schema-only`. Killer case: a turn-1 `aggregated` insight is replayed by the client at turn-2 `schema-only` — the assistant turn carrying model-emitted figures egresses regardless of the current posture. History is client-supplied and untrusted every turn, so the only enforceable control is at send-time.

## Fix (Option B — "drop, not redact", send-time re-gate)
When the active posture forbids aggregated egress (`!egressPermitsCellData()`, fail-closed on a null/unwired guard), at the request-building seam — before the `NlAskRequest` is constructed, so both providers are covered in one place:

- **Drop assistant-role history turns**, keep the user's own turns. Assistant turns replay `emit_insight`/`emit_email_draft` figures.
- **Strip `currentQuery` filter members** — clear `filters[].members` while keeping the query structure (measures/rows/columns/cube + filter dimension/hierarchy/level refs). The model still sees the query shape, not which members were picked.

Applied in both `askInternal` (the `/ai/ask` seam) and the `askChained` preamble, mirroring the existing `cellsetDigest` strip and its fail-closed semantics. Both re-gates are **copy-not-mutate**: history is filtered into a new list; `currentQuery` is redacted on a mapper round-trip copy, so the caller-owned objects are never touched.

The agentic `toolTranscript` needed no change — its egress-withheld path (`resultDigest == null`) already holds, and under `schema-only` the chained loop stops before it ever executes/digests, so no data-bearing tool turn is produced. Confirmed with a test.

## Tests
Added to `AiAskServiceTest`, mirroring the #1554 egress/digest-strip tests:
- `schema-only`: assistant history turns dropped, user turns kept; `currentQuery.filters[].members` cleared, structure retained.
- `aggregated`: history + currentQuery pass through untouched.
- Fail-closed: null/unwired guard drops + strips.
- No mutation of the caller's original `history`/`currentQuery`.
- `toolTranscript` withheld-path stays withheld under `schema-only`.

One pre-existing test (`passesQuestionAndHistoryToProviderUnchanged`) asserted full-history passthrough with no guard wired; it now wires an `AGGREGATED` posture to keep asserting the plumbing forwards history intact (the fail-closed drop is covered by the dedicated tests).

`mvn -o -pl saiku-core/saiku-service test -Dtest=AiAskServiceTest,OssieAiAskServiceTest,AiPolicyGuardTest,ToolTurnTest` → 103 tests, 0 failures. spotless:apply clean.
