### PR TITLE
bump postgresql + owasp-java-html-sanitizer to clear HIGH advisories (alerts 505, 508)

### DIFF
--- a/saiku-bom/pom.xml
+++ b/saiku-bom/pom.xml
@@ -64,9 +64,9 @@
         <graphqlJavaExtendedScalars.version>24.0</graphqlJavaExtendedScalars.version>
         <!-- OWASP Java HTML Sanitizer: allowlist-sanitizes client-supplied
              summaryHtml before it's assembled into the outbound email body
-             (EmailMessageAssembler). 20240325.1 is the latest published
+             (EmailMessageAssembler). 20260101.1 is the latest published
              release on Maven Central as of this pin. -->
-        <owasp.html.sanitizer.version>20240325.1</owasp.html.sanitizer.version>
+        <owasp.html.sanitizer.version>20260101.1</owasp.html.sanitizer.version>
     </properties>
 
     <dependencyManagement>
@@ -87,7 +87,7 @@
             <dependency>
                 <groupId>org.postgresql</groupId>
                 <artifactId>postgresql</artifactId>
-                <version>42.7.11</version>
+                <version>42.7.12</version>
             </dependency>
             <!-- quack-jdbc: JDBC driver for DuckDB's native Quack client-server
                  protocol (jdbc:quack://). Lets Ossie warehouses target a remote


### PR DESCRIPTION
## What

Bumps two direct managed dependency versions in `saiku-bom/pom.xml` to clear two HIGH Dependabot advisories:

- **org.postgresql:postgresql** `42.7.11` -> `42.7.12` (clears Dependabot alert 505). Patch release within the maintained 42.7.x JDBC4-driver line — pure-API drop-in, no code changes.
- **com.googlecode.owasp-java-html-sanitizer** `20240325.1` -> `20260101.1` (clears Dependabot alert 508). Forward bump on the date-versioned release line.

Note: these are Dependabot **alert** numbers, not issue numbers — referenced in prose only.

## Where

Both are declared once, in `saiku-bom/pom.xml`:
- postgresql as a `<version>` literal on the managed dependency.
- owasp-java-html-sanitizer via the `owasp.html.sanitizer.version` property (comment updated to match).

Grep across all `pom.xml` confirms no second declaration or hardcoded old version left behind. Consumers (`saiku-webapp`, `saiku-core/saiku-sql` for postgres; `saiku-core/saiku-web` for the sanitizer) reference the managed version with no local override.

## Sanitizer API-change risk

Single call site: `saiku-core/saiku-web/.../email/EmailMessageAssembler.java` uses `Sanitizers.FORMATTING/BLOCKS/LINKS/TABLES`, `PolicyFactory.and(...)`, and `.sanitize(String)` — the stable core public API, unchanged across the 2024->2026 releases. Low risk.

## Build / test

`mvn -B -ntp -pl saiku-core/saiku-web,saiku-core/saiku-sql -am test` — **BUILD SUCCESS**.
- `saiku-web`: 564 tests, 0 failures — including `EmailMessageAssemblerTest` (13/13), which exercises the sanitizer path with the new version.
- `saiku-sql`: compiled + tested against postgres 42.7.12.
