### PR TITLE
bump brace-expansion + postcss to clear npm advisories (Dependabot alerts #504, #509)

### DIFF
--- a/saiku-ui/package-lock.json
+++ b/saiku-ui/package-lock.json
@@ -3709,16 +3709,16 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/buffer-image-size": {
@@ -5417,9 +5417,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.12",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
-      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "devOptional": true,
       "funding": [
         {
@@ -5738,9 +5738,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.14",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
-      "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
+      "version": "8.5.24",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.24.tgz",
+      "integrity": "sha512-8RyVklq0owXUTa4xlpzu4l9AaVKIdQvAcOHZWaMh98HgySsUtxRVf/chRe3dsSLqb6i40BzGRzEUddRaI+9TSw==",
       "devOptional": true,
       "funding": [
         {
@@ -5758,7 +5758,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },


### PR DESCRIPTION
Clears two HIGH npm Dependabot alerts on the SvelteKit UI (`saiku-ui/`), both transitive dependencies resolved via `npm audit fix` (no `--force`, no `package.json` change):

- **Dependabot alert #504 — `brace-expansion`** (DoS advisories GHSA-3jxr-9vmj-r5cp, GHSA-mh99-v99m-4gvg). Pulled in transitively via `eslint > minimatch > brace-expansion`. Bumped `5.0.6 -> 5.0.8` (fixed in 5.0.7).
- **Dependabot alert #509 — `postcss`** (path-traversal in source-map auto-loading, GHSA-r28c-9q8g-f849). Pulled in transitively via `vite` and `eslint-plugin-svelte`. Bumped `8.5.14 -> 8.5.24` (fixed in 8.5.18).

Both are patch-level bumps that already sit inside the existing semver ranges, so only `package-lock.json` changed. A third transitive, `nanoid` (a `postcss` dependency), moved `3.3.12 -> 3.3.16` as part of the same `postcss` subtree — harmless patch bump, no direct-dep or override involvement.

### Verification (run on Node 24 locally; CI baseline is Node 20)
- `npm audit` -> **0 vulnerabilities**
- `npm ls brace-expansion postcss` -> only `brace-expansion@5.0.8` and `postcss@8.5.24`
- `npm ci` -> clean (added 396 packages)
- `npm run build` -> **pass** (full prod build: `build:app` + `build:embed` + `build:embed-npm` + `build:embed-react-npm`) — this is the #1551 gate
- `npm run check` -> **0 errors** (2 pre-existing unrelated warnings)

No `overrides` were needed. No parent packages were force-bumped.
