### PR TITLE
bump jackson to 2.21.5 to clear GHSA advisories (Dependabot alerts 510-516)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
         <jersey.version>3.1.9</jersey.version>
         <maven.build.timestamp.format>yyyyMMdd-HHmm</maven.build.timestamp.format>
         <saiku-query.version>0.4-SNAPSHOT</saiku-query.version>
-        <jackson.version>2.19.4</jackson.version>
+        <jackson.version>2.21.5</jackson.version>
         <!-- bi.saiku.ossie:ossie-core — external Ossie/OSI parser library
              (spiculedata/ossie). Track its releases and bump here. -->
         <ossie.version>0.1.0</ossie.version>

--- a/saiku-bom/pom.xml
+++ b/saiku-bom/pom.xml
@@ -38,13 +38,20 @@
         <batik.version>1.19</batik.version>
         <jersey.version>3.1.9</jersey.version>
         <saiku-query.version>0.4-SNAPSHOT</saiku-query.version>
-        <jackson.version>2.19.4</jackson.version>
+        <jackson.version>2.21.5</jackson.version>
+        <!-- jackson-annotations stopped shipping patch releases at 2.20; from
+             then on it versions at the minor boundary only (2.20, 2.21, 2.22)
+             — there is no jackson-annotations 2.21.5. jackson-databind 2.21.5
+             pulls jackson-annotations 2.21 transitively, so pin the annotations
+             artifact to that. Annotations carries no CVEs; the GHSA advisories
+             we are clearing are in jackson-core + jackson-databind. -->
+        <jackson.annotations.version>2.21</jackson.annotations.version>
         <arrow.version>18.2.0</arrow.version>
         <caffeine.version>3.2.4</caffeine.version>
         <!-- JSON Schema (draft 2020-12) validator for the AiQueryRequest
              body. Used by AiRequestSchemaValidator to enforce shape errors
              before the converter's domain-resolution layer runs. Apache 2.0,
-             ~200KB, no heavy transitives. Pairs with Jackson 2.19.x. -->
+             ~200KB, no heavy transitives. Pairs with Jackson 2.21.x. -->
         <jsonSchemaValidator.version>1.5.8</jsonSchemaValidator.version>
         <!-- Spring GraphQL 1.4.x is the current release line paired with Spring
              Framework 6.2.x. Provides the GraphQlSource / GraphQlHttpHandler
@@ -334,7 +341,7 @@
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-annotations</artifactId>
-                <version>${jackson.version}</version>
+                <version>${jackson.annotations.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.saikuanalytics</groupId>


### PR DESCRIPTION
## What

Bumps `jackson.version` from **2.19.4** to **2.21.5** across the reactor to clear seven Dependabot advisories on `jackson-core` and `jackson-databind`.

These are Dependabot **security-alert** numbers 510, 511, 512, 513, 514, 515 and 516 (not issue numbers). The advisories require 2.21.4 or later, and alert 514 specifically needs 2.21.5, so 2.21.5 is the minimum that clears all seven. 2.21.5 is the latest stable release on the 2.21.x line; I stayed on 2.21.x rather than jumping to 2.22.x to keep the behavioural delta to the two minor versions this change already crosses.

## Changes

- `pom.xml` — `<jackson.version>` 2.19.4 -> 2.21.5 (root, defensive shadow).
- `saiku-bom/pom.xml` — `<jackson.version>` 2.19.4 -> 2.21.5. Every managed jackson artifact (`jackson-databind`, `jackson-core`, `jackson-dataformat-yaml`, `jackson-jaxrs-json-provider`) resolves through this property.
- `saiku-bom/pom.xml` — new `<jackson.annotations.version>2.21</jackson.annotations.version>` property, and the `jackson-annotations` management entry now uses it. **Why:** jackson-annotations stopped shipping patch releases at 2.20 and now versions only at the minor boundary — there is no `jackson-annotations:2.21.5`. `jackson-databind:2.21.5` pulls `jackson-annotations:2.21` transitively, so the BOM pins the annotations artifact to that exact version. Annotations carries no CVEs; all seven advisories are in core + databind.

## Verification

- `mvn -o -pl saiku-core/saiku-service test` — **636 tests, 0 failures, 0 errors**. (One surefire fork-VM startup crash on `AiAuditLogTest` was an environmental Windows flake; the class passes 9/9 when run in isolation.)
- Targeted jackson-serialization/coercion tests all green: `SaikuUserSerializationTest`, `OssieYamlWriterTest`, `AiRequestSchemaValidatorTest`, `SchemaSnapshotTest`, `AiQueryDocsExamplesTest`, `MdxEchoGoldenTest`, `SuggestionSetTest`, plus DTO/query tests.
- `test-compile` of the other jackson-consuming core modules (`saiku-semantic`, `saiku-web`, `saiku-sql`) — clean.
- `dependency:tree` confirms alignment: `saiku-service` and `saiku-webapp` resolve databind/core/yaml at 2.21.5 and annotations at 2.21, no 2.19/2.20 straggler.

2.19 -> 2.21 crosses two minor versions (2.20 and 2.21 both shifted coercion / `JsonNodeFeature` / number-handling defaults); the serialization test suite exercised those paths and stayed green.

## Note for reviewers

`jersey-media-json-jackson:3.1.9` pulls `jackson-module-jakarta-xmlbind-annotations:2.17.2` as a transitive that the BOM does not manage — a pre-existing skew (it was 2.17.2 under 2.19.4 too, since it tracks Jersey, not `jackson.version`). It is outside the scope of these seven alerts. A follow-up could align it (2.21.5 exists for that module) or import the jackson-bom; left out here to keep this a focused security bump.
