### PR TITLE
Hotfix 4.6.4 — inline-tile embed RLS bypass (security)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,20 @@
 All notable changes to Saiku are documented here. This project follows
 [Semantic Versioning](https://semver.org/).
 
+## 4.6.4 — 2026-07-30
+
+Security patch release.
+
+### Security
+- **Inline-tile embed RLS bypass** — an embed iframe guest could read the row-level-security
+  scope from their own token's `saiku.filters` claim and send a crafted client filter override
+  that **widened** (added hidden members) or **stripped** the forced RLS filter on an inline
+  dashboard tile. The inline path applied the forced filters first and then let client overrides
+  remove/replace them. Forced filters are now applied **last and authoritatively**: on every
+  forced axis the effective member set is always a subset of the forced set — a client can only
+  narrow within the forced scope, never widen, strip, or change the operator. The saved/reference
+  tile path was not affected (it uses the fail-closed `forcedFilters` channel).
+
 ## 4.6.3 — 2026-07-20
 
 Patch release.

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <groupId>org.saikuanalytics</groupId>
     <artifactId>saiku</artifactId>
     <packaging>pom</packaging>
-    <version>4.6.3</version>
+    <version>4.6.4</version>
     <name>Saiku Module Project</name>
     <scm>
         <developerConnection>

--- a/saiku-bom/pom.xml
+++ b/saiku-bom/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.saikuanalytics</groupId>
     <artifactId>saiku-bom</artifactId>
-    <version>4.6.3</version>
+    <version>4.6.4</version>
     <packaging>pom</packaging>
     <name>Saiku BOM</name>
     <description>Central dependency-version catalogue for Saiku modules.</description>

--- a/saiku-core/pom.xml
+++ b/saiku-core/pom.xml
@@ -2,14 +2,14 @@
     <parent>
         <artifactId>saiku</artifactId>
         <groupId>org.saikuanalytics</groupId>
-        <version>4.6.3</version>
+        <version>4.6.4</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>
     <artifactId>saiku-core</artifactId>
     <packaging>pom</packaging>
     <name>saiku - core libraries</name>
-    <version>4.6.3</version>
+    <version>4.6.4</version>
 
     <modules>
         <module>saiku-olap-util</module>

--- a/saiku-core/saiku-olap-util/pom.xml
+++ b/saiku-core/saiku-olap-util/pom.xml
@@ -3,11 +3,11 @@
     <parent>
         <artifactId>saiku-core</artifactId>
         <groupId>org.saikuanalytics</groupId>
-        <version>4.6.3</version>
+        <version>4.6.4</version>
     </parent>
 	<artifactId>saiku-olap-util</artifactId>
 	<packaging>jar</packaging>
-	<version>4.6.3</version>
+	<version>4.6.4</version>
 	<name>saiku olap util</name>
 	<properties>
 		<maven.compiler.source>1.8</maven.compiler.source>

--- a/saiku-core/saiku-semantic/pom.xml
+++ b/saiku-core/saiku-semantic/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <artifactId>saiku-core</artifactId>
         <groupId>org.saikuanalytics</groupId>
-        <version>4.6.3</version>
+        <version>4.6.4</version>
     </parent>
 
     <artifactId>saiku-semantic</artifactId>

--- a/saiku-core/saiku-service/pom.xml
+++ b/saiku-core/saiku-service/pom.xml
@@ -2,12 +2,12 @@
     <parent>
         <artifactId>saiku-core</artifactId>
         <groupId>org.saikuanalytics</groupId>
-        <version>4.6.3</version>
+        <version>4.6.4</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>jar</packaging>
     <artifactId>saiku-service</artifactId>
-    <version>4.6.3</version>
+    <version>4.6.4</version>
     <name>saiku - services</name>
     <build>
         <plugins>

--- a/saiku-core/saiku-sql/pom.xml
+++ b/saiku-core/saiku-sql/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.saikuanalytics</groupId>
         <artifactId>saiku-core</artifactId>
-        <version>4.6.3</version>
+        <version>4.6.4</version>
     </parent>
 
     <artifactId>saiku-sql</artifactId>

--- a/saiku-core/saiku-web/pom.xml
+++ b/saiku-core/saiku-web/pom.xml
@@ -2,11 +2,11 @@
     <parent>
         <artifactId>saiku-core</artifactId>
         <groupId>org.saikuanalytics</groupId>
-        <version>4.6.3</version>
+        <version>4.6.4</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>saiku-web</artifactId>
-    <version>4.6.3</version>
+    <version>4.6.4</version>
     <name>saiku - web</name>
     <packaging>jar</packaging>
 

--- a/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/embed/EmbedViewResource.java
+++ b/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/embed/EmbedViewResource.java
@@ -233,13 +233,19 @@ public class EmbedViewResource {
         try {
             Response result = sessionService.runAs(g.ownerUser, g.ownerRoles, () -> {
                 if ("inline".equals(q.kind) && q.body != null) {
-                    // saiku#1104: inject the JWT's forced RLS filters into the
-                    // inline query before execution; they ride the standard
-                    // (validated) slicer path in AiSchemaConverter.
-                    injectForcedFilters(q.body, g);
-                    // Filter-tile overrides splice on top of any authored / forced filters. If a
-                    // filter tile drives the same dimension as an authored filter, the override wins.
+                    // Order is LOAD-BEARING for RLS (saiku#1104 + security review): apply the
+                    // client filter-tile overrides FIRST (they may narrow/add on any axis), then
+                    // apply the token's forced RLS filters LAST and authoritatively.
                     mergeFilterOverrides(q.body, filterOverrides);
+                    // executeAi (AiSchemaConverter) has NO forced-filter channel and REJECTS two
+                    // filters on one hierarchy, and members inside one filter UNION (Mondrian
+                    // aggregates the set). So we can't append a second same-axis filter and can't
+                    // trust the client's members. applyForcedFilters collapses each forced axis to a
+                    // SINGLE server-computed filter whose members are the forced set intersected with
+                    // whatever the client/author put on that axis — a client can only narrow WITHIN
+                    // the forced set, never widen, strip, or change the operator. A malformed forced
+                    // claim throws here (fail-closed) BEFORE executeAi ever runs.
+                    applyForcedFilters(q.body, parseForcedFilters(g));
                     return aiQueryResource.executeAi(q.body, "records");
                 } else if ("reference".equals(q.kind) && q.path != null) {
                     AiSavedQueryRequest sreq = new AiSavedQueryRequest();
@@ -438,10 +444,15 @@ public class EmbedViewResource {
     }
 
     /**
-     * Splice runtime filter overrides onto an AiQueryRequest before executeAi. For each
-     * override, replace an existing filter that targets the same dimension/hierarchy/level
-     * (case-insensitive); append if no match. Empty-members overrides are pruned before the
-     * merge so a "clear filter" from a filter tile removes the corresponding slicer entirely.
+     * Splice runtime filter-tile overrides onto an AiQueryRequest. For each override, replace an
+     * existing filter that targets the same dimension/hierarchy/level (case-insensitive); append if
+     * no match. Empty-members overrides are pruned so a "clear filter" from a filter tile removes
+     * the corresponding slicer entirely.
+     *
+     * <p>SECURITY: this runs BEFORE {@link #applyForcedFilters}, so it never sees a forced RLS
+     * filter (they aren't in the list yet) and is therefore structurally incapable of removing or
+     * widening one. Any client selection it leaves on a forced axis is subsequently clamped by
+     * {@link #applyForcedFilters}. It must never be called after the forced filters are applied.
      */
     private static void mergeFilterOverrides(AiQueryRequest req, java.util.List<AiFilterSelection> overrides) {
         if (req == null || overrides == null || overrides.isEmpty()) return;
@@ -465,6 +476,83 @@ public class EmbedViewResource {
             current.add(o);
         }
         req.setFilters(current);
+    }
+
+    /**
+     * Apply the token's forced RLS filters to an inline query body AUTHORITATIVELY and LAST — the
+     * fix for the inline RLS-bypass (security review). {@code executeAi} has no separate forced
+     * channel (unlike {@code executeSaved}), rejects two filters on one hierarchy, and unions the
+     * members inside a single filter — so we can't trust the client's list and can't append a
+     * second same-axis filter. For each forced filter we therefore:
+     * <ol>
+     *   <li>remove every existing (authored OR client) filter on the same axis, remembering the
+     *       first one;</li>
+     *   <li>emit a SINGLE authoritative filter for that axis. When both the forced filter and the
+     *       removed client/authored filter are plain {@code op:"in"} member sets, the emitted
+     *       members are {@code clientMembers ∩ forcedMembers} (client can only narrow WITHIN the
+     *       forced set; any out-of-scope member is dropped). An empty intersection falls back to
+     *       the forced ceiling — NEVER empty (empty members would read as "unrestricted"). Any
+     *       other operator on either side discards the client contribution and applies the forced
+     *       filter verbatim.</li>
+     * </ol>
+     * Net invariant: on every forced axis the effective member set is always ⊆ the forced set, so
+     * a client can never widen, strip, or change the operator of an RLS restriction.
+     */
+    private static void applyForcedFilters(AiQueryRequest req, java.util.List<AiFilterSelection> forced) {
+        if (req == null || forced == null || forced.isEmpty()) return;
+        java.util.List<AiFilterSelection> current = req.getFilters();
+        if (current == null) current = new java.util.ArrayList<>();
+        for (AiFilterSelection f : forced) {
+            if (f == null || f.getDimension() == null) continue;
+            // Remove every same-axis filter (authored or client); remember the first for narrowing.
+            AiFilterSelection existing = null;
+            java.util.Iterator<AiFilterSelection> it = current.iterator();
+            while (it.hasNext()) {
+                AiFilterSelection e = it.next();
+                if (e == null) {
+                    it.remove();
+                    continue;
+                }
+                if (sameAxis(e, f)) {
+                    if (existing == null) existing = e;
+                    it.remove();
+                }
+            }
+            // Default: the forced filter is authoritative verbatim. Only when BOTH sides are plain
+            // op:"in" member sets do we honour a client NARROWING (intersection within the forced set).
+            AiFilterSelection effective = f;
+            if (isInOp(f) && existing != null && isInOp(existing)) {
+                java.util.List<String> narrowed = intersectMembers(existing.getMembers(), f.getMembers());
+                java.util.List<String> members =
+                        narrowed.isEmpty() ? new java.util.ArrayList<>(f.getMembers()) : narrowed;
+                effective = new AiFilterSelection(f.getDimension(), f.getHierarchy(), f.getLevel(), members);
+                effective.setOp("in");
+            }
+            current.add(effective);
+        }
+        req.setFilters(current);
+    }
+
+    /** True when the filter is a plain member-set inclusion (op "in" / null / empty). Only these
+     *  can be safely member-intersected; any other op (not_in / between / relative / …) on a forced
+     *  axis makes the client contribution non-narrowing, so the forced filter is applied verbatim. */
+    private static boolean isInOp(AiFilterSelection f) {
+        String op = f.getOp();
+        return op == null || op.isBlank() || "in".equalsIgnoreCase(op);
+    }
+
+    /** Members of {@code client} that are ALSO in {@code forced} (exact-match on MDX unique names),
+     *  preserving the client order. This is the RLS clamp: anything the client named outside the
+     *  forced set is dropped. */
+    private static java.util.List<String> intersectMembers(
+            java.util.List<String> client, java.util.List<String> forced) {
+        java.util.List<String> out = new java.util.ArrayList<>();
+        if (client == null || forced == null) return out;
+        java.util.Set<String> allowed = new java.util.HashSet<>(forced);
+        for (String m : client) {
+            if (m != null && allowed.contains(m)) out.add(m);
+        }
+        return out;
     }
 
     private static boolean sameAxis(AiFilterSelection a, AiFilterSelection b) {
@@ -516,19 +604,6 @@ public class EmbedViewResource {
                 .entity(Map.of("status", "EMBED_INVALID", "error", "Embed link is invalid or expired."))
                 .type(MediaType.APPLICATION_JSON)
                 .build());
-    }
-
-    /**
-     * saiku#1104 — append the JWT's forced RLS filters to an inline query. They
-     * ride the standard validated slicer path (AiSchemaConverter), so a forced
-     * filter can't inject bad MDX. A malformed claim must NOT degrade to an
-     * unfiltered query — a parse failure throws, and the caller fails closed.
-     */
-    private void injectForcedFilters(AiQueryRequest body, EmbedGuestDetails g) {
-        if (body == null) {
-            return;
-        }
-        body.getFilters().addAll(parseForcedFilters(g));
     }
 
     /**

--- a/saiku-core/saiku-web/src/test/java/org/saiku/web/rest/resources/embed/EmbedViewResourceTest.java
+++ b/saiku-core/saiku-web/src/test/java/org/saiku/web/rest/resources/embed/EmbedViewResourceTest.java
@@ -1,11 +1,14 @@
 package org.saiku.web.rest.resources.embed;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 import jakarta.ws.rs.core.Response;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Supplier;
@@ -13,6 +16,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.saiku.service.datasource.DatasourceService;
+import org.saiku.service.olap.ai.AiFilterSelection;
 import org.saiku.service.olap.ai.AiQueryRequest;
 import org.saiku.service.olap.ai.AiSavedQueryRequest;
 import org.saiku.service.olap.ai.audit.AiAuditEntry;
@@ -310,7 +314,140 @@ public class EmbedViewResourceTest {
         assertTrue(e.endpoint.contains("/embed/"));
     }
 
+    /* ------ security review: forced-RLS vs client-override collision (inline) ------ */
+    // The bug: on the inline path, forced RLS filters were injected FIRST then the
+    // client override REMOVED the same-axis forced filter and appended the client's
+    // members. A client could therefore widen (union in extra members) or strip
+    // (empty members) the RLS restriction. These prove the fix — forced filters are
+    // applied LAST and authoritatively; a client can only NARROW within the forced set.
+
+    private static final String DASH_INLINE_TILE =
+            "{\"layout\":{\"tiles\":[{\"id\":\"t1\",\"query\":{\"kind\":\"inline\",\"body\":{}}}]}}";
+    // Forced: Customer ∈ {acme}
+    private static final String FORCE_CUSTOMER_ACME =
+            "[{\"dimension\":\"Customer\",\"hierarchy\":\"Customer\",\"level\":\"Customer\",\"op\":\"in\","
+                    + "\"members\":[\"[Customer].[acme]\"]}]";
+    // Forced: Customer ∈ {acme, bigcorp} — used for the legitimate-narrow test
+    private static final String FORCE_CUSTOMER_ACME_BIGCORP =
+            "[{\"dimension\":\"Customer\",\"hierarchy\":\"Customer\",\"level\":\"Customer\",\"op\":\"in\","
+                    + "\"members\":[\"[Customer].[acme]\",\"[Customer].[bigcorp]\"]}]";
+
+    @Test
+    public void dashboard_inline_client_cannot_widen_forced_rls() {
+        // Exploit (a): client override widens Customer to {acme, competitor}. competitor must
+        // never reach the engine — the executed filter stays Customer ∈ {acme}.
+        ds.fileContent = DASH_INLINE_TILE;
+        pinGuestJwt("dashboard", "/homes/admin/exec.saikudash", "admin", List.of(), "u_1", FORCE_CUSTOMER_ACME);
+
+        Response r = resource.tileQuery(
+                "homes/admin/exec.saikudash",
+                "t1",
+                overrides(in("Customer", "[Customer].[acme]", "[Customer].[competitor]")));
+
+        assertEquals(200, r.getStatus());
+        AiFilterSelection cust = onlyFilterFor(ai.lastAiRequest.getFilters(), "Customer");
+        assertEquals(List.of("[Customer].[acme]"), cust.getMembers());
+        assertFalse(
+                "competitor must never reach the engine (RLS widen blocked)",
+                cust.getMembers().contains("[Customer].[competitor]"));
+    }
+
+    @Test
+    public void dashboard_inline_client_cannot_strip_forced_rls() {
+        // Exploit (b): client override with members:[] to strip the slicer. Forced Customer ∈
+        // {acme} must still be enforced.
+        ds.fileContent = DASH_INLINE_TILE;
+        pinGuestJwt("dashboard", "/homes/admin/exec.saikudash", "admin", List.of(), "u_1", FORCE_CUSTOMER_ACME);
+
+        Response r = resource.tileQuery("homes/admin/exec.saikudash", "t1", overrides(in("Customer")));
+
+        assertEquals(200, r.getStatus());
+        AiFilterSelection cust = onlyFilterFor(ai.lastAiRequest.getFilters(), "Customer");
+        assertEquals("RLS strip blocked — forced members re-applied", List.of("[Customer].[acme]"), cust.getMembers());
+    }
+
+    @Test
+    public void dashboard_inline_client_cannot_escape_forced_rls_via_operator() {
+        // Exploit variant: client tries op:"not_in" on the forced axis to invert it. The
+        // non-"in" operator on a forced axis discards the client contribution — forced applies
+        // verbatim as op:"in" {acme}.
+        ds.fileContent = DASH_INLINE_TILE;
+        pinGuestJwt("dashboard", "/homes/admin/exec.saikudash", "admin", List.of(), "u_1", FORCE_CUSTOMER_ACME);
+
+        Response r = resource.tileQuery(
+                "homes/admin/exec.saikudash", "t1", overrides(notIn("Customer", "[Customer].[acme]")));
+
+        assertEquals(200, r.getStatus());
+        AiFilterSelection cust = onlyFilterFor(ai.lastAiRequest.getFilters(), "Customer");
+        assertEquals("forced op must win", "in", cust.getOp());
+        assertEquals(List.of("[Customer].[acme]"), cust.getMembers());
+    }
+
+    @Test
+    public void dashboard_inline_client_narrow_within_forced_set_is_honoured() {
+        // Legitimate: forced Customer ∈ {acme, bigcorp}; client narrows to {acme}. The narrow is
+        // honoured because it stays WITHIN the forced set.
+        ds.fileContent = DASH_INLINE_TILE;
+        pinGuestJwt("dashboard", "/homes/admin/exec.saikudash", "admin", List.of(), "u_1", FORCE_CUSTOMER_ACME_BIGCORP);
+
+        Response r =
+                resource.tileQuery("homes/admin/exec.saikudash", "t1", overrides(in("Customer", "[Customer].[acme]")));
+
+        assertEquals(200, r.getStatus());
+        AiFilterSelection cust = onlyFilterFor(ai.lastAiRequest.getFilters(), "Customer");
+        assertEquals(List.of("[Customer].[acme]"), cust.getMembers());
+    }
+
+    @Test
+    public void dashboard_inline_client_narrows_different_axis_keeps_both() {
+        // Exploit (c) / legitimate: client narrows a DIFFERENT axis (Product). Both the forced
+        // Customer RLS and the client's Product narrowing apply.
+        ds.fileContent = DASH_INLINE_TILE;
+        pinGuestJwt("dashboard", "/homes/admin/exec.saikudash", "admin", List.of(), "u_1", FORCE_CUSTOMER_ACME);
+
+        Response r =
+                resource.tileQuery("homes/admin/exec.saikudash", "t1", overrides(in("Product", "[Product].[widgets]")));
+
+        assertEquals(200, r.getStatus());
+        List<AiFilterSelection> fs = ai.lastAiRequest.getFilters();
+        assertEquals(List.of("[Customer].[acme]"), onlyFilterFor(fs, "Customer").getMembers());
+        assertEquals(
+                List.of("[Product].[widgets]"), onlyFilterFor(fs, "Product").getMembers());
+    }
+
     /* --------------------------- helpers ---------------------------- */
+
+    /** Build a TileQueryOverrides from client filter selections. */
+    private static EmbedViewResource.TileQueryOverrides overrides(AiFilterSelection... fs) {
+        EmbedViewResource.TileQueryOverrides o = new EmbedViewResource.TileQueryOverrides();
+        o.filters = new ArrayList<>(Arrays.asList(fs));
+        return o;
+    }
+
+    /** op:"in" client filter on dim (dim=hierarchy=level for the test cube). */
+    private static AiFilterSelection in(String dim, String... members) {
+        AiFilterSelection f = new AiFilterSelection(dim, dim, dim, new ArrayList<>(Arrays.asList(members)));
+        f.setOp("in");
+        return f;
+    }
+
+    /** op:"not_in" client filter — used to prove an operator swap can't escape the RLS clamp. */
+    private static AiFilterSelection notIn(String dim, String... members) {
+        AiFilterSelection f = new AiFilterSelection(dim, dim, dim, new ArrayList<>(Arrays.asList(members)));
+        f.setOp("not_in");
+        return f;
+    }
+
+    /** Assert exactly one filter targets {@code dim} (executeAi rejects duplicate hierarchies) and
+     *  return it. */
+    private static AiFilterSelection onlyFilterFor(List<AiFilterSelection> filters, String dim) {
+        List<AiFilterSelection> matches = new ArrayList<>();
+        for (AiFilterSelection f : filters) {
+            if (dim.equals(f.getDimension())) matches.add(f);
+        }
+        assertEquals("exactly one " + dim + " slicer (executeAi rejects duplicate hierarchies)", 1, matches.size());
+        return matches.get(0);
+    }
 
     private void pinGuestJwt(
             String kind, String path, String user, List<String> roles, String sub, String forcedFiltersJson) {

--- a/saiku-launcher/pom.xml
+++ b/saiku-launcher/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.saikuanalytics</groupId>
         <artifactId>saiku</artifactId>
-        <version>4.6.3</version>
+        <version>4.6.4</version>
     </parent>
 
     <artifactId>saiku-launcher</artifactId>

--- a/saiku-webapp/pom.xml
+++ b/saiku-webapp/pom.xml
@@ -2,11 +2,11 @@
     <parent>
         <artifactId>saiku</artifactId>
         <groupId>org.saikuanalytics</groupId>
-        <version>4.6.3</version>
+        <version>4.6.4</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>saiku-webapp</artifactId>
-    <version>4.6.3</version>
+    <version>4.6.4</version>
     <name>saiku - webapp</name>
     <packaging>war</packaging>
     <build>


### PR DESCRIPTION
## Security hotfix 4.6.4 — inline-tile embed RLS bypass

**Affects shipped dashboard embeds.** A pre-existing row-level-security bypass on the embed inline-tile query path.

### The vulnerability
`EmbedViewResource.tileQuery` (inline branch) applied the token's forced RLS filters **first** (`injectForcedFilters`), then ran `mergeFilterOverrides` on the client-supplied filter overrides. `mergeFilterOverrides` removes any same-axis filter and appends the client's members — so it removed the forced RLS filter and replaced it with the client's list.

An embed iframe guest can decode their own RLS scope from the token's `saiku.filters` claim and send an override that either:
- **widens** it (union in members outside the forced set), or
- **strips** it (empty members ⇒ "no restriction").

The saved/reference tile path was **not** affected — it uses the separate `forcedFilters` channel that `executeSaved` applies fail-closed.

### The fix — forced filters are authoritative and applied last
The inline path now:
1. runs `mergeFilterOverrides` **first** on the client filters (client can narrow/add on any axis);
2. runs the new `applyForcedFilters` **last** — for each forced axis it removes every same-axis filter (authored or client) and emits a single `op:"in"` filter whose members = `clientMembers ∩ forcedMembers`.
   - empty intersection ⇒ falls back to the forced set (never empty/unrestricted);
   - a non-`in` client op on a forced axis ⇒ forced filter applied verbatim.

`executeAi` has no forced-filter channel and rejects two filters on one hierarchy (members inside one filter UNION), so a single authoritative filter is the only safe shape.

**Invariant:** on every forced axis the effective member set is always ⊆ the forced set — a client can never widen, strip, or change the operator of an RLS restriction. `mergeFilterOverrides` now runs before enforcement, so it can no longer see (or remove) a forced filter. The now-unused `injectForcedFilters` was removed.

### Regression tests (dashboard inline tile)
- widen `{acme, competitor}` ⇒ executed filter is exactly `{acme}`;
- strip `members:[]` ⇒ forced `{acme}` re-applied;
- `not_in {acme}` on the forced axis ⇒ forced applied verbatim as `op:"in" {acme}`;
- client narrows a different axis (Product) ⇒ both forced Customer and client Product apply;
- legitimate narrow-within-forced (forced `{acme, bigcorp}`, client `{acme}`) ⇒ honored as `{acme}`.

### Verification (JDK 21)
`mvn -pl saiku-core/saiku-web -am test -Dtest=EmbedViewResourceTest,EmbedAuthFilterTest` → **39 green** (EmbedViewResourceTest 21, EmbedAuthFilterTest 18). All existing embed tests stay green.

### Release
- Reactor bumped 4.6.3 → 4.6.4 (all modules); no `4.6.3` remains in poms.
- `CHANGELOG.md` `## 4.6.4` security entry added.
