### PR TITLE
import jackson-bom to align the stray transitive jackson-module and retire the manual annotations pin

### DIFF
--- a/saiku-bom/pom.xml
+++ b/saiku-bom/pom.xml
@@ -39,13 +39,6 @@
         <jersey.version>3.1.9</jersey.version>
         <saiku-query.version>0.4-SNAPSHOT</saiku-query.version>
         <jackson.version>2.21.5</jackson.version>
-        <!-- jackson-annotations stopped shipping patch releases at 2.20; from
-             then on it versions at the minor boundary only (2.20, 2.21, 2.22)
-             — there is no jackson-annotations 2.21.5. jackson-databind 2.21.5
-             pulls jackson-annotations 2.21 transitively, so pin the annotations
-             artifact to that. Annotations carries no CVEs; the GHSA advisories
-             we are clearing are in jackson-core + jackson-databind. -->
-        <jackson.annotations.version>2.21</jackson.annotations.version>
         <arrow.version>18.2.0</arrow.version>
         <caffeine.version>3.2.4</caffeine.version>
         <!-- JSON Schema (draft 2020-12) validator for the AiQueryRequest
@@ -78,6 +71,21 @@
 
     <dependencyManagement>
         <dependencies>
+            <!-- Import the Jackson BOM so EVERY jackson artifact — including the
+                 ones pulled in transitively (e.g. jackson-module-jakarta-xmlbind-annotations
+                 via jersey-media-json-jackson) — resolves to one coordinated 2.21.x
+                 set instead of drifting to an old transitive version. The BOM also
+                 pins jackson-annotations itself (2.21, since annotations ships no
+                 2.21.5), which is why the manual annotations pin is no longer needed.
+                 Explicit jackson entries below still win over an imported BOM, but
+                 they match the BOM's versions so there is no divergence. -->
+            <dependency>
+                <groupId>com.fasterxml.jackson</groupId>
+                <artifactId>jackson-bom</artifactId>
+                <version>${jackson.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
             <dependency>
                 <groupId>org.glassfish.jersey.test-framework</groupId>
                 <artifactId>jersey-test-framework-core</artifactId>
@@ -338,11 +346,6 @@
                 <artifactId>jackson-core</artifactId>
                 <version>${jackson.version}</version>
             </dependency-->
-            <dependency>
-                <groupId>com.fasterxml.jackson.core</groupId>
-                <artifactId>jackson-annotations</artifactId>
-                <version>${jackson.annotations.version}</version>
-            </dependency>
             <dependency>
                 <groupId>org.saikuanalytics</groupId>
                 <artifactId>saiku-web</artifactId>


### PR DESCRIPTION
## What

Fast-follow to #1588. That change got saiku's own jackson artifacts to 2.21.5 via `${jackson.version}` and added a **manual** `jackson.annotations.version=2.21` pin (annotations ships no 2.21.5). But it left one jackson artifact unmanaged: `jersey-media-json-jackson:3.1.9` pulls `jackson-module-jakarta-xmlbind-annotations` transitively, and with nothing managing it that landed on **2.17.2** — four minors behind databind 2.21.5.

Rather than add yet another explicit pin for that one module, I imported the **Jackson BOM** in `saiku-bom`, which manages *every* jackson artifact (including the stray transitive one) to a single coordinated set. I also retired the manual annotations pin, because jackson-bom sets `jackson-annotations` to 2.21 itself — the pin is now redundant.

## Changes (`saiku-bom/pom.xml`)

- **Added** the `com.fasterxml.jackson:jackson-bom:${jackson.version}` import (`<type>pom</type>`, `<scope>import</scope>`) at the top of `<dependencyManagement>`.
- **Removed** the `<jackson.annotations.version>2.21</jackson.annotations.version>` property and its explanatory comment, plus the explicit `jackson-annotations` management entry that referenced it — the imported BOM manages annotations now.
- **Kept** the existing explicit entries for jackson-core / databind / dataformat-yaml / jaxrs-json-provider (they already read `${jackson.version}` = 2.21.5, which matches the BOM exactly, so there is no divergence and the diff stays minimal).

## Proof (`dependency:tree` on saiku-webapp, the module that pulls Jersey)

```
+- com.fasterxml.jackson.core:jackson-databind:jar:2.21.5:compile
+- com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:jar:2.21.5:compile
+- com.fasterxml.jackson.core:jackson-core:jar:2.21.5:compile
|  \- com.fasterxml.jackson.datatype:jackson-datatype-jsr310:jar:2.21.5:compile
\- org.glassfish.jersey.media:jersey-media-json-jackson:jar:3.1.9:compile
   +- com.fasterxml.jackson.core:jackson-annotations:jar:2.21:compile
   \- com.fasterxml.jackson.module:jackson-module-jakarta-xmlbind-annotations:jar:2.21.5:compile
```

The previously-stray `jackson-module-jakarta-xmlbind-annotations` now resolves to **2.21.5** (was 2.17.2); everything else is coordinated — core/databind/yaml/jsr310 at 2.21.5, annotations at 2.21.

## Note

The BOM also now governs `jackson-datatype-jsr310`, a transitive of `arrow-vector:18.2.0` (which imports jackson-bom 2.18.2). It moves 2.18.2 -> 2.21.5, aligning Arrow's jackson usage with ours. Same-line minor bump, all-jackson-coordinated — flagging it since it's a resolution shift beyond the target module.

## Testing

`mvn -o -pl saiku-core/saiku-service,saiku-core/saiku-web -am test` — BUILD SUCCESS (saiku-web 594 tests, 0 failures; saiku-service green). Confirmed `jackson-module-jakarta-xmlbind-annotations:2.21.5` and its sibling jars publish on Maven Central. saiku-webapp / saiku-launcher lean on CI (webapp triggers the Node toolchain build).
