### PR TITLE
#1605 - show dashboard titles (not raw .saikudash paths) in the list

### DIFF
--- a/saiku-ui/src/lib/api/dashboards.test.ts
+++ b/saiku-ui/src/lib/api/dashboards.test.ts
@@ -12,6 +12,7 @@ import { describe, expect, it } from "vitest";
 import {
   cloneDashboardWithFreshIds,
   cloneTileWithFreshId,
+  displayPath,
   normaliseDashboardPath,
   normaliseRepoPath,
   toRepoRelative,
@@ -109,6 +110,24 @@ describe("toRepoRelative", () => {
 
   it("returns already-relative input cleaned up", () => {
     expect(toRepoRelative("/homes/admin/foo.saikudash/")).toBe("homes/admin/foo.saikudash");
+  });
+});
+
+describe("displayPath", () => {
+  it("drops the .saikudash extension but keeps the folder path", () => {
+    expect(displayPath("homes/admin/sales.saikudash")).toBe("homes/admin/sales");
+  });
+
+  it("drops the extension from a bare filename", () => {
+    expect(displayPath("welcome.saikudash")).toBe("welcome");
+  });
+
+  it("leaves a path without the extension unchanged", () => {
+    expect(displayPath("homes/admin/sales")).toBe("homes/admin/sales");
+  });
+
+  it("only strips a trailing extension, not one mid-path", () => {
+    expect(displayPath("homes/a.saikudash/b.saikudash")).toBe("homes/a.saikudash/b");
   });
 });
 

--- a/saiku-ui/src/lib/api/dashboards.ts
+++ b/saiku-ui/src/lib/api/dashboards.ts
@@ -669,6 +669,16 @@ export function normaliseRepoPath(path: string): string {
   return path.replace(/\/+/g, "/").replace(/^\/+|\/+$/g, "");
 }
 
+/** Drop the reserved `.saikudash` extension for display. The repository
+ *  stores dashboards as `<name>.saikudash` files, but the extension is an
+ *  implementation detail the catalogue shouldn't surface — a path shown to
+ *  a user should read `homes/admin/sales`, not `homes/admin/sales.saikudash`.
+ *  Directory segments and anything before the extension pass through
+ *  untouched; a path without the extension is returned unchanged. (#1605) */
+export function displayPath(path: string): string {
+  return path.endsWith(".saikudash") ? path.slice(0, -".saikudash".length) : path;
+}
+
 async function readError(res: Response): Promise<string> {
   try {
     const body = (await res.json()) as DashboardErrorResponse;

--- a/saiku-ui/src/lib/views/dashboard/DashboardCataloguePinned.svelte
+++ b/saiku-ui/src/lib/views/dashboard/DashboardCataloguePinned.svelte
@@ -17,19 +17,20 @@
   import { base } from "$app/paths";
   import { Button } from "$lib/components/ui";
   import { Star } from "lucide-svelte";
-  import { toRepoRelative } from "$lib/api/dashboards";
+  import { toRepoRelative, displayPath } from "$lib/api/dashboards";
   import type { RepositoryNode } from "$lib/api/repository";
 
   interface Props {
     favourites: RepositoryNode[];
     recents: RepositoryNode[];
     onToggleFavourite: (relPath: string) => void;
-    /** Used to render the entry label — usually the parent's basename
-     *  helper that strips the .saikudash extension. */
-    basename: (relPath: string) => string;
+    /** Resolves a node to its human label — the dashboard's own title when
+     *  known, else its filename slug. Lets the pinned rows read the real
+     *  title rather than a raw `.saikudash` filename. (#1605) */
+    titleFor: (node: RepositoryNode) => string;
   }
 
-  let { favourites, recents, onToggleFavourite, basename }: Props = $props();
+  let { favourites, recents, onToggleFavourite, titleFor }: Props = $props();
 </script>
 
 {#if favourites.length > 0}
@@ -41,9 +42,9 @@
       {#each favourites as e (e.path)}
         {@const relPath = toRepoRelative(e.path)}
         <li class="row">
-          <a class="link" href="{base}/dashboards/{relPath}" title={relPath}>
-            <span class="name">{basename(relPath)}</span>
-            <span class="text-fg-muted text-xs overflow-hidden text-ellipsis whitespace-nowrap">{relPath}</span>
+          <a class="link" href="{base}/dashboards/{relPath}" aria-label={titleFor(e)} title={displayPath(relPath)}>
+            <span class="name">{titleFor(e)}</span>
+            <span class="text-fg-muted text-xs overflow-hidden text-ellipsis whitespace-nowrap">{displayPath(relPath)}</span>
           </a>
           <Button variant="outline" class="icon-only star star--on" onclick={() => onToggleFavourite(relPath)} title="Remove from favourites" aria-label="Remove from favourites" aria-pressed="true">
             <Star size={14} fill="currentColor" />
@@ -61,9 +62,9 @@
       {#each recents as e (e.path)}
         {@const relPath = toRepoRelative(e.path)}
         <li class="row">
-          <a class="link" href="{base}/dashboards/{relPath}" title={relPath}>
-            <span class="name">{basename(relPath)}</span>
-            <span class="text-fg-muted text-xs overflow-hidden text-ellipsis whitespace-nowrap">{relPath}</span>
+          <a class="link" href="{base}/dashboards/{relPath}" aria-label={titleFor(e)} title={displayPath(relPath)}>
+            <span class="name">{titleFor(e)}</span>
+            <span class="text-fg-muted text-xs overflow-hidden text-ellipsis whitespace-nowrap">{displayPath(relPath)}</span>
           </a>
         </li>
       {/each}

--- a/saiku-ui/src/lib/views/dashboard/DashboardCatalogueTree.svelte
+++ b/saiku-ui/src/lib/views/dashboard/DashboardCatalogueTree.svelte
@@ -14,6 +14,7 @@
    */
   import { base } from "$app/paths";
   import { Button } from "$lib/components/ui";
+  import { displayPath } from "$lib/api/dashboards";
   import {
     Copy,
     ShieldCheck,
@@ -75,9 +76,9 @@
 
 {#snippet dashboardRow(relPath: string, label: string)}
   {@const isFav = favouriteDashboards.isFavourite(relPath)}
-  <a class="link" href="{base}/dashboards/{relPath}" title={relPath}>
+  <a class="link" href="{base}/dashboards/{relPath}" aria-label={label} title={displayPath(relPath)}>
     <span class="name">{label}</span>
-    <span class="text-fg-muted text-xs overflow-hidden text-ellipsis whitespace-nowrap">{relPath}</span>
+    <span class="text-fg-muted text-xs overflow-hidden text-ellipsis whitespace-nowrap">{displayPath(relPath)}</span>
   </a>
   <Button variant="outline" class="icon-only star {isFav ? 'star--on' : ''}" onclick={() => onToggleFavourite(relPath)} title={isFav ? "Remove from favourites" : "Add to favourites"} aria-label={isFav ? "Remove from favourites" : "Add to favourites"} aria-pressed={isFav}>
     <Star size={14} fill={isFav ? "currentColor" : "none"} />

--- a/saiku-ui/src/lib/views/dashboard/DashboardIndex.svelte
+++ b/saiku-ui/src/lib/views/dashboard/DashboardIndex.svelte
@@ -32,6 +32,7 @@
     newTileId,
     normaliseDashboardPath,
     toRepoRelative,
+    displayPath,
     saveDashboard,
   } from "$lib/api/dashboards";
   import { getTemplate, instantiateTemplate } from "$lib/dashboard/templates";
@@ -319,6 +320,14 @@
     return p.endsWith(".saikudash") ? p.slice(0, -".saikudash".length) : p;
   }
 
+  /** Friendly label for a repo node: the dashboard's own title (from the
+   *  enrichment fetch) when known, else its filename slug. Used by the
+   *  pinned Favourites / Recently-viewed rows so they read the human title
+   *  rather than a raw `.saikudash` filename. (#1605) */
+  function titleForNode(n: RepositoryNode): string {
+    return catalogueMeta.get(n.path)?.title ?? basename(toRepoRelative(n.path));
+  }
+
   /** Resolve {@code recentDashboards.all()} / {@code favouriteDashboards.all()}
    *  against the live entry list so paths that no longer exist (or that
    *  the user can't see for ACL reasons) don't show as broken links.
@@ -583,7 +592,7 @@
         favourites={favouriteEntries}
         recents={recentEntries}
         onToggleFavourite={toggleFavourite}
-        {basename}
+        titleFor={titleForNode}
       />
     {/if}
 
@@ -628,9 +637,9 @@
          folder tree. `showMove` adds the #937 "move to folder" button. -->
     {#snippet dashboardRow(relPath: string, label: string, showMove: boolean)}
       {@const isFav = favouriteDashboards.isFavourite(relPath)}
-      <a class="link" href="{base}/dashboards/{relPath}" title={relPath}>
+      <a class="link" href="{base}/dashboards/{relPath}" aria-label={label} title={displayPath(relPath)}>
         <span class="font-medium">{label}</span>
-        <span class="text-xs text-fg-muted whitespace-nowrap overflow-hidden text-ellipsis">{relPath}</span>
+        <span class="text-xs text-fg-muted whitespace-nowrap overflow-hidden text-ellipsis">{displayPath(relPath)}</span>
       </a>
       <Button variant="outline" class="icon-only star {isFav ? 'star--on' : ''}" onclick={() => toggleFavourite(relPath)} title={isFav ? "Remove from favourites" : "Add to favourites"} aria-label={isFav ? "Remove from favourites" : "Add to favourites"} aria-pressed={isFav}>
         <Star size={14} fill={isFav ? "currentColor" : "none"} />


### PR DESCRIPTION
Fixes #1605 — dashboards list now shows friendly titles instead of raw `.saikudash` paths (and uses the title as the link's accessible name). Display-only: hrefs/nav still use the real path.