### PR TITLE
#1595 - give chart titles their own band so they don't overlap the plot

### DIFF
--- a/saiku-ui/src/lib/charts/build.test.ts
+++ b/saiku-ui/src/lib/charts/build.test.ts
@@ -233,6 +233,26 @@ describe("buildChartOption — title & legend", () => {
     expect((opt.legend as { bottom: number }).bottom).toBe(10);
   });
 
+  test("#1595 title sits in its own top band and the grid reserves room below it", () => {
+    // Roomy chart: title pinned near the top, plot pushed below the title band.
+    const roomy = buildChartOption(sample(), "bar", opts({ title: "My chart" })) as Record<string, unknown>;
+    expect((roomy.title as { top: number }).top).toBe(8);
+    expect((roomy.grid as { top: number }).top).toBe(50);
+
+    // Compact tile WITH a title reserves the title band (was a flat 24 that
+    // let the title overlap the top gridline / data).
+    const compactTitled = buildChartOption(sample(), "bar", opts({ title: "My chart" }), undefined, {
+      compact: true,
+    }) as Record<string, unknown>;
+    expect((compactTitled.grid as { top: number }).top).toBe(44);
+
+    // Compact tile WITHOUT a title is unchanged (no wasted header band).
+    const compactBare = buildChartOption(sample(), "bar", opts({ title: "" }), undefined, {
+      compact: true,
+    }) as Record<string, unknown>;
+    expect((compactBare.grid as { top: number }).top).toBe(24);
+  });
+
   test("compact legend defaults to a bottom scroll legend (legacy-tile parity)", () => {
     const opt = buildChartOption(sample(), "bar", opts({ legendPosition: "bottom" }), undefined, {
       compact: true,

--- a/saiku-ui/src/lib/charts/build.ts
+++ b/saiku-ui/src/lib/charts/build.ts
@@ -112,10 +112,18 @@ function compactLegend(o: ChartOptions, tk: ThemeTokens): Record<string, unknown
   return base;
 }
 
+// #1595: the title gets its own band pinned to the very top (a small `top`
+// inset) so it reads as a header rather than floating into the plot. The
+// cartesian grids below reserve `grid.top` room beneath this band via
+// `TITLE_GRID_TOP` so the title never overlaps the top gridline / data.
 function titleConfig(o: ChartOptions, tk: ThemeTokens): Record<string, unknown> | undefined {
   if (!o.title) return undefined;
-  return { text: o.title, left: "center", textStyle: { color: tk.fg } };
+  return { text: o.title, left: "center", top: 8, textStyle: { color: tk.fg } };
 }
+
+// #1595: grid.top (px) that reserves a clear band for the title above the plot
+// in compact tiles. Roomy charts already reserve their own (title ? 50 : …).
+const TITLE_GRID_TOP = 44;
 
 function linearRegression(vals: (number | null)[]): number[] {
   const n = vals.length;
@@ -798,8 +806,8 @@ export function buildChartOption(
       // a horizontal legend there. Rotated x-axis labels need ~60px
       // bottom room.
       grid: compact
-        ? { left: 96, top: 24, right: 16, bottom: 60 }
-        : { left: 120, top: 40, right: 96, bottom: 60 },
+        ? { left: 96, top: title ? TITLE_GRID_TOP : 24, right: 16, bottom: 60 }
+        : { left: 120, top: title ? 56 : 40, right: 96, bottom: 60 },
       xAxis: {
         ...baseAxis,
         // Heatmap categories had the same readability problem as scatter
@@ -923,7 +931,7 @@ export function buildChartOption(
       // #1080: roomy gets a slider + inside zoom; compact gets inside-only. The
       // roomy slider sits at the bottom, so reserve a little extra grid bottom.
       grid: compact
-        ? { top: 24, left: 48, right: 16, bottom: 56 }
+        ? { top: title ? TITLE_GRID_TOP : 24, left: 48, right: 16, bottom: 56 }
         : { left: 60, top: title ? 50 : 40, right: 40, bottom: 56 },
       // scatter / bubble: never draw the visible slider (the points
       // already show the full distribution and the slider added clutter
@@ -988,7 +996,7 @@ export function buildChartOption(
       tooltip: { trigger: "axis", ...tooltipStyle },
       legend,
       grid: compact
-        ? { top: 24, left: 48, right: 16, bottom: 56 }
+        ? { top: title ? TITLE_GRID_TOP : 24, left: 48, right: 16, bottom: 56 }
         : { left: 60, top: title ? 50 : 30, right: 40, bottom: 56 },
       // waterfall is a single ordered sequence — no useful "zoom window"
       // semantics. Inside-zoom stays for power users, slider hidden.
@@ -1149,7 +1157,7 @@ export function buildChartOption(
     // otherwise the plot area gets squashed for an affordance that
     // isn't present (saiku follow-up to #1080 + screenshot 2026-06-07).
     grid: compact
-      ? { top: 24, left: 48, right: 16, bottom: 36 }
+      ? { top: title ? TITLE_GRID_TOP : 24, left: 48, right: 16, bottom: 36 }
       : {
           left: 60,
           top: title ? 50 : 40,


### PR DESCRIPTION
Driving the FoodMart demo dashboard, the chart title (e.g. "Unit Sales & Store Sales by Quarter") was being drawn inside the plot area, colliding with the top gridline and the data.

The title now sits in its own band pinned to the top of the chart, and the plot grid reserves room below it so the two never overlap.

What changed (all in `saiku-ui/src/lib/charts/build.ts`, ECharts option builder):
- `title.top` is now pinned to `8` so the title reads as a header rather than floating over the plot.
- The compact-tile cartesian grids (bar / line / area, scatter / bubble, waterfall, heatmap) reserved a flat `grid.top: 24` regardless of whether a title was present, which is what let the title collide with the data. They now reserve a title band (`grid.top: 44`) when a title is set and stay at `24` when there is none, so titleless tiles keep their full plot height.
- The heatmap's roomy grid used a flat `grid.top: 40`; it now reserves `56` when a title is present. The other roomy grids already reserved `title ? 50` and are unchanged.

Scope is deliberately limited to the title band and `grid.top`. Axis labels, series, and legend were left untouched.

Added a unit test asserting the title band and the grid-top reservation (compact-with-title, compact-without-title, roomy-with-title).

Verification:
- `npx vitest run src/lib/charts/build.test.ts` - 96 passed (existing no-title snapshots are byte-identical since every change is gated on a title being present).
- `npm run check` - 0 errors (2 pre-existing unrelated warnings).

Fixes #1595