### PR TITLE
fix(dashboard): render markdown in text tiles instead of raw source

### DIFF
--- a/saiku-ui/src/lib/views/dashboard/TileEditorText.svelte
+++ b/saiku-ui/src/lib/views/dashboard/TileEditorText.svelte
@@ -11,6 +11,6 @@
 </script>
 
 <label class="field">
-  <span>Markdown / HTML (sanitised on render)</span>
+  <span>Markdown (sanitised on render)</span>
   <textarea bind:value={text} rows="10"></textarea>
 </label>

--- a/saiku-ui/src/lib/views/dashboard/tiles/TextTile.svelte
+++ b/saiku-ui/src/lib/views/dashboard/tiles/TextTile.svelte
@@ -1,17 +1,28 @@
 <script lang="ts">
   /*
-   * Text annotation tile. Stores raw text/HTML in tile.text and renders
-   * it after sanitisation via DOMPurify. No query, no filters, no
-   * subscriptions — purely declarative.
+   * Text annotation tile. Stores markdown in tile.text, renders it to
+   * HTML with renderTinyMarkdown, then sanitises the result via DOMPurify
+   * before insertion. No query, no filters, no subscriptions — purely
+   * declarative.
+   *
+   * Why two stages: renderTinyMarkdown escapes every source node before
+   * emitting the small set of structural tags it supports (headings,
+   * bold/italic, bullets, inline code, http(s) links) — so its output is
+   * already HTML-safe, exactly as it is trusted in the AI Ask drawer.
+   * DOMPurify is kept as defence-in-depth because a TextTile's text is
+   * analyst-controllable (JCR write access), so a bug in the renderer must
+   * not become a stored-XSS sink.
    *
    * Threat model: a malicious analyst with write access to the JCR
-   * repository injects script tags or javascript: URLs. DOMPurify
-   * strips scripts, event handlers, and dangerous URL schemes by
-   * default; a sanity test in the project's vitest harness asserts
-   * the common XSS payloads don't survive (task #14).
+   * repository injects script tags or javascript: URLs. renderTinyMarkdown
+   * escapes them to inert text; DOMPurify additionally strips scripts,
+   * event handlers, and dangerous URL schemes. A sanity test in the
+   * project's vitest harness asserts the common XSS payloads don't survive
+   * (task #14).
    */
 
   import DOMPurify from "dompurify";
+  import { renderTinyMarkdown } from "$lib/api/tinyMarkdown";
   import type { DashboardTile } from "$lib/api/dashboards";
 
   interface Props {
@@ -35,7 +46,9 @@
     FORBID_TAGS: ["style", "embed", "object", "iframe", "form"],
   };
 
-  let safeHtml = $derived(DOMPurify.sanitize(tile.text ?? "", SANITISE_CONFIG));
+  let safeHtml = $derived(
+    DOMPurify.sanitize(renderTinyMarkdown(tile.text ?? ""), SANITISE_CONFIG),
+  );
 </script>
 
 <div class="text-tile">

--- a/saiku-ui/src/lib/views/dashboard/tiles/textTile.test.ts
+++ b/saiku-ui/src/lib/views/dashboard/tiles/textTile.test.ts
@@ -31,6 +31,7 @@
 
 import { describe, test, expect } from "vitest";
 import DOMPurify from "dompurify";
+import { renderTinyMarkdown } from "$lib/api/tinyMarkdown";
 
 // Mirror TextTile.svelte's SANITISE_CONFIG exactly — tests cover the
 // real component contract, not a synthetic config.
@@ -38,6 +39,12 @@ function sanitise(input: string): string {
   return DOMPurify.sanitize(input, {
     FORBID_TAGS: ["style", "embed", "object", "iframe", "form"],
   });
+}
+
+// Mirror TextTile.svelte's full render pipeline: markdown -> HTML via
+// renderTinyMarkdown, then DOMPurify. tile.text is stored as markdown.
+function render(input: string): string {
+  return sanitise(renderTinyMarkdown(input));
 }
 
 describe("TextTile DOMPurify config", () => {
@@ -89,5 +96,40 @@ describe("TextTile DOMPurify config", () => {
     const out = sanitise('<object data="x">malicious</object>safe');
     expect(out).not.toContain("<object");
     expect(out).toContain("safe");
+  });
+});
+
+describe("TextTile markdown rendering (#1602)", () => {
+  test("renders a heading instead of showing the literal '#'", () => {
+    const out = render("# Sales report");
+    expect(out).toMatch(/<h[1-6]>Sales report<\/h[1-6]>/);
+    expect(out).not.toContain("# Sales report");
+  });
+
+  test("renders **bold** as <strong>, not literal asterisks", () => {
+    const out = render("**Login:** demo");
+    expect(out).toContain("<strong>Login:</strong>");
+    expect(out).not.toContain("**Login:**");
+  });
+
+  test("renders `inline code` as <code>, not literal backticks", () => {
+    const out = render("Use the `admin` account");
+    expect(out).toContain("<code>admin</code>");
+    expect(out).not.toContain("`admin`");
+  });
+
+  test("renders bullet lists", () => {
+    const out = render("- first\n- second");
+    expect(out).toContain("<ul>");
+    expect(out).toContain("<li>first</li>");
+    expect(out).toContain("<li>second</li>");
+  });
+
+  test("markdown pipeline still neutralises embedded XSS", () => {
+    const out = render("# Hi\n\n<script>alert(1)</script>");
+    // The renderer escapes source before emitting tags, so the payload
+    // survives only as inert, escaped text — never as a live <script> tag.
+    expect(out).not.toMatch(/<script/i);
+    expect(out).toContain("&lt;script&gt;");
   });
 });


### PR DESCRIPTION
## Problem

The Welcome text tile on the demo dashboard showed literal markdown — `#`, backticks, `**Login:**` — instead of formatted text.

Text tiles store **markdown** in `tile.text` (the dashboard templates and demo dashboards all use `#` headings, `**bold**`, `` `code` ``), and the tile editor field is labelled "Markdown". But `TextTile.svelte` only ran `DOMPurify.sanitize` over the raw string. DOMPurify treats markdown punctuation as plain text, so the syntax passed straight through and rendered literally in the viewer.

## Fix

Pipe `tile.text` through `renderTinyMarkdown` (the same escape-first markdown renderer the AI Ask drawer already trusts) before DOMPurify:

- `renderTinyMarkdown` escapes every source node before emitting its small set of structural tags (headings, bold/italic, bullets, inline code, http(s) links), so its output is already HTML-safe.
- DOMPurify stays on as **defence-in-depth** — a text tile's content is analyst-controllable via JCR write access, so a bug in the renderer must never become a stored-XSS sink. No new `{@html}` sink is introduced; the existing sanitised sink is preserved.

Raw HTML in a text tile is now escaped rather than rendered, so the editor label drops the "/ HTML" affordance to match the new behaviour.

## Verification

- `npm run check` — 0 errors (2 pre-existing warnings unrelated to this change).
- `vitest` on `textTile.test.ts` — 13 passed, including new cases asserting `#`/`**`/`` ` `` render as `<h*>`/`<strong>`/`<code>` and that an embedded `<script>` payload survives only as inert escaped text.

Fixes #1602
