### PR TITLE
feat(analyze): double-click a measure/level in the sidebar tree to add it

### DIFF
--- a/saiku-ui/src/lib/views/DimensionList.svelte
+++ b/saiku-ui/src/lib/views/DimensionList.svelte
@@ -72,9 +72,14 @@
     if (e.dataTransfer) e.dataTransfer.effectAllowed = "move";
   }
 
-  /** Click-to-drop: add measure onto COLUMNS as a measure. Mirrors the
-   *  drag-drop payload but skips the DnD machinery. Old UI behaviour. */
-  function onMeasureClick(m: SaikuMeasure): void {
+  /** #1608: add a measure to the Measures shelf — a measure's natural
+   *  axis. Reuses query.addMeasure, the SAME mutator QueryCanvas.onDropAxis
+   *  invokes on a drag-drop, so a double-click and a drop converge on
+   *  identical query state (and the same reactivity via markDirty).
+   *  addMeasure dedupes by uniqueName, so repeat activations are safe
+   *  no-ops. Wired to dblclick (mouse/touch) + keyboard activation on the
+   *  tree buttons; a bare single mouse-click no longer mutates the query. */
+  function onMeasureAdd(m: SaikuMeasure): void {
     query.addMeasure({
       name: m.name,
       uniqueName: m.uniqueName,
@@ -93,8 +98,12 @@
     });
   }
 
-  /** Click-to-drop: drop a level onto ROWS by default. */
-  function onLevelClick(dim: SaikuDimension, hier: SaikuHierarchy, lvl: SaikuLevel): void {
+  /** #1608: add a dimension level to ROWS — a level's natural default
+   *  axis. Reuses query.includeLevel, the SAME mutator the drag-drop drop
+   *  handler (QueryCanvas.onDropAxis) calls, so double-click and drop
+   *  converge on identical query state. includeLevel is idempotent for a
+   *  level already on-axis. Wired to dblclick + keyboard on the tree row. */
+  function onLevelAdd(dim: SaikuDimension, hier: SaikuHierarchy, lvl: SaikuLevel): void {
     query.includeLevel("ROWS", {
       dimensionName: dim.name,
       dimensionUniqueName: dim.uniqueName,
@@ -449,7 +458,8 @@
                 draggable="true"
                 title={measure.caption}
                 ondragstart={(e) => onMeasureDragStart(e, measure)}
-                onclick={() => onMeasureClick(measure)}
+                ondblclick={() => onMeasureAdd(measure)}
+                onclick={(e) => { if (e.detail === 0) onMeasureAdd(measure); }}
               >
                 <span class="tree__icon tree__icon--measure" aria-hidden="true">
                   {#if measure.calculated}<FunctionSquare size={13} />{:else}<Sigma size={13} />{/if}
@@ -479,7 +489,8 @@
                         draggable="true"
                         title={measure.caption}
                         ondragstart={(e) => onMeasureDragStart(e, measure)}
-                        onclick={() => onMeasureClick(measure)}
+                        ondblclick={() => onMeasureAdd(measure)}
+                        onclick={(e) => { if (e.detail === 0) onMeasureAdd(measure); }}
                       >
                         <span class="tree__icon tree__icon--measure" aria-hidden="true">
                           {#if measure.calculated}<FunctionSquare size={13} />{:else}<Sigma size={13} />{/if}
@@ -539,7 +550,8 @@
                             draggable="true"
                             title={lvl.caption}
                             ondragstart={(e) => onLevelDragStart(e, dim, hier, lvl)}
-                            onclick={() => onLevelClick(dim, hier, lvl)}
+                            ondblclick={() => onLevelAdd(dim, hier, lvl)}
+                            onclick={(e) => { if (e.detail === 0) onLevelAdd(dim, hier, lvl); }}
                           >
                             <span class="tree__icon text-fg-subtle" aria-hidden="true"><Minus size={11} /></span>
                             <span class="flex-1 overflow-hidden text-ellipsis whitespace-nowrap">{lvl.caption || lvl.name}</span>
@@ -574,7 +586,8 @@
                                   draggable="true"
                                   title={lvl.caption}
                                   ondragstart={(e) => onLevelDragStart(e, dim, hier, lvl)}
-                                  onclick={() => onLevelClick(dim, hier, lvl)}
+                                  ondblclick={() => onLevelAdd(dim, hier, lvl)}
+                                  onclick={(e) => { if (e.detail === 0) onLevelAdd(dim, hier, lvl); }}
                                 >
                                   <span class="tree__icon text-fg-subtle" aria-hidden="true"><Minus size={11} /></span>
                                   <span class="flex-1 overflow-hidden text-ellipsis whitespace-nowrap">{lvl.caption || lvl.name}</span>


### PR DESCRIPTION
## What

In the analyze query builder, the left-hand cube tree now adds a field on **double-click**: double-click a measure to drop it on the Measures shelf, double-click a dimension level to put it on Rows (its natural default axis). Drag-and-drop is unchanged.

## Why

Drag was meant to be the primary path, but the sidebar tree was also mutating the query on a bare **single click** — so just clicking a row to browse the cube could silently add a measure/level. That is undiscoverable and easy to trigger by accident. Double-click is the gesture people reach for, and it makes adding a deliberate action.

## How

Both handlers reuse the exact mutators the drop handler already calls — `query.addMeasure` and `query.includeLevel` (see `QueryCanvas.onDropAxis`) — so a double-click and a drop converge on identical query state and reactivity (`markDirty`). A measure routes to the Measures shelf; a level routes to Rows.

Keyboard activation (Enter/Space) still adds through the same path, detected via `event.detail === 0`, so the tree stays keyboard-accessible for the a11y case the issue calls out. A plain single mouse-click no longer changes the query.

- `addMeasure` dedupes by `uniqueName` and `includeLevel` is idempotent for a level already on-axis, so repeat activations (or a stray extra click) are safe no-ops.

## Verify

- `npm run check` — 0 errors (2 pre-existing warnings in unrelated files).
- `npx eslint src/lib/views/DimensionList.svelte` — clean.
- Related vitest (`ossieQuery`, `starterCube`) — 70 passing.

Fixes #1608
