### PR TITLE
polish(analyze): styled hover tooltips on icon-only query toolbar buttons

### DIFF
--- a/saiku-ui/src/lib/views/WorkspaceToolbar.svelte
+++ b/saiku-ui/src/lib/views/WorkspaceToolbar.svelte
@@ -23,6 +23,7 @@
     Redo2,
     Mail,
   } from "lucide-svelte";
+  import { Tooltip } from "$lib/components/ui";
   import SaveQueryModal from "$lib/modals/SaveQueryModal.svelte";
   import SavedQueriesModal from "$lib/modals/SavedQueriesModal.svelte";
   import EmailMeThisModal from "$lib/modals/EmailMeThisModal.svelte";
@@ -374,50 +375,59 @@
 
 <div class="toolbar" role="toolbar" aria-label="Workspace toolbar">
   <div class="flex items-center gap-0.5 relative" role="group" aria-label="File">
-    <button class="tb-btn" title={i18n.t("toolbar.new")} aria-label={i18n.t("toolbar.new")} onclick={onNew}>
-      <FilePlus2 size={18} />
-    </button>
-    <button class="tb-btn" title={i18n.t("toolbar.open")} aria-label={i18n.t("toolbar.open")} onclick={onOpen}>
-      <FolderOpen size={18} />
-    </button>
-    <button
-      class="tb-btn relative"
-      title={query.dirty ? `${i18n.t("toolbar.save")} (unsaved changes)` : i18n.t("toolbar.save")}
-      aria-label={i18n.t("toolbar.save")}
-      onclick={onSave}
-    >
-      <Save size={18} />
-      {#if query.dirty}
-        <span class="tb-btn__dot" aria-hidden="true"></span>
-      {/if}
-    </button>
-    <button class="tb-btn" title={i18n.t("toolbar.saveAs")} aria-label={i18n.t("toolbar.saveAs")} onclick={onSaveAs}>
-      <Copy size={18} />
-    </button>
+    <Tooltip text={i18n.t("toolbar.new")}>
+      <button class="tb-btn" aria-label={i18n.t("toolbar.new")} onclick={onNew}>
+        <FilePlus2 size={18} />
+      </button>
+    </Tooltip>
+    <Tooltip text={i18n.t("toolbar.open")}>
+      <button class="tb-btn" aria-label={i18n.t("toolbar.open")} onclick={onOpen}>
+        <FolderOpen size={18} />
+      </button>
+    </Tooltip>
+    <Tooltip text={query.dirty ? `${i18n.t("toolbar.save")} (unsaved changes)` : i18n.t("toolbar.save")}>
+      <button
+        class="tb-btn relative"
+        aria-label={i18n.t("toolbar.save")}
+        onclick={onSave}
+      >
+        <Save size={18} />
+        {#if query.dirty}
+          <span class="tb-btn__dot" aria-hidden="true"></span>
+        {/if}
+      </button>
+    </Tooltip>
+    <Tooltip text={i18n.t("toolbar.saveAs")}>
+      <button class="tb-btn" aria-label={i18n.t("toolbar.saveAs")} onclick={onSaveAs}>
+        <Copy size={18} />
+      </button>
+    </Tooltip>
   </div>
   <div class="toolbar__sep"></div>
   <!-- Undo / redo. Disabled-state mirrors the store's canUndo / canRedo so the
        button visually goes inert at the end of each stack rather than no-oping
        on click. Cmd-Z / Cmd-Shift-Z keyboard shortcuts in the wrapper below. -->
   <div class="flex items-center gap-0.5 relative" role="group" aria-label="Undo / redo">
-    <button
-      class="tb-btn"
-      title={platform.isMac ? "Undo (⌘Z)" : "Undo (Ctrl+Z)"}
-      aria-label="Undo"
-      disabled={!query.canUndo}
-      onclick={() => query.undo()}
-    >
-      <Undo2 size={18} />
-    </button>
-    <button
-      class="tb-btn"
-      title={platform.isMac ? "Redo (⇧⌘Z)" : "Redo (Ctrl+Shift+Z)"}
-      aria-label="Redo"
-      disabled={!query.canRedo}
-      onclick={() => query.redo()}
-    >
-      <Redo2 size={18} />
-    </button>
+    <Tooltip text={platform.isMac ? "Undo (⌘Z)" : "Undo (Ctrl+Z)"}>
+      <button
+        class="tb-btn"
+        aria-label="Undo"
+        disabled={!query.canUndo}
+        onclick={() => query.undo()}
+      >
+        <Undo2 size={18} />
+      </button>
+    </Tooltip>
+    <Tooltip text={platform.isMac ? "Redo (⇧⌘Z)" : "Redo (Ctrl+Shift+Z)"}>
+      <button
+        class="tb-btn"
+        aria-label="Redo"
+        disabled={!query.canRedo}
+        onclick={() => query.redo()}
+      >
+        <Redo2 size={18} />
+      </button>
+    </Tooltip>
   </div>
   <div class="toolbar__sep"></div>
   <div class="flex items-center gap-0.5 relative relative" role="group" aria-label="Query">
@@ -462,9 +472,11 @@
       </div>
     {/if}
     {#if query.current?.type !== "MDX"}
-      <button class="tb-btn" title={i18n.t("toolbar.swap")} aria-label={i18n.t("toolbar.swap")} onclick={() => query.swapAxes()}>
-        <ArrowLeftRight size={18} />
-      </button>
+      <Tooltip text={i18n.t("toolbar.swap")}>
+        <button class="tb-btn" aria-label={i18n.t("toolbar.swap")} onclick={() => query.swapAxes()}>
+          <ArrowLeftRight size={18} />
+        </button>
+      </Tooltip>
     {/if}
   </div>
   {#if onAskAi}


### PR DESCRIPTION
## What

The analyze query toolbar exposes several icon-only buttons — New, Open, Save, Save As, Undo, Redo, and Swap axes — that are ambiguous on sight. They already had native `title` attributes, but native tooltips are slow to appear (~700ms), unstyled, and do not surface on keyboard focus.

This wraps those buttons in the existing design-system `Tooltip` component so the label shows on hover **and** focus via the styled, snappier (300ms) hint used elsewhere in the app. The redundant native `title` is removed from the wrapped buttons to avoid a double tooltip; `aria-label` stays for assistive tech.

## Why it is safe

- `Tooltip` renders its trigger through a `display:contents` span, so the flex toolbar layout and every button's click behaviour are unchanged.
- No handlers, stores, or button semantics were touched — markup only.
- The Save button keeps its `relative` class, so the unsaved-changes dot still positions correctly.

## Scope

Only the icon-only buttons were changed. The labelled buttons (Run, Tools, Export, "Email me this") are left exactly as-is, keeping this clear of the separate "Email me this" rename work.

## Verify

- `npm run check` passes (0 errors; the 2 warnings are pre-existing and in unrelated files).

Fixes #1609
