### PR TITLE
#1606 - show one consistent dashboard title everywhere

### DIFF
--- a/saiku-ui/src/lib/views/dashboard/DashboardCataloguePinned.svelte
+++ b/saiku-ui/src/lib/views/dashboard/DashboardCataloguePinned.svelte
@@ -1,3 +1,17 @@
+<script module lang="ts">
+  /** A pinned dashboard row (favourite or recent) with its title already
+   *  resolved by the parent. Carrying the resolved title as plain reactive
+   *  data — rather than a `titleFor(node)` closure over the parent's
+   *  catalogue metadata — means the rows re-render the moment the friendly
+   *  title lands, keeping them consistent with the list + tree. (#1606) */
+  export interface PinnedDashboard {
+    /** Repo-relative path incl. `.saikudash`; used for the link + favourite toggle. */
+    path: string;
+    /** Friendly title — the dashboard's own name when loaded, else its filename slug. */
+    title: string;
+  }
+</script>
+
 <script lang="ts">
   /*
    * Pinned sections — Favourites + "Recently viewed" — extracted from
@@ -11,26 +25,22 @@
    *                 whole interaction.
    *
    * Parent provides the resolved entry arrays (already filtered against
-   * the live listing for ACL / deleted paths). `toRepoRelative` is
-   * imported here to avoid threading the helper through a prop.
+   * the live listing for ACL / deleted paths). Each row carries its
+   * already-resolved friendly title; `toRepoRelative` is imported here to
+   * avoid threading the helper through a prop.
    */
   import { base } from "$app/paths";
   import { Button } from "$lib/components/ui";
   import { Star } from "lucide-svelte";
   import { toRepoRelative, displayPath } from "$lib/api/dashboards";
-  import type { RepositoryNode } from "$lib/api/repository";
 
   interface Props {
-    favourites: RepositoryNode[];
-    recents: RepositoryNode[];
+    favourites: PinnedDashboard[];
+    recents: PinnedDashboard[];
     onToggleFavourite: (relPath: string) => void;
-    /** Resolves a node to its human label — the dashboard's own title when
-     *  known, else its filename slug. Lets the pinned rows read the real
-     *  title rather than a raw `.saikudash` filename. (#1605) */
-    titleFor: (node: RepositoryNode) => string;
   }
 
-  let { favourites, recents, onToggleFavourite, titleFor }: Props = $props();
+  let { favourites, recents, onToggleFavourite }: Props = $props();
 </script>
 
 {#if favourites.length > 0}
@@ -42,8 +52,8 @@
       {#each favourites as e (e.path)}
         {@const relPath = toRepoRelative(e.path)}
         <li class="row">
-          <a class="link" href="{base}/dashboards/{relPath}" aria-label={titleFor(e)} title={displayPath(relPath)}>
-            <span class="name">{titleFor(e)}</span>
+          <a class="link" href="{base}/dashboards/{relPath}" aria-label={e.title} title={displayPath(relPath)}>
+            <span class="name">{e.title}</span>
             <span class="text-fg-muted text-xs overflow-hidden text-ellipsis whitespace-nowrap">{displayPath(relPath)}</span>
           </a>
           <Button variant="outline" class="icon-only star star--on" onclick={() => onToggleFavourite(relPath)} title="Remove from favourites" aria-label="Remove from favourites" aria-pressed="true">
@@ -62,8 +72,8 @@
       {#each recents as e (e.path)}
         {@const relPath = toRepoRelative(e.path)}
         <li class="row">
-          <a class="link" href="{base}/dashboards/{relPath}" aria-label={titleFor(e)} title={displayPath(relPath)}>
-            <span class="name">{titleFor(e)}</span>
+          <a class="link" href="{base}/dashboards/{relPath}" aria-label={e.title} title={displayPath(relPath)}>
+            <span class="name">{e.title}</span>
             <span class="text-fg-muted text-xs overflow-hidden text-ellipsis whitespace-nowrap">{displayPath(relPath)}</span>
           </a>
         </li>

--- a/saiku-ui/src/lib/views/dashboard/DashboardIndex.svelte
+++ b/saiku-ui/src/lib/views/dashboard/DashboardIndex.svelte
@@ -51,7 +51,9 @@
   import EmptyState from "$lib/components/EmptyState.svelte";
   import DashboardIndexFilters from "$lib/views/dashboard/DashboardIndexFilters.svelte";
   import DashboardCatalogueTree from "$lib/views/dashboard/DashboardCatalogueTree.svelte";
-  import DashboardCataloguePinned from "$lib/views/dashboard/DashboardCataloguePinned.svelte";
+  import DashboardCataloguePinned, {
+    type PinnedDashboard,
+  } from "$lib/views/dashboard/DashboardCataloguePinned.svelte";
   import {
     Copy,
     ShieldCheck,
@@ -343,14 +345,25 @@
     return out;
   }
 
-  let recentEntries = $derived(resolveEntries(recentDashboards.all()));
-  let favouriteEntries = $derived(
+  /** Resolve the pinned nodes AND bake in each dashboard's friendly title.
+   *  Reading {@link titleForNode} (hence {@link catalogueMeta}) inside the
+   *  derivation is what makes these recompute when the enrichment fetch
+   *  lands — so the pinned rows switch from filename slug to friendly title
+   *  in lock-step with the list + tree, instead of staying stuck on the
+   *  slug they first rendered with (#1606). */
+  let recentEntries = $derived<PinnedDashboard[]>(
+    resolveEntries(recentDashboards.all()).map((n) => ({
+      path: n.path,
+      title: titleForNode(n),
+    })),
+  );
+  let favouriteEntries = $derived<PinnedDashboard[]>(
     resolveEntries(
       favouriteDashboards
         .all()
         .slice()
         .sort((a, b) => basename(a).localeCompare(basename(b))),
-    ),
+    ).map((n) => ({ path: n.path, title: titleForNode(n) })),
   );
 
   function toggleFavourite(path: string): void {
@@ -592,7 +605,6 @@
         favourites={favouriteEntries}
         recents={recentEntries}
         onToggleFavourite={toggleFavourite}
-        titleFor={titleForNode}
       />
     {/if}
 


### PR DESCRIPTION
## What

On `/ui/dashboards`, the same dashboard could appear under two different names: the **Recently viewed** / **Favourites** cards showed the raw filename slug (e.g. `welcome`) while the main **list** row showed the friendly title (`Welcome to Saiku - FoodMart overview`). One dashboard, two identities.

## Why

The list and folder tree bake the resolved title into `$derived` data, so they light up the friendly title the moment the per-dashboard enrichment fetch lands. The pinned section (#1234 extraction) was instead fed plain `RepositoryNode[]` arrays plus a `titleFor(node)` closure over the catalogue metadata. Those arrays don't depend on the metadata, so the pinned rows painted the filename slug on first render and never re-rendered once the titles resolved — leaving them stuck on the slug while the list showed the title.

## Fix

Unify the pinned rows onto the **same** title source the list and tree use:

- Resolve each pinned entry's friendly title in the parent (`DashboardIndex`) as part of a `$derived` that reads the catalogue metadata (via the existing `titleForNode`), so the recents/favourites arrays recompute in lock-step with the list + tree.
- `DashboardCataloguePinned` now renders the already-resolved title from its entry data (a small `PinnedDashboard` `{ path, title }` shape) instead of calling a `titleFor` closure, dropping that prop.

Builds directly on #1605's title resolution — no `displayPath` rework.

## Verification

- `npm run check` — 0 errors (2 pre-existing warnings in unrelated files).
- `vitest run` on the dashboards / recents / favourites suites — 54 passed.

Fixes #1606
