### PR TITLE
polish(dashboard): default new text tiles to a single row tall

### DIFF
--- a/saiku-ui/src/lib/dashboard/tilePlacement.test.ts
+++ b/saiku-ui/src/lib/dashboard/tilePlacement.test.ts
@@ -194,6 +194,6 @@ describe("buildTile", () => {
     expect(filter.h).toBe(1);
     const text = buildTile(emptyLayout(), "text", "t");
     expect(text.w).toBe(6);
-    expect(text.h).toBe(2);
+    expect(text.h).toBe(1);
   });
 });

--- a/saiku-ui/src/lib/dashboard/tilePlacement.ts
+++ b/saiku-ui/src/lib/dashboard/tilePlacement.ts
@@ -9,7 +9,10 @@ import type { DashboardLayout, DashboardTile, TileType } from "$lib/api/dashboar
 /** Default size for each tile type. Tuned for the 12-column grid:
  *  - chart / table fill half the row (analyst can resize later)
  *  - filter is a wide skinny strip (full row, 1 row tall)
- *  - text is half-width, slightly shorter than chart/table
+ *  - text is half-width and a single row tall — a short note or heading
+ *    shouldn't reserve a big block of empty space that shoves charts
+ *    below the fold (#1603). The analyst resizes it up when the note is
+ *    long; the grid's auto-rows also let it grow to fit taller content.
  *  - kpi is a compact card — quarter-row width, 2 rows tall, so four
  *    fit across the top of a dashboard */
 export function defaultSizeFor(type: TileType): { w: number; h: number } {
@@ -21,7 +24,7 @@ export function defaultSizeFor(type: TileType): { w: number; h: number } {
     case "filter":
       return { w: 12, h: 1 };
     case "text":
-      return { w: 6, h: 2 };
+      return { w: 6, h: 1 };
     case "kpi":
       return { w: 3, h: 2 };
     case "image":


### PR DESCRIPTION
## What

A newly-added **text / note** tile defaulted to `h: 2`. With the dashboard grid's `grid-auto-rows: minmax(80px, auto)`, that reserves ~160px of height even for a one-line blurb, leaving a large empty block that pushes the charts below it off the fold (#1603).

This changes the default height for **text** tiles only, from `h: 2` to `h: 1` (one row, ~80px), in `defaultSizeFor()`. Short notes and headings now sit tight to their content. Analysts can still drag-resize a longer note taller, and the grid's `auto` row max lets a tile grow to fit taller content.

## Scope

- Only the `text` case in `defaultSizeFor` (`saiku-ui/src/lib/dashboard/tilePlacement.ts`) changes. Chart, table, KPI, filter and image defaults are untouched.
- Updated the matching unit expectation in `tilePlacement.test.ts`.

## Note / follow-up

The seeded demo dashboard's "Header" tile in `templates.ts` is a deliberate full-width banner (`w: 12, h: 2`) and is left as-is; it is not the newly-added-tile path this issue is about. Any oversize in a specific stored/seed dashboard layout would be separate seed data, not this UI default.

## Verify

- `npm run check` — 0 errors (2 pre-existing unrelated warnings).
- `npx vitest run` on tilePlacement / aiDashboardAssembler / textTile suites — 39 passed.

Fixes #1603
