### PR TITLE
polish(charts): reserve grid.bottom for rotated category labels so they don't clip

### DIFF
--- a/saiku-ui/src/lib/charts/build.test.ts
+++ b/saiku-ui/src/lib/charts/build.test.ts
@@ -1110,6 +1110,94 @@ describe("buildChartOption — x-axis label width per axis", () => {
 });
 
 // ---------------------------------------------------------------------------
+// #1598: rotated category (x-axis) tick labels were clipping at the tile edge.
+// Long member captions (city names like "Beverly Hills") rotate ~30° past 8
+// categories and drop diagonally BELOW the axis; the grid.bottom didn't reserve
+// that vertical extent, so they were cut off. The fix reserves grid.bottom for
+// the rotated drop AND ellipsizes to a responsive width (compact tiles thin
+// aggressively, roomy charts show more) so an over-long label ends in "…"
+// rather than clipping. Composes additively with #1596's axis-title room.
+// ---------------------------------------------------------------------------
+describe("buildChartOption — rotated category label clipping (#1598)", () => {
+  function rowsProjection(n: number, name?: string): ChartProjection {
+    return {
+      rowCategories: Array.from({ length: n }, (_, i) => `Very Long City Name ${i}`),
+      columnCategories: ["Sales"],
+      matrix: Array.from({ length: n }, (_, i) => [100 + i]),
+      ...(name ? { categoryAxisName: name } : {}),
+    };
+  }
+  const xLabelOf = (opt: Record<string, unknown>) =>
+    (opt.xAxis as { axisLabel: { rotate: number; width: number; overflow?: string; ellipsis?: string } })
+      .axisLabel;
+  const bottomOf = (opt: Record<string, unknown>) => (opt.grid as { bottom: number }).bottom;
+
+  test("crowded bar (>8 categories) rotates and ellipsizes with a truncation width", () => {
+    const opt = buildChartOption(rowsProjection(20), "bar", opts(), undefined, {
+      chartWidth: 900,
+    }) as Record<string, unknown>;
+    const label = xLabelOf(opt);
+    expect(label.rotate).toBe(30);
+    // A rotated over-long label truncates + ends in an ellipsis (never clips).
+    expect(label.overflow).toBe("truncate");
+    expect(label.ellipsis).toBe("…");
+    expect(label.width).toBeGreaterThan(0);
+  });
+
+  test("rotated axis reserves MORE grid.bottom than a non-rotated one (the clip fix)", () => {
+    const flat = buildChartOption(rowsProjection(4), "bar", opts(), undefined, {
+      chartWidth: 900,
+    }) as Record<string, unknown>;
+    const rotated = buildChartOption(rowsProjection(20), "bar", opts(), undefined, {
+      chartWidth: 900,
+    }) as Record<string, unknown>;
+    // Rotation only kicks in past 8 categories; the 4-category axis is flat.
+    expect(xLabelOf(flat).rotate).toBe(0);
+    expect(xLabelOf(rotated).rotate).toBe(30);
+    // The rotated axis reserves extra bottom room for the diagonal drop so the
+    // labels clear the plot instead of clipping at the tile edge.
+    expect(bottomOf(rotated)).toBeGreaterThan(bottomOf(flat));
+  });
+
+  test("compact tiles thin the rotated label harder than roomy charts", () => {
+    const roomy = buildChartOption(rowsProjection(20), "bar", opts(), undefined, {
+      compact: false,
+      chartWidth: 900,
+    }) as Record<string, unknown>;
+    const compact = buildChartOption(rowsProjection(20), "bar", opts(), undefined, {
+      compact: true,
+      chartWidth: 300,
+    }) as Record<string, unknown>;
+    // Compact caps the label narrower (earlier ellipsis) and, because a narrower
+    // label drops less, reserves less bottom than the roomy chart.
+    expect(xLabelOf(compact).width).toBeLessThan(xLabelOf(roomy).width);
+    expect(bottomOf(compact)).toBeLessThan(bottomOf(roomy));
+  });
+
+  test("tick-label room and axis-title room (#1596) compose additively", () => {
+    // Same rotated axis, with and without a category dimension title. The
+    // #1598 tick reserve and the #1596 axis-name reserve are independent, so
+    // adding a title grows the bottom further still.
+    const noTitle = buildChartOption(rowsProjection(20), "bar", opts()) as Record<string, unknown>;
+    const titled = buildChartOption(rowsProjection(20, "City"), "bar", opts()) as Record<
+      string,
+      unknown
+    >;
+    expect(xLabelOf(titled).rotate).toBe(30);
+    expect(bottomOf(titled)).toBeGreaterThan(bottomOf(noTitle));
+  });
+
+  test("waterfall rotated labels also reserve bottom room", () => {
+    const flat = buildChartOption(rowsProjection(4), "waterfall", opts()) as Record<string, unknown>;
+    const rotated = buildChartOption(rowsProjection(20), "waterfall", opts()) as Record<
+      string,
+      unknown
+    >;
+    expect(bottomOf(rotated)).toBeGreaterThan(bottomOf(flat));
+  });
+});
+
+// ---------------------------------------------------------------------------
 // #1596: axis TITLES. Charts were rendering with bare axis numbers and no
 // measure/dimension name. The value axis defaults to the measure name(s)
 // (columnCategories); the category axis defaults to the row dimension name the

--- a/saiku-ui/src/lib/charts/build.ts
+++ b/saiku-ui/src/lib/charts/build.ts
@@ -624,7 +624,16 @@ export function buildChartOption(
   // y-side had 50+ series (user feedback 2026-06-07: a single "Cust…"
   // label clipped to 5 chars on a 1400px-wide chart). Callers pass the
   // axis-specific count explicitly via {@link catLabel}.
-  const ROTATED_LABEL_WIDTH = 160;
+  // #1598: when the category axis crowds, tick labels rotate to read diagonally.
+  // The truncation width is RESPONSIVE — compact tiles thin aggressively (a short
+  // cap, so long city names ellipsize early instead of sprawling off a small
+  // tile), roomy charts show more. axisLabelConfig gives every rotated label
+  // `overflow:"truncate"` + `ellipsis`, so an over-long label ends in "…" rather
+  // than clipping. The matching grid.bottom reservation is `rotatedTickBottom()`
+  // below — the two are derived from the same width + angle so they never
+  // disagree.
+  const ROTATED_LABEL_ANGLE = 30;
+  const ROTATED_LABEL_WIDTH = compact ? 72 : 160;
   const catLabel = (rotate = 0, axisCategoryCount = cols.length || 1) => {
     if (rotate !== 0) {
       return {
@@ -637,6 +646,23 @@ export function buildChartOption(
       ? 100
       : deriveAxisLabelWidth(geom.chartWidth ?? 0, axisCategoryCount);
     return { color: tk.fgMuted, rotate, ...axisLabelConfig(w) };
+  };
+
+  // #1598: extra grid.bottom (px) a rotated tick label needs so its DIAGONAL DROP
+  // clears the plot instead of clipping at the tile edge. A label capped at
+  // ROTATED_LABEL_WIDTH and rotated ROTATED_LABEL_ANGLE° drops width·sin θ and its
+  // glyph box adds line·cos θ; we reserve only the part BEYOND the single
+  // horizontal label row that the base grid.bottom already covers. Returns 0 when
+  // the axis isn't rotated (legacy layout unchanged). This is TICK-label room and
+  // is added ALONGSIDE #1596's axis-NAME room (catNameBottomPad) — the two are
+  // independent and compose, so a rotated axis that also has a dimension title
+  // reserves room for both.
+  const ROTATED_TICK_LINE_PX = 16;
+  const rotatedTickBottom = (rotated: boolean): number => {
+    if (!rotated) return 0;
+    const rad = (ROTATED_LABEL_ANGLE * Math.PI) / 180;
+    const extent = ROTATED_LABEL_WIDTH * Math.sin(rad) + ROTATED_TICK_LINE_PX * Math.cos(rad);
+    return Math.max(0, Math.ceil(extent) - ROTATED_TICK_LINE_PX);
   };
 
   const legend = compact ? compactLegend(o, tk) : legendConfig(o, tk);
@@ -1043,13 +1069,15 @@ export function buildChartOption(
             top: title ? TITLE_GRID_TOP : 24,
             left: 48 + VALUE_NAME_LEFT_PAD,
             right: 16,
-            bottom: 56 + catNameBottomPad(rows.length > 8),
+            // #1598: + rotatedTickBottom so rotated tick labels don't clip.
+            bottom: 56 + catNameBottomPad(rows.length > 8) + rotatedTickBottom(rows.length > 8),
           }
         : {
             left: 60 + VALUE_NAME_LEFT_PAD,
             top: title ? 50 : 30,
             right: 40,
-            bottom: 56 + catNameBottomPad(rows.length > 8),
+            // #1598: + rotatedTickBottom so rotated tick labels don't clip.
+            bottom: 56 + catNameBottomPad(rows.length > 8) + rotatedTickBottom(rows.length > 8),
           },
       // waterfall is a single ordered sequence — no useful "zoom window"
       // semantics. Inside-zoom stays for power users, slider hidden.
@@ -1057,8 +1085,8 @@ export function buildChartOption(
       xAxis: {
         ...baseAxis,
         // waterfall's x-axis is `rows`; pass rows.length so the
-        // per-label width is computed against the right dim.
-        axisLabel: catLabel(rows.length > 8 ? 30 : 0, rows.length),
+        // per-label width is computed against the right dim. #1598: angle const.
+        axisLabel: catLabel(rows.length > 8 ? ROTATED_LABEL_ANGLE : 0, rows.length),
         data: rows,
         // #1596: category-dimension title (or the user override).
         ...catNameCfg(rows.length > 8),
@@ -1226,13 +1254,18 @@ export function buildChartOption(
           top: title ? TITLE_GRID_TOP : 24,
           left: 48 + VALUE_NAME_LEFT_PAD,
           right: 16,
-          bottom: 36 + catNameBottomPad(xRotated),
+          // #1598: + rotatedTickBottom so rotated tick labels don't clip.
+          bottom: 36 + catNameBottomPad(xRotated) + rotatedTickBottom(xRotated),
         }
       : {
           left: 60 + VALUE_NAME_LEFT_PAD,
           top: title ? 50 : 40,
           right: hasRight ? 60 : 40,
-          bottom: (rows.length >= ZOOM_SLIDER_MIN_CATEGORIES ? 76 : 40) + catNameBottomPad(xRotated),
+          // #1598: + rotatedTickBottom so rotated tick labels clear the slider/edge.
+          bottom:
+            (rows.length >= ZOOM_SLIDER_MIN_CATEGORIES ? 76 : 40) +
+            catNameBottomPad(xRotated) +
+            rotatedTickBottom(xRotated),
         },
     // bar / line / area: x-axis is `rows`.
     dataZoom: dataZoomConfig(compact, rows.length), // #1080: x-axis zoom + pan
@@ -1242,8 +1275,8 @@ export function buildChartOption(
       // per-label width is computed against the right dim — the old
       // max(rows, cols) cramped scatter / bar single-category x-axes
       // to 40px when the y side had many series ("Cust…" / "CA /…"
-      // 2026-06-07 screenshot).
-      axisLabel: catLabel(xRotated ? 30 : 0, rows.length),
+      // 2026-06-07 screenshot). #1598: rotate uses ROTATED_LABEL_ANGLE.
+      axisLabel: catLabel(xRotated ? ROTATED_LABEL_ANGLE : 0, rows.length),
       data: rows,
       // #1596: category-dimension title (or the user override); nothing drawn
       // when neither is present.


### PR DESCRIPTION
## What & why

Long bar-chart category (x-axis) labels — city names like "Beverly Hills" or "San Francisco" — rotate ~30° once there are more than 8 categories and drop diagonally below the axis. `grid.bottom` didn't reserve room for that vertical drop, so the labels were clipped at the bottom edge of the chart/tile (#1598).

## Changes (all in `charts/build.ts`, the ECharts option builder)

- **Reserve bottom room for the rotated drop.** New `rotatedTickBottom(rotated)` helper computes the vertical extent a width-capped label projects when rotated (`width·sin θ + line·cos θ`), reserving only the part beyond the single horizontal label row the base `grid.bottom` already covers. Added to the `grid.bottom` of the bar/line/area branch and the waterfall branch. Returns 0 when the axis isn't rotated, so the non-rotated layout is unchanged.
- **Composes with the axis-title room.** The tick-label reserve is added *alongside* the existing `catNameBottomPad` (the #1596 axis-name room), not in place of it — an axis with both a rotated tick label and a dimension title now reserves room for each.
- **Responsive truncation width.** `ROTATED_LABEL_WIDTH` is now `compact ? 72 : 160` — compact dashboard tiles thin the label harder (earlier ellipsis, smaller drop), roomy workspace charts keep the wider budget. Rotated labels already carry `overflow:"truncate"` + `ellipsis`, so an over-long label ends in a "…" instead of clipping.
- Rotation angle is now the named `ROTATED_LABEL_ANGLE` (30°) shared by the axis-label config and the bottom-reserve math, so the two can't drift apart.

## Tests

Added a `rotated category label clipping (#1598)` describe block in `build.test.ts`: rotated axis ellipsizes with a truncation width; rotated reserves more `grid.bottom` than a flat axis; compact thins harder and reserves less than roomy; tick-room and axis-title room compose additively; waterfall covered too. `npm run check` clean (0 errors); full `build.test.ts` green (116 tests).

Fixes #1598