### PR TITLE
fix(charts): drop the top legend below the title band on titled charts

### DIFF
--- a/saiku-ui/src/lib/charts/build.test.ts
+++ b/saiku-ui/src/lib/charts/build.test.ts
@@ -253,6 +253,32 @@ describe("buildChartOption — title & legend", () => {
     expect((compactBare.grid as { top: number }).top).toBe(24);
   });
 
+  test("#1622 titled chart pushes a top legend below the #1595 title band", () => {
+    // Titled + top legend: legend drops below the title band (title.top:8) so
+    // it no longer draws on top of the title text.
+    const titledTop = buildChartOption(sample(), "bar", opts({ title: "My chart", legendPosition: "top" })) as Record<
+      string,
+      unknown
+    >;
+    expect((titledTop.legend as { top: number }).top).toBe(32);
+
+    // No title + top legend: unchanged default (top:10).
+    const untitledTop = buildChartOption(sample(), "bar", opts({ title: "", legendPosition: "top" })) as Record<
+      string,
+      unknown
+    >;
+    expect((untitledTop.legend as { top: number }).top).toBe(10);
+
+    // Titled but non-top legend: unchanged (only the top legend overlapped).
+    const titledBottom = buildChartOption(
+      sample(),
+      "bar",
+      opts({ title: "My chart", legendPosition: "bottom" }),
+    ) as Record<string, unknown>;
+    expect((titledBottom.legend as { bottom: number }).bottom).toBe(10);
+    expect((titledBottom.legend as { top?: number }).top).toBeUndefined();
+  });
+
   test("compact legend defaults to a bottom scroll legend (legacy-tile parity)", () => {
     const opt = buildChartOption(sample(), "bar", opts({ legendPosition: "bottom" }), undefined, {
       compact: true,

--- a/saiku-ui/src/lib/charts/build.ts
+++ b/saiku-ui/src/lib/charts/build.ts
@@ -82,7 +82,11 @@ export interface ChartGeometry {
 function legendConfig(o: ChartOptions, tk: ThemeTokens): Record<string, unknown> {
   if (!o.showLegend) return { show: false };
   const position: Record<string, unknown> = { textStyle: { color: tk.fg } };
-  if (o.legendPosition === "top") position.top = 10;
+  // #1622: with a title present the #1595 title band sits at the very top
+  // (title.top:8); a top legend at the default top:10 would draw on top of it
+  // and read as missing. Push the legend below the title band when titled;
+  // untitled charts keep the original top:10.
+  if (o.legendPosition === "top") position.top = o.title ? 32 : 10;
   else if (o.legendPosition === "bottom") position.bottom = 10;
   else if (o.legendPosition === "left") {
     position.left = 10;


### PR DESCRIPTION
## What

On a titled chart the top legend disappeared behind the title. #1595 gave the chart title its own band pinned to the top (`title.top: 8`), but the default top legend still sat at `top: 10`, so it drew on top of the title text and read as a missing legend.

## Fix

In `legendConfig` (`saiku-ui/src/lib/charts/build.ts`), when a title is present **and** the legend is at the top, push the legend down to `top: 32` — below the title band, mirroring the `grid.top` reservation #1595 added for the plot. Untitled charts keep the original `top: 10`, and legends on the bottom/left/right are untouched.

## Scope

- Only the top-legend `top` value changes, gated on `o.title` being set. No title, or a non-top legend, is byte-for-byte unchanged.
- Compact/dashboard tile legends are not touched.

## Test

Added a case to `build.test.ts`: titled + top legend → `legend.top === 32`; untitled + top legend → `legend.top === 10`; titled + bottom legend → `legend.bottom === 10` with no `top`. Full suite (116 tests) and `npm run check` pass.

Fixes #1622
