### PR TITLE
feat: migrate the visual cube/schema designer into Saiku (admin + backend + AI)

### DIFF
--- a/docs/plans/2026-07-31-cube-designer-migration.md
+++ b/docs/plans/2026-07-31-cube-designer-migration.md
@@ -25,7 +25,15 @@ saiku-cloud #1180).
   (rename / hierarchy / aggregator / degenerateDim / ignore) applied via `POST /{sessionId}/ops`,
   persisted through `MondrianSchemaWriter`.
 
-So the migration is a **reconciliation**, not greenfield. **Decision D1 (below) is which model wins.**
+So the migration is a **reconciliation**, not greenfield.
+
+**Decision D1 — RESOLVED: replace.** The old server-driven schema-generator is retired; the Svelte
+canvas designer becomes *the* OSS cube designer. Nuance to honour: "remove the schema-generator" means
+retiring its **UI + SuggestionOp orchestration** (`/admin/schema-generator/[dataSourceId]` route,
+`src/lib/components/schemagen/*`, `schemaGen.ts`, the `SchemaGeneratorResource` session/ops/suggestions
+surface). Its **low-level building blocks stay and get repurposed** behind the new thin endpoints — the
+new designer still needs introspection (`JdbcIntrospector`) and a Mondrian writer/save path
+(`MondrianSchemaWriter`). So we delete the orchestration + UI, keep the primitives.
 
 ## Stack + primitive parity (the easy part)
 
@@ -70,15 +78,23 @@ wrapping capability that already exists server-side.
 
 ## DimSum (the AI) — injected capability
 
-Per the agreed model, DimSum is an **optional injected capability**. saiku-ui's "DimSum" is
-NL-to-query (fixed 4-tool set: query / insight / view_change / refusal, cube-locked) — the **wrong
-shape** for schema authoring. The reusable parts are the transport (`ask/chain/stream` SSE,
-`aiAsk.ts` parser) and the `AgentSpace`/`AgentSkill` persona plumbing; the tools would need to be a
-new schema-authoring set emitting `SuggestionOp`s against a schema-gen session.
+**Decision D2 — RESOLVED: build OSS schema-authoring AI now.**
 
-**Recommendation for OSS v1:** ship the designer's AI **slot empty** in OSS (manual designer only);
-Cloud keeps its gateway-backed DimSum. Building an OSS schema-authoring agent is a separate follow-up,
-not a blocker for the migration.
+Key architecture point: the designer's DimSum **tool executors already run client-side**
+(`dimsum-tools.ts` mutates `SchemaCanvasStore` via `add_table` / `add_join` / `create_dimension` /
+`add_measure` / …). The server's only job is one **agent turn**: own the system prompt + schema-authoring
+tool schemas, call the LLM, and return the tool-use blocks for the client to execute — exactly what the
+Cloud gateway's `/me/inference/dimsum` does. So the OSS build is a **new Saiku endpoint** (e.g.
+`POST /rest/saiku/api/ai/cube-designer/turn`) that:
+
+- reuses `AiAskService`'s LLM plumbing (provider call, streaming) + the `AgentSpace`/`AgentSkill`
+  persona/skills infra as-is,
+- carries a **schema-authoring** system prompt + the designer's client-side canvas tool schemas
+  (NOT the query-oriented `query/insight/view_change/refusal` set, and NOT server `SuggestionOp`s),
+- returns `{ content: AnthropicBlock[] }` for the client's existing agent loop.
+
+The OSS `CubeDesignerAI` adapter's `fetchImpl` points DimSum at this endpoint; Cloud keeps its
+gateway-backed one. This reuses Saiku's AI transport wholesale — only the tool set + prompt differ.
 
 ## Admin wiring
 
@@ -95,12 +111,25 @@ dynamic route**. Follow that precedent: `src/routes/admin/cube-designer/[dataSou
 - **1b — move the components**: copy `schema-canvas/**` into `saiku-ui/src/lib/cube-designer/`;
   reconcile primitives (Popover wrap, lucide rename, `$lib` paths). svelte-check green; port the store
   tests (they travel unchanged).
-- **1c — OSS backend endpoints**: the 3 REST wrappers (introspect, sample, m3→m4). Integration-test each.
+- **1c — OSS backend endpoints**: the 3 REST wrappers over existing building blocks — introspect
+  (`JdbcIntrospector`), table-sample, m3→m4-convert (`RolapSchemaUpgrader`). Integration-test each.
 - **1d — OSS adapter + admin route**: `src/lib/cube-designer/oss-backend.ts` mapping the interface to
-  the new + existing endpoints; the `/admin/cube-designer/[dataSourceId]` route wiring it.
-- **1e — publish** the package from saiku-ui's release flow.
-- **1f — saiku-cloud consumes** the published package (replace its local `schema-canvas/` dir with the
+  the new + existing endpoints; the dedicated `/admin/cube-designer/[dataSourceId]` route (mirrors
+  schema-generator; launched from a `DatasourcesAdmin` action; `prerender=false`).
+- **1e — OSS DimSum endpoint** (D2): `POST /rest/saiku/api/ai/cube-designer/turn` — schema-authoring
+  agent turn over `AiAskService`, returning tool-use blocks the client executes; wire the OSS
+  `CubeDesignerAI` adapter to it.
+- **1f — retire the old schema-generator** (D1): remove the `/admin/schema-generator` route,
+  `components/schemagen/*`, `schemaGen.ts`, and the `SchemaGeneratorResource` orchestration
+  (session/ops/suggestions), keeping `JdbcIntrospector` + `MondrianSchemaWriter` (now used by 1c).
+  Update `DatasourcesAdmin` action → the new designer.
+- **1g — publish** the package from saiku-ui's release flow.
+- **1h — saiku-cloud consumes** the published package (replace its local `schema-canvas/` dir with the
   dep + its gateway adapter); delete the local copy. All saiku-cloud prototype + live smokes stay green.
+
+**Note on the other developer:** 1f deletes a recently-built OSS surface (schema-generator). Coordinate
+before merging — the removal PR should be explicit and land after the replacement is in place, so
+`development` is never left without a designer.
 
 ## Rollback
 
@@ -108,12 +137,12 @@ Each phase is independently revertable. The package is additive to saiku-ui unti
 its local copy until the published package is proven, so the consume step (1f) is a swap that can be
 reverted by restoring the local dir. No engine/data-plane changes.
 
-## Open decisions (need your call before 1b)
+## Decisions (resolved 2026-07-31)
 
-- **D1 — Two designers or one?** Ship the Svelte canvas designer **alongside** the existing
-  schema-generator (fastest; two overlapping surfaces for a while), or **converge** the Svelte UI onto
-  the schema-generator's `SuggestionOp` backend (less duplication, much more reconciliation)?
-  *Recommendation: alongside for v1, converge later.*
-- **D2 — DimSum in OSS v1?** Empty AI slot (recommended) vs build the schema-authoring agent now.
-- **D3 — Package name/registry.** `@concepttocloud/saiku-cube-designer` on public npm (mirrors embed)?
-- **D4 — Admin surface.** Dedicated route (recommended, mirrors schema-generator) vs a new admin SPA tab.
+- **D1 — Replace.** Retire the old server-driven schema-generator (UI + SuggestionOp orchestration);
+  the Svelte canvas designer becomes the OSS cube designer. Keep + repurpose `JdbcIntrospector` +
+  `MondrianSchemaWriter`.
+- **D2 — Build OSS AI now.** New `.../ai/cube-designer/turn` endpoint over `AiAskService`, returning
+  tool-use blocks for the client's existing agent loop (client-side canvas tools; not SuggestionOps).
+- **D3 — `@concepttocloud/saiku-cube-designer`** on public npm (mirrors `embed`).
+- **D4 — Dedicated route**, mirroring the schema-generator.

--- a/docs/plans/2026-07-31-cube-designer-migration.md
+++ b/docs/plans/2026-07-31-cube-designer-migration.md
@@ -1,0 +1,119 @@
+# Cube/Schema Designer migration into OSS Saiku — Phase 1 plan
+
+**Status:** draft for review · **Branch:** `feature/cube-designer` (worktree) · **Date:** 2026-07-31
+
+## Goal
+
+Open-source the visual **cube/schema designer** (the SvelteKit canvas + inspector +
+workbench, ~25k LOC) that currently lives in the closed `saiku-cloud` dashboard, by
+moving it into `saiku-ui`, wiring it into the **admin panel**, and publishing it as a
+reusable npm package that `saiku-cloud` consumes back — **no code duplication**.
+
+Prep already done in `saiku-cloud` (Phase 0, shipped): the designer's backend calls were
+refactored behind an injected `CubeDesignerBackend` (+ optional `CubeDesignerAI`) resolved
+from Svelte context, so each host supplies its own adapter. The components hard-code no
+backend URL. `SchemaCanvasStore`'s behaviour is now locked by tests (72 store tests,
+saiku-cloud #1180).
+
+## The headline finding — OSS already has a cube designer
+
+`saiku-ui` ships a **server-driven schema generator** that overlaps the designer:
+
+- Client: `src/lib/api/schemaGen.ts` (base `/rest/saiku/admin/schema-generator`)
+- Route: `src/routes/admin/schema-generator/[dataSourceId]/+page.svelte`
+- Backend: `SchemaGeneratorResource.java` + a `SuggestionOp` model
+  (rename / hierarchy / aggregator / degenerateDim / ignore) applied via `POST /{sessionId}/ops`,
+  persisted through `MondrianSchemaWriter`.
+
+So the migration is a **reconciliation**, not greenfield. **Decision D1 (below) is which model wins.**
+
+## Stack + primitive parity (the easy part)
+
+`saiku-ui` is the same stack (SvelteKit 2 + Svelte 5 + Tailwind v4 + `bits-ui` + `tailwind-variants`).
+Primitive reconciliation for the port:
+
+| Designer needs | saiku-ui | Action |
+|---|---|---|
+| `components/ui/button.svelte` | ✅ identical path + `tailwind-variants` | none |
+| `design-system/SortableColumnHeader` | ✅ identical | verify prop shape |
+| `design-system/FeedbackBanner` | ✅ identical | verify tone vocab |
+| `design-system/primitives/Popover` | ❌ absent (only `Tooltip`) | **wrap `bits-ui` Popover** (already a dep) like `components/ui/tooltip.svelte` |
+| `@lucide/svelte` | ❌ uses older `lucide-svelte ^1` | **rename import** across the designer (icon names match) |
+
+## Publish recipe (mirror `embed-npm`)
+
+saiku-ui already publishes sub-packages from its `dist/`:
+- `vite.config.embed.ts` — standalone lib-mode build, `emptyOutDir:false`, unique filename.
+- `scripts/stage-embed-npm.mjs` — copies bundle + rewrites a committed `package.template.json`
+  (name `@concepttocloud/saiku-embed`), version tracked from `saiku-ui/package.json`, generated
+  `package.json` is git-ignored.
+- `.github/workflows/release.yml` job `npm-embed` → **published to public npm (npmjs.org)**, not
+  GitHub Packages (correction to the earlier assumption — only the Java jars go to GH Packages).
+
+**Recipe for `@concepttocloud/saiku-cube-designer`:** copy `vite.config.embed.ts` (ESM lib, drop
+`customElement`), add `cube-designer-npm/package.template.json` + stage script, chain a resilient
+`build:cube-designer*` into `build`, add a release.yml publish job. Must not clobber
+`dist/{index.html,saiku-embed.js}` (unique output filename; `emptyOutDir:false`).
+
+## Backend adapter mapping (the hard part) — Saiku REST → `CubeDesignerBackend`
+
+| Adapter method | OSS backing | Status |
+|---|---|---|
+| `loadSchema` | `repository.ts` (`/api/repository/resource`) + `adminSchemas` + schemagen save | ✅ covered |
+| `tryQuery` | `query.ts` `POST /api/query/execute` (ThinQuery) | ✅ covered |
+| `profileConnection` (raw tables/columns) | `JdbcIntrospector` exists but only invoked internally by schemagen `start` — **no standalone REST** | ⚠️ **gap** — either drive via schemagen `start`→`draft`, or add a small read-only `/introspect` endpoint |
+| `sample` (preview rows for an arbitrary JDBC table) | only SQL-preview + OSSIE row-detail exist | ⚠️ **gap** — add a thin `SELECT … LIMIT n` endpoint (or reuse the introspector path) |
+| `convertSchema` (M3→M4) | no converter class in `saiku-core`; but the **Mondrian-4 fork (`pentaho:mondrian:4.8.1.x`, `RolapSchemaUpgrader`) is already a Saiku dependency** — this is what saiku-cloud's gateway already proxies to | ⚠️ **gap = a thin REST wrapper** around the existing upgrader, not a from-scratch converter |
+
+Net backend work: **3 small REST endpoints** (introspect, table-sample, m3→m4-convert-wrapper), each
+wrapping capability that already exists server-side.
+
+## DimSum (the AI) — injected capability
+
+Per the agreed model, DimSum is an **optional injected capability**. saiku-ui's "DimSum" is
+NL-to-query (fixed 4-tool set: query / insight / view_change / refusal, cube-locked) — the **wrong
+shape** for schema authoring. The reusable parts are the transport (`ask/chain/stream` SSE,
+`aiAsk.ts` parser) and the `AgentSpace`/`AgentSkill` persona plumbing; the tools would need to be a
+new schema-authoring set emitting `SuggestionOp`s against a schema-gen session.
+
+**Recommendation for OSS v1:** ship the designer's AI **slot empty** in OSS (manual designer only);
+Cloud keeps its gateway-backed DimSum. Building an OSS schema-authoring agent is a separate follow-up,
+not a blocker for the migration.
+
+## Admin wiring
+
+Admin is a tabbed SPA (`/admin/+page.svelte`), except the schema-generator which is a **dedicated
+dynamic route**. Follow that precedent: `src/routes/admin/cube-designer/[dataSourceId]/+page.svelte`
+(`prerender=false`), launched from a per-datasource action in `DatasourcesAdmin.svelte`, returning to
+`/admin?tab=datasources`. The route provides the OSS `CubeDesignerBackend` via `setCubeDesignerBackend`.
+
+## Phased steps
+
+- **1a — package skeleton** (saiku-ui): add the build + stage + template + release job for
+  `@concepttocloud/saiku-cube-designer` producing an empty/placeholder export. Prove publish plumbing
+  before moving code.
+- **1b — move the components**: copy `schema-canvas/**` into `saiku-ui/src/lib/cube-designer/`;
+  reconcile primitives (Popover wrap, lucide rename, `$lib` paths). svelte-check green; port the store
+  tests (they travel unchanged).
+- **1c — OSS backend endpoints**: the 3 REST wrappers (introspect, sample, m3→m4). Integration-test each.
+- **1d — OSS adapter + admin route**: `src/lib/cube-designer/oss-backend.ts` mapping the interface to
+  the new + existing endpoints; the `/admin/cube-designer/[dataSourceId]` route wiring it.
+- **1e — publish** the package from saiku-ui's release flow.
+- **1f — saiku-cloud consumes** the published package (replace its local `schema-canvas/` dir with the
+  dep + its gateway adapter); delete the local copy. All saiku-cloud prototype + live smokes stay green.
+
+## Rollback
+
+Each phase is independently revertable. The package is additive to saiku-ui until 1f; saiku-cloud keeps
+its local copy until the published package is proven, so the consume step (1f) is a swap that can be
+reverted by restoring the local dir. No engine/data-plane changes.
+
+## Open decisions (need your call before 1b)
+
+- **D1 — Two designers or one?** Ship the Svelte canvas designer **alongside** the existing
+  schema-generator (fastest; two overlapping surfaces for a while), or **converge** the Svelte UI onto
+  the schema-generator's `SuggestionOp` backend (less duplication, much more reconciliation)?
+  *Recommendation: alongside for v1, converge later.*
+- **D2 — DimSum in OSS v1?** Empty AI slot (recommended) vs build the schema-authoring agent now.
+- **D3 — Package name/registry.** `@concepttocloud/saiku-cube-designer` on public npm (mirrors embed)?
+- **D4 — Admin surface.** Dedicated route (recommended, mirrors schema-generator) vs a new admin SPA tab.

--- a/saiku-core/saiku-service/src/main/java/mondrian/rolap/M3ToM4Converter.java
+++ b/saiku-core/saiku-service/src/main/java/mondrian/rolap/M3ToM4Converter.java
@@ -1,0 +1,256 @@
+package mondrian.rolap;
+
+import java.io.PrintWriter;
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.util.Locale;
+import java.util.Properties;
+import java.util.logging.Logger;
+import javax.sql.DataSource;
+import mondrian.olap.MondrianDef;
+import mondrian.olap.Util;
+import mondrian.util.ByteString;
+import org.eigenbase.xom.DOMWrapper;
+import org.eigenbase.xom.Parser;
+import org.eigenbase.xom.XOMUtil;
+
+/**
+ * Converts a Mondrian&nbsp;3 (legacy) schema XML to a real Mondrian&nbsp;4
+ * schema (<code>metamodelVersion="4.x"</code>, {@code <PhysicalSchema>},
+ * {@code <MeasureGroups>}) using the engine's OWN
+ * {@link RolapSchemaUpgrader#upgrade} — the exact code Mondrian&nbsp;4 runs
+ * when it loads a legacy schema, so the output is faithful (calculated
+ * members, annotations, degenerate dims, time hierarchies all preserved),
+ * not a hand-rolled transform.
+ *
+ * <p>Lives in package {@code mondrian.rolap} because the upgrader's entry
+ * points ({@code upgrade}, {@link SchemaKey}, {@link SchemaContentKey},
+ * {@link ConnectionKey}, the {@code RolapSchemaLoader(null)} ctor) are
+ * package-private. Exposes ONE public method so callers (the engine's
+ * convert endpoint) can drive it by reflection without a compile-time
+ * Mondrian dependency.
+ *
+ * <h2>Requires the tables to exist</h2>
+ * The upgrader introspects JDBC metadata for every referenced table +
+ * column (a missing table/column is fatal), so the target warehouse must
+ * already contain the schema's tables with the right columns — rows are NOT
+ * required. Callers get a typed {@link ConversionException}
+ * ({@link Failure#TABLES_MISSING} / {@link Failure#CONNECTION_FAILED} /
+ * {@link Failure#NOT_UPGRADABLE}) so they can 422 with an actionable message.
+ */
+public final class M3ToM4Converter {
+
+    private static final org.slf4j.Logger LOG = org.slf4j.LoggerFactory.getLogger(M3ToM4Converter.class);
+
+    /** Why a conversion could not be produced. */
+    public enum Failure {
+        /** A table (or column) the schema references does not exist in the warehouse. */
+        TABLES_MISSING,
+        /**
+         * The warehouse connection could not be opened at all (unreachable host,
+         * wrong credentials, bad JDBC URL). Distinct from a schema problem — the
+         * caller should fix the connection, not the schema.
+         */
+        CONNECTION_FAILED,
+        /** The schema is malformed / uses a construct the upgrader rejects. */
+        NOT_UPGRADABLE
+    }
+
+    /** Thrown when the M3 schema cannot be upgraded. */
+    public static final class ConversionException extends Exception {
+        private static final long serialVersionUID = 1L;
+        private final Failure failure;
+
+        ConversionException(Failure failure, String message, Throwable cause) {
+            super(message, cause);
+            this.failure = failure;
+        }
+
+        public Failure failure() {
+            return failure;
+        }
+
+        /** Machine token for the API body: {@code tables_missing} / {@code not_upgradable}. */
+        public String token() {
+            return failure.name().toLowerCase(Locale.ROOT);
+        }
+    }
+
+    private M3ToM4Converter() {}
+
+    /**
+     * Convert legacy Mondrian-3 XML to Mondrian-4 XML, resolving physical
+     * tables against the given warehouse connection.
+     *
+     * @param m3Xml    the Mondrian 3 (legacy) schema XML
+     * @param jdbcUrl  the warehouse JDBC URL (drives dialect detection)
+     * @param user     JDBC user (may be null — some URLs carry auth inline)
+     * @param password JDBC password (may be null)
+     * @return real Mondrian 4 schema XML
+     * @throws ConversionException with a typed {@link Failure} on any failure
+     */
+    public static String convert(String m3Xml, String jdbcUrl, String user, String password)
+            throws ConversionException {
+        NonClosingSingleConnectionDataSource ds = null;
+        try {
+            // Opening the warehouse connection is part of the conversion, so
+            // keep it inside the try: a connect failure (unreachable host, wrong
+            // credentials, malformed URL) then classifies as a typed
+            // CONNECTION_FAILED instead of escaping as an untyped 500.
+            ds = new NonClosingSingleConnectionDataSource(jdbcUrl, user, password);
+
+            Parser parser = XOMUtil.createDefaultParser();
+            parser.setKeepPositions(true);
+            DOMWrapper def = parser.parse(m3Xml);
+
+            RolapSchemaLoader loader = new RolapSchemaLoader(null);
+            Util.PropertyList connectInfo = Util.parseConnectString("Provider=mondrian;Jdbc=" + jdbcUrl);
+            ByteString md5 = new ByteString(Util.digestMd5(m3Xml));
+            SchemaKey key = new SchemaKey(
+                    SchemaContentKey.create(connectInfo, "cloud:convert", m3Xml),
+                    ConnectionKey.create(null, ds, "cloud:convert", null, null, null, null));
+
+            MondrianDef.Schema m4 = RolapSchemaUpgrader.upgrade(loader, def, key, md5, connectInfo, ds, false);
+            return m4.toXML();
+        } catch (Throwable t) {
+            throw classify(t);
+        } finally {
+            if (ds != null) {
+                ds.closeUnderlying();
+            }
+        }
+    }
+
+    /** Map an upgrader failure to a typed {@link ConversionException}. */
+    private static ConversionException classify(Throwable t) {
+        // Walk the cause chain — the informative message can be nested.
+        for (Throwable c = t; c != null; c = c.getCause()) {
+            String m = c.getMessage();
+            if (m != null && m.toLowerCase(Locale.ROOT).contains("does not exist in database")) {
+                LOG.info("M3->M4 conversion: referenced table missing ({})", m);
+                return new ConversionException(
+                        Failure.TABLES_MISSING,
+                        "the schema references a table that does not exist in the warehouse",
+                        t);
+            }
+        }
+        // A failure to OPEN the warehouse connection — the datasource ctor wraps
+        // the driver's SQLException in this exact IllegalStateException message.
+        // Checked after TABLES_MISSING (a missing-relation error is more
+        // specific) but before the NOT_UPGRADABLE fallback.
+        for (Throwable c = t; c != null; c = c.getCause()) {
+            String m = c.getMessage();
+            if (m != null && m.contains("could not open warehouse connection")) {
+                LOG.info("M3->M4 conversion: warehouse connection could not be opened ({})", m);
+                return new ConversionException(
+                        Failure.CONNECTION_FAILED, "could not connect to the warehouse to upgrade the schema", t);
+            }
+        }
+        LOG.warn("M3->M4 conversion failed", t);
+        return new ConversionException(Failure.NOT_UPGRADABLE, "the schema could not be upgraded to Mondrian 4", t);
+    }
+
+    /**
+     * A {@link DataSource} that hands out ONE underlying connection, wrapped so
+     * {@code close()} is a no-op — Mondrian opens + closes several connections
+     * during a schema load, and (for a file-backed embedded DB like the test's
+     * DuckDB) they must share the same session. A concrete class, so its
+     * identity {@code hashCode}/{@code equals} satisfy Mondrian's
+     * {@code DialectManager} WeakHashMap key requirement.
+     */
+    static final class NonClosingSingleConnectionDataSource implements DataSource {
+        private final Connection shared;
+
+        NonClosingSingleConnectionDataSource(String url, String user, String password) {
+            try {
+                Properties props = new Properties();
+                if (user != null) {
+                    props.put("user", user);
+                }
+                if (password != null) {
+                    props.put("password", password);
+                }
+                this.shared = DriverManager.getConnection(url, props);
+            } catch (java.sql.SQLException e) {
+                throw new IllegalStateException("could not open warehouse connection for conversion", e);
+            }
+        }
+
+        void closeUnderlying() {
+            try {
+                shared.close();
+            } catch (java.sql.SQLException ignore) {
+                // best-effort
+            }
+        }
+
+        @Override
+        public Connection getConnection() {
+            return (Connection) Proxy.newProxyInstance(
+                    getClass().getClassLoader(), new Class<?>[] {Connection.class}, new NonClosingHandler(shared));
+        }
+
+        @Override
+        public Connection getConnection(String username, String pwd) {
+            return getConnection();
+        }
+
+        @Override
+        public PrintWriter getLogWriter() {
+            return null;
+        }
+
+        @Override
+        public void setLogWriter(PrintWriter out) {}
+
+        @Override
+        public void setLoginTimeout(int seconds) {}
+
+        @Override
+        public int getLoginTimeout() {
+            return 0;
+        }
+
+        @Override
+        public Logger getParentLogger() {
+            return Logger.getGlobal();
+        }
+
+        @Override
+        public <T> T unwrap(Class<T> iface) {
+            return iface.cast(this);
+        }
+
+        @Override
+        public boolean isWrapperFor(Class<?> iface) {
+            return iface.isInstance(this);
+        }
+    }
+
+    /** Delegates every Connection method except close(), which is a no-op. */
+    private static final class NonClosingHandler implements InvocationHandler {
+        private final Connection target;
+
+        NonClosingHandler(Connection target) {
+            this.target = target;
+        }
+
+        @Override
+        public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
+            if ("close".equals(method.getName())) {
+                return null;
+            }
+            if ("isClosed".equals(method.getName())) {
+                return Boolean.FALSE;
+            }
+            try {
+                return method.invoke(target, args);
+            } catch (java.lang.reflect.InvocationTargetException e) {
+                throw e.getCause();
+            }
+        }
+    }
+}

--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ai/cubedesigner/CubeDesignerAiService.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ai/cubedesigner/CubeDesignerAiService.java
@@ -1,0 +1,164 @@
+/*
+ * Copyright 2026 Spicule Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ */
+package org.saiku.service.olap.ai.cubedesigner;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * The DimSum schema-authoring agent turn for the cube designer.
+ *
+ * <p>Saiku's built-in {@code /ai/ask} stack is a closed, hard-coded 6-tool query
+ * flow whose {@code NlAskResponse} collapses the model output to one payload — it
+ * cannot return raw content blocks or take an arbitrary tool set. So this
+ * replicates just the transport (JDK {@link HttpClient} → Anthropic Messages
+ * API, same as {@code AnthropicNlAskProvider}) but supplies the designer's OWN
+ * tool set + system prompt and returns the raw {@code content[]} untouched — the
+ * client (dimsum-tools.ts) executes the returned tool calls locally.
+ *
+ * <p>The tool schemas ({@code cube-designer/tools.json}) and system prompt
+ * ({@code cube-designer/system-prompt.md}) are the same contract the Cloud
+ * gateway uses, so the client's executors work unchanged. Config reuses the
+ * {@code saiku.ai.ask.*} placeholders / {@code ANTHROPIC_API_KEY} env.
+ */
+public class CubeDesignerAiService {
+
+    private static final Logger LOG = LoggerFactory.getLogger(CubeDesignerAiService.class);
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    private static final String DEFAULT_ENDPOINT = "https://api.anthropic.com/v1/messages";
+    private static final String DEFAULT_MODEL = "claude-sonnet-4-6";
+    private static final String API_VERSION = "2023-06-01";
+    private static final int MAX_TOKENS = 4096;
+
+    private final String apiKey;
+    private final String model;
+    private final String endpoint;
+    private final Duration timeout;
+    private final HttpClient http;
+
+    private final String systemPrompt;
+    private final JsonNode tools;
+
+    public CubeDesignerAiService(String apiKey, String model, String endpoint, int timeoutSeconds) {
+        this.apiKey = notBlank(apiKey) ? apiKey.trim() : System.getenv("ANTHROPIC_API_KEY");
+        this.model = notBlank(model) ? model.trim() : DEFAULT_MODEL;
+        this.endpoint = notBlank(endpoint) ? endpoint.trim() : DEFAULT_ENDPOINT;
+        int t = timeoutSeconds <= 0 ? 60 : Math.min(Math.max(timeoutSeconds, 5), 900);
+        this.timeout = Duration.ofSeconds(t);
+        this.http = HttpClient.newHttpClient();
+        this.systemPrompt = loadResource("/cube-designer/system-prompt.md");
+        this.tools = loadJsonResource("/cube-designer/tools.json");
+    }
+
+    /** True when an API key is configured — callers should 503 when this is false. */
+    public boolean isConfigured() {
+        return notBlank(apiKey);
+    }
+
+    /**
+     * Run one agent turn. Returns the Anthropic response's {@code content} array
+     * (text + tool_use blocks) verbatim, for the client to render + execute.
+     *
+     * @throws IllegalStateException if the AI is not configured (no API key)
+     * @throws IOException on a transport / upstream error
+     */
+    public JsonNode turn(JsonNode messages, String canvasSummary) throws IOException {
+        if (!isConfigured()) {
+            throw new IllegalStateException("cube-designer AI is not configured (no API key)");
+        }
+        String body = buildRequestBody(messages, canvasSummary);
+        HttpRequest req = HttpRequest.newBuilder()
+                .uri(URI.create(endpoint))
+                .timeout(timeout)
+                .header("content-type", "application/json")
+                .header("x-api-key", apiKey)
+                .header("anthropic-version", API_VERSION)
+                .POST(HttpRequest.BodyPublishers.ofString(body, StandardCharsets.UTF_8))
+                .build();
+        HttpResponse<String> resp;
+        try {
+            resp = http.send(req, HttpResponse.BodyHandlers.ofString());
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new IOException("cube-designer AI call interrupted", e);
+        }
+        if (resp.statusCode() / 100 != 2) {
+            LOG.warn("cube-designer AI turn upstream {} ", resp.statusCode());
+            throw new IOException("AI provider returned HTTP " + resp.statusCode());
+        }
+        return parseContent(resp.body());
+    }
+
+    /**
+     * Build the Anthropic Messages request body: the designer's tool set + system
+     * prompt (with the per-turn canvas state appended), the caller's messages
+     * verbatim, and {@code tool_choice:auto} (DimSum both calls tools and emits
+     * closing prose). Package-visible for unit testing without a network call.
+     */
+    String buildRequestBody(JsonNode messages, String canvasSummary) {
+        ObjectNode root = MAPPER.createObjectNode();
+        root.put("model", model);
+        root.put("max_tokens", MAX_TOKENS);
+        String system = systemPrompt;
+        if (notBlank(canvasSummary)) {
+            system = systemPrompt + "\n\n# CURRENT CANVAS STATE\n" + canvasSummary;
+        }
+        root.put("system", system);
+        root.set("tools", tools);
+        ObjectNode toolChoice = MAPPER.createObjectNode();
+        toolChoice.put("type", "auto");
+        root.set("tool_choice", toolChoice);
+        root.set("messages", messages == null ? MAPPER.createArrayNode() : messages);
+        try {
+            return MAPPER.writeValueAsString(root);
+        } catch (IOException e) {
+            throw new IllegalStateException("could not serialise AI request", e);
+        }
+    }
+
+    /** Extract the {@code content} block array from an Anthropic response body. */
+    JsonNode parseContent(String responseBody) throws IOException {
+        JsonNode root = MAPPER.readTree(responseBody);
+        JsonNode content = root.path("content");
+        return content.isArray() ? content : MAPPER.createArrayNode();
+    }
+
+    private static boolean notBlank(String s) {
+        return s != null && !s.isBlank();
+    }
+
+    private static String loadResource(String path) {
+        try (InputStream in = CubeDesignerAiService.class.getResourceAsStream(path)) {
+            if (in == null) {
+                throw new IllegalStateException("missing classpath resource " + path);
+            }
+            return new String(in.readAllBytes(), StandardCharsets.UTF_8);
+        } catch (IOException e) {
+            throw new IllegalStateException("could not read " + path, e);
+        }
+    }
+
+    private static JsonNode loadJsonResource(String path) {
+        try {
+            return MAPPER.readTree(loadResource(path));
+        } catch (IOException e) {
+            throw new IllegalStateException("could not parse " + path, e);
+        }
+    }
+}

--- a/saiku-core/saiku-service/src/main/resources/cube-designer/system-prompt.md
+++ b/saiku-core/saiku-service/src/main/resources/cube-designer/system-prompt.md
@@ -1,0 +1,45 @@
+You are DimSum, an agent helping the user build a **Mondrian 4** OLAP schema on the Saiku SCHEMA DESIGNER canvas.
+You author a Mondrian 4 schema — NOT Mondrian 3. Everything you create maps to Mondrian 4 constructs: a `<PhysicalSchema>` of tables + links, shared `<Dimension>`s with `<Attributes>` and `<Hierarchies>`/`<Level>`s, and a `<Cube>` whose `<MeasureGroup>` binds measures to the fact and links each dimension via `<ForeignKeyLink>`. You never write XML yourself — you build the model through tools and the canvas emits Mondrian 4 for you.
+
+There are two layers, and you work them in order:
+
+PHYSICAL LAYER (tables + joins):
+  - Lay out the tables the cube needs and the joins between them.
+  - list_tables / describe_table / list_joins read what is on the canvas and what the connection offers.
+  - add_table_to_canvas / remove_table_from_canvas / add_join / remove_join change the physical layout. Every mutation is snapshotted for undo, so attempt them freely.
+  - arrange_canvas re-lays out the tables (star / layered / grid / byJoins).
+
+LOGICAL LAYER (the cube — dimensions, hierarchies, levels, fact, measures):
+  - list_dimensions reads the logical model built so far (fact table, dimensions, hierarchies, levels, measures).
+  - set_fact_table designates the one fact table (the grain of measurement, e.g. sales_fact). Do this once, before adding measures.
+  - create_dimension makes a shared dimension bound to a dimension table. Give it the dimension table's `primaryKeyColumn` (its row key) AND the `foreignKeyColumn` on the FACT table that joins to it — that pairing becomes the Mondrian 4 ForeignKeyLink. Use `type: "Time"` for date/calendar dimensions.
+  - add_hierarchy adds a named hierarchy to a dimension (e.g. "Geography", "Calendar").
+  - add_level adds a level to a hierarchy, referencing a column of the dimension's table. Add levels COARSEST-FIRST (Year before Quarter before Month; Country before State before City).
+  - A cube's measures live inside a MEASURE GROUP bound to the fact table (Mondrian 4 `<MeasureGroup>`). add_measure folds a numeric fact column (with an aggregator: sum / count / avg / min / max / distinct-count / median / percentile) into that group, creating a default group if none exists — use aggregator `count` with no column for a plain row-count measure. `median` and `percentile` are non-additive distribution aggregators (computed via PERCENTILE_CONT); for `percentile` pass the `percentile` fraction 0–100 (e.g. 90 for a p90 measure). add_measure_group creates an extra named group on the cube; you only need it for the uncommon case of a cube with two facts at different grains — the default group from add_measure covers ordinary cubes.
+
+RECOMMENDED WORKFLOW when the user asks you to "build a cube", "add dimensions/measures", or "finish the schema":
+  1. Make sure the fact table and each dimension table are on the canvas (add_table_to_canvas) and joined (add_join on fact.fk = dim.pk).
+  2. set_fact_table on the fact.
+  3. For each dimension table: create_dimension (with its primaryKeyColumn + the fact-side foreignKeyColumn), then add_hierarchy, then add_level for each descriptive column coarse→fine.
+  4. add_measure for each numeric fact column worth aggregating (amounts, quantities, counts). Always give the fact at least one measure — a cube with no measure is not queryable.
+  5. Prefer sensible names ("Customer", "Geography", "Unit Sales") over raw column names.
+
+YOU HAVE TOOLS. Use them. Prefer calling tools over guessing.
+  - Call read tools (list_tables, describe_table, list_joins, list_dimensions) whenever you are unsure of the current state or the available columns.
+  - perform_action is the escape hatch for viewport + toolbar controls the user could reach with a button: zoom in / out, fit-to-view, zoom to 100 %, centre the view on all tables or one table, and undo the last change. When a user says "center the items on canvas", "zoom in", "fit the view", "undo that", call perform_action — never say you cannot control the view.
+
+BIAS TO ACTION:
+  - When the user asks a factual question ("what tables can I use?", "what dimensions have I got?"), call a read tool and answer from real data.
+  - When the user asks for a change ("build a cube", "add a Time dimension", "add a sales measure", "zoom in"), call the appropriate tools. Do NOT ask for confirmation first — the canvas has a Confirm/Cancel banner and an Undo button, so speculative attempts are cheap.
+  - When the user affirms an earlier plan you offered ("yes please", "do it"), immediately call the tools to execute it.
+
+RESOLVING COLUMN NAMES:
+  1. Check tables ALREADY ON CANVAS first. If a column matches exactly one canvas table, use it — no clarification needed. describe_table lists a table's columns.
+  2. If it matches multiple canvas tables, briefly ask which (with a plausible best guess).
+  3. If a needed table is only in the profile catalog (not yet on canvas), call add_table_to_canvas THEN the join / logical tools in the same turn.
+
+FINISHING A TURN:
+  - Once your tool calls are complete, emit a short natural-language summary of what you built and any sensible follow-ups (e.g. "added a Customer dimension with a Geography hierarchy and 3 measures — want a Time dimension next?").
+  - Never emit raw XML in your text response. The model is built through tools; the canvas renders the Mondrian 4 XML/YAML.
+
+SEMANTIC (cube-link) JOINS are read-only. If the user asks to modify one, tell them to change the dimension's foreign key instead.

--- a/saiku-core/saiku-service/src/main/resources/cube-designer/tools.json
+++ b/saiku-core/saiku-service/src/main/resources/cube-designer/tools.json
@@ -1,0 +1,235 @@
+[
+  {
+    "name": "list_tables",
+    "description": "List every table on this connection, split into `onCanvas` (already laid out) and `available` (in the profile catalog but not on canvas yet).  Call this whenever the user asks what tables they have or what tables they can use.",
+    "input_schema": {
+      "type": "object",
+      "properties": {},
+      "required": []
+    }
+  },
+  {
+    "name": "describe_table",
+    "description": "Return full column list + neighbors (joins involving this table) for one table.  Table names are matched case-insensitively, with or without schema prefix.",
+    "input_schema": {
+      "type": "object",
+      "properties": {
+        "qualifiedName": {
+          "type": "string",
+          "description": "Table name, optionally schema-qualified: \"public.customer\" or \"customer\"."
+        }
+      },
+      "required": ["qualifiedName"]
+    }
+  },
+  {
+    "name": "list_joins",
+    "description": "List every join on the canvas, split into `userMade` (physical, editable) and `semantic` (cube-link, read-only).  Use this to answer \"what joins exist\" questions.",
+    "input_schema": {
+      "type": "object",
+      "properties": {},
+      "required": []
+    }
+  },
+  {
+    "name": "add_table_to_canvas",
+    "description": "Add a table from the profile catalog to the canvas.  Idempotent — no-op if the table is already on canvas.  Returns { added: boolean, tableId, reason? }.",
+    "input_schema": {
+      "type": "object",
+      "properties": {
+        "qualifiedName": {
+          "type": "string",
+          "description": "Table name, optionally schema-qualified: \"public.customer\"."
+        }
+      },
+      "required": ["qualifiedName"]
+    }
+  },
+  {
+    "name": "remove_table_from_canvas",
+    "description": "Remove a table from the canvas.  Also removes any joins touching this table.  Returns { removed: boolean, joinsRemoved: number }.",
+    "input_schema": {
+      "type": "object",
+      "properties": {
+        "qualifiedName": {
+          "type": "string",
+          "description": "Table on canvas, optionally schema-qualified."
+        }
+      },
+      "required": ["qualifiedName"]
+    }
+  },
+  {
+    "name": "add_join",
+    "description": "Create a physical join between two column endpoints.  Both tables must already be on canvas — if a required table is missing, call add_table_to_canvas first, then call add_join.  Returns { added: boolean, joinId, reason? }.",
+    "input_schema": {
+      "type": "object",
+      "properties": {
+        "from": {
+          "type": "object",
+          "properties": {
+            "table": { "type": "string", "description": "Source table name (schema-qualified ok)." },
+            "column": { "type": "string", "description": "Source column name." }
+          },
+          "required": ["table", "column"]
+        },
+        "to": {
+          "type": "object",
+          "properties": {
+            "table": { "type": "string", "description": "Target table name (schema-qualified ok)." },
+            "column": { "type": "string", "description": "Target column name." }
+          },
+          "required": ["table", "column"]
+        }
+      },
+      "required": ["from", "to"]
+    }
+  },
+  {
+    "name": "remove_join",
+    "description": "Delete a physical join by its endpoints.  Only affects user-made joins; semantic cube-links are read-only.",
+    "input_schema": {
+      "type": "object",
+      "properties": {
+        "from": {
+          "type": "object",
+          "properties": {
+            "table": { "type": "string" },
+            "column": { "type": "string" }
+          },
+          "required": ["table", "column"]
+        },
+        "to": {
+          "type": "object",
+          "properties": {
+            "table": { "type": "string" },
+            "column": { "type": "string" }
+          },
+          "required": ["table", "column"]
+        }
+      },
+      "required": ["from", "to"]
+    }
+  },
+  {
+    "name": "arrange_canvas",
+    "description": "Re-arrange the tables on the canvas into a tidy layout.  Same operation the toolbar \"Arrange\" button runs.  Use when the user asks to arrange / lay out / tidy / auto-layout / organize / grid the canvas.  Modes: `star` (dim tables radiate around the fact — default, matches the button), `layered` (top-down hierarchy), `grid` (uniform grid), `byJoins` (cluster by join graph).",
+    "input_schema": {
+      "type": "object",
+      "properties": {
+        "mode": {
+          "type": "string",
+          "enum": ["star", "layered", "grid", "byJoins"],
+          "description": "Layout mode — defaults to `star` when omitted (matches the toolbar Arrange button)."
+        }
+      },
+      "required": []
+    }
+  },
+  {
+    "name": "perform_action",
+    "description": "Trigger a canvas viewport or toolbar control the user could normally reach with a UI button.  Use this for zoom / fit / centre / undo asks.  Actions:\n  - `zoom_in` — same as the + button on the canvas controls.\n  - `zoom_out` — same as the − button.\n  - `fit_view` — same as the fullscreen button; frames every table on the canvas.\n  - `zoom_to_100` — reset zoom to 100 %.\n  - `center_view` — centre the viewport on all tables (equivalent to fit_view; use when the user says \"center the items on canvas\" or \"center everything\").\n  - `center_view_on_table` — pan and zoom onto ONE specific table; requires the extra `qualifiedName` argument.\n  - `undo_last_change` — same as the toolbar Undo button; reverts the most recent DimSum or user edit.\nCall this whenever the user asks for one of those operations — never say \"I can't control the view\" or \"I can't undo\".",
+    "input_schema": {
+      "type": "object",
+      "properties": {
+        "action": {
+          "type": "string",
+          "enum": ["zoom_in", "zoom_out", "fit_view", "zoom_to_100", "center_view", "center_view_on_table", "undo_last_change"],
+          "description": "Which action to perform."
+        },
+        "qualifiedName": {
+          "type": "string",
+          "description": "ONLY for action=center_view_on_table: the table to centre on, optionally schema-qualified."
+        }
+      },
+      "required": ["action"]
+    }
+  },
+  {
+    "name": "list_dimensions",
+    "description": "Read the cube's LOGICAL model built so far: the fact table, every dimension (with its table, primary key, foreign key, type and hierarchies→levels), and every measure. Call this before adding logical structure so you don't duplicate what already exists.",
+    "input_schema": {
+      "type": "object",
+      "properties": {},
+      "required": []
+    }
+  },
+  {
+    "name": "set_fact_table",
+    "description": "Designate the cube's FACT table (the table whose rows are the grain of measurement, e.g. sales_fact). Measures live on this table and every dimension links to it. A cube has exactly one fact table — calling this again moves the designation. The table must already be on the canvas. Returns { factTable }.",
+    "input_schema": {
+      "type": "object",
+      "properties": {
+        "qualifiedName": { "type": "string", "description": "Fact table on canvas, optionally schema-qualified." }
+      },
+      "required": ["qualifiedName"]
+    }
+  },
+  {
+    "name": "create_dimension",
+    "description": "Create a Mondrian 4 shared dimension bound to a dimension table. `primaryKeyColumn` is that table's own key; `foreignKeyColumn` is the column ON THE FACT TABLE that joins to it (the ForeignKeyLink). Add a physical join between fact.foreignKeyColumn and table.primaryKeyColumn too (add_join) so the link resolves. Returns { dimension }.",
+    "input_schema": {
+      "type": "object",
+      "properties": {
+        "table": { "type": "string", "description": "Dimension table on canvas, optionally schema-qualified." },
+        "primaryKeyColumn": { "type": "string", "description": "The dimension table's primary-key column (its unique row id)." },
+        "foreignKeyColumn": { "type": "string", "description": "The FACT-table column that joins to this dimension (its ForeignKeyLink)." },
+        "name": { "type": "string", "description": "Dimension name. Defaults to the table name." },
+        "type": { "type": "string", "enum": ["Standard", "Time", "Geographic"], "description": "Dimension type. Use `Time` for date/calendar dimensions (needed for time intelligence)." }
+      },
+      "required": ["table", "primaryKeyColumn"]
+    }
+  },
+  {
+    "name": "add_hierarchy",
+    "description": "Add a named hierarchy to an existing dimension. A hierarchy groups levels coarse→fine (e.g. Country → State → City). A dimension can have several (e.g. a Time dim with Calendar and Fiscal). Add levels to it with add_level. Returns { dimension, hierarchy }.",
+    "input_schema": {
+      "type": "object",
+      "properties": {
+        "dimension": { "type": "string", "description": "Existing dimension name." },
+        "name": { "type": "string", "description": "Hierarchy name, e.g. \"Geography\" or \"Calendar\"." },
+        "hasAll": { "type": "boolean", "description": "Whether the hierarchy has an (All) member. Defaults to true." }
+      },
+      "required": ["dimension", "name"]
+    }
+  },
+  {
+    "name": "add_level",
+    "description": "Add a level to a hierarchy, referencing one column of the dimension's table. Add levels coarsest-first (Year before Month; Country before City). `column` must exist on the dimension's table. Returns { dimension, hierarchy, level }.",
+    "input_schema": {
+      "type": "object",
+      "properties": {
+        "dimension": { "type": "string", "description": "Existing dimension name." },
+        "hierarchy": { "type": "string", "description": "Existing hierarchy name on that dimension." },
+        "column": { "type": "string", "description": "Column on the dimension's table to expose as this level." },
+        "name": { "type": "string", "description": "Level name. Defaults to the column name." }
+      },
+      "required": ["dimension", "hierarchy", "column"]
+    }
+  },
+  {
+    "name": "add_measure",
+    "description": "Add a measure to the cube's measure group (set_fact_table first). A cube's measures live inside a measure group bound to the fact table; this folds the column into that group (creating a default one if none) as well as registering the measure. Use aggregator `count` with no column for a row-count measure. Returns { measure, measureGroup }.",
+    "input_schema": {
+      "type": "object",
+      "properties": {
+        "column": { "type": "string", "description": "Numeric column on the fact table. Omit only for a count(*) row-count measure." },
+        "aggregator": { "type": "string", "enum": ["sum", "count", "avg", "min", "max", "distinct-count", "median", "percentile"], "description": "Aggregation function. Defaults to sum. `median` and `percentile` are non-additive (computed via PERCENTILE_CONT at the queried grain) — use them for distribution measures like median order value or p90 latency." },
+        "percentile": { "type": "integer", "minimum": 0, "maximum": 100, "description": "Only for aggregator=percentile: the fraction 0–100 (e.g. 90 for p90). Ignored otherwise; defaults to 50." },
+        "name": { "type": "string", "description": "Measure name. Defaults to the column name." }
+      },
+      "required": ["aggregator"]
+    }
+  },
+  {
+    "name": "add_measure_group",
+    "description": "Create a named measure group on the cube, bound to the fact table (set_fact_table first). A measure group collects measures that share a fact table and dimension links — most cubes need only the default group, so only call this when you deliberately want a second group (e.g. two facts at different grains). add_measure folds measures into a group automatically. Returns { measureGroup }.",
+    "input_schema": {
+      "type": "object",
+      "properties": {
+        "name": { "type": "string", "description": "Measure group name. Defaults to \"Group N\"." }
+      },
+      "required": []
+    }
+  }
+]

--- a/saiku-core/saiku-service/src/test/java/org/saiku/service/olap/ai/cubedesigner/CubeDesignerAiServiceTest.java
+++ b/saiku-core/saiku-service/src/test/java/org/saiku/service/olap/ai/cubedesigner/CubeDesignerAiServiceTest.java
@@ -1,0 +1,83 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ */
+package org.saiku.service.olap.ai.cubedesigner;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.Test;
+
+/**
+ * Unit tests for the cube-designer DimSum agent-turn request shaping + response
+ * parsing — the pure parts, no network. The actual Anthropic round-trip needs a
+ * live API key and is out of scope here.
+ */
+public class CubeDesignerAiServiceTest {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    private static CubeDesignerAiService svc() {
+        // A non-blank key makes isConfigured() true without touching the env.
+        return new CubeDesignerAiService("test-key", "claude-test", "https://example.invalid", 60);
+    }
+
+    @Test
+    public void isConfigured_trueWhenKeyPresent() {
+        assertTrue(svc().isConfigured());
+    }
+
+    @Test
+    public void buildRequestBody_carriesPromptTools_canvasState_andMessagesVerbatim() throws Exception {
+        JsonNode messages = MAPPER.readTree("[{\"role\":\"user\",\"content\":\"draft me a cube\"}]");
+        String body = svc().buildRequestBody(messages, "TABLES: sales, customer");
+        JsonNode root = MAPPER.readTree(body);
+
+        assertEquals("claude-test", root.path("model").asText());
+        // System = the DimSum prompt with the per-turn canvas state appended.
+        String system = root.path("system").asText();
+        assertTrue("prompt", system.contains("DimSum"));
+        assertTrue("canvas state appended", system.contains("TABLES: sales, customer"));
+        // Tools passed through verbatim — the 16-tool Cloud contract.
+        assertTrue("tools array", root.path("tools").isArray());
+        assertEquals(16, root.path("tools").size());
+        assertEquals("auto", root.path("tool_choice").path("type").asText());
+        // Messages verbatim.
+        assertEquals(messages, root.path("messages"));
+    }
+
+    @Test
+    public void buildRequestBody_omitsCanvasStateWhenBlank() throws Exception {
+        JsonNode messages = MAPPER.createArrayNode();
+        String body = svc().buildRequestBody(messages, "   ");
+        JsonNode root = MAPPER.readTree(body);
+        assertTrue(root.path("system").asText().length() > 0);
+        // Blank canvas summary must not append the CURRENT CANVAS STATE header.
+        assertTrue(!root.path("system").asText().contains("CURRENT CANVAS STATE"));
+    }
+
+    @Test
+    public void parseContent_returnsTheContentBlockArrayVerbatim() throws Exception {
+        String anthropic = "{\"id\":\"msg_1\",\"content\":["
+                + "{\"type\":\"text\",\"text\":\"On it.\"},"
+                + "{\"type\":\"tool_use\",\"id\":\"t1\",\"name\":\"add_table_to_canvas\",\"input\":{\"qualifiedName\":\"public.sales\"}}"
+                + "]}";
+        JsonNode content = svc().parseContent(anthropic);
+        assertTrue(content.isArray());
+        assertEquals(2, content.size());
+        assertEquals("tool_use", content.get(1).path("type").asText());
+        assertEquals("add_table_to_canvas", content.get(1).path("name").asText());
+    }
+
+    @Test
+    public void parseContent_emptyArrayWhenNoContent() throws Exception {
+        JsonNode content = svc().parseContent("{\"id\":\"x\"}");
+        assertTrue(content.isArray());
+        assertEquals(0, content.size());
+    }
+}

--- a/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/cubedesigner/CubeDesignerResource.java
+++ b/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/cubedesigner/CubeDesignerResource.java
@@ -1,0 +1,285 @@
+/*
+ * Copyright 2026 Paul Stoellberger / Spicule
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ */
+package org.saiku.web.rest.resources.cubedesigner;
+
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.Properties;
+import mondrian.rolap.M3ToM4Converter;
+import org.saiku.datasources.connection.ISaikuConnection;
+import org.saiku.datasources.datasource.SaikuDatasource;
+import org.saiku.service.datasource.DatasourceService;
+import org.saiku.service.schema.generate.introspect.JdbcIntrospector;
+import org.saiku.service.schema.generate.model.DbColumn;
+import org.saiku.service.schema.generate.model.DbModel;
+import org.saiku.service.schema.generate.model.DbTable;
+import org.saiku.service.user.UserService;
+import org.saiku.web.rest.resources.schemagen.DatasourceJdbcConnectionProvider;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Read-mostly backend for the cube/schema designer UI ({@code saiku-ui/src/lib/cube-designer}).
+ * Three endpoints matching the designer's {@code CubeDesignerBackend} adapter:
+ *
+ * <ul>
+ *   <li>{@code GET  /introspect/{dataSourceId}} — the datasource's tables + columns (source sidebar)</li>
+ *   <li>{@code GET  /sample/{dataSourceId}?table=&amp;schema=&amp;limit=} — preview rows for a table</li>
+ *   <li>{@code POST /convert} — upgrade a Mondrian-3 schema XML to Mondrian-4</li>
+ * </ul>
+ *
+ * <p>Auth mirrors the schema-generator: an inline {@code userService.isAdmin()} guard (403 for
+ * non-admins). {@code userService} is optional so the constructor stays test-friendly — when null,
+ * the guard no-ops (headless/test mode). Registered as a Spring bean in {@code saiku-beans.xml};
+ * the Jersey application auto-scans {@code @Path} beans.
+ */
+@Path("/saiku/admin/cube-designer")
+public class CubeDesignerResource {
+
+    private static final Logger LOG = LoggerFactory.getLogger(CubeDesignerResource.class);
+    private static final String MONDRIAN_PREFIX = "jdbc:mondrian:";
+    private static final int DEFAULT_SAMPLE_LIMIT = 25;
+    private static final int MAX_SAMPLE_LIMIT = 500;
+
+    private final DatasourceJdbcConnectionProvider connectionProvider;
+    private final DatasourceService datasourceService;
+    private UserService userService; // optional; see class doc
+
+    public CubeDesignerResource(
+            DatasourceJdbcConnectionProvider connectionProvider, DatasourceService datasourceService) {
+        this.connectionProvider = Objects.requireNonNull(connectionProvider, "connectionProvider");
+        this.datasourceService = Objects.requireNonNull(datasourceService, "datasourceService");
+    }
+
+    public void setUserService(UserService userService) {
+        this.userService = userService;
+    }
+
+    // ── DTOs ────────────────────────────────────────────────────────────────
+    public record ColumnView(String name, String type, boolean nullable, boolean primaryKey) {}
+
+    public record TableView(String schema, String name, List<ColumnView> columns) {}
+
+    public record IntrospectResult(List<TableView> tables) {}
+
+    public record SampleResult(List<String> columns, List<List<Object>> rows) {}
+
+    public record ConvertRequest(String mondrianXml, String dataSourceId) {}
+
+    public record ConvertResult(String mondrianXml) {}
+
+    // ── (1) introspect ───────────────────────────────────────────────────────
+    @GET
+    @Path("/introspect/{dataSourceId}")
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response introspect(@PathParam("dataSourceId") String dataSourceId) {
+        Response forbidden = adminGuard();
+        if (forbidden != null) {
+            return forbidden;
+        }
+        // Skip row-count estimates (threshold 0) — an interactive designer call
+        // must not fire COUNT(*) across every table.
+        JdbcIntrospector introspector = new JdbcIntrospector(new JdbcIntrospector.Options()
+                .withTableSizeThreshold(0)
+                .withIncludeTableTypes(List.of("TABLE", "VIEW")));
+        try (Connection conn = connectionProvider.get(dataSourceId)) {
+            DbModel model = introspector.introspect(conn);
+            List<TableView> tables = new ArrayList<>(model.tables().size());
+            for (DbTable t : model.tables()) {
+                List<ColumnView> cols = new ArrayList<>(t.columns().size());
+                for (DbColumn c : t.columns()) {
+                    cols.add(new ColumnView(
+                            c.name(), c.type() == null ? null : c.type().getName(), c.nullable(), c.primaryKey()));
+                }
+                tables.add(new TableView(t.schema(), t.name(), cols));
+            }
+            return Response.ok(new IntrospectResult(tables)).build();
+        } catch (SQLException e) {
+            LOG.warn("cube-designer introspect failed for '{}'", dataSourceId, e);
+            return Response.status(Response.Status.INTERNAL_SERVER_ERROR)
+                    .entity("could not introspect the datasource")
+                    .build();
+        }
+    }
+
+    // ── (2) sample ────────────────────────────────────────────────────────────
+    @GET
+    @Path("/sample/{dataSourceId}")
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response sample(
+            @PathParam("dataSourceId") String dataSourceId,
+            @QueryParam("table") String table,
+            @QueryParam("schema") String schema,
+            @QueryParam("limit") Integer limit) {
+        Response forbidden = adminGuard();
+        if (forbidden != null) {
+            return forbidden;
+        }
+        if (table == null || table.isBlank()) {
+            return Response.status(Response.Status.BAD_REQUEST)
+                    .entity("missing 'table'")
+                    .build();
+        }
+        int cap = clampLimit(limit);
+        // `limit` may arrive as a schema-qualified "schema.table" (the designer
+        // sends the qualified name) — split it if `schema` wasn't passed.
+        String tbl = table;
+        String sch = schema;
+        if ((sch == null || sch.isBlank()) && table.contains(".")) {
+            int dot = table.indexOf('.');
+            sch = table.substring(0, dot);
+            tbl = table.substring(dot + 1);
+        }
+        String sql = "SELECT * FROM " + quoteQualified(sch, tbl);
+        try (Connection conn = connectionProvider.get(dataSourceId);
+                Statement st = conn.createStatement()) {
+            // setMaxRows caps the result dialect-independently (no LIMIT/TOP/ROWNUM rewrite).
+            st.setMaxRows(cap);
+            try (ResultSet rs = st.executeQuery(sql)) {
+                ResultSetMetaData md = rs.getMetaData();
+                int n = md.getColumnCount();
+                List<String> cols = new ArrayList<>(n);
+                for (int i = 1; i <= n; i++) {
+                    cols.add(md.getColumnLabel(i));
+                }
+                List<List<Object>> rows = new ArrayList<>();
+                while (rs.next()) {
+                    List<Object> row = new ArrayList<>(n);
+                    for (int i = 1; i <= n; i++) {
+                        row.add(rs.getObject(i));
+                    }
+                    rows.add(row);
+                }
+                return Response.ok(new SampleResult(cols, rows)).build();
+            }
+        } catch (SQLException e) {
+            LOG.warn("cube-designer sample failed for '{}' table '{}'", dataSourceId, table, e);
+            return Response.status(Response.Status.INTERNAL_SERVER_ERROR)
+                    .entity("could not sample the table")
+                    .build();
+        }
+    }
+
+    // ── (3) convert (Mondrian 3 → 4) ──────────────────────────────────────────
+    @POST
+    @Path("/convert")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response convert(ConvertRequest req) {
+        Response forbidden = adminGuard();
+        if (forbidden != null) {
+            return forbidden;
+        }
+        if (req == null || req.mondrianXml() == null || req.mondrianXml().isBlank()) {
+            return Response.status(Response.Status.BAD_REQUEST)
+                    .entity("missing 'mondrianXml'")
+                    .build();
+        }
+        JdbcCoords coords;
+        try {
+            coords = resolveCoords(req.dataSourceId());
+        } catch (SQLException e) {
+            return Response.status(Response.Status.NOT_FOUND)
+                    .entity("unknown datasource")
+                    .build();
+        }
+        try {
+            String m4 = M3ToM4Converter.convert(req.mondrianXml(), coords.jdbcUrl(), coords.user(), coords.password());
+            return Response.ok(new ConvertResult(m4)).build();
+        } catch (M3ToM4Converter.ConversionException e) {
+            // 422 Unprocessable — the schema/connection is the problem, not the request shape.
+            // The typed token lets the UI show an actionable reason.
+            return Response.status(422).entity(e.token()).build();
+        }
+    }
+
+    // ── helpers ───────────────────────────────────────────────────────────────
+    private Response adminGuard() {
+        if (userService == null) {
+            return null; // test / headless mode
+        }
+        if (!userService.isAdmin()) {
+            return Response.status(Response.Status.FORBIDDEN).build();
+        }
+        return null;
+    }
+
+    private static int clampLimit(Integer limit) {
+        if (limit == null || limit <= 0) {
+            return DEFAULT_SAMPLE_LIMIT;
+        }
+        return Math.min(limit, MAX_SAMPLE_LIMIT);
+    }
+
+    /** SQL-standard identifier quoting (double-quote, doubling embedded quotes) to avoid injection. */
+    private static String quoteQualified(String schema, String table) {
+        String t = quoteIdent(table);
+        return (schema == null || schema.isBlank()) ? t : quoteIdent(schema) + "." + t;
+    }
+
+    private static String quoteIdent(String ident) {
+        return "\"" + ident.replace("\"", "\"\"") + "\"";
+    }
+
+    /** Raw JDBC coordinates for the converter (which opens its own DataSource). */
+    private record JdbcCoords(String jdbcUrl, String user, String password) {}
+
+    private JdbcCoords resolveCoords(String dataSourceId) throws SQLException {
+        SaikuDatasource ds = datasourceService.getDatasource(dataSourceId);
+        if (ds == null || ds.getProperties() == null) {
+            throw new SQLException("no Saiku datasource named '" + dataSourceId + "'");
+        }
+        Properties props = ds.getProperties();
+        String location = props.getProperty(ISaikuConnection.URL_KEY);
+        if (location == null || location.isEmpty()) {
+            throw new SQLException("datasource '" + dataSourceId + "' has no location");
+        }
+        String jdbcUrl = location.startsWith(MONDRIAN_PREFIX) ? extractJdbc(location) : location;
+        if (jdbcUrl == null || !jdbcUrl.startsWith("jdbc:")) {
+            throw new SQLException("datasource '" + dataSourceId + "' has no resolvable JDBC URL");
+        }
+        return new JdbcCoords(
+                jdbcUrl,
+                props.getProperty(ISaikuConnection.USERNAME_KEY),
+                props.getProperty(ISaikuConnection.PASSWORD_KEY));
+    }
+
+    /**
+     * Pull the inner {@code Jdbc=} URL out of a Mondrian location string
+     * ({@code jdbc:mondrian:Jdbc=jdbc:...;JdbcDrivers=...}). The inner value is a
+     * {@code jdbc:} URL that may contain {@code =} but, by Mondrian convention, no {@code ;}.
+     */
+    private static String extractJdbc(String location) {
+        String body = location.substring(MONDRIAN_PREFIX.length());
+        String needle = "Jdbc=";
+        int idx = body.indexOf(needle);
+        while (idx > 0 && body.charAt(idx - 1) != ';') {
+            idx = body.indexOf(needle, idx + 1);
+        }
+        if (idx < 0) {
+            return null;
+        }
+        int start = idx + needle.length();
+        int end = body.indexOf(';', start);
+        return (end < 0 ? body.substring(start) : body.substring(start, end)).trim();
+    }
+}

--- a/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/cubedesigner/CubeDesignerResource.java
+++ b/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/cubedesigner/CubeDesignerResource.java
@@ -6,6 +6,9 @@
  */
 package org.saiku.web.rest.resources.cubedesigner;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.POST;
@@ -15,6 +18,7 @@ import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
+import java.io.IOException;
 import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.ResultSetMetaData;
@@ -28,6 +32,7 @@ import mondrian.rolap.M3ToM4Converter;
 import org.saiku.datasources.connection.ISaikuConnection;
 import org.saiku.datasources.datasource.SaikuDatasource;
 import org.saiku.service.datasource.DatasourceService;
+import org.saiku.service.olap.ai.cubedesigner.CubeDesignerAiService;
 import org.saiku.service.schema.generate.introspect.JdbcIntrospector;
 import org.saiku.service.schema.generate.model.DbColumn;
 import org.saiku.service.schema.generate.model.DbModel;
@@ -60,9 +65,12 @@ public class CubeDesignerResource {
     private static final int DEFAULT_SAMPLE_LIMIT = 25;
     private static final int MAX_SAMPLE_LIMIT = 500;
 
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
     private final DatasourceJdbcConnectionProvider connectionProvider;
     private final DatasourceService datasourceService;
     private UserService userService; // optional; see class doc
+    private CubeDesignerAiService aiService; // optional; absent ⇒ /turn 503s
 
     public CubeDesignerResource(
             DatasourceJdbcConnectionProvider connectionProvider, DatasourceService datasourceService) {
@@ -72,6 +80,10 @@ public class CubeDesignerResource {
 
     public void setUserService(UserService userService) {
         this.userService = userService;
+    }
+
+    public void setAiService(CubeDesignerAiService aiService) {
+        this.aiService = aiService;
     }
 
     // ── DTOs ────────────────────────────────────────────────────────────────
@@ -86,6 +98,8 @@ public class CubeDesignerResource {
     public record ConvertRequest(String mondrianXml, String dataSourceId) {}
 
     public record ConvertResult(String mondrianXml) {}
+
+    public record TurnRequest(JsonNode messages, String canvasSummary) {}
 
     // ── (1) introspect ───────────────────────────────────────────────────────
     @GET
@@ -209,6 +223,39 @@ public class CubeDesignerResource {
             // 422 Unprocessable — the schema/connection is the problem, not the request shape.
             // The typed token lets the UI show an actionable reason.
             return Response.status(422).entity(e.token()).build();
+        }
+    }
+
+    // ── (4) DimSum AI turn ─────────────────────────────────────────────────────
+    @POST
+    @Path("/turn")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response turn(TurnRequest req) {
+        Response forbidden = adminGuard();
+        if (forbidden != null) {
+            return forbidden;
+        }
+        if (aiService == null || !aiService.isConfigured()) {
+            return Response.status(Response.Status.SERVICE_UNAVAILABLE)
+                    .entity("The schema-authoring AI is not configured on this server.")
+                    .build();
+        }
+        try {
+            JsonNode content =
+                    aiService.turn(req == null ? null : req.messages(), req == null ? null : req.canvasSummary());
+            ObjectNode out = MAPPER.createObjectNode();
+            out.set("content", content);
+            return Response.ok(out).build();
+        } catch (IllegalStateException e) {
+            return Response.status(Response.Status.SERVICE_UNAVAILABLE)
+                    .entity("The schema-authoring AI is not configured on this server.")
+                    .build();
+        } catch (IOException e) {
+            LOG.warn("cube-designer AI turn failed", e);
+            return Response.status(Response.Status.BAD_GATEWAY)
+                    .entity("The AI provider could not be reached.")
+                    .build();
         }
     }
 

--- a/saiku-core/saiku-web/src/test/java/org/saiku/web/rest/resources/cubedesigner/CubeDesignerResourceTest.java
+++ b/saiku-core/saiku-web/src/test/java/org/saiku/web/rest/resources/cubedesigner/CubeDesignerResourceTest.java
@@ -1,0 +1,156 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ */
+package org.saiku.web.rest.resources.cubedesigner;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import jakarta.ws.rs.core.Response;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.Statement;
+import java.util.List;
+import java.util.Properties;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.saiku.datasources.connection.ISaikuConnection;
+import org.saiku.datasources.datasource.SaikuDatasource;
+import org.saiku.service.datasource.DatasourceService;
+import org.saiku.web.rest.resources.cubedesigner.CubeDesignerResource.IntrospectResult;
+import org.saiku.web.rest.resources.cubedesigner.CubeDesignerResource.SampleResult;
+import org.saiku.web.rest.resources.cubedesigner.CubeDesignerResource.TableView;
+import org.saiku.web.rest.resources.schemagen.DatasourceJdbcConnectionProvider;
+
+/**
+ * End-to-end tests for {@link CubeDesignerResource} against a real H2 in-memory DB. The datasource
+ * service is mocked to hand back a {@link SaikuDatasource} whose location is the H2 JDBC URL, so the
+ * production {@link DatasourceJdbcConnectionProvider} resolves a live connection exactly as it would
+ * against a real Saiku datasource. userService is left null → the admin guard no-ops (headless).
+ */
+public class CubeDesignerResourceTest {
+
+    private static final String JDBC_URL = "jdbc:h2:mem:cube-designer;DB_CLOSE_DELAY=-1";
+    private static final String DATA_SOURCE_ID = "test-ds";
+
+    private Connection seedConn;
+    private CubeDesignerResource resource;
+
+    @Before
+    public void setUp() throws Exception {
+        seedConn = DriverManager.getConnection(JDBC_URL, "sa", "");
+        try (Statement st = seedConn.createStatement()) {
+            st.execute("DROP ALL OBJECTS");
+            st.execute("CREATE SCHEMA test");
+            st.execute("CREATE TABLE test.customer (id INT PRIMARY KEY, name VARCHAR(64))");
+            st.execute("INSERT INTO test.customer VALUES (1, 'alice')");
+            st.execute("INSERT INTO test.customer VALUES (2, 'bob')");
+        }
+
+        Properties props = new Properties();
+        props.setProperty(ISaikuConnection.URL_KEY, JDBC_URL);
+        props.setProperty(ISaikuConnection.USERNAME_KEY, "sa");
+        props.setProperty(ISaikuConnection.PASSWORD_KEY, "");
+        SaikuDatasource ds = new SaikuDatasource(DATA_SOURCE_ID, SaikuDatasource.Type.OLAP, props);
+
+        StubDatasourceService datasourceService = new StubDatasourceService(DATA_SOURCE_ID, ds);
+        DatasourceJdbcConnectionProvider provider = new DatasourceJdbcConnectionProvider(datasourceService);
+        resource = new CubeDesignerResource(provider, datasourceService);
+    }
+
+    /** Hand-rolled stub (house pattern — saiku-web has no Mockito), serving one datasource by id. */
+    private static final class StubDatasourceService extends DatasourceService {
+        private final String id;
+        private final SaikuDatasource ds;
+
+        StubDatasourceService(String id, SaikuDatasource ds) {
+            this.id = id;
+            this.ds = ds;
+        }
+
+        @Override
+        public SaikuDatasource getDatasource(String datasourceName) {
+            return id.equals(datasourceName) ? ds : null;
+        }
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        if (seedConn != null && !seedConn.isClosed()) {
+            seedConn.close();
+        }
+    }
+
+    // -- (1) introspect ---------------------------------------------------------
+
+    @Test
+    public void introspect_returnsSeededTableAndColumns() {
+        Response r = resource.introspect(DATA_SOURCE_ID);
+        assertEquals(200, r.getStatus());
+        IntrospectResult body = (IntrospectResult) r.getEntity();
+        assertNotNull(body);
+        TableView customer = body.tables().stream()
+                .filter(t -> "CUSTOMER".equalsIgnoreCase(t.name()))
+                .findFirst()
+                .orElse(null);
+        assertNotNull("CUSTOMER table should be introspected", customer);
+        List<String> colNames =
+                customer.columns().stream().map(c -> c.name().toUpperCase()).toList();
+        assertTrue(colNames.contains("ID"));
+        assertTrue(colNames.contains("NAME"));
+    }
+
+    // -- (2) sample -------------------------------------------------------------
+
+    @Test
+    public void sample_returnsColumnsAndRows() {
+        Response r = resource.sample(DATA_SOURCE_ID, "CUSTOMER", "TEST", 10);
+        assertEquals(200, r.getStatus());
+        SampleResult body = (SampleResult) r.getEntity();
+        assertNotNull(body);
+        assertEquals(2, body.columns().size()); // ID, NAME
+        assertEquals(2, body.rows().size()); // alice, bob
+    }
+
+    @Test
+    public void sample_capsRowsViaLimit() {
+        Response r = resource.sample(DATA_SOURCE_ID, "CUSTOMER", "TEST", 1);
+        assertEquals(200, r.getStatus());
+        SampleResult body = (SampleResult) r.getEntity();
+        assertEquals(1, body.rows().size());
+    }
+
+    @Test
+    public void sample_acceptsSchemaQualifiedTable() {
+        // The designer sends "schema.table"; the endpoint splits it when no schema param is given.
+        Response r = resource.sample(DATA_SOURCE_ID, "TEST.CUSTOMER", null, 10);
+        assertEquals(200, r.getStatus());
+        SampleResult body = (SampleResult) r.getEntity();
+        assertEquals(2, body.rows().size());
+    }
+
+    @Test
+    public void sample_missingTableIs400() {
+        Response r = resource.sample(DATA_SOURCE_ID, null, null, 10);
+        assertEquals(400, r.getStatus());
+    }
+
+    // -- (3) convert ------------------------------------------------------------
+
+    @Test
+    public void convert_missingXmlIs400() {
+        Response r = resource.convert(new CubeDesignerResource.ConvertRequest("  ", DATA_SOURCE_ID));
+        assertEquals(400, r.getStatus());
+    }
+
+    @Test
+    public void convert_unknownDatasourceIs404() {
+        Response r = resource.convert(new CubeDesignerResource.ConvertRequest("<Schema name=\"x\"/>", "no-such-ds"));
+        assertEquals(404, r.getStatus());
+    }
+}

--- a/saiku-ui/package-lock.json
+++ b/saiku-ui/package-lock.json
@@ -8,17 +8,20 @@
       "name": "saiku-ui",
       "version": "3.20.0",
       "dependencies": {
+        "@xyflow/svelte": "^1.6.0",
         "apache-arrow": "^21.2.0",
         "bits-ui": "^2.18.1",
         "clsx": "^2.1.1",
         "css-tree": "^3.2.1",
         "echarts": "^6.0.0",
+        "elkjs": "^0.11.1",
         "html-to-image": "^1.11.13",
         "jspdf": "^4.2.1",
         "lucide-svelte": "^1.0.1",
         "monaco-editor": "^0.56.0",
         "tailwind-merge": "^3.6.0",
-        "tailwind-variants": "^3.2.2"
+        "tailwind-variants": "^3.2.2",
+        "yaml": "^2.9.0"
       },
       "devDependencies": {
         "@chromatic-com/storybook": "^5.2.1",
@@ -2493,6 +2496,15 @@
         "vite": "^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/@svelte-put/shortcut": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@svelte-put/shortcut/-/shortcut-4.2.0.tgz",
+      "integrity": "sha512-hqNLo4yEc++SLgAkZUvuwMxIAsii9qjQtTuzfcYVf3xRxa+0HFcfaWFK7LdU3l+15s9SYVNbPB0qQj9CHFqSuw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "svelte": "^5.1.0"
+      }
+    },
     "node_modules/@sveltejs/acorn-typescript": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/@sveltejs/acorn-typescript/-/acorn-typescript-1.0.11.tgz",
@@ -3066,6 +3078,55 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-drag": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-drag/-/d3-drag-3.0.7.tgz",
+      "integrity": "sha512-HE3jVKlzU9AaMazNufooRJ5ZpWmLIoc90A37WU2JMmeq28w1FQqCZswHZ3xR+SuxYftzHq6WU6KJHvqxKzTxxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-selection": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@types/d3-selection/-/d3-selection-3.0.11.tgz",
+      "integrity": "sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-transition": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-transition/-/d3-transition-3.0.9.tgz",
+      "integrity": "sha512-uZS5shfxzO3rGlu0cC3bjmMFKsXv+SmZZcgp0KD22ts4uGXp5EVYGzu/0YdwZeKmddhcAccYtREJKkPfXkZuCg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-zoom": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-zoom/-/d3-zoom-3.0.8.tgz",
+      "integrity": "sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-interpolate": "*",
+        "@types/d3-selection": "*"
+      }
+    },
     "node_modules/@types/deep-eql": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
@@ -3547,6 +3608,36 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@xyflow/svelte": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/@xyflow/svelte/-/svelte-1.6.2.tgz",
+      "integrity": "sha512-wImcz0c4mCa2SYxo5p1YSBqdTBqI4Ky2CYO6XZfNqMIxVr6mB2cdVaduJqHuqTETQuUKv4Gr0eh3Ev3iU8k8fg==",
+      "license": "MIT",
+      "dependencies": {
+        "@svelte-put/shortcut": "^4.1.0",
+        "@xyflow/system": "0.0.79"
+      },
+      "peerDependencies": {
+        "svelte": "^5.25.0"
+      }
+    },
+    "node_modules/@xyflow/system": {
+      "version": "0.0.79",
+      "resolved": "https://registry.npmjs.org/@xyflow/system/-/system-0.0.79.tgz",
+      "integrity": "sha512-czLyOh91NF0hIzbNzwi8I6GlqG23BHh2435OddfI6uiaLH3xdrdygO93gqgH1Bv9mhy8XPFQJOBn1FTq4LvEWA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-drag": "^3.0.7",
+        "@types/d3-interpolate": "^3.0.4",
+        "@types/d3-selection": "^3.0.10",
+        "@types/d3-transition": "^3.0.8",
+        "@types/d3-zoom": "^3.0.8",
+        "d3-drag": "^3.0.0",
+        "d3-interpolate": "^3.0.1",
+        "d3-selection": "^3.0.0",
+        "d3-zoom": "^3.0.0"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
@@ -3940,6 +4031,111 @@
       "license": "MIT",
       "peer": true
     },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-dispatch": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-3.0.1.tgz",
+      "integrity": "sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-drag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-drag/-/d3-drag-3.0.0.tgz",
+      "integrity": "sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-selection": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-selection": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
+      "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-transition": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-transition/-/d3-transition-3.0.1.tgz",
+      "integrity": "sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3",
+        "d3-dispatch": "1 - 3",
+        "d3-ease": "1 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-timer": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "d3-selection": "2 - 3"
+      }
+    },
+    "node_modules/d3-zoom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-zoom/-/d3-zoom-3.0.0.tgz",
+      "integrity": "sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-drag": "2 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-selection": "2 - 3",
+        "d3-transition": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/data-urls": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
@@ -4137,6 +4333,12 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
       "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg==",
       "license": "0BSD"
+    },
+    "node_modules/elkjs": {
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/elkjs/-/elkjs-0.11.1.tgz",
+      "integrity": "sha512-zxxR9k+rx5ktMwT/FwyLdPCrq7xN6e4VGGHH8hA01vVYKjTFik7nHOxBnAYtrgYUB1RpAiLvA1/U2YraWxyKKg==",
+      "license": "EPL-2.0"
     },
     "node_modules/enhanced-resolve": {
       "version": "5.24.3",
@@ -7929,6 +8131,21 @@
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
     },
     "node_modules/yocto-queue": {
       "version": "0.1.0",

--- a/saiku-ui/package.json
+++ b/saiku-ui/package.json
@@ -57,17 +57,20 @@
     "vitest": "^4.1.10"
   },
   "dependencies": {
+    "@xyflow/svelte": "^1.6.0",
     "apache-arrow": "^21.2.0",
     "bits-ui": "^2.18.1",
     "clsx": "^2.1.1",
     "css-tree": "^3.2.1",
     "echarts": "^6.0.0",
+    "elkjs": "^0.11.1",
     "html-to-image": "^1.11.13",
     "jspdf": "^4.2.1",
     "lucide-svelte": "^1.0.1",
     "monaco-editor": "^0.56.0",
     "tailwind-merge": "^3.6.0",
-    "tailwind-variants": "^3.2.2"
+    "tailwind-variants": "^3.2.2",
+    "yaml": "^2.9.0"
   },
   "overrides": {
     "dompurify": "^3.4.0",

--- a/saiku-ui/src/lib/cube-designer/ActiveSetPanel.svelte
+++ b/saiku-ui/src/lib/cube-designer/ActiveSetPanel.svelte
@@ -1,0 +1,144 @@
+<!--
+  Active-set picks panel — pinned at the top of the joins panel. One panel,
+  two modes: pick mode ("Picked columns (N)" + "Match N picks") and auto mode
+  ("Matching <col> (N)" + "Link N similar matches"). Self-contained: reads the
+  store's active-set + highlight state and owns the transient group-name input
+  + the link-similar count.
+-->
+<script lang="ts">
+	import { ArrowLeftRight, X } from 'lucide-svelte';
+	import type { SchemaCanvasStore } from './state.svelte.js';
+
+	interface Props {
+		store: SchemaCanvasStore;
+	}
+
+	let { store }: Props = $props();
+
+	/** Group name typed into the picks-panel input before Match.  Lives
+	 *  in the view (not the store) because it's transient and shouldn't
+	 *  persist across sessions or follow connection switches.  Prefilled
+	 *  from `store.autoPickGroupName()` whenever the user hasn't edited
+	 *  the input themselves — that way Enter or Match "just works" with
+	 *  a sensible default. */
+	let pickGroupName = $state('');
+	/** Once the user types into the group-name field, stop overwriting
+	 *  it with the auto-name.  Reset on commit or Clear. */
+	let userTouchedName = $state(false);
+
+	const autoName = $derived(store.autoPickGroupName());
+	$effect(() => {
+		if (!userTouchedName) {
+			pickGroupName = autoName;
+		}
+	});
+
+	function commitPicks() {
+		// Empty string falls back to the auto-name inside commitEShiftPicks
+		// via the caller — we send whatever's in the input (which we've
+		// already synced to autoName unless the user typed).
+		store.commitEShiftPicks(pickGroupName || autoName);
+		pickGroupName = '';
+		userTouchedName = false;
+	}
+</script>
+
+{#if store.activeSet.length > 0 && store.activeSetMode !== 'none'}
+	{@const set = store.activeSet}
+	{@const mode = store.activeSetMode}
+	{@const colname = store.highlightedColumn}
+	<div
+		class="flex shrink-0 flex-col gap-2 border-b border-border bg-card px-3 py-3"
+		data-testid="canvas-active-set-panel"
+	>
+		<div class="flex items-center justify-between gap-2">
+			<span class="text-[10px] font-semibold tracking-wider text-muted-foreground uppercase">
+				{#if mode === 'pick'}
+					Picked columns ({set.length})
+				{:else}
+					Matching <span class="font-mono normal-case">{colname}</span> ({set.length})
+				{/if}
+			</span>
+			<button
+				type="button"
+				onclick={() => {
+					store.cancelEShift();
+					store.highlightedColumn = null;
+					store.highlightOriginTableId = null;
+					pickGroupName = '';
+					userTouchedName = false;
+				}}
+				class="rounded text-[11px] font-medium text-muted-foreground underline-offset-2 hover:text-foreground hover:underline"
+				data-testid="canvas-active-set-clear"
+			>
+				Clear
+			</button>
+		</div>
+		<!-- Pick mode → X per row toggles via the same
+		     pushEShiftPick API.  Auto mode is read-only
+		     (clearing via Clear / emptying the search). -->
+		<ul
+			class="-mx-1 max-h-40 space-y-1 overflow-y-auto px-1 text-[11px]"
+			data-testid="canvas-active-set-list"
+		>
+			{#each set as p (`${p.tableId}:${p.columnName}`)}
+				{@const tbl = store.doc.tables.find((t) => t.id === p.tableId)}
+				<li
+					class="flex items-center justify-between gap-2 rounded border border-border bg-background px-2 py-1.5 text-foreground"
+					data-testid="canvas-active-set-row"
+				>
+					<span class="min-w-0 truncate font-mono">
+						<span class="opacity-60">{tbl?.name ?? p.tableId}.</span>{p.columnName}
+					</span>
+					{#if mode === 'pick'}
+						<button
+							type="button"
+							onclick={() => store.pushEShiftPick(p.tableId, p.columnName)}
+							class="inline-flex h-4 w-4 shrink-0 items-center justify-center rounded text-muted-foreground hover:bg-accent hover:text-accent-foreground"
+							aria-label="Remove pick"
+							title="Remove from picks"
+							data-testid="canvas-active-set-remove"
+						>
+							<X class="h-3 w-3" aria-hidden="true" />
+						</button>
+					{/if}
+				</li>
+			{/each}
+		</ul>
+		{#if mode === 'pick'}
+			{@const canMatch = set.length >= 2}
+			<label
+				class="flex flex-col gap-1 text-[10px] font-semibold tracking-wider text-muted-foreground uppercase"
+			>
+				Group name
+				<input
+					type="text"
+					bind:value={pickGroupName}
+					oninput={() => (userTouchedName = true)}
+					onkeydown={(e) => {
+						if (e.key === 'Enter' && canMatch) {
+							e.preventDefault();
+							commitPicks();
+						}
+					}}
+					placeholder={autoName || 'e.g. Product Key'}
+					class="h-8 w-full rounded border border-input bg-background px-2 text-xs font-normal text-foreground normal-case placeholder:text-muted-foreground focus:border-ring focus:ring-1 focus:ring-ring focus:outline-none"
+					data-testid="canvas-active-set-group-name"
+				/>
+			</label>
+			<button
+				type="button"
+				onclick={commitPicks}
+				disabled={!canMatch}
+				class="inline-flex h-8 w-full items-center justify-center gap-1.5 rounded bg-primary px-2 text-xs font-medium text-primary-foreground transition-opacity hover:opacity-90 disabled:opacity-50"
+				title={set.length < 2
+					? 'Pick at least two columns on different tables'
+					: `Wire the first pick to the other ${set.length - 1} under "${pickGroupName || autoName}"`}
+				data-testid="canvas-active-set-commit-picks"
+			>
+				<ArrowLeftRight class="h-3.5 w-3.5" aria-hidden="true" />
+				Match {set.length} picks
+			</button>
+		{/if}
+	</div>
+{/if}

--- a/saiku-ui/src/lib/cube-designer/AskDimSumWidget.svelte
+++ b/saiku-ui/src/lib/cube-designer/AskDimSumWidget.svelte
@@ -1,0 +1,392 @@
+<!--
+  Ask DimSum floating widget — the schema canvas's inline AI chat.
+
+  Lifts the whole widget out of SchemaCanvasView so that giant file
+  isn't the only place the chat DOM lives.  All state lives on the
+  parent (persisted per connection); this component just binds the
+  reactive bag it needs and calls back for the two side-effectful
+  actions (draft new turn, clear history).
+
+  Two collapse controls:
+    - `expanded` toggles the body (chat log + input) into a header-only
+      strip.  Chevron in the header.
+    - `visible` (bindable) is the "hide entirely" state — EyeOff in the
+      header sets it false; the parent handles the reopen chip.
+-->
+<script lang="ts">
+	import {
+		ChevronDown,
+		ChevronRight,
+		Sparkles,
+		EyeOff,
+		Maximize2,
+		Trash2,
+		AlertTriangle,
+		Loader2,
+		X
+	} from 'lucide-svelte';
+	import type { AnthropicBlock, ChatMessage, DimSumMutationResult } from './ai-chat-types';
+
+	interface Props {
+		/** Body-visible state.  `true` = full chat panel, `false` = just
+		 *  the header row.  Bindable so the parent can honour the widget's
+		 *  chevron toggle. */
+		expanded: boolean;
+		/** Whole-widget visibility.  Setting `false` (via the EyeOff in
+		 *  the header) hides the widget entirely; the parent's reopen
+		 *  chip flips it back to `true`. */
+		visible: boolean;
+		/** Rolling conversation.  Read-only from the widget's side. */
+		messages: ChatMessage[];
+		/** True while a draft is in flight — disables the input + button. */
+		drafting: boolean;
+		/** Freeform user intent bound to the textarea. */
+		intent: string;
+		/** Mutation-summary banner state.  Cleared by Confirm/Cancel. */
+		result: DimSumMutationResult | null;
+		/** Error banner state.  Cleared by the Dismiss ✕. */
+		error: string | null;
+		/** Whether the popped-out chat modal is open. */
+		chatOpen: boolean;
+		/** Whether the full-text error modal is open. */
+		errorOpen: boolean;
+		/** Non-null when a source is connected; null disables the Send
+		 *  button with a "Pick a connection first" tooltip. */
+		connectionId: string | null;
+		/** When true, the widget fills its parent's height (used inside the
+		 *  right-side canvas column where JOINS + DimSum share a flex column).
+		 *  Overrides the fixed 420px expanded height and drops `shrink-0` so
+		 *  the flex parent can bound it. */
+		fillContainer?: boolean;
+
+		onDraft: () => void;
+		onClearChat: () => void;
+		/** Confirm a mutation-result banner: clear the previous doc and
+		 *  wipe the banner. */
+		onConfirmResult: () => void;
+		/** Cancel a mutation-result banner: undo the mutation and wipe
+		 *  the banner. */
+		onCancelResult: () => void;
+	}
+
+	// `$bindable()` is a compiler macro, not a plain assignment — the eslint
+	// `no-useless-assignment` rule doesn't know that.  Disable per-line for
+	// the three props whose next mutation is in a nested handler (visible,
+	// chatOpen, errorOpen) so the rule doesn't false-positive.
+	let {
+		expanded = $bindable(),
+		 
+		visible = $bindable(),
+		messages,
+		drafting,
+		intent = $bindable(),
+		result = $bindable(),
+		error = $bindable(),
+		 
+		chatOpen = $bindable(),
+		 
+		errorOpen = $bindable(),
+		connectionId,
+		fillContainer = false,
+		onDraft,
+		onClearChat,
+		onConfirmResult,
+		onCancelResult
+	}: Props = $props();
+
+	// In fillContainer mode the widget IS the panel — the collapse-to-header
+	// state was for the old bottom-left placement (#1154) where it ate the
+	// canvas edge before the user opted in. When we're the paired half beside
+	// JOINS in the right column, expanded is the only useful state; forcing it
+	// keeps the reopen-chip → click round-trip landing on a live body instead
+	// of an empty header (reported 2026-07-30).
+	const bodyOpen = $derived(fillContainer ? true : expanded);
+
+	function toggleBody() {
+		if (fillContainer) return;
+		expanded = !expanded;
+	}
+
+	let logEl = $state<HTMLDivElement | null>(null);
+	// Auto-scroll the log to the bottom on new messages / drafting flip.
+	$effect(() => {
+		if (!bodyOpen) return;
+		void messages.length;
+		void drafting;
+		queueMicrotask(() => {
+			if (logEl) logEl.scrollTop = logEl.scrollHeight;
+		});
+	});
+</script>
+
+<div
+	class="flex flex-col rounded border border-border bg-card {fillContainer
+		? 'h-full min-h-0 flex-1'
+		: 'shrink-0'}"
+	data-testid="canvas-ai-section"
+	style:height={fillContainer ? undefined : expanded ? '420px' : 'auto'}
+>
+	<!-- Wrapper is a div (not a button) so it can host the nested Hide /
+	     Pop-out / Clear buttons without invalid <button> nesting.  A
+	     `role="button"` + keydown handles the collapse toggle. In
+	     fillContainer mode the body never collapses, so the wrapper drops
+	     its button semantics + cursor + chevron. -->
+	<div
+		role={fillContainer ? undefined : 'button'}
+		tabindex={fillContainer ? undefined : 0}
+		onclick={fillContainer ? undefined : toggleBody}
+		onkeydown={fillContainer
+			? undefined
+			: (e) => {
+					if (e.key === 'Enter' || e.key === ' ') {
+						e.preventDefault();
+						toggleBody();
+					}
+				}}
+		class="flex shrink-0 items-center gap-1.5 px-3 py-2 text-left text-[11px] font-semibold tracking-wide text-muted-foreground uppercase {fillContainer
+			? ''
+			: 'cursor-pointer hover:bg-accent/40'}"
+		data-testid="canvas-ai-section-toggle"
+		aria-expanded={bodyOpen}
+	>
+		{#if !fillContainer}
+			{#if bodyOpen}
+				<ChevronDown class="h-3.5 w-3.5" aria-hidden="true" />
+			{:else}
+				<ChevronRight class="h-3.5 w-3.5" aria-hidden="true" />
+			{/if}
+		{/if}
+		<Sparkles class="h-3.5 w-3.5 text-primary" aria-hidden="true" />
+		<span class="flex-1">Ask DimSum</span>
+		<button
+			type="button"
+			onclick={(e) => {
+				e.stopPropagation();
+				visible = false;
+			}}
+			class="rounded p-0.5 text-muted-foreground hover:bg-accent hover:text-accent-foreground"
+			aria-label="Hide DimSum panel"
+			title="Hide DimSum"
+			data-testid="canvas-ai-panel-hide"
+		>
+			<EyeOff class="h-3 w-3" aria-hidden="true" />
+		</button>
+		{#if bodyOpen}
+			<button
+				type="button"
+				onclick={(e) => {
+					e.stopPropagation();
+					chatOpen = true;
+				}}
+				class="rounded p-0.5 text-muted-foreground hover:bg-accent hover:text-accent-foreground"
+				aria-label="Pop out to expanded chat"
+				title="Pop out to a bigger side-panel chat"
+				data-testid="canvas-ai-chat-open"
+			>
+				<Maximize2 class="h-3 w-3" aria-hidden="true" />
+			</button>
+			{#if messages.length > 0}
+				<button
+					type="button"
+					onclick={(e) => {
+						e.stopPropagation();
+						onClearChat();
+					}}
+					class="rounded p-0.5 text-muted-foreground hover:bg-accent hover:text-accent-foreground"
+					aria-label="Clear chat"
+					title="Clear conversation"
+				>
+					<Trash2 class="h-3 w-3" aria-hidden="true" />
+				</button>
+			{/if}
+		{:else if messages.length > 0}
+			<span class="text-[10px] font-normal text-muted-foreground normal-case">
+				{messages.length} turn{messages.length === 1 ? '' : 's'}
+			</span>
+		{/if}
+	</div>
+
+	{#if bodyOpen}
+		<!-- Message log — same rendering path as the pop-out side panel. -->
+		<div
+			bind:this={logEl}
+			class="min-h-0 flex-1 space-y-2 overflow-y-auto px-3 py-2"
+			data-testid="canvas-ai-sidebar-log"
+		>
+			{#if messages.length === 0 && !drafting}
+				<p class="text-[11px] leading-snug text-muted-foreground">
+					Ask about your schema — e.g. <em>"what tables can I use?"</em> or request changes like
+					<em>"add a join between sales_fact.customer_id and customer.customer_id"</em>.
+				</p>
+			{/if}
+			{#each messages as m, i (i)}
+				{@const blocks = (
+					typeof m.content === 'string' ? [{ type: 'text', text: m.content }] : m.content
+				) as AnthropicBlock[]}
+				{@const isToolResultTurn =
+					m.role === 'user' &&
+					Array.isArray(m.content) &&
+					(m.content as AnthropicBlock[]).every((b) => b.type === 'tool_result')}
+				{#if isToolResultTurn}
+					<div class="flex flex-wrap gap-1" data-testid="canvas-ai-sidebar-toolresults">
+						{#each blocks as b, bi (bi)}
+							{#if b.type === 'tool_result'}
+								<span
+									class="rounded border border-border bg-muted/30 px-1.5 py-0.5 text-[9px] {b.is_error
+										? 'text-destructive'
+										: 'text-success'}"
+								>
+									{b.is_error ? '✗' : '✓'} result
+								</span>
+							{/if}
+						{/each}
+					</div>
+				{:else}
+					<div
+						class="flex {m.role === 'user' ? 'justify-end' : 'justify-start'}"
+						data-testid="canvas-ai-sidebar-message"
+						data-role={m.role}
+					>
+						<div
+							class="max-w-full rounded-lg px-2 py-1.5 text-[11px] leading-snug {m.role === 'user'
+								? 'bg-primary text-primary-foreground'
+								: 'border border-border bg-muted/40 text-foreground'}"
+						>
+							{#each blocks as b, bi (bi)}
+								{#if b.type === 'text' && b.text}
+									<p class="whitespace-pre-wrap">{b.text}</p>
+								{:else if b.type === 'tool_use'}
+									<div
+										class="my-0.5 inline-flex items-center gap-1 rounded border border-primary/40 bg-primary/5 px-1 py-0.5 font-mono text-[9px] text-primary"
+									>
+										<Sparkles class="h-2 w-2" aria-hidden="true" />
+										{b.name}
+									</div>
+								{/if}
+							{/each}
+						</div>
+					</div>
+				{/if}
+			{/each}
+			{#if drafting}
+				<div class="flex justify-start">
+					<div
+						class="rounded-lg border border-border bg-muted/40 px-2 py-1 text-[11px] text-muted-foreground"
+					>
+						<Loader2 class="mr-1 inline h-2.5 w-2.5 animate-spin" aria-hidden="true" />
+						Working…
+					</div>
+				</div>
+			{/if}
+		</div>
+
+		{#if result}
+			<div class="shrink-0 border-t border-primary/30 bg-primary/5 px-3 py-2 text-[10px]">
+				<div class="mb-1 flex items-center justify-between gap-1">
+					<span class="font-semibold text-primary">
+						DimSum changed the canvas
+						{#if result.tables !== 0}
+							· {result.tables > 0 ? '+' : ''}{result.tables} table{Math.abs(result.tables) === 1
+								? ''
+								: 's'}
+						{/if}
+						{#if result.joins !== 0}
+							· {result.joins > 0 ? '+' : ''}{result.joins} join{Math.abs(result.joins) === 1
+								? ''
+								: 's'}
+						{/if}
+					</span>
+				</div>
+				<div class="flex gap-1">
+					<button
+						type="button"
+						onclick={() => {
+							onConfirmResult();
+							result = null;
+						}}
+						class="flex-1 rounded bg-primary px-2 py-1 text-[10px] font-semibold tracking-wider text-primary-foreground uppercase hover:bg-primary/90"
+						data-testid="canvas-ai-sidebar-confirm"
+					>
+						Confirm
+					</button>
+					<button
+						type="button"
+						onclick={() => {
+							onCancelResult();
+							result = null;
+						}}
+						class="flex-1 rounded border border-border bg-background px-2 py-1 text-[10px] font-semibold tracking-wider text-muted-foreground uppercase hover:border-primary hover:text-primary"
+						data-testid="canvas-ai-sidebar-cancel"
+					>
+						Cancel
+					</button>
+				</div>
+			</div>
+		{/if}
+
+		{#if error}
+			<div
+				class="flex shrink-0 items-center gap-2 border-t border-destructive/40 bg-destructive/10 px-3 py-1.5 text-[11px] text-destructive"
+				data-testid="canvas-ai-error"
+			>
+				<AlertTriangle class="h-3 w-3 shrink-0" aria-hidden="true" />
+				<span class="flex-1 truncate font-medium">1 issue</span>
+				<button
+					type="button"
+					onclick={() => (errorOpen = true)}
+					class="shrink-0 rounded px-1.5 py-0.5 text-[10px] font-semibold tracking-wider uppercase hover:bg-destructive/20"
+					data-testid="canvas-ai-error-open"
+				>
+					See →
+				</button>
+				<button
+					type="button"
+					onclick={() => (error = null)}
+					class="shrink-0 rounded p-0.5 hover:bg-destructive/20"
+					aria-label="Dismiss"
+					title="Dismiss"
+					data-testid="canvas-ai-error-dismiss"
+				>
+					<X class="h-3 w-3" aria-hidden="true" />
+				</button>
+			</div>
+		{/if}
+
+		<div class="flex shrink-0 items-end gap-1.5 border-t border-border p-2">
+			<textarea
+				bind:value={intent}
+				onkeydown={(e) => {
+					if (e.key === 'Enter' && !e.shiftKey) {
+						e.preventDefault();
+						onDraft();
+					}
+				}}
+				placeholder="Ask DimSum about your schema… (Enter to send)"
+				rows="2"
+				maxlength="2000"
+				disabled={drafting}
+				class="min-h-0 flex-1 resize-none rounded border border-input bg-background px-2 py-1 text-[11px] leading-snug placeholder:text-muted-foreground focus:border-ring focus:ring-1 focus:ring-ring focus:outline-none disabled:opacity-60"
+				data-testid="canvas-ai-intent"
+			></textarea>
+			<button
+				type="button"
+				onclick={() => onDraft()}
+				disabled={drafting || !connectionId || !intent.trim()}
+				class="inline-flex h-7 shrink-0 items-center gap-1 rounded bg-primary px-2 text-[11px] font-medium text-primary-foreground hover:bg-primary/90 disabled:opacity-50"
+				data-testid="canvas-ai-draft"
+				title={!connectionId
+					? 'Pick a connection first'
+					: !intent.trim()
+						? 'Type something first'
+						: 'Send to DimSum'}
+			>
+				{#if drafting}
+					<Loader2 class="h-3 w-3 animate-spin" aria-hidden="true" />
+				{:else}
+					<Sparkles class="h-3 w-3" aria-hidden="true" />
+					Send
+				{/if}
+			</button>
+		</div>
+	{/if}
+</div>

--- a/saiku-ui/src/lib/cube-designer/CanvasEdge.svelte
+++ b/saiku-ui/src/lib/cube-designer/CanvasEdge.svelte
@@ -1,0 +1,349 @@
+<!--
+  Canvas schema designer — CanvasEdge.
+
+  Custom @xyflow/svelte edge type that renders one curve per
+  table-pair and stacks role-playing-dimension joins into a single
+  popover-style label.
+
+  Why aggregate at the table-pair level: if a fact joins `date` three
+  times via order_date_id / ship_date_id / invoice_date_id, three
+  bezier curves end up stacking with their labels piled on the same
+  midpoint and the user can't tell them apart. We render ONE curve per
+  pair (using the first join's handles for geometry) and a count badge;
+  click the badge to see + delete each individual join.
+
+  Selection + delete are wired via `EdgeLabel`'s `selectEdgeOnClick`
+  (one click selects the edge, no fighting with focus state) plus the
+  inline X buttons inside the popover.
+-->
+<script lang="ts">
+	import {
+		BaseEdge,
+		EdgeLabel,
+		getBezierPath,
+		getSmoothStepPath,
+		type EdgeProps
+	} from '@xyflow/svelte';
+	import { X, Layers } from 'lucide-svelte';
+	import type { SchemaCanvasJoin } from './types.js';
+
+	interface CanvasEdgeData {
+		/** All joins between this edge's source/target tables. */
+		joins: SchemaCanvasJoin[];
+		/** Path rendering style — chosen at the canvas level. */
+		edgeStyle: 'bezier' | 'smoothstep' | 'step';
+		/** Focus dimming — when ON, drop the whole edge to low opacity. */
+		isFaded: boolean;
+		/** True when any focus / selection is active on the canvas.
+		 *  We use it to drop ALL labels (even highlighted ones) below
+		 *  the focused node's z-index so the focused table card stays
+		 *  readable — otherwise the join label for "fact_count ↔
+		 *  fact_count" sits on top of the table's column rows. */
+		focusActive: boolean;
+		onDelete: (joinId: string) => void;
+		/** Picking a row in the multi-join popover marks the parent
+		 *  edge as selected so the curve gets the same red glow as
+		 *  clicking the line directly. */
+		onSelect?: (joinId: string) => void;
+	}
+
+	let {
+		id,
+		sourceX,
+		sourceY,
+		targetX,
+		targetY,
+		sourcePosition,
+		targetPosition,
+		selected,
+		data,
+		markerEnd,
+		style
+	}: EdgeProps & { data: CanvasEdgeData } = $props();
+
+	// `bezier` = the original smooth curves. `smoothstep` = orthogonal
+	// with rounded corners (8px). `step` = same path with zero corner
+	// radius for sharp right angles — both use the same underlying
+	// xyflow helper just differently parameterised.
+	const path = $derived.by(() => {
+		const args = {
+			sourceX,
+			sourceY,
+			sourcePosition,
+			targetX,
+			targetY,
+			targetPosition
+		};
+		if (data.edgeStyle === 'smoothstep') return getSmoothStepPath({ ...args, borderRadius: 8 });
+		if (data.edgeStyle === 'step') return getSmoothStepPath({ ...args, borderRadius: 0 });
+		return getBezierPath(args);
+	});
+	const edgePath = $derived(path[0]);
+	const labelX = $derived(path[1]);
+	const labelY = $derived(path[2]);
+	const joins = $derived(data.joins);
+	const single = $derived(joins.length === 1);
+
+	// Popover for the multi-join case — opens on click of the count
+	// badge. We don't auto-open because users hover-scan the canvas.
+	let popoverOpen = $state(false);
+</script>
+
+<BaseEdge
+	{id}
+	path={edgePath}
+	{markerEnd}
+	style={(style ?? '') + (data.isFaded ? '; opacity: 0.2;' : '')}
+/>
+
+<EdgeLabel x={labelX} y={labelY} selectEdgeOnClick>
+	{#if single}
+		{@const j = joins[0]}
+		<div
+			class="canvas-edge-label"
+			class:selected
+			class:faded={data.isFaded}
+			class:focus-active={data.focusActive}
+			data-testid="canvas-edge-label"
+		>
+			<span class="font-mono">
+				{j.sourceColumnName} <span class="opacity-70">↔</span>
+				{j.targetColumnName}
+			</span>
+			<button
+				type="button"
+				class="canvas-edge-delete"
+				title="Delete join"
+				aria-label="Delete join"
+				onclick={(e) => {
+					e.stopPropagation();
+					data.onDelete(j.id);
+				}}
+				data-testid="canvas-edge-delete"
+			>
+				<X class="h-3 w-3" aria-hidden="true" />
+			</button>
+		</div>
+	{:else}
+		<div
+			class="canvas-edge-label"
+			class:selected
+			class:faded={data.isFaded}
+			class:focus-active={data.focusActive}
+			class:popover-open={popoverOpen}
+			data-testid="canvas-edge-label-multi"
+		>
+			<button
+				type="button"
+				class="canvas-edge-pill"
+				onclick={(e) => {
+					e.stopPropagation();
+					popoverOpen = !popoverOpen;
+				}}
+				data-testid="canvas-edge-multi-toggle"
+			>
+				<Layers class="h-3 w-3" aria-hidden="true" />
+				{joins.length} joins
+			</button>
+			{#if popoverOpen}
+				<div class="canvas-edge-popover" role="menu">
+					<div class="canvas-edge-popover-header">Joins</div>
+					{#each joins as j (j.id)}
+						<!-- Click anywhere on the row → mark the parent edge
+						     selected (so the curve glows red) and close the
+						     popover. Delete × still stops propagation so it
+						     can't be hit by accident. -->
+						<button
+							type="button"
+							class="canvas-edge-popover-row"
+							onclick={(e) => {
+								e.stopPropagation();
+								data.onSelect?.(j.id);
+								popoverOpen = false;
+							}}
+							data-testid="canvas-edge-popover-row"
+						>
+							<span class="truncate font-mono">
+								{j.sourceColumnName} <span class="opacity-70">↔</span>
+								{j.targetColumnName}
+							</span>
+							<span
+								role="button"
+								tabindex="0"
+								class="canvas-edge-delete"
+								title="Delete join"
+								aria-label="Delete join"
+								onclick={(e) => {
+									e.stopPropagation();
+									data.onDelete(j.id);
+								}}
+								onkeydown={(e) => {
+									if (e.key === 'Enter' || e.key === ' ') {
+										e.preventDefault();
+										e.stopPropagation();
+										data.onDelete(j.id);
+									}
+								}}
+								data-testid="canvas-edge-popover-delete"
+							>
+								<X class="h-3 w-3" aria-hidden="true" />
+							</span>
+						</button>
+					{/each}
+				</div>
+			{/if}
+		</div>
+	{/if}
+</EdgeLabel>
+
+<style>
+	.canvas-edge-label {
+		display: inline-flex;
+		align-items: center;
+		gap: 4px;
+		padding: 2px 4px 2px 8px;
+		border-radius: 4px;
+		/* Light-mode default — soft lavender card with deep indigo
+		   text. Brand-red glow still wins on selected. */
+		border: 1px solid hsl(263 40% 75%);
+		background: hsl(263 60% 94%);
+		/* Widen the paint area so the underlying edge stroke can't
+		   peek through where the label sits — SVG paths are drawn in
+		   the same layer and a selected edge (bumped z within xyflow)
+		   can otherwise appear ON TOP of the label. The box-shadow
+		   halo is a solid card-colour ring around the label that acts
+		   as a bigger opaque canvas covering the line. */
+		box-shadow: 0 0 0 3px hsl(263 60% 94%);
+		color: hsl(263 60% 25%);
+		font-size: 11px;
+		line-height: 1.2;
+		font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+		white-space: nowrap;
+		pointer-events: all;
+		transition:
+			border-color 120ms ease,
+			box-shadow 120ms ease;
+		position: relative;
+		/* Escape SvelteFlow's node stacking context — labels MUST be
+		   above any table card they happen to cross. !important
+		   because xyflow's EdgeLabel wrapper sets its own stacking
+		   context that can swallow a non-important z-index. The label
+		   has `pointer-events: all` only on itself, not the layer
+		   above it, so table clicks elsewhere pass through fine. */
+		z-index: 99999 !important;
+		position: relative;
+		isolation: isolate;
+	}
+	/* When the popover is open, lift the entire label above its
+	   siblings so neighbouring edge labels can't paint over the
+	   expansion. Same trick as the focused-node zIndex bump. */
+	.canvas-edge-label.popover-open {
+		z-index: 100001 !important;
+	}
+	.canvas-edge-label.faded {
+		opacity: 0.2;
+		/* Strip the filled rectangle on faded labels so a 6%-opacity
+		   purple block doesn't read as a faint card on the dark
+		   canvas. Pure-text fade is what the user actually wants. */
+		background: transparent !important;
+		border-color: transparent !important;
+		box-shadow: none !important;
+	}
+	/* z-index inside .canvas-edge-label can't beat xyflow's outer
+	   labels container, which paints above the nodes container by
+	   source order. The real fix lives in flow-themed.has-focus
+	   below, which flips the two containers' stacking. */
+	.canvas-edge-label.selected {
+		border-color: hsl(var(--primary));
+		box-shadow:
+			0 0 0 1px hsl(var(--primary) / 0.5),
+			0 0 14px 2px hsl(var(--primary) / 0.4);
+	}
+	.canvas-edge-pill {
+		display: inline-flex;
+		align-items: center;
+		gap: 4px;
+		padding: 1px 6px 1px 4px;
+		border: none;
+		background: transparent;
+		color: inherit;
+		font-size: 11px;
+		font-weight: 500;
+		font-family: inherit;
+		cursor: pointer;
+	}
+	.canvas-edge-delete {
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		width: 16px;
+		height: 16px;
+		border-radius: 3px;
+		border: none;
+		background: transparent;
+		color: hsl(var(--muted-foreground));
+		cursor: pointer;
+		transition:
+			background 120ms ease,
+			color 120ms ease;
+	}
+	.canvas-edge-delete:hover {
+		background: hsl(var(--destructive));
+		color: hsl(var(--destructive-foreground));
+	}
+	.canvas-edge-popover {
+		position: absolute;
+		top: calc(100% + 4px);
+		left: 50%;
+		transform: translateX(-50%);
+		min-width: 220px;
+		max-width: 340px;
+		padding: 4px;
+		border-radius: 6px;
+		border: 1px solid hsl(var(--border));
+		background: hsl(var(--card));
+		/* Pin the row text to the theme's foreground so the rows aren't
+		   stuck inheriting the lavender label color (unreadable on a
+		   white card in light mode). */
+		color: hsl(var(--foreground));
+		box-shadow: 0 8px 24px hsl(0 0% 0% / 0.35);
+		z-index: 50;
+	}
+	.canvas-edge-popover-header {
+		padding: 4px 8px;
+		border-bottom: 1px solid hsl(var(--border));
+		font-size: 10px;
+		font-weight: 500;
+		letter-spacing: 0.04em;
+		text-transform: uppercase;
+		color: hsl(var(--muted-foreground));
+	}
+	.canvas-edge-popover-row {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		gap: 6px;
+		width: 100%;
+		padding: 4px 6px;
+		border-radius: 3px;
+		border: none;
+		background: transparent;
+		font-size: 11px;
+		font-family: inherit;
+		color: hsl(var(--foreground));
+		text-align: left;
+		cursor: pointer;
+	}
+	.canvas-edge-popover-row:hover {
+		background: hsl(var(--accent));
+		color: hsl(var(--accent-foreground));
+	}
+
+	/* Dark-mode flip: deep indigo card + soft lavender text for the
+	   pill label, keeping the popover on theme tokens. */
+	:global([data-theme='dark']) .canvas-edge-label {
+		border-color: hsl(263 50% 35%);
+		background: hsl(263 55% 22%);
+		color: hsl(260 30% 92%);
+	}
+</style>

--- a/saiku-ui/src/lib/cube-designer/CanvasPane.svelte
+++ b/saiku-ui/src/lib/cube-designer/CanvasPane.svelte
@@ -1,0 +1,715 @@
+<!--
+  The canvas region for the schema designer: the @xyflow/svelte SvelteFlow
+  pane (custom TableNode + CanvasEdge), the floating Source + DimSum overlays,
+  the pick-mode bubble, the empty-state card, the "Joins (N)" reopen chip, and
+  the selected-table detail strip.
+
+  Presentational: reads/writes the shared SchemaCanvasStore directly and owns
+  the canvas-local interaction wiring (drop / connect / canvas keys + the
+  search-highlight, jump, pick-toggle and hide-panels effects). The parent
+  owns nodes/edges ($state + sync effects, bound in here so SvelteFlow can
+  write back) and the DimSum chat state (threaded in as the `dimSumWidget`
+  snippet). SvelteFlow theming lives in this component's <style>.
+-->
+<script lang="ts">
+	import {
+		SvelteFlow,
+		Background,
+		Controls,
+		MiniMap,
+		type Node,
+		type Edge,
+		type Connection
+	} from '@xyflow/svelte';
+	import '@xyflow/svelte/dist/style.css';
+	import { untrack, type Snippet } from 'svelte';
+	import { ChevronRight, X, EyeOff } from 'lucide-svelte';
+	import TableNode from './TableNode.svelte';
+	import CanvasEdge from './CanvasEdge.svelte';
+	import JumpHandler from './JumpHandler.svelte';
+	import TableSidebar from './TableSidebar.svelte';
+	import type { SchemaCanvasStore } from './state.svelte.js';
+	import { parseConnectionJoin, parseDroppedTableCandidates } from './canvas-dnd.js';
+
+	interface Props {
+		store: SchemaCanvasStore;
+		nodes: Node[];
+		edges: Edge[];
+		focusActive: boolean;
+		joinsPanelOpen: boolean;
+		sourceVisible: boolean;
+		dimSumVisible: boolean;
+		canvasRegionEl: HTMLDivElement | null;
+		/** Source/Schema pickers snippet threaded to TableSidebar. */
+		sourceContext?: Snippet;
+	}
+
+	let {
+		store,
+		nodes = $bindable(),
+		edges = $bindable(),
+		focusActive,
+		joinsPanelOpen = $bindable(),
+		sourceVisible = $bindable(),
+		dimSumVisible = $bindable(),
+		canvasRegionEl = $bindable(),
+		sourceContext
+	}: Props = $props();
+
+	const nodeTypes = { table: TableNode };
+	 
+	const edgeTypes = { canvasJoin: CanvasEdge } as any;
+
+	const schemaFilteredSourceTables = $derived(
+		store.selectedSchema
+			? store.sourceTables.filter((t) => t.schema === store.selectedSchema)
+			: store.sourceTables
+	);
+
+	// Column name driving the "Pull in N with <colname>" CTA.  Prefer
+	// the click-driven highlight (its "add this column's peers" intent
+	// is unambiguous), otherwise fall back to the sidebar search text
+	// interpreted as an exact column name — that way the button also
+	// appears when the user typed a full column name into the search
+	// (which clears the highlight per setSidebarQueryFromUser).
+	const pullInColname = $derived(store.highlightedColumn ?? store.sidebarQuery.trim());
+	// "Pull in N with <colname>" — off-canvas tables that have a column
+	// exactly matching pullInColname.
+	const pullInMatches = $derived.by(() => {
+		if (!pullInColname) return 0;
+		const lc = pullInColname.toLowerCase();
+		return store.sourceTables.filter(
+			(c) =>
+				!store.tableIdentitiesOnCanvas.has(c.schema ? `${c.schema}.${c.name}` : c.name) &&
+				c.columns.some((col) => col.name.toLowerCase() === lc)
+		).length;
+	});
+
+	function handleConnect(connection: Connection) {
+		// Handle parsing (`<tableId>:<columnName>:in|out`) lives in ./canvas-dnd
+		// so it's unit-testable; the store mutation stays here.
+		const parsed = parseConnectionJoin(connection);
+		if (!parsed) return;
+		store.addJoin({ ...parsed, kind: 'inner' });
+	}
+
+	// Drag-from-sidebar — pane drop handler.
+	function handlePaneDragOver(e: DragEvent) {
+		e.preventDefault();
+		if (e.dataTransfer) e.dataTransfer.dropEffect = 'copy';
+	}
+
+	function handlePaneDrop(e: DragEvent) {
+		e.preventDefault();
+		// Prefer the multi-table payload (new). Fall back to the
+		// single-table payload for any legacy drop source.
+		const arrayPayload = e.dataTransfer?.getData('application/x-saiku-tables');
+		const singlePayload = e.dataTransfer?.getData('application/x-saiku-table');
+		// Payload parsing (multi/legacy formats + malformed guard) lives in
+		// ./canvas-dnd; the position maths + store mutation stay here.
+		const candidates = parseDroppedTableCandidates(arrayPayload, singlePayload);
+		if (candidates.length === 0) return;
+		const rect = (e.currentTarget as HTMLElement).getBoundingClientRect();
+		const baseX = e.clientX - rect.left;
+		const baseY = e.clientY - rect.top;
+		// Each addTable / addJoin snapshots on its own so Undo peels the
+		// drop off one table at a time (last-in-first-out).  Batching used
+		// to wrap this in withUndoBatch — one snapshot for the whole drop
+		// meant Undo wiped every table added in a single gesture, which
+		// wasn't what users expected.
+		candidates.forEach((candidate, i) => {
+			const added = store.addTable(candidate, {
+				x: baseX + i * 40,
+				y: baseY + i * 280
+			});
+			if (store.autoSuggestOnDrop) {
+				store.runAutoSuggestForTable(added.id);
+			}
+		});
+		// Drop consumed the selection.
+		store.sidebarSelectedIdentities = new Set();
+	}
+
+	function handleCanvasKey(e: KeyboardEvent) {
+		// Don't steal keys when the user is typing in an input/textarea/select.
+		const target = e.target as HTMLElement | null;
+		const inField = target !== null && ['INPUT', 'TEXTAREA', 'SELECT'].includes(target.tagName);
+		if (inField) return;
+		// ESC: cancel either an E-shift collection in progress, or a
+		// pending click-to-join arm, in that order.
+		if (e.key === 'Escape') {
+			if (store.pickModeActive || store.eShiftPicks.length > 0) {
+				store.cancelEShift();
+				return;
+			}
+			if (store.pendingJoinSource !== null) {
+				store.pendingJoinSource = null;
+				store.highlightedColumn = null;
+				store.sidebarQuery = '';
+				return;
+			}
+		}
+		// Backspace/Delete on a selected join removes it.
+		if ((e.key === 'Backspace' || e.key === 'Delete') && store.selectedJoinId) {
+			e.preventDefault();
+			store.removeJoin(store.selectedJoinId);
+		}
+	}
+
+	// Keyboard shortcuts for Create Joins Mode:
+	//   ⌘/Ctrl+J → toggle the mode on/off (mnemonic: Join).  Requires
+	//              the modifier so a stray `j` typed anywhere on the
+	//              page (a div with focus after a click, a search box
+	//              our INPUT guard misses) can't accidentally toggle it.
+	//   Enter    → commit current picks (>=2) as join(s), using the
+	//              auto-name from the picked columns.  The picks-panel
+	//              input has its own local Enter handler, so this only
+	//              fires when the input isn't focused.
+	//   Escape   → cancel picks + exit the mode
+	// Enter + Escape still ignore INPUT/TEXTAREA/SELECT focus so typing
+	// in a search or the group-name field isn't hijacked.
+	$effect(() => {
+		function down(e: KeyboardEvent) {
+			if (e.repeat) return;
+			if ((e.key === 'j' || e.key === 'J') && (e.metaKey || e.ctrlKey)) {
+				e.preventDefault();
+				store.togglePickMode();
+				return;
+			}
+			const target = e.target as HTMLElement | null;
+			const inField = target && ['INPUT', 'TEXTAREA', 'SELECT'].includes(target.tagName);
+			if (inField) return;
+			if (e.key === 'Enter' && store.eShiftPicks.length >= 2) {
+				e.preventDefault();
+				store.commitEShiftPicks(store.autoPickGroupName());
+				return;
+			}
+			if (e.key === 'Escape' && (store.pickModeActive || store.eShiftPicks.length > 0)) {
+				e.preventDefault();
+				store.cancelEShift();
+				return;
+			}
+		}
+		function up() {
+			// no-op: pick mode is sticky.  Kept so the matching
+			// addEventListener / removeEventListener pair stays balanced.
+		}
+		window.addEventListener('keydown', down);
+		window.addEventListener('keyup', up);
+		return () => {
+			window.removeEventListener('keydown', down);
+			window.removeEventListener('keyup', up);
+		};
+	});
+
+	// `\` toggles BOTH side panels (Source + Joins) at once, matching
+	// Figma's "hide UI" shortcut.  If either is closed, the tap opens
+	// both; if both are open, it closes both.  Skipped when the user
+	// is typing in an input.
+	$effect(() => {
+		function down(e: KeyboardEvent) {
+			if (e.repeat) return;
+			if (e.key !== '\\') return;
+			const target = e.target as HTMLElement | null;
+			if (target && ['INPUT', 'TEXTAREA', 'SELECT'].includes(target.tagName)) return;
+			const allOpen = sourceVisible && dimSumVisible && joinsPanelOpen;
+			sourceVisible = !allOpen;
+			dimSumVisible = !allOpen;
+			joinsPanelOpen = !allOpen;
+		}
+		window.addEventListener('keydown', down);
+		return () => window.removeEventListener('keydown', down);
+	});
+
+	// Sidebar search → active set, in auto mode. If the user types an
+	// EXACT column name (case-insensitive) that exists on any canvas
+	// table, light up every matching row via `highlightedColumn`. We
+	// only clear the highlight when the user empties the search box
+	// AFTER having driven the highlight via search — a click-initiated
+	// highlight survives a manual search clear (tracked via
+	// `store.highlightSource`).
+	$effect(() => {
+		const q = store.sidebarQuery.trim();
+		const qLc = q.toLowerCase();
+		untrack(() => {
+			if (!q) {
+				if (store.highlightSource === 'search') {
+					store.highlightedColumn = null;
+					store.highlightOriginTableId = null;
+					store.highlightSource = null;
+				}
+				return;
+			}
+			// `activeSet` uses exact case-sensitive matches, so we surface
+			// the actual on-canvas column name (not the user's typed
+			// casing) when we find one.
+			let canonical: string | null = null;
+			for (const t of store.doc.tables) {
+				for (const c of t.columns) {
+					if (c.name.toLowerCase() === qLc) {
+						canonical = c.name;
+						break;
+					}
+				}
+				if (canonical) break;
+			}
+			if (!canonical) {
+				// Typing a substring like `cust` shouldn't trigger a glow;
+				// also drop any stale search-driven highlight.
+				if (store.highlightSource === 'search') {
+					store.highlightedColumn = null;
+					store.highlightOriginTableId = null;
+					store.highlightSource = null;
+				}
+				return;
+			}
+			// Don't clobber a click-driven highlight on a different name.
+			if (store.highlightSource === 'click' && store.highlightedColumn !== null) return;
+			if (store.highlightedColumn !== canonical) {
+				store.highlightedColumn = canonical;
+				store.highlightOriginTableId = null;
+				store.highlightSource = 'search';
+			}
+		});
+	});
+
+	// Jump-to-table from sidebar — when a result row's "on canvas" link
+	// is clicked, the sidebar stamps `store.requestedJumpTarget`. The
+	// actual `setCenter()` call happens inside the SvelteFlow tree via
+	// the JumpHandler child below (which can call useSvelteFlow()).
+	$effect(() => {
+		const target = store.requestedJumpTarget;
+		if (!target) return;
+		untrack(() => {
+			store.selectedTableId = target.tableId;
+			if (target.columnName) {
+				store.highlightedColumn = target.columnName;
+				store.highlightOriginTableId = null;
+				store.highlightSource = 'click';
+			}
+		});
+	});
+</script>
+
+<!-- Sidebar Pull-in chip — passed to TableSidebar's `afterSearch`
+     slot so it lands right under the search input, above any
+     fields-matching results. Empty state stays out of the
+     sidebar entirely. -->
+{#snippet sidebarPullInChip()}
+	{#if pullInColname}
+		{@const colname = pullInColname}
+		{#if pullInMatches > 0}
+			<!-- Summary + CTA — clarifies what the green button actually
+			     does (adds the off-canvas tables to the canvas, doesn't
+			     join them unless Auto-join is on). -->
+			<div class="space-y-1.5">
+				<p class="text-[11px] leading-snug text-muted-foreground">
+					{pullInMatches}
+					{pullInMatches === 1 ? 'table has' : 'tables have'}
+					<span class="font-mono text-foreground">{colname}</span>
+					but
+					{pullInMatches === 1 ? 'is' : 'are'}
+					not on the canvas yet.
+				</p>
+				<button
+					type="button"
+					onclick={() => store.pullInMatchingColumnTables(colname)}
+					class="inline-flex h-8 w-full items-center justify-center gap-1.5 rounded border border-success bg-success px-2 text-xs font-medium whitespace-nowrap text-success-foreground transition-opacity hover:opacity-90"
+					data-testid="canvas-pull-in-matching"
+					title={store.autoSuggestOnDrop
+						? `Pull in ${pullInMatches} matching table(s) and auto-link by column name`
+						: `Pull in ${pullInMatches} matching table(s) — turn on Auto-join to also link them`}
+				>
+					Pull in {pullInMatches}
+					{pullInMatches === 1 ? 'matching table' : 'matching tables'}
+				</button>
+			</div>
+		{/if}
+	{/if}
+{/snippet}
+
+<div
+	bind:this={canvasRegionEl}
+	class="relative flex-1"
+	role="region"
+	aria-label="Schema canvas"
+	tabindex={-1}
+	ondragover={handlePaneDragOver}
+	ondrop={handlePaneDrop}
+	onkeydown={handleCanvasKey}
+	style:--right-panel-offset="{store.joinsPanelWidth + 16}px"
+>
+	<!-- Pick-mode bubble — floats at the top centre of the canvas
+	     while pick mode is active.  Tells the user what mode
+	     they're in (⌘J to toggle), what to do (click columns
+	     across tables), and what happens at the end (Match in
+	     the right-rail panel, name the group). -->
+	{#if store.pickModeActive}
+		<div
+			class="pointer-events-none absolute top-3 left-1/2 -translate-x-1/2"
+			style:z-index="200"
+			data-testid="canvas-pick-mode-bubble"
+		>
+			<div
+				class="pointer-events-auto relative flex w-[min(420px,calc(100vw-2rem))] flex-col gap-1 rounded-lg border-2 border-primary/70 bg-primary/15 px-4 py-3 text-xs text-foreground shadow-[0_4px_18px_-2px_hsl(var(--primary)/0.35)] backdrop-blur"
+			>
+				<div class="text-[10px] font-semibold tracking-wider text-primary uppercase">
+					Create Joins Mode
+				</div>
+				<p class="pr-6 leading-snug">
+					Click columns across tables and press Enter to create a join, or name the join in the
+					JOINS panel on the right before creating.
+				</p>
+				<button
+					type="button"
+					onclick={() => store.togglePickMode()}
+					class="absolute top-2 right-2 inline-flex h-5 w-5 items-center justify-center rounded text-muted-foreground hover:bg-accent hover:text-accent-foreground"
+					aria-label="Exit Create Joins Mode"
+					title="Exit Create Joins Mode (⌘J)"
+					data-testid="canvas-pick-mode-exit"
+				>
+					<X class="h-3 w-3" aria-hidden="true" />
+				</button>
+			</div>
+		</div>
+	{/if}
+	<!-- Left overlay — SOURCE panel floats over the canvas
+	     (top-left). DimSum used to stack under it here; it now lives
+	     on the right beside JOINS (see SchemaCanvasView, which also
+	     owns the JOINS + DimSum reopen chips). Container is
+	     transparent / pointer-events-none so canvas underneath is
+	     clickable everywhere the actual panel/chip isn't. -->
+	<div
+		class="pointer-events-none absolute inset-y-2 left-2 z-20 flex flex-col gap-2"
+		style:width="{store.sidebarWidth}px"
+	>
+		{#if sourceVisible}
+			<div
+				class="pointer-events-auto flex min-h-0 flex-1 flex-col overflow-hidden rounded border border-border bg-card shadow-md"
+				data-testid="canvas-source-panel-floating"
+			>
+				<header
+					class="flex shrink-0 items-center justify-between gap-2 border-b border-border px-3 py-2 text-xs font-semibold tracking-wider uppercase"
+					style:color="hsl(var(--muted-foreground))"
+				>
+					<span>Source Tables ({schemaFilteredSourceTables.length})</span>
+					<button
+						type="button"
+						onclick={() => (sourceVisible = false)}
+						class="inline-flex h-5 w-5 items-center justify-center rounded transition-colors hover:bg-accent hover:text-accent-foreground"
+						aria-label="Hide source panel"
+						title="Hide source panel"
+						data-testid="canvas-tables-panel-close"
+					>
+						<EyeOff class="h-3.5 w-3.5" aria-hidden="true" />
+					</button>
+				</header>
+				<div class="min-h-0 flex-1 overflow-hidden">
+					<TableSidebar
+						tables={schemaFilteredSourceTables}
+						loading={store.sourceLoading}
+						error={store.sourceError}
+						query={store.sidebarQuery}
+						onQueryChange={(q) => store.setSidebarQueryFromUser(q)}
+						onCanvasIdentities={store.tableIdentitiesOnCanvas}
+						width={store.sidebarWidth}
+						onWidthChange={(px) => (store.sidebarWidth = px)}
+						selectedIdentities={store.sidebarSelectedIdentities}
+						onSelectionChange={(next) => (store.sidebarSelectedIdentities = next)}
+						afterSearch={sidebarPullInChip}
+						{sourceContext}
+						onJumpToCanvasTable={(identity, columnName) => {
+							const tbl = store.doc.tables.find(
+								(t) => (t.schema ? `${t.schema}.${t.name}` : t.name) === identity
+							);
+							if (!tbl) return;
+							store.requestedJumpTarget = {
+								tableId: tbl.id,
+								columnName,
+								ts: Date.now()
+							};
+						}}
+						onAddToCanvas={(t) => {
+							const rightmost = store.doc.tables.reduce(
+								(mx, tt) => Math.max(mx, tt.position.x + 200),
+								0
+							);
+							store.addTable(t, {
+								x: rightmost + 40,
+								y: 80 + (store.doc.tables.length % 4) * 240
+							});
+						}}
+					/>
+				</div>
+			</div>
+		{:else}
+			<button
+				type="button"
+				onclick={() => (sourceVisible = true)}
+				class="pointer-events-auto inline-flex h-7 shrink-0 items-center gap-1 self-start rounded border border-input bg-card px-2 text-xs font-medium shadow-sm transition-colors hover:bg-accent hover:text-accent-foreground"
+				data-testid="canvas-tables-panel-open"
+				title="Show source panel"
+			>
+				<ChevronRight class="h-3.5 w-3.5" aria-hidden="true" />
+				Source
+			</button>
+		{/if}
+	</div>
+	{#if store.doc.tables.length === 0}
+		<!-- Empty-state (#1087) — flexes to whatever gap the canvas
+		     column has between the flanking source-list + joins
+		     panels.  `min-w-0` on the outer flex + `max-w-full` on
+		     the card lets it shrink; `text-balance` on the label
+		     keeps line breaks tidy at narrow widths so the message
+		     never clips.  Below 280px container width, the message
+		     collapses to a short-form label so cmux-narrow browsers
+		     still get a readable prompt.
+		     Left inset matches the SOURCE overlay's width when open
+		     so the card centres in the *visible* canvas gap, not
+		     behind the sidebar. -->
+		<div
+			class="@container pointer-events-none absolute top-0 bottom-0 z-10 flex min-w-0 items-center justify-center px-4 text-center"
+			style:left="{sourceVisible ? store.sidebarWidth + 16 : 8}px"
+			style:right="{joinsPanelOpen ? store.joinsPanelWidth + 16 : 8}px"
+			data-testid="canvas-empty"
+		>
+			<div
+				class="max-w-md min-w-0 rounded-lg border border-border bg-card p-4 text-card-foreground shadow-md"
+			>
+				<p class="text-sm font-medium text-balance">
+					<span class="hidden @[280px]:inline">Drag a table from the left to get started.</span>
+					<span class="@[280px]:hidden">Drag a table here.</span>
+				</p>
+				<p class="mt-1 text-xs text-balance text-muted-foreground @max-[280px]:hidden">
+					Start creating joins by turning on Create Joins Mode or wire columns to one another.
+				</p>
+			</div>
+		</div>
+	{/if}
+	<div onkeydown={handleCanvasKey} role="presentation" class="contents">
+		<SvelteFlow
+			bind:nodes
+			bind:edges
+			{nodeTypes}
+			{edgeTypes}
+			onconnect={handleConnect}
+			onpaneclick={() => {
+				store.clearAllInteractions();
+				// SvelteFlow's bound edges/nodes arrays sometimes
+				// retain `selected: true` after the pane click —
+				// the sync $effect would then re-stamp the stale
+				// selection back onto the store, undoing the
+				// clear (the canvas would stay green-highlighted
+				// even though clearAllInteractions ran).  Reset
+				// both arrays here to keep the store as the
+				// source of truth.
+				edges = edges.map((e) => ({ ...e, selected: false }));
+				nodes = nodes.map((n) => ({ ...n, selected: false }));
+			}}
+			proOptions={{ hideAttribution: true }}
+			class={`flow-themed !bg-background${focusActive ? ' has-focus' : ''}`}
+		>
+			<Background />
+			<!-- Controls sit at bottom-right, shifted LEFT of the
+			     MiniMap so both share the same corner without
+			     overlapping.  Vertical stack — matches the original
+			     SvelteFlow default look.  Both are also pushed LEFT
+			     by the right-hand panel column width so they don't
+			     hide behind the JOINS / DimSum overlays; handled in
+			     <style> via the inherited `--right-panel-offset`
+			     custom property. -->
+			<Controls position="bottom-right" orientation="vertical" />
+			<MiniMap pannable zoomable position="bottom-right" />
+			<JumpHandler {store} />
+		</SvelteFlow>
+	</div>
+	<!--
+		Selected-table detail strip.  Floats top-centre, appears when
+		a table or a column is picked.  Answers "which one did I just
+		click?" without the user having to hover the (fixed-width,
+		sometimes truncated) node header.  Fixes #971 at the
+		readability level while the w-60 node width stays intact for
+		canvas density.
+
+		Content ladder — prefer the more specific selection:
+			column-highlight active → `schema.table > column`
+			else table selected     → `schema.table`
+	-->
+	{#if store.selectedTableId || store.highlightOriginTableId}
+		{@const highlightTable = store.highlightOriginTableId
+			? store.doc.tables.find((t) => t.id === store.highlightOriginTableId)
+			: null}
+		{@const primaryTable =
+			highlightTable ??
+			(store.selectedTableId ? store.doc.tables.find((t) => t.id === store.selectedTableId) : null)}
+		{#if primaryTable}
+			{@const highlightedCol =
+				highlightTable && store.highlightedColumn ? store.highlightedColumn : null}
+			{@const highlightedColMeta = highlightedCol
+				? primaryTable.columns.find((c) => c.name === highlightedCol)
+				: null}
+			<!-- Shift LEFT when the joins panel is collapsed — otherwise
+			     this pill overlaps the "Joins (N)" open-button that sits
+			     at top-right of the canvas.  When the panel is open,
+			     it's a sibling column so top-3 right-3 is clear. -->
+			<div
+				class="pointer-events-none absolute top-3 z-20 flex max-w-[min(360px,calc(100%-2rem))] flex-col gap-0.5 rounded-md border border-border bg-card/95 px-3 py-2 text-xs shadow-md backdrop-blur {joinsPanelOpen
+					? 'right-3'
+					: 'right-28'}"
+				data-testid="canvas-selected-table-strip"
+			>
+				<span class="text-[9px] font-semibold tracking-wider text-muted-foreground uppercase">
+					Currently selected
+				</span>
+				<div class="flex items-center gap-1">
+					<span
+						class="truncate font-mono"
+						title={primaryTable.schema
+							? `${primaryTable.schema}.${primaryTable.name}`
+							: primaryTable.name}
+						data-testid="canvas-selected-table-name"
+					>
+						{#if primaryTable.schema}<span class="text-muted-foreground"
+								>{primaryTable.schema}.</span
+							>{/if}{primaryTable.name}
+					</span>
+					{#if highlightedCol}
+						<span class="shrink-0 text-muted-foreground">›</span>
+						<span
+							class="truncate font-mono"
+							title={highlightedColMeta
+								? `${highlightedCol} (${highlightedColMeta.sqlType})`
+								: highlightedCol}
+							data-testid="canvas-selected-column-name"
+						>
+							{highlightedCol}{#if highlightedColMeta}<span class="ml-1 text-muted-foreground"
+									>({highlightedColMeta.sqlType})</span
+								>{/if}
+						</span>
+					{/if}
+				</div>
+			</div>
+		{/if}
+	{/if}
+</div>
+
+<style>
+	/* SvelteFlow's `.svelte-flow__edge-label` is an HTML div, not SVG —
+	   so `fill:` does nothing. Its colours are wired via two CSS vars
+	   (`--xy-edge-label-color`, `--xy-edge-label-background-color`)
+	   that default to white-on-inherit. Setting the vars on
+	   `.svelte-flow` (SvelteFlow's own root class) puts them in scope
+	   for every child, including the portal-rendered edge labels. The
+	   non-global `.flow-themed` selector got Svelte-hashed and never
+	   matched SvelteFlow's internal container — hence the previous
+	   no-op. Use `:global()` to keep the selector raw. */
+	:global(.svelte-flow.flow-themed) {
+		/* Deep indigo-purple for join labels so they read as a different
+		   "kind of thing" from the charcoal table cards. */
+		--xy-edge-label-color: hsl(260 30% 92%);
+		--xy-edge-label-background-color: hsl(263 55% 22%);
+	}
+	/* The xyflow EdgeLabel WRAPPER (`.svelte-flow__edge-label`) had its
+	   own background + border + z-index in earlier versions of this
+	   file. Both are now harmful: my CanvasEdge's inner `.canvas-edge-label`
+	   div already paints the pill, so the wrapper background showed
+	   as a SECOND rectangle behind it (Amelia's "absolutely opaque
+	   over the tables" complaint). And the wrapper's `z-index: 99999`
+	   forced labels above the focused table card. Everything below is
+	   intentionally minimal — let the inner div be the label and let
+	   xyflow's default stacking put labels under nodes when focus is
+	   active. Without `.has-focus` we still want labels readable when
+	   they cross unrelated tables, so the wrapper gets a high z-index
+	   in the idle state only. */
+	:global(.svelte-flow.flow-themed:not(.has-focus) .svelte-flow__edge-label),
+	:global(.svelte-flow.flow-themed:not(.has-focus) .svelte-flow__edge-labels) {
+		z-index: 99999 !important;
+	}
+	/* xyflow's default CSS sets a background + padding on the
+	   `.svelte-flow__edge-label` wrapper, using the
+	   `--xy-edge-label-background-color` var we hand it for the SVG
+	   fallback path. That paints a SECOND rectangle behind our inner
+	   `.canvas-edge-label` div — which is what kept showing up at
+	   full purple even when we faded the inner div to opacity 0.06.
+	   Strip the wrapper bare so only the inner div paints. */
+	:global(.svelte-flow.flow-themed .svelte-flow__edge-label) {
+		background: transparent !important;
+		border: none !important;
+		padding: 0 !important;
+	}
+	/* When focus is active, drop the whole labels container UNDER the
+	   nodes container. This is the only reliable way to keep focused
+	   table cards readable — z-index on individual label divs can't
+	   escape their wrapper container's stacking. */
+	:global(.svelte-flow.flow-themed.has-focus .svelte-flow__edge-labels) {
+		z-index: 0 !important;
+	}
+	:global(.svelte-flow.flow-themed.has-focus .svelte-flow__nodes) {
+		z-index: 1 !important;
+	}
+	/* SVG-rendered fallback path (used when `label` is a plain string
+	   without rich content). Different properties — fill / stroke. */
+	:global(.svelte-flow.flow-themed .svelte-flow__edge-text) {
+		fill: hsl(var(--foreground)) !important;
+		font-size: 11px;
+		font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+	}
+	:global(.svelte-flow.flow-themed .svelte-flow__edge-textbg) {
+		fill: hsl(var(--muted)) !important;
+		stroke: hsl(var(--border));
+		stroke-width: 1;
+	}
+	:global(.svelte-flow.flow-themed .svelte-flow__edge.selected .svelte-flow__edge-textbg),
+	:global(.svelte-flow.flow-themed .svelte-flow__edge:focus .svelte-flow__edge-textbg) {
+		stroke: hsl(var(--primary)) !important;
+		stroke-width: 1.5;
+		filter: drop-shadow(0 0 8px hsl(var(--primary) / 0.55));
+	}
+	/* MiniMap — give it a real border + a sharper viewport mask so the
+	   shape reads in both light and dark mode. The default ghosting was
+	   especially bad in light mode where the mask had no contrast.
+	   `right` is shifted LEFT by `--right-panel-offset` (set on the
+	   canvas wrapper as `joinsPanelWidth + 16px`) so the minimap clears
+	   the JOINS / Ask DimSum column that always reserves that width on
+	   the right, whether panels or chips are showing. */
+	:global(.svelte-flow__minimap) {
+		background: hsl(var(--card));
+		border: 1px solid hsl(var(--border));
+		border-radius: 6px;
+		box-shadow: 0 2px 6px hsl(0 0% 0% / 0.08);
+		overflow: hidden;
+		right: var(--right-panel-offset, 0px) !important;
+	}
+	:global(.svelte-flow__minimap-mask) {
+		fill: hsl(var(--background) / 0.45);
+		stroke: hsl(var(--foreground) / 0.25);
+		stroke-width: 1.5;
+	}
+	/* Node thumbnails inside the minimap — give them a soft outline so
+	   the object shapes are legible against the canvas background. */
+	:global(.svelte-flow__minimap-node) {
+		fill: hsl(var(--card-foreground) / 0.25);
+		stroke: hsl(var(--foreground) / 0.4);
+		stroke-width: 1;
+	}
+	/* Controls panel (zoom in / out / fit-view / lock) — same story; the
+	   default white-on-white loses against the dashboard's dark card.
+	   `right` sits 216px LEFT of the minimap (200px minimap width +
+	   16px gutter), then plus `--right-panel-offset` so both clear the
+	   right-hand JOINS / DimSum column. */
+	:global(.svelte-flow__controls) {
+		background: hsl(var(--card));
+		border: 1px solid hsl(var(--border));
+		box-shadow: none;
+		right: calc(var(--right-panel-offset, 0px) + 216px) !important;
+	}
+	:global(.svelte-flow__controls-button) {
+		background: hsl(var(--card));
+		border-bottom: 1px solid hsl(var(--border));
+		fill: hsl(var(--foreground));
+	}
+	:global(.svelte-flow__controls-button:hover) {
+		background: hsl(var(--accent));
+		fill: hsl(var(--accent-foreground));
+	}
+</style>

--- a/saiku-ui/src/lib/cube-designer/CanvasToolbar.svelte
+++ b/saiku-ui/src/lib/cube-designer/CanvasToolbar.svelte
@@ -1,0 +1,484 @@
+<!--
+  Schema-canvas top toolbar — mode toggles (pick / auto-join / join-lines /
+  cube-links / highlight-focus), edge-style radios, columns-shown stepper,
+  expand/collapse, and the Arrange split-button + layout menu.
+
+  Presentational: reads/writes the shared SchemaCanvasStore directly (the
+  mutation boundary), owns only the transient toggle-flash + layout-menu
+  state, and delegates the actual layout run to the parent via `onArrange`
+  (shared with the DimSum arrange_canvas tool).
+-->
+<script lang="ts">
+	import {
+		Sparkles,
+		AlertTriangle,
+		Network,
+		Grid3x3,
+		Workflow as WorkflowIcon,
+		ChevronDown,
+		Star
+	} from 'lucide-svelte';
+	import type { SchemaCanvasStore } from './state.svelte.js';
+	import type { LayoutMode } from './layout.js';
+	import Tooltip from '$lib/components/ui/tooltip.svelte';
+
+	interface Props {
+		store: SchemaCanvasStore;
+		physicalJoinCount: number;
+		semanticJoinCount: number;
+		arranging: boolean;
+		lastLayoutMode: LayoutMode;
+		/** Run a layout — shared with the DimSum arrange_canvas tool, so it
+		 *  lives in the parent (it reads the canvas region rect). */
+		onArrange: (mode: LayoutMode) => void;
+	}
+
+	let { store, physicalJoinCount, semanticJoinCount, arranging, lastLayoutMode, onArrange }: Props =
+		$props();
+
+	const joinLinesOn = $derived(!store.joinsHidden);
+	// Cube-link joins are only relevant when at least one such join exists.
+	const hasCubeLinkJoins = $derived(
+		store.doc.joins.some((j) => j.origin === 'cube-link' || j.origin === 'inferred-fk')
+	);
+	// Expand/Collapse toggle state — true when EVERY table has been
+	// explicitly expanded (collapsed === false).
+	const everyTableExpanded = $derived(
+		store.doc.tables.length > 0 && store.doc.tables.every((t) => t.collapsed === false)
+	);
+
+	let layoutMenuOpen = $state(false);
+	function handleMenuKey(e: KeyboardEvent) {
+		if (e.key === 'Escape') layoutMenuOpen = false;
+	}
+	// Run a layout and close the menu — mirrors the old handleLayout, which
+	// set layoutMenuOpen=false before awaiting applyLayout.
+	function runLayout(mode: LayoutMode) {
+		layoutMenuOpen = false;
+		onArrange(mode);
+	}
+
+	const LAYOUT_CHOICES: Array<{
+		mode: LayoutMode;
+		label: string;
+		hint: string;
+		icon: typeof Sparkles;
+	}> = [
+		{
+			mode: 'star',
+			label: 'Star schema',
+			hint: 'Fact at centre, dimensions in a ring',
+			icon: Sparkles
+		},
+		{
+			mode: 'layered',
+			label: 'Layered',
+			hint: 'Hierarchical top-down, follows joins',
+			icon: WorkflowIcon
+		},
+		{
+			mode: 'byJoins',
+			label: 'By joins',
+			hint: 'Concentric rings by hops from the fact',
+			icon: Network
+		},
+		{
+			mode: 'grid',
+			label: 'Grid',
+			hint: 'Even rows, alphabetical reset',
+			icon: Grid3x3
+		}
+	];
+</script>
+
+<!-- Compact label-plus-switch toggle used for every on/off view option
+     in the toolbar.  Kills the bordered-pill button treatment (which
+     ate horizontal space with its own border + "· ON/OFF" text) in
+     favour of a small track+dot slide — the animation IS the visual
+     confirmation of the flip. -->
+{#snippet toolbarSwitch(
+	label: string,
+	checked: boolean,
+	onchange: () => void,
+	testid: string,
+	tooltip: string,
+	disabled: boolean = false
+)}
+	<button
+		type="button"
+		role="switch"
+		aria-checked={checked}
+		aria-label={label}
+		title={tooltip}
+		onclick={onchange}
+		{disabled}
+		class="inline-flex h-6 shrink-0 cursor-pointer items-center gap-1.5 rounded px-1 text-xs font-medium whitespace-nowrap text-foreground focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary disabled:cursor-not-allowed disabled:opacity-50"
+		data-testid={testid}
+	>
+		<span>{label}</span>
+		<span
+			class="relative inline-flex h-3.5 w-6 shrink-0 items-center rounded-full transition-colors"
+			class:bg-success={checked}
+			class:bg-muted={!checked}
+		>
+			<span
+				class="pointer-events-none absolute inline-block h-2.5 w-2.5 rounded-full bg-background shadow transition-transform"
+				class:translate-x-3={checked}
+				class:translate-x-0.5={!checked}
+				aria-hidden="true"
+			></span>
+		</span>
+	</button>
+{/snippet}
+
+<!-- Toolbar wraps to a second row when the viewport can't fit the full
+     control strip — beats cramming + truncating.  Quick fix; a follow-up
+     could collapse low-priority toggles behind a `…` menu when the row
+     overflows, but the simple wrap covers 90% of the real cases. -->
+<div class="flex items-center justify-between gap-3 border-b border-border bg-card px-4 py-2">
+	<div class="flex flex-1 flex-wrap items-center gap-x-3 gap-y-2">
+		<span class="text-xs text-muted-foreground" data-testid="canvas-table-count">
+			{store.doc.tables.length}
+			{store.doc.tables.length === 1 ? 'table' : 'tables'} ·
+			{physicalJoinCount}
+			{physicalJoinCount === 1 ? 'join' : 'joins'}{semanticJoinCount > 0
+				? ` · ${semanticJoinCount} semantic`
+				: ''}
+		</span>
+
+		<!-- Pick-mode toggle — compact label + switch.  The animated
+		     slide is the "just flipped" confirmation; no full pill
+		     border needed. -->
+		{@render toolbarSwitch(
+			'Create Joins',
+			store.pickModeActive,
+			() => store.togglePickMode(),
+			'canvas-pick-mode-toggle',
+			'Turn on to click columns across tables and wire joins between them. ⌘+click also picks columns without turning the mode on. Shortcut: ⌘J.'
+		)}
+
+		<!-- Auto-join on drop toggle -->
+		{@render toolbarSwitch(
+			'Auto-join on drop',
+			store.autoSuggestOnDrop,
+			() => (store.autoSuggestOnDrop = !store.autoSuggestOnDrop),
+			'canvas-auto-suggest-toggle',
+			'When on, dropping a new table onto the canvas automatically wires joins for any columns whose names match tables already on the canvas.'
+		)}
+
+		<!-- Show/hide join LINES on the canvas. Distinct from the eye
+		     icon in the joins-panel header, which hides the whole
+		     right-hand panel. This one keeps the panel + data intact
+		     and just stops drawing the curves + labels on the canvas. -->
+		{@render toolbarSwitch(
+			'Join lines',
+			joinLinesOn,
+			() => (store.joinsHidden = joinLinesOn),
+			'canvas-toolbar-join-lines-toggle',
+			joinLinesOn
+				? 'Hide the arcs and labels drawn between joined columns. Joins stay in your data — the canvas just gets quieter. Pair with Highlight joins to see what is wired via green column rows instead.'
+				: 'Draw the arcs and labels between joined columns on the canvas.',
+			store.doc.joins.length === 0
+		)}
+
+		<!-- Cube-links toggle.  Shows the cube-side <ForeignKeyLink>
+		     joins that the importer auto-inferred from MeasureGroups.
+		     They're semantic, not physical, so they're hidden by
+		     default; flipping ON renders them dashed + muted so the
+		     visual distinction stays unmistakable.  Only enabled when
+		     at least one cube-link join exists. -->
+		{#if hasCubeLinkJoins}
+			{@render toolbarSwitch(
+				'Cube links',
+				store.showCubeLinks,
+				() => (store.showCubeLinks = !store.showCubeLinks),
+				'canvas-toolbar-cube-links-toggle',
+				store.showCubeLinks
+					? 'Hide the dashed lines the importer inferred from cube dimension links. You just see the physical joins you drew.'
+					: 'Show extra dashed lines for joins the importer inferred from cube dimension links. Read-only — remove them from the cube inspector, not the canvas.'
+			)}
+		{/if}
+
+		<!-- Highlight joins toggle -->
+		{@render toolbarSwitch(
+			'Highlight joins',
+			store.highlightFocusedColumns,
+			() => {
+				const next = !store.highlightFocusedColumns;
+				store.highlightFocusedColumns = next;
+				// Toggling OFF also drops any stale name-match highlight
+				// so the user isn't left wondering why columns still glow.
+				if (!next) {
+					store.highlightedColumn = null;
+					store.highlightOriginTableId = null;
+					store.highlightSource = null;
+				}
+			},
+			'canvas-highlight-focused-toggle',
+			'Click a table to see which columns have joins.'
+		)}
+
+		{#if store.thresholdSoft}
+			<span
+				class="inline-flex items-center gap-1 rounded bg-warning/15 px-2 py-0.5 text-xs text-warning"
+				data-testid="canvas-threshold-warning"
+			>
+				<AlertTriangle class="h-3.5 w-3.5" aria-hidden="true" />
+				Many tables — consider grouping
+			</span>
+		{/if}
+	</div>
+	<div class="flex items-center gap-2">
+		<!-- Join line style picker — icons-only, tooltips carry the name.
+		     Each icon is an inline SVG that shows the actual shape of the
+		     route it selects (curved bezier, rounded orthogonal, sharp
+		     orthogonal), so the picker is self-explanatory at a glance.
+		     Hidden entirely when Join lines is OFF — the picker only
+		     affects lines that are being drawn. -->
+		{#if joinLinesOn}
+			<div
+				class="flex h-6 rounded border border-border bg-card p-0.5 text-[11px]"
+				role="radiogroup"
+				aria-label="Join line style"
+			>
+				<Tooltip text="Curved bezier lines — the smoothest look, best for a small canvas.">
+					<button
+						type="button"
+						role="radio"
+						aria-checked={store.edgeStyle === 'bezier'}
+						onclick={() => (store.edgeStyle = 'bezier')}
+						aria-label="Curved lines"
+						class="flex items-center justify-center rounded px-1.5 transition-colors"
+						class:bg-primary={store.edgeStyle === 'bezier'}
+						class:text-primary-foreground={store.edgeStyle === 'bezier'}
+						class:text-foreground={store.edgeStyle !== 'bezier'}
+						data-testid="canvas-edge-style-bezier"
+					>
+						<svg viewBox="0 0 20 12" class="h-3 w-5" aria-hidden="true">
+							<path
+								d="M1 6 C 6 6, 6 2, 10 2 S 14 10, 19 10"
+								fill="none"
+								stroke="currentColor"
+								stroke-width="1.5"
+								stroke-linecap="round"
+							/>
+						</svg>
+					</button>
+				</Tooltip>
+				<Tooltip text="Rounded right-angle lines — orthogonal routing with soft corners.">
+					<button
+						type="button"
+						role="radio"
+						aria-checked={store.edgeStyle === 'smoothstep'}
+						onclick={() => (store.edgeStyle = 'smoothstep')}
+						aria-label="Rounded step lines"
+						class="flex items-center justify-center rounded px-1.5 transition-colors"
+						class:bg-primary={store.edgeStyle === 'smoothstep'}
+						class:text-primary-foreground={store.edgeStyle === 'smoothstep'}
+						class:text-foreground={store.edgeStyle !== 'smoothstep'}
+						data-testid="canvas-edge-style-smoothstep"
+					>
+						<svg viewBox="0 0 20 12" class="h-3 w-5" aria-hidden="true">
+							<path
+								d="M1 10 H 8 Q 10 10 10 8 V 4 Q 10 2 12 2 H 19"
+								fill="none"
+								stroke="currentColor"
+								stroke-width="1.5"
+								stroke-linecap="round"
+							/>
+						</svg>
+					</button>
+				</Tooltip>
+				<Tooltip text="Sharp right-angle lines — orthogonal routing with square corners.">
+					<button
+						type="button"
+						role="radio"
+						aria-checked={store.edgeStyle === 'step'}
+						onclick={() => (store.edgeStyle = 'step')}
+						aria-label="Step lines"
+						class="flex items-center justify-center rounded px-1.5 transition-colors"
+						class:bg-primary={store.edgeStyle === 'step'}
+						class:text-primary-foreground={store.edgeStyle === 'step'}
+						class:text-foreground={store.edgeStyle !== 'step'}
+						data-testid="canvas-edge-style-step"
+					>
+						<svg viewBox="0 0 20 12" class="h-3 w-5" aria-hidden="true">
+							<path
+								d="M1 10 H 10 V 2 H 19"
+								fill="none"
+								stroke="currentColor"
+								stroke-width="1.5"
+								stroke-linecap="round"
+							/>
+						</svg>
+					</button>
+				</Tooltip>
+			</div>
+		{/if}
+
+		<!-- Default-columns-shown — global preference for how many
+		     rows each table card shows. 0 collapses every table to
+		     its header; per-table chevron still overrides.  The
+		     number input + stacked ▲/▼ stepper share one bordered
+		     box so they read as a single control; the label sits
+		     outside on the left. Native spin buttons are hidden so
+		     only the custom stepper drives the value. -->
+		<Tooltip text="How many columns each table card shows by default (0 = header only).">
+			<div
+				class="flex items-center gap-1.5 text-xs text-foreground"
+				data-testid="canvas-default-columns"
+			>
+				<span>Show columns</span>
+				<span class="flex h-6 items-stretch rounded border border-input bg-background">
+					<input
+						type="number"
+						min="0"
+						value={store.defaultColumnsShown}
+						oninput={(e) => {
+							const raw = Number.parseInt(e.currentTarget.value, 10);
+							store.defaultColumnsShown = Number.isFinite(raw) ? Math.max(0, raw) : 0;
+						}}
+						class="nodrag h-full w-10 border-none bg-transparent px-1 text-center text-xs text-foreground outline-none [-moz-appearance:textfield] focus:outline-none [&::-webkit-inner-spin-button]:m-0 [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:m-0 [&::-webkit-outer-spin-button]:appearance-none"
+						aria-label="Default columns shown"
+					/>
+					<span class="flex flex-col border-l border-input">
+						<button
+							type="button"
+							onclick={() => (store.defaultColumnsShown = store.defaultColumnsShown + 1)}
+							class="nodrag flex h-1/2 w-4 items-center justify-center text-[8px] leading-none text-muted-foreground transition-colors hover:bg-accent hover:text-accent-foreground"
+							title="Show one more column per table"
+							aria-label="Increase columns"
+						>
+							▲
+						</button>
+						<button
+							type="button"
+							onclick={() =>
+								(store.defaultColumnsShown = Math.max(0, store.defaultColumnsShown - 1))}
+							class="nodrag flex h-1/2 w-4 items-center justify-center border-t border-input text-[8px] leading-none text-muted-foreground transition-colors hover:bg-accent hover:text-accent-foreground"
+							title="Show one fewer column per table"
+							aria-label="Decrease columns"
+						>
+							▼
+						</button>
+					</span>
+				</span>
+			</div>
+		</Tooltip>
+		<!-- Single Expand/Collapse toggle. The Show input above tells
+		     things WHAT to collapse to (e.g. 8 cols). The button
+		     ALTERNATES between forcing every table to show ALL columns
+		     and dropping the overrides so they all follow the global
+		     default again. -->
+		<button
+			type="button"
+			onclick={() => {
+				if (everyTableExpanded) store.resetCollapseOverrides();
+				else store.expandAllTables();
+			}}
+			disabled={store.doc.tables.length === 0}
+			class="nodrag inline-flex h-7 items-center gap-1 rounded border border-input bg-background px-2 text-xs font-medium transition-colors hover:bg-accent hover:text-accent-foreground disabled:cursor-not-allowed disabled:opacity-50"
+			title={everyTableExpanded
+				? `Collapse to the current Show value`
+				: `Show every column on every table`}
+			data-testid="canvas-expand-collapse-toggle"
+		>
+			{everyTableExpanded ? 'Collapse all' : 'Expand all'}
+		</button>
+
+		<!-- Arrange split-button: click the left half to re-apply the
+		     last layout, click the chevron to pick a different one. -->
+		<div class="relative flex">
+			<button
+				type="button"
+				onclick={() => runLayout(store.defaultLayoutMode)}
+				disabled={arranging || store.doc.tables.length === 0}
+				class="inline-flex h-8 items-center gap-1.5 rounded-l border border-r-0 border-input bg-background px-2.5 text-xs font-medium transition-colors hover:bg-accent hover:text-accent-foreground disabled:cursor-not-allowed disabled:opacity-50"
+				data-testid="canvas-arrange"
+				title={`Re-apply ${LAYOUT_CHOICES.find((c) => c.mode === store.defaultLayoutMode)?.label ?? 'layout'} (pinned default)`}
+			>
+				<Sparkles class="h-3.5 w-3.5" aria-hidden="true" />
+				{arranging ? 'Arranging…' : 'Arrange'}
+			</button>
+			<button
+				type="button"
+				onclick={() => (layoutMenuOpen = !layoutMenuOpen)}
+				onkeydown={handleMenuKey}
+				disabled={arranging || store.doc.tables.length === 0}
+				aria-expanded={layoutMenuOpen}
+				aria-haspopup="menu"
+				aria-label="Pick a layout"
+				class="inline-flex h-8 items-center rounded-r border border-input bg-background px-1.5 text-xs transition-colors hover:bg-accent hover:text-accent-foreground disabled:cursor-not-allowed disabled:opacity-50"
+				data-testid="canvas-arrange-menu"
+			>
+				<ChevronDown class="h-3.5 w-3.5" aria-hidden="true" />
+			</button>
+			{#if layoutMenuOpen}
+				<!-- svelte-ignore a11y_no_static_element_interactions a11y_click_events_have_key_events -->
+				<div class="fixed inset-0 z-30" onclick={() => (layoutMenuOpen = false)}></div>
+				<div
+					role="menu"
+					class="absolute top-full right-0 z-40 mt-1 w-64 rounded-md border border-border bg-card p-1 shadow-lg"
+					data-testid="canvas-arrange-menu-list"
+				>
+					<div
+						class="border-b border-border px-2 py-1.5 text-[10px] font-medium tracking-wider text-muted-foreground uppercase"
+					>
+						Organise canvas
+					</div>
+					{#each LAYOUT_CHOICES as choice (choice.mode)}
+						{@const Icon = choice.icon}
+						{@const isActive = choice.mode === lastLayoutMode}
+						{@const isDefault = choice.mode === store.defaultLayoutMode}
+						<!-- Row = run-this-layout.  Pin icon on the right
+						     = mark this layout as the default that the
+						     main "Arrange" button applies.  Click on the
+						     pin doesn't run the layout (stopPropagation),
+						     and all layouts stay individually clickable
+						     via the rest of the row. -->
+						<div
+							class="group relative flex w-full items-stretch rounded transition-colors hover:bg-accent hover:text-accent-foreground"
+							class:bg-accent={isActive}
+							class:text-accent-foreground={isActive}
+						>
+							<button
+								type="button"
+								role="menuitem"
+								onclick={() => runLayout(choice.mode)}
+								class="flex flex-1 items-start gap-2 rounded-l px-2 py-1.5 text-left text-xs"
+								data-testid={`canvas-arrange-${choice.mode}`}
+							>
+								<Icon class="mt-0.5 h-3.5 w-3.5 shrink-0" aria-hidden="true" />
+								<span class="flex flex-1 flex-col gap-0.5">
+									<span class="font-medium">{choice.label}</span>
+									<span class="text-[10px] text-muted-foreground">{choice.hint}</span>
+								</span>
+							</button>
+							<button
+								type="button"
+								onclick={(e) => {
+									e.stopPropagation();
+									store.setDefaultLayoutMode(choice.mode);
+								}}
+								class="inline-flex w-8 shrink-0 items-center justify-center rounded-r transition-colors hover:bg-accent hover:text-accent-foreground"
+								class:text-primary={isDefault}
+								class:text-muted-foreground={!isDefault}
+								title={isDefault
+									? `${choice.label} is the default Arrange action`
+									: `Make ${choice.label} the default Arrange action`}
+								aria-label={isDefault ? 'Default layout' : 'Set as default layout'}
+								aria-pressed={isDefault}
+								data-testid={`canvas-arrange-pin-${choice.mode}`}
+							>
+								<Star
+									class={`h-3.5 w-3.5 ${isDefault ? 'fill-current' : 'opacity-40 group-hover:opacity-100'}`}
+									aria-hidden="true"
+								/>
+							</button>
+						</div>
+					{/each}
+				</div>
+			{/if}
+		</div>
+	</div>
+</div>

--- a/saiku-ui/src/lib/cube-designer/CanvasToolbar.svelte
+++ b/saiku-ui/src/lib/cube-designer/CanvasToolbar.svelte
@@ -20,7 +20,7 @@
 	} from 'lucide-svelte';
 	import type { SchemaCanvasStore } from './state.svelte.js';
 	import type { LayoutMode } from './layout.js';
-	import Tooltip from '$lib/components/ui/tooltip.svelte';
+	import Tooltip from './primitives/tooltip.svelte';
 
 	interface Props {
 		store: SchemaCanvasStore;

--- a/saiku-ui/src/lib/cube-designer/ConfirmCubePane.svelte
+++ b/saiku-ui/src/lib/cube-designer/ConfirmCubePane.svelte
@@ -1,0 +1,644 @@
+<!--
+  Confirm-cube / Validate pane — extracted from WorkbenchView.svelte
+  (audit finding #1039, stage 2 template split).
+
+  Renders when `store.mode === 'validate'`: a left cube rail, a sub-tab
+  strip (Model / Sample data / Try a query), and the Model surface
+  (Semantic/Physical renderer + read-only cube outline tree).
+
+  The Sample-data and Try-a-query tab bodies stay in the shell (they are
+  shared with the inspector drawer) and are passed in as snippet props so
+  they keep closing over the shell scope. Cube switching and the outline
+  collapse-section toggle stay shell-owned and arrive as callbacks; the
+  four writable UI flags (`validateTab`, `modelViewMode`, `modelResetTs`,
+  `outlineCollapsed`) are `$bindable` so their shell-side persistence
+  effects still fire.
+-->
+<script lang="ts">
+	import type { Snippet } from 'svelte';
+	import {
+		Database,
+		ChevronRight,
+		ChevronDown,
+		ChevronLeft,
+		Layers,
+		Sigma,
+		ListTree,
+		Rows3,
+		EyeOff
+	} from 'lucide-svelte';
+	import ConfirmCubeCanvas from './confirm-cube/ConfirmCubeCanvas.svelte';
+	import CubeDag from './confirm-cube/CubeDag.svelte';
+	import type { SchemaCanvasStore } from './state.svelte.js';
+	import type { WorkbenchCube, WorkbenchMeasureGroup } from './workbench-cubes';
+
+	type ValidateTab = 'canvas' | 'sample-data' | 'try-query';
+	type ModelViewMode = 'semantic' | 'physical';
+	type OutlineSection = 'facts' | 'mgs' | 'dims';
+
+	interface Props {
+		store: SchemaCanvasStore;
+		cubes: WorkbenchCube[];
+		selectedCubeId: string;
+		selectedCube: WorkbenchCube | undefined;
+		factsMeasureGroups: WorkbenchMeasureGroup[];
+		isSchemaSaved: boolean;
+		isSchemaDirty: boolean;
+		validateTab: ValidateTab;
+		modelViewMode: ModelViewMode;
+		modelResetTs: number;
+		/** Bump counter from the parent — forces the Confirm cube's
+		 *  model renderers to re-derive against the latest MG shape
+		 *  after upstream FK / dim-link mutations (#1088). */
+		refreshSignal?: number;
+		outlineCollapsed: boolean;
+		outlineCollapsedSections: Set<OutlineSection>;
+		switchCube: (id: string) => void;
+		toggleOutlineSection: (s: OutlineSection) => void;
+		sampleDataTab: Snippet;
+		tryQueryTab: Snippet;
+	}
+
+	let {
+		store,
+		cubes,
+		selectedCubeId,
+		selectedCube,
+		factsMeasureGroups,
+		isSchemaSaved,
+		isSchemaDirty,
+		validateTab = $bindable(),
+		modelViewMode = $bindable(),
+		modelResetTs = $bindable(),
+		refreshSignal = 0,
+		outlineCollapsed = $bindable(),
+		outlineCollapsedSections,
+		switchCube,
+		toggleOutlineSection,
+		sampleDataTab,
+		tryQueryTab
+	}: Props = $props();
+</script>
+
+<div
+	class="flex h-full min-h-0 flex-1 flex-row gap-3 overflow-hidden p-3"
+	data-testid="canvas-validate-view"
+>
+	<!-- LEFT: cube list.  Reuses the visual treatment of the cube-
+	     manage rail on the Facts & Measures tab so authors read the
+	     two rails as the same control. -->
+	<div
+		class="flex w-72 shrink-0 flex-col gap-1 overflow-hidden rounded border bg-elev-2"
+		style:border-color="hsl(var(--border))"
+		data-testid="canvas-validate-cubes-rail"
+	>
+		<div
+			class="shrink-0 border-b px-2 py-1 text-[10px] font-semibold tracking-wider uppercase"
+			style:border-color="hsl(var(--border))"
+			style:color="hsl(var(--muted-foreground))"
+		>
+			Cubes · {cubes.length}
+		</div>
+		<div class="flex min-h-0 flex-1 flex-col overflow-y-auto">
+			{#each cubes as c (c.id)}
+				{@const active = c.id === selectedCubeId}
+				{@const rowMGs = active ? factsMeasureGroups : (c.measureGroups ?? [])}
+				{@const rowLinkedDimIds = new Set(
+					rowMGs.flatMap((mg) => (mg.dimensionLinks ?? []).map((l) => l.dimensionId))
+				)}
+				{@const rowLinkedDims = store.dimensions.filter((d) => rowLinkedDimIds.has(d.id))}
+				{@const rowMGCount = rowMGs.length}
+				{@const rowDimCount = rowLinkedDims.length}
+				{@const rowHierCount = rowLinkedDims.reduce(
+					(acc, d) => acc + (d.hierarchies?.length ?? 0),
+					0
+				)}
+				{@const rowLevelCount = rowLinkedDims.reduce(
+					(acc, d) => acc + (d.hierarchies ?? []).reduce((s, h) => s + (h.levels?.length ?? 0), 0),
+					0
+				)}
+				{@const revealClass = active ? 'inline-flex' : 'hidden group-hover/cuberow:inline-flex'}
+				<!-- Cube row.  Each cube gets its own "Open in Saiku"
+				     button on the right so the rail becomes the central
+				     confirmation surface: pick a cube, see it in the
+				     model tab, launch it in Studio.  Red dot on the
+				     LEFT marks the active row. -->
+				<div
+					class="group/cuberow relative flex flex-col gap-0.5 border-b px-2 py-1.5 last:border-b-0 {active
+						? 'bg-primary/10'
+						: ''}"
+					style:border-color="hsl(var(--border))"
+					data-testid="canvas-validate-cube-item"
+					data-cube-id={c.id}
+				>
+					<div class="flex items-center gap-1 pr-24">
+						<span class="w-2 shrink-0 text-[10px] leading-none text-primary">
+							{active ? '●' : ''}
+						</span>
+						<button
+							type="button"
+							onclick={() => switchCube(c.id)}
+							class="min-w-0 flex-1 truncate text-left text-[11px] {active
+								? 'font-semibold text-foreground'
+								: 'text-muted-foreground hover:text-foreground'}"
+							title={c.name || 'Untitled cube'}
+						>
+							{c.name || 'Untitled cube'}
+						</button>
+					</div>
+					<!-- Open in Saiku — absolute-positioned so it's
+					     vertically centred against the WHOLE row (name +
+					     summary chips), not just the name row.  z-10 keeps
+					     it above the row content on hover; the pr-24 on
+					     the name row reserves horizontal space so long
+					     cube names don't slide under the button. -->
+					{#if isSchemaSaved && !isSchemaDirty}
+						<!-- Enabled — full red CTA.  This IS the payoff
+						     button: it takes all the authoring work into
+						     Studio.  Solid primary fill + white text +
+						     shadow. -->
+						<a
+							href="/saiku/launch"
+							target="_blank"
+							rel="noopener noreferrer"
+							onclick={() => {
+								if (c.id !== selectedCubeId) switchCube(c.id);
+							}}
+							class="{revealClass} absolute top-1/2 right-2 z-10 shrink-0 -translate-y-1/2 items-center gap-1 rounded-md border border-primary bg-primary px-2.5 py-1 text-[10px] font-semibold text-primary-foreground shadow-sm transition hover:bg-primary/90"
+							data-testid="canvas-validate-open-in-saiku"
+							data-cube-id={c.id}
+							title={`Open "${c.name || 'Untitled cube'}" in the Saiku Studio UI`}
+						>
+							Open in Saiku
+							<span aria-hidden="true">↗</span>
+						</a>
+					{:else}
+						<span
+							role="button"
+							aria-disabled="true"
+							tabindex={-1}
+							class="{revealClass} pointer-events-auto absolute top-1/2 right-2 z-10 shrink-0 -translate-y-1/2 cursor-not-allowed items-center gap-1 rounded-md border border-border bg-card px-2 py-1 text-[10px] font-semibold text-muted-foreground opacity-60 shadow-sm"
+							data-testid="canvas-validate-open-in-saiku-disabled"
+							data-cube-id={c.id}
+							title={isSchemaSaved
+								? `You have unsaved changes.  Hit Save (top-right) — Mondrian schemas save as one file, so all cubes save together.  After save, this opens "${c.name || 'Untitled cube'}" in Studio.`
+								: `Save the schema first via Save (top-right) — Mondrian schemas save as one file, so all cubes save together.  After save, this opens "${c.name || 'Untitled cube'}" in Studio.`}
+						>
+							Open in Saiku
+							<span aria-hidden="true">↗</span>
+						</span>
+					{/if}
+					<!-- Summary line: MG · linked dims · hierarchies · levels.
+					     Icons match the ones used elsewhere on the pane
+					     (Σ, Layers, ListTree) rendered in muted foreground
+					     so the numbers do the talking. -->
+					<div
+						class="flex items-center gap-2 pl-3 font-mono text-[9px] text-muted-foreground"
+						data-testid="canvas-validate-cube-summary"
+					>
+						<span
+							class="inline-flex items-center gap-0.5 leading-none"
+							title="{rowMGCount} measure group{rowMGCount === 1 ? '' : 's'}"
+						>
+							<Sigma class="h-2.5 w-2.5" aria-hidden="true" />
+							{rowMGCount}
+						</span>
+						<span
+							class="inline-flex items-center gap-0.5 leading-none"
+							title="{rowDimCount} linked dimension{rowDimCount === 1 ? '' : 's'}"
+						>
+							<Layers class="h-2.5 w-2.5" aria-hidden="true" />
+							{rowDimCount}
+						</span>
+						<span
+							class="inline-flex items-center gap-0.5 leading-none"
+							title="{rowHierCount} hierarch{rowHierCount === 1 ? 'y' : 'ies'}"
+						>
+							<ListTree class="h-2.5 w-2.5" aria-hidden="true" />
+							{rowHierCount}
+						</span>
+						<span
+							class="inline-flex items-center gap-0.5 leading-none"
+							title="{rowLevelCount} level{rowLevelCount === 1 ? '' : 's'}"
+						>
+							<Rows3 class="h-2.5 w-2.5" aria-hidden="true" />
+							{rowLevelCount}
+						</span>
+					</div>
+				</div>
+			{/each}
+		</div>
+		<!-- Legend for the per-cube summary icons above.  Pinned at
+		     the bottom of the rail (outside the scroll region) so it
+		     stays visible while the cube list scrolls. -->
+		<div
+			class="grid shrink-0 grid-cols-2 gap-x-3 gap-y-1 border-t px-2 py-1.5 text-[9px] text-muted-foreground"
+			style:border-color="hsl(var(--border))"
+			data-testid="canvas-validate-cubes-legend"
+		>
+			<span class="inline-flex items-center gap-1 leading-none">
+				<Sigma class="h-2.5 w-2.5 shrink-0" aria-hidden="true" /> Measure Groups
+			</span>
+			<span class="inline-flex items-center gap-1 leading-none">
+				<Layers class="h-2.5 w-2.5 shrink-0" aria-hidden="true" /> Dimensions
+			</span>
+			<span class="inline-flex items-center gap-1 leading-none">
+				<ListTree class="h-2.5 w-2.5 shrink-0" aria-hidden="true" /> Hierarchies
+			</span>
+			<span class="inline-flex items-center gap-1 leading-none">
+				<Rows3 class="h-2.5 w-2.5 shrink-0" aria-hidden="true" /> Levels
+			</span>
+		</div>
+	</div>
+
+	<!-- RIGHT: sub-tab strip + content area.  Aligns top-to-top with
+	     the cubes rail — the old shared "Open in Saiku" action row
+	     is gone; per-row buttons live in the cubes rail now. -->
+	<div class="flex min-w-0 flex-1 flex-col gap-3 overflow-hidden">
+		<div
+			class="flex shrink-0 items-stretch overflow-hidden rounded border"
+			style:border-color="hsl(var(--border))"
+			role="tablist"
+			aria-label="Confirm cube sub-view"
+		>
+			{#snippet vtab(t: ValidateTab, label: string, testid: string)}
+				<!-- Sub-tab styling.
+				     • Active: white surface + red text + red glow ring
+				       (softer than the top-level red fill, louder than
+				       the third-level Semantic/Physical toggle).
+				     • Inactive: muted grey text on the muted rail
+				       surface. -->
+				<button
+					type="button"
+					role="tab"
+					aria-selected={validateTab === t}
+					onclick={() => (validateTab = t)}
+					class="relative inline-flex min-w-0 flex-1 items-center justify-center gap-1 truncate border-l px-3 py-1.5 text-[11px] font-semibold tracking-wide first:border-l-0 {validateTab ===
+					t
+						? 'z-10 bg-white text-primary ring-2 ring-primary/50 ring-inset dark:bg-neutral-900'
+						: 'bg-elev-2 text-muted-foreground hover:bg-accent/40'}"
+					style:border-color="hsl(var(--border))"
+					data-testid={testid}
+				>
+					{label}
+				</button>
+			{/snippet}
+			{@render vtab('canvas', 'Model', 'canvas-validate-tab-canvas')}
+			{@render vtab('sample-data', 'Sample data', 'canvas-validate-tab-sample-data')}
+			{@render vtab('try-query', 'Try a query', 'canvas-validate-tab-try-query')}
+		</div>
+		<div class="flex min-h-0 flex-1 flex-col overflow-hidden">
+			{#if validateTab === 'canvas'}
+				{@render confirmCubeModel()}
+			{:else if validateTab === 'sample-data'}
+				{@render sampleDataTab()}
+			{:else}
+				{@render tryQueryTab()}
+			{/if}
+		</div>
+	</div>
+</div>
+
+<!-- ── Confirm cube > Canvas sub-tab.  Read-only star diagram: the
+     selected cube's fact table sits at the centre, each linked dim
+     table radiates out around it.  Lines drawn as SVG so they scale
+     with the layout.  Not editable — this is a "here's the shape of
+     what you built" view; edits live on the Dim & Hier / Facts &
+     Measures tabs. -->
+{#snippet cubeOutlinePanel(cube: WorkbenchCube | undefined, mgs: WorkbenchMeasureGroup[])}
+	<!-- Read-only cube outline.  Colored icons + collapsible sections —
+	     no edit affordances (per Tom) but still a proper view of the
+	     cube, not a stripped-down text dump. -->
+	{#if !cube || mgs.length === 0}
+		<p class="text-[11px] text-muted-foreground italic">
+			Nothing to outline yet — pick a fact table + link a dimension in Facts &amp; Measures.
+		</p>
+	{:else}
+		{@const factIds = new Set(mgs.map((mg) => mg.factTableId ?? '').filter((id) => id.length > 0))}
+		{@const factTables = [...factIds]
+			.map((id) => store.doc.tables.find((t) => t.id === id))
+			.filter((t) => t !== undefined)}
+		{@const linkedDimIds = new Set(
+			mgs.flatMap((mg) => (mg.dimensionLinks ?? []).map((l) => l.dimensionId))
+		)}
+		{@const linkedDims = store.dimensions.filter((d) => linkedDimIds.has(d.id))}
+		{@const factsOpen = !outlineCollapsedSections.has('facts')}
+		{@const mgsOpen = !outlineCollapsedSections.has('mgs')}
+		{@const dimsOpen = !outlineCollapsedSections.has('dims')}
+		<div class="flex flex-col gap-3">
+			<!-- Cube name -->
+			<div class="truncate text-[12px] font-semibold text-foreground">
+				{cube.name || 'Untitled cube'}
+			</div>
+
+			<!-- Fact Tables section -->
+			{#if factTables.length > 0}
+				<section class="flex flex-col gap-1">
+					<button
+						type="button"
+						onclick={() => toggleOutlineSection('facts')}
+						class="flex w-full items-center gap-1.5 text-left"
+					>
+						{#if factsOpen}
+							<ChevronDown class="h-3 w-3 shrink-0 text-muted-foreground" aria-hidden="true" />
+						{:else}
+							<ChevronRight class="h-3 w-3 shrink-0 text-muted-foreground" aria-hidden="true" />
+						{/if}
+						<Database class="h-3 w-3 shrink-0 text-primary" aria-hidden="true" />
+						<span class="text-[10px] font-semibold tracking-wider text-muted-foreground uppercase">
+							Fact Tables
+						</span>
+						<span class="ml-auto font-mono text-[10px] text-muted-foreground">
+							{factTables.length}
+						</span>
+					</button>
+					{#if factsOpen}
+						<ul class="flex flex-col gap-0.5 pl-6 font-mono text-[11px]">
+							{#each factTables as t (t.id)}
+								<li
+									class="truncate text-foreground"
+									title={t.schema ? `${t.schema}.${t.name}` : t.name}
+								>
+									{t.name}
+								</li>
+							{/each}
+						</ul>
+					{/if}
+				</section>
+			{/if}
+
+			<!-- Measure Groups section -->
+			<section class="flex flex-col gap-1">
+				<button
+					type="button"
+					onclick={() => toggleOutlineSection('mgs')}
+					class="flex w-full items-center gap-1.5 text-left"
+				>
+					{#if mgsOpen}
+						<ChevronDown class="h-3 w-3 shrink-0 text-muted-foreground" aria-hidden="true" />
+					{:else}
+						<ChevronRight class="h-3 w-3 shrink-0 text-muted-foreground" aria-hidden="true" />
+					{/if}
+					<Sigma class="h-3 w-3 shrink-0 text-primary" aria-hidden="true" />
+					<span class="text-[10px] font-semibold tracking-wider text-muted-foreground uppercase">
+						Measure Groups
+					</span>
+					<span class="ml-auto font-mono text-[10px] text-muted-foreground">
+						{mgs.length}
+					</span>
+				</button>
+				{#if mgsOpen}
+					<ul class="flex flex-col gap-2 pl-6">
+						{#each mgs as mg (mg.id)}
+							<li class="flex flex-col gap-0.5">
+								<div
+									class="flex items-center gap-1.5 truncate text-[11px] font-semibold text-foreground"
+								>
+									<Sigma class="h-2.5 w-2.5 shrink-0 text-primary" aria-hidden="true" />
+									<span class="truncate">{mg.name ?? 'Untitled MG'}</span>
+								</div>
+								{#if (mg.measureColumns ?? []).length > 0}
+									<ul class="flex flex-col gap-0 pl-5 font-mono text-[10px] text-muted-foreground">
+										{#each mg.measureColumns ?? [] as m (m)}
+											<li class="truncate" title={m}>{m}</li>
+										{/each}
+									</ul>
+								{:else}
+									<p class="pl-5 text-[10px] text-muted-foreground italic opacity-70">
+										No measures picked
+									</p>
+								{/if}
+							</li>
+						{/each}
+					</ul>
+				{/if}
+			</section>
+
+			<!-- Dimensions section -->
+			<section class="flex flex-col gap-1">
+				<button
+					type="button"
+					onclick={() => toggleOutlineSection('dims')}
+					class="flex w-full items-center gap-1.5 text-left"
+				>
+					{#if dimsOpen}
+						<ChevronDown class="h-3 w-3 shrink-0 text-muted-foreground" aria-hidden="true" />
+					{:else}
+						<ChevronRight class="h-3 w-3 shrink-0 text-muted-foreground" aria-hidden="true" />
+					{/if}
+					<Layers class="h-3 w-3 shrink-0 text-primary" aria-hidden="true" />
+					<span class="text-[10px] font-semibold tracking-wider text-muted-foreground uppercase">
+						Dimensions
+					</span>
+					<span class="ml-auto font-mono text-[10px] text-muted-foreground">
+						{linkedDims.length}
+					</span>
+				</button>
+				{#if dimsOpen}
+					<ul class="flex flex-col gap-2 pl-6">
+						{#each linkedDims as d (d.id)}
+							<li class="flex flex-col gap-0.5">
+								<div
+									class="flex items-center gap-1.5 truncate text-[11px] font-semibold text-foreground"
+								>
+									<Layers class="h-2.5 w-2.5 shrink-0 text-primary" aria-hidden="true" />
+									<span class="truncate">{d.name ?? 'Untitled dim'}</span>
+								</div>
+								{#if (d.hierarchies ?? []).length > 0}
+									<ul class="flex flex-col gap-1 pl-5">
+										{#each d.hierarchies ?? [] as h (h.id)}
+											<li class="flex flex-col gap-0">
+												<div class="flex items-center gap-1.5 truncate text-[10px] text-foreground">
+													<ListTree
+														class="h-2.5 w-2.5 shrink-0 text-muted-foreground"
+														aria-hidden="true"
+													/>
+													<span class="truncate">{h.name ?? 'Untitled hierarchy'}</span>
+												</div>
+												{#if (h.levels ?? []).length > 0}
+													<ol
+														class="flex flex-col gap-0 pl-5 font-mono text-[10px] text-muted-foreground"
+													>
+														{#each h.levels ?? [] as lvl, i (lvl.id)}
+															<li class="truncate" title={lvl.columnName}>
+																<span class="opacity-40">{i + 1}.</span>
+																{lvl.columnName}
+															</li>
+														{/each}
+													</ol>
+												{/if}
+											</li>
+										{/each}
+									</ul>
+								{:else}
+									<p class="pl-5 text-[10px] text-muted-foreground italic opacity-70">
+										No hierarchies yet
+									</p>
+								{/if}
+							</li>
+						{/each}
+					</ul>
+				{/if}
+			</section>
+		</div>
+	{/if}
+{/snippet}
+
+{#snippet confirmCubeModel()}
+	<!-- Unified cube view — Semantic (DAG: fact → MG → dim →
+	     hierarchies → levels) or Physical (fact table + dim tables
+	     with FK↔PK edges).  Two lenses on the same cube; toggle
+	     up top picks which renderer mounts.  Defaults to Semantic
+	     per Amelia's preference. -->
+	{@const cube = selectedCube}
+	{@const cubeMGs =
+		cube && cube.id === selectedCubeId ? factsMeasureGroups : (cube?.measureGroups ?? [])}
+	<div
+		class="relative flex min-h-0 flex-1 overflow-hidden rounded border bg-elev-2"
+		style:border-color="hsl(var(--border))"
+		data-testid="canvas-validate-model"
+	>
+		<!-- Top-left overlay: Cube · <name> pill + Semantic/Physical
+		     toggle, side by side.  Sits above whichever renderer is
+		     mounted so it visually anchors the model surface. -->
+		<div class="absolute top-2 left-3 z-10 flex items-center gap-2">
+			<div
+				class="pointer-events-none rounded border bg-elev-2/90 px-2 py-1 font-mono text-[10px] tracking-wider"
+				style:border-color="hsl(var(--border))"
+				style:color="hsl(var(--muted-foreground))"
+				data-testid="canvas-validate-cube-label"
+			>
+				<span class="uppercase">Cube</span>
+				<span class="opacity-50">·</span>
+				<span class="font-normal text-foreground normal-case">
+					{cube?.name ?? 'Untitled cube'}
+				</span>
+			</div>
+			<div
+				class="flex items-stretch overflow-hidden rounded border bg-elev-2/90"
+				style:border-color="hsl(var(--border))"
+				role="tablist"
+				aria-label="Cube view mode"
+				data-testid="canvas-validate-model-toggle"
+			>
+				<!-- Semantic / Physical toggle — third-level nav, softest
+				     hierarchy: both segments on the same card surface, only
+				     the text color changes (foreground for active, muted
+				     grey for inactive).  No red.  Red lives on the
+				     top-level Schema Canvas → Confirm cube control. -->
+				<button
+					type="button"
+					role="tab"
+					aria-selected={modelViewMode === 'semantic'}
+					onclick={() => (modelViewMode = 'semantic')}
+					class="inline-flex items-center bg-card px-2 py-1 text-[10px] font-semibold tracking-wide transition-colors {modelViewMode ===
+					'semantic'
+						? 'text-foreground'
+						: 'text-muted-foreground hover:text-foreground'}"
+					data-testid="canvas-validate-model-semantic"
+				>
+					Semantic
+				</button>
+				<button
+					type="button"
+					role="tab"
+					aria-selected={modelViewMode === 'physical'}
+					onclick={() => (modelViewMode = 'physical')}
+					class="inline-flex items-center border-l bg-card px-2 py-1 text-[10px] font-semibold tracking-wide transition-colors {modelViewMode ===
+					'physical'
+						? 'text-foreground'
+						: 'text-muted-foreground hover:text-foreground'}"
+					style:border-color="hsl(var(--border))"
+					data-testid="canvas-validate-model-physical"
+				>
+					Physical
+				</button>
+			</div>
+		</div>
+		<!-- Reset positions moved to the bottom-left overlay.  Bumps a
+		     signal both renderers watch to snap positions home. -->
+		<button
+			type="button"
+			onclick={() => (modelResetTs = modelResetTs + 1)}
+			class="absolute bottom-2 left-3 z-10 inline-flex items-center gap-1 rounded border border-border bg-card px-2 py-1 text-[10px] font-semibold tracking-wide text-muted-foreground uppercase shadow-sm hover:bg-accent hover:text-accent-foreground"
+			data-testid="canvas-validate-model-reset"
+			title="Restore the default layout — drops any drags you've done"
+		>
+			Reset positions
+		</button>
+		<!-- Force a full remount of the active renderer on cube switch. -->
+		<div class="flex min-h-0 flex-1">
+			<div class="relative flex min-h-0 flex-1 overflow-hidden">
+				<!-- Re-open Tree View chip (floats top-right of the canvas
+				     when the panel is hidden).  Same UX as the joins-panel
+				     re-open pill on the schema canvas. -->
+				{#if outlineCollapsed}
+					<button
+						type="button"
+						onclick={() => (outlineCollapsed = false)}
+						class="absolute top-2 right-2 z-10 inline-flex items-center gap-1 rounded border border-border bg-card px-2 py-1 text-[10px] font-semibold tracking-wide text-muted-foreground uppercase shadow-sm hover:bg-accent hover:text-accent-foreground"
+						data-testid="canvas-validate-model-tree-panel-reopen"
+						title="Show the tree view"
+					>
+						<ChevronLeft class="h-3 w-3" aria-hidden="true" />
+						Tree View
+					</button>
+				{/if}
+				{#key `${modelViewMode}::${cube?.id ?? '__none__'}`}
+					{#if modelViewMode === 'semantic'}
+						<CubeDag
+							{store}
+							cubeId={cube?.id ?? null}
+							measureGroups={cubeMGs}
+							resetSignal={modelResetTs}
+							{refreshSignal}
+						/>
+					{:else}
+						<ConfirmCubeCanvas
+							{store}
+							cubeId={cube?.id ?? null}
+							measureGroups={cubeMGs}
+							resetSignal={modelResetTs}
+							{refreshSignal}
+						/>
+					{/if}
+				{/key}
+			</div>
+			<!-- RIGHT: cube outline panel — read-only per Tom, styled with
+			     colored icons + collapsible sections.  Collapse pattern
+			     mirrors the schema canvas joins/source panels: the whole
+			     panel disappears (freeing the canvas), and a floating
+			     "Tree view" chip appears at the canvas top-right to
+			     re-open. -->
+			{#if !outlineCollapsed}
+				<aside
+					class="flex w-64 shrink-0 flex-col overflow-hidden border-l bg-elev-2/40 text-[11px]"
+					style:border-color="hsl(var(--border))"
+					data-testid="canvas-validate-model-tree-panel"
+				>
+					<header
+						class="flex shrink-0 items-center justify-between gap-2 border-b bg-elev-2 px-2 py-1.5"
+						style:border-color="hsl(var(--border))"
+					>
+						<span class="text-[10px] font-semibold tracking-wider text-muted-foreground uppercase">
+							Tree View
+						</span>
+						<button
+							type="button"
+							onclick={() => (outlineCollapsed = true)}
+							class="shrink-0 rounded p-0.5 text-muted-foreground hover:bg-accent hover:text-accent-foreground"
+							aria-label="Hide tree view — open more canvas space"
+							title="Hide tree view (use the pill at top-right to re-open)"
+							data-testid="canvas-validate-model-tree-panel-collapse"
+						>
+							<EyeOff class="h-3.5 w-3.5" aria-hidden="true" />
+						</button>
+					</header>
+					<div class="min-h-0 flex-1 overflow-auto p-2">
+						{@render cubeOutlinePanel(cube, cubeMGs)}
+					</div>
+				</aside>
+			{/if}
+		</div>
+	</div>
+{/snippet}

--- a/saiku-ui/src/lib/cube-designer/DimSumChatDock.svelte
+++ b/saiku-ui/src/lib/cube-designer/DimSumChatDock.svelte
@@ -1,0 +1,287 @@
+<!--
+  DimSum overlays for the schema canvas:
+    - the full-text AI error modal ("See issue")
+    - the popped-out persistent chat dock (rolling multi-turn conversation)
+
+  Presentational: the conversation state + the agent loop live in the parent
+  SchemaCanvasView; this component renders them and reports user intent back
+  via `onSend` / `onClearChat` + two-way `bind:` props. Owns only the
+  chat-log scroll ref + its auto-scroll-to-bottom effect.
+-->
+<script lang="ts">
+	import { Sparkles, AlertTriangle, X, Loader2 } from 'lucide-svelte';
+	import type { SchemaCanvasStore } from './state.svelte.js';
+	import type { AnthropicBlock, ChatMessage } from './ai-chat-types';
+
+	interface Props {
+		store: SchemaCanvasStore;
+		messages: ChatMessage[];
+		drafting: boolean;
+		error: string | null;
+		chatOpen: boolean;
+		errorOpen: boolean;
+		chatDraft: string;
+		onClearChat: () => void;
+		onSend: (draft: string) => void;
+	}
+
+	let {
+		store,
+		messages,
+		drafting,
+		error,
+		chatOpen = $bindable(),
+		errorOpen = $bindable(),
+		chatDraft = $bindable(),
+		onClearChat,
+		onSend
+	}: Props = $props();
+
+	// Chat-log DOM ref for auto-scroll to bottom on new messages / on chat
+	// modal open. Behaves like claude.ai — replies keep the log pinned at the
+	// latest turn without the user manually scrolling.
+	let aiChatLogEl = $state<HTMLDivElement | null>(null);
+	$effect(() => {
+		if (!chatOpen) return;
+		// Depend on messages.length + drafting flag so the effect fires both
+		// when a new turn lands AND when the "Working…" indicator toggles.
+		void messages.length;
+		void drafting;
+		queueMicrotask(() => {
+			if (aiChatLogEl) aiChatLogEl.scrollTop = aiChatLogEl.scrollHeight;
+		});
+	});
+</script>
+
+<!-- Full-text error modal — the compact "1 issue" bar in the AI
+     section is where you click "See issue" to get here.  Payload
+     is the raw error text (API 4xx body, network msg, etc.) with
+     a Copy button so you can paste it into a bug report. -->
+{#if errorOpen && error}
+	<div
+		class="fixed inset-0 z-50 flex items-center justify-center bg-background/80 p-6"
+		role="dialog"
+		aria-modal="true"
+		aria-labelledby="canvas-ai-error-modal-title"
+	>
+		<div
+			class="flex h-full max-h-[70vh] w-full max-w-2xl flex-col rounded-lg border border-destructive/40 bg-card p-4 shadow-xl"
+		>
+			<header class="mb-2 flex items-center justify-between gap-2">
+				<h2
+					id="canvas-ai-error-modal-title"
+					class="flex items-center gap-1.5 text-sm font-semibold text-destructive"
+				>
+					<AlertTriangle class="h-4 w-4" aria-hidden="true" />
+					AI issue
+				</h2>
+				<div class="flex items-center gap-1.5">
+					<button
+						type="button"
+						onclick={() => navigator.clipboard?.writeText(error ?? '')}
+						class="rounded border border-border px-2 py-1 text-[10px] font-semibold tracking-wider text-muted-foreground uppercase hover:bg-accent hover:text-accent-foreground"
+						title="Copy the full error text"
+						data-testid="canvas-ai-error-copy"
+					>
+						Copy
+					</button>
+					<button
+						type="button"
+						onclick={() => (errorOpen = false)}
+						class="rounded p-1 text-muted-foreground hover:bg-accent hover:text-accent-foreground"
+						aria-label="Close"
+					>
+						<X class="h-4 w-4" aria-hidden="true" />
+					</button>
+				</div>
+			</header>
+			<pre
+				class="min-h-0 flex-1 overflow-auto rounded border border-border bg-muted/40 p-3 font-mono text-[11px] leading-relaxed whitespace-pre-wrap"
+				data-testid="canvas-ai-error-full">{error}</pre>
+		</div>
+	</div>
+{/if}
+
+<!-- Persistent chat modal — full rolling multi-turn conversation
+     with Claude about the current canvas.  History persists per
+     connection via localStorage; Clear chat wipes it. Alternating
+     user/assistant bubbles mimic a claude.ai-style thread; input
+     bar at the bottom with Enter-to-send (Shift+Enter newline). -->
+{#if chatOpen}
+	<!-- Side-panel dock instead of a full-screen overlay — the
+	     canvas stays visible + interactive on the left, DimSum
+	     conversation lives on the right.  Non-modal so the user
+	     can still drag tables around while a reply is in flight. -->
+	<div
+		class="pointer-events-none fixed inset-0 z-40 flex justify-end"
+		aria-labelledby="canvas-ai-chat-title"
+	>
+		<div
+			class="pointer-events-auto flex h-full w-full max-w-md flex-col border-l border-border bg-card shadow-xl"
+			role="dialog"
+			aria-labelledby="canvas-ai-chat-title"
+		>
+			<header
+				class="flex shrink-0 items-center justify-between gap-2 border-b border-border px-4 py-3"
+			>
+				<h2 id="canvas-ai-chat-title" class="flex items-center gap-1.5 text-sm font-semibold">
+					<Sparkles class="h-3.5 w-3.5 text-primary" aria-hidden="true" />
+					DimSum · this canvas
+				</h2>
+				<div class="flex items-center gap-1.5">
+					<button
+						type="button"
+						onclick={onClearChat}
+						disabled={messages.length === 0}
+						class="rounded border border-border px-2 py-1 text-[10px] font-semibold tracking-wider text-muted-foreground uppercase hover:bg-accent hover:text-accent-foreground disabled:cursor-not-allowed disabled:opacity-50"
+						title="Wipe the conversation history"
+						data-testid="canvas-ai-chat-clear"
+					>
+						Clear chat
+					</button>
+					<button
+						type="button"
+						onclick={() => (chatOpen = false)}
+						class="rounded p-1 text-muted-foreground hover:bg-accent hover:text-accent-foreground"
+						aria-label="Close chat"
+					>
+						<X class="h-4 w-4" aria-hidden="true" />
+					</button>
+				</div>
+			</header>
+
+			<div
+				bind:this={aiChatLogEl}
+				class="min-h-0 flex-1 space-y-3 overflow-y-auto px-4 py-4"
+				data-testid="canvas-ai-chat-log"
+			>
+				{#if messages.length === 0 && !drafting}
+					<div class="flex h-full flex-col items-center justify-center gap-2 text-center">
+						<Sparkles class="h-6 w-6 text-primary" aria-hidden="true" />
+						<p class="text-sm font-medium">Start a conversation about this canvas</p>
+						<p class="max-w-[42ch] text-xs text-muted-foreground">
+							Ask questions (“what cubes are here?”) or request changes (“add a join from
+							orders.customer_id to customers.id”). History persists per connection.
+						</p>
+					</div>
+				{:else}
+					{#each messages as m, i (i)}
+						{@const blocks = (
+							typeof m.content === 'string' ? [{ type: 'text', text: m.content }] : m.content
+						) as AnthropicBlock[]}
+						{@const isToolResultTurn =
+							m.role === 'user' &&
+							Array.isArray(m.content) &&
+							(m.content as AnthropicBlock[]).every((b) => b.type === 'tool_result')}
+						{#if isToolResultTurn}
+							<!-- Tool results — one small pill per result so
+							     the conversation shows the reads/mutations
+							     happening without shouting the JSON output. -->
+							<div class="flex flex-col gap-1" data-testid="canvas-ai-chat-toolresults">
+								{#each blocks as b, bi (bi)}
+									{#if b.type === 'tool_result'}
+										<div
+											class="self-start rounded border border-border bg-muted/30 px-2 py-1 text-[10px] text-muted-foreground"
+										>
+											<span class={b.is_error ? 'text-destructive' : 'text-success'}>
+												{b.is_error ? '✗' : '✓'}
+											</span>
+											<span class="ml-1 font-mono">tool result</span>
+										</div>
+									{/if}
+								{/each}
+							</div>
+						{:else}
+							<div
+								class="flex gap-2 {m.role === 'user' ? 'justify-end' : 'justify-start'}"
+								data-testid="canvas-ai-chat-message"
+								data-role={m.role}
+							>
+								<div
+									class="max-w-[80%] rounded-lg px-3 py-2 text-xs leading-relaxed {m.role === 'user'
+										? 'bg-primary text-primary-foreground'
+										: 'border border-border bg-muted/40 text-foreground'}"
+								>
+									{#if m.role === 'assistant'}
+										<div
+											class="mb-1 flex items-center gap-1 text-[9px] font-semibold tracking-wider text-muted-foreground uppercase"
+										>
+											<Sparkles class="h-2.5 w-2.5 text-primary" aria-hidden="true" />
+											DimSum
+										</div>
+									{/if}
+									{#each blocks as b, bi (bi)}
+										{#if b.type === 'text' && b.text}
+											<p class="whitespace-pre-wrap">{b.text}</p>
+										{:else if b.type === 'tool_use'}
+											<!-- Tool call pill — small mono label -->
+											<div
+												class="my-1 inline-flex items-center gap-1 rounded border border-primary/40 bg-primary/5 px-1.5 py-0.5 font-mono text-[10px] text-primary"
+											>
+												<Sparkles class="h-2.5 w-2.5" aria-hidden="true" />
+												{b.name}
+												{#if Object.keys(b.input ?? {}).length > 0}
+													<span class="text-muted-foreground"
+														>({Object.entries(b.input)
+															.map(
+																([k, v]) => `${k}=${typeof v === 'string' ? v : JSON.stringify(v)}`
+															)
+															.join(', ')})</span
+													>
+												{/if}
+											</div>
+										{/if}
+									{/each}
+								</div>
+							</div>
+						{/if}
+					{/each}
+					{#if drafting}
+						<div class="flex justify-start gap-2">
+							<div
+								class="max-w-[80%] rounded-lg border border-border bg-muted/40 px-3 py-2 text-xs text-muted-foreground"
+							>
+								<Loader2 class="mr-1 inline h-3 w-3 animate-spin" aria-hidden="true" />
+								Working…
+							</div>
+						</div>
+					{/if}
+				{/if}
+			</div>
+
+			<footer class="shrink-0 border-t border-border p-3">
+				<div class="flex items-end gap-2">
+					<textarea
+						bind:value={chatDraft}
+						onkeydown={(e) => {
+							if (e.key === 'Enter' && !e.shiftKey) {
+								e.preventDefault();
+								onSend(chatDraft);
+							}
+						}}
+						placeholder="Reply to the AI — Enter to send, Shift+Enter for a new line."
+						rows="2"
+						maxlength="2000"
+						disabled={drafting}
+						class="min-h-0 flex-1 resize-none rounded border border-input bg-background px-2 py-1.5 text-xs leading-relaxed placeholder:text-muted-foreground focus:border-ring focus:ring-1 focus:ring-ring focus:outline-none disabled:opacity-60"
+						data-testid="canvas-ai-chat-input"
+					></textarea>
+					<button
+						type="button"
+						onclick={() => onSend(chatDraft)}
+						disabled={drafting || !store.connectionId || !chatDraft.trim()}
+						class="inline-flex h-8 shrink-0 items-center gap-1 rounded bg-primary px-3 text-xs font-medium text-primary-foreground hover:bg-primary/90 disabled:opacity-50"
+						data-testid="canvas-ai-chat-send"
+					>
+						{#if drafting}
+							<Loader2 class="h-3 w-3 animate-spin" aria-hidden="true" />
+						{:else}
+							<Sparkles class="h-3 w-3" aria-hidden="true" />
+						{/if}
+						Send
+					</button>
+				</div>
+			</footer>
+		</div>
+	</div>
+{/if}

--- a/saiku-ui/src/lib/cube-designer/DimensionsHierarchiesPane.svelte
+++ b/saiku-ui/src/lib/cube-designer/DimensionsHierarchiesPane.svelte
@@ -1,0 +1,2225 @@
+<!--
+  DimensionsHierarchiesPane — the Dimensions / Attributes / Hierarchies column
+  cluster extracted from WorkbenchView.svelte (audit finding #1039). Owns the
+  three reorderable columns of the schema designer's Columns (workbench) mode:
+  the Dimensions pane (source-table / join-group picker + saved-dimension
+  list), the Attributes pane (per-dimension attribute checklist), and the
+  Hierarchies pane (hierarchy list + level drop zones).
+
+  Like FactsMeasuresPane, it owns NO durable state. The shell (WorkbenchView)
+  keeps the single source of truth for every selection / drag / edit variable
+  and threads it in via props + `bind:`. This component only READS props,
+  mutates the shared reactive `store` it is handed in place, and calls shell
+  callbacks for every structural mutation — so behaviour is byte-for-byte
+  identical to the inline snippets it replaced. Every value the template
+  reassigns is a `$bindable()` prop bound from the shell (never a duplicated
+  source of truth). The local type aliases (PaneKind / FocusKind / DimSortKey /
+  DropTarget / JoinGroupRow) mirror the shell's — simple shapes kept in
+  lock-step rather than widening a shared module surface.
+-->
+<script lang="ts">
+	import {
+		Database,
+		ChevronDown,
+		ChevronUp,
+		GripVertical,
+		Plus,
+		X,
+		Layers,
+		ListTree,
+		Search,
+		AlertCircle,
+		KeyRound
+	} from 'lucide-svelte';
+	import Popover from '$lib/design-system/primitives/Popover.svelte';
+	import SortableColumnHeader from '$lib/design-system/SortableColumnHeader.svelte';
+	import { dimKeyIdentity, resolveKeyAttribute } from './state.svelte.js';
+	import type { SchemaCanvasStore } from './state.svelte.js';
+	import {
+		ATTRIBUTE_MIME,
+		readAttributeDrag,
+		readLevelMoveDrag,
+		isContentDrag
+	} from './workbench-dnd';
+	import type { AttributeDragPayload } from './workbench-dnd';
+	import type { SchemaCanvasTable, SchemaCanvasDimension, SchemaCanvasHierarchy } from './types.js';
+
+	// Mirrors the shell's local unions / shapes (kept in lock-step).
+	type PaneKind = 'dimensions' | 'attributes' | 'hierarchies';
+	type FocusKind = 'dim' | 'hierarchy' | 'attribute' | 'measure' | 'mg' | 'cube' | 'calc';
+	type DimSortKey = 'idx' | 'name' | 'type' | 'cols';
+	type DropTarget =
+		| { kind: 'dim-zone' }
+		| { kind: 'dim'; id: string }
+		| { kind: 'hierarchy'; dimensionId: string; hierarchyId: string }
+		| { kind: 'measure-zone' };
+	interface JoinGroupRow {
+		key: string;
+		label: string;
+		tableNames: string[];
+		tableIds: string[];
+	}
+
+	interface Props {
+		store: SchemaCanvasStore;
+		columnSlots: PaneKind[];
+		paneDragIndex: number | null;
+		paneDragOverIndex: number | null;
+		dimSortKey: DimSortKey;
+		dimSortDir: 'asc' | 'desc';
+		attributeCount: number;
+		hierarchyCount: number;
+		levelCount: number;
+		selectedDimension: SchemaCanvasDimension | null;
+		selectedHierarchy: SchemaCanvasHierarchy | null;
+		joinGroupsRail: JoinGroupRow[];
+		PANE_KIND_ICONS: Record<PaneKind, typeof Layers>;
+		PANE_KIND_LABELS: Record<PaneKind, string>;
+		// ── bindable: shell owns the source of truth, child writes via bind: ──
+		attributesPaneMode: 'edit' | 'saved';
+		contentDragOverHierarchyId: string | null;
+		deletingDimId: string | null;
+		dimDragOverHierName: boolean;
+		dimensionPaneFilter: string;
+		dimensionPaneMode: 'edit' | 'saved';
+		dimensionPreviewKey: string | null;
+		editingDimNameId: string | null;
+		editingHierNameId: string | null;
+		focusDimId: string | null;
+		hierarchyExplicitlyClicked: boolean;
+		manualAddDimName: string;
+		manualAddDimOpen: boolean;
+		manualAddDimSourceKey: string;
+		selectedAttributeKey: string | null;
+		selectedLevelId: string | null;
+		selectedDimensionId: string | null;
+		selectedHierarchyId: string | null;
+		selectedMeasureId: string | null;
+		// ── shell callbacks (every structural mutation routes back here) ──
+		focus: (kind: FocusKind, id: string) => void;
+		isFocused: (kind: FocusKind, id: string | null | undefined) => boolean;
+		isContext: (kind: FocusKind, id: string | null | undefined) => boolean;
+		autoFocus: (node: HTMLInputElement, shouldFocus: boolean) => { update(active: boolean): void };
+		columnTypeFor: (tableId: string, columnName: string) => string | undefined;
+		dropRingFor: (target: DropTarget) => string;
+		addHierarchyFromAttribute: (dimId: string, tableId: string, columnName: string) => void;
+		commitDimensionName: (dimId: string) => void;
+		commitHierarchyName: (dimId: string, hierId: string) => void;
+		createDimFromJoinGroup: (group: JoinGroupRow) => SchemaCanvasDimension;
+		createDimFromTable: (table: SchemaCanvasTable) => SchemaCanvasDimension;
+		handleAttributeDragStart: (e: DragEvent, payload: AttributeDragPayload) => void;
+		handleDimensionDrop: (e: DragEvent, dimension: SchemaCanvasDimension) => void;
+		handleDragLeave: (e: DragEvent, target: DropTarget) => void;
+		handleDragOver: (e: DragEvent, target: DropTarget) => void;
+		handlePaneDragEnd: () => void;
+		handlePaneDragLeave: (idx: number) => void;
+		handlePaneDragOver: (e: DragEvent, idx: number) => void;
+		handlePaneDragStart: (e: DragEvent, idx: number) => void;
+		handlePaneDrop: (e: DragEvent, targetIdx: number) => void;
+		renameDimension: (id: string, name: string) => void;
+		renameHierarchy: (dimId: string, hierId: string, name: string) => void;
+		requestDeleteHierarchy: (dimId: string, hierId: string) => void;
+		resetManualAddDim: () => void;
+		toggleDimSort: (key: DimSortKey) => void;
+	}
+
+	let {
+		store,
+		columnSlots,
+		paneDragIndex,
+		paneDragOverIndex,
+		dimSortKey,
+		dimSortDir,
+		attributeCount,
+		hierarchyCount,
+		levelCount,
+		selectedDimension,
+		selectedHierarchy,
+		joinGroupsRail,
+		PANE_KIND_ICONS,
+		PANE_KIND_LABELS,
+		attributesPaneMode = $bindable(),
+		contentDragOverHierarchyId = $bindable(),
+		deletingDimId = $bindable(),
+		dimDragOverHierName = $bindable(),
+		dimensionPaneFilter = $bindable(),
+		dimensionPaneMode = $bindable(),
+		dimensionPreviewKey = $bindable(),
+		editingDimNameId = $bindable(),
+		editingHierNameId = $bindable(),
+		focusDimId = $bindable(),
+		 
+		hierarchyExplicitlyClicked = $bindable(),
+		manualAddDimName = $bindable(),
+		manualAddDimOpen = $bindable(),
+		manualAddDimSourceKey = $bindable(),
+		 
+		selectedAttributeKey = $bindable(),
+		selectedLevelId = $bindable(),
+		selectedDimensionId = $bindable(),
+		 
+		selectedHierarchyId = $bindable(),
+		 
+		selectedMeasureId = $bindable(),
+		focus,
+		isFocused,
+		isContext,
+		autoFocus,
+		columnTypeFor,
+		dropRingFor,
+		addHierarchyFromAttribute,
+		commitDimensionName,
+		commitHierarchyName,
+		createDimFromJoinGroup,
+		createDimFromTable,
+		handleAttributeDragStart,
+		handleDimensionDrop,
+		handleDragLeave,
+		handleDragOver,
+		handlePaneDragEnd,
+		handlePaneDragLeave,
+		handlePaneDragOver,
+		handlePaneDragStart,
+		handlePaneDrop,
+		renameDimension,
+		renameHierarchy,
+		requestDeleteHierarchy,
+		resetManualAddDim,
+		toggleDimSort
+	}: Props = $props();
+
+	// Attribute-edit DRAFT — All / Clear / checkbox mutations write here
+	// instead of directly to the store, so switching dims mid-edit doesn't
+	// silently commit whatever the user was toying with.  Confirm pill in
+	// the pane header commits (or a click on saved-mode Edit re-seeds the
+	// draft).  Discarded on dim change.  Reported 2026-07-31 — attribute
+	// setup should feel intentional; casual clicks shouldn't persist.
+	type AttrDraftEntry = { tableId: string; columnName: string };
+	let attrsDraft = $state<AttrDraftEntry[] | null>(null);
+
+	// Seed the draft whenever the user enters edit mode or picks a
+	// different dim while already in edit mode.  Dropping the draft back
+	// to null on exit / switch keeps the mental model clean — the pane
+	// only holds pending edits while it's actively in edit mode.
+	$effect(() => {
+		if (attributesPaneMode !== 'edit') {
+			attrsDraft = null;
+			return;
+		}
+		if (!selectedDimension) {
+			attrsDraft = null;
+			return;
+		}
+		const dimId = selectedDimension.id;
+		attrsDraft = (selectedDimension.attributes ?? []).map((a) => ({
+			tableId: a.tableId,
+			columnName: a.columnName
+		}));
+		// Explicit read of dimId so this re-runs on dim switch.
+		void dimId;
+	});
+
+	// True when the draft differs from the committed attributes on the
+	// selected dim — drives the Confirm pill's "unsaved" visual + tells
+	// the commit path whether it has work to do.
+	const attrsDraftDirty = $derived.by(() => {
+		if (attrsDraft === null || !selectedDimension) return false;
+		const committed = selectedDimension.attributes ?? [];
+		if (attrsDraft.length !== committed.length) return true;
+		const key = (a: AttrDraftEntry) => `${a.tableId}::${a.columnName}`;
+		const draftKeys = new Set(attrsDraft.map(key));
+		return committed.some((a) => !draftKeys.has(key(a)));
+	});
+
+	function commitAttrsDraft(dimId: string) {
+		if (attrsDraft === null) return;
+		store.setAttributes(dimId, attrsDraft);
+	}
+</script>
+
+<!-- Root markup = the former `columnsPanes` snippet body. -->
+<div class="flex h-full min-h-0 flex-1 gap-3 overflow-hidden" data-testid="workbench-columns-view">
+	{#each columnSlots as kind, idx (idx)}
+		{@render columnsPane(idx, kind)}
+	{/each}
+</div>
+
+{#snippet columnsPane(idx: number, kind: PaneKind)}
+	{@const Icon = PANE_KIND_ICONS[kind]}
+	{@const isReorderTarget = paneDragOverIndex === idx && paneDragIndex !== idx}
+	{@const isReorderSource = paneDragIndex === idx}
+	<!-- Cross-pane "disabled" rule: the Hierarchies pane (kind +
+	     header AND body) dims ONLY when there's an actual gate to
+	     enforce — a dim is selected AND its attributes are still
+	     in edit mode.  Previously the outer disabled fired whenever
+	     `attributesPaneMode === 'edit'` regardless of whether a dim
+	     had been picked, so the pane showed greyed-out even in its
+	     empty state ("Compose a hierarchy") when there was nothing
+	     to gate against.  Other panes are never disabled by
+	     another pane's state. -->
+	{@const isDisabled =
+		kind === 'hierarchies' && !!selectedDimension && attributesPaneMode === 'edit'}
+	<section
+		class="flex h-full min-w-0 flex-1 flex-col rounded-md border bg-elev-1 transition-colors {isReorderTarget
+			? 'border-primary'
+			: ''} {isReorderSource ? 'opacity-50' : ''} {isDisabled ? 'workbench-pane-disabled' : ''}"
+		style:border-color={isReorderTarget ? '' : 'hsl(var(--border))'}
+		ondragover={(e) => handlePaneDragOver(e, idx)}
+		ondragleave={() => handlePaneDragLeave(idx)}
+		ondrop={(e) => handlePaneDrop(e, idx)}
+		data-testid="workbench-columns-pane"
+		data-pane-index={idx}
+		data-pane-kind={kind}
+	>
+		<!-- Pane header: grip + icon + LABEL + per-kind context + action
+		     pill (Edit / + Add).  This is the ONLY title strip per
+		     pane — no inner sub-headers; the body just renders the
+		     content boxes.  Background is bg-muted so the title strip
+		     reads as a distinct strata above the white content. -->
+		<header
+			class="flex shrink-0 items-center gap-2 border-b bg-elev-1 px-2.5 py-2 transition-opacity"
+			style:border-color="hsl(var(--border))"
+		>
+			<span
+				role="button"
+				tabindex="0"
+				draggable="true"
+				ondragstart={(e) => handlePaneDragStart(e, idx)}
+				ondragend={handlePaneDragEnd}
+				class="-ml-1 shrink-0 cursor-grab rounded p-1 text-muted-foreground hover:bg-accent hover:text-accent-foreground active:cursor-grabbing"
+				aria-label="Drag to reorder this column"
+				title="Drag to reorder"
+				data-testid="workbench-pane-grip"
+			>
+				<GripVertical class="h-3 w-3" aria-hidden="true" />
+			</span>
+			<Icon class="h-3.5 w-3.5 shrink-0 text-primary" aria-hidden="true" />
+			<span
+				class="shrink-0 text-[11px] font-semibold tracking-wider uppercase"
+				data-testid="workbench-pane-label"
+			>
+				{PANE_KIND_LABELS[kind]}
+			</span>
+			{@render paneHeaderContext(kind)}
+			<div class="ml-auto flex shrink-0 items-center gap-1">
+				{@render paneHeaderActions(kind)}
+			</div>
+		</header>
+
+		<!-- `scrollbar-gutter: stable both-edges` reserves matching space on
+		     LEFT and RIGHT so adding/removing a scrollbar doesn't shift
+		     content AND the left/right padding visually balances even when
+		     there's no scrollbar yet (the prior `stable` alone reserved
+		     only on the right, giving the pane an uneven look). -->
+		<div class="min-h-0 flex-1 [scrollbar-gutter:stable_both-edges] overflow-y-auto bg-card p-2">
+			{#if kind === 'dimensions'}
+				{@render paneDimensions()}
+			{:else if kind === 'attributes'}
+				{@render paneAttributes()}
+			{:else if kind === 'hierarchies'}
+				{@render paneHierarchies()}
+			{/if}
+		</div>
+	</section>
+{/snippet}
+
+{#snippet paneHeaderContext(kind: PaneKind)}
+	<!--
+		Pane header eyebrow counts.  Written in plain English (`7 attributes`
+		not `|A|=7`) so the number reads without math notation.  Fixes #970.
+		Each entry gets a `title` tooltip echoing the same phrase for the
+		truncation tail.
+	-->
+	{#if kind === 'dimensions'}
+		{@const n = store.dimensions.length}
+		<span
+			class="truncate font-mono text-[10px]"
+			style:color="hsl(var(--muted-foreground))"
+			title="{n} dimension{n === 1 ? '' : 's'}"
+		>
+			· {n} dimension{n === 1 ? '' : 's'}
+		</span>
+	{:else if kind === 'attributes'}
+		<!-- Pane header shows the CUBE-WIDE count, not the selected dim's
+		     count — the pane body already renders the selected dim's
+		     attrs beneath, so repeating "· Store ·" up here was noise. -->
+		<span
+			class="truncate font-mono text-[10px]"
+			style:color="hsl(var(--muted-foreground))"
+			title="{attributeCount} attribute{attributeCount === 1 ? '' : 's'}"
+		>
+			· {attributeCount} attribute{attributeCount === 1 ? '' : 's'}
+		</span>
+	{:else if kind === 'hierarchies'}
+		<span
+			class="truncate font-mono text-[10px]"
+			style:color="hsl(var(--muted-foreground))"
+			title="{hierarchyCount} hierarch{hierarchyCount === 1
+				? 'y'
+				: 'ies'} · {levelCount} level{levelCount === 1 ? '' : 's'}"
+		>
+			· {hierarchyCount} hierarch{hierarchyCount === 1 ? 'y' : 'ies'} ·
+			{levelCount} level{levelCount === 1 ? '' : 's'}
+		</span>
+	{/if}
+{/snippet}
+
+{#snippet paneHeaderActions(kind: PaneKind)}
+	{#if kind === 'dimensions'}
+		<!-- Edit pill: flips the pane between the source picker (which is
+		     the only place to CREATE a new dimension by binding it to a
+		     source table or join group) and the saved list.  The 054d
+		     restructure removed the per-row pencil but accidentally
+		     yanked this pill too, leaving no way back to edit once dims
+		     existed — regression fix. -->
+		<button
+			type="button"
+			onclick={() => (dimensionPaneMode = dimensionPaneMode === 'edit' ? 'saved' : 'edit')}
+			class="inline-flex items-center gap-1 rounded-full border px-2 py-0.5 text-[10px] font-semibold tracking-wider uppercase transition-colors {dimensionPaneMode ===
+			'edit'
+				? 'border-primary bg-primary text-primary-foreground'
+				: 'border-border text-muted-foreground hover:bg-accent hover:text-accent-foreground'}"
+			data-testid="workbench-pane-dimensions-toggle"
+			title={dimensionPaneMode === 'edit'
+				? 'Done picking — switch to saved dim list'
+				: 'Add / edit dim source bindings'}
+		>
+			{dimensionPaneMode === 'edit' ? 'Confirm' : 'Edit'}
+		</button>
+	{:else if kind === 'attributes'}
+		{#if selectedDimension}
+			<button
+				type="button"
+				onclick={() => {
+					if (attributesPaneMode === 'edit' && selectedDimension) {
+						commitAttrsDraft(selectedDimension.id);
+					}
+					attributesPaneMode = attributesPaneMode === 'edit' ? 'saved' : 'edit';
+				}}
+				class="inline-flex items-center gap-1 rounded-full border px-2 py-0.5 text-[10px] font-semibold tracking-wider uppercase transition-colors {attributesPaneMode ===
+				'edit'
+					? 'border-primary bg-primary text-primary-foreground'
+					: 'border-border text-muted-foreground hover:bg-accent hover:text-accent-foreground'}"
+				title={attributesPaneMode === 'edit'
+					? attrsDraftDirty
+						? 'Save changes to this dimension'
+						: 'Close edit mode (no changes to save)'
+					: 'Edit the attributes on this dimension'}
+				data-testid="workbench-pane-attributes-toggle"
+			>
+				{attributesPaneMode === 'edit' ? 'Confirm' : 'Edit'}
+			</button>
+		{/if}
+	{:else if kind === 'hierarchies'}
+		<!-- Hierarchies are always editable when not disabled by the
+		     Attributes-pane lock, so no Edit pill — just the Add button
+		     in the corner. -->
+		{#if selectedDimension}
+			<button
+				type="button"
+				onclick={() => {
+					const h = store.addHierarchy(selectedDimension.id);
+					if (h) {
+						selectedHierarchyId = h.id;
+						hierarchyExplicitlyClicked = true;
+						editingHierNameId = h.id;
+					}
+				}}
+				class="inline-flex items-center gap-1 rounded-full border border-border px-2 py-0.5 text-[10px] font-semibold tracking-wider text-muted-foreground uppercase hover:bg-accent hover:text-accent-foreground"
+				data-testid="workbench-pane-add-hierarchy"
+				title="Add a hierarchy"
+			>
+				<Plus class="h-2.5 w-2.5" aria-hidden="true" />
+				Add hierarchy
+			</button>
+		{/if}
+	{/if}
+{/snippet}
+
+{#snippet paneDimensions()}
+	<!-- Phase 1 Column 1: the dim pane IS the source picker.  Two
+	     modes —
+	       edit:  checklist of every on-canvas table + join group;
+	              check → instantly create a dim bound to that source.
+	       saved: numbered list of dims with rename-inline + original
+	              source subtitle.
+	     The pill button in the sub-header flips between them ("EDIT ON"
+	     in edit mode, "EDIT" off in saved mode).  Defaults to edit
+	     when there are no dims yet so the empty state is a useful
+	     pick-something surface, not a blank wall. -->
+	{#if dimensionPaneMode === 'edit'}
+		{@render paneDimensionsEdit()}
+	{:else}
+		{@render paneDimensionsSaved()}
+	{/if}
+{/snippet}
+
+<!-- eslint-disable-next-line @typescript-eslint/no-unused-vars -->
+{#snippet paneDimensionsSubHeader(showSave: boolean)}
+	<div class="flex shrink-0 items-center justify-between gap-2 pb-2">
+		<span
+			class="text-[10px] font-semibold tracking-wider uppercase"
+			style:color="hsl(var(--muted-foreground))"
+		>
+			{showSave ? 'Pick tables & joins for dimensions' : 'Saved dimensions'}
+		</span>
+		<button
+			type="button"
+			onclick={() => (dimensionPaneMode = showSave ? 'saved' : 'edit')}
+			class="inline-flex items-center gap-1 rounded-full border px-2 py-0.5 text-[10px] font-semibold tracking-wider uppercase transition-colors {showSave
+				? 'border-primary bg-primary text-primary-foreground'
+				: 'border-border text-muted-foreground hover:bg-accent hover:text-accent-foreground'}"
+			data-testid="workbench-pane-dim-toggle"
+			title={showSave ? 'Done picking — switch to saved list' : 'Pick more / unpick sources'}
+		>
+			{#if showSave}
+				Edit · on
+			{:else}
+				Edit
+			{/if}
+		</button>
+	</div>
+{/snippet}
+
+{#snippet paneDimensionsEdit()}
+	{@const tableLabel = (t: SchemaCanvasTable) => (t.schema ? `${t.schema}.${t.name}` : t.name)}
+	{@const tableEntries = store.doc.tables.map((t) => ({
+		kind: 'table' as const,
+		id: t.id,
+		key: `table:${t.id}`,
+		label: tableLabel(t),
+		suffix: 'tbl',
+		ref: t
+	}))}
+	{@const joinEntries = joinGroupsRail.map((g) => ({
+		kind: 'join' as const,
+		id: g.key,
+		key: `join:${g.key}`,
+		label: g.label,
+		suffix: 'Join',
+		ref: g
+	}))}
+	{@const allEntries = [...tableEntries, ...joinEntries].sort((a, b) =>
+		a.label.localeCompare(b.label)
+	)}
+	{@const filterNeedle = dimensionPaneFilter.trim().toLowerCase()}
+	{@const filtered =
+		filterNeedle === ''
+			? allEntries
+			: allEntries.filter((e) => e.label.toLowerCase().includes(filterNeedle))}
+	{@const dimsForTable = (tableId: string) =>
+		store.dimensions.filter(
+			(d) => (d.sourceTableId ?? d.primaryKeyTableId) === tableId && !d.foreignKey
+		)}
+	{@const dimsForJoinGroup = (group: (typeof joinEntries)[number]['ref']) =>
+		store.dimensions.filter((d) => d.sourceJoinGroupKey === group.key)}
+	<div class="flex h-full flex-col gap-2" data-testid="workbench-pane-dimensions-edit">
+		<!-- One table can back many dimensions (role-playing dims:
+		     order_date / ship_date / invoice_date all use `date`).  Each
+		     row's +Add dim button creates ANOTHER dim from that source;
+		     names auto-dedupe (Store → Store (1) → Store (2)).  Delete
+		     happens in the Saved pane (✕ on each row). -->
+		<p class="shrink-0 px-1 text-[11px] leading-snug" style:color="hsl(var(--muted-foreground))">
+			Click <span class="font-medium">+ Add dim</span> on a source to bind a new dimension. Multiple dims
+			per source are fine — names dedupe automatically.
+		</p>
+		<!-- Search across the unified source list -->
+		<div class="relative shrink-0">
+			<Search
+				class="pointer-events-none absolute top-1/2 left-2 h-3 w-3 -translate-y-1/2 opacity-50"
+				aria-hidden="true"
+			/>
+			<input
+				type="search"
+				bind:value={dimensionPaneFilter}
+				placeholder="Search tables or joins…"
+				aria-label="Filter sources"
+				class="h-7 w-full rounded border bg-background py-1 pr-7 pl-7 text-[11px] focus:border-ring focus:ring-1 focus:ring-ring focus:outline-none"
+				style:border-color="hsl(var(--border))"
+				data-testid="workbench-pane-dim-search"
+			/>
+			{#if dimensionPaneFilter}
+				<button
+					type="button"
+					onclick={() => (dimensionPaneFilter = '')}
+					class="absolute top-1/2 right-1 inline-flex h-5 w-5 -translate-y-1/2 items-center justify-center rounded text-muted-foreground hover:bg-accent hover:text-accent-foreground"
+					aria-label="Clear filter"
+					title="Clear filter"
+				>
+					<X class="h-3 w-3" aria-hidden="true" />
+				</button>
+			{/if}
+		</div>
+
+		{#if allEntries.length === 0}
+			<div class="flex flex-1 flex-col items-center justify-center gap-1 p-3 text-center">
+				<Database class="h-5 w-5" aria-hidden="true" style="color: hsl(var(--muted-foreground))" />
+				<p class="text-xs font-medium">Nothing on the canvas yet</p>
+				<p class="text-[11px]" style="color: hsl(var(--muted-foreground))">
+					Flip back to Schema Canvas to add tables.
+				</p>
+			</div>
+		{:else}
+			<ol class="flex flex-col gap-0.5">
+				{#each filtered as entry (entry.key)}
+					{@const existingDims =
+						entry.kind === 'table'
+							? dimsForTable(entry.id)
+							: dimsForJoinGroup(entry.ref as JoinGroupRow)}
+					{@const existingCount = existingDims.length}
+					<li class="flex flex-col">
+						<!--
+							Row is display-only in edit mode.  The +Add dim button
+							is the sole action; the row body doesn't toggle any
+							Attribute-pane preview (edit mode is for building the
+							dim list, attributes come later in the saved view).
+						-->
+						<div
+							class="flex items-center gap-2 rounded px-1.5 py-1.5 text-[11px]"
+							data-testid="workbench-pane-source-row"
+							data-source-kind={entry.kind}
+						>
+							{#if entry.kind === 'table'}
+								<Database class="h-3.5 w-3.5 shrink-0 text-muted-foreground" aria-hidden="true" />
+							{:else}
+								<Layers class="h-3.5 w-3.5 shrink-0 text-primary" aria-hidden="true" />
+							{/if}
+							<span class="min-w-0 flex-1 truncate font-mono">{entry.label}</span>
+							<span class="shrink-0 font-mono text-[9px] tracking-wide uppercase opacity-50">
+								{entry.suffix}
+							</span>
+							{#if existingCount > 0}
+								<span
+									class="shrink-0 rounded-full border px-1.5 py-0.5 font-mono text-[10px]"
+									style:background-color="hsl(var(--elev-1))"
+									style:border-color="hsl(var(--border))"
+									style:color="hsl(var(--foreground))"
+									title="{existingCount} dim{existingCount === 1
+										? ''
+										: 's'} already drawn from this source"
+								>
+									{existingCount} dim{existingCount === 1 ? '' : 's'}
+								</span>
+							{/if}
+							<button
+								type="button"
+								onclick={() => {
+									// Edit mode: add the dim and leave the Attributes
+									// pane alone.  The user came here to build a dim
+									// list, not to bounce the attribute selection
+									// around every time they click Add.
+									if (entry.kind === 'table') {
+										createDimFromTable(entry.ref as SchemaCanvasTable);
+									} else {
+										createDimFromJoinGroup(entry.ref as JoinGroupRow);
+									}
+								}}
+								class="inline-flex shrink-0 items-center gap-1 rounded border border-border bg-background px-2.5 py-1 text-[11px] text-muted-foreground transition-colors hover:bg-accent hover:text-accent-foreground"
+								data-testid="workbench-pane-source-add-dim"
+								data-source-key={entry.key}
+								title="Bind a new dimension to {entry.label}"
+							>
+								<Plus class="h-3 w-3" aria-hidden="true" />
+								Add dim
+							</button>
+						</div>
+						<!-- Preview lands in the Attributes pane (disabled style) rather
+						     than inline under the row — see paneAttributes when no dim is
+						     selected.  Keeps the picker compact + lets the user see the
+						     columns in the same place where committed attributes show up. -->
+					</li>
+				{/each}
+				{#if filtered.length === 0}
+					<li
+						class="rounded border border-dashed p-3 text-center text-[11px]"
+						style:border-color="hsl(var(--border))"
+						style:color="hsl(var(--muted-foreground))"
+					>
+						No source matches "{dimensionPaneFilter}".
+					</li>
+				{/if}
+			</ol>
+		{/if}
+	</div>
+{/snippet}
+
+{#snippet paneDimensionsSaved()}
+	{@const savedTableEntries = store.doc.tables.map((t) => ({
+		kind: 'table' as const,
+		id: t.id,
+		key: `table:${t.id}`,
+		label: t.schema ? `${t.schema}.${t.name}` : t.name,
+		suffix: 'tbl',
+		ref: t
+	}))}
+	{@const savedJoinEntries = joinGroupsRail.map((g) => ({
+		kind: 'join' as const,
+		id: g.key,
+		key: `join:${g.key}`,
+		label: g.label,
+		suffix: 'Join',
+		ref: g
+	}))}
+	{@const savedAllEntries = [...savedTableEntries, ...savedJoinEntries].sort((a, b) =>
+		a.label.localeCompare(b.label)
+	)}
+	{@const sortedDims = (() => {
+		const withMeta = store.dimensions.map((dim, idx) => {
+			const dimSrcId = dim.sourceTableId ?? dim.primaryKeyTableId;
+			const sourceTable = dimSrcId ? store.doc.tables.find((t) => t.id === dimSrcId) : null;
+			const isJoinSourced = !!dim.sourceJoinGroupKey;
+			const isHanger = !!dim.hanger;
+			// Split the "(unbound)" case: was a source ever picked
+			// (dimSrcId set) that now doesn't resolve — likely a
+			// stale ID from persisted state — or is the dim truly
+			// bare (no source ever bound).
+			const staleSource = !!dimSrcId && !sourceTable && !isJoinSourced;
+			const sourceLabel = isHanger
+				? '(hanger)'
+				: isJoinSourced
+					? (dim.sourceJoinGroupKey ?? '')
+					: sourceTable
+						? sourceTable.schema
+							? `${sourceTable.schema}.${sourceTable.name}`
+							: sourceTable.name
+						: staleSource
+							? '(source removed from canvas)'
+							: '(unbound)';
+			const sourceKind: 'join' | 'table' | 'unbound' | 'hanger' = isHanger
+				? 'hanger'
+				: isJoinSourced
+					? 'join'
+					: sourceTable
+						? 'table'
+						: 'unbound';
+			// Show the count of attributes PICKED for this dim, not the
+			// total columns on the source table.  The saved list is
+			// per-dim, so "24" was misleading — it read as "this dim
+			// has 24 attributes" when it really meant "the source
+			// table has 24 columns".  Attributes are the semantic
+			// unit anyway.
+			const sourceColCount = dim.attributes?.length ?? 0;
+			// PK-missing flag — fires as soon as the dim has any
+			// attributes but its stored key doesn't resolve to one.
+			// Applies uniformly to dims created any way (drag-to-add,
+			// per-source +Add dim button, bottom-of-pane +Add Dimension
+			// form) — Mondrian requires a key on every non-hanger dim
+			// regardless of whether hierarchies exist yet, so the alert
+			// no longer waits on a hierarchy to appear.
+			const pkResolvedKey = resolveKeyAttribute(dim);
+			const pkMissing = !isHanger && !pkResolvedKey && (dim.attributes ?? []).length > 0;
+			const pkMissingReason = pkMissing
+				? dimKeyIdentity(dim)
+					? `${dim.name} carries a key value ("${dimKeyIdentity(dim)}") that matches more than one attribute — pick which one in the Inspector.`
+					: `${dim.name} has no primary key — Mondrian needs one on every dim. Set it in the Inspector.`
+				: null;
+			return {
+				dim,
+				idx,
+				sourceLabel,
+				sourceKind,
+				sourceColCount,
+				isHanger,
+				pkMissing,
+				pkMissingReason,
+				staleSource
+			};
+		});
+		// Hangers always render; they're rendered disabled/greyed
+		// downstream so the user can see them but can't act on them
+		// (we don't fully support them yet).  They sort with everything
+		// else — the "(hanger)" label + disabled style tell the story.
+		if (dimSortKey === 'idx') return withMeta;
+		const sign = dimSortDir === 'asc' ? 1 : -1;
+		return [...withMeta].sort((a, b) => {
+			if (dimSortKey === 'name') {
+				return sign * (a.dim.name || '').localeCompare(b.dim.name || '');
+			}
+			if (dimSortKey === 'type') {
+				return sign * a.sourceKind.localeCompare(b.sourceKind);
+			}
+			if (dimSortKey === 'cols') {
+				return sign * (a.sourceColCount - b.sourceColCount);
+			}
+			return 0;
+		});
+	})()}
+	<div class="flex h-full min-h-0 flex-col gap-2" data-testid="workbench-pane-dimensions-saved">
+		<!-- Tabular layout: Name · Type · Cols · X.  Each header (except X)
+			     is clickable to sort; same column twice flips direction, third
+			     click restores creation order.  Row index badges were removed —
+			     insertion order isn't semantic (sort by name if you need it). -->
+		<div
+			class="grid shrink-0 grid-cols-[1fr_4rem_3.5rem_1.75rem] items-center gap-1 border-b px-2 py-1 text-[9px] font-semibold tracking-wider uppercase"
+			style:border-color="hsl(var(--border))"
+			style:color="hsl(var(--muted-foreground))"
+		>
+			<SortableColumnHeader
+				label="Name"
+				sortKey="name"
+				activeKey={dimSortKey}
+				direction={dimSortDir}
+				onToggle={toggleDimSort}
+			/>
+			<SortableColumnHeader
+				label="Type"
+				sortKey="type"
+				activeKey={dimSortKey}
+				direction={dimSortDir}
+				onToggle={toggleDimSort}
+			/>
+			<div class="justify-self-center">
+				<SortableColumnHeader
+					label="Attrs"
+					sortKey="cols"
+					activeKey={dimSortKey}
+					direction={dimSortDir}
+					onToggle={toggleDimSort}
+				/>
+			</div>
+			<span></span>
+		</div>
+		<div
+			class="flex min-h-0 flex-1 flex-col overflow-y-auto rounded border bg-elev-2"
+			style:border-color="hsl(var(--border))"
+		>
+			{#each sortedDims as { dim, sourceLabel, sourceKind, sourceColCount, pkMissing, pkMissingReason, staleSource }, displayIdx (dim.id)}
+				{@const isActive = isFocused('dim', dim.id)}
+				{@const isCtx = isContext('dim', dim.id)}
+				{@const isHangerRow = !!dim.hanger}
+				{@const isConfirmingDelete = deletingDimId === dim.id}
+				<div
+					role="button"
+					tabindex={isHangerRow ? -1 : 0}
+					aria-disabled={isHangerRow ? 'true' : undefined}
+					title={isHangerRow
+						? "Hanger dimension — the schema designer can't author these yet."
+						: undefined}
+					onclick={() => {
+						if (isHangerRow) return;
+						if (isConfirmingDelete) return;
+						selectedDimensionId = dim.id;
+						selectedHierarchyId = null;
+						hierarchyExplicitlyClicked = false;
+						selectedMeasureId = null;
+						selectedAttributeKey = null;
+						focus('dim', dim.id);
+						attributesPaneMode = (dim.attributes?.length ?? 0) === 0 ? 'edit' : 'saved';
+					}}
+					onkeydown={(e) => {
+						if (isHangerRow) return;
+						if (isConfirmingDelete) return;
+						if (e.key === 'Enter' || e.key === ' ') {
+							e.preventDefault();
+							selectedDimensionId = dim.id;
+							selectedHierarchyId = null;
+							hierarchyExplicitlyClicked = false;
+							selectedMeasureId = null;
+							selectedAttributeKey = null;
+							focus('dim', dim.id);
+							attributesPaneMode = (dim.attributes?.length ?? 0) === 0 ? 'edit' : 'saved';
+						}
+					}}
+					class="grid {isConfirmingDelete
+						? 'grid-cols-[1fr_auto]'
+						: 'grid-cols-[1fr_4rem_3.5rem_1.75rem]'} items-center gap-1 border-b px-2 py-1.5 text-[11px] transition-colors {isHangerRow
+						? 'cursor-not-allowed opacity-50'
+						: 'cursor-pointer'} {isConfirmingDelete
+						? 'workbench-row-confirming-delete'
+						: isActive
+							? 'workbench-row-selected'
+							: isCtx
+								? 'workbench-row-context'
+								: `border-border ${isHangerRow ? '' : 'hover:bg-accent/40'} ${displayIdx % 2 === 0 ? 'bg-muted/8' : 'bg-elev-2'}`}"
+					style:border-color={isActive || isCtx ? '' : 'hsl(var(--border))'}
+					style:background-color={isConfirmingDelete ? 'hsl(var(--destructive) / 0.08)' : undefined}
+					style:border-left={isConfirmingDelete ? '2px solid hsl(var(--destructive))' : undefined}
+					data-testid="workbench-pane-dimension"
+					data-dimension-id={dim.id}
+				>
+					<div class="flex min-w-0 flex-col">
+						{#if editingDimNameId === dim.id}
+							<input
+								type="text"
+								value={dim.name}
+								oninput={(e) => renameDimension(dim.id, e.currentTarget.value)}
+								onclick={(e) => e.stopPropagation()}
+								onkeydown={(e) => {
+									e.stopPropagation();
+									if (e.key === 'Enter' || e.key === 'Escape') {
+										(e.currentTarget as HTMLInputElement).blur();
+									}
+								}}
+								onblur={() => {
+									commitDimensionName(dim.id);
+									editingDimNameId = null;
+								}}
+								placeholder="Dimension name"
+								aria-label="Dimension name"
+								class="h-5 min-w-0 rounded border bg-background px-1 font-medium focus:border-ring focus:ring-1 focus:ring-ring focus:outline-none"
+								style:border-color="hsl(var(--border))"
+								use:autoFocus={focusDimId === dim.id || editingDimNameId === dim.id}
+							/>
+						{:else}
+							<span class="flex min-w-0 items-center gap-1">
+								{#if pkMissing}
+									<!-- PK-missing warning — yellow AlertCircle, tooltip
+										     explains what the engine will reject.  Sits
+										     BEFORE the name so the eye catches it. -->
+									<AlertCircle
+										class="h-3 w-3 shrink-0 text-warning"
+										aria-label={pkMissingReason ?? 'Primary key missing'}
+									/>
+								{/if}
+								<span
+									role="button"
+									tabindex="0"
+									ondblclick={(e) => {
+										e.stopPropagation();
+										editingDimNameId = dim.id;
+									}}
+									onkeydown={(e) => {
+										if (e.key === 'F2') {
+											e.preventDefault();
+											e.stopPropagation();
+											editingDimNameId = dim.id;
+										}
+									}}
+									class="block min-w-0 truncate leading-5 font-medium"
+									title="Double-click to rename"
+								>
+									{dim.name || 'Untitled dimension'}
+								</span>
+							</span>
+						{/if}
+						<span
+							class="flex min-w-0 items-center gap-1 truncate font-mono text-[9px] {staleSource
+								? 'text-warning'
+								: ''}"
+							style:color={staleSource ? undefined : 'hsl(var(--muted-foreground))'}
+							title={staleSource
+								? `Source table for "${dim.name}" is no longer on the canvas. Rebind it in the Inspector.`
+								: sourceLabel}
+						>
+							{#if staleSource}
+								<AlertCircle class="h-3 w-3 shrink-0" aria-hidden="true" />
+							{/if}
+							<span class="min-w-0 truncate">{sourceLabel}</span>
+						</span>
+					</div>
+					{#if isConfirmingDelete}
+						<!-- Right-side inline confirm — replaces Type / Cols / ✕
+							     with "Delete? [Yes] [No]" on the SAME row.  No modal,
+							     no new row underneath. -->
+						<div
+							class="flex shrink-0 items-center gap-3 pl-2"
+							onclick={(e) => e.stopPropagation()}
+							onkeydown={(e) => e.stopPropagation()}
+							role="group"
+							aria-label="Confirm deletion"
+						>
+							<span
+								class="text-[11px] font-semibold tracking-wide"
+								style:color="hsl(var(--destructive))"
+							>
+								Delete?
+							</span>
+							<button
+								type="button"
+								onclick={() => {
+									const removingId = dim.id;
+									deletingDimId = null;
+									store.removeDimension(removingId);
+									if (selectedDimensionId === removingId) {
+										selectedDimensionId = null;
+										selectedHierarchyId = null;
+									}
+									if (focusDimId === removingId) focusDimId = null;
+								}}
+								class="inline-flex min-w-[3.5rem] items-center justify-center rounded border px-3 py-1 text-[11px] font-semibold text-white shadow-sm transition-colors hover:opacity-90"
+								style:background-color="hsl(var(--destructive))"
+								style:border-color="hsl(var(--destructive))"
+								data-testid="workbench-pane-dim-delete-confirm"
+							>
+								Yes
+							</button>
+							<button
+								type="button"
+								onclick={() => (deletingDimId = null)}
+								class="inline-flex min-w-[3.5rem] items-center justify-center rounded border border-border bg-background px-3 py-1 text-[11px] font-semibold hover:bg-accent hover:text-accent-foreground"
+								data-testid="workbench-pane-dim-delete-cancel"
+							>
+								No
+							</button>
+						</div>
+					{:else}
+						<span
+							class="shrink-0 font-mono text-[9px] tracking-wide uppercase"
+							style:color="hsl(var(--muted-foreground))"
+						>
+							{sourceKind}
+						</span>
+						<span
+							class="shrink-0 justify-self-center text-center font-mono text-[10px] tabular-nums"
+						>
+							{sourceColCount}
+						</span>
+						{#if isHangerRow}
+							<span class="shrink-0 justify-self-center"></span>
+						{:else}
+							<button
+								type="button"
+								onclick={(e) => {
+									e.stopPropagation();
+									deletingDimId = dim.id;
+								}}
+								class="inline-flex h-5 w-5 shrink-0 items-center justify-center justify-self-center rounded text-muted-foreground hover:bg-destructive/10 hover:text-destructive"
+								aria-label="Delete {dim.name || 'this dimension'}"
+								title="Delete {dim.name || 'this dimension'}"
+								data-testid="workbench-pane-dim-delete"
+							>
+								<X class="h-3 w-3" aria-hidden="true" />
+							</button>
+						{/if}
+					{/if}
+				</div>
+			{/each}
+
+			<!-- Manual add path — dashed "Add Dimension" pill lives as
+				     the LAST ITEM in the list itself.  When the list has
+				     dims, it sits below the last row; when the list is
+				     empty, it appears at the top (only content in the
+				     container).  Flows with the list; not fixed to the
+				     bottom of the pane. -->
+			{#if savedAllEntries.length > 0}
+				<div class="p-2">
+					{#if !manualAddDimOpen}
+						<button
+							type="button"
+							onclick={() => {
+								manualAddDimOpen = true;
+								manualAddDimName = '';
+								manualAddDimSourceKey = '';
+							}}
+							class="flex w-full items-center justify-center gap-1.5 rounded border-2 border-dashed px-3 py-2 text-[11px] font-semibold tracking-wide text-muted-foreground uppercase transition-colors hover:border-primary/50 hover:bg-accent hover:text-accent-foreground"
+							style:border-color="hsl(var(--border))"
+							data-testid="workbench-pane-add-dimension-manual"
+						>
+							<Plus class="h-3.5 w-3.5" aria-hidden="true" />
+							Add Dimension
+						</button>
+					{:else}
+						<div
+							class="flex flex-col gap-2 rounded border-2 border-dashed p-2"
+							style:border-color="hsl(var(--primary) / 0.5)"
+							data-testid="workbench-pane-add-dimension-form"
+						>
+							<label class="flex flex-col gap-1">
+								<span
+									class="text-[9px] font-semibold tracking-wider uppercase"
+									style:color="hsl(var(--muted-foreground))">Name</span
+								>
+								<input
+									type="text"
+									bind:value={manualAddDimName}
+									placeholder="e.g. Order Date"
+									class="h-7 rounded border bg-background px-2 text-[11px] focus:border-ring focus:ring-1 focus:ring-ring focus:outline-none"
+									style:border-color="hsl(var(--border))"
+									data-testid="workbench-pane-add-dimension-name"
+								/>
+							</label>
+							<label class="flex flex-col gap-1">
+								<span
+									class="text-[9px] font-semibold tracking-wider uppercase"
+									style:color="hsl(var(--muted-foreground))">Source</span
+								>
+								<!-- Flat picker — appearance-none strips macOS's glossy
+									     chrome, and a hand-drawn ChevronDown overlays via
+									     the relative <span>. -->
+								<span class="relative">
+									<select
+										bind:value={manualAddDimSourceKey}
+										class="h-7 w-full appearance-none rounded border bg-background px-2 pr-7 font-mono text-[11px] focus:border-ring focus:ring-1 focus:ring-ring focus:outline-none"
+										style:border-color="hsl(var(--border))"
+										data-testid="workbench-pane-add-dimension-source"
+									>
+										<option value="" disabled>— pick a table or join —</option>
+										{#each savedAllEntries as entry (entry.key)}
+											<option value={entry.key}>{entry.label} · {entry.suffix}</option>
+										{/each}
+									</select>
+									<ChevronDown
+										class="pointer-events-none absolute top-1/2 right-2 size-3.5 -translate-y-1/2 text-muted-foreground"
+										aria-hidden="true"
+									/>
+								</span>
+							</label>
+							<div class="flex items-center justify-end gap-2 pt-1">
+								<button
+									type="button"
+									onclick={resetManualAddDim}
+									class="inline-flex min-w-[3.5rem] items-center justify-center rounded border border-border bg-background px-3 py-1 text-[11px] font-semibold hover:bg-accent hover:text-accent-foreground"
+									data-testid="workbench-pane-add-dimension-cancel"
+								>
+									Cancel
+								</button>
+								<button
+									type="button"
+									disabled={!manualAddDimSourceKey}
+									onclick={() => {
+										const key = manualAddDimSourceKey;
+										if (!key) return;
+										const entry = savedAllEntries.find((e) => e.key === key);
+										if (!entry) return;
+										const trimmedName = manualAddDimName.trim();
+										if (entry.kind === 'table') {
+											const t = entry.ref as SchemaCanvasTable;
+											store.addDimension({
+												name: trimmedName || t.name,
+												tableId: t.id
+											});
+										} else {
+											const group = entry.ref as JoinGroupRow;
+											const dim = store.addDimension({
+												name: trimmedName || group.key,
+												tableId: group.tableIds[0]
+											});
+											store.updateDimension(dim.id, { sourceJoinGroupKey: group.key });
+										}
+										resetManualAddDim();
+									}}
+									class="inline-flex min-w-[3.5rem] items-center justify-center rounded border border-primary bg-primary px-3 py-1 text-[11px] font-semibold text-primary-foreground shadow-sm transition-colors hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-50"
+									data-testid="workbench-pane-add-dimension-confirm"
+								>
+									Add
+								</button>
+							</div>
+						</div>
+					{/if}
+				</div>
+			{/if}
+		</div>
+	</div>
+{/snippet}
+
+<!-- eslint-disable-next-line @typescript-eslint/no-unused-vars -->
+{#snippet paneDimensionRow(dim: SchemaCanvasDimension)}
+	{@const isSelected = isFocused('dim', dim.id)}
+	<!-- Row is a div (not a button) so it can host an editable name
+	     input.  Clicking the row sets selection; clicking the input
+	     focuses for renaming without triggering the row's selection
+	     handler (the input's pointer event terminates there).  The
+	     `use:autoFocus` action picks up the newly-created dim id and
+	     auto-selects its placeholder text, matching the Cards-view
+	     "click Add → type immediately" UX. -->
+	<div
+		role="button"
+		tabindex="0"
+		onclick={() => {
+			selectedDimensionId = dim.id;
+			selectedHierarchyId = dim.hierarchies[0]?.id ?? null;
+			selectedMeasureId = null;
+			focus('dim', dim.id);
+		}}
+		onkeydown={(e) => {
+			if (e.key === 'Enter' || e.key === ' ') {
+				e.preventDefault();
+				selectedDimensionId = dim.id;
+				selectedHierarchyId = dim.hierarchies[0]?.id ?? null;
+				selectedMeasureId = null;
+				focus('dim', dim.id);
+			}
+		}}
+		ondragover={(e) => handleDragOver(e, { kind: 'dim', id: dim.id })}
+		ondragleave={(e) => handleDragLeave(e, { kind: 'dim', id: dim.id })}
+		ondrop={(e) => handleDimensionDrop(e, dim)}
+		class="flex items-center gap-1.5 rounded border px-2 py-1.5 text-left text-xs transition-colors {isSelected
+			? 'workbench-row-selected'
+			: 'border-transparent hover:bg-accent/40'} {dropRingFor({ kind: 'dim', id: dim.id })}"
+		data-testid="workbench-pane-dimension"
+		data-dimension-id={dim.id}
+	>
+		<Layers class="h-3.5 w-3.5 shrink-0 text-primary" aria-hidden="true" />
+		<input
+			type="text"
+			value={dim.name}
+			oninput={(e) => renameDimension(dim.id, e.currentTarget.value)}
+			onclick={(e) => e.stopPropagation()}
+			onkeydown={(e) => e.stopPropagation()}
+			placeholder="Dimension name"
+			aria-label="Dimension name"
+			class="h-5 min-w-0 flex-1 rounded border border-transparent bg-transparent px-1 font-medium hover:border-input focus:border-ring focus:bg-background focus:ring-1 focus:ring-ring focus:outline-none"
+			data-testid="workbench-pane-dimension-name"
+			use:autoFocus={focusDimId === dim.id}
+		/>
+		<span class="shrink-0 font-mono text-[10px] text-muted-foreground">
+			{dim.hierarchies.reduce((n, h) => n + h.levels.length, 0)} levels
+		</span>
+		<button
+			type="button"
+			onclick={(e) => {
+				e.stopPropagation();
+				store.removeDimension(dim.id);
+				if (selectedDimensionId === dim.id) {
+					selectedDimensionId = null;
+					selectedHierarchyId = null;
+				}
+			}}
+			class="shrink-0 rounded p-0.5 text-muted-foreground hover:bg-accent hover:text-accent-foreground"
+			aria-label="Delete dimension"
+			title="Delete dimension"
+		>
+			<X class="h-2.5 w-2.5" aria-hidden="true" />
+		</button>
+	</div>
+{/snippet}
+
+<!-- eslint-disable-next-line @typescript-eslint/no-unused-vars -->
+{#snippet paneSubHeader(leftLabel: string, editing: boolean, setEditing: (next: boolean) => void)}
+	<div class="flex shrink-0 items-center justify-between gap-2 pb-2">
+		<span
+			class="text-[10px] font-semibold tracking-wider uppercase"
+			style:color="hsl(var(--muted-foreground))"
+		>
+			{leftLabel}
+		</span>
+		<button
+			type="button"
+			onclick={() => setEditing(!editing)}
+			class="inline-flex items-center gap-1 rounded-full border px-2 py-0.5 text-[10px] font-semibold tracking-wider uppercase transition-colors {editing
+				? 'border-primary bg-primary text-primary-foreground'
+				: 'border-border text-muted-foreground hover:bg-accent hover:text-accent-foreground'}"
+			data-testid="workbench-pane-sub-toggle"
+			title={editing ? 'Done editing — show saved list' : 'Edit the full list'}
+		>
+			{#if editing}
+				Edit · on
+			{:else}
+				Edit
+			{/if}
+		</button>
+	</div>
+{/snippet}
+
+{#snippet paneAttributes()}
+	{@const dim = selectedDimension}
+	{@const previewKey = dimensionPreviewKey ?? ''}
+	{@const previewTable = previewKey.startsWith('table:')
+		? (store.doc.tables.find((t) => t.id === previewKey.slice('table:'.length)) ?? null)
+		: null}
+	{#if !dim && previewTable}
+		<!--
+			Preview from the Dimensions picker.  The user clicked a table row
+			but hasn't checked it yet — show its columns here disabled so they
+			can verify what's inside before committing.  Once they check the
+			row, the dim is created + selected and the regular Attributes view
+			takes over.
+		-->
+		<div
+			class="flex h-full min-h-0 flex-col gap-2 p-2"
+			data-testid="workbench-pane-attributes-preview"
+		>
+			<header class="flex shrink-0 items-center gap-1.5">
+				<Database class="h-3.5 w-3.5 shrink-0 text-primary" aria-hidden="true" />
+				<span
+					class="min-w-0 flex-1 truncate text-[10px] font-semibold tracking-wider uppercase"
+					style:color="hsl(var(--muted-foreground))"
+				>
+					Preview · {previewTable.schema
+						? `${previewTable.schema}.${previewTable.name}`
+						: previewTable.name}
+				</span>
+				<button
+					type="button"
+					onclick={() => (dimensionPreviewKey = null)}
+					class="shrink-0 rounded px-1.5 py-0.5 text-[10px] font-semibold tracking-wider text-muted-foreground uppercase hover:bg-accent hover:text-accent-foreground"
+					aria-label="Clear preview"
+					title="Clear preview"
+				>
+					Clear
+				</button>
+			</header>
+			<ul
+				class="flex min-h-0 flex-1 flex-col gap-0.5 overflow-y-auto rounded border bg-muted/30 px-2 py-1.5 opacity-60"
+				style:border-color="hsl(var(--border))"
+				aria-label="Columns in {previewTable.name} (preview only)"
+			>
+				{#each previewTable.columns as col (col.name)}
+					<li
+						class="flex cursor-not-allowed items-center gap-2 rounded px-1.5 py-1 text-[11px]"
+						aria-disabled="true"
+					>
+						<Database class="h-3 w-3 shrink-0 text-muted-foreground" aria-hidden="true" />
+						<span class="min-w-0 flex-1 truncate font-mono">{col.name}</span>
+						{#if col.sqlType}
+							<span class="shrink-0 font-mono text-[9px] tracking-wide uppercase opacity-60">
+								{col.sqlType}
+							</span>
+						{/if}
+					</li>
+				{/each}
+			</ul>
+			<p
+				class="shrink-0 text-[10px] leading-snug italic"
+				style:color="hsl(var(--muted-foreground))"
+			>
+				Read-only preview. Check this table in the Dimensions list to start editing its attributes.
+			</p>
+		</div>
+	{:else if !dim}
+		<div class="flex h-full flex-col items-center justify-center gap-1 p-3 text-center">
+			<Database class="h-5 w-5" aria-hidden="true" style="color: hsl(var(--muted-foreground))" />
+			<p class="text-xs font-medium">Pick a dimension</p>
+			<p class="text-[11px]" style="color: hsl(var(--muted-foreground))">
+				Click a saved dim to define its attributes, or click a table in the Dimensions list to
+				preview its columns.
+			</p>
+		</div>
+	{:else}
+		{@const boundTable =
+			(dim.sourceTableId ?? dim.primaryKeyTableId)
+				? (store.doc.tables.find((t) => t.id === (dim.sourceTableId ?? dim.primaryKeyTableId)) ??
+					null)
+				: null}
+		{#if !boundTable}
+			<!-- Fallback state: dim has no table binding.  Happens when
+			     an imported XML declared a table that isn't on the
+			     canvas, or when a fresh dim hasn't been linked yet.
+			     The Inspector is the fix location (Properties tab → set
+			     the PK; picking one binds the dim to that table).
+			     If the schema intended this dim to be degenerate (members
+			     live on the fact), that's also set from the Inspector. -->
+			<div class="flex h-full flex-col items-center justify-center gap-1 p-3 text-center">
+				<Database class="h-5 w-5" aria-hidden="true" style="color: hsl(var(--muted-foreground))" />
+				<p class="text-xs font-medium">No table bound</p>
+				<p class="text-[11px]" style="color: hsl(var(--muted-foreground))">
+					Set a primary key in the Inspector to bind this dim to a table.
+				</p>
+			</div>
+		{:else}
+			{@const dimHasHierarchies = dim.hierarchies.length > 0}
+			{@const needsKey = !!(dim.sourceTableId ?? dim.primaryKeyTableId) && dimHasHierarchies}
+			{@const keyMissing = needsKey && !resolveKeyAttribute(dim)}
+			<!-- Wrap the pane body + inline key alert so the alert sits at
+			     the TOP, right under the section header.  Icon-only so it
+			     doesn't crowd the pane; the full explanation lives in the
+			     Inspector (hover the icon for a tooltip).  The engine
+			     rejects a dim-with-hierarchies without a join key, so
+			     surfacing it here saves the user a round-trip. -->
+			<div class="flex h-full min-h-0 flex-col gap-2">
+				{#if keyMissing}
+					<div
+						class="flex shrink-0 items-center justify-end"
+						data-testid="workbench-pane-attributes-key-warning"
+					>
+						<span
+							class="inline-flex h-5 items-center gap-1 rounded-full border border-warning/50 bg-warning/15 px-2 text-warning"
+							title="Mondrian needs a join key for a dimension with hierarchies — the engine will reject this schema at load. Pick a key attribute in the Inspector."
+						>
+							<AlertCircle class="h-3 w-3 shrink-0" aria-hidden="true" />
+							<span class="font-mono text-[9px] font-semibold tracking-wider uppercase">
+								Key missing
+							</span>
+						</span>
+					</div>
+				{/if}
+				<div class="flex min-h-0 flex-1 flex-col">
+					{#if attributesPaneMode === 'edit'}
+						{@render paneAttributesEdit(boundTable)}
+					{:else}
+						{@render paneAttributesSaved(dim, boundTable)}
+					{/if}
+				</div>
+			</div>
+		{/if}
+	{/if}
+{/snippet}
+
+{#snippet paneAttributesEdit(boundTable: SchemaCanvasTable)}
+	{@const sortedCols = [...boundTable.columns].sort((a, b) => a.name.localeCompare(b.name))}
+	<!-- Read the DRAFT rather than dim.attributes — see the top-of-file
+	     $effect that seeds it whenever the user enters edit mode or
+	     switches dims.  Nothing here writes to the store; the Confirm
+	     pill in the pane header does. -->
+	{@const draft = attrsDraft ?? []}
+	{@const allIn = sortedCols.every((c) =>
+		draft.some((a) => a.tableId === boundTable.id && a.columnName === c.name)
+	)}
+	<div class="flex h-full flex-col gap-2" data-testid="workbench-pane-attributes-edit">
+		<!-- All / Clear bulk replace.  No Include / Exclude flip —
+		     checkboxes mean "in draft" unambiguously now; the two bulk
+		     buttons cover the "want most" / "want few" extremes. -->
+		<div class="flex items-center gap-1.5 text-[10px]">
+			<button
+				type="button"
+				onclick={() => {
+					attrsDraft = sortedCols.map((c) => ({
+						tableId: boundTable.id,
+						columnName: c.name
+					}));
+				}}
+				class="rounded px-1.5 py-0.5 text-muted-foreground hover:bg-accent hover:text-accent-foreground disabled:opacity-50"
+				disabled={allIn}
+			>
+				All
+			</button>
+			<button
+				type="button"
+				onclick={() => {
+					attrsDraft = [];
+				}}
+				class="rounded px-1.5 py-0.5 text-muted-foreground hover:bg-accent hover:text-accent-foreground disabled:opacity-50"
+				disabled={draft.length === 0}
+			>
+				Clear
+			</button>
+			<span class="ml-auto text-muted-foreground">
+				{draft.length} of {sortedCols.length} selected{attrsDraftDirty ? ' · unsaved' : ''}
+			</span>
+		</div>
+		<ol class="flex flex-col gap-0.5">
+			{#each sortedCols as col (col.name)}
+				{@const inA = draft.some((a) => a.tableId === boundTable.id && a.columnName === col.name)}
+				<li>
+					<label
+						class="flex cursor-pointer items-center gap-1.5 rounded border bg-elev-2 px-1.5 py-0.5 text-[11px] hover:bg-accent/40"
+						style:border-color="hsl(var(--border))"
+					>
+						<input
+							type="checkbox"
+							checked={inA}
+							onchange={(e) => {
+								if (e.currentTarget.checked && !inA) {
+									attrsDraft = [
+										...(attrsDraft ?? []),
+										{ tableId: boundTable.id, columnName: col.name }
+									];
+								} else if (!e.currentTarget.checked && inA) {
+									attrsDraft = (attrsDraft ?? []).filter(
+										(a) => !(a.tableId === boundTable.id && a.columnName === col.name)
+									);
+								}
+							}}
+							class="h-3 w-3 shrink-0"
+						/>
+						<span class="min-w-0 flex-1 truncate font-mono">{col.name}</span>
+						{#if col.sqlType}
+							<span class="shrink-0 font-mono text-[9px] tracking-wide uppercase opacity-50">
+								{col.sqlType}
+							</span>
+						{/if}
+					</label>
+				</li>
+			{/each}
+		</ol>
+	</div>
+{/snippet}
+
+{#snippet paneAttributesSaved(dim: SchemaCanvasDimension, boundTable: SchemaCanvasTable)}
+	{@const A = dim.attributes ?? []}
+	{@const sortedA = [...A].sort((a, b) => a.columnName.localeCompare(b.columnName))}
+	<!-- Single resolved key attribute — one shared source of truth for the
+	     KEY badge across every row, so ambiguous schemas (Product with two
+	     attributes sharing columnName='product_id') don't double-light. -->
+	{@const paneResolvedKey = resolveKeyAttribute(dim)}
+	<div class="flex h-full flex-col gap-2" data-testid="workbench-pane-attributes-saved">
+		{#if sortedA.length === 0}
+			<p
+				class="rounded border border-dashed p-2 text-center text-[11px]"
+				style:border-color="hsl(var(--border))"
+				style:color="hsl(var(--muted-foreground))"
+			>
+				No attributes saved. Hit <span class="font-medium">Edit</span> to pick from
+				<span class="font-mono">{boundTable.name}</span>.
+			</p>
+		{:else}
+			<!-- Column headers — NAME | KEY | TYPE, aligned to the data rows below.
+			     Setting the key here is now interactive: click the key icon on
+			     any row to set / unset the dim's key.  Matches the Mondrian
+			     model where exactly one attribute is the dim key. -->
+			<div
+				class="flex shrink-0 items-center gap-2 border-b px-2 pb-1 text-[9px] font-semibold tracking-wider text-muted-foreground uppercase"
+				style:border-color="hsl(var(--border))"
+			>
+				<span class="h-3 w-3 shrink-0" aria-hidden="true"></span>
+				<span class="min-w-0 flex-1">Name</span>
+				<span class="flex w-6 shrink-0 justify-center">Key</span>
+				<span class="w-14 shrink-0 text-right">Type</span>
+			</div>
+			<ul class="flex flex-col gap-1">
+				{#each sortedA as a, __ai (`${a.tableId}::${a.columnName}::${a.name ?? __ai}`)}
+					{@const dimSrcIdSaved = dim.sourceTableId ?? dim.primaryKeyTableId}
+					{@const sqlType = columnTypeFor(a.tableId, a.columnName)}
+					{@const attrKey = `${a.tableId}::${a.columnName}::${a.name ?? __ai}`}
+					{@const attrIdent = a.name ?? a.columnName}
+					{@const isKeyAttr =
+						!!paneResolvedKey &&
+						paneResolvedKey.attr.tableId === a.tableId &&
+						paneResolvedKey.attr.columnName === a.columnName &&
+						(paneResolvedKey.attr.name ?? paneResolvedKey.attr.columnName) === attrIdent}
+					{@const displayName = a.name ?? a.columnName}
+					{@const hasCaption = a.name && a.name !== a.columnName}
+					<li
+						draggable="true"
+						ondragstart={(e) =>
+							handleAttributeDragStart(e, {
+								tableId: a.tableId,
+								columnName: a.columnName
+							})}
+						onclick={() => {
+							selectedAttributeKey = attrKey;
+							selectedMeasureId = null;
+							selectedHierarchyId = null;
+							focus('attribute', attrKey);
+						}}
+						onkeydown={(e) => {
+							if (e.key === 'Enter' || e.key === ' ') {
+								e.preventDefault();
+								selectedAttributeKey = attrKey;
+								selectedMeasureId = null;
+								selectedHierarchyId = null;
+								focus('attribute', attrKey);
+							}
+						}}
+						role="button"
+						tabindex="0"
+						class="group flex cursor-grab items-start gap-2 rounded border bg-elev-2 px-2 py-1 text-[11px] transition-colors active:cursor-grabbing {isFocused(
+							'attribute',
+							attrKey
+						)
+							? 'workbench-row-selected'
+							: 'hover:bg-accent/40'} {isKeyAttr ? 'bg-primary/5' : ''}"
+						style:border-color={isFocused('attribute', attrKey) ? '' : 'hsl(var(--border))'}
+						data-testid="workbench-pane-saved-attribute"
+						data-attribute={a.columnName}
+						title="Click to inspect · drag into a hierarchy in the Content pane"
+					>
+						<GripVertical
+							class="mt-0.5 h-3 w-3 shrink-0 text-muted-foreground"
+							aria-hidden="true"
+						/>
+						<!-- Name cell: display-name caption from the schema on the
+						     primary line, raw SQL column name below in mono
+						     when a caption exists AND differs.  Falls back to
+						     the raw column name if no caption. -->
+						<span class="flex min-w-0 flex-1 flex-col leading-tight">
+							<span class="min-w-0 truncate text-foreground">{displayName}</span>
+							{#if hasCaption}
+								<span class="min-w-0 truncate font-mono text-[9px] text-muted-foreground">
+									{a.columnName}
+								</span>
+							{/if}
+						</span>
+						<!-- Interactive Key toggle — always visible when the row IS
+						     the key, appears on hover otherwise.  Stops row-click
+						     propagation so setting the key doesn't also select
+						     the row for inspection. -->
+						<button
+							type="button"
+							onclick={(e) => {
+								e.stopPropagation();
+								if (isKeyAttr) {
+									store.updateDimension(dim.id, {
+										foreignKey: undefined,
+										primaryKey: undefined,
+										primaryKeyTableId: undefined
+									});
+								} else {
+									// primaryKey = attribute IDENTITY (logical name
+									// if set, columnName as fallback) so two attrs
+									// on the same column disambiguate.  foreignKey
+									// stays as the raw column since that's what
+									// the fact's ForeignKeyLink expects.
+									store.updateDimension(dim.id, {
+										foreignKey: a.columnName,
+										primaryKey: attrIdent,
+										primaryKeyTableId: a.tableId !== dimSrcIdSaved ? a.tableId : undefined
+									});
+								}
+							}}
+							onkeydown={(e) => e.stopPropagation()}
+							class="mt-0.5 flex h-5 w-6 shrink-0 items-center justify-center rounded border transition-colors {isKeyAttr
+								? 'border-primary bg-primary/10 text-primary'
+								: 'border-border text-muted-foreground opacity-0 group-hover:opacity-100 hover:border-primary/60 hover:text-primary'}"
+							aria-pressed={isKeyAttr}
+							aria-label={isKeyAttr ? 'Unmark as key' : 'Set as key'}
+							title={isKeyAttr ? 'Unmark as key' : 'Set as key'}
+							data-testid="workbench-attr-iskey-{a.columnName}"
+						>
+							<KeyRound class="h-3 w-3" aria-hidden="true" />
+						</button>
+						<!-- Type cell — fixed width, right-aligned, well-separated
+						     from the Key chip so the two read as distinct chips. -->
+						<span
+							class="w-14 shrink-0 pt-0.5 text-right font-mono text-[9px] tracking-wide uppercase opacity-50"
+						>
+							{sqlType ?? ''}
+						</span>
+					</li>
+				{/each}
+			</ul>
+		{/if}
+	</div>
+{/snippet}
+
+{#snippet paneHierarchies()}
+	{@const dim = selectedDimension}
+	{@const disabledForAttrs = attributesPaneMode === 'edit'}
+	{#if !dim}
+		<!-- Empty state carries the direction, not "disabled" chrome.
+		     Colour reads as regular foreground so the header + prompt
+		     don't collapse into a wash of grey (the pane still has a
+		     job to do, it just needs a dim first). -->
+		<div class="flex h-full flex-col items-center justify-center gap-1.5 p-4 text-center">
+			<ListTree class="h-6 w-6 text-primary" aria-hidden="true" />
+			<p class="text-sm font-semibold">Compose a hierarchy</p>
+			<p class="max-w-[28ch] text-[11px] leading-relaxed text-muted-foreground">
+				Pick a dimension on the left, then stack its attributes into levels here.
+			</p>
+		</div>
+	{:else}
+		<!-- Disable the whole Hierarchies pane while Attributes is in
+		     edit mode.  Hierarchies are composed from A (the saved
+		     attribute set), so editing them while A is still in flux
+		     creates dangling state and confuses the user.  Switch
+		     Attributes to saved to unlock. -->
+		<div class="flex h-full flex-col">
+			{#if disabledForAttrs}
+				<!-- Attributes still in edit mode — hierarchies compose
+				     FROM saved attributes, so we gate until confirm.
+				     Phrased as a forward-looking prompt rather than a
+				     locked-out banner. -->
+				<p
+					class="mb-1 shrink-0 rounded border border-primary/30 bg-primary/5 p-1.5 text-center text-[10px] font-medium text-primary"
+				>
+					Choose an attribute — save the Attributes column to unlock hierarchies.
+				</p>
+			{/if}
+			<div
+				class="flex min-h-0 flex-1 flex-col {disabledForAttrs ? 'pointer-events-none' : ''}"
+				aria-disabled={disabledForAttrs}
+			>
+				{@render paneHierarchiesEdit(dim)}
+			</div>
+		</div>
+	{/if}
+{/snippet}
+
+{#snippet hierarchyDropZone(dim: SchemaCanvasDimension, hier: SchemaCanvasHierarchy)}
+	{@const dropActive = contentDragOverHierarchyId === hier.id}
+	<!-- Levels render in AUTHORED order (coarse → fine: Year → Quarter → Month
+	     → Day), NOT alphabetically — sorting by column name scrambled the
+	     hierarchy so it no longer made sense (reported 2026-07-29). The array
+	     order is the source of truth (addLevel appends; the model documents it
+	     as ordered coarse → fine). -->
+	{@const displayLevels = hier.levels}
+	<!-- Generous per-hierarchy drop zone.  Designed to fill the
+	     RIGHT-side panel of the new Hierarchies pane (flex-1 +
+	     min-h-0 in the parent), so the dashed target box is big and
+	     obvious, not a tiny sliver. -->
+	<div
+		class="flex min-h-0 flex-1 flex-col overflow-y-auto rounded border-2 border-dashed bg-elev-2 p-1 transition-colors {dropActive
+			? 'border-primary bg-primary/5'
+			: ''}"
+		style:border-color={dropActive ? '' : 'hsl(var(--border))'}
+		ondragover={(e) => {
+			if (!isContentDrag(e)) return;
+			e.preventDefault();
+			if (e.dataTransfer) e.dataTransfer.dropEffect = 'copy';
+			contentDragOverHierarchyId = hier.id;
+		}}
+		ondragleave={(e) => {
+			// Only clear if the cursor genuinely leaves the box (browser
+			// fires dragleave when crossing into a child element too).
+			const t = e.relatedTarget as Node | null;
+			if (!t || !(e.currentTarget as HTMLElement).contains(t)) {
+				if (contentDragOverHierarchyId === hier.id) contentDragOverHierarchyId = null;
+			}
+		}}
+		ondrop={(e) => {
+			contentDragOverHierarchyId = null;
+			const attr = readAttributeDrag(e);
+			if (attr) {
+				e.preventDefault();
+				e.stopPropagation();
+				// Seed the level's display name from the attribute's caption
+				// (if any) so the two-line "Display / raw_col" pattern shows
+				// up automatically — otherwise every fresh level defaults to
+				// name = columnName and both lines read identical.
+				const sourceAttr = (dim.attributes ?? []).find(
+					(a) => a.tableId === attr.tableId && a.columnName === attr.columnName
+				);
+				store.addLevel(dim.id, hier.id, {
+					tableId: attr.tableId,
+					columnName: attr.columnName,
+					name: sourceAttr?.name
+				});
+				return;
+			}
+			const move = readLevelMoveDrag(e);
+			if (move) {
+				e.preventDefault();
+				e.stopPropagation();
+				if (move.hierId === hier.id) return;
+				const srcDim = store.dimensions.find((d) => d.id === move.dimId);
+				const srcHier = srcDim?.hierarchies.find((h) => h.id === move.hierId);
+				const srcLevel = srcHier?.levels.find((l) => l.id === move.levelId);
+				if (!srcLevel) return;
+				store.removeLevel(move.dimId, move.hierId, move.levelId);
+				store.addLevel(dim.id, hier.id, {
+					tableId: srcLevel.tableId,
+					columnName: srcLevel.columnName,
+					name: srcLevel.name
+				});
+			}
+		}}
+		data-testid="workbench-pane-hierarchy-drop"
+		data-hierarchy-id={hier.id}
+	>
+		{#if hier.levels.length === 0}
+			<!-- Empty state:
+			     • TOP: dashed "+ Add Level" pill (matches +Add Dimension /
+			       +Add Hierarchy across the pane; opens the same attribute
+			       picker Popover as the below-list button does).
+			     • CENTER: hint text reminding you the drop zone is live too. -->
+			<div class="flex flex-1 flex-col">
+				{#if (dim.attributes ?? []).length > 0}
+					<div class="shrink-0 px-1 pt-1">
+						<Popover side="bottom" align="center" sideOffset={6}>
+							{#snippet trigger({ props })}
+								<button
+									{...props}
+									type="button"
+									class="flex w-full items-center justify-center gap-1.5 rounded border-2 border-dashed px-3 py-2 text-[11px] font-semibold tracking-wide text-muted-foreground uppercase transition-colors hover:border-primary/50 hover:bg-accent hover:text-accent-foreground"
+									style:border-color="hsl(var(--border))"
+									data-testid="workbench-pane-hierarchy-add-picker"
+								>
+									<Plus class="h-3.5 w-3.5" aria-hidden="true" />
+									Add Level
+								</button>
+							{/snippet}
+							{#snippet content()}
+								<div class="flex w-56 flex-col gap-1 p-2">
+									<span
+										class="mb-1 text-[9px] font-semibold tracking-wider uppercase"
+										style:color="hsl(var(--muted-foreground))"
+									>
+										Add attributes
+									</span>
+									<ul class="flex max-h-56 flex-col gap-0.5 overflow-y-auto">
+										{#each dim.attributes ?? [] as attr, __ai (`${attr.tableId}::${attr.columnName}::${attr.name ?? __ai}`)}
+											{@const inHier = hier.levels.some(
+												(l) => l.tableId === attr.tableId && l.columnName === attr.columnName
+											)}
+											<li>
+												<label
+													class="flex w-full cursor-pointer items-center gap-1.5 rounded px-2 py-1 text-[11px] hover:bg-accent/40"
+												>
+													<input
+														type="checkbox"
+														class="h-3 w-3"
+														checked={inHier}
+														onchange={() => {
+															if (inHier) {
+																const lvl = hier.levels.find(
+																	(l) =>
+																		l.tableId === attr.tableId && l.columnName === attr.columnName
+																);
+																if (lvl) store.removeLevel(dim.id, hier.id, lvl.id);
+															} else {
+																store.addLevel(dim.id, hier.id, {
+																	tableId: attr.tableId,
+																	columnName: attr.columnName
+																});
+															}
+														}}
+														data-testid="workbench-pane-hierarchy-add-checkbox"
+														data-column={attr.columnName}
+													/>
+													<span class="flex min-w-0 flex-1 flex-col leading-tight">
+														<span class="min-w-0 truncate">
+															{attr.name || attr.columnName}
+														</span>
+														{#if attr.name && attr.name !== attr.columnName}
+															<span
+																class="min-w-0 truncate font-mono text-[9px] text-muted-foreground"
+															>
+																{attr.columnName}
+															</span>
+														{/if}
+													</span>
+												</label>
+											</li>
+										{/each}
+									</ul>
+								</div>
+							{/snippet}
+						</Popover>
+					</div>
+				{/if}
+				<div class="flex flex-1 items-center justify-center px-4">
+					<p
+						class="max-w-[24ch] text-center text-[11px] leading-relaxed italic"
+						style:color="hsl(var(--muted-foreground))"
+					>
+						Drag and drop attributes to add as hierarchy levels.
+					</p>
+				</div>
+			</div>
+		{:else}
+			<!-- Members as simple table-style rows.  Two-line name cell
+			     mirrors the Attributes pane: display name on top (falls
+			     back to the underlying attribute's name), raw column
+			     underneath in mono when they differ. -->
+			<ul class="flex flex-col">
+				{#each displayLevels as lvl, idx (lvl.id)}
+					{@const sqlType = columnTypeFor(lvl.tableId, lvl.columnName)}
+					{@const sourceAttr = (dim.attributes ?? []).find(
+						(a) => a.tableId === lvl.tableId && a.columnName === lvl.columnName
+					)}
+					{@const attrRemoved = !sourceAttr}
+					{@const displayName = lvl.name || sourceAttr?.name || lvl.columnName}
+					{@const showRawUnderneath = displayName !== lvl.columnName}
+					{@const levelSelected = selectedLevelId === lvl.id}
+					<li
+						class="flex cursor-pointer items-start gap-2 border-b px-2 py-1 text-[11px] hover:bg-accent/40 {levelSelected
+							? 'ring-1 ring-primary ring-inset'
+							: ''} {attrRemoved ? '' : idx % 2 === 0 ? 'bg-muted/40' : 'bg-muted/15'}"
+						style:border-color={attrRemoved ? 'hsl(var(--warning) / 0.5)' : 'hsl(var(--border))'}
+						style:background-color={attrRemoved ? 'hsl(var(--warning) / 0.08)' : undefined}
+						style:border-left={attrRemoved ? '2px solid hsl(var(--warning))' : undefined}
+						role="button"
+						tabindex="0"
+						aria-pressed={levelSelected}
+						onclick={() => {
+							selectedHierarchyId = hier.id;
+							selectedLevelId = lvl.id;
+							selectedAttributeKey = null;
+						}}
+						onkeydown={(e) => {
+							if (e.key === 'Enter' || e.key === ' ') {
+								e.preventDefault();
+								selectedHierarchyId = hier.id;
+								selectedLevelId = lvl.id;
+								selectedAttributeKey = null;
+							}
+						}}
+						data-testid="workbench-pane-hierarchy-row"
+						data-selected={levelSelected ? 'true' : undefined}
+						data-attr-removed={attrRemoved ? 'true' : undefined}
+					>
+						{#if attrRemoved}
+							<AlertCircle
+								class="mt-0.5 h-3 w-3 shrink-0 text-warning"
+								aria-hidden="true"
+								aria-label="Source attribute removed"
+							/>
+						{/if}
+						<span
+							class="flex min-w-0 flex-1 flex-col leading-tight {attrRemoved ? 'text-warning' : ''}"
+							title={attrRemoved
+								? `"${lvl.columnName}" is no longer in this dimension's attributes. Re-add the attribute, or remove this level.`
+								: undefined}
+						>
+							<span class="min-w-0 truncate">{displayName}</span>
+							{#if showRawUnderneath}
+								<span class="min-w-0 truncate font-mono text-[9px] text-muted-foreground">
+									{lvl.columnName}
+								</span>
+							{/if}
+						</span>
+						{#if attrRemoved}
+							<span
+								class="mt-0.5 shrink-0 font-mono text-[9px] font-semibold tracking-wide text-warning uppercase"
+								title="This level references an attribute that was removed from the dimension."
+							>
+								Source removed
+							</span>
+						{:else if sqlType}
+							<span class="mt-0.5 shrink-0 font-mono text-[9px] tracking-wide uppercase opacity-60">
+								{sqlType}
+							</span>
+						{/if}
+						<!-- Reorder within the hierarchy (coarse↔fine). Drag-to-reorder
+						     in a text list is fiddly, so use explicit up/down controls. -->
+						<button
+							type="button"
+							disabled={idx === 0}
+							onclick={(e) => {
+								e.stopPropagation();
+								store.moveLevel(dim.id, hier.id, lvl.id, -1);
+							}}
+							class="mt-0.5 shrink-0 rounded p-0.5 text-muted-foreground hover:bg-accent hover:text-accent-foreground disabled:pointer-events-none disabled:opacity-30"
+							aria-label="Move level up (coarser)"
+							title="Move up (coarser)"
+							data-testid="workbench-pane-level-up"
+						>
+							<ChevronUp class="h-2.5 w-2.5" aria-hidden="true" />
+						</button>
+						<button
+							type="button"
+							disabled={idx === displayLevels.length - 1}
+							onclick={(e) => {
+								e.stopPropagation();
+								store.moveLevel(dim.id, hier.id, lvl.id, 1);
+							}}
+							class="mt-0.5 shrink-0 rounded p-0.5 text-muted-foreground hover:bg-accent hover:text-accent-foreground disabled:pointer-events-none disabled:opacity-30"
+							aria-label="Move level down (finer)"
+							title="Move down (finer)"
+							data-testid="workbench-pane-level-down"
+						>
+							<ChevronDown class="h-2.5 w-2.5" aria-hidden="true" />
+						</button>
+						<button
+							type="button"
+							onclick={(e) => {
+								e.stopPropagation();
+								store.removeLevel(dim.id, hier.id, lvl.id);
+							}}
+							class="mt-0.5 shrink-0 rounded p-0.5 text-muted-foreground hover:bg-accent hover:text-accent-foreground"
+							aria-label="Remove member"
+							title="Remove from this hierarchy"
+						>
+							<X class="h-2.5 w-2.5" aria-hidden="true" />
+						</button>
+					</li>
+				{/each}
+			</ul>
+			<!-- Bottom-of-content dashed "+ Add Level" pill.  Mirror of
+			     the +Add Dimension and +Add Hierarchy buttons.  Reuses the
+			     same attribute picker Popover the empty state offers, so
+			     the interaction stays consistent whether the hierarchy is
+			     fresh or already has levels. -->
+			{#if (dim.attributes ?? []).length > 0}
+				<div class="mt-1 px-1">
+					<Popover side="bottom" align="center" sideOffset={6}>
+						{#snippet trigger({ props })}
+							<button
+								{...props}
+								type="button"
+								class="flex w-full items-center justify-center gap-1.5 rounded border-2 border-dashed px-3 py-2 text-[11px] font-semibold tracking-wide text-muted-foreground uppercase transition-colors hover:border-primary/50 hover:bg-accent hover:text-accent-foreground"
+								style:border-color="hsl(var(--border))"
+								data-testid="workbench-pane-hierarchy-add-level-bottom"
+							>
+								<Plus class="h-3.5 w-3.5" aria-hidden="true" />
+								Add Level
+							</button>
+						{/snippet}
+						{#snippet content()}
+							<div class="flex w-56 flex-col gap-1 p-2">
+								<span
+									class="mb-1 text-[9px] font-semibold tracking-wider uppercase"
+									style:color="hsl(var(--muted-foreground))"
+								>
+									Add attributes
+								</span>
+								<ul class="flex max-h-56 flex-col gap-0.5 overflow-y-auto">
+									{#each dim.attributes ?? [] as attr, __ai (`${attr.tableId}::${attr.columnName}::${attr.name ?? __ai}`)}
+										{@const inHier = hier.levels.some(
+											(l) => l.tableId === attr.tableId && l.columnName === attr.columnName
+										)}
+										<li>
+											<label
+												class="flex w-full cursor-pointer items-center gap-1.5 rounded px-2 py-1 text-[11px] hover:bg-accent/40"
+											>
+												<input
+													type="checkbox"
+													class="h-3 w-3"
+													checked={inHier}
+													onchange={() => {
+														if (inHier) {
+															const lvl = hier.levels.find(
+																(l) =>
+																	l.tableId === attr.tableId && l.columnName === attr.columnName
+															);
+															if (lvl) store.removeLevel(dim.id, hier.id, lvl.id);
+														} else {
+															// Carry the attribute's display name onto the level
+															// so the two-line pattern shows up from the first
+															// frame (see hierarchyDropZone ondrop for context).
+															store.addLevel(dim.id, hier.id, {
+																tableId: attr.tableId,
+																columnName: attr.columnName,
+																name: attr.name
+															});
+														}
+													}}
+													data-testid="workbench-pane-hierarchy-add-level-checkbox"
+													data-column={attr.columnName}
+												/>
+												<span class="min-w-0 flex-1 truncate font-mono">
+													{attr.columnName}
+												</span>
+											</label>
+										</li>
+									{/each}
+								</ul>
+							</div>
+						{/snippet}
+					</Popover>
+				</div>
+			{/if}
+		{/if}
+	</div>
+{/snippet}
+
+{#snippet hierarchyListRow(dim: SchemaCanvasDimension, hier: SchemaCanvasHierarchy)}
+	{@const isSelected = isFocused('hierarchy', hier.id)}
+	<li
+		role="button"
+		tabindex="0"
+		onclick={() => {
+			selectedHierarchyId = hier.id;
+			hierarchyExplicitlyClicked = true;
+			focus('hierarchy', hier.id);
+		}}
+		onkeydown={(e) => {
+			if (e.key === 'Enter' || e.key === ' ') {
+				e.preventDefault();
+				selectedHierarchyId = hier.id;
+				hierarchyExplicitlyClicked = true;
+				focus('hierarchy', hier.id);
+			}
+		}}
+		class="flex cursor-pointer items-center gap-1.5 rounded border bg-elev-2 px-2 py-1 text-[11px] transition-colors {isSelected
+			? 'workbench-row-selected'
+			: 'border-border hover:bg-accent/40'}"
+		data-testid="workbench-pane-hierarchy-list-row"
+		data-hierarchy-id={hier.id}
+	>
+		<ListTree class="h-3 w-3 shrink-0 text-primary" aria-hidden="true" />
+		{#if editingHierNameId === hier.id}
+			<input
+				type="text"
+				value={hier.name}
+				oninput={(e) => renameHierarchy(dim.id, hier.id, e.currentTarget.value)}
+				onclick={(e) => e.stopPropagation()}
+				onkeydown={(e) => {
+					e.stopPropagation();
+					if (e.key === 'Enter' || e.key === 'Escape') {
+						(e.currentTarget as HTMLInputElement).blur();
+					}
+				}}
+				onblur={() => {
+					commitHierarchyName(dim.id, hier.id);
+					editingHierNameId = null;
+				}}
+				placeholder="Hierarchy name"
+				aria-label="Hierarchy name"
+				class="h-5 min-w-0 flex-1 rounded border bg-background px-1 font-medium focus:border-ring focus:ring-1 focus:ring-ring focus:outline-none"
+				style:border-color="hsl(var(--border))"
+				use:autoFocus={editingHierNameId === hier.id}
+			/>
+		{:else}
+			<span
+				role="button"
+				tabindex="0"
+				ondblclick={(e) => {
+					e.stopPropagation();
+					editingHierNameId = hier.id;
+				}}
+				onkeydown={(e) => {
+					if (e.key === 'F2' || e.key === 'Enter') {
+						e.preventDefault();
+						e.stopPropagation();
+						editingHierNameId = hier.id;
+					}
+				}}
+				class="block min-w-0 flex-1 truncate leading-5 font-medium"
+				title="Double-click to rename"
+			>
+				{hier.name || 'Untitled hierarchy'}
+			</span>
+		{/if}
+		<span class="shrink-0 font-mono text-[9px] text-muted-foreground">
+			{hier.levels.length}
+		</span>
+		<button
+			type="button"
+			onclick={(e) => {
+				e.stopPropagation();
+				requestDeleteHierarchy(dim.id, hier.id);
+			}}
+			class="shrink-0 rounded p-0.5 text-muted-foreground hover:bg-accent hover:text-accent-foreground"
+			aria-label="Delete hierarchy"
+			title="Delete hierarchy"
+		>
+			<X class="h-2.5 w-2.5" aria-hidden="true" />
+		</button>
+	</li>
+{/snippet}
+
+{#snippet hierarchyRightPanel(dim: SchemaCanvasDimension)}
+	{@const hier = selectedHierarchy}
+	<div class="flex min-h-0 flex-1 flex-col">
+		{#if hier}
+			<!-- Inline header lives on the Content eyebrow row now, so
+			     no separate header line here. -->
+			{@render hierarchyDropZone(dim, hier)}
+		{:else}
+			<div
+				class="flex h-full flex-col items-center justify-center gap-1 rounded border-2 border-dashed p-3 text-center"
+				style:border-color="hsl(var(--border))"
+				style:color="hsl(var(--muted-foreground))"
+			>
+				<ListTree class="h-5 w-5" aria-hidden="true" />
+				{#if dim.hierarchies.length === 0}
+					<p class="text-xs font-medium" style:color="hsl(var(--foreground))">No hierarchies yet</p>
+					<p class="text-[11px]">
+						Hit <span class="font-medium">+ Add</span> to make one.
+					</p>
+				{:else}
+					<p class="text-xs font-medium" style:color="hsl(var(--foreground))">Pick a hierarchy</p>
+					<p class="text-[11px]">Click one on the left to see its content.</p>
+				{/if}
+			</div>
+		{/if}
+	</div>
+{/snippet}
+
+{#snippet paneHierarchiesEdit(dim: SchemaCanvasDimension)}
+	<div class="flex h-full flex-col gap-2" data-testid="workbench-pane-hierarchies-edit">
+		<!-- Two-column body per the sketch.
+		     Left:  the LIST of hierarchies (name + count + X per row).
+		     Right: a big drop zone showing the SELECTED hierarchy's
+		            content.  Empty state when nothing's picked. -->
+		{@render hierarchyTwoColumnBody(dim)}
+	</div>
+{/snippet}
+
+{#snippet hierarchyTwoColumnBody(dim: SchemaCanvasDimension)}
+	<!-- Shared body for both edit + saved.  Two columns side by side
+	     with "Name" / "Content" eyebrow labels above each.  The Name
+	     column always shows a hint when the dim has no hierarchies
+	     yet; the Content column always renders its own empty state. -->
+	<div class="flex min-h-0 flex-1 gap-2">
+		<div class="flex w-2/5 shrink-0 flex-col gap-1">
+			<span
+				class="text-[10px] font-semibold tracking-wider uppercase"
+				style:color="hsl(var(--muted-foreground))"
+			>
+				Name
+			</span>
+			<!-- Whole Name column body is a drop target — dropping an
+			     attribute creates a single-level hierarchy named after
+			     it.  Mirror of the facts side's drag-into-Name. -->
+			<div
+				class="flex min-h-0 flex-1 flex-col gap-1 overflow-y-auto rounded px-0.5 transition-colors {dimDragOverHierName
+					? 'bg-primary/5 ring-1 ring-primary/40'
+					: ''}"
+				ondragover={(e) => {
+					const tt = e.dataTransfer?.types ?? [];
+					if (!Array.from(tt).includes(ATTRIBUTE_MIME)) return;
+					e.preventDefault();
+					if (e.dataTransfer) e.dataTransfer.dropEffect = 'copy';
+					dimDragOverHierName = true;
+				}}
+				ondragleave={(e) => {
+					const t = e.relatedTarget as Node | null;
+					if (!t || !(e.currentTarget as HTMLElement).contains(t)) {
+						dimDragOverHierName = false;
+					}
+				}}
+				ondrop={(e) => {
+					dimDragOverHierName = false;
+					const attr = readAttributeDrag(e);
+					if (attr) {
+						e.preventDefault();
+						e.stopPropagation();
+						addHierarchyFromAttribute(dim.id, attr.tableId, attr.columnName);
+					}
+				}}
+				data-testid="workbench-pane-hierarchy-name-col"
+			>
+				{#if dim.hierarchies.length === 0}
+					<!-- Empty state — first-touch affordance is a real button that
+					     creates a hierarchy (was a hint pointing at the header
+					     Add).  Drop-a-single-attribute path stays live via the
+					     drop handler on this same column. -->
+					<button
+						type="button"
+						onclick={() => {
+							const h = store.addHierarchy(dim.id);
+							if (h) {
+								selectedHierarchyId = h.id;
+								hierarchyExplicitlyClicked = true;
+								editingHierNameId = h.id;
+							}
+						}}
+						class="flex w-full flex-col items-center justify-center gap-1 rounded border border-dashed p-3 text-center text-[11px] transition-colors hover:border-primary hover:bg-primary/5"
+						style:border-color="hsl(var(--border))"
+						style:color="hsl(var(--muted-foreground))"
+						data-testid="workbench-pane-hierarchy-empty-add"
+					>
+						<Plus class="h-3.5 w-3.5" aria-hidden="true" />
+						<span>Add hierarchy</span>
+						<span class="text-[9px] opacity-60">or drop a single attribute</span>
+					</button>
+				{:else}
+					<ul class="flex flex-col gap-1" data-testid="workbench-pane-hierarchy-list">
+						{#each dim.hierarchies as hier (hier.id)}
+							{@render hierarchyListRow(dim, hier)}
+						{/each}
+					</ul>
+					<!-- Bottom-of-panel dashed "Add hierarchy" button, mirroring
+					     the +Add Dimension affordance under the Dimensions saved
+					     list.  Header +Add is still there for muscle memory; this
+					     one is the natural next-gesture after eyeballing the
+					     current hierarchies. -->
+					<button
+						type="button"
+						onclick={() => {
+							const h = store.addHierarchy(dim.id);
+							if (h) {
+								selectedHierarchyId = h.id;
+								hierarchyExplicitlyClicked = true;
+								editingHierNameId = h.id;
+							}
+						}}
+						class="mt-1 flex w-full items-center justify-center gap-1.5 rounded border-2 border-dashed px-3 py-2 text-[11px] font-semibold tracking-wide text-muted-foreground uppercase transition-colors hover:border-primary/50 hover:bg-accent hover:text-accent-foreground"
+						style:border-color="hsl(var(--border))"
+						data-testid="workbench-pane-hierarchy-add-bottom"
+					>
+						<Plus class="h-3.5 w-3.5" aria-hidden="true" />
+						Add Hierarchy
+					</button>
+				{/if}
+			</div>
+			<!-- Drop-hint footnote — sits under the Hierarchies name column.
+			     Kept text-left + readable (11px, not italic) so it reads as
+			     help copy, not a footnote-in-a-footnote. -->
+			<p
+				class="shrink-0 self-start px-1 pt-1 text-left text-[11px] leading-snug transition-colors {dimDragOverHierName
+					? 'font-medium text-primary'
+					: ''}"
+				style:color={dimDragOverHierName ? '' : 'hsl(var(--muted-foreground))'}
+			>
+				{#if dimDragOverHierName}
+					Drop to create a one-attribute hierarchy
+				{:else}
+					Drop a single attribute here to auto-create a hierarchy for it.
+				{/if}
+			</p>
+		</div>
+		<div class="flex min-h-0 flex-1 flex-col gap-1">
+			<!-- "CONTENT · [name] · count" inline header — no extra row
+			     for the selected hierarchy name.  Same line that the
+			     other column eyebrows use. -->
+			<span
+				class="flex shrink-0 items-baseline gap-1.5 text-[10px] font-semibold tracking-wider uppercase"
+				style:color="hsl(var(--muted-foreground))"
+			>
+				<span>Content</span>
+				{#if selectedHierarchy}
+					<span class="font-mono text-[10px] normal-case opacity-80">
+						· [{selectedHierarchy.name || 'untitled'}]
+					</span>
+					<span class="ml-auto font-mono text-[9px] opacity-60">
+						{selectedHierarchy.levels.length}
+					</span>
+				{/if}
+			</span>
+			{@render hierarchyRightPanel(dim)}
+		</div>
+	</div>
+{/snippet}

--- a/saiku-ui/src/lib/cube-designer/DimensionsHierarchiesPane.svelte
+++ b/saiku-ui/src/lib/cube-designer/DimensionsHierarchiesPane.svelte
@@ -31,8 +31,8 @@
 		AlertCircle,
 		KeyRound
 	} from 'lucide-svelte';
-	import Popover from '$lib/design-system/primitives/Popover.svelte';
-	import SortableColumnHeader from '$lib/design-system/SortableColumnHeader.svelte';
+	import Popover from './primitives/Popover.svelte';
+	import SortableColumnHeader from './primitives/SortableColumnHeader.svelte';
 	import { dimKeyIdentity, resolveKeyAttribute } from './state.svelte.js';
 	import type { SchemaCanvasStore } from './state.svelte.js';
 	import {

--- a/saiku-ui/src/lib/cube-designer/FactsMeasuresPane.svelte
+++ b/saiku-ui/src/lib/cube-designer/FactsMeasuresPane.svelte
@@ -1,0 +1,2039 @@
+<!--
+  FactsMeasuresPane — the Facts & Measures column cluster extracted from
+  WorkbenchView.svelte (audit finding #1039). Owns the three reorderable panes
+  (Fact & Measures / Measure Groups / Calculations) and the per-measure-group
+  editor (fact table picker, measures checklist, dimension links) that live in
+  the schema designer's Facts mode.
+
+  Deliberately owns NO durable state. The shell (WorkbenchView) keeps the
+  single source of truth for every cube-swap / persistence variable and threads
+  it in via props + `bind:`. This component only READS props, mutates the
+  shared reactive structures it is handed in place (`store`,
+  `factsMeasureGroups` items, `factsSelectedMeasures`), and calls shell
+  callbacks for every structural mutation — so behaviour is byte-for-byte
+  identical to the inline snippets it replaced. Every value the template
+  reassigns is a `$bindable()` prop bound from the shell (never a duplicated
+  source of truth).
+-->
+<script lang="ts">
+	import {
+		Database,
+		ChevronDown,
+		GripVertical,
+		Plus,
+		X,
+		Layers,
+		Sigma,
+		ListTree,
+		Search,
+		Pencil,
+		Check,
+		AlertCircle
+	} from 'lucide-svelte';
+	import { Select as SelectPrimitive } from 'bits-ui';
+	import type { SvelteSet } from 'svelte/reactivity';
+	import { calcMode } from './workbench-cubes';
+	import { FACTS_MEASURE_MIME, FACTS_MEASURE_GROUP_MIME } from './workbench-dnd';
+	import type { FactsCalc, FactsCalcMode, WorkbenchMeasureGroup } from './workbench-cubes';
+	import type { SchemaCanvasMeasure } from './types.js';
+	import type { SchemaCanvasStore } from './state.svelte.js';
+
+	// Mirrors the shell's local unions (kept in lock-step; simple string
+	// literals, so re-declaring here beats widening the module surface).
+	type FactsPaneKind = 'fact' | 'groups' | 'calculations';
+	type FocusKind = 'dim' | 'hierarchy' | 'attribute' | 'measure' | 'mg' | 'cube' | 'calc';
+	type CalcOp = '+' | '-' | '*' | '/';
+
+	interface Props {
+		store: SchemaCanvasStore;
+		factsSlots: FactsPaneKind[];
+		factsPaneDragIndex: number | null;
+		factsPaneDragOverIndex: number | null;
+		AGGREGATORS: SchemaCanvasMeasure['aggregator'][];
+		ALLOW_GROUP_DROP_ON_CALC: boolean;
+		/** SvelteSet owned by the shell; the pane mutates it in place. */
+		factsSelectedMeasures: SvelteSet<string>;
+		// ── bindable: shell owns the source of truth, child writes via bind: ──
+		factsEditMode: boolean;
+		factsSelectedTableId: string | null;
+		factsTableSearch: string;
+		factsTableConfirmed: boolean;
+		factsMeasureGroups: WorkbenchMeasureGroup[];
+		factsSelectedGroupId: string | null;
+		factsEditingMeasureGroupId: string | null;
+		focusGroupId: string | null;
+		factsCalcs: FactsCalc[];
+		factsEditingCalcId: string | null;
+		editingMeasureCaption: string | null;
+		// ── shell callbacks (every structural mutation routes back here) ──
+		// Selection setters are write-only from this pane (it never reads the
+		// selection back), so they route through callbacks rather than bound
+		// props — the shell keeps the single source of truth.
+		selectMgMeasure: (measureId: string) => void;
+		selectMgDimension: (dimId: string) => void;
+		selectFactsCalc: (calcId: string) => void;
+		handleFactsPaneDragStart: (e: DragEvent, idx: number) => void;
+		handleFactsPaneDragOver: (e: DragEvent, idx: number) => void;
+		handleFactsPaneDragLeave: (idx: number) => void;
+		handleFactsPaneDrop: (e: DragEvent, targetIdx: number) => void;
+		handleFactsPaneDragEnd: () => void;
+		addFactsMeasureGroup: () => void;
+		removeFactsMeasureGroup: (id: string) => void;
+		renameFactsMeasureGroup: (id: string, name: string) => void;
+		addFactsCalc: () => void;
+		removeFactsCalc: (calcId: string) => void;
+		renameFactsCalc: (calcId: string, name: string) => void;
+		addCalcMeasure: (calcId: string, name: string, fromGroup?: boolean) => void;
+		addCalcOperator: (calcId: string, op: CalcOp) => void;
+		popCalcToken: (calcId: string) => void;
+		clearCalcTokens: (calcId: string) => void;
+		setCalcMode: (calcId: string, mode: FactsCalcMode) => void;
+		updateCalcFormula: (calcId: string, formula: string) => void;
+		calcNeedsMeasure: (c: FactsCalc) => boolean;
+		formatCalcOp: (op: CalcOp) => string;
+		commitMeasureCaption: (g: WorkbenchMeasureGroup, col: string, nextValue: string) => void;
+		focus: (kind: FocusKind, id: string) => void;
+		isFocused: (kind: FocusKind, id: string | null | undefined) => boolean;
+		autoFocus: (node: HTMLInputElement, shouldFocus: boolean) => { update(active: boolean): void };
+	}
+
+	let {
+		store,
+		factsSlots,
+		factsPaneDragIndex,
+		factsPaneDragOverIndex,
+		AGGREGATORS,
+		ALLOW_GROUP_DROP_ON_CALC,
+		factsSelectedMeasures,
+		factsEditMode = $bindable(),
+		factsSelectedTableId = $bindable(),
+		factsTableSearch = $bindable(),
+		factsTableConfirmed = $bindable(),
+		factsMeasureGroups = $bindable(),
+		factsSelectedGroupId = $bindable(),
+		factsEditingMeasureGroupId = $bindable(),
+		focusGroupId = $bindable(),
+		factsCalcs = $bindable(),
+		factsEditingCalcId = $bindable(),
+		editingMeasureCaption = $bindable(),
+		selectMgMeasure,
+		selectMgDimension,
+		selectFactsCalc,
+		handleFactsPaneDragStart,
+		handleFactsPaneDragOver,
+		handleFactsPaneDragLeave,
+		handleFactsPaneDrop,
+		handleFactsPaneDragEnd,
+		addFactsMeasureGroup,
+		removeFactsMeasureGroup,
+		renameFactsMeasureGroup,
+		addFactsCalc,
+		removeFactsCalc,
+		renameFactsCalc,
+		addCalcMeasure,
+		addCalcOperator,
+		popCalcToken,
+		clearCalcTokens,
+		setCalcMode,
+		updateCalcFormula,
+		calcNeedsMeasure,
+		formatCalcOp,
+		commitMeasureCaption,
+		focus,
+		isFocused,
+		autoFocus
+	}: Props = $props();
+
+	// These three were `{@const}` at the root of the `factsPanePrototype`
+	// snippet; at a component root `{@const}` has no valid parent, so they move
+	// to `$derived` (identical reactive semantics — read-only in the template).
+	const tablesOnCanvas = $derived(store.doc.tables);
+	const chosenTable = $derived(tablesOnCanvas.find((t) => t.id === factsSelectedTableId) ?? null);
+	const numericCols = $derived(
+		chosenTable?.columns.filter((c) =>
+			['INT2', 'INT4', 'INT8', 'NUMERIC', 'FLOAT4', 'FLOAT8', 'DECIMAL'].some((t) =>
+				(c.sqlType ?? '').toUpperCase().includes(t)
+			)
+		) ?? []
+	);
+</script>
+
+<!-- Reorderable: drag the grip in either pane's header to swap
+	     Fact & Measures and Measure Groups.  Same UX as the dim
+	     columnSlots reorder, but with its own MIME so drags can't
+	     cross over. -->
+{#each factsSlots as kind, idx (kind)}
+	{@const isReorderTarget = factsPaneDragOverIndex === idx && factsPaneDragIndex !== idx}
+	{@const isReorderSource = factsPaneDragIndex === idx}
+	{#if kind === 'fact'}
+		<!-- Pane 1: UNIFIED FACT + MEASURES (single column, four states).
+	     Encodes Amelia's sketch:
+	       1. Pick     — full picker (search + tabular list, radios)
+	       2. Picked   — one row selected, "Confirm fact table" CTA
+	                     visible; Measures still gated
+	       3. Confirmed — Fact collapses to chosen-table summary with a
+	                      Change pill; Measures section becomes active
+	                      with its own Edit toggle + checkbox list
+	       4. Saved    — outer Edit OFF; both sections collapse to a
+	                     read-only "Table name + chosen measures"
+	     The whole pane's Edit pill governs state 4; the inner Confirm
+	     gates the 2→3 transition; Measures' Edit pill toggles inside 3. -->
+		<section
+			class="flex min-w-0 flex-1 flex-col overflow-hidden rounded-md border bg-elev-1 transition-colors {isReorderTarget
+				? 'border-primary'
+				: ''} {isReorderSource ? 'opacity-50' : ''}"
+			style:border-color={isReorderTarget ? '' : 'hsl(var(--border))'}
+			ondragover={(e) => handleFactsPaneDragOver(e, idx)}
+			ondragleave={() => handleFactsPaneDragLeave(idx)}
+			ondrop={(e) => handleFactsPaneDrop(e, idx)}
+			data-pane-index={idx}
+			data-pane-kind={kind}
+		>
+			<header
+				class="flex shrink-0 items-center justify-between gap-2 border-b bg-elev-1 px-2.5 py-2"
+				style:border-color="hsl(var(--border))"
+			>
+				<div class="flex min-w-0 items-center gap-1.5">
+					<span
+						role="button"
+						tabindex="0"
+						draggable="true"
+						ondragstart={(e) => handleFactsPaneDragStart(e, idx)}
+						ondragend={handleFactsPaneDragEnd}
+						class="-ml-1 shrink-0 cursor-grab rounded p-1 text-muted-foreground hover:bg-accent hover:text-accent-foreground active:cursor-grabbing"
+						aria-label="Drag to reorder this pane"
+						title="Drag to reorder"
+					>
+						<GripVertical class="h-3 w-3" aria-hidden="true" />
+					</span>
+					<Database class="h-3.5 w-3.5 shrink-0 text-primary" aria-hidden="true" />
+					<span class="text-[11px] font-semibold tracking-wider uppercase"> Fact & Measures </span>
+				</div>
+				<button
+					type="button"
+					onclick={() => (factsEditMode = !factsEditMode)}
+					class="inline-flex shrink-0 items-center gap-1 rounded-full px-2 py-0.5 text-[10px] font-semibold tracking-wider uppercase {factsEditMode
+						? 'border border-primary bg-primary text-primary-foreground'
+						: 'border border-border text-muted-foreground hover:bg-accent hover:text-accent-foreground'}"
+					title="Toggle edit mode"
+				>
+					Edit · {factsEditMode ? 'on' : 'off'}
+				</button>
+			</header>
+			<div
+				class="flex min-h-0 flex-1 [scrollbar-gutter:stable] flex-col gap-2 overflow-y-auto bg-card p-2"
+			>
+				{#if tablesOnCanvas.length === 0}
+					<p
+						class="rounded border border-dashed p-3 text-center text-[11px]"
+						style:border-color="hsl(var(--border))"
+						style:color="hsl(var(--muted-foreground))"
+					>
+						No tables on canvas. Flip back to Schema Canvas to add some.
+					</p>
+				{:else if !factsEditMode}
+					<!-- State 4 — saved.  Concise read-only summary. -->
+					{#if chosenTable}
+						<p
+							class="text-[10px] tracking-wide uppercase"
+							style:color="hsl(var(--muted-foreground))"
+						>
+							Fact table
+						</p>
+						<div
+							class="flex items-center gap-1.5 rounded border bg-elev-2 px-1.5 py-1 text-[11px]"
+							style:border-color="hsl(var(--border))"
+						>
+							<Database class="h-3 w-3 shrink-0 text-primary" aria-hidden="true" />
+							<span class="min-w-0 flex-1 truncate font-mono">
+								{chosenTable.schema ? `${chosenTable.schema}.` : ''}{chosenTable.name}
+							</span>
+						</div>
+						<p
+							class="mt-2 text-[10px] tracking-wide uppercase"
+							style:color="hsl(var(--muted-foreground))"
+						>
+							Chosen measures · {factsSelectedMeasures.size}
+						</p>
+						<!-- Saved-view rows are still draggable into a measure group's
+					     Content drop zone — same pattern as the dim Saved
+					     Attributes pane that drags into hierarchies.  Grip
+					     handle + the whole row are the drag source. -->
+						<div class="flex flex-col gap-1">
+							{#each numericCols.filter((c) => factsSelectedMeasures.has(c.name)) as col (col.name)}
+								<div
+									class="flex cursor-grab items-center gap-1.5 rounded border bg-elev-2 px-1.5 py-1 text-[11px] hover:bg-accent/30 active:cursor-grabbing"
+									style:border-color="hsl(var(--border))"
+									draggable="true"
+									ondragstart={(e) => {
+										if (!e.dataTransfer) return;
+										e.dataTransfer.setData(FACTS_MEASURE_MIME, col.name);
+										e.dataTransfer.effectAllowed = 'copy';
+									}}
+									title="Drag into a measure group’s Content column"
+									data-testid="workbench-fact-measure-chosen-row"
+								>
+									<GripVertical
+										class="h-3 w-3 shrink-0 text-muted-foreground/60"
+										aria-hidden="true"
+									/>
+									<Sigma class="h-3 w-3 shrink-0 text-primary" aria-hidden="true" />
+									<span class="min-w-0 flex-1 truncate font-mono">{col.name}</span>
+								</div>
+							{/each}
+							{#if factsSelectedMeasures.size === 0}
+								<p
+									class="rounded border border-dashed p-2 text-center text-[10px]"
+									style:border-color="hsl(var(--border))"
+									style:color="hsl(var(--muted-foreground))"
+								>
+									No measures picked. Turn edit on to choose some.
+								</p>
+							{/if}
+						</div>
+					{:else}
+						<p
+							class="rounded border border-dashed p-3 text-center text-[11px]"
+							style:border-color="hsl(var(--border))"
+							style:color="hsl(var(--muted-foreground))"
+						>
+							No fact table picked. Turn edit on to choose one.
+						</p>
+					{/if}
+				{:else if !factsTableConfirmed}
+					<!-- States 1 + 2 — pick the fact table.  When a row is
+				     selected, a Confirm CTA appears.  Measures section is
+				     gated (greyed stub) until confirm. -->
+					<p class="text-[10px] tracking-wide uppercase" style:color="hsl(var(--muted-foreground))">
+						Step 1 — pick the fact table (one per cube).
+					</p>
+					<div class="relative shrink-0">
+						<Search
+							class="pointer-events-none absolute top-1/2 left-2 h-3 w-3 -translate-y-1/2 opacity-50"
+							aria-hidden="true"
+						/>
+						<input
+							type="search"
+							bind:value={factsTableSearch}
+							placeholder="Search tables…"
+							aria-label="Search fact tables"
+							class="h-7 w-full rounded border bg-elev-1 py-1 pr-2 pl-7 text-[11px] focus:border-ring focus:ring-1 focus:ring-ring focus:outline-none"
+							style:border-color="hsl(var(--border))"
+						/>
+					</div>
+					{@const _q = factsTableSearch.trim().toLowerCase()}
+					{@const filteredTables = _q
+						? tablesOnCanvas.filter((t) => {
+								const full = (t.schema ? `${t.schema}.` : '') + t.name;
+								return full.toLowerCase().includes(_q);
+							})
+						: tablesOnCanvas}
+					<p class="shrink-0 text-[10px]" style:color="hsl(var(--muted-foreground))">
+						{#if _q}
+							Showing {filteredTables.length} of {tablesOnCanvas.length}
+						{:else}
+							{tablesOnCanvas.length}
+							{tablesOnCanvas.length === 1 ? 'table' : 'tables'} available
+						{/if}
+					</p>
+					<div
+						class="flex min-h-0 flex-col overflow-hidden rounded border bg-elev-1"
+						style:border-color="hsl(var(--border))"
+					>
+						<div
+							class="flex shrink-0 items-center gap-2 border-b bg-elev-1 px-2 py-1.5 text-[9px] font-semibold tracking-wider uppercase"
+							style:border-color="hsl(var(--border))"
+							style:color="hsl(var(--muted-foreground))"
+						>
+							<span class="w-4 shrink-0"></span>
+							<span class="min-w-0 flex-1">Fact Table Name</span>
+							<span class="shrink-0">Columns</span>
+						</div>
+						<div class="flex flex-col overflow-y-auto">
+							{#if filteredTables.length === 0}
+								<p class="p-3 text-center text-[11px]" style:color="hsl(var(--muted-foreground))">
+									No tables match "{factsTableSearch}".
+								</p>
+							{:else}
+								{#each filteredTables as t (t.id)}
+									{@const isSel = t.id === factsSelectedTableId}
+									<label
+										class="flex cursor-pointer items-center gap-2 border-b px-2 py-1.5 text-[11px] last:border-b-0 hover:bg-accent/40 {isSel
+											? 'bg-accent'
+											: ''}"
+										style:border-color="hsl(var(--border))"
+									>
+										<input
+											type="radio"
+											name="fact-table-proto"
+											checked={isSel}
+											onchange={() => {
+												factsSelectedTableId = t.id;
+												factsSelectedMeasures.clear();
+											}}
+											class="h-3 w-3 shrink-0"
+										/>
+										<span class="min-w-0 flex-1 truncate font-mono">
+											{t.schema ? `${t.schema}.` : ''}{t.name}
+										</span>
+										<span class="shrink-0 font-mono text-[10px] tabular-nums opacity-70">
+											{t.columns.length}
+										</span>
+									</label>
+								{/each}
+							{/if}
+						</div>
+					</div>
+					<!-- Confirm CTA appears once a row is selected (state 2). -->
+					{#if chosenTable}
+						<div class="mt-1 flex shrink-0 justify-end">
+							<button
+								type="button"
+								onclick={() => {
+									factsTableConfirmed = true;
+								}}
+								class="inline-flex items-center gap-1 rounded-full border border-primary bg-primary px-2.5 py-1 text-[10px] font-semibold tracking-wider text-primary-foreground uppercase hover:bg-primary/90"
+							>
+								Confirm fact table
+							</button>
+						</div>
+					{/if}
+				{:else if chosenTable}
+					<!-- State 3 — confirmed.  Fact collapses to a one-row summary
+				     with a Change pill; Measures becomes the live surface. -->
+					<p class="text-[10px] tracking-wide uppercase" style:color="hsl(var(--muted-foreground))">
+						Fact table
+					</p>
+					<div
+						class="flex items-center gap-1.5 rounded border bg-elev-2 px-1.5 py-1 text-[11px]"
+						style:border-color="hsl(var(--border))"
+					>
+						<Database class="h-3 w-3 shrink-0 text-primary" aria-hidden="true" />
+						<span class="min-w-0 flex-1 truncate font-mono">
+							{chosenTable.schema ? `${chosenTable.schema}.` : ''}{chosenTable.name}
+						</span>
+						{#if factsEditMode}
+							<!-- Change pill — only visible while the whole pane is
+						     in edit mode.  Resets confirmation so the table
+						     picker reopens above. -->
+							<button
+								type="button"
+								onclick={() => {
+									factsTableConfirmed = false;
+								}}
+								class="inline-flex shrink-0 items-center gap-1 rounded-full border border-border px-1.5 py-0.5 text-[9px] font-semibold tracking-wider text-muted-foreground uppercase hover:bg-accent hover:text-accent-foreground"
+								title="Change fact table"
+							>
+								<Pencil class="h-2.5 w-2.5" aria-hidden="true" />
+								Change
+							</button>
+						{/if}
+					</div>
+
+					<!-- Measures section — own header + Edit pill. -->
+					<div class="mt-2 flex shrink-0 items-center justify-between">
+						<div class="flex items-center gap-1.5">
+							<Sigma class="h-3 w-3 shrink-0 text-primary" aria-hidden="true" />
+							<span
+								class="text-[10px] font-semibold tracking-wider uppercase"
+								style:color="hsl(var(--muted-foreground))"
+							>
+								Measures
+							</span>
+							<span class="font-mono text-[10px] opacity-60">
+								· {factsSelectedMeasures.size}/{numericCols.length}
+							</span>
+						</div>
+					</div>
+					{#if numericCols.length === 0}
+						<p
+							class="rounded border border-dashed p-2 text-center text-[10px]"
+							style:border-color="hsl(var(--border))"
+							style:color="hsl(var(--muted-foreground))"
+						>
+							No numeric columns on this fact table.
+						</p>
+					{:else}
+						<!-- All / Clear bulk replace — same shape as the dim
+					     Attributes pane.  Provides the "want most" /
+					     "want few" shortcuts for big fact tables. -->
+						<div class="flex shrink-0 items-center gap-1.5 text-[10px]">
+							<button
+								type="button"
+								onclick={() => {
+									factsSelectedMeasures.clear();
+									for (const c of numericCols) factsSelectedMeasures.add(c.name);
+								}}
+								class="rounded px-1.5 py-0.5 text-muted-foreground hover:bg-accent hover:text-accent-foreground disabled:opacity-50"
+								disabled={factsSelectedMeasures.size === numericCols.length}
+							>
+								All
+							</button>
+							<button
+								type="button"
+								onclick={() => factsSelectedMeasures.clear()}
+								class="rounded px-1.5 py-0.5 text-muted-foreground hover:bg-accent hover:text-accent-foreground disabled:opacity-50"
+								disabled={factsSelectedMeasures.size === 0}
+							>
+								Clear
+							</button>
+						</div>
+						<div class="flex flex-col gap-1">
+							{#each numericCols as col (col.name)}
+								{@const checked = factsSelectedMeasures.has(col.name)}
+								<!-- Plain div (not <label>) so the inner checkbox
+							     doesn't eat the mousedown that initiates a
+							     drag.  Grip + name area are the drag source;
+							     the checkbox is its own click target. -->
+								<div
+									class="flex items-center gap-1.5 rounded border bg-elev-2 px-1.5 py-1 text-[11px] hover:bg-accent/30 {checked
+										? 'cursor-grab active:cursor-grabbing'
+										: ''}"
+									style:border-color="hsl(var(--border))"
+									draggable={checked}
+									ondragstart={(e) => {
+										if (!checked || !e.dataTransfer) return;
+										e.dataTransfer.setData(FACTS_MEASURE_MIME, col.name);
+										e.dataTransfer.effectAllowed = 'copy';
+									}}
+									title={checked
+										? 'Drag into a measure group’s Content column'
+										: 'Tick first, then drag into a measure group'}
+									data-testid="workbench-fact-measure-row"
+								>
+									<GripVertical
+										class="h-3 w-3 shrink-0 text-muted-foreground/60 {checked ? '' : 'opacity-40'}"
+										aria-hidden="true"
+									/>
+									<input
+										type="checkbox"
+										{checked}
+										onchange={(e) => {
+											if (e.currentTarget.checked) factsSelectedMeasures.add(col.name);
+											else factsSelectedMeasures.delete(col.name);
+										}}
+										class="h-3 w-3 shrink-0 cursor-pointer"
+										aria-label="Pick {col.name}"
+									/>
+									<!-- Name area is plain spans (no button) so the
+								     dragstart on the parent div is never eaten by
+								     a click target.  Toggling the checkbox is
+								     the input's own click handler. -->
+									<span
+										role="presentation"
+										onclick={() => {
+											if (factsSelectedMeasures.has(col.name))
+												factsSelectedMeasures.delete(col.name);
+											else factsSelectedMeasures.add(col.name);
+										}}
+										class="flex min-w-0 flex-1 cursor-pointer items-center gap-1.5"
+									>
+										<span class="min-w-0 flex-1 truncate font-mono">{col.name}</span>
+										{#if col.sqlType}
+											<span
+												class="shrink-0 font-mono text-[9px] tracking-wide uppercase opacity-50"
+											>
+												{col.sqlType}
+											</span>
+										{/if}
+									</span>
+								</div>
+							{/each}
+						</div>
+					{/if}
+				{/if}
+			</div>
+		</section>
+	{:else if kind === 'groups'}
+		<!-- Pane 2: MEASURE GROUPS — fact-side analogue of dim Hierarchies.
+	     Two sub-columns, mirroring hierarchyTwoColumnBody exactly:
+	       Name    — list of groups (w-2/5, with add-group + drag-to-
+	                 create from a chosen measure)
+	       Content — the picked group's included measures (flex-1, drop
+	                 zone that accepts measures from Fact & Measures and
+	                 cross-group moves).
+	     Note: this body is a near-verbatim copy of hierarchyTwoColumnBody
+	     rather than a shared snippet — the dim and fact sides use
+	     different state shapes / drop MIMEs / row chrome, so factoring
+	     them into one generic snippet would balloon the call-signature
+	     for no real reuse win.  Calc storage moved to cube-scope
+	     factsCalcs and rendered by its own pane (kind === 'calculations').
+	     v2 (Mondrian 4): a measure group is its own authoring surface —
+	     pick a fact table later per-MG, not up-front for the cube.  Add-MG
+	     no longer gates on a chosen fact + picked measures; it just spawns
+	     an empty named row in label-edit mode. -->
+		{@const factsGroupsLocked = false}
+		{@const selectedGroup = factsMeasureGroups.find((g) => g.id === factsSelectedGroupId) ?? null}
+		<!-- 2x width vs the calculations pane: MG editor now hosts the
+			     fact + measures + dimensions sub-columns side-by-side, so it
+			     needs the bulk of the horizontal real estate. -->
+		<section
+			class="flex min-w-0 flex-[2] flex-col overflow-hidden rounded-md border bg-elev-1 transition-colors {isReorderTarget
+				? 'border-primary'
+				: ''} {isReorderSource ? 'opacity-50' : ''}"
+			style:border-color={isReorderTarget ? '' : 'hsl(var(--border))'}
+			ondragover={(e) => handleFactsPaneDragOver(e, idx)}
+			ondragleave={() => handleFactsPaneDragLeave(idx)}
+			ondrop={(e) => handleFactsPaneDrop(e, idx)}
+			data-pane-index={idx}
+			data-pane-kind={kind}
+		>
+			<header
+				class="flex shrink-0 items-center justify-between gap-2 border-b bg-elev-1 px-2.5 py-2"
+				style:border-color="hsl(var(--border))"
+			>
+				<div class="flex min-w-0 items-center gap-1.5">
+					<span
+						role="button"
+						tabindex="0"
+						draggable="true"
+						ondragstart={(e) => handleFactsPaneDragStart(e, idx)}
+						ondragend={handleFactsPaneDragEnd}
+						class="-ml-1 shrink-0 cursor-grab rounded p-1 text-muted-foreground hover:bg-accent hover:text-accent-foreground active:cursor-grabbing"
+						aria-label="Drag to reorder this pane"
+						title="Drag to reorder"
+					>
+						<GripVertical class="h-3 w-3" aria-hidden="true" />
+					</span>
+					<ListTree class="h-3.5 w-3.5 shrink-0 text-primary" aria-hidden="true" />
+					<span class="text-[11px] font-semibold tracking-wider uppercase"> Measure Groups </span>
+					{#if chosenTable}
+						<span class="font-mono text-[10px] text-muted-foreground">
+							· {factsMeasureGroups.length}
+						</span>
+					{/if}
+				</div>
+				<div class="flex items-center gap-1">
+					<!-- Identical to the dim Hierarchies pane: no Edit pill —
+				     groups are always editable.  An Add button creates a
+				     new (empty, single-measure-friendly) group; the rest
+				     of the editing affordances (rename, remove, drag) are
+				     always visible. -->
+					<button
+						type="button"
+						onclick={() => addFactsMeasureGroup()}
+						disabled={factsGroupsLocked}
+						class="inline-flex items-center gap-1 rounded-full border border-border px-2 py-0.5 text-[10px] font-semibold tracking-wider text-muted-foreground uppercase hover:bg-accent hover:text-accent-foreground disabled:cursor-not-allowed disabled:opacity-50"
+						title="Add a measure group"
+					>
+						<Plus class="h-2.5 w-2.5" aria-hidden="true" />
+						Add
+					</button>
+				</div>
+			</header>
+			<div class="flex min-h-0 flex-1 flex-col overflow-hidden bg-card p-2">
+				{#if true}
+					<!-- Two-column body — Name (w-2/5) + Content (flex-1),
+				     same proportions and shell as hierarchyTwoColumnBody.
+				     Mondrian 4 reverse: the user can author measure groups
+				     before picking measures or even a fact table — those
+				     get bound later, per MG, in the row's detail. -->
+					<div class="flex min-h-0 flex-1 gap-2">
+						<!-- ── NAME COLUMN ─────────────────────────────────────── -->
+						<!-- Equal-width 3-column layout once MG pane spans 2x:
+							     Name | Fact+Measures | Dimensions all flex-1 so a wide
+							     workbench reads as a clean tabular form. -->
+						<div class="flex min-w-0 flex-1 flex-col gap-1">
+							<span
+								class="truncate text-[10px] font-semibold tracking-wider uppercase"
+								style:color="hsl(var(--muted-foreground))"
+							>
+								Name
+							</span>
+							<div
+								class="flex min-h-0 flex-1 flex-col gap-1 overflow-y-auto rounded px-0.5"
+								data-testid="workbench-pane-measure-groups-name-col"
+							>
+								{#if factsMeasureGroups.length === 0}
+									<button
+										type="button"
+										onclick={() => addFactsMeasureGroup()}
+										class="flex flex-1 flex-col items-center justify-center gap-1 rounded border border-dashed p-3 text-center text-[11px] hover:bg-accent/30"
+										style:border-color="hsl(var(--border))"
+										style:color="hsl(var(--muted-foreground))"
+										title="Create a new measure group"
+									>
+										<Plus class="h-4 w-4" aria-hidden="true" />
+										<span>New measure group</span>
+									</button>
+								{:else}
+									<ul class="flex flex-col gap-1">
+										{#each factsMeasureGroups as g (g.id)}
+											{@const isSel = isFocused('mg', g.id)}
+											<!-- Mirrors hierarchyListRow: <li role=button + tabindex=0,
+												     icon + (input when editing, else span with dblclick-to-rename)
+												     + count + delete X.  Drag-into-calc bindings (draggable +
+												     ondragstart + title) are gated by ALLOW_GROUP_DROP_ON_CALC
+												     so flipping the const back to `true` re-enables BOTH the
+												     source-side drag affordance and the calc-pane drop target
+												     in lockstep — nothing visual happens while the flag is off. -->
+											<li
+												role="button"
+												tabindex="0"
+												onclick={() => {
+													factsSelectedGroupId = g.id;
+													focus('mg', g.id);
+												}}
+												onkeydown={(e) => {
+													if (e.key === 'Enter' || e.key === ' ') {
+														e.preventDefault();
+														factsSelectedGroupId = g.id;
+														focus('mg', g.id);
+													}
+												}}
+												class="flex cursor-pointer items-center gap-1.5 rounded border bg-elev-2 px-2 py-1 text-[11px] transition-colors {isSel
+													? 'workbench-row-selected'
+													: 'border-border hover:bg-accent/40'}"
+												data-testid="workbench-measure-group-list-row"
+												data-group-id={g.id}
+												draggable={ALLOW_GROUP_DROP_ON_CALC}
+												ondragstart={(e) => {
+													if (!ALLOW_GROUP_DROP_ON_CALC) return;
+													if (!e.dataTransfer) return;
+													e.dataTransfer.setData(FACTS_MEASURE_GROUP_MIME, g.id);
+													e.dataTransfer.effectAllowed = 'copy';
+												}}
+												title={ALLOW_GROUP_DROP_ON_CALC
+													? 'Drag into a calculation’s formula'
+													: undefined}
+											>
+												<ListTree
+													class="h-3 w-3 shrink-0 text-muted-foreground"
+													aria-hidden="true"
+												/>
+												{#if factsEditingMeasureGroupId === g.id}
+													<input
+														type="text"
+														value={g.name}
+														oninput={(e) => renameFactsMeasureGroup(g.id, e.currentTarget.value)}
+														onclick={(e) => e.stopPropagation()}
+														onkeydown={(e) => {
+															e.stopPropagation();
+															if (e.key === 'Enter' || e.key === 'Escape') {
+																(e.currentTarget as HTMLInputElement).blur();
+															}
+														}}
+														onblur={() => {
+															if (focusGroupId === g.id) focusGroupId = null;
+															factsEditingMeasureGroupId = null;
+														}}
+														placeholder="Group name"
+														aria-label="Group name"
+														class="h-5 min-w-0 flex-1 rounded border bg-background px-1 font-medium focus:border-ring focus:ring-1 focus:ring-ring focus:outline-none"
+														style:border-color="hsl(var(--border))"
+														use:autoFocus={focusGroupId === g.id ||
+															factsEditingMeasureGroupId === g.id}
+													/>
+												{:else}
+													<span
+														role="button"
+														tabindex="0"
+														ondblclick={(e) => {
+															e.stopPropagation();
+															factsEditingMeasureGroupId = g.id;
+														}}
+														onkeydown={(e) => {
+															if (e.key === 'F2' || e.key === 'Enter') {
+																e.preventDefault();
+																e.stopPropagation();
+																factsEditingMeasureGroupId = g.id;
+															}
+														}}
+														class="block min-w-0 flex-1 truncate leading-5 font-medium"
+														title="Double-click to rename"
+													>
+														{g.name || 'Untitled group'}
+													</span>
+												{/if}
+												<span class="shrink-0 font-mono text-[9px] text-muted-foreground">
+													{g.measureColumns.length}
+												</span>
+												{#if !g.factTableId || (g.dimensionLinks ?? []).length === 0}
+													<!-- MG incomplete — Mondrian 4 requires every measure
+														     group to bind to ONE fact table and link to 1+
+														     dimensions.  Warning flags whichever is missing. -->
+													<span
+														class="shrink-0 text-warning"
+														title={!g.factTableId && (g.dimensionLinks ?? []).length === 0
+															? 'Pick a fact table and at least one dimension'
+															: !g.factTableId
+																? 'No fact table picked — pick one in the editor'
+																: 'No dimensions linked yet — pick at least one in the editor'}
+														aria-label="Measure group is incomplete"
+														data-testid="workbench-measure-group-incomplete"
+													>
+														<AlertCircle class="h-3 w-3" aria-hidden="true" />
+													</span>
+												{/if}
+												<button
+													type="button"
+													onclick={(e) => {
+														e.stopPropagation();
+														factsEditingMeasureGroupId = g.id;
+														focusGroupId = g.id;
+													}}
+													class="shrink-0 rounded p-0.5 text-muted-foreground hover:bg-accent hover:text-accent-foreground"
+													aria-label="Rename group"
+													title="Rename group"
+													data-testid="workbench-measure-group-rename"
+												>
+													<Pencil class="h-2.5 w-2.5" aria-hidden="true" />
+												</button>
+												<button
+													type="button"
+													onclick={(e) => {
+														e.stopPropagation();
+														removeFactsMeasureGroup(g.id);
+													}}
+													class="shrink-0 rounded p-0.5 text-muted-foreground hover:bg-accent hover:text-accent-foreground"
+													aria-label="Remove group"
+													title="Remove group"
+												>
+													<X class="h-2.5 w-2.5" aria-hidden="true" />
+												</button>
+											</li>
+										{/each}
+									</ul>
+								{/if}
+							</div>
+						</div>
+						<!-- ── CONTENT COLUMN ──────────────────────────────────── -->
+						<!-- Per-MG editor.  A measure group binds to ONE fact table
+							     (Mondrian 4 lets different MGs in the same cube point at
+							     different facts) and links to 1+ shared dimensions.  This
+							     column hosts all three picks for the selected MG: fact
+							     table radio, measures checklist (cols of the chosen fact),
+							     dim links checklist (every schema dim).  Checkbox UX over
+							     drag/drop — easier to reverse, easier to see what's on
+							     and what's off at a glance. -->
+						{@render paneMeasureGroupContent(selectedGroup)}
+					</div>
+				{/if}
+			</div>
+		</section>
+	{:else if kind === 'calculations'}
+		<!-- Pane 3: CALCULATIONS — cube-scope <CalculatedMember> editor.
+	     Mondrian 4 puts these directly under <Cube>, not nested in a
+	     measure group, so the pane lists every calc in the cube as a
+	     stacked card list and a calc can freely reference any measure
+	     on any group.  Selection is pane-local (factsSelectedCalcId).
+	     v2 (post-MG-restructure): the cube no longer has a single fact
+	     table — measures live per-MG.  Builder is accessible at all
+	     times; the chip palette draws from the union of every MG's
+	     measureColumns. -->
+		<!-- Builder is always accessible — measure tokens come from
+			     drag-from-MG-chip via FACTS_MEASURE_MIME. -->
+		<section
+			class="flex min-w-0 flex-1 flex-col overflow-hidden rounded-md border bg-elev-1 transition-colors {isReorderTarget
+				? 'border-primary'
+				: ''} {isReorderSource ? 'opacity-50' : ''}"
+			style:border-color={isReorderTarget ? '' : 'hsl(var(--border))'}
+			ondragover={(e) => handleFactsPaneDragOver(e, idx)}
+			ondragleave={() => handleFactsPaneDragLeave(idx)}
+			ondrop={(e) => handleFactsPaneDrop(e, idx)}
+			data-pane-index={idx}
+			data-pane-kind={kind}
+		>
+			<header
+				class="flex shrink-0 items-center justify-between gap-2 border-b bg-elev-1 px-2.5 py-2"
+				style:border-color="hsl(var(--border))"
+			>
+				<div class="flex min-w-0 flex-1 items-center gap-1.5">
+					<span
+						role="button"
+						tabindex="0"
+						draggable="true"
+						ondragstart={(e) => handleFactsPaneDragStart(e, idx)}
+						ondragend={handleFactsPaneDragEnd}
+						class="-ml-1 shrink-0 cursor-grab rounded p-1 text-muted-foreground hover:bg-accent hover:text-accent-foreground active:cursor-grabbing"
+						aria-label="Drag to reorder this pane"
+						title="Drag to reorder"
+					>
+						<GripVertical class="h-3 w-3" aria-hidden="true" />
+					</span>
+					<Sigma class="h-3.5 w-3.5 shrink-0 text-primary" aria-hidden="true" />
+					<span class="min-w-0 truncate text-[11px] font-semibold tracking-wider uppercase">
+						Calculations
+					</span>
+					{#if chosenTable}
+						<span class="shrink-0 font-mono text-[10px] text-muted-foreground">
+							· {factsCalcs.length}
+						</span>
+					{/if}
+				</div>
+				<div class="flex shrink-0 items-center justify-end gap-1">
+					<button
+						type="button"
+						onclick={() => addFactsCalc()}
+						class="inline-flex items-center gap-1 rounded-full border border-border px-2 py-0.5 text-[10px] font-semibold tracking-wider text-muted-foreground uppercase hover:bg-accent hover:text-accent-foreground"
+						title="Add a calculated measure"
+					>
+						<Plus class="h-2.5 w-2.5" aria-hidden="true" />
+						<span class="hidden md:inline">Add calc</span>
+					</button>
+					<!-- Pane-level Edit pill removed — calcs edit per-card
+				     via the pencil icon in each calc header. -->
+				</div>
+			</header>
+			<div class="flex min-h-0 flex-1 flex-col overflow-hidden bg-card p-2">
+				{#if factsCalcs.length === 0}
+					<button
+						type="button"
+						onclick={() => addFactsCalc()}
+						class="flex flex-1 flex-col items-center justify-center gap-1 rounded border border-dashed p-3 text-center text-[11px] hover:bg-accent/30"
+						style:border-color="hsl(var(--border))"
+						style:color="hsl(var(--muted-foreground))"
+						title="Add the first calculated measure"
+					>
+						<Plus class="h-4 w-4" aria-hidden="true" />
+						<span>New calculated measure</span>
+						<span class="text-[9px] opacity-70">e.g. Profit = [Sales] − [Cost]</span>
+					</button>
+				{:else}
+					<div
+						class="flex min-h-0 flex-1 flex-col gap-2 overflow-y-auto rounded border bg-elev-2 p-1.5"
+						style:border-color="hsl(var(--border))"
+					>
+						{#each factsCalcs as c (c.id)}
+							{@const mode = calcMode(c)}
+							{@const needsMeasure = calcNeedsMeasure(c)}
+							{@const isSelected = isFocused('calc', c.id)}
+							{@const isEditingThis = factsEditingCalcId === c.id}
+							<section
+								class="flex flex-col gap-1.5 rounded border bg-elev-2 p-1.5 transition-colors {isSelected
+									? 'workbench-row-selected-outline'
+									: 'border-border'}"
+								style:border-color={isSelected ? '' : 'hsl(var(--border))'}
+								onclick={() => {
+									selectFactsCalc(c.id);
+								}}
+								onkeydown={(e) => {
+									if (e.key === 'Enter' || e.key === ' ') {
+										e.preventDefault();
+										selectFactsCalc(c.id);
+									}
+								}}
+								role="button"
+								tabindex="0"
+							>
+								<header class="flex items-center gap-1.5">
+									<Sigma class="h-3 w-3 shrink-0 text-primary" aria-hidden="true" />
+									{#if isEditingThis}
+										<input
+											type="text"
+											value={c.name}
+											oninput={(e) => renameFactsCalc(c.id, e.currentTarget.value)}
+											onclick={(e) => e.stopPropagation()}
+											placeholder="Name the result (e.g. Profit)"
+											class="h-5 min-w-0 flex-1 rounded border border-transparent bg-transparent px-1 text-[11px] font-medium focus:border-border focus:bg-elev-1"
+											aria-label="Calculation name"
+										/>
+										<button
+											type="button"
+											onclick={(e) => {
+												e.stopPropagation();
+												removeFactsCalc(c.id);
+											}}
+											class="shrink-0 rounded p-0.5 text-muted-foreground hover:bg-destructive/15 hover:text-destructive"
+											aria-label="Remove calculation"
+											title="Remove"
+										>
+											<X class="h-3 w-3" aria-hidden="true" />
+										</button>
+									{:else}
+										<span class="min-w-0 flex-1 truncate text-[11px] font-medium">
+											{c.name || 'Untitled calculation'}
+										</span>
+									{/if}
+									<!-- Pencil / Check toggle — flips THIS calc into
+								     edit mode without affecting others.  Read-only
+								     by default so the user can review without
+								     accidentally mutating tokens. -->
+									<button
+										type="button"
+										onclick={(e) => {
+											e.stopPropagation();
+											factsEditingCalcId = isEditingThis ? null : c.id;
+										}}
+										class="shrink-0 rounded p-0.5 text-muted-foreground hover:bg-accent hover:text-accent-foreground"
+										aria-label={isEditingThis ? 'Done editing' : 'Edit calculation'}
+										title={isEditingThis ? 'Done editing' : 'Edit'}
+									>
+										{#if isEditingThis}
+											<Check class="h-3 w-3" aria-hidden="true" />
+										{:else}
+											<Pencil class="h-3 w-3" aria-hidden="true" />
+										{/if}
+									</button>
+								</header>
+								{#if isEditingThis}
+									<div
+										class="inline-flex shrink-0 self-start overflow-hidden rounded border text-[9px] font-semibold tracking-wider uppercase"
+										style:border-color="hsl(var(--border))"
+										role="tablist"
+									>
+										<button
+											type="button"
+											role="tab"
+											aria-selected={mode === 'build'}
+											onclick={(e) => {
+												e.stopPropagation();
+												setCalcMode(c.id, 'build');
+											}}
+											class="px-2 py-0.5 {mode === 'build'
+												? 'bg-primary text-primary-foreground'
+												: 'bg-muted/40 text-muted-foreground hover:bg-accent/40'}"
+										>
+											Build
+										</button>
+										<button
+											type="button"
+											role="tab"
+											aria-selected={mode === 'expression'}
+											onclick={(e) => {
+												e.stopPropagation();
+												setCalcMode(c.id, 'expression');
+											}}
+											class="border-l px-2 py-0.5 {mode === 'expression'
+												? 'bg-primary text-primary-foreground'
+												: 'text-muted-foreground hover:bg-accent/40'}"
+											style:border-color="hsl(var(--border))"
+										>
+											Expression
+										</button>
+									</div>
+								{/if}
+								{#if mode === 'build'}
+									<div
+										class="flex flex-wrap items-center gap-1 rounded border-2 border-dashed bg-elev-2 p-1.5 font-mono text-[11px] transition-colors hover:bg-accent/10"
+										style:border-color="hsl(var(--border))"
+										ondragover={(e) => {
+											if (!needsMeasure) return;
+											const tt = e.dataTransfer?.types ?? [];
+											// Group-drop is feature-flagged off; only accept it
+											// when `ALLOW_GROUP_DROP_ON_CALC` is true.
+											const ok =
+												Array.from(tt).includes(FACTS_MEASURE_MIME) ||
+												(ALLOW_GROUP_DROP_ON_CALC &&
+													Array.from(tt).includes(FACTS_MEASURE_GROUP_MIME));
+											if (!ok) return;
+											e.preventDefault();
+											if (e.dataTransfer) e.dataTransfer.dropEffect = 'copy';
+										}}
+										ondrop={(e) => {
+											if (!needsMeasure) return;
+											const tt = e.dataTransfer?.types ?? [];
+											if (Array.from(tt).includes(FACTS_MEASURE_MIME)) {
+												e.preventDefault();
+												e.stopPropagation();
+												const col = e.dataTransfer?.getData(FACTS_MEASURE_MIME);
+												if (col) addCalcMeasure(c.id, col);
+												return;
+											}
+											// Group-drop branch — guarded by the feature flag.
+											if (
+												ALLOW_GROUP_DROP_ON_CALC &&
+												Array.from(tt).includes(FACTS_MEASURE_GROUP_MIME)
+											) {
+												e.preventDefault();
+												e.stopPropagation();
+												const groupId = e.dataTransfer?.getData(FACTS_MEASURE_GROUP_MIME);
+												const group = factsMeasureGroups.find((mg) => mg.id === groupId);
+												if (!group) return;
+												// Expand every measure in the group into tokens
+												// joined by `+`.  Lets the user quickly build a
+												// sum-of-group calc; they can rewire operators
+												// after the fact via the per-token undo.
+												group.measureColumns.forEach((name, i) => {
+													if (i > 0) addCalcOperator(c.id, '+');
+													addCalcMeasure(c.id, name, true);
+												});
+											}
+										}}
+										role="region"
+										aria-label="Calculation formula — drop measures or click the picker"
+									>
+										{#if c.tokens.length === 0}
+											<span class="text-[10px] italic" style:color="hsl(var(--muted-foreground))">
+												Drop a measure here, or click one below.
+											</span>
+										{:else}
+											{#each c.tokens as t, i (i)}
+												{#if t.kind === 'measure'}
+													<span
+														class="rounded px-1.5 py-0.5 {t.fromGroup
+															? 'bg-primary/15 text-primary'
+															: ''}"
+														style:background-color={t.fromGroup ? '' : 'hsl(150 55% 88%)'}
+														style:color={t.fromGroup ? '' : 'hsl(150 55% 22%)'}
+													>
+														[{t.name}]
+													</span>
+												{:else}
+													<span class="px-0.5 opacity-70">{formatCalcOp(t.op)}</span>
+												{/if}
+											{/each}
+										{/if}
+										{#if isEditingThis && c.tokens.length > 0}
+											<button
+												type="button"
+												onclick={(e) => {
+													e.stopPropagation();
+													popCalcToken(c.id);
+												}}
+												class="ml-auto shrink-0 rounded px-1 py-0.5 text-[10px] text-muted-foreground hover:bg-accent hover:text-accent-foreground"
+												title="Undo last token"
+											>
+												←
+											</button>
+										{/if}
+									</div>
+									{#if isEditingThis}
+										{#if needsMeasure}
+											<!-- Picker dropped — the user drags measures (or
+										     groups) from the Fact pane / Measure Groups
+										     content directly into the formula chip area
+										     above. -->
+											<span
+												class="text-[9px] tracking-wider uppercase italic"
+												style:color="hsl(var(--muted-foreground))"
+											>
+												Drag a measure or group into the formula above.
+											</span>
+										{:else}
+											<div class="flex items-center gap-1.5">
+												<span
+													class="text-[9px] tracking-wider uppercase"
+													style:color="hsl(var(--muted-foreground))"
+												>
+													Operator
+												</span>
+												<select
+													value=""
+													onclick={(e) => e.stopPropagation()}
+													onchange={(e) => {
+														const v = e.currentTarget.value;
+														if (v === '+' || v === '-' || v === '*' || v === '/') {
+															addCalcOperator(c.id, v);
+															e.currentTarget.value = '';
+														}
+													}}
+													class="h-6 rounded border bg-elev-1 px-1 font-mono text-[11px]"
+													style:border-color="hsl(var(--border))"
+													aria-label="Operator"
+												>
+													<option value="" disabled selected>Choose…</option>
+													<option value="+">+ (add)</option>
+													<option value="-">− (subtract)</option>
+													<option value="*">× (multiply)</option>
+													<option value="/">÷ (divide)</option>
+												</select>
+												<button
+													type="button"
+													onclick={(e) => {
+														e.stopPropagation();
+														clearCalcTokens(c.id);
+													}}
+													class="ml-auto rounded px-1.5 py-0.5 text-[10px] text-muted-foreground hover:bg-accent hover:text-accent-foreground"
+													title="Clear formula"
+												>
+													Clear
+												</button>
+											</div>
+										{/if}
+									{/if}
+								{:else if isEditingThis}
+									<textarea
+										value={c.formula ?? ''}
+										oninput={(e) => updateCalcFormula(c.id, e.currentTarget.value)}
+										onclick={(e) => e.stopPropagation()}
+										placeholder="e.g. IIF([Cost] = 0, NULL, [Profit] / [Cost])"
+										rows="3"
+										class="min-h-0 w-full resize-y rounded border bg-muted/40 px-1.5 py-1 font-mono text-[11px] focus:border-ring focus:ring-1 focus:ring-ring focus:outline-none"
+										style:border-color="hsl(var(--border))"
+										aria-label="Free-text formula"
+									></textarea>
+								{:else}
+									<div
+										class="rounded border bg-elev-1 px-1.5 py-1 font-mono text-[11px]"
+										style:border-color="hsl(var(--border))"
+										style:color={(c.formula ?? '') ? 'inherit' : 'hsl(var(--muted-foreground))'}
+									>
+										{c.formula || 'No formula yet.'}
+									</div>
+								{/if}
+							</section>
+						{/each}
+					</div>
+				{/if}
+			</div>
+		</section>
+	{/if}
+{/each}
+
+{#snippet paneMeasureGroupContent(g: WorkbenchMeasureGroup | null)}
+	<!-- Outer flex-[3] (vs the Name column's flex-1) shifts the horizontal
+	     budget so Fact+Measures and Dimensions each get ~37.5% of the MG
+	     pane instead of a flat 1/3.  The Name column (list of MG names)
+	     doesn't need that much room; the two editor boxes do.
+
+	     Layout: LEFT column stacks Fact Table (top) + Measures (bottom)
+	     as two independent boxes with their own Confirm/Edit; RIGHT column
+	     is the Dimensions box, unchanged shape from before.  Fact →
+	     Measures is a sequential gate: measures locked until fact is
+	     confirmed.  #972 fixed the visibility of CONFIRM; this refactor
+	     fixes the model itself. -->
+	<div class="flex min-h-0 min-w-0 flex-[3] flex-col gap-1">
+		<span
+			class="truncate text-[10px] font-semibold tracking-wider uppercase"
+			style:color="hsl(var(--muted-foreground))"
+		>
+			Content
+		</span>
+		{#if !g}
+			<div
+				class="flex flex-1 items-center justify-center rounded border border-dashed p-3 text-center text-[11px]"
+				style:border-color="hsl(var(--border))"
+				style:color="hsl(var(--muted-foreground))"
+			>
+				Pick a group on the left.
+			</div>
+		{:else}
+			{@const factTable = g.factTableId
+				? (store.doc.tables.find((t) => t.id === g.factTableId) ?? null)
+				: null}
+			{@const dimLinks = g.dimensionLinks ?? []}
+			{@const canConfirmFact = !!g.factTableId}
+			{@const canConfirmMeasures = !!g.factConfirmed && g.measureColumns.length > 0}
+			{@const factSaved = !!g.factConfirmed && !!factTable}
+			{@const measuresSaved = !!g.measuresConfirmed && !!factTable && g.measureColumns.length > 0}
+			<div
+				class="flex min-h-0 flex-1 gap-2 overflow-hidden"
+				data-testid="workbench-pane-measure-group-editor"
+				data-group-id={g.id}
+			>
+				<!-- ── LEFT column: FACT TABLE (top) + MEASURES (bottom) ─── -->
+				<div class="flex min-h-0 flex-1 flex-col gap-2">
+					<!-- Box 1 — FACT TABLE. Scoped to canvas tables (#975):
+					     `store.doc.tables` is the pool the user drew on the
+					     schema canvas — that IS the fact-table candidate list.
+					     Was reading from `store.sourceTables` (the whole
+					     warehouse), which offered facts you hadn't even joined
+					     into the schema. -->
+					<section
+						class="flex min-h-0 flex-col gap-2 rounded border bg-elev-2 p-2"
+						style:border-color="hsl(var(--border))"
+						data-testid="workbench-pane-measure-group-fact"
+					>
+						<div
+							class="flex items-center justify-between gap-2 border-b pb-1.5"
+							style:border-color="hsl(var(--border))"
+						>
+							<span
+								class="flex items-center gap-1.5 text-[10px] font-semibold tracking-wider uppercase"
+								style:color="hsl(var(--muted-foreground))"
+							>
+								Fact Table
+								{#if !factSaved && store.doc.tables.length > 0}
+									<!-- Count hint — signals a scrollable list at a
+									     glance without waiting for the user to notice
+									     the scrollbar. -->
+									<span class="font-mono text-[9px] normal-case opacity-70">
+										· {store.doc.tables.length} on canvas
+									</span>
+								{/if}
+							</span>
+							{#if factSaved}
+								<button
+									type="button"
+									onclick={() => {
+										// Rebinding wipes measures — warn if any are picked.
+										// Native confirm() is fine for now; swap to a themed
+										// dialog when the DS Dialog primitive is migrated in.
+										const dirty = !!g.measuresConfirmed || g.measureColumns.length > 0;
+										if (
+											dirty &&
+											!confirm(
+												'Rebinding the fact table will clear your measures and captions. Continue?'
+											)
+										) {
+											return;
+										}
+										g.factConfirmed = false;
+										if (dirty) {
+											g.measuresConfirmed = false;
+											g.measureColumns = [];
+											g.measureCaptions = {};
+										}
+									}}
+									class="rounded-full border border-border px-2 py-0.5 text-[9px] font-semibold tracking-wider text-muted-foreground uppercase hover:bg-accent hover:text-accent-foreground"
+									data-testid="workbench-mg-fact-edit"
+								>
+									Edit
+								</button>
+							{:else}
+								<button
+									type="button"
+									disabled={!canConfirmFact}
+									onclick={() => (g.factConfirmed = true)}
+									class="rounded-full bg-primary px-3 py-1 text-[10px] font-bold tracking-wider text-primary-foreground uppercase shadow-sm transition-colors hover:bg-primary/90 disabled:cursor-not-allowed disabled:bg-muted disabled:text-muted-foreground disabled:shadow-none"
+									data-testid="workbench-mg-fact-confirm"
+								>
+									Confirm
+								</button>
+							{/if}
+						</div>
+						{#if factSaved && factTable}
+							<!-- Saved row — plain treatment (no red-tinted glow),
+							     matches the Dimensions saved row shape. -->
+							<div
+								class="flex items-center gap-2 rounded border bg-card px-2 py-1.5 text-[11px]"
+								style:border-color="hsl(var(--border))"
+								data-testid="workbench-mg-fact-saved-row"
+							>
+								<Database class="h-3.5 w-3.5 shrink-0 text-primary" aria-hidden="true" />
+								<div class="flex min-w-0 flex-1 flex-col leading-tight">
+									<span class="truncate font-medium">{factTable.name}</span>
+									{#if factTable.schema}
+										<span
+											class="truncate font-mono text-[9px]"
+											style:color="hsl(var(--muted-foreground))"
+										>
+											{factTable.schema}.{factTable.name}
+										</span>
+									{/if}
+								</div>
+								<span
+									class="shrink-0 rounded border px-1.5 py-0 font-mono text-[8px] tracking-wider uppercase"
+									style:border-color="hsl(var(--border))"
+									style:color="hsl(var(--muted-foreground))"
+								>
+									TABLE
+								</span>
+							</div>
+						{:else}
+							<!-- Edit view — scrolling radio list of canvas tables. -->
+							{#if store.doc.tables.length === 0}
+								<p
+									class="rounded border border-dashed p-2 text-center text-[11px]"
+									style:border-color="hsl(var(--border))"
+									style:color="hsl(var(--muted-foreground))"
+								>
+									Draw tables on the schema canvas first — they'll show here.
+								</p>
+							{:else}
+								<ul
+									class="workbench-scroll flex max-h-52 flex-col gap-0.5 overflow-y-auto pr-1"
+									data-testid="workbench-mg-fact-radio-list"
+								>
+									{#each store.doc.tables as t (t.id)}
+										{@const checked = g.factTableId === t.id}
+										<li>
+											<label
+												class="flex w-full cursor-pointer items-center gap-1.5 rounded border px-2 py-1 text-[11px] transition-colors {checked
+													? 'border-primary bg-primary/10'
+													: 'border-border hover:bg-accent/40'}"
+												style:border-color={checked ? '' : 'hsl(var(--border))'}
+											>
+												<input
+													type="radio"
+													class="h-3 w-3"
+													name="mg-{g.id}-fact"
+													{checked}
+													onchange={() => {
+														if (checked) return;
+														g.factTableId = t.id;
+														// Rebind clears any prior measure picks that
+														// don't exist on the newly-picked fact table.
+														const cols = new Set(t.columns.map((c) => c.name));
+														g.measureColumns = g.measureColumns.filter((c) => cols.has(c));
+														g.measureCaptions = Object.fromEntries(
+															Object.entries(g.measureCaptions ?? {}).filter(([k]) => cols.has(k))
+														);
+													}}
+													data-testid="workbench-mg-fact-radio"
+													data-table-id={t.id}
+												/>
+												<Database
+													class="h-3 w-3 shrink-0 text-muted-foreground"
+													aria-hidden="true"
+												/>
+												<div class="flex min-w-0 flex-1 flex-col leading-tight">
+													<span class="truncate font-mono">{t.name}</span>
+													{#if t.schema}
+														<span
+															class="truncate font-mono text-[9px]"
+															style:color="hsl(var(--muted-foreground))"
+														>
+															{t.schema}.{t.name}
+														</span>
+													{/if}
+												</div>
+											</label>
+										</li>
+									{/each}
+								</ul>
+							{/if}
+						{/if}
+					</section>
+
+					<!-- Box 2 — MEASURES. Gated on Fact confirmed; shows an
+					     "Pick a fact table first" empty state until then.
+					     Edit view = scrolling checkbox list of the fact's
+					     columns.  Saved view = rows matching the Dimensions
+					     pattern (numbered badge + editable caption + muted
+					     column name below + type badge + pencil/×).
+					     Captions round-trip through `<Measure caption="…">`
+					     in the emitted M4 XML. -->
+					<section
+						class="flex min-h-0 flex-1 flex-col gap-2 rounded border bg-elev-2 p-2 transition-opacity"
+						style:border-color="hsl(var(--border))"
+						class:opacity-55={!g.factConfirmed}
+						data-testid="workbench-pane-measure-group-measures"
+					>
+						<div
+							class="flex items-center justify-between gap-2 border-b pb-1.5"
+							style:border-color="hsl(var(--border))"
+						>
+							<span
+								class="flex items-center gap-1.5 text-[10px] font-semibold tracking-wider uppercase"
+								style:color="hsl(var(--muted-foreground))"
+							>
+								<!-- Sigma moved here from per-row: every saved measure is
+								     an aggregation, so the icon reads clearest as a mark on
+								     the *section* rather than repeated on every row.
+								     Reclaims horizontal space in the row. -->
+								<Sigma class="h-3 w-3 shrink-0 text-primary" aria-hidden="true" />
+								<span>Measures</span>
+								{#if !measuresSaved && factTable && g.factConfirmed}
+									<!-- Column count of the picked fact — signals list
+									     length + indicates the picker will scroll. -->
+									<span class="font-mono text-[9px] normal-case opacity-70">
+										· {factTable.columns.length} columns
+									</span>
+								{:else if measuresSaved}
+									<span class="font-mono text-[9px] normal-case opacity-70">
+										· {g.measureColumns.length} picked
+									</span>
+								{/if}
+							</span>
+							{#if measuresSaved}
+								<button
+									type="button"
+									onclick={() => (g.measuresConfirmed = false)}
+									class="rounded-full border border-border px-2 py-0.5 text-[9px] font-semibold tracking-wider text-muted-foreground uppercase hover:bg-accent hover:text-accent-foreground"
+									data-testid="workbench-mg-measures-edit"
+								>
+									Edit
+								</button>
+							{:else}
+								<button
+									type="button"
+									disabled={!canConfirmMeasures}
+									onclick={() => (g.measuresConfirmed = true)}
+									class="rounded-full bg-primary px-3 py-1 text-[10px] font-bold tracking-wider text-primary-foreground uppercase shadow-sm transition-colors hover:bg-primary/90 disabled:cursor-not-allowed disabled:bg-muted disabled:text-muted-foreground disabled:shadow-none"
+									data-testid="workbench-mg-measures-confirm"
+								>
+									Confirm
+								</button>
+							{/if}
+						</div>
+						{#if !g.factConfirmed}
+							<div
+								class="flex flex-1 items-center justify-center rounded border border-dashed p-3 text-center text-[11px] italic"
+								style:border-color="hsl(var(--border))"
+								style:color="hsl(var(--muted-foreground))"
+							>
+								Pick + confirm a Fact Table first.<br />Measures come from its columns.
+							</div>
+						{:else if measuresSaved && factTable}
+							<!-- Saved rows — Dimensions-shape (numbered badge,
+							     editable caption on top, real column name below,
+							     type badge, inline pencil/×). -->
+							<div
+								class="workbench-scroll flex min-h-0 flex-1 flex-col gap-1 overflow-y-auto pr-1"
+								data-testid="workbench-mg-measures-saved-list"
+							>
+								{#each g.measureColumns as col (col)}
+									{@const caption = g.measureCaptions?.[col] ?? col}
+									{@const isEditing = editingMeasureCaption === `${g.id}::${col}`}
+									{@const storeMeasure = store.measures.find(
+										(mm) => mm.tableId === g.factTableId && mm.columnName === col
+									)}
+									{@const isSelected = !!storeMeasure && isFocused('measure', storeMeasure.id)}
+									{@const currentAgg = storeMeasure?.aggregator ?? 'sum'}
+									{@const aggLabel =
+										currentAgg === 'distinct-count'
+											? 'Distinct count'
+											: currentAgg.charAt(0).toUpperCase() + currentAgg.slice(1)}
+									<!-- Row is a click-target: single-click selects the measure so
+									     the Inspector Properties tab shows aggregator / formatString
+									     (name / caption editable inline via the pencil).  Fixes
+									     the #974 discoverability gap. -->
+									<div
+										role="button"
+										tabindex="0"
+										draggable="true"
+										ondragstart={(e) => {
+											// FACTS_MEASURE_MIME payload lets the MG Name column
+											// (spawn-new-MG-from-measure) and the Calculations
+											// formula drop zone (add [measure] token) both consume
+											// this row as a drag source. Regression from the
+											// 07756ed7 MG-editor rewrite — the previous chip-style
+											// row was draggable; the row-with-inspector-click
+											// replacement forgot to preserve draggable.
+											if (!e.dataTransfer) return;
+											e.dataTransfer.setData(FACTS_MEASURE_MIME, col);
+											e.dataTransfer.effectAllowed = 'copy';
+										}}
+										onclick={(e) => {
+											// Ignore clicks that bubbled from an inner control
+											// (pencil / × / caption editor / input).  Only the
+											// bare row area toggles selection.
+											const t = e.target as HTMLElement;
+											if (t.closest('button, input')) return;
+											if (storeMeasure) {
+												selectMgMeasure(storeMeasure.id);
+											}
+										}}
+										onkeydown={(e) => {
+											if (e.key === 'Enter' || e.key === ' ') {
+												e.preventDefault();
+												if (storeMeasure) {
+													selectMgMeasure(storeMeasure.id);
+												}
+											}
+										}}
+										class="flex cursor-grab items-center gap-2 rounded border px-2 py-1.5 text-[11px] transition-colors active:cursor-grabbing {isSelected
+											? 'workbench-row-selected'
+											: 'border-border bg-card hover:bg-accent/30'}"
+										style:border-color={isSelected ? '' : 'hsl(var(--border))'}
+										title="Click to inspect · double-click name to rename · drag to a measure group or calc"
+										data-testid="workbench-mg-measure-saved-row"
+										data-column={col}
+									>
+										<div class="flex min-w-0 flex-1 flex-col leading-tight">
+											{#if isEditing}
+												<input
+													type="text"
+													class="w-full rounded border bg-background px-1 py-0.5 text-[12px] font-medium"
+													style:border-color="hsl(var(--primary))"
+													value={caption}
+													autofocus
+													onblur={(e) => {
+														commitMeasureCaption(g, col, (e.target as HTMLInputElement).value);
+													}}
+													onkeydown={(e) => {
+														if (e.key === 'Enter') {
+															e.preventDefault();
+															commitMeasureCaption(
+																g,
+																col,
+																(e.currentTarget as HTMLInputElement).value
+															);
+														} else if (e.key === 'Escape') {
+															e.preventDefault();
+															editingMeasureCaption = null;
+														}
+													}}
+													data-testid="workbench-mg-measure-caption-input"
+												/>
+											{:else}
+												<!-- Caption is a plain span, not a button, so:
+												     (a) single-click bubbles up to the row's
+												     onclick → Inspector selection fires,
+												     (b) double-click still enters inline
+												     rename mode.  Cursor stays `pointer` from
+												     the row so the whole area reads as one
+												     clickable target with no dead zones. -->
+												<span
+													class="truncate font-medium select-none"
+													ondblclick={() => (editingMeasureCaption = `${g.id}::${col}`)}
+													data-testid="workbench-mg-measure-caption"
+												>
+													{caption}
+												</span>
+											{/if}
+											<span
+												class="truncate font-mono text-[9px] select-none"
+												style:color="hsl(var(--muted-foreground))"
+											>
+												{col}
+											</span>
+										</div>
+										<!-- Aggregator dropdown — inline, so users can flip
+										     sum → count / avg / distinct-count without a
+										     round-trip through the Inspector.  Common case
+										     (e.g. `customer_id` shouldn't be SUM, needs
+										     DISTINCT COUNT) fixed in one click.  Fixes the
+										     #974 discoverability gap for aggregators.
+										     Stops click propagation so opening this doesn't
+										     fire the row's "click to inspect" handler. -->
+										<SelectPrimitive.Root
+											type="single"
+											value={currentAgg}
+											onValueChange={(v) => {
+												const next = v as SchemaCanvasMeasure['aggregator'];
+												if (storeMeasure) {
+													store.updateMeasure(storeMeasure.id, { aggregator: next });
+												} else if (g.factTableId) {
+													store.addMeasure({
+														tableId: g.factTableId,
+														columnName: col,
+														aggregator: next
+													});
+												}
+											}}
+										>
+											<!-- `text-foreground` is explicit here so the label stays
+											     readable when the parent row is selected (bg-success)
+											     — otherwise Tailwind inherits `text-primary-foreground`
+											     from the row and renders black on the dark trigger. -->
+											<SelectPrimitive.Trigger
+												onclick={(e: MouseEvent) => e.stopPropagation()}
+												class="inline-flex h-6 w-24 shrink-0 items-center justify-between gap-1 rounded-md border border-border bg-background px-2 text-[11px] font-normal tracking-normal text-foreground capitalize hover:bg-accent focus-visible:border-ring focus-visible:ring-1 focus-visible:ring-ring focus-visible:outline-none"
+												title="Aggregator — how this measure rolls up across rows"
+												data-testid="workbench-mg-measure-aggregator"
+											>
+												<span class="truncate">{aggLabel}</span>
+												<ChevronDown class="h-2.5 w-2.5 shrink-0 opacity-60" aria-hidden="true" />
+											</SelectPrimitive.Trigger>
+											<SelectPrimitive.Portal>
+												<SelectPrimitive.Content
+													class="z-50 flex min-w-48 flex-col overflow-hidden rounded-md border border-border bg-popover p-1 text-xs shadow-md"
+													sideOffset={4}
+												>
+													{#each AGGREGATORS as agg (agg)}
+														<SelectPrimitive.Item
+															value={agg}
+															class="flex cursor-pointer items-center gap-2 rounded px-2 py-1.5 outline-none data-[highlighted]:bg-accent data-[highlighted]:text-accent-foreground data-[state=checked]:font-semibold"
+														>
+															<span class="min-w-0 flex-1 truncate text-[11px] capitalize">
+																{agg === 'distinct-count' ? 'Distinct count' : agg}
+															</span>
+															{#if currentAgg === agg}
+																<Check class="size-3 shrink-0 text-primary" aria-hidden="true" />
+															{/if}
+														</SelectPrimitive.Item>
+													{/each}
+												</SelectPrimitive.Content>
+											</SelectPrimitive.Portal>
+										</SelectPrimitive.Root>
+										<!-- Percentile value (0–100) — only for the `percentile`
+										     aggregator; median is the implicit 50th and needs none.
+										     Defaults to 50 when left blank. -->
+										{#if currentAgg === 'percentile'}
+											<input
+												type="number"
+												min="0"
+												max="100"
+												value={storeMeasure?.percentile ?? 50}
+												onclick={(e) => e.stopPropagation()}
+												oninput={(e) => {
+													e.stopPropagation();
+													if (!storeMeasure) return;
+													const raw = e.currentTarget.value;
+													const next =
+														raw === '' ? undefined : Math.max(0, Math.min(100, Number(raw)));
+													store.updateMeasure(storeMeasure.id, { percentile: next });
+												}}
+												class="h-6 w-12 shrink-0 rounded-md border border-border bg-background px-1 text-[11px] text-foreground tabular-nums focus-visible:border-ring focus-visible:ring-1 focus-visible:ring-ring focus-visible:outline-none"
+												title="Percentile (0–100) — defaults to 50"
+												aria-label="Percentile value"
+												data-testid="workbench-mg-measure-percentile"
+											/>
+										{/if}
+										<button
+											type="button"
+											onclick={(e) => {
+												e.stopPropagation();
+												editingMeasureCaption = `${g.id}::${col}`;
+											}}
+											class="shrink-0 rounded p-0.5 text-muted-foreground hover:bg-accent hover:text-accent-foreground"
+											title="Rename caption"
+											aria-label="Rename caption"
+											data-testid="workbench-mg-measure-rename"
+										>
+											<Pencil class="h-3 w-3" aria-hidden="true" />
+										</button>
+										<!-- No × here — removal happens through EDIT mode
+										     (uncheck the column).  Protects against accidental
+										     deletion + reclaims horizontal space. -->
+									</div>
+								{/each}
+							</div>
+						{:else if factTable}
+							<!-- Bulk All / Clear — mirrors the Attributes picker
+							     pattern.  Toggling each column individually on a
+							     wide fact table (20+ cols) is friction; #1009
+							     asked for these controls. -->
+							{@const allMeasuresIn = factTable.columns.every((c) =>
+								g.measureColumns.includes(c.name)
+							)}
+							<div class="flex shrink-0 items-center gap-1.5 text-[10px]">
+								<button
+									type="button"
+									onclick={() => {
+										const factId = g.factTableId;
+										if (!factId) return;
+										for (const col of factTable.columns) {
+											if (!g.measureColumns.includes(col.name)) {
+												g.measureColumns = [...g.measureColumns, col.name];
+												if (
+													!store.measures.find(
+														(mm) => mm.tableId === factId && mm.columnName === col.name
+													)
+												) {
+													store.addMeasure({ tableId: factId, columnName: col.name });
+												}
+											}
+										}
+									}}
+									class="rounded px-1.5 py-0.5 text-muted-foreground hover:bg-accent hover:text-accent-foreground disabled:opacity-50"
+									disabled={allMeasuresIn}
+									data-testid="workbench-mg-measures-all"
+								>
+									All
+								</button>
+								<button
+									type="button"
+									onclick={() => {
+										const factId = g.factTableId;
+										// Purge every store measure that belonged to this MG's
+										// fact so the Inspector doesn't lag with orphans.
+										if (factId) {
+											for (const col of g.measureColumns) {
+												const orphan = store.measures.find(
+													(mm) => mm.tableId === factId && mm.columnName === col
+												);
+												if (orphan) store.removeMeasure(orphan.id);
+											}
+										}
+										g.measureColumns = [];
+									}}
+									class="rounded px-1.5 py-0.5 text-muted-foreground hover:bg-accent hover:text-accent-foreground disabled:opacity-50"
+									disabled={g.measureColumns.length === 0}
+									data-testid="workbench-mg-measures-clear"
+								>
+									Clear
+								</button>
+								<span class="ml-auto text-muted-foreground">
+									{g.measureColumns.length} of {factTable.columns.length} selected
+								</span>
+							</div>
+							<!-- Edit view — checkbox list of fact's columns.
+							     `flex-1 min-h-0` so the list fills whatever vertical
+							     space the box has, rather than capping at max-h-52
+							     and leaving dead whitespace below. -->
+							<ul
+								class="workbench-scroll flex min-h-0 flex-1 flex-col gap-0.5 overflow-y-auto pr-1"
+								data-testid="workbench-mg-measure-checklist"
+							>
+								{#each factTable.columns as col (col.name)}
+									{@const checked = g.measureColumns.includes(col.name)}
+									<li>
+										<label
+											class="flex w-full items-center gap-1.5 rounded border border-border px-2 py-1 text-[11px] transition-colors hover:bg-accent/40 {checked
+												? 'cursor-grab active:cursor-grabbing'
+												: 'cursor-pointer'}"
+											style:border-color="hsl(var(--border))"
+											draggable={checked}
+											ondragstart={(e) => {
+												// Checked-only drag source in edit mode — mirrors
+												// the saved row so users can drag straight from the
+												// checklist without needing to hit Confirm first.
+												if (!checked || !e.dataTransfer) return;
+												e.dataTransfer.setData(FACTS_MEASURE_MIME, col.name);
+												e.dataTransfer.effectAllowed = 'copy';
+											}}
+											title={checked
+												? 'Drag into another measure group or a calc formula'
+												: 'Tick first, then drag'}
+										>
+											<input
+												type="checkbox"
+												class="h-3 w-3"
+												{checked}
+												onchange={() => {
+													if (checked) {
+														g.measureColumns = g.measureColumns.filter((c) => c !== col.name);
+														// Keep `store.measures` in sync so the Inspector
+														// stays consistent with what the MG holds.  If
+														// the same column is used by another MG, this
+														// will re-create on next tick — cheap.
+														const orphan = store.measures.find(
+															(mm) => mm.tableId === g.factTableId && mm.columnName === col.name
+														);
+														if (orphan) store.removeMeasure(orphan.id);
+													} else {
+														g.measureColumns = [...g.measureColumns, col.name];
+														if (
+															g.factTableId &&
+															!store.measures.find(
+																(mm) => mm.tableId === g.factTableId && mm.columnName === col.name
+															)
+														) {
+															// Seeds default aggregator='sum' + name=column.
+															// Editable later via the Inspector.
+															store.addMeasure({
+																tableId: g.factTableId,
+																columnName: col.name
+															});
+														}
+													}
+												}}
+												data-testid="workbench-mg-measure-checkbox"
+												data-column={col.name}
+											/>
+											<Sigma class="h-3 w-3 shrink-0 text-primary" aria-hidden="true" />
+											<span class="min-w-0 flex-1 truncate font-mono">{col.name}</span>
+											{#if col.sqlType}
+												<span
+													class="shrink-0 font-mono text-[9px]"
+													style:color="hsl(var(--muted-foreground))"
+												>
+													{col.sqlType}
+												</span>
+											{/if}
+										</label>
+									</li>
+								{/each}
+							</ul>
+						{/if}
+					</section>
+				</div>
+
+				<!-- ── RIGHT sub-column: DIMENSIONS ────────────────────────
+				     Own Confirm at the top.  Saved + edit views are both
+				     vertical stacks (NOT flex-wrap chips) — each dim is a
+				     full-width row.  An MG without dimensionLinks gets the
+				     warning icon on its Name row, so the visual gate is
+				     global. -->
+				<section
+					class="flex min-h-0 flex-1 flex-col gap-2 overflow-y-auto rounded border bg-elev-2 p-2"
+					style:border-color="hsl(var(--border))"
+					data-testid="workbench-pane-measure-group-dims"
+				>
+					<!-- Sticky header — same rationale as Fact + Measures.  #972 -->
+					<div
+						class="sticky top-0 z-10 flex items-center justify-between gap-2 border-b bg-elev-2 pb-1.5"
+						style:border-color="hsl(var(--border))"
+					>
+						<span
+							class="text-[10px] font-semibold tracking-wider uppercase"
+							style:color="hsl(var(--muted-foreground))"
+						>
+							Linked dimensions
+						</span>
+						{#if g.dimsConfirmed && dimLinks.length > 0}
+							<button
+								type="button"
+								onclick={() => (g.dimsConfirmed = false)}
+								class="rounded-full border border-border px-2 py-0.5 text-[9px] font-semibold tracking-wider text-muted-foreground uppercase hover:bg-accent hover:text-accent-foreground"
+								data-testid="workbench-mg-dims-edit"
+							>
+								Edit
+							</button>
+						{:else}
+							<button
+								type="button"
+								disabled={dimLinks.length === 0}
+								onclick={() => (g.dimsConfirmed = true)}
+								class="rounded-full bg-primary px-3 py-1 text-[10px] font-bold tracking-wider text-primary-foreground uppercase shadow-sm transition-colors hover:bg-primary/90 disabled:cursor-not-allowed disabled:bg-muted disabled:text-muted-foreground disabled:shadow-none"
+								data-testid="workbench-mg-dims-confirm"
+							>
+								Confirm
+							</button>
+						{/if}
+					</div>
+					{#if g.dimsConfirmed && dimLinks.length > 0}
+						<div class="flex flex-col gap-1">
+							{#each dimLinks as link (link.dimensionId)}
+								{@const dim = store.dimensions.find((d) => d.id === link.dimensionId)}
+								{#if dim}
+									{@const dimSourceId = dim.sourceTableId ?? dim.primaryKeyTableId}
+									{@const dimTable = dimSourceId
+										? (store.doc.tables.find((t) => t.id === dimSourceId) ?? null)
+										: null}
+									{@const isDegenerate =
+										!!factTable && !!dimSourceId && dimSourceId === factTable.id}
+									<div
+										class="flex items-center gap-2 rounded border bg-card px-2 py-1.5 text-[11px]"
+										style:border-color="hsl(var(--border))"
+										data-testid="workbench-mg-dim-chip"
+										data-dim-id={dim.id}
+									>
+										<Layers class="h-3.5 w-3.5 shrink-0 text-primary" aria-hidden="true" />
+										<div class="flex min-w-0 flex-1 flex-col leading-tight">
+											<span class="truncate font-medium">
+												{dim.name || 'Untitled dimension'}
+											</span>
+											{#if dimTable}
+												<span
+													class="truncate font-mono text-[9px]"
+													style:color="hsl(var(--muted-foreground))"
+												>
+													{dimTable.schema ? `${dimTable.schema}.${dimTable.name}` : dimTable.name}
+												</span>
+											{:else}
+												<span
+													class="truncate font-mono text-[9px] italic"
+													style:color="hsl(var(--muted-foreground))"
+												>
+													(unbound)
+												</span>
+											{/if}
+										</div>
+										<!-- Fact-side FK column.  Lives on the MG link
+										     (`link.foreignKeyColumn`) → emitted as
+										     `<ForeignKeyLink foreignKeyColumn="X"/>`.
+										     The FK MUST be a column on this MG's fact
+										     table — Mondrian schema constraint — so the
+										     dropdown lists `factTable.columns`.  No
+										     auto-suggest: user picks explicitly.
+										     Special case: a dim whose source table IS the
+										     MG's fact table is a *degenerate* dim — Mondrian
+										     emits <FactLink> (no FK column at all). -->
+										{#if !factTable}
+											<span
+												class="inline-flex shrink-0 items-center gap-1 rounded border border-warning/50 bg-warning/10 px-1.5 py-0.5 text-[10px] text-warning italic"
+												title="Pick a fact table on this measure group first."
+												data-testid="workbench-mg-dim-fk-nofact"
+											>
+												<AlertCircle class="h-3 w-3 shrink-0" aria-hidden="true" />
+												Fact not set
+											</span>
+										{:else if isDegenerate}
+											<span
+												class="inline-flex shrink-0 items-center gap-1 rounded border border-primary/40 bg-primary/5 px-1.5 py-0.5 font-mono text-[10px] text-primary"
+												title={`Degenerate dimension — "${dim.name}" lives on the fact table "${factTable.name}". Mondrian emits <FactLink dimension="${dim.name}"/> and no foreign key is needed.`}
+												data-testid="workbench-mg-dim-fk-degenerate"
+											>
+												FactLink
+											</span>
+										{:else if !dimTable}
+											<button
+												type="button"
+												onclick={() => {
+													selectMgDimension(dim.id);
+												}}
+												class="inline-flex shrink-0 items-center gap-1 rounded border border-warning/50 bg-warning/10 px-1.5 py-0.5 text-[10px] text-warning transition-colors hover:border-warning hover:bg-warning/20"
+												title={`"${dim.name || 'Untitled dimension'}" has no source table bound. Click to select it — then bind a table in the Inspector Properties tab.`}
+												data-testid="workbench-mg-dim-fk-unbound"
+											>
+												<AlertCircle class="h-3 w-3 shrink-0" aria-hidden="true" />
+												Dim unbound
+											</button>
+										{:else}
+											<span
+												class="flex shrink-0 items-center gap-1 text-[10px] text-muted-foreground"
+												title={`Fact-side foreign key column · emitted as <ForeignKeyLink foreignKeyColumn="…" /> on this measure group. Must be a column on "${factTable.name}".`}
+											>
+												{#if !link.foreignKeyColumn}
+													<button
+														type="button"
+														onclick={() => {
+															selectMgDimension(dim.id);
+														}}
+														class="shrink-0 rounded p-0.5 text-warning hover:bg-warning/10"
+														aria-label="FK not set — open Inspector"
+														title={`No FK column set for "${dim.name || 'this dimension'}". Pick one from ${factTable.name} — or click to open the Inspector.`}
+														data-testid="workbench-mg-dim-fk-missing"
+													>
+														<AlertCircle class="h-3 w-3 shrink-0" aria-hidden="true" />
+													</button>
+												{/if}
+												<span>FK</span>
+												<!-- Flat picker — `appearance-none` strips macOS's
+												     glossy chrome bevel + gradient, and a hand-drawn
+												     ChevronDown overlays via the wrapping <span>. -->
+												<span class="relative shrink-0">
+													<select
+														value={link.foreignKeyColumn}
+														onchange={(e) => {
+															link.foreignKeyColumn = (e.currentTarget as HTMLSelectElement).value;
+														}}
+														class="h-5 w-full appearance-none rounded border bg-background px-1 pr-5 font-mono text-[10px] text-foreground focus:border-ring focus:ring-1 focus:ring-ring focus:outline-none"
+														style:border-color="hsl(var(--border))"
+														data-testid="workbench-mg-dim-fk-select"
+														data-dim-id={dim.id}
+													>
+														<option value="" disabled={!!link.foreignKeyColumn}>
+															— pick FK column —
+														</option>
+														{#each factTable.columns as col (col.name)}
+															<option value={col.name}>{col.name}</option>
+														{/each}
+													</select>
+													<ChevronDown
+														class="pointer-events-none absolute top-1/2 right-1 size-3 -translate-y-1/2 text-muted-foreground"
+														aria-hidden="true"
+													/>
+												</span>
+											</span>
+										{/if}
+									</div>
+								{/if}
+							{/each}
+						</div>
+					{:else if store.dimensions.length === 0}
+						<p
+							class="rounded border border-dashed p-2 text-center text-[11px]"
+							style:border-color="hsl(var(--border))"
+							style:color="hsl(var(--muted-foreground))"
+						>
+							Define dimensions in the step above first.
+						</p>
+					{:else}
+						<ul class="flex flex-col gap-0.5">
+							{#each store.dimensions as dim (dim.id)}
+								{@const linked = dimLinks.some((l) => l.dimensionId === dim.id)}
+								<li>
+									<label
+										class="flex cursor-pointer items-center gap-1.5 rounded border px-2 py-1 text-[11px] transition-colors {linked
+											? 'border-primary bg-primary/5'
+											: 'border-border hover:bg-accent/40'}"
+										style:border-color={linked ? '' : 'hsl(var(--border))'}
+									>
+										<input
+											type="checkbox"
+											class="h-3 w-3"
+											checked={linked}
+											onchange={() => {
+												const current = g.dimensionLinks ?? [];
+												if (linked) {
+													g.dimensionLinks = current.filter((l) => l.dimensionId !== dim.id);
+												} else {
+													// If the dim lives on this MG's fact table, it's
+													// degenerate — Mondrian wants <FactLink>, not
+													// <ForeignKeyLink>.  Tag the new link accordingly
+													// so no FK picker appears.
+													const dimSrc = dim.sourceTableId ?? dim.primaryKeyTableId;
+													const degenerate = !!factTable && dimSrc === factTable.id;
+													g.dimensionLinks = [
+														...current,
+														{
+															dimensionId: dim.id,
+															foreignKeyColumn: '',
+															linkKind: degenerate ? 'fact' : 'foreign-key'
+														}
+													];
+												}
+											}}
+											data-testid="workbench-mg-dim-checkbox"
+											data-dim-id={dim.id}
+										/>
+										<Layers class="h-3 w-3 shrink-0 text-primary" aria-hidden="true" />
+										<span class="min-w-0 flex-1 truncate font-medium">
+											{dim.name || 'Untitled dimension'}
+										</span>
+									</label>
+								</li>
+							{/each}
+						</ul>
+					{/if}
+				</section>
+			</div>
+		{/if}
+	</div>
+{/snippet}

--- a/saiku-ui/src/lib/cube-designer/InspectorProperties.svelte
+++ b/saiku-ui/src/lib/cube-designer/InspectorProperties.svelte
@@ -1,0 +1,1381 @@
+<!--
+  Inspector › Properties tab — extracted from WorkbenchView.svelte (#1039
+  stage 2). Metadata inspector for the selected schema object; reads shell
+  selection/cube state via props and routes mutations back through store
+  methods + callbacks (mutation boundary unchanged). Only
+  `selectedTreeMeasureGroupId` is written here, so it is `$bindable`.
+-->
+<script lang="ts">
+	import { Sigma, Database, Hash, ListTree, Layers, ChevronDown, Plus } from 'lucide-svelte';
+	import { Select as SelectPrimitive } from 'bits-ui';
+	import { SchemaCanvasStore, dimKeyIdentity, resolveKeyAttribute } from './state.svelte.js';
+	import type {
+		SchemaCanvasDimension,
+		SchemaCanvasHierarchy,
+		SchemaCanvasLevel,
+		SchemaCanvasMeasure
+	} from './types.js';
+	import type { WorkbenchCube, WorkbenchMeasureGroup } from './workbench-cubes';
+
+	type SchemaCanvasAttribute = NonNullable<SchemaCanvasDimension['attributes']>[number];
+
+	interface Props {
+		store: SchemaCanvasStore;
+		cubes: WorkbenchCube[];
+		selectedCubeId: string;
+		factsMeasureGroups: WorkbenchMeasureGroup[];
+		selectedDimension: SchemaCanvasDimension | null;
+		selectedHierarchy: SchemaCanvasHierarchy | null;
+		selectedMeasure: SchemaCanvasMeasure | null;
+		selectedAttribute: SchemaCanvasAttribute | null;
+		selectedLevel: SchemaCanvasLevel | null;
+		selectedTreeMeasureGroup: WorkbenchMeasureGroup | null;
+		selectedTreeCube: WorkbenchCube | null;
+		hierarchyExplicitlyClicked: boolean;
+		renameCube: (id: string, name: string) => void;
+		selectTreeMeasureGroup: (cubeId: string, mgId: string) => void;
+		addMeasureGroupToCube: (cubeId: string) => void;
+		renameHierarchy: (dimId: string, hierId: string, name: string) => void;
+		commitHierarchyName: (dimId: string, hierId: string) => void;
+		renameDimension: (id: string, name: string) => void;
+		commitDimensionName: (id: string) => void;
+		tableNameFor: (tableId: string) => string;
+		columnTypeFor: (tableId: string, columnName: string) => string | undefined;
+	}
+
+	let {
+		store,
+		cubes,
+		selectedCubeId,
+		factsMeasureGroups,
+		selectedDimension: dim,
+		selectedHierarchy: hier,
+		selectedMeasure: measure,
+		selectedAttribute: attr,
+		selectedLevel: level,
+		selectedTreeMeasureGroup: treeMG,
+		selectedTreeCube: treeCube,
+		hierarchyExplicitlyClicked,
+		renameCube,
+		selectTreeMeasureGroup,
+		addMeasureGroupToCube,
+		renameHierarchy,
+		commitHierarchyName,
+		renameDimension,
+		commitDimensionName,
+		tableNameFor,
+		columnTypeFor
+	}: Props = $props();
+
+	const AGGREGATORS: SchemaCanvasMeasure['aggregator'][] = [
+		'sum',
+		'count',
+		'avg',
+		'min',
+		'max',
+		'distinct-count',
+		'median',
+		'percentile'
+	];
+
+	// ── saiku.semantic.* annotation editing ──
+	// Merge one key into an element's annotation map (blank ⇒ delete the key;
+	// empty map ⇒ drop the field). Keyed by the bare suffix (e.g. 'description').
+	function mergeAnn(
+		current: Record<string, string> | undefined,
+		key: string,
+		value: string
+	): Record<string, string> | undefined {
+		const next = { ...(current ?? {}) };
+		if (value.trim()) next[key] = value.trim();
+		else delete next[key];
+		return Object.keys(next).length > 0 ? next : undefined;
+	}
+	function setMeasureAnn(m: SchemaCanvasMeasure, key: string, value: string) {
+		store.updateMeasure(m.id, { annotations: mergeAnn(m.annotations, key, value) });
+	}
+	function setDimAnn(d: SchemaCanvasDimension, key: string, value: string) {
+		store.updateDimension(d.id, { annotations: mergeAnn(d.annotations, key, value) });
+	}
+	function setLevelAnn(
+		dimId: string,
+		hierId: string,
+		lvl: { id: string; annotations?: Record<string, string> },
+		key: string,
+		value: string
+	) {
+		store.updateLevel(dimId, hierId, lvl.id, {
+			annotations: mergeAnn(lvl.annotations, key, value)
+		});
+	}
+</script>
+
+{#snippet propField(
+	label: string,
+	value: string,
+	onInput: (v: string) => void,
+	onBlur?: () => void,
+	placeholder?: string,
+	testid?: string
+)}
+	<label class="flex flex-col gap-1">
+		<span class="text-[10px] tracking-wide uppercase" style:color="hsl(var(--muted-foreground))">
+			{label}
+		</span>
+		<input
+			type="text"
+			{value}
+			{placeholder}
+			oninput={(e) => onInput(e.currentTarget.value)}
+			onblur={onBlur}
+			class="h-7 rounded border border-border bg-background px-2 font-mono text-[11px] text-foreground focus-visible:border-ring focus-visible:ring-1 focus-visible:ring-ring focus-visible:outline-none"
+			data-testid={testid}
+		/>
+	</label>
+{/snippet}
+
+{#snippet propTextarea(label: string, value: string, onInput: (v: string) => void)}
+	<label class="col-span-full flex flex-col gap-1">
+		<span class="text-[10px] tracking-wide uppercase" style:color="hsl(var(--muted-foreground))">
+			{label}
+		</span>
+		<textarea
+			{value}
+			rows={2}
+			oninput={(e) => onInput(e.currentTarget.value)}
+			class="min-h-14 rounded border border-border bg-background p-2 text-[11px] text-foreground focus-visible:border-ring focus-visible:ring-1 focus-visible:ring-ring focus-visible:outline-none"
+		></textarea>
+	</label>
+{/snippet}
+
+{#snippet columnSelect(
+	label: string,
+	value: string,
+	columns: { name: string }[],
+	onChange: (v: string | undefined) => void,
+	testid: string
+)}
+	<label class="flex flex-col gap-1">
+		<span class="text-[10px] tracking-wide uppercase" style:color="hsl(var(--muted-foreground))">
+			{label}
+		</span>
+		<select
+			{value}
+			onchange={(e) => onChange(e.currentTarget.value || undefined)}
+			class="h-7 rounded border border-border bg-background px-2 font-mono text-[11px] text-foreground focus-visible:border-ring focus-visible:ring-1 focus-visible:ring-ring focus-visible:outline-none"
+			data-testid={testid}
+		>
+			<option value="">—</option>
+			{#each columns as col (col.name)}
+				<option value={col.name}>{col.name}</option>
+			{/each}
+		</select>
+	</label>
+{/snippet}
+
+{#snippet propGroupHeader(title: string, description: string)}
+	<header class="flex flex-col gap-0.5">
+		<span class="text-[11px] font-semibold tracking-wider text-foreground uppercase">
+			{title}
+		</span>
+		{#if description}
+			<span class="text-[10px] leading-snug" style:color="hsl(var(--muted-foreground))">
+				{description}
+			</span>
+		{/if}
+	</header>
+{/snippet}
+
+<div
+	class="@container flex h-full flex-col gap-5 text-xs"
+	data-testid="workbench-inspector-properties"
+>
+	{#if treeMG}
+		<!-- <MeasureGroup> properties — metadata only.  Authoring lives
+			     in the Measure Groups pane (Columns view); Properties is
+			     just the thing's metadata, identical in shape to Measure /
+			     Dimension props above.  Keeping Properties metadata-only
+			     across both views means the inspector reads the same
+			     regardless of which view the user is in. -->
+		{@const treeMGFact = treeMG.factTableId
+			? (store.doc.tables.find((t) => t.id === treeMG.factTableId)?.name ?? '—')
+			: '—'}
+		<header class="flex items-center gap-1.5">
+			<Sigma class="h-3.5 w-3.5 shrink-0 text-primary" aria-hidden="true" />
+			<span
+				class="text-[10px] font-semibold tracking-wider uppercase"
+				style:color="hsl(var(--muted-foreground))"
+			>
+				&lt;MeasureGroup&gt;
+			</span>
+		</header>
+		<div
+			class="grid grid-cols-1 gap-3 @[500px]:grid-cols-2 @[800px]:grid-cols-3 @[1100px]:grid-cols-4"
+		>
+			{@render propField('name', treeMG.name, (v) => {
+				treeMG.name = v;
+			})}
+			<div class="flex flex-col gap-1">
+				<span
+					class="text-[10px] tracking-wide uppercase"
+					style:color="hsl(var(--muted-foreground))"
+				>
+					fact table
+				</span>
+				<span class="h-7 truncate rounded border border-border bg-muted/40 px-2 py-1 font-mono">
+					{treeMGFact}
+				</span>
+			</div>
+			<div class="flex flex-col gap-1">
+				<span
+					class="text-[10px] tracking-wide uppercase"
+					style:color="hsl(var(--muted-foreground))"
+				>
+					measures
+				</span>
+				<span class="h-7 truncate rounded border border-border bg-muted/40 px-2 py-1 font-mono">
+					{treeMG.measureColumns.length}
+				</span>
+			</div>
+			<div class="flex flex-col gap-1">
+				<span
+					class="text-[10px] tracking-wide uppercase"
+					style:color="hsl(var(--muted-foreground))"
+				>
+					dim links
+				</span>
+				<span class="h-7 truncate rounded border border-border bg-muted/40 px-2 py-1 font-mono">
+					{(treeMG.dimensionLinks ?? []).length}
+				</span>
+			</div>
+		</div>
+		<p class="shrink-0 text-[10px] leading-snug" style:color="hsl(var(--muted-foreground))">
+			Author this measure group in the Measure Groups pane (Columns view).
+		</p>
+	{:else if treeCube && !measure && !attr && !hier && !dim}
+		<!-- <Cube> properties — surfaced when a cube root node is
+			     selected with nothing more specific.  Rename input +
+			     a compact list of MGs with quick add; the per-MG
+			     editor lives one click away on the MG row.  Mirrors
+			     the inspectorCubes affordances scoped to a single
+			     cube so the user doesn't have to leave the Properties
+			     tab to manage MGs. -->
+		{@const cubeMGs = treeCube.id === selectedCubeId ? factsMeasureGroups : treeCube.measureGroups}
+		{@const docCube = store.cubes.find((c) => c.id === treeCube.id)}
+		{@const cubeMeasures = [...new Set(cubeMGs.flatMap((g) => g.measureColumns))]}
+		<header class="flex items-center gap-1.5">
+			<Database class="h-3.5 w-3.5 shrink-0 text-primary" aria-hidden="true" />
+			<span
+				class="text-[10px] font-semibold tracking-wider uppercase"
+				style:color="hsl(var(--muted-foreground))"
+			>
+				&lt;Cube&gt;
+			</span>
+		</header>
+		<div
+			class="grid grid-cols-1 gap-3 @[500px]:grid-cols-2 @[800px]:grid-cols-3 @[1100px]:grid-cols-4"
+		>
+			{@render propField('name', treeCube.name, (v) => renameCube(treeCube.id, v))}
+			<div class="flex flex-col gap-1">
+				<span
+					class="text-[10px] tracking-wide uppercase"
+					style:color="hsl(var(--muted-foreground))"
+				>
+					measure groups
+				</span>
+				<span class="h-7 truncate rounded border border-border bg-muted/40 px-2 py-1 font-mono">
+					{(treeCube.id === selectedCubeId ? factsMeasureGroups : treeCube.measureGroups).length}
+				</span>
+			</div>
+		</div>
+		<div class="flex min-h-0 flex-1 flex-col gap-1.5 overflow-hidden">
+			<div class="flex shrink-0 items-center justify-between gap-2">
+				<span
+					class="text-[10px] font-semibold tracking-wider uppercase"
+					style:color="hsl(var(--muted-foreground))"
+				>
+					Measure groups
+				</span>
+				<button
+					type="button"
+					onclick={() => addMeasureGroupToCube(treeCube.id)}
+					class="inline-flex shrink-0 items-center gap-1 rounded border px-2 py-0.5 text-[10px] font-semibold tracking-wider uppercase hover:bg-accent/40"
+					style:border-color="hsl(var(--border))"
+					data-testid="workbench-inspector-cube-mg-add"
+				>
+					<Plus class="h-2.5 w-2.5" aria-hidden="true" />
+					Add
+				</button>
+			</div>
+			<div
+				class="flex min-h-0 flex-1 flex-col overflow-y-auto rounded border bg-elev-2"
+				style:border-color="hsl(var(--border))"
+			>
+				{#if cubeMGs.length === 0}
+					<p class="p-3 text-[11px]" style:color="hsl(var(--muted-foreground))">
+						No measure groups yet.
+					</p>
+				{:else}
+					{#each cubeMGs as mg (mg.id)}
+						<button
+							type="button"
+							onclick={() => selectTreeMeasureGroup(treeCube.id, mg.id)}
+							class="flex items-center gap-2 border-b px-2 py-1.5 text-left text-[11px] hover:bg-accent/40"
+							style:border-color="hsl(var(--border))"
+							data-testid="workbench-inspector-cube-mg-row"
+							data-mg-id={mg.id}
+						>
+							<Sigma class="h-3 w-3 shrink-0 text-primary" aria-hidden="true" />
+							<span class="min-w-0 flex-1 truncate font-medium">
+								{mg.name || 'Untitled group'}
+							</span>
+							<span
+								class="shrink-0 font-mono text-[9px]"
+								style:color="hsl(var(--muted-foreground))"
+							>
+								{mg.measureColumns.length} m · {(mg.dimensionLinks ?? []).length} d
+							</span>
+						</button>
+					{/each}
+				{/if}
+			</div>
+		</div>
+		<!-- Time calculations — declarative YoY / PoP / YTD / rolling metrics
+		     (Mondrian 4 <TimeCalc>). Cube-scoped, edited on the doc via the
+		     store; requires a Time dimension with a Years level in the cube. -->
+		<div class="flex flex-col gap-2">
+			<div class="flex items-center justify-between gap-2">
+				<span class="text-[11px] font-semibold tracking-wider text-foreground uppercase">
+					Time calculations
+				</span>
+				<button
+					type="button"
+					onclick={() => store.addTimeCalc(treeCube.id, { measure: cubeMeasures[0] ?? '' })}
+					class="inline-flex shrink-0 items-center gap-1 rounded border px-2 py-0.5 text-[10px] font-semibold tracking-wider uppercase hover:bg-accent/40"
+					style:border-color="hsl(var(--border))"
+					data-testid="inspector-timecalc-add"
+				>
+					<Plus class="h-2.5 w-2.5" aria-hidden="true" />
+					Add
+				</button>
+			</div>
+			<p class="text-[10px] leading-snug" style:color="hsl(var(--muted-foreground))">
+				YoY / PoP / YTD / rolling over a measure. Needs a Time dimension with a
+				<span class="font-medium">Years</span> level (set level types on the dimension's hierarchy).
+			</p>
+			{#each docCube?.timeCalcs ?? [] as tc (tc.id)}
+				<div
+					class="flex flex-col gap-1.5 rounded border border-border bg-background p-2"
+					data-testid="inspector-timecalc-row"
+				>
+					<div class="flex items-center gap-2">
+						<input
+							type="text"
+							value={tc.name}
+							placeholder="Name (e.g. Revenue YoY)"
+							oninput={(e) =>
+								store.updateTimeCalc(treeCube.id, tc.id, { name: e.currentTarget.value })}
+							class="h-6 min-w-0 flex-1 rounded border border-border bg-background px-2 text-[11px] text-foreground focus-visible:border-ring focus-visible:ring-1 focus-visible:ring-ring focus-visible:outline-none"
+						/>
+						<button
+							type="button"
+							onclick={() => store.removeTimeCalc(treeCube.id, tc.id)}
+							class="shrink-0 rounded p-0.5 text-muted-foreground hover:bg-accent hover:text-destructive"
+							title="Remove"
+							aria-label="Remove time calculation"
+						>
+							×
+						</button>
+					</div>
+					<div class="flex gap-2">
+						<select
+							value={tc.type}
+							onchange={(e) =>
+								store.updateTimeCalc(treeCube.id, tc.id, {
+									type: e.currentTarget.value as 'yoy' | 'pop' | 'ytd' | 'rolling'
+								})}
+							class="h-6 flex-1 rounded border border-border bg-background px-1 text-[10px] text-foreground"
+							title="Metric type"
+						>
+							<option value="yoy">YoY (year-over-year)</option>
+							<option value="pop">PoP (period-over-period)</option>
+							<option value="ytd">YTD (year-to-date)</option>
+							<option value="rolling">Rolling window</option>
+						</select>
+						<select
+							value={tc.measure}
+							onchange={(e) =>
+								store.updateTimeCalc(treeCube.id, tc.id, { measure: e.currentTarget.value })}
+							class="h-6 flex-1 rounded border border-border bg-background px-1 text-[10px] text-foreground"
+							title="Measure"
+						>
+							{#if cubeMeasures.length === 0}
+								<option value="">— add a measure first —</option>
+							{/if}
+							{#each cubeMeasures as m (m)}
+								<option value={m}>{m}</option>
+							{/each}
+						</select>
+					</div>
+					{#if tc.type === 'rolling'}
+						<div class="flex gap-2">
+							<input
+								type="number"
+								min="1"
+								value={tc.window ?? ''}
+								placeholder="window (periods)"
+								oninput={(e) => {
+									const v = e.currentTarget.value;
+									store.updateTimeCalc(treeCube.id, tc.id, {
+										window: v === '' ? undefined : Math.max(1, Number(v))
+									});
+								}}
+								class="h-6 flex-1 rounded border border-border bg-background px-2 text-[10px] text-foreground tabular-nums"
+							/>
+							<select
+								value={tc.function ?? 'sum'}
+								onchange={(e) =>
+									store.updateTimeCalc(treeCube.id, tc.id, {
+										function: e.currentTarget.value as 'sum' | 'avg'
+									})}
+								class="h-6 flex-1 rounded border border-border bg-background px-1 text-[10px] text-foreground"
+								title="Window aggregation"
+							>
+								<option value="sum">sum</option>
+								<option value="avg">avg</option>
+							</select>
+						</div>
+					{/if}
+					<input
+						type="text"
+						value={tc.formatString ?? ''}
+						placeholder="Format string (e.g. 0.0%)"
+						oninput={(e) =>
+							store.updateTimeCalc(treeCube.id, tc.id, {
+								formatString: e.currentTarget.value || undefined
+							})}
+						class="h-6 rounded border border-border bg-background px-2 text-[11px] text-foreground focus-visible:border-ring focus-visible:ring-1 focus-visible:ring-ring focus-visible:outline-none"
+					/>
+				</div>
+			{/each}
+		</div>
+	{:else if measure}
+		<!-- <Measure> properties — name, aggregator, formatString.  Column
+			     binding shown read-only (set at drop time; changing column
+			     means making a new measure). -->
+		<header class="flex items-center gap-1.5">
+			<Hash class="h-3.5 w-3.5 shrink-0 text-primary" aria-hidden="true" />
+			<span
+				class="text-[10px] font-semibold tracking-wider uppercase"
+				style:color="hsl(var(--muted-foreground))"
+			>
+				&lt;Measure&gt;
+			</span>
+		</header>
+		<div
+			class="grid grid-cols-1 gap-3 @[500px]:grid-cols-2 @[800px]:grid-cols-3 @[1100px]:grid-cols-4"
+		>
+			{@render propField('name', measure.name, (v) => store.updateMeasure(measure.id, { name: v }))}
+			<div class="flex flex-col gap-1">
+				<span
+					class="text-[10px] tracking-wide uppercase"
+					style:color="hsl(var(--muted-foreground))"
+				>
+					aggregator
+				</span>
+				<SelectPrimitive.Root
+					type="single"
+					value={measure.aggregator}
+					onValueChange={(v) =>
+						store.updateMeasure(measure.id, {
+							aggregator: v as SchemaCanvasMeasure['aggregator']
+						})}
+				>
+					<SelectPrimitive.Trigger
+						class="inline-flex h-7 items-center justify-between gap-1 rounded-md border border-border bg-background px-2 text-left text-[11px] hover:bg-accent focus-visible:border-ring focus-visible:ring-1 focus-visible:ring-ring focus-visible:outline-none"
+					>
+						<span class="truncate">{measure.aggregator}</span>
+						<ChevronDown class="h-3 w-3 shrink-0 opacity-60" aria-hidden="true" />
+					</SelectPrimitive.Trigger>
+					<SelectPrimitive.Portal>
+						<SelectPrimitive.Content
+							class="z-50 flex max-h-64 min-w-40 flex-col overflow-y-auto rounded-md border border-border bg-popover p-1 text-xs shadow-md"
+							sideOffset={4}
+						>
+							{#each AGGREGATORS as agg (agg)}
+								<SelectPrimitive.Item
+									value={agg}
+									class="cursor-pointer rounded px-2 py-1.5 outline-none data-[highlighted]:bg-accent data-[highlighted]:text-accent-foreground data-[state=checked]:font-semibold"
+								>
+									{agg}
+								</SelectPrimitive.Item>
+							{/each}
+						</SelectPrimitive.Content>
+					</SelectPrimitive.Portal>
+				</SelectPrimitive.Root>
+			</div>
+			<div class="flex flex-col gap-1">
+				<span
+					class="text-[10px] tracking-wide uppercase"
+					style:color="hsl(var(--muted-foreground))"
+				>
+					column
+				</span>
+				<span class="h-7 truncate rounded border border-border bg-muted/40 px-2 py-1 font-mono">
+					{tableNameFor(measure.tableId)}.{measure.columnName}
+				</span>
+			</div>
+			{@render propField(
+				'formatString',
+				measure.formatString ?? '',
+				(v) => store.updateMeasure(measure.id, { formatString: v.trim() || undefined }),
+				undefined,
+				'$#,##0.00'
+			)}
+		</div>
+		<!-- saiku.semantic.* annotations — optional AI/governance metadata. -->
+		{@const mAnn = measure.annotations ?? {}}
+		<div class="flex flex-col gap-2 border-t border-border pt-3">
+			{@render propGroupHeader(
+				'Annotations',
+				'Optional AI & governance metadata (saiku.semantic.*).'
+			)}
+			{@render propField('description', mAnn.description ?? '', (v) =>
+				setMeasureAnn(measure, 'description', v)
+			)}
+			{@render propField(
+				'synonyms',
+				mAnn.synonyms ?? '',
+				(v) => setMeasureAnn(measure, 'synonyms', v),
+				undefined,
+				'revenue, sales, turnover'
+			)}
+			<div class="grid grid-cols-2 gap-2">
+				{@render propField(
+					'unit',
+					mAnn.unit ?? '',
+					(v) => setMeasureAnn(measure, 'unit', v),
+					undefined,
+					'USD, kWh, count'
+				)}
+				{@render propField(
+					'currency',
+					mAnn.currency ?? '',
+					(v) => setMeasureAnn(measure, 'currency', v),
+					undefined,
+					'USD'
+				)}
+			</div>
+			<label class="flex flex-col gap-1">
+				<span
+					class="text-[10px] tracking-wide uppercase"
+					style:color="hsl(var(--muted-foreground))"
+				>
+					aggregation kind
+				</span>
+				<select
+					value={mAnn.aggregation_kind ?? ''}
+					onchange={(e) => setMeasureAnn(measure, 'aggregation_kind', e.currentTarget.value)}
+					class="h-7 rounded border border-border bg-background px-1 text-[11px] text-foreground"
+				>
+					<option value="">—</option>
+					<option value="sum">sum</option>
+					<option value="count">count</option>
+					<option value="distinct-count">distinct-count</option>
+					<option value="non-additive">non-additive</option>
+				</select>
+			</label>
+			<label class="flex items-center gap-2 text-[11px]">
+				<input
+					type="checkbox"
+					checked={mAnn.pii === 'true'}
+					onchange={(e) => setMeasureAnn(measure, 'pii', e.currentTarget.checked ? 'true' : '')}
+					data-testid="inspector-measure-pii"
+				/>
+				<span>PII — redact values in AI / drillthrough / embed</span>
+			</label>
+		</div>
+	{:else if level && dim && hier}
+		<!-- <Level> properties — the user clicked a level chip in the Hierarchies
+		     pane. Rename (logical name), caption (display label), the Time-grain
+		     `levelType`, and the saiku.semantic.* annotations all live here. -->
+		{@const lAnn = level.annotations ?? {}}
+		<header class="flex items-center gap-1.5">
+			<ListTree class="h-3.5 w-3.5 shrink-0 text-primary" aria-hidden="true" />
+			<span
+				class="text-[10px] font-semibold tracking-wider uppercase"
+				style:color="hsl(var(--muted-foreground))"
+			>
+				&lt;Level&gt; · {dim.name} / {hier.name}
+			</span>
+		</header>
+		<div class="flex flex-col gap-2">
+			<label class="flex flex-col gap-1 text-[10px] tracking-wide uppercase">
+				<span style:color="hsl(var(--muted-foreground))">name</span>
+				<input
+					type="text"
+					value={level.name}
+					placeholder={level.columnName}
+					oninput={(e) =>
+						store.updateLevel(dim.id, hier.id, level.id, {
+							name: e.currentTarget.value.trim() || level.columnName
+						})}
+					class="h-7 rounded border border-border bg-background px-2 text-[11px] text-foreground focus-visible:border-ring focus-visible:ring-1 focus-visible:ring-ring focus-visible:outline-none"
+					data-testid="inspector-level-name"
+				/>
+			</label>
+			<label class="flex flex-col gap-1 text-[10px] tracking-wide uppercase">
+				<span style:color="hsl(var(--muted-foreground))">caption</span>
+				<input
+					type="text"
+					value={level.caption ?? ''}
+					placeholder="display label (optional)"
+					oninput={(e) =>
+						store.updateLevel(dim.id, hier.id, level.id, {
+							caption: e.currentTarget.value.trim() || undefined
+						})}
+					class="h-7 rounded border border-border bg-background px-2 text-[11px] text-foreground focus-visible:border-ring focus-visible:ring-1 focus-visible:ring-ring focus-visible:outline-none"
+					data-testid="inspector-level-caption"
+				/>
+			</label>
+			<div class="flex flex-col gap-1">
+				<span
+					class="text-[10px] tracking-wide uppercase"
+					style:color="hsl(var(--muted-foreground))"
+				>
+					column
+				</span>
+				<span
+					class="h-7 truncate rounded border border-border bg-muted/40 px-2 py-1 font-mono text-[11px]"
+				>
+					{tableNameFor(level.tableId)}.{level.columnName}
+				</span>
+			</div>
+			{#if dim.dimensionType === 'Time'}
+				<label class="flex flex-col gap-1 text-[10px] tracking-wide uppercase">
+					<span style:color="hsl(var(--muted-foreground))">level type (time grain)</span>
+					<select
+						value={level.levelType ?? ''}
+						onchange={(e) => {
+							const v = e.currentTarget.value;
+							store.updateLevel(dim.id, hier.id, level.id, {
+								levelType:
+									v === ''
+										? undefined
+										: (v as 'TimeYears' | 'TimeQuarters' | 'TimeMonths' | 'TimeDays')
+							});
+						}}
+						class="h-7 rounded border border-border bg-background px-2 text-[11px] text-foreground focus-visible:border-ring focus-visible:ring-1 focus-visible:ring-ring focus-visible:outline-none"
+						data-testid="inspector-level-leveltype-single"
+					>
+						<option value="">— type —</option>
+						<option value="TimeYears">Years</option>
+						<option value="TimeQuarters">Quarters</option>
+						<option value="TimeMonths">Months</option>
+						<option value="TimeDays">Days</option>
+					</select>
+				</label>
+			{/if}
+		</div>
+		<div class="flex flex-col gap-2 border-t border-border pt-2">
+			<div
+				class="text-[10px] font-medium tracking-wide uppercase"
+				style:color="hsl(var(--muted-foreground))"
+			>
+				Annotations (AI &amp; governance)
+			</div>
+			<input
+				type="text"
+				value={lAnn.description ?? ''}
+				placeholder="description"
+				oninput={(e) => setLevelAnn(dim.id, hier.id, level, 'description', e.currentTarget.value)}
+				class="h-7 rounded border border-border bg-background px-2 text-[11px] text-foreground"
+			/>
+			<input
+				type="text"
+				value={lAnn.synonyms ?? ''}
+				placeholder="synonyms (csv)"
+				oninput={(e) => setLevelAnn(dim.id, hier.id, level, 'synonyms', e.currentTarget.value)}
+				class="h-7 rounded border border-border bg-background px-2 text-[11px] text-foreground"
+			/>
+			<div class="grid grid-cols-2 gap-1.5">
+				<select
+					value={lAnn.cardinality ?? ''}
+					onchange={(e) =>
+						setLevelAnn(dim.id, hier.id, level, 'cardinality', e.currentTarget.value)}
+					class="h-7 rounded border border-border bg-background px-1 text-[11px] text-foreground"
+					title="Member-count hint"
+				>
+					<option value="">cardinality —</option>
+					<option value="low">low</option>
+					<option value="medium">medium</option>
+					<option value="high">high</option>
+				</select>
+				<select
+					value={lAnn.grain ?? ''}
+					onchange={(e) => setLevelAnn(dim.id, hier.id, level, 'grain', e.currentTarget.value)}
+					class="h-7 rounded border border-border bg-background px-1 text-[11px] text-foreground"
+					title="Time grain"
+				>
+					<option value="">grain —</option>
+					<option value="year">year</option>
+					<option value="quarter">quarter</option>
+					<option value="month">month</option>
+					<option value="week">week</option>
+					<option value="day">day</option>
+					<option value="hour">hour</option>
+					<option value="minute">minute</option>
+				</select>
+			</div>
+			<label class="flex items-center gap-2 text-[11px]">
+				<input
+					type="checkbox"
+					checked={lAnn.pii === 'true'}
+					onchange={(e) =>
+						setLevelAnn(dim.id, hier.id, level, 'pii', e.currentTarget.checked ? 'true' : '')}
+					data-testid="inspector-level-pii-single"
+				/>
+				<span>PII — redact members in AI / drillthrough / embed</span>
+			</label>
+		</div>
+	{:else if attr && dim}
+		<!-- <Attribute> properties (#959) — the logical name plus the optional M4
+		     display / sort / caption column overrides and a description. The key
+		     column is the attribute's identity (how levels + the fact link resolve
+		     to it) so it stays read-only; re-pick the attribute to change it. -->
+		{@const attrCols = store.doc.tables.find((t) => t.id === attr.tableId)?.columns ?? []}
+		<header class="flex items-center gap-1.5">
+			<Database class="h-3.5 w-3.5 shrink-0 text-primary" aria-hidden="true" />
+			<span
+				class="text-[10px] font-semibold tracking-wider uppercase"
+				style:color="hsl(var(--muted-foreground))"
+			>
+				&lt;Attribute&gt; · {dim.name}
+			</span>
+		</header>
+		<div
+			class="grid grid-cols-1 gap-3 @[500px]:grid-cols-2 @[800px]:grid-cols-3 @[1100px]:grid-cols-4"
+		>
+			{@render propField(
+				'name',
+				attr.name ?? attr.columnName,
+				(v) =>
+					store.updateAttribute(dim.id, attr.tableId, attr.columnName, {
+						name: v.trim() || undefined
+					}),
+				undefined,
+				attr.columnName,
+				'inspector-attr-name'
+			)}
+			<div class="flex flex-col gap-1">
+				<span
+					class="text-[10px] tracking-wide uppercase"
+					style:color="hsl(var(--muted-foreground))"
+				>
+					key column
+				</span>
+				<span class="h-7 truncate rounded border border-border bg-muted/40 px-2 py-1 font-mono">
+					{tableNameFor(attr.tableId)}.{attr.columnName}
+				</span>
+			</div>
+			<div class="flex flex-col gap-1">
+				<span
+					class="text-[10px] tracking-wide uppercase"
+					style:color="hsl(var(--muted-foreground))"
+				>
+					sql type
+				</span>
+				<span class="h-7 truncate rounded border border-border bg-muted/40 px-2 py-1 font-mono">
+					{columnTypeFor(attr.tableId, attr.columnName) || '—'}
+				</span>
+			</div>
+			{@render columnSelect(
+				'name column (display)',
+				attr.nameColumn ?? '',
+				attrCols,
+				(v) => store.updateAttribute(dim.id, attr.tableId, attr.columnName, { nameColumn: v }),
+				'inspector-attr-namecolumn'
+			)}
+			{@render columnSelect(
+				'order by',
+				attr.orderByColumn ?? '',
+				attrCols,
+				(v) => store.updateAttribute(dim.id, attr.tableId, attr.columnName, { orderByColumn: v }),
+				'inspector-attr-orderby'
+			)}
+			{@render columnSelect(
+				'caption column',
+				attr.captionColumn ?? '',
+				attrCols,
+				(v) => store.updateAttribute(dim.id, attr.tableId, attr.columnName, { captionColumn: v }),
+				'inspector-attr-captioncolumn'
+			)}
+		</div>
+		{@render propTextarea('description', attr.description ?? '', (v) =>
+			store.updateAttribute(dim.id, attr.tableId, attr.columnName, {
+				description: v.trim() || undefined
+			})
+		)}
+	{:else if hier && dim && hierarchyExplicitlyClicked}
+		<header class="flex items-center gap-1.5">
+			<ListTree class="h-3.5 w-3.5 shrink-0 text-primary" aria-hidden="true" />
+			<span
+				class="text-[10px] font-semibold tracking-wider uppercase"
+				style:color="hsl(var(--muted-foreground))"
+			>
+				&lt;Hierarchy&gt; · {dim.name}
+			</span>
+		</header>
+		<div
+			class="grid grid-cols-1 gap-3 @[500px]:grid-cols-2 @[800px]:grid-cols-3 @[1100px]:grid-cols-4"
+		>
+			{@render propField(
+				'name',
+				hier.name,
+				(v) => renameHierarchy(dim.id, hier.id, v),
+				() => commitHierarchyName(dim.id, hier.id)
+			)}
+			<div class="flex flex-col gap-1">
+				<span
+					class="text-[10px] tracking-wide uppercase"
+					style:color="hsl(var(--muted-foreground))"
+				>
+					hasAll
+				</span>
+				<SelectPrimitive.Root
+					type="single"
+					value={String(hier.hasAll)}
+					onValueChange={(v) =>
+						store.updateHierarchy(dim.id, hier.id, {
+							hasAll: v === 'true'
+						})}
+				>
+					<SelectPrimitive.Trigger
+						class="inline-flex h-7 items-center justify-between gap-1 rounded-md border border-border bg-background px-2 text-left text-[11px] hover:bg-accent focus-visible:border-ring focus-visible:ring-1 focus-visible:ring-ring focus-visible:outline-none"
+					>
+						<span class="truncate">{String(hier.hasAll)}</span>
+						<ChevronDown class="h-3 w-3 shrink-0 opacity-60" aria-hidden="true" />
+					</SelectPrimitive.Trigger>
+					<SelectPrimitive.Portal>
+						<SelectPrimitive.Content
+							class="z-50 flex min-w-40 flex-col overflow-y-auto rounded-md border border-border bg-popover p-1 text-xs shadow-md"
+							sideOffset={4}
+						>
+							{#each ['true', 'false'] as opt (opt)}
+								<SelectPrimitive.Item
+									value={opt}
+									class="cursor-pointer rounded px-2 py-1.5 outline-none data-[highlighted]:bg-accent data-[highlighted]:text-accent-foreground data-[state=checked]:font-semibold"
+								>
+									{opt}
+								</SelectPrimitive.Item>
+							{/each}
+						</SelectPrimitive.Content>
+					</SelectPrimitive.Portal>
+				</SelectPrimitive.Root>
+			</div>
+			{@render propField(
+				'allMemberName',
+				hier.allMemberName ?? '',
+				(v) =>
+					store.updateHierarchy(dim.id, hier.id, {
+						allMemberName: v.trim() || undefined
+					}),
+				undefined,
+				'(All)',
+				'inspector-hierarchy-allmembername'
+			)}
+			{@render propField(
+				'defaultMember',
+				hier.defaultMember ?? '',
+				(v) =>
+					store.updateHierarchy(dim.id, hier.id, {
+						defaultMember: v.trim() || undefined
+					}),
+				undefined,
+				'[Customer].[All]'
+			)}
+			{@render propField(
+				'caption',
+				hier.caption ?? '',
+				(v) => store.updateHierarchy(dim.id, hier.id, { caption: v.trim() || undefined }),
+				undefined,
+				'Display label',
+				'inspector-hierarchy-caption'
+			)}
+			{@render propTextarea('description', hier.description ?? '', (v) =>
+				store.updateHierarchy(dim.id, hier.id, {
+					description: v.trim() || undefined
+				})
+			)}
+		</div>
+		<!-- Levels — with a per-level `levelType` picker for Time dimensions.
+		     Marking Year/Quarter/Month/Day is the prerequisite for time
+		     intelligence (a TimeYears level is required by <TimeCalc>). -->
+		<div class="flex flex-col gap-1.5">
+			<div
+				class="text-[10px] font-medium tracking-wide uppercase"
+				style:color="hsl(var(--muted-foreground))"
+			>
+				Levels ({hier.levels.length})
+			</div>
+			{#each hier.levels as lvl (lvl.id)}
+				{@const lAnn = lvl.annotations ?? {}}
+				<div class="flex flex-col gap-1.5 rounded border border-border bg-background px-2 py-1.5">
+					<div class="flex items-center justify-between gap-2">
+						<span class="min-w-0 flex-1 truncate text-[11px]" title={lvl.columnName}
+							>{lvl.name}</span
+						>
+						{#if dim.dimensionType === 'Time'}
+							<select
+								class="h-6 shrink-0 rounded border border-border bg-background px-1 text-[10px] text-foreground focus-visible:border-ring focus-visible:ring-1 focus-visible:ring-ring focus-visible:outline-none"
+								value={lvl.levelType ?? ''}
+								onchange={(e) => {
+									const v = e.currentTarget.value;
+									store.updateLevel(dim.id, hier.id, lvl.id, {
+										levelType:
+											v === ''
+												? undefined
+												: (v as 'TimeYears' | 'TimeQuarters' | 'TimeMonths' | 'TimeDays')
+									});
+								}}
+								title="Level type — mark the time grain so the engine can drive time intelligence"
+								data-testid="inspector-level-leveltype"
+							>
+								<option value="">— type —</option>
+								<option value="TimeYears">Years</option>
+								<option value="TimeQuarters">Quarters</option>
+								<option value="TimeMonths">Months</option>
+								<option value="TimeDays">Days</option>
+							</select>
+						{/if}
+					</div>
+					<!-- Level saiku.semantic.* annotations (optional). -->
+					<input
+						type="text"
+						value={lAnn.description ?? ''}
+						placeholder="description"
+						oninput={(e) => setLevelAnn(dim.id, hier.id, lvl, 'description', e.currentTarget.value)}
+						class="h-6 rounded border border-border bg-background px-2 text-[10px] text-foreground"
+					/>
+					<input
+						type="text"
+						value={lAnn.synonyms ?? ''}
+						placeholder="synonyms (csv)"
+						oninput={(e) => setLevelAnn(dim.id, hier.id, lvl, 'synonyms', e.currentTarget.value)}
+						class="h-6 rounded border border-border bg-background px-2 text-[10px] text-foreground"
+					/>
+					<div class="grid grid-cols-2 gap-1.5">
+						<select
+							value={lAnn.cardinality ?? ''}
+							onchange={(e) =>
+								setLevelAnn(dim.id, hier.id, lvl, 'cardinality', e.currentTarget.value)}
+							class="h-6 rounded border border-border bg-background px-1 text-[10px] text-foreground"
+							title="Member-count hint"
+						>
+							<option value="">cardinality —</option>
+							<option value="low">low</option>
+							<option value="medium">medium</option>
+							<option value="high">high</option>
+						</select>
+						<select
+							value={lAnn.grain ?? ''}
+							onchange={(e) => setLevelAnn(dim.id, hier.id, lvl, 'grain', e.currentTarget.value)}
+							class="h-6 rounded border border-border bg-background px-1 text-[10px] text-foreground"
+							title="Time grain (drives date-filter + time-series inference)"
+						>
+							<option value="">grain —</option>
+							<option value="year">year</option>
+							<option value="quarter">quarter</option>
+							<option value="month">month</option>
+							<option value="week">week</option>
+							<option value="day">day</option>
+							<option value="hour">hour</option>
+							<option value="minute">minute</option>
+						</select>
+					</div>
+					<label class="flex items-center gap-2 text-[10px]">
+						<input
+							type="checkbox"
+							checked={lAnn.pii === 'true'}
+							onchange={(e) =>
+								setLevelAnn(dim.id, hier.id, lvl, 'pii', e.currentTarget.checked ? 'true' : '')}
+							data-testid="inspector-level-pii"
+						/>
+						<span>PII — redact members in AI / drillthrough / embed</span>
+					</label>
+				</div>
+			{/each}
+			{#if dim.dimensionType !== 'Time'}
+				<p class="text-[10px]" style:color="hsl(var(--muted-foreground))">
+					Set the dimension type to <span class="font-medium">Time</span> (on the dimension) to assign
+					level types and unlock time intelligence.
+				</p>
+			{/if}
+		</div>
+	{:else if dim}
+		{@const boundTable =
+			(dim.sourceTableId ?? dim.primaryKeyTableId)
+				? store.doc.tables.find((t) => t.id === (dim.sourceTableId ?? dim.primaryKeyTableId))
+				: null}
+		{@const isDegenerate = !boundTable}
+		{@const dimHasHierarchies = dim.hierarchies.length > 0}
+		{@const needsKey = !isDegenerate && dimHasHierarchies}
+		{@const inspectorDimKey = dimKeyIdentity(dim)}
+		{@const inspectorResolvedKey = resolveKeyAttribute(dim)}
+		<!-- Alert / "required" pill fire when the schema carries a key
+			     value the app can't tie back to a specific attribute — that
+			     covers both "no value" (dimKey null) and "ambiguous value"
+			     (dimKey present but resolveKeyAttribute returned null). -->
+		{@const keyMissing = needsKey && !inspectorResolvedKey}
+		{@const inspectorKeyAttr = inspectorResolvedKey?.attr ?? null}
+		<!-- Select's active value must match one of the Select.Items —
+			     items use attr.name ?? attr.columnName.  When resolution
+			     failed but a raw value is stored, leave the value empty
+			     so the trigger falls back to the "Unset (no key)" display
+			     rather than silently locking to the wrong attribute. -->
+		{@const inspectorSelectValue = inspectorKeyAttr
+			? (inspectorKeyAttr.name ?? inspectorKeyAttr.columnName)
+			: ''}
+		<header class="flex items-center gap-1.5">
+			<Layers class="h-3.5 w-3.5 shrink-0 text-primary" aria-hidden="true" />
+			<span
+				class="text-[10px] font-semibold tracking-wider uppercase"
+				style:color="hsl(var(--muted-foreground))"
+			>
+				&lt;Dimension&gt;
+			</span>
+		</header>
+		<!-- Field groups (#1063) — Identity / Binding / Behavior sit
+		     side-by-side as columns (wrap at narrow widths).  Fields
+		     within each group stack vertically.  Documentation
+		     (long-form textarea) drops to a full-width row below so
+		     it gets breathing room to wrap. -->
+		<div
+			class="grid grid-cols-1 gap-x-8 gap-y-6 @[500px]:grid-cols-2 @[900px]:grid-cols-3"
+			data-testid="workbench-inspector-groups"
+		>
+			<!-- Identity column -->
+			<div class="flex flex-col gap-2">
+				{@render propGroupHeader(
+					'Identity',
+					'What this dimension is called and how it displays to users.'
+				)}
+				<div class="flex flex-col gap-2">
+					{@render propField(
+						'name',
+						dim.name,
+						(v) => renameDimension(dim.id, v),
+						() => commitDimensionName(dim.id)
+					)}
+					{@render propField(
+						'caption',
+						dim.caption ?? '',
+						(v) => store.updateDimension(dim.id, { caption: v.trim() || undefined }),
+						undefined,
+						'Display label'
+					)}
+				</div>
+			</div>
+
+			<!-- Binding column -->
+			<div class="flex flex-col gap-2">
+				{@render propGroupHeader(
+					'Binding',
+					'Where this dimension comes from and which attribute is the join key.'
+				)}
+				<div class="flex flex-col gap-2">
+					<!-- Table is read-only — the source is set by picking
+					     a table in the Dimensions list. -->
+					<div class="flex flex-col gap-1">
+						<span
+							class="text-[10px] tracking-wide uppercase"
+							style:color="hsl(var(--muted-foreground))"
+						>
+							table
+						</span>
+						<span class="h-7 truncate rounded border border-border bg-muted/40 px-2 py-1 font-mono">
+							{dim.sourceJoinGroupKey ?? boundTable?.name ?? '(unbound)'}
+						</span>
+					</div>
+					<!--
+						Primary key is a dim-level dropdown — pick which
+						attribute carries the join column.  Mondrian's
+						model: ONE attribute per dim is the key.
+					-->
+					<div class="flex flex-col gap-1">
+						<span
+							class="text-[10px] tracking-wide uppercase {keyMissing ? 'text-warning' : ''}"
+							style:color={keyMissing ? undefined : 'hsl(var(--muted-foreground))'}
+						>
+							primary key
+							{#if keyMissing}<span class="ml-1 normal-case">· required</span>{/if}
+						</span>
+						<SelectPrimitive.Root
+							type="single"
+							value={inspectorSelectValue}
+							onValueChange={(v) => {
+								const attr = (dim.attributes ?? []).find((a) => (a.name ?? a.columnName) === v);
+								store.updateDimension(dim.id, {
+									primaryKey: v || undefined,
+									primaryKeyTableId: attr?.tableId,
+									foreignKey: attr?.columnName || v || undefined
+								});
+							}}
+						>
+							<SelectPrimitive.Trigger
+								class="inline-flex h-7 items-center justify-between gap-1 rounded-md border border-border bg-background px-2 text-left font-mono text-[11px] hover:bg-accent focus-visible:border-ring focus-visible:ring-1 focus-visible:ring-ring focus-visible:outline-none"
+								data-testid="workbench-dim-primary-key-select"
+							>
+								<span class="truncate">
+									{#if inspectorKeyAttr}
+										{inspectorKeyAttr.name ?? inspectorKeyAttr.columnName}
+									{:else if inspectorDimKey}
+										<span class="text-warning">{inspectorDimKey}</span>
+										<span class="ml-1 text-[10px] text-muted-foreground italic">
+											· ambiguous — pick one
+										</span>
+									{:else}
+										<span class="text-muted-foreground italic">Unset (no key)</span>
+									{/if}
+								</span>
+								<ChevronDown class="h-3 w-3 shrink-0 opacity-60" aria-hidden="true" />
+							</SelectPrimitive.Trigger>
+							<SelectPrimitive.Portal>
+								<SelectPrimitive.Content
+									class="z-50 flex max-h-64 min-w-40 flex-col overflow-y-auto rounded-md border border-border bg-popover p-1 text-xs shadow-md"
+									sideOffset={4}
+								>
+									<SelectPrimitive.Item
+										value=""
+										class="cursor-pointer rounded px-2 py-1.5 outline-none data-[highlighted]:bg-accent data-[highlighted]:text-accent-foreground data-[state=checked]:font-semibold"
+									>
+										<span class="text-muted-foreground italic">Unset (no key)</span>
+									</SelectPrimitive.Item>
+									{#each dim.attributes ?? [] as a, __pki (`${a.tableId}::${a.columnName}::${a.name ?? __pki}`)}
+										{@const attrId = a.name ?? a.columnName}
+										<SelectPrimitive.Item
+											value={attrId}
+											class="cursor-pointer rounded px-2 py-1.5 font-mono outline-none data-[highlighted]:bg-accent data-[highlighted]:text-accent-foreground data-[state=checked]:font-semibold"
+										>
+											{a.name ?? a.columnName}
+										</SelectPrimitive.Item>
+									{/each}
+								</SelectPrimitive.Content>
+							</SelectPrimitive.Portal>
+						</SelectPrimitive.Root>
+					</div>
+				</div>
+			</div>
+
+			<!-- Behavior column -->
+			<div class="flex flex-col gap-2">
+				{@render propGroupHeader('Behavior', 'How Mondrian treats this dimension at query time.')}
+				<div class="flex flex-col gap-2">
+					<div class="flex flex-col gap-1">
+						<span
+							class="text-[10px] tracking-wide uppercase"
+							style:color="hsl(var(--muted-foreground))"
+						>
+							type
+						</span>
+						<SelectPrimitive.Root
+							type="single"
+							value={dim.dimensionType ?? 'Standard'}
+							onValueChange={(v) =>
+								store.updateDimension(dim.id, {
+									dimensionType: v as 'Standard' | 'Time' | 'Geographic'
+								})}
+						>
+							<SelectPrimitive.Trigger
+								class="inline-flex h-7 items-center justify-between gap-1 rounded-md border border-border bg-background px-2 text-left text-[11px] hover:bg-accent focus-visible:border-ring focus-visible:ring-1 focus-visible:ring-ring focus-visible:outline-none"
+							>
+								<span class="truncate">{dim.dimensionType ?? 'Standard'}</span>
+								<ChevronDown class="h-3 w-3 shrink-0 opacity-60" aria-hidden="true" />
+							</SelectPrimitive.Trigger>
+							<SelectPrimitive.Portal>
+								<SelectPrimitive.Content
+									class="z-50 flex min-w-40 flex-col overflow-y-auto rounded-md border border-border bg-popover p-1 text-xs shadow-md"
+									sideOffset={4}
+								>
+									{#each ['Standard', 'Time', 'Geographic'] as opt (opt)}
+										<SelectPrimitive.Item
+											value={opt}
+											class="cursor-pointer rounded px-2 py-1.5 outline-none data-[highlighted]:bg-accent data-[highlighted]:text-accent-foreground data-[state=checked]:font-semibold"
+										>
+											{opt}
+										</SelectPrimitive.Item>
+									{/each}
+								</SelectPrimitive.Content>
+							</SelectPrimitive.Portal>
+						</SelectPrimitive.Root>
+					</div>
+				</div>
+			</div>
+		</div>
+
+		<!-- Documentation — full-width row below the 3-column grid
+		     so the description textarea has room to wrap. -->
+		<div class="flex flex-col gap-2">
+			{@render propGroupHeader(
+				'Documentation',
+				'Free-form notes surfaced in the schema catalog and MCP tooling.'
+			)}
+			<div class="flex flex-col gap-2">
+				<label class="flex flex-col gap-1">
+					<span
+						class="text-[10px] tracking-wide uppercase"
+						style:color="hsl(var(--muted-foreground))"
+					>
+						description
+					</span>
+					<textarea
+						value={dim.description ?? ''}
+						rows={2}
+						oninput={(e) =>
+							store.updateDimension(dim.id, {
+								description: e.currentTarget.value.trim() || undefined
+							})}
+						class="min-h-14 rounded border bg-background p-2 text-[11px]"
+						style:border-color="hsl(var(--border))"
+					></textarea>
+				</label>
+			</div>
+		</div>
+		{@const dAnn = dim.annotations ?? {}}
+		<div class="flex flex-col gap-2 border-t border-border pt-3">
+			{@render propGroupHeader('Annotations', 'Optional AI context (saiku.semantic.*).')}
+			{@render propField(
+				'AI description',
+				dAnn.description ?? '',
+				(v) => setDimAnn(dim, 'description', v),
+				undefined,
+				'Business meaning surfaced to the AI'
+			)}
+			{@render propField(
+				'synonyms',
+				dAnn.synonyms ?? '',
+				(v) => setDimAnn(dim, 'synonyms', v),
+				undefined,
+				'store, location, site'
+			)}
+		</div>
+		{#if needsKey && keyMissing}
+			<p
+				class="rounded border border-warning bg-warning/10 px-2 py-1 text-[10px] text-warning"
+				data-testid="workbench-dim-key-warning"
+			>
+				Mondrian needs a join key for a dimension with hierarchies — the engine will reject this
+				schema at load.
+			</p>
+		{/if}
+
+		<!-- Used-in-cubes — cross-cube aggregation showing where this
+			     dim is linked, with the FK column / link kind / via* for
+			     each.  Read-only summary so the user can see at a glance
+			     whether their multi-cube schema is consistent.  Editing
+			     stays on the MG editor (single source of truth for FK). -->
+		{@const usages = (() => {
+			const out: Array<{
+				cubeName: string;
+				mgName: string;
+				linkKind: 'foreign-key' | 'fact' | 'reference';
+				fk: string;
+				via?: string;
+			}> = [];
+			for (const c of cubes) {
+				const mgs = c.id === selectedCubeId ? factsMeasureGroups : c.measureGroups;
+				for (const mg of mgs) {
+					for (const link of mg.dimensionLinks ?? []) {
+						if (link.dimensionId !== dim.id) continue;
+						out.push({
+							cubeName: c.name,
+							mgName: mg.name,
+							linkKind: link.linkKind ?? 'foreign-key',
+							fk: link.foreignKeyColumn,
+							via:
+								link.viaDimension && link.viaAttribute
+									? `${link.viaDimension}.${link.viaAttribute}`
+									: undefined
+						});
+					}
+				}
+			}
+			return out;
+		})()}
+		<div class="flex flex-col gap-1.5">
+			<span
+				class="text-[10px] font-semibold tracking-wider uppercase"
+				style:color="hsl(var(--muted-foreground))"
+			>
+				Used in cubes
+				{#if usages.length > 0}
+					<span class="font-mono normal-case">· {usages.length}</span>
+				{/if}
+			</span>
+			{#if usages.length === 0}
+				<p
+					class="rounded border border-dashed p-2 text-center text-[10px]"
+					style:border-color="hsl(var(--border))"
+					style:color="hsl(var(--muted-foreground))"
+				>
+					This dimension isn't linked from any measure group yet.
+				</p>
+			{:else}
+				<div
+					class="grid grid-cols-[1fr_1fr_4.5rem_1fr] gap-x-2 gap-y-0.5 rounded border bg-elev-2 p-2 text-[10px]"
+					style:border-color="hsl(var(--border))"
+					data-testid="workbench-dim-used-in-cubes"
+				>
+					<span
+						class="font-semibold tracking-wider uppercase"
+						style:color="hsl(var(--muted-foreground))">Cube</span
+					>
+					<span
+						class="font-semibold tracking-wider uppercase"
+						style:color="hsl(var(--muted-foreground))">Measure group</span
+					>
+					<span
+						class="font-semibold tracking-wider uppercase"
+						style:color="hsl(var(--muted-foreground))">Kind</span
+					>
+					<span
+						class="font-semibold tracking-wider uppercase"
+						style:color="hsl(var(--muted-foreground))">Foreign key</span
+					>
+					{#each usages as u, i (i)}
+						<span class="truncate font-medium">{u.cubeName}</span>
+						<span class="truncate font-mono">{u.mgName}</span>
+						<span
+							class="truncate font-mono"
+							style:color={u.linkKind === 'fact' || u.linkKind === 'reference'
+								? 'hsl(var(--primary))'
+								: undefined}
+						>
+							{u.linkKind}
+						</span>
+						<span class="truncate font-mono">
+							{#if u.linkKind === 'fact'}
+								—
+							{:else if u.via}
+								{u.via}
+							{:else}
+								{u.fk || '(not set)'}
+							{/if}
+						</span>
+					{/each}
+				</div>
+			{/if}
+		</div>
+
+		<div class="flex flex-col gap-1 text-[10px]" style:color="hsl(var(--muted-foreground))">
+			{(dim.attributes ?? []).length} attribute(s) · {dim.hierarchies.length} hierarchy/ies
+		</div>
+	{:else}
+		<div class="flex h-full flex-col items-center justify-center gap-1 text-center">
+			<p class="text-xs font-medium">Nothing selected</p>
+			<p class="text-[11px]" style="color: hsl(var(--muted-foreground))">
+				Click a dimension, hierarchy, attribute, or measure to inspect its properties.
+			</p>
+		</div>
+	{/if}
+</div>

--- a/saiku-ui/src/lib/cube-designer/JoinsPanel.svelte
+++ b/saiku-ui/src/lib/cube-designer/JoinsPanel.svelte
@@ -1,0 +1,771 @@
+<!--
+  Right-rail joins panel for the schema canvas: physical join groups
+  (rename / focus / collapse / remove-endpoint), the active-set picks panel,
+  the read-only semantic-joins accordion, and the Select / Reorganize / Delete
+  bulk modes + their footer toolbars and the delete-all confirm modal.
+
+  Presentational: reads/writes the shared SchemaCanvasStore directly, and owns
+  the panel-local interaction state (select / reorganize / group-edit /
+  collapse). Join-group derivations come in as props (shared with the toolbar
+  counts). `onFlushEdges` lets delete-all clear the parent's bound SvelteFlow
+  edges array synchronously — the one piece of parent state it can't own.
+-->
+<script lang="ts">
+	import {
+		ChevronRight,
+		ChevronDown,
+		Trash2,
+		Pencil,
+		ChevronsDownUp,
+		ChevronsUpDown,
+		EyeOff,
+		MoreHorizontal
+	} from 'lucide-svelte';
+	import { SchemaCanvasStore } from './state.svelte.js';
+	import type { JoinGroupRender } from './join-groups.js';
+	import ActiveSetPanel from './ActiveSetPanel.svelte';
+	import SemanticJoinsAccordion from './SemanticJoinsAccordion.svelte';
+
+	interface Props {
+		store: SchemaCanvasStore;
+		joinGroups: JoinGroupRender[];
+		physicalJoinGroups: JoinGroupRender[];
+		semanticJoinGroups: JoinGroupRender[];
+		physicalJoinCount: number;
+		semanticJoinCount: number;
+		joinsPanelOpen: boolean;
+		/** Flush the parent's bound SvelteFlow edges array (delete-all only). */
+		onFlushEdges: () => void;
+	}
+
+	let {
+		store,
+		joinGroups,
+		physicalJoinGroups,
+		semanticJoinGroups,
+		physicalJoinCount,
+		semanticJoinCount,
+		joinsPanelOpen = $bindable(),
+		onFlushEdges
+	}: Props = $props();
+
+	// Lookup table for join row labels — name resolution is cheap so we
+	// just derive a map from id → table on every render.
+	const tableById = $derived(new Map(store.doc.tables.map((t) => [t.id, t])));
+
+	let editingGroupKey = $state<string | null>(null);
+	let editingGroupDraft = $state('');
+	let collapsedJoinGroups = $state<Set<string>>(new Set());
+	// Default-collapse newly-seen groups so the panel reads as a compact
+	// label list at first glance. Once the user expands one, our
+	// "seenGroupKeys" tracker remembers it and won't re-collapse on the
+	// next derivation pass.
+	const seenGroupKeys = new Set<string>();
+	$effect(() => {
+		const next = new Set(collapsedJoinGroups);
+		let changed = false;
+		for (const g of joinGroups) {
+			if (!seenGroupKeys.has(g.canonicalKey)) {
+				seenGroupKeys.add(g.canonicalKey);
+				next.add(g.canonicalKey);
+				changed = true;
+			}
+		}
+		if (changed) collapsedJoinGroups = next;
+	});
+	function toggleJoinGroupCollapse(canonicalKey: string) {
+		const next = new Set(collapsedJoinGroups);
+		if (next.has(canonicalKey)) next.delete(canonicalKey);
+		else next.add(canonicalKey);
+		collapsedJoinGroups = next;
+	}
+	// All-groups collapse state — when ANY group is collapsed, the
+	// header button reads "expand all"; when nothing's collapsed it
+	// reads "collapse all".
+	const allGroupsExpanded = $derived(collapsedJoinGroups.size === 0);
+	function toggleAllJoinGroups() {
+		if (allGroupsExpanded) {
+			collapsedJoinGroups = new Set(joinGroups.map((g) => g.canonicalKey));
+		} else {
+			collapsedJoinGroups = new Set();
+		}
+	}
+	function startGroupEdit(group: JoinGroupRender) {
+		editingGroupKey = group.canonicalKey;
+		editingGroupDraft = group.label;
+	}
+	function commitGroupEdit() {
+		if (editingGroupKey === null) return;
+		store.renameJoinGroup(editingGroupKey, editingGroupDraft);
+		editingGroupKey = null;
+		editingGroupDraft = '';
+	}
+	function cancelGroupEdit() {
+		editingGroupKey = null;
+		editingGroupDraft = '';
+	}
+
+	// Bulk-select state inside the joins panel. Off by default; entering
+	// select mode shows a checkbox on every row + a "Delete N" footer.
+	let joinsSelectMode = $state(false);
+	let joinsSelectedIds = $state<Set<string>>(new Set());
+	function selectAllJoins() {
+		joinsSelectedIds = new Set(store.doc.joins.map((j) => j.id));
+	}
+	function clearJoinSelection() {
+		joinsSelectedIds = new Set();
+	}
+	function exitSelectMode() {
+		joinsSelectMode = false;
+		clearJoinSelection();
+	}
+	function deleteSelectedJoins() {
+		if (joinsSelectedIds.size === 0) return;
+		store.removeJoins(joinsSelectedIds);
+		exitSelectMode();
+	}
+	function deleteAllJoins() {
+		store.removeAllJoins();
+		// Force-flush the bound edges array immediately.  The
+		// edges-sync $effect will sync to []` next microtask anyway,
+		// but SvelteFlow has been observed holding onto a previous
+		// frame of edges if the same render tick also handles modal
+		// dismissal — explicitly emptying the array here means there's
+		// no window for a stale line to survive the click.
+		onFlushEdges();
+		exitSelectMode();
+		confirmingDeleteAllJoins = false;
+	}
+	let confirmingDeleteAllJoins = $state(false);
+
+	// Joins-panel ellipsis menu — Select / Reorganize / Delete-all entry points.
+	let joinsMenuOpen = $state(false);
+
+	// Reorganize mode — merge groups, or move endpoints in/out of a group.
+	// Mutually exclusive with joinsSelectMode; entering one exits the other.
+	let reorganizeMode = $state(false);
+	let reorganizeSelectedGroups = $state<Set<string>>(new Set()); // group LABELS
+	let reorganizeSelectedJoinIds = $state<Set<string>>(new Set());
+	let mergeNamingActive = $state(false);
+	let mergeNameInput = $state('');
+
+	function enterSelectMode() {
+		exitReorganize();
+		joinsSelectMode = true;
+	}
+	function enterReorganize() {
+		exitSelectMode();
+		reorganizeMode = true;
+		clearReorganizeSelection();
+	}
+	function clearReorganizeSelection() {
+		reorganizeSelectedGroups = new Set();
+		reorganizeSelectedJoinIds = new Set();
+		mergeNamingActive = false;
+		mergeNameInput = '';
+	}
+	function exitReorganize() {
+		reorganizeMode = false;
+		clearReorganizeSelection();
+	}
+	function toggleReorganizeGroup(label: string) {
+		const next = new Set(reorganizeSelectedGroups);
+		if (next.has(label)) next.delete(label);
+		else next.add(label);
+		reorganizeSelectedGroups = next;
+	}
+	// Per-join reorganize checkbox — the join list surfaces one row
+	// per physical join now (see the pair-rendered <ul> below), so
+	// each checkbox toggles exactly its join id in / out of the
+	// selection set. selectedCanonicalKeys() still folds those ids
+	// back into canonical keys for Merge and Ungroup, so the toolbar
+	// semantics are unchanged.
+	function toggleReorganizeJoin(joinId: string) {
+		const next = new Set(reorganizeSelectedJoinIds);
+		if (next.has(joinId)) next.delete(joinId);
+		else next.add(joinId);
+		reorganizeSelectedJoinIds = next;
+	}
+	// Canonical keys of every join implied by the current selection — from
+	// selected group labels AND from selected endpoint rows. Used by both
+	// Merge and Ungroup.
+	function selectedCanonicalKeys(): Set<string> {
+		const keys = new Set<string>();
+		for (const g of joinGroups) {
+			if (reorganizeSelectedGroups.has(g.label)) {
+				keys.add(g.canonicalKey);
+			}
+		}
+		for (const j of store.doc.joins) {
+			if (reorganizeSelectedJoinIds.has(j.id)) {
+				keys.add(SchemaCanvasStore.joinCanonicalKey(j));
+			}
+		}
+		return keys;
+	}
+	// Merge needs 2+ DIFFERENT canonical keys picked — two endpoints in
+	// the same group share one key and would merge into themselves.
+	const canMerge = $derived.by(() => {
+		// Touch reactive selections so $derived re-runs on toggle.
+		void reorganizeSelectedGroups;
+		void reorganizeSelectedJoinIds;
+		return selectedCanonicalKeys().size >= 2;
+	});
+	const canUngroup = $derived(reorganizeSelectedJoinIds.size >= 1);
+	function applyMerge() {
+		const label = mergeNameInput.trim();
+		if (!label) return;
+		for (const k of selectedCanonicalKeys()) store.renameJoinGroup(k, label);
+		exitReorganize();
+	}
+	function applyUngroup() {
+		// Only strip canonical keys implied by endpoint selection — group
+		// headers don't ungroup on their own (the spec wires Ungroup to
+		// endpoint rows specifically). Empty label drops the rename so the
+		// group reverts to its canonical key.
+		const keys = new Set<string>();
+		for (const j of store.doc.joins) {
+			if (reorganizeSelectedJoinIds.has(j.id)) {
+				keys.add(SchemaCanvasStore.joinCanonicalKey(j));
+			}
+		}
+		for (const k of keys) store.renameJoinGroup(k, '');
+		exitReorganize();
+	}
+</script>
+
+{#if joinsPanelOpen}
+	<!-- Floating card. Positioned by the right-side column wrapper in
+	     SchemaCanvasView (`absolute top-2 right-2 bottom-2`, width
+	     driven by `joinsPanelWidth`). Here we just fill the top half
+	     of that column: `flex-1 min-h-0 w-full` lets DimSum share the
+	     bottom half. `pointer-events-auto` guards against any future
+	     ancestor going pointer-events-none. -->
+	<aside
+		class="pointer-events-auto relative flex min-h-0 w-full flex-1 flex-col overflow-hidden rounded border border-border bg-card shadow-md"
+		aria-label="Joins panel"
+		data-testid="canvas-joins-panel"
+	>
+		<!-- Splitter handle — drag the LEFT edge of the joins
+		     panel to resize.  Mirrors the source-tables sidebar's
+		     splitter.  Clamps at 220-560px so the panel can't
+		     vanish or eat the canvas. -->
+		<div
+			role="separator"
+			aria-orientation="vertical"
+			aria-label="Resize joins panel"
+			title="Drag to resize"
+			class="absolute top-0 bottom-0 left-[-4px] z-20 flex w-2 cursor-ew-resize items-center justify-center text-muted-foreground/40 transition-colors hover:bg-primary/20 hover:text-foreground"
+			onpointerdown={(e) => {
+				e.preventDefault();
+				const startX = e.clientX;
+				const startW = store.joinsPanelWidth;
+				const move = (ev: PointerEvent) => {
+					const dx = startX - ev.clientX;
+					const next = Math.max(220, Math.min(560, startW + dx));
+					store.joinsPanelWidth = next;
+				};
+				const up = () => {
+					window.removeEventListener('pointermove', move);
+					window.removeEventListener('pointerup', up);
+				};
+				window.addEventListener('pointermove', move);
+				window.addEventListener('pointerup', up);
+			}}
+			data-testid="canvas-joins-panel-splitter"
+		>
+			<span class="font-mono text-[8px] tracking-wider opacity-70">||</span>
+		</div>
+		<div
+			class="flex items-center justify-between border-b border-border px-3 py-2 text-xs font-semibold tracking-wider uppercase"
+			style:color="hsl(var(--muted-foreground))"
+		>
+			<span>Joins ({physicalJoinCount})</span>
+			<div class="flex items-center gap-1">
+				<!-- Expand/collapse-all groups — chevrons pointing
+			     INWARD when groups are expanded (click → collapse
+			     all), OUTWARD when at least one is collapsed
+			     (click → expand all). Mirrors the table-card
+			     chevron semantics. -->
+				{#if joinGroups.length > 1}
+					<button
+						type="button"
+						onclick={toggleAllJoinGroups}
+						class="inline-flex h-5 w-5 items-center justify-center rounded transition-colors hover:bg-accent hover:text-accent-foreground"
+						aria-label={allGroupsExpanded ? 'Collapse all groups' : 'Expand all groups'}
+						title={allGroupsExpanded ? 'Collapse all groups' : 'Expand all groups'}
+						data-testid="canvas-joins-panel-toggle-all-groups"
+					>
+						{#if allGroupsExpanded}
+							<ChevronsDownUp class="h-3.5 w-3.5" aria-hidden="true" />
+						{:else}
+							<ChevronsUpDown class="h-3.5 w-3.5" aria-hidden="true" />
+						{/if}
+					</button>
+				{/if}
+				<!-- Eye icon = close the WHOLE joins panel (right
+			     column). Re-open via the chevron-pill that
+			     appears in the canvas top-right. The line
+			     visibility toggle lives in the canvas
+			     toolbar — these are two different things. -->
+				<button
+					type="button"
+					onclick={() => (joinsPanelOpen = false)}
+					class="inline-flex h-5 w-5 items-center justify-center rounded transition-colors hover:bg-accent hover:text-accent-foreground"
+					aria-label="Hide joins panel"
+					title="Hide the joins panel (use the chevron at top-right to re-open)"
+					data-testid="canvas-joins-panel-close"
+				>
+					<EyeOff class="h-3.5 w-3.5" aria-hidden="true" />
+				</button>
+				<!-- Ellipsis menu — Select / Reorganize / Delete-all.
+			     Same shape as the canvas import/export menus. -->
+				{#if store.doc.joins.length > 0}
+					<div class="relative">
+						<button
+							type="button"
+							onclick={() => (joinsMenuOpen = !joinsMenuOpen)}
+							aria-expanded={joinsMenuOpen}
+							aria-haspopup="menu"
+							class="inline-flex h-5 w-5 items-center justify-center rounded transition-colors hover:bg-accent hover:text-accent-foreground"
+							aria-label="Joins panel actions"
+							title="Joins panel actions"
+							data-testid="canvas-joins-panel-menu-button"
+						>
+							<MoreHorizontal class="h-3.5 w-3.5" aria-hidden="true" />
+						</button>
+						{#if joinsMenuOpen}
+							<!-- svelte-ignore a11y_no_static_element_interactions a11y_click_events_have_key_events -->
+							<div class="fixed inset-0 z-30" onclick={() => (joinsMenuOpen = false)}></div>
+							<div
+								role="menu"
+								class="absolute top-full right-0 z-40 mt-1 w-80 rounded-md border border-border bg-card p-1 normal-case shadow-lg"
+								data-testid="canvas-joins-panel-menu"
+							>
+								<button
+									type="button"
+									role="menuitem"
+									onclick={() => {
+										joinsMenuOpen = false;
+										enterSelectMode();
+									}}
+									class="flex w-full items-start gap-2 rounded px-2 py-1.5 text-left text-xs transition-colors hover:bg-accent hover:text-accent-foreground"
+									data-testid="canvas-joins-panel-menu-select"
+								>
+									<span class="flex flex-1 flex-col gap-0.5">
+										<span class="text-xs font-medium tracking-normal">Select joins</span>
+										<span class="text-[10px] font-normal tracking-normal text-muted-foreground">
+											Pick individual joins for bulk delete
+										</span>
+									</span>
+								</button>
+								<button
+									type="button"
+									role="menuitem"
+									onclick={() => {
+										joinsMenuOpen = false;
+										enterReorganize();
+									}}
+									class="flex w-full items-start gap-2 rounded px-2 py-1.5 text-left text-xs transition-colors hover:bg-accent hover:text-accent-foreground"
+									data-testid="canvas-joins-panel-menu-reorganize"
+								>
+									<span class="flex flex-1 flex-col gap-0.5">
+										<span class="text-xs font-medium tracking-normal">Reorganize joins</span>
+										<span class="text-[10px] font-normal tracking-normal text-muted-foreground">
+											Merge groups, or move a join in or out of a group
+										</span>
+									</span>
+								</button>
+								<button
+									type="button"
+									role="menuitem"
+									onclick={() => {
+										joinsMenuOpen = false;
+										confirmingDeleteAllJoins = true;
+									}}
+									class="flex w-full items-start gap-2 rounded px-2 py-1.5 text-left text-xs text-destructive transition-colors hover:bg-destructive hover:text-destructive-foreground"
+									data-testid="canvas-joins-panel-menu-delete-all"
+								>
+									<span class="flex flex-1 flex-col gap-0.5">
+										<span class="text-xs font-medium tracking-normal">Delete all joins</span>
+										<span class="text-[10px] font-normal tracking-normal opacity-80">
+											Remove every join from the canvas
+										</span>
+									</span>
+								</button>
+							</div>
+						{/if}
+					</div>
+				{/if}
+			</div>
+		</div>
+
+		<!-- Bulk-action toolbar — only visible in Select mode.
+	     Entry-points (Select / Delete-all) live in the
+	     ellipsis menu in the header. -->
+		{#if joinsSelectMode && store.doc.joins.length > 0}
+			<div
+				class="flex items-center gap-1 border-b border-border bg-background px-2 py-1.5"
+				data-testid="canvas-joins-panel-bulk-toolbar"
+			>
+				<button
+					type="button"
+					onclick={joinsSelectedIds.size === store.doc.joins.length
+						? clearJoinSelection
+						: selectAllJoins}
+					class="inline-flex h-6 items-center justify-center rounded border border-input bg-background px-2 text-[11px] font-medium transition-colors hover:bg-accent hover:text-accent-foreground"
+					data-testid="canvas-joins-panel-select-all"
+				>
+					{joinsSelectedIds.size === store.doc.joins.length ? 'None' : 'All'}
+				</button>
+				<button
+					type="button"
+					onclick={exitSelectMode}
+					class="inline-flex h-6 flex-1 items-center justify-center rounded border border-input bg-background px-2 text-[11px] font-medium transition-colors hover:bg-accent hover:text-accent-foreground"
+					data-testid="canvas-joins-panel-select-cancel"
+				>
+					Cancel
+				</button>
+				<button
+					type="button"
+					onclick={deleteSelectedJoins}
+					disabled={joinsSelectedIds.size === 0}
+					class="inline-flex h-6 items-center justify-center rounded border border-destructive/40 bg-destructive px-2 text-[11px] font-medium text-destructive-foreground transition-colors hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-40"
+					data-testid="canvas-joins-panel-delete-selected"
+				>
+					Delete {joinsSelectedIds.size}
+				</button>
+			</div>
+		{/if}
+
+		<ActiveSetPanel {store} />
+
+		<div class="flex-1 overflow-y-auto p-2">
+			<!-- The old "Link N similar with <colname>" purple button
+			     that used to sit here got folded into the green CTA
+			     up in the active-set panel (with a descriptor +
+			     auto-join tip underneath).  One button, one place. -->
+			{#if store.doc.joins.length === 0}
+				<p
+					class="rounded border border-dashed p-3 text-xs"
+					style:border-color="hsl(var(--border))"
+					style:color="hsl(var(--muted-foreground))"
+					data-testid="canvas-joins-panel-empty"
+				>
+					No joins yet. Drag column-to-column on the canvas, or press
+					<span class="font-mono">⌘J</span> to enter Create Joins Mode and click columns across tables.
+				</p>
+			{:else}
+				<div class="space-y-3">
+					{#each physicalJoinGroups as group (group.canonicalKey)}
+						{@const isGroupCollapsed = collapsedJoinGroups.has(group.canonicalKey)}
+						<section
+							class="group/section space-y-1"
+							data-testid="canvas-joins-panel-group"
+							data-group-key={group.canonicalKey}
+						>
+							<header class="flex items-center gap-1.5 border-b border-border pb-1">
+								{#if reorganizeMode}
+									<input
+										type="checkbox"
+										class="h-3.5 w-3.5 shrink-0 cursor-pointer accent-primary"
+										checked={reorganizeSelectedGroups.has(group.label)}
+										onchange={() => toggleReorganizeGroup(group.label)}
+										aria-label={`Select group ${group.label}`}
+										data-testid="canvas-joins-panel-group-checkbox"
+									/>
+								{/if}
+								<button
+									type="button"
+									onclick={() => toggleJoinGroupCollapse(group.canonicalKey)}
+									class="inline-flex h-4 w-4 shrink-0 items-center justify-center rounded text-muted-foreground transition-colors hover:bg-accent hover:text-accent-foreground"
+									title={isGroupCollapsed ? 'Expand group' : 'Collapse group'}
+									aria-expanded={!isGroupCollapsed}
+									data-testid="canvas-joins-panel-group-toggle"
+								>
+									{#if isGroupCollapsed}
+										<ChevronRight class="h-3 w-3" aria-hidden="true" />
+									{:else}
+										<ChevronDown class="h-3 w-3" aria-hidden="true" />
+									{/if}
+								</button>
+								{#if editingGroupKey === group.canonicalKey}
+									<!-- svelte-ignore a11y_autofocus -->
+									<input
+										type="text"
+										bind:value={editingGroupDraft}
+										onkeydown={(e) => {
+											if (e.key === 'Enter') {
+												e.preventDefault();
+												commitGroupEdit();
+											} else if (e.key === 'Escape') {
+												e.preventDefault();
+												cancelGroupEdit();
+											}
+										}}
+										onblur={commitGroupEdit}
+										class="h-6 flex-1 rounded border border-input bg-background px-2 text-xs"
+										placeholder={group.canonicalKey}
+										autofocus
+										data-testid="canvas-joins-panel-group-input"
+									/>
+								{:else}
+									{@const isGroupFocused =
+										store.focusKind === 'group' && store.focusKey === group.label}
+									<button
+										type="button"
+										onclick={() => store.focusGroup(group.label)}
+										class="group/header flex flex-1 items-center gap-1.5 truncate text-left text-[11px] font-medium tracking-wide transition-colors"
+										class:text-primary={isGroupFocused}
+										class:text-foreground={!isGroupFocused}
+										class:hover:text-primary={!isGroupFocused}
+										title="Click to focus on these joins (click again to clear)"
+										data-testid="canvas-joins-panel-group-label"
+									>
+										<span class="truncate font-mono">{group.label}</span>
+									</button>
+									<button
+										type="button"
+										onclick={() => startGroupEdit(group)}
+										class="inline-flex h-4 w-4 shrink-0 items-center justify-center rounded text-muted-foreground opacity-0 transition-opacity group-hover/section:opacity-100 hover:bg-accent hover:text-accent-foreground"
+										title="Rename group"
+										aria-label="Rename group"
+										data-testid="canvas-joins-panel-group-rename"
+									>
+										<Pencil class="h-3 w-3" aria-hidden="true" />
+									</button>
+									<span class="shrink-0 text-[10px] text-muted-foreground tabular-nums">
+										{group.joins.length}
+									</span>
+								{/if}
+							</header>
+							{#if !isGroupCollapsed}
+								<!-- Per-join pairs — each row is one physical join with
+								     both endpoints spelled out (src.col ↔ tgt.col) so
+								     ambiguous groupings (same source paired with two
+								     different target columns) surface as two distinct
+								     rows. Schema.table origin sits under each column
+								     name in muted mono, mirroring the workbench
+								     inspector caption/column pattern. Delete removes
+								     the join outright; the reorganize checkbox toggles
+								     that specific join id in the selection set. -->
+								<ul class="space-y-1">
+									{#each group.joins as j (j.id)}
+										{@const srcTable = tableById.get(j.sourceTableId)}
+										{@const tgtTable = tableById.get(j.targetTableId)}
+										{@const srcName = srcTable?.name ?? '?'}
+										{@const tgtName = tgtTable?.name ?? '?'}
+										{@const srcSchema = srcTable?.schema ?? null}
+										{@const tgtSchema = tgtTable?.schema ?? null}
+										<li
+											class="flex items-start gap-2 rounded border p-2 text-xs transition-colors hover:bg-accent"
+											style:border-color="hsl(var(--border))"
+											style:background="hsl(var(--background))"
+											data-testid="canvas-joins-panel-join"
+											data-join-id={j.id}
+										>
+											{#if reorganizeMode}
+												<input
+													type="checkbox"
+													class="mt-0.5 h-3.5 w-3.5 shrink-0 cursor-pointer accent-primary"
+													checked={reorganizeSelectedJoinIds.has(j.id)}
+													onchange={() => toggleReorganizeJoin(j.id)}
+													aria-label={`Select join ${srcName}.${j.sourceColumnName} to ${tgtName}.${j.targetColumnName}`}
+													data-testid="canvas-joins-panel-join-checkbox"
+												/>
+											{:else}
+												<button
+													type="button"
+													class="mt-0.5 shrink-0 rounded p-0.5 transition-colors hover:bg-destructive/10 hover:text-destructive"
+													style:color="hsl(var(--muted-foreground))"
+													aria-label={`Delete join ${srcName}.${j.sourceColumnName} to ${tgtName}.${j.targetColumnName}`}
+													title="Delete this join"
+													onclick={(e) => {
+														e.stopPropagation();
+														store.removeJoin(j.id);
+													}}
+													data-testid="canvas-joins-panel-join-delete"
+												>
+													<Trash2 class="h-3 w-3" aria-hidden="true" />
+												</button>
+											{/if}
+											<div class="flex min-w-0 flex-1 items-center gap-2">
+												<div class="flex min-w-0 flex-1 flex-col font-mono leading-tight">
+													<span class="min-w-0 truncate">
+														{srcName}<span class="text-muted-foreground">.</span
+														>{j.sourceColumnName}
+													</span>
+													{#if srcSchema}
+														<span
+															class="min-w-0 truncate text-[10px] text-muted-foreground"
+															title={`${srcSchema}.${srcName}`}
+														>
+															{srcSchema}
+														</span>
+													{/if}
+												</div>
+												<span class="shrink-0 text-muted-foreground select-none" aria-hidden="true"
+													>↔</span
+												>
+												<div class="flex min-w-0 flex-1 flex-col font-mono leading-tight">
+													<span class="min-w-0 truncate">
+														{tgtName}<span class="text-muted-foreground">.</span
+														>{j.targetColumnName}
+													</span>
+													{#if tgtSchema}
+														<span
+															class="min-w-0 truncate text-[10px] text-muted-foreground"
+															title={`${tgtSchema}.${tgtName}`}
+														>
+															{tgtSchema}
+														</span>
+													{/if}
+												</div>
+											</div>
+										</li>
+									{/each}
+								</ul>
+							{/if}
+						</section>
+					{/each}
+				</div>
+			{/if}
+
+			<SemanticJoinsAccordion {store} {semanticJoinGroups} {semanticJoinCount} />
+		</div>
+
+		<!-- Reorganize-mode footer toolbar — contextual: Merge
+		     appears with 2+ selections, Ungroup with 1+ endpoint
+		     rows. Inline name input takes over when "Merge into
+		     one" is pressed. -->
+		{#if reorganizeMode}
+			<div
+				class="flex shrink-0 flex-col gap-2 border-t border-border bg-background px-2 py-2"
+				data-testid="canvas-joins-panel-reorganize-toolbar"
+			>
+				{#if mergeNamingActive}
+					<input
+						type="text"
+						bind:value={mergeNameInput}
+						placeholder="Name the merged group, e.g. Customer Key"
+						onkeydown={(e) => {
+							if (e.key === 'Enter') {
+								e.preventDefault();
+								applyMerge();
+							} else if (e.key === 'Escape') {
+								e.preventDefault();
+								mergeNamingActive = false;
+								mergeNameInput = '';
+							}
+						}}
+						class="h-7 w-full rounded border border-input bg-card px-2 text-xs"
+						data-testid="canvas-joins-panel-reorganize-merge-name"
+					/>
+					<div class="flex items-center gap-1">
+						<button
+							type="button"
+							onclick={() => {
+								mergeNamingActive = false;
+								mergeNameInput = '';
+							}}
+							class="inline-flex h-6 flex-1 items-center justify-center rounded border border-input bg-background px-2 text-[11px] font-medium transition-colors hover:bg-accent hover:text-accent-foreground"
+							data-testid="canvas-joins-panel-reorganize-merge-cancel"
+						>
+							Cancel
+						</button>
+						<button
+							type="button"
+							onclick={applyMerge}
+							disabled={!mergeNameInput.trim()}
+							class="inline-flex h-6 flex-1 items-center justify-center rounded bg-primary px-2 text-[11px] font-medium text-primary-foreground transition-opacity hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-40"
+							data-testid="canvas-joins-panel-reorganize-merge-confirm"
+						>
+							Confirm
+						</button>
+					</div>
+				{:else}
+					<div class="flex items-center gap-1">
+						{#if canMerge}
+							<button
+								type="button"
+								onclick={() => {
+									mergeNamingActive = true;
+									mergeNameInput = '';
+								}}
+								class="inline-flex h-6 flex-1 items-center justify-center rounded border border-input bg-background px-2 text-[11px] font-medium transition-colors hover:bg-accent hover:text-accent-foreground"
+								data-testid="canvas-joins-panel-reorganize-merge"
+							>
+								Merge into one
+							</button>
+						{/if}
+						{#if canUngroup}
+							<button
+								type="button"
+								onclick={applyUngroup}
+								class="inline-flex h-6 flex-1 items-center justify-center rounded border border-input bg-background px-2 text-[11px] font-medium transition-colors hover:bg-accent hover:text-accent-foreground"
+								data-testid="canvas-joins-panel-reorganize-ungroup"
+							>
+								Ungroup
+							</button>
+						{/if}
+						<button
+							type="button"
+							onclick={exitReorganize}
+							class="inline-flex h-6 flex-1 items-center justify-center rounded border border-input bg-background px-2 text-[11px] font-medium transition-colors hover:bg-accent hover:text-accent-foreground"
+							data-testid="canvas-joins-panel-reorganize-cancel"
+						>
+							Cancel
+						</button>
+					</div>
+				{/if}
+			</div>
+		{/if}
+
+		<!-- Pathfinder removed pending UX rework — see saiku-cloud#957.  Underlying
+		     store API (pathfinderResult / armPathfinder / findPath /
+		     clearPathfinder / applyPathfinderJoins) intentionally
+		     left intact so the next iteration can drop a new UI
+		     back in without touching the store. -->
+	</aside>
+{/if}
+
+<!-- Delete-all-joins confirmation modal. Same shape as the host page's
+     Reset modal so the two destructive actions feel consistent. -->
+{#if confirmingDeleteAllJoins}
+	<div
+		class="fixed inset-0 z-50 flex items-center justify-center bg-background/80 p-4"
+		role="dialog"
+		aria-modal="true"
+		aria-labelledby="delete-all-joins-title"
+		data-testid="canvas-joins-delete-all-modal"
+	>
+		<div class="w-full max-w-md rounded-lg border border-border bg-card p-5 shadow-xl">
+			<h2 id="delete-all-joins-title" class="text-base font-semibold">Delete every join?</h2>
+			<p class="mt-2 text-sm text-muted-foreground">
+				This will remove all {store.doc.joins.length} join{store.doc.joins.length === 1 ? '' : 's'} on
+				this canvas. The tables themselves stay where they are — only the join wires get wiped, so you
+				can re-draw them however you want.
+			</p>
+			<p class="mt-2 text-xs text-muted-foreground">This can't be undone.</p>
+			<div class="mt-4 flex justify-end gap-2">
+				<button
+					type="button"
+					onclick={() => (confirmingDeleteAllJoins = false)}
+					class="inline-flex h-9 items-center justify-center rounded border border-input bg-background px-3 text-sm font-medium transition-colors hover:bg-accent hover:text-accent-foreground"
+					data-testid="canvas-joins-delete-all-cancel"
+				>
+					Cancel
+				</button>
+				<button
+					type="button"
+					onclick={deleteAllJoins}
+					class="inline-flex h-9 items-center justify-center gap-1.5 rounded bg-destructive px-3 text-sm font-medium text-destructive-foreground transition-opacity hover:opacity-90"
+					data-testid="canvas-joins-delete-all-confirm"
+				>
+					<Trash2 class="h-3.5 w-3.5" aria-hidden="true" />
+					Delete every join
+				</button>
+			</div>
+		</div>
+	</div>
+{/if}

--- a/saiku-ui/src/lib/cube-designer/JumpHandler.svelte
+++ b/saiku-ui/src/lib/cube-designer/JumpHandler.svelte
@@ -1,0 +1,90 @@
+<!--
+  Tiny child of SvelteFlow that watches store.requestedJumpTarget and
+  store.requestedCanvasAction, dispatching each to the matching
+  useSvelteFlow() imperative method (setCenter / zoomIn / zoomOut /
+  fitView / zoomTo). The hook only works inside the SvelteFlow
+  subtree, so this component sits next to <Background>/<Controls>/<MiniMap>
+  and provides the AI (and any other consumer) with a store-mediated
+  view-controls API. Renders no DOM of its own.
+-->
+<script lang="ts">
+	import { useSvelteFlow } from '@xyflow/svelte';
+	import { onMount, tick } from 'svelte';
+	import { SchemaCanvasStore } from './state.svelte.js';
+
+	interface Props {
+		store: SchemaCanvasStore;
+	}
+
+	let { store }: Props = $props();
+	const flow = useSvelteFlow();
+
+	// Approx node dims used to centre on the card's middle, not its
+	// top-left corner. The table cards have a fixed width in TableNode
+	// and a variable height depending on visible columns — using the
+	// width is safe; the height estimate keeps the card roughly centred
+	// without needing a real measurement pass.
+	const APPROX_NODE_W = 240;
+	const APPROX_NODE_H = 220;
+
+	// One-shot fit-on-mount (#1085 + #1086).  The <SvelteFlow fitView>
+	// prop re-triggers when `bind:nodes` mutates (delete a table →
+	// viewport jerks); passing it imperatively here fires exactly
+	// once, at mount, and never again.  `maxZoom` caps the initial
+	// zoom so a canvas with one small table doesn't fill the viewport
+	// with that single card.
+	onMount(() => {
+		void (async () => {
+			await tick();
+			await flow.fitView({ padding: 0.2, maxZoom: 0.9 });
+		})();
+	});
+
+	$effect(() => {
+		const target = store.requestedJumpTarget;
+		if (!target) return;
+		const t = store.doc.tables.find((tt) => tt.id === target.tableId);
+		if (!t) return;
+		(async () => {
+			// Wait a tick so any preceding store-driven node updates have
+			// flushed into SvelteFlow's internal position cache before we
+			// ask it to centre.
+			await tick();
+			await flow.setCenter(t.position.x + APPROX_NODE_W / 2, t.position.y + APPROX_NODE_H / 2, {
+				duration: 350,
+				zoom: 1
+			});
+		})();
+	});
+
+	// Viewport action dispatch — DimSum (or any UI) sets
+	// store.requestedCanvasAction, we execute against the imperative
+	// SvelteFlow API and clear.  center_view fits to all nodes, which is
+	// what "center everything on canvas" naturally means.
+	$effect(() => {
+		const req = store.requestedCanvasAction;
+		if (!req) return;
+		(async () => {
+			await tick();
+			switch (req.kind) {
+				case 'zoom_in':
+					await flow.zoomIn({ duration: 250 });
+					break;
+				case 'zoom_out':
+					await flow.zoomOut({ duration: 250 });
+					break;
+				case 'zoom_to_100': {
+					// Keep the current pan, only change zoom to 100 %.
+					// setViewport is on the public type; zoomTo isn't.
+					const vp = flow.getViewport();
+					await flow.setViewport({ x: vp.x, y: vp.y, zoom: 1 }, { duration: 250 });
+					break;
+				}
+				case 'fit_view':
+				case 'center_view':
+					await flow.fitView({ duration: 350, padding: 0.15 });
+					break;
+			}
+		})();
+	});
+</script>

--- a/saiku-ui/src/lib/cube-designer/SchemaCanvasView.svelte
+++ b/saiku-ui/src/lib/cube-designer/SchemaCanvasView.svelte
@@ -21,7 +21,7 @@
 	import DimSumChatDock from './DimSumChatDock.svelte';
 	import JoinsPanel from './JoinsPanel.svelte';
 	import CanvasPane from './CanvasPane.svelte';
-	import Toast from '$lib/design-system/Toast.svelte';
+	import Toast from './primitives/Toast.svelte';
 	import { computeJoinGroups, isSemanticGroup } from './join-groups.js';
 	import type {
 		AnthropicToolUseBlock,

--- a/saiku-ui/src/lib/cube-designer/SchemaCanvasView.svelte
+++ b/saiku-ui/src/lib/cube-designer/SchemaCanvasView.svelte
@@ -1,0 +1,725 @@
+<!--
+  Canvas schema designer — main canvas view.
+
+  Hosts @xyflow/svelte's SvelteFlow with a custom TableNode type, the
+  left TableSidebar, a top toolbar (mode switch, Arrange button), and the
+  pane drop-target that creates new TableNode instances when the user
+  drags from the sidebar.
+
+  Column-to-column edges are created via SvelteFlow's onconnect — when
+  the user drags from an output handle on table A's column to an input
+  handle on table B's column, we mint a SchemaCanvasJoin and the
+  auto-suggester offers more candidate joins between the same pair if
+  any are obvious.
+-->
+<script lang="ts">
+	import type { Node, Edge } from '@xyflow/svelte';
+	import { untrack } from 'svelte';
+	import { ChevronRight, Sparkles } from 'lucide-svelte';
+	import AskDimSumWidget from './AskDimSumWidget.svelte';
+	import CanvasToolbar from './CanvasToolbar.svelte';
+	import DimSumChatDock from './DimSumChatDock.svelte';
+	import JoinsPanel from './JoinsPanel.svelte';
+	import CanvasPane from './CanvasPane.svelte';
+	import Toast from '$lib/design-system/Toast.svelte';
+	import { computeJoinGroups, isSemanticGroup } from './join-groups.js';
+	import type {
+		AnthropicToolUseBlock,
+		AnthropicToolResultBlock,
+		ChatMessage,
+		DimSumMutationResult
+	} from './ai-chat-types';
+	import type { SchemaCanvasStore } from './state.svelte.js';
+	import { applyLayout, type LayoutMode } from './layout.js';
+	import { buildCanvasSummary, executeDimSumTool, DIMSUM_MUTATION_TOOLS } from './dimsum-tools.js';
+	import { postDimSumTurn } from './dimsum-agent.js';
+	import { getCubeDesignerAI } from './backend';
+	import { buildFlowNodes, buildFlowEdges, type FlowFocus } from './canvas-flow.js';
+
+	interface Props {
+		store: SchemaCanvasStore;
+		/** Optional snippet threaded to TableSidebar as its sourceContext —
+		 *  the canvas page uses this to put the Source + Schema pickers
+		 *  above the source-tables list instead of the top toolbar. */
+		sourceContext?: import('svelte').Snippet;
+		/** Draft-with-AI seed: a description auto-fired into DimSum once the
+		 *  connection's table catalog has loaded (from /schemas → canvas). */
+		seedIntent?: string;
+		/** True when the page arrived via `?openFrom` (opening a saved schema).
+		 *  The chat starts EMPTY instead of restoring the connection's chat, so
+		 *  the opened schema's conversation is fresh with no flash of the old one. */
+		openArrival?: boolean;
+	}
+
+	let { store, sourceContext, seedIntent, openArrival }: Props = $props();
+
+	// Injected AI adapter (optional). Its fetchImpl points the DimSum turn at the
+	// host's AI endpoint; absent ⇒ default transport (/api/inference/dimsum).
+	const designerAI = getCubeDesignerAI();
+
+	// Single-join selection (clicking a row in the joins panel) layers
+	// on top of group/table focus: when a join id is selected, ONLY that
+	// join + its two endpoints stay vivid; everything else fades. Lets a
+	// user inspect one specific relationship without losing the wider
+	// focus model.
+	const focusedTableIds = $derived.by(() => {
+		const out = new Set<string>(store.tableIdsInFocus());
+		const selJoinId = store.selectedJoinId;
+		if (selJoinId !== null) {
+			const j = store.doc.joins.find((jj) => jj.id === selJoinId);
+			if (j) {
+				out.clear();
+				out.add(j.sourceTableId);
+				out.add(j.targetTableId);
+			}
+		}
+		return out;
+	});
+	const focusedJoinIds = $derived.by(() => {
+		const out = new Set<string>(store.joinIdsInFocus());
+		const selJoinId = store.selectedJoinId;
+		if (selJoinId !== null) {
+			out.clear();
+			out.add(selJoinId);
+		}
+		return out;
+	});
+	// Focus only "activates" (fade everything else) when the selection
+	// actually pulls in more than itself. A table with NO joins to any
+	// other table would otherwise drop the whole canvas to 20% opacity
+	// and leave the lonely card sitting alone — not useful. In that
+	// case treat focus as inactive so the rest of the canvas stays
+	// readable.
+	// Pick mode is the highest-priority signal — it forces focusActive
+	// OFF so no table can fade behind a focus that was lingering from
+	// before pick mode started (or that got set by another path mid-
+	// pick).  Without this gate the user clicks a column, the parent
+	// table picks up SvelteFlow's selection, and the rest of the canvas
+	// dims out from under their next pick.
+	// AI-assist section state — brought back into the sidebar.  Lives
+	// below the source-tables list (anchored to the bottom of the
+	// column). Owns its own intent textarea, loading + error state, and
+	// result summary so the host page doesn't have to thread anything
+	// through.  Restore of the pre-drop shape from commit 37e1c6b.
+	// Minimised by default — a fresh/opened canvas shows only the collapsed
+	// "Ask DimSum" header (+ turn count). Any AI activity (Draft-with-AI seed,
+	// manual draft, or a chat send — all funnel through runDraftWithAI) expands
+	// it so the conversation is visible. Reported 2026-07-29.
+	let dimSumExpanded = $state(false);
+	let aiIntent = $state('');
+	let aiChatOpen = $state(false);
+	let aiChatDraft = $state('');
+	let aiDrafting = $state(false);
+	let aiError = $state<string | null>(null);
+	/** Modal open state for the "See issue" full-text error view. */
+	let aiErrorOpen = $state(false);
+	// Rolling multi-turn conversation.  Populated on every Ask AI + every
+	// send from the chat modal; both the sidebar widget AND the chat
+	// modal read from this list.  Persisted per connection so a page
+	// reload doesn't lose context.  Shared types live in ./ai-chat-types
+	// so AskDimSumWidget can render blocks without duplicating the shape.
+	let aiMessages = $state<ChatMessage[]>([]);
+	function chatStorageKey(): string {
+		return `saiku.canvas.ai.chat:${store.connectionId || 'unbound'}`;
+	}
+	// Restore saved chat on mount + on connection switch — but NOT on
+	// every re-render.  Bug I hit before: the effect re-fired mid-loop
+	// and wiped fresh in-flight messages before the assistant's reply
+	// landed.  Track the last-restored connection so we only reload
+	// when it actually changes.
+	let lastRestoredConnection: string | null = null;
+	$effect(() => {
+		if (typeof window === 'undefined') return;
+		const currentConn = store.connectionId || 'unbound';
+		if (lastRestoredConnection === currentConn) return;
+		lastRestoredConnection = currentConn;
+		// Opening a saved schema (?openFrom): don't restore the connection's chat
+		// — it belonged to a different schema/draft. Start empty + persist so the
+		// opened schema's conversation is fresh, with no flash of the old chat.
+		if (openArrival) {
+			aiMessages = [];
+			persistChat();
+			return;
+		}
+		try {
+			const raw = window.localStorage.getItem(chatStorageKey());
+			aiMessages = raw ? (JSON.parse(raw) as ChatMessage[]) : [];
+		} catch {
+			aiMessages = [];
+		}
+	});
+	function persistChat() {
+		if (typeof window === 'undefined') return;
+		try {
+			window.localStorage.setItem(chatStorageKey(), JSON.stringify(aiMessages));
+		} catch {
+			/* quota / private browsing — non-fatal */
+		}
+	}
+	function clearChat() {
+		aiMessages = [];
+		persistChat();
+	}
+	// Reset the DimSum chat when the user switches to a different cube — each
+	// cube gets a fresh conversation instead of one ever-growing thread. The
+	// first non-null cube is adopted silently so the restored chat isn't wiped
+	// on load, and a remount (which preserves store.activeCubeId) doesn't count
+	// as a switch.
+	let lastChatCubeId: string | null = null;
+	$effect(() => {
+		const cid = store.activeCubeId;
+		if (cid === null) return;
+		if (lastChatCubeId === null) {
+			lastChatCubeId = cid;
+			return;
+		}
+		if (cid !== lastChatCubeId) {
+			lastChatCubeId = cid;
+			clearChat();
+		}
+	});
+	// Draft-with-AI seed (from /schemas): auto-fire the description into
+	// DimSum exactly once, after the connection's table catalog has loaded
+	// (so list_tables / describe_table see real tables), with a higher
+	// iteration cap since a full star schema needs many tool turns. The draft
+	// surfaces in the always-visible floating sidebar widget — we deliberately
+	// DON'T pop open the larger chat dock (aiChatOpen), which would duplicate
+	// the same conversation the sidebar is already showing (reported
+	// 2026-07-29). The user pops the dock out themselves via the maximize icon.
+	let seedFired = false;
+	$effect(() => {
+		if (seedFired || !seedIntent?.trim()) return;
+		if (!store.connectionId || store.sourceLoading || store.sourceTables.length === 0) return;
+		seedFired = true;
+		// A Draft-with-AI request starts a CLEAN conversation — wipe any chat
+		// restored from a prior session (or retained in memory across an SPA
+		// nav) so the drafted cube isn't appended to an unrelated thread.
+		clearChat();
+		void runDraftWithAI(seedIntent, 16);
+	});
+	// Opening/duplicating a saved schema from the library (loadFromLibrary bumps
+	// store.chatResetNonce) starts a fresh DimSum conversation — the connection's
+	// restored chat belonged to a different schema/draft.
+	let lastChatResetNonce = store.chatResetNonce;
+	$effect(() => {
+		const n = store.chatResetNonce;
+		if (n !== lastChatResetNonce) {
+			lastChatResetNonce = n;
+			clearChat();
+		}
+	});
+	// The popped-out chat dock owns its own log-scroll ref + effect (see
+	// DimSumChatDock). Here we keep only the inline sidebar-chat scroll.
+	// Same pattern for the inline sidebar chat — pins the message log
+	// to the bottom whenever a turn lands.  Fires only while the section
+	// is open (bind:this stays null otherwise).
+	let aiSidebarLogEl = $state<HTMLDivElement | null>(null);
+	$effect(() => {
+		if (!dimSumExpanded) return;
+		void aiMessages.length;
+		void aiDrafting;
+		queueMicrotask(() => {
+			if (aiSidebarLogEl) aiSidebarLogEl.scrollTop = aiSidebarLogEl.scrollHeight;
+		});
+	});
+	let aiResult = $state<DimSumMutationResult | null>(null);
+
+	async function runDraftWithAI(overrideIntent?: string, maxIterations = 8) {
+		const intent = (overrideIntent ?? aiIntent).trim();
+		if (aiDrafting || !store.connectionId || !intent) return;
+		aiDrafting = true;
+		aiError = null;
+		aiResult = null;
+		// Doing AI stuff → expand the (minimised-by-default) sidebar so the
+		// conversation is visible as DimSum works. We stop here: the larger
+		// popped-out chat DOCK (aiChatOpen) stays closed — the sidebar already
+		// shows this conversation, so opening both is a duplicate. The user
+		// pops the dock out themselves via the maximize icon.
+		dimSumExpanded = true;
+
+		// Snapshot the pre-turn state so Cancel + toolbar Undo can revert
+		// the whole batch of mutations DimSum makes in this turn.  JSON
+		// round-trip because structuredClone can't clone Svelte 5 `$state`
+		// proxies (DataCloneError).
+		const preTurnDoc = JSON.parse(JSON.stringify(store.doc)) as typeof store.doc;
+		const preTableCount = store.doc.tables.length;
+		const preJoinCount = store.doc.joins.length;
+
+		// Append user's turn to the running history.
+		aiMessages = [...aiMessages, { role: 'user', content: intent, ts: Date.now() }];
+		persistChat();
+
+		try {
+			// Agent loop — up to `maxIterations` (default 8) to keep worst-case
+			// cost bounded.  A from-scratch "draft me a cube" seed passes a
+			// higher cap since a full star schema needs many tool turns (tables
+			// + joins + dimensions + levels + measures).  Each iteration: send
+			// messages → get content blocks → if any tool_use, execute + append
+			// tool_result + loop; if only text, we're done.
+			let mutated = false;
+			for (let iter = 0; iter < maxIterations; iter++) {
+				const canvasSummary = buildCanvasSummary(store);
+				// saiku-cloud#1078: the DimSum agent loop has its own gateway
+				// endpoint now (server owns the system prompt + tool schemas);
+				// /api/inference/propose stays the one-shot SchemaProfile flow.
+				// Request/response shaping + gateway error handling live in
+				// ./dimsum-agent so the wire format is unit-testable.
+				const content = await postDimSumTurn(aiMessages, canvasSummary, designerAI?.fetchImpl);
+				// Append Claude's response to history verbatim.
+				aiMessages = [...aiMessages, { role: 'assistant', content, ts: Date.now() }];
+				persistChat();
+
+				const toolUses = content.filter((b): b is AnthropicToolUseBlock => b.type === 'tool_use');
+				if (toolUses.length === 0) break; // Claude is done — text-only response.
+
+				const toolResults: AnthropicToolResultBlock[] = [];
+				for (const tu of toolUses) {
+					const { content: result, isError } = await executeDimSumTool(store, tu.name, tu.input, {
+						arrangeCanvas: handleLayout
+					});
+					toolResults.push({
+						type: 'tool_result',
+						tool_use_id: tu.id,
+						content: result,
+						is_error: isError
+					});
+					// Track whether ANY mutation succeeded so we can show the
+					// Confirm/Cancel banner after the loop settles.
+					if (!isError && DIMSUM_MUTATION_TOOLS.has(tu.name)) mutated = true;
+				}
+				aiMessages = [...aiMessages, { role: 'user', content: toolResults, ts: Date.now() }];
+				persistChat();
+			}
+
+			// Wire up the Confirm/Cancel banner if the loop actually
+			// touched the canvas.  Cancel reverts to the pre-turn snapshot
+			// via the store's undo slot.
+			if (mutated) {
+				store.previousDoc = preTurnDoc;
+				aiResult = {
+					tables: store.doc.tables.length - preTableCount,
+					joins: store.doc.joins.length - preJoinCount,
+					warnings: []
+				};
+			}
+		} catch (e) {
+			aiError = e instanceof Error ? e.message : 'AI call failed.';
+		} finally {
+			aiDrafting = false;
+			if (overrideIntent === undefined) aiIntent = '';
+			else aiChatDraft = '';
+		}
+	}
+
+	const focusActive = $derived(
+		!store.pickModeActive &&
+			((store.focusKind !== 'none' && focusedTableIds.size > 1) || store.selectedJoinId !== null)
+	);
+	// Per-(tableId, columnName) keys of every column endpoint participating
+	// in a focused join. TableNode highlights matching column rows green so
+	// the user can see WHICH columns the focused group/table is wired
+	// through, not just which tables are connected.
+
+	const focusedColumnKeys = $derived.by(() => {
+		const out = new Set<string>();
+		if (!focusActive) return out;
+		// Gated by the toggle so users who'd rather follow the lines
+		// (and keep the layout stable) don't get the in-table green
+		// highlight + auto-expand.  Group focus auto-flips the toggle
+		// ON via store.focusGroup, but the user is still free to turn
+		// it off mid-focus if they want.
+		if (!store.highlightFocusedColumns) return out;
+		for (const j of store.doc.joins) {
+			if (!focusedJoinIds.has(j.id)) continue;
+			out.add(`${j.sourceTableId}:${j.sourceColumnName}`);
+			out.add(`${j.targetTableId}:${j.targetColumnName}`);
+		}
+		return out;
+	});
+	// `${tableId}:${columnName}` keys for EVERY column that participates
+	// in ANY join — so TableNode can hide the handle dots on columns
+	// that aren't wired (they're still in the DOM as functional anchor
+	// points but rendered invisible unless the column row is hovered).
+	const connectedColumnKeys = $derived.by(() => {
+		const out = new Set<string>();
+		for (const j of store.doc.joins) {
+			out.add(`${j.sourceTableId}:${j.sourceColumnName}`);
+			out.add(`${j.targetTableId}:${j.targetColumnName}`);
+		}
+		return out;
+	});
+
+	// Node/edge derivations are pure — see ./canvas-flow (unit-tested). The
+	// component owns only the reactive plumbing (focus deriveds in, $state
+	// bindings + sync effects below).
+	const flowFocus = $derived<FlowFocus>({
+		focusActive,
+		focusedTableIds,
+		focusedColumnKeys,
+		connectedColumnKeys,
+		focusedJoinIds
+	});
+	const flowNodes = $derived<Node[]>(buildFlowNodes(store, flowFocus));
+	const flowEdges = $derived<Edge[]>(buildFlowEdges(store, flowFocus));
+
+	// Wrap in $state so SvelteFlow's bindings can write back. SvelteFlow
+	// mutates the bound arrays in place when the user drags nodes,
+	// selects them, etc. — we then sync those mutations back to the
+	// authoritative store via $effects below.
+	let nodes = $state<Node[]>([]);
+	let edges = $state<Edge[]>([]);
+	$effect(() => {
+		nodes = flowNodes;
+	});
+	$effect(() => {
+		edges = flowEdges;
+	});
+
+	// Sync user-driven position changes from SvelteFlow's nodes array
+	// back to the store. We compare against the store's stored positions
+	// so we don't loop on store-driven updates.
+	$effect(() => {
+		for (const n of nodes) {
+			const stored = store.doc.tables.find((t) => t.id === n.id);
+			if (!stored) continue;
+			if (stored.position.x !== n.position.x || stored.position.y !== n.position.y) {
+				store.moveTable(n.id, { x: n.position.x, y: n.position.y });
+			}
+			if ((n.selected ?? false) !== (store.selectedTableId === n.id)) {
+				store.selectedTableId = n.selected ? n.id : null;
+			}
+		}
+	});
+
+	// Edges-sync — propagate xyflow-driven selection changes back to the
+	// store.  Tricky because the bound `edges` array uses SvelteFlow-style
+	// ids (`edge:tbl_xxx::tbl_yyy`, one per table-pair) while the store's
+	// `selectedJoinId` is a real join id (`join_xxx`).  Two distinct
+	// formats — mapping naïvely (writing `e.id` into selectedJoinId)
+	// silently corrupts selection because focusedColumnKeys can then
+	// never match any `j.id`, so the endpoint rows never light up green
+	// AND the canvas gets stuck ping-ponging between flowEdges and
+	// edges-sync rewriting selectedJoinId every microtask.  The previous
+	// version of this effect did exactly that, which is what made the
+	// "click join → click pane" highlight refuse to clear: it was a
+	// reactivity-cycle artefact, not a "the clear didn't run" bug.
+	//
+	// Two cases to handle:
+	//
+	//  1. xyflow reports an edge `selected: true` (user clicked the
+	//     curve).  For a single-join edge we can map it to the real
+	//     join id via `e.data.joins[0].id`; for a multi-join edge there
+	//     isn't a single join to pick (that's what the popover is for),
+	//     so we don't change selectedJoinId — the popover row's
+	//     `data.onSelect(j.id)` is the canonical setter for that case.
+	//
+	//  2. xyflow reports NO edge selected (pane click, deselect).  Mirror
+	//     null into the store.
+	$effect(() => {
+		const selectedEdge = edges.find((e) => e.selected);
+		if (!selectedEdge) {
+			if (store.selectedJoinId !== null) store.selectedJoinId = null;
+			return;
+		}
+		 
+		const edgeJoins = (selectedEdge.data as any)?.joins as Array<{ id: string }> | undefined;
+		if (edgeJoins && edgeJoins.length === 1) {
+			const joinId = edgeJoins[0].id;
+			if (store.selectedJoinId !== joinId) store.selectedJoinId = joinId;
+		}
+		// Multi-join edge selected by xyflow but store already has a real
+		// join id (popover path) — leave it alone.
+	});
+
+	// Auto-flip the column-highlight toggle ON when a single join is
+	// selected.  Same UX promise as group-focus: clicking a join is the
+	// user saying "show me what this links," and the endpoint column
+	// rows are the natural answer.  The user remains free to toggle
+	// off mid-focus.
+	$effect(() => {
+		const id = store.selectedJoinId;
+		untrack(() => {
+			if (id !== null) store.highlightFocusedColumns = true;
+		});
+	});
+
+	// Selecting a table on the canvas focuses it — its joins stay vivid,
+	// everything else fades. Deselecting (pane click / another selection)
+	// clears focus. ONLY selectedTableId is tracked here: untrack the
+	// focus-state reads so that focusing via another path (e.g. clicking
+	// a group label in the joins panel) doesn't re-fire this effect and
+	// clobber the group focus by re-asserting the stale selection.
+	//
+	// IMPORTANT: skip the auto-focus when pick mode is active. In pick
+	// mode every column click auto-selects the parent node (SvelteFlow
+	// behaviour); without this guard, the FIRST pick would focus that
+	// table and fade everything else, making the rest of the canvas
+	// almost un-clickable for the next pick.
+	$effect(() => {
+		const id = store.selectedTableId;
+		const pickMode = store.pickModeActive;
+		untrack(() => {
+			if (pickMode) {
+				// Stay neutral while picking — clear any focus that
+				// was lingering from before pick mode started.
+				if (store.focusKind !== 'none') store.clearFocus();
+				return;
+			}
+			if (id === null) {
+				if (store.focusKind === 'table') store.clearFocus();
+			} else {
+				if (store.focusKind !== 'table' || store.focusKey !== id) {
+					store.focusKind = 'table';
+					store.focusKey = id;
+				}
+			}
+		});
+	});
+
+	// Arrange state — shared by the toolbar (Arrange button) and the DimSum
+	// arrange_canvas tool, so it stays in the shell alongside handleLayout
+	// (which reads the canvas region rect). The toolbar owns its own
+	// transient toggle-flash + layout-menu state.
+	let arranging = $state(false);
+	let lastLayoutMode = $state<LayoutMode>('star');
+
+	// Reference to the canvas region div, so the grid layout can fit its
+	// column count to the visible area rather than a fixed step-function.
+	let canvasRegionEl = $state<HTMLDivElement | null>(null);
+
+	async function handleLayout(mode: LayoutMode) {
+		if (store.doc.tables.length === 0) return;
+		arranging = true;
+		lastLayoutMode = mode;
+		try {
+			// Pass the user's actual "Show N cols/table" setting so the
+			// layout estimates heights from what the canvas RENDERS,
+			// not from every column the table has.  Also pass the
+			// canvas region's measured dimensions so the grid layout
+			// can size its column count to whatever's actually visible.
+			const rect = canvasRegionEl?.getBoundingClientRect();
+			const next = await applyLayout(store.doc, mode, {
+				visibleColumnsCap: store.defaultColumnsShown,
+				canvasWidth: rect?.width ?? 0,
+				canvasHeight: rect?.height ?? 0
+			});
+			for (const t of next.tables) {
+				store.moveTable(t.id, t.position);
+			}
+		} finally {
+			arranging = false;
+		}
+	}
+
+	// Joins panel — collapsible right rail. Default OPEN on mount so the
+	// "Currently selected" pill never has to compete with the collapsed
+	// panel edge for horizontal space (Amelia's report — the pill was
+	// floating over the closed panel's header).  User toggle still wins
+	// after the initial render.
+	let joinsPanelOpen = $state(true);
+	// Source-tables sidebar mirrors joinsPanelOpen: closable via an
+	// EyeOff button in its header, re-openable via a floating chip on
+	// the canvas's top-left corner.
+	// Source lives in the LEFT overlay column (CanvasPane), DimSum lives
+	// in the bottom half of the RIGHT overlay column beside JOINS. Each
+	// has its own EyeOff button; when hidden the parent renders a reopen
+	// chip at the panel's natural corner (Source top-left, DimSum below
+	// JOINS on the right).
+	let sourceVisible = $state(true);
+	// #1154 kept DimSum minimized when it sat bottom-LEFT (it ate the
+	// left canvas edge before the user opted in). On the right column it
+	// is the paired half beside JOINS, so it's visible by default; the
+	// EyeOff in the widget header collapses it to a reopen chip.
+	let dimSumVisible = $state(true);
+
+	// When Create Joins Mode turns on, force the JOINS panel open so
+	// the picks accumulate in a visible pane and the "Match N picks"
+	// CTA + auto-name input are reachable.  Turning the mode back off
+	// leaves the panel alone (user may want to keep reviewing joins).
+	$effect(() => {
+		if (store.pickModeActive) {
+			untrack(() => {
+				joinsPanelOpen = true;
+			});
+		}
+	});
+
+	// Join-creation toast.  The store's `lastJoinFeedback` is a bump
+	// counter (`id`) + message; every drag / click / commit that adds a
+	// join sets it, batch paths overwrite with a summary.  We watch the
+	// `id` (not the message) so re-firing with the same text still shows
+	// a fresh toast, and auto-dismiss after 3.5s.
+	let joinToast = $state<string | null>(null);
+	let joinToastTimer: ReturnType<typeof setTimeout> | null = null;
+	$effect(() => {
+		const feedback = store.lastJoinFeedback;
+		if (!feedback) return;
+		untrack(() => {
+			joinToast = feedback.message;
+			if (joinToastTimer) clearTimeout(joinToastTimer);
+			joinToastTimer = setTimeout(() => {
+				joinToast = null;
+				joinToastTimer = null;
+			}, 3500);
+		});
+	});
+	// Join groups drive the toolbar counts, the canvas "Joins (N)" chip, and
+	// the JoinsPanel. Grouping is pure — see ./join-groups. The panel owns its
+	// own interaction state (select / reorganize / edit / collapse).
+	const joinGroups = $derived(computeJoinGroups(store));
+	const physicalJoinGroups = $derived(joinGroups.filter((g) => !isSemanticGroup(g)));
+	const semanticJoinGroups = $derived(joinGroups.filter((g) => isSemanticGroup(g)));
+	const physicalJoinCount = $derived(physicalJoinGroups.reduce((n, g) => n + g.joins.length, 0));
+	const semanticJoinCount = $derived(semanticJoinGroups.reduce((n, g) => n + g.joins.length, 0));
+</script>
+
+<!-- DimSum sidebar widget — rendered here (the shell owns the chat state)
+     and mounted inside the right-side floating column beside JOINS. The
+     shell exposes it as a snippet so the JSX below stays legible. -->
+{#snippet askDimSumWidget()}
+	<AskDimSumWidget
+		bind:expanded={dimSumExpanded}
+		bind:visible={dimSumVisible}
+		messages={aiMessages}
+		drafting={aiDrafting}
+		bind:intent={aiIntent}
+		bind:result={aiResult}
+		bind:error={aiError}
+		bind:chatOpen={aiChatOpen}
+		bind:errorOpen={aiErrorOpen}
+		connectionId={store.connectionId}
+		fillContainer
+		onDraft={() => void runDraftWithAI()}
+		onClearChat={clearChat}
+		onConfirmResult={() => store.clearPreviousDoc()}
+		onCancelResult={() => store.undo()}
+	/>
+{/snippet}
+
+<div class="flex h-full min-h-0 flex-1 flex-col">
+	<CanvasToolbar
+		{store}
+		{physicalJoinCount}
+		{semanticJoinCount}
+		{arranging}
+		{lastLayoutMode}
+		onArrange={handleLayout}
+	/>
+
+	<div class="flex flex-1 overflow-hidden">
+		<!-- Source + DimSum render as floating cards INSIDE the canvas
+		     container (see the `canvas-source-panel-floating` /
+		     `canvas-ai-panel-floating` blocks below).  Canvas is full
+		     width from the left edge; canvas dots show through wherever
+		     the panels/chips aren't sitting. -->
+
+		<DimSumChatDock
+			{store}
+			messages={aiMessages}
+			drafting={aiDrafting}
+			error={aiError}
+			bind:chatOpen={aiChatOpen}
+			bind:errorOpen={aiErrorOpen}
+			bind:chatDraft={aiChatDraft}
+			onClearChat={clearChat}
+			onSend={(draft) => void runDraftWithAI(draft)}
+		/>
+
+		<!-- CanvasPane + right-side floating column share a `relative`
+		     wrapper so JOINS + DimSum can absolute-overlay the right
+		     edge of the canvas, mirroring the way the SOURCE panel
+		     floats over the left edge from inside CanvasPane.
+		     CanvasPane grows to fill the whole width; the right
+		     column is a flex column iterated in fixed order
+		     [JOINS, DimSum]. For each entry an OPEN panel takes
+		     flex-1 (grows to fill), a CLOSED entry renders a compact
+		     reopen chip (auto-height, self-end). Net behaviour:
+		     collapsed chips stack at the TOP of the column, panels
+		     grow into whatever remains below them, and any empty
+		     tail sits safely above the SvelteFlow MiniMap which
+		     lives at the canvas's bottom-right. -->
+		<div class="relative flex flex-1 overflow-hidden">
+			<CanvasPane
+				{store}
+				bind:nodes
+				bind:edges
+				{focusActive}
+				bind:joinsPanelOpen
+				bind:sourceVisible
+				bind:dimSumVisible
+				bind:canvasRegionEl
+				{sourceContext}
+			/>
+			<div
+				class="pointer-events-none absolute top-2 right-2 bottom-2 z-20 flex flex-col gap-2"
+				style:width="{store.joinsPanelWidth}px"
+				data-testid="canvas-right-column"
+			>
+				<!-- JOINS: panel (flex-1) when open, chip (auto-height, self-end) when closed. -->
+				{#if joinsPanelOpen}
+					<div class="flex min-h-0 flex-1 flex-col">
+						<JoinsPanel
+							{store}
+							{joinGroups}
+							{physicalJoinGroups}
+							{semanticJoinGroups}
+							{physicalJoinCount}
+							{semanticJoinCount}
+							bind:joinsPanelOpen
+							onFlushEdges={() => (edges = [])}
+						/>
+					</div>
+				{:else}
+					<button
+						type="button"
+						onclick={() => (joinsPanelOpen = true)}
+						class="pointer-events-auto inline-flex h-7 items-center gap-1 self-end rounded border border-input bg-card px-2 text-xs font-medium shadow-sm transition-colors hover:bg-accent hover:text-accent-foreground"
+						data-testid="canvas-joins-panel-open"
+						title="Show joins panel"
+					>
+						<ChevronRight class="h-3.5 w-3.5" aria-hidden="true" />
+						Joins ({physicalJoinCount})
+					</button>
+				{/if}
+				<!-- DimSum: panel (flex-1) when open, chip (auto-height, self-end) when closed.
+				     Closed chip lands directly under the JOINS panel/chip so it never
+				     collides with the SvelteFlow MiniMap at the bottom-right of the canvas. -->
+				{#if dimSumVisible}
+					<div
+						class="pointer-events-auto flex min-h-0 flex-1 flex-col"
+						data-testid="canvas-ai-panel-floating"
+					>
+						{@render askDimSumWidget()}
+					</div>
+				{:else}
+					<button
+						type="button"
+						onclick={() => (dimSumVisible = true)}
+						class="pointer-events-auto inline-flex h-7 items-center gap-1 self-end rounded border border-input bg-card px-2 text-xs font-medium shadow-sm transition-colors hover:bg-accent hover:text-accent-foreground"
+						data-testid="canvas-ai-panel-open"
+						title="Show DimSum"
+					>
+						<Sparkles class="h-3.5 w-3.5 text-primary" aria-hidden="true" />
+						Ask DimSum
+					</button>
+				{/if}
+			</div>
+		</div>
+	</div>
+</div>
+
+{#if joinToast}
+	<Toast
+		tone="success"
+		testid="canvas-join-toast"
+		onDismiss={() => {
+			joinToast = null;
+			if (joinToastTimer) {
+				clearTimeout(joinToastTimer);
+				joinToastTimer = null;
+			}
+		}}
+	>
+		{joinToast}
+	</Toast>
+{/if}

--- a/saiku-ui/src/lib/cube-designer/SemanticJoinsAccordion.svelte
+++ b/saiku-ui/src/lib/cube-designer/SemanticJoinsAccordion.svelte
@@ -1,0 +1,78 @@
+<!--
+  Semantic-joins accordion (collapsed by default) — surfaces cube-side links
+  (FactLink / ReferenceLink / ForeignKeyLink) that Mondrian 4 expresses inside
+  <MeasureGroup><DimensionLinks>, plus legacy inferred-FK joins. Read-only: the
+  schema designer creates these from cube authoring, not via the canvas.
+-->
+<script lang="ts">
+	import { ChevronDown } from 'lucide-svelte';
+	import type { SchemaCanvasStore } from './state.svelte.js';
+	import type { JoinGroupRender } from './join-groups.js';
+
+	interface Props {
+		store: SchemaCanvasStore;
+		semanticJoinGroups: JoinGroupRender[];
+		semanticJoinCount: number;
+	}
+
+	let { store, semanticJoinGroups, semanticJoinCount }: Props = $props();
+
+	let semanticSectionExpanded = $state<boolean>(false);
+</script>
+
+{#if semanticJoinCount > 0}
+	<section
+		class="mt-3 rounded border border-dashed border-border"
+		data-testid="canvas-joins-panel-semantic"
+	>
+		<button
+			type="button"
+			onclick={() => (semanticSectionExpanded = !semanticSectionExpanded)}
+			class="flex w-full items-center justify-between gap-2 rounded px-3 py-2 text-left text-[11px] font-medium tracking-wider uppercase transition-colors hover:bg-accent"
+			style:color="hsl(var(--muted-foreground))"
+			aria-expanded={semanticSectionExpanded}
+			data-testid="canvas-joins-panel-semantic-toggle"
+		>
+			<span class="flex items-center gap-1.5">
+				<span
+					class="inline-flex h-3.5 w-3.5 items-center justify-center transition-transform"
+					style:transform={semanticSectionExpanded ? 'none' : 'rotate(-90deg)'}
+				>
+					<ChevronDown class="h-3.5 w-3.5" aria-hidden="true" />
+				</span>
+				Semantic joins ({semanticJoinCount})
+			</span>
+			<span class="text-[10px] font-normal normal-case opacity-70"> cube-side · read-only </span>
+		</button>
+		{#if semanticSectionExpanded}
+			<div class="space-y-1 border-t border-dashed border-border px-2 py-2">
+				{#each semanticJoinGroups as group (group.canonicalKey)}
+					<section
+						class="rounded border border-dashed border-border/60 bg-muted/30 px-2 py-1.5"
+						data-testid="canvas-joins-panel-semantic-group"
+						data-group-key={group.canonicalKey}
+					>
+						<header
+							class="text-[11px] font-medium tracking-wide"
+							style:color="hsl(var(--muted-foreground))"
+						>
+							{group.label}
+							<span class="ml-1 text-[10px] opacity-60">
+								({group.joins.length})
+							</span>
+						</header>
+						<ul class="mt-1 space-y-0.5 font-mono text-[10px] opacity-75">
+							{#each group.joins as j (j.id)}
+								{@const src = store.doc.tables.find((t) => t.id === j.sourceTableId)}
+								{@const tgt = store.doc.tables.find((t) => t.id === j.targetTableId)}
+								<li>
+									{src?.name ?? '?'}.{j.sourceColumnName} → {tgt?.name ?? '?'}.{j.targetColumnName}
+								</li>
+							{/each}
+						</ul>
+					</section>
+				{/each}
+			</div>
+		{/if}
+	</section>
+{/if}

--- a/saiku-ui/src/lib/cube-designer/TableNode.svelte
+++ b/saiku-ui/src/lib/cube-designer/TableNode.svelte
@@ -1,0 +1,381 @@
+<!--
+  Canvas schema designer — TableNode.
+
+  Custom @xyflow/svelte node type that renders one table on the canvas.
+  Headers carry the table name + role badge (Fact / Dimension / Bridge).
+  Rows below list each column with a small handle on each side so the
+  user can drag column-to-column to wire a join.
+
+  Visual states:
+   - normal: muted border, card background.
+   - selected: brand-red ring.
+   - fact: heavier border, brand-tinted background.
+-->
+<script lang="ts">
+	import { Handle, Position, type NodeProps } from '@xyflow/svelte';
+	import { X, ChevronsDownUp, ChevronsUpDown } from 'lucide-svelte';
+	import type { SchemaCanvasTable } from './types.js';
+
+	interface TableNodeData {
+		table: SchemaCanvasTable;
+		highlightedColumn: string | null;
+		/** Armed source for click-to-join. When a column on this table is
+		 *  the pending source, the row gets a brand-ring + helper hint. */
+		pendingJoinSource: { tableId: string; columnName: string } | null;
+		/** While the user is holding E, every clicked column lands here.
+		 *  On release, the store joins every distinct pair across the set. */
+		eShiftPicks: Array<{ tableId: string; columnName: string }>;
+		/** Global "show first N columns" preference from the canvas store.
+		 *  0 = headers only. Per-table `collapsed` overrides this. */
+		defaultColumnsShown: number;
+		/** When focus is active and this table isn't in scope, fade. */
+		isFaded: boolean;
+		/** `${tableId}:${columnName}` keys for every column row that
+		 *  participates in a focused join — TableNode highlights matching
+		 *  rows green so the user can see WHICH columns are wired. */
+		focusedColumnKeys: Set<string>;
+		/** `${tableId}:${columnName}` keys for every column that has a
+		 *  join. Handle dots are visible on those rows; on un-joined
+		 *  rows the dots are hidden until the row is hovered (still
+		 *  draggable to make new joins). */
+		connectedColumnKeys: Set<string>;
+		/** When this table is part of a focus, auto-show every column
+		 *  so the wired columns are visible without manual expansion. */
+		forceExpandedByFocus: boolean;
+		onPromoteToFact: (tableId: string) => void;
+		onRemove: (tableId: string) => void;
+		onColumnClick: (tableId: string, columnName: string, metaOrCtrl: boolean) => void;
+		onToggleCollapsed: (tableId: string) => void;
+		onExpandFully: (tableId: string) => void;
+	}
+
+	let { data, selected }: NodeProps & { data: TableNodeData } = $props();
+	const table = $derived(data.table);
+	const hasHighlightedColumn = $derived(
+		data.highlightedColumn !== null && table.columns.some((c) => c.name === data.highlightedColumn)
+	);
+
+	/**
+	 * How many columns to actually render in the body. Priority order:
+	 *   1. Per-table user override (`table.collapsed`: true → 0; false → all)
+	 *   2. Global default from the store (`defaultColumnsShown`)
+	 *   3. Fallback: show all
+	 * Returning 0 makes the body collapse to a single "anchor" handle row
+	 * so existing joins still point at a DOM element.
+	 */
+	const visibleCount = $derived.by(() => {
+		if (data.forceExpandedByFocus) return table.columns.length;
+		if (table.collapsed === true) return 0;
+		if (table.collapsed === false) return table.columns.length;
+		return Math.max(0, Math.min(data.defaultColumnsShown, table.columns.length));
+	});
+	const visibleColumns = $derived(table.columns.slice(0, visibleCount));
+	const hiddenCount = $derived(table.columns.length - visibleCount);
+</script>
+
+<div
+	class="w-60 rounded-md border bg-card text-sm shadow-sm transition-opacity"
+	class:border-border={!selected && !hasHighlightedColumn}
+	class:ring-2={selected}
+	class:ring-primary={selected}
+	class:ring-success={!selected && hasHighlightedColumn}
+	class:shadow-success={hasHighlightedColumn}
+	style:box-shadow={hasHighlightedColumn ? '0 0 24px 2px hsl(var(--success) / 0.45)' : undefined}
+	style:opacity={data.isFaded ? 0.2 : 1}
+	data-testid="canvas-table-node"
+	data-table-id={table.id}
+>
+	<!-- Peer model — every table is equal.  No "fact" badge, no
+	     brand-red border.
+
+	     Header layout — table name only.  User already knows which
+	     schema is bound (it's the one they picked in the toolbar
+	     dropdown); a per-node schema chip is redundant noise.  Names
+	     wrap up to 2 lines (line-clamp-2) before ellipsising; the whole
+	     header carries a native `title` tooltip with the qualified name
+	     for the tail cases that still overflow.  Fixes #969, #971. -->
+	<div
+		class="flex items-start justify-between gap-2 rounded-t-md border-b border-border bg-muted px-3 py-2"
+		title={table.schema ? `${table.schema}.${table.name}` : table.name}
+	>
+		<div class="min-w-0 flex-1">
+			<div
+				class="line-clamp-2 font-mono text-xs leading-tight break-all"
+				data-testid="canvas-table-name"
+			>
+				{table.name}
+			</div>
+		</div>
+		<div class="flex items-center gap-1">
+			<button
+				type="button"
+				class="nodrag rounded p-1 text-xs opacity-70 hover:bg-background/30 hover:opacity-100"
+				title={table.collapsed ? 'Expand columns' : 'Collapse to header'}
+				aria-label={table.collapsed ? 'Expand columns' : 'Collapse to header'}
+				onpointerdown={(e) => e.stopPropagation()}
+				onclick={(e) => {
+					e.stopPropagation();
+					data.onToggleCollapsed(table.id);
+				}}
+				data-testid="canvas-toggle-collapsed"
+			>
+				{#if table.collapsed}
+					<ChevronsUpDown class="h-3.5 w-3.5" aria-hidden="true" />
+				{:else}
+					<ChevronsDownUp class="h-3.5 w-3.5" aria-hidden="true" />
+				{/if}
+			</button>
+			<button
+				type="button"
+				class="nodrag rounded p-1 text-xs opacity-70 hover:bg-background/30 hover:opacity-100"
+				title="Remove from canvas"
+				aria-label="Remove from canvas"
+				onpointerdown={(e) => e.stopPropagation()}
+				onclick={(e) => {
+					e.stopPropagation();
+					data.onRemove(table.id);
+				}}
+				data-testid="canvas-remove-table"
+			>
+				<X class="h-3.5 w-3.5" aria-hidden="true" />
+			</button>
+		</div>
+	</div>
+	<!-- Visible-columns slice = user-collapsed?0 : user-expanded?all : global default.
+	     Scrolling was banned (it clipped handles off-screen so SvelteFlow
+	     couldn't track join endpoints), so any hidden columns are
+	     surfaced via the footer below. -->
+	{#if visibleCount > 0}
+		<ul class="py-1 text-xs">
+			{#each visibleColumns as col (col.name)}
+				{@const isHighlighted = data.highlightedColumn === col.name}
+				{@const ePickIndex = data.eShiftPicks.findIndex(
+					(p) => p.tableId === table.id && p.columnName === col.name
+				)}
+				{@const isEPicked = ePickIndex >= 0}
+				{@const isJoinFocused = data.focusedColumnKeys.has(`${table.id}:${col.name}`)}
+				{@const isConnected = data.connectedColumnKeys.has(`${table.id}:${col.name}`)}
+				<!-- Two distinct row colours so manual picks vs auto matches
+				     never blur into each other:
+				       • GREEN (success) — name-matched by search/click, or
+				         currently in a focused join.  "The system found this."
+				       • YELLOW (warning) — explicit user pick in pick mode.
+				         "I chose this."
+				     A row that's BOTH highlighted AND picked falls under
+				     pick-priority (yellow wins) because the intent is more
+				     deliberate. -->
+				{@const showPick = isEPicked}
+				{@const showHighlight = !isEPicked && (isHighlighted || isJoinFocused)}
+				<li
+					class="group relative flex items-center justify-between gap-2 px-3 py-1 transition-colors"
+					class:bg-warning={showPick}
+					class:text-warning-foreground={showPick}
+					class:hover:bg-warning={showPick}
+					class:bg-success={showHighlight}
+					class:text-success-foreground={showHighlight}
+					class:hover:bg-success={showHighlight}
+					class:hover:bg-accent={!showPick && !showHighlight}
+					class:hover:text-accent-foreground={!showPick && !showHighlight}
+					class:row-connected={isConnected}
+					data-testid="canvas-table-column"
+					data-column-name={col.name}
+				>
+					<!-- Stacked handles so the chosen side picks the shortest
+				     path. Each column has BOTH a source and a target on
+				     each side (left = `:in-left` / `:out-left`,
+				     right = `:in-right` / `:out-right`). flowEdges picks
+				     the actual handle IDs based on which side of source
+				     vs. target the table sits on, so the line takes the
+				     straightest route. Visually only one dot per side
+				     reads because the pair overlaps. -->
+					<Handle
+						type="target"
+						position={Position.Left}
+						id={`${table.id}:${col.name}:in-left`}
+						class="!h-2 !w-2 !border-input !bg-background"
+					/>
+					<Handle
+						type="source"
+						position={Position.Left}
+						id={`${table.id}:${col.name}:out-left`}
+						class="!h-2 !w-2 !border-input !bg-background"
+					/>
+					<button
+						type="button"
+						class="nodrag flex flex-1 cursor-pointer items-center justify-between gap-2 truncate text-left"
+						onpointerdown={(e) => e.stopPropagation()}
+						onclick={(e) => {
+							e.stopPropagation();
+							data.onColumnClick(table.id, col.name, e.metaKey || e.ctrlKey);
+						}}
+						title={`${col.name} · ${col.sqlType}`}
+					>
+						<span class="truncate font-mono">{col.name}</span>
+						{#if isEPicked}
+							<span
+								class="shrink-0 rounded bg-success-foreground/15 px-1.5 py-0.5 text-[9px] font-medium tracking-wider uppercase"
+								title="E-shift pick #{ePickIndex + 1}"
+							>
+								#{ePickIndex + 1}
+							</span>
+						{:else}
+							<span class="shrink-0 text-[10px] uppercase opacity-60">{col.sqlType}</span>
+						{/if}
+					</button>
+					<Handle
+						type="source"
+						position={Position.Right}
+						id={`${table.id}:${col.name}:out-right`}
+						class="!h-2 !w-2 !border-input !bg-background"
+					/>
+					<Handle
+						type="target"
+						position={Position.Right}
+						id={`${table.id}:${col.name}:in-right`}
+						class="!h-2 !w-2 !border-input !bg-background"
+					/>
+				</li>
+			{/each}
+		</ul>
+		{#if hiddenCount > 0}
+			<!-- "+ N more" footer — clickable button that expands the
+			     table to show every column. Also anchors hidden columns'
+			     handles so any joins to them still point at a DOM
+			     element while the footer is showing. -->
+			<button
+				type="button"
+				class="nodrag relative flex w-full items-center justify-center border-t border-border px-3 py-1 text-[10px] font-medium text-muted-foreground transition-colors hover:bg-accent hover:text-accent-foreground"
+				title="Show all {table.columns.length} columns"
+				onpointerdown={(e) => e.stopPropagation()}
+				onclick={(e) => {
+					e.stopPropagation();
+					data.onExpandFully(table.id);
+				}}
+				data-testid="canvas-table-expand-more"
+			>
+				+ {hiddenCount} more
+				{#each table.columns.slice(visibleCount) as col (col.name)}
+					<Handle
+						type="target"
+						position={Position.Left}
+						id={`${table.id}:${col.name}:in-left`}
+						class="!h-2 !w-2 !border-input !bg-background"
+						style="top: 50%;"
+					/>
+					<Handle
+						type="source"
+						position={Position.Left}
+						id={`${table.id}:${col.name}:out-left`}
+						class="!h-2 !w-2 !border-input !bg-background"
+						style="top: 50%;"
+					/>
+					<Handle
+						type="source"
+						position={Position.Right}
+						id={`${table.id}:${col.name}:out-right`}
+						class="!h-2 !w-2 !border-input !bg-background"
+						style="top: 50%;"
+					/>
+					<Handle
+						type="target"
+						position={Position.Right}
+						id={`${table.id}:${col.name}:in-right`}
+						class="!h-2 !w-2 !border-input !bg-background"
+						style="top: 50%;"
+					/>
+				{/each}
+			</button>
+		{/if}
+	{:else}
+		<!-- Fully collapsed: every column's source/target handles stack at
+		     the header midline so existing joins point at a DOM element. -->
+		<div class="relative h-2 w-full">
+			{#each table.columns as col (col.name)}
+				<Handle
+					type="target"
+					position={Position.Left}
+					id={`${table.id}:${col.name}:in-left`}
+					class="!h-2 !w-2 !border-input !bg-background"
+					style="top: 50%;"
+				/>
+				<Handle
+					type="source"
+					position={Position.Left}
+					id={`${table.id}:${col.name}:out-left`}
+					class="!h-2 !w-2 !border-input !bg-background"
+					style="top: 50%;"
+				/>
+				<Handle
+					type="source"
+					position={Position.Right}
+					id={`${table.id}:${col.name}:out-right`}
+					class="!h-2 !w-2 !border-input !bg-background"
+					style="top: 50%;"
+				/>
+				<Handle
+					type="target"
+					position={Position.Right}
+					id={`${table.id}:${col.name}:in-right`}
+					class="!h-2 !w-2 !border-input !bg-background"
+					style="top: 50%;"
+				/>
+			{/each}
+		</div>
+	{/if}
+</div>
+
+<style>
+	/* Handle dots are visible only when the column has a join, OR when
+	   the user hovers the row (so unjoined columns are still draggable
+	   to make new connections). Cuts visual noise on tall tables where
+	   most columns aren't wired. */
+	li :global(.svelte-flow__handle) {
+		opacity: 0;
+		transition: opacity 120ms ease;
+	}
+	li.row-connected :global(.svelte-flow__handle),
+	li:hover :global(.svelte-flow__handle) {
+		opacity: 1;
+	}
+
+	/* Light-mode override for the column-highlight green. The default
+	   `--success` token resolves to a saturated emerald that's hard on
+	   the eyes against the white column row. Soften to pale mint with
+	   deep mint text so it still reads "highlighted" without shouting. */
+	:global(:root:not([data-theme='dark'])) li.bg-success {
+		background-color: hsl(150 55% 88%);
+		color: hsl(150 55% 22%);
+	}
+	:global(:root:not([data-theme='dark'])) li.hover\:bg-success:hover {
+		background-color: hsl(150 55% 84%);
+		color: hsl(150 55% 22%);
+	}
+	/* Light-mode override for the pick yellow.  Same softening logic as
+	   the green — the raw `--warning` is a saturated amber that pops too
+	   hard against a white row.  Pale butter with deep ochre text. */
+	:global(:root:not([data-theme='dark'])) li.bg-warning {
+		background-color: hsl(45 90% 86%);
+		color: hsl(35 70% 22%);
+	}
+	:global(:root:not([data-theme='dark'])) li.hover\:bg-warning:hover {
+		background-color: hsl(45 90% 80%);
+		color: hsl(35 70% 22%);
+	}
+
+	/* Dark-mode overrides — the raw `--success-foreground` /
+	   `--warning-foreground` tokens are white, which is unreadable against
+	   the bright meadow / honey highlight colors on the row.  Force deep
+	   ink text so column name + SQL type stay legible on both states. */
+	:global(:root[data-theme='dark']) li.bg-success {
+		color: hsl(150 60% 12%);
+	}
+	:global(:root[data-theme='dark']) li.hover\:bg-success:hover {
+		color: hsl(150 60% 12%);
+	}
+	:global(:root[data-theme='dark']) li.bg-warning {
+		color: hsl(35 70% 14%);
+	}
+	:global(:root[data-theme='dark']) li.hover\:bg-warning:hover {
+		color: hsl(35 70% 14%);
+	}
+</style>

--- a/saiku-ui/src/lib/cube-designer/TableSidebar.svelte
+++ b/saiku-ui/src/lib/cube-designer/TableSidebar.svelte
@@ -1,0 +1,615 @@
+<!--
+  Canvas schema designer — left sidebar.
+
+  Renders the source-table catalog (loaded from
+  /api/inference/profile-connection) as a searchable, schema-grouped
+  list. Each row is draggable onto the canvas — when the user drops, the
+  parent canvas's onPaneDrop handler picks up the drag payload and
+  creates a node.
+
+  Tables already on the canvas are shown dimmed with an "on canvas"
+  indicator so the user doesn't double-add them.
+-->
+<script lang="ts">
+	import { Search, GripVertical, ChevronRight, Plus } from 'lucide-svelte';
+	import type { SourceTableCandidate } from './types.js';
+
+	interface Props {
+		tables: SourceTableCandidate[];
+		loading: boolean;
+		error: string | null;
+		query: string;
+		onQueryChange: (q: string) => void;
+		/** Set of `schema.name` identities currently on the canvas. */
+		onCanvasIdentities: Set<string>;
+		/** Identities whose row should be drag-disabled. Defaults to
+		 *  `onCanvasIdentities` (Canvas view — can't add the same table
+		 *  twice). Workbench passes its own working-set identities, so
+		 *  on-canvas tables stay draggable to be added to the workbench. */
+		disabledIdentities?: Set<string>;
+		/** Pixel width — bound from the parent so the value persists across view swaps. */
+		width: number;
+		onWidthChange: (px: number) => void;
+		/** Two-way selection set. Click toggles single, Shift/Cmd toggles
+		 *  in-set; the parent's drop handler clears after a successful drop. */
+		selectedIdentities: Set<string>;
+		onSelectionChange: (next: Set<string>) => void;
+		/** Optional snippet rendered between the search input and the
+		 *  results list — used by the canvas view to drop the
+		 *  "Pull in N with `<colname>`" chip in the right spot
+		 *  (above the field-match results, below the search). */
+		afterSearch?: import('svelte').Snippet;
+		/** Optional snippet rendered at the very top of the sidebar,
+		 *  above the "Source tables" header — used by the canvas view
+		 *  to co-locate the source-connection + schema pickers with the
+		 *  tables they list.  Frees the top toolbar for canvas-only
+		 *  actions and gives the tables list its provenance context. */
+		sourceContext?: import('svelte').Snippet;
+		/** When set, the "on canvas" indicator on each result row becomes
+		 *  an underlined link that calls this with the `schema.name`
+		 *  identity (and, for field matches, the column name). The
+		 *  Canvas view uses it to centre+select the matching table; the
+		 *  Workbench view leaves it unset so the indicator stays a pill. */
+		onJumpToCanvasTable?: (identity: string, columnName?: string) => void;
+		/** Called when the user clicks the hover-revealed "+ Add to canvas"
+		 *  button on a table row.  Same shape as a drag-drop or "add via
+		 *  MCP" — the parent decides where to place the node.  Left unset
+		 *  by hosts that don't want the affordance (e.g. Workbench source
+		 *  panel). */
+		onAddToCanvas?: (t: SourceTableCandidate) => void;
+	}
+
+	let {
+		tables,
+		loading,
+		error,
+		query,
+		onQueryChange,
+		onCanvasIdentities,
+		disabledIdentities,
+		width,
+		onWidthChange,
+		selectedIdentities,
+		onSelectionChange,
+		afterSearch,
+		sourceContext,
+		onJumpToCanvasTable,
+		onAddToCanvas
+	}: Props = $props();
+	// Default: same set as on-canvas (Canvas view's behaviour). Workbench
+	// overrides to its working-set so on-canvas-but-not-in-workbench
+	// tables stay draggable.
+	// Only EXPLICIT disabledIdentities count as disabled.  Tables that
+	// are already on canvas are NOT disabled — clicking such a row
+	// jumps the canvas to that table instead of arming a drag.
+	const disabledSet = $derived(disabledIdentities ?? new Set<string>());
+
+	const MIN_WIDTH = 220;
+	const MAX_WIDTH = 560;
+
+	function handleSplitterPointerDown(e: PointerEvent) {
+		e.preventDefault();
+		const startX = e.clientX;
+		const startWidth = width;
+		(e.target as HTMLElement).setPointerCapture(e.pointerId);
+		function move(ev: PointerEvent) {
+			const next = Math.max(MIN_WIDTH, Math.min(MAX_WIDTH, startWidth + (ev.clientX - startX)));
+			onWidthChange(next);
+		}
+		function up(ev: PointerEvent) {
+			(e.target as HTMLElement).releasePointerCapture(ev.pointerId);
+			window.removeEventListener('pointermove', move);
+			window.removeEventListener('pointerup', up);
+		}
+		window.addEventListener('pointermove', move);
+		window.addEventListener('pointerup', up);
+	}
+
+	function ident(t: SourceTableCandidate): string {
+		return t.schema ? `${t.schema}.${t.name}` : t.name;
+	}
+	function isOnCanvas(t: SourceTableCandidate): boolean {
+		return onCanvasIdentities.has(ident(t));
+	}
+	function isDisabled(t: SourceTableCandidate): boolean {
+		return disabledSet.has(ident(t));
+	}
+	function isSelected(t: SourceTableCandidate): boolean {
+		return selectedIdentities.has(ident(t));
+	}
+	// Range-select anchor (#1083) — the identity of the last row the user
+	// individually clicked (plain or Cmd/Ctrl click). Shift-click selects
+	// the contiguous range between this anchor and the clicked row; it does
+	// NOT move the anchor. Null until the first individual click.
+	let anchorId = $state<string | null>(null);
+
+	function handleRowClick(e: MouseEvent, t: SourceTableCandidate) {
+		if (isDisabled(t)) return;
+		const id = ident(t);
+		// Modifier semantics follow the macOS/list convention:
+		//   • Shift        → range-select from the anchor to this row.
+		//   • Cmd / Ctrl   → toggle THIS row in/out of the selection.
+		//   • plain click  → single-select (replace with just this row).
+		const isRange = e.shiftKey;
+		const isToggle = e.metaKey || e.ctrlKey;
+
+		// Plain click on an on-canvas table jumps the canvas to it (the
+		// modifier paths below intentionally fall through to selection so
+		// the user can still multi-pick on-canvas rows).
+		if (!isRange && !isToggle && isOnCanvas(t) && onJumpToCanvasTable) {
+			onJumpToCanvasTable(id);
+			return;
+		}
+
+		if (isRange) {
+			// Resolve indices over the CURRENT visible order. With no anchor
+			// yet (or a stale anchor no longer visible), Shift behaves like a
+			// plain click and seeds the anchor.
+			const order = flatVisibleIdentities;
+			const from = anchorId === null ? -1 : order.indexOf(anchorId);
+			const to = order.indexOf(id);
+			if (from === -1 || to === -1) {
+				const single = new Set<string>([id]);
+				anchorId = id;
+				onSelectionChange(single);
+				return;
+			}
+			const [lo, hi] = from <= to ? [from, to] : [to, from];
+			// Add the contiguous range to the existing selection (union).
+			// Anchor stays put so the user can grow/shrink the range.
+			const next = new Set(selectedIdentities);
+			for (const rid of order.slice(lo, hi + 1)) next.add(rid);
+			onSelectionChange(next);
+			return;
+		}
+
+		const next = new Set(selectedIdentities);
+		if (isToggle) {
+			if (next.has(id)) next.delete(id);
+			else next.add(id);
+		} else {
+			// Plain click — replace selection with just this row.
+			next.clear();
+			next.add(id);
+		}
+		// Both plain and toggle clicks re-anchor to this row.
+		anchorId = id;
+		onSelectionChange(next);
+	}
+
+	// Two parallel result sets when the user is actively searching:
+	//   - Table matches  — tables whose qualified name contains the query.
+	//   - Field matches  — tables that have one or more columns matching
+	//                      the query; we keep the matching column names so
+	//                      they can be displayed under the table.
+	// When the query is empty we just show the schema-grouped table list.
+	const tableMatches = $derived.by(() => {
+		const q = query.trim().toLowerCase();
+		if (!q) return tables;
+		return tables.filter((t) => {
+			const qualified = (t.schema ? `${t.schema}.${t.name}` : t.name).toLowerCase();
+			return qualified.includes(q);
+		});
+	});
+
+	// Per-column-mention rows. If `customer_id` appears in 3 tables, that
+	// becomes 3 rows — column name on the left, parent table name beside
+	// it. Sorted alphabetically by column then by table.
+	const fieldMatches = $derived.by<Array<{ column: string; table: SourceTableCandidate }>>(() => {
+		const q = query.trim().toLowerCase();
+		if (!q) return [];
+		const out: Array<{ column: string; table: SourceTableCandidate }> = [];
+		for (const t of tables) {
+			const qualified = (t.schema ? `${t.schema}.${t.name}` : t.name).toLowerCase();
+			// Skip tables whose NAME matched — they live in the Tables section.
+			if (qualified.includes(q)) continue;
+			for (const c of t.columns) {
+				if (c.name.toLowerCase().includes(q)) {
+					out.push({ column: c.name, table: t });
+				}
+			}
+		}
+		out.sort((a, b) => {
+			const ca = a.column.localeCompare(b.column);
+			if (ca !== 0) return ca;
+			return a.table.name.localeCompare(b.table.name);
+		});
+		return out;
+	});
+
+	// Sort control state — clickable column headers cycle through
+	// (name-asc → name-desc → cols-desc → cols-asc → name-asc).  Split
+	// into (key, direction) so the header can render its active arrow
+	// independently.  Persisted per-workspace so the choice sticks
+	// across reloads.
+	const SORT_STORAGE_KEY = 'saiku.canvas.sidebar.sort';
+	type SortKey = 'name' | 'cols';
+	type SortDir = 'asc' | 'desc';
+	let sortBy = $state<SortKey>('cols');
+	let sortDir = $state<SortDir>('desc');
+	$effect(() => {
+		if (typeof window === 'undefined') return;
+		try {
+			const raw = window.localStorage.getItem(SORT_STORAGE_KEY);
+			if (!raw) return;
+			const parsed = JSON.parse(raw) as { by?: SortKey; dir?: SortDir };
+			if (parsed.by === 'name' || parsed.by === 'cols') sortBy = parsed.by;
+			if (parsed.dir === 'asc' || parsed.dir === 'desc') sortDir = parsed.dir;
+		} catch {
+			/* corrupt / unavailable — keep defaults */
+		}
+	});
+	function toggleSort(next: SortKey): void {
+		if (sortBy === next) {
+			sortDir = sortDir === 'asc' ? 'desc' : 'asc';
+		} else {
+			sortBy = next;
+			// Sensible defaults: name → asc (A→Z), cols → desc (biggest first).
+			sortDir = next === 'name' ? 'asc' : 'desc';
+		}
+		try {
+			window.localStorage.setItem(SORT_STORAGE_KEY, JSON.stringify({ by: sortBy, dir: sortDir }));
+		} catch {
+			/* quota / private browsing — non-fatal */
+		}
+	}
+
+	const grouped = $derived.by(() => {
+		const byGroup = new Map<string, SourceTableCandidate[]>();
+		for (const t of tableMatches) {
+			const key = t.schema ?? '(no schema)';
+			if (!byGroup.has(key)) byGroup.set(key, []);
+			byGroup.get(key)!.push(t);
+		}
+		const cmp = (a: SourceTableCandidate, b: SourceTableCandidate) => {
+			const flip = sortDir === 'asc' ? 1 : -1;
+			if (sortBy === 'name') return a.name.localeCompare(b.name) * flip;
+			return (a.columns.length - b.columns.length) * flip;
+		};
+		return [...byGroup.entries()]
+			.sort(([a], [b]) => a.localeCompare(b))
+			.map(([schema, tables]) => ({
+				schema,
+				tables: [...tables].sort(cmp)
+			}));
+	});
+
+	const isSearching = $derived(query.trim().length > 0);
+
+	// Flattened identity list in the exact order the grouped rows render
+	// (schema group order, then each group's sorted tables). Drives
+	// Shift-click range resolution (#1083) so the range matches what the
+	// user actually sees.
+	const flatVisibleIdentities = $derived(
+		grouped.flatMap((group) => group.tables.map((t) => ident(t)))
+	);
+
+	function handleDragStart(e: DragEvent, t: SourceTableCandidate) {
+		if (!e.dataTransfer) return;
+		// On-canvas tables are non-draggable (#1084) — belt-and-braces
+		// no-op in case a drag still starts (e.g. keyboard-driven DnD).
+		// Re-dragging an on-canvas table would otherwise add a duplicate
+		// node.
+		if (isOnCanvas(t)) {
+			e.preventDefault();
+			return;
+		}
+		e.dataTransfer.effectAllowed = 'copy';
+		// If the dragged row is part of the current selection, drag the
+		// WHOLE selection. Otherwise just this one (don't disturb
+		// whatever was selected — matches Finder behaviour).
+		const inSelection = isSelected(t);
+		const bundle = inSelection ? tables.filter((c) => selectedIdentities.has(ident(c))) : [t];
+		// Drop targets prefer the array payload but fall back to the
+		// singular for backwards-compat with anything we missed.
+		e.dataTransfer.setData('application/x-saiku-tables', JSON.stringify(bundle));
+		e.dataTransfer.setData('application/x-saiku-table', JSON.stringify(t));
+		e.dataTransfer.setData(
+			'text/plain',
+			bundle.map((c) => (c.schema ? `${c.schema}.${c.name}` : c.name)).join(', ')
+		);
+	}
+</script>
+
+<!-- min-h-0 on the aside lets `flex-1` on the scroll region below
+     actually take effect when the sidebar is height-constrained by
+     a narrow viewport; without it the sourceContext + header + search
+     stack can eat all the space and leave the tables list with no
+     scroll area (the "spills into the section above" bug from #1003). -->
+<!-- SOURCE header + EyeOff removed — the wrapping card in
+     SchemaCanvasView now owns those, matching the DimSum card style. -->
+<!-- No bg-card / border on the aside — the wrapping card in
+     SchemaCanvasView owns the panel chrome now. -->
+<aside
+	class="relative flex h-full min-h-0 flex-1 shrink-0 flex-col gap-3 p-3"
+	style:width="{width}px"
+	aria-label="Source"
+	data-testid="canvas-sidebar"
+>
+	<!-- Tables sub-header removed — count now lives inline in the panel
+	     header ("Source Tables (N)"), matching the JOINS panel pattern. -->
+
+	<div class="relative shrink-0">
+		<Search
+			class="pointer-events-none absolute top-1/2 left-3 h-4 w-4 -translate-y-1/2 text-muted-foreground"
+			aria-hidden="true"
+		/>
+		<input
+			type="search"
+			placeholder="Search tables…"
+			aria-label="Search tables"
+			class="h-9 w-full rounded border border-input bg-background pr-3 pl-9 text-sm"
+			value={query}
+			oninput={(e) => onQueryChange((e.currentTarget as HTMLInputElement).value)}
+			data-testid="canvas-sidebar-search"
+		/>
+	</div>
+
+	{#if afterSearch}
+		<div class="shrink-0">
+			{@render afterSearch()}
+		</div>
+	{/if}
+
+	{#if loading}
+		<p class="text-xs text-muted-foreground" data-testid="canvas-sidebar-loading">
+			Profiling your data source — this can take a moment for big warehouses…
+		</p>
+	{:else if error}
+		<p
+			class="rounded border border-destructive/40 bg-destructive/10 p-2 text-xs text-destructive"
+			data-testid="canvas-sidebar-error"
+		>
+			{error}
+		</p>
+	{:else if isSearching && tableMatches.length === 0 && fieldMatches.length === 0}
+		<p class="text-xs text-muted-foreground" data-testid="canvas-sidebar-empty">
+			No tables or fields match "{query}".
+		</p>
+	{:else if tables.length === 0}
+		<p class="text-xs text-muted-foreground" data-testid="canvas-sidebar-empty">
+			No tables found in this data source.
+		</p>
+	{:else}
+		<!-- min-h-0 is the flex-column contract that unlocks the scroll —
+		     `flex-1` alone gives the container 100% remaining height ONLY
+		     if the flex parent lets children shrink below their intrinsic
+		     content height, which requires min-h-0.  Without it a tall
+		     rows list forces the parent to grow past the viewport and
+		     the scroll region silently disappears (see #1003). -->
+		<div class="min-h-0 flex-1 overflow-y-auto" data-testid="canvas-sidebar-list">
+			<!-- Tables section — shown either as schema-grouped (no search)
+			     or as a flat list of name-matching tables (when searching). -->
+			{#if tableMatches.length > 0}
+				{#if isSearching}
+					<div
+						class="mb-1 border-b border-border pb-1 text-[10px] font-medium tracking-wider text-muted-foreground uppercase"
+					>
+						Tables matching "{query}" ({tableMatches.length})
+					</div>
+				{/if}
+				<!-- Sort controls — two clickable "column headers" (Name /
+				     Cols) that cycle between asc/desc.  Active column
+				     shows an arrow (↑ asc, ↓ desc); inactive shows a
+				     dim ↕ hinting it's clickable. -->
+				<div
+					class="mb-1 flex items-center justify-between gap-2 border-b border-border pb-1"
+					data-testid="canvas-sidebar-sort"
+				>
+					<button
+						type="button"
+						onclick={() => toggleSort('name')}
+						class="text-[10px] font-medium tracking-wider uppercase hover:text-foreground {sortBy ===
+						'name'
+							? 'text-foreground'
+							: 'text-muted-foreground'}"
+						data-testid="canvas-sidebar-sort-name"
+						title="Sort tables by name"
+					>
+						Name
+						<span class="ml-0.5 opacity-70">
+							{sortBy === 'name' ? (sortDir === 'asc' ? '↑' : '↓') : '↕'}
+						</span>
+					</button>
+					<button
+						type="button"
+						onclick={() => toggleSort('cols')}
+						class="text-[10px] font-medium tracking-wider uppercase hover:text-foreground {sortBy ===
+						'cols'
+							? 'text-foreground'
+							: 'text-muted-foreground'}"
+						data-testid="canvas-sidebar-sort-cols"
+						title="Sort tables by column count"
+					>
+						Cols
+						<span class="ml-0.5 opacity-70">
+							{sortBy === 'cols' ? (sortDir === 'asc' ? '↑' : '↓') : '↕'}
+						</span>
+					</button>
+				</div>
+				{#each grouped as group (group.schema)}
+					<div class="mb-2">
+						{#if !isSearching}
+							<div
+								class="sticky top-0 z-10 bg-card py-1 text-[10px] font-medium tracking-wider text-muted-foreground uppercase"
+							>
+								{group.schema}
+								<span class="opacity-70">({group.tables.length})</span>
+							</div>
+						{/if}
+						<ul class="space-y-0.5">
+							{#each group.tables as t (`${group.schema}.${t.name}`)}
+								{@const rowDisabled = isDisabled(t)}
+								{@const rowOnCanvas = isOnCanvas(t)}
+								{@const rowSelected = isSelected(t)}
+								<li>
+									<div
+										role="button"
+										tabindex={rowDisabled ? -1 : 0}
+										aria-disabled={rowDisabled ? 'true' : undefined}
+										draggable={!rowDisabled && !rowOnCanvas}
+										ondragstart={(e) => handleDragStart(e, t)}
+										onclick={(e) => handleRowClick(e, t)}
+										onkeydown={(e) => {
+											if (rowDisabled) return;
+											if (e.key !== 'Enter' && e.key !== ' ') return;
+											e.preventDefault();
+											handleRowClick(e as unknown as MouseEvent, t);
+										}}
+										class="group/tblrow flex w-full items-center justify-between gap-2 rounded px-2 py-1 text-left text-xs transition-[filter] hover:brightness-125"
+										class:cursor-grab={!rowOnCanvas && !rowDisabled}
+										class:active:cursor-grabbing={!rowOnCanvas && !rowDisabled}
+										class:cursor-pointer={rowOnCanvas && !rowDisabled}
+										class:opacity-50={rowDisabled}
+										class:cursor-not-allowed={rowDisabled}
+										class:bg-primary={rowSelected}
+										class:text-primary-foreground={rowSelected}
+										class:hover:bg-accent={!rowSelected}
+										class:hover:text-accent-foreground={!rowSelected}
+										data-testid="canvas-sidebar-table"
+										data-identity={ident(t)}
+										data-selected={rowSelected}
+										data-oncanvas={rowOnCanvas}
+										title={t.schema ? `${t.schema}.${t.name}` : t.name}
+									>
+										<!-- Always render the schema prefix on the title row so
+										     these read clearly as TABLES (vs. column-match rows
+										     in the Fields section, which omit the prefix). -->
+										<span class="truncate font-mono">
+											{#if t.schema}<span class="opacity-60">{t.schema}.</span>{/if}{t.name}
+										</span>
+										<!-- Right side: hover-swaps `N cols` → `+ Add to canvas`
+										     when the host wired `onAddToCanvas` AND the row isn't
+										     already on canvas.  On-canvas rows keep their label
+										     since the whole-row click already jumps. -->
+										{#if rowOnCanvas || !onAddToCanvas || rowDisabled}
+											<span class="shrink-0 text-[10px] text-muted-foreground">
+												{#if rowOnCanvas}on canvas{:else}{t.columns.length} cols{/if}
+											</span>
+										{:else}
+											<span
+												class="shrink-0 text-[10px] text-muted-foreground group-hover/tblrow:hidden"
+												>{t.columns.length} cols</span
+											>
+											<button
+												type="button"
+												onclick={(e) => {
+													e.stopPropagation();
+													onAddToCanvas?.(t);
+												}}
+												class="hidden shrink-0 items-center gap-1 rounded border border-border bg-background px-1.5 py-0.5 text-[10px] font-semibold text-foreground transition-colors group-hover/tblrow:inline-flex hover:bg-accent hover:text-accent-foreground"
+												aria-label={`Add ${t.schema ? `${t.schema}.${t.name}` : t.name} to canvas`}
+												title="Add to canvas"
+												data-testid="canvas-sidebar-add-to-canvas"
+											>
+												<Plus class="h-3 w-3" aria-hidden="true" />
+												Add to canvas
+											</button>
+										{/if}
+									</div>
+								</li>
+							{/each}
+						</ul>
+					</div>
+				{/each}
+			{/if}
+
+			<!-- Fields section — one row per (column, table) pair. -->
+			{#if isSearching && fieldMatches.length > 0}
+				<div
+					class="mt-2 mb-1 border-t border-b border-border py-1 text-[10px] font-medium tracking-wider text-muted-foreground uppercase"
+				>
+					Fields matching "{query}" ({fieldMatches.length})
+				</div>
+				<ul class="space-y-1">
+					{#each fieldMatches as fm (`${fm.table.schema ?? ''}.${fm.table.name}::${fm.column}`)}
+						{@const t = fm.table}
+						{@const onCanvas = isOnCanvas(t)}
+						{@const disabled = isDisabled(t)}
+						<li>
+							<button
+								type="button"
+								draggable={!disabled && !onCanvas}
+								ondragstart={(e) => handleDragStart(e, t)}
+								onclick={(e) => handleRowClick(e, t)}
+								class="grid w-full grid-cols-[1fr_auto] gap-x-2 gap-y-0.5 rounded border border-border px-2 py-1.5 text-left text-xs transition-[filter] hover:brightness-125"
+								class:cursor-grab={!onCanvas && !disabled}
+								class:active:cursor-grabbing={!onCanvas && !disabled}
+								class:cursor-pointer={onCanvas && !disabled}
+								class:opacity-50={disabled}
+								class:cursor-not-allowed={disabled}
+								class:bg-primary={isSelected(t)}
+								class:text-primary-foreground={isSelected(t)}
+								class:hover:bg-accent={!isSelected(t)}
+								class:hover:text-accent-foreground={!isSelected(t)}
+								{disabled}
+								data-testid="canvas-sidebar-field"
+								data-identity={ident(t)}
+								data-selected={isSelected(t)}
+								data-oncanvas={onCanvas}
+							>
+								<span class="truncate font-mono">{fm.column}</span>
+								{#if onCanvas && onJumpToCanvasTable}
+									<span
+										role="link"
+										tabindex="0"
+										onclick={(e) => {
+											e.stopPropagation();
+											onJumpToCanvasTable?.(ident(t), fm.column);
+										}}
+										onkeydown={(e) => {
+											if (e.key !== 'Enter' && e.key !== ' ') return;
+											e.preventDefault();
+											e.stopPropagation();
+											onJumpToCanvasTable?.(ident(t), fm.column);
+										}}
+										class="inline-flex shrink-0 cursor-pointer items-center gap-0.5 text-[10px] text-primary underline underline-offset-2 hover:text-primary/80"
+										data-testid="canvas-sidebar-jump-field"
+										title="Centre this table on the canvas and highlight {fm.column}"
+									>
+										on canvas
+										<ChevronRight class="h-3 w-3" aria-hidden="true" />
+									</span>
+								{:else if onCanvas}
+									<span class="shrink-0 text-[10px] text-muted-foreground">on canvas</span>
+								{:else}
+									<span class="shrink-0 text-[10px] text-muted-foreground">
+										{t.columns.length} cols
+									</span>
+								{/if}
+								<span
+									class="col-span-2 truncate text-[10px] text-muted-foreground"
+									title={t.schema ? `${t.schema}.${t.name}` : t.name}
+								>
+									in <span class="font-mono">{t.schema ? `${t.schema}.` : ''}{t.name}</span>
+								</span>
+							</button>
+						</li>
+					{/each}
+				</ul>
+			{/if}
+		</div>
+	{/if}
+
+	<!-- Splitter handle — drag the right edge of the sidebar to resize. -->
+	<button
+		type="button"
+		aria-label="Resize sidebar"
+		title="Drag to resize"
+		class="absolute top-0 right-[-4px] bottom-0 z-20 flex w-2 cursor-ew-resize items-center justify-center text-muted-foreground/40 transition-colors hover:bg-primary/20 hover:text-foreground"
+		onpointerdown={handleSplitterPointerDown}
+		data-testid="canvas-sidebar-splitter"
+	>
+		<GripVertical class="h-3 w-3" aria-hidden="true" />
+	</button>
+
+	<!-- Source info block — anchored to the BOTTOM of the aside.  Was at
+	     the top; moved so the Tables list dominates the vertical space
+	     and the source is a footer reminder, not a heading. -->
+	{#if sourceContext}
+		<div class="-mx-3 shrink-0 border-t border-border/60"></div>
+		<div class="shrink-0 pt-1" data-testid="canvas-sidebar-source-context">
+			{@render sourceContext()}
+		</div>
+	{/if}
+</aside>

--- a/saiku-ui/src/lib/cube-designer/WorkbenchView.svelte
+++ b/saiku-ui/src/lib/cube-designer/WorkbenchView.svelte
@@ -65,7 +65,7 @@
 		ChevronsUpDown,
 		KeyRound
 	} from 'lucide-svelte';
-	import Button from '$lib/components/ui/button.svelte';
+	import Button from './primitives/button.svelte';
 	import ConfirmCubePane from './ConfirmCubePane.svelte';
 	import FactsMeasuresPane from './FactsMeasuresPane.svelte';
 	import DimensionsHierarchiesPane from './DimensionsHierarchiesPane.svelte';

--- a/saiku-ui/src/lib/cube-designer/WorkbenchView.svelte
+++ b/saiku-ui/src/lib/cube-designer/WorkbenchView.svelte
@@ -1,0 +1,6191 @@
+<!--
+  Step 2 of the cube-authoring flow — the Dimensions Workbench.
+
+  Renders on the same /cubes/new/canvas route (the page chrome,
+  tab toggle, and save bar all live on +page.svelte); this file owns
+  the three-region body when `store.mode === 'binary'`.
+
+    1. Left rail   — two stacked, independently collapsible panes.
+                     Top: "Join groups" — read-only context derived
+                     from Step 1's joins (group label + participating
+                     tables). Bottom: "Tables" — every on-canvas
+                     table, each individually collapsible. Columns
+                     inside the tables pane are the only drag sources
+                     (payload: `{tableId, columnName, columnType}`).
+    2. Center      — two zones stacked: DIMENSIONS (cards w/
+                     hierarchies + ordered levels, OR a Mondrian-style
+                     nested outline — toggled by a Cards | Tree
+                     segmented control) on top, MEASURES (aggregated
+                     fact-side columns) below. Drop a column on the
+                     dimensions zone to create a new dimension; drop
+                     on an existing dimension to append a level; drop
+                     on the measures zone to create a sum-by-default
+                     measure. Drops work identically in both views.
+    3. Right rail  — read-only summary of the joins authored in
+                     Step 1. We surface them so the user can see HOW
+                     a level reachable via a join is reached, but
+                     editing joins stays a Step 1 concern (click
+                     "back to Schema Canvas" — i.e. flip the tab).
+
+  Drag-and-drop uses native HTML5 DnD with a single MIME type
+  (`application/x-saiku-column`). Drop targets `preventDefault` on
+  dragover and read the JSON payload on drop. We don't model
+  drag previews or drop validation beyond "is it our payload" — the
+  one-MIME / one-shape rule keeps the logic linear.
+
+  Mondrian export wiring lives elsewhere (mondrian-export.ts) — the
+  job of THIS file is only to get well-shaped dimensions/measures
+  into the store. A follow-up PR will teach the exporter to read
+  `store.dimensions` + `store.measures`.
+-->
+<script lang="ts">
+	import {
+		Database,
+		ChevronRight,
+		ChevronDown,
+		ChevronUp,
+		ChevronLeft,
+		GripVertical,
+		Plus,
+		X,
+		Layers,
+		Sigma,
+		Box,
+		Lock,
+		PanelRight,
+		PanelBottom,
+		Copy,
+		Hash,
+		ListTree,
+		Search,
+		Pencil,
+		Check,
+		Maximize2,
+		Minimize2,
+		ChevronsUpDown,
+		KeyRound
+	} from 'lucide-svelte';
+	import Button from '$lib/components/ui/button.svelte';
+	import ConfirmCubePane from './ConfirmCubePane.svelte';
+	import FactsMeasuresPane from './FactsMeasuresPane.svelte';
+	import DimensionsHierarchiesPane from './DimensionsHierarchiesPane.svelte';
+	import InspectorProperties from './InspectorProperties.svelte';
+	import { onMount, untrack } from 'svelte';
+	import { SvelteSet } from 'svelte/reactivity';
+	import { SchemaCanvasStore, dimKeyIdentity, resolveKeyAttribute } from './state.svelte.js';
+	import { getCubeDesignerBackend } from './backend';
+	import { mondrianXmlToYaml } from './mondrian-xml-to-yaml';
+	import { highlightXml, highlightYaml } from './code-highlight';
+	import { exportToMondrianXml } from './mondrian-export';
+	import { classifyColumn, isNumericKind } from './workbench-columns';
+	import {
+		COLUMN_MIME,
+		TABLE_MIME,
+		JOINGROUP_MIME,
+		FACTS_PANE_REORDER_MIME,
+		PANE_REORDER_MIME,
+		ATTRIBUTE_MIME,
+		readColumnPayload,
+		readTablePayload,
+		readJoinGroupPayload,
+		isAnyWorkbenchDrag,
+		isPaneReorderDrag,
+		isFactsPaneReorderDrag
+	} from './workbench-dnd';
+	import type {
+		ColumnDragPayload,
+		TableDragPayload,
+		JoinGroupDragPayload,
+		AttributeDragPayload
+	} from './workbench-dnd';
+	import { blankCube, cubeFromDoc, cubeToDoc, renderCalcTokens } from './workbench-cubes';
+	import type {
+		FactsCalcToken,
+		FactsCalcMode,
+		FactsCalc,
+		FactsMeasureGroup,
+		WorkbenchMeasureGroup,
+		WorkbenchCube
+	} from './workbench-cubes';
+	import type {
+		SchemaCanvasTable,
+		SchemaCanvasColumn,
+		SchemaCanvasDimension,
+		SchemaCanvasHierarchy,
+		SchemaCanvasLevel,
+		SchemaCanvasMeasure,
+		SourceTableCandidate,
+		SchemaCanvasCube
+	} from './types.js';
+
+	interface Props {
+		store: SchemaCanvasStore;
+		/** Has the current schema ever been saved to the gateway. */
+		isSchemaSaved?: boolean;
+		/** Has the schema been mutated since the last save?  Together
+		 *  with `isSchemaSaved`, drives the per-cube rail "Open in Saiku"
+		 *  button — greyed out when dirty/unsaved (with a tooltip
+		 *  pointing at the top-right Save), enabled when saved+clean. */
+		isSchemaDirty?: boolean;
+	}
+
+	let { store, isSchemaSaved = false, isSchemaDirty = true }: Props = $props();
+
+	// Injected backend (Sample-data + Try-a-query transport); host-provided.
+	const designerBackend = getCubeDesignerBackend();
+
+	// The workbench DnD MIME contract + payload parsers/predicates live in
+	// ./workbench-dnd (imported above). The drag *handlers* that mutate
+	// component state stay below and reference the imported MIMEs.
+	type FactsPaneKind = 'fact' | 'groups' | 'calculations';
+
+	function loadFactsSlots(): FactsPaneKind[] {
+		// v2 default — the cube-level 'fact' pane was absorbed into the
+		// per-MG editor in the Measure Groups Content column, so it no
+		// longer appears as a standalone pane.  Anyone with a persisted
+		// shape that still includes 'fact' migrates by dropping it; the
+		// per-MG editor takes over its job.
+		const fallback: FactsPaneKind[] = ['groups', 'calculations'];
+		if (typeof localStorage === 'undefined') return fallback;
+		try {
+			const raw = localStorage.getItem('saiku.workbench.factsPrototypeState');
+			if (!raw) return fallback;
+			const obj = JSON.parse(raw) as { slots?: string[] } | null;
+			const s = obj?.slots;
+			if (Array.isArray(s) && s.length > 0) {
+				// Drop legacy 'fact' slot; ensure 'groups' + 'calculations'
+				// are both present, preserving user-ordered slots.
+				const filtered = s.filter(
+					(k): k is FactsPaneKind => k === 'groups' || k === 'calculations'
+				);
+				const hasGroups = filtered.includes('groups');
+				const hasCalcs = filtered.includes('calculations');
+				if (hasGroups && hasCalcs && filtered.length === 2) {
+					return filtered;
+				}
+				if (hasGroups && !hasCalcs) {
+					return [...filtered, 'calculations'];
+				}
+				if (!hasGroups && hasCalcs) {
+					return ['groups', ...filtered];
+				}
+			}
+		} catch {
+			// fall through
+		}
+		return fallback;
+	}
+	let factsSlots = $state<FactsPaneKind[]>(loadFactsSlots());
+	let factsPaneDragIndex = $state<number | null>(null);
+	let factsPaneDragOverIndex = $state<number | null>(null);
+	function handleFactsPaneDragStart(e: DragEvent, idx: number) {
+		if (!e.dataTransfer) return;
+		e.dataTransfer.setData(FACTS_PANE_REORDER_MIME, String(idx));
+		e.dataTransfer.effectAllowed = 'move';
+		factsPaneDragIndex = idx;
+	}
+	function handleFactsPaneDragOver(e: DragEvent, idx: number) {
+		if (!isFactsPaneReorderDrag(e)) return;
+		e.preventDefault();
+		if (e.dataTransfer) e.dataTransfer.dropEffect = 'move';
+		factsPaneDragOverIndex = idx;
+	}
+	function handleFactsPaneDragLeave(idx: number) {
+		if (factsPaneDragOverIndex === idx) factsPaneDragOverIndex = null;
+	}
+	function handleFactsPaneDrop(e: DragEvent, targetIdx: number) {
+		if (!isFactsPaneReorderDrag(e)) return;
+		e.preventDefault();
+		const raw = e.dataTransfer?.getData(FACTS_PANE_REORDER_MIME) ?? '';
+		const srcIdx = Number(raw);
+		factsPaneDragIndex = null;
+		factsPaneDragOverIndex = null;
+		if (!Number.isFinite(srcIdx) || srcIdx === targetIdx) return;
+		const next = [...factsSlots];
+		const [moved] = next.splice(srcIdx, 1);
+		next.splice(targetIdx, 0, moved);
+		factsSlots = next;
+	}
+	function handleFactsPaneDragEnd() {
+		factsPaneDragIndex = null;
+		factsPaneDragOverIndex = null;
+	}
+
+	// ColumnDragPayload / TableDragPayload / JoinGroupDragPayload live in
+	// ./workbench-dnd (imported above).
+
+	// classifyColumn / isNumericKind (sqlType → coarse Mondrian kind) live
+	// in ./workbench-columns (imported above).
+
+	// ── Left rail: TWO stacked panes ─────────────────────────────────
+	// Top:    "Join groups" — read-only context derived from the joins
+	//         authored in Step 1. Each group lists the participating
+	//         table names so the workbench user can see which tables
+	//         hang together without flipping tabs.
+	// Bottom: "Tables" — every on-canvas table; columns inside are the
+	//         drag sources that feed the dimensions + measures zones.
+	// The two sections collapse independently.
+
+	interface JoinGroupRow {
+		key: string;
+		label: string;
+		tableNames: string[];
+		tableIds: string[];
+	}
+
+	const joinGroupsRail = $derived.by<JoinGroupRow[]>(() => {
+		const tableName = (id: string) => store.doc.tables.find((t) => t.id === id)?.name ?? id;
+		// Preserve first-seen order so it matches Step 1's panel ordering.
+		const order: string[] = [];
+		const buckets = new Map<string, { label: string; tableIds: Set<string> }>();
+		for (const j of store.doc.joins) {
+			const label = store.joinGroupLabelFor(j);
+			let entry = buckets.get(label);
+			if (!entry) {
+				entry = { label, tableIds: new Set() };
+				buckets.set(label, entry);
+				order.push(label);
+			}
+			entry.tableIds.add(j.sourceTableId);
+			entry.tableIds.add(j.targetTableId);
+		}
+		return order.map((label) => {
+			const entry = buckets.get(label)!;
+			const ids = Array.from(entry.tableIds);
+			return {
+				key: label,
+				label,
+				tableIds: ids,
+				tableNames: ids.map(tableName).sort((a, b) => a.localeCompare(b))
+			};
+		});
+	});
+
+	// Section + row collapse state for the left rail. Sections are
+	// independent (collapsing "Join groups" doesn't collapse "Tables").
+	let railJoinGroupsCollapsed = $state(false);
+	let railTablesCollapsed = $state(false);
+	let collapsedJoinGroupRows = $state<Set<string>>(new Set());
+	let collapsedTables = $state<Set<string>>(new Set());
+
+	// Free-text filter across table + column names — matched
+	// case-insensitively.  Empty string = no filter (show every table
+	// collapsed per the default).  When the query is non-empty:
+	//   • tables whose name matches are shown (collapsed or not is up
+	//     to the user — match isn't enough to auto-expand columns).
+	//   • tables with at least one column matching are shown AND
+	//     auto-expanded so the matching column is visible.
+	let tableFilterQuery = $state('');
+	const tableFilterQ = $derived(tableFilterQuery.trim().toLowerCase());
+	function tableMatchesFilter(t: SchemaCanvasTable): boolean {
+		if (tableFilterQ.length === 0) return true;
+		const ident = (t.schema ? `${t.schema}.${t.name}` : t.name).toLowerCase();
+		if (ident.includes(tableFilterQ)) return true;
+		return t.columns.some((c) => c.name.toLowerCase().includes(tableFilterQ));
+	}
+	function columnMatchesFilter(colName: string): boolean {
+		if (tableFilterQ.length === 0) return true;
+		return colName.toLowerCase().includes(tableFilterQ);
+	}
+	const filteredTables = $derived(store.doc.tables.filter(tableMatchesFilter));
+	// Auto-expand any table whose match is via a column (so the match
+	// is actually visible without an extra click).  Doesn't toggle
+	// `collapsedTables` itself — we just read this Set inside the
+	// per-row `isCollapsed` decision so the user's manual collapse
+	// state survives clearing the search.
+	const forceOpenForFilter = $derived.by(() => {
+		const out = new Set<string>();
+		if (tableFilterQ.length === 0) return out;
+		for (const t of store.doc.tables) {
+			if (t.columns.some((c) => c.name.toLowerCase().includes(tableFilterQ))) {
+				out.add(t.id);
+			}
+		}
+		return out;
+	});
+
+	function toggleJoinGroupRow(key: string) {
+		const next = new Set(collapsedJoinGroupRows);
+		if (next.has(key)) next.delete(key);
+		else next.add(key);
+		collapsedJoinGroupRows = next;
+	}
+
+	function toggleTableCollapsed(tableId: string) {
+		const next = new Set(collapsedTables);
+		if (next.has(tableId)) next.delete(tableId);
+		else next.add(tableId);
+		collapsedTables = next;
+	}
+
+	// Default-collapse join-group rows so the pane reads as a compact
+	// label list at first glance (mirrors Step 1's joins panel).
+	const seenJoinGroupKeys = new Set<string>();
+	$effect(() => {
+		const next = new Set(collapsedJoinGroupRows);
+		let changed = false;
+		for (const g of joinGroupsRail) {
+			if (!seenJoinGroupKeys.has(g.key)) {
+				seenJoinGroupKeys.add(g.key);
+				next.add(g.key);
+				changed = true;
+			}
+		}
+		if (changed) collapsedJoinGroupRows = next;
+	});
+
+	// Default-collapse tables for the same reason — when the user lands
+	// on the workbench they should see EVERY on-canvas table as a tight
+	// name list, not a wall of columns.  Each table id is tracked once
+	// so re-expanding then dropping new tables on the canvas (Step 1)
+	// doesn't re-collapse the ones the user already opened.
+	const seenTableIds = new Set<string>();
+	$effect(() => {
+		const next = new Set(collapsedTables);
+		let changed = false;
+		for (const t of store.doc.tables) {
+			if (!seenTableIds.has(t.id)) {
+				seenTableIds.add(t.id);
+				next.add(t.id);
+				changed = true;
+			}
+		}
+		if (changed) collapsedTables = next;
+	});
+
+	// ── Center: view toggle (cards ↔ tree ↔ columns) ────────────────
+	// Persisted per-user in localStorage so a refresh doesn't reset the
+	// analyst's chosen layout.
+	//   - cards: dim cards + right Measures rail (legacy)
+	//   - tree:  Mondrian-style outline + right Measures rail
+	//   - columns: Miller-style swappable panes (the new default; ships
+	//     the IA closest to how Saiku consumes a cube)
+	// 'facts' used to be a separate view mode; it's now a collapsible
+	// section inside Columns, so any persisted 'facts' falls back to
+	// 'columns' on load.
+	type ViewMode = 'cards' | 'tree' | 'columns';
+	const VIEW_MODE_STORAGE_KEY = 'saiku.workbench.viewMode';
+	function loadInitialViewMode(): ViewMode {
+		if (typeof localStorage === 'undefined') return 'columns';
+		const raw = localStorage.getItem(VIEW_MODE_STORAGE_KEY);
+		if (raw === 'cards' || raw === 'tree' || raw === 'columns') return raw;
+		return 'columns';
+	}
+	let viewMode = $state<ViewMode>(loadInitialViewMode());
+	$effect(() => {
+		if (typeof localStorage === 'undefined') return;
+		try {
+			localStorage.setItem(VIEW_MODE_STORAGE_KEY, viewMode);
+		} catch {
+			// localStorage may be unavailable (private browsing, quota).
+			// Tolerate silently — the in-memory choice still works for
+			// the session.
+		}
+	});
+
+	// ── Columns view: 3 swappable Miller-style panes ────────────────
+	// Each slot can render one of a few pane kinds.  Defaults match the
+	// common authoring path (dims → drill into hier levels → measures
+	// alongside).  Per-user persistence comes later; for now this is
+	// component-local so the prototype is reversible.
+	// POC pane set, set-theoretically faithful:
+	//   - dimensions: list of D (the user's named dim collection)
+	//   - attributes: defines A ⊆ T for the selected dim (checkbox UI)
+	//   - hierarchies: list of h_j (each a subset of A) for the selected
+	//     dim — each row exposes its OWN content drop zone on the right
+	//     so the "Hierarchy content" pane folded into this one (the
+	//     drag-and-drop target IS the hierarchy row itself).
+	type PaneKind = 'dimensions' | 'attributes' | 'hierarchies';
+	// Default loadout: the cube tree pane (dims + measures together —
+	// Saiku renders them as siblings under the cube, so the authoring
+	// surface mirrors that), then a Levels pane to drill into the
+	// selected hierarchy, then a Properties inspector.  Variable-length
+	// — users add/remove columns from the top "Add column" menu, and
+	// each pane has its own delete X.  No hard cap; the layout flexes
+	// to fill the width.
+	// Fixed 4-pane set: Source / Attributes / Hierarchies / Content.
+	// Order is user-controllable via the grip drag-handle on each
+	// header; the kind set itself isn't user-mutable (no Add column,
+	// no per-pane kind picker, no remove X).  Reorder lives on; the
+	// Add-column-menu, the kind dropdown, and the X were dropped once
+	// the design locked to four panes.
+	let columnSlots = $state<PaneKind[]>(['dimensions', 'attributes', 'hierarchies']);
+
+	// ── Pane drag-to-reorder ────────────────────────────────────────
+	// HTML5 DnD with a distinct MIME so it doesn't collide with column /
+	// table / join-group drags (those mimes route to handleDragOver +
+	// the existing zone handlers).  `paneDragIndex` tracks the source
+	// for cursor styling; `paneDragOverIndex` tracks the hover target
+	// for the dashed-ring cue.
+	let paneDragIndex = $state<number | null>(null);
+	let paneDragOverIndex = $state<number | null>(null);
+
+	function handlePaneDragStart(e: DragEvent, idx: number) {
+		if (!e.dataTransfer) return;
+		e.dataTransfer.setData(PANE_REORDER_MIME, String(idx));
+		e.dataTransfer.effectAllowed = 'move';
+		paneDragIndex = idx;
+	}
+	function handlePaneDragOver(e: DragEvent, idx: number) {
+		if (!isPaneReorderDrag(e)) return;
+		e.preventDefault();
+		if (e.dataTransfer) e.dataTransfer.dropEffect = 'move';
+		paneDragOverIndex = idx;
+	}
+	function handlePaneDragLeave(idx: number) {
+		if (paneDragOverIndex === idx) paneDragOverIndex = null;
+	}
+	function handlePaneDrop(e: DragEvent, targetIdx: number) {
+		if (!isPaneReorderDrag(e)) return;
+		e.preventDefault();
+		e.stopPropagation();
+		const raw = e.dataTransfer?.getData(PANE_REORDER_MIME) ?? '';
+		const sourceIdx = raw === '' ? null : Number(raw);
+		paneDragIndex = null;
+		paneDragOverIndex = null;
+		if (sourceIdx === null || !Number.isInteger(sourceIdx) || sourceIdx === targetIdx) return;
+		const next = [...columnSlots];
+		const [moved] = next.splice(sourceIdx, 1);
+		next.splice(targetIdx, 0, moved);
+		columnSlots = next;
+	}
+	function handlePaneDragEnd() {
+		paneDragIndex = null;
+		paneDragOverIndex = null;
+	}
+	const PANE_KIND_LABELS: Record<PaneKind, string> = {
+		dimensions: 'Dimensions',
+		attributes: 'Attributes',
+		hierarchies: 'Hierarchies'
+	};
+	const PANE_KIND_ICONS: Record<PaneKind, typeof Layers> = {
+		dimensions: Layers,
+		attributes: Database,
+		hierarchies: ListTree
+	};
+	// Cross-pane selection state — clicking an item in one pane lights
+	// up the others (Levels reads the selected hierarchy, Properties
+	// reads whatever was last clicked).
+	let selectedDimensionId = $state<string | null>(null);
+	let selectedHierarchyId = $state<string | null>(null);
+	let selectedMeasureId = $state<string | null>(null);
+	// ── Focus subject — the LAST clicked thing across all panes.  This
+	// is what "bright green = actively selected" tracks, and what the
+	// Inspector renders.  When focus moves to a hierarchy, the parent
+	// dim's row fades from green to grey (context, not active).  Click
+	// empty pane background → focusSubject = null, all rows plain. ──
+	type FocusKind = 'dim' | 'hierarchy' | 'attribute' | 'measure' | 'mg' | 'cube' | 'calc';
+	let focusSubject = $state<{ kind: FocusKind; id: string } | null>(null);
+	function focus(kind: FocusKind, id: string) {
+		focusSubject = { kind, id };
+	}
+	function isFocused(kind: FocusKind, id: string | null | undefined): boolean {
+		return id != null && focusSubject?.kind === kind && focusSubject.id === id;
+	}
+	// Grey "last-selected here" — this pane still has a row selected in
+	// state, but focus has moved elsewhere.  Used to keep the user's
+	// parent-chain visible without competing with the active subject.
+	function isContext(kind: FocusKind, id: string | null | undefined): boolean {
+		if (id == null) return false;
+		if (focusSubject?.kind === kind && focusSubject.id === id) return false;
+		if (kind === 'dim') return selectedDimensionId === id;
+		if (kind === 'hierarchy') return selectedHierarchyId === id;
+		if (kind === 'measure') return selectedMeasureId === id;
+		return false;
+	}
+	// Attributes have no stable id (they're `{tableId, columnName}` pairs
+	// inside a dimension's attributes[] array), so the selection key is a
+	// composite "<tableId>::<columnName>".  Cleared whenever the active
+	// dimension changes.
+	let selectedAttributeKey = $state<string | null>(null);
+	// Level chip selected in the Hierarchies pane (unique level id) — routes the
+	// inspector to the <Level> branch. Cleared alongside selectedAttributeKey.
+	let selectedLevelId = $state<string | null>(null);
+	// Tracks whether the current `selectedHierarchyId` was set by an
+	// explicit user click (`true`) or by the auto-select-first-hierarchy
+	// effect below (`false`).  The Inspector reads this to decide whether
+	// to show <Hierarchy> props or fall back to <Dimension> props: when a
+	// user just clicks a dim row, they expect the dim's properties — not
+	// the auto-selected first hierarchy's.  Only an explicit hier click in
+	// the Hierarchies pane flips this back to true.
+	let hierarchyExplicitlyClicked = $state<boolean>(false);
+	// First-visit / cross-tab default selection lives in the per-tab
+	// inspector memory block further down (search "Per-tab inspector
+	// memory"). That block covers this file's original one-shot "snap to
+	// first dim on mount" behaviour AND its F&M equivalent, plus the
+	// D&H ↔ F&M snapshot/restore.
+	$effect(() => {
+		const dim = selectedDimensionId
+			? store.dimensions.find((d) => d.id === selectedDimensionId)
+			: null;
+		if (dim && selectedHierarchyId === null && dim.hierarchies.length > 0) {
+			selectedHierarchyId = dim.hierarchies[0].id;
+			// Auto-selection — Inspector should still show the dim, not the hier.
+			hierarchyExplicitlyClicked = false;
+		}
+	});
+	// Dimensions pane has two modes mirroring the source-picker drawing:
+	//   - edit:  source checklist (tables + join groups).  Checking
+	//            creates a dim bound to the source; unchecking deletes
+	//            the dim.  Includes a per-pane search.
+	//   - saved: the numbered list of dims with renamable labels and a
+	//            tiny subtitle naming the original source.
+	// Defaults to 'saved' when the doc was loaded with existing dims
+	// (Step 2 reopened on a cube that's already partly authored) and to
+	// 'edit' when nothing's saved yet — so the empty state reads as
+	// "pick something" rather than a blank list.
+	let dimensionPaneMode = $state<'edit' | 'saved'>(store.dimensions.length > 0 ? 'saved' : 'edit');
+	// Which source row in the dim picker is currently expanded to preview its
+	// columns/attributes.  One at a time — clicking another row collapses the
+	// previous one.  Click on the row body toggles; click on the checkbox is
+	// stopped so checking doesn't also toggle the preview.
+	let dimensionPreviewKey = $state<string | null>(null);
+	let dimensionPaneFilter = $state('');
+	// Manual "Add Dimension" form at the bottom of the edit pane.
+	// Fast path (per-source +Add dim button) auto-names after the source;
+	// this path lets the user type a semantic name up front and pick a
+	// source from a dropdown.  Both routes end up calling the same
+	// createDimFromTable / createDimFromJoinGroup helpers.
+	let manualAddDimOpen = $state(false);
+	let manualAddDimName = $state('');
+	let manualAddDimSourceKey = $state('');
+	function resetManualAddDim(): void {
+		manualAddDimOpen = false;
+		manualAddDimName = '';
+		manualAddDimSourceKey = '';
+	}
+
+	// ── Bottom inspector panel (Properties / Code) ──────────────────
+	// Resizable + hideable.  Tabs:
+	//   - properties: editable fields for whatever the user has
+	//     selected (dim / hier).
+	//   - code:       Mondrian XML of the whole cube — read-only
+	//     "what's getting exported" view.
+	// Height + collapsed + active tab persist in localStorage so the
+	// analyst's layout sticks across refresh.
+	// Inspector tabs are now Properties + Code only.  Sample-data,
+	// try-query and cubes-linkage moved to the top-level `Validate` tab
+	// (they used to live inside the Inspector as sub-tabs which made the
+	// drawer feel like a mini-app).  Legacy persisted values fall back
+	// to `properties` in loadInspectorTab.
+	type InspectorTab = 'properties' | 'code' | 'sample-data' | 'try-query' | 'cubes';
+	const INSPECTOR_TABS: readonly InspectorTab[] = ['properties', 'code'] as const;
+	/** Sub-tab within the top-level `Confirm cube` view.  The three
+	 *  original tabs (Sample data / Try query / Cubes linkage) used to
+	 *  be Inspector tabs.  `canvas` + `tree` were added per #1065 to
+	 *  give the cube author a spatial view of what they built and a
+	 *  schema-wide outline.  `canvas` is the default landing so a fresh
+	 *  Confirm-cube visit shows the shape of the selected cube first. */
+	type ValidateTab = 'canvas' | 'sample-data' | 'try-query';
+	const VALIDATE_TABS: readonly ValidateTab[] = ['canvas', 'sample-data', 'try-query'];
+	// Physical (tables + FK↔PK) vs Semantic (DAG: fact → MG → dim →
+	// hierarchies → levels) toggle inside the Confirm cube > Model
+	// sub-tab.  Both are lenses on the same cube; the toggle picks
+	// which renderer mounts.  Defaults to semantic per Amelia's
+	// preference — the semantic view reads as "what the cube IS",
+	// physical is the "how it wires up" second look.
+	type ModelViewMode = 'semantic' | 'physical';
+	const MODEL_VIEW_KEY = 'saiku.workbench.confirmCubeModelView';
+	function loadModelView(): ModelViewMode {
+		if (typeof window === 'undefined') return 'semantic';
+		const v = window.localStorage.getItem(MODEL_VIEW_KEY);
+		return v === 'physical' ? 'physical' : 'semantic';
+	}
+	let modelViewMode = $state<ModelViewMode>(loadModelView());
+	// Bump counter for "Reset positions" — one signal watched by whichever
+	// renderer (CubeDag / ConfirmCubeCanvas) is mounted in the Model tab.
+	let modelResetTs = $state<number>(0);
+	// Bump counter for "force re-derive on tab entry" (#1088).  Deep
+	// mutations in Facts & Measures (e.g. FK column swap) don't always
+	// propagate cleanly through the local `factsMeasureGroups` proxy
+	// into the Confirm cube renderer.  Bumping this whenever the user
+	// enters the validate view forces every downstream `$derived` /
+	// `$effect` that watches it to re-run against the latest MG shape.
+	let confirmCubeRefreshTs = $state<number>(0);
+	$effect(() => {
+		if (store.mode === 'validate') {
+			untrack(() => {
+				confirmCubeRefreshTs = confirmCubeRefreshTs + 1;
+			});
+		}
+	});
+	// Right-panel tree outline state — whole-panel collapse + per-section
+	// collapse.  Sections default open; user preference persists per
+	// session via localStorage.
+	const OUTLINE_COLLAPSED_KEY = 'saiku.workbench.confirmCubeOutlineCollapsed';
+	const OUTLINE_SECTIONS_KEY = 'saiku.workbench.confirmCubeOutlineSections';
+	function loadOutlineCollapsed(): boolean {
+		if (typeof window === 'undefined') return false;
+		return window.localStorage.getItem(OUTLINE_COLLAPSED_KEY) === '1';
+	}
+	function loadOutlineSections(): Set<'facts' | 'mgs' | 'dims'> {
+		if (typeof window === 'undefined') return new Set();
+		try {
+			const raw = window.localStorage.getItem(OUTLINE_SECTIONS_KEY);
+			if (!raw) return new Set();
+			const arr = JSON.parse(raw) as string[];
+			return new Set(
+				arr.filter(
+					(s): s is 'facts' | 'mgs' | 'dims' => s === 'facts' || s === 'mgs' || s === 'dims'
+				)
+			);
+		} catch {
+			return new Set();
+		}
+	}
+	let outlineCollapsed = $state<boolean>(loadOutlineCollapsed());
+	let outlineCollapsedSections = $state<Set<'facts' | 'mgs' | 'dims'>>(loadOutlineSections());
+	$effect(() => {
+		if (typeof window === 'undefined') return;
+		try {
+			window.localStorage.setItem(OUTLINE_COLLAPSED_KEY, outlineCollapsed ? '1' : '0');
+			window.localStorage.setItem(
+				OUTLINE_SECTIONS_KEY,
+				JSON.stringify([...outlineCollapsedSections])
+			);
+		} catch {
+			// ignore
+		}
+	});
+	function toggleOutlineSection(s: 'facts' | 'mgs' | 'dims'): void {
+		const next = new Set(outlineCollapsedSections);
+		if (next.has(s)) next.delete(s);
+		else next.add(s);
+		outlineCollapsedSections = next;
+	}
+	$effect(() => {
+		if (typeof window === 'undefined') return;
+		try {
+			window.localStorage.setItem(MODEL_VIEW_KEY, modelViewMode);
+		} catch {
+			// ignore
+		}
+	});
+	const VALIDATE_TAB_KEY = 'saiku.workbench.validateTab';
+	function loadValidateTab(): ValidateTab {
+		if (typeof window === 'undefined') return 'canvas';
+		const v = window.localStorage.getItem(VALIDATE_TAB_KEY);
+		return VALIDATE_TABS.includes(v as ValidateTab) ? (v as ValidateTab) : 'canvas';
+	}
+	let validateTab = $state<ValidateTab>(loadValidateTab());
+
+	// Copy-to-clipboard flash for the inspector code panel.  Flips to
+	// true for ~1.2s after a successful write so the button label reads
+	// "Copied" as feedback.
+	let codeCopyFlash = $state<boolean>(false);
+	let codeCopyTimer: ReturnType<typeof setTimeout> | null = null;
+	// Code-tab format toggle (#1080): show the schema as Mondrian 4 XML or the
+	// equivalent M4 YAML (both from the one XML emitter → no drift).
+	let codeFormat = $state<'xml' | 'yaml'>('xml');
+	async function copyInspectorCode(xml: string) {
+		try {
+			await navigator.clipboard.writeText(xml);
+			codeCopyFlash = true;
+			if (codeCopyTimer) clearTimeout(codeCopyTimer);
+			codeCopyTimer = setTimeout(() => {
+				codeCopyFlash = false;
+			}, 1200);
+		} catch {
+			// Silent — clipboard write can reject on non-secure contexts.
+		}
+	}
+
+	// Cube-panel local UI state.  Draft only — permissions aren't wired
+	// to the backend yet.  Structure mirrors the schema ACL (workspace-
+	// role grants + a visibility toggle) so this maps 1:1 when the API
+	// lands.  See #1029 for the underlying cube ACL work.
+	let cubePermissionsOpen = $state<boolean>(false);
+	let cubeNewFormOpen = $state<boolean>(false);
+	let cubeNewFormName = $state<string>('');
+	let cubeNewFormVisibility = $state<'private' | 'workspace' | 'public'>('workspace');
+	let cubeNewFormGroups = $state<string>('');
+	$effect(() => {
+		if (typeof window !== 'undefined') {
+			localStorage.setItem(VALIDATE_TAB_KEY, validateTab);
+		}
+	});
+	// Columns view layout — two stacked sections (Dimensions + Facts) on
+	// the left, an Inspector drawer on the right.  Each main section
+	// collapses to a strip via its chevron; the drawer collapses to a
+	// thin vertical strip.  Fractions/widths persist so the layout
+	// sticks across refresh.
+	const DIM_FACTS_FRACTION_KEY = 'saiku.workbench.dimFactsFraction';
+	const DIM_SECTION_COLLAPSED_KEY = 'saiku.workbench.dimCollapsed';
+	const FACTS_SECTION_COLLAPSED_KEY = 'saiku.workbench.factsCollapsed';
+	const INSPECTOR_DRAWER_WIDTH_KEY = 'saiku.workbench.inspectorDrawerWidth';
+	const INSPECTOR_COLLAPSED_KEY = 'saiku.workbench.inspectorCollapsed';
+	const INSPECTOR_TAB_KEY = 'saiku.workbench.inspectorTab';
+	function loadDimFactsFraction(): number {
+		const DEFAULT = 0.65; // Dimensions gets the lion's share by default
+		if (typeof localStorage === 'undefined') return DEFAULT;
+		const raw = localStorage.getItem(DIM_FACTS_FRACTION_KEY);
+		const n = raw ? Number(raw) : NaN;
+		return Number.isFinite(n) && n >= 0.1 && n <= 0.9 ? n : DEFAULT;
+	}
+	function loadBoolLS(key: string, fallback: boolean): boolean {
+		if (typeof localStorage === 'undefined') return fallback;
+		const raw = localStorage.getItem(key);
+		if (raw === 'true') return true;
+		if (raw === 'false') return false;
+		return fallback;
+	}
+	function loadInspectorDrawerWidth(): number {
+		const DEFAULT = 400;
+		if (typeof localStorage === 'undefined') return DEFAULT;
+		const raw = localStorage.getItem(INSPECTOR_DRAWER_WIDTH_KEY);
+		const n = raw ? Number(raw) : NaN;
+		return Number.isFinite(n) && n >= 240 && n <= 4000 ? n : DEFAULT;
+	}
+	// Inspector moved from the RIGHT-hand column to a BOTTOM row.  Height
+	// takes over the role width used to play.  Range guarded so the top
+	// panes always keep at least ~200px of vertical room.
+	const INSPECTOR_DRAWER_HEIGHT_KEY = 'saiku.workbench.inspectorDrawerHeight';
+	function loadInspectorDrawerHeight(): number {
+		const DEFAULT = 280;
+		if (typeof localStorage === 'undefined') return DEFAULT;
+		const raw = localStorage.getItem(INSPECTOR_DRAWER_HEIGHT_KEY);
+		const n = raw ? Number(raw) : NaN;
+		// Runtime cap is dynamic (viewport-relative); persistence just
+		// enforces sanity (positive + not absurd).
+		return Number.isFinite(n) && n >= 160 && n <= 4000 ? n : DEFAULT;
+	}
+	function loadInspectorTab(): InspectorTab {
+		if (typeof localStorage === 'undefined') return 'properties';
+		const v = localStorage.getItem(INSPECTOR_TAB_KEY);
+		return INSPECTOR_TABS.includes(v as InspectorTab) ? (v as InspectorTab) : 'properties';
+	}
+	let dimFactsFraction = $state<number>(loadDimFactsFraction());
+	// Defaults: BOTH stacked sections (Dimensions + Facts/Measures) expanded
+	// at roughly half height each, and the Inspector drawer visible — first
+	// landing should already show the workbench's full surface area so the
+	// user doesn't have to hunt for the panes that matter.  Returning users
+	// retain whatever they last toggled (loadBoolLS reads localStorage first).
+	let dimSectionCollapsed = $state<boolean>(loadBoolLS(DIM_SECTION_COLLAPSED_KEY, false));
+	let factsSectionCollapsed = $state<boolean>(loadBoolLS(FACTS_SECTION_COLLAPSED_KEY, false));
+	let inspectorCollapsed = $state<boolean>(loadBoolLS(INSPECTOR_COLLAPSED_KEY, false));
+	let inspectorDrawerWidth = $state<number>(loadInspectorDrawerWidth());
+	let inspectorDrawerHeight = $state<number>(loadInspectorDrawerHeight());
+	// Inspector docking side — user's choice.  Mirrors the "docked to
+	// side / bottom" toggle DevTools has.  Persisted so it survives
+	// reloads.  Chevrons + resize handles + collapsed strip flip
+	// orientation based on this.
+	const INSPECTOR_POSITION_KEY = 'saiku.workbench.inspectorPosition';
+	type InspectorPosition = 'bottom' | 'right';
+	function loadInspectorPosition(): InspectorPosition {
+		if (typeof localStorage === 'undefined') return 'bottom';
+		const v = localStorage.getItem(INSPECTOR_POSITION_KEY);
+		return v === 'right' || v === 'bottom' ? v : 'bottom';
+	}
+	let inspectorPosition = $state<InspectorPosition>(loadInspectorPosition());
+	$effect(() => {
+		if (typeof localStorage !== 'undefined') {
+			localStorage.setItem(INSPECTOR_POSITION_KEY, inspectorPosition);
+		}
+	});
+	$effect(() => {
+		// Both stacked sections can't be collapsed simultaneously — leave
+		// at least one expanded so the main area isn't empty.
+		if (dimSectionCollapsed && factsSectionCollapsed) {
+			factsSectionCollapsed = false;
+		}
+	});
+	// Top-level tab selection drives which stacked section is visible:
+	// `workbench` → dim visible, facts collapsed; `facts` → the reverse.
+	// The collapse buttons stay hidden in these modes so the user picks
+	// tabs at the top, not stack-collapse chevrons inside the view.
+	$effect(() => {
+		if (store.mode === 'workbench') {
+			dimSectionCollapsed = false;
+			factsSectionCollapsed = true;
+		} else if (store.mode === 'facts') {
+			dimSectionCollapsed = true;
+			factsSectionCollapsed = false;
+		}
+	});
+	let inspectorTab = $state<InspectorTab>(loadInspectorTab());
+	// Maximize the Inspector drawer to cover the whole workbench body so
+	// the Sample-data table / Try-a-query result has room to breathe.
+	// Session-only — purposely doesn't persist; the user opts in each
+	// time they want to drill into the inspector's content.
+	let inspectorMaximized = $state<boolean>(false);
+	let workbenchBodyEl = $state<HTMLDivElement | null>(null);
+	let inspectorDrawerEl = $state<HTMLDivElement | null>(null);
+
+	// ── Facts-mode prototype state ────────────────────────────────────
+	// Visual sketch only — not wired to the doc, but persisted in
+	// localStorage so the chosen fact table, measures, groups and
+	// calculations survive reloads (the dim side persists via the
+	// store; the facts prototype persists here).
+	// Editorial: calculated measures will probably move to a
+	// cube-level (or workspace-level) catalog one day rather than live
+	// nested inside a measure group.  Mondrian allows both; we'll keep
+	// them nested for the prototype since that maps 1-1 to Amelia's
+	// sketch, but the helpers below are pure so the eventual lift is
+	// just relocating storage.
+	//
+	// A calculation has two builder modes the user can flip between:
+	//   - `build`      — drag/click chips: alternating measure / op
+	//                    tokens that always stay well-formed.
+	//   - `expression` — free-text formula for anything the chip
+	//                    builder can't express (CASE, IIF, ratios with
+	//                    constants, etc.).
+	// Switching build→expression seeds the textarea with the rendered
+	// chip formula so nothing is lost.  Switching back warns first.
+	// FactsCalcToken / FactsCalcMode / FactsCalc / FactsMeasureGroup and the
+	// WorkbenchCube model live in ./workbench-cubes (imported above).
+	const FACTS_STATE_KEY = 'saiku.workbench.factsPrototypeState';
+	type FactsPersistedState = {
+		editMode: boolean;
+		selectedTableId: string | null;
+		tableConfirmed: boolean;
+		selectedMeasures: string[];
+		tableSearch: string;
+		measureGroups: FactsMeasureGroup[];
+		selectedGroupId: string | null;
+		groupsEditMode: boolean;
+		// Cube-scope calc storage — Mondrian 4 puts <CalculatedMember>
+		// at <Cube>, not nested under <MeasureGroup>, so a calc can
+		// reference any measure on any group.  Pre-refactor persisted
+		// states had calcs nested in each measure group; loadFactsState
+		// migrates them up into this flat array.
+		factsCalcs: FactsCalc[];
+		selectedCalcId: string | null;
+		calcsEditMode: boolean;
+		slots: FactsPaneKind[];
+		groupSeq: number;
+		calcSeq: number;
+	};
+	// Feature flag — drag-a-measure-group → calc formula drop.  When the
+	// user dropped a group onto a calc, every measure in the group was
+	// pushed as a `+`-joined chip sequence.  Powerful for sum-of-group
+	// calcs, but it caught newer users out — one drop suddenly produced
+	// 4–8 chips and a formula they didn't ask for.  Off by default; flip
+	// to `true` here to re-enable.  No user-visible toggle yet — see
+	// saiku-cloud#965 for the eventual UI when the workbench has a
+	// settings drawer to host it.
+	const ALLOW_GROUP_DROP_ON_CALC = false;
+	// Legacy persisted shape we still need to read on first load to
+	// migrate calcs out of measure groups.  Newer writes never include
+	// `calculations` on a group.
+	type LegacyFactsMeasureGroup = FactsMeasureGroup & {
+		calculations?: FactsCalc[];
+		measureCaptions?: Record<string, string>;
+	};
+	function loadFactsState(): Partial<FactsPersistedState> {
+		if (typeof localStorage === 'undefined') return {};
+		try {
+			const raw = localStorage.getItem(FACTS_STATE_KEY);
+			if (!raw) return {};
+			const parsed = JSON.parse(raw) as Partial<
+				Omit<FactsPersistedState, 'measureGroups'> & {
+					measureGroups: LegacyFactsMeasureGroup[];
+				}
+			>;
+			// Splat any legacy in-group calcs up to the cube-scope array
+			// and strip them from the groups.  Also ensure each calc has
+			// the `tokens` array (legacy used `formula`).
+			const migratedCalcs: FactsCalc[] = Array.isArray(parsed.factsCalcs) ? parsed.factsCalcs : [];
+			if (Array.isArray(parsed.measureGroups)) {
+				for (const g of parsed.measureGroups) {
+					if (!Array.isArray(g.measureColumns)) g.measureColumns = [];
+					if (!g.measureCaptions || typeof g.measureCaptions !== 'object') {
+						g.measureCaptions = {};
+					}
+					if (Array.isArray(g.calculations)) {
+						for (const c of g.calculations) migratedCalcs.push(c);
+						delete g.calculations;
+					}
+				}
+			}
+			for (const c of migratedCalcs) {
+				if (!Array.isArray(c.tokens)) c.tokens = [];
+			}
+			const result: Partial<FactsPersistedState> = {
+				...parsed,
+				factsCalcs: migratedCalcs,
+				measureGroups: parsed.measureGroups as FactsMeasureGroup[] | undefined
+			};
+			return result;
+		} catch {
+			return {};
+		}
+	}
+	// ── Cubes (Mondrian 4) ────────────────────────────────────────────
+	// A schema can declare multiple cubes; each cube owns its measure
+	// groups, dim-link mapping (which dimensions the cube binds + via
+	// which FK column on the fact table), and calculated members.  v1
+	// keeps the workbench pane layout single-cube — the selected cube's
+	// state hydrates the existing `factsX` live variables via switchCube.
+	// Per-MG `factTableId` lets Mondrian 4's "different MG, different
+	// fact table" pattern be modelled even if the v1 UI defaults all MGs
+	// in a cube to the cube's currently-picked fact.
+	// MeasureGroupDimLink / WorkbenchMeasureGroup / WorkbenchCube live in
+	// ./workbench-cubes (imported above) so the doc⇄workbench mapping is
+	// unit-testable outside a Svelte render harness.
+	type CubesPersistedState = {
+		cubes: WorkbenchCube[];
+		selectedCubeId: string;
+	};
+	function loadCubesState(): CubesPersistedState {
+		// The durable cube model now lives on the doc — the store migrates
+		// any legacy `saiku.workbench.cubesState` into `doc.cubes` on load,
+		// so hydrating from the doc is enough for external (DimSum / import)
+		// writes to appear on a WorkbenchView remount.
+		const docCubes = store.cubes;
+		if (docCubes.length > 0) {
+			const cubes = docCubes.map(cubeFromDoc);
+			return { cubes, selectedCubeId: cubes[0].id };
+		}
+		// Legacy fallback: the even-older single-cube facts prototype under
+		// FACTS_STATE_KEY.  Wrap it into a freshly-named "Cube 1".
+		const legacy = loadFactsState();
+		const cube: WorkbenchCube = {
+			...blankCube('cube-1', 'Cube 1'),
+			editMode: legacy.editMode ?? true,
+			selectedTableId: legacy.selectedTableId ?? null,
+			tableConfirmed: legacy.tableConfirmed ?? false,
+			selectedMeasures: legacy.selectedMeasures ?? [],
+			tableSearch: legacy.tableSearch ?? '',
+			measureGroups: (legacy.measureGroups ?? []).map((g) => ({
+				...g,
+				factTableId: legacy.selectedTableId ?? null,
+				dimensionLinks: []
+			})),
+			selectedGroupId: legacy.selectedGroupId ?? null,
+			groupsEditMode: legacy.groupsEditMode ?? true,
+			groupSeq: legacy.groupSeq ?? 0,
+			factsCalcs: legacy.factsCalcs ?? [],
+			selectedCalcId: legacy.selectedCalcId ?? null,
+			calcsEditMode: legacy.calcsEditMode ?? true,
+			calcSeq: legacy.calcSeq ?? 0
+		};
+		return { cubes: [cube], selectedCubeId: cube.id };
+	}
+	const _cubesInit = loadCubesState();
+	let cubes = $state<WorkbenchCube[]>(_cubesInit.cubes);
+	// Prefer the store's active cube so the selection SURVIVES the
+	// DimSum-triggered remount (workbenchKey bump); fall back to the loaded
+	// default. store.activeCubeId is kept in sync by the effect below.
+	const _resolvedSelectedCubeId =
+		store.activeCubeId && _cubesInit.cubes.some((c) => c.id === store.activeCubeId)
+			? store.activeCubeId
+			: _cubesInit.selectedCubeId;
+	let selectedCubeId = $state<string>(_resolvedSelectedCubeId);
+	// Guard the persist effect against spurious writes: only push to
+	// `store.setCubes` when the trimmed doc shape actually changed (UI-only
+	// edits like search text / edit-mode toggles must NOT dirty the doc).
+	// Seeded with the current mapping so the first post-mount run is a no-op.
+	let lastPersistedCubesJson = JSON.stringify(_cubesInit.cubes.map(cubeToDoc));
+	// Mirror the selected cube into the store: keeps it stable across remounts
+	// and lets the DimSum chat (SchemaCanvasView) reset when the cube changes.
+	$effect(() => {
+		store.activeCubeId = selectedCubeId;
+	});
+	const _liveCubeInit =
+		_cubesInit.cubes.find((c) => c.id === _resolvedSelectedCubeId) ?? _cubesInit.cubes[0];
+	// _factsInit kept under the same name so the existing factsX state
+	// initializers below don't need to change.  Populated from the live
+	// cube's snapshot.  Any future cube-level field that wants to wire
+	// into the live state just adds itself here.
+	const _factsInit: Partial<FactsPersistedState> = {
+		editMode: _liveCubeInit.editMode,
+		selectedTableId: _liveCubeInit.selectedTableId,
+		tableConfirmed: _liveCubeInit.tableConfirmed,
+		selectedMeasures: _liveCubeInit.selectedMeasures,
+		tableSearch: _liveCubeInit.tableSearch,
+		measureGroups: _liveCubeInit.measureGroups as FactsMeasureGroup[],
+		selectedGroupId: _liveCubeInit.selectedGroupId,
+		groupsEditMode: _liveCubeInit.groupsEditMode,
+		factsCalcs: _liveCubeInit.factsCalcs,
+		selectedCalcId: _liveCubeInit.selectedCalcId,
+		calcsEditMode: _liveCubeInit.calcsEditMode,
+		groupSeq: _liveCubeInit.groupSeq,
+		calcSeq: _liveCubeInit.calcSeq
+	};
+	let factsEditMode = $state<boolean>(_factsInit.editMode ?? true);
+	let factsSelectedTableId = $state<string | null>(_factsInit.selectedTableId ?? null);
+	let factsTableConfirmed = $state<boolean>(_factsInit.tableConfirmed ?? false);
+	// When no fact has been picked yet — OR the previously picked table got
+	// removed from the canvas — make sure the picker list is the visible
+	// branch in the Facts & Measures pane.  Three things can leave us
+	// looking at a silently empty pane:
+	//   1. factsSelectedTableId is null (fresh workbench)
+	//   2. factsSelectedTableId points to a table no longer on the canvas
+	//      (user removed it via the schema canvas)
+	//   3. factsTableConfirmed is stale-true from a previous session even
+	//      though no table is actually selected
+	// All three reset to the same "show the picker" state here.
+	$effect(() => {
+		const stillOnCanvas = factsSelectedTableId
+			? store.doc.tables.some((t) => t.id === factsSelectedTableId)
+			: false;
+		if (!stillOnCanvas) {
+			if (factsSelectedTableId !== null) factsSelectedTableId = null;
+			if (!factsEditMode) factsEditMode = true;
+			if (factsTableConfirmed) factsTableConfirmed = false;
+		}
+	});
+	const factsSelectedMeasures = new SvelteSet<string>(_factsInit.selectedMeasures ?? []);
+	let factsTableSearch = $state<string>(_factsInit.tableSearch ?? '');
+
+	// Measure groups — the fact-side analogue of hierarchies.  A group
+	// is a named collection of measures (same fact table).  Two-column
+	// body that exactly mirrors the dim Hierarchies pane:
+	// Name list | Content (included measures).  Calculated measures
+	// live at cube scope in their own pane (factsCalcs).
+	let factsMeasureGroups = $state<WorkbenchMeasureGroup[]>(
+		(_factsInit.measureGroups ?? []) as WorkbenchMeasureGroup[]
+	);
+	let factsSelectedGroupId = $state<string | null>(_factsInit.selectedGroupId ?? null);
+	let factsGroupsEditMode = $state<boolean>(_factsInit.groupsEditMode ?? true);
+	let factsGroupSeq = _factsInit.groupSeq ?? 0;
+	function nextFactsGroupName(): string {
+		const used = new Set(factsMeasureGroups.map((g) => g.name));
+		let i = factsMeasureGroups.length + 1;
+		while (used.has(`Group ${i}`)) i++;
+		return `Group ${i}`;
+	}
+	function addFactsMeasureGroup() {
+		const g: FactsMeasureGroup = {
+			id: `mg-${++factsGroupSeq}`,
+			name: nextFactsGroupName(),
+			measureColumns: []
+		};
+		factsMeasureGroups.push(g);
+		factsSelectedGroupId = g.id;
+		focusGroupId = g.id;
+		factsEditingMeasureGroupId = g.id;
+	}
+	function removeFactsMeasureGroup(id: string) {
+		factsMeasureGroups = factsMeasureGroups.filter((g) => g.id !== id);
+		if (factsSelectedGroupId === id) factsSelectedGroupId = null;
+	}
+	function renameFactsMeasureGroup(id: string, name: string) {
+		const g = factsMeasureGroups.find((x) => x.id === id);
+		if (g) g.name = name;
+	}
+
+	// Calculated measures live at CUBE scope (Mondrian 4 puts
+	// <CalculatedMember> directly under <Cube>, alongside
+	// <MeasureGroups>).  A calc can reference any measure on any group.
+	// Flat array; helpers take (calcId, …) only.
+	let factsCalcs = $state<FactsCalc[]>(_factsInit.factsCalcs ?? []);
+	let factsSelectedCalcId = $state<string | null>(_factsInit.selectedCalcId ?? null);
+	let factsCalcsEditMode = $state<boolean>(_factsInit.calcsEditMode ?? true);
+	// Per-calc edit toggle.  null = no calc in edit mode.  Replaces
+	// the old pane-wide factsCalcsEditMode for the row-level controls
+	// (rename input, build/expression toggle, remove X) so the user
+	// can sit in read-mode on every calc except the one they're
+	// actively shaping.
+	let factsEditingCalcId = $state<string | null>(null);
+	let factsCalcSeq = _factsInit.calcSeq ?? 0;
+
+	// ── Cube CRUD + live-state swap buffer ───────────────────────────
+	// Switching cubes snapshots the leaving cube's live state into the
+	// cubes[] entry and then hydrates the entering cube's state back into
+	// the live `factsX` variables.  Persist effect (further down) maps the
+	// live state into the selected cube and writes the trimmed cube list to
+	// the doc via `store.setCubes` on every change.
+	let cubeSeq = (() => {
+		let max = 0;
+		for (const c of cubes) {
+			const m = /cube-(\d+)/.exec(c.id);
+			if (m) max = Math.max(max, parseInt(m[1], 10));
+		}
+		return max;
+	})();
+	const selectedCube = $derived(cubes.find((c) => c.id === selectedCubeId) ?? cubes[0]);
+
+	// Rewrite `linkKind` on every MG dim link so degenerate dims (dim
+	// source table === MG's fact table) get 'fact' and everything else
+	// gets 'foreign-key'.  Called ONE-SHOT on hydrate/import (below) and
+	// on the checkbox handler — NOT as a reactive $effect, because deep
+	// reactivity on `factsMeasureGroups` + mutation-inside-effect can
+	// starve the UI on large schemas.
+	onMount(() => {
+		normalizeDegenerateLinks(factsMeasureGroups);
+		for (const c of cubes) normalizeDegenerateLinks(c.measureGroups ?? []);
+	});
+	function normalizeDegenerateLinks(mgs: WorkbenchMeasureGroup[]): void {
+		const tableById = new Map(store.doc.tables.map((t) => [t.id, t]));
+		const dimById = new Map(store.dimensions.map((d) => [d.id, d]));
+		for (const mg of mgs) {
+			if (!mg.dimensionLinks) continue;
+			const fact = mg.factTableId ? tableById.get(mg.factTableId) : null;
+			for (const link of mg.dimensionLinks) {
+				const dim = dimById.get(link.dimensionId);
+				if (!dim) continue;
+				const dimSrc = dim.sourceTableId ?? dim.primaryKeyTableId;
+				const isDegenerate = !!fact && !!dimSrc && dimSrc === fact.id;
+				if (isDegenerate && link.linkKind !== 'fact') {
+					link.linkKind = 'fact';
+					if (link.foreignKeyColumn) link.foreignKeyColumn = '';
+				} else if (!isDegenerate && link.linkKind === 'fact') {
+					link.linkKind = 'foreign-key';
+				}
+			}
+		}
+	}
+	function snapshotLiveIntoCube(target: WorkbenchCube): void {
+		target.editMode = factsEditMode;
+		target.selectedTableId = factsSelectedTableId;
+		target.tableConfirmed = factsTableConfirmed;
+		target.selectedMeasures = [...factsSelectedMeasures];
+		target.tableSearch = factsTableSearch;
+		target.measureGroups = $state.snapshot(factsMeasureGroups) as WorkbenchMeasureGroup[];
+		target.selectedGroupId = factsSelectedGroupId;
+		target.groupsEditMode = factsGroupsEditMode;
+		target.groupSeq = factsGroupSeq;
+		target.factsCalcs = $state.snapshot(factsCalcs) as FactsCalc[];
+		target.selectedCalcId = factsSelectedCalcId;
+		target.calcsEditMode = factsCalcsEditMode;
+		target.calcSeq = factsCalcSeq;
+	}
+	/** The selected cube's in-flight (unsaved) `factsX` state as a plain
+	 *  snapshot object — the overlay applied to the selected cube before it
+	 *  is mapped to the durable doc shape. */
+	function liveCubeSnapshot() {
+		return {
+			editMode: factsEditMode,
+			selectedTableId: factsSelectedTableId,
+			tableConfirmed: factsTableConfirmed,
+			selectedMeasures: [...factsSelectedMeasures],
+			tableSearch: factsTableSearch,
+			measureGroups: $state.snapshot(factsMeasureGroups) as WorkbenchMeasureGroup[],
+			selectedGroupId: factsSelectedGroupId,
+			groupsEditMode: factsGroupsEditMode,
+			groupSeq: factsGroupSeq,
+			factsCalcs: $state.snapshot(factsCalcs) as FactsCalc[],
+			selectedCalcId: factsSelectedCalcId,
+			calcsEditMode: factsCalcsEditMode,
+			calcSeq: factsCalcSeq
+		};
+	}
+	/** The doc-shape cube list reflecting live (unsaved) edits — the SINGLE
+	 *  source of truth the persist path AND the inspector Code-tab preview
+	 *  both feed through `exportToMondrianXml`, so the previewed Mondrian 4
+	 *  XML is byte-identical to what a save/export emits (#1038). */
+	function liveDocCubes(): SchemaCanvasCube[] {
+		const snap = liveCubeSnapshot();
+		const liveCubes = ($state.snapshot(cubes) as WorkbenchCube[]).map((c) =>
+			c.id === selectedCubeId ? { ...c, ...snap } : c
+		);
+		return liveCubes.map(cubeToDoc);
+	}
+	/** Read-only Mondrian 4 XML for the inspector Code tab.  Runs the live
+	 *  workbench state through the CANONICAL exporter (`exportToMondrianXml`)
+	 *  — the same emitter the save/export path uses — so preview == export.
+	 *  Degrades to a comment (never throws) while the schema is incomplete
+	 *  (e.g. no fact table yet), the one state where the exporter throws. */
+	function workbenchPreviewXml(): string {
+		try {
+			return exportToMondrianXml({ ...store.doc, cubes: liveDocCubes() });
+		} catch (e) {
+			const msg = e instanceof Error ? e.message : 'Nothing to preview yet';
+			return `<?xml version="1.0" encoding="UTF-8"?>\n<!-- ${msg} -->`;
+		}
+	}
+	function hydrateLiveFromCube(source: WorkbenchCube): void {
+		factsEditMode = source.editMode;
+		factsSelectedTableId = source.selectedTableId;
+		factsTableConfirmed = source.tableConfirmed;
+		factsSelectedMeasures.clear();
+		for (const m of source.selectedMeasures) factsSelectedMeasures.add(m);
+		factsTableSearch = source.tableSearch;
+		factsMeasureGroups = source.measureGroups;
+		factsSelectedGroupId = source.selectedGroupId;
+		factsGroupsEditMode = source.groupsEditMode;
+		factsGroupSeq = source.groupSeq;
+		factsCalcs = source.factsCalcs;
+		factsSelectedCalcId = source.selectedCalcId;
+		factsCalcsEditMode = source.calcsEditMode;
+		factsCalcSeq = source.calcSeq;
+		normalizeDegenerateLinks(factsMeasureGroups);
+	}
+	function switchCube(targetId: string): void {
+		if (targetId === selectedCubeId) return;
+		const target = cubes.find((c) => c.id === targetId);
+		if (!target) return;
+		const leaving = cubes.find((c) => c.id === selectedCubeId);
+		if (leaving) snapshotLiveIntoCube(leaving);
+		hydrateLiveFromCube(target);
+		selectedCubeId = targetId;
+	}
+	function nextCubeName(): string {
+		const used = new Set(cubes.map((c) => c.name));
+		let i = cubes.length + 1;
+		while (used.has(`Cube ${i}`)) i++;
+		return `Cube ${i}`;
+	}
+	// UI state for the header cube switcher + inspector Cubes tab.
+	let cubeMenuOpen = $state<boolean>(false);
+	function addCube(): WorkbenchCube {
+		// Snapshot current cube before adding so live state isn't lost.
+		const leaving = cubes.find((c) => c.id === selectedCubeId);
+		if (leaving) snapshotLiveIntoCube(leaving);
+		const fresh = blankCube(`cube-${++cubeSeq}`, nextCubeName());
+		cubes.push(fresh);
+		hydrateLiveFromCube(fresh);
+		selectedCubeId = fresh.id;
+		return fresh;
+	}
+	function renameCube(id: string, name: string): void {
+		const c = cubes.find((x) => x.id === id);
+		if (c) c.name = name;
+	}
+	function addFactsCalc() {
+		const c: FactsCalc = {
+			id: `calc-${++factsCalcSeq}`,
+			name: '',
+			tokens: []
+		};
+		factsCalcs.push(c);
+		factsSelectedCalcId = c.id;
+		// New calcs land in edit mode so the user can type immediately.
+		factsEditingCalcId = c.id;
+	}
+
+	// Backfill factTableId on legacy MGs.  Looks at BOTH the canvas table
+	// list (store.doc.tables) AND the full source catalog (store.sourceTables)
+	// since legacy MGs often reference columns on a source table that
+	// isn't on the canvas yet.  When the unique match is source-only, the
+	// source table gets auto-added to the canvas at a free corner so the
+	// picker (which reads canvas tables) actually has it.
+	$effect(() => {
+		if (store.doc.tables.length === 0 && store.sourceTables.length === 0) return;
+		const matchesAll = (cols: string[], colSet: Set<string>) => cols.every((c) => colSet.has(c));
+		const inferOnMG = (mg: WorkbenchMeasureGroup) => {
+			if (mg.factTableId || mg.measureColumns.length === 0) return;
+			// First try canvas tables — fast path, no side-effects.
+			const onCanvas = store.doc.tables.filter((t) => {
+				const cols = new Set(t.columns.map((c) => c.name));
+				return matchesAll(mg.measureColumns, cols);
+			});
+			if (onCanvas.length === 1) {
+				mg.factTableId = onCanvas[0].id;
+				return;
+			}
+			if (onCanvas.length > 1) return; // ambiguous — let the user pick
+			// Fall through to the full source catalog.
+			const inSource = store.sourceTables.filter((t) => {
+				const cols = new Set(t.columns.map((c) => c.name));
+				return matchesAll(mg.measureColumns, cols);
+			});
+			if (inSource.length !== 1) return;
+			const cand = inSource[0];
+			// Auto-add at the bottom so an arranged canvas isn't blown up.
+			const maxY = store.doc.tables.reduce((m, t) => Math.max(m, t.position.y), 0);
+			const fresh = store.addTable(cand, { x: 40, y: maxY + 240 });
+			mg.factTableId = fresh.id;
+		};
+		for (const mg of factsMeasureGroups) inferOnMG(mg);
+		for (const cube of cubes) {
+			if (cube.id === selectedCubeId) continue;
+			for (const mg of cube.measureGroups) inferOnMG(mg);
+		}
+	});
+	// Bind a measure group to a source-catalog table.  The canvas is just
+	// the visual model — the SOURCE OF TRUTH for "what tables/columns
+	// exist" is `store.sourceTables` (the full source catalog).  If the
+	// picked source table isn't on the canvas yet, we add it transparently
+	// so factTableId (which references a canvas-id) has something to point
+	// at.  Measures already picked on the MG are filtered to those that
+	// still exist on the new fact.
+	function bindMGToSourceTable(mg: WorkbenchMeasureGroup, cand: SourceTableCandidate) {
+		const existing = store.doc.tables.find(
+			(t) => t.name === cand.name && (t.schema ?? null) === (cand.schema ?? null)
+		);
+		let tableId: string;
+		let columnNames: Set<string>;
+		if (existing) {
+			tableId = existing.id;
+			columnNames = new Set(existing.columns.map((c) => c.name));
+		} else {
+			const maxY = store.doc.tables.reduce((m, t) => Math.max(m, t.position.y), 0);
+			const fresh = store.addTable(cand, { x: 40, y: maxY + 240 });
+			tableId = fresh.id;
+			columnNames = new Set(fresh.columns.map((c) => c.name));
+		}
+		mg.factTableId = tableId;
+		mg.measureColumns = mg.measureColumns.filter((c) => columnNames.has(c));
+	}
+
+	function removeFactsCalc(calcId: string) {
+		factsCalcs = factsCalcs.filter((c) => c.id !== calcId);
+		if (factsSelectedCalcId === calcId) factsSelectedCalcId = null;
+		if (factsEditingCalcId === calcId) factsEditingCalcId = null;
+	}
+	function renameFactsCalc(calcId: string, name: string) {
+		const c = factsCalcs.find((x) => x.id === calcId);
+		if (c) c.name = name;
+	}
+	function findFactsCalc(calcId: string): FactsCalc | null {
+		return factsCalcs.find((c) => c.id === calcId) ?? null;
+	}
+	// Sequence-builder ops.  We enforce the alternating shape:
+	// measure-op-measure-op-… so the formula is always well-formed.
+	function calcLastToken(c: FactsCalc): FactsCalcToken | null {
+		return c.tokens.length === 0 ? null : c.tokens[c.tokens.length - 1];
+	}
+	function calcNeedsMeasure(c: FactsCalc): boolean {
+		const last = calcLastToken(c);
+		return last === null || last.kind === 'op';
+	}
+	function calcNeedsOperator(c: FactsCalc): boolean {
+		const last = calcLastToken(c);
+		return last !== null && last.kind === 'measure';
+	}
+	function addCalcMeasure(calcId: string, name: string, fromGroup = false) {
+		const c = findFactsCalc(calcId);
+		if (!c || !calcNeedsMeasure(c)) return;
+		c.tokens.push({ kind: 'measure', name, fromGroup });
+	}
+	function addCalcOperator(calcId: string, op: '+' | '-' | '*' | '/') {
+		const c = findFactsCalc(calcId);
+		if (!c || !calcNeedsOperator(c)) return;
+		c.tokens.push({ kind: 'op', op });
+	}
+	function popCalcToken(calcId: string) {
+		const c = findFactsCalc(calcId);
+		if (!c) return;
+		c.tokens.pop();
+	}
+	function clearCalcTokens(calcId: string) {
+		const c = findFactsCalc(calcId);
+		if (!c) return;
+		c.tokens = [];
+	}
+	function formatCalcOp(op: '+' | '-' | '*' | '/'): string {
+		return op === '*' ? '×' : op === '/' ? '÷' : op === '-' ? '−' : '+';
+	}
+	// renderCalcTokens / calcMode live in ./workbench-cubes (imported above).
+	function setCalcMode(calcId: string, mode: FactsCalcMode) {
+		const c = findFactsCalc(calcId);
+		if (!c) return;
+		if (mode === 'expression' && (c.formula ?? '') === '') {
+			c.formula = renderCalcTokens(c);
+		}
+		c.mode = mode;
+	}
+	function updateCalcFormula(calcId: string, formula: string) {
+		const c = findFactsCalc(calcId);
+		if (c) c.formula = formula;
+	}
+	// When a new measure group is born (via the Add button), its name
+	// input gets focus + text selected so the user can rename without an
+	// extra click — mirrors Hierarchies' editingHierNameId + autoFocus
+	// action.
+	let focusGroupId = $state<string | null>(null);
+	// Mirror Hierarchies' editing pattern: single click on a measure
+	// group just selects it; double click swaps to an editable input.
+	// Newly-created groups auto-enter edit mode via factsEditingMeasureGroupId
+	// being set in addFactsMeasureGroup.
+	let factsEditingMeasureGroupId = $state<string | null>(null);
+	// Group-drop helpers (`addMeasureToGroup`, `removeMeasureFromGroup`,
+	// `factsDragOverGroupId`, `readFactsMeasureMoveDrag`) were removed when
+	// the per-MG editor replaced the legacy drop-into-group pattern.  The
+	// per-MG editor toggles `measureColumns` directly on the MG object.
+	// readFactsMeasureDrag lives in ./workbench-dnd (imported above).
+	$effect(() => {
+		if (typeof localStorage === 'undefined') return;
+		try {
+			localStorage.setItem(DIM_FACTS_FRACTION_KEY, String(dimFactsFraction));
+			localStorage.setItem(DIM_SECTION_COLLAPSED_KEY, String(dimSectionCollapsed));
+			localStorage.setItem(FACTS_SECTION_COLLAPSED_KEY, String(factsSectionCollapsed));
+			localStorage.setItem(INSPECTOR_COLLAPSED_KEY, String(inspectorCollapsed));
+			localStorage.setItem(INSPECTOR_DRAWER_WIDTH_KEY, String(inspectorDrawerWidth));
+			localStorage.setItem(INSPECTOR_DRAWER_HEIGHT_KEY, String(inspectorDrawerHeight));
+			localStorage.setItem(INSPECTOR_TAB_KEY, inspectorTab);
+			// Cubes state — the durable model now lives on the doc.  Snapshot
+			// the live `factsX` variables into the selected cube, map the
+			// whole cube list to the trimmed doc shape, and push it through
+			// `store.setCubes` (which persists the doc).  Guarded on a JSON
+			// diff so UI-only edits (search text, edit-mode toggles) don't
+			// dirty the doc.  Slots stay in the legacy FACTS_STATE_KEY so
+			// loadFactsSlots() (called above this $effect) keeps working.
+			const docCubes = liveDocCubes();
+			const nextJson = JSON.stringify(docCubes);
+			if (nextJson !== lastPersistedCubesJson) {
+				lastPersistedCubesJson = nextJson;
+				store.setCubes(docCubes);
+			}
+			// Slots-only legacy payload — loadFactsSlots() reads `.slots`.
+			localStorage.setItem(FACTS_STATE_KEY, JSON.stringify({ slots: [...factsSlots] }));
+		} catch {
+			// Storage unavailable — tolerate silently.
+		}
+	});
+	// Vertical resize between Dimensions and Facts sections (inside the
+	// main stack on the left).  Pointer-based; clamps 10–90%.
+	let dimFactsResizing = $state(false);
+	function handleDimFactsResizeStart(e: PointerEvent) {
+		e.preventDefault();
+		dimFactsResizing = true;
+		const bodyEl = workbenchBodyEl;
+		if (!bodyEl) return;
+		const onMove = (ev: PointerEvent) => {
+			const rect = bodyEl.getBoundingClientRect();
+			// Dimensions section sits at top → its height = cursor.y − rect.top.
+			const topHeight = ev.clientY - rect.top;
+			const fraction = Math.max(0.1, Math.min(0.9, topHeight / rect.height));
+			dimFactsFraction = fraction;
+		};
+		const onUp = () => {
+			dimFactsResizing = false;
+			window.removeEventListener('pointermove', onMove);
+			window.removeEventListener('pointerup', onUp);
+		};
+		window.addEventListener('pointermove', onMove);
+		window.addEventListener('pointerup', onUp);
+	}
+	// Resize the Inspector drawer.  Axis depends on where it's docked:
+	//   - `bottom`: pointer distance from the outer's bottom edge → height.
+	//   - `right`:  pointer distance from the outer's right edge  → width.
+	let inspectorDrawerResizing = $state(false);
+	function handleInspectorDrawerResizeStart(e: PointerEvent) {
+		e.preventDefault();
+		inspectorDrawerResizing = true;
+		const outerEl = workbenchBodyEl?.parentElement;
+		if (!outerEl) return;
+		// Drag caps at 50% of the viewport — past that the user should
+		// hit Maximize (fullscreen) rather than nudging via drag.  Lower
+		// bounds stay wide enough to keep the drawer usable.
+		const onMove = (ev: PointerEvent) => {
+			const rect = outerEl.getBoundingClientRect();
+			if (inspectorPosition === 'bottom') {
+				const heightPx = rect.bottom - ev.clientY;
+				const max = window.innerHeight / 2;
+				inspectorDrawerHeight = Math.max(160, Math.min(max, heightPx));
+			} else {
+				const widthPx = rect.right - ev.clientX;
+				const max = window.innerWidth / 2;
+				inspectorDrawerWidth = Math.max(240, Math.min(max, widthPx));
+			}
+		};
+		const onUp = () => {
+			inspectorDrawerResizing = false;
+			window.removeEventListener('pointermove', onMove);
+			window.removeEventListener('pointerup', onUp);
+		};
+		window.addEventListener('pointermove', onMove);
+		window.addEventListener('pointerup', onUp);
+	}
+
+	// ── Tree-view RIGHT-side inspector (horizontal split) ──────────────
+	// Same Properties / Code surface as the Columns bottom inspector,
+	// but docked on the right side of the tree view and resized along
+	// the X axis.  Reuses inspectorTab + the inspectorProperties /
+	// inspectorCode snippets — only the orientation, fraction key, and
+	// collapse state are independent.
+	const TREE_INSPECTOR_FRACTION_KEY = 'saiku.workbench.treeInspectorFraction';
+	const TREE_INSPECTOR_COLLAPSED_KEY = 'saiku.workbench.treeInspectorCollapsed';
+	function loadTreeInspectorFraction(): number {
+		const DEFAULT = 0.35; // tree gets the lion's share by default
+		if (typeof localStorage === 'undefined') return DEFAULT;
+		const raw = localStorage.getItem(TREE_INSPECTOR_FRACTION_KEY);
+		const n = raw ? Number(raw) : NaN;
+		return Number.isFinite(n) && n >= 0.1 && n <= 0.9 ? n : DEFAULT;
+	}
+	function loadTreeInspectorCollapsed(): boolean {
+		if (typeof localStorage === 'undefined') return false;
+		return localStorage.getItem(TREE_INSPECTOR_COLLAPSED_KEY) === 'true';
+	}
+	let treeInspectorFraction = $state<number>(loadTreeInspectorFraction());
+	let treeInspectorCollapsed = $state<boolean>(loadTreeInspectorCollapsed());
+	let treeWorkbenchBodyEl = $state<HTMLDivElement | null>(null);
+	$effect(() => {
+		if (typeof localStorage === 'undefined') return;
+		try {
+			localStorage.setItem(TREE_INSPECTOR_FRACTION_KEY, String(treeInspectorFraction));
+			localStorage.setItem(TREE_INSPECTOR_COLLAPSED_KEY, String(treeInspectorCollapsed));
+		} catch {
+			// Storage unavailable — tolerate silently.
+		}
+	});
+	let treeInspectorResizing = $state(false);
+	function handleTreeInspectorResizeStart(e: PointerEvent) {
+		e.preventDefault();
+		treeInspectorResizing = true;
+		const bodyEl = treeWorkbenchBodyEl;
+		if (!bodyEl) return;
+		const onMove = (ev: PointerEvent) => {
+			const rect = bodyEl.getBoundingClientRect();
+			// Distance from cursor to right edge = inspector's intended width.
+			const rightWidth = rect.right - ev.clientX;
+			const fraction = Math.max(0.1, Math.min(0.9, rightWidth / rect.width));
+			treeInspectorFraction = fraction;
+		};
+		const onUp = () => {
+			treeInspectorResizing = false;
+			window.removeEventListener('pointermove', onMove);
+			window.removeEventListener('pointerup', onUp);
+		};
+		window.addEventListener('pointermove', onMove);
+		window.addEventListener('pointerup', onUp);
+	}
+
+	// ── Delete-confirmation modal ────────────────────────────────────
+	// Dim/hier deletes route through here so the user sees what they
+	// lose (attribute count, hierarchy count, member count, etc.)
+	// before a destructive action.
+	interface ConfirmDelete {
+		kind: 'dim' | 'hier';
+		dimId: string;
+		hierId?: string;
+		title: string;
+		impact: string[];
+	}
+	let confirmDelete = $state<ConfirmDelete | null>(null);
+	// requestDeleteDimension was called by the row-level "X" button that
+	// used to sit on every dim in the pane; the button is gone (deletes
+	// route through the Inspector now), so the helper is unused.  Kept
+	// the confirm-modal machinery for the hier/measure delete paths.
+	function requestDeleteHierarchy(dimId: string, hierId: string) {
+		const d = store.dimensions.find((x) => x.id === dimId);
+		const h = d?.hierarchies.find((x) => x.id === hierId);
+		if (!d || !h) return;
+		confirmDelete = {
+			kind: 'hier',
+			dimId,
+			hierId,
+			title: `Delete hierarchy "${h.name}"?`,
+			impact: [
+				`${h.levels.length} member level${h.levels.length === 1 ? '' : 's'} will be removed from this hierarchy.`,
+				`The attributes themselves stay in the dimension's set A and can be re-added to another hierarchy.`
+			]
+		};
+	}
+	function confirmDeletion() {
+		if (!confirmDelete) return;
+		if (confirmDelete.kind === 'dim') {
+			store.removeDimension(confirmDelete.dimId);
+			if (selectedDimensionId === confirmDelete.dimId) {
+				selectedDimensionId = null;
+				selectedHierarchyId = null;
+			}
+		} else if (confirmDelete.kind === 'hier' && confirmDelete.hierId) {
+			if (selectedHierarchyId === confirmDelete.hierId) selectedHierarchyId = null;
+			store.removeHierarchy(confirmDelete.dimId, confirmDelete.hierId);
+		}
+		confirmDelete = null;
+	}
+	function cancelDeletion() {
+		confirmDelete = null;
+	}
+
+	// Attribute-removal confirmation: if a hierarchy depends on the
+	// attribute (any level matches by tableId + columnName), warn the
+	// user before stripping it.  Confirming removes the attribute AND
+	// all matching levels from each affected hierarchy.
+	interface ConfirmRemoveAttribute {
+		dimId: string;
+		tableId: string;
+		columnName: string;
+		affected: { hierId: string; hierName: string }[];
+	}
+	let confirmRemoveAttr = $state<ConfirmRemoveAttribute | null>(null);
+	// Kept for the confirmation modal + potential future direct-remove
+	// paths — currently only reachable if a caller re-wires it (the pane
+	// prop was dropped when the attributes-edit draft flow landed).
+	// eslint-disable-next-line @typescript-eslint/no-unused-vars
+	function requestRemoveAttribute(dimId: string, tableId: string, columnName: string) {
+		const d = store.dimensions.find((x) => x.id === dimId);
+		if (!d) return;
+		const affected: { hierId: string; hierName: string }[] = [];
+		for (const h of d.hierarchies) {
+			if (h.levels.some((l) => l.tableId === tableId && l.columnName === columnName)) {
+				affected.push({ hierId: h.id, hierName: h.name });
+			}
+		}
+		if (affected.length === 0) {
+			store.removeAttribute(dimId, tableId, columnName);
+			return;
+		}
+		confirmRemoveAttr = { dimId, tableId, columnName, affected };
+	}
+	function confirmRemoveAttribute() {
+		if (!confirmRemoveAttr) return;
+		const { dimId, tableId, columnName, affected } = confirmRemoveAttr;
+		for (const a of affected) {
+			const d = store.dimensions.find((x) => x.id === dimId);
+			const h = d?.hierarchies.find((x) => x.id === a.hierId);
+			const lvl = h?.levels.find((l) => l.tableId === tableId && l.columnName === columnName);
+			if (lvl) store.removeLevel(dimId, a.hierId, lvl.id);
+		}
+		store.removeAttribute(dimId, tableId, columnName);
+		confirmRemoveAttr = null;
+	}
+	function cancelRemoveAttribute() {
+		confirmRemoveAttr = null;
+	}
+
+	// Double-click-to-edit on title labels.  Default: titles render as
+	// spans, so clicking the row body fires selection.  Double-clicking
+	// the title switches the span to an inline input.  On blur or
+	// Enter, switches back.  Newly-created dims/hiers automatically
+	// enter edit mode so the user can name them immediately.
+	let editingDimNameId = $state<string | null>(null);
+	let editingHierNameId = $state<string | null>(null);
+	// Inline caption editor for a measure inside a Measure Group.
+	// Value shape: `${groupId}::${columnName}` (or null).  Set on
+	// pencil-click / double-click; cleared on blur, Enter, Escape.
+	let editingMeasureCaption = $state<string | null>(null);
+
+	function commitMeasureCaption(g: WorkbenchMeasureGroup, col: string, nextValue: string): void {
+		const clean = nextValue.trim();
+		const current = g.measureCaptions ?? {};
+		if (!clean || clean === col) {
+			// Empty or equal-to-column-name → treat as "no override";
+			// keep the map lean so serialisation doesn't carry noise.
+			if (col in current) {
+				const next = { ...current };
+				delete next[col];
+				g.measureCaptions = next;
+			}
+		} else {
+			g.measureCaptions = { ...current, [col]: clean };
+		}
+		editingMeasureCaption = null;
+	}
+
+	// Same edit/save shell on Attributes + Hierarchies per image 21.
+	//   - Attributes edit:  full checkbox list of T's columns (defines A).
+	//   - Attributes saved: condensed view of just the saved A; each row
+	//                       is draggable so the user can pull attributes
+	//                       into Col 4 (Content).  The edit/save toggle
+	//                       IS the "hide unused" — saved mode hides what
+	//                       isn't in A, edit mode shows the full T.
+	//   - Hierarchies edit: rename inputs + Make hierarchy.
+	//   - Hierarchies saved: hierarchies as read-only labels.
+	let attributesPaneMode = $state<'edit' | 'saved'>('edit');
+	// Sort state for the Dimensions table.  Defaults to "creation
+	// order" — represented internally as sortKey='idx' / asc which
+	// the sorter treats as a no-op.
+	type DimSortKey = 'idx' | 'name' | 'type' | 'cols';
+	let dimSortKey = $state<DimSortKey>('idx');
+	let dimSortDir = $state<'asc' | 'desc'>('asc');
+	// Which dim's Saved-pane row is currently in "confirm delete" state.
+	// Only one row can be confirming at a time; clicking ✕ on a
+	// different row moves the confirm to that one.
+	let deletingDimId = $state<string | null>(null);
+	function toggleDimSort(key: DimSortKey) {
+		if (dimSortKey === key) {
+			// Same column → flip direction, or unset back to creation order
+			// on the third click.
+			if (dimSortDir === 'asc') {
+				dimSortDir = 'desc';
+			} else {
+				dimSortKey = 'idx';
+				dimSortDir = 'asc';
+			}
+		} else {
+			dimSortKey = key;
+			dimSortDir = 'asc';
+		}
+	}
+	// Drag-into-Hierarchies-Name-column → auto-create a single-level
+	// hierarchy named after the dropped attribute.  Mirror of the facts
+	// side's drag-into-Measure-Groups-Name → single-measure group.
+	let dimDragOverHierName = $state<boolean>(false);
+	function addHierarchyFromAttribute(dimId: string, tableId: string, columnName: string) {
+		const h = store.addHierarchy(dimId, columnName);
+		if (h) {
+			store.addLevel(dimId, h.id, { tableId, columnName });
+			selectedHierarchyId = h.id;
+			hierarchyExplicitlyClicked = true;
+			// Open the name in rename mode so the autoFocus action
+			// focuses + selects the text immediately on drop.
+			editingHierNameId = h.id;
+		}
+	}
+	// When the user picks a different dimension, default the Attributes
+	// pane to whichever mode is useful: 'saved' if the dim already has
+	// attributes (so the Hierarchies pane is instantly usable) or
+	// 'edit' if it's empty (so the user starts building immediately).
+	// Manual toggle still wins until the next dim switch.
+	let lastAttrInitDimId = $state<string | null>(null);
+	$effect(() => {
+		const dim = selectedDimension;
+		if (!dim) {
+			lastAttrInitDimId = null;
+			return;
+		}
+		if (dim.id !== lastAttrInitDimId) {
+			lastAttrInitDimId = dim.id;
+			attributesPaneMode = (dim.attributes?.length ?? 0) > 0 ? 'saved' : 'edit';
+		}
+	});
+
+	// Attribute / level drag MIMEs + payload types + readAttributeDrag /
+	// readLevelMoveDrag / isContentDrag live in ./workbench-dnd (imported
+	// above). The attribute serialiser stays here (component-facing).
+	function handleAttributeDragStart(e: DragEvent, payload: AttributeDragPayload): void {
+		if (!e.dataTransfer) return;
+		e.dataTransfer.setData(ATTRIBUTE_MIME, JSON.stringify(payload));
+		e.dataTransfer.effectAllowed = 'copyMove';
+	}
+	// Highlight target hierarchy row in Col 4 during a content drag.
+	let contentDragOverHierarchyId = $state<string | null>(null);
+	// Hierarchy level chips render alphabetically — display-only, doesn't
+	// mutate the stored level order.  Toggle removed: hierarchies are
+	// unordered sets in Mondrian's model, so ordered display would imply
+	// semantics the schema doesn't carry.
+	const selectedDimension = $derived(
+		selectedDimensionId
+			? (store.dimensions.find((d) => d.id === selectedDimensionId) ?? null)
+			: null
+	);
+	// Only honour an explicit hierarchy selection — no fallback to the
+	// first hierarchy.  The Hierarchy content pane wants null when the
+	// user hasn't picked one, so it can render the "Pick a hierarchy"
+	// empty state instead of bleeding the first one's chips in.
+	const selectedHierarchy = $derived(
+		selectedDimension && selectedHierarchyId
+			? (selectedDimension.hierarchies.find((h) => h.id === selectedHierarchyId) ?? null)
+			: null
+	);
+	const selectedMeasure = $derived(
+		selectedMeasureId ? (store.measures.find((m) => m.id === selectedMeasureId) ?? null) : null
+	);
+	const selectedAttribute = $derived.by(() => {
+		if (!selectedAttributeKey || !selectedDimension) return null;
+		const [tableId, columnName] = selectedAttributeKey.split('::');
+		return (
+			(selectedDimension.attributes ?? []).find(
+				(a) => a.tableId === tableId && a.columnName === columnName
+			) ?? null
+		);
+	});
+	// The level (a member of the selected hierarchy) whose chip the user clicked
+	// in the Hierarchies pane. Drives the <Level> inspector branch (rename /
+	// caption / levelType). Level ids are unique so a plain id lookup suffices.
+	const selectedLevel = $derived(
+		selectedHierarchy && selectedLevelId
+			? (selectedHierarchy.levels.find((l) => l.id === selectedLevelId) ?? null)
+			: null
+	);
+
+	// ── Cube readiness — derived "what's missing" for sample-data / try-query ──
+	// The new Inspector tabs need to know whether the cube has enough on the
+	// canvas to actually run.  `missing` is a list of plain-English deficiencies
+	// the empty-state can render so the user knows what to author next.
+	//
+	// Source of truth for "the fact table" is `factsSelectedTableId` (set by
+	// the workbench's fact-table picker), not `role === 'fact'` — the picker
+	// is the canonical workbench-side selection.  Fall back to role only when
+	// no workbench pick has been made yet (legacy / freshly loaded canvases).
+	const cubeFactTable = $derived.by(() => {
+		const picked = factsSelectedTableId
+			? store.doc.tables.find((t) => t.id === factsSelectedTableId)
+			: undefined;
+		return picked ?? store.doc.tables.find((t) => t.role === 'fact') ?? null;
+	});
+	const sampleDataReadiness = $derived.by<{ ready: boolean; missing: string[] }>(() => {
+		const missing: string[] = [];
+		if (!cubeFactTable) missing.push('Pick a fact table');
+		if (!store.doc.connectionId) missing.push('Pick a data source');
+		return { ready: missing.length === 0, missing };
+	});
+	const tryQueryReadiness = $derived.by<{ ready: boolean; missing: string[] }>(() => {
+		const missing: string[] = [];
+		if (!cubeFactTable) missing.push('Pick a fact table');
+		if ((store.measures ?? []).length === 0) missing.push('Add at least one measure');
+		const hasDim =
+			(store.dimensions ?? []).length > 0 ||
+			store.doc.joins.some(
+				(j) => j.sourceTableId === cubeFactTable?.id || j.targetTableId === cubeFactTable?.id
+			);
+		if (!hasDim) missing.push('Add at least one dimension');
+		return { ready: missing.length === 0, missing };
+	});
+
+	// Sample-data fetch state — keyed by `${connectionId}::${factTableName}`
+	// so switching connection or fact retriggers a load.
+	type SampleDataState =
+		| { kind: 'idle' }
+		| { kind: 'loading' }
+		| { kind: 'error'; message: string }
+		| { kind: 'ready'; columns: string[]; rows: Array<Record<string, unknown>> };
+	let sampleDataKey = $state<string | null>(null);
+	let sampleData = $state<SampleDataState>({ kind: 'idle' });
+	// Row-count picker for the Sample data tab.  Bounded by the proxy
+	// (LIMIT_MAX = 100).  Preset chips render below; changing the chip
+	// rekeys sampleDataKey and the effect refires.
+	const SAMPLE_ROW_LIMITS: readonly number[] = [5, 25, 50, 100];
+	let sampleRowLimit = $state<number>(5);
+	async function loadSampleData(): Promise<void> {
+		if (!cubeFactTable || !store.doc.connectionId) return;
+		const limit = sampleRowLimit;
+		const key = `${store.doc.connectionId}::${cubeFactTable.schema ?? ''}::${cubeFactTable.name}::${limit}`;
+		if (sampleDataKey === key && (sampleData.kind === 'loading' || sampleData.kind === 'ready')) {
+			return;
+		}
+		sampleDataKey = key;
+		sampleData = { kind: 'loading' };
+		try {
+			const tableArg = cubeFactTable.schema
+				? `${cubeFactTable.schema}.${cubeFactTable.name}`
+				: cubeFactTable.name;
+			const resp = await designerBackend.sample(store.doc.connectionId, tableArg, limit);
+			if (!resp.ok) {
+				sampleData = {
+					kind: 'error',
+					message: `Couldn't fetch sample rows (HTTP ${resp.status})`
+				};
+				return;
+			}
+			const body = (await resp.json()) as {
+				columns?: string[];
+				rows?: Array<Record<string, unknown> | unknown[]>;
+			};
+			const cols = body.columns ?? [];
+			const rawRows = body.rows ?? [];
+			// Gateway can return rows as ARRAYS (positional values) or as
+			// OBJECTS keyed by column name — accept both.  Positional arrays
+			// are common when the gateway proxies a generic JDBC ResultSet.
+			// Zip array rows back into objects so the renderer's `row[col]`
+			// lookup just works.
+			const rows = rawRows.map((r) => {
+				if (Array.isArray(r)) {
+					const obj: Record<string, unknown> = {};
+					cols.forEach((c, i) => {
+						obj[c] = r[i];
+					});
+					return obj;
+				}
+				return r;
+			});
+			sampleData = { kind: 'ready', columns: cols, rows };
+		} catch (err) {
+			sampleData = {
+				kind: 'error',
+				message: err instanceof Error ? err.message : 'Failed to load sample rows.'
+			};
+		}
+	}
+	// Re-fetch when the Sample data tab becomes active and the cube is
+	// ready.  Sample data now lives on the Confirm cube tab
+	// (validateTab === 'sample-data') as well as the old inspector drawer
+	// tab (inspectorTab === 'sample-data') — trigger on either.
+	$effect(() => {
+		const onValidate = store.mode === 'validate' && validateTab === 'sample-data';
+		const onInspector = inspectorTab === 'sample-data';
+		if (!onValidate && !onInspector) return;
+		if (!sampleDataReadiness.ready) return;
+		// Read sampleRowLimit here so the effect re-runs when the chip
+		// changes — $effect tracks synchronous reads in this body, not
+		// reads inside the async loadSampleData microtask.
+		void sampleRowLimit;
+		void loadSampleData();
+	});
+
+	// ── Try a Query — runs MDX against the unsaved cube via the existing
+	// `/api/inference/try-query` endpoint (originally built for the AI
+	// inference flow; reused here since the proposal shape + payload are
+	// the same).  Builds a starter MDX from the cube's first measure ×
+	// first dim level and posts.  Result rendered as a flat table inline.
+	type TryQueryState =
+		| { kind: 'idle' }
+		| { kind: 'loading'; mdx: string }
+		| { kind: 'error'; mdx: string; message: string }
+		| {
+				kind: 'ready';
+				mdx: string;
+				columns: string[];
+				rows: Array<Record<string, unknown>>;
+				truncated?: boolean;
+				durationMs?: number;
+		  };
+	let tryQueryState = $state<TryQueryState>({ kind: 'idle' });
+	// Try-a-query composer — user picks measure / dim / hierarchy / level
+	// via dropdowns; the picks generate an MDX seed.  "Show MDX" toggles
+	// a textarea below; when set, the textarea contents take precedence
+	// over the generated MDX so power users can hand-edit.
+	let tryQueryMeasure = $state<string | null>(null);
+	let tryQueryDimensionId = $state<string | null>(null);
+	let tryQueryHierarchyId = $state<string | null>(null);
+	let tryQueryLevelId = $state<string | null>(null);
+	let tryQueryMdxOverride = $state<string | null>(null);
+	// Resolve picked ids → objects, defaulting to first-available if the
+	// user hasn't touched the dropdowns yet.
+	const tryQueryPickedMeasure = $derived.by(() =>
+		tryQueryMeasure && (store.measures ?? []).some((m) => m.name === tryQueryMeasure)
+			? tryQueryMeasure
+			: ((store.measures ?? [])[0]?.name ?? null)
+	);
+	const tryQueryPickedDim = $derived.by(() =>
+		tryQueryDimensionId
+			? ((store.dimensions ?? []).find((d) => d.id === tryQueryDimensionId) ??
+				(store.dimensions ?? [])[0] ??
+				null)
+			: ((store.dimensions ?? [])[0] ?? null)
+	);
+	const tryQueryPickedHier = $derived.by(() => {
+		const dim = tryQueryPickedDim;
+		if (!dim) return null;
+		const hiers = dim.hierarchies ?? [];
+		return (
+			(tryQueryHierarchyId ? hiers.find((h) => h.id === tryQueryHierarchyId) : null) ??
+			hiers[0] ??
+			null
+		);
+	});
+	const tryQueryPickedLevel = $derived.by(() => {
+		const hier = tryQueryPickedHier;
+		if (!hier) return null;
+		const levels = hier.levels ?? [];
+		return (
+			(tryQueryLevelId ? levels.find((l) => l.id === tryQueryLevelId) : null) ?? levels[0] ?? null
+		);
+	});
+	// MDX generated from the picked measure / dim / hier / level.  Used
+	// as the Run source when the MDX override is null.
+	const tryQueryGeneratedMdx = $derived.by<string | null>(() => {
+		const cubeName = selectedCube?.name;
+		const m = tryQueryPickedMeasure;
+		const dim = tryQueryPickedDim;
+		const hier = tryQueryPickedHier;
+		const level = tryQueryPickedLevel;
+		if (!cubeName || !m || !dim || !hier || !level) return null;
+		return [
+			`SELECT NON EMPTY { [Measures].[${m}] } ON COLUMNS,`,
+			`       NON EMPTY { [${dim.name}].[${hier.name}].[${level.name}].MEMBERS } ON ROWS`,
+			`FROM [${cubeName}]`
+		].join('\n');
+	});
+	// Source of truth for Run: user override (if set), else the picker.
+	const tryQueryEffectiveMdx = $derived(tryQueryMdxOverride ?? tryQueryGeneratedMdx);
+	function buildTryQueryProposal(): {
+		schemaName: string;
+		cubes: Array<{
+			name: string;
+			factTableSchema?: string | null;
+			factTableName: string;
+			measures: Array<{ name: string; aggregator: string; column?: string }>;
+			dimensions: Array<{
+				name: string;
+				foreignKey: string;
+				tableSchema?: string | null;
+				tableName: string;
+				primaryKey: string;
+				levels: Array<{ name: string; column: string; type: string; levelType?: string | null }>;
+			}>;
+		}>;
+	} | null {
+		const cube = selectedCube;
+		if (!cube) return null;
+		// The gateway parses this into its full SchemaProposal IR: a
+		// MeasureProposal needs name + aggregator (+ column unless count(*)); a
+		// DimensionProposal needs foreignKey + tableName + primaryKey + levels
+		// (with a column). Build the complete shape from the canvas doc.
+		const fact = store.doc.tables.find((t) => t.role === 'fact') ?? null;
+		if (!fact) return null;
+
+		const measures = (store.measures ?? [])
+			.filter((m) => m.tableId === fact.id)
+			.map((m) => {
+				const mp: { name: string; aggregator: string; column?: string } = {
+					name: m.name,
+					aggregator: m.aggregator
+				};
+				if (m.columnName) mp.column = m.columnName;
+				return mp;
+			});
+		if (measures.length === 0) return null;
+
+		const factCol = (name: string | null | undefined): string | null =>
+			name
+				? (fact.columns.find((c) => c.name.toLowerCase() === name.toLowerCase())?.name ?? null)
+				: null;
+		const resolveFk = (d: SchemaCanvasDimension): string | null => {
+			if (d.foreignKey) return d.foreignKey;
+			const dimTableId = d.primaryKeyTableId ?? d.sourceTableId ?? null;
+			if (dimTableId) {
+				for (const j of store.doc.joins) {
+					if (j.sourceTableId === fact.id && j.targetTableId === dimTableId)
+						return j.sourceColumnName;
+					if (j.targetTableId === fact.id && j.sourceTableId === dimTableId)
+						return j.targetColumnName;
+				}
+			}
+			const dimTable = store.doc.tables.find((t) => t.id === dimTableId);
+			return factCol(d.primaryKey) ?? (dimTable ? factCol(`${dimTable.name}_id`) : null);
+		};
+
+		const dimensions = (store.dimensions ?? [])
+			.map((d) => {
+				const dimTable = store.doc.tables.find(
+					(t) => t.id === (d.primaryKeyTableId ?? d.sourceTableId)
+				);
+				return {
+					name: d.name,
+					foreignKey: resolveFk(d) ?? '',
+					tableSchema: dimTable?.schema ?? null,
+					tableName: dimTable?.name ?? '',
+					primaryKey: d.primaryKey ?? '',
+					levels: d.hierarchies.flatMap((h) =>
+						h.levels.map((l) => ({ name: l.name, column: l.columnName, type: 'String' }))
+					)
+				};
+			})
+			// Only dimensions the gateway IR can accept (all required fields + ≥1 level).
+			.filter((d) => d.tableName && d.foreignKey && d.primaryKey && d.levels.length > 0);
+
+		return {
+			schemaName: store.doc.label || 'Untitled',
+			cubes: [
+				{
+					name: cube.name,
+					factTableSchema: fact.schema ?? null,
+					factTableName: fact.name,
+					measures,
+					dimensions
+				}
+			]
+		};
+	}
+	function buildTryQueryMdx(): string | null {
+		const cubeName = selectedCube?.name;
+		const firstMeasure = store.measures?.[0]?.name;
+		const firstDim = store.dimensions?.[0];
+		const firstHier = firstDim?.hierarchies?.[0];
+		const firstLevel = firstHier?.levels?.[0];
+		if (!cubeName || !firstMeasure || !firstDim || !firstHier || !firstLevel) return null;
+		return [
+			`SELECT NON EMPTY { [Measures].[${firstMeasure}] } ON COLUMNS,`,
+			`       NON EMPTY { [${firstDim.name}].[${firstHier.name}].[${firstLevel.name}].MEMBERS } ON ROWS`,
+			`FROM [${cubeName}]`
+		].join('\n');
+	}
+	async function runTryQuery(): Promise<void> {
+		// Prefer user override (edited MDX textarea) → generated MDX
+		// (from the dropdowns) → legacy first-of-everything fallback.
+		const mdx =
+			(tryQueryMdxOverride && tryQueryMdxOverride.trim().length > 0
+				? tryQueryMdxOverride
+				: tryQueryGeneratedMdx) ?? buildTryQueryMdx();
+		const proposal = buildTryQueryProposal();
+		const cube = selectedCube;
+		const connectionId = store.doc.connectionId;
+		if (!mdx || !proposal || !cube || !connectionId) return;
+		tryQueryState = { kind: 'loading', mdx };
+		try {
+			const resp = await designerBackend.tryQuery({
+				proposal,
+				connectionId,
+				mdx,
+				cubeName: cube.name
+			});
+			const body = (await resp.json().catch(() => null)) as {
+				columns?: string[];
+				rows?: Array<Record<string, unknown> | unknown[]>;
+				truncated?: boolean;
+				durationMs?: number;
+				error?: string;
+				message?: string;
+			} | null;
+			if (!resp.ok || !body) {
+				tryQueryState = {
+					kind: 'error',
+					mdx,
+					message: body?.message ?? `Couldn't run the preview query (HTTP ${resp.status})`
+				};
+				return;
+			}
+			const cols = body.columns ?? [];
+			const rawRows = body.rows ?? [];
+			// Same array-or-object row normalisation as Sample Data.
+			const rows = rawRows.map((r) => {
+				if (Array.isArray(r)) {
+					const obj: Record<string, unknown> = {};
+					cols.forEach((c, i) => {
+						obj[c] = r[i];
+					});
+					return obj;
+				}
+				return r;
+			});
+			tryQueryState = {
+				kind: 'ready',
+				mdx,
+				columns: cols,
+				rows,
+				truncated: body.truncated,
+				durationMs: body.durationMs
+			};
+		} catch (err) {
+			tryQueryState = {
+				kind: 'error',
+				mdx,
+				message: err instanceof Error ? err.message : "Couldn't run the preview query"
+			};
+		}
+	}
+
+	// When set, the dim card whose id matches this auto-focuses its name
+	// input on mount and selects whatever's already there.  The user
+	// expects to start typing the name immediately after clicking "Add
+	// dimension"; without this the focus would stay on the trigger button.
+	let focusDimId = $state<string | null>(null);
+	function addDimensionAndFocus() {
+		const dim = store.addDimension();
+		focusDimId = dim.id;
+		// New dim → drop straight into rename mode so the user can
+		// type its name without needing to double-click.
+		editingDimNameId = dim.id;
+	}
+	/** Use:focus action — wires a fresh-rendered input to grab focus +
+	 *  select-all when the dim it belongs to matches `focusDimId`. The
+	 *  flag is cleared after first use so a re-render doesn't keep
+	 *  stealing focus. */
+	function autoFocus(node: HTMLInputElement, shouldFocus: boolean) {
+		function tryFocus(active: boolean) {
+			if (active) {
+				node.focus();
+				node.select();
+				focusDimId = null;
+			}
+		}
+		tryFocus(shouldFocus);
+		return {
+			update(active: boolean) {
+				tryFocus(active);
+			}
+		};
+	}
+
+	// Tree-view per-row collapse state, independent of the cards view.
+	let collapsedTreeDimensions = $state<Set<string>>(new Set());
+	let collapsedTreeHierarchies = $state<Set<string>>(new Set());
+	// Cube-aware tree state.  Cubes + measure groups are collapsible
+	// (default expanded so a fresh user sees their structure) and
+	// selectable — when the user clicks a cube or MG row, the inspector
+	// Properties tab routes to a cube-props view or the per-MG editor
+	// (paneMeasureGroupContent) respectively.
+	let collapsedTreeCubes = $state<Set<string>>(new Set());
+	let collapsedTreeMeasureGroups = $state<Set<string>>(new Set());
+	let collapsedSharedDimensions = $state<boolean>(false);
+	let selectedTreeCubeId = $state<string | null>(null);
+	let selectedTreeMeasureGroupId = $state<string | null>(null);
+	// Which scope the tree column is focused on.  The schema has TWO
+	// concerns — shared dimensions (their hierarchies + attributes) and
+	// cubes (their MGs + per-MG facts/measures/dim links).  Surfacing
+	// both at once made the column header read confusingly as
+	// "DIMENSIONS" while listing Cubes underneath; the toggle lets the
+	// user pick one focus.  Default: 'cubes' since the workbench is
+	// primarily for cube authoring.
+	let treeFocus = $state<'dims' | 'cubes'>('cubes');
+
+	function toggleTreeDimension(id: string) {
+		const next = new Set(collapsedTreeDimensions);
+		if (next.has(id)) next.delete(id);
+		else next.add(id);
+		collapsedTreeDimensions = next;
+	}
+
+	function toggleTreeHierarchy(id: string) {
+		const next = new Set(collapsedTreeHierarchies);
+		if (next.has(id)) next.delete(id);
+		else next.add(id);
+		collapsedTreeHierarchies = next;
+	}
+
+	function toggleTreeMeasureGroup(id: string) {
+		const next = new Set(collapsedTreeMeasureGroups);
+		if (next.has(id)) next.delete(id);
+		else next.add(id);
+		collapsedTreeMeasureGroups = next;
+	}
+
+	// Bulk-collapse / bulk-expand for the tree view header.  Touches
+	// every collapse set + the Shared Dimensions toggle in one swoop
+	// so the user can see-all-at-once or fold-everything-down without
+	// chevron-hunting node-by-node.  For MG ids the live `factsX` set
+	// holds the selected cube's MGs; non-selected cubes carry their
+	// own snapshot — collect both so a "collapse all" actually does.
+	function expandAllTree() {
+		collapsedTreeDimensions = new Set();
+		collapsedTreeHierarchies = new Set();
+		collapsedTreeCubes = new Set();
+		collapsedTreeMeasureGroups = new Set();
+		collapsedSharedDimensions = false;
+	}
+	// Derived "anything collapsed?" for the stacked-chevron toggle.
+	const anyTreeCollapsed = $derived(
+		collapsedTreeDimensions.size > 0 ||
+			collapsedTreeHierarchies.size > 0 ||
+			collapsedTreeCubes.size > 0 ||
+			collapsedTreeMeasureGroups.size > 0 ||
+			collapsedSharedDimensions
+	);
+	function collapseAllTree() {
+		collapsedTreeDimensions = new Set(store.dimensions.map((d) => d.id));
+		collapsedTreeHierarchies = new Set(
+			store.dimensions.flatMap((d) => (d.hierarchies ?? []).map((h) => h.id))
+		);
+		collapsedTreeCubes = new Set(cubes.map((c) => c.id));
+		const allMGIds: string[] = [];
+		for (const c of cubes) {
+			const mgs = c.id === selectedCubeId ? factsMeasureGroups : c.measureGroups;
+			for (const mg of mgs) allMGIds.push(mg.id);
+		}
+		collapsedTreeMeasureGroups = new Set(allMGIds);
+		collapsedSharedDimensions = true;
+	}
+
+	// Selecting a measure group node.  Also switches cubes if the MG
+	// belongs to a different cube — the per-MG editor reads from the
+	// live factsMeasureGroups, so the right cube has to be hydrated
+	// before the editor can mutate it.
+	function selectTreeMeasureGroup(cubeId: string, mgId: string) {
+		if (cubeId !== selectedCubeId) switchCube(cubeId);
+		selectedTreeCubeId = cubeId;
+		selectedTreeMeasureGroupId = mgId;
+		factsSelectedGroupId = mgId;
+		selectedDimensionId = null;
+		selectedHierarchyId = null;
+		selectedMeasureId = null;
+		selectedAttributeKey = null;
+		selectedLevelId = null;
+		focus('mg', mgId);
+		inspectorTab = 'properties';
+	}
+	// Inspector <Cube> "Add measure group" — hydrate the target cube (so the
+	// live factsMeasureGroups is the right one), append a group, then point
+	// the tree selection at it.  Extracted so InspectorProperties.svelte can
+	// fire it via one callback rather than binding selectedTreeMeasureGroupId
+	// back out (which it only writes, never reads).
+	function addMeasureGroupToCube(cubeId: string): void {
+		if (cubeId !== selectedCubeId) switchCube(cubeId);
+		addFactsMeasureGroup();
+		selectedTreeMeasureGroupId = factsSelectedGroupId;
+	}
+
+	// ── Selection transitions fired from FactsMeasuresPane ───────────────
+	// The Facts pane is write-only for these selection ids (it never reads
+	// them back), so they route through callbacks instead of bound props —
+	// the shell stays the single source of truth for the cross-pane selection.
+	function selectMgMeasure(measureId: string): void {
+		selectedMeasureId = measureId;
+		selectedAttributeKey = null;
+		selectedLevelId = null;
+		selectedHierarchyId = null;
+		focus('measure', measureId);
+	}
+	function selectMgDimension(dimId: string): void {
+		selectedDimensionId = dimId;
+		selectedMeasureId = null;
+		selectedAttributeKey = null;
+		selectedLevelId = null;
+		selectedHierarchyId = null;
+	}
+	function selectFactsCalc(calcId: string): void {
+		factsSelectedCalcId = calcId;
+		focus('calc', calcId);
+	}
+
+	// Derived getters used by the inspector + MG tree row.  Read from
+	// the LIVE factsMeasureGroups (not cube.measureGroups) because the
+	// per-MG editor mutates the live state — only the selected cube's
+	// MGs are live; switching cubes snapshots/hydrates.
+	const selectedTreeMeasureGroup = $derived(
+		selectedTreeMeasureGroupId
+			? (factsMeasureGroups.find((g) => g.id === selectedTreeMeasureGroupId) ?? null)
+			: null
+	);
+	const selectedTreeCube = $derived(
+		selectedTreeCubeId ? (cubes.find((c) => c.id === selectedTreeCubeId) ?? null) : null
+	);
+
+	// ── Per-tab inspector memory (D&H ↔ F&M) ────────────────────────
+	// The bottom Inspector panel is shared by the Dimensions &
+	// Hierarchies tab and the Facts & Measures tab, but each tab has
+	// its own idea of "what to inspect".  Without per-tab memory, the
+	// last selection on one tab bleeds through to the other (e.g.
+	// selecting a dim on D&H, switching to F&M, still seeing the dim).
+	//
+	// Contract:
+	//   • First visit to a primary tab (workbench / facts) → snap to
+	//     the first thing on that tab (first dim on D&H; first measure
+	//     → first MG → cube on F&M).
+	//   • Subsequent visits to a primary tab → restore whatever was
+	//     last selected on THAT tab.
+	//   • Entering canvas / validate mode is a no-op — those views
+	//     don't render the shared Inspector.
+	//
+	// Implementation: capture every id feeding InspectorProperties'
+	// else-if chain (treeMG > treeCube > measure > level > attr >
+	// hier > dim) into an outgoing snapshot on tab exit, then clear
+	// and restore/default on tab enter.  Restoration validates each
+	// id still exists (a dim / measure could have been deleted while
+	// the tab was inactive); anything dangling drops back to the
+	// first-visit default.
+	type InspectorSnapshot = {
+		treeMGId: string | null;
+		treeCubeId: string | null;
+		measureId: string | null;
+		dimensionId: string | null;
+		hierarchyId: string | null;
+		attributeKey: string | null;
+		levelId: string | null;
+		hierExplicit: boolean;
+		focus: { kind: FocusKind; id: string } | null;
+	};
+	let lastDhSnapshot: InspectorSnapshot | null = null;
+	let lastFmSnapshot: InspectorSnapshot | null = null;
+
+	function captureInspectorSnapshot(): InspectorSnapshot {
+		return {
+			treeMGId: selectedTreeMeasureGroupId,
+			treeCubeId: selectedTreeCubeId,
+			measureId: selectedMeasureId,
+			dimensionId: selectedDimensionId,
+			hierarchyId: selectedHierarchyId,
+			attributeKey: selectedAttributeKey,
+			levelId: selectedLevelId,
+			hierExplicit: hierarchyExplicitlyClicked,
+			focus: focusSubject
+		};
+	}
+
+	function clearInspectorSelection(): void {
+		selectedTreeMeasureGroupId = null;
+		selectedTreeCubeId = null;
+		selectedMeasureId = null;
+		selectedDimensionId = null;
+		selectedHierarchyId = null;
+		selectedAttributeKey = null;
+		selectedLevelId = null;
+		hierarchyExplicitlyClicked = false;
+		focusSubject = null;
+	}
+
+	/** Push a snapshot back into the live ids, dropping any id whose
+	 *  referent no longer exists.  Returns true when at least one id
+	 *  survived — callers use that to decide whether to fall back to a
+	 *  fresh first-visit default. */
+	function restoreInspectorSnapshot(snap: InspectorSnapshot): boolean {
+		const dimAlive = snap.dimensionId
+			? store.dimensions.some((d) => d.id === snap.dimensionId)
+			: false;
+		const measureAlive = snap.measureId
+			? store.measures.some((m) => m.id === snap.measureId)
+			: false;
+		const mgAlive = snap.treeMGId
+			? factsMeasureGroups.some((g) => g.id === snap.treeMGId) ||
+				cubes.some((c) => (c.measureGroups ?? []).some((g) => g.id === snap.treeMGId))
+			: false;
+		const cubeAlive = snap.treeCubeId ? cubes.some((c) => c.id === snap.treeCubeId) : false;
+		selectedTreeMeasureGroupId = mgAlive ? snap.treeMGId : null;
+		selectedTreeCubeId = cubeAlive ? snap.treeCubeId : null;
+		selectedMeasureId = measureAlive ? snap.measureId : null;
+		selectedDimensionId = dimAlive ? snap.dimensionId : null;
+		selectedHierarchyId = dimAlive ? snap.hierarchyId : null;
+		selectedAttributeKey = dimAlive ? snap.attributeKey : null;
+		selectedLevelId = dimAlive ? snap.levelId : null;
+		hierarchyExplicitlyClicked = snap.hierExplicit;
+		// Only restore focus if its referent survives; otherwise leave
+		// null so the row that ends up as the default paints as focused.
+		const focusAlive =
+			snap.focus === null ||
+			(snap.focus.kind === 'dim' && dimAlive) ||
+			(snap.focus.kind === 'measure' && measureAlive) ||
+			(snap.focus.kind === 'mg' && mgAlive) ||
+			(snap.focus.kind === 'cube' && cubeAlive) ||
+			(snap.focus.kind === 'hierarchy' && dimAlive) ||
+			(snap.focus.kind === 'attribute' && dimAlive) ||
+			(snap.focus.kind === 'calc' && true);
+		focusSubject = focusAlive ? snap.focus : null;
+		return dimAlive || measureAlive || mgAlive || cubeAlive;
+	}
+
+	function applyDefaultDhSelection(): void {
+		const first = store.dimensions[0];
+		if (first) {
+			selectedDimensionId = first.id;
+			focus('dim', first.id);
+		}
+	}
+
+	function applyDefaultFmSelection(): void {
+		const firstMeasure = store.measures[0];
+		if (firstMeasure) {
+			selectedMeasureId = firstMeasure.id;
+			focus('measure', firstMeasure.id);
+			return;
+		}
+		const firstMg = factsMeasureGroups[0];
+		if (firstMg) {
+			selectedTreeMeasureGroupId = firstMg.id;
+			selectedTreeCubeId = selectedCubeId;
+			factsSelectedGroupId = firstMg.id;
+			focus('mg', firstMg.id);
+			return;
+		}
+		if (selectedCubeId) {
+			selectedTreeCubeId = selectedCubeId;
+			focus('cube', selectedCubeId);
+		}
+	}
+
+	function enterDhTab(): void {
+		clearInspectorSelection();
+		if (lastDhSnapshot) {
+			restoreInspectorSnapshot(lastDhSnapshot);
+			if (selectedDimensionId === null) applyDefaultDhSelection();
+		} else {
+			applyDefaultDhSelection();
+		}
+	}
+
+	function enterFmTab(): void {
+		clearInspectorSelection();
+		if (lastFmSnapshot) {
+			restoreInspectorSnapshot(lastFmSnapshot);
+			const hasAny =
+				selectedMeasureId !== null ||
+				selectedTreeMeasureGroupId !== null ||
+				selectedTreeCubeId !== null ||
+				selectedDimensionId !== null;
+			if (!hasAny) applyDefaultFmSelection();
+		} else {
+			applyDefaultFmSelection();
+		}
+	}
+
+	// Track the last PRIMARY tab so canvas / validate visits pass
+	// through without disturbing the D&H ↔ F&M snapshot bookkeeping.
+	// Starts null so the very first mount into a primary tab runs
+	// enterDhTab / enterFmTab (subsuming the file's original one-shot
+	// "snap to first dim on mount" behaviour, now generalised across
+	// both tabs).
+	let previousPrimaryTab: 'workbench' | 'facts' | null = null;
+	$effect(() => {
+		const mode = store.mode;
+		if (mode !== 'workbench' && mode !== 'facts') return;
+		if (mode === previousPrimaryTab) return;
+		untrack(() => {
+			if (previousPrimaryTab === 'workbench') lastDhSnapshot = captureInspectorSnapshot();
+			else if (previousPrimaryTab === 'facts') lastFmSnapshot = captureInspectorSnapshot();
+			if (mode === 'workbench') enterDhTab();
+			else enterFmTab();
+			previousPrimaryTab = mode;
+		});
+	});
+
+	// ── Column drag source ──────────────────────────────────────────
+
+	function handleColumnDragStart(
+		e: DragEvent,
+		table: SchemaCanvasTable,
+		column: SchemaCanvasColumn
+	) {
+		if (!e.dataTransfer) return;
+		const payload: ColumnDragPayload = {
+			tableId: table.id,
+			columnName: column.name,
+			columnType: classifyColumn(column.sqlType)
+		};
+		e.dataTransfer.setData(COLUMN_MIME, JSON.stringify(payload));
+		e.dataTransfer.effectAllowed = 'copy';
+	}
+
+	// readColumnPayload / isColumnDrag live in ./workbench-dnd (imported above).
+
+	function handleTableDragStart(e: DragEvent, table: SchemaCanvasTable) {
+		if (!e.dataTransfer) return;
+		const payload: TableDragPayload = { tableId: table.id };
+		e.dataTransfer.setData(TABLE_MIME, JSON.stringify(payload));
+		e.dataTransfer.effectAllowed = 'copy';
+	}
+	// readTablePayload lives in ./workbench-dnd (imported above).
+
+	function handleJoinGroupDragStart(e: DragEvent, row: JoinGroupRow) {
+		if (!e.dataTransfer) return;
+		// Map participating table NAMES back to ids — joinGroupsRail
+		// stores names for display, but the drop handler needs ids.
+		const tableIds = row.tableNames
+			.map((name) => store.doc.tables.find((t) => t.name === name)?.id)
+			.filter((id): id is string => typeof id === 'string');
+		const payload: JoinGroupDragPayload = { key: row.key, tableIds };
+		e.dataTransfer.setData(JOINGROUP_MIME, JSON.stringify(payload));
+		e.dataTransfer.effectAllowed = 'copy';
+	}
+	// readJoinGroupPayload / isAnyWorkbenchDrag live in ./workbench-dnd
+	// (imported above).
+
+	// ── Center zone drops ───────────────────────────────────────────
+	// We track which drop target is hovered so we can paint the
+	// dashed primary border on JUST that one. A single $state ref
+	// (kind + id) is enough — only one element can be the active
+	// drop target at any moment.
+
+	type DropTarget =
+		| { kind: 'dim-zone' }
+		| { kind: 'dim'; id: string }
+		| { kind: 'hierarchy'; dimensionId: string; hierarchyId: string }
+		| { kind: 'measure-zone' };
+
+	let activeDropTarget = $state<DropTarget | null>(null);
+
+	function dropTargetMatches(a: DropTarget | null, b: DropTarget): boolean {
+		if (!a || a.kind !== b.kind) return false;
+		if (a.kind === 'dim' && b.kind === 'dim') return a.id === b.id;
+		if (a.kind === 'hierarchy' && b.kind === 'hierarchy') {
+			return a.dimensionId === b.dimensionId && a.hierarchyId === b.hierarchyId;
+		}
+		return true;
+	}
+
+	function handleDragOver(e: DragEvent, target: DropTarget) {
+		if (!isAnyWorkbenchDrag(e)) return;
+		e.preventDefault();
+		// `dragover` bubbles — the innermost target fires first, then
+		// every ancestor does too.  Without stopPropagation the outer
+		// dim ZONE would overwrite `activeDropTarget` after a nested
+		// dim CARD set it, painting the giant zone-wide red ring
+		// even though the user is targeting a specific card.  Stop the
+		// bubble so the deepest match wins.
+		e.stopPropagation();
+		if (e.dataTransfer) e.dataTransfer.dropEffect = 'copy';
+		if (!dropTargetMatches(activeDropTarget, target)) activeDropTarget = target;
+	}
+
+	function handleDragLeave(e: DragEvent, target: DropTarget) {
+		// Only clear when the cursor leaves the element entirely (not
+		// when it crosses into a child).
+		const related = e.relatedTarget as Node | null;
+		const current = e.currentTarget as Node | null;
+		if (related && current && current.contains(related)) return;
+		if (dropTargetMatches(activeDropTarget, target)) activeDropTarget = null;
+	}
+
+	/** Walk a table's columns and append them as levels under the given
+	 *  hierarchy.  Used by table + join-group drops so the user gets a
+	 *  populated dim from one gesture; they can prune unwanted levels. */
+	// eslint-disable-next-line @typescript-eslint/no-unused-vars
+	function addAllColumnsAsLevels(
+		dimensionId: string,
+		hierarchyId: string,
+		table: SchemaCanvasTable
+	): void {
+		for (const col of table.columns) {
+			store.addLevel(dimensionId, hierarchyId, {
+				tableId: table.id,
+				columnName: col.name,
+				type: classifyColumn(col.sqlType)
+			});
+		}
+	}
+
+	/** Create a dim from a table or join group.  Returns the dim but
+	 *  does NOT auto-select it — selection happens only when the user
+	 *  explicitly clicks a row in saved mode.  Auto-selecting during
+	 *  multi-pick re-targets the Attributes pane on every checkbox
+	 *  click, which feels broken when you're still composing the D set. */
+	function createDimFromTable(table: SchemaCanvasTable): SchemaCanvasDimension {
+		return store.addDimension({ name: table.name, tableId: table.id });
+	}
+	function createDimFromJoinGroup(group: JoinGroupRow): SchemaCanvasDimension {
+		const dim = store.addDimension({ name: group.key, tableId: group.tableIds[0] });
+		store.updateDimension(dim.id, { sourceJoinGroupKey: group.key });
+		return dim;
+	}
+
+	function handleDimensionsZoneDrop(e: DragEvent) {
+		activeDropTarget = null;
+		e.preventDefault();
+		// Scope of THIS handler: dimensions and their source binding ONLY.
+		// Level / measure population happens elsewhere (the user will
+		// define levels explicitly inside hierarchies once that part of
+		// the UI is wired).  Column drops are no-ops here on purpose.
+		const tablePayload = readTablePayload(e);
+		if (tablePayload) {
+			const table = store.doc.tables.find((t) => t.id === tablePayload.tableId);
+			if (!table) return;
+			const dim = store.addDimension({ name: table.name, tableId: table.id });
+			focusDimId = dim.id;
+			selectedDimensionId = dim.id;
+			selectedHierarchyId = dim.hierarchies[0]?.id ?? null;
+			return;
+		}
+		const groupPayload = readJoinGroupPayload(e);
+		if (groupPayload) {
+			const dim = store.addDimension({
+				name: groupPayload.key,
+				tableId: groupPayload.tableIds[0]
+			});
+			focusDimId = dim.id;
+			selectedDimensionId = dim.id;
+			selectedHierarchyId = dim.hierarchies[0]?.id ?? null;
+		}
+	}
+
+	/** Resolve a hierarchy to host a new bulk drop (table or join group).
+	 *
+	 *  Mondrian convention (visible in Saiku's demo Sales cube): when a
+	 *  hierarchy's name matches its parent dim's name, it's the IMPLICIT
+	 *  DEFAULT — Saiku hides the hierarchy node and renders levels right
+	 *  under the dim (Product, Performance Season Day).  When the names
+	 *  differ, Saiku shows the hierarchy as an explicit node (Store/Stores,
+	 *  Customer/Customers, Promotion/Media Type).
+	 *
+	 *  So:
+	 *   - If there's an empty hier lying around (typically the implicit
+	 *     default `addDimension` seeds with the dim's name), populate it
+	 *     WITHOUT renaming.  Renaming would silently turn the implicit
+	 *     default into an explicit hierarchy on export.
+	 *   - Only a second/third drop creates a new EXPLICIT hier named
+	 *     after the source — by convention these are the named alternates
+	 *     ("Stores", "Calendar"/"Fiscal" on a Time dim, etc.). */
+	// eslint-disable-next-line @typescript-eslint/no-unused-vars
+	function claimOrCreateHierarchyForBulkDrop(
+		dimension: SchemaCanvasDimension,
+		sourceName: string
+	): SchemaCanvasHierarchy | null {
+		const empty = dimension.hierarchies.find((h) => h.levels.length === 0);
+		if (empty) return empty;
+		return store.addHierarchy(dimension.id, sourceName);
+	}
+
+	function handleDimensionDrop(e: DragEvent, dimension: SchemaCanvasDimension) {
+		activeDropTarget = null;
+		e.preventDefault();
+		e.stopPropagation();
+		// Scope: dim source binding ONLY.  Column drops are no-ops here
+		// on purpose — levels are user-defined elsewhere once that part
+		// of the UI is wired.  Table / join drop = bind primaryKeyTableId.
+		const tablePayload = readTablePayload(e);
+		if (tablePayload) {
+			const table = store.doc.tables.find((t) => t.id === tablePayload.tableId);
+			if (!table) return;
+			store.updateDimension(dimension.id, { sourceTableId: table.id });
+			selectedDimensionId = dimension.id;
+			selectedHierarchyId = dimension.hierarchies[0]?.id ?? null;
+			return;
+		}
+		const groupPayload = readJoinGroupPayload(e);
+		if (groupPayload) {
+			store.updateDimension(dimension.id, {
+				sourceTableId: groupPayload.tableIds[0]
+			});
+			selectedDimensionId = dimension.id;
+			selectedHierarchyId = dimension.hierarchies[0]?.id ?? null;
+		}
+	}
+
+	function handleHierarchyDrop(e: DragEvent, dimension: SchemaCanvasDimension) {
+		activeDropTarget = null;
+		e.preventDefault();
+		e.stopPropagation();
+		// Scope: dim source binding ONLY (same as the dim-level handler).
+		// Column drops on a hierarchy are no-ops on purpose.  Table /
+		// join drop = bind the parent dim's primaryKeyTableId.
+		const tablePayload = readTablePayload(e);
+		if (tablePayload) {
+			const table = store.doc.tables.find((t) => t.id === tablePayload.tableId);
+			if (!table) return;
+			store.updateDimension(dimension.id, { sourceTableId: table.id });
+			return;
+		}
+		const groupPayload = readJoinGroupPayload(e);
+		if (groupPayload) {
+			store.updateDimension(dimension.id, {
+				sourceTableId: groupPayload.tableIds[0]
+			});
+		}
+	}
+
+	function handleMeasuresZoneDrop(e: DragEvent) {
+		activeDropTarget = null;
+		const payload = readColumnPayload(e);
+		if (!payload) return;
+		e.preventDefault();
+		// Measures default to sum.  Non-numeric drops still land,
+		// just as `count` — the user picks the aggregator anyway.
+		const aggregator: SchemaCanvasMeasure['aggregator'] = isNumericKind(payload.columnType)
+			? 'sum'
+			: 'count';
+		store.addMeasure({
+			tableId: payload.tableId,
+			columnName: payload.columnName,
+			aggregator
+		});
+	}
+
+	// ── Inline rename helpers ────────────────────────────────────────
+	// `oninput`-driven so every keystroke persists via the store
+	// methods (which `touch()` + saveToStorage).
+
+	function renameDimension(id: string, name: string) {
+		store.updateDimension(id, { name });
+	}
+
+	function renameHierarchy(dimId: string, hierId: string, name: string) {
+		store.updateHierarchy(dimId, hierId, { name });
+	}
+	/** Enforce sibling-unique hier name at commit time (blur).  Lets the
+	 *  user type freely (no mid-keystroke suffixing) and only resolves
+	 *  collisions when they leave the input.  Suffixes with "(2)", "(3)"
+	 *  on collision. */
+	function commitHierarchyName(dimId: string, hierId: string) {
+		const d = store.dimensions.find((x) => x.id === dimId);
+		const h = d?.hierarchies.find((x) => x.id === hierId);
+		if (!d || !h) return;
+		const desired = h.name.trim();
+		const siblings = d.hierarchies.filter((x) => x.id !== hierId).map((x) => x.name);
+		if (!siblings.includes(desired)) return;
+		let n = 2;
+		while (siblings.includes(`${desired} (${n})`)) n++;
+		store.updateHierarchy(dimId, hierId, { name: `${desired} (${n})` });
+	}
+	/** Same idea for dim names — collision-free at the cube level. */
+	function commitDimensionName(dimId: string) {
+		const d = store.dimensions.find((x) => x.id === dimId);
+		if (!d) return;
+		const desired = d.name.trim();
+		const siblings = store.dimensions.filter((x) => x.id !== dimId).map((x) => x.name);
+		if (!siblings.includes(desired)) return;
+		let n = 2;
+		while (siblings.includes(`${desired} (${n})`)) n++;
+		store.updateDimension(dimId, { name: `${desired} (${n})` });
+	}
+
+	function renameLevel(dimId: string, hierId: string, levelId: string, name: string) {
+		store.updateLevel(dimId, hierId, levelId, { name });
+	}
+
+	function renameMeasure(measureId: string, name: string) {
+		store.updateMeasure(measureId, { name });
+	}
+
+	// Look up a level's source table name for the badge that reads
+	// "from Customer" next to a level row.
+	function tableNameFor(tableId: string): string {
+		return store.doc.tables.find((t) => t.id === tableId)?.name ?? tableId;
+	}
+	// Look up the SQL type (VARCHAR, INT2, …) for a (tableId, columnName)
+	// pair — used to surface type chips next to attribute / level rows
+	// so the user gets the same info they see on the schema canvas.
+	function columnTypeFor(tableId: string, columnName: string): string | undefined {
+		return store.doc.tables
+			.find((t) => t.id === tableId)
+			?.columns.find((c) => c.name === columnName)?.sqlType;
+	}
+
+	const AGGREGATORS: SchemaCanvasMeasure['aggregator'][] = [
+		'sum',
+		'count',
+		'avg',
+		'min',
+		'max',
+		'distinct-count',
+		'median',
+		'percentile'
+	];
+
+	// ── Right rail: read-only joins summary ──────────────────────────
+	// One line per join, grouped under the user-renamed label so it
+	// matches what Step 1 shows. Lets the workbench user see "Region
+	// is reachable via customer.region_id ↔ region.id" without
+	// flipping tabs.
+
+	interface JoinGroupSummary {
+		label: string;
+		joins: Array<{
+			id: string;
+			fromTable: string;
+			fromColumn: string;
+			toTable: string;
+			toColumn: string;
+		}>;
+	}
+
+	// eslint-disable-next-line @typescript-eslint/no-unused-vars
+	const joinGroups = $derived.by<JoinGroupSummary[]>(() => {
+		const tableName = (id: string) => store.doc.tables.find((t) => t.id === id)?.name ?? id;
+		const buckets = new Map<string, JoinGroupSummary>();
+		for (const j of store.doc.joins) {
+			const label = store.joinGroupLabelFor(j);
+			const entry = buckets.get(label) ?? { label, joins: [] };
+			entry.joins.push({
+				id: j.id,
+				fromTable: tableName(j.sourceTableId),
+				fromColumn: j.sourceColumnName,
+				toTable: tableName(j.targetTableId),
+				toColumn: j.targetColumnName
+			});
+			buckets.set(label, entry);
+		}
+		return Array.from(buckets.values()).sort((a, b) => a.label.localeCompare(b.label));
+	});
+
+	// Quick stats for pane-header eyebrows.  dimensionCount is used from
+	// paneHeaderContext(kind='dimensions') via store.dimensions.length —
+	// no dedicated derived for it since the paneHeader reads the array
+	// directly.  Attribute / hierarchy / level counts feed the other
+	// eyebrow lines; measureCount feeds the tree-view stat block.
+	const attributeCount = $derived(
+		store.dimensions.reduce((n, d) => n + (d.attributes ?? []).length, 0)
+	);
+	const hierarchyCount = $derived(store.dimensions.reduce((n, d) => n + d.hierarchies.length, 0));
+	const levelCount = $derived(
+		store.dimensions.reduce((n, d) => n + d.hierarchies.reduce((m, h) => m + h.levels.length, 0), 0)
+	);
+	const measureCount = $derived(store.measures.length);
+
+	// Border colour helper for the drop-target ring.  Resting state is
+	// `border-transparent` so the dashed outline disappears when nothing
+	// is being dragged — the giant always-on dashed rectangles read as
+	// visual noise.  Active drag-over goes `border-primary`; idle-while-
+	// a-drag-is-happening goes `border-border` so the user can see WHICH
+	// zone is hover-able vs which is currently the target.
+	const isDragging = $derived(activeDropTarget !== null);
+	function dropRingFor(target: DropTarget): string {
+		if (dropTargetMatches(activeDropTarget, target)) return 'border-primary';
+		return isDragging ? 'border-border' : 'border-transparent';
+	}
+</script>
+
+<div class="flex h-full min-h-0 flex-1 overflow-hidden" data-testid="canvas-workbench-view">
+	{#if store.mode === 'validate'}
+		<ConfirmCubePane
+			{store}
+			{cubes}
+			{selectedCubeId}
+			{selectedCube}
+			{factsMeasureGroups}
+			{isSchemaSaved}
+			{isSchemaDirty}
+			refreshSignal={confirmCubeRefreshTs}
+			bind:validateTab
+			bind:modelViewMode
+			bind:modelResetTs
+			bind:outlineCollapsed
+			{outlineCollapsedSections}
+			{switchCube}
+			{toggleOutlineSection}
+			sampleDataTab={inspectorSampleData}
+			tryQueryTab={inspectorTryQuery}
+		/>
+	{:else}
+		<!-- ── LEFT RAIL: two stacked panes (join groups + tables) ───────
+	     Only shown in Cards view, where the centre is dim-card workspace
+	     and a tables/joins rail provides drop sources.  Hidden in Columns
+	     mode (source picker is in the Dimensions pane) and in Tree mode
+	     (tree already shows Shared Dimensions + Cubes; a duplicate joins
+	     rail just adds noise). -->
+		{#if viewMode === 'cards'}
+			<aside
+				class="flex w-72 shrink-0 flex-col border-r bg-card"
+				style:border-color="hsl(var(--border))"
+				aria-label="Tables on canvas"
+				data-testid="workbench-tables-rail"
+			>
+				<!-- ─ COLUMN-LEVEL SEARCH ─ -->
+				<!-- Search lives at the very top of the rail (above both pane
+		     headers) so it filters across Join groups + Tables + columns
+		     without the user hunting for it inside a collapsible. -->
+				{#if store.doc.tables.length > 0}
+					<div class="shrink-0 border-b px-2 py-2" style:border-color="hsl(var(--border))">
+						<div class="relative">
+							<Search
+								class="pointer-events-none absolute top-1/2 left-2 h-3 w-3 -translate-y-1/2 opacity-50"
+								aria-hidden="true"
+							/>
+							<input
+								type="search"
+								bind:value={tableFilterQuery}
+								placeholder="Filter tables or columns…"
+								aria-label="Filter tables or columns"
+								class="h-7 w-full rounded border bg-background py-1 pr-2 pl-7 text-xs focus:border-ring focus:ring-1 focus:ring-ring focus:outline-none"
+								style:border-color="hsl(var(--border))"
+								data-testid="workbench-table-filter-input"
+							/>
+						</div>
+					</div>
+				{/if}
+
+				<!-- ─ TOP PANE: read-only join groups from Step 1 ─ -->
+				<section
+					class="flex shrink-0 flex-col border-b"
+					style:border-color="hsl(var(--border))"
+					data-testid="workbench-joingroups-pane"
+				>
+					<button
+						type="button"
+						onclick={() => (railJoinGroupsCollapsed = !railJoinGroupsCollapsed)}
+						class="flex w-full items-center gap-1.5 border-b px-3 py-2 text-left hover:bg-accent/40"
+						style:border-color="hsl(var(--border))"
+						aria-expanded={!railJoinGroupsCollapsed}
+						aria-controls="workbench-joingroups-body"
+					>
+						<div class="min-w-0 flex-1">
+							<div
+								class="text-[10px] font-medium tracking-wider uppercase"
+								style:color="hsl(var(--muted-foreground))"
+							>
+								Join groups
+							</div>
+							<div class="mt-0.5 text-[11px] text-muted-foreground">
+								{joinGroupsRail.length}
+								{joinGroupsRail.length === 1 ? 'group' : 'groups'} · read-only
+							</div>
+						</div>
+						{#if railJoinGroupsCollapsed}
+							<ChevronRight class="h-3 w-3 shrink-0 opacity-60" aria-hidden="true" />
+						{:else}
+							<ChevronDown class="h-3 w-3 shrink-0 opacity-60" aria-hidden="true" />
+						{/if}
+					</button>
+
+					{#if !railJoinGroupsCollapsed}
+						<div
+							id="workbench-joingroups-body"
+							class="max-h-48 shrink-0 overflow-y-auto bg-background"
+						>
+							{#if joinGroupsRail.length === 0}
+								<div class="p-3">
+									<p
+										class="rounded border border-dashed p-2 text-[11px]"
+										style:border-color="hsl(var(--border))"
+										style:color="hsl(var(--muted-foreground))"
+									>
+										No joins wired yet. Flip back to Schema Canvas to draw some.
+									</p>
+								</div>
+							{:else}
+								<ul>
+									{#each joinGroupsRail as g (g.key)}
+										{@const isRowCollapsed = collapsedJoinGroupRows.has(g.key)}
+										<li
+											class="flex flex-wrap border-b last:border-b-0"
+											style:border-color="hsl(var(--border))"
+											data-testid="workbench-joingroup-row"
+										>
+											<button
+												type="button"
+												onclick={() => toggleJoinGroupRow(g.key)}
+												draggable="true"
+												ondragstart={(e) => handleJoinGroupDragStart(e, g)}
+												class="flex flex-1 cursor-grab items-center gap-1.5 px-3 py-1.5 text-left text-xs hover:bg-accent/40 active:cursor-grabbing"
+												title="Click to expand member tables, drag to bind a dimension"
+											>
+												{#if isRowCollapsed}
+													<ChevronRight class="h-3 w-3 shrink-0 opacity-60" aria-hidden="true" />
+												{:else}
+													<ChevronDown class="h-3 w-3 shrink-0 opacity-60" aria-hidden="true" />
+												{/if}
+												<Layers class="h-3 w-3 shrink-0 text-primary" aria-hidden="true" />
+												<span class="truncate font-medium">{g.label}</span>
+												<span class="ml-auto text-[10px] opacity-60">{g.tableNames.length}</span>
+											</button>
+											<!-- Click-to-create-dim from this join group -->
+											<button
+												type="button"
+												onclick={() => createDimFromJoinGroup(g)}
+												class="shrink-0 px-2 text-muted-foreground hover:bg-accent/40 hover:text-foreground"
+												aria-label="Create dimension from this join group"
+												title="Create dimension bound to this join group"
+												data-testid="workbench-joingroup-create-dim"
+											>
+												<Layers class="h-3 w-3" aria-hidden="true" />
+											</button>
+											{#if !isRowCollapsed}
+												<ul class="pr-3 pb-1 pl-7">
+													{#each g.tableNames as name, idx (`${name}::${idx}`)}
+														<li
+															class="truncate py-0.5 font-mono text-[11px]"
+															style:color="hsl(var(--muted-foreground))"
+														>
+															{name}
+														</li>
+													{/each}
+												</ul>
+											{/if}
+										</li>
+									{/each}
+								</ul>
+							{/if}
+						</div>
+					{/if}
+				</section>
+
+				<!-- ─ BOTTOM PANE: tables + columns (drag sources) ─ -->
+				<section class="flex min-h-0 flex-1 flex-col" data-testid="workbench-tables-pane">
+					<button
+						type="button"
+						onclick={() => (railTablesCollapsed = !railTablesCollapsed)}
+						class="flex w-full items-center gap-1.5 border-b px-3 py-2 text-left hover:bg-accent/40"
+						style:border-color="hsl(var(--border))"
+						aria-expanded={!railTablesCollapsed}
+						aria-controls="workbench-tables-body"
+					>
+						<div class="min-w-0 flex-1">
+							<div
+								class="text-[10px] font-medium tracking-wider uppercase"
+								style:color="hsl(var(--muted-foreground))"
+							>
+								Tables
+							</div>
+							<div class="mt-0.5 text-[11px] text-muted-foreground">
+								{store.doc.tables.length}
+								{store.doc.tables.length === 1 ? 'table' : 'tables'} · drag columns
+							</div>
+						</div>
+						{#if railTablesCollapsed}
+							<ChevronRight class="h-3 w-3 shrink-0 opacity-60" aria-hidden="true" />
+						{:else}
+							<ChevronDown class="h-3 w-3 shrink-0 opacity-60" aria-hidden="true" />
+						{/if}
+					</button>
+
+					{#if !railTablesCollapsed}
+						<div id="workbench-tables-body" class="min-h-0 flex-1 overflow-y-auto bg-background">
+							{#if store.doc.tables.length === 0}
+								<div class="p-3">
+									<div
+										class="rounded border border-dashed p-3 text-center text-xs"
+										style:border-color="hsl(var(--border))"
+										style:color="hsl(var(--muted-foreground))"
+									>
+										No tables yet — flip back to <span class="font-medium text-foreground"
+											>Schema Canvas</span
+										> to add some.
+									</div>
+								</div>
+							{:else if filteredTables.length === 0}
+								<div class="p-3">
+									<div
+										class="rounded border border-dashed p-3 text-center text-xs"
+										style:border-color="hsl(var(--border))"
+										style:color="hsl(var(--muted-foreground))"
+									>
+										No matches for <span class="font-mono text-foreground">{tableFilterQuery}</span
+										>.
+									</div>
+								</div>
+							{:else}
+								<ul>
+									{#each filteredTables as t (t.id)}
+										{@const isCollapsed =
+											collapsedTables.has(t.id) && !forceOpenForFilter.has(t.id)}
+										<li
+											class="flex border-b"
+											style:border-color="hsl(var(--border))"
+											data-testid="workbench-table-row"
+										>
+											<button
+												type="button"
+												onclick={() => toggleTableCollapsed(t.id)}
+												draggable="true"
+												ondragstart={(e) => handleTableDragStart(e, t)}
+												class="flex flex-1 cursor-grab items-center gap-1.5 px-3 py-1.5 text-left text-xs hover:bg-accent/40 active:cursor-grabbing"
+												title="Click to expand columns, drag to bind a dimension"
+											>
+												{#if isCollapsed}
+													<ChevronRight class="h-3 w-3 shrink-0 opacity-60" aria-hidden="true" />
+												{:else}
+													<ChevronDown class="h-3 w-3 shrink-0 opacity-60" aria-hidden="true" />
+												{/if}
+												<Database class="h-3 w-3 shrink-0 opacity-70" aria-hidden="true" />
+												<span class="truncate font-mono">
+													{#if t.schema}<span class="opacity-60">{t.schema}.</span>{/if}{t.name}
+												</span>
+												<span class="ml-auto text-[10px] opacity-60">{t.columns.length}</span>
+											</button>
+											<!-- Click-to-create-dim: makes a dim bound to this T -->
+											<button
+												type="button"
+												onclick={() => createDimFromTable(t)}
+												class="shrink-0 px-2 text-muted-foreground hover:bg-accent/40 hover:text-foreground"
+												aria-label="Create dimension from this table"
+												title="Create dimension bound to this table"
+												data-testid="workbench-table-create-dim"
+											>
+												<Layers class="h-3 w-3" aria-hidden="true" />
+											</button>
+											{#if !isCollapsed}
+												<ul class="pb-1">
+													{#each t.columns.filter( (c) => columnMatchesFilter(c.name) ) as col (col.name)}
+														{@const kind = classifyColumn(col.sqlType)}
+														<li
+															draggable="true"
+															ondragstart={(e) => handleColumnDragStart(e, t, col)}
+															class="group flex cursor-grab items-center gap-1.5 px-3 py-1 pl-7 text-[11px] hover:bg-accent/40 active:cursor-grabbing"
+															data-testid="workbench-column-row"
+															data-table-id={t.id}
+															data-column-name={col.name}
+														>
+															<GripVertical
+																class="h-3 w-3 shrink-0 opacity-30 group-hover:opacity-70"
+																aria-hidden="true"
+															/>
+															<span class="truncate font-mono">{col.name}</span>
+															<span
+																class="ml-auto shrink-0 font-mono text-[9px] tracking-wide uppercase opacity-50"
+																title={col.sqlType}
+															>
+																{kind ?? col.sqlType}
+															</span>
+														</li>
+													{/each}
+												</ul>
+											{/if}
+										</li>
+									{/each}
+								</ul>
+							{/if}
+						</div>
+					{/if}
+				</section>
+			</aside>
+		{/if}
+
+		<!-- ── CENTER: dimensions + measures authoring ─────────────────── -->
+		<div class="flex h-full min-h-0 flex-1 flex-col overflow-hidden bg-elev-0">
+			<!-- Sub-header removed: the "Schema" title, the Columns/Tree view
+		     toggle, and the aggregate `N dimensions · N levels · N measures`
+		     block all landed on the pane headers (dims/attrs/hier show
+		     their own counts, F&M shows its own measures count, and the
+		     tab bar drives the surface).  Tree view will move to the
+		     `Confirm cube` tab as a schema outline. -->
+
+			<!-- Single-column flex layout — the second 360px grid column that
+		     used to host the inline Measures rail is gone (Measures moved
+		     to the outer aside for Cards/Tree, and becomes a pane in
+		     Columns mode), so the dimensions area now uses the full
+		     width and isn't constrained by a phantom reserved column. -->
+			<!-- No inner padding — panes render flush to the page shell edges,
+		     matching how Schema Canvas fills its own container. -->
+			<div class="flex min-h-0 flex-1 flex-col gap-3 overflow-auto">
+				<!-- DIMENSIONS ZONE -->
+				<section
+					class="flex h-full min-h-0 flex-1 flex-col gap-2"
+					data-testid="workbench-dimensions-zone"
+				>
+					<!-- Columns mode has no outer section title (each pane owns
+				     its own header), so the title row was rendering as an
+				     empty 0-height row + a gap-2 that ate 8px above the
+				     panes.  Guard the whole row on viewMode !== 'columns'. -->
+					{#if viewMode !== 'columns'}
+						<div class="flex items-center justify-between gap-2">
+							<!-- Tree focus toggle — picks which root branch fills the
+						     column.  The schema has TWO concerns that don't nest
+						     under each other (shared dimensions on one side, cubes
+						     with their MGs on the other), so a single "DIMENSIONS"
+						     header was misleading. -->
+							<div class="flex flex-wrap items-center gap-2">
+								<div
+									class="inline-flex overflow-hidden rounded border"
+									style:border-color="hsl(var(--border))"
+									role="group"
+									aria-label="Tree focus"
+									data-testid="workbench-tree-focus-toggle"
+								>
+									<button
+										type="button"
+										onclick={() => (treeFocus = 'dims')}
+										aria-pressed={treeFocus === 'dims'}
+										class="inline-flex items-center gap-1 px-2.5 py-1 text-[11px] font-semibold tracking-wide uppercase transition-colors {treeFocus ===
+										'dims'
+											? 'bg-primary text-primary-foreground'
+											: 'text-muted-foreground hover:bg-accent/40'}"
+										data-testid="workbench-tree-focus-dims"
+									>
+										<Layers class="h-3 w-3" aria-hidden="true" />
+										Dimensions &amp; Hierarchies
+									</button>
+									<button
+										type="button"
+										onclick={() => (treeFocus = 'cubes')}
+										aria-pressed={treeFocus === 'cubes'}
+										class="inline-flex items-center gap-1 border-l px-2.5 py-1 text-[11px] font-semibold tracking-wide uppercase transition-colors {treeFocus ===
+										'cubes'
+											? 'bg-primary text-primary-foreground'
+											: 'text-muted-foreground hover:bg-accent/40'}"
+										style:border-color="hsl(var(--border))"
+										data-testid="workbench-tree-focus-cubes"
+									>
+										<Sigma class="h-3 w-3" aria-hidden="true" />
+										Cube Facts &amp; Measures
+									</button>
+								</div>
+								{#if treeFocus === 'dims'}
+									<Button
+										size="sm"
+										variant="ghost"
+										onclick={() => addDimensionAndFocus()}
+										data-testid="workbench-add-dimension"
+									>
+										<Plus class="h-3 w-3" aria-hidden="true" />
+										Add dimension
+									</Button>
+								{:else}
+									<Button
+										size="sm"
+										variant="ghost"
+										onclick={() => {
+											const fresh = addCube();
+											selectedTreeCubeId = fresh.id;
+											selectedTreeMeasureGroupId = null;
+										}}
+										data-testid="workbench-tree-add-cube"
+									>
+										<Plus class="h-3 w-3" aria-hidden="true" />
+										New cube
+									</Button>
+								{/if}
+							</div>
+							<!-- Tree / Columns toggle moved to the top "Dimensions
+						     Workbench" header bar (centered) so this section
+						     toolbar reads cleaner. -->
+						</div>
+					{/if}
+
+					{#if viewMode === 'columns'}
+						<!-- Columns view layout: a horizontal split.  On the left,
+					     a vertical stack of two collapsible sections —
+					     Dimensions (Create Your Dimensions & Hierarchies)
+					     on top and Facts (Fact & Measures + Measure Groups
+					     + Calculated Measures) underneath — separated by a
+					     drag-resize handle.  On the right, an Inspector
+					     drawer with Properties / Code tabs that collapses
+					     to a thin vertical strip.
+					     Each of the three regions can be hidden so the
+					     user focuses on whatever they're editing without
+					     leaving this screen. -->
+						<!-- Layout axis depends on the Inspector's docking side.
+					     `bottom` → flex-col (drawer sits under the panes).
+					     `right`  → flex-row (drawer sits to the right of them). -->
+						<div
+							class="flex h-full min-h-0 gap-2 {inspectorPosition === 'bottom'
+								? 'flex-col'
+								: 'flex-row'}"
+						>
+							<!-- LEFT MAIN STACK: Dimensions on top, Facts below.
+						     Hidden when the inspector is maximized so the
+						     drawer's content (Sample data table / Try a query
+						     result) takes over the whole workbench area. -->
+							{#if !inspectorMaximized}
+								<div bind:this={workbenchBodyEl} class="flex min-h-0 min-w-0 flex-1 flex-col gap-2">
+									<!-- Dim body renders ONLY in the workbench tab.  In `facts`
+								     (or `validate`) mode the top-level tab bar drives
+								     what's showing — collapsed strip within this view
+								     would be confusing extra chrome. -->
+									{#if store.mode !== 'workbench'}
+										<!-- Nothing — dim section belongs to another tab. -->
+									{:else if dimSectionCollapsed}
+										<button
+											type="button"
+											onclick={() => (dimSectionCollapsed = false)}
+											class="flex shrink-0 items-center justify-between gap-2 rounded border bg-elev-2 px-3 py-1.5 text-[11px] font-semibold tracking-wider text-muted-foreground uppercase hover:bg-accent/40"
+											style:border-color="hsl(var(--border))"
+											data-testid="workbench-dim-section-expand"
+											title="Expand dimensions area"
+										>
+											<ChevronDown class="h-3 w-3 shrink-0" aria-hidden="true" />
+											<span class="flex-1 text-left">Create Your Dimensions &amp; Hierarchies</span>
+										</button>
+									{:else}
+										<!-- Section frame chrome removed — the title sits
+								     directly above the content as a small eyebrow,
+								     no rounded border / bg-elev-2 wrap. -->
+										<!-- Section eyebrow + collapse chevron removed — the step
+									     indicator above the tab bar already tells the user
+									     they're on Dimensions & Hierarchies. -->
+										<div
+											class="flex min-h-0 flex-col"
+											style:flex={factsSectionCollapsed ? '1 1 0' : `${dimFactsFraction} 1 0`}
+										>
+											<div class="flex min-h-0 flex-1 overflow-hidden">
+												<DimensionsHierarchiesPane
+													{store}
+													{columnSlots}
+													{paneDragIndex}
+													{paneDragOverIndex}
+													{dimSortKey}
+													{dimSortDir}
+													{attributeCount}
+													{hierarchyCount}
+													{levelCount}
+													{selectedDimension}
+													{selectedHierarchy}
+													{joinGroupsRail}
+													{PANE_KIND_ICONS}
+													{PANE_KIND_LABELS}
+													bind:attributesPaneMode
+													bind:contentDragOverHierarchyId
+													bind:deletingDimId
+													bind:dimDragOverHierName
+													bind:dimensionPaneFilter
+													bind:dimensionPaneMode
+													bind:dimensionPreviewKey
+													bind:editingDimNameId
+													bind:editingHierNameId
+													bind:focusDimId
+													bind:hierarchyExplicitlyClicked
+													bind:manualAddDimName
+													bind:manualAddDimOpen
+													bind:manualAddDimSourceKey
+													bind:selectedAttributeKey
+													bind:selectedLevelId
+													bind:selectedDimensionId
+													bind:selectedHierarchyId
+													bind:selectedMeasureId
+													{focus}
+													{isFocused}
+													{isContext}
+													{autoFocus}
+													{columnTypeFor}
+													{dropRingFor}
+													{addHierarchyFromAttribute}
+													{commitDimensionName}
+													{commitHierarchyName}
+													{createDimFromJoinGroup}
+													{createDimFromTable}
+													{handleAttributeDragStart}
+													{handleDimensionDrop}
+													{handleDragLeave}
+													{handleDragOver}
+													{handlePaneDragEnd}
+													{handlePaneDragLeave}
+													{handlePaneDragOver}
+													{handlePaneDragStart}
+													{handlePaneDrop}
+													{renameDimension}
+													{renameHierarchy}
+													{requestDeleteHierarchy}
+													{resetManualAddDim}
+													{toggleDimSort}
+												/>
+											</div>
+										</div>
+									{/if}
+									<!-- Vertical resize handle between Dim and Facts.
+							     Only useful when both sections are expanded —
+							     otherwise the open one takes the full height. -->
+									{#if !dimSectionCollapsed && !factsSectionCollapsed}
+										<div
+											role="separator"
+											aria-orientation="horizontal"
+											aria-label="Resize dimensions / facts split"
+											onpointerdown={handleDimFactsResizeStart}
+											class="workbench-resize-handle flex h-3 shrink-0 cursor-row-resize items-center justify-center rounded {dimFactsResizing
+												? 'workbench-resize-handle-active'
+												: ''}"
+											data-testid="workbench-dim-facts-resize"
+											title="Drag to resize"
+										>
+											<div class="h-1 w-16 rounded-full"></div>
+										</div>
+									{/if}
+									<!-- Top-level tab drives mode; facts body renders ONLY in
+								     the `facts` tab.  The collapsed-strip button used to
+								     appear when a user closed the facts pane from within
+								     the workbench view — with the tab bar that path is
+								     gone, so we skip the strip entirely in wrong-mode. -->
+									{#if store.mode !== 'facts'}
+										<!-- Nothing — the facts section belongs to another tab. -->
+									{:else if factsSectionCollapsed}
+										<button
+											type="button"
+											onclick={() => (factsSectionCollapsed = false)}
+											class="flex shrink-0 items-center justify-between gap-2 rounded border bg-elev-2 px-3 py-1.5 text-[11px] font-semibold tracking-wider text-muted-foreground uppercase hover:bg-accent/40"
+											style:border-color="hsl(var(--border))"
+											data-testid="workbench-facts-section-expand"
+											title="Expand facts area"
+										>
+											<ChevronUp class="h-3 w-3 shrink-0" aria-hidden="true" />
+											<span class="flex-1 text-left"
+												>Facts &amp; Measures — {selectedCube?.name ?? 'Cube'}</span
+											>
+										</button>
+									{:else}
+										<!-- gap-3 matches the horizontal gap between Measure Groups
+									     and Calculations below so vertical and horizontal
+									     breathing room stay symmetric. -->
+										<div class="flex min-h-0 flex-1 flex-col gap-3">
+											<!-- Full-width Cube picker panel — its own bordered
+										     surface at the top of the tab so it reads as "you
+										     are choosing a cube to work on".  Matches the pane
+										     chrome (rounded border, header eyebrow, body). -->
+											<section
+												class="flex shrink-0 flex-col rounded-md border bg-elev-1"
+												style:border-color="hsl(var(--border))"
+												data-testid="workbench-cube-picker-panel"
+											>
+												<header
+													class="flex shrink-0 items-center gap-2 border-b bg-elev-1 px-2.5 py-1.5"
+													style:border-color="hsl(var(--border))"
+												>
+													<Box class="h-3.5 w-3.5 shrink-0 text-primary" aria-hidden="true" />
+													<span class="text-[11px] font-semibold tracking-wider uppercase">
+														Cube
+													</span>
+													<span
+														class="truncate text-[10px]"
+														style:color="hsl(var(--muted-foreground))"
+													>
+														— pick a cube to see its facts and measures below
+													</span>
+													<!-- Header-right actions: "New cube" and "Edit permissions".
+												     Both trigger the expanded 2-column view (right side
+												     hosts either the new-cube form or the selected cube's
+												     permissions).  Keeping the picker row below tight. -->
+													<div class="ml-auto flex shrink-0 items-center gap-1">
+														<button
+															type="button"
+															onclick={() => {
+																cubePermissionsOpen = true;
+																cubeNewFormOpen = true;
+																cubeNewFormName = '';
+																cubeNewFormVisibility = 'workspace';
+																cubeNewFormGroups = '';
+															}}
+															class="inline-flex items-center gap-1 rounded border px-2 py-0.5 text-[10px] font-medium text-primary hover:bg-primary/10"
+															style:border-color="hsl(var(--primary))"
+															data-testid="workbench-cube-header-new"
+															title="Create a new cube"
+														>
+															<Plus class="h-3 w-3" aria-hidden="true" />
+															New cube
+														</button>
+														<button
+															type="button"
+															onclick={() => {
+																cubePermissionsOpen = !cubePermissionsOpen;
+																cubeNewFormOpen = false;
+															}}
+															class="inline-flex items-center gap-1 rounded border px-2 py-0.5 text-[10px] font-medium text-muted-foreground hover:bg-accent/40"
+															style:border-color="hsl(var(--border))"
+															data-testid="workbench-cube-header-edit-perms"
+															title="Cube properties"
+														>
+															<Lock class="h-3 w-3" aria-hidden="true" />
+															Cube properties
+														</button>
+													</div>
+												</header>
+												{#if !cubePermissionsOpen}
+													<!-- Compact mode: just the picker.  Actions moved to
+												     the header top-right. -->
+													<div class="p-2">
+														{@render cubeSwitcher()}
+													</div>
+												{:else}
+													<!-- Expanded mode: 2-column layout.  LEFT = scrollable
+												     list of cubes; RIGHT = details (name +
+												     permissions) for the selected cube OR the inline
+												     new-cube form when the user hit "New cube". -->
+													<div
+														class="flex min-h-[240px] flex-row gap-3 border-t p-2"
+														style:border-color="hsl(var(--border))"
+														data-testid="workbench-cube-manage"
+													>
+														<!-- LEFT: cube list + "+ New cube" at the bottom. -->
+														<div
+															class="flex w-40 shrink-0 flex-col gap-1 rounded border bg-elev-2"
+															style:border-color="hsl(var(--border))"
+														>
+															<div
+																class="shrink-0 border-b px-2 py-1 text-[10px] font-semibold tracking-wider uppercase"
+																style:border-color="hsl(var(--border))"
+																style:color="hsl(var(--muted-foreground))"
+															>
+																Cubes · {cubes.length}
+															</div>
+															<div
+																class="flex min-h-0 flex-1 flex-col overflow-y-auto"
+																data-testid="workbench-cube-manage-list"
+															>
+																{#each cubes as c (c.id)}
+																	{@const active = c.id === selectedCubeId && !cubeNewFormOpen}
+																	<button
+																		type="button"
+																		onclick={() => {
+																			switchCube(c.id);
+																			cubeNewFormOpen = false;
+																		}}
+																		class="flex items-center justify-between gap-2 border-b px-2 py-1.5 text-left text-[11px] last:border-b-0 {active
+																			? 'bg-primary/10 font-semibold text-foreground'
+																			: 'text-muted-foreground hover:bg-accent/40'}"
+																		style:border-color="hsl(var(--border))"
+																		data-testid="workbench-cube-manage-item"
+																		data-cube-id={c.id}
+																	>
+																		<span class="truncate">{c.name || 'Untitled cube'}</span>
+																		{#if active}
+																			<span class="shrink-0 text-primary">●</span>
+																		{/if}
+																	</button>
+																{/each}
+															</div>
+															<button
+																type="button"
+																onclick={() => {
+																	cubeNewFormOpen = true;
+																	cubeNewFormName = '';
+																	cubeNewFormVisibility = 'workspace';
+																	cubeNewFormGroups = '';
+																}}
+																class="flex shrink-0 items-center gap-1 border-t px-2 py-1.5 text-left text-[11px] font-medium text-primary hover:bg-primary/10"
+																style:border-color="hsl(var(--border))"
+																data-testid="workbench-cube-picker-new"
+															>
+																<Plus class="h-3 w-3" aria-hidden="true" />
+																New cube
+															</button>
+														</div>
+														<!-- RIGHT: details / new-cube form. -->
+														<div
+															class="flex min-w-0 flex-1 flex-col gap-2 overflow-y-auto"
+															data-testid="workbench-cube-manage-detail"
+														>
+															{#if cubeNewFormOpen}
+																<div
+																	class="flex flex-col gap-2"
+																	data-testid="workbench-cube-new-form"
+																>
+																	<label class="flex flex-col gap-1 text-[11px]">
+																		<span
+																			class="text-[10px] font-semibold tracking-wider uppercase"
+																			style:color="hsl(var(--muted-foreground))"
+																		>
+																			Cube name
+																		</span>
+																		<input
+																			type="text"
+																			bind:value={cubeNewFormName}
+																			placeholder="e.g. Sales"
+																			class="h-7 rounded border bg-background px-2 text-[11px] focus:border-ring focus:ring-1 focus:ring-ring focus:outline-none"
+																			style:border-color="hsl(var(--border))"
+																			data-testid="workbench-cube-new-name"
+																		/>
+																	</label>
+																	{@render permissionsFieldset('workbench-cube-new')}
+																	<div class="flex items-center justify-end gap-2 pt-1">
+																		<button
+																			type="button"
+																			onclick={() => (cubeNewFormOpen = false)}
+																			class="rounded px-3 py-1 text-[11px] text-muted-foreground hover:bg-accent/40"
+																			data-testid="workbench-cube-new-cancel"
+																		>
+																			Cancel
+																		</button>
+																		<button
+																			type="button"
+																			onclick={() => {
+																				const fresh = addCube();
+																				if (cubeNewFormName.trim()) {
+																					renameCube(fresh.id, cubeNewFormName.trim());
+																				}
+																				switchCube(fresh.id);
+																				cubeNewFormOpen = false;
+																			}}
+																			class="inline-flex items-center gap-1 rounded bg-primary px-3 py-1 text-[11px] font-medium text-primary-foreground hover:bg-primary/90"
+																			data-testid="workbench-cube-new-create"
+																		>
+																			<Plus class="h-3 w-3" aria-hidden="true" />
+																			Create cube
+																		</button>
+																	</div>
+																</div>
+															{:else if selectedCube}
+																<label class="flex flex-col gap-1 text-[11px]">
+																	<span
+																		class="text-[10px] font-semibold tracking-wider uppercase"
+																		style:color="hsl(var(--muted-foreground))"
+																	>
+																		Cube name
+																	</span>
+																	<input
+																		type="text"
+																		value={selectedCube.name}
+																		oninput={(e) =>
+																			renameCube(selectedCube!.id, e.currentTarget.value)}
+																		placeholder="Cube name"
+																		class="h-7 rounded border bg-background px-2 text-[11px] focus:border-ring focus:ring-1 focus:ring-ring focus:outline-none"
+																		style:border-color="hsl(var(--border))"
+																		data-testid="workbench-cube-manage-name"
+																	/>
+																</label>
+																<div
+																	class="mt-1 flex items-center gap-1 text-[10px]"
+																	style:color="hsl(var(--muted-foreground))"
+																>
+																	<Lock class="h-3 w-3" aria-hidden="true" />
+																	Permissions — draft, not yet wired
+																</div>
+																{@render permissionsFieldset('workbench-cube-existing')}
+															{:else}
+																<p class="text-[11px] text-muted-foreground">
+																	Pick a cube on the left, or hit “New cube” to add one.
+																</p>
+															{/if}
+														</div>
+													</div>
+													<button
+														type="button"
+														onclick={() => {
+															cubePermissionsOpen = false;
+															cubeNewFormOpen = false;
+														}}
+														class="flex shrink-0 items-center justify-center gap-1 border-t px-2 py-1 text-[10px] font-semibold tracking-wider text-muted-foreground uppercase hover:bg-accent/40"
+														style:border-color="hsl(var(--border))"
+														data-testid="workbench-cube-manage-close"
+													>
+														<ChevronUp class="h-3 w-3" aria-hidden="true" />
+														Collapse
+													</button>
+												{/if}
+											</section>
+											<!-- F&M body: MG + Add Calc panes fill the rest. -->
+											<div class="flex min-h-0 flex-1 overflow-hidden">
+												<div class="flex h-full min-h-0 w-full flex-row gap-3">
+													<FactsMeasuresPane
+														{store}
+														{factsSlots}
+														{factsPaneDragIndex}
+														{factsPaneDragOverIndex}
+														{AGGREGATORS}
+														{ALLOW_GROUP_DROP_ON_CALC}
+														{factsSelectedMeasures}
+														bind:factsEditMode
+														bind:factsSelectedTableId
+														bind:factsTableSearch
+														bind:factsTableConfirmed
+														bind:factsMeasureGroups
+														bind:factsSelectedGroupId
+														bind:factsEditingMeasureGroupId
+														bind:focusGroupId
+														bind:factsCalcs
+														bind:factsEditingCalcId
+														bind:editingMeasureCaption
+														{selectMgMeasure}
+														{selectMgDimension}
+														{selectFactsCalc}
+														{handleFactsPaneDragStart}
+														{handleFactsPaneDragOver}
+														{handleFactsPaneDragLeave}
+														{handleFactsPaneDrop}
+														{handleFactsPaneDragEnd}
+														{addFactsMeasureGroup}
+														{removeFactsMeasureGroup}
+														{renameFactsMeasureGroup}
+														{addFactsCalc}
+														{removeFactsCalc}
+														{renameFactsCalc}
+														{addCalcMeasure}
+														{addCalcOperator}
+														{popCalcToken}
+														{clearCalcTokens}
+														{setCalcMode}
+														{updateCalcFormula}
+														{calcNeedsMeasure}
+														{formatCalcOp}
+														{commitMeasureCaption}
+														{focus}
+														{isFocused}
+														{autoFocus}
+													/>
+												</div>
+											</div>
+										</div>
+									{/if}
+								</div>
+							{/if}
+							<!-- INSPECTOR DRAWER.  Orientation follows `inspectorPosition`:
+						       - bottom → horizontal strip / row-drag resize / height
+						       - right  → vertical strip / col-drag resize / width
+						     Chevrons flip Up/Down vs Left/Right accordingly. -->
+							{#if inspectorCollapsed}
+								{#if inspectorPosition === 'bottom'}
+									<button
+										type="button"
+										onclick={() => (inspectorCollapsed = false)}
+										class="flex h-8 w-full shrink-0 items-center justify-between gap-2 rounded border bg-elev-2 px-2 py-1 text-[10px] font-semibold tracking-wider text-muted-foreground uppercase hover:bg-accent/40"
+										style:border-color="hsl(var(--border))"
+										data-testid="workbench-inspector-drawer-expand"
+										title="Open inspector drawer"
+									>
+										<ChevronUp class="h-3 w-3" aria-hidden="true" />
+										<span>Inspector</span>
+										<ChevronUp class="h-3 w-3 opacity-0" aria-hidden="true" />
+									</button>
+								{:else}
+									<button
+										type="button"
+										onclick={() => (inspectorCollapsed = false)}
+										class="flex h-full w-8 shrink-0 flex-col items-center justify-start gap-2 rounded border bg-elev-2 px-1 py-2 text-[10px] font-semibold tracking-wider text-muted-foreground uppercase hover:bg-accent/40"
+										style:border-color="hsl(var(--border))"
+										data-testid="workbench-inspector-drawer-expand"
+										title="Open inspector drawer"
+									>
+										<ChevronLeft class="h-3 w-3" aria-hidden="true" />
+										<span style:writing-mode="vertical-rl">Inspector</span>
+									</button>
+								{/if}
+							{:else}
+								{#if !inspectorMaximized}
+									{#if inspectorPosition === 'bottom'}
+										<div
+											role="separator"
+											aria-orientation="horizontal"
+											aria-label="Resize inspector drawer"
+											onpointerdown={handleInspectorDrawerResizeStart}
+											class="workbench-resize-handle flex h-3 w-full shrink-0 cursor-row-resize items-center justify-center rounded {inspectorDrawerResizing
+												? 'workbench-resize-handle-active'
+												: ''}"
+											data-testid="workbench-inspector-drawer-resize"
+											title="Drag to resize"
+										>
+											<div class="h-1 w-16 rounded-full"></div>
+										</div>
+									{:else}
+										<div
+											role="separator"
+											aria-orientation="vertical"
+											aria-label="Resize inspector drawer"
+											onpointerdown={handleInspectorDrawerResizeStart}
+											class="workbench-resize-handle flex w-3 shrink-0 cursor-col-resize flex-col items-center justify-center rounded {inspectorDrawerResizing
+												? 'workbench-resize-handle-active'
+												: ''}"
+											data-testid="workbench-inspector-drawer-resize"
+											title="Drag to resize"
+										>
+											<div class="h-16 w-1 rounded-full"></div>
+										</div>
+									{/if}
+								{/if}
+								{#if inspectorPosition === 'bottom'}
+									<div
+										bind:this={inspectorDrawerEl}
+										class="flex min-h-0 w-full min-w-0 flex-col {inspectorMaximized
+											? 'flex-1'
+											: 'shrink-0'}"
+										style:height={inspectorMaximized ? undefined : `${inspectorDrawerHeight}px`}
+										data-testid="workbench-inspector-drawer"
+									>
+										{@render inspectorPanel()}
+									</div>
+								{:else}
+									<div
+										bind:this={inspectorDrawerEl}
+										class="flex h-full min-h-0 min-w-0 flex-col {inspectorMaximized
+											? 'flex-1'
+											: 'shrink-0'}"
+										style:width={inspectorMaximized ? undefined : `${inspectorDrawerWidth}px`}
+										data-testid="workbench-inspector-drawer"
+									>
+										{@render inspectorPanel()}
+									</div>
+								{/if}
+							{/if}
+						</div>
+					{:else if viewMode === 'cards'}
+						<!-- Drop zone fallback / empty hint AND the cards live in
+					     the same dnd container.  The container itself accepts
+					     drops to create a new dimension; existing dim cards
+					     intercept drops at their level.
+					     When empty AND nothing is being dragged, the zone
+					     shows a muted dashed boundary so the user can see
+					     it's a target — otherwise the hint floats in white
+					     space.  Once a dim card is in place we drop the
+					     boundary so the cards aren't visually wrapped. -->
+						<div
+							role="region"
+							aria-label="Dimensions drop zone"
+							class="grid flex-1 grid-cols-1 gap-2 rounded-md border-2 border-dashed p-2 transition-colors lg:grid-cols-2 {dropRingFor(
+								{ kind: 'dim-zone' }
+							)} {store.dimensions.length === 0 && !isDragging ? 'border-border' : ''}"
+							ondragover={(e) => handleDragOver(e, { kind: 'dim-zone' })}
+							ondragleave={(e) => handleDragLeave(e, { kind: 'dim-zone' })}
+							ondrop={handleDimensionsZoneDrop}
+							data-testid="workbench-dimensions-drop"
+						>
+							{#if store.dimensions.length === 0}
+								<div
+									class="col-span-full flex flex-col items-center justify-center gap-2 p-8 text-center"
+									style:color="hsl(var(--muted-foreground))"
+								>
+									<Layers class="h-6 w-6" aria-hidden="true" />
+									<p class="text-sm font-medium" style:color="hsl(var(--foreground))">
+										No dimensions yet
+									</p>
+									<p class="max-w-sm text-xs leading-relaxed">
+										Drag a column, a table, or a join group from the left rail to create your first
+										dimension — or start with an empty card and pull columns into it.
+									</p>
+									<Button
+										size="sm"
+										variant="outline"
+										onclick={() => addDimensionAndFocus()}
+										data-testid="workbench-empty-add-dimension"
+										class="mt-1"
+									>
+										<Plus class="h-3 w-3" aria-hidden="true" />
+										Add a dimension
+									</Button>
+								</div>
+							{/if}
+
+							{#each store.dimensions as dim (dim.id)}
+								{@render dimensionCard(dim)}
+							{/each}
+						</div>
+					{:else}
+						<!-- Tree view: rendered via the shared `treeView` snippet
+						     (also used by the Confirm cube > Tree sub-tab). -->
+						{@render treeView()}
+					{/if}
+				</section>
+			</div>
+		</div>
+
+		<!-- ── RIGHT RAIL: Measures.  Only relevant in Cards view, where
+	     dimensions live as cards in the centre and measures need a
+	     dedicated drop zone on the side.
+	     Hidden in Columns mode — Measures is a dockable pane there.
+	     Hidden in Tree mode — measures now live inside per-MG nodes
+	     under each cube, so a global rail showing store.measures is
+	     stale + redundant with the tree's own measure rendering. -->
+		{#if viewMode === 'cards'}
+			<aside
+				class="flex w-72 shrink-0 flex-col gap-3 overflow-y-auto border-l p-3"
+				style:background="hsl(var(--card))"
+				style:border-color="hsl(var(--border))"
+				aria-label="Measures"
+				data-testid="workbench-measures-rail"
+			>
+				<section class="flex min-h-0 flex-1 flex-col gap-2" data-testid="workbench-measures-zone">
+					<div class="flex items-center justify-between">
+						<div class="flex items-center gap-1.5">
+							<Sigma class="h-3.5 w-3.5 text-primary" aria-hidden="true" />
+							<h3 class="text-xs font-semibold tracking-wide uppercase">Measures</h3>
+						</div>
+						<span class="text-[10px] text-muted-foreground">
+							{measureCount}
+							{measureCount === 1 ? 'measure' : 'measures'}
+						</span>
+					</div>
+					{#if viewMode === 'cards'}
+						<div
+							role="region"
+							aria-label="Measures drop zone"
+							class="flex min-h-[220px] flex-1 flex-col gap-1.5 rounded-md border-2 border-dashed p-2 transition-colors {dropRingFor(
+								{ kind: 'measure-zone' }
+							)}"
+							ondragover={(e) => handleDragOver(e, { kind: 'measure-zone' })}
+							ondragleave={(e) => handleDragLeave(e, { kind: 'measure-zone' })}
+							ondrop={handleMeasuresZoneDrop}
+							data-testid="workbench-measures-drop"
+						>
+							{#if store.measures.length === 0}
+								<div
+									class="flex flex-1 flex-col items-center justify-center gap-1 p-4 text-center"
+									style:color="hsl(var(--muted-foreground))"
+								>
+									<Sigma class="h-5 w-5" aria-hidden="true" />
+									<p class="text-xs font-medium" style:color="hsl(var(--foreground))">
+										Drag a numeric column here to add a measure.
+									</p>
+									<p class="text-[11px]">Defaults to <span class="font-mono">sum</span>.</p>
+								</div>
+							{:else}
+								{#each store.measures as m (m.id)}
+									{@render measureRow(m)}
+								{/each}
+							{/if}
+						</div>
+					{:else}
+						<div
+							role="region"
+							aria-label="Measures tree"
+							class="flex min-h-[220px] flex-1 flex-col gap-0.5 rounded-md border-2 border-dashed p-2 transition-colors {dropRingFor(
+								{ kind: 'measure-zone' }
+							)}"
+							ondragover={(e) => handleDragOver(e, { kind: 'measure-zone' })}
+							ondragleave={(e) => handleDragLeave(e, { kind: 'measure-zone' })}
+							ondrop={handleMeasuresZoneDrop}
+							data-testid="workbench-measures-tree"
+						>
+							{@render treeRootRow('Measures', 'measure')}
+							{#if store.measures.length === 0}
+								<p class="px-2 pl-6 text-[11px]" style:color="hsl(var(--muted-foreground))">
+									Drag a numeric column onto this region to add one.
+								</p>
+							{:else}
+								{#each store.measures as m (m.id)}
+									{@render measureTreeRow(m)}
+								{/each}
+							{/if}
+						</div>
+					{/if}
+				</section>
+			</aside>
+		{/if}
+	{/if}
+</div>
+
+<!-- ── Cube switcher — inline popover at the top of Facts & Measures.
+     Shows the active cube's name as a clickable trigger; menu lists every
+     cube + a "+ New cube" affordance.  Renames + deletes live in the
+     Inspector's Cubes tab; this stays a one-tap switcher.  Click-outside
+     closes the menu via a window-level handler the trigger registers
+     on open. ──────────────────────────────────────────────────────── -->
+{#snippet cubeSwitcher()}
+	{@const cube = selectedCube}
+	{#if cube}
+		<div class="relative min-w-0 flex-1">
+			<button
+				type="button"
+				onclick={(e) => {
+					e.stopPropagation();
+					cubeMenuOpen = !cubeMenuOpen;
+				}}
+				class="inline-flex w-full items-center justify-between gap-1 truncate rounded border bg-background px-2 py-1 text-[11px] font-semibold tracking-wider uppercase transition-colors hover:bg-accent/40 focus-visible:border-ring focus-visible:ring-1 focus-visible:ring-ring focus-visible:outline-none"
+				style:border-color="hsl(var(--border))"
+				style:color="hsl(var(--foreground))"
+				data-testid="workbench-cube-switcher-trigger"
+				aria-haspopup="menu"
+				aria-expanded={cubeMenuOpen}
+				title="Switch cube"
+			>
+				<span class="min-w-0 flex-1 truncate text-left">{cube.name || 'Untitled cube'}</span>
+				<ChevronDown class="h-3 w-3 shrink-0" aria-hidden="true" />
+			</button>
+			{#if cubeMenuOpen}
+				<!-- Backdrop catches outside clicks. -->
+				<button
+					type="button"
+					class="fixed inset-0 z-30 cursor-default"
+					onclick={() => (cubeMenuOpen = false)}
+					aria-label="Close cube menu"
+					tabindex="-1"
+				></button>
+				<div
+					role="menu"
+					class="absolute top-full right-0 left-0 z-40 mt-1 flex flex-col gap-0.5 rounded-md border bg-popover p-1 shadow-md"
+					style:border-color="hsl(var(--border))"
+					data-testid="workbench-cube-switcher-menu"
+				>
+					{#each cubes as c (c.id)}
+						{@const active = c.id === selectedCubeId}
+						<button
+							type="button"
+							onclick={() => {
+								switchCube(c.id);
+								cubeMenuOpen = false;
+							}}
+							class="flex items-center justify-between gap-2 rounded px-2 py-1 text-left text-[11px] {active
+								? 'bg-accent font-semibold text-accent-foreground'
+								: 'hover:bg-accent/40'}"
+							data-testid="workbench-cube-switcher-item"
+							data-cube-id={c.id}
+						>
+							<span class="truncate">{c.name || 'Untitled cube'}</span>
+							{#if active}
+								<span class="shrink-0 font-mono text-[9px] opacity-70">●</span>
+							{/if}
+						</button>
+					{/each}
+					<div class="my-1 h-px shrink-0" style:background-color="hsl(var(--border))"></div>
+					<button
+						type="button"
+						onclick={() => {
+							addCube();
+							cubeMenuOpen = false;
+						}}
+						class="flex items-center gap-2 rounded px-2 py-1 text-left text-[11px] text-primary hover:bg-accent/40"
+						data-testid="workbench-cube-switcher-add"
+					>
+						<Plus class="h-3 w-3 shrink-0" aria-hidden="true" />
+						New cube
+					</button>
+				</div>
+			{/if}
+		</div>
+	{/if}
+{/snippet}
+
+<!-- ── Cube permissions fieldset ──────────────────────────────────
+     Draft UI shared by (a) the collapsible Permissions section on
+     an existing cube and (b) the inline new-cube form.  Two knobs
+     mirror the schema-level ACL (`SaikuAclBackend`):
+       - visibility: private / workspace / public
+       - groups: comma-separated group names granted read+query
+     Nothing is persisted here yet — the eventual backend is the
+     cube ACL work tracked in #1029. -->
+{#snippet permissionsFieldset(idPrefix: string)}
+	<div class="flex flex-col gap-2 text-[11px]">
+		<div class="flex flex-col gap-1">
+			<span
+				class="text-[10px] font-semibold tracking-wider uppercase"
+				style:color="hsl(var(--muted-foreground))"
+			>
+				Visibility
+			</span>
+			<div
+				class="inline-flex w-full overflow-hidden rounded border"
+				style:border-color="hsl(var(--border))"
+				role="radiogroup"
+				aria-label="Cube visibility"
+			>
+				{#snippet visRadio(value: 'private' | 'workspace' | 'public', label: string, desc: string)}
+					<button
+						type="button"
+						role="radio"
+						aria-checked={cubeNewFormVisibility === value}
+						onclick={() => (cubeNewFormVisibility = value)}
+						class="inline-flex flex-1 flex-col items-start gap-0.5 border-l px-2 py-1 text-left transition-colors first:border-l-0 {cubeNewFormVisibility ===
+						value
+							? 'bg-primary text-primary-foreground'
+							: 'hover:bg-accent/40'}"
+						style:border-color="hsl(var(--border))"
+						data-testid="{idPrefix}-visibility-{value}"
+					>
+						<span class="text-[10px] font-semibold uppercase">{label}</span>
+						<span class="text-[9px] opacity-80">{desc}</span>
+					</button>
+				{/snippet}
+				{@render visRadio('private', 'Private', 'Only you')}
+				{@render visRadio('workspace', 'Workspace', 'Everyone in this workspace')}
+				{@render visRadio('public', 'Public', 'Anyone with a query link')}
+			</div>
+		</div>
+		<label class="flex flex-col gap-1">
+			<span
+				class="text-[10px] font-semibold tracking-wider uppercase"
+				style:color="hsl(var(--muted-foreground))"
+			>
+				Groups with access
+			</span>
+			<input
+				type="text"
+				bind:value={cubeNewFormGroups}
+				placeholder="finance-analysts, ops-leads"
+				class="h-7 rounded border bg-background px-2 text-[11px] focus:border-ring focus:ring-1 focus:ring-ring focus:outline-none"
+				style:border-color="hsl(var(--border))"
+				data-testid="{idPrefix}-groups"
+			/>
+			<span class="text-[10px] opacity-70">
+				Comma-separated group names. Members of these groups get read + query.
+			</span>
+		</label>
+	</div>
+{/snippet}
+
+<!-- ── Dimension card snippet ────────────────────────────────────── -->
+{#snippet dimensionCard(dim: SchemaCanvasDimension)}
+	<article
+		class="flex flex-col rounded-md border bg-card p-2 shadow-sm transition-colors {dropRingFor({
+			kind: 'dim',
+			id: dim.id
+		})}"
+		style:border-color="hsl(var(--border))"
+		ondragover={(e) => handleDragOver(e, { kind: 'dim', id: dim.id })}
+		ondragleave={(e) => handleDragLeave(e, { kind: 'dim', id: dim.id })}
+		ondrop={(e) => handleDimensionDrop(e, dim)}
+		data-testid="workbench-dimension-card"
+		data-dimension-id={dim.id}
+	>
+		<header class="flex items-center gap-2">
+			<Layers class="h-3.5 w-3.5 shrink-0 text-primary" aria-hidden="true" />
+			<input
+				type="text"
+				value={dim.name}
+				oninput={(e) => renameDimension(dim.id, e.currentTarget.value)}
+				placeholder="Dimension name"
+				aria-label="Dimension name"
+				class="h-6 min-w-0 flex-1 rounded border border-transparent bg-transparent px-1 text-xs font-semibold hover:border-input focus:border-ring focus:bg-background focus:ring-1 focus:ring-ring focus:outline-none"
+				data-testid="workbench-dimension-name"
+				use:autoFocus={focusDimId === dim.id}
+			/>
+			<button
+				type="button"
+				onclick={() => store.removeDimension(dim.id)}
+				class="shrink-0 rounded p-1 text-muted-foreground transition-colors hover:bg-accent hover:text-accent-foreground"
+				aria-label="Delete dimension"
+				title="Delete dimension"
+				data-testid="workbench-dimension-delete"
+			>
+				<X class="h-3 w-3" aria-hidden="true" />
+			</button>
+		</header>
+
+		<div class="mt-2 space-y-2">
+			{#if dim.hierarchies.length === 1}
+				<!-- Singleton hierarchy — render the levels list flat inside
+				     the dim card.  No hierarchy name, no hier chrome, no
+				     "All" checkbox: most dims have exactly one drill path
+				     and the hierarchy is implicit in the dim itself.  The
+				     "Split into hierarchies" link below reveals the
+				     multi-hierarchy UI on demand. -->
+				{@render levelListInline(dim, dim.hierarchies[0])}
+				<button
+					type="button"
+					onclick={() => store.addHierarchy(dim.id)}
+					class="flex w-full items-center justify-center gap-1 rounded py-1 text-[10px] text-muted-foreground transition-colors hover:bg-accent hover:text-accent-foreground"
+					data-testid="workbench-split-hierarchies"
+					title="Add a second drilldown path (e.g. Calendar / Fiscal on a Time dim)"
+				>
+					<Plus class="h-3 w-3" aria-hidden="true" />
+					Split into hierarchies
+				</button>
+			{:else}
+				{#each dim.hierarchies as hier (hier.id)}
+					{@render hierarchyBlock(dim, hier)}
+				{/each}
+				<button
+					type="button"
+					onclick={() => store.addHierarchy(dim.id)}
+					class="flex w-full items-center justify-center gap-1 rounded border border-dashed py-1 text-[10px] text-muted-foreground transition-colors hover:bg-accent hover:text-accent-foreground"
+					style:border-color="hsl(var(--border))"
+					data-testid="workbench-add-hierarchy"
+				>
+					<Plus class="h-3 w-3" aria-hidden="true" />
+					Add hierarchy
+				</button>
+			{/if}
+		</div>
+	</article>
+{/snippet}
+
+<!-- ── Inline level list (singleton-hierarchy mode) ──────────────── -->
+<!--
+   When a dim has exactly one hierarchy we render its levels flat inside
+   the dim card, with no hierarchy header.  Drops still land on the dim
+   card itself (handleDimensionDrop → dim.hierarchies[0]), so the
+   gesture is identical; the user just never sees the word "hierarchy".
+   Same row markup as the multi-hierarchy hierarchyBlock so behaviour is
+   consistent — re-use the level row, the empty-state hint, the drag
+   semantics.
+-->
+{#snippet levelListInline(dim: SchemaCanvasDimension, hier: SchemaCanvasHierarchy)}
+	<ol class="space-y-1" data-testid="workbench-level-list-inline" data-hierarchy-id={hier.id}>
+		{#each hier.levels as lvl, idx (lvl.id)}
+			<li
+				class="flex items-center gap-1.5 rounded border bg-elev-2 px-1.5 py-1 text-[11px]"
+				style:border-color="hsl(var(--border))"
+				data-testid="workbench-level-row"
+			>
+				<span
+					class="inline-flex h-4 w-4 shrink-0 items-center justify-center rounded bg-accent font-mono text-[9px] text-accent-foreground"
+					aria-label="Level position"
+				>
+					{idx + 1}
+				</span>
+				<input
+					type="text"
+					value={lvl.name}
+					oninput={(e) => renameLevel(dim.id, hier.id, lvl.id, e.currentTarget.value)}
+					placeholder="Level"
+					aria-label="Level name"
+					class="h-5 min-w-0 flex-1 rounded border border-transparent bg-transparent px-1 hover:border-input focus:border-ring focus:bg-background focus:ring-1 focus:ring-ring focus:outline-none"
+				/>
+				<span
+					class="shrink-0 truncate font-mono text-[9px] tracking-wide opacity-60"
+					title="{tableNameFor(lvl.tableId)}.{lvl.columnName}"
+				>
+					{tableNameFor(lvl.tableId)}.{lvl.columnName}
+				</span>
+				<button
+					type="button"
+					onclick={() => store.removeLevel(dim.id, hier.id, lvl.id)}
+					class="shrink-0 rounded p-0.5 text-muted-foreground transition-colors hover:bg-accent hover:text-accent-foreground"
+					aria-label="Remove level"
+					title="Remove level"
+				>
+					<X class="h-2.5 w-2.5" aria-hidden="true" />
+				</button>
+			</li>
+		{/each}
+		{#if hier.levels.length === 0}
+			<li
+				class="rounded border border-dashed px-1.5 py-2 text-center text-[10px]"
+				style:border-color="hsl(var(--border))"
+				style:color="hsl(var(--muted-foreground))"
+			>
+				Drag a column here.
+			</li>
+		{/if}
+	</ol>
+{/snippet}
+
+<!-- ── Hierarchy block snippet ──────────────────────────────────── -->
+{#snippet hierarchyBlock(dim: SchemaCanvasDimension, hier: SchemaCanvasHierarchy)}
+	<section
+		class="rounded border p-1.5 transition-colors {dropRingFor({
+			kind: 'hierarchy',
+			dimensionId: dim.id,
+			hierarchyId: hier.id
+		})}"
+		style:background="hsl(var(--background))"
+		role="group"
+		aria-label="Hierarchy {hier.name}"
+		ondragover={(e) =>
+			handleDragOver(e, { kind: 'hierarchy', dimensionId: dim.id, hierarchyId: hier.id })}
+		ondragleave={(e) =>
+			handleDragLeave(e, { kind: 'hierarchy', dimensionId: dim.id, hierarchyId: hier.id })}
+		ondrop={(e) => handleHierarchyDrop(e, dim)}
+		data-testid="workbench-hierarchy"
+		data-hierarchy-id={hier.id}
+	>
+		<header class="flex items-center gap-1.5">
+			<ChevronDown class="h-3 w-3 shrink-0 opacity-50" aria-hidden="true" />
+			<input
+				type="text"
+				value={hier.name}
+				oninput={(e) => renameHierarchy(dim.id, hier.id, e.currentTarget.value)}
+				placeholder="Hierarchy"
+				aria-label="Hierarchy name"
+				class="h-5 min-w-0 flex-1 rounded border border-transparent bg-transparent px-1 text-[11px] font-medium hover:border-input focus:border-ring focus:bg-background focus:ring-1 focus:ring-ring focus:outline-none"
+			/>
+			<label
+				class="inline-flex shrink-0 items-center gap-1 text-[10px] text-muted-foreground"
+				title="Mondrian hasAll attribute"
+			>
+				<input
+					type="checkbox"
+					checked={hier.hasAll}
+					onchange={(e) =>
+						store.updateHierarchy(dim.id, hier.id, { hasAll: e.currentTarget.checked })}
+					class="h-3 w-3"
+				/>
+				All
+			</label>
+			<button
+				type="button"
+				onclick={() => store.removeHierarchy(dim.id, hier.id)}
+				class="shrink-0 rounded p-0.5 text-muted-foreground transition-colors hover:bg-accent hover:text-accent-foreground"
+				aria-label="Delete hierarchy"
+				title="Delete hierarchy"
+			>
+				<X class="h-2.5 w-2.5" aria-hidden="true" />
+			</button>
+		</header>
+
+		<ol class="mt-1.5 space-y-1">
+			{#each hier.levels as lvl, idx (lvl.id)}
+				<li
+					class="flex items-center gap-1.5 rounded border bg-elev-2 px-1.5 py-1 text-[11px]"
+					style:border-color="hsl(var(--border))"
+					data-testid="workbench-level-row"
+				>
+					<span
+						class="inline-flex h-4 w-4 shrink-0 items-center justify-center rounded bg-accent font-mono text-[9px] text-accent-foreground"
+						aria-label="Level position"
+					>
+						{idx + 1}
+					</span>
+					<input
+						type="text"
+						value={lvl.name}
+						oninput={(e) => renameLevel(dim.id, hier.id, lvl.id, e.currentTarget.value)}
+						placeholder="Level"
+						aria-label="Level name"
+						class="h-5 min-w-0 flex-1 rounded border border-transparent bg-transparent px-1 hover:border-input focus:border-ring focus:bg-background focus:ring-1 focus:ring-ring focus:outline-none"
+					/>
+					<span
+						class="shrink-0 truncate font-mono text-[9px] tracking-wide opacity-60"
+						title="{tableNameFor(lvl.tableId)}.{lvl.columnName}"
+					>
+						{tableNameFor(lvl.tableId)}.{lvl.columnName}
+					</span>
+					<button
+						type="button"
+						onclick={() => store.removeLevel(dim.id, hier.id, lvl.id)}
+						class="shrink-0 rounded p-0.5 text-muted-foreground transition-colors hover:bg-accent hover:text-accent-foreground"
+						aria-label="Remove level"
+						title="Remove level"
+					>
+						<X class="h-2.5 w-2.5" aria-hidden="true" />
+					</button>
+				</li>
+			{/each}
+			{#if hier.levels.length === 0 && !dim.hierarchies.some((h) => h.levels.length > 0)}
+				<!-- Show the empty-state nudge only when the WHOLE dim is
+				     empty.  Once any other hierarchy in this dim has
+				     content, the empty siblings are obvious from their
+				     own missing rows — no need to re-pitch "drag a column
+				     here" inside each one. -->
+				<li
+					class="rounded border border-dashed px-1.5 py-2 text-center text-[10px]"
+					style:border-color="hsl(var(--border))"
+					style:color="hsl(var(--muted-foreground))"
+				>
+					Drag a column here.
+				</li>
+			{/if}
+		</ol>
+	</section>
+{/snippet}
+
+<!-- ── Measure row snippet ──────────────────────────────────────── -->
+{#snippet measureRow(m: SchemaCanvasMeasure)}
+	<div
+		role="button"
+		tabindex="0"
+		onclick={() => {
+			selectedMeasureId = m.id;
+			selectedAttributeKey = null;
+			selectedLevelId = null;
+			selectedHierarchyId = null;
+			focus('measure', m.id);
+		}}
+		onkeydown={(e) => {
+			if (e.key === 'Enter' || e.key === ' ') {
+				e.preventDefault();
+				selectedMeasureId = m.id;
+				selectedAttributeKey = null;
+				selectedLevelId = null;
+				selectedHierarchyId = null;
+				focus('measure', m.id);
+			}
+		}}
+		class="flex cursor-pointer items-center gap-2 rounded border bg-elev-2 px-2 py-1.5 transition-colors {isFocused(
+			'measure',
+			m.id
+		)
+			? 'workbench-row-selected'
+			: 'hover:bg-accent/30'}"
+		style:border-color={isFocused('measure', m.id) ? '' : 'hsl(var(--border))'}
+		data-testid="workbench-measure-row"
+		data-measure-id={m.id}
+	>
+		<Hash class="h-3 w-3 shrink-0 text-primary" aria-hidden="true" />
+		<input
+			type="text"
+			value={m.name}
+			oninput={(e) => renameMeasure(m.id, e.currentTarget.value)}
+			placeholder="Measure name"
+			aria-label="Measure name"
+			class="h-6 min-w-0 flex-1 rounded border border-transparent bg-transparent px-1 text-xs font-medium hover:border-input focus:border-ring focus:bg-background focus:ring-1 focus:ring-ring focus:outline-none"
+		/>
+		<select
+			value={m.aggregator}
+			onchange={(e) =>
+				store.updateMeasure(m.id, {
+					aggregator: e.currentTarget.value as SchemaCanvasMeasure['aggregator']
+				})}
+			class="h-6 shrink-0 rounded border bg-background px-1 font-mono text-[10px]"
+			style:border-color="hsl(var(--border))"
+			aria-label="Aggregator"
+		>
+			{#each AGGREGATORS as agg (agg)}
+				<option value={agg}>{agg}</option>
+			{/each}
+		</select>
+		<span
+			class="shrink-0 truncate font-mono text-[10px] opacity-70"
+			title="{tableNameFor(m.tableId)}.{m.columnName}"
+		>
+			{tableNameFor(m.tableId)}.{m.columnName}
+		</span>
+		<button
+			type="button"
+			onclick={() => store.removeMeasure(m.id)}
+			class="shrink-0 rounded p-1 text-muted-foreground transition-colors hover:bg-accent hover:text-accent-foreground"
+			aria-label="Delete measure"
+			title="Delete measure"
+			data-testid="workbench-measure-delete"
+		>
+			<X class="h-3 w-3" aria-hidden="true" />
+		</button>
+	</div>
+{/snippet}
+
+<!-- ── Tree-view snippets ───────────────────────────────────────── -->
+<!--
+   The tree renders the same dimensions / hierarchies / levels / measures
+   data as the cards view, but as a Mondrian-style nested outline. Each
+   row is hairline-dense (text-xs / [11px], py-0.5–py-1) with no card
+   chrome. Drop semantics match the cards view: the Dimensions root +
+   each Dimension card accept column drops as a new level (auto-creating
+   a hierarchy if needed); each Hierarchy row accepts drops as a level;
+   the Measures root accepts drops as a new measure. Faint right-aligned
+   `[Type]` tags make the Mondrian model legible at a glance.
+-->
+
+{#snippet typeTag(label: string)}
+	<span
+		class="ml-auto shrink-0 rounded px-1.5 py-0.5 text-[9px] font-medium tracking-wide uppercase"
+		style:color="hsl(var(--muted-foreground))"
+		style:background="hsl(var(--accent))"
+	>
+		{label}
+	</span>
+{/snippet}
+
+{#snippet treeRootRow(label: string, kind: 'dimension' | 'measure')}
+	<div
+		class="flex items-center gap-1.5 px-1 py-1 text-xs font-semibold"
+		data-testid="workbench-tree-root"
+		data-tree-root={kind}
+	>
+		<ChevronDown class="h-3 w-3 shrink-0 opacity-60" aria-hidden="true" />
+		{#if kind === 'dimension'}
+			<Layers class="h-3 w-3 shrink-0 text-primary" aria-hidden="true" />
+		{:else}
+			<Sigma class="h-3 w-3 shrink-0 text-primary" aria-hidden="true" />
+		{/if}
+		<span class="truncate">{label}</span>
+	</div>
+{/snippet}
+
+{#snippet dimensionTreeRow(dim: SchemaCanvasDimension)}
+	{@const isCollapsed = collapsedTreeDimensions.has(dim.id)}
+	<div
+		class="group flex flex-col rounded transition-colors {dropRingFor({
+			kind: 'dim',
+			id: dim.id
+		})} border border-transparent"
+		ondragover={(e) => handleDragOver(e, { kind: 'dim', id: dim.id })}
+		ondragleave={(e) => handleDragLeave(e, { kind: 'dim', id: dim.id })}
+		ondrop={(e) => handleDimensionDrop(e, dim)}
+		data-testid="workbench-tree-dimension"
+		data-dimension-id={dim.id}
+	>
+		<div class="flex items-center gap-1 pr-1 pl-4 text-xs hover:bg-accent/40">
+			<button
+				type="button"
+				onclick={() => toggleTreeDimension(dim.id)}
+				class="shrink-0 rounded p-0.5 text-muted-foreground hover:text-foreground"
+				aria-label={isCollapsed ? 'Expand dimension' : 'Collapse dimension'}
+			>
+				{#if isCollapsed}
+					<ChevronRight class="h-3 w-3" aria-hidden="true" />
+				{:else}
+					<ChevronDown class="h-3 w-3" aria-hidden="true" />
+				{/if}
+			</button>
+			<Layers class="h-3 w-3 shrink-0 text-primary" aria-hidden="true" />
+			<input
+				type="text"
+				value={dim.name}
+				oninput={(e) => renameDimension(dim.id, e.currentTarget.value)}
+				placeholder="Dimension name"
+				aria-label="Dimension name"
+				class="h-5 min-w-0 flex-1 rounded border border-transparent bg-transparent px-1 text-xs font-medium hover:border-input focus:border-ring focus:bg-background focus:ring-1 focus:ring-ring focus:outline-none"
+				data-testid="workbench-tree-dimension-name"
+				use:autoFocus={focusDimId === dim.id}
+			/>
+			{@render typeTag('Dimension')}
+			<button
+				type="button"
+				onclick={() => store.removeDimension(dim.id)}
+				class="ml-1 shrink-0 rounded p-0.5 text-muted-foreground opacity-0 transition-colors group-hover:opacity-100 hover:bg-accent hover:text-accent-foreground"
+				aria-label="Delete dimension"
+				title="Delete dimension"
+			>
+				<X class="h-2.5 w-2.5" aria-hidden="true" />
+			</button>
+		</div>
+
+		{#if !isCollapsed}
+			<div class="flex flex-col">
+				{#if dim.hierarchies.length === 1}
+					<!-- Singleton hierarchy in the tree view too — skip the
+					     hierarchy row entirely and render its levels indented
+					     directly under the dim row.  Reveal the multi-hierarchy
+					     UI via "Split into hierarchies" below. -->
+					{@const hier = dim.hierarchies[0]}
+					{#if hier.levels.length === 0}
+						<p class="py-0.5 pr-2 pl-10 text-[10px]" style:color="hsl(var(--muted-foreground))">
+							Drag a column onto this dimension.
+						</p>
+					{:else}
+						{#each hier.levels as lvl (lvl.id)}
+							{@render levelTreeRow(dim, hier, lvl, 'pl-10')}
+						{/each}
+					{/if}
+					<button
+						type="button"
+						onclick={() => store.addHierarchy(dim.id)}
+						class="flex items-center gap-1 rounded px-1 py-0.5 pl-10 text-left text-[11px] text-muted-foreground hover:bg-accent/40"
+						data-testid="workbench-tree-split-hierarchies"
+						title="Add a second drilldown path (e.g. Calendar / Fiscal on a Time dim)"
+					>
+						<Plus class="h-3 w-3" aria-hidden="true" />
+						Split into hierarchies
+					</button>
+				{:else}
+					{#each dim.hierarchies as hier (hier.id)}
+						{@render hierarchyTreeRow(dim, hier)}
+					{/each}
+					<button
+						type="button"
+						onclick={() => store.addHierarchy(dim.id)}
+						class="flex items-center gap-1 rounded px-1 py-0.5 pl-10 text-left text-[11px] text-muted-foreground hover:bg-accent/40"
+						data-testid="workbench-tree-add-hierarchy"
+					>
+						<Plus class="h-3 w-3" aria-hidden="true" />
+						Add hierarchy
+					</button>
+				{/if}
+				<!-- Attributes section — every attribute on the dim, showing
+				     the display-name caption (from the schema) as the
+				     primary label with the raw SQL column name below.  A
+				     key icon on the LEFT swaps in when this row is the
+				     dim's primary key; a hover-to-set key toggle on the
+				     RIGHT sits in its own chip separated from the type
+				     tag.  Mondrian 4 needs exactly one key attribute per
+				     dim (marks the PK column on the dim table); marking
+				     one unmarks any other. -->
+				{#if (dim.attributes ?? []).length > 0}
+					<div
+						class="mt-1 flex items-center gap-1 pl-10 text-[10px] font-semibold tracking-wider uppercase"
+						style:color="hsl(var(--muted-foreground))"
+					>
+						Attributes
+					</div>
+					{#if !dimKeyIdentity(dim)}
+						<!-- Empty-state hint — only when no key selected.
+						     Sits below the Attributes header; muted so it
+						     doesn't shout at the user, small icon so it
+						     reads as guidance not an error. -->
+						<div
+							class="mt-0.5 flex items-center gap-1.5 pl-10 text-[10px] leading-snug text-muted-foreground"
+							data-testid="workbench-tree-attribute-empty-key"
+						>
+							<KeyRound class="h-3 w-3 shrink-0" aria-hidden="true" />
+							<span>
+								No key selected — click the
+								<KeyRound class="inline h-2.5 w-2.5" aria-hidden="true" />
+								icon on an attribute, or set it in the Inspector.
+							</span>
+						</div>
+					{/if}
+					{@const treeResolvedKey = resolveKeyAttribute(dim)}
+					{#each dim.attributes ?? [] as attr, __ai (`${attr.tableId}::${attr.columnName}::${attr.name ?? __ai}`)}
+						{@const dimSrcId = dim.sourceTableId ?? dim.primaryKeyTableId}
+						{@const attrIdent = attr.name ?? attr.columnName}
+						<!-- Compare against the SINGLE resolved key attribute — logical
+						     match first, column-fallback only when unambiguous. -->
+						{@const isKey =
+							!!treeResolvedKey &&
+							treeResolvedKey.attr.tableId === attr.tableId &&
+							treeResolvedKey.attr.columnName === attr.columnName &&
+							(treeResolvedKey.attr.name ?? treeResolvedKey.attr.columnName) === attrIdent}
+						{@const displayName = attr.name ?? attr.columnName}
+						{@const hasCaption = attr.name && attr.name !== attr.columnName}
+						<div
+							class="group flex items-start gap-2 rounded pr-1 pl-10 text-[11px] hover:bg-accent/40 {isKey
+								? 'bg-primary/5'
+								: ''}"
+							data-testid="workbench-tree-attribute"
+							data-column={attr.columnName}
+						>
+							<span
+								class="mt-0.5 flex h-4 w-3 shrink-0 items-center justify-center"
+								aria-hidden="true"
+							>
+								{#if isKey}
+									<KeyRound class="h-3 w-3 text-primary" aria-hidden="true" />
+								{:else}
+									<span class="text-muted-foreground">•</span>
+								{/if}
+							</span>
+							<span class="flex min-w-0 flex-1 flex-col leading-tight">
+								<!-- Primary line: caption from the schema when
+								     present, otherwise the raw column name. -->
+								<span class="min-w-0 truncate text-foreground">{displayName}</span>
+								<!-- Secondary line: the raw SQL column name in
+								     mono, muted, only when a caption exists AND
+								     differs from the column. -->
+								{#if hasCaption}
+									<span class="min-w-0 truncate font-mono text-[10px] text-muted-foreground">
+										{attr.columnName}
+									</span>
+								{/if}
+							</span>
+							<button
+								type="button"
+								onclick={() => {
+									if (isKey) {
+										dim.primaryKey = undefined;
+										dim.primaryKeyTableId = undefined;
+									} else {
+										// primaryKey holds the ATTRIBUTE's identity (logical
+										// name first, columnName as fallback), not just the
+										// column — two attributes on the same column need to
+										// disambiguate.
+										dim.primaryKey = attrIdent;
+										dim.primaryKeyTableId = attr.tableId !== dimSrcId ? attr.tableId : undefined;
+									}
+								}}
+								class="mt-0.5 flex h-5 w-5 shrink-0 items-center justify-center rounded-md border transition-colors {isKey
+									? 'border-primary bg-primary/10 text-primary'
+									: 'border-border text-muted-foreground opacity-0 group-hover:opacity-100 hover:border-primary/60 hover:text-primary'}"
+								aria-pressed={isKey}
+								aria-label={isKey ? 'Unmark as key' : 'Set as key'}
+								title={isKey ? 'Unmark as key' : 'Set as key'}
+								data-testid="workbench-tree-attribute-key"
+							>
+								<KeyRound class="h-3 w-3" aria-hidden="true" />
+							</button>
+							<!-- Type tag pushed to its own space so it reads
+							     as a distinct chip, not conflated with the
+							     PK toggle. -->
+							<span class="ml-1 shrink-0">
+								{@render typeTag('Attribute')}
+							</span>
+						</div>
+					{/each}
+				{/if}
+			</div>
+		{/if}
+	</div>
+{/snippet}
+
+{#snippet hierarchyTreeRow(dim: SchemaCanvasDimension, hier: SchemaCanvasHierarchy)}
+	{@const isCollapsed = collapsedTreeHierarchies.has(hier.id)}
+	<div
+		class="group flex flex-col rounded transition-colors {dropRingFor({
+			kind: 'hierarchy',
+			dimensionId: dim.id,
+			hierarchyId: hier.id
+		})} border border-transparent"
+		ondragover={(e) =>
+			handleDragOver(e, { kind: 'hierarchy', dimensionId: dim.id, hierarchyId: hier.id })}
+		ondragleave={(e) =>
+			handleDragLeave(e, { kind: 'hierarchy', dimensionId: dim.id, hierarchyId: hier.id })}
+		ondrop={(e) => handleHierarchyDrop(e, dim)}
+		data-testid="workbench-tree-hierarchy"
+		data-hierarchy-id={hier.id}
+	>
+		<div class="flex items-center gap-1 pr-1 pl-8 text-[11px] hover:bg-accent/40">
+			<button
+				type="button"
+				onclick={() => toggleTreeHierarchy(hier.id)}
+				class="shrink-0 rounded p-0.5 text-muted-foreground hover:text-foreground"
+				aria-label={isCollapsed ? 'Expand hierarchy' : 'Collapse hierarchy'}
+			>
+				{#if isCollapsed}
+					<ChevronRight class="h-3 w-3" aria-hidden="true" />
+				{:else}
+					<ChevronDown class="h-3 w-3" aria-hidden="true" />
+				{/if}
+			</button>
+			<input
+				type="text"
+				value={hier.name}
+				oninput={(e) => renameHierarchy(dim.id, hier.id, e.currentTarget.value)}
+				placeholder="Hierarchy"
+				aria-label="Hierarchy name"
+				class="h-5 min-w-0 flex-1 rounded border border-transparent bg-transparent px-1 text-[11px] hover:border-input focus:border-ring focus:bg-background focus:ring-1 focus:ring-ring focus:outline-none"
+			/>
+			{@render typeTag('Hierarchy')}
+			<button
+				type="button"
+				onclick={() => store.removeHierarchy(dim.id, hier.id)}
+				class="ml-1 shrink-0 rounded p-0.5 text-muted-foreground opacity-0 transition-colors group-hover:opacity-100 hover:bg-accent hover:text-accent-foreground"
+				aria-label="Delete hierarchy"
+				title="Delete hierarchy"
+			>
+				<X class="h-2.5 w-2.5" aria-hidden="true" />
+			</button>
+		</div>
+
+		{#if !isCollapsed}
+			{#if hier.levels.length === 0}
+				<p class="py-0.5 pr-2 pl-14 text-[10px]" style:color="hsl(var(--muted-foreground))">
+					Drag a column or pick an attribute below to add a level.
+				</p>
+			{:else}
+				{#each hier.levels as lvl (lvl.id)}
+					{@render levelTreeRow(dim, hier, lvl)}
+				{/each}
+			{/if}
+			<!-- Manual "Add level" picker — drag/drop is the headline UX, but
+			     a select-based picker makes the affordance explicit in the
+			     tree view (mirrors the columns view's Attributes pane). -->
+			{@const usedCols = new Set(hier.levels.map((l) => l.columnName))}
+			{@const availableAttrs = (dim.attributes ?? []).filter((a) => !usedCols.has(a.columnName))}
+			{#if availableAttrs.length > 0}
+				<div class="flex items-center gap-1 py-0.5 pl-14">
+					<Plus class="h-3 w-3 shrink-0 text-muted-foreground" aria-hidden="true" />
+					<select
+						value=""
+						onchange={(e) => {
+							const target = e.currentTarget;
+							const ident = target.value;
+							if (!ident) return;
+							// value is the attribute IDENTITY (logical name if set,
+							// columnName otherwise) — disambiguates two attributes
+							// on the same column.
+							const attr = (dim.attributes ?? []).find((a) => (a.name ?? a.columnName) === ident);
+							if (attr) {
+								store.addLevel(dim.id, hier.id, {
+									tableId: attr.tableId,
+									columnName: attr.columnName
+								});
+							}
+							target.value = '';
+						}}
+						class="h-5 max-w-[14rem] rounded border bg-background px-1 text-[11px] focus:border-ring focus:ring-1 focus:ring-ring focus:outline-none"
+						style:border-color="hsl(var(--border))"
+						data-testid="workbench-tree-add-level"
+					>
+						<option value="">Add level…</option>
+						{#each availableAttrs as a, __lai (`${a.tableId}::${a.columnName}::${a.name ?? __lai}`)}
+							{@const ident = a.name ?? a.columnName}
+							<option value={ident}>{ident}</option>
+						{/each}
+					</select>
+				</div>
+			{:else if (dim.attributes ?? []).length === 0}
+				<p class="py-0.5 pr-2 pl-14 text-[10px]" style:color="hsl(var(--muted-foreground))">
+					Pick attributes on the dimension first (Columns view → Attributes pane).
+				</p>
+			{/if}
+		{/if}
+	</div>
+{/snippet}
+
+{#snippet levelTreeRow(
+	dim: SchemaCanvasDimension,
+	hier: SchemaCanvasHierarchy,
+	lvl: SchemaCanvasLevel,
+	indentClass: string = 'pl-14'
+)}
+	<!-- Level rename intentionally disabled in tree view (saiku-cloud
+	     followup).  A Mondrian Level is a bound REFERENCE to an attribute
+	     column; the displayed label is the column itself.  Renaming would
+	     decouple display from the binding and is a separate concern that
+	     hasn't been spec'd yet. -->
+	<div
+		class="group flex items-center gap-1 rounded pr-1 text-[11px] hover:bg-accent/40 {indentClass}"
+		data-testid="workbench-tree-level"
+		data-level-id={lvl.id}
+	>
+		<span class="shrink-0 text-muted-foreground" aria-hidden="true">•</span>
+		<span class="min-w-0 flex-1 truncate">{lvl.columnName}</span>
+		<span
+			class="shrink-0 truncate font-mono text-[9px] opacity-60"
+			title="{tableNameFor(lvl.tableId)}.{lvl.columnName}"
+		>
+			{tableNameFor(lvl.tableId)}.{lvl.columnName}
+		</span>
+		{@render typeTag('Level')}
+		<button
+			type="button"
+			onclick={() => store.removeLevel(dim.id, hier.id, lvl.id)}
+			class="ml-1 shrink-0 rounded p-0.5 text-muted-foreground opacity-0 transition-colors group-hover:opacity-100 hover:bg-accent hover:text-accent-foreground"
+			aria-label="Remove level"
+			title="Remove level"
+		>
+			<X class="h-2.5 w-2.5" aria-hidden="true" />
+		</button>
+	</div>
+{/snippet}
+
+{#snippet measureTreeRow(m: SchemaCanvasMeasure)}
+	<div
+		class="group flex items-center gap-1 rounded pr-1 pl-6 text-[11px] hover:bg-accent/40"
+		data-testid="workbench-tree-measure"
+		data-measure-id={m.id}
+	>
+		<span class="shrink-0 text-muted-foreground" aria-hidden="true">•</span>
+		<Hash class="h-3 w-3 shrink-0 text-primary" aria-hidden="true" />
+		<input
+			type="text"
+			value={m.name}
+			oninput={(e) => renameMeasure(m.id, e.currentTarget.value)}
+			placeholder="Measure name"
+			aria-label="Measure name"
+			class="h-5 min-w-0 flex-1 rounded border border-transparent bg-transparent px-1 hover:border-input focus:border-ring focus:bg-background focus:ring-1 focus:ring-ring focus:outline-none"
+		/>
+		<select
+			value={m.aggregator}
+			onchange={(e) =>
+				store.updateMeasure(m.id, {
+					aggregator: e.currentTarget.value as SchemaCanvasMeasure['aggregator']
+				})}
+			class="h-5 shrink-0 rounded border bg-background px-1 font-mono text-[9px]"
+			style:border-color="hsl(var(--border))"
+			aria-label="Aggregator"
+		>
+			{#each AGGREGATORS as agg (agg)}
+				<option value={agg}>{agg}</option>
+			{/each}
+		</select>
+		<span
+			class="shrink-0 truncate font-mono text-[9px] opacity-60"
+			title="{tableNameFor(m.tableId)}.{m.columnName}"
+		>
+			{tableNameFor(m.tableId)}.{m.columnName}
+		</span>
+		{@render typeTag('Measure')}
+		<button
+			type="button"
+			onclick={() => store.removeMeasure(m.id)}
+			class="ml-1 shrink-0 rounded p-0.5 text-muted-foreground opacity-0 transition-colors group-hover:opacity-100 hover:bg-accent hover:text-accent-foreground"
+			aria-label="Delete measure"
+			title="Delete measure"
+		>
+			<X class="h-2.5 w-2.5" aria-hidden="true" />
+		</button>
+	</div>
+{/snippet}
+
+<!-- ── Measure group tree row ────────────────────────────────────────
+     Child of a cube node.  Shows fact-table + measures + dimension
+     links as plain-text children for at-a-glance scanning; the actual
+     editing UI is the existing `paneMeasureGroupContent` snippet,
+     surfaced via the Inspector Properties tab when the MG row is
+     selected.  This keeps the canonical editor in one place. -->
+{#snippet measureGroupTreeRow(cube: WorkbenchCube, mg: WorkbenchMeasureGroup)}
+	{@const isCollapsed = collapsedTreeMeasureGroups.has(mg.id)}
+	{@const isSelected = isFocused('mg', mg.id)}
+	{@const factTable = mg.factTableId
+		? (store.doc.tables.find((t) => t.id === mg.factTableId) ?? null)
+		: null}
+	{@const dimLinks = mg.dimensionLinks ?? []}
+	<div
+		class="group flex flex-col rounded border border-transparent"
+		data-testid="workbench-tree-mg"
+		data-mg-id={mg.id}
+	>
+		<div
+			role="button"
+			tabindex="0"
+			onclick={() => selectTreeMeasureGroup(cube.id, mg.id)}
+			onkeydown={(e) => {
+				if (e.key === 'Enter' || e.key === ' ') {
+					e.preventDefault();
+					selectTreeMeasureGroup(cube.id, mg.id);
+				}
+			}}
+			class="flex cursor-pointer items-center gap-1 pr-1 pl-6 text-[11px] hover:bg-accent/40 {isSelected
+				? 'workbench-row-selected'
+				: ''}"
+		>
+			<button
+				type="button"
+				onclick={(e) => {
+					e.stopPropagation();
+					toggleTreeMeasureGroup(mg.id);
+				}}
+				class="shrink-0 rounded p-0.5 text-muted-foreground hover:text-foreground"
+				aria-label={isCollapsed ? 'Expand measure group' : 'Collapse measure group'}
+			>
+				{#if isCollapsed}
+					<ChevronRight class="h-3 w-3" aria-hidden="true" />
+				{:else}
+					<ChevronDown class="h-3 w-3" aria-hidden="true" />
+				{/if}
+			</button>
+			<Sigma class="h-3 w-3 shrink-0 text-primary" aria-hidden="true" />
+			{#if factsEditingMeasureGroupId === mg.id && cube.id === selectedCubeId}
+				<input
+					type="text"
+					value={mg.name}
+					oninput={(e) => renameFactsMeasureGroup(mg.id, e.currentTarget.value)}
+					onclick={(e) => e.stopPropagation()}
+					onkeydown={(e) => {
+						e.stopPropagation();
+						if (e.key === 'Enter' || e.key === 'Escape') {
+							(e.currentTarget as HTMLInputElement).blur();
+						}
+					}}
+					onblur={() => (factsEditingMeasureGroupId = null)}
+					placeholder="Measure group"
+					aria-label="Measure group name"
+					class="h-5 min-w-0 flex-1 rounded border bg-background px-1 font-medium focus:border-ring focus:ring-1 focus:ring-ring focus:outline-none"
+					style:border-color="hsl(var(--border))"
+					use:autoFocus={factsEditingMeasureGroupId === mg.id}
+				/>
+			{:else}
+				<span class="min-w-0 flex-1 truncate font-medium" title="Click to edit; pencil to rename">
+					{mg.name || 'Untitled group'}
+				</span>
+			{/if}
+			{@render typeTag('Measure group')}
+			<button
+				type="button"
+				onclick={(e) => {
+					e.stopPropagation();
+					if (cube.id !== selectedCubeId) switchCube(cube.id);
+					factsEditingMeasureGroupId = mg.id;
+				}}
+				class="ml-1 shrink-0 rounded p-0.5 text-muted-foreground opacity-0 transition-colors group-hover:opacity-100 hover:bg-accent hover:text-accent-foreground"
+				aria-label="Rename measure group"
+				title="Rename measure group"
+				data-testid="workbench-tree-mg-rename"
+			>
+				<Pencil class="h-2.5 w-2.5" aria-hidden="true" />
+			</button>
+			<button
+				type="button"
+				onclick={(e) => {
+					e.stopPropagation();
+					if (cube.id !== selectedCubeId) switchCube(cube.id);
+					removeFactsMeasureGroup(mg.id);
+					if (selectedTreeMeasureGroupId === mg.id) selectedTreeMeasureGroupId = null;
+				}}
+				class="shrink-0 rounded p-0.5 text-muted-foreground opacity-0 transition-colors group-hover:opacity-100 hover:bg-accent hover:text-accent-foreground"
+				aria-label="Delete measure group"
+				title="Delete measure group"
+				data-testid="workbench-tree-mg-delete"
+			>
+				<X class="h-2.5 w-2.5" aria-hidden="true" />
+			</button>
+		</div>
+		{#if !isCollapsed}
+			<div class="flex flex-col">
+				<!-- Fact table child node.  In edit surfaces (D&H tree view)
+				     the user can change the binding inline via a <select>.
+				     On the Confirm cube > Tree sub-tab (store.mode ===
+				     'validate') this row is read-only — Confirm is a
+				     visualization, not another edit surface. -->
+				<div
+					class="flex items-center gap-1 rounded pr-1 pl-12 text-[11px] text-muted-foreground"
+					data-testid="workbench-tree-mg-fact"
+				>
+					<Database class="h-3 w-3 shrink-0" aria-hidden="true" />
+					{#if store.mode === 'validate'}
+						<!-- Read-only in Confirm cube. -->
+						{#if factTable}
+							<span class="min-w-0 flex-1 truncate font-mono" title="Fact table: {factTable.name}">
+								{factTable.name}
+							</span>
+						{:else}
+							<span class="min-w-0 flex-1 truncate text-warning italic"> Fact table not set </span>
+						{/if}
+					{:else if store.sourceTables.length === 0}
+						<span class="min-w-0 flex-1 truncate italic">
+							Source catalog is empty — pick a Source on the top bar.
+						</span>
+					{:else}
+						<select
+							value={mg.factTableId
+								? (() => {
+										const onCanvas = store.doc.tables.find((t) => t.id === mg.factTableId);
+										if (!onCanvas) return '';
+										return `${onCanvas.schema ?? ''}::${onCanvas.name}`;
+									})()
+								: ''}
+							onchange={(e) => {
+								const target = e.currentTarget;
+								const key = target.value;
+								if (!key) return;
+								if (cube.id !== selectedCubeId) switchCube(cube.id);
+								const liveMG = factsMeasureGroups.find((x) => x.id === mg.id);
+								if (!liveMG) return;
+								const [schema, name] = key.split('::');
+								const cand = store.sourceTables.find(
+									(t) => t.name === name && (t.schema ?? '') === schema
+								);
+								if (cand) bindMGToSourceTable(liveMG, cand);
+							}}
+							class="h-5 min-w-0 flex-1 rounded border bg-background px-1 text-[11px] focus:border-ring focus:ring-1 focus:ring-ring focus:outline-none {mg.factTableId
+								? 'font-mono'
+								: 'italic'}"
+							style:border-color="hsl(var(--border))"
+							data-testid="workbench-tree-mg-fact-picker"
+							title={factTable ? `Fact table: ${factTable.name}` : 'Pick a fact table'}
+						>
+							<option value="" disabled={!!mg.factTableId}>Pick a fact table…</option>
+							{#each store.sourceTables as t (`${t.schema ?? ''}::${t.name}`)}
+								<option value="{t.schema ?? ''}::{t.name}">{t.name}</option>
+							{/each}
+						</select>
+					{/if}
+					{@render typeTag('Fact')}
+				</div>
+				<!-- Measures child nodes — one row per measureColumns entry. -->
+				{#if mg.measureColumns.length === 0}
+					<p class="py-0.5 pr-2 pl-12 text-[10px]" style:color="hsl(var(--muted-foreground))">
+						No measures picked yet.
+					</p>
+				{:else}
+					{#each mg.measureColumns as col (col)}
+						<div
+							class="flex items-center gap-1 rounded pr-1 pl-12 text-[11px] hover:bg-accent/40"
+							data-testid="workbench-tree-mg-measure"
+							data-column={col}
+						>
+							<Hash class="h-3 w-3 shrink-0 text-primary" aria-hidden="true" />
+							<span class="min-w-0 flex-1 truncate font-mono">{col}</span>
+							{@render typeTag('Measure')}
+						</div>
+					{/each}
+				{/if}
+				<!-- Dimension links — resolved to dim name via store.dimensions. -->
+				{#if dimLinks.length === 0}
+					<p class="py-0.5 pr-2 pl-12 text-[10px]" style:color="hsl(var(--muted-foreground))">
+						No shared dimensions linked yet.
+					</p>
+				{:else}
+					{#each dimLinks as link (link.dimensionId)}
+						{@const dim = store.dimensions.find((d) => d.id === link.dimensionId)}
+						<div
+							class="flex items-center gap-1 rounded pr-1 pl-12 text-[11px] hover:bg-accent/40"
+							data-testid="workbench-tree-mg-dimlink"
+							data-dim-id={link.dimensionId}
+						>
+							<Layers class="h-3 w-3 shrink-0 text-primary" aria-hidden="true" />
+							<span class="min-w-0 flex-1 truncate font-medium">
+								{dim?.name ?? '(missing dimension)'}
+							</span>
+							{#if link.foreignKeyColumn}
+								<span
+									class="shrink-0 truncate font-mono text-[9px] opacity-60"
+									title={link.foreignKeyColumn}
+								>
+									fk: {link.foreignKeyColumn}
+								</span>
+							{/if}
+							{@render typeTag('Link')}
+						</div>
+					{/each}
+				{/if}
+			</div>
+		{/if}
+	</div>
+{/snippet}
+
+<!-- ── Columns view: 3 swappable Miller-style panes ───────────────── -->
+<!--
+   Each pane has a header strip with a kind-picker and a Pin toggle.
+   Pinned panes can't be repurposed (prevents the user from accidentally
+   blowing away the Dimensions pane while clicking around). Default
+   slots are pre-pinned for a first-timer so the layout is stable until
+   they explicitly unpin one.
+
+   Selection model: clicking a dim/hierarchy/measure in any pane sets
+   the shared selected* state, which other panes read.  E.g. clicking
+   "Customer" in a Dimensions pane updates the Levels pane (which shows
+   the implicit-default hier's levels by default) and the Properties
+   pane.
+-->
+
+<!-- ── Confirm cube > Tree sub-tab.  Read-only outline of the whole
+     schema.  Every cube is a root: its fact table, measure groups,
+     dim links stack underneath.  Shared dimensions live in their own
+     bucket at the bottom (schema-scope, not tied to any one cube).
+     Purely informational — no drag, no edit; edit surfaces stay on
+     the Dim & Hier and Facts & Measures tabs. -->
+
+<!-- ── Deprecated tree view, re-exposed as a snippet so the
+     Confirm cube > Tree sub-tab can render the same DOM the
+     D&H tab used to render when viewMode === 'tree'.  All
+     state coupling (treeWorkbenchBodyEl, treeInspectorFraction,
+     treeFocus, etc.) is preserved. -->
+{#snippet treeView()}
+	<div bind:this={treeWorkbenchBodyEl} class="flex h-full min-h-0 flex-1 flex-row gap-2">
+		<!-- LEFT: tree (existing dim-zone div) -->
+		<div
+			role="region"
+			aria-label="Schema tree"
+			class="flex min-h-0 flex-col gap-0.5 overflow-y-auto rounded-md border-2 border-dashed p-2 transition-colors {dropRingFor(
+				{ kind: 'dim-zone' }
+			)} {store.dimensions.length === 0 && !isDragging ? 'border-border' : ''}"
+			style:flex={treeInspectorCollapsed ? '1 1 0' : `${1 - treeInspectorFraction} 1 0`}
+			ondragover={(e) => handleDragOver(e, { kind: 'dim-zone' })}
+			ondragleave={(e) => handleDragLeave(e, { kind: 'dim-zone' })}
+			ondrop={handleDimensionsZoneDrop}
+			data-testid="workbench-dimensions-tree"
+		>
+			<!-- Cube switcher header.  Mirrors the Columns view's
+							     Facts & Measures section header so the user has
+							     ONE affordance ("which cube am I in?") whichever
+							     view they're using.  Reuses the cubeSwitcher
+							     snippet — single source of truth. -->
+			<div
+				class="flex shrink-0 items-center gap-2 border-b pb-1.5"
+				style:border-color="hsl(var(--border))"
+				data-testid="workbench-tree-cube-header"
+			>
+				<!-- Cube switcher only relevant when the tree is focused
+								     on cube facts/measures.  In dims-focus mode shared
+								     dimensions belong to the schema (not any one cube),
+								     so the switcher would be misleading. -->
+				{#if treeFocus === 'cubes'}
+					<span
+						class="shrink-0 text-[11px] font-semibold tracking-wider uppercase"
+						style:color="hsl(var(--muted-foreground))"
+					>
+						Cube
+					</span>
+					{#if store.mode === 'validate'}
+						<!-- Confirm cube > Tree: the cubes rail on the left
+						     already handles cube selection, so we skip the
+						     dropdown and just show the current cube name
+						     as context. -->
+						<span
+							class="min-w-0 flex-1 truncate text-[11px] font-semibold text-foreground"
+							title={selectedCube?.name || 'Untitled cube'}
+						>
+							{selectedCube?.name || 'Untitled cube'}
+						</span>
+					{:else}
+						{@render cubeSwitcher()}
+					{/if}
+				{:else}
+					<span
+						class="flex-1 text-[11px] font-semibold tracking-wider uppercase"
+						style:color="hsl(var(--muted-foreground))"
+					>
+						Shared across the schema
+					</span>
+				{/if}
+				<!-- Single stacked-chevron toggle replaces the prior
+								     expand-/collapse-all pair.  "Anything collapsed?
+								     → expand it all; everything expanded → collapse
+								     it all."  Touches every collapse Set in the
+								     tree plus the Shared Dimensions branch flag. -->
+				<button
+					type="button"
+					onclick={() => (anyTreeCollapsed ? expandAllTree() : collapseAllTree())}
+					class="shrink-0 rounded p-0.5 text-muted-foreground hover:bg-accent hover:text-accent-foreground"
+					aria-label={anyTreeCollapsed ? 'Expand all' : 'Collapse all'}
+					title={anyTreeCollapsed ? 'Expand all' : 'Collapse all'}
+					data-testid="workbench-tree-expand-collapse-toggle"
+				>
+					<ChevronsUpDown class="h-3 w-3" aria-hidden="true" />
+				</button>
+			</div>
+			<!-- ── Measure groups of the selected cube ─────────
+							     The cube switcher in the header already names the
+							     active cube, so a "Cubes" root + per-cube nodes
+							     would duplicate that affordance.  Show the MGs of
+							     the selected cube directly. -->
+			{#if treeFocus === 'cubes' && selectedCube}
+				{@const cubeMGs =
+					selectedCube.id === selectedCubeId ? factsMeasureGroups : selectedCube.measureGroups}
+				{#each cubeMGs as mg (mg.id)}
+					{@render measureGroupTreeRow(selectedCube, mg)}
+				{/each}
+				{#if store.mode !== 'validate'}
+					<button
+						type="button"
+						onclick={() => {
+							if (selectedCube.id !== selectedCubeId) switchCube(selectedCube.id);
+							addFactsMeasureGroup();
+							selectedTreeMeasureGroupId = factsSelectedGroupId;
+							selectedTreeCubeId = selectedCube.id;
+						}}
+						class="flex items-center gap-1 rounded px-2 py-0.5 pl-2 text-left text-[11px] text-muted-foreground hover:bg-accent/40"
+						data-testid="workbench-tree-mg-add"
+					>
+						<Plus class="h-3 w-3" aria-hidden="true" />
+						New measure group
+					</button>
+				{/if}
+			{/if}
+			<!-- ── Shared Dimensions branch ─────────────────── -->
+			{#if treeFocus === 'dims'}
+				{#if store.dimensions.length === 0}
+					<div
+						class="flex flex-col items-center justify-center gap-2 p-8 text-center"
+						style:color="hsl(var(--muted-foreground))"
+					>
+						<p class="text-sm font-medium" style:color="hsl(var(--foreground))">
+							No dimensions yet
+						</p>
+						<p class="max-w-sm text-xs leading-relaxed">
+							Drag a column, a table, or a join group from the left rail — or hit
+							<span class="font-medium">Add dimension</span> at the top.
+						</p>
+					</div>
+				{/if}
+				{#each store.dimensions as dim (dim.id)}
+					{@render dimensionTreeRow(dim)}
+				{/each}
+				{#if store.mode !== 'validate'}
+					<button
+						type="button"
+						onclick={() => addDimensionAndFocus()}
+						class="flex items-center gap-1 rounded px-2 py-0.5 pl-6 text-left text-[11px] text-muted-foreground hover:bg-accent/40"
+						data-testid="workbench-tree-add-dimension"
+					>
+						<Plus class="h-3 w-3" aria-hidden="true" />
+						Add dimension
+					</button>
+				{/if}
+			{/if}
+		</div>
+
+		<!-- HANDLE: vertical resize bar.  Pointerdown
+						     uncollapses if needed, then starts the drag —
+						     same UX as the Columns bottom-inspector handle. -->
+		<div
+			role="separator"
+			aria-orientation="vertical"
+			aria-label="Resize tree inspector"
+			onpointerdown={(e) => {
+				if (treeInspectorCollapsed) treeInspectorCollapsed = false;
+				handleTreeInspectorResizeStart(e);
+			}}
+			class="workbench-resize-handle workbench-resize-handle-vertical flex w-3 shrink-0 cursor-col-resize items-center justify-center rounded {treeInspectorResizing
+				? 'workbench-resize-handle-active'
+				: ''}"
+			data-testid="workbench-tree-inspector-resize"
+			title="Drag to resize · click to restore split"
+		>
+			<div class="h-16 w-1 rounded-full"></div>
+		</div>
+
+		<!-- RIGHT: inspector.  Visually identical to the
+						     Columns bottom inspector (header + tab strip +
+						     body) — only the collapse chevron points right
+						     (collapse-to-right) and the collapsed strip is a
+						     vertical sliver. -->
+		{#if treeInspectorCollapsed}
+			<button
+				type="button"
+				onclick={() => (treeInspectorCollapsed = false)}
+				class="flex w-8 shrink-0 flex-col items-center justify-between gap-2 rounded border bg-elev-2 px-1 py-2 text-[11px] font-semibold tracking-wider text-muted-foreground uppercase hover:bg-accent/40"
+				style:border-color="hsl(var(--border))"
+				data-testid="workbench-tree-inspector-expand"
+				title="Expand inspector"
+			>
+				<ChevronLeft class="h-3 w-3" aria-hidden="true" />
+				<span class="[transform:rotate(180deg)] [writing-mode:vertical-rl]"> Inspector </span>
+				<span></span>
+			</button>
+		{:else}
+			<div
+				class="flex min-h-0 flex-col rounded border bg-elev-2"
+				style:flex="{treeInspectorFraction} 1 0"
+				style:border-color="hsl(var(--border))"
+				data-testid="workbench-tree-inspector"
+			>
+				<!-- Header mirrors the Columns bottom-inspector
+								     header — INSPECTOR label + collapse
+								     chevron (points right = collapse-to-right). -->
+				<header
+					class="flex shrink-0 items-center justify-between gap-2 border-b bg-elev-1 px-3 py-1.5"
+					style:border-color="hsl(var(--border))"
+				>
+					<span
+						class="text-[11px] font-semibold tracking-wider uppercase"
+						style:color="hsl(var(--muted-foreground))"
+					>
+						Inspector
+					</span>
+					<button
+						type="button"
+						onclick={() => (treeInspectorCollapsed = true)}
+						class="shrink-0 rounded p-1 text-muted-foreground hover:bg-accent hover:text-accent-foreground"
+						aria-label="Collapse inspector"
+						title="Collapse inspector"
+						data-testid="workbench-tree-inspector-collapse"
+					>
+						<ChevronRight class="h-3 w-3" aria-hidden="true" />
+					</button>
+				</header>
+				<!-- Body: tabs + content inside p-3 padded flex column,
+								     mirroring the dim frame pattern (header → whitespace
+								     → content). -->
+				<div class="flex min-h-0 flex-1 flex-col gap-3 overflow-hidden p-3">
+					<div class="flex shrink-0">
+						{@render inspectorTabStrip('workbench-tree-inspector-tab')}
+					</div>
+					<!-- Content area: `overflow-hidden` + `min-w-0` clip horizontal
+									     overflow so a wide Sample-data table doesn't push the tab
+									     strip + drawer wider than the inspector's actual width.
+									     Vertical overflow handled here (drawer is a bottom row). -->
+					<div class="min-h-0 min-w-0 flex-1 overflow-x-hidden overflow-y-auto">
+						{#if inspectorTab === 'properties'}
+							{@render inspectorProperties()}
+						{:else}
+							{@render inspectorCode()}
+						{/if}
+					</div>
+				</div>
+			</div>
+		{/if}
+	</div>
+{/snippet}
+
+<!-- ── Inspector tab strip — collapses to a styled dropdown when the
+     drawer is narrower than ~420px.  The dropdown gets a distinct
+     primary-bordered "View" label so it reads as a different control
+     than the row of buttons, not just a shrunken one.  Used by both
+     the Tree-view inspector and the Columns-view drawer.  idPrefix
+     parameter scopes data-testids so the existing Playwright selectors
+     ("workbench-inspector-tab-*" vs "workbench-tree-inspector-tab-*")
+     keep working. ──────────────────────────────────────────────────── -->
+{#snippet inspectorTabStrip(idPrefix: string)}
+	<div class="@container/insptabs w-full">
+		<!-- Wide: understated underlined tabs.  Sample-data / Try-a-query /
+		     Cubes moved to the top-level `Validate` tab so those wide result
+		     tables get the whole workbench area instead of being crammed
+		     into the drawer. -->
+		<div
+			class="flex w-full items-end gap-4 border-b @max-[420px]/insptabs:hidden"
+			style:border-color="hsl(var(--border))"
+			role="tablist"
+		>
+			<button
+				type="button"
+				role="tab"
+				aria-selected={inspectorTab === 'properties'}
+				onclick={() => (inspectorTab = 'properties')}
+				class="-mb-px inline-flex items-center gap-1 border-b-2 px-1 pb-1.5 text-[11px] transition-colors {inspectorTab ===
+				'properties'
+					? 'border-primary text-foreground'
+					: 'border-transparent text-muted-foreground hover:text-foreground'}"
+				data-testid="{idPrefix}-properties"
+			>
+				Properties
+			</button>
+			<button
+				type="button"
+				role="tab"
+				aria-selected={inspectorTab === 'code'}
+				onclick={() => (inspectorTab = 'code')}
+				class="-mb-px inline-flex items-center gap-1 border-b-2 px-1 pb-1.5 font-mono text-[11px] transition-colors {inspectorTab ===
+				'code'
+					? 'border-primary text-foreground'
+					: 'border-transparent text-muted-foreground hover:text-foreground'}"
+				data-testid="{idPrefix}-code"
+			>
+				&lt;/Code&gt;
+			</button>
+		</div>
+		<!-- Narrow: dropdown picker.  Primary-bordered "View" pill on the
+		     left signals "this is a switcher, not a single button"; the
+		     selected tab name fills the rest.  Uses a native <select> so
+		     keyboard / VO behaviour is free. -->
+		<div
+			class="hidden w-full items-stretch overflow-hidden rounded border @max-[420px]/insptabs:flex"
+			style:border-color="hsl(var(--primary))"
+		>
+			<span
+				class="flex shrink-0 items-center px-2 py-1 text-[10px] font-semibold tracking-wider uppercase"
+				style:color="hsl(var(--primary))"
+				style:background-color="hsl(var(--primary) / 0.1)"
+			>
+				View
+			</span>
+			<select
+				bind:value={inspectorTab}
+				class="flex-1 cursor-pointer bg-transparent px-2 py-1 text-[11px] font-semibold focus:outline-none"
+				data-testid="{idPrefix}-select"
+				aria-label="Inspector view"
+			>
+				<option value="properties">Properties</option>
+				<option value="code">&lt;/Code&gt;</option>
+			</select>
+		</div>
+	</div>
+{/snippet}
+
+<!-- ── Inspector panel (right-hand drawer in Columns view) ─────────── -->
+{#snippet inspectorPanel()}
+	<div
+		class="flex h-full min-h-0 w-full flex-col overflow-hidden rounded border bg-elev-2"
+		style:border-color="hsl(var(--border))"
+		data-testid="workbench-inspector"
+	>
+		<!-- Header bar.  Collapse chevron sits on the LEFT (the pane-facing
+		     edge of the drawer) so it lands in the same visual spot as the
+		     expand chevron on the collapsed strip — the button doesn't
+		     move as you toggle expanded/collapsed.  Maximize + dock-side
+		     toggle live on the right, since they're independent of the
+		     open/close motion. -->
+		<header
+			class="flex shrink-0 items-center gap-2 border-b bg-elev-1 px-3 py-1.5"
+			style:border-color="hsl(var(--border))"
+		>
+			<button
+				type="button"
+				onclick={() => {
+					inspectorMaximized = false;
+					inspectorCollapsed = true;
+				}}
+				class="shrink-0 rounded p-1 text-muted-foreground hover:bg-accent hover:text-accent-foreground"
+				aria-label="Collapse inspector drawer"
+				title="Collapse drawer"
+				data-testid="workbench-inspector-collapse"
+			>
+				<!-- Chevron matches the collapsed-strip's chevron:
+				     ChevronUp for bottom-dock, ChevronLeft for right-dock. -->
+				{#if inspectorPosition === 'bottom'}
+					<ChevronDown class="h-3 w-3" aria-hidden="true" />
+				{:else}
+					<ChevronRight class="h-3 w-3" aria-hidden="true" />
+				{/if}
+			</button>
+			<span class="text-[11px] font-semibold tracking-wider uppercase"> Inspector </span>
+			<div class="ml-auto flex items-center gap-1">
+				<button
+					type="button"
+					onclick={() => (inspectorMaximized = !inspectorMaximized)}
+					class="shrink-0 rounded p-1 text-muted-foreground hover:bg-accent hover:text-accent-foreground"
+					aria-label={inspectorMaximized ? 'Restore inspector drawer' : 'Maximize inspector drawer'}
+					title={inspectorMaximized ? 'Restore drawer' : 'Maximize drawer'}
+					data-testid="workbench-inspector-maximize"
+				>
+					{#if inspectorMaximized}
+						<Minimize2 class="h-3 w-3" aria-hidden="true" />
+					{:else}
+						<Maximize2 class="h-3 w-3" aria-hidden="true" />
+					{/if}
+				</button>
+				<!-- Dock-side toggle — DevTools-style "put me on the side vs
+				     the bottom".  Icon shows the OTHER position (what you'll
+				     get if you click). -->
+				<button
+					type="button"
+					onclick={() => (inspectorPosition = inspectorPosition === 'bottom' ? 'right' : 'bottom')}
+					class="shrink-0 rounded p-1 text-muted-foreground hover:bg-accent hover:text-accent-foreground"
+					aria-label={inspectorPosition === 'bottom'
+						? 'Dock inspector to right'
+						: 'Dock inspector to bottom'}
+					title={inspectorPosition === 'bottom' ? 'Dock to side' : 'Dock to bottom'}
+					data-testid="workbench-inspector-position"
+				>
+					{#if inspectorPosition === 'bottom'}
+						<PanelRight class="h-3 w-3" aria-hidden="true" />
+					{:else}
+						<PanelBottom class="h-3 w-3" aria-hidden="true" />
+					{/if}
+				</button>
+			</div>
+		</header>
+		<!-- Body: tab strip + content inside a p-3 padded flex column,
+			     mirroring the "Create Your Dimensions & Hierarchies" frame's
+			     header → whitespace → content pattern.  Tabs are no longer
+			     sub-chrome (no border-b); they sit inside the padded area
+			     with a gap-3 between them and the content. -->
+		<div class="flex min-h-0 flex-1 flex-col gap-3 overflow-hidden p-3">
+			<div class="flex shrink-0">
+				{@render inspectorTabStrip('workbench-inspector-tab')}
+			</div>
+			<!-- Content area: `overflow-hidden` + `min-w-0` clip horizontal
+			     overflow so a wide Sample-data table doesn't push the tab strip
+			     + drawer wider than the inspector's actual width.  Vertical
+			     overflow is handled here (drawer is now a bottom row and
+			     content can grow past its height). -->
+			<div class="min-h-0 min-w-0 flex-1 overflow-x-hidden overflow-y-auto">
+				{#if inspectorTab === 'properties'}
+					{@render inspectorProperties()}
+				{:else}
+					{@render inspectorCode()}
+				{/if}
+			</div>
+		</div>
+	</div>
+{/snippet}
+
+<!-- Inspector › Properties tab.  Thin wrapper mounting the extracted
+     InspectorProperties.svelte (#1039 stage 2) so both render sites
+     (columns inspector + tree inspector) stay `{@render inspectorProperties()}`
+     and the shell keeps ONE source of truth for the props/bind wiring. -->
+{#snippet inspectorProperties()}
+	<InspectorProperties
+		{store}
+		{cubes}
+		{selectedCubeId}
+		{factsMeasureGroups}
+		{selectedDimension}
+		{selectedHierarchy}
+		{selectedMeasure}
+		{selectedAttribute}
+		{selectedLevel}
+		{selectedTreeMeasureGroup}
+		{selectedTreeCube}
+		{hierarchyExplicitlyClicked}
+		{renameCube}
+		{selectTreeMeasureGroup}
+		{addMeasureGroupToCube}
+		{renameHierarchy}
+		{commitHierarchyName}
+		{renameDimension}
+		{commitDimensionName}
+		{tableNameFor}
+		{columnTypeFor}
+	/>
+{/snippet}
+
+{#snippet inspectorCode()}
+	{@const xml = workbenchPreviewXml()}
+	{@const code = codeFormat === 'yaml' ? mondrianXmlToYaml(xml) : xml}
+	{@const html = codeFormat === 'yaml' ? highlightYaml(code) : highlightXml(code)}
+	<!-- Relative wrapper hosts the floating format toggle + Copy button.  The
+	     <pre> scrolls inside it; the controls stay pinned to the top-right. -->
+	<div class="relative h-full">
+		<!-- The <pre> body MUST hug {@html} with no surrounding whitespace: a
+		     <pre> preserves it, so a newline/indent before the content would
+		     push the FIRST rendered line right (reported: `schema:` over-indented
+		     while later lines sat correctly). eslint-disable is block-form + outside
+		     the <pre> for the same reason (a comment inside would leak whitespace). -->
+		<!-- eslint-disable svelte/no-at-html-tags -->
+		<pre
+			class="xml-code h-full overflow-auto p-3 font-mono text-[11px] leading-relaxed break-words whitespace-pre-wrap"
+			style:background="hsl(var(--background))"
+			data-testid="workbench-inspector-code">{@html html}</pre>
+		<!-- eslint-enable svelte/no-at-html-tags -->
+		<!-- XML / YAML toggle (#1080).  Both render from the one M4 XML emitter
+		     (YAML derived via mondrianXmlToYaml) so they never disagree. -->
+		<div
+			class="absolute top-2 right-20 z-10 inline-flex overflow-hidden rounded border text-[10px] font-medium shadow-sm"
+			style:border-color="hsl(var(--border))"
+			data-testid="workbench-inspector-code-format"
+		>
+			<button
+				type="button"
+				onclick={() => (codeFormat = 'xml')}
+				class="px-2 py-1 {codeFormat === 'xml'
+					? 'bg-primary text-primary-foreground'
+					: 'bg-elev-2 text-muted-foreground hover:bg-accent/40'}"
+				data-testid="workbench-inspector-code-format-xml"
+				title="Show as Mondrian 4 XML">XML</button
+			>
+			<button
+				type="button"
+				onclick={() => (codeFormat = 'yaml')}
+				class="px-2 py-1 {codeFormat === 'yaml'
+					? 'bg-primary text-primary-foreground'
+					: 'bg-elev-2 text-muted-foreground hover:bg-accent/40'}"
+				data-testid="workbench-inspector-code-format-yaml"
+				title="Show as Mondrian 4 YAML">YAML</button
+			>
+		</div>
+		<button
+			type="button"
+			onclick={() => copyInspectorCode(code)}
+			class="absolute top-2 right-2 z-10 inline-flex items-center gap-1 rounded border bg-elev-2 px-2 py-1 text-[10px] font-medium text-muted-foreground shadow-sm hover:bg-accent/40"
+			style:border-color="hsl(var(--border))"
+			data-testid="workbench-inspector-code-copy"
+			title={codeFormat === 'yaml' ? 'Copy YAML' : 'Copy XML'}
+		>
+			{#if codeCopyFlash}
+				<Check class="h-3 w-3 text-primary" aria-hidden="true" />
+				<span class="text-primary">Copied</span>
+			{:else}
+				<Copy class="h-3 w-3" aria-hidden="true" />
+				<span>Copy</span>
+			{/if}
+		</button>
+	</div>
+{/snippet}
+
+<!--
+	Sample data tab.  Mirrors the AI-wizard's per-cube "Sample data" tab
+	(see `/schemas/new`).  When the canvas has a fact table picked + a
+	connection, fetches 5 rows from /api/inference/sample/<connId> and
+	renders a compact table.  Otherwise: empty state listing what the
+	user needs to do.
+-->
+{#snippet inspectorSampleData()}
+	<div class="flex h-full flex-col gap-3 p-3 text-xs" data-testid="workbench-inspector-sample-data">
+		{#if !sampleDataReadiness.ready}
+			<div class="flex flex-1 flex-col items-center justify-center gap-2 text-center">
+				<p class="text-xs font-semibold">Sample data isn't ready yet</p>
+				<p class="text-[11px]" style="color: hsl(var(--muted-foreground))">
+					Finish the cube before sample rows will populate:
+				</p>
+				<ul class="flex flex-col gap-1 text-left text-[11px]">
+					{#each sampleDataReadiness.missing as item (item)}
+						<li class="flex items-center gap-1.5">
+							<span
+								class="inline-block h-1.5 w-1.5 shrink-0 rounded-full"
+								style:background-color="hsl(var(--primary))"
+							></span>
+							{item}
+						</li>
+					{/each}
+				</ul>
+			</div>
+		{:else}
+			<header class="flex shrink-0 items-center justify-between gap-2">
+				<div class="flex min-w-0 flex-1 flex-col gap-0.5">
+					<span class="truncate text-xs font-semibold">
+						{cubeFactTable?.schema
+							? `${cubeFactTable.schema}.${cubeFactTable.name}`
+							: cubeFactTable?.name}
+					</span>
+					<span class="text-[10px]" style:color="hsl(var(--muted-foreground))">
+						First {sampleRowLimit} row{sampleRowLimit === 1 ? '' : 's'} from the fact table
+					</span>
+				</div>
+				<!-- Row-count chips + Refresh.  Picking a chip re-keys the
+				     fetch (see sampleDataKey) so the effect refires. -->
+				<div class="flex shrink-0 items-center gap-2">
+					<div
+						class="inline-flex overflow-hidden rounded border"
+						style:border-color="hsl(var(--border))"
+						role="radiogroup"
+						aria-label="Number of sample rows"
+					>
+						{#each SAMPLE_ROW_LIMITS as n (n)}
+							<button
+								type="button"
+								role="radio"
+								aria-checked={sampleRowLimit === n}
+								onclick={() => (sampleRowLimit = n)}
+								class="border-l px-2 py-0.5 text-[10px] font-semibold tracking-wide first:border-l-0 {sampleRowLimit ===
+								n
+									? 'bg-primary/10 text-primary'
+									: 'text-muted-foreground hover:bg-accent/40 hover:text-foreground'}"
+								style:border-color="hsl(var(--border))"
+								data-testid="sample-data-row-chip"
+								data-row-count={n}
+								title={`Show ${n} row${n === 1 ? '' : 's'}`}
+							>
+								{n}
+							</button>
+						{/each}
+					</div>
+					<button
+						type="button"
+						onclick={() => {
+							sampleDataKey = null;
+							void loadSampleData();
+						}}
+						class="rounded border px-2 py-0.5 text-[10px] font-semibold tracking-wide uppercase hover:bg-accent hover:text-accent-foreground"
+						style:border-color="hsl(var(--border))"
+						title="Refresh sample data"
+					>
+						Refresh
+					</button>
+				</div>
+			</header>
+			{#if sampleData.kind === 'idle' || sampleData.kind === 'loading'}
+				<p class="text-[11px]" style:color="hsl(var(--muted-foreground))">Loading sample…</p>
+			{:else if sampleData.kind === 'error'}
+				<p
+					class="rounded border p-2 text-[11px] text-destructive"
+					style:border-color="hsl(var(--destructive))"
+				>
+					{sampleData.message}
+				</p>
+			{:else}
+				<!-- min-w-full lets the table grow to its natural content width
+				     so the container's overflow-auto fires when columns add up
+				     to more than the inspector's width.  table-auto = columns
+				     size to their content rather than splitting the container
+				     equally. -->
+				<div
+					class="min-h-0 flex-1 overflow-auto rounded border"
+					style:border-color="hsl(var(--border))"
+				>
+					<table class="min-w-full table-auto font-mono text-[10px]">
+						<thead class="sticky top-0 bg-elev-1">
+							<tr>
+								{#each sampleData.columns as col (col)}
+									<th
+										class="border-b px-2 py-1 text-left font-semibold whitespace-nowrap"
+										style:border-color="hsl(var(--border))"
+									>
+										{col}
+									</th>
+								{/each}
+							</tr>
+						</thead>
+						<tbody>
+							{#each sampleData.rows as row, i (i)}
+								<tr class="border-b" style:border-color="hsl(var(--border))">
+									{#each sampleData.columns as col (col)}
+										<td class="px-2 py-1 whitespace-nowrap">
+											{row[col] === null || row[col] === undefined ? '—' : String(row[col])}
+										</td>
+									{/each}
+								</tr>
+							{/each}
+						</tbody>
+					</table>
+				</div>
+			{/if}
+		{/if}
+	</div>
+{/snippet}
+
+<!--
+	Try a query tab.  Posts the workbench's MDX scaffold + a proposal
+	shape to /api/inference/try-query (originally built for AI-draft
+	cubes; same shape works for the workbench-authored ones too).
+	Renders the result inline as a flat table.
+-->
+{#snippet inspectorTryQuery()}
+	{@const previewMdx = tryQueryEffectiveMdx}
+	{@const measureName = tryQueryPickedMeasure}
+	{@const levelName = tryQueryPickedLevel?.name}
+	<div class="flex h-full flex-col gap-3 p-3 text-xs" data-testid="workbench-inspector-try-query">
+		{#if !tryQueryReadiness.ready}
+			<div class="flex flex-1 flex-col items-center justify-center gap-2 text-center">
+				<p class="text-xs font-semibold">Try a query isn't ready yet</p>
+				<p class="text-[11px]" style:color="hsl(var(--muted-foreground))">
+					Finish the cube before you can run a test query:
+				</p>
+				<ul class="flex flex-col gap-1 text-left text-[11px]">
+					{#each tryQueryReadiness.missing as item (item)}
+						<li class="flex items-center gap-1.5">
+							<span
+								class="inline-block h-1.5 w-1.5 shrink-0 rounded-full"
+								style:background-color="hsl(var(--primary))"
+							></span>
+							{item}
+						</li>
+					{/each}
+				</ul>
+			</div>
+		{:else if previewMdx}
+			<!-- Header: MDX label + Copy + Run.  Open in Saiku lives on
+			     each cube row in the left rail — no need to repeat it
+			     here. -->
+			<div class="flex shrink-0 items-center justify-between gap-2">
+				<span
+					class="inline-flex items-center gap-1 text-[10px] font-semibold tracking-wider uppercase"
+					style:color="hsl(var(--muted-foreground))"
+				>
+					MDX
+					<span class="ml-1 normal-case opacity-70">
+						· {measureName} by {levelName}
+					</span>
+					{#if tryQueryMdxOverride !== null}
+						<span
+							class="ml-1 rounded bg-warning/20 px-1 text-[9px] font-medium text-warning normal-case"
+							title="MDX has been hand-edited"
+						>
+							edited
+						</span>
+					{/if}
+				</span>
+				<div class="flex shrink-0 items-center gap-1.5">
+					{#if tryQueryMdxOverride !== null}
+						<button
+							type="button"
+							onclick={() => (tryQueryMdxOverride = null)}
+							class="text-[10px] font-medium text-primary hover:underline"
+							data-testid="workbench-try-query-mdx-reset"
+							title="Discard edits and restore the auto-generated MDX"
+						>
+							Reset
+						</button>
+					{/if}
+					<button
+						type="button"
+						onclick={() => {
+							if (typeof navigator !== 'undefined' && navigator.clipboard) {
+								void navigator.clipboard.writeText(previewMdx);
+							}
+						}}
+						class="inline-flex items-center gap-1 rounded border px-2 py-0.5 text-[10px] font-semibold tracking-wider uppercase hover:bg-accent/40"
+						style:border-color="hsl(var(--border))"
+						data-testid="workbench-try-query-copy"
+					>
+						Copy
+					</button>
+					<button
+						type="button"
+						onclick={() => void runTryQuery()}
+						disabled={tryQueryState.kind === 'loading'}
+						class="inline-flex items-center gap-1 rounded bg-primary px-2 py-0.5 text-[10px] font-semibold tracking-wider text-primary-foreground uppercase hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-50"
+						data-testid="workbench-try-query-run"
+					>
+						{tryQueryState.kind === 'loading' ? 'Running…' : 'Run'}
+					</button>
+				</div>
+			</div>
+			<!-- MDX textarea — visible + editable by default.  Typing seeds
+			     tryQueryMdxOverride; Run uses the textarea contents; Reset
+			     (header) drops the override and snaps back to the seed. -->
+			<textarea
+				class="shrink-0 resize-y rounded border bg-elev-1 p-2 font-mono text-[10px] leading-relaxed focus:border-ring focus:ring-1 focus:ring-ring focus:outline-none"
+				style:border-color="hsl(var(--border))"
+				style:min-height="6rem"
+				style:max-height="16rem"
+				rows="5"
+				spellcheck="false"
+				value={previewMdx}
+				oninput={(e) => (tryQueryMdxOverride = (e.currentTarget as HTMLTextAreaElement).value)}
+				data-testid="workbench-try-query-mdx"
+			></textarea>
+
+			{#if tryQueryState.kind === 'idle'}
+				<div class="flex flex-1 items-center justify-center text-center">
+					<p class="text-[11px]" style:color="hsl(var(--muted-foreground))">
+						Hit <strong>Run</strong> to execute the MDX against the unsaved cube.
+					</p>
+				</div>
+			{:else if tryQueryState.kind === 'loading'}
+				<div class="flex flex-1 items-center justify-center">
+					<p class="text-[11px]" style:color="hsl(var(--muted-foreground))">Running query…</p>
+				</div>
+			{:else if tryQueryState.kind === 'error'}
+				<div
+					class="rounded border border-destructive/40 bg-destructive/10 p-2 text-[11px] text-destructive"
+					data-testid="workbench-try-query-error"
+				>
+					{tryQueryState.message}
+				</div>
+			{:else}
+				<div class="flex shrink-0 items-center justify-between gap-2">
+					<span
+						class="text-[10px] font-semibold tracking-wider uppercase"
+						style:color="hsl(var(--muted-foreground))"
+					>
+						Result · {tryQueryState.rows.length} row{tryQueryState.rows.length === 1 ? '' : 's'}
+						{#if tryQueryState.durationMs !== undefined}
+							<span class="ml-1 normal-case opacity-70">({tryQueryState.durationMs}ms)</span>
+						{/if}
+					</span>
+					{#if tryQueryState.truncated}
+						<span
+							class="rounded border border-warning/40 bg-warning/10 px-1.5 text-[9px] text-warning"
+						>
+							truncated
+						</span>
+					{/if}
+				</div>
+				<div
+					class="min-h-0 flex-1 overflow-auto rounded border bg-elev-1"
+					style:border-color="hsl(var(--border))"
+					data-testid="workbench-try-query-result"
+				>
+					{#if tryQueryState.rows.length === 0}
+						<p class="p-3 text-center text-[11px]" style:color="hsl(var(--muted-foreground))">
+							No rows returned.
+						</p>
+					{:else}
+						<table class="min-w-full table-auto font-mono text-[10px]">
+							<thead class="sticky top-0 bg-elev-1">
+								<tr>
+									{#each tryQueryState.columns as col, i (i)}
+										<th
+											class="border-b px-2 py-1 text-left font-semibold whitespace-nowrap"
+											style:border-color="hsl(var(--border))"
+										>
+											{col}
+										</th>
+									{/each}
+								</tr>
+							</thead>
+							<tbody>
+								{#each tryQueryState.rows as row, i (i)}
+									<tr class="border-b" style:border-color="hsl(var(--border))">
+										{#each tryQueryState.columns as col, j (j)}
+											<td class="px-2 py-1 whitespace-nowrap">
+												{row[col] === null || row[col] === undefined ? '—' : String(row[col])}
+											</td>
+										{/each}
+									</tr>
+								{/each}
+							</tbody>
+						</table>
+					{/if}
+				</div>
+			{/if}
+		{:else}
+			<div class="flex flex-1 flex-col items-center justify-center gap-2 text-center">
+				<p class="text-xs font-semibold">Cube is ready</p>
+				<p class="text-[11px]" style:color="hsl(var(--muted-foreground))">
+					Pick at least one measure + one dimension level to generate a sample query.
+				</p>
+			</div>
+		{/if}
+	</div>
+{/snippet}
+
+<!-- ── Delete confirmation modal ────────────────────────────────── -->
+{#if confirmDelete}
+	<div
+		class="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4"
+		role="dialog"
+		aria-modal="true"
+		aria-labelledby="confirm-delete-title"
+		data-testid="workbench-confirm-delete"
+	>
+		<button
+			type="button"
+			class="absolute inset-0 cursor-default"
+			aria-label="Cancel"
+			onclick={cancelDeletion}
+		></button>
+		<div
+			class="relative z-10 w-full max-w-md rounded-lg border bg-elev-4 p-5 shadow-xl"
+			style:border-color="hsl(var(--border))"
+		>
+			<h3
+				id="confirm-delete-title"
+				class="mb-3 text-sm font-semibold"
+				style:color="hsl(var(--foreground))"
+			>
+				{confirmDelete.title}
+			</h3>
+			<p
+				class="mb-2 text-[11px] tracking-wider uppercase"
+				style:color="hsl(var(--muted-foreground))"
+			>
+				What you'll lose
+			</p>
+			<ul class="mb-4 list-disc space-y-1 pl-5 text-xs" style:color="hsl(var(--foreground))">
+				{#each confirmDelete.impact as line, i (i)}
+					<li>{line}</li>
+				{/each}
+			</ul>
+			<div class="flex justify-end gap-2">
+				<button
+					type="button"
+					onclick={cancelDeletion}
+					class="rounded border border-border px-3 py-1.5 text-xs font-medium hover:bg-accent hover:text-accent-foreground"
+					data-testid="workbench-confirm-delete-cancel"
+				>
+					Cancel
+				</button>
+				<button
+					type="button"
+					onclick={confirmDeletion}
+					class="rounded border border-destructive bg-destructive px-3 py-1.5 text-xs font-medium text-destructive-foreground hover:opacity-90"
+					data-testid="workbench-confirm-delete-confirm"
+				>
+					Delete
+				</button>
+			</div>
+		</div>
+	</div>
+{/if}
+
+<!-- ── Attribute-removal confirmation modal ─────────────────────── -->
+{#if confirmRemoveAttr}
+	<div
+		class="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4"
+		role="dialog"
+		aria-modal="true"
+		aria-labelledby="confirm-remove-attr-title"
+		data-testid="workbench-confirm-remove-attribute"
+	>
+		<button
+			type="button"
+			class="absolute inset-0 cursor-default"
+			aria-label="Cancel"
+			onclick={cancelRemoveAttribute}
+		></button>
+		<div
+			class="relative z-10 w-full max-w-md rounded-lg border bg-elev-4 p-5 shadow-xl"
+			style:border-color="hsl(var(--border))"
+		>
+			<h3
+				id="confirm-remove-attr-title"
+				class="mb-3 text-sm font-semibold"
+				style:color="hsl(var(--foreground))"
+			>
+				Remove attribute "{confirmRemoveAttr.columnName}"?
+			</h3>
+			<p class="mb-2 text-xs" style:color="hsl(var(--foreground))">
+				{confirmRemoveAttr.affected.length} hierarch{confirmRemoveAttr.affected.length === 1
+					? 'y depends'
+					: 'ies depend'} on this attribute. Removing it will also remove the matching level from:
+			</p>
+			<ul class="mb-4 list-disc space-y-1 pl-5 text-xs" style:color="hsl(var(--foreground))">
+				{#each confirmRemoveAttr.affected as a (a.hierId)}
+					<li>{a.hierName}</li>
+				{/each}
+			</ul>
+			<div class="flex justify-end gap-2">
+				<button
+					type="button"
+					onclick={cancelRemoveAttribute}
+					class="rounded border border-border px-3 py-1.5 text-xs font-medium hover:bg-accent hover:text-accent-foreground"
+					data-testid="workbench-confirm-remove-attr-cancel"
+				>
+					Cancel
+				</button>
+				<button
+					type="button"
+					onclick={confirmRemoveAttribute}
+					class="rounded border border-destructive bg-destructive px-3 py-1.5 text-xs font-medium text-destructive-foreground hover:opacity-90"
+					data-testid="workbench-confirm-remove-attr-confirm"
+				>
+					Remove
+				</button>
+			</div>
+		</div>
+	</div>
+{/if}
+
+<style>
+	/* Resize handle (between top + bottom workbench sections) — grip
+	   colour and hover lift, distinct from default border so it reads
+	   in both themes. */
+	:global(.workbench-resize-handle) > div {
+		background-color: hsl(var(--border));
+		transition: background-color 120ms ease;
+	}
+	:global(.workbench-resize-handle):hover > div {
+		background-color: hsl(var(--primary));
+	}
+	:global(.workbench-resize-handle-active) > div {
+		background-color: hsl(var(--primary));
+	}
+	:global([data-theme='dark'] .workbench-resize-handle) > div {
+		background-color: hsl(220 10% 45%);
+	}
+	:global([data-theme='dark'] .workbench-resize-handle):hover > div {
+		background-color: hsl(220 90% 65%);
+	}
+
+	/* Softer "gated" appearance for a whole pane section — used on
+	   the Hierarchies pane while Attributes is mid-edit.  Reads as
+	   "not clickable yet" without going invisible; opacity is high
+	   enough that headings, prompt copy and icons stay legible so
+	   the user can still see what's waiting for them. */
+	:global(.workbench-pane-disabled) {
+		opacity: 0.65;
+		pointer-events: none;
+	}
+	:global([data-theme='dark'] .workbench-pane-disabled) {
+		opacity: 0.6;
+	}
+
+	/* Surface elevation overrides moved to layout.css via the
+	   --elev-0…--elev-4 scale.  Workbench now uses bg-elev-* classes
+	   directly so light + dark modes share the same role mapping. */
+
+	/* XML syntax highlighting palette — IDE-style: tag (blue), attr
+	   (warm yellow), string (green), comment (muted grey). */
+	:global(.xml-code .xml-tag) {
+		color: hsl(210 80% 50%);
+		font-weight: 600;
+	}
+	:global(.xml-code .xml-attr) {
+		color: hsl(35 80% 45%);
+	}
+	:global(.xml-code .xml-string) {
+		color: hsl(140 55% 40%);
+	}
+	:global(.xml-code .xml-comment) {
+		color: hsl(0 0% 50%);
+		font-style: italic;
+	}
+	:global([data-theme='dark'] .xml-code .xml-tag) {
+		color: hsl(210 80% 65%);
+	}
+	:global([data-theme='dark'] .xml-code .xml-attr) {
+		color: hsl(35 90% 65%);
+	}
+	:global([data-theme='dark'] .xml-code .xml-string) {
+		color: hsl(140 55% 60%);
+	}
+	:global([data-theme='dark'] .xml-code .xml-comment) {
+		color: hsl(0 0% 55%);
+	}
+
+	/* Selected-row appearance matches the canvas "highlighted column"
+	   treatment.  Light mode: pale mint bg + deep mint text.  Dark
+	   mode: bright emerald bg + black text.  Same HSL values the
+	   TableNode uses so the workbench reads consistent with the
+	   canvas selection. */
+	:global(.workbench-row-selected) {
+		background-color: hsl(150 55% 88%);
+		color: hsl(150 55% 22%);
+		border-color: hsl(150 55% 35%);
+	}
+	:global([data-theme='dark'] .workbench-row-selected) {
+		background-color: hsl(150 55% 62%);
+		color: hsl(0 0% 6%);
+		border-color: hsl(150 55% 30%);
+	}
+	/* Context state — "last selected in this pane, but focus has moved
+	   elsewhere."  Muted grey so it doesn't compete with the bright
+	   green of the actively-focused row.  Same in both themes: a soft
+	   muted surface + border, no color shift on the text.  Fixes the
+	   "everything looks selected" bug when multiple panes each held
+	   their own bright highlight. */
+	:global(.workbench-row-context) {
+		background-color: hsl(var(--muted));
+		border-color: hsl(var(--border));
+	}
+	/* Outline-only variant — same green border, no fill.  Used on
+	   calc cards where filling the whole card would compete with
+	   the chip/textarea content inside. */
+	:global(.workbench-row-selected-outline) {
+		border-color: hsl(150 55% 35%);
+		box-shadow: 0 0 0 1px hsl(150 55% 35%);
+	}
+	:global([data-theme='dark'] .workbench-row-selected-outline) {
+		border-color: hsl(150 55% 50%);
+		box-shadow: 0 0 0 1px hsl(150 55% 50%);
+	}
+	/* Sub-labels inside a selected row inherit the row color but drop
+	   opacity so they stay legible without their original
+	   muted-foreground gray (which disappears on green). */
+	:global(.workbench-row-selected *[style*='muted-foreground']),
+	:global(.workbench-row-selected .text-muted-foreground) {
+		color: inherit !important;
+		opacity: 0.7;
+	}
+	/* Number badges keep their accent bg / fg so they stay visible. */
+	:global(.workbench-row-selected .bg-accent) {
+		background-color: hsl(150 55% 22%);
+		color: hsl(150 55% 88%);
+	}
+	/* Editable inputs inside a selected (mint) row get a plain white
+	   surface with dark text in light mode — the row's mint fill is
+	   pale enough that a white input reads cleanly as a distinct
+	   editable affordance.  Dark mode keeps a dark-grey surface with
+	   white text so the input contrasts against the bright emerald
+	   selected-row fill. */
+	:global(.workbench-row-selected input[type='text']),
+	:global(.workbench-row-selected textarea) {
+		background-color: hsl(0 0% 100%);
+		color: hsl(220 12% 18%);
+		border-color: hsl(220 12% 70%);
+	}
+	:global(.workbench-row-selected input[type='text']::placeholder),
+	:global(.workbench-row-selected textarea::placeholder) {
+		color: hsl(220 8% 55%);
+	}
+	:global([data-theme='dark'] .workbench-row-selected input[type='text']),
+	:global([data-theme='dark'] .workbench-row-selected textarea) {
+		background-color: hsl(220 10% 28%);
+		color: hsl(0 0% 100%);
+		border-color: hsl(220 12% 18%);
+	}
+	:global([data-theme='dark'] .workbench-row-selected input[type='text']::placeholder),
+	:global([data-theme='dark'] .workbench-row-selected textarea::placeholder) {
+		color: hsl(220 8% 65%);
+	}
+	:global(.workbench-row-selected input[type='text']::selection),
+	:global(.workbench-row-selected textarea::selection) {
+		background-color: hsl(210 90% 60%);
+		color: hsl(0 0% 100%);
+	}
+
+	/* System-dark fallback — when no explicit data-theme attr is set
+	   but the OS prefers dark, mirror every hardcoded
+	   `[data-theme='dark']` rule above.  Without these the workbench
+	   reads as a light-mode bleed (pale mint row, blue xml tags, etc)
+	   against an otherwise-dark surface.  The `:not([data-theme='light'])`
+	   keeps explicit light override winning over the OS pref. */
+	@media (prefers-color-scheme: dark) {
+		:global(:root:not([data-theme='light']) .workbench-resize-handle) > div {
+			background-color: hsl(220 10% 45%);
+		}
+		:global(:root:not([data-theme='light']) .workbench-resize-handle):hover > div {
+			background-color: hsl(220 90% 65%);
+		}
+		:global(:root:not([data-theme='light']) .workbench-pane-disabled) {
+			opacity: 0.6;
+		}
+		:global(:root:not([data-theme='light']) .xml-code .xml-tag) {
+			color: hsl(210 80% 65%);
+		}
+		:global(:root:not([data-theme='light']) .xml-code .xml-attr) {
+			color: hsl(35 90% 65%);
+		}
+		:global(:root:not([data-theme='light']) .xml-code .xml-string) {
+			color: hsl(140 55% 60%);
+		}
+		:global(:root:not([data-theme='light']) .xml-code .xml-comment) {
+			color: hsl(0 0% 55%);
+		}
+		:global(:root:not([data-theme='light']) .workbench-row-selected) {
+			background-color: hsl(150 55% 62%);
+			color: hsl(0 0% 6%);
+			border-color: hsl(150 55% 30%);
+		}
+		:global(:root:not([data-theme='light']) .workbench-row-selected-outline) {
+			border-color: hsl(150 55% 50%);
+			box-shadow: 0 0 0 1px hsl(150 55% 50%);
+		}
+	}
+</style>

--- a/saiku-ui/src/lib/cube-designer/ai-chat-types.ts
+++ b/saiku-ui/src/lib/cube-designer/ai-chat-types.ts
@@ -1,0 +1,50 @@
+/**
+ * Anthropic-shaped conversation types used by the Ask DimSum flow.
+ *
+ * Storing content blocks client-side in the same shape we send to and
+ * receive from the tool-use API means we don't have to translate
+ * between UI and API formats every turn.  Extended-thinking blocks
+ * MUST be preserved on the assistant turn — Anthropic verifies the
+ * signature and errors out if it's dropped.
+ */
+
+export interface AnthropicTextBlock {
+	type: 'text';
+	text: string;
+}
+export interface AnthropicToolUseBlock {
+	type: 'tool_use';
+	id: string;
+	name: string;
+	input: Record<string, unknown>;
+}
+export interface AnthropicToolResultBlock {
+	type: 'tool_result';
+	tool_use_id: string;
+	content: string;
+	is_error?: boolean;
+}
+export interface AnthropicThinkingBlock {
+	type: 'thinking';
+	thinking: string;
+	signature: string;
+}
+export type AnthropicBlock =
+	| AnthropicTextBlock
+	| AnthropicToolUseBlock
+	| AnthropicToolResultBlock
+	| AnthropicThinkingBlock;
+
+export interface ChatMessage {
+	role: 'user' | 'assistant';
+	content: string | AnthropicBlock[];
+	ts: number;
+}
+
+/** Summary of a completed DimSum canvas mutation, shown as the
+ *  Confirm/Cancel banner inside the widget. */
+export interface DimSumMutationResult {
+	tables: number;
+	joins: number;
+	warnings: string[];
+}

--- a/saiku-ui/src/lib/cube-designer/ai-chat-types.ts
+++ b/saiku-ui/src/lib/cube-designer/ai-chat-types.ts
@@ -9,42 +9,42 @@
  */
 
 export interface AnthropicTextBlock {
-	type: 'text';
-	text: string;
+  type: "text";
+  text: string;
 }
 export interface AnthropicToolUseBlock {
-	type: 'tool_use';
-	id: string;
-	name: string;
-	input: Record<string, unknown>;
+  type: "tool_use";
+  id: string;
+  name: string;
+  input: Record<string, unknown>;
 }
 export interface AnthropicToolResultBlock {
-	type: 'tool_result';
-	tool_use_id: string;
-	content: string;
-	is_error?: boolean;
+  type: "tool_result";
+  tool_use_id: string;
+  content: string;
+  is_error?: boolean;
 }
 export interface AnthropicThinkingBlock {
-	type: 'thinking';
-	thinking: string;
-	signature: string;
+  type: "thinking";
+  thinking: string;
+  signature: string;
 }
 export type AnthropicBlock =
-	| AnthropicTextBlock
-	| AnthropicToolUseBlock
-	| AnthropicToolResultBlock
-	| AnthropicThinkingBlock;
+  | AnthropicTextBlock
+  | AnthropicToolUseBlock
+  | AnthropicToolResultBlock
+  | AnthropicThinkingBlock;
 
 export interface ChatMessage {
-	role: 'user' | 'assistant';
-	content: string | AnthropicBlock[];
-	ts: number;
+  role: "user" | "assistant";
+  content: string | AnthropicBlock[];
+  ts: number;
 }
 
 /** Summary of a completed DimSum canvas mutation, shown as the
  *  Confirm/Cancel banner inside the widget. */
 export interface DimSumMutationResult {
-	tables: number;
-	joins: number;
-	warnings: string[];
+  tables: number;
+  joins: number;
+  warnings: string[];
 }

--- a/saiku-ui/src/lib/cube-designer/auto-suggest.ts
+++ b/saiku-ui/src/lib/cube-designer/auto-suggest.ts
@@ -15,117 +15,138 @@
  *
  * Returns an ordered list of candidate joins, highest-confidence first.
  */
-import type { SchemaCanvasTable, SchemaCanvasJoinKind } from './types.js';
+import type { SchemaCanvasTable, SchemaCanvasJoinKind } from "./types.js";
 
 export interface JoinSuggestion {
-	sourceColumnName: string;
-	targetColumnName: string;
-	kind: SchemaCanvasJoinKind;
-	confidence: 'high' | 'medium' | 'low';
-	reason: string;
+  sourceColumnName: string;
+  targetColumnName: string;
+  kind: SchemaCanvasJoinKind;
+  confidence: "high" | "medium" | "low";
+  reason: string;
 }
 
 export function suggestJoins(
-	source: SchemaCanvasTable,
-	target: SchemaCanvasTable
+  source: SchemaCanvasTable,
+  target: SchemaCanvasTable,
 ): JoinSuggestion[] {
-	const out: JoinSuggestion[] = [];
-	const seen = new Set<string>();
+  const out: JoinSuggestion[] = [];
+  const seen = new Set<string>();
 
-	const sourceColumns = source.columns.map((c) => c.name.toLowerCase());
-	const targetColumns = target.columns.map((c) => c.name.toLowerCase());
-	const sourceColumnsOriginal = new Map(source.columns.map((c) => [c.name.toLowerCase(), c.name]));
-	const targetColumnsOriginal = new Map(target.columns.map((c) => [c.name.toLowerCase(), c.name]));
+  const sourceColumns = source.columns.map((c) => c.name.toLowerCase());
+  const targetColumns = target.columns.map((c) => c.name.toLowerCase());
+  const sourceColumnsOriginal = new Map(
+    source.columns.map((c) => [c.name.toLowerCase(), c.name]),
+  );
+  const targetColumnsOriginal = new Map(
+    target.columns.map((c) => [c.name.toLowerCase(), c.name]),
+  );
 
-	const push = (
-		src: string,
-		tgt: string,
-		confidence: JoinSuggestion['confidence'],
-		reason: string
-	) => {
-		const key = `${src}=${tgt}`;
-		if (seen.has(key)) return;
-		seen.add(key);
-		out.push({
-			sourceColumnName: src,
-			targetColumnName: tgt,
-			kind: 'inner',
-			confidence,
-			reason
-		});
-	};
+  const push = (
+    src: string,
+    tgt: string,
+    confidence: JoinSuggestion["confidence"],
+    reason: string,
+  ) => {
+    const key = `${src}=${tgt}`;
+    if (seen.has(key)) return;
+    seen.add(key);
+    out.push({
+      sourceColumnName: src,
+      targetColumnName: tgt,
+      kind: "inner",
+      confidence,
+      reason,
+    });
+  };
 
-	// 1. Exact matches.
-	for (const sc of sourceColumns) {
-		if (targetColumns.includes(sc)) {
-			push(
-				sourceColumnsOriginal.get(sc)!,
-				targetColumnsOriginal.get(sc)!,
-				'high',
-				`Exact column-name match (${sc})`
-			);
-		}
-	}
+  // 1. Exact matches.
+  for (const sc of sourceColumns) {
+    if (targetColumns.includes(sc)) {
+      push(
+        sourceColumnsOriginal.get(sc)!,
+        targetColumnsOriginal.get(sc)!,
+        "high",
+        `Exact column-name match (${sc})`,
+      );
+    }
+  }
 
-	// 2. <table_name>_id pattern — source column matches `<target_name>_id` AND target has the canonical id.
-	const targetNameLower = target.name.toLowerCase();
-	const targetSingular = targetNameLower.endsWith('s')
-		? targetNameLower.slice(0, -1)
-		: targetNameLower;
-	const sourceNameLower = source.name.toLowerCase();
-	const sourceSingular = sourceNameLower.endsWith('s')
-		? sourceNameLower.slice(0, -1)
-		: sourceNameLower;
+  // 2. <table_name>_id pattern — source column matches `<target_name>_id` AND target has the canonical id.
+  const targetNameLower = target.name.toLowerCase();
+  const targetSingular = targetNameLower.endsWith("s")
+    ? targetNameLower.slice(0, -1)
+    : targetNameLower;
+  const sourceNameLower = source.name.toLowerCase();
+  const sourceSingular = sourceNameLower.endsWith("s")
+    ? sourceNameLower.slice(0, -1)
+    : sourceNameLower;
 
-	const candidateIdColsTgt = ['id', `${targetSingular}_id`, `${targetNameLower}_id`];
-	for (const srcCol of sourceColumns) {
-		if (srcCol === `${targetSingular}_id` || srcCol === `${targetNameLower}_id`) {
-			for (const tgtCandidate of candidateIdColsTgt) {
-				if (targetColumns.includes(tgtCandidate)) {
-					push(
-						sourceColumnsOriginal.get(srcCol)!,
-						targetColumnsOriginal.get(tgtCandidate)!,
-						'high',
-						`Foreign-key naming convention (${srcCol} → ${tgtCandidate})`
-					);
-				}
-			}
-		}
-	}
-	// reverse direction — target side has the FK
-	const candidateIdColsSrc = ['id', `${sourceSingular}_id`, `${sourceNameLower}_id`];
-	for (const tgtCol of targetColumns) {
-		if (tgtCol === `${sourceSingular}_id` || tgtCol === `${sourceNameLower}_id`) {
-			for (const srcCandidate of candidateIdColsSrc) {
-				if (sourceColumns.includes(srcCandidate)) {
-					push(
-						sourceColumnsOriginal.get(srcCandidate)!,
-						targetColumnsOriginal.get(tgtCol)!,
-						'high',
-						`Foreign-key naming convention (${srcCandidate} → ${tgtCol})`
-					);
-				}
-			}
-		}
-	}
+  const candidateIdColsTgt = [
+    "id",
+    `${targetSingular}_id`,
+    `${targetNameLower}_id`,
+  ];
+  for (const srcCol of sourceColumns) {
+    if (
+      srcCol === `${targetSingular}_id` ||
+      srcCol === `${targetNameLower}_id`
+    ) {
+      for (const tgtCandidate of candidateIdColsTgt) {
+        if (targetColumns.includes(tgtCandidate)) {
+          push(
+            sourceColumnsOriginal.get(srcCol)!,
+            targetColumnsOriginal.get(tgtCandidate)!,
+            "high",
+            `Foreign-key naming convention (${srcCol} → ${tgtCandidate})`,
+          );
+        }
+      }
+    }
+  }
+  // reverse direction — target side has the FK
+  const candidateIdColsSrc = [
+    "id",
+    `${sourceSingular}_id`,
+    `${sourceNameLower}_id`,
+  ];
+  for (const tgtCol of targetColumns) {
+    if (
+      tgtCol === `${sourceSingular}_id` ||
+      tgtCol === `${sourceNameLower}_id`
+    ) {
+      for (const srcCandidate of candidateIdColsSrc) {
+        if (sourceColumns.includes(srcCandidate)) {
+          push(
+            sourceColumnsOriginal.get(srcCandidate)!,
+            targetColumnsOriginal.get(tgtCol)!,
+            "high",
+            `Foreign-key naming convention (${srcCandidate} → ${tgtCol})`,
+          );
+        }
+      }
+    }
+  }
 
-	// 3. Looser — any pair of `<root>_id` columns on each side where the
-	// root matches between them. e.g. `customer_id` ↔ `customer_id`
-	// already covered above; this picks up softer cases.
-	for (const sc of sourceColumns) {
-		const m = sc.match(/^(.+)_id$/);
-		if (!m) continue;
-		const root = m[1];
-		const tgtCandidate = `${root}_id`;
-		if (sourceColumnsOriginal.has(sc) && targetColumnsOriginal.has(tgtCandidate)) {
-			push(
-				sourceColumnsOriginal.get(sc)!,
-				targetColumnsOriginal.get(tgtCandidate)!,
-				'medium',
-				`Both sides have ${tgtCandidate}`
-			);
-		}
-	}
+  // 3. Looser — any pair of `<root>_id` columns on each side where the
+  // root matches between them. e.g. `customer_id` ↔ `customer_id`
+  // already covered above; this picks up softer cases.
+  for (const sc of sourceColumns) {
+    const m = sc.match(/^(.+)_id$/);
+    if (!m) continue;
+    const root = m[1];
+    const tgtCandidate = `${root}_id`;
+    if (
+      sourceColumnsOriginal.has(sc) &&
+      targetColumnsOriginal.has(tgtCandidate)
+    ) {
+      push(
+        sourceColumnsOriginal.get(sc)!,
+        targetColumnsOriginal.get(tgtCandidate)!,
+        "medium",
+        `Both sides have ${tgtCandidate}`,
+      );
+    }
+  }
 
-	return out;
+  return out;
 }

--- a/saiku-ui/src/lib/cube-designer/auto-suggest.ts
+++ b/saiku-ui/src/lib/cube-designer/auto-suggest.ts
@@ -1,0 +1,131 @@
+/**
+ * Canvas schema designer — join auto-suggest.
+ *
+ * Given a pair of tables on the canvas, propose candidate join columns
+ * based on name match heuristics. The user confirms or rejects each
+ * suggestion; this is not auto-creation, just a starting point.
+ *
+ * Heuristics, in order:
+ *   1. Exact column-name match on both sides (e.g. `customer_id` ↔ `customer_id`).
+ *   2. Table-named match — column on dim equals `<dim_name>_id` and fact
+ *      has a column matching that pattern (e.g. dim `customer` with `id` ↔
+ *      fact's `customer_id`).
+ *   3. PK-style: any column ending in `_id` on the fact that matches the
+ *      dim's name root.
+ *
+ * Returns an ordered list of candidate joins, highest-confidence first.
+ */
+import type { SchemaCanvasTable, SchemaCanvasJoinKind } from './types.js';
+
+export interface JoinSuggestion {
+	sourceColumnName: string;
+	targetColumnName: string;
+	kind: SchemaCanvasJoinKind;
+	confidence: 'high' | 'medium' | 'low';
+	reason: string;
+}
+
+export function suggestJoins(
+	source: SchemaCanvasTable,
+	target: SchemaCanvasTable
+): JoinSuggestion[] {
+	const out: JoinSuggestion[] = [];
+	const seen = new Set<string>();
+
+	const sourceColumns = source.columns.map((c) => c.name.toLowerCase());
+	const targetColumns = target.columns.map((c) => c.name.toLowerCase());
+	const sourceColumnsOriginal = new Map(source.columns.map((c) => [c.name.toLowerCase(), c.name]));
+	const targetColumnsOriginal = new Map(target.columns.map((c) => [c.name.toLowerCase(), c.name]));
+
+	const push = (
+		src: string,
+		tgt: string,
+		confidence: JoinSuggestion['confidence'],
+		reason: string
+	) => {
+		const key = `${src}=${tgt}`;
+		if (seen.has(key)) return;
+		seen.add(key);
+		out.push({
+			sourceColumnName: src,
+			targetColumnName: tgt,
+			kind: 'inner',
+			confidence,
+			reason
+		});
+	};
+
+	// 1. Exact matches.
+	for (const sc of sourceColumns) {
+		if (targetColumns.includes(sc)) {
+			push(
+				sourceColumnsOriginal.get(sc)!,
+				targetColumnsOriginal.get(sc)!,
+				'high',
+				`Exact column-name match (${sc})`
+			);
+		}
+	}
+
+	// 2. <table_name>_id pattern — source column matches `<target_name>_id` AND target has the canonical id.
+	const targetNameLower = target.name.toLowerCase();
+	const targetSingular = targetNameLower.endsWith('s')
+		? targetNameLower.slice(0, -1)
+		: targetNameLower;
+	const sourceNameLower = source.name.toLowerCase();
+	const sourceSingular = sourceNameLower.endsWith('s')
+		? sourceNameLower.slice(0, -1)
+		: sourceNameLower;
+
+	const candidateIdColsTgt = ['id', `${targetSingular}_id`, `${targetNameLower}_id`];
+	for (const srcCol of sourceColumns) {
+		if (srcCol === `${targetSingular}_id` || srcCol === `${targetNameLower}_id`) {
+			for (const tgtCandidate of candidateIdColsTgt) {
+				if (targetColumns.includes(tgtCandidate)) {
+					push(
+						sourceColumnsOriginal.get(srcCol)!,
+						targetColumnsOriginal.get(tgtCandidate)!,
+						'high',
+						`Foreign-key naming convention (${srcCol} → ${tgtCandidate})`
+					);
+				}
+			}
+		}
+	}
+	// reverse direction — target side has the FK
+	const candidateIdColsSrc = ['id', `${sourceSingular}_id`, `${sourceNameLower}_id`];
+	for (const tgtCol of targetColumns) {
+		if (tgtCol === `${sourceSingular}_id` || tgtCol === `${sourceNameLower}_id`) {
+			for (const srcCandidate of candidateIdColsSrc) {
+				if (sourceColumns.includes(srcCandidate)) {
+					push(
+						sourceColumnsOriginal.get(srcCandidate)!,
+						targetColumnsOriginal.get(tgtCol)!,
+						'high',
+						`Foreign-key naming convention (${srcCandidate} → ${tgtCol})`
+					);
+				}
+			}
+		}
+	}
+
+	// 3. Looser — any pair of `<root>_id` columns on each side where the
+	// root matches between them. e.g. `customer_id` ↔ `customer_id`
+	// already covered above; this picks up softer cases.
+	for (const sc of sourceColumns) {
+		const m = sc.match(/^(.+)_id$/);
+		if (!m) continue;
+		const root = m[1];
+		const tgtCandidate = `${root}_id`;
+		if (sourceColumnsOriginal.has(sc) && targetColumnsOriginal.has(tgtCandidate)) {
+			push(
+				sourceColumnsOriginal.get(sc)!,
+				targetColumnsOriginal.get(tgtCandidate)!,
+				'medium',
+				`Both sides have ${tgtCandidate}`
+			);
+		}
+	}
+
+	return out;
+}

--- a/saiku-ui/src/lib/cube-designer/backend.ts
+++ b/saiku-ui/src/lib/cube-designer/backend.ts
@@ -18,20 +18,20 @@
  * a SEPARATE, OPTIONAL context: a host that doesn't provide it gets the manual
  * designer with the AI surface disabled.
  */
-import { getContext, setContext } from 'svelte';
+import { getContext, setContext } from "svelte";
 
 /** Backend transport for the designer's data-plane calls. URL-only seam. */
 export interface CubeDesignerBackend {
-	/** Profile a connection → table/column catalog for the source sidebar. */
-	profileConnection(connectionId: string): Promise<Response>;
-	/** Fetch up to `limit` preview rows for a fact table (Sample-data tab). */
-	sample(connectionId: string, table: string, limit: number): Promise<Response>;
-	/** Run a starter query against the unsaved proposal (Try-a-query tab). */
-	tryQuery(body: unknown): Promise<Response>;
-	/** Load a saved schema's Mondrian XML from the library into the canvas. */
-	loadSchema(entryId: string): Promise<Response>;
-	/** Convert pasted legacy Mondrian-3 XML → Mondrian-4. */
-	convertSchema(body: unknown): Promise<Response>;
+  /** Profile a connection → table/column catalog for the source sidebar. */
+  profileConnection(connectionId: string): Promise<Response>;
+  /** Fetch up to `limit` preview rows for a fact table (Sample-data tab). */
+  sample(connectionId: string, table: string, limit: number): Promise<Response>;
+  /** Run a starter query against the unsaved proposal (Try-a-query tab). */
+  tryQuery(body: unknown): Promise<Response>;
+  /** Load a saved schema's Mondrian XML from the library into the canvas. */
+  loadSchema(entryId: string): Promise<Response>;
+  /** Convert pasted legacy Mondrian-3 XML → Mondrian-4. */
+  convertSchema(body: unknown): Promise<Response>;
 }
 
 /** Optional AI transport for the DimSum agent turn. Absent ⇒ AI disabled
@@ -39,35 +39,35 @@ export interface CubeDesignerBackend {
  *  transport). `fetchImpl` is the existing dimsum-agent injection seam — a host
  *  provides one to point the DimSum turn at its own AI endpoint. */
 export interface CubeDesignerAI {
-	fetchImpl?: typeof fetch;
+  fetchImpl?: typeof fetch;
 }
 
-const BACKEND_KEY = Symbol('cube-designer-backend');
-const AI_KEY = Symbol('cube-designer-ai');
+const BACKEND_KEY = Symbol("cube-designer-backend");
+const AI_KEY = Symbol("cube-designer-ai");
 
 /** Host: provide the backend to the designer subtree (call during init). */
 export function setCubeDesignerBackend(backend: CubeDesignerBackend): void {
-	setContext(BACKEND_KEY, backend);
+  setContext(BACKEND_KEY, backend);
 }
 
 /** Host: provide the optional AI adapter to the designer subtree. */
 export function setCubeDesignerAI(ai: CubeDesignerAI): void {
-	setContext(AI_KEY, ai);
+  setContext(AI_KEY, ai);
 }
 
 /** Designer component: resolve the backend. Throws if the host forgot to wire
  *  one — a loud failure beats a silent hard-coded fallback. */
 export function getCubeDesignerBackend(): CubeDesignerBackend {
-	const backend = getContext<CubeDesignerBackend | undefined>(BACKEND_KEY);
-	if (!backend) {
-		throw new Error(
-			'CubeDesignerBackend not provided — call setCubeDesignerBackend() in a host ancestor.'
-		);
-	}
-	return backend;
+  const backend = getContext<CubeDesignerBackend | undefined>(BACKEND_KEY);
+  if (!backend) {
+    throw new Error(
+      "CubeDesignerBackend not provided — call setCubeDesignerBackend() in a host ancestor.",
+    );
+  }
+  return backend;
 }
 
 /** Designer component: resolve the optional AI adapter (null ⇒ AI disabled). */
 export function getCubeDesignerAI(): CubeDesignerAI | null {
-	return getContext<CubeDesignerAI | undefined>(AI_KEY) ?? null;
+  return getContext<CubeDesignerAI | undefined>(AI_KEY) ?? null;
 }

--- a/saiku-ui/src/lib/cube-designer/backend.ts
+++ b/saiku-ui/src/lib/cube-designer/backend.ts
@@ -1,0 +1,73 @@
+/**
+ * Cube-designer backend seam (saiku-cloud → OSS extraction, Phase 0).
+ *
+ * The designer component library is otherwise host-agnostic — its only tie to a
+ * backend is a handful of network calls (profile a connection, sample rows, run
+ * a try-query, load / convert a schema, and the optional DimSum AI turn). Rather
+ * than hard-code the Cloud `/api/*` URLs inside the components, they resolve a
+ * {@link CubeDesignerBackend} from Svelte context, so each host wires its own:
+ *
+ *   - Saiku **Cloud**  → the existing `/api/inference/*` + `/api/schemas/*`
+ *     proxies (which re-sign to the gateway `/me/*`).
+ *   - Saiku **OSS**    → Saiku's own REST (`/saiku/api/schemagen`, AI Query API,
+ *     repository resource).
+ *
+ * Each method returns a raw {@link Response} so call sites keep their existing
+ * `resp.ok` / `resp.status` / `resp.json()` handling verbatim — the seam only
+ * owns URL construction, nothing else. The DimSum AI ({@link CubeDesignerAI}) is
+ * a SEPARATE, OPTIONAL context: a host that doesn't provide it gets the manual
+ * designer with the AI surface disabled.
+ */
+import { getContext, setContext } from 'svelte';
+
+/** Backend transport for the designer's data-plane calls. URL-only seam. */
+export interface CubeDesignerBackend {
+	/** Profile a connection → table/column catalog for the source sidebar. */
+	profileConnection(connectionId: string): Promise<Response>;
+	/** Fetch up to `limit` preview rows for a fact table (Sample-data tab). */
+	sample(connectionId: string, table: string, limit: number): Promise<Response>;
+	/** Run a starter query against the unsaved proposal (Try-a-query tab). */
+	tryQuery(body: unknown): Promise<Response>;
+	/** Load a saved schema's Mondrian XML from the library into the canvas. */
+	loadSchema(entryId: string): Promise<Response>;
+	/** Convert pasted legacy Mondrian-3 XML → Mondrian-4. */
+	convertSchema(body: unknown): Promise<Response>;
+}
+
+/** Optional AI transport for the DimSum agent turn. Absent ⇒ AI disabled
+ *  (Phase 1 will gate the DimSum surface on presence; Phase 0 only routes the
+ *  transport). `fetchImpl` is the existing dimsum-agent injection seam — a host
+ *  provides one to point the DimSum turn at its own AI endpoint. */
+export interface CubeDesignerAI {
+	fetchImpl?: typeof fetch;
+}
+
+const BACKEND_KEY = Symbol('cube-designer-backend');
+const AI_KEY = Symbol('cube-designer-ai');
+
+/** Host: provide the backend to the designer subtree (call during init). */
+export function setCubeDesignerBackend(backend: CubeDesignerBackend): void {
+	setContext(BACKEND_KEY, backend);
+}
+
+/** Host: provide the optional AI adapter to the designer subtree. */
+export function setCubeDesignerAI(ai: CubeDesignerAI): void {
+	setContext(AI_KEY, ai);
+}
+
+/** Designer component: resolve the backend. Throws if the host forgot to wire
+ *  one — a loud failure beats a silent hard-coded fallback. */
+export function getCubeDesignerBackend(): CubeDesignerBackend {
+	const backend = getContext<CubeDesignerBackend | undefined>(BACKEND_KEY);
+	if (!backend) {
+		throw new Error(
+			'CubeDesignerBackend not provided — call setCubeDesignerBackend() in a host ancestor.'
+		);
+	}
+	return backend;
+}
+
+/** Designer component: resolve the optional AI adapter (null ⇒ AI disabled). */
+export function getCubeDesignerAI(): CubeDesignerAI | null {
+	return getContext<CubeDesignerAI | undefined>(AI_KEY) ?? null;
+}

--- a/saiku-ui/src/lib/cube-designer/bundle.ts
+++ b/saiku-ui/src/lib/cube-designer/bundle.ts
@@ -1,0 +1,82 @@
+/**
+ * Canvas schema designer — JSON bundle export/import.
+ *
+ * The canvas localStorage doc isn't portable — it lives in one
+ * browser, under one origin. A bundle is the same SchemaCanvasState
+ * wrapped in a versioned envelope with a discriminator tag so the
+ * importer can tell what file it's looking at. Modelled after
+ * pipecleaner's `_type` / `_version` / `_exportedAt` pattern so the
+ * shape evolves cleanly.
+ */
+import type { SchemaCanvasState } from './types.js';
+
+const BUNDLE_TYPE = 'saiku-canvas-bundle';
+const BUNDLE_VERSION = 1;
+
+export interface SchemaCanvasBundle {
+	_type: typeof BUNDLE_TYPE;
+	_version: number;
+	_exportedAt: string;
+	/** Connection the doc was authored against. The importer uses it
+	 *  as a hint only — the user can land it on any connection. */
+	connectionId: string;
+	doc: SchemaCanvasState;
+}
+
+export function exportBundle(state: SchemaCanvasState): SchemaCanvasBundle {
+	return {
+		_type: BUNDLE_TYPE,
+		_version: BUNDLE_VERSION,
+		_exportedAt: new Date().toISOString(),
+		connectionId: state.connectionId,
+		doc: state
+	};
+}
+
+export function serializeBundle(state: SchemaCanvasState): string {
+	return JSON.stringify(exportBundle(state), null, 2);
+}
+
+export interface ImportedBundle {
+	connectionId: string;
+	doc: SchemaCanvasState;
+}
+
+/**
+ * Parse + validate a JSON bundle. Throws with a human-readable message
+ * if the file isn't a Saiku canvas bundle or is from a future schema
+ * version we don't understand yet.
+ */
+export function parseBundle(json: string): ImportedBundle {
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(json);
+	} catch {
+		throw new Error("That doesn't look like JSON.");
+	}
+	if (typeof parsed !== 'object' || parsed === null) {
+		throw new Error('Bundle is empty or malformed.');
+	}
+	const b = parsed as Partial<SchemaCanvasBundle>;
+	if (b._type !== BUNDLE_TYPE) {
+		throw new Error(
+			`Not a Saiku canvas bundle (found _type="${String(b._type)}"). Expected "${BUNDLE_TYPE}".`
+		);
+	}
+	if (typeof b._version !== 'number' || b._version > BUNDLE_VERSION) {
+		throw new Error(
+			`Bundle version ${String(b._version)} is newer than this dashboard knows about (max ${BUNDLE_VERSION}).`
+		);
+	}
+	if (!b.doc || typeof b.doc !== 'object') {
+		throw new Error('Bundle has no canvas doc inside.');
+	}
+	const doc = b.doc as SchemaCanvasState;
+	if (doc.version !== 1) {
+		throw new Error(`Canvas doc version ${doc.version} is not supported.`);
+	}
+	return {
+		connectionId: typeof b.connectionId === 'string' ? b.connectionId : doc.connectionId,
+		doc
+	};
+}

--- a/saiku-ui/src/lib/cube-designer/bundle.ts
+++ b/saiku-ui/src/lib/cube-designer/bundle.ts
@@ -8,38 +8,38 @@
  * pipecleaner's `_type` / `_version` / `_exportedAt` pattern so the
  * shape evolves cleanly.
  */
-import type { SchemaCanvasState } from './types.js';
+import type { SchemaCanvasState } from "./types.js";
 
-const BUNDLE_TYPE = 'saiku-canvas-bundle';
+const BUNDLE_TYPE = "saiku-canvas-bundle";
 const BUNDLE_VERSION = 1;
 
 export interface SchemaCanvasBundle {
-	_type: typeof BUNDLE_TYPE;
-	_version: number;
-	_exportedAt: string;
-	/** Connection the doc was authored against. The importer uses it
-	 *  as a hint only — the user can land it on any connection. */
-	connectionId: string;
-	doc: SchemaCanvasState;
+  _type: typeof BUNDLE_TYPE;
+  _version: number;
+  _exportedAt: string;
+  /** Connection the doc was authored against. The importer uses it
+   *  as a hint only — the user can land it on any connection. */
+  connectionId: string;
+  doc: SchemaCanvasState;
 }
 
 export function exportBundle(state: SchemaCanvasState): SchemaCanvasBundle {
-	return {
-		_type: BUNDLE_TYPE,
-		_version: BUNDLE_VERSION,
-		_exportedAt: new Date().toISOString(),
-		connectionId: state.connectionId,
-		doc: state
-	};
+  return {
+    _type: BUNDLE_TYPE,
+    _version: BUNDLE_VERSION,
+    _exportedAt: new Date().toISOString(),
+    connectionId: state.connectionId,
+    doc: state,
+  };
 }
 
 export function serializeBundle(state: SchemaCanvasState): string {
-	return JSON.stringify(exportBundle(state), null, 2);
+  return JSON.stringify(exportBundle(state), null, 2);
 }
 
 export interface ImportedBundle {
-	connectionId: string;
-	doc: SchemaCanvasState;
+  connectionId: string;
+  doc: SchemaCanvasState;
 }
 
 /**
@@ -48,35 +48,36 @@ export interface ImportedBundle {
  * version we don't understand yet.
  */
 export function parseBundle(json: string): ImportedBundle {
-	let parsed: unknown;
-	try {
-		parsed = JSON.parse(json);
-	} catch {
-		throw new Error("That doesn't look like JSON.");
-	}
-	if (typeof parsed !== 'object' || parsed === null) {
-		throw new Error('Bundle is empty or malformed.');
-	}
-	const b = parsed as Partial<SchemaCanvasBundle>;
-	if (b._type !== BUNDLE_TYPE) {
-		throw new Error(
-			`Not a Saiku canvas bundle (found _type="${String(b._type)}"). Expected "${BUNDLE_TYPE}".`
-		);
-	}
-	if (typeof b._version !== 'number' || b._version > BUNDLE_VERSION) {
-		throw new Error(
-			`Bundle version ${String(b._version)} is newer than this dashboard knows about (max ${BUNDLE_VERSION}).`
-		);
-	}
-	if (!b.doc || typeof b.doc !== 'object') {
-		throw new Error('Bundle has no canvas doc inside.');
-	}
-	const doc = b.doc as SchemaCanvasState;
-	if (doc.version !== 1) {
-		throw new Error(`Canvas doc version ${doc.version} is not supported.`);
-	}
-	return {
-		connectionId: typeof b.connectionId === 'string' ? b.connectionId : doc.connectionId,
-		doc
-	};
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(json);
+  } catch {
+    throw new Error("That doesn't look like JSON.");
+  }
+  if (typeof parsed !== "object" || parsed === null) {
+    throw new Error("Bundle is empty or malformed.");
+  }
+  const b = parsed as Partial<SchemaCanvasBundle>;
+  if (b._type !== BUNDLE_TYPE) {
+    throw new Error(
+      `Not a Saiku canvas bundle (found _type="${String(b._type)}"). Expected "${BUNDLE_TYPE}".`,
+    );
+  }
+  if (typeof b._version !== "number" || b._version > BUNDLE_VERSION) {
+    throw new Error(
+      `Bundle version ${String(b._version)} is newer than this dashboard knows about (max ${BUNDLE_VERSION}).`,
+    );
+  }
+  if (!b.doc || typeof b.doc !== "object") {
+    throw new Error("Bundle has no canvas doc inside.");
+  }
+  const doc = b.doc as SchemaCanvasState;
+  if (doc.version !== 1) {
+    throw new Error(`Canvas doc version ${doc.version} is not supported.`);
+  }
+  return {
+    connectionId:
+      typeof b.connectionId === "string" ? b.connectionId : doc.connectionId,
+    doc,
+  };
 }

--- a/saiku-ui/src/lib/cube-designer/canvas-dnd.test.ts
+++ b/saiku-ui/src/lib/cube-designer/canvas-dnd.test.ts
@@ -1,70 +1,81 @@
 /**
  * Unit tests for the canvas drag-and-drop + connection-handle parsers.
  */
-import { describe, it, expect } from 'vitest';
-import { parseConnectionJoin, parseDroppedTableCandidates } from './canvas-dnd.js';
-import type { SourceTableCandidate } from './types.js';
+import { describe, it, expect } from "vitest";
+import {
+  parseConnectionJoin,
+  parseDroppedTableCandidates,
+} from "./canvas-dnd.js";
+import type { SourceTableCandidate } from "./types.js";
 
-describe('parseConnectionJoin', () => {
-	it('extracts column names from `<tableId>:<column>:<dir>` handles', () => {
-		const parsed = parseConnectionJoin({
-			source: 'tbl_a',
-			target: 'tbl_b',
-			sourceHandle: 'tbl_a:product_id:out-right',
-			targetHandle: 'tbl_b:product_id:in-left'
-		});
-		expect(parsed).toEqual({
-			sourceTableId: 'tbl_a',
-			sourceColumnName: 'product_id',
-			targetTableId: 'tbl_b',
-			targetColumnName: 'product_id'
-		});
-	});
+describe("parseConnectionJoin", () => {
+  it("extracts column names from `<tableId>:<column>:<dir>` handles", () => {
+    const parsed = parseConnectionJoin({
+      source: "tbl_a",
+      target: "tbl_b",
+      sourceHandle: "tbl_a:product_id:out-right",
+      targetHandle: "tbl_b:product_id:in-left",
+    });
+    expect(parsed).toEqual({
+      sourceTableId: "tbl_a",
+      sourceColumnName: "product_id",
+      targetTableId: "tbl_b",
+      targetColumnName: "product_id",
+    });
+  });
 
-	it('returns null when a handle is missing', () => {
-		expect(
-			parseConnectionJoin({ source: 'a', target: 'b', sourceHandle: null, targetHandle: 'b:x:in' })
-		).toBeNull();
-	});
+  it("returns null when a handle is missing", () => {
+    expect(
+      parseConnectionJoin({
+        source: "a",
+        target: "b",
+        sourceHandle: null,
+        targetHandle: "b:x:in",
+      }),
+    ).toBeNull();
+  });
 
-	it('returns null when a handle has no column segment', () => {
-		expect(
-			parseConnectionJoin({
-				source: 'a',
-				target: 'b',
-				sourceHandle: 'a:',
-				targetHandle: 'b:x:in'
-			})
-		).toBeNull();
-	});
+  it("returns null when a handle has no column segment", () => {
+    expect(
+      parseConnectionJoin({
+        source: "a",
+        target: "b",
+        sourceHandle: "a:",
+        targetHandle: "b:x:in",
+      }),
+    ).toBeNull();
+  });
 });
 
-describe('parseDroppedTableCandidates', () => {
-	const one: SourceTableCandidate = {
-		schema: 'public',
-		name: 'sales',
-		columns: [{ name: 'id', sqlType: 'INT' }],
-		onCanvas: false
-	};
-	const two: SourceTableCandidate = { ...one, name: 'product' };
+describe("parseDroppedTableCandidates", () => {
+  const one: SourceTableCandidate = {
+    schema: "public",
+    name: "sales",
+    columns: [{ name: "id", sqlType: "INT" }],
+    onCanvas: false,
+  };
+  const two: SourceTableCandidate = { ...one, name: "product" };
 
-	it('prefers the multi-table array payload', () => {
-		const out = parseDroppedTableCandidates(JSON.stringify([one, two]), JSON.stringify(one));
-		expect(out.map((t) => t.name)).toEqual(['sales', 'product']);
-	});
+  it("prefers the multi-table array payload", () => {
+    const out = parseDroppedTableCandidates(
+      JSON.stringify([one, two]),
+      JSON.stringify(one),
+    );
+    expect(out.map((t) => t.name)).toEqual(["sales", "product"]);
+  });
 
-	it('falls back to the single-table payload', () => {
-		const out = parseDroppedTableCandidates(undefined, JSON.stringify(one));
-		expect(out).toHaveLength(1);
-		expect(out[0].name).toBe('sales');
-	});
+  it("falls back to the single-table payload", () => {
+    const out = parseDroppedTableCandidates(undefined, JSON.stringify(one));
+    expect(out).toHaveLength(1);
+    expect(out[0].name).toBe("sales");
+  });
 
-	it('returns [] when neither payload is present', () => {
-		expect(parseDroppedTableCandidates(undefined, undefined)).toEqual([]);
-		expect(parseDroppedTableCandidates('', '')).toEqual([]);
-	});
+  it("returns [] when neither payload is present", () => {
+    expect(parseDroppedTableCandidates(undefined, undefined)).toEqual([]);
+    expect(parseDroppedTableCandidates("", "")).toEqual([]);
+  });
 
-	it('returns [] on malformed JSON instead of throwing', () => {
-		expect(parseDroppedTableCandidates('{not json', null)).toEqual([]);
-	});
+  it("returns [] on malformed JSON instead of throwing", () => {
+    expect(parseDroppedTableCandidates("{not json", null)).toEqual([]);
+  });
 });

--- a/saiku-ui/src/lib/cube-designer/canvas-dnd.test.ts
+++ b/saiku-ui/src/lib/cube-designer/canvas-dnd.test.ts
@@ -1,0 +1,70 @@
+/**
+ * Unit tests for the canvas drag-and-drop + connection-handle parsers.
+ */
+import { describe, it, expect } from 'vitest';
+import { parseConnectionJoin, parseDroppedTableCandidates } from './canvas-dnd.js';
+import type { SourceTableCandidate } from './types.js';
+
+describe('parseConnectionJoin', () => {
+	it('extracts column names from `<tableId>:<column>:<dir>` handles', () => {
+		const parsed = parseConnectionJoin({
+			source: 'tbl_a',
+			target: 'tbl_b',
+			sourceHandle: 'tbl_a:product_id:out-right',
+			targetHandle: 'tbl_b:product_id:in-left'
+		});
+		expect(parsed).toEqual({
+			sourceTableId: 'tbl_a',
+			sourceColumnName: 'product_id',
+			targetTableId: 'tbl_b',
+			targetColumnName: 'product_id'
+		});
+	});
+
+	it('returns null when a handle is missing', () => {
+		expect(
+			parseConnectionJoin({ source: 'a', target: 'b', sourceHandle: null, targetHandle: 'b:x:in' })
+		).toBeNull();
+	});
+
+	it('returns null when a handle has no column segment', () => {
+		expect(
+			parseConnectionJoin({
+				source: 'a',
+				target: 'b',
+				sourceHandle: 'a:',
+				targetHandle: 'b:x:in'
+			})
+		).toBeNull();
+	});
+});
+
+describe('parseDroppedTableCandidates', () => {
+	const one: SourceTableCandidate = {
+		schema: 'public',
+		name: 'sales',
+		columns: [{ name: 'id', sqlType: 'INT' }],
+		onCanvas: false
+	};
+	const two: SourceTableCandidate = { ...one, name: 'product' };
+
+	it('prefers the multi-table array payload', () => {
+		const out = parseDroppedTableCandidates(JSON.stringify([one, two]), JSON.stringify(one));
+		expect(out.map((t) => t.name)).toEqual(['sales', 'product']);
+	});
+
+	it('falls back to the single-table payload', () => {
+		const out = parseDroppedTableCandidates(undefined, JSON.stringify(one));
+		expect(out).toHaveLength(1);
+		expect(out[0].name).toBe('sales');
+	});
+
+	it('returns [] when neither payload is present', () => {
+		expect(parseDroppedTableCandidates(undefined, undefined)).toEqual([]);
+		expect(parseDroppedTableCandidates('', '')).toEqual([]);
+	});
+
+	it('returns [] on malformed JSON instead of throwing', () => {
+		expect(parseDroppedTableCandidates('{not json', null)).toEqual([]);
+	});
+});

--- a/saiku-ui/src/lib/cube-designer/canvas-dnd.ts
+++ b/saiku-ui/src/lib/cube-designer/canvas-dnd.ts
@@ -6,23 +6,23 @@
  * maths, store mutation); these functions own only the payload/handle
  * *parsing*, which is pure string work and unit-testable in isolation.
  */
-import type { SourceTableCandidate } from './types.js';
+import type { SourceTableCandidate } from "./types.js";
 
 /** A join's endpoints parsed from a SvelteFlow connection — ready to hand to
  *  `store.addJoin` (the component adds `kind`). */
 export interface ParsedConnectionJoin {
-	sourceTableId: string;
-	sourceColumnName: string;
-	targetTableId: string;
-	targetColumnName: string;
+  sourceTableId: string;
+  sourceColumnName: string;
+  targetTableId: string;
+  targetColumnName: string;
 }
 
 /** Minimal shape of SvelteFlow's `Connection` we depend on. */
 export interface ConnectionLike {
-	source: string;
-	target: string;
-	sourceHandle?: string | null;
-	targetHandle?: string | null;
+  source: string;
+  target: string;
+  sourceHandle?: string | null;
+  targetHandle?: string | null;
 }
 
 /**
@@ -31,17 +31,19 @@ export interface ConnectionLike {
  * `null` when either handle is missing or malformed (no column segment) so the
  * caller can bail without creating a bogus join.
  */
-export function parseConnectionJoin(connection: ConnectionLike): ParsedConnectionJoin | null {
-	if (!connection.sourceHandle || !connection.targetHandle) return null;
-	const [, sourceColumnName] = connection.sourceHandle.split(':');
-	const [, targetColumnName] = connection.targetHandle.split(':');
-	if (!sourceColumnName || !targetColumnName) return null;
-	return {
-		sourceTableId: connection.source,
-		sourceColumnName,
-		targetTableId: connection.target,
-		targetColumnName
-	};
+export function parseConnectionJoin(
+  connection: ConnectionLike,
+): ParsedConnectionJoin | null {
+  if (!connection.sourceHandle || !connection.targetHandle) return null;
+  const [, sourceColumnName] = connection.sourceHandle.split(":");
+  const [, targetColumnName] = connection.targetHandle.split(":");
+  if (!sourceColumnName || !targetColumnName) return null;
+  return {
+    sourceTableId: connection.source,
+    sourceColumnName,
+    targetTableId: connection.target,
+    targetColumnName,
+  };
 }
 
 /**
@@ -52,15 +54,15 @@ export function parseConnectionJoin(connection: ConnectionLike): ParsedConnectio
  * malformed — the caller treats an empty result as "nothing to drop".
  */
 export function parseDroppedTableCandidates(
-	arrayPayload: string | undefined | null,
-	singlePayload: string | undefined | null
+  arrayPayload: string | undefined | null,
+  singlePayload: string | undefined | null,
 ): SourceTableCandidate[] {
-	if (!arrayPayload && !singlePayload) return [];
-	try {
-		return arrayPayload
-			? (JSON.parse(arrayPayload) as SourceTableCandidate[])
-			: [JSON.parse(singlePayload!) as SourceTableCandidate];
-	} catch {
-		return [];
-	}
+  if (!arrayPayload && !singlePayload) return [];
+  try {
+    return arrayPayload
+      ? (JSON.parse(arrayPayload) as SourceTableCandidate[])
+      : [JSON.parse(singlePayload!) as SourceTableCandidate];
+  } catch {
+    return [];
+  }
 }

--- a/saiku-ui/src/lib/cube-designer/canvas-dnd.ts
+++ b/saiku-ui/src/lib/cube-designer/canvas-dnd.ts
@@ -1,0 +1,66 @@
+/**
+ * Canvas drag-and-drop + connection-handle parsing — pure helpers lifted out
+ * of SchemaCanvasView.svelte (audit finding #1040).
+ *
+ * The component keeps the DOM event wiring (`ondrop`, `onconnect`, position
+ * maths, store mutation); these functions own only the payload/handle
+ * *parsing*, which is pure string work and unit-testable in isolation.
+ */
+import type { SourceTableCandidate } from './types.js';
+
+/** A join's endpoints parsed from a SvelteFlow connection — ready to hand to
+ *  `store.addJoin` (the component adds `kind`). */
+export interface ParsedConnectionJoin {
+	sourceTableId: string;
+	sourceColumnName: string;
+	targetTableId: string;
+	targetColumnName: string;
+}
+
+/** Minimal shape of SvelteFlow's `Connection` we depend on. */
+export interface ConnectionLike {
+	source: string;
+	target: string;
+	sourceHandle?: string | null;
+	targetHandle?: string | null;
+}
+
+/**
+ * Parse a SvelteFlow connection into join endpoints. Handles are formatted
+ * `<tableId>:<columnName>:in|out`; we pull the column names back out. Returns
+ * `null` when either handle is missing or malformed (no column segment) so the
+ * caller can bail without creating a bogus join.
+ */
+export function parseConnectionJoin(connection: ConnectionLike): ParsedConnectionJoin | null {
+	if (!connection.sourceHandle || !connection.targetHandle) return null;
+	const [, sourceColumnName] = connection.sourceHandle.split(':');
+	const [, targetColumnName] = connection.targetHandle.split(':');
+	if (!sourceColumnName || !targetColumnName) return null;
+	return {
+		sourceTableId: connection.source,
+		sourceColumnName,
+		targetTableId: connection.target,
+		targetColumnName
+	};
+}
+
+/**
+ * Parse the table candidates from a pane-drop's dataTransfer payloads.
+ * Prefers the multi-table payload (`application/x-saiku-tables`), falling back
+ * to the single-table payload (`application/x-saiku-table`) from any legacy
+ * drop source. Returns `[]` when neither payload is present or the JSON is
+ * malformed — the caller treats an empty result as "nothing to drop".
+ */
+export function parseDroppedTableCandidates(
+	arrayPayload: string | undefined | null,
+	singlePayload: string | undefined | null
+): SourceTableCandidate[] {
+	if (!arrayPayload && !singlePayload) return [];
+	try {
+		return arrayPayload
+			? (JSON.parse(arrayPayload) as SourceTableCandidate[])
+			: [JSON.parse(singlePayload!) as SourceTableCandidate];
+	} catch {
+		return [];
+	}
+}

--- a/saiku-ui/src/lib/cube-designer/canvas-flow.test.ts
+++ b/saiku-ui/src/lib/cube-designer/canvas-flow.test.ts
@@ -1,183 +1,205 @@
 /**
  * Unit tests for the SvelteFlow node/edge builders.
  */
-import { describe, it, expect } from 'vitest';
-import { SchemaCanvasStore } from './state.svelte.js';
-import type { SourceTableCandidate } from './types.js';
-import { buildFlowNodes, buildFlowEdges, type FlowFocus } from './canvas-flow.js';
+import { describe, it, expect } from "vitest";
+import { SchemaCanvasStore } from "./state.svelte.js";
+import type { SourceTableCandidate } from "./types.js";
+import {
+  buildFlowNodes,
+  buildFlowEdges,
+  type FlowFocus,
+} from "./canvas-flow.js";
 
 function candidate(name: string, columns: string[]): SourceTableCandidate {
-	return {
-		schema: 'public',
-		name,
-		columns: columns.map((c) => ({ name: c, sqlType: 'INTEGER' })),
-		onCanvas: false
-	};
+  return {
+    schema: "public",
+    name,
+    columns: columns.map((c) => ({ name: c, sqlType: "INTEGER" })),
+    onCanvas: false,
+  };
 }
 
-function addTable(store: SchemaCanvasStore, name: string, columns: string[], x = 0): string {
-	return store.addTable(candidate(name, columns), { x, y: 0 }).id;
+function addTable(
+  store: SchemaCanvasStore,
+  name: string,
+  columns: string[],
+  x = 0,
+): string {
+  return store.addTable(candidate(name, columns), { x, y: 0 }).id;
 }
 
 const NO_FOCUS: FlowFocus = {
-	focusActive: false,
-	focusedTableIds: new Set(),
-	focusedColumnKeys: new Set(),
-	connectedColumnKeys: new Set(),
-	focusedJoinIds: new Set()
+  focusActive: false,
+  focusedTableIds: new Set(),
+  focusedColumnKeys: new Set(),
+  connectedColumnKeys: new Set(),
+  focusedJoinIds: new Set(),
 };
 
-describe('buildFlowNodes', () => {
-	it('maps each canvas table to a table node carrying its position + data', () => {
-		const store = new SchemaCanvasStore('c1');
-		const id = addTable(store, 'sales', ['id', 'amount'], 120);
+describe("buildFlowNodes", () => {
+  it("maps each canvas table to a table node carrying its position + data", () => {
+    const store = new SchemaCanvasStore("c1");
+    const id = addTable(store, "sales", ["id", "amount"], 120);
 
-		const nodes = buildFlowNodes(store, NO_FOCUS);
+    const nodes = buildFlowNodes(store, NO_FOCUS);
 
-		expect(nodes).toHaveLength(1);
-		expect(nodes[0].id).toBe(id);
-		expect(nodes[0].type).toBe('table');
-		expect(nodes[0].position).toEqual({ x: 120, y: 0 });
-		expect((nodes[0].data as { table: { name: string } }).table.name).toBe('sales');
-	});
+    expect(nodes).toHaveLength(1);
+    expect(nodes[0].id).toBe(id);
+    expect(nodes[0].type).toBe("table");
+    expect(nodes[0].position).toEqual({ x: 120, y: 0 });
+    expect((nodes[0].data as { table: { name: string } }).table.name).toBe(
+      "sales",
+    );
+  });
 
-	it('lifts the selected node to the front and fades unfocused peers', () => {
-		const store = new SchemaCanvasStore('c2');
-		const a = addTable(store, 'a', ['id']);
-		const b = addTable(store, 'b', ['id']);
-		store.selectedTableId = a;
-		const focus: FlowFocus = { ...NO_FOCUS, focusActive: true, focusedTableIds: new Set([a]) };
+  it("lifts the selected node to the front and fades unfocused peers", () => {
+    const store = new SchemaCanvasStore("c2");
+    const a = addTable(store, "a", ["id"]);
+    const b = addTable(store, "b", ["id"]);
+    store.selectedTableId = a;
+    const focus: FlowFocus = {
+      ...NO_FOCUS,
+      focusActive: true,
+      focusedTableIds: new Set([a]),
+    };
 
-		const nodes = buildFlowNodes(store, focus);
-		const nodeA = nodes.find((n) => n.id === a)!;
-		const nodeB = nodes.find((n) => n.id === b)!;
+    const nodes = buildFlowNodes(store, focus);
+    const nodeA = nodes.find((n) => n.id === a)!;
+    const nodeB = nodes.find((n) => n.id === b)!;
 
-		expect(nodeA.zIndex).toBe(100);
-		expect(nodeA.selected).toBe(true);
-		expect((nodeB.data as { isFaded: boolean }).isFaded).toBe(true);
-		expect((nodeA.data as { isFaded: boolean }).isFaded).toBe(false);
-	});
+    expect(nodeA.zIndex).toBe(100);
+    expect(nodeA.selected).toBe(true);
+    expect((nodeB.data as { isFaded: boolean }).isFaded).toBe(true);
+    expect((nodeA.data as { isFaded: boolean }).isFaded).toBe(false);
+  });
 
-	it('column-click callback pushes a pick in pick mode, else arms a join', () => {
-		const store = new SchemaCanvasStore('c3');
-		const id = addTable(store, 'sales', ['product_id']);
-		store.pickModeActive = true;
+  it("column-click callback pushes a pick in pick mode, else arms a join", () => {
+    const store = new SchemaCanvasStore("c3");
+    const id = addTable(store, "sales", ["product_id"]);
+    store.pickModeActive = true;
 
-		const node = buildFlowNodes(store, NO_FOCUS)[0];
-		(node.data as { onColumnClick: (t: string, c: string) => void }).onColumnClick(
-			id,
-			'product_id'
-		);
+    const node = buildFlowNodes(store, NO_FOCUS)[0];
+    (
+      node.data as { onColumnClick: (t: string, c: string) => void }
+    ).onColumnClick(id, "product_id");
 
-		expect(store.eShiftPicks).toEqual([{ tableId: id, columnName: 'product_id' }]);
-	});
+    expect(store.eShiftPicks).toEqual([
+      { tableId: id, columnName: "product_id" },
+    ]);
+  });
 });
 
-describe('SchemaCanvasStore.addTable dedupe (#1084)', () => {
-	it('does not push a second node for the same schema+name identity', () => {
-		// Arrange
-		const store = new SchemaCanvasStore('dedupe-1');
-		const first = store.addTable(candidate('customer', ['customer_id', 'fullname']), {
-			x: 0,
-			y: 0
-		});
+describe("SchemaCanvasStore.addTable dedupe (#1084)", () => {
+  it("does not push a second node for the same schema+name identity", () => {
+    // Arrange
+    const store = new SchemaCanvasStore("dedupe-1");
+    const first = store.addTable(
+      candidate("customer", ["customer_id", "fullname"]),
+      {
+        x: 0,
+        y: 0,
+      },
+    );
 
-		// Act — re-add the same physical table (e.g. a re-drag / re-tool call).
-		const second = store.addTable(candidate('customer', ['customer_id', 'fullname']), {
-			x: 400,
-			y: 200
-		});
+    // Act — re-add the same physical table (e.g. a re-drag / re-tool call).
+    const second = store.addTable(
+      candidate("customer", ["customer_id", "fullname"]),
+      {
+        x: 400,
+        y: 200,
+      },
+    );
 
-		// Assert — one node only, and the existing node is returned untouched.
-		expect(store.doc.tables).toHaveLength(1);
-		expect(second.id).toBe(first.id);
-		expect(second.position).toEqual({ x: 0, y: 0 });
-	});
+    // Assert — one node only, and the existing node is returned untouched.
+    expect(store.doc.tables).toHaveLength(1);
+    expect(second.id).toBe(first.id);
+    expect(second.position).toEqual({ x: 0, y: 0 });
+  });
 
-	it('treats same name in different schemas as distinct tables', () => {
-		// Arrange
-		const store = new SchemaCanvasStore('dedupe-2');
-		const publicOrders: SourceTableCandidate = {
-			schema: 'public',
-			name: 'orders',
-			columns: [{ name: 'id', sqlType: 'INTEGER' }],
-			onCanvas: false
-		};
-		const stagingOrders: SourceTableCandidate = {
-			...publicOrders,
-			schema: 'staging'
-		};
+  it("treats same name in different schemas as distinct tables", () => {
+    // Arrange
+    const store = new SchemaCanvasStore("dedupe-2");
+    const publicOrders: SourceTableCandidate = {
+      schema: "public",
+      name: "orders",
+      columns: [{ name: "id", sqlType: "INTEGER" }],
+      onCanvas: false,
+    };
+    const stagingOrders: SourceTableCandidate = {
+      ...publicOrders,
+      schema: "staging",
+    };
 
-		// Act
-		store.addTable(publicOrders, { x: 0, y: 0 });
-		store.addTable(stagingOrders, { x: 0, y: 0 });
+    // Act
+    store.addTable(publicOrders, { x: 0, y: 0 });
+    store.addTable(stagingOrders, { x: 0, y: 0 });
 
-		// Assert — schema is part of the identity, so both land.
-		expect(store.doc.tables).toHaveLength(2);
-	});
+    // Assert — schema is part of the identity, so both land.
+    expect(store.doc.tables).toHaveLength(2);
+  });
 });
 
-describe('buildFlowEdges', () => {
-	it('returns [] when join lines are hidden', () => {
-		const store = new SchemaCanvasStore('e1');
-		const a = addTable(store, 'a', ['id']);
-		const b = addTable(store, 'b', ['id']);
-		store.addJoin({
-			sourceTableId: a,
-			sourceColumnName: 'id',
-			targetTableId: b,
-			targetColumnName: 'id',
-			kind: 'inner'
-		});
-		store.joinsHidden = true;
-		expect(buildFlowEdges(store, NO_FOCUS)).toEqual([]);
-	});
+describe("buildFlowEdges", () => {
+  it("returns [] when join lines are hidden", () => {
+    const store = new SchemaCanvasStore("e1");
+    const a = addTable(store, "a", ["id"]);
+    const b = addTable(store, "b", ["id"]);
+    store.addJoin({
+      sourceTableId: a,
+      sourceColumnName: "id",
+      targetTableId: b,
+      targetColumnName: "id",
+      kind: "inner",
+    });
+    store.joinsHidden = true;
+    expect(buildFlowEdges(store, NO_FOCUS)).toEqual([]);
+  });
 
-	it('aggregates multiple joins between the same pair into one edge', () => {
-		const store = new SchemaCanvasStore('e2');
-		const fact = addTable(store, 'fact', ['order_date', 'ship_date'], 0);
-		const date = addTable(store, 'date', ['d'], 400);
-		store.addJoin({
-			sourceTableId: fact,
-			sourceColumnName: 'order_date',
-			targetTableId: date,
-			targetColumnName: 'd',
-			kind: 'inner'
-		});
-		store.addJoin({
-			sourceTableId: fact,
-			sourceColumnName: 'ship_date',
-			targetTableId: date,
-			targetColumnName: 'd',
-			kind: 'inner'
-		});
+  it("aggregates multiple joins between the same pair into one edge", () => {
+    const store = new SchemaCanvasStore("e2");
+    const fact = addTable(store, "fact", ["order_date", "ship_date"], 0);
+    const date = addTable(store, "date", ["d"], 400);
+    store.addJoin({
+      sourceTableId: fact,
+      sourceColumnName: "order_date",
+      targetTableId: date,
+      targetColumnName: "d",
+      kind: "inner",
+    });
+    store.addJoin({
+      sourceTableId: fact,
+      sourceColumnName: "ship_date",
+      targetTableId: date,
+      targetColumnName: "d",
+      kind: "inner",
+    });
 
-		const edges = buildFlowEdges(store, NO_FOCUS);
-		expect(edges).toHaveLength(1);
-		expect((edges[0].data as { joins: unknown[] }).joins).toHaveLength(2);
-		// fact is left of date → exit right, enter left.
-		expect(edges[0].sourceHandle).toContain(':out-right');
-		expect(edges[0].targetHandle).toContain(':in-left');
-	});
+    const edges = buildFlowEdges(store, NO_FOCUS);
+    expect(edges).toHaveLength(1);
+    expect((edges[0].data as { joins: unknown[] }).joins).toHaveLength(2);
+    // fact is left of date → exit right, enter left.
+    expect(edges[0].sourceHandle).toContain(":out-right");
+    expect(edges[0].targetHandle).toContain(":in-left");
+  });
 
-	it('hides cube-link joins unless showCubeLinks is on, then styles them dashed', () => {
-		const store = new SchemaCanvasStore('e3');
-		const a = addTable(store, 'a', ['id']);
-		const b = addTable(store, 'b', ['id']);
-		store.addJoin({
-			sourceTableId: a,
-			sourceColumnName: 'id',
-			targetTableId: b,
-			targetColumnName: 'id',
-			kind: 'inner',
-			origin: 'cube-link'
-		});
+  it("hides cube-link joins unless showCubeLinks is on, then styles them dashed", () => {
+    const store = new SchemaCanvasStore("e3");
+    const a = addTable(store, "a", ["id"]);
+    const b = addTable(store, "b", ["id"]);
+    store.addJoin({
+      sourceTableId: a,
+      sourceColumnName: "id",
+      targetTableId: b,
+      targetColumnName: "id",
+      kind: "inner",
+      origin: "cube-link",
+    });
 
-		expect(buildFlowEdges(store, NO_FOCUS)).toHaveLength(0);
-		store.showCubeLinks = true;
-		const edges = buildFlowEdges(store, NO_FOCUS);
-		expect(edges).toHaveLength(1);
-		expect(edges[0].style).toContain('stroke-dasharray');
-		expect((edges[0].data as { readOnly: boolean }).readOnly).toBe(true);
-	});
+    expect(buildFlowEdges(store, NO_FOCUS)).toHaveLength(0);
+    store.showCubeLinks = true;
+    const edges = buildFlowEdges(store, NO_FOCUS);
+    expect(edges).toHaveLength(1);
+    expect(edges[0].style).toContain("stroke-dasharray");
+    expect((edges[0].data as { readOnly: boolean }).readOnly).toBe(true);
+  });
 });

--- a/saiku-ui/src/lib/cube-designer/canvas-flow.test.ts
+++ b/saiku-ui/src/lib/cube-designer/canvas-flow.test.ts
@@ -1,0 +1,183 @@
+/**
+ * Unit tests for the SvelteFlow node/edge builders.
+ */
+import { describe, it, expect } from 'vitest';
+import { SchemaCanvasStore } from './state.svelte.js';
+import type { SourceTableCandidate } from './types.js';
+import { buildFlowNodes, buildFlowEdges, type FlowFocus } from './canvas-flow.js';
+
+function candidate(name: string, columns: string[]): SourceTableCandidate {
+	return {
+		schema: 'public',
+		name,
+		columns: columns.map((c) => ({ name: c, sqlType: 'INTEGER' })),
+		onCanvas: false
+	};
+}
+
+function addTable(store: SchemaCanvasStore, name: string, columns: string[], x = 0): string {
+	return store.addTable(candidate(name, columns), { x, y: 0 }).id;
+}
+
+const NO_FOCUS: FlowFocus = {
+	focusActive: false,
+	focusedTableIds: new Set(),
+	focusedColumnKeys: new Set(),
+	connectedColumnKeys: new Set(),
+	focusedJoinIds: new Set()
+};
+
+describe('buildFlowNodes', () => {
+	it('maps each canvas table to a table node carrying its position + data', () => {
+		const store = new SchemaCanvasStore('c1');
+		const id = addTable(store, 'sales', ['id', 'amount'], 120);
+
+		const nodes = buildFlowNodes(store, NO_FOCUS);
+
+		expect(nodes).toHaveLength(1);
+		expect(nodes[0].id).toBe(id);
+		expect(nodes[0].type).toBe('table');
+		expect(nodes[0].position).toEqual({ x: 120, y: 0 });
+		expect((nodes[0].data as { table: { name: string } }).table.name).toBe('sales');
+	});
+
+	it('lifts the selected node to the front and fades unfocused peers', () => {
+		const store = new SchemaCanvasStore('c2');
+		const a = addTable(store, 'a', ['id']);
+		const b = addTable(store, 'b', ['id']);
+		store.selectedTableId = a;
+		const focus: FlowFocus = { ...NO_FOCUS, focusActive: true, focusedTableIds: new Set([a]) };
+
+		const nodes = buildFlowNodes(store, focus);
+		const nodeA = nodes.find((n) => n.id === a)!;
+		const nodeB = nodes.find((n) => n.id === b)!;
+
+		expect(nodeA.zIndex).toBe(100);
+		expect(nodeA.selected).toBe(true);
+		expect((nodeB.data as { isFaded: boolean }).isFaded).toBe(true);
+		expect((nodeA.data as { isFaded: boolean }).isFaded).toBe(false);
+	});
+
+	it('column-click callback pushes a pick in pick mode, else arms a join', () => {
+		const store = new SchemaCanvasStore('c3');
+		const id = addTable(store, 'sales', ['product_id']);
+		store.pickModeActive = true;
+
+		const node = buildFlowNodes(store, NO_FOCUS)[0];
+		(node.data as { onColumnClick: (t: string, c: string) => void }).onColumnClick(
+			id,
+			'product_id'
+		);
+
+		expect(store.eShiftPicks).toEqual([{ tableId: id, columnName: 'product_id' }]);
+	});
+});
+
+describe('SchemaCanvasStore.addTable dedupe (#1084)', () => {
+	it('does not push a second node for the same schema+name identity', () => {
+		// Arrange
+		const store = new SchemaCanvasStore('dedupe-1');
+		const first = store.addTable(candidate('customer', ['customer_id', 'fullname']), {
+			x: 0,
+			y: 0
+		});
+
+		// Act — re-add the same physical table (e.g. a re-drag / re-tool call).
+		const second = store.addTable(candidate('customer', ['customer_id', 'fullname']), {
+			x: 400,
+			y: 200
+		});
+
+		// Assert — one node only, and the existing node is returned untouched.
+		expect(store.doc.tables).toHaveLength(1);
+		expect(second.id).toBe(first.id);
+		expect(second.position).toEqual({ x: 0, y: 0 });
+	});
+
+	it('treats same name in different schemas as distinct tables', () => {
+		// Arrange
+		const store = new SchemaCanvasStore('dedupe-2');
+		const publicOrders: SourceTableCandidate = {
+			schema: 'public',
+			name: 'orders',
+			columns: [{ name: 'id', sqlType: 'INTEGER' }],
+			onCanvas: false
+		};
+		const stagingOrders: SourceTableCandidate = {
+			...publicOrders,
+			schema: 'staging'
+		};
+
+		// Act
+		store.addTable(publicOrders, { x: 0, y: 0 });
+		store.addTable(stagingOrders, { x: 0, y: 0 });
+
+		// Assert — schema is part of the identity, so both land.
+		expect(store.doc.tables).toHaveLength(2);
+	});
+});
+
+describe('buildFlowEdges', () => {
+	it('returns [] when join lines are hidden', () => {
+		const store = new SchemaCanvasStore('e1');
+		const a = addTable(store, 'a', ['id']);
+		const b = addTable(store, 'b', ['id']);
+		store.addJoin({
+			sourceTableId: a,
+			sourceColumnName: 'id',
+			targetTableId: b,
+			targetColumnName: 'id',
+			kind: 'inner'
+		});
+		store.joinsHidden = true;
+		expect(buildFlowEdges(store, NO_FOCUS)).toEqual([]);
+	});
+
+	it('aggregates multiple joins between the same pair into one edge', () => {
+		const store = new SchemaCanvasStore('e2');
+		const fact = addTable(store, 'fact', ['order_date', 'ship_date'], 0);
+		const date = addTable(store, 'date', ['d'], 400);
+		store.addJoin({
+			sourceTableId: fact,
+			sourceColumnName: 'order_date',
+			targetTableId: date,
+			targetColumnName: 'd',
+			kind: 'inner'
+		});
+		store.addJoin({
+			sourceTableId: fact,
+			sourceColumnName: 'ship_date',
+			targetTableId: date,
+			targetColumnName: 'd',
+			kind: 'inner'
+		});
+
+		const edges = buildFlowEdges(store, NO_FOCUS);
+		expect(edges).toHaveLength(1);
+		expect((edges[0].data as { joins: unknown[] }).joins).toHaveLength(2);
+		// fact is left of date → exit right, enter left.
+		expect(edges[0].sourceHandle).toContain(':out-right');
+		expect(edges[0].targetHandle).toContain(':in-left');
+	});
+
+	it('hides cube-link joins unless showCubeLinks is on, then styles them dashed', () => {
+		const store = new SchemaCanvasStore('e3');
+		const a = addTable(store, 'a', ['id']);
+		const b = addTable(store, 'b', ['id']);
+		store.addJoin({
+			sourceTableId: a,
+			sourceColumnName: 'id',
+			targetTableId: b,
+			targetColumnName: 'id',
+			kind: 'inner',
+			origin: 'cube-link'
+		});
+
+		expect(buildFlowEdges(store, NO_FOCUS)).toHaveLength(0);
+		store.showCubeLinks = true;
+		const edges = buildFlowEdges(store, NO_FOCUS);
+		expect(edges).toHaveLength(1);
+		expect(edges[0].style).toContain('stroke-dasharray');
+		expect((edges[0].data as { readOnly: boolean }).readOnly).toBe(true);
+	});
+});

--- a/saiku-ui/src/lib/cube-designer/canvas-flow.ts
+++ b/saiku-ui/src/lib/cube-designer/canvas-flow.ts
@@ -7,17 +7,17 @@
  * `Node[]` / `Edge[]` arrays SvelteFlow renders. Callbacks close over the
  * store (the mutation boundary) exactly as they did inline.
  */
-import type { Node, Edge } from '@xyflow/svelte';
-import { SchemaCanvasStore } from './state.svelte.js';
-import type { SchemaCanvasJoin } from './types.js';
+import type { Node, Edge } from "@xyflow/svelte";
+import { SchemaCanvasStore } from "./state.svelte.js";
+import type { SchemaCanvasJoin } from "./types.js";
 
 /** Focus/selection state the builders read (derived in the component). */
 export interface FlowFocus {
-	focusActive: boolean;
-	focusedTableIds: Set<string>;
-	focusedColumnKeys: Set<string>;
-	connectedColumnKeys: Set<string>;
-	focusedJoinIds: Set<string>;
+  focusActive: boolean;
+  focusedTableIds: Set<string>;
+  focusedColumnKeys: Set<string>;
+  connectedColumnKeys: Set<string>;
+  focusedJoinIds: Set<string>;
 }
 
 /**
@@ -25,59 +25,67 @@ export interface FlowFocus {
  * lift to the front; faded peers dim. Column-click / promote / remove /
  * collapse callbacks route through the store.
  */
-export function buildFlowNodes(store: SchemaCanvasStore, focus: FlowFocus): Node[] {
-	const { focusActive, focusedTableIds, focusedColumnKeys, connectedColumnKeys } = focus;
-	return store.doc.tables.map((t) => {
-		const isInFocus = focusActive && focusedTableIds.has(t.id);
-		return {
-			id: t.id,
-			type: 'table',
-			position: t.position,
-			draggable: true,
-			deletable: true,
-			// Lift focused/selected tables to the front so they never hide
-			// behind faded peers when cards overlap.
-			zIndex: isInFocus || store.selectedTableId === t.id ? 100 : 0,
-			data: {
-				table: t,
-				highlightedColumn: store.highlightedColumn,
-				pendingJoinSource: store.pendingJoinSource,
-				eShiftPicks: store.eShiftPicks,
-				defaultColumnsShown: store.defaultColumnsShown,
-				focusedColumnKeys,
-				connectedColumnKeys,
-				/** When the table is in focus we auto-expand it so the user
-				 *  can see WHICH columns are wired without manually
-				 *  toggling. TableNode reads this to bypass the global
-				 *  Show-N-cols cap. */
-				// Auto-expand on focus only when the green-highlight toggle
-				// is on. Off-by-default keeps the layout stable — a focus
-				// tap won't grow a card into space the arrange reserved.
-				forceExpandedByFocus: isInFocus && store.highlightFocusedColumns,
-				isFaded: focusActive && !focusedTableIds.has(t.id),
-				onPromoteToFact: (id: string) => store.setTableRole(id, 'fact'),
-				onRemove: (id: string) => store.removeTable(id),
-				onColumnClick: (tableId: string, col: string, metaOrCtrl: boolean) => {
-					// Two ways a column click accumulates into the pick set:
-					//   1. Create Joins Mode is on (toggled by ⌘J).
-					//   2. Cmd/Ctrl is held during the click — an accelerator
-					//      that skips the mode toggle so you can pick columns
-					//      across tables without turning the mode on first.
-					// Re-clicking an already-picked column removes it.  Plain
-					// clicks outside the mode go through the normal
-					// highlight / click-to-join flow.
-					if (store.pickModeActive || metaOrCtrl) {
-						store.pushEShiftPick(tableId, col);
-					} else {
-						store.tryColumnClickJoin(tableId, col);
-					}
-				},
-				onToggleCollapsed: (id: string) => store.toggleTableCollapsed(id),
-				onExpandFully: (id: string) => store.expandTableFully(id)
-			},
-			selected: store.selectedTableId === t.id
-		};
-	});
+export function buildFlowNodes(
+  store: SchemaCanvasStore,
+  focus: FlowFocus,
+): Node[] {
+  const {
+    focusActive,
+    focusedTableIds,
+    focusedColumnKeys,
+    connectedColumnKeys,
+  } = focus;
+  return store.doc.tables.map((t) => {
+    const isInFocus = focusActive && focusedTableIds.has(t.id);
+    return {
+      id: t.id,
+      type: "table",
+      position: t.position,
+      draggable: true,
+      deletable: true,
+      // Lift focused/selected tables to the front so they never hide
+      // behind faded peers when cards overlap.
+      zIndex: isInFocus || store.selectedTableId === t.id ? 100 : 0,
+      data: {
+        table: t,
+        highlightedColumn: store.highlightedColumn,
+        pendingJoinSource: store.pendingJoinSource,
+        eShiftPicks: store.eShiftPicks,
+        defaultColumnsShown: store.defaultColumnsShown,
+        focusedColumnKeys,
+        connectedColumnKeys,
+        /** When the table is in focus we auto-expand it so the user
+         *  can see WHICH columns are wired without manually
+         *  toggling. TableNode reads this to bypass the global
+         *  Show-N-cols cap. */
+        // Auto-expand on focus only when the green-highlight toggle
+        // is on. Off-by-default keeps the layout stable — a focus
+        // tap won't grow a card into space the arrange reserved.
+        forceExpandedByFocus: isInFocus && store.highlightFocusedColumns,
+        isFaded: focusActive && !focusedTableIds.has(t.id),
+        onPromoteToFact: (id: string) => store.setTableRole(id, "fact"),
+        onRemove: (id: string) => store.removeTable(id),
+        onColumnClick: (tableId: string, col: string, metaOrCtrl: boolean) => {
+          // Two ways a column click accumulates into the pick set:
+          //   1. Create Joins Mode is on (toggled by ⌘J).
+          //   2. Cmd/Ctrl is held during the click — an accelerator
+          //      that skips the mode toggle so you can pick columns
+          //      across tables without turning the mode on first.
+          // Re-clicking an already-picked column removes it.  Plain
+          // clicks outside the mode go through the normal
+          // highlight / click-to-join flow.
+          if (store.pickModeActive || metaOrCtrl) {
+            store.pushEShiftPick(tableId, col);
+          } else {
+            store.tryColumnClickJoin(tableId, col);
+          }
+        },
+        onToggleCollapsed: (id: string) => store.toggleTableCollapsed(id),
+        onExpandFully: (id: string) => store.expandTableFully(id),
+      },
+      selected: store.selectedTableId === t.id,
+    };
+  });
 }
 
 /**
@@ -87,83 +95,88 @@ export function buildFlowNodes(store: SchemaCanvasStore, focus: FlowFocus): Node
  * `data.joins` array carries every join in the pair (CanvasEdge renders a
  * popover when >1). Returns `[]` when join lines are hidden.
  */
-export function buildFlowEdges(store: SchemaCanvasStore, focus: FlowFocus): Edge[] {
-	const { focusActive, focusedJoinIds } = focus;
-	// Joins-hidden toggle — return nothing so SvelteFlow paints zero
-	// edges. Underlying joins stay intact in the doc.
-	if (store.joinsHidden) return [];
-	// Cube-link / inferred-fk joins are auto-derived from MeasureGroup
-	// <ForeignKeyLink>s — semantic, not physical.  Hidden by default so
-	// the canvas matches the source PhysicalSchema's <Link> set.  Toggle
-	// on via store.showCubeLinks to render them (dashed/muted).
-	const visibleJoins = store.doc.joins.filter((j) => {
-		const origin = j.origin ?? 'physical';
-		return origin === 'physical' || store.showCubeLinks;
-	});
-	const groups = new Map<string, SchemaCanvasJoin[]>();
-	for (const j of visibleJoins) {
-		const key = [j.sourceTableId, j.targetTableId].sort().join('::');
-		const arr = groups.get(key) ?? [];
-		arr.push(j);
-		groups.set(key, arr);
-	}
-	const tableById = new Map(store.doc.tables.map((t) => [t.id, t]));
-	const APPROX_TABLE_WIDTH = 240;
-	const out: Edge[] = [];
-	for (const [, joins] of groups) {
-		const head = joins[0];
-		const isSelected = joins.some((j) => store.selectedJoinId === j.id);
-		// Pick handle sides so the line takes the shortest path between
-		// tables. Compare table CENTRES: if source sits to the LEFT of
-		// target, exit source right and enter target left; otherwise
-		// the opposite. Tables with no position default to (0,0).
-		const sourceT = tableById.get(head.sourceTableId);
-		const targetT = tableById.get(head.targetTableId);
-		const sourceCx = (sourceT?.position.x ?? 0) + APPROX_TABLE_WIDTH / 2;
-		const targetCx = (targetT?.position.x ?? 0) + APPROX_TABLE_WIDTH / 2;
-		const sourceOnLeft = sourceCx <= targetCx;
-		const sourceSide = sourceOnLeft ? 'right' : 'left';
-		const targetSide = sourceOnLeft ? 'left' : 'right';
-		// Style by origin: physical (default) gets the full primary
-		// stroke; cube-link / inferred-fk renders muted + dashed so
-		// the visual distinction is unmistakable at a glance.
-		const isCubeLink = joins.every((j) => j.origin === 'cube-link' || j.origin === 'inferred-fk');
-		const edgeStyle = isCubeLink
-			? 'stroke: hsl(var(--muted-foreground)); stroke-width: 1.5; stroke-dasharray: 6 3; opacity: 0.65;'
-			: 'stroke: hsl(var(--primary)); stroke-width: 1.5;';
-		out.push({
-			id: `edge:${head.sourceTableId}::${head.targetTableId}`,
-			type: 'canvasJoin',
-			source: head.sourceTableId,
-			target: head.targetTableId,
-			sourceHandle: `${head.sourceTableId}:${head.sourceColumnName}:out-${sourceSide}`,
-			targetHandle: `${head.targetTableId}:${head.targetColumnName}:in-${targetSide}`,
-			style: edgeStyle,
-			selected: isSelected,
-			// Default xyflow stacking — edges under nodes. True
-			// route-around-obstacles requires a custom orthogonal
-			// router (queued); zIndex hacks only swap which problem
-			// you see.
-			data: {
-				joins,
-				edgeStyle: store.edgeStyle,
-				isFaded: focusActive && !joins.some((j) => focusedJoinIds.has(j.id)),
-				focusActive,
-				// Cube-link joins are read-only on the canvas — the
-				// MeasureGroup's DimensionLinks own them.  Delete via
-				// the MG editor instead.  `readOnly` reaches the edge
-				// component which suppresses delete + drag handles.
-				readOnly: isCubeLink,
-				onDelete: (joinId: string) => {
-					if (isCubeLink) return;
-					store.removeJoin(joinId);
-				},
-				onSelect: (joinId: string) => {
-					if (isCubeLink) return;
-					store.selectedJoinId = joinId;
-				}
-			}
-		});
-	}
-	return out;
+export function buildFlowEdges(
+  store: SchemaCanvasStore,
+  focus: FlowFocus,
+): Edge[] {
+  const { focusActive, focusedJoinIds } = focus;
+  // Joins-hidden toggle — return nothing so SvelteFlow paints zero
+  // edges. Underlying joins stay intact in the doc.
+  if (store.joinsHidden) return [];
+  // Cube-link / inferred-fk joins are auto-derived from MeasureGroup
+  // <ForeignKeyLink>s — semantic, not physical.  Hidden by default so
+  // the canvas matches the source PhysicalSchema's <Link> set.  Toggle
+  // on via store.showCubeLinks to render them (dashed/muted).
+  const visibleJoins = store.doc.joins.filter((j) => {
+    const origin = j.origin ?? "physical";
+    return origin === "physical" || store.showCubeLinks;
+  });
+  const groups = new Map<string, SchemaCanvasJoin[]>();
+  for (const j of visibleJoins) {
+    const key = [j.sourceTableId, j.targetTableId].sort().join("::");
+    const arr = groups.get(key) ?? [];
+    arr.push(j);
+    groups.set(key, arr);
+  }
+  const tableById = new Map(store.doc.tables.map((t) => [t.id, t]));
+  const APPROX_TABLE_WIDTH = 240;
+  const out: Edge[] = [];
+  for (const [, joins] of groups) {
+    const head = joins[0];
+    const isSelected = joins.some((j) => store.selectedJoinId === j.id);
+    // Pick handle sides so the line takes the shortest path between
+    // tables. Compare table CENTRES: if source sits to the LEFT of
+    // target, exit source right and enter target left; otherwise
+    // the opposite. Tables with no position default to (0,0).
+    const sourceT = tableById.get(head.sourceTableId);
+    const targetT = tableById.get(head.targetTableId);
+    const sourceCx = (sourceT?.position.x ?? 0) + APPROX_TABLE_WIDTH / 2;
+    const targetCx = (targetT?.position.x ?? 0) + APPROX_TABLE_WIDTH / 2;
+    const sourceOnLeft = sourceCx <= targetCx;
+    const sourceSide = sourceOnLeft ? "right" : "left";
+    const targetSide = sourceOnLeft ? "left" : "right";
+    // Style by origin: physical (default) gets the full primary
+    // stroke; cube-link / inferred-fk renders muted + dashed so
+    // the visual distinction is unmistakable at a glance.
+    const isCubeLink = joins.every(
+      (j) => j.origin === "cube-link" || j.origin === "inferred-fk",
+    );
+    const edgeStyle = isCubeLink
+      ? "stroke: hsl(var(--muted-foreground)); stroke-width: 1.5; stroke-dasharray: 6 3; opacity: 0.65;"
+      : "stroke: hsl(var(--primary)); stroke-width: 1.5;";
+    out.push({
+      id: `edge:${head.sourceTableId}::${head.targetTableId}`,
+      type: "canvasJoin",
+      source: head.sourceTableId,
+      target: head.targetTableId,
+      sourceHandle: `${head.sourceTableId}:${head.sourceColumnName}:out-${sourceSide}`,
+      targetHandle: `${head.targetTableId}:${head.targetColumnName}:in-${targetSide}`,
+      style: edgeStyle,
+      selected: isSelected,
+      // Default xyflow stacking — edges under nodes. True
+      // route-around-obstacles requires a custom orthogonal
+      // router (queued); zIndex hacks only swap which problem
+      // you see.
+      data: {
+        joins,
+        edgeStyle: store.edgeStyle,
+        isFaded: focusActive && !joins.some((j) => focusedJoinIds.has(j.id)),
+        focusActive,
+        // Cube-link joins are read-only on the canvas — the
+        // MeasureGroup's DimensionLinks own them.  Delete via
+        // the MG editor instead.  `readOnly` reaches the edge
+        // component which suppresses delete + drag handles.
+        readOnly: isCubeLink,
+        onDelete: (joinId: string) => {
+          if (isCubeLink) return;
+          store.removeJoin(joinId);
+        },
+        onSelect: (joinId: string) => {
+          if (isCubeLink) return;
+          store.selectedJoinId = joinId;
+        },
+      },
+    });
+  }
+  return out;
 }

--- a/saiku-ui/src/lib/cube-designer/canvas-flow.ts
+++ b/saiku-ui/src/lib/cube-designer/canvas-flow.ts
@@ -1,0 +1,169 @@
+/**
+ * SvelteFlow node/edge builders — pure derivations lifted out of
+ * SchemaCanvasView.svelte (audit finding #1040, template-decompose pass).
+ *
+ * The component keeps the `$derived`/`$state`/`$effect` reactivity; these
+ * functions own the pure transform from the store + focus state into the
+ * `Node[]` / `Edge[]` arrays SvelteFlow renders. Callbacks close over the
+ * store (the mutation boundary) exactly as they did inline.
+ */
+import type { Node, Edge } from '@xyflow/svelte';
+import { SchemaCanvasStore } from './state.svelte.js';
+import type { SchemaCanvasJoin } from './types.js';
+
+/** Focus/selection state the builders read (derived in the component). */
+export interface FlowFocus {
+	focusActive: boolean;
+	focusedTableIds: Set<string>;
+	focusedColumnKeys: Set<string>;
+	connectedColumnKeys: Set<string>;
+	focusedJoinIds: Set<string>;
+}
+
+/**
+ * Derive SvelteFlow nodes from the store's tables. Focused/selected tables
+ * lift to the front; faded peers dim. Column-click / promote / remove /
+ * collapse callbacks route through the store.
+ */
+export function buildFlowNodes(store: SchemaCanvasStore, focus: FlowFocus): Node[] {
+	const { focusActive, focusedTableIds, focusedColumnKeys, connectedColumnKeys } = focus;
+	return store.doc.tables.map((t) => {
+		const isInFocus = focusActive && focusedTableIds.has(t.id);
+		return {
+			id: t.id,
+			type: 'table',
+			position: t.position,
+			draggable: true,
+			deletable: true,
+			// Lift focused/selected tables to the front so they never hide
+			// behind faded peers when cards overlap.
+			zIndex: isInFocus || store.selectedTableId === t.id ? 100 : 0,
+			data: {
+				table: t,
+				highlightedColumn: store.highlightedColumn,
+				pendingJoinSource: store.pendingJoinSource,
+				eShiftPicks: store.eShiftPicks,
+				defaultColumnsShown: store.defaultColumnsShown,
+				focusedColumnKeys,
+				connectedColumnKeys,
+				/** When the table is in focus we auto-expand it so the user
+				 *  can see WHICH columns are wired without manually
+				 *  toggling. TableNode reads this to bypass the global
+				 *  Show-N-cols cap. */
+				// Auto-expand on focus only when the green-highlight toggle
+				// is on. Off-by-default keeps the layout stable — a focus
+				// tap won't grow a card into space the arrange reserved.
+				forceExpandedByFocus: isInFocus && store.highlightFocusedColumns,
+				isFaded: focusActive && !focusedTableIds.has(t.id),
+				onPromoteToFact: (id: string) => store.setTableRole(id, 'fact'),
+				onRemove: (id: string) => store.removeTable(id),
+				onColumnClick: (tableId: string, col: string, metaOrCtrl: boolean) => {
+					// Two ways a column click accumulates into the pick set:
+					//   1. Create Joins Mode is on (toggled by ⌘J).
+					//   2. Cmd/Ctrl is held during the click — an accelerator
+					//      that skips the mode toggle so you can pick columns
+					//      across tables without turning the mode on first.
+					// Re-clicking an already-picked column removes it.  Plain
+					// clicks outside the mode go through the normal
+					// highlight / click-to-join flow.
+					if (store.pickModeActive || metaOrCtrl) {
+						store.pushEShiftPick(tableId, col);
+					} else {
+						store.tryColumnClickJoin(tableId, col);
+					}
+				},
+				onToggleCollapsed: (id: string) => store.toggleTableCollapsed(id),
+				onExpandFully: (id: string) => store.expandTableFully(id)
+			},
+			selected: store.selectedTableId === t.id
+		};
+	});
+}
+
+/**
+ * Aggregate joins by table-pair so role-playing dimensions (fact joining
+ * `date` via order_date_id + ship_date_id + invoice_date_id) don't stack
+ * overlapping labels at the same bezier midpoint. One Edge per pair; its
+ * `data.joins` array carries every join in the pair (CanvasEdge renders a
+ * popover when >1). Returns `[]` when join lines are hidden.
+ */
+export function buildFlowEdges(store: SchemaCanvasStore, focus: FlowFocus): Edge[] {
+	const { focusActive, focusedJoinIds } = focus;
+	// Joins-hidden toggle — return nothing so SvelteFlow paints zero
+	// edges. Underlying joins stay intact in the doc.
+	if (store.joinsHidden) return [];
+	// Cube-link / inferred-fk joins are auto-derived from MeasureGroup
+	// <ForeignKeyLink>s — semantic, not physical.  Hidden by default so
+	// the canvas matches the source PhysicalSchema's <Link> set.  Toggle
+	// on via store.showCubeLinks to render them (dashed/muted).
+	const visibleJoins = store.doc.joins.filter((j) => {
+		const origin = j.origin ?? 'physical';
+		return origin === 'physical' || store.showCubeLinks;
+	});
+	const groups = new Map<string, SchemaCanvasJoin[]>();
+	for (const j of visibleJoins) {
+		const key = [j.sourceTableId, j.targetTableId].sort().join('::');
+		const arr = groups.get(key) ?? [];
+		arr.push(j);
+		groups.set(key, arr);
+	}
+	const tableById = new Map(store.doc.tables.map((t) => [t.id, t]));
+	const APPROX_TABLE_WIDTH = 240;
+	const out: Edge[] = [];
+	for (const [, joins] of groups) {
+		const head = joins[0];
+		const isSelected = joins.some((j) => store.selectedJoinId === j.id);
+		// Pick handle sides so the line takes the shortest path between
+		// tables. Compare table CENTRES: if source sits to the LEFT of
+		// target, exit source right and enter target left; otherwise
+		// the opposite. Tables with no position default to (0,0).
+		const sourceT = tableById.get(head.sourceTableId);
+		const targetT = tableById.get(head.targetTableId);
+		const sourceCx = (sourceT?.position.x ?? 0) + APPROX_TABLE_WIDTH / 2;
+		const targetCx = (targetT?.position.x ?? 0) + APPROX_TABLE_WIDTH / 2;
+		const sourceOnLeft = sourceCx <= targetCx;
+		const sourceSide = sourceOnLeft ? 'right' : 'left';
+		const targetSide = sourceOnLeft ? 'left' : 'right';
+		// Style by origin: physical (default) gets the full primary
+		// stroke; cube-link / inferred-fk renders muted + dashed so
+		// the visual distinction is unmistakable at a glance.
+		const isCubeLink = joins.every((j) => j.origin === 'cube-link' || j.origin === 'inferred-fk');
+		const edgeStyle = isCubeLink
+			? 'stroke: hsl(var(--muted-foreground)); stroke-width: 1.5; stroke-dasharray: 6 3; opacity: 0.65;'
+			: 'stroke: hsl(var(--primary)); stroke-width: 1.5;';
+		out.push({
+			id: `edge:${head.sourceTableId}::${head.targetTableId}`,
+			type: 'canvasJoin',
+			source: head.sourceTableId,
+			target: head.targetTableId,
+			sourceHandle: `${head.sourceTableId}:${head.sourceColumnName}:out-${sourceSide}`,
+			targetHandle: `${head.targetTableId}:${head.targetColumnName}:in-${targetSide}`,
+			style: edgeStyle,
+			selected: isSelected,
+			// Default xyflow stacking — edges under nodes. True
+			// route-around-obstacles requires a custom orthogonal
+			// router (queued); zIndex hacks only swap which problem
+			// you see.
+			data: {
+				joins,
+				edgeStyle: store.edgeStyle,
+				isFaded: focusActive && !joins.some((j) => focusedJoinIds.has(j.id)),
+				focusActive,
+				// Cube-link joins are read-only on the canvas — the
+				// MeasureGroup's DimensionLinks own them.  Delete via
+				// the MG editor instead.  `readOnly` reaches the edge
+				// component which suppresses delete + drag handles.
+				readOnly: isCubeLink,
+				onDelete: (joinId: string) => {
+					if (isCubeLink) return;
+					store.removeJoin(joinId);
+				},
+				onSelect: (joinId: string) => {
+					if (isCubeLink) return;
+					store.selectedJoinId = joinId;
+				}
+			}
+		});
+	}
+	return out;
+}

--- a/saiku-ui/src/lib/cube-designer/code-highlight.test.ts
+++ b/saiku-ui/src/lib/cube-designer/code-highlight.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from 'vitest';
+import { highlightXml, highlightYaml, escapeBasic } from './code-highlight';
+
+/**
+ * Strip the highlighter's own `<span class="...">` wrappers to recover the
+ * text a user actually sees. If the highlighter is correct, this equals the
+ * HTML-escaped source — no `class="..."` or stray `>` leaking into the text.
+ */
+function visibleText(html: string): string {
+	return html.replace(/<span class="[\w-]+">/g, '').replace(/<\/span>/g, '');
+}
+
+describe('highlightXml', () => {
+	it('does NOT leak span markup into an attribute (the reported bug)', () => {
+		const src = '<Attribute name="product_name" keyColumn="product_name" />';
+		const html = highlightXml(src);
+		// The exact garbage from the bug report must not appear.
+		expect(html).not.toContain('name=class=');
+		expect(html).not.toContain('=class="xml-string"');
+		// Every emitted span is a clean, well-formed open tag.
+		expect(html).not.toMatch(/<span\s+<span/);
+		// What the user sees is just the escaped XML — no highlighter internals.
+		expect(visibleText(html)).toBe(escapeBasic(src));
+	});
+
+	it('wraps tag names, attribute names and quoted values exactly once', () => {
+		const html = highlightXml('<Dimension key="k">');
+		expect(html).toContain('<span class="xml-tag">Dimension</span>');
+		expect(html).toContain('<span class="xml-attr">key</span>');
+		expect(html).toContain('<span class="xml-string">"k"</span>');
+		// `class="xml-attr"` inside our own span must not get re-wrapped.
+		expect(html).not.toContain('<span class="xml-string">"xml-attr"</span>');
+		expect(html).not.toContain('<span class="xml-string">"xml-tag"</span>');
+	});
+
+	it('highlights comments without touching their inner text', () => {
+		const html = highlightXml('<!-- No key: set a PK -->');
+		expect(html).toContain('<span class="xml-comment">');
+		expect(visibleText(html)).toBe(escapeBasic('<!-- No key: set a PK -->'));
+	});
+
+	it('handles a full multi-attribute element cleanly', () => {
+		const src = '<Table name="product" schema="public" keyColumn="product_id" />';
+		const html = highlightXml(src);
+		expect(visibleText(html)).toBe(escapeBasic(src));
+		expect(html).not.toContain('class=class');
+	});
+});
+
+describe('highlightYaml', () => {
+	it('does not let the key span collide with quoted values', () => {
+		const src = 'name: "product_name"';
+		const html = highlightYaml(src);
+		expect(html).toContain('<span class="xml-tag">name</span>:');
+		expect(html).toContain('<span class="xml-string">"product_name"</span>');
+		// The key span's own `class="xml-tag"` must not be re-wrapped as a value.
+		expect(html).not.toContain('<span class="xml-string">"xml-tag"</span>');
+		expect(visibleText(html)).toBe(src);
+	});
+
+	it('handles list items and nested keys per line', () => {
+		const src = '  - source: "Store"';
+		const html = highlightYaml(src);
+		expect(html).toContain('<span class="xml-tag">source</span>:');
+		expect(html).toContain('<span class="xml-string">"Store"</span>');
+		expect(visibleText(html)).toBe(src);
+	});
+});

--- a/saiku-ui/src/lib/cube-designer/code-highlight.test.ts
+++ b/saiku-ui/src/lib/cube-designer/code-highlight.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect } from 'vitest';
-import { highlightXml, highlightYaml, escapeBasic } from './code-highlight';
+import { describe, it, expect } from "vitest";
+import { highlightXml, highlightYaml, escapeBasic } from "./code-highlight";
 
 /**
  * Strip the highlighter's own `<span class="...">` wrappers to recover the
@@ -7,62 +7,63 @@ import { highlightXml, highlightYaml, escapeBasic } from './code-highlight';
  * HTML-escaped source — no `class="..."` or stray `>` leaking into the text.
  */
 function visibleText(html: string): string {
-	return html.replace(/<span class="[\w-]+">/g, '').replace(/<\/span>/g, '');
+  return html.replace(/<span class="[\w-]+">/g, "").replace(/<\/span>/g, "");
 }
 
-describe('highlightXml', () => {
-	it('does NOT leak span markup into an attribute (the reported bug)', () => {
-		const src = '<Attribute name="product_name" keyColumn="product_name" />';
-		const html = highlightXml(src);
-		// The exact garbage from the bug report must not appear.
-		expect(html).not.toContain('name=class=');
-		expect(html).not.toContain('=class="xml-string"');
-		// Every emitted span is a clean, well-formed open tag.
-		expect(html).not.toMatch(/<span\s+<span/);
-		// What the user sees is just the escaped XML — no highlighter internals.
-		expect(visibleText(html)).toBe(escapeBasic(src));
-	});
+describe("highlightXml", () => {
+  it("does NOT leak span markup into an attribute (the reported bug)", () => {
+    const src = '<Attribute name="product_name" keyColumn="product_name" />';
+    const html = highlightXml(src);
+    // The exact garbage from the bug report must not appear.
+    expect(html).not.toContain("name=class=");
+    expect(html).not.toContain('=class="xml-string"');
+    // Every emitted span is a clean, well-formed open tag.
+    expect(html).not.toMatch(/<span\s+<span/);
+    // What the user sees is just the escaped XML — no highlighter internals.
+    expect(visibleText(html)).toBe(escapeBasic(src));
+  });
 
-	it('wraps tag names, attribute names and quoted values exactly once', () => {
-		const html = highlightXml('<Dimension key="k">');
-		expect(html).toContain('<span class="xml-tag">Dimension</span>');
-		expect(html).toContain('<span class="xml-attr">key</span>');
-		expect(html).toContain('<span class="xml-string">"k"</span>');
-		// `class="xml-attr"` inside our own span must not get re-wrapped.
-		expect(html).not.toContain('<span class="xml-string">"xml-attr"</span>');
-		expect(html).not.toContain('<span class="xml-string">"xml-tag"</span>');
-	});
+  it("wraps tag names, attribute names and quoted values exactly once", () => {
+    const html = highlightXml('<Dimension key="k">');
+    expect(html).toContain('<span class="xml-tag">Dimension</span>');
+    expect(html).toContain('<span class="xml-attr">key</span>');
+    expect(html).toContain('<span class="xml-string">"k"</span>');
+    // `class="xml-attr"` inside our own span must not get re-wrapped.
+    expect(html).not.toContain('<span class="xml-string">"xml-attr"</span>');
+    expect(html).not.toContain('<span class="xml-string">"xml-tag"</span>');
+  });
 
-	it('highlights comments without touching their inner text', () => {
-		const html = highlightXml('<!-- No key: set a PK -->');
-		expect(html).toContain('<span class="xml-comment">');
-		expect(visibleText(html)).toBe(escapeBasic('<!-- No key: set a PK -->'));
-	});
+  it("highlights comments without touching their inner text", () => {
+    const html = highlightXml("<!-- No key: set a PK -->");
+    expect(html).toContain('<span class="xml-comment">');
+    expect(visibleText(html)).toBe(escapeBasic("<!-- No key: set a PK -->"));
+  });
 
-	it('handles a full multi-attribute element cleanly', () => {
-		const src = '<Table name="product" schema="public" keyColumn="product_id" />';
-		const html = highlightXml(src);
-		expect(visibleText(html)).toBe(escapeBasic(src));
-		expect(html).not.toContain('class=class');
-	});
+  it("handles a full multi-attribute element cleanly", () => {
+    const src =
+      '<Table name="product" schema="public" keyColumn="product_id" />';
+    const html = highlightXml(src);
+    expect(visibleText(html)).toBe(escapeBasic(src));
+    expect(html).not.toContain("class=class");
+  });
 });
 
-describe('highlightYaml', () => {
-	it('does not let the key span collide with quoted values', () => {
-		const src = 'name: "product_name"';
-		const html = highlightYaml(src);
-		expect(html).toContain('<span class="xml-tag">name</span>:');
-		expect(html).toContain('<span class="xml-string">"product_name"</span>');
-		// The key span's own `class="xml-tag"` must not be re-wrapped as a value.
-		expect(html).not.toContain('<span class="xml-string">"xml-tag"</span>');
-		expect(visibleText(html)).toBe(src);
-	});
+describe("highlightYaml", () => {
+  it("does not let the key span collide with quoted values", () => {
+    const src = 'name: "product_name"';
+    const html = highlightYaml(src);
+    expect(html).toContain('<span class="xml-tag">name</span>:');
+    expect(html).toContain('<span class="xml-string">"product_name"</span>');
+    // The key span's own `class="xml-tag"` must not be re-wrapped as a value.
+    expect(html).not.toContain('<span class="xml-string">"xml-tag"</span>');
+    expect(visibleText(html)).toBe(src);
+  });
 
-	it('handles list items and nested keys per line', () => {
-		const src = '  - source: "Store"';
-		const html = highlightYaml(src);
-		expect(html).toContain('<span class="xml-tag">source</span>:');
-		expect(html).toContain('<span class="xml-string">"Store"</span>');
-		expect(visibleText(html)).toBe(src);
-	});
+  it("handles list items and nested keys per line", () => {
+    const src = '  - source: "Store"';
+    const html = highlightYaml(src);
+    expect(html).toContain('<span class="xml-tag">source</span>:');
+    expect(html).toContain('<span class="xml-string">"Store"</span>');
+    expect(visibleText(html)).toBe(src);
+  });
 });

--- a/saiku-ui/src/lib/cube-designer/code-highlight.ts
+++ b/saiku-ui/src/lib/cube-designer/code-highlight.ts
@@ -1,0 +1,61 @@
+/**
+ * Syntax highlighters for the schema-canvas Code tab (XML + YAML previews).
+ *
+ * Extracted from WorkbenchView so the string logic is unit-testable (the
+ * dashboard has no Svelte render tests). Rendered via `{@html}`, so the
+ * output must be well-formed: each highlighter is SINGLE-PASS.
+ *
+ * Why single-pass matters: the old implementation ran several sequential
+ * `.replace()`es. Each inserted `<span class="...">`, and a *later* pass then
+ * matched the `class="..."` (or the quotes) inside that span — corrupting the
+ * markup into visible garbage like `name=class="xml-string">"product_name"`
+ * (note the stray `>` that would never validate). A single alternation pass
+ * never re-scans its own replacement text, so tokens can't corrupt each other.
+ */
+
+/** Escape the three HTML-structural characters so `{@html}` renders text, not markup. */
+export function escapeBasic(s: string): string {
+	return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+}
+
+/**
+ * Highlight XML: tag names, attribute names, quoted values, comments.
+ * Operates on the HTML-escaped source (so `<` is already `&lt;`).
+ */
+export function highlightXml(src: string): string {
+	const s = escapeBasic(src);
+	return s.replace(
+		// comment | quoted-value | tag-open + name | attribute-name (before `=`)
+		/(&lt;!--[\s\S]*?--&gt;)|("[^"]*")|(&lt;\/?)([A-Za-z][\w:-]*)|([\w:-]+)(?==)/g,
+		(_m, comment, str, open, tag, attr) => {
+			if (comment) return `<span class="xml-comment">${comment}</span>`;
+			if (str) return `<span class="xml-string">${str}</span>`;
+			if (open) return `${open}<span class="xml-tag">${tag}</span>`;
+			if (attr) return `<span class="xml-attr">${attr}</span>`;
+			return _m;
+		}
+	);
+}
+
+/**
+ * Highlight YAML: leading keys → xml-tag, quoted values → xml-string.
+ * Per-line + single-pass for the same anti-collision reason as {@link highlightXml}.
+ */
+export function highlightYaml(src: string): string {
+	return src
+		.split('\n')
+		.map((line) =>
+			escapeBasic(line).replace(
+				// leading key (`indent key:`) | quoted string value
+				/^(\s*-?\s*)([\w.]+)(:)|("[^"]*")/g,
+				(_m, indent, key, colon, str) => {
+					if (str) return `<span class="xml-string">${str}</span>`;
+					if (key !== undefined) {
+						return `${indent}<span class="xml-tag">${key}</span>${colon}`;
+					}
+					return _m;
+				}
+			)
+		)
+		.join('\n');
+}

--- a/saiku-ui/src/lib/cube-designer/code-highlight.ts
+++ b/saiku-ui/src/lib/cube-designer/code-highlight.ts
@@ -15,7 +15,7 @@
 
 /** Escape the three HTML-structural characters so `{@html}` renders text, not markup. */
 export function escapeBasic(s: string): string {
-	return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+  return s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
 }
 
 /**
@@ -23,18 +23,18 @@ export function escapeBasic(s: string): string {
  * Operates on the HTML-escaped source (so `<` is already `&lt;`).
  */
 export function highlightXml(src: string): string {
-	const s = escapeBasic(src);
-	return s.replace(
-		// comment | quoted-value | tag-open + name | attribute-name (before `=`)
-		/(&lt;!--[\s\S]*?--&gt;)|("[^"]*")|(&lt;\/?)([A-Za-z][\w:-]*)|([\w:-]+)(?==)/g,
-		(_m, comment, str, open, tag, attr) => {
-			if (comment) return `<span class="xml-comment">${comment}</span>`;
-			if (str) return `<span class="xml-string">${str}</span>`;
-			if (open) return `${open}<span class="xml-tag">${tag}</span>`;
-			if (attr) return `<span class="xml-attr">${attr}</span>`;
-			return _m;
-		}
-	);
+  const s = escapeBasic(src);
+  return s.replace(
+    // comment | quoted-value | tag-open + name | attribute-name (before `=`)
+    /(&lt;!--[\s\S]*?--&gt;)|("[^"]*")|(&lt;\/?)([A-Za-z][\w:-]*)|([\w:-]+)(?==)/g,
+    (_m, comment, str, open, tag, attr) => {
+      if (comment) return `<span class="xml-comment">${comment}</span>`;
+      if (str) return `<span class="xml-string">${str}</span>`;
+      if (open) return `${open}<span class="xml-tag">${tag}</span>`;
+      if (attr) return `<span class="xml-attr">${attr}</span>`;
+      return _m;
+    },
+  );
 }
 
 /**
@@ -42,20 +42,20 @@ export function highlightXml(src: string): string {
  * Per-line + single-pass for the same anti-collision reason as {@link highlightXml}.
  */
 export function highlightYaml(src: string): string {
-	return src
-		.split('\n')
-		.map((line) =>
-			escapeBasic(line).replace(
-				// leading key (`indent key:`) | quoted string value
-				/^(\s*-?\s*)([\w.]+)(:)|("[^"]*")/g,
-				(_m, indent, key, colon, str) => {
-					if (str) return `<span class="xml-string">${str}</span>`;
-					if (key !== undefined) {
-						return `${indent}<span class="xml-tag">${key}</span>${colon}`;
-					}
-					return _m;
-				}
-			)
-		)
-		.join('\n');
+  return src
+    .split("\n")
+    .map((line) =>
+      escapeBasic(line).replace(
+        // leading key (`indent key:`) | quoted string value
+        /^(\s*-?\s*)([\w.]+)(:)|("[^"]*")/g,
+        (_m, indent, key, colon, str) => {
+          if (str) return `<span class="xml-string">${str}</span>`;
+          if (key !== undefined) {
+            return `${indent}<span class="xml-tag">${key}</span>${colon}`;
+          }
+          return _m;
+        },
+      ),
+    )
+    .join("\n");
 }

--- a/saiku-ui/src/lib/cube-designer/confirm-cube/ConfirmCubeCanvas.svelte
+++ b/saiku-ui/src/lib/cube-designer/confirm-cube/ConfirmCubeCanvas.svelte
@@ -1,0 +1,295 @@
+<!--
+  Confirm cube canvas — purpose-built visualization of ONE cube.
+
+    - Purple fact-table card(s) in the middle
+    - Every linked dim card arrayed around the fact
+    - Multiple measure groups sharing a fact table share a card (the
+      fact card lists each MG name as a chip)
+    - Multiple fact tables (a cube with MGs on different facts) each
+      get their own cluster, stacked vertically
+    - Edges labelled with the FK column
+    - Degenerate dims get a FactLink badge (no external edge)
+
+  No drag, no source sidebar, no pick mode.  Just the cube.
+-->
+<script lang="ts">
+	import {
+		SvelteFlow,
+		Background,
+		Controls,
+		type Node,
+		type Edge,
+		MarkerType
+	} from '@xyflow/svelte';
+	import '@xyflow/svelte/dist/style.css';
+	import { untrack } from 'svelte';
+	import type { SchemaCanvasStore } from '../state.svelte';
+	import FactCard from './FactCard.svelte';
+	import DimCard from './DimCard.svelte';
+	import FKLabelEdge from './FKLabelEdge.svelte';
+
+	interface ConfirmMeasureGroup {
+		id: string;
+		name?: string;
+		factTableId?: string | null;
+		dimensionLinks?: Array<{
+			dimensionId: string;
+			foreignKeyColumn: string;
+			linkKind?: 'foreign-key' | 'fact' | 'reference';
+		}>;
+	}
+
+	interface Props {
+		store: SchemaCanvasStore;
+		cubeId: string | null;
+		measureGroups: ConfirmMeasureGroup[];
+		/** Bump counter from the parent — when it changes, reset node
+		 *  positions to the computed layout (drops user drags). */
+		resetSignal?: number;
+		/** Bump counter from the parent — forces every downstream
+		 *  derivation to re-run against the latest MG shape.  Belt-
+		 *  and-braces refresh for FK / dim-link mutations that
+		 *  Svelte 5's deep proxy doesn't propagate reliably through
+		 *  the local MG state (#1088). */
+		refreshSignal?: number;
+	}
+
+	let { store, cubeId, measureGroups, resetSignal = 0, refreshSignal = 0 }: Props = $props();
+
+	const nodeTypes = { fact: FactCard, dim: DimCard };
+	 
+	const edgeTypes = { 'fk-label': FKLabelEdge } as any;
+
+	function resolveTable(id: string | null | undefined) {
+		if (!id) return null;
+		return store.doc.tables.find((t) => t.id === id) ?? null;
+	}
+	function resolveDim(id: string) {
+		return store.dimensions.find((d) => d.id === id) ?? null;
+	}
+
+	// Group MGs by their fact table so a fact shared across MGs shows
+	// as ONE card with multiple MG chips (mirrors Mondrian semantics).
+	const clusters = $derived.by(() => {
+		// Void-read `refreshSignal` so a tab-entry bump forces this
+		// derivation to re-run against the latest measureGroups shape
+		// (#1088).  Otherwise deep FK / dim-link mutations upstream
+		// don't reliably invalidate the derivation.
+		void refreshSignal;
+		const byFact = new Map<
+			string,
+			{
+				factTable: ReturnType<typeof resolveTable>;
+				mgs: ConfirmMeasureGroup[];
+				dimLinks: Array<{
+					mgId: string;
+					dimensionId: string;
+					foreignKeyColumn: string;
+					linkKind: 'foreign-key' | 'fact' | 'reference';
+				}>;
+			}
+		>();
+		for (const mg of measureGroups) {
+			const key = mg.factTableId ?? '__unbound__';
+			if (!byFact.has(key)) {
+				byFact.set(key, { factTable: resolveTable(mg.factTableId), mgs: [], dimLinks: [] });
+			}
+			const bucket = byFact.get(key)!;
+			bucket.mgs.push(mg);
+			for (const link of mg.dimensionLinks ?? []) {
+				bucket.dimLinks.push({
+					mgId: mg.id,
+					dimensionId: link.dimensionId,
+					foreignKeyColumn: link.foreignKeyColumn,
+					linkKind: link.linkKind ?? 'foreign-key'
+				});
+			}
+		}
+		return [...byFact.entries()].map(([key, v]) => ({ key, ...v }));
+	});
+
+	// Layout: for each cluster, put the fact in the middle and stack
+	// dims to the right in a vertical column (kept simple + readable).
+	// Clusters themselves stack vertically with generous padding.
+	const CLUSTER_V_GAP = 120;
+	const FACT_X = 0;
+	const DIM_X = 380;
+	const DIM_STEP = 96;
+
+	const nodes = $derived.by<Node[]>(() => {
+		const out: Node[] = [];
+		let yCursor = 0;
+		for (const cluster of clusters) {
+			const seenDimId = new Set<string>();
+			// De-dupe dim links so a dim used by multiple MGs on the same
+			// fact table renders once (the fact card already shows every
+			// MG name).
+			const uniqDims = cluster.dimLinks.filter((l) => {
+				if (seenDimId.has(l.dimensionId)) return false;
+				seenDimId.add(l.dimensionId);
+				return true;
+			});
+			const nDims = Math.max(1, uniqDims.length);
+			const clusterHeight = (nDims - 1) * DIM_STEP;
+			const factY = yCursor + clusterHeight / 2;
+			const factTable = cluster.factTable;
+			const factName = factTable?.name ?? '(fact table not on canvas)';
+			const factSubtitle = factTable?.schema ? `${factTable.schema}.${factTable.name}` : null;
+			out.push({
+				id: `fact:${cluster.key}`,
+				type: 'fact',
+				position: { x: FACT_X, y: factY },
+				draggable: true,
+				selectable: false,
+				data: {
+					tableName: factName,
+					tableSubtitle: factSubtitle,
+					mgNames: cluster.mgs.map((m) => m.name ?? 'Untitled MG')
+				}
+			});
+			let dimY = yCursor;
+			for (const l of uniqDims) {
+				const dim = resolveDim(l.dimensionId);
+				const dimSrcId = dim?.sourceTableId ?? dim?.primaryKeyTableId ?? null;
+				const dimTable = resolveTable(dimSrcId);
+				const isDegenerate =
+					l.linkKind === 'fact' || (!!factTable && !!dimSrcId && dimSrcId === factTable.id);
+				out.push({
+					id: `dim:${cluster.key}:${l.dimensionId}`,
+					type: 'dim',
+					position: { x: DIM_X, y: dimY },
+					draggable: true,
+					selectable: false,
+					data: {
+						dimName: dim?.name ?? '(missing dim)',
+						tableName: dimTable?.name ?? null,
+						tableSubtitle: dimTable?.schema
+							? `${dimTable.schema}.${dimTable.name}`
+							: (dimTable?.name ?? null),
+						isDegenerate,
+						fkColumn: l.foreignKeyColumn || null,
+						primaryKey: dim?.primaryKey ?? null
+					}
+				});
+				dimY += DIM_STEP;
+			}
+			yCursor += Math.max(DIM_STEP, clusterHeight) + CLUSTER_V_GAP;
+		}
+		return out;
+	});
+
+	const edges = $derived.by<Edge[]>(() => {
+		const out: Edge[] = [];
+		for (const cluster of clusters) {
+			const seen = new Set<string>();
+			for (const l of cluster.dimLinks) {
+				if (seen.has(l.dimensionId)) continue;
+				seen.add(l.dimensionId);
+				const dim = resolveDim(l.dimensionId);
+				const dimSrcId = dim?.sourceTableId ?? dim?.primaryKeyTableId ?? null;
+				const isDegenerate =
+					l.linkKind === 'fact' ||
+					(!!cluster.factTable && !!dimSrcId && dimSrcId === cluster.factTable.id);
+				if (isDegenerate) {
+					// FactLink dim — no external FK/PK.  Faint dashed grey
+					// line to its MG's fact table so the user can tell
+					// WHICH cube/MG this factlink belongs to when multiple
+					// MGs are on different fact tables.  Label reads
+					// "on fact" so the pattern is obvious in plain English.
+					out.push({
+						id: `e:factlink:${cluster.key}:${l.dimensionId}`,
+						source: `fact:${cluster.key}`,
+						target: `dim:${cluster.key}:${l.dimensionId}`,
+						type: 'fk-label',
+						data: { label: 'on fact' },
+						style:
+							'stroke: hsl(var(--muted-foreground)); stroke-width: 1; stroke-dasharray: 4 4; opacity: 0.5;',
+						selectable: false,
+						deletable: false
+					});
+					continue;
+				}
+				const label = `${l.foreignKeyColumn || '?'} → ${dim?.primaryKey ?? '?'}`;
+				out.push({
+					id: `e:${cluster.key}:${l.dimensionId}`,
+					source: `fact:${cluster.key}`,
+					target: `dim:${cluster.key}:${l.dimensionId}`,
+					// Custom edge — renders the FK→PK label via foreignObject
+					// with real CSS so the text is guaranteed readable on any
+					// theme.  SvelteFlow's default edge label uses an SVG
+					// <rect>+<text> that ignored our labelStyle/labelBgStyle
+					// and rendered as an opaque white block covering the text.
+					type: 'fk-label',
+					data: { label },
+					style: 'stroke: hsl(275 55% 60% / 0.7); stroke-width: 1.5;',
+					markerEnd: { type: MarkerType.ArrowClosed, color: 'hsl(275 55% 60%)' },
+					selectable: false,
+					deletable: false
+				});
+			}
+		}
+		return out;
+	});
+
+	// Sync computed → SvelteFlow bindables.  Preserve user-dragged
+	// positions on subsequent data changes; `resetSignal` (parent-owned
+	// bump counter) resets to computed layout when it changes.
+	let flowNodes = $state<Node[]>([]);
+	let flowEdges = $state<Edge[]>([]);
+	$effect(() => {
+		const computed = nodes;
+		const reset = resetSignal;
+		untrack(() => {
+			if (reset > 0) {
+				flowNodes = computed;
+				return;
+			}
+			const posById = new Map(flowNodes.map((n) => [n.id, n.position]));
+			flowNodes = computed.map((n) => {
+				const savedPos = posById.get(n.id);
+				return savedPos ? { ...n, position: savedPos } : n;
+			});
+		});
+	});
+	$effect(() => {
+		flowEdges = edges;
+	});
+
+	const hasContent = $derived(clusters.length > 0);
+</script>
+
+<div class="relative h-full w-full" data-testid="confirm-cube-canvas">
+	{#if !cubeId || !hasContent}
+		<div
+			class="flex h-full flex-col items-center justify-center gap-2 p-4 text-center"
+			style:background-color="hsl(var(--muted)/0.2)"
+		>
+			<p class="text-sm font-medium">Nothing to confirm yet</p>
+			<p class="max-w-md text-[11px] text-muted-foreground">
+				Head to <span class="font-medium">Facts &amp; Measures</span> and set up a measure group — its
+				fact table and linked dimensions will appear here.
+			</p>
+		</div>
+	{:else}
+		<!-- Reset positions button lives in the parent confirmCubeModel
+		     wrapper now (bottom-left overlay of the model container). -->
+		<SvelteFlow
+			bind:nodes={flowNodes}
+			bind:edges={flowEdges}
+			{nodeTypes}
+			{edgeTypes}
+			fitView
+			fitViewOptions={{ padding: 0.2 }}
+			panOnDrag
+			zoomOnScroll
+			nodesDraggable
+			nodesConnectable={false}
+			edgesFocusable={false}
+			proOptions={{ hideAttribution: true }}
+			class="!bg-background"
+		>
+			<Background />
+			<Controls position="bottom-right" orientation="vertical" showLock={false} />
+		</SvelteFlow>
+	{/if}
+</div>

--- a/saiku-ui/src/lib/cube-designer/confirm-cube/CubeDag.svelte
+++ b/saiku-ui/src/lib/cube-designer/confirm-cube/CubeDag.svelte
@@ -1,0 +1,318 @@
+<!--
+  Semantic cube DAG — reflects the CUBE model, not the physical schema.
+
+  Left → right columns:
+    1. Fact tables (one card per unique fact-table on this cube)
+    2. Measure Groups (each card lists its measures inline)
+    3. Linked Dimensions (each card lists its hierarchies + levels inline;
+       everything open by default — the whole cube reads at a glance)
+
+  Edges are semantic:
+    - fact → MG (which MG uses this fact table)
+    - MG → dim (dim linked into this MG via a DimensionLink)
+
+  No physical tables under dims (per Amelia's direction — dim card just
+  shows the dim's own name, hierarchies, levels).
+-->
+<script lang="ts">
+	import { SvelteFlow, Background, Controls, type Node, type Edge } from '@xyflow/svelte';
+	import '@xyflow/svelte/dist/style.css';
+	import { untrack } from 'svelte';
+	import type { SchemaCanvasStore } from '../state.svelte';
+	import CubeDagFact from './CubeDagFact.svelte';
+	import CubeDagMG from './CubeDagMG.svelte';
+	import CubeDagDim from './CubeDagDim.svelte';
+
+	interface DagMeasureGroup {
+		id: string;
+		name?: string;
+		factTableId?: string | null;
+		measureColumns?: string[];
+		dimensionLinks?: Array<{
+			dimensionId: string;
+			foreignKeyColumn: string;
+			linkKind?: 'foreign-key' | 'fact' | 'reference';
+		}>;
+	}
+
+	interface Props {
+		store: SchemaCanvasStore;
+		cubeId: string | null;
+		measureGroups: DagMeasureGroup[];
+		/** Bump counter from the parent — when it changes, reset node
+		 *  positions to the computed layout (drops user drags). */
+		resetSignal?: number;
+		/** Bump counter from the parent — forces `clusters` to re-run
+		 *  against the latest MG shape.  Handles the deep-FK mutation
+		 *  path that Svelte 5's local-$state proxy doesn't reliably
+		 *  invalidate through prop passthrough (#1088). */
+		refreshSignal?: number;
+	}
+
+	let { store, cubeId, measureGroups, resetSignal = 0, refreshSignal = 0 }: Props = $props();
+
+	const nodeTypes = { 'dag-fact': CubeDagFact, 'dag-mg': CubeDagMG, 'dag-dim': CubeDagDim };
+
+	function tableById(id: string | null | undefined) {
+		if (!id) return null;
+		return store.doc.tables.find((t) => t.id === id) ?? null;
+	}
+	function dimById(id: string) {
+		return store.dimensions.find((d) => d.id === id) ?? null;
+	}
+
+	// Column layout constants
+	const FACT_X = 0;
+	const MG_X = 340;
+	const DIM_X = 700;
+	const V_STEP = 40;
+
+	// Rough per-node height so we can lay things out without measuring.
+	// Cards are variable-height (each MG's measure list, each dim's
+	// hierarchy list) — use a `base + rows * step` approximation.
+	const FACT_BASE_H = 72;
+	const MG_BASE_H = 68;
+	const MG_MEASURE_H = 18;
+	const DIM_BASE_H = 60;
+	const DIM_HIER_HEAD_H = 24;
+	const DIM_LEVEL_H = 18;
+
+	interface FactCluster {
+		key: string;
+		factId: string | null;
+		mgs: DagMeasureGroup[];
+	}
+
+	const clusters = $derived.by<FactCluster[]>(() => {
+		// Void-read `refreshSignal` so a tab-entry bump forces this
+		// derivation to re-run against the latest MG shape (#1088).
+		void refreshSignal;
+		const byFact = new Map<string, FactCluster>();
+		for (const mg of measureGroups) {
+			const key = mg.factTableId ?? '__unbound__';
+			if (!byFact.has(key)) {
+				byFact.set(key, { key, factId: mg.factTableId ?? null, mgs: [] });
+			}
+			byFact.get(key)!.mgs.push(mg);
+		}
+		return [...byFact.values()];
+	});
+
+	// Every dim linked into ANY of this cube's MGs (deduped, preserving
+	// first-seen order — matches how the user encounters them).
+	const linkedDimIds = $derived.by(() => {
+		const seen = new Set<string>();
+		const out: string[] = [];
+		for (const mg of measureGroups) {
+			for (const link of mg.dimensionLinks ?? []) {
+				if (seen.has(link.dimensionId)) continue;
+				seen.add(link.dimensionId);
+				out.push(link.dimensionId);
+			}
+		}
+		return out;
+	});
+
+	const nodes = $derived.by<Node[]>(() => {
+		const out: Node[] = [];
+
+		// Column 1 + 2: fact tables and their measure groups, clustered
+		// so each fact's MGs stack next to it.
+		let yCursor = 0;
+		for (const cluster of clusters) {
+			const factTable = tableById(cluster.factId);
+			const factName = factTable?.name ?? '(fact table not on canvas)';
+			const factSubtitle = factTable?.schema ? `${factTable.schema}.${factTable.name}` : null;
+
+			// Compute the vertical span this cluster needs (max of the fact
+			// card and the stack of MG cards).
+			const clusterMgSpan = cluster.mgs.reduce(
+				(acc, mg) => acc + (MG_BASE_H + (mg.measureColumns?.length ?? 0) * MG_MEASURE_H) + V_STEP,
+				-V_STEP
+			);
+			const clusterHeight = Math.max(FACT_BASE_H, clusterMgSpan);
+
+			const factY = yCursor + Math.max(0, (clusterHeight - FACT_BASE_H) / 2);
+			out.push({
+				id: `fact:${cluster.key}`,
+				type: 'dag-fact',
+				position: { x: FACT_X, y: factY },
+				draggable: true,
+				selectable: false,
+				data: {
+					tableName: factName,
+					tableSubtitle: factSubtitle,
+					mgNames: cluster.mgs.map((m) => m.name ?? 'Untitled MG')
+				}
+			});
+
+			let mgY = yCursor;
+			for (const mg of cluster.mgs) {
+				const measures = mg.measureColumns ?? [];
+				const height = MG_BASE_H + measures.length * MG_MEASURE_H;
+				out.push({
+					id: `mg:${mg.id}`,
+					type: 'dag-mg',
+					position: { x: MG_X, y: mgY },
+					draggable: true,
+					selectable: false,
+					data: {
+						name: mg.name ?? 'Untitled MG',
+						measures
+					}
+				});
+				mgY += height + V_STEP;
+			}
+
+			yCursor += clusterHeight + V_STEP * 2;
+		}
+
+		// Column 3: linked dimensions.  Each card lists its hierarchies +
+		// levels inline (everything open by default).
+		let dimY = 0;
+		for (const dimId of linkedDimIds) {
+			const dim = dimById(dimId);
+			if (!dim) continue;
+			const hiers = dim.hierarchies ?? [];
+			const height =
+				DIM_BASE_H +
+				hiers.reduce((acc, h) => acc + DIM_HIER_HEAD_H + (h.levels?.length ?? 0) * DIM_LEVEL_H, 0);
+			out.push({
+				id: `dim:${dimId}`,
+				type: 'dag-dim',
+				position: { x: DIM_X, y: dimY },
+				draggable: true,
+				selectable: false,
+				data: {
+					name: dim.name ?? 'Untitled dim',
+					hierarchies: hiers.map((h) => ({
+						id: h.id,
+						name: h.name ?? 'Untitled hierarchy',
+						levels: (h.levels ?? []).map((l) => ({
+							id: l.id,
+							name: l.columnName
+						}))
+					}))
+				}
+			});
+			dimY += height + V_STEP;
+		}
+
+		return out;
+	});
+
+	const edges = $derived.by<Edge[]>(() => {
+		const out: Edge[] = [];
+		// fact → MG
+		for (const cluster of clusters) {
+			for (const mg of cluster.mgs) {
+				out.push({
+					id: `e:fact-mg:${cluster.key}:${mg.id}`,
+					source: `fact:${cluster.key}`,
+					target: `mg:${mg.id}`,
+					type: 'default',
+					style: 'stroke: hsl(var(--muted-foreground)); stroke-width: 1.25; opacity: 0.7;',
+					selectable: false,
+					deletable: false
+				});
+			}
+		}
+		// MG → dim (via dimension links).  Degenerate 'fact' links get
+		// a faint dashed "on fact" line so the semantic view mirrors
+		// the physical view — otherwise degenerate dims float without
+		// a visible tie to their MG.
+		for (const mg of measureGroups) {
+			for (const link of mg.dimensionLinks ?? []) {
+				const kind = link.linkKind ?? 'foreign-key';
+				if (kind === 'fact') {
+					out.push({
+						id: `e:mg-dim-onfact:${mg.id}:${link.dimensionId}`,
+						source: `mg:${mg.id}`,
+						target: `dim:${link.dimensionId}`,
+						type: 'default',
+						label: 'on fact',
+						labelStyle: 'font-family: ui-monospace, monospace; font-size: 10px;',
+						style:
+							'stroke: hsl(var(--muted-foreground)); stroke-width: 1; stroke-dasharray: 4 4; opacity: 0.5;',
+						selectable: false,
+						deletable: false
+					});
+					continue;
+				}
+				out.push({
+					id: `e:mg-dim:${mg.id}:${link.dimensionId}`,
+					source: `mg:${mg.id}`,
+					target: `dim:${link.dimensionId}`,
+					type: 'default',
+					style: 'stroke: hsl(275 55% 60% / 0.7); stroke-width: 1.5;',
+					selectable: false,
+					deletable: false
+				});
+			}
+		}
+		return out;
+	});
+
+	// Sync computed → SvelteFlow bindables.  Preserve user-dragged
+	// positions on subsequent data changes; `resetSignal` is a
+	// parent-owned bump counter — the parent's Reset positions button
+	// changes it, next tick throws away the drags and re-lays-out.
+	let flowNodes = $state<Node[]>([]);
+	let flowEdges = $state<Edge[]>([]);
+	$effect(() => {
+		const computed = nodes;
+		const reset = resetSignal;
+		untrack(() => {
+			if (reset > 0) {
+				flowNodes = computed;
+				return;
+			}
+			const posById = new Map(flowNodes.map((n) => [n.id, n.position]));
+			flowNodes = computed.map((n) => {
+				const savedPos = posById.get(n.id);
+				return savedPos ? { ...n, position: savedPos } : n;
+			});
+		});
+	});
+	$effect(() => {
+		flowEdges = edges;
+	});
+
+	const hasContent = $derived(clusters.length > 0 || linkedDimIds.length > 0);
+</script>
+
+<div class="relative h-full w-full" data-testid="cube-dag">
+	{#if !cubeId || !hasContent}
+		<div
+			class="flex h-full flex-col items-center justify-center gap-2 p-4 text-center"
+			style:background-color="hsl(var(--muted)/0.2)"
+		>
+			<p class="text-sm font-medium">Nothing to map yet</p>
+			<p class="max-w-md text-[11px] text-muted-foreground">
+				Set up a measure group + link at least one dimension on <span class="font-medium"
+					>Facts &amp; Measures</span
+				>. The DAG will draw itself.
+			</p>
+		</div>
+	{:else}
+		<!-- Cube pill, Semantic/Physical toggle, and Reset positions all
+		     live in the parent confirmCubeModel wrapper now. -->
+		<SvelteFlow
+			bind:nodes={flowNodes}
+			bind:edges={flowEdges}
+			{nodeTypes}
+			fitView
+			fitViewOptions={{ padding: 0.15 }}
+			panOnDrag
+			zoomOnScroll
+			nodesDraggable
+			nodesConnectable={false}
+			edgesFocusable={false}
+			proOptions={{ hideAttribution: true }}
+			class="!bg-background"
+		>
+			<Background />
+			<Controls position="bottom-right" orientation="vertical" showLock={false} />
+		</SvelteFlow>
+	{/if}
+</div>

--- a/saiku-ui/src/lib/cube-designer/confirm-cube/CubeDagDim.svelte
+++ b/saiku-ui/src/lib/cube-designer/confirm-cube/CubeDagDim.svelte
@@ -1,0 +1,79 @@
+<!--
+  Dimension node in the cube DAG.  Header (dim name) + every hierarchy
+  + every level inside each hierarchy, all expanded by default.  No
+  source table listed — semantic view only.
+-->
+<script lang="ts">
+	import { Handle, Position, type NodeProps } from '@xyflow/svelte';
+
+	interface DimHierLevel {
+		id: string;
+		name: string;
+	}
+	interface DimHier {
+		id: string;
+		name: string;
+		levels: DimHierLevel[];
+	}
+	interface DimData {
+		name: string;
+		hierarchies: DimHier[];
+	}
+
+	let { data }: NodeProps & { data: DimData } = $props();
+</script>
+
+<div
+	class="max-w-72 min-w-56 rounded-md border bg-card px-3 py-2 shadow-sm"
+	style:border-color="hsl(var(--border))"
+	data-testid="cube-dag-dim"
+>
+	<div class="flex items-center gap-2">
+		<span
+			class="rounded-full border border-primary/40 bg-primary/10 px-1.5 py-0.5 font-mono text-[9px] font-bold tracking-wider text-primary uppercase"
+		>
+			Dim
+		</span>
+		<div class="min-w-0 flex-1 truncate font-semibold">{data.name}</div>
+	</div>
+	{#if data.hierarchies.length > 0}
+		<ul class="mt-2 flex flex-col gap-2 pt-1.5" style:border-top="1px solid hsl(var(--border))">
+			{#each data.hierarchies as h (h.id)}
+				<li>
+					<div class="flex items-center gap-1.5 text-[10px] font-semibold tracking-wide">
+						<span
+							class="rounded px-1 py-0.5 font-mono text-[9px] uppercase"
+							style:background-color="hsl(var(--muted))"
+							style:color="hsl(var(--muted-foreground))"
+						>
+							Hier
+						</span>
+						<span class="min-w-0 truncate">{h.name}</span>
+					</div>
+					{#if h.levels.length > 0}
+						<ol class="mt-0.5 flex flex-col gap-0.5 pl-4 font-mono text-[10px]">
+							{#each h.levels as lvl, i (lvl.id)}
+								<li class="flex items-center gap-1.5 truncate">
+									<span class="w-3 shrink-0 text-right text-muted-foreground opacity-60">
+										{i + 1}
+									</span>
+									<span class="truncate">{lvl.name}</span>
+								</li>
+							{/each}
+						</ol>
+					{:else}
+						<p class="mt-0.5 pl-4 text-[10px] italic opacity-60">No levels yet</p>
+					{/if}
+				</li>
+			{/each}
+		</ul>
+	{:else}
+		<p
+			class="mt-2 pt-1.5 text-[10px] italic opacity-60"
+			style:border-top="1px solid hsl(var(--border))"
+		>
+			No hierarchies yet
+		</p>
+	{/if}
+	<Handle type="target" position={Position.Left} style="opacity: 0; pointer-events: none;" />
+</div>

--- a/saiku-ui/src/lib/cube-designer/confirm-cube/CubeDagFact.svelte
+++ b/saiku-ui/src/lib/cube-designer/confirm-cube/CubeDagFact.svelte
@@ -1,0 +1,60 @@
+<!--
+  Fact-table node in the cube DAG.  Compact card — table name +
+  qualified subtitle + which MGs use it (as small chips).  Purple
+  tinted (matches the earlier confirm cube canvas's fact styling).
+-->
+<script lang="ts">
+	import { Handle, Position, type NodeProps } from '@xyflow/svelte';
+
+	interface FactData {
+		tableName: string;
+		tableSubtitle: string | null;
+		mgNames: string[];
+	}
+
+	let { data }: NodeProps & { data: FactData } = $props();
+</script>
+
+<!-- Pastel bg via scoped style so light + dark render right
+     regardless of Tailwind JIT scanning arbitrary values. -->
+<div
+	class="cube-dag-fact max-w-64 min-w-52 rounded-md border px-3 py-2 text-foreground shadow-sm dark:text-white"
+	style:border-color="hsl(275 35% 78%)"
+	data-testid="cube-dag-fact"
+>
+	<div class="flex items-center gap-2">
+		<!-- FACT chip: dusty pastel purple + white text; text centered
+		     via inline-flex + items/justify-center. -->
+		<span
+			class="inline-flex items-center justify-center rounded-full px-2 py-0.5 font-mono text-[9px] font-bold tracking-wider text-white uppercase"
+			style:background-color="hsl(275 30% 55%)"
+		>
+			Fact
+		</span>
+		<div class="min-w-0 flex-1 truncate font-mono text-xs font-semibold">
+			{data.tableName}
+		</div>
+	</div>
+	{#if data.tableSubtitle}
+		<div class="mt-0.5 truncate pl-0.5 font-mono text-[10px] opacity-70">
+			{data.tableSubtitle}
+		</div>
+	{/if}
+	<Handle type="source" position={Position.Right} style="opacity: 0; pointer-events: none;" />
+</div>
+
+<style>
+	/* Light default; dark swaps under the app's [data-theme] rules
+	   (see FactCard.svelte for the reasoning). */
+	.cube-dag-fact {
+		background-color: hsl(275 45% 96%);
+	}
+	:global(:root[data-theme='dark']) .cube-dag-fact {
+		background-color: hsl(275 35% 22%);
+	}
+	@media (prefers-color-scheme: dark) {
+		:global(:root:not([data-theme='light'])) .cube-dag-fact {
+			background-color: hsl(275 35% 22%);
+		}
+	}
+</style>

--- a/saiku-ui/src/lib/cube-designer/confirm-cube/CubeDagMG.svelte
+++ b/saiku-ui/src/lib/cube-designer/confirm-cube/CubeDagMG.svelte
@@ -1,0 +1,53 @@
+<!--
+  Measure Group node in the cube DAG.  Header + inline list of the
+  MG's measure columns.  Handles on both sides so fact→MG edges
+  come in from the left and MG→dim edges leave from the right.
+-->
+<script lang="ts">
+	import { Handle, Position, type NodeProps } from '@xyflow/svelte';
+
+	interface MGData {
+		name: string;
+		measures: string[];
+	}
+
+	let { data }: NodeProps & { data: MGData } = $props();
+</script>
+
+<div
+	class="max-w-64 min-w-48 rounded-md border bg-card px-3 py-2 shadow-sm"
+	style:border-color="hsl(var(--border))"
+	data-testid="cube-dag-mg"
+>
+	<div class="flex items-center gap-2">
+		<span
+			class="rounded-full border border-primary/40 bg-primary/10 px-1.5 py-0.5 font-mono text-[9px] font-bold tracking-wider text-primary uppercase"
+		>
+			MG
+		</span>
+		<div class="min-w-0 flex-1 truncate font-semibold">{data.name}</div>
+	</div>
+	{#if data.measures.length > 0}
+		<ul
+			class="mt-2 flex flex-col gap-0.5 pt-1.5 pl-1 font-mono text-[10px]"
+			style:border-top="1px solid hsl(var(--border))"
+			style:color="hsl(var(--muted-foreground))"
+		>
+			{#each data.measures as m (m)}
+				<li class="truncate">
+					<span class="opacity-50">Σ</span>
+					{m}
+				</li>
+			{/each}
+		</ul>
+	{:else}
+		<p
+			class="mt-2 pt-1.5 text-[10px] italic opacity-60"
+			style:border-top="1px solid hsl(var(--border))"
+		>
+			No measures picked
+		</p>
+	{/if}
+	<Handle type="target" position={Position.Left} style="opacity: 0; pointer-events: none;" />
+	<Handle type="source" position={Position.Right} style="opacity: 0; pointer-events: none;" />
+</div>

--- a/saiku-ui/src/lib/cube-designer/confirm-cube/DimCard.svelte
+++ b/saiku-ui/src/lib/cube-designer/confirm-cube/DimCard.svelte
@@ -1,0 +1,67 @@
+<!--
+  Dimension card for the Confirm cube canvas.  Shows the dim name +
+  its source table.  Degenerate dims (FactLink) get a subtle badge
+  because there's no separate table to point at.
+-->
+<script lang="ts">
+	import { Handle, Position, type NodeProps } from '@xyflow/svelte';
+
+	interface DimCardData {
+		dimName: string;
+		tableName: string | null;
+		tableSubtitle: string | null;
+		isDegenerate: boolean;
+		fkColumn: string | null;
+		primaryKey: string | null;
+	}
+
+	let { data }: NodeProps & { data: DimCardData } = $props();
+</script>
+
+<div
+	class="max-w-56 min-w-44 rounded-md border bg-card px-2.5 py-1.5 text-xs shadow-sm"
+	style:border-color="hsl(var(--border))"
+	data-testid="confirm-dim-card"
+>
+	<div class="flex items-center gap-1.5">
+		{#if data.isDegenerate}
+			<span
+				class="rounded-full px-1.5 py-0.5 font-mono text-[9px] font-bold tracking-wider text-primary uppercase"
+				style:background-color="hsl(var(--primary) / 0.15)"
+				style:border="1px solid hsl(var(--primary) / 0.4)"
+				title="Degenerate dimension — Mondrian emits <FactLink> instead of <ForeignKeyLink>."
+			>
+				FactLink
+			</span>
+		{:else}
+			<span
+				class="rounded-full px-1.5 py-0.5 font-mono text-[9px] font-bold tracking-wider uppercase"
+				style:background-color="hsl(var(--muted-foreground) / 0.15)"
+				style:color="hsl(var(--muted-foreground))"
+			>
+				Dim
+			</span>
+		{/if}
+		<div class="min-w-0 flex-1 truncate font-medium">{data.dimName}</div>
+	</div>
+	{#if data.tableName}
+		<div
+			class="mt-0.5 truncate pl-0.5 font-mono text-[10px]"
+			style:color="hsl(var(--muted-foreground))"
+		>
+			{data.tableSubtitle ?? data.tableName}
+		</div>
+	{/if}
+	{#if !data.isDegenerate && (data.fkColumn || data.primaryKey)}
+		<div
+			class="mt-1 pt-1 font-mono text-[9px]"
+			style:border-top="1px solid hsl(var(--border))"
+			style:color="hsl(var(--muted-foreground))"
+		>
+			{data.fkColumn ?? '?'} <span class="opacity-60">→</span>
+			{data.primaryKey ?? '?'}
+		</div>
+	{/if}
+	<Handle type="target" position={Position.Left} style="opacity: 0; pointer-events: none;" />
+	<Handle type="target" position={Position.Right} style="opacity: 0; pointer-events: none;" />
+</div>

--- a/saiku-ui/src/lib/cube-designer/confirm-cube/FKLabelEdge.svelte
+++ b/saiku-ui/src/lib/cube-designer/confirm-cube/FKLabelEdge.svelte
@@ -1,0 +1,51 @@
+<!--
+  Custom edge for the Confirm cube Canvas.  Renders a bezier path with
+  a foreignObject-hosted HTML label at the midpoint — full CSS control,
+  so the label is guaranteed readable on any theme (no SvelteFlow-
+  default white <rect> covering the text).
+-->
+<script lang="ts">
+	import { BaseEdge, EdgeLabel, getBezierPath, type EdgeProps } from '@xyflow/svelte';
+
+	interface FKLabelEdgeData {
+		label: string;
+	}
+
+	let {
+		id,
+		sourceX,
+		sourceY,
+		targetX,
+		targetY,
+		sourcePosition,
+		targetPosition,
+		markerEnd,
+		style,
+		data
+	}: EdgeProps & { data?: FKLabelEdgeData } = $props();
+
+	const path = $derived(
+		getBezierPath({
+			sourceX,
+			sourceY,
+			sourcePosition,
+			targetX,
+			targetY,
+			targetPosition
+		})
+	);
+</script>
+
+<BaseEdge {id} path={path[0]} {markerEnd} {style} />
+{#if data?.label}
+	<!-- `transparent={true}` on EdgeLabel drops the default
+	     .svelte-flow__edge-label background frame; only our themed
+	     pill inside stays visible. -->
+	<EdgeLabel x={path[1]} y={path[2]} transparent>
+		<div
+			class="pointer-events-none rounded bg-card/90 px-1.5 py-0.5 font-mono text-[10px] whitespace-nowrap text-foreground"
+		>
+			{data.label}
+		</div>
+	</EdgeLabel>
+{/if}

--- a/saiku-ui/src/lib/cube-designer/confirm-cube/FactCard.svelte
+++ b/saiku-ui/src/lib/cube-designer/confirm-cube/FactCard.svelte
@@ -1,0 +1,85 @@
+<!--
+  Purple-accented fact-table card for the Confirm cube canvas.  Shows
+  the table name + the measure-group names whose fact table this is.
+  Handles on both sides so dim edges can attach on whichever side
+  the layout puts them.
+-->
+<script lang="ts">
+	import { Handle, Position, type NodeProps } from '@xyflow/svelte';
+
+	interface FactCardData {
+		tableName: string;
+		tableSubtitle: string | null;
+		mgNames: string[];
+	}
+
+	let { data }: NodeProps & { data: FactCardData } = $props();
+</script>
+
+<!-- Pastel bg via a scoped style block so light + dark render right
+     regardless of Tailwind JIT scanning arbitrary values. -->
+<div
+	class="fact-card max-w-64 min-w-52 rounded-lg border px-3 py-2 text-foreground shadow-sm dark:text-white"
+	style:border-color="hsl(275 35% 78%)"
+	data-testid="confirm-fact-card"
+>
+	<div class="flex items-center gap-2">
+		<!-- FACT chip: dusty pastel purple + white text.  Text centered
+		     via inline-flex + items/justify-center. -->
+		<span
+			class="inline-flex items-center justify-center rounded-full px-2 py-0.5 font-mono text-[9px] font-bold tracking-wider text-white uppercase"
+			style:background-color="hsl(275 30% 55%)"
+		>
+			Fact
+		</span>
+		<div class="min-w-0 flex-1 truncate font-mono text-xs font-semibold">
+			{data.tableName}
+		</div>
+	</div>
+	{#if data.tableSubtitle}
+		<div class="mt-0.5 truncate pl-0.5 font-mono text-[10px] opacity-70">
+			{data.tableSubtitle}
+		</div>
+	{/if}
+	{#if data.mgNames.length > 0}
+		<div
+			class="mt-2 flex flex-wrap gap-1 pt-1.5"
+			style:border-top="1px solid hsl(275 40% 45% / 0.5)"
+		>
+			<span class="text-[9px] font-semibold tracking-wider uppercase opacity-60">MG</span>
+			{#each data.mgNames as name (name)}
+				<span
+					class="rounded px-1.5 py-0.5 text-[10px] font-medium"
+					style:background-color="hsl(275 55% 40% / 0.5)"
+					style:color="hsl(275 30% 95%)"
+				>
+					{name}
+				</span>
+			{/each}
+		</div>
+	{/if}
+	<!-- Handles on both sides so edges can leave in either direction -->
+	<Handle type="source" position={Position.Right} style="opacity: 0; pointer-events: none;" />
+	<Handle type="source" position={Position.Left} style="opacity: 0; pointer-events: none;" />
+	<Handle type="target" position={Position.Right} style="opacity: 0; pointer-events: none;" />
+	<Handle type="target" position={Position.Left} style="opacity: 0; pointer-events: none;" />
+</div>
+
+<style>
+	/* Light default — pale lavender wash.  Dark bg swaps under the SAME
+	   rule the app-wide tokens use: explicit [data-theme='dark'] override,
+	   OR system dark with no explicit [data-theme='light'] override.
+	   Plain `:global(.dark)` doesn't fire in this app — theme uses
+	   [data-theme] attrs, not a .dark class. */
+	.fact-card {
+		background-color: hsl(275 45% 96%);
+	}
+	:global(:root[data-theme='dark']) .fact-card {
+		background-color: hsl(275 35% 22%);
+	}
+	@media (prefers-color-scheme: dark) {
+		:global(:root:not([data-theme='light'])) .fact-card {
+			background-color: hsl(275 35% 22%);
+		}
+	}
+</style>

--- a/saiku-ui/src/lib/cube-designer/dimsum-agent.test.ts
+++ b/saiku-ui/src/lib/cube-designer/dimsum-agent.test.ts
@@ -1,0 +1,66 @@
+/**
+ * Unit tests for the DimSum agent-loop request/response shaping.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { buildDimSumRequestBody, postDimSumTurn } from './dimsum-agent.js';
+import type { AnthropicBlock, ChatMessage } from './ai-chat-types';
+
+describe('buildDimSumRequestBody', () => {
+	it('strips the display-only ts and carries the canvas summary', () => {
+		const messages: ChatMessage[] = [
+			{ role: 'user', content: 'draft me a cube', ts: 111 },
+			{ role: 'assistant', content: [{ type: 'text', text: 'ok' }], ts: 222 }
+		];
+
+		const body = buildDimSumRequestBody(messages, 'SUMMARY');
+
+		expect(body.canvasSummary).toBe('SUMMARY');
+		expect(body.messages).toEqual([
+			{ role: 'user', content: 'draft me a cube' },
+			{ role: 'assistant', content: [{ type: 'text', text: 'ok' }] }
+		]);
+		// The ts field must not leak to the wire.
+		expect(body.messages.every((m) => !('ts' in m))).toBe(true);
+	});
+});
+
+describe('postDimSumTurn', () => {
+	function jsonResponse(status: number, payload: unknown): Response {
+		return {
+			ok: status >= 200 && status < 300,
+			status,
+			json: async () => payload
+		} as unknown as Response;
+	}
+
+	it('posts to the DimSum endpoint and returns the assistant content blocks', async () => {
+		const blocks: AnthropicBlock[] = [{ type: 'text', text: 'done' }];
+		const fetchImpl = vi.fn(async () =>
+			jsonResponse(200, { stopReason: 'end_turn', content: blocks })
+		);
+
+		const out = await postDimSumTurn(
+			[{ role: 'user', content: 'hi', ts: 1 }],
+			'SUMMARY',
+			fetchImpl as unknown as typeof fetch
+		);
+
+		expect(out).toEqual(blocks);
+		expect(fetchImpl).toHaveBeenCalledTimes(1);
+		const [url, init] = fetchImpl.mock.calls[0] as unknown as [string, RequestInit];
+		expect(url).toBe('/api/inference/dimsum');
+		expect(init.method).toBe('POST');
+		expect(JSON.parse(init.body as string).canvasSummary).toBe('SUMMARY');
+	});
+
+	it('returns an empty array when the payload has no content', async () => {
+		const fetchImpl = vi.fn(async () => jsonResponse(200, { stopReason: 'end_turn' }));
+		const out = await postDimSumTurn([], 'S', fetchImpl as unknown as typeof fetch);
+		expect(out).toEqual([]);
+	});
+
+	it('throws a gateway-shaped error on a non-2xx response', async () => {
+		const fetchImpl = vi.fn(async () => jsonResponse(500, { message: 'kaboom' }));
+		await expect(postDimSumTurn([], 'S', fetchImpl as unknown as typeof fetch)).rejects.toThrow();
+	});
+});

--- a/saiku-ui/src/lib/cube-designer/dimsum-agent.test.ts
+++ b/saiku-ui/src/lib/cube-designer/dimsum-agent.test.ts
@@ -1,66 +1,79 @@
 /**
  * Unit tests for the DimSum agent-loop request/response shaping.
  */
-import { describe, it, expect, vi } from 'vitest';
-import { buildDimSumRequestBody, postDimSumTurn } from './dimsum-agent.js';
-import type { AnthropicBlock, ChatMessage } from './ai-chat-types';
+import { describe, it, expect, vi } from "vitest";
+import { buildDimSumRequestBody, postDimSumTurn } from "./dimsum-agent.js";
+import type { AnthropicBlock, ChatMessage } from "./ai-chat-types";
 
-describe('buildDimSumRequestBody', () => {
-	it('strips the display-only ts and carries the canvas summary', () => {
-		const messages: ChatMessage[] = [
-			{ role: 'user', content: 'draft me a cube', ts: 111 },
-			{ role: 'assistant', content: [{ type: 'text', text: 'ok' }], ts: 222 }
-		];
+describe("buildDimSumRequestBody", () => {
+  it("strips the display-only ts and carries the canvas summary", () => {
+    const messages: ChatMessage[] = [
+      { role: "user", content: "draft me a cube", ts: 111 },
+      { role: "assistant", content: [{ type: "text", text: "ok" }], ts: 222 },
+    ];
 
-		const body = buildDimSumRequestBody(messages, 'SUMMARY');
+    const body = buildDimSumRequestBody(messages, "SUMMARY");
 
-		expect(body.canvasSummary).toBe('SUMMARY');
-		expect(body.messages).toEqual([
-			{ role: 'user', content: 'draft me a cube' },
-			{ role: 'assistant', content: [{ type: 'text', text: 'ok' }] }
-		]);
-		// The ts field must not leak to the wire.
-		expect(body.messages.every((m) => !('ts' in m))).toBe(true);
-	});
+    expect(body.canvasSummary).toBe("SUMMARY");
+    expect(body.messages).toEqual([
+      { role: "user", content: "draft me a cube" },
+      { role: "assistant", content: [{ type: "text", text: "ok" }] },
+    ]);
+    // The ts field must not leak to the wire.
+    expect(body.messages.every((m) => !("ts" in m))).toBe(true);
+  });
 });
 
-describe('postDimSumTurn', () => {
-	function jsonResponse(status: number, payload: unknown): Response {
-		return {
-			ok: status >= 200 && status < 300,
-			status,
-			json: async () => payload
-		} as unknown as Response;
-	}
+describe("postDimSumTurn", () => {
+  function jsonResponse(status: number, payload: unknown): Response {
+    return {
+      ok: status >= 200 && status < 300,
+      status,
+      json: async () => payload,
+    } as unknown as Response;
+  }
 
-	it('posts to the DimSum endpoint and returns the assistant content blocks', async () => {
-		const blocks: AnthropicBlock[] = [{ type: 'text', text: 'done' }];
-		const fetchImpl = vi.fn(async () =>
-			jsonResponse(200, { stopReason: 'end_turn', content: blocks })
-		);
+  it("posts to the DimSum endpoint and returns the assistant content blocks", async () => {
+    const blocks: AnthropicBlock[] = [{ type: "text", text: "done" }];
+    const fetchImpl = vi.fn(async () =>
+      jsonResponse(200, { stopReason: "end_turn", content: blocks }),
+    );
 
-		const out = await postDimSumTurn(
-			[{ role: 'user', content: 'hi', ts: 1 }],
-			'SUMMARY',
-			fetchImpl as unknown as typeof fetch
-		);
+    const out = await postDimSumTurn(
+      [{ role: "user", content: "hi", ts: 1 }],
+      "SUMMARY",
+      fetchImpl as unknown as typeof fetch,
+    );
 
-		expect(out).toEqual(blocks);
-		expect(fetchImpl).toHaveBeenCalledTimes(1);
-		const [url, init] = fetchImpl.mock.calls[0] as unknown as [string, RequestInit];
-		expect(url).toBe('/api/inference/dimsum');
-		expect(init.method).toBe('POST');
-		expect(JSON.parse(init.body as string).canvasSummary).toBe('SUMMARY');
-	});
+    expect(out).toEqual(blocks);
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchImpl.mock.calls[0] as unknown as [
+      string,
+      RequestInit,
+    ];
+    expect(url).toBe("/api/inference/dimsum");
+    expect(init.method).toBe("POST");
+    expect(JSON.parse(init.body as string).canvasSummary).toBe("SUMMARY");
+  });
 
-	it('returns an empty array when the payload has no content', async () => {
-		const fetchImpl = vi.fn(async () => jsonResponse(200, { stopReason: 'end_turn' }));
-		const out = await postDimSumTurn([], 'S', fetchImpl as unknown as typeof fetch);
-		expect(out).toEqual([]);
-	});
+  it("returns an empty array when the payload has no content", async () => {
+    const fetchImpl = vi.fn(async () =>
+      jsonResponse(200, { stopReason: "end_turn" }),
+    );
+    const out = await postDimSumTurn(
+      [],
+      "S",
+      fetchImpl as unknown as typeof fetch,
+    );
+    expect(out).toEqual([]);
+  });
 
-	it('throws a gateway-shaped error on a non-2xx response', async () => {
-		const fetchImpl = vi.fn(async () => jsonResponse(500, { message: 'kaboom' }));
-		await expect(postDimSumTurn([], 'S', fetchImpl as unknown as typeof fetch)).rejects.toThrow();
-	});
+  it("throws a gateway-shaped error on a non-2xx response", async () => {
+    const fetchImpl = vi.fn(async () =>
+      jsonResponse(500, { message: "kaboom" }),
+    );
+    await expect(
+      postDimSumTurn([], "S", fetchImpl as unknown as typeof fetch),
+    ).rejects.toThrow();
+  });
 });

--- a/saiku-ui/src/lib/cube-designer/dimsum-agent.ts
+++ b/saiku-ui/src/lib/cube-designer/dimsum-agent.ts
@@ -8,13 +8,16 @@
  * the running chat history + canvas summary, and turning one HTTP turn into
  * the assistant's content blocks (throwing a gateway-shaped Error on failure).
  */
-import { readGatewayErrorMessage } from './gateway-errors';
-import type { AnthropicBlock, ChatMessage } from './ai-chat-types';
+import { readGatewayErrorMessage } from "./gateway-errors";
+import type { AnthropicBlock, ChatMessage } from "./ai-chat-types";
 
 /** Wire body the gateway's DimSum endpoint expects. */
 export interface DimSumRequestBody {
-	messages: Array<{ role: ChatMessage['role']; content: ChatMessage['content'] }>;
-	canvasSummary: string;
+  messages: Array<{
+    role: ChatMessage["role"];
+    content: ChatMessage["content"];
+  }>;
+  canvasSummary: string;
 }
 
 /**
@@ -23,13 +26,13 @@ export interface DimSumRequestBody {
  * `{ role, content }` — the `ts` display metadata never goes to the server.
  */
 export function buildDimSumRequestBody(
-	messages: ChatMessage[],
-	canvasSummary: string
+  messages: ChatMessage[],
+  canvasSummary: string,
 ): DimSumRequestBody {
-	return {
-		messages: messages.map((m) => ({ role: m.role, content: m.content })),
-		canvasSummary
-	};
+  return {
+    messages: messages.map((m) => ({ role: m.role, content: m.content })),
+    canvasSummary,
+  };
 }
 
 /**
@@ -42,27 +45,31 @@ export function buildDimSumRequestBody(
  * network (defaults to the global `fetch`).
  */
 export async function postDimSumTurn(
-	messages: ChatMessage[],
-	canvasSummary: string,
-	fetchImpl: typeof fetch = fetch
+  messages: ChatMessage[],
+  canvasSummary: string,
+  fetchImpl: typeof fetch = fetch,
 ): Promise<AnthropicBlock[]> {
-	const resp = await fetchImpl('/api/inference/dimsum', {
-		method: 'POST',
-		headers: { 'Content-Type': 'application/json' },
-		body: JSON.stringify(buildDimSumRequestBody(messages, canvasSummary))
-	});
-	if (!resp.ok) {
-		const body = (await resp.json().catch(() => ({}))) as {
-			message?: string;
-			error?: string;
-		};
-		throw new Error(
-			readGatewayErrorMessage(resp.status, body, `AI call failed (HTTP ${resp.status}).`)
-		);
-	}
-	const payload = (await resp.json()) as {
-		stopReason?: string;
-		content?: AnthropicBlock[];
-	};
-	return payload.content ?? [];
+  const resp = await fetchImpl("/api/inference/dimsum", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(buildDimSumRequestBody(messages, canvasSummary)),
+  });
+  if (!resp.ok) {
+    const body = (await resp.json().catch(() => ({}))) as {
+      message?: string;
+      error?: string;
+    };
+    throw new Error(
+      readGatewayErrorMessage(
+        resp.status,
+        body,
+        `AI call failed (HTTP ${resp.status}).`,
+      ),
+    );
+  }
+  const payload = (await resp.json()) as {
+    stopReason?: string;
+    content?: AnthropicBlock[];
+  };
+  return payload.content ?? [];
 }

--- a/saiku-ui/src/lib/cube-designer/dimsum-agent.ts
+++ b/saiku-ui/src/lib/cube-designer/dimsum-agent.ts
@@ -1,0 +1,68 @@
+/**
+ * DimSum agent-loop request/response shaping — lifted out of
+ * SchemaCanvasView.svelte (audit finding #1040).
+ *
+ * The `.svelte` component still owns the loop orchestration + all reactive
+ * `$state` (drafting flag, error text, message history). These pure helpers
+ * own the wire format: building the `/api/inference/dimsum` request body from
+ * the running chat history + canvas summary, and turning one HTTP turn into
+ * the assistant's content blocks (throwing a gateway-shaped Error on failure).
+ */
+import { readGatewayErrorMessage } from './gateway-errors';
+import type { AnthropicBlock, ChatMessage } from './ai-chat-types';
+
+/** Wire body the gateway's DimSum endpoint expects. */
+export interface DimSumRequestBody {
+	messages: Array<{ role: ChatMessage['role']; content: ChatMessage['content'] }>;
+	canvasSummary: string;
+}
+
+/**
+ * Build the `/api/inference/dimsum` request body from the rolling chat
+ * history + the current canvas summary. Strips each turn down to
+ * `{ role, content }` — the `ts` display metadata never goes to the server.
+ */
+export function buildDimSumRequestBody(
+	messages: ChatMessage[],
+	canvasSummary: string
+): DimSumRequestBody {
+	return {
+		messages: messages.map((m) => ({ role: m.role, content: m.content })),
+		canvasSummary
+	};
+}
+
+/**
+ * Run one DimSum agent turn against the gateway and return the assistant's
+ * content blocks. Throws a gateway-shaped Error (via
+ * {@link readGatewayErrorMessage}) on a non-2xx response so the caller's
+ * try/catch can surface it as `aiError`.
+ *
+ * `fetchImpl` is injectable so unit tests can drive the shaping without a
+ * network (defaults to the global `fetch`).
+ */
+export async function postDimSumTurn(
+	messages: ChatMessage[],
+	canvasSummary: string,
+	fetchImpl: typeof fetch = fetch
+): Promise<AnthropicBlock[]> {
+	const resp = await fetchImpl('/api/inference/dimsum', {
+		method: 'POST',
+		headers: { 'Content-Type': 'application/json' },
+		body: JSON.stringify(buildDimSumRequestBody(messages, canvasSummary))
+	});
+	if (!resp.ok) {
+		const body = (await resp.json().catch(() => ({}))) as {
+			message?: string;
+			error?: string;
+		};
+		throw new Error(
+			readGatewayErrorMessage(resp.status, body, `AI call failed (HTTP ${resp.status}).`)
+		);
+	}
+	const payload = (await resp.json()) as {
+		stopReason?: string;
+		content?: AnthropicBlock[];
+	};
+	return payload.content ?? [];
+}

--- a/saiku-ui/src/lib/cube-designer/dimsum-tools.test.ts
+++ b/saiku-ui/src/lib/cube-designer/dimsum-tools.test.ts
@@ -5,639 +5,710 @@
  * Node-env vitest; no Svelte render harness needed (the store is a plain
  * runes class that works headless).
  */
-import { describe, it, expect, vi } from 'vitest';
-import { SchemaCanvasStore } from './state.svelte.js';
-import type { SourceTableCandidate } from './types.js';
+import { describe, it, expect, vi } from "vitest";
+import { SchemaCanvasStore } from "./state.svelte.js";
+import type { SourceTableCandidate } from "./types.js";
 import {
-	buildCanvasSummary,
-	executeDimSumTool,
-	reconcileMeasureGroupLinks,
-	findTableByName,
-	DIMSUM_MUTATION_TOOLS,
-	type DimSumToolDeps
-} from './dimsum-tools.js';
+  buildCanvasSummary,
+  executeDimSumTool,
+  reconcileMeasureGroupLinks,
+  findTableByName,
+  DIMSUM_MUTATION_TOOLS,
+  type DimSumToolDeps,
+} from "./dimsum-tools.js";
 
 // ── fixtures ─────────────────────────────────────────────────────
 function candidate(
-	name: string,
-	columns: string[],
-	schema: string | null = 'public'
+  name: string,
+  columns: string[],
+  schema: string | null = "public",
 ): SourceTableCandidate {
-	return {
-		schema,
-		name,
-		columns: columns.map((c) => ({ name: c, sqlType: 'INTEGER' })),
-		onCanvas: false
-	};
+  return {
+    schema,
+    name,
+    columns: columns.map((c) => ({ name: c, sqlType: "INTEGER" })),
+    onCanvas: false,
+  };
 }
 
 function makeStore(): SchemaCanvasStore {
-	return new SchemaCanvasStore('conn-dimsum');
+  return new SchemaCanvasStore("conn-dimsum");
 }
 
 function noopDeps(): DimSumToolDeps {
-	return { arrangeCanvas: vi.fn(async () => {}) };
+  return { arrangeCanvas: vi.fn(async () => {}) };
 }
 
 /** Add a table to the canvas and return its id. */
-function addCanvasTable(store: SchemaCanvasStore, name: string, columns: string[]): string {
-	return store.addTable(candidate(name, columns), { x: 0, y: 0 }).id;
+function addCanvasTable(
+  store: SchemaCanvasStore,
+  name: string,
+  columns: string[],
+): string {
+  return store.addTable(candidate(name, columns), { x: 0, y: 0 }).id;
 }
 
 function parse(content: string): Record<string, unknown> {
-	return JSON.parse(content) as Record<string, unknown>;
+  return JSON.parse(content) as Record<string, unknown>;
 }
 
-describe('DIMSUM_MUTATION_TOOLS', () => {
-	it('contains the ten mutating tools and excludes read-only ones', () => {
-		expect(DIMSUM_MUTATION_TOOLS.size).toBe(10);
-		expect(DIMSUM_MUTATION_TOOLS.has('add_join')).toBe(true);
-		expect(DIMSUM_MUTATION_TOOLS.has('add_measure')).toBe(true);
-		expect(DIMSUM_MUTATION_TOOLS.has('list_tables')).toBe(false);
-		expect(DIMSUM_MUTATION_TOOLS.has('arrange_canvas')).toBe(false);
-	});
+describe("DIMSUM_MUTATION_TOOLS", () => {
+  it("contains the ten mutating tools and excludes read-only ones", () => {
+    expect(DIMSUM_MUTATION_TOOLS.size).toBe(10);
+    expect(DIMSUM_MUTATION_TOOLS.has("add_join")).toBe(true);
+    expect(DIMSUM_MUTATION_TOOLS.has("add_measure")).toBe(true);
+    expect(DIMSUM_MUTATION_TOOLS.has("list_tables")).toBe(false);
+    expect(DIMSUM_MUTATION_TOOLS.has("arrange_canvas")).toBe(false);
+  });
 });
 
-describe('executeDimSumTool — read-only tools', () => {
-	it('list_tables splits on-canvas from available catalog tables', async () => {
-		const store = makeStore();
-		addCanvasTable(store, 'sales', ['id', 'amount']);
-		store.sourceTables = [candidate('sales', ['id', 'amount']), candidate('product', ['id'])];
+describe("executeDimSumTool — read-only tools", () => {
+  it("list_tables splits on-canvas from available catalog tables", async () => {
+    const store = makeStore();
+    addCanvasTable(store, "sales", ["id", "amount"]);
+    store.sourceTables = [
+      candidate("sales", ["id", "amount"]),
+      candidate("product", ["id"]),
+    ];
 
-		const { content, isError } = await executeDimSumTool(store, 'list_tables', {}, noopDeps());
+    const { content, isError } = await executeDimSumTool(
+      store,
+      "list_tables",
+      {},
+      noopDeps(),
+    );
 
-		expect(isError).toBe(false);
-		const out = parse(content) as {
-			onCanvas: Array<{ qualifiedName: string }>;
-			available: Array<{ qualifiedName: string }>;
-		};
-		expect(out.onCanvas.map((t) => t.qualifiedName)).toEqual(['public.sales']);
-		// `sales` is on canvas so it's filtered out of available.
-		expect(out.available.map((t) => t.qualifiedName)).toEqual(['public.product']);
-	});
+    expect(isError).toBe(false);
+    const out = parse(content) as {
+      onCanvas: Array<{ qualifiedName: string }>;
+      available: Array<{ qualifiedName: string }>;
+    };
+    expect(out.onCanvas.map((t) => t.qualifiedName)).toEqual(["public.sales"]);
+    // `sales` is on canvas so it's filtered out of available.
+    expect(out.available.map((t) => t.qualifiedName)).toEqual([
+      "public.product",
+    ]);
+  });
 
-	it('describe_table returns columns + neighbouring joins for a canvas table', async () => {
-		const store = makeStore();
-		const salesId = addCanvasTable(store, 'sales', ['id', 'product_id']);
-		const productId = addCanvasTable(store, 'product', ['product_id', 'name']);
-		store.addJoin({
-			sourceTableId: salesId,
-			sourceColumnName: 'product_id',
-			targetTableId: productId,
-			targetColumnName: 'product_id',
-			kind: 'inner'
-		});
+  it("describe_table returns columns + neighbouring joins for a canvas table", async () => {
+    const store = makeStore();
+    const salesId = addCanvasTable(store, "sales", ["id", "product_id"]);
+    const productId = addCanvasTable(store, "product", ["product_id", "name"]);
+    store.addJoin({
+      sourceTableId: salesId,
+      sourceColumnName: "product_id",
+      targetTableId: productId,
+      targetColumnName: "product_id",
+      kind: "inner",
+    });
 
-		const { content, isError } = await executeDimSumTool(
-			store,
-			'describe_table',
-			{ qualifiedName: 'public.sales' },
-			noopDeps()
-		);
+    const { content, isError } = await executeDimSumTool(
+      store,
+      "describe_table",
+      { qualifiedName: "public.sales" },
+      noopDeps(),
+    );
 
-		expect(isError).toBe(false);
-		const out = parse(content) as {
-			onCanvas: boolean;
-			columns: Array<{ name: string }>;
-			joinsInvolving: Array<{ neighbor: string; thisColumn: string; neighborColumn: string }>;
-		};
-		expect(out.onCanvas).toBe(true);
-		expect(out.columns.map((c) => c.name)).toEqual(['id', 'product_id']);
-		expect(out.joinsInvolving).toHaveLength(1);
-		expect(out.joinsInvolving[0].neighbor).toBe('public.product');
-	});
+    expect(isError).toBe(false);
+    const out = parse(content) as {
+      onCanvas: boolean;
+      columns: Array<{ name: string }>;
+      joinsInvolving: Array<{
+        neighbor: string;
+        thisColumn: string;
+        neighborColumn: string;
+      }>;
+    };
+    expect(out.onCanvas).toBe(true);
+    expect(out.columns.map((c) => c.name)).toEqual(["id", "product_id"]);
+    expect(out.joinsInvolving).toHaveLength(1);
+    expect(out.joinsInvolving[0].neighbor).toBe("public.product");
+  });
 
-	it('describe_table errors on an unknown table', async () => {
-		const store = makeStore();
-		const { content, isError } = await executeDimSumTool(
-			store,
-			'describe_table',
-			{ qualifiedName: 'nope' },
-			noopDeps()
-		);
-		expect(isError).toBe(true);
-		expect(parse(content).error).toContain('No table named');
-	});
+  it("describe_table errors on an unknown table", async () => {
+    const store = makeStore();
+    const { content, isError } = await executeDimSumTool(
+      store,
+      "describe_table",
+      { qualifiedName: "nope" },
+      noopDeps(),
+    );
+    expect(isError).toBe(true);
+    expect(parse(content).error).toContain("No table named");
+  });
 
-	it('list_dimensions reports the fact table, dims and measures', async () => {
-		const store = makeStore();
-		const salesId = addCanvasTable(store, 'sales', ['id', 'amount']);
-		store.setTableRole(salesId, 'fact');
-		store.addMeasure({ tableId: salesId, columnName: 'amount', aggregator: 'sum' });
+  it("list_dimensions reports the fact table, dims and measures", async () => {
+    const store = makeStore();
+    const salesId = addCanvasTable(store, "sales", ["id", "amount"]);
+    store.setTableRole(salesId, "fact");
+    store.addMeasure({
+      tableId: salesId,
+      columnName: "amount",
+      aggregator: "sum",
+    });
 
-		const { content } = await executeDimSumTool(store, 'list_dimensions', {}, noopDeps());
-		const out = parse(content) as { factTable: string; measures: Array<{ column: string }> };
-		expect(out.factTable).toBe('public.sales');
-		expect(out.measures[0].column).toBe('amount');
-	});
+    const { content } = await executeDimSumTool(
+      store,
+      "list_dimensions",
+      {},
+      noopDeps(),
+    );
+    const out = parse(content) as {
+      factTable: string;
+      measures: Array<{ column: string }>;
+    };
+    expect(out.factTable).toBe("public.sales");
+    expect(out.measures[0].column).toBe("amount");
+  });
 });
 
-describe('executeDimSumTool — canvas mutations', () => {
-	it('add_table_to_canvas pulls a catalog table onto the canvas', async () => {
-		const store = makeStore();
-		store.sourceTables = [candidate('product', ['product_id'])];
+describe("executeDimSumTool — canvas mutations", () => {
+  it("add_table_to_canvas pulls a catalog table onto the canvas", async () => {
+    const store = makeStore();
+    store.sourceTables = [candidate("product", ["product_id"])];
 
-		const { content, isError } = await executeDimSumTool(
-			store,
-			'add_table_to_canvas',
-			{ qualifiedName: 'public.product' },
-			noopDeps()
-		);
+    const { content, isError } = await executeDimSumTool(
+      store,
+      "add_table_to_canvas",
+      { qualifiedName: "public.product" },
+      noopDeps(),
+    );
 
-		expect(isError).toBe(false);
-		expect(parse(content).added).toBe(true);
-		expect(store.doc.tables).toHaveLength(1);
-		expect(store.doc.tables[0].name).toBe('product');
-	});
+    expect(isError).toBe(false);
+    expect(parse(content).added).toBe(true);
+    expect(store.doc.tables).toHaveLength(1);
+    expect(store.doc.tables[0].name).toBe("product");
+  });
 
-	it('add_table_to_canvas is idempotent when already present', async () => {
-		const store = makeStore();
-		addCanvasTable(store, 'product', ['product_id']);
-		store.sourceTables = [candidate('product', ['product_id'])];
+  it("add_table_to_canvas is idempotent when already present", async () => {
+    const store = makeStore();
+    addCanvasTable(store, "product", ["product_id"]);
+    store.sourceTables = [candidate("product", ["product_id"])];
 
-		const { content } = await executeDimSumTool(
-			store,
-			'add_table_to_canvas',
-			{ qualifiedName: 'public.product' },
-			noopDeps()
-		);
-		expect(parse(content).added).toBe(false);
-		expect(parse(content).reason).toBe('already_on_canvas');
-		expect(store.doc.tables).toHaveLength(1);
-	});
+    const { content } = await executeDimSumTool(
+      store,
+      "add_table_to_canvas",
+      { qualifiedName: "public.product" },
+      noopDeps(),
+    );
+    expect(parse(content).added).toBe(false);
+    expect(parse(content).reason).toBe("already_on_canvas");
+    expect(store.doc.tables).toHaveLength(1);
+  });
 
-	it('add_join wires two canvas columns and remove_join drops it', async () => {
-		const store = makeStore();
-		addCanvasTable(store, 'sales', ['product_id']);
-		addCanvasTable(store, 'product', ['product_id']);
+  it("add_join wires two canvas columns and remove_join drops it", async () => {
+    const store = makeStore();
+    addCanvasTable(store, "sales", ["product_id"]);
+    addCanvasTable(store, "product", ["product_id"]);
 
-		const add = await executeDimSumTool(
-			store,
-			'add_join',
-			{
-				from: { table: 'sales', column: 'product_id' },
-				to: { table: 'product', column: 'product_id' }
-			},
-			noopDeps()
-		);
-		expect(add.isError).toBe(false);
-		expect(store.doc.joins).toHaveLength(1);
+    const add = await executeDimSumTool(
+      store,
+      "add_join",
+      {
+        from: { table: "sales", column: "product_id" },
+        to: { table: "product", column: "product_id" },
+      },
+      noopDeps(),
+    );
+    expect(add.isError).toBe(false);
+    expect(store.doc.joins).toHaveLength(1);
 
-		const rm = await executeDimSumTool(
-			store,
-			'remove_join',
-			{
-				from: { table: 'sales', column: 'product_id' },
-				to: { table: 'product', column: 'product_id' }
-			},
-			noopDeps()
-		);
-		expect(rm.isError).toBe(false);
-		expect(store.doc.joins).toHaveLength(0);
-	});
+    const rm = await executeDimSumTool(
+      store,
+      "remove_join",
+      {
+        from: { table: "sales", column: "product_id" },
+        to: { table: "product", column: "product_id" },
+      },
+      noopDeps(),
+    );
+    expect(rm.isError).toBe(false);
+    expect(store.doc.joins).toHaveLength(0);
+  });
 
-	it('add_join errors when a column is missing', async () => {
-		const store = makeStore();
-		addCanvasTable(store, 'sales', ['product_id']);
-		addCanvasTable(store, 'product', ['product_id']);
-		const { isError, content } = await executeDimSumTool(
-			store,
-			'add_join',
-			{ from: { table: 'sales', column: 'ghost' }, to: { table: 'product', column: 'product_id' } },
-			noopDeps()
-		);
-		expect(isError).toBe(true);
-		expect(parse(content).reason).toContain('ghost');
-		expect(store.doc.joins).toHaveLength(0);
-	});
+  it("add_join errors when a column is missing", async () => {
+    const store = makeStore();
+    addCanvasTable(store, "sales", ["product_id"]);
+    addCanvasTable(store, "product", ["product_id"]);
+    const { isError, content } = await executeDimSumTool(
+      store,
+      "add_join",
+      {
+        from: { table: "sales", column: "ghost" },
+        to: { table: "product", column: "product_id" },
+      },
+      noopDeps(),
+    );
+    expect(isError).toBe(true);
+    expect(parse(content).reason).toContain("ghost");
+    expect(store.doc.joins).toHaveLength(0);
+  });
 
-	it('remove_table_from_canvas removes the table and reports cascaded joins', async () => {
-		const store = makeStore();
-		const salesId = addCanvasTable(store, 'sales', ['product_id']);
-		const productId = addCanvasTable(store, 'product', ['product_id']);
-		store.addJoin({
-			sourceTableId: salesId,
-			sourceColumnName: 'product_id',
-			targetTableId: productId,
-			targetColumnName: 'product_id',
-			kind: 'inner'
-		});
+  it("remove_table_from_canvas removes the table and reports cascaded joins", async () => {
+    const store = makeStore();
+    const salesId = addCanvasTable(store, "sales", ["product_id"]);
+    const productId = addCanvasTable(store, "product", ["product_id"]);
+    store.addJoin({
+      sourceTableId: salesId,
+      sourceColumnName: "product_id",
+      targetTableId: productId,
+      targetColumnName: "product_id",
+      kind: "inner",
+    });
 
-		const { content } = await executeDimSumTool(
-			store,
-			'remove_table_from_canvas',
-			{ qualifiedName: 'public.product' },
-			noopDeps()
-		);
-		expect(parse(content).removed).toBe(true);
-		expect(parse(content).joinsRemoved).toBe(1);
-		expect(store.doc.tables).toHaveLength(1);
-		expect(store.doc.joins).toHaveLength(0);
-	});
+    const { content } = await executeDimSumTool(
+      store,
+      "remove_table_from_canvas",
+      { qualifiedName: "public.product" },
+      noopDeps(),
+    );
+    expect(parse(content).removed).toBe(true);
+    expect(parse(content).joinsRemoved).toBe(1);
+    expect(store.doc.tables).toHaveLength(1);
+    expect(store.doc.joins).toHaveLength(0);
+  });
 
-	it('arrange_canvas delegates to the injected arrangeCanvas dep', async () => {
-		const store = makeStore();
-		addCanvasTable(store, 'sales', ['id']);
-		const deps = noopDeps();
+  it("arrange_canvas delegates to the injected arrangeCanvas dep", async () => {
+    const store = makeStore();
+    addCanvasTable(store, "sales", ["id"]);
+    const deps = noopDeps();
 
-		const { content, isError } = await executeDimSumTool(
-			store,
-			'arrange_canvas',
-			{ mode: 'star' },
-			deps
-		);
-		expect(isError).toBe(false);
-		expect(parse(content).arranged).toBe(true);
-		expect(deps.arrangeCanvas).toHaveBeenCalledWith('star');
-	});
+    const { content, isError } = await executeDimSumTool(
+      store,
+      "arrange_canvas",
+      { mode: "star" },
+      deps,
+    );
+    expect(isError).toBe(false);
+    expect(parse(content).arranged).toBe(true);
+    expect(deps.arrangeCanvas).toHaveBeenCalledWith("star");
+  });
 
-	it('arrange_canvas short-circuits on an empty canvas without calling the dep', async () => {
-		const store = makeStore();
-		const deps = noopDeps();
-		const { content } = await executeDimSumTool(store, 'arrange_canvas', {}, deps);
-		expect(parse(content).arranged).toBe(false);
-		expect(deps.arrangeCanvas).not.toHaveBeenCalled();
-	});
+  it("arrange_canvas short-circuits on an empty canvas without calling the dep", async () => {
+    const store = makeStore();
+    const deps = noopDeps();
+    const { content } = await executeDimSumTool(
+      store,
+      "arrange_canvas",
+      {},
+      deps,
+    );
+    expect(parse(content).arranged).toBe(false);
+    expect(deps.arrangeCanvas).not.toHaveBeenCalled();
+  });
 });
 
-describe('executeDimSumTool — perform_action', () => {
-	it('zoom actions stamp requestedCanvasAction', async () => {
-		const store = makeStore();
-		const { content } = await executeDimSumTool(
-			store,
-			'perform_action',
-			{ action: 'zoom_in' },
-			noopDeps()
-		);
-		expect(parse(content).performed).toBe('zoom_in');
-		expect(store.requestedCanvasAction?.kind).toBe('zoom_in');
-	});
+describe("executeDimSumTool — perform_action", () => {
+  it("zoom actions stamp requestedCanvasAction", async () => {
+    const store = makeStore();
+    const { content } = await executeDimSumTool(
+      store,
+      "perform_action",
+      { action: "zoom_in" },
+      noopDeps(),
+    );
+    expect(parse(content).performed).toBe("zoom_in");
+    expect(store.requestedCanvasAction?.kind).toBe("zoom_in");
+  });
 
-	it('undo_last_change no-ops when there is nothing to undo', async () => {
-		const store = makeStore();
-		const { content } = await executeDimSumTool(
-			store,
-			'perform_action',
-			{ action: 'undo_last_change' },
-			noopDeps()
-		);
-		expect(parse(content).performed).toBe(false);
-	});
+  it("undo_last_change no-ops when there is nothing to undo", async () => {
+    const store = makeStore();
+    const { content } = await executeDimSumTool(
+      store,
+      "perform_action",
+      { action: "undo_last_change" },
+      noopDeps(),
+    );
+    expect(parse(content).performed).toBe(false);
+  });
 
-	it('center_view_on_table sets a jump target for a known table', async () => {
-		const store = makeStore();
-		const salesId = addCanvasTable(store, 'sales', ['id']);
-		const { content } = await executeDimSumTool(
-			store,
-			'perform_action',
-			{ action: 'center_view_on_table', qualifiedName: 'public.sales' },
-			noopDeps()
-		);
-		expect(parse(content).performed).toBe('center_view_on_table');
-		expect(store.requestedJumpTarget?.tableId).toBe(salesId);
-	});
+  it("center_view_on_table sets a jump target for a known table", async () => {
+    const store = makeStore();
+    const salesId = addCanvasTable(store, "sales", ["id"]);
+    const { content } = await executeDimSumTool(
+      store,
+      "perform_action",
+      { action: "center_view_on_table", qualifiedName: "public.sales" },
+      noopDeps(),
+    );
+    expect(parse(content).performed).toBe("center_view_on_table");
+    expect(store.requestedJumpTarget?.tableId).toBe(salesId);
+  });
 
-	it('unknown action id errors', async () => {
-		const store = makeStore();
-		const { isError, content } = await executeDimSumTool(
-			store,
-			'perform_action',
-			{ action: 'nope' },
-			noopDeps()
-		);
-		expect(isError).toBe(true);
-		expect(parse(content).error).toContain('Unknown action id');
-	});
+  it("unknown action id errors", async () => {
+    const store = makeStore();
+    const { isError, content } = await executeDimSumTool(
+      store,
+      "perform_action",
+      { action: "nope" },
+      noopDeps(),
+    );
+    expect(isError).toBe(true);
+    expect(parse(content).error).toContain("Unknown action id");
+  });
 });
 
-describe('executeDimSumTool — logical layer (dims / measures)', () => {
-	it('set_fact_table promotes a canvas table to the fact role', async () => {
-		const store = makeStore();
-		const salesId = addCanvasTable(store, 'sales', ['id', 'amount']);
-		const { isError } = await executeDimSumTool(
-			store,
-			'set_fact_table',
-			{ qualifiedName: 'public.sales' },
-			noopDeps()
-		);
-		expect(isError).toBe(false);
-		expect(findTableByName(store, 'public.sales')?.role).toBe('fact');
-		expect(store.doc.tables.find((t) => t.id === salesId)?.role).toBe('fact');
-	});
+describe("executeDimSumTool — logical layer (dims / measures)", () => {
+  it("set_fact_table promotes a canvas table to the fact role", async () => {
+    const store = makeStore();
+    const salesId = addCanvasTable(store, "sales", ["id", "amount"]);
+    const { isError } = await executeDimSumTool(
+      store,
+      "set_fact_table",
+      { qualifiedName: "public.sales" },
+      noopDeps(),
+    );
+    expect(isError).toBe(false);
+    expect(findTableByName(store, "public.sales")?.role).toBe("fact");
+    expect(store.doc.tables.find((t) => t.id === salesId)?.role).toBe("fact");
+  });
 
-	it('create_dimension seeds the PK as an attribute and errors on duplicates', async () => {
-		const store = makeStore();
-		addCanvasTable(store, 'product', ['product_id', 'name']);
+  it("create_dimension seeds the PK as an attribute and errors on duplicates", async () => {
+    const store = makeStore();
+    addCanvasTable(store, "product", ["product_id", "name"]);
 
-		const first = await executeDimSumTool(
-			store,
-			'create_dimension',
-			{ table: 'product', name: 'Product', primaryKeyColumn: 'product_id' },
-			noopDeps()
-		);
-		expect(first.isError).toBe(false);
-		const dim = store.dimensions.find((d) => d.name === 'Product');
-		expect(dim).toBeDefined();
-		expect(dim?.primaryKey).toBe('product_id');
-		expect(dim?.attributes?.some((a) => a.columnName === 'product_id')).toBe(true);
+    const first = await executeDimSumTool(
+      store,
+      "create_dimension",
+      { table: "product", name: "Product", primaryKeyColumn: "product_id" },
+      noopDeps(),
+    );
+    expect(first.isError).toBe(false);
+    const dim = store.dimensions.find((d) => d.name === "Product");
+    expect(dim).toBeDefined();
+    expect(dim?.primaryKey).toBe("product_id");
+    expect(dim?.attributes?.some((a) => a.columnName === "product_id")).toBe(
+      true,
+    );
 
-		const dup = await executeDimSumTool(
-			store,
-			'create_dimension',
-			{ table: 'product', name: 'Product' },
-			noopDeps()
-		);
-		expect(dup.isError).toBe(true);
-		expect(parse(dup.content).reason).toContain('already exists');
-	});
+    const dup = await executeDimSumTool(
+      store,
+      "create_dimension",
+      { table: "product", name: "Product" },
+      noopDeps(),
+    );
+    expect(dup.isError).toBe(true);
+    expect(parse(dup.content).reason).toContain("already exists");
+  });
 
-	it('create_dimension errors when the primary-key column is absent', async () => {
-		const store = makeStore();
-		addCanvasTable(store, 'product', ['product_id']);
-		const { isError, content } = await executeDimSumTool(
-			store,
-			'create_dimension',
-			{ table: 'product', name: 'Product', primaryKeyColumn: 'ghost' },
-			noopDeps()
-		);
-		expect(isError).toBe(true);
-		expect(parse(content).reason).toContain('ghost');
-	});
+  it("create_dimension errors when the primary-key column is absent", async () => {
+    const store = makeStore();
+    addCanvasTable(store, "product", ["product_id"]);
+    const { isError, content } = await executeDimSumTool(
+      store,
+      "create_dimension",
+      { table: "product", name: "Product", primaryKeyColumn: "ghost" },
+      noopDeps(),
+    );
+    expect(isError).toBe(true);
+    expect(parse(content).reason).toContain("ghost");
+  });
 
-	it('add_hierarchy then add_level builds a level backed by an attribute', async () => {
-		const store = makeStore();
-		addCanvasTable(store, 'product', ['product_id', 'category']);
-		await executeDimSumTool(
-			store,
-			'create_dimension',
-			{ table: 'product', name: 'Product', primaryKeyColumn: 'product_id' },
-			noopDeps()
-		);
-		await executeDimSumTool(
-			store,
-			'add_hierarchy',
-			{ dimension: 'Product', name: 'Products' },
-			noopDeps()
-		);
-		const level = await executeDimSumTool(
-			store,
-			'add_level',
-			{ dimension: 'Product', hierarchy: 'Products', column: 'category' },
-			noopDeps()
-		);
-		expect(level.isError).toBe(false);
-		const dim = store.dimensions.find((d) => d.name === 'Product')!;
-		const hier = dim.hierarchies.find((h) => h.name === 'Products')!;
-		expect(hier.levels.some((l) => l.columnName === 'category')).toBe(true);
-		expect(dim.attributes?.some((a) => a.columnName === 'category')).toBe(true);
-	});
+  it("add_hierarchy then add_level builds a level backed by an attribute", async () => {
+    const store = makeStore();
+    addCanvasTable(store, "product", ["product_id", "category"]);
+    await executeDimSumTool(
+      store,
+      "create_dimension",
+      { table: "product", name: "Product", primaryKeyColumn: "product_id" },
+      noopDeps(),
+    );
+    await executeDimSumTool(
+      store,
+      "add_hierarchy",
+      { dimension: "Product", name: "Products" },
+      noopDeps(),
+    );
+    const level = await executeDimSumTool(
+      store,
+      "add_level",
+      { dimension: "Product", hierarchy: "Products", column: "category" },
+      noopDeps(),
+    );
+    expect(level.isError).toBe(false);
+    const dim = store.dimensions.find((d) => d.name === "Product")!;
+    const hier = dim.hierarchies.find((h) => h.name === "Products")!;
+    expect(hier.levels.some((l) => l.columnName === "category")).toBe(true);
+    expect(dim.attributes?.some((a) => a.columnName === "category")).toBe(true);
+  });
 
-	it('add_level preserves the coarse→fine order DimSum adds levels in', async () => {
-		// DimSum is instructed (tool schema + system prompt) to add levels
-		// coarsest-first. add_level appends, so the stored order must match the
-		// call order — and with the pane no longer sorting alphabetically
-		// (saiku-cloud#1174), that authored order is what the user sees.
-		const store = makeStore();
-		addCanvasTable(store, 'dim_date', [
-			'date_key',
-			'year',
-			'quarter',
-			'month_of_year',
-			'day_of_month'
-		]);
-		await executeDimSumTool(
-			store,
-			'create_dimension',
-			{ table: 'dim_date', name: 'Time', primaryKeyColumn: 'date_key', type: 'Time' },
-			noopDeps()
-		);
-		await executeDimSumTool(
-			store,
-			'add_hierarchy',
-			{ dimension: 'Time', name: 'Calendar' },
-			noopDeps()
-		);
-		// Add coarsest-first — the order the AI is told to use.
-		for (const column of ['year', 'quarter', 'month_of_year', 'day_of_month']) {
-			await executeDimSumTool(
-				store,
-				'add_level',
-				{ dimension: 'Time', hierarchy: 'Calendar', column },
-				noopDeps()
-			);
-		}
-		const hier = store.dimensions
-			.find((d) => d.name === 'Time')!
-			.hierarchies.find((h) => h.name === 'Calendar')!;
-		expect(hier.levels.map((l) => l.columnName)).toEqual([
-			'year',
-			'quarter',
-			'month_of_year',
-			'day_of_month'
-		]);
-	});
+  it("add_level preserves the coarse→fine order DimSum adds levels in", async () => {
+    // DimSum is instructed (tool schema + system prompt) to add levels
+    // coarsest-first. add_level appends, so the stored order must match the
+    // call order — and with the pane no longer sorting alphabetically
+    // (saiku-cloud#1174), that authored order is what the user sees.
+    const store = makeStore();
+    addCanvasTable(store, "dim_date", [
+      "date_key",
+      "year",
+      "quarter",
+      "month_of_year",
+      "day_of_month",
+    ]);
+    await executeDimSumTool(
+      store,
+      "create_dimension",
+      {
+        table: "dim_date",
+        name: "Time",
+        primaryKeyColumn: "date_key",
+        type: "Time",
+      },
+      noopDeps(),
+    );
+    await executeDimSumTool(
+      store,
+      "add_hierarchy",
+      { dimension: "Time", name: "Calendar" },
+      noopDeps(),
+    );
+    // Add coarsest-first — the order the AI is told to use.
+    for (const column of ["year", "quarter", "month_of_year", "day_of_month"]) {
+      await executeDimSumTool(
+        store,
+        "add_level",
+        { dimension: "Time", hierarchy: "Calendar", column },
+        noopDeps(),
+      );
+    }
+    const hier = store.dimensions
+      .find((d) => d.name === "Time")!
+      .hierarchies.find((h) => h.name === "Calendar")!;
+    expect(hier.levels.map((l) => l.columnName)).toEqual([
+      "year",
+      "quarter",
+      "month_of_year",
+      "day_of_month",
+    ]);
+  });
 
-	it('add_measure requires a fact table', async () => {
-		const store = makeStore();
-		addCanvasTable(store, 'sales', ['amount']);
-		const { isError, content } = await executeDimSumTool(
-			store,
-			'add_measure',
-			{ column: 'amount', aggregator: 'sum' },
-			noopDeps()
-		);
-		expect(isError).toBe(true);
-		expect(parse(content).reason).toContain('No fact table');
-	});
+  it("add_measure requires a fact table", async () => {
+    const store = makeStore();
+    addCanvasTable(store, "sales", ["amount"]);
+    const { isError, content } = await executeDimSumTool(
+      store,
+      "add_measure",
+      { column: "amount", aggregator: "sum" },
+      noopDeps(),
+    );
+    expect(isError).toBe(true);
+    expect(parse(content).reason).toContain("No fact table");
+  });
 
-	it('add_measure folds the column into a measure group on the cube', async () => {
-		const store = makeStore();
-		const salesId = addCanvasTable(store, 'sales', ['amount', 'product_id']);
-		store.setTableRole(salesId, 'fact');
+  it("add_measure folds the column into a measure group on the cube", async () => {
+    const store = makeStore();
+    const salesId = addCanvasTable(store, "sales", ["amount", "product_id"]);
+    store.setTableRole(salesId, "fact");
 
-		const { content, isError } = await executeDimSumTool(
-			store,
-			'add_measure',
-			{ column: 'amount', aggregator: 'sum', name: 'Revenue' },
-			noopDeps()
-		);
-		expect(isError).toBe(false);
-		expect(parse(content).measureGroup).toBe('Measures');
-		expect(store.cubes).toHaveLength(1);
-		expect(store.cubes[0].measureGroups[0].measureColumns).toContain('amount');
-	});
+    const { content, isError } = await executeDimSumTool(
+      store,
+      "add_measure",
+      { column: "amount", aggregator: "sum", name: "Revenue" },
+      noopDeps(),
+    );
+    expect(isError).toBe(false);
+    expect(parse(content).measureGroup).toBe("Measures");
+    expect(store.cubes).toHaveLength(1);
+    expect(store.cubes[0].measureGroups[0].measureColumns).toContain("amount");
+  });
 
-	it('add_measure carries the percentile fraction for a percentile aggregator', async () => {
-		const store = makeStore();
-		const salesId = addCanvasTable(store, 'sales', ['latency_ms']);
-		store.setTableRole(salesId, 'fact');
+  it("add_measure carries the percentile fraction for a percentile aggregator", async () => {
+    const store = makeStore();
+    const salesId = addCanvasTable(store, "sales", ["latency_ms"]);
+    store.setTableRole(salesId, "fact");
 
-		const { isError } = await executeDimSumTool(
-			store,
-			'add_measure',
-			{ column: 'latency_ms', aggregator: 'percentile', percentile: 90, name: 'P90 Latency' },
-			noopDeps()
-		);
-		expect(isError).toBe(false);
-		const m = store.measures.find((mm) => mm.name === 'P90 Latency');
-		expect(m?.aggregator).toBe('percentile');
-		expect(m?.percentile).toBe(90);
-	});
+    const { isError } = await executeDimSumTool(
+      store,
+      "add_measure",
+      {
+        column: "latency_ms",
+        aggregator: "percentile",
+        percentile: 90,
+        name: "P90 Latency",
+      },
+      noopDeps(),
+    );
+    expect(isError).toBe(false);
+    const m = store.measures.find((mm) => mm.name === "P90 Latency");
+    expect(m?.aggregator).toBe("percentile");
+    expect(m?.percentile).toBe(90);
+  });
 
-	it('add_measure with a count aggregator and no column skips the group fold', async () => {
-		const store = makeStore();
-		const salesId = addCanvasTable(store, 'sales', ['amount']);
-		store.setTableRole(salesId, 'fact');
-		const { content, isError } = await executeDimSumTool(
-			store,
-			'add_measure',
-			{ aggregator: 'count' },
-			noopDeps()
-		);
-		expect(isError).toBe(false);
-		expect(parse(content).measureGroup).toBeNull();
-	});
+  it("add_measure with a count aggregator and no column skips the group fold", async () => {
+    const store = makeStore();
+    const salesId = addCanvasTable(store, "sales", ["amount"]);
+    store.setTableRole(salesId, "fact");
+    const { content, isError } = await executeDimSumTool(
+      store,
+      "add_measure",
+      { aggregator: "count" },
+      noopDeps(),
+    );
+    expect(isError).toBe(false);
+    expect(parse(content).measureGroup).toBeNull();
+  });
 
-	it('add_measure_group needs a fact and creates a group on the cube', async () => {
-		const store = makeStore();
-		const salesId = addCanvasTable(store, 'sales', ['amount']);
-		store.setTableRole(salesId, 'fact');
-		const { content, isError } = await executeDimSumTool(
-			store,
-			'add_measure_group',
-			{ name: 'Sales facts' },
-			noopDeps()
-		);
-		expect(isError).toBe(false);
-		expect(parse(content).measureGroup).toBe('Sales facts');
-		expect(store.cubes[0].measureGroups.some((g) => g.name === 'Sales facts')).toBe(true);
-	});
+  it("add_measure_group needs a fact and creates a group on the cube", async () => {
+    const store = makeStore();
+    const salesId = addCanvasTable(store, "sales", ["amount"]);
+    store.setTableRole(salesId, "fact");
+    const { content, isError } = await executeDimSumTool(
+      store,
+      "add_measure_group",
+      { name: "Sales facts" },
+      noopDeps(),
+    );
+    expect(isError).toBe(false);
+    expect(parse(content).measureGroup).toBe("Sales facts");
+    expect(
+      store.cubes[0].measureGroups.some((g) => g.name === "Sales facts"),
+    ).toBe(true);
+  });
 });
 
-describe('executeDimSumTool — unknown tool + throw safety', () => {
-	it('returns an error for an unknown tool name', async () => {
-		const store = makeStore();
-		const { isError, content } = await executeDimSumTool(store, 'frobnicate', {}, noopDeps());
-		expect(isError).toBe(true);
-		expect(parse(content).error).toContain('Unknown tool');
-	});
+describe("executeDimSumTool — unknown tool + throw safety", () => {
+  it("returns an error for an unknown tool name", async () => {
+    const store = makeStore();
+    const { isError, content } = await executeDimSumTool(
+      store,
+      "frobnicate",
+      {},
+      noopDeps(),
+    );
+    expect(isError).toBe(true);
+    expect(parse(content).error).toContain("Unknown tool");
+  });
 });
 
-describe('reconcileMeasureGroupLinks', () => {
-	it('links a dimension via its explicit foreignKey', () => {
-		const store = makeStore();
-		const salesId = addCanvasTable(store, 'sales', ['prod_fk', 'amount']);
-		const productId = addCanvasTable(store, 'product', ['product_id']);
-		store.setTableRole(salesId, 'fact');
-		const dim = store.addDimension({ name: 'Product', tableId: productId });
-		store.updateDimension(dim.id, { primaryKeyTableId: productId, foreignKey: 'prod_fk' });
-		const cube = store.addCube({ name: 'Sales' });
-		const mg = store.addMeasureGroup(cube.id, { name: 'Facts', factTableId: salesId })!;
+describe("reconcileMeasureGroupLinks", () => {
+  it("links a dimension via its explicit foreignKey", () => {
+    const store = makeStore();
+    const salesId = addCanvasTable(store, "sales", ["prod_fk", "amount"]);
+    const productId = addCanvasTable(store, "product", ["product_id"]);
+    store.setTableRole(salesId, "fact");
+    const dim = store.addDimension({ name: "Product", tableId: productId });
+    store.updateDimension(dim.id, {
+      primaryKeyTableId: productId,
+      foreignKey: "prod_fk",
+    });
+    const cube = store.addCube({ name: "Sales" });
+    const mg = store.addMeasureGroup(cube.id, {
+      name: "Facts",
+      factTableId: salesId,
+    })!;
 
-		reconcileMeasureGroupLinks(store);
+    reconcileMeasureGroupLinks(store);
 
-		const link = store.cubes[0].measureGroups
-			.find((g) => g.id === mg.id)!
-			.dimensionLinks?.find((l) => l.dimensionId === dim.id);
-		expect(link?.foreignKeyColumn).toBe('prod_fk');
-		expect(link?.linkKind).toBe('foreign-key');
-	});
+    const link = store.cubes[0].measureGroups
+      .find((g) => g.id === mg.id)!
+      .dimensionLinks?.find((l) => l.dimensionId === dim.id);
+    expect(link?.foreignKeyColumn).toBe("prod_fk");
+    expect(link?.linkKind).toBe("foreign-key");
+  });
 
-	it('links a dimension via an existing canvas join when no explicit FK is set', () => {
-		const store = makeStore();
-		const salesId = addCanvasTable(store, 'sales', ['product_id', 'amount']);
-		const productId = addCanvasTable(store, 'product', ['product_id']);
-		store.setTableRole(salesId, 'fact');
-		store.addJoin({
-			sourceTableId: salesId,
-			sourceColumnName: 'product_id',
-			targetTableId: productId,
-			targetColumnName: 'product_id',
-			kind: 'inner'
-		});
-		const dim = store.addDimension({ name: 'Product', tableId: productId });
-		store.updateDimension(dim.id, { primaryKeyTableId: productId });
-		const cube = store.addCube({ name: 'Sales' });
-		store.addMeasureGroup(cube.id, { name: 'Facts', factTableId: salesId });
+  it("links a dimension via an existing canvas join when no explicit FK is set", () => {
+    const store = makeStore();
+    const salesId = addCanvasTable(store, "sales", ["product_id", "amount"]);
+    const productId = addCanvasTable(store, "product", ["product_id"]);
+    store.setTableRole(salesId, "fact");
+    store.addJoin({
+      sourceTableId: salesId,
+      sourceColumnName: "product_id",
+      targetTableId: productId,
+      targetColumnName: "product_id",
+      kind: "inner",
+    });
+    const dim = store.addDimension({ name: "Product", tableId: productId });
+    store.updateDimension(dim.id, { primaryKeyTableId: productId });
+    const cube = store.addCube({ name: "Sales" });
+    store.addMeasureGroup(cube.id, { name: "Facts", factTableId: salesId });
 
-		reconcileMeasureGroupLinks(store);
+    reconcileMeasureGroupLinks(store);
 
-		const link = store.cubes[0].measureGroups[0].dimensionLinks?.find(
-			(l) => l.dimensionId === dim.id
-		);
-		expect(link?.foreignKeyColumn).toBe('product_id');
-	});
+    const link = store.cubes[0].measureGroups[0].dimensionLinks?.find(
+      (l) => l.dimensionId === dim.id,
+    );
+    expect(link?.foreignKeyColumn).toBe("product_id");
+  });
 
-	it('falls back to the star-schema convention (fact column matches the dim PK)', () => {
-		const store = makeStore();
-		const salesId = addCanvasTable(store, 'sales', ['product_id', 'amount']);
-		const productId = addCanvasTable(store, 'product', ['product_id']);
-		store.setTableRole(salesId, 'fact');
-		const dim = store.addDimension({ name: 'Product', tableId: productId });
-		// No foreignKey, no join — only the PK name matching a fact column.
-		store.updateDimension(dim.id, { primaryKeyTableId: productId, primaryKey: 'product_id' });
-		const cube = store.addCube({ name: 'Sales' });
-		store.addMeasureGroup(cube.id, { name: 'Facts', factTableId: salesId });
+  it("falls back to the star-schema convention (fact column matches the dim PK)", () => {
+    const store = makeStore();
+    const salesId = addCanvasTable(store, "sales", ["product_id", "amount"]);
+    const productId = addCanvasTable(store, "product", ["product_id"]);
+    store.setTableRole(salesId, "fact");
+    const dim = store.addDimension({ name: "Product", tableId: productId });
+    // No foreignKey, no join — only the PK name matching a fact column.
+    store.updateDimension(dim.id, {
+      primaryKeyTableId: productId,
+      primaryKey: "product_id",
+    });
+    const cube = store.addCube({ name: "Sales" });
+    store.addMeasureGroup(cube.id, { name: "Facts", factTableId: salesId });
 
-		reconcileMeasureGroupLinks(store);
+    reconcileMeasureGroupLinks(store);
 
-		const link = store.cubes[0].measureGroups[0].dimensionLinks?.find(
-			(l) => l.dimensionId === dim.id
-		);
-		expect(link?.foreignKeyColumn).toBe('product_id');
-		expect(link?.linkKind).toBe('foreign-key');
-	});
+    const link = store.cubes[0].measureGroups[0].dimensionLinks?.find(
+      (l) => l.dimensionId === dim.id,
+    );
+    expect(link?.foreignKeyColumn).toBe("product_id");
+    expect(link?.linkKind).toBe("foreign-key");
+  });
 
-	it('marks a degenerate dimension on the fact table as a fact link', () => {
-		const store = makeStore();
-		const salesId = addCanvasTable(store, 'sales', ['payment_type', 'amount']);
-		store.setTableRole(salesId, 'fact');
-		const dim = store.addDimension({ name: 'Payment', tableId: salesId });
-		store.updateDimension(dim.id, { primaryKeyTableId: salesId, foreignKey: 'payment_type' });
-		const cube = store.addCube({ name: 'Sales' });
-		store.addMeasureGroup(cube.id, { name: 'Facts', factTableId: salesId });
+  it("marks a degenerate dimension on the fact table as a fact link", () => {
+    const store = makeStore();
+    const salesId = addCanvasTable(store, "sales", ["payment_type", "amount"]);
+    store.setTableRole(salesId, "fact");
+    const dim = store.addDimension({ name: "Payment", tableId: salesId });
+    store.updateDimension(dim.id, {
+      primaryKeyTableId: salesId,
+      foreignKey: "payment_type",
+    });
+    const cube = store.addCube({ name: "Sales" });
+    store.addMeasureGroup(cube.id, { name: "Facts", factTableId: salesId });
 
-		reconcileMeasureGroupLinks(store);
+    reconcileMeasureGroupLinks(store);
 
-		const link = store.cubes[0].measureGroups[0].dimensionLinks?.find(
-			(l) => l.dimensionId === dim.id
-		);
-		expect(link?.linkKind).toBe('fact');
-	});
+    const link = store.cubes[0].measureGroups[0].dimensionLinks?.find(
+      (l) => l.dimensionId === dim.id,
+    );
+    expect(link?.linkKind).toBe("fact");
+  });
 });
 
-describe('buildCanvasSummary', () => {
-	it('summarises tables and splits user-made from semantic joins', () => {
-		const store = makeStore();
-		const salesId = addCanvasTable(store, 'sales', ['product_id', 'amount']);
-		const productId = addCanvasTable(store, 'product', ['product_id']);
-		store.addJoin({
-			sourceTableId: salesId,
-			sourceColumnName: 'product_id',
-			targetTableId: productId,
-			targetColumnName: 'product_id',
-			kind: 'inner',
-			origin: 'physical'
-		});
-		store.addJoin({
-			sourceTableId: salesId,
-			sourceColumnName: 'amount',
-			targetTableId: productId,
-			targetColumnName: 'product_id',
-			kind: 'inner',
-			origin: 'cube-link'
-		});
+describe("buildCanvasSummary", () => {
+  it("summarises tables and splits user-made from semantic joins", () => {
+    const store = makeStore();
+    const salesId = addCanvasTable(store, "sales", ["product_id", "amount"]);
+    const productId = addCanvasTable(store, "product", ["product_id"]);
+    store.addJoin({
+      sourceTableId: salesId,
+      sourceColumnName: "product_id",
+      targetTableId: productId,
+      targetColumnName: "product_id",
+      kind: "inner",
+      origin: "physical",
+    });
+    store.addJoin({
+      sourceTableId: salesId,
+      sourceColumnName: "amount",
+      targetTableId: productId,
+      targetColumnName: "product_id",
+      kind: "inner",
+      origin: "cube-link",
+    });
 
-		const summary = buildCanvasSummary(store);
-		expect(summary).toContain('ON-CANVAS TABLES (2):');
-		expect(summary).toContain('public.sales: [product_id:INTEGER, amount:INTEGER]');
-		expect(summary).toContain('USER-MADE JOINS (1):');
-		expect(summary).toContain('SEMANTIC (cube-link, read-only) JOINS (1):');
-	});
+    const summary = buildCanvasSummary(store);
+    expect(summary).toContain("ON-CANVAS TABLES (2):");
+    expect(summary).toContain(
+      "public.sales: [product_id:INTEGER, amount:INTEGER]",
+    );
+    expect(summary).toContain("USER-MADE JOINS (1):");
+    expect(summary).toContain("SEMANTIC (cube-link, read-only) JOINS (1):");
+  });
 
-	it('reports empties cleanly on a blank canvas', () => {
-		const summary = buildCanvasSummary(makeStore());
-		expect(summary).toContain('ON-CANVAS TABLES (0):');
-		expect(summary).toContain('  (none)');
-	});
+  it("reports empties cleanly on a blank canvas", () => {
+    const summary = buildCanvasSummary(makeStore());
+    expect(summary).toContain("ON-CANVAS TABLES (0):");
+    expect(summary).toContain("  (none)");
+  });
 });

--- a/saiku-ui/src/lib/cube-designer/dimsum-tools.test.ts
+++ b/saiku-ui/src/lib/cube-designer/dimsum-tools.test.ts
@@ -1,0 +1,643 @@
+/**
+ * Unit tests for the DimSum tool executors — the payoff of audit finding
+ * #1040. Each executor is driven against a real {@link SchemaCanvasStore} and
+ * we assert both the returned tool-result text AND the resulting store state.
+ * Node-env vitest; no Svelte render harness needed (the store is a plain
+ * runes class that works headless).
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { SchemaCanvasStore } from './state.svelte.js';
+import type { SourceTableCandidate } from './types.js';
+import {
+	buildCanvasSummary,
+	executeDimSumTool,
+	reconcileMeasureGroupLinks,
+	findTableByName,
+	DIMSUM_MUTATION_TOOLS,
+	type DimSumToolDeps
+} from './dimsum-tools.js';
+
+// ── fixtures ─────────────────────────────────────────────────────
+function candidate(
+	name: string,
+	columns: string[],
+	schema: string | null = 'public'
+): SourceTableCandidate {
+	return {
+		schema,
+		name,
+		columns: columns.map((c) => ({ name: c, sqlType: 'INTEGER' })),
+		onCanvas: false
+	};
+}
+
+function makeStore(): SchemaCanvasStore {
+	return new SchemaCanvasStore('conn-dimsum');
+}
+
+function noopDeps(): DimSumToolDeps {
+	return { arrangeCanvas: vi.fn(async () => {}) };
+}
+
+/** Add a table to the canvas and return its id. */
+function addCanvasTable(store: SchemaCanvasStore, name: string, columns: string[]): string {
+	return store.addTable(candidate(name, columns), { x: 0, y: 0 }).id;
+}
+
+function parse(content: string): Record<string, unknown> {
+	return JSON.parse(content) as Record<string, unknown>;
+}
+
+describe('DIMSUM_MUTATION_TOOLS', () => {
+	it('contains the ten mutating tools and excludes read-only ones', () => {
+		expect(DIMSUM_MUTATION_TOOLS.size).toBe(10);
+		expect(DIMSUM_MUTATION_TOOLS.has('add_join')).toBe(true);
+		expect(DIMSUM_MUTATION_TOOLS.has('add_measure')).toBe(true);
+		expect(DIMSUM_MUTATION_TOOLS.has('list_tables')).toBe(false);
+		expect(DIMSUM_MUTATION_TOOLS.has('arrange_canvas')).toBe(false);
+	});
+});
+
+describe('executeDimSumTool — read-only tools', () => {
+	it('list_tables splits on-canvas from available catalog tables', async () => {
+		const store = makeStore();
+		addCanvasTable(store, 'sales', ['id', 'amount']);
+		store.sourceTables = [candidate('sales', ['id', 'amount']), candidate('product', ['id'])];
+
+		const { content, isError } = await executeDimSumTool(store, 'list_tables', {}, noopDeps());
+
+		expect(isError).toBe(false);
+		const out = parse(content) as {
+			onCanvas: Array<{ qualifiedName: string }>;
+			available: Array<{ qualifiedName: string }>;
+		};
+		expect(out.onCanvas.map((t) => t.qualifiedName)).toEqual(['public.sales']);
+		// `sales` is on canvas so it's filtered out of available.
+		expect(out.available.map((t) => t.qualifiedName)).toEqual(['public.product']);
+	});
+
+	it('describe_table returns columns + neighbouring joins for a canvas table', async () => {
+		const store = makeStore();
+		const salesId = addCanvasTable(store, 'sales', ['id', 'product_id']);
+		const productId = addCanvasTable(store, 'product', ['product_id', 'name']);
+		store.addJoin({
+			sourceTableId: salesId,
+			sourceColumnName: 'product_id',
+			targetTableId: productId,
+			targetColumnName: 'product_id',
+			kind: 'inner'
+		});
+
+		const { content, isError } = await executeDimSumTool(
+			store,
+			'describe_table',
+			{ qualifiedName: 'public.sales' },
+			noopDeps()
+		);
+
+		expect(isError).toBe(false);
+		const out = parse(content) as {
+			onCanvas: boolean;
+			columns: Array<{ name: string }>;
+			joinsInvolving: Array<{ neighbor: string; thisColumn: string; neighborColumn: string }>;
+		};
+		expect(out.onCanvas).toBe(true);
+		expect(out.columns.map((c) => c.name)).toEqual(['id', 'product_id']);
+		expect(out.joinsInvolving).toHaveLength(1);
+		expect(out.joinsInvolving[0].neighbor).toBe('public.product');
+	});
+
+	it('describe_table errors on an unknown table', async () => {
+		const store = makeStore();
+		const { content, isError } = await executeDimSumTool(
+			store,
+			'describe_table',
+			{ qualifiedName: 'nope' },
+			noopDeps()
+		);
+		expect(isError).toBe(true);
+		expect(parse(content).error).toContain('No table named');
+	});
+
+	it('list_dimensions reports the fact table, dims and measures', async () => {
+		const store = makeStore();
+		const salesId = addCanvasTable(store, 'sales', ['id', 'amount']);
+		store.setTableRole(salesId, 'fact');
+		store.addMeasure({ tableId: salesId, columnName: 'amount', aggregator: 'sum' });
+
+		const { content } = await executeDimSumTool(store, 'list_dimensions', {}, noopDeps());
+		const out = parse(content) as { factTable: string; measures: Array<{ column: string }> };
+		expect(out.factTable).toBe('public.sales');
+		expect(out.measures[0].column).toBe('amount');
+	});
+});
+
+describe('executeDimSumTool — canvas mutations', () => {
+	it('add_table_to_canvas pulls a catalog table onto the canvas', async () => {
+		const store = makeStore();
+		store.sourceTables = [candidate('product', ['product_id'])];
+
+		const { content, isError } = await executeDimSumTool(
+			store,
+			'add_table_to_canvas',
+			{ qualifiedName: 'public.product' },
+			noopDeps()
+		);
+
+		expect(isError).toBe(false);
+		expect(parse(content).added).toBe(true);
+		expect(store.doc.tables).toHaveLength(1);
+		expect(store.doc.tables[0].name).toBe('product');
+	});
+
+	it('add_table_to_canvas is idempotent when already present', async () => {
+		const store = makeStore();
+		addCanvasTable(store, 'product', ['product_id']);
+		store.sourceTables = [candidate('product', ['product_id'])];
+
+		const { content } = await executeDimSumTool(
+			store,
+			'add_table_to_canvas',
+			{ qualifiedName: 'public.product' },
+			noopDeps()
+		);
+		expect(parse(content).added).toBe(false);
+		expect(parse(content).reason).toBe('already_on_canvas');
+		expect(store.doc.tables).toHaveLength(1);
+	});
+
+	it('add_join wires two canvas columns and remove_join drops it', async () => {
+		const store = makeStore();
+		addCanvasTable(store, 'sales', ['product_id']);
+		addCanvasTable(store, 'product', ['product_id']);
+
+		const add = await executeDimSumTool(
+			store,
+			'add_join',
+			{
+				from: { table: 'sales', column: 'product_id' },
+				to: { table: 'product', column: 'product_id' }
+			},
+			noopDeps()
+		);
+		expect(add.isError).toBe(false);
+		expect(store.doc.joins).toHaveLength(1);
+
+		const rm = await executeDimSumTool(
+			store,
+			'remove_join',
+			{
+				from: { table: 'sales', column: 'product_id' },
+				to: { table: 'product', column: 'product_id' }
+			},
+			noopDeps()
+		);
+		expect(rm.isError).toBe(false);
+		expect(store.doc.joins).toHaveLength(0);
+	});
+
+	it('add_join errors when a column is missing', async () => {
+		const store = makeStore();
+		addCanvasTable(store, 'sales', ['product_id']);
+		addCanvasTable(store, 'product', ['product_id']);
+		const { isError, content } = await executeDimSumTool(
+			store,
+			'add_join',
+			{ from: { table: 'sales', column: 'ghost' }, to: { table: 'product', column: 'product_id' } },
+			noopDeps()
+		);
+		expect(isError).toBe(true);
+		expect(parse(content).reason).toContain('ghost');
+		expect(store.doc.joins).toHaveLength(0);
+	});
+
+	it('remove_table_from_canvas removes the table and reports cascaded joins', async () => {
+		const store = makeStore();
+		const salesId = addCanvasTable(store, 'sales', ['product_id']);
+		const productId = addCanvasTable(store, 'product', ['product_id']);
+		store.addJoin({
+			sourceTableId: salesId,
+			sourceColumnName: 'product_id',
+			targetTableId: productId,
+			targetColumnName: 'product_id',
+			kind: 'inner'
+		});
+
+		const { content } = await executeDimSumTool(
+			store,
+			'remove_table_from_canvas',
+			{ qualifiedName: 'public.product' },
+			noopDeps()
+		);
+		expect(parse(content).removed).toBe(true);
+		expect(parse(content).joinsRemoved).toBe(1);
+		expect(store.doc.tables).toHaveLength(1);
+		expect(store.doc.joins).toHaveLength(0);
+	});
+
+	it('arrange_canvas delegates to the injected arrangeCanvas dep', async () => {
+		const store = makeStore();
+		addCanvasTable(store, 'sales', ['id']);
+		const deps = noopDeps();
+
+		const { content, isError } = await executeDimSumTool(
+			store,
+			'arrange_canvas',
+			{ mode: 'star' },
+			deps
+		);
+		expect(isError).toBe(false);
+		expect(parse(content).arranged).toBe(true);
+		expect(deps.arrangeCanvas).toHaveBeenCalledWith('star');
+	});
+
+	it('arrange_canvas short-circuits on an empty canvas without calling the dep', async () => {
+		const store = makeStore();
+		const deps = noopDeps();
+		const { content } = await executeDimSumTool(store, 'arrange_canvas', {}, deps);
+		expect(parse(content).arranged).toBe(false);
+		expect(deps.arrangeCanvas).not.toHaveBeenCalled();
+	});
+});
+
+describe('executeDimSumTool — perform_action', () => {
+	it('zoom actions stamp requestedCanvasAction', async () => {
+		const store = makeStore();
+		const { content } = await executeDimSumTool(
+			store,
+			'perform_action',
+			{ action: 'zoom_in' },
+			noopDeps()
+		);
+		expect(parse(content).performed).toBe('zoom_in');
+		expect(store.requestedCanvasAction?.kind).toBe('zoom_in');
+	});
+
+	it('undo_last_change no-ops when there is nothing to undo', async () => {
+		const store = makeStore();
+		const { content } = await executeDimSumTool(
+			store,
+			'perform_action',
+			{ action: 'undo_last_change' },
+			noopDeps()
+		);
+		expect(parse(content).performed).toBe(false);
+	});
+
+	it('center_view_on_table sets a jump target for a known table', async () => {
+		const store = makeStore();
+		const salesId = addCanvasTable(store, 'sales', ['id']);
+		const { content } = await executeDimSumTool(
+			store,
+			'perform_action',
+			{ action: 'center_view_on_table', qualifiedName: 'public.sales' },
+			noopDeps()
+		);
+		expect(parse(content).performed).toBe('center_view_on_table');
+		expect(store.requestedJumpTarget?.tableId).toBe(salesId);
+	});
+
+	it('unknown action id errors', async () => {
+		const store = makeStore();
+		const { isError, content } = await executeDimSumTool(
+			store,
+			'perform_action',
+			{ action: 'nope' },
+			noopDeps()
+		);
+		expect(isError).toBe(true);
+		expect(parse(content).error).toContain('Unknown action id');
+	});
+});
+
+describe('executeDimSumTool — logical layer (dims / measures)', () => {
+	it('set_fact_table promotes a canvas table to the fact role', async () => {
+		const store = makeStore();
+		const salesId = addCanvasTable(store, 'sales', ['id', 'amount']);
+		const { isError } = await executeDimSumTool(
+			store,
+			'set_fact_table',
+			{ qualifiedName: 'public.sales' },
+			noopDeps()
+		);
+		expect(isError).toBe(false);
+		expect(findTableByName(store, 'public.sales')?.role).toBe('fact');
+		expect(store.doc.tables.find((t) => t.id === salesId)?.role).toBe('fact');
+	});
+
+	it('create_dimension seeds the PK as an attribute and errors on duplicates', async () => {
+		const store = makeStore();
+		addCanvasTable(store, 'product', ['product_id', 'name']);
+
+		const first = await executeDimSumTool(
+			store,
+			'create_dimension',
+			{ table: 'product', name: 'Product', primaryKeyColumn: 'product_id' },
+			noopDeps()
+		);
+		expect(first.isError).toBe(false);
+		const dim = store.dimensions.find((d) => d.name === 'Product');
+		expect(dim).toBeDefined();
+		expect(dim?.primaryKey).toBe('product_id');
+		expect(dim?.attributes?.some((a) => a.columnName === 'product_id')).toBe(true);
+
+		const dup = await executeDimSumTool(
+			store,
+			'create_dimension',
+			{ table: 'product', name: 'Product' },
+			noopDeps()
+		);
+		expect(dup.isError).toBe(true);
+		expect(parse(dup.content).reason).toContain('already exists');
+	});
+
+	it('create_dimension errors when the primary-key column is absent', async () => {
+		const store = makeStore();
+		addCanvasTable(store, 'product', ['product_id']);
+		const { isError, content } = await executeDimSumTool(
+			store,
+			'create_dimension',
+			{ table: 'product', name: 'Product', primaryKeyColumn: 'ghost' },
+			noopDeps()
+		);
+		expect(isError).toBe(true);
+		expect(parse(content).reason).toContain('ghost');
+	});
+
+	it('add_hierarchy then add_level builds a level backed by an attribute', async () => {
+		const store = makeStore();
+		addCanvasTable(store, 'product', ['product_id', 'category']);
+		await executeDimSumTool(
+			store,
+			'create_dimension',
+			{ table: 'product', name: 'Product', primaryKeyColumn: 'product_id' },
+			noopDeps()
+		);
+		await executeDimSumTool(
+			store,
+			'add_hierarchy',
+			{ dimension: 'Product', name: 'Products' },
+			noopDeps()
+		);
+		const level = await executeDimSumTool(
+			store,
+			'add_level',
+			{ dimension: 'Product', hierarchy: 'Products', column: 'category' },
+			noopDeps()
+		);
+		expect(level.isError).toBe(false);
+		const dim = store.dimensions.find((d) => d.name === 'Product')!;
+		const hier = dim.hierarchies.find((h) => h.name === 'Products')!;
+		expect(hier.levels.some((l) => l.columnName === 'category')).toBe(true);
+		expect(dim.attributes?.some((a) => a.columnName === 'category')).toBe(true);
+	});
+
+	it('add_level preserves the coarse→fine order DimSum adds levels in', async () => {
+		// DimSum is instructed (tool schema + system prompt) to add levels
+		// coarsest-first. add_level appends, so the stored order must match the
+		// call order — and with the pane no longer sorting alphabetically
+		// (saiku-cloud#1174), that authored order is what the user sees.
+		const store = makeStore();
+		addCanvasTable(store, 'dim_date', [
+			'date_key',
+			'year',
+			'quarter',
+			'month_of_year',
+			'day_of_month'
+		]);
+		await executeDimSumTool(
+			store,
+			'create_dimension',
+			{ table: 'dim_date', name: 'Time', primaryKeyColumn: 'date_key', type: 'Time' },
+			noopDeps()
+		);
+		await executeDimSumTool(
+			store,
+			'add_hierarchy',
+			{ dimension: 'Time', name: 'Calendar' },
+			noopDeps()
+		);
+		// Add coarsest-first — the order the AI is told to use.
+		for (const column of ['year', 'quarter', 'month_of_year', 'day_of_month']) {
+			await executeDimSumTool(
+				store,
+				'add_level',
+				{ dimension: 'Time', hierarchy: 'Calendar', column },
+				noopDeps()
+			);
+		}
+		const hier = store.dimensions
+			.find((d) => d.name === 'Time')!
+			.hierarchies.find((h) => h.name === 'Calendar')!;
+		expect(hier.levels.map((l) => l.columnName)).toEqual([
+			'year',
+			'quarter',
+			'month_of_year',
+			'day_of_month'
+		]);
+	});
+
+	it('add_measure requires a fact table', async () => {
+		const store = makeStore();
+		addCanvasTable(store, 'sales', ['amount']);
+		const { isError, content } = await executeDimSumTool(
+			store,
+			'add_measure',
+			{ column: 'amount', aggregator: 'sum' },
+			noopDeps()
+		);
+		expect(isError).toBe(true);
+		expect(parse(content).reason).toContain('No fact table');
+	});
+
+	it('add_measure folds the column into a measure group on the cube', async () => {
+		const store = makeStore();
+		const salesId = addCanvasTable(store, 'sales', ['amount', 'product_id']);
+		store.setTableRole(salesId, 'fact');
+
+		const { content, isError } = await executeDimSumTool(
+			store,
+			'add_measure',
+			{ column: 'amount', aggregator: 'sum', name: 'Revenue' },
+			noopDeps()
+		);
+		expect(isError).toBe(false);
+		expect(parse(content).measureGroup).toBe('Measures');
+		expect(store.cubes).toHaveLength(1);
+		expect(store.cubes[0].measureGroups[0].measureColumns).toContain('amount');
+	});
+
+	it('add_measure carries the percentile fraction for a percentile aggregator', async () => {
+		const store = makeStore();
+		const salesId = addCanvasTable(store, 'sales', ['latency_ms']);
+		store.setTableRole(salesId, 'fact');
+
+		const { isError } = await executeDimSumTool(
+			store,
+			'add_measure',
+			{ column: 'latency_ms', aggregator: 'percentile', percentile: 90, name: 'P90 Latency' },
+			noopDeps()
+		);
+		expect(isError).toBe(false);
+		const m = store.measures.find((mm) => mm.name === 'P90 Latency');
+		expect(m?.aggregator).toBe('percentile');
+		expect(m?.percentile).toBe(90);
+	});
+
+	it('add_measure with a count aggregator and no column skips the group fold', async () => {
+		const store = makeStore();
+		const salesId = addCanvasTable(store, 'sales', ['amount']);
+		store.setTableRole(salesId, 'fact');
+		const { content, isError } = await executeDimSumTool(
+			store,
+			'add_measure',
+			{ aggregator: 'count' },
+			noopDeps()
+		);
+		expect(isError).toBe(false);
+		expect(parse(content).measureGroup).toBeNull();
+	});
+
+	it('add_measure_group needs a fact and creates a group on the cube', async () => {
+		const store = makeStore();
+		const salesId = addCanvasTable(store, 'sales', ['amount']);
+		store.setTableRole(salesId, 'fact');
+		const { content, isError } = await executeDimSumTool(
+			store,
+			'add_measure_group',
+			{ name: 'Sales facts' },
+			noopDeps()
+		);
+		expect(isError).toBe(false);
+		expect(parse(content).measureGroup).toBe('Sales facts');
+		expect(store.cubes[0].measureGroups.some((g) => g.name === 'Sales facts')).toBe(true);
+	});
+});
+
+describe('executeDimSumTool — unknown tool + throw safety', () => {
+	it('returns an error for an unknown tool name', async () => {
+		const store = makeStore();
+		const { isError, content } = await executeDimSumTool(store, 'frobnicate', {}, noopDeps());
+		expect(isError).toBe(true);
+		expect(parse(content).error).toContain('Unknown tool');
+	});
+});
+
+describe('reconcileMeasureGroupLinks', () => {
+	it('links a dimension via its explicit foreignKey', () => {
+		const store = makeStore();
+		const salesId = addCanvasTable(store, 'sales', ['prod_fk', 'amount']);
+		const productId = addCanvasTable(store, 'product', ['product_id']);
+		store.setTableRole(salesId, 'fact');
+		const dim = store.addDimension({ name: 'Product', tableId: productId });
+		store.updateDimension(dim.id, { primaryKeyTableId: productId, foreignKey: 'prod_fk' });
+		const cube = store.addCube({ name: 'Sales' });
+		const mg = store.addMeasureGroup(cube.id, { name: 'Facts', factTableId: salesId })!;
+
+		reconcileMeasureGroupLinks(store);
+
+		const link = store.cubes[0].measureGroups
+			.find((g) => g.id === mg.id)!
+			.dimensionLinks?.find((l) => l.dimensionId === dim.id);
+		expect(link?.foreignKeyColumn).toBe('prod_fk');
+		expect(link?.linkKind).toBe('foreign-key');
+	});
+
+	it('links a dimension via an existing canvas join when no explicit FK is set', () => {
+		const store = makeStore();
+		const salesId = addCanvasTable(store, 'sales', ['product_id', 'amount']);
+		const productId = addCanvasTable(store, 'product', ['product_id']);
+		store.setTableRole(salesId, 'fact');
+		store.addJoin({
+			sourceTableId: salesId,
+			sourceColumnName: 'product_id',
+			targetTableId: productId,
+			targetColumnName: 'product_id',
+			kind: 'inner'
+		});
+		const dim = store.addDimension({ name: 'Product', tableId: productId });
+		store.updateDimension(dim.id, { primaryKeyTableId: productId });
+		const cube = store.addCube({ name: 'Sales' });
+		store.addMeasureGroup(cube.id, { name: 'Facts', factTableId: salesId });
+
+		reconcileMeasureGroupLinks(store);
+
+		const link = store.cubes[0].measureGroups[0].dimensionLinks?.find(
+			(l) => l.dimensionId === dim.id
+		);
+		expect(link?.foreignKeyColumn).toBe('product_id');
+	});
+
+	it('falls back to the star-schema convention (fact column matches the dim PK)', () => {
+		const store = makeStore();
+		const salesId = addCanvasTable(store, 'sales', ['product_id', 'amount']);
+		const productId = addCanvasTable(store, 'product', ['product_id']);
+		store.setTableRole(salesId, 'fact');
+		const dim = store.addDimension({ name: 'Product', tableId: productId });
+		// No foreignKey, no join — only the PK name matching a fact column.
+		store.updateDimension(dim.id, { primaryKeyTableId: productId, primaryKey: 'product_id' });
+		const cube = store.addCube({ name: 'Sales' });
+		store.addMeasureGroup(cube.id, { name: 'Facts', factTableId: salesId });
+
+		reconcileMeasureGroupLinks(store);
+
+		const link = store.cubes[0].measureGroups[0].dimensionLinks?.find(
+			(l) => l.dimensionId === dim.id
+		);
+		expect(link?.foreignKeyColumn).toBe('product_id');
+		expect(link?.linkKind).toBe('foreign-key');
+	});
+
+	it('marks a degenerate dimension on the fact table as a fact link', () => {
+		const store = makeStore();
+		const salesId = addCanvasTable(store, 'sales', ['payment_type', 'amount']);
+		store.setTableRole(salesId, 'fact');
+		const dim = store.addDimension({ name: 'Payment', tableId: salesId });
+		store.updateDimension(dim.id, { primaryKeyTableId: salesId, foreignKey: 'payment_type' });
+		const cube = store.addCube({ name: 'Sales' });
+		store.addMeasureGroup(cube.id, { name: 'Facts', factTableId: salesId });
+
+		reconcileMeasureGroupLinks(store);
+
+		const link = store.cubes[0].measureGroups[0].dimensionLinks?.find(
+			(l) => l.dimensionId === dim.id
+		);
+		expect(link?.linkKind).toBe('fact');
+	});
+});
+
+describe('buildCanvasSummary', () => {
+	it('summarises tables and splits user-made from semantic joins', () => {
+		const store = makeStore();
+		const salesId = addCanvasTable(store, 'sales', ['product_id', 'amount']);
+		const productId = addCanvasTable(store, 'product', ['product_id']);
+		store.addJoin({
+			sourceTableId: salesId,
+			sourceColumnName: 'product_id',
+			targetTableId: productId,
+			targetColumnName: 'product_id',
+			kind: 'inner',
+			origin: 'physical'
+		});
+		store.addJoin({
+			sourceTableId: salesId,
+			sourceColumnName: 'amount',
+			targetTableId: productId,
+			targetColumnName: 'product_id',
+			kind: 'inner',
+			origin: 'cube-link'
+		});
+
+		const summary = buildCanvasSummary(store);
+		expect(summary).toContain('ON-CANVAS TABLES (2):');
+		expect(summary).toContain('public.sales: [product_id:INTEGER, amount:INTEGER]');
+		expect(summary).toContain('USER-MADE JOINS (1):');
+		expect(summary).toContain('SEMANTIC (cube-link, read-only) JOINS (1):');
+	});
+
+	it('reports empties cleanly on a blank canvas', () => {
+		const summary = buildCanvasSummary(makeStore());
+		expect(summary).toContain('ON-CANVAS TABLES (0):');
+		expect(summary).toContain('  (none)');
+	});
+});

--- a/saiku-ui/src/lib/cube-designer/dimsum-tools.ts
+++ b/saiku-ui/src/lib/cube-designer/dimsum-tools.ts
@@ -13,36 +13,40 @@
  * imports {@link executeDimSumTool} + {@link buildCanvasSummary} +
  * {@link reconcileMeasureGroupLinks} and calls them from `runDraftWithAI`.
  */
-import { SchemaCanvasStore } from './state.svelte.js';
-import type { LayoutMode } from './layout.js';
-import type { SchemaCanvasCube, SchemaCanvasMeasure, SchemaCanvasMeasureGroup } from './types.js';
+import { SchemaCanvasStore } from "./state.svelte.js";
+import type { LayoutMode } from "./layout.js";
+import type {
+  SchemaCanvasCube,
+  SchemaCanvasMeasure,
+  SchemaCanvasMeasureGroup,
+} from "./types.js";
 
 /** Tool names that MUTATE the canvas — `runDraftWithAI` tracks whether any
  *  succeeded so it can raise the Confirm/Cancel banner after the loop. */
 export const DIMSUM_MUTATION_TOOLS: ReadonlySet<string> = new Set([
-	'add_table_to_canvas',
-	'remove_table_from_canvas',
-	'add_join',
-	'remove_join',
-	'set_fact_table',
-	'create_dimension',
-	'add_hierarchy',
-	'add_level',
-	'add_measure',
-	'add_measure_group'
+  "add_table_to_canvas",
+  "remove_table_from_canvas",
+  "add_join",
+  "remove_join",
+  "set_fact_table",
+  "create_dimension",
+  "add_hierarchy",
+  "add_level",
+  "add_measure",
+  "add_measure_group",
 ]);
 
 /** Side-effecting dependencies the executor can't own (they touch component
  *  `$state` / the SvelteFlow viewport). Passed in so the executor stays pure
  *  over the store. */
 export interface DimSumToolDeps {
-	/** Runs the same layout path as the toolbar Arrange button. */
-	arrangeCanvas: (mode: LayoutMode) => Promise<void>;
+  /** Runs the same layout path as the toolbar Arrange button. */
+  arrangeCanvas: (mode: LayoutMode) => Promise<void>;
 }
 
 /** `schema.name` or bare `name` for a table-shaped record. */
 function qname(t: { schema: string | null; name: string }): string {
-	return t.schema ? `${t.schema}.${t.name}` : t.name;
+  return t.schema ? `${t.schema}.${t.name}` : t.name;
 }
 
 /**
@@ -51,29 +55,37 @@ function qname(t: { schema: string | null; name: string }): string {
  * UPPER vs lower case.
  */
 export function findTableByName(store: SchemaCanvasStore, qualified: string) {
-	const q = qualified.trim().toLowerCase();
-	return store.doc.tables.find((t) => {
-		const full = qname(t).toLowerCase();
-		return full === q || t.name.toLowerCase() === q;
-	});
+  const q = qualified.trim().toLowerCase();
+  return store.doc.tables.find((t) => {
+    const full = qname(t).toLowerCase();
+    return full === q || t.name.toLowerCase() === q;
+  });
 }
 
 /** Same as {@link findTableByName} but against the connection's source catalog. */
-export function findSourceTableByName(store: SchemaCanvasStore, qualified: string) {
-	const q = qualified.trim().toLowerCase();
-	return store.sourceTables.find((t) => {
-		const full = qname(t).toLowerCase();
-		return full === q || t.name.toLowerCase() === q;
-	});
+export function findSourceTableByName(
+  store: SchemaCanvasStore,
+  qualified: string,
+) {
+  const q = qualified.trim().toLowerCase();
+  return store.sourceTables.find((t) => {
+    const full = qname(t).toLowerCase();
+    return full === q || t.name.toLowerCase() === q;
+  });
 }
 
-function tableNameById(store: SchemaCanvasStore, id: string | null | undefined): string | null {
-	const t = id ? store.doc.tables.find((x) => x.id === id) : undefined;
-	return t ? qname(t) : null;
+function tableNameById(
+  store: SchemaCanvasStore,
+  id: string | null | undefined,
+): string | null {
+  const t = id ? store.doc.tables.find((x) => x.id === id) : undefined;
+  return t ? qname(t) : null;
 }
 
 function findDimByName(store: SchemaCanvasStore, n: string) {
-	return (store.doc.dimensions ?? []).find((d) => d.name.toLowerCase() === n.trim().toLowerCase());
+  return (store.doc.dimensions ?? []).find(
+    (d) => d.name.toLowerCase() === n.trim().toLowerCase(),
+  );
 }
 
 // ── Cube helpers for grouped measure writes ──────────────────────
@@ -83,18 +95,19 @@ function findDimByName(store: SchemaCanvasStore, n: string) {
 // (creating one if none); reuse the group already bound to the fact, or
 // spin up a default one.
 function ensureCube(store: SchemaCanvasStore): SchemaCanvasCube {
-	return store.cubes[0] ?? store.addCube({ name: 'Cube 1' });
+  return store.cubes[0] ?? store.addCube({ name: "Cube 1" });
 }
 
 function ensureMeasureGroup(
-	store: SchemaCanvasStore,
-	cube: SchemaCanvasCube,
-	factTableId: string
+  store: SchemaCanvasStore,
+  cube: SchemaCanvasCube,
+  factTableId: string,
 ): SchemaCanvasMeasureGroup | null {
-	const existing =
-		cube.measureGroups.find((g) => g.factTableId === factTableId) ?? cube.measureGroups[0];
-	if (existing) return existing;
-	return store.addMeasureGroup(cube.id, { name: 'Measures', factTableId });
+  const existing =
+    cube.measureGroups.find((g) => g.factTableId === factTableId) ??
+    cube.measureGroups[0];
+  if (existing) return existing;
+  return store.addMeasureGroup(cube.id, { name: "Measures", factTableId });
 }
 
 /**
@@ -104,42 +117,46 @@ function ensureMeasureGroup(
  * into the next Claude call as well.
  */
 export function buildCanvasSummary(store: SchemaCanvasStore): string {
-	const tableNameFor = (id: string): string => {
-		const t = store.doc.tables.find((x) => x.id === id);
-		if (!t) return id;
-		return qname(t);
-	};
-	const canvasTableLines = store.doc.tables.map((t) => {
-		const qualified = qname(t);
-		const cols = t.columns.map((c) => `${c.name}${c.sqlType ? `:${c.sqlType}` : ''}`).join(', ');
-		return `  - ${qualified}: [${cols || '(no columns)'}]`;
-	});
-	const userMadeJoins = store.doc.joins.filter((j) => (j.origin ?? 'physical') === 'physical');
-	const semanticJoins = store.doc.joins.filter(
-		(j) => j.origin === 'cube-link' || j.origin === 'inferred-fk'
-	);
-	const userMadeLines = userMadeJoins.map(
-		(j) =>
-			`  - ${tableNameFor(j.sourceTableId)}.${j.sourceColumnName}  ↔  ${tableNameFor(
-				j.targetTableId
-			)}.${j.targetColumnName}`
-	);
-	const semanticLines = semanticJoins.map(
-		(j) =>
-			`  - ${tableNameFor(j.sourceTableId)}.${j.sourceColumnName}  ↔  ${tableNameFor(
-				j.targetTableId
-			)}.${j.targetColumnName}  (origin: ${j.origin ?? 'inferred-fk'})`
-	);
-	return [
-		`ON-CANVAS TABLES (${store.doc.tables.length}):`,
-		...(canvasTableLines.length === 0 ? ['  (none)'] : canvasTableLines),
-		'',
-		`USER-MADE JOINS (${userMadeJoins.length}):`,
-		...(userMadeLines.length === 0 ? ['  (none)'] : userMadeLines),
-		'',
-		`SEMANTIC (cube-link, read-only) JOINS (${semanticJoins.length}):`,
-		...(semanticLines.length === 0 ? ['  (none)'] : semanticLines)
-	].join('\n');
+  const tableNameFor = (id: string): string => {
+    const t = store.doc.tables.find((x) => x.id === id);
+    if (!t) return id;
+    return qname(t);
+  };
+  const canvasTableLines = store.doc.tables.map((t) => {
+    const qualified = qname(t);
+    const cols = t.columns
+      .map((c) => `${c.name}${c.sqlType ? `:${c.sqlType}` : ""}`)
+      .join(", ");
+    return `  - ${qualified}: [${cols || "(no columns)"}]`;
+  });
+  const userMadeJoins = store.doc.joins.filter(
+    (j) => (j.origin ?? "physical") === "physical",
+  );
+  const semanticJoins = store.doc.joins.filter(
+    (j) => j.origin === "cube-link" || j.origin === "inferred-fk",
+  );
+  const userMadeLines = userMadeJoins.map(
+    (j) =>
+      `  - ${tableNameFor(j.sourceTableId)}.${j.sourceColumnName}  ↔  ${tableNameFor(
+        j.targetTableId,
+      )}.${j.targetColumnName}`,
+  );
+  const semanticLines = semanticJoins.map(
+    (j) =>
+      `  - ${tableNameFor(j.sourceTableId)}.${j.sourceColumnName}  ↔  ${tableNameFor(
+        j.targetTableId,
+      )}.${j.targetColumnName}  (origin: ${j.origin ?? "inferred-fk"})`,
+  );
+  return [
+    `ON-CANVAS TABLES (${store.doc.tables.length}):`,
+    ...(canvasTableLines.length === 0 ? ["  (none)"] : canvasTableLines),
+    "",
+    `USER-MADE JOINS (${userMadeJoins.length}):`,
+    ...(userMadeLines.length === 0 ? ["  (none)"] : userMadeLines),
+    "",
+    `SEMANTIC (cube-link, read-only) JOINS (${semanticJoins.length}):`,
+    ...(semanticLines.length === 0 ? ["  (none)"] : semanticLines),
+  ].join("\n");
 }
 
 /**
@@ -155,47 +172,51 @@ export function buildCanvasSummary(store: SchemaCanvasStore): string {
  * Idempotent — setMeasureGroupDimLink upserts by dimensionId.
  */
 export function reconcileMeasureGroupLinks(store: SchemaCanvasStore): void {
-	for (const cube of store.cubes) {
-		for (const mg of cube.measureGroups) {
-			const factId = mg.factTableId ?? null;
-			if (!factId) continue;
-			const factTable = store.doc.tables.find((t) => t.id === factId);
-			const factCol = (name: string | null | undefined): string | null => {
-				if (!name || !factTable) return null;
-				return (
-					factTable.columns.find((c) => c.name.toLowerCase() === name.toLowerCase())?.name ?? null
-				);
-			};
-			for (const dim of store.doc.dimensions ?? []) {
-				const dimTableId = dim.primaryKeyTableId ?? dim.sourceTableId ?? null;
-				let fk = dim.foreignKey ?? null;
-				if (!fk && dimTableId) {
-					for (const j of store.doc.joins) {
-						if (j.sourceTableId === factId && j.targetTableId === dimTableId) {
-							fk = j.sourceColumnName;
-							break;
-						}
-						if (j.targetTableId === factId && j.sourceTableId === dimTableId) {
-							fk = j.targetColumnName;
-							break;
-						}
-					}
-				}
-				if (!fk && dimTableId !== factId) {
-					// Star-schema fallback: the fact usually carries a column named
-					// like the dimension's key (product_id) or `<dim table>_id`.
-					const dimTable = store.doc.tables.find((t) => t.id === dimTableId);
-					fk = factCol(dim.primaryKey) ?? (dimTable ? factCol(`${dimTable.name}_id`) : null);
-				}
-				if (!fk) continue;
-				store.setMeasureGroupDimLink(cube.id, mg.id, {
-					dimensionId: dim.id,
-					foreignKeyColumn: fk,
-					linkKind: dimTableId === factId ? 'fact' : 'foreign-key'
-				});
-			}
-		}
-	}
+  for (const cube of store.cubes) {
+    for (const mg of cube.measureGroups) {
+      const factId = mg.factTableId ?? null;
+      if (!factId) continue;
+      const factTable = store.doc.tables.find((t) => t.id === factId);
+      const factCol = (name: string | null | undefined): string | null => {
+        if (!name || !factTable) return null;
+        return (
+          factTable.columns.find(
+            (c) => c.name.toLowerCase() === name.toLowerCase(),
+          )?.name ?? null
+        );
+      };
+      for (const dim of store.doc.dimensions ?? []) {
+        const dimTableId = dim.primaryKeyTableId ?? dim.sourceTableId ?? null;
+        let fk = dim.foreignKey ?? null;
+        if (!fk && dimTableId) {
+          for (const j of store.doc.joins) {
+            if (j.sourceTableId === factId && j.targetTableId === dimTableId) {
+              fk = j.sourceColumnName;
+              break;
+            }
+            if (j.targetTableId === factId && j.sourceTableId === dimTableId) {
+              fk = j.targetColumnName;
+              break;
+            }
+          }
+        }
+        if (!fk && dimTableId !== factId) {
+          // Star-schema fallback: the fact usually carries a column named
+          // like the dimension's key (product_id) or `<dim table>_id`.
+          const dimTable = store.doc.tables.find((t) => t.id === dimTableId);
+          fk =
+            factCol(dim.primaryKey) ??
+            (dimTable ? factCol(`${dimTable.name}_id`) : null);
+        }
+        if (!fk) continue;
+        store.setMeasureGroupDimLink(cube.id, mg.id, {
+          dimensionId: dim.id,
+          foreignKeyColumn: fk,
+          linkKind: dimTableId === factId ? "fact" : "foreign-key",
+        });
+      }
+    }
+  }
 }
 
 /**
@@ -204,604 +225,653 @@ export function reconcileMeasureGroupLinks(store: SchemaCanvasStore): void {
  * `isError` flag.
  */
 export async function executeDimSumTool(
-	store: SchemaCanvasStore,
-	name: string,
-	input: Record<string, unknown>,
-	deps: DimSumToolDeps
+  store: SchemaCanvasStore,
+  name: string,
+  input: Record<string, unknown>,
+  deps: DimSumToolDeps,
 ): Promise<{ content: string; isError: boolean }> {
-	try {
-		if (name === 'list_tables') {
-			const onCanvas = store.doc.tables.map((t) => ({
-				qualifiedName: qname(t),
-				columnCount: t.columns.length
-			}));
-			const onCanvasNames = new Set(onCanvas.map((t) => t.qualifiedName.toLowerCase()));
-			const available = store.sourceTables
-				.map((t) => ({
-					qualifiedName: qname(t),
-					columnCount: t.columns.length
-				}))
-				.filter((t) => !onCanvasNames.has(t.qualifiedName.toLowerCase()));
-			return {
-				content: JSON.stringify({ onCanvas, available }),
-				isError: false
-			};
-		}
-		if (name === 'describe_table') {
-			const qualified = String(input.qualifiedName ?? '');
-			const t = findTableByName(store, qualified) ?? findSourceTableByName(store, qualified);
-			if (!t) {
-				return {
-					content: JSON.stringify({
-						error: `No table named "${qualified}" is on the canvas or in the connection catalog.`
-					}),
-					isError: true
-				};
-			}
-			const canvasT = findTableByName(store, qualified);
-			const joinsInvolving = canvasT
-				? store.doc.joins
-						.filter((j) => j.sourceTableId === canvasT.id || j.targetTableId === canvasT.id)
-						.map((j) => {
-							const other =
-								j.sourceTableId === canvasT.id
-									? store.doc.tables.find((tt) => tt.id === j.targetTableId)
-									: store.doc.tables.find((tt) => tt.id === j.sourceTableId);
-							return {
-								neighbor: other ? qname(other) : '(unknown)',
-								thisColumn:
-									j.sourceTableId === canvasT.id ? j.sourceColumnName : j.targetColumnName,
-								neighborColumn:
-									j.sourceTableId === canvasT.id ? j.targetColumnName : j.sourceColumnName,
-								origin: j.origin ?? 'physical'
-							};
-						})
-				: [];
-			return {
-				content: JSON.stringify({
-					qualifiedName: qname(t),
-					onCanvas: !!canvasT,
-					columns: t.columns.map((c) => ({ name: c.name, sqlType: c.sqlType })),
-					joinsInvolving
-				}),
-				isError: false
-			};
-		}
-		if (name === 'list_joins') {
-			const tableNameFor = (id: string) => {
-				const t = store.doc.tables.find((x) => x.id === id);
-				if (!t) return id;
-				return qname(t);
-			};
-			const userMade: Array<{
-				from: { table: string; column: string };
-				to: { table: string; column: string };
-			}> = [];
-			const semantic: Array<{
-				from: { table: string; column: string };
-				to: { table: string; column: string };
-				origin: string;
-			}> = [];
-			for (const j of store.doc.joins) {
-				const dto = {
-					from: { table: tableNameFor(j.sourceTableId), column: j.sourceColumnName },
-					to: { table: tableNameFor(j.targetTableId), column: j.targetColumnName }
-				};
-				if ((j.origin ?? 'physical') === 'physical') userMade.push(dto);
-				else semantic.push({ ...dto, origin: j.origin ?? 'inferred-fk' });
-			}
-			return { content: JSON.stringify({ userMade, semantic }), isError: false };
-		}
-		if (name === 'add_table_to_canvas') {
-			const qualified = String(input.qualifiedName ?? '');
-			const existing = findTableByName(store, qualified);
-			if (existing) {
-				return {
-					content: JSON.stringify({
-						added: false,
-						reason: 'already_on_canvas',
-						tableId: existing.id
-					}),
-					isError: false
-				};
-			}
-			const candidate = findSourceTableByName(store, qualified);
-			if (!candidate) {
-				return {
-					content: JSON.stringify({
-						added: false,
-						reason: `No table named "${qualified}" in the connection catalog.`
-					}),
-					isError: true
-				};
-			}
-			// Position new tables in a rough grid to the right of existing ones.
-			const rightmost = store.doc.tables.reduce((mx, t) => Math.max(mx, t.position.x + 200), 0);
-			const added = store.addTable(candidate, {
-				x: rightmost + 40,
-				y: 80 + (store.doc.tables.length % 4) * 240
-			});
-			return {
-				content: JSON.stringify({
-					added: true,
-					tableId: added.id,
-					qualifiedName: qname(added)
-				}),
-				isError: false
-			};
-		}
-		if (name === 'remove_table_from_canvas') {
-			const qualified = String(input.qualifiedName ?? '');
-			const t = findTableByName(store, qualified);
-			if (!t) {
-				return {
-					content: JSON.stringify({
-						removed: false,
-						reason: `No table "${qualified}" on canvas.`
-					}),
-					isError: true
-				};
-			}
-			const joinsRemoved = store.doc.joins.filter(
-				(j) => j.sourceTableId === t.id || j.targetTableId === t.id
-			).length;
-			store.removeTable(t.id);
-			return {
-				content: JSON.stringify({ removed: true, joinsRemoved }),
-				isError: false
-			};
-		}
-		if (name === 'add_join') {
-			const fromIn = (input.from ?? {}) as { table?: unknown; column?: unknown };
-			const toIn = (input.to ?? {}) as { table?: unknown; column?: unknown };
-			const fromTable = findTableByName(store, String(fromIn.table ?? ''));
-			const toTable = findTableByName(store, String(toIn.table ?? ''));
-			if (!fromTable || !toTable) {
-				return {
-					content: JSON.stringify({
-						added: false,
-						reason: `Both tables must be on the canvas first. Missing: ${
-							!fromTable ? fromIn.table : ''
-						}${!fromTable && !toTable ? ', ' : ''}${!toTable ? toIn.table : ''}`
-					}),
-					isError: true
-				};
-			}
-			const fromCol = String(fromIn.column ?? '');
-			const toCol = String(toIn.column ?? '');
-			if (!fromTable.columns.some((c) => c.name === fromCol)) {
-				return {
-					content: JSON.stringify({
-						added: false,
-						reason: `Column "${fromCol}" not found on ${fromTable.name}.`
-					}),
-					isError: true
-				};
-			}
-			if (!toTable.columns.some((c) => c.name === toCol)) {
-				return {
-					content: JSON.stringify({
-						added: false,
-						reason: `Column "${toCol}" not found on ${toTable.name}.`
-					}),
-					isError: true
-				};
-			}
-			const created = store.addJoin({
-				sourceTableId: fromTable.id,
-				sourceColumnName: fromCol,
-				targetTableId: toTable.id,
-				targetColumnName: toCol,
-				kind: 'inner',
-				origin: 'physical'
-			});
-			return {
-				content: JSON.stringify({ added: true, joinId: created.id }),
-				isError: false
-			};
-		}
-		if (name === 'remove_join') {
-			const fromIn = (input.from ?? {}) as { table?: unknown; column?: unknown };
-			const toIn = (input.to ?? {}) as { table?: unknown; column?: unknown };
-			const fromTable = findTableByName(store, String(fromIn.table ?? ''));
-			const toTable = findTableByName(store, String(toIn.table ?? ''));
-			if (!fromTable || !toTable) {
-				return {
-					content: JSON.stringify({
-						removed: false,
-						reason: 'One or both tables not on canvas.'
-					}),
-					isError: true
-				};
-			}
-			const target = store.doc.joins.find(
-				(j) =>
-					(j.origin ?? 'physical') === 'physical' &&
-					((j.sourceTableId === fromTable.id &&
-						j.sourceColumnName === fromIn.column &&
-						j.targetTableId === toTable.id &&
-						j.targetColumnName === toIn.column) ||
-						(j.sourceTableId === toTable.id &&
-							j.sourceColumnName === toIn.column &&
-							j.targetTableId === fromTable.id &&
-							j.targetColumnName === fromIn.column))
-			);
-			if (!target) {
-				return {
-					content: JSON.stringify({
-						removed: false,
-						reason: 'No matching physical join found (semantic cube-links are read-only).'
-					}),
-					isError: true
-				};
-			}
-			store.removeJoin(target.id);
-			return { content: JSON.stringify({ removed: true }), isError: false };
-		}
-		if (name === 'arrange_canvas') {
-			// Same code path as the toolbar Arrange button — reuses the
-			// component's handleLayout via deps so layout tweaks stay in one place.
-			const mode = (String(input.mode ?? 'star') as LayoutMode) || 'star';
-			if (store.doc.tables.length === 0) {
-				return {
-					content: JSON.stringify({
-						arranged: false,
-						reason: 'No tables on canvas to arrange.'
-					}),
-					isError: false
-				};
-			}
-			await deps.arrangeCanvas(mode);
-			return {
-				content: JSON.stringify({
-					arranged: true,
-					mode,
-					tableCount: store.doc.tables.length
-				}),
-				isError: false
-			};
-		}
-		if (name === 'perform_action') {
-			// Generic action registry — every button that DimSum should
-			// be able to trigger has an id here.  Adding a new UI
-			// button = add a case here + list it in the system prompt
-			// server-side.  Keeps the "AI parity with every button"
-			// principle in one place.
-			const actionId = String(input.action ?? '');
-			switch (actionId) {
-				case 'zoom_in':
-				case 'zoom_out':
-				case 'fit_view':
-				case 'zoom_to_100':
-				case 'center_view':
-					store.requestedCanvasAction = { kind: actionId, ts: Date.now() };
-					return {
-						content: JSON.stringify({ performed: actionId }),
-						isError: false
-					};
-				case 'undo_last_change':
-					if (!store.previousDoc) {
-						return {
-							content: JSON.stringify({
-								performed: false,
-								reason:
-									'No prior state to undo — nothing has changed since the last confirmed edit.'
-							}),
-							isError: false
-						};
-					}
-					store.undo();
-					return {
-						content: JSON.stringify({ performed: 'undo_last_change' }),
-						isError: false
-					};
-				case 'center_view_on_table': {
-					const qualified = String(input.qualifiedName ?? '');
-					const t = findTableByName(store, qualified);
-					if (!t) {
-						return {
-							content: JSON.stringify({
-								error: `No canvas table named "${qualified}" — add it first, or check the spelling.`
-							}),
-							isError: true
-						};
-					}
-					store.requestedJumpTarget = { tableId: t.id, ts: Date.now() };
-					return {
-						content: JSON.stringify({
-							performed: 'center_view_on_table',
-							qualifiedName: qualified
-						}),
-						isError: false
-					};
-				}
-				default:
-					return {
-						content: JSON.stringify({
-							error: `Unknown action id: "${actionId}". Available: zoom_in, zoom_out, fit_view, zoom_to_100, center_view, undo_last_change, center_view_on_table.`
-						}),
-						isError: true
-					};
-			}
-		}
-		// ── Logical layer (Mondrian 4 cube: dimensions, hierarchies,
-		//    levels, fact + measures) ──────────────────────────────────
-		if (name === 'list_dimensions') {
-			const fact = store.doc.tables.find((t) => t.role === 'fact');
-			const dimensions = (store.doc.dimensions ?? []).map((d) => ({
-				name: d.name,
-				table: tableNameById(store, d.primaryKeyTableId),
-				primaryKey: d.primaryKey ?? null,
-				foreignKey: d.foreignKey ?? null,
-				type: d.dimensionType ?? 'Standard',
-				hierarchies: d.hierarchies.map((h) => ({
-					name: h.name,
-					hasAll: h.hasAll,
-					levels: h.levels.map((l) => l.name)
-				}))
-			}));
-			const measures = (store.doc.measures ?? []).map((m) => ({
-				name: m.name,
-				column: m.columnName,
-				aggregator: m.aggregator,
-				table: tableNameById(store, m.tableId)
-			}));
-			return {
-				content: JSON.stringify({
-					factTable: fact ? qname(fact) : null,
-					dimensions,
-					measures
-				}),
-				isError: false
-			};
-		}
-		if (name === 'set_fact_table') {
-			const t = findTableByName(store, String(input.qualifiedName ?? ''));
-			if (!t) {
-				return {
-					content: JSON.stringify({
-						ok: false,
-						reason: `No table "${input.qualifiedName}" on canvas — add_table_to_canvas first.`
-					}),
-					isError: true
-				};
-			}
-			store.setTableRole(t.id, 'fact');
-			return { content: JSON.stringify({ ok: true, factTable: qname(t) }), isError: false };
-		}
-		if (name === 'create_dimension') {
-			const t = findTableByName(store, String(input.table ?? ''));
-			if (!t) {
-				return {
-					content: JSON.stringify({
-						ok: false,
-						reason: `No table "${input.table}" on canvas — add_table_to_canvas first.`
-					}),
-					isError: true
-				};
-			}
-			const pk = String(input.primaryKeyColumn ?? '');
-			if (pk && !t.columns.some((c) => c.name === pk)) {
-				return {
-					content: JSON.stringify({
-						ok: false,
-						reason: `Primary-key column "${pk}" not found on ${t.name}.`
-					}),
-					isError: true
-				};
-			}
-			const dimName = input.name ? String(input.name) : undefined;
-			if (dimName && findDimByName(store, dimName)) {
-				return {
-					content: JSON.stringify({
-						ok: false,
-						reason: `Dimension "${dimName}" already exists.`
-					}),
-					isError: true
-				};
-			}
-			const dim = store.addDimension({ name: dimName, tableId: t.id });
-			const patch: Record<string, unknown> = { primaryKeyTableId: t.id };
-			if (pk) patch.primaryKey = pk;
-			if (input.foreignKeyColumn) patch.foreignKey = String(input.foreignKeyColumn);
-			if (input.type) patch.dimensionType = String(input.type);
-			store.updateDimension(dim.id, patch);
-			// Seed the primary-key column as an attribute so the dimension
-			// has a resolvable KEY (resolveKeyAttribute matches an attribute
-			// whose columnName === dim.primaryKey) — otherwise the workbench
-			// shows "KEY MISSING" and 0 attributes.
-			if (pk) store.addAttribute(dim.id, t.id, pk);
-			// Link this dimension into any existing measure group (covers the
-			// dimensions-after-measures order) + refresh the workbench.
-			reconcileMeasureGroupLinks(store);
-			store.bumpWorkbenchReload();
-			return {
-				content: JSON.stringify({
-					ok: true,
-					dimension: dim.name,
-					table: qname(t),
-					primaryKey: pk || null,
-					foreignKey: input.foreignKeyColumn ? String(input.foreignKeyColumn) : null
-				}),
-				isError: false
-			};
-		}
-		if (name === 'add_hierarchy') {
-			const d = findDimByName(store, String(input.dimension ?? ''));
-			if (!d) {
-				return {
-					content: JSON.stringify({
-						ok: false,
-						reason: `No dimension "${input.dimension}" — create_dimension first.`
-					}),
-					isError: true
-				};
-			}
-			const h = store.addHierarchy(d.id, input.name ? String(input.name) : undefined);
-			if (h && input.hasAll === false) store.updateHierarchy(d.id, h.id, { hasAll: false });
-			return {
-				content: JSON.stringify({ ok: true, dimension: d.name, hierarchy: h?.name }),
-				isError: false
-			};
-		}
-		if (name === 'add_level') {
-			const d = findDimByName(store, String(input.dimension ?? ''));
-			if (!d) {
-				return {
-					content: JSON.stringify({
-						ok: false,
-						reason: `No dimension "${input.dimension}" — create_dimension first.`
-					}),
-					isError: true
-				};
-			}
-			const h = d.hierarchies.find(
-				(x) =>
-					x.name.toLowerCase() ===
-					String(input.hierarchy ?? '')
-						.trim()
-						.toLowerCase()
-			);
-			if (!h) {
-				return {
-					content: JSON.stringify({
-						ok: false,
-						reason: `No hierarchy "${input.hierarchy}" on ${d.name} — add_hierarchy first.`
-					}),
-					isError: true
-				};
-			}
-			const dimTable = store.doc.tables.find((x) => x.id === d.primaryKeyTableId);
-			const col = String(input.column ?? '');
-			if (!dimTable || !dimTable.columns.some((c) => c.name === col)) {
-				return {
-					content: JSON.stringify({
-						ok: false,
-						reason: `Column "${col}" not found on the dimension's table ${dimTable?.name ?? '(unknown)'}.`
-					}),
-					isError: true
-				};
-			}
-			const lvl = store.addLevel(d.id, h.id, {
-				tableId: dimTable.id,
-				columnName: col,
-				name: input.name ? String(input.name) : undefined
-			});
-			// M4 levels reference an attribute — materialise the column as a
-			// dimension attribute so the level resolves and the Attrs count
-			// reflects it.
-			store.addAttribute(d.id, dimTable.id, col);
-			return {
-				content: JSON.stringify({
-					ok: true,
-					dimension: d.name,
-					hierarchy: h.name,
-					level: lvl?.name
-				}),
-				isError: false
-			};
-		}
-		if (name === 'add_measure') {
-			const fact = store.doc.tables.find((t) => t.role === 'fact');
-			if (!fact) {
-				return {
-					content: JSON.stringify({
-						ok: false,
-						reason: 'No fact table set — call set_fact_table first.'
-					}),
-					isError: true
-				};
-			}
-			const agg = String(input.aggregator ?? 'sum');
-			const col = input.column ? String(input.column) : '';
-			if (agg !== 'count' && !fact.columns.some((c) => c.name === col)) {
-				return {
-					content: JSON.stringify({
-						ok: false,
-						reason: `Column "${col}" not found on the fact table ${fact.name}.`
-					}),
-					isError: true
-				};
-			}
-			// Percentile fraction (0–100) — only for aggregator 'percentile'
-			// (median is the implicit 50th). Clamped; invalid/absent → default 50.
-			const percentile =
-				agg === 'percentile' && input.percentile != null && !Number.isNaN(Number(input.percentile))
-					? Math.max(0, Math.min(100, Math.round(Number(input.percentile))))
-					: undefined;
-			const m = store.addMeasure({
-				tableId: fact.id,
-				// count(*) has no column; leave it empty so the emitter drops it.
-				columnName: col,
-				aggregator: agg as SchemaCanvasMeasure['aggregator'],
-				name: input.name ? String(input.name) : col ? undefined : 'Row count',
-				percentile
-			});
-			// Also fold the column into a measure group on the selected
-			// cube so the workbench + export show a grouped measure.  A
-			// count(*) row-count measure has no column — skip the group
-			// add for it (nothing to fold).
-			let measureGroupName: string | null = null;
-			if (col) {
-				const cube = ensureCube(store);
-				const mg = ensureMeasureGroup(store, cube, fact.id);
-				if (mg) {
-					if (!mg.measureColumns.includes(col)) {
-						store.toggleMeasureColumn(cube.id, mg.id, col);
-					}
-					measureGroupName = mg.name;
-				}
-			}
-			reconcileMeasureGroupLinks(store);
-			store.bumpWorkbenchReload();
-			return {
-				content: JSON.stringify({
-					ok: true,
-					measure: m.name,
-					aggregator: agg,
-					measureGroup: measureGroupName
-				}),
-				isError: false
-			};
-		}
-		if (name === 'add_measure_group') {
-			const fact = store.doc.tables.find((t) => t.role === 'fact');
-			if (!fact) {
-				return {
-					content: JSON.stringify({
-						ok: false,
-						reason: 'No fact table set — call set_fact_table first.'
-					}),
-					isError: true
-				};
-			}
-			const cube = ensureCube(store);
-			const mg = store.addMeasureGroup(cube.id, {
-				name: input.name ? String(input.name) : undefined,
-				factTableId: fact.id
-			});
-			reconcileMeasureGroupLinks(store);
-			store.bumpWorkbenchReload();
-			return {
-				content: JSON.stringify({
-					ok: true,
-					measureGroup: mg?.name ?? null,
-					cube: cube.name,
-					factTable: qname(fact)
-				}),
-				isError: false
-			};
-		}
-		return {
-			content: JSON.stringify({ error: `Unknown tool: ${name}` }),
-			isError: true
-		};
-	} catch (err) {
-		return {
-			content: JSON.stringify({
-				error: err instanceof Error ? err.message : 'tool execution threw'
-			}),
-			isError: true
-		};
-	}
+  try {
+    if (name === "list_tables") {
+      const onCanvas = store.doc.tables.map((t) => ({
+        qualifiedName: qname(t),
+        columnCount: t.columns.length,
+      }));
+      const onCanvasNames = new Set(
+        onCanvas.map((t) => t.qualifiedName.toLowerCase()),
+      );
+      const available = store.sourceTables
+        .map((t) => ({
+          qualifiedName: qname(t),
+          columnCount: t.columns.length,
+        }))
+        .filter((t) => !onCanvasNames.has(t.qualifiedName.toLowerCase()));
+      return {
+        content: JSON.stringify({ onCanvas, available }),
+        isError: false,
+      };
+    }
+    if (name === "describe_table") {
+      const qualified = String(input.qualifiedName ?? "");
+      const t =
+        findTableByName(store, qualified) ??
+        findSourceTableByName(store, qualified);
+      if (!t) {
+        return {
+          content: JSON.stringify({
+            error: `No table named "${qualified}" is on the canvas or in the connection catalog.`,
+          }),
+          isError: true,
+        };
+      }
+      const canvasT = findTableByName(store, qualified);
+      const joinsInvolving = canvasT
+        ? store.doc.joins
+            .filter(
+              (j) =>
+                j.sourceTableId === canvasT.id ||
+                j.targetTableId === canvasT.id,
+            )
+            .map((j) => {
+              const other =
+                j.sourceTableId === canvasT.id
+                  ? store.doc.tables.find((tt) => tt.id === j.targetTableId)
+                  : store.doc.tables.find((tt) => tt.id === j.sourceTableId);
+              return {
+                neighbor: other ? qname(other) : "(unknown)",
+                thisColumn:
+                  j.sourceTableId === canvasT.id
+                    ? j.sourceColumnName
+                    : j.targetColumnName,
+                neighborColumn:
+                  j.sourceTableId === canvasT.id
+                    ? j.targetColumnName
+                    : j.sourceColumnName,
+                origin: j.origin ?? "physical",
+              };
+            })
+        : [];
+      return {
+        content: JSON.stringify({
+          qualifiedName: qname(t),
+          onCanvas: !!canvasT,
+          columns: t.columns.map((c) => ({ name: c.name, sqlType: c.sqlType })),
+          joinsInvolving,
+        }),
+        isError: false,
+      };
+    }
+    if (name === "list_joins") {
+      const tableNameFor = (id: string) => {
+        const t = store.doc.tables.find((x) => x.id === id);
+        if (!t) return id;
+        return qname(t);
+      };
+      const userMade: Array<{
+        from: { table: string; column: string };
+        to: { table: string; column: string };
+      }> = [];
+      const semantic: Array<{
+        from: { table: string; column: string };
+        to: { table: string; column: string };
+        origin: string;
+      }> = [];
+      for (const j of store.doc.joins) {
+        const dto = {
+          from: {
+            table: tableNameFor(j.sourceTableId),
+            column: j.sourceColumnName,
+          },
+          to: {
+            table: tableNameFor(j.targetTableId),
+            column: j.targetColumnName,
+          },
+        };
+        if ((j.origin ?? "physical") === "physical") userMade.push(dto);
+        else semantic.push({ ...dto, origin: j.origin ?? "inferred-fk" });
+      }
+      return {
+        content: JSON.stringify({ userMade, semantic }),
+        isError: false,
+      };
+    }
+    if (name === "add_table_to_canvas") {
+      const qualified = String(input.qualifiedName ?? "");
+      const existing = findTableByName(store, qualified);
+      if (existing) {
+        return {
+          content: JSON.stringify({
+            added: false,
+            reason: "already_on_canvas",
+            tableId: existing.id,
+          }),
+          isError: false,
+        };
+      }
+      const candidate = findSourceTableByName(store, qualified);
+      if (!candidate) {
+        return {
+          content: JSON.stringify({
+            added: false,
+            reason: `No table named "${qualified}" in the connection catalog.`,
+          }),
+          isError: true,
+        };
+      }
+      // Position new tables in a rough grid to the right of existing ones.
+      const rightmost = store.doc.tables.reduce(
+        (mx, t) => Math.max(mx, t.position.x + 200),
+        0,
+      );
+      const added = store.addTable(candidate, {
+        x: rightmost + 40,
+        y: 80 + (store.doc.tables.length % 4) * 240,
+      });
+      return {
+        content: JSON.stringify({
+          added: true,
+          tableId: added.id,
+          qualifiedName: qname(added),
+        }),
+        isError: false,
+      };
+    }
+    if (name === "remove_table_from_canvas") {
+      const qualified = String(input.qualifiedName ?? "");
+      const t = findTableByName(store, qualified);
+      if (!t) {
+        return {
+          content: JSON.stringify({
+            removed: false,
+            reason: `No table "${qualified}" on canvas.`,
+          }),
+          isError: true,
+        };
+      }
+      const joinsRemoved = store.doc.joins.filter(
+        (j) => j.sourceTableId === t.id || j.targetTableId === t.id,
+      ).length;
+      store.removeTable(t.id);
+      return {
+        content: JSON.stringify({ removed: true, joinsRemoved }),
+        isError: false,
+      };
+    }
+    if (name === "add_join") {
+      const fromIn = (input.from ?? {}) as {
+        table?: unknown;
+        column?: unknown;
+      };
+      const toIn = (input.to ?? {}) as { table?: unknown; column?: unknown };
+      const fromTable = findTableByName(store, String(fromIn.table ?? ""));
+      const toTable = findTableByName(store, String(toIn.table ?? ""));
+      if (!fromTable || !toTable) {
+        return {
+          content: JSON.stringify({
+            added: false,
+            reason: `Both tables must be on the canvas first. Missing: ${
+              !fromTable ? fromIn.table : ""
+            }${!fromTable && !toTable ? ", " : ""}${!toTable ? toIn.table : ""}`,
+          }),
+          isError: true,
+        };
+      }
+      const fromCol = String(fromIn.column ?? "");
+      const toCol = String(toIn.column ?? "");
+      if (!fromTable.columns.some((c) => c.name === fromCol)) {
+        return {
+          content: JSON.stringify({
+            added: false,
+            reason: `Column "${fromCol}" not found on ${fromTable.name}.`,
+          }),
+          isError: true,
+        };
+      }
+      if (!toTable.columns.some((c) => c.name === toCol)) {
+        return {
+          content: JSON.stringify({
+            added: false,
+            reason: `Column "${toCol}" not found on ${toTable.name}.`,
+          }),
+          isError: true,
+        };
+      }
+      const created = store.addJoin({
+        sourceTableId: fromTable.id,
+        sourceColumnName: fromCol,
+        targetTableId: toTable.id,
+        targetColumnName: toCol,
+        kind: "inner",
+        origin: "physical",
+      });
+      return {
+        content: JSON.stringify({ added: true, joinId: created.id }),
+        isError: false,
+      };
+    }
+    if (name === "remove_join") {
+      const fromIn = (input.from ?? {}) as {
+        table?: unknown;
+        column?: unknown;
+      };
+      const toIn = (input.to ?? {}) as { table?: unknown; column?: unknown };
+      const fromTable = findTableByName(store, String(fromIn.table ?? ""));
+      const toTable = findTableByName(store, String(toIn.table ?? ""));
+      if (!fromTable || !toTable) {
+        return {
+          content: JSON.stringify({
+            removed: false,
+            reason: "One or both tables not on canvas.",
+          }),
+          isError: true,
+        };
+      }
+      const target = store.doc.joins.find(
+        (j) =>
+          (j.origin ?? "physical") === "physical" &&
+          ((j.sourceTableId === fromTable.id &&
+            j.sourceColumnName === fromIn.column &&
+            j.targetTableId === toTable.id &&
+            j.targetColumnName === toIn.column) ||
+            (j.sourceTableId === toTable.id &&
+              j.sourceColumnName === toIn.column &&
+              j.targetTableId === fromTable.id &&
+              j.targetColumnName === fromIn.column)),
+      );
+      if (!target) {
+        return {
+          content: JSON.stringify({
+            removed: false,
+            reason:
+              "No matching physical join found (semantic cube-links are read-only).",
+          }),
+          isError: true,
+        };
+      }
+      store.removeJoin(target.id);
+      return { content: JSON.stringify({ removed: true }), isError: false };
+    }
+    if (name === "arrange_canvas") {
+      // Same code path as the toolbar Arrange button — reuses the
+      // component's handleLayout via deps so layout tweaks stay in one place.
+      const mode = (String(input.mode ?? "star") as LayoutMode) || "star";
+      if (store.doc.tables.length === 0) {
+        return {
+          content: JSON.stringify({
+            arranged: false,
+            reason: "No tables on canvas to arrange.",
+          }),
+          isError: false,
+        };
+      }
+      await deps.arrangeCanvas(mode);
+      return {
+        content: JSON.stringify({
+          arranged: true,
+          mode,
+          tableCount: store.doc.tables.length,
+        }),
+        isError: false,
+      };
+    }
+    if (name === "perform_action") {
+      // Generic action registry — every button that DimSum should
+      // be able to trigger has an id here.  Adding a new UI
+      // button = add a case here + list it in the system prompt
+      // server-side.  Keeps the "AI parity with every button"
+      // principle in one place.
+      const actionId = String(input.action ?? "");
+      switch (actionId) {
+        case "zoom_in":
+        case "zoom_out":
+        case "fit_view":
+        case "zoom_to_100":
+        case "center_view":
+          store.requestedCanvasAction = { kind: actionId, ts: Date.now() };
+          return {
+            content: JSON.stringify({ performed: actionId }),
+            isError: false,
+          };
+        case "undo_last_change":
+          if (!store.previousDoc) {
+            return {
+              content: JSON.stringify({
+                performed: false,
+                reason:
+                  "No prior state to undo — nothing has changed since the last confirmed edit.",
+              }),
+              isError: false,
+            };
+          }
+          store.undo();
+          return {
+            content: JSON.stringify({ performed: "undo_last_change" }),
+            isError: false,
+          };
+        case "center_view_on_table": {
+          const qualified = String(input.qualifiedName ?? "");
+          const t = findTableByName(store, qualified);
+          if (!t) {
+            return {
+              content: JSON.stringify({
+                error: `No canvas table named "${qualified}" — add it first, or check the spelling.`,
+              }),
+              isError: true,
+            };
+          }
+          store.requestedJumpTarget = { tableId: t.id, ts: Date.now() };
+          return {
+            content: JSON.stringify({
+              performed: "center_view_on_table",
+              qualifiedName: qualified,
+            }),
+            isError: false,
+          };
+        }
+        default:
+          return {
+            content: JSON.stringify({
+              error: `Unknown action id: "${actionId}". Available: zoom_in, zoom_out, fit_view, zoom_to_100, center_view, undo_last_change, center_view_on_table.`,
+            }),
+            isError: true,
+          };
+      }
+    }
+    // ── Logical layer (Mondrian 4 cube: dimensions, hierarchies,
+    //    levels, fact + measures) ──────────────────────────────────
+    if (name === "list_dimensions") {
+      const fact = store.doc.tables.find((t) => t.role === "fact");
+      const dimensions = (store.doc.dimensions ?? []).map((d) => ({
+        name: d.name,
+        table: tableNameById(store, d.primaryKeyTableId),
+        primaryKey: d.primaryKey ?? null,
+        foreignKey: d.foreignKey ?? null,
+        type: d.dimensionType ?? "Standard",
+        hierarchies: d.hierarchies.map((h) => ({
+          name: h.name,
+          hasAll: h.hasAll,
+          levels: h.levels.map((l) => l.name),
+        })),
+      }));
+      const measures = (store.doc.measures ?? []).map((m) => ({
+        name: m.name,
+        column: m.columnName,
+        aggregator: m.aggregator,
+        table: tableNameById(store, m.tableId),
+      }));
+      return {
+        content: JSON.stringify({
+          factTable: fact ? qname(fact) : null,
+          dimensions,
+          measures,
+        }),
+        isError: false,
+      };
+    }
+    if (name === "set_fact_table") {
+      const t = findTableByName(store, String(input.qualifiedName ?? ""));
+      if (!t) {
+        return {
+          content: JSON.stringify({
+            ok: false,
+            reason: `No table "${input.qualifiedName}" on canvas — add_table_to_canvas first.`,
+          }),
+          isError: true,
+        };
+      }
+      store.setTableRole(t.id, "fact");
+      return {
+        content: JSON.stringify({ ok: true, factTable: qname(t) }),
+        isError: false,
+      };
+    }
+    if (name === "create_dimension") {
+      const t = findTableByName(store, String(input.table ?? ""));
+      if (!t) {
+        return {
+          content: JSON.stringify({
+            ok: false,
+            reason: `No table "${input.table}" on canvas — add_table_to_canvas first.`,
+          }),
+          isError: true,
+        };
+      }
+      const pk = String(input.primaryKeyColumn ?? "");
+      if (pk && !t.columns.some((c) => c.name === pk)) {
+        return {
+          content: JSON.stringify({
+            ok: false,
+            reason: `Primary-key column "${pk}" not found on ${t.name}.`,
+          }),
+          isError: true,
+        };
+      }
+      const dimName = input.name ? String(input.name) : undefined;
+      if (dimName && findDimByName(store, dimName)) {
+        return {
+          content: JSON.stringify({
+            ok: false,
+            reason: `Dimension "${dimName}" already exists.`,
+          }),
+          isError: true,
+        };
+      }
+      const dim = store.addDimension({ name: dimName, tableId: t.id });
+      const patch: Record<string, unknown> = { primaryKeyTableId: t.id };
+      if (pk) patch.primaryKey = pk;
+      if (input.foreignKeyColumn)
+        patch.foreignKey = String(input.foreignKeyColumn);
+      if (input.type) patch.dimensionType = String(input.type);
+      store.updateDimension(dim.id, patch);
+      // Seed the primary-key column as an attribute so the dimension
+      // has a resolvable KEY (resolveKeyAttribute matches an attribute
+      // whose columnName === dim.primaryKey) — otherwise the workbench
+      // shows "KEY MISSING" and 0 attributes.
+      if (pk) store.addAttribute(dim.id, t.id, pk);
+      // Link this dimension into any existing measure group (covers the
+      // dimensions-after-measures order) + refresh the workbench.
+      reconcileMeasureGroupLinks(store);
+      store.bumpWorkbenchReload();
+      return {
+        content: JSON.stringify({
+          ok: true,
+          dimension: dim.name,
+          table: qname(t),
+          primaryKey: pk || null,
+          foreignKey: input.foreignKeyColumn
+            ? String(input.foreignKeyColumn)
+            : null,
+        }),
+        isError: false,
+      };
+    }
+    if (name === "add_hierarchy") {
+      const d = findDimByName(store, String(input.dimension ?? ""));
+      if (!d) {
+        return {
+          content: JSON.stringify({
+            ok: false,
+            reason: `No dimension "${input.dimension}" — create_dimension first.`,
+          }),
+          isError: true,
+        };
+      }
+      const h = store.addHierarchy(
+        d.id,
+        input.name ? String(input.name) : undefined,
+      );
+      if (h && input.hasAll === false)
+        store.updateHierarchy(d.id, h.id, { hasAll: false });
+      return {
+        content: JSON.stringify({
+          ok: true,
+          dimension: d.name,
+          hierarchy: h?.name,
+        }),
+        isError: false,
+      };
+    }
+    if (name === "add_level") {
+      const d = findDimByName(store, String(input.dimension ?? ""));
+      if (!d) {
+        return {
+          content: JSON.stringify({
+            ok: false,
+            reason: `No dimension "${input.dimension}" — create_dimension first.`,
+          }),
+          isError: true,
+        };
+      }
+      const h = d.hierarchies.find(
+        (x) =>
+          x.name.toLowerCase() ===
+          String(input.hierarchy ?? "")
+            .trim()
+            .toLowerCase(),
+      );
+      if (!h) {
+        return {
+          content: JSON.stringify({
+            ok: false,
+            reason: `No hierarchy "${input.hierarchy}" on ${d.name} — add_hierarchy first.`,
+          }),
+          isError: true,
+        };
+      }
+      const dimTable = store.doc.tables.find(
+        (x) => x.id === d.primaryKeyTableId,
+      );
+      const col = String(input.column ?? "");
+      if (!dimTable || !dimTable.columns.some((c) => c.name === col)) {
+        return {
+          content: JSON.stringify({
+            ok: false,
+            reason: `Column "${col}" not found on the dimension's table ${dimTable?.name ?? "(unknown)"}.`,
+          }),
+          isError: true,
+        };
+      }
+      const lvl = store.addLevel(d.id, h.id, {
+        tableId: dimTable.id,
+        columnName: col,
+        name: input.name ? String(input.name) : undefined,
+      });
+      // M4 levels reference an attribute — materialise the column as a
+      // dimension attribute so the level resolves and the Attrs count
+      // reflects it.
+      store.addAttribute(d.id, dimTable.id, col);
+      return {
+        content: JSON.stringify({
+          ok: true,
+          dimension: d.name,
+          hierarchy: h.name,
+          level: lvl?.name,
+        }),
+        isError: false,
+      };
+    }
+    if (name === "add_measure") {
+      const fact = store.doc.tables.find((t) => t.role === "fact");
+      if (!fact) {
+        return {
+          content: JSON.stringify({
+            ok: false,
+            reason: "No fact table set — call set_fact_table first.",
+          }),
+          isError: true,
+        };
+      }
+      const agg = String(input.aggregator ?? "sum");
+      const col = input.column ? String(input.column) : "";
+      if (agg !== "count" && !fact.columns.some((c) => c.name === col)) {
+        return {
+          content: JSON.stringify({
+            ok: false,
+            reason: `Column "${col}" not found on the fact table ${fact.name}.`,
+          }),
+          isError: true,
+        };
+      }
+      // Percentile fraction (0–100) — only for aggregator 'percentile'
+      // (median is the implicit 50th). Clamped; invalid/absent → default 50.
+      const percentile =
+        agg === "percentile" &&
+        input.percentile != null &&
+        !Number.isNaN(Number(input.percentile))
+          ? Math.max(0, Math.min(100, Math.round(Number(input.percentile))))
+          : undefined;
+      const m = store.addMeasure({
+        tableId: fact.id,
+        // count(*) has no column; leave it empty so the emitter drops it.
+        columnName: col,
+        aggregator: agg as SchemaCanvasMeasure["aggregator"],
+        name: input.name ? String(input.name) : col ? undefined : "Row count",
+        percentile,
+      });
+      // Also fold the column into a measure group on the selected
+      // cube so the workbench + export show a grouped measure.  A
+      // count(*) row-count measure has no column — skip the group
+      // add for it (nothing to fold).
+      let measureGroupName: string | null = null;
+      if (col) {
+        const cube = ensureCube(store);
+        const mg = ensureMeasureGroup(store, cube, fact.id);
+        if (mg) {
+          if (!mg.measureColumns.includes(col)) {
+            store.toggleMeasureColumn(cube.id, mg.id, col);
+          }
+          measureGroupName = mg.name;
+        }
+      }
+      reconcileMeasureGroupLinks(store);
+      store.bumpWorkbenchReload();
+      return {
+        content: JSON.stringify({
+          ok: true,
+          measure: m.name,
+          aggregator: agg,
+          measureGroup: measureGroupName,
+        }),
+        isError: false,
+      };
+    }
+    if (name === "add_measure_group") {
+      const fact = store.doc.tables.find((t) => t.role === "fact");
+      if (!fact) {
+        return {
+          content: JSON.stringify({
+            ok: false,
+            reason: "No fact table set — call set_fact_table first.",
+          }),
+          isError: true,
+        };
+      }
+      const cube = ensureCube(store);
+      const mg = store.addMeasureGroup(cube.id, {
+        name: input.name ? String(input.name) : undefined,
+        factTableId: fact.id,
+      });
+      reconcileMeasureGroupLinks(store);
+      store.bumpWorkbenchReload();
+      return {
+        content: JSON.stringify({
+          ok: true,
+          measureGroup: mg?.name ?? null,
+          cube: cube.name,
+          factTable: qname(fact),
+        }),
+        isError: false,
+      };
+    }
+    return {
+      content: JSON.stringify({ error: `Unknown tool: ${name}` }),
+      isError: true,
+    };
+  } catch (err) {
+    return {
+      content: JSON.stringify({
+        error: err instanceof Error ? err.message : "tool execution threw",
+      }),
+      isError: true,
+    };
+  }
 }

--- a/saiku-ui/src/lib/cube-designer/dimsum-tools.ts
+++ b/saiku-ui/src/lib/cube-designer/dimsum-tools.ts
@@ -1,0 +1,807 @@
+/**
+ * DimSum tool executors — pure logic lifted out of SchemaCanvasView.svelte
+ * (audit finding #1040).
+ *
+ * Each executor takes the {@link SchemaCanvasStore}, a tool name, and the
+ * tool input, mutates the store *through its own methods* (the store stays
+ * the mutation boundary — no direct doc mutation here), and returns a JSON
+ * string ready to drop into an Anthropic `tool_result` block. Keeping these
+ * in a plain `.ts` module makes the whole AI-call surface unit-testable
+ * against a constructed store — the point of the finding.
+ *
+ * The `.svelte` component keeps ownership of reactivity + the agent loop; it
+ * imports {@link executeDimSumTool} + {@link buildCanvasSummary} +
+ * {@link reconcileMeasureGroupLinks} and calls them from `runDraftWithAI`.
+ */
+import { SchemaCanvasStore } from './state.svelte.js';
+import type { LayoutMode } from './layout.js';
+import type { SchemaCanvasCube, SchemaCanvasMeasure, SchemaCanvasMeasureGroup } from './types.js';
+
+/** Tool names that MUTATE the canvas — `runDraftWithAI` tracks whether any
+ *  succeeded so it can raise the Confirm/Cancel banner after the loop. */
+export const DIMSUM_MUTATION_TOOLS: ReadonlySet<string> = new Set([
+	'add_table_to_canvas',
+	'remove_table_from_canvas',
+	'add_join',
+	'remove_join',
+	'set_fact_table',
+	'create_dimension',
+	'add_hierarchy',
+	'add_level',
+	'add_measure',
+	'add_measure_group'
+]);
+
+/** Side-effecting dependencies the executor can't own (they touch component
+ *  `$state` / the SvelteFlow viewport). Passed in so the executor stays pure
+ *  over the store. */
+export interface DimSumToolDeps {
+	/** Runs the same layout path as the toolbar Arrange button. */
+	arrangeCanvas: (mode: LayoutMode) => Promise<void>;
+}
+
+/** `schema.name` or bare `name` for a table-shaped record. */
+function qname(t: { schema: string | null; name: string }): string {
+	return t.schema ? `${t.schema}.${t.name}` : t.name;
+}
+
+/**
+ * Resolve a `schema.name` or `name` string against the store's on-canvas
+ * tables — matches case-insensitively so DimSum doesn't need to worry about
+ * UPPER vs lower case.
+ */
+export function findTableByName(store: SchemaCanvasStore, qualified: string) {
+	const q = qualified.trim().toLowerCase();
+	return store.doc.tables.find((t) => {
+		const full = qname(t).toLowerCase();
+		return full === q || t.name.toLowerCase() === q;
+	});
+}
+
+/** Same as {@link findTableByName} but against the connection's source catalog. */
+export function findSourceTableByName(store: SchemaCanvasStore, qualified: string) {
+	const q = qualified.trim().toLowerCase();
+	return store.sourceTables.find((t) => {
+		const full = qname(t).toLowerCase();
+		return full === q || t.name.toLowerCase() === q;
+	});
+}
+
+function tableNameById(store: SchemaCanvasStore, id: string | null | undefined): string | null {
+	const t = id ? store.doc.tables.find((x) => x.id === id) : undefined;
+	return t ? qname(t) : null;
+}
+
+function findDimByName(store: SchemaCanvasStore, n: string) {
+	return (store.doc.dimensions ?? []).find((d) => d.name.toLowerCase() === n.trim().toLowerCase());
+}
+
+// ── Cube helpers for grouped measure writes ──────────────────────
+// DimSum authors measures INTO a measure group on the selected cube
+// (the durable doc model), not just the flat `store.measures` list, so
+// the workbench + export show a grouped measure.  Pick the first cube
+// (creating one if none); reuse the group already bound to the fact, or
+// spin up a default one.
+function ensureCube(store: SchemaCanvasStore): SchemaCanvasCube {
+	return store.cubes[0] ?? store.addCube({ name: 'Cube 1' });
+}
+
+function ensureMeasureGroup(
+	store: SchemaCanvasStore,
+	cube: SchemaCanvasCube,
+	factTableId: string
+): SchemaCanvasMeasureGroup | null {
+	const existing =
+		cube.measureGroups.find((g) => g.factTableId === factTableId) ?? cube.measureGroups[0];
+	if (existing) return existing;
+	return store.addMeasureGroup(cube.id, { name: 'Measures', factTableId });
+}
+
+/**
+ * Build the JSON canvas snapshot the backend prepends as a synthetic priming
+ * turn so Claude has fresh state before it decides whether to call tools.
+ * Rebuilt every turn so mid-loop mutations by earlier tool calls reflect back
+ * into the next Claude call as well.
+ */
+export function buildCanvasSummary(store: SchemaCanvasStore): string {
+	const tableNameFor = (id: string): string => {
+		const t = store.doc.tables.find((x) => x.id === id);
+		if (!t) return id;
+		return qname(t);
+	};
+	const canvasTableLines = store.doc.tables.map((t) => {
+		const qualified = qname(t);
+		const cols = t.columns.map((c) => `${c.name}${c.sqlType ? `:${c.sqlType}` : ''}`).join(', ');
+		return `  - ${qualified}: [${cols || '(no columns)'}]`;
+	});
+	const userMadeJoins = store.doc.joins.filter((j) => (j.origin ?? 'physical') === 'physical');
+	const semanticJoins = store.doc.joins.filter(
+		(j) => j.origin === 'cube-link' || j.origin === 'inferred-fk'
+	);
+	const userMadeLines = userMadeJoins.map(
+		(j) =>
+			`  - ${tableNameFor(j.sourceTableId)}.${j.sourceColumnName}  ↔  ${tableNameFor(
+				j.targetTableId
+			)}.${j.targetColumnName}`
+	);
+	const semanticLines = semanticJoins.map(
+		(j) =>
+			`  - ${tableNameFor(j.sourceTableId)}.${j.sourceColumnName}  ↔  ${tableNameFor(
+				j.targetTableId
+			)}.${j.targetColumnName}  (origin: ${j.origin ?? 'inferred-fk'})`
+	);
+	return [
+		`ON-CANVAS TABLES (${store.doc.tables.length}):`,
+		...(canvasTableLines.length === 0 ? ['  (none)'] : canvasTableLines),
+		'',
+		`USER-MADE JOINS (${userMadeJoins.length}):`,
+		...(userMadeLines.length === 0 ? ['  (none)'] : userMadeLines),
+		'',
+		`SEMANTIC (cube-link, read-only) JOINS (${semanticJoins.length}):`,
+		...(semanticLines.length === 0 ? ['  (none)'] : semanticLines)
+	].join('\n');
+}
+
+/**
+ * Link every dimension to each measure group bound to a fact table (the M4
+ * `<ForeignKeyLink>`s). Without these a DimSum-built cube shows "LINKED
+ * DIMENSIONS" all unchecked and the group is incomplete. Resolve the
+ * fact-side FK column, in order:
+ *   1. `dim.foreignKey` (set by create_dimension's foreignKeyColumn);
+ *   2. a canvas join between the fact and the dimension's table;
+ *   3. star-schema convention — a fact column whose name matches the
+ *      dimension's primary key (`product_id` on both sides) or `<table>_id`.
+ * A dimension on the fact table itself links as a degenerate `fact` link.
+ * Idempotent — setMeasureGroupDimLink upserts by dimensionId.
+ */
+export function reconcileMeasureGroupLinks(store: SchemaCanvasStore): void {
+	for (const cube of store.cubes) {
+		for (const mg of cube.measureGroups) {
+			const factId = mg.factTableId ?? null;
+			if (!factId) continue;
+			const factTable = store.doc.tables.find((t) => t.id === factId);
+			const factCol = (name: string | null | undefined): string | null => {
+				if (!name || !factTable) return null;
+				return (
+					factTable.columns.find((c) => c.name.toLowerCase() === name.toLowerCase())?.name ?? null
+				);
+			};
+			for (const dim of store.doc.dimensions ?? []) {
+				const dimTableId = dim.primaryKeyTableId ?? dim.sourceTableId ?? null;
+				let fk = dim.foreignKey ?? null;
+				if (!fk && dimTableId) {
+					for (const j of store.doc.joins) {
+						if (j.sourceTableId === factId && j.targetTableId === dimTableId) {
+							fk = j.sourceColumnName;
+							break;
+						}
+						if (j.targetTableId === factId && j.sourceTableId === dimTableId) {
+							fk = j.targetColumnName;
+							break;
+						}
+					}
+				}
+				if (!fk && dimTableId !== factId) {
+					// Star-schema fallback: the fact usually carries a column named
+					// like the dimension's key (product_id) or `<dim table>_id`.
+					const dimTable = store.doc.tables.find((t) => t.id === dimTableId);
+					fk = factCol(dim.primaryKey) ?? (dimTable ? factCol(`${dimTable.name}_id`) : null);
+				}
+				if (!fk) continue;
+				store.setMeasureGroupDimLink(cube.id, mg.id, {
+					dimensionId: dim.id,
+					foreignKeyColumn: fk,
+					linkKind: dimTableId === factId ? 'fact' : 'foreign-key'
+				});
+			}
+		}
+	}
+}
+
+/**
+ * Execute one DimSum tool call locally against the store. Returns a JSON
+ * string ready to be dropped into an Anthropic tool_result block, plus an
+ * `isError` flag.
+ */
+export async function executeDimSumTool(
+	store: SchemaCanvasStore,
+	name: string,
+	input: Record<string, unknown>,
+	deps: DimSumToolDeps
+): Promise<{ content: string; isError: boolean }> {
+	try {
+		if (name === 'list_tables') {
+			const onCanvas = store.doc.tables.map((t) => ({
+				qualifiedName: qname(t),
+				columnCount: t.columns.length
+			}));
+			const onCanvasNames = new Set(onCanvas.map((t) => t.qualifiedName.toLowerCase()));
+			const available = store.sourceTables
+				.map((t) => ({
+					qualifiedName: qname(t),
+					columnCount: t.columns.length
+				}))
+				.filter((t) => !onCanvasNames.has(t.qualifiedName.toLowerCase()));
+			return {
+				content: JSON.stringify({ onCanvas, available }),
+				isError: false
+			};
+		}
+		if (name === 'describe_table') {
+			const qualified = String(input.qualifiedName ?? '');
+			const t = findTableByName(store, qualified) ?? findSourceTableByName(store, qualified);
+			if (!t) {
+				return {
+					content: JSON.stringify({
+						error: `No table named "${qualified}" is on the canvas or in the connection catalog.`
+					}),
+					isError: true
+				};
+			}
+			const canvasT = findTableByName(store, qualified);
+			const joinsInvolving = canvasT
+				? store.doc.joins
+						.filter((j) => j.sourceTableId === canvasT.id || j.targetTableId === canvasT.id)
+						.map((j) => {
+							const other =
+								j.sourceTableId === canvasT.id
+									? store.doc.tables.find((tt) => tt.id === j.targetTableId)
+									: store.doc.tables.find((tt) => tt.id === j.sourceTableId);
+							return {
+								neighbor: other ? qname(other) : '(unknown)',
+								thisColumn:
+									j.sourceTableId === canvasT.id ? j.sourceColumnName : j.targetColumnName,
+								neighborColumn:
+									j.sourceTableId === canvasT.id ? j.targetColumnName : j.sourceColumnName,
+								origin: j.origin ?? 'physical'
+							};
+						})
+				: [];
+			return {
+				content: JSON.stringify({
+					qualifiedName: qname(t),
+					onCanvas: !!canvasT,
+					columns: t.columns.map((c) => ({ name: c.name, sqlType: c.sqlType })),
+					joinsInvolving
+				}),
+				isError: false
+			};
+		}
+		if (name === 'list_joins') {
+			const tableNameFor = (id: string) => {
+				const t = store.doc.tables.find((x) => x.id === id);
+				if (!t) return id;
+				return qname(t);
+			};
+			const userMade: Array<{
+				from: { table: string; column: string };
+				to: { table: string; column: string };
+			}> = [];
+			const semantic: Array<{
+				from: { table: string; column: string };
+				to: { table: string; column: string };
+				origin: string;
+			}> = [];
+			for (const j of store.doc.joins) {
+				const dto = {
+					from: { table: tableNameFor(j.sourceTableId), column: j.sourceColumnName },
+					to: { table: tableNameFor(j.targetTableId), column: j.targetColumnName }
+				};
+				if ((j.origin ?? 'physical') === 'physical') userMade.push(dto);
+				else semantic.push({ ...dto, origin: j.origin ?? 'inferred-fk' });
+			}
+			return { content: JSON.stringify({ userMade, semantic }), isError: false };
+		}
+		if (name === 'add_table_to_canvas') {
+			const qualified = String(input.qualifiedName ?? '');
+			const existing = findTableByName(store, qualified);
+			if (existing) {
+				return {
+					content: JSON.stringify({
+						added: false,
+						reason: 'already_on_canvas',
+						tableId: existing.id
+					}),
+					isError: false
+				};
+			}
+			const candidate = findSourceTableByName(store, qualified);
+			if (!candidate) {
+				return {
+					content: JSON.stringify({
+						added: false,
+						reason: `No table named "${qualified}" in the connection catalog.`
+					}),
+					isError: true
+				};
+			}
+			// Position new tables in a rough grid to the right of existing ones.
+			const rightmost = store.doc.tables.reduce((mx, t) => Math.max(mx, t.position.x + 200), 0);
+			const added = store.addTable(candidate, {
+				x: rightmost + 40,
+				y: 80 + (store.doc.tables.length % 4) * 240
+			});
+			return {
+				content: JSON.stringify({
+					added: true,
+					tableId: added.id,
+					qualifiedName: qname(added)
+				}),
+				isError: false
+			};
+		}
+		if (name === 'remove_table_from_canvas') {
+			const qualified = String(input.qualifiedName ?? '');
+			const t = findTableByName(store, qualified);
+			if (!t) {
+				return {
+					content: JSON.stringify({
+						removed: false,
+						reason: `No table "${qualified}" on canvas.`
+					}),
+					isError: true
+				};
+			}
+			const joinsRemoved = store.doc.joins.filter(
+				(j) => j.sourceTableId === t.id || j.targetTableId === t.id
+			).length;
+			store.removeTable(t.id);
+			return {
+				content: JSON.stringify({ removed: true, joinsRemoved }),
+				isError: false
+			};
+		}
+		if (name === 'add_join') {
+			const fromIn = (input.from ?? {}) as { table?: unknown; column?: unknown };
+			const toIn = (input.to ?? {}) as { table?: unknown; column?: unknown };
+			const fromTable = findTableByName(store, String(fromIn.table ?? ''));
+			const toTable = findTableByName(store, String(toIn.table ?? ''));
+			if (!fromTable || !toTable) {
+				return {
+					content: JSON.stringify({
+						added: false,
+						reason: `Both tables must be on the canvas first. Missing: ${
+							!fromTable ? fromIn.table : ''
+						}${!fromTable && !toTable ? ', ' : ''}${!toTable ? toIn.table : ''}`
+					}),
+					isError: true
+				};
+			}
+			const fromCol = String(fromIn.column ?? '');
+			const toCol = String(toIn.column ?? '');
+			if (!fromTable.columns.some((c) => c.name === fromCol)) {
+				return {
+					content: JSON.stringify({
+						added: false,
+						reason: `Column "${fromCol}" not found on ${fromTable.name}.`
+					}),
+					isError: true
+				};
+			}
+			if (!toTable.columns.some((c) => c.name === toCol)) {
+				return {
+					content: JSON.stringify({
+						added: false,
+						reason: `Column "${toCol}" not found on ${toTable.name}.`
+					}),
+					isError: true
+				};
+			}
+			const created = store.addJoin({
+				sourceTableId: fromTable.id,
+				sourceColumnName: fromCol,
+				targetTableId: toTable.id,
+				targetColumnName: toCol,
+				kind: 'inner',
+				origin: 'physical'
+			});
+			return {
+				content: JSON.stringify({ added: true, joinId: created.id }),
+				isError: false
+			};
+		}
+		if (name === 'remove_join') {
+			const fromIn = (input.from ?? {}) as { table?: unknown; column?: unknown };
+			const toIn = (input.to ?? {}) as { table?: unknown; column?: unknown };
+			const fromTable = findTableByName(store, String(fromIn.table ?? ''));
+			const toTable = findTableByName(store, String(toIn.table ?? ''));
+			if (!fromTable || !toTable) {
+				return {
+					content: JSON.stringify({
+						removed: false,
+						reason: 'One or both tables not on canvas.'
+					}),
+					isError: true
+				};
+			}
+			const target = store.doc.joins.find(
+				(j) =>
+					(j.origin ?? 'physical') === 'physical' &&
+					((j.sourceTableId === fromTable.id &&
+						j.sourceColumnName === fromIn.column &&
+						j.targetTableId === toTable.id &&
+						j.targetColumnName === toIn.column) ||
+						(j.sourceTableId === toTable.id &&
+							j.sourceColumnName === toIn.column &&
+							j.targetTableId === fromTable.id &&
+							j.targetColumnName === fromIn.column))
+			);
+			if (!target) {
+				return {
+					content: JSON.stringify({
+						removed: false,
+						reason: 'No matching physical join found (semantic cube-links are read-only).'
+					}),
+					isError: true
+				};
+			}
+			store.removeJoin(target.id);
+			return { content: JSON.stringify({ removed: true }), isError: false };
+		}
+		if (name === 'arrange_canvas') {
+			// Same code path as the toolbar Arrange button — reuses the
+			// component's handleLayout via deps so layout tweaks stay in one place.
+			const mode = (String(input.mode ?? 'star') as LayoutMode) || 'star';
+			if (store.doc.tables.length === 0) {
+				return {
+					content: JSON.stringify({
+						arranged: false,
+						reason: 'No tables on canvas to arrange.'
+					}),
+					isError: false
+				};
+			}
+			await deps.arrangeCanvas(mode);
+			return {
+				content: JSON.stringify({
+					arranged: true,
+					mode,
+					tableCount: store.doc.tables.length
+				}),
+				isError: false
+			};
+		}
+		if (name === 'perform_action') {
+			// Generic action registry — every button that DimSum should
+			// be able to trigger has an id here.  Adding a new UI
+			// button = add a case here + list it in the system prompt
+			// server-side.  Keeps the "AI parity with every button"
+			// principle in one place.
+			const actionId = String(input.action ?? '');
+			switch (actionId) {
+				case 'zoom_in':
+				case 'zoom_out':
+				case 'fit_view':
+				case 'zoom_to_100':
+				case 'center_view':
+					store.requestedCanvasAction = { kind: actionId, ts: Date.now() };
+					return {
+						content: JSON.stringify({ performed: actionId }),
+						isError: false
+					};
+				case 'undo_last_change':
+					if (!store.previousDoc) {
+						return {
+							content: JSON.stringify({
+								performed: false,
+								reason:
+									'No prior state to undo — nothing has changed since the last confirmed edit.'
+							}),
+							isError: false
+						};
+					}
+					store.undo();
+					return {
+						content: JSON.stringify({ performed: 'undo_last_change' }),
+						isError: false
+					};
+				case 'center_view_on_table': {
+					const qualified = String(input.qualifiedName ?? '');
+					const t = findTableByName(store, qualified);
+					if (!t) {
+						return {
+							content: JSON.stringify({
+								error: `No canvas table named "${qualified}" — add it first, or check the spelling.`
+							}),
+							isError: true
+						};
+					}
+					store.requestedJumpTarget = { tableId: t.id, ts: Date.now() };
+					return {
+						content: JSON.stringify({
+							performed: 'center_view_on_table',
+							qualifiedName: qualified
+						}),
+						isError: false
+					};
+				}
+				default:
+					return {
+						content: JSON.stringify({
+							error: `Unknown action id: "${actionId}". Available: zoom_in, zoom_out, fit_view, zoom_to_100, center_view, undo_last_change, center_view_on_table.`
+						}),
+						isError: true
+					};
+			}
+		}
+		// ── Logical layer (Mondrian 4 cube: dimensions, hierarchies,
+		//    levels, fact + measures) ──────────────────────────────────
+		if (name === 'list_dimensions') {
+			const fact = store.doc.tables.find((t) => t.role === 'fact');
+			const dimensions = (store.doc.dimensions ?? []).map((d) => ({
+				name: d.name,
+				table: tableNameById(store, d.primaryKeyTableId),
+				primaryKey: d.primaryKey ?? null,
+				foreignKey: d.foreignKey ?? null,
+				type: d.dimensionType ?? 'Standard',
+				hierarchies: d.hierarchies.map((h) => ({
+					name: h.name,
+					hasAll: h.hasAll,
+					levels: h.levels.map((l) => l.name)
+				}))
+			}));
+			const measures = (store.doc.measures ?? []).map((m) => ({
+				name: m.name,
+				column: m.columnName,
+				aggregator: m.aggregator,
+				table: tableNameById(store, m.tableId)
+			}));
+			return {
+				content: JSON.stringify({
+					factTable: fact ? qname(fact) : null,
+					dimensions,
+					measures
+				}),
+				isError: false
+			};
+		}
+		if (name === 'set_fact_table') {
+			const t = findTableByName(store, String(input.qualifiedName ?? ''));
+			if (!t) {
+				return {
+					content: JSON.stringify({
+						ok: false,
+						reason: `No table "${input.qualifiedName}" on canvas — add_table_to_canvas first.`
+					}),
+					isError: true
+				};
+			}
+			store.setTableRole(t.id, 'fact');
+			return { content: JSON.stringify({ ok: true, factTable: qname(t) }), isError: false };
+		}
+		if (name === 'create_dimension') {
+			const t = findTableByName(store, String(input.table ?? ''));
+			if (!t) {
+				return {
+					content: JSON.stringify({
+						ok: false,
+						reason: `No table "${input.table}" on canvas — add_table_to_canvas first.`
+					}),
+					isError: true
+				};
+			}
+			const pk = String(input.primaryKeyColumn ?? '');
+			if (pk && !t.columns.some((c) => c.name === pk)) {
+				return {
+					content: JSON.stringify({
+						ok: false,
+						reason: `Primary-key column "${pk}" not found on ${t.name}.`
+					}),
+					isError: true
+				};
+			}
+			const dimName = input.name ? String(input.name) : undefined;
+			if (dimName && findDimByName(store, dimName)) {
+				return {
+					content: JSON.stringify({
+						ok: false,
+						reason: `Dimension "${dimName}" already exists.`
+					}),
+					isError: true
+				};
+			}
+			const dim = store.addDimension({ name: dimName, tableId: t.id });
+			const patch: Record<string, unknown> = { primaryKeyTableId: t.id };
+			if (pk) patch.primaryKey = pk;
+			if (input.foreignKeyColumn) patch.foreignKey = String(input.foreignKeyColumn);
+			if (input.type) patch.dimensionType = String(input.type);
+			store.updateDimension(dim.id, patch);
+			// Seed the primary-key column as an attribute so the dimension
+			// has a resolvable KEY (resolveKeyAttribute matches an attribute
+			// whose columnName === dim.primaryKey) — otherwise the workbench
+			// shows "KEY MISSING" and 0 attributes.
+			if (pk) store.addAttribute(dim.id, t.id, pk);
+			// Link this dimension into any existing measure group (covers the
+			// dimensions-after-measures order) + refresh the workbench.
+			reconcileMeasureGroupLinks(store);
+			store.bumpWorkbenchReload();
+			return {
+				content: JSON.stringify({
+					ok: true,
+					dimension: dim.name,
+					table: qname(t),
+					primaryKey: pk || null,
+					foreignKey: input.foreignKeyColumn ? String(input.foreignKeyColumn) : null
+				}),
+				isError: false
+			};
+		}
+		if (name === 'add_hierarchy') {
+			const d = findDimByName(store, String(input.dimension ?? ''));
+			if (!d) {
+				return {
+					content: JSON.stringify({
+						ok: false,
+						reason: `No dimension "${input.dimension}" — create_dimension first.`
+					}),
+					isError: true
+				};
+			}
+			const h = store.addHierarchy(d.id, input.name ? String(input.name) : undefined);
+			if (h && input.hasAll === false) store.updateHierarchy(d.id, h.id, { hasAll: false });
+			return {
+				content: JSON.stringify({ ok: true, dimension: d.name, hierarchy: h?.name }),
+				isError: false
+			};
+		}
+		if (name === 'add_level') {
+			const d = findDimByName(store, String(input.dimension ?? ''));
+			if (!d) {
+				return {
+					content: JSON.stringify({
+						ok: false,
+						reason: `No dimension "${input.dimension}" — create_dimension first.`
+					}),
+					isError: true
+				};
+			}
+			const h = d.hierarchies.find(
+				(x) =>
+					x.name.toLowerCase() ===
+					String(input.hierarchy ?? '')
+						.trim()
+						.toLowerCase()
+			);
+			if (!h) {
+				return {
+					content: JSON.stringify({
+						ok: false,
+						reason: `No hierarchy "${input.hierarchy}" on ${d.name} — add_hierarchy first.`
+					}),
+					isError: true
+				};
+			}
+			const dimTable = store.doc.tables.find((x) => x.id === d.primaryKeyTableId);
+			const col = String(input.column ?? '');
+			if (!dimTable || !dimTable.columns.some((c) => c.name === col)) {
+				return {
+					content: JSON.stringify({
+						ok: false,
+						reason: `Column "${col}" not found on the dimension's table ${dimTable?.name ?? '(unknown)'}.`
+					}),
+					isError: true
+				};
+			}
+			const lvl = store.addLevel(d.id, h.id, {
+				tableId: dimTable.id,
+				columnName: col,
+				name: input.name ? String(input.name) : undefined
+			});
+			// M4 levels reference an attribute — materialise the column as a
+			// dimension attribute so the level resolves and the Attrs count
+			// reflects it.
+			store.addAttribute(d.id, dimTable.id, col);
+			return {
+				content: JSON.stringify({
+					ok: true,
+					dimension: d.name,
+					hierarchy: h.name,
+					level: lvl?.name
+				}),
+				isError: false
+			};
+		}
+		if (name === 'add_measure') {
+			const fact = store.doc.tables.find((t) => t.role === 'fact');
+			if (!fact) {
+				return {
+					content: JSON.stringify({
+						ok: false,
+						reason: 'No fact table set — call set_fact_table first.'
+					}),
+					isError: true
+				};
+			}
+			const agg = String(input.aggregator ?? 'sum');
+			const col = input.column ? String(input.column) : '';
+			if (agg !== 'count' && !fact.columns.some((c) => c.name === col)) {
+				return {
+					content: JSON.stringify({
+						ok: false,
+						reason: `Column "${col}" not found on the fact table ${fact.name}.`
+					}),
+					isError: true
+				};
+			}
+			// Percentile fraction (0–100) — only for aggregator 'percentile'
+			// (median is the implicit 50th). Clamped; invalid/absent → default 50.
+			const percentile =
+				agg === 'percentile' && input.percentile != null && !Number.isNaN(Number(input.percentile))
+					? Math.max(0, Math.min(100, Math.round(Number(input.percentile))))
+					: undefined;
+			const m = store.addMeasure({
+				tableId: fact.id,
+				// count(*) has no column; leave it empty so the emitter drops it.
+				columnName: col,
+				aggregator: agg as SchemaCanvasMeasure['aggregator'],
+				name: input.name ? String(input.name) : col ? undefined : 'Row count',
+				percentile
+			});
+			// Also fold the column into a measure group on the selected
+			// cube so the workbench + export show a grouped measure.  A
+			// count(*) row-count measure has no column — skip the group
+			// add for it (nothing to fold).
+			let measureGroupName: string | null = null;
+			if (col) {
+				const cube = ensureCube(store);
+				const mg = ensureMeasureGroup(store, cube, fact.id);
+				if (mg) {
+					if (!mg.measureColumns.includes(col)) {
+						store.toggleMeasureColumn(cube.id, mg.id, col);
+					}
+					measureGroupName = mg.name;
+				}
+			}
+			reconcileMeasureGroupLinks(store);
+			store.bumpWorkbenchReload();
+			return {
+				content: JSON.stringify({
+					ok: true,
+					measure: m.name,
+					aggregator: agg,
+					measureGroup: measureGroupName
+				}),
+				isError: false
+			};
+		}
+		if (name === 'add_measure_group') {
+			const fact = store.doc.tables.find((t) => t.role === 'fact');
+			if (!fact) {
+				return {
+					content: JSON.stringify({
+						ok: false,
+						reason: 'No fact table set — call set_fact_table first.'
+					}),
+					isError: true
+				};
+			}
+			const cube = ensureCube(store);
+			const mg = store.addMeasureGroup(cube.id, {
+				name: input.name ? String(input.name) : undefined,
+				factTableId: fact.id
+			});
+			reconcileMeasureGroupLinks(store);
+			store.bumpWorkbenchReload();
+			return {
+				content: JSON.stringify({
+					ok: true,
+					measureGroup: mg?.name ?? null,
+					cube: cube.name,
+					factTable: qname(fact)
+				}),
+				isError: false
+			};
+		}
+		return {
+			content: JSON.stringify({ error: `Unknown tool: ${name}` }),
+			isError: true
+		};
+	} catch (err) {
+		return {
+			content: JSON.stringify({
+				error: err instanceof Error ? err.message : 'tool execution threw'
+			}),
+			isError: true
+		};
+	}
+}

--- a/saiku-ui/src/lib/cube-designer/gateway-errors.ts
+++ b/saiku-ui/src/lib/cube-designer/gateway-errors.ts
@@ -1,0 +1,30 @@
+/**
+ * Client-safe gateway error-message helper (saiku-cloud#1043).
+ *
+ * The precedence "gateway `message`, then its `error` code, then a generic
+ * HTTP-status fallback" (saiku-cloud#852) was copy-pasted inline across
+ * several CLIENT surfaces (`.svelte` components + browser fetch handlers).
+ * Lifted here so the precedence lives in one place.
+ *
+ * IMPORTANT: this module MUST stay client-safe — no `$lib/server/*` and no
+ * `$env/dynamic/private` imports — because it is imported into `.svelte`
+ * components that run in the browser. The server-side twin is
+ * `readGatewayError(resp)` in `$lib/server/gateway`, which takes a raw
+ * `Response` and parses it; this one takes an already-parsed body + status
+ * so it can be used synchronously after a caller's own `resp.json()`.
+ *
+ * @param status - the HTTP status of the failed response.
+ * @param body - the parsed JSON body (or null/undefined for a non-JSON /
+ *   empty body).
+ * @param fallback - optional surface-specific message used when the body
+ *   carries neither `message` nor `error`. Defaults to a generic
+ *   `Request failed (HTTP <status>)`. Callers pass their existing wording
+ *   here so migrating an inline copy is behaviour-preserving.
+ */
+export function readGatewayErrorMessage(
+	status: number,
+	body: { message?: string; error?: string } | null | undefined,
+	fallback?: string
+): string {
+	return body?.message ?? body?.error ?? fallback ?? `Request failed (HTTP ${status})`;
+}

--- a/saiku-ui/src/lib/cube-designer/gateway-errors.ts
+++ b/saiku-ui/src/lib/cube-designer/gateway-errors.ts
@@ -22,9 +22,14 @@
  *   here so migrating an inline copy is behaviour-preserving.
  */
 export function readGatewayErrorMessage(
-	status: number,
-	body: { message?: string; error?: string } | null | undefined,
-	fallback?: string
+  status: number,
+  body: { message?: string; error?: string } | null | undefined,
+  fallback?: string,
 ): string {
-	return body?.message ?? body?.error ?? fallback ?? `Request failed (HTTP ${status})`;
+  return (
+    body?.message ??
+    body?.error ??
+    fallback ??
+    `Request failed (HTTP ${status})`
+  );
 }

--- a/saiku-ui/src/lib/cube-designer/index.ts
+++ b/saiku-ui/src/lib/cube-designer/index.ts
@@ -1,0 +1,49 @@
+/**
+ * Public API of `@concepttocloud/saiku-cube-designer`.
+ *
+ * The visual cube/schema designer, host-agnostic: mount the views, provide a
+ * {@link CubeDesignerBackend} (and optional {@link CubeDesignerAI}) via context,
+ * and the designer profiles / authors / emits Mondrian 4. Both Saiku OSS and
+ * Saiku Cloud consume this one source of truth with their own adapters.
+ */
+
+// ── Mount points ────────────────────────────────────────────────────────────
+export { default as SchemaCanvasView } from "./SchemaCanvasView.svelte";
+export { default as WorkbenchView } from "./WorkbenchView.svelte";
+
+// ── Store ───────────────────────────────────────────────────────────────────
+export { SchemaCanvasStore } from "./state.svelte";
+
+// ── Backend seam (host provides the adapter) ─────────────────────────────────
+export {
+  setCubeDesignerBackend,
+  setCubeDesignerAI,
+  getCubeDesignerBackend,
+  getCubeDesignerAI,
+  type CubeDesignerBackend,
+  type CubeDesignerAI,
+} from "./backend";
+
+// ── Mondrian emit / import ───────────────────────────────────────────────────
+export { exportToMondrianXml, exportToMondrianYaml } from "./mondrian-export";
+export { importFromMondrianXml } from "./mondrian-import";
+
+// ── Source profiling ─────────────────────────────────────────────────────────
+export { parseProfileTables } from "./profile-types";
+export type {
+  ProfileTableSummary,
+  ProfileColumnSummary,
+} from "./profile-types";
+
+// ── Core types ───────────────────────────────────────────────────────────────
+export type {
+  SchemaCanvasState,
+  SourceTableCandidate,
+  SchemaCanvasTable,
+  SchemaCanvasJoin,
+  SchemaCanvasDimension,
+  SchemaCanvasHierarchy,
+  SchemaCanvasLevel,
+  SchemaCanvasMeasure,
+  SchemaCanvasCube,
+} from "./types";

--- a/saiku-ui/src/lib/cube-designer/join-groups.test.ts
+++ b/saiku-ui/src/lib/cube-designer/join-groups.test.ts
@@ -1,0 +1,77 @@
+/**
+ * Unit tests for the join-group derivation helpers.
+ */
+import { describe, it, expect } from 'vitest';
+import { SchemaCanvasStore } from './state.svelte.js';
+import type { SourceTableCandidate } from './types.js';
+import { computeJoinGroups, isSemanticGroup } from './join-groups.js';
+
+function candidate(name: string, columns: string[]): SourceTableCandidate {
+	return {
+		schema: 'public',
+		name,
+		columns: columns.map((c) => ({ name: c, sqlType: 'INTEGER' })),
+		onCanvas: false
+	};
+}
+
+function addTable(store: SchemaCanvasStore, name: string, columns: string[]): string {
+	return store.addTable(candidate(name, columns), { x: 0, y: 0 }).id;
+}
+
+describe('computeJoinGroups', () => {
+	it('groups joins by rendered label preserving insertion order', () => {
+		const store = new SchemaCanvasStore('jg1');
+		const a = addTable(store, 'a', ['x', 'y']);
+		const b = addTable(store, 'b', ['x', 'y']);
+		store.addJoin({
+			sourceTableId: a,
+			sourceColumnName: 'x',
+			targetTableId: b,
+			targetColumnName: 'x',
+			kind: 'inner'
+		});
+		store.addJoin({
+			sourceTableId: a,
+			sourceColumnName: 'y',
+			targetTableId: b,
+			targetColumnName: 'y',
+			kind: 'inner'
+		});
+
+		const groups = computeJoinGroups(store);
+		// Two distinct column pairs → two groups, each with one join.
+		expect(groups).toHaveLength(2);
+		expect(groups.every((g) => g.joins.length === 1)).toBe(true);
+	});
+});
+
+describe('isSemanticGroup', () => {
+	it('is true only when every join is cube-link / inferred-fk', () => {
+		const store = new SchemaCanvasStore('jg2');
+		const a = addTable(store, 'a', ['x']);
+		const b = addTable(store, 'b', ['x']);
+		store.addJoin({
+			sourceTableId: a,
+			sourceColumnName: 'x',
+			targetTableId: b,
+			targetColumnName: 'x',
+			kind: 'inner',
+			origin: 'cube-link'
+		});
+		expect(isSemanticGroup(computeJoinGroups(store)[0])).toBe(true);
+
+		const store2 = new SchemaCanvasStore('jg3');
+		const c = addTable(store2, 'a', ['x']);
+		const d = addTable(store2, 'b', ['x']);
+		store2.addJoin({
+			sourceTableId: c,
+			sourceColumnName: 'x',
+			targetTableId: d,
+			targetColumnName: 'x',
+			kind: 'inner',
+			origin: 'physical'
+		});
+		expect(isSemanticGroup(computeJoinGroups(store2)[0])).toBe(false);
+	});
+});

--- a/saiku-ui/src/lib/cube-designer/join-groups.test.ts
+++ b/saiku-ui/src/lib/cube-designer/join-groups.test.ts
@@ -1,77 +1,81 @@
 /**
  * Unit tests for the join-group derivation helpers.
  */
-import { describe, it, expect } from 'vitest';
-import { SchemaCanvasStore } from './state.svelte.js';
-import type { SourceTableCandidate } from './types.js';
-import { computeJoinGroups, isSemanticGroup } from './join-groups.js';
+import { describe, it, expect } from "vitest";
+import { SchemaCanvasStore } from "./state.svelte.js";
+import type { SourceTableCandidate } from "./types.js";
+import { computeJoinGroups, isSemanticGroup } from "./join-groups.js";
 
 function candidate(name: string, columns: string[]): SourceTableCandidate {
-	return {
-		schema: 'public',
-		name,
-		columns: columns.map((c) => ({ name: c, sqlType: 'INTEGER' })),
-		onCanvas: false
-	};
+  return {
+    schema: "public",
+    name,
+    columns: columns.map((c) => ({ name: c, sqlType: "INTEGER" })),
+    onCanvas: false,
+  };
 }
 
-function addTable(store: SchemaCanvasStore, name: string, columns: string[]): string {
-	return store.addTable(candidate(name, columns), { x: 0, y: 0 }).id;
+function addTable(
+  store: SchemaCanvasStore,
+  name: string,
+  columns: string[],
+): string {
+  return store.addTable(candidate(name, columns), { x: 0, y: 0 }).id;
 }
 
-describe('computeJoinGroups', () => {
-	it('groups joins by rendered label preserving insertion order', () => {
-		const store = new SchemaCanvasStore('jg1');
-		const a = addTable(store, 'a', ['x', 'y']);
-		const b = addTable(store, 'b', ['x', 'y']);
-		store.addJoin({
-			sourceTableId: a,
-			sourceColumnName: 'x',
-			targetTableId: b,
-			targetColumnName: 'x',
-			kind: 'inner'
-		});
-		store.addJoin({
-			sourceTableId: a,
-			sourceColumnName: 'y',
-			targetTableId: b,
-			targetColumnName: 'y',
-			kind: 'inner'
-		});
+describe("computeJoinGroups", () => {
+  it("groups joins by rendered label preserving insertion order", () => {
+    const store = new SchemaCanvasStore("jg1");
+    const a = addTable(store, "a", ["x", "y"]);
+    const b = addTable(store, "b", ["x", "y"]);
+    store.addJoin({
+      sourceTableId: a,
+      sourceColumnName: "x",
+      targetTableId: b,
+      targetColumnName: "x",
+      kind: "inner",
+    });
+    store.addJoin({
+      sourceTableId: a,
+      sourceColumnName: "y",
+      targetTableId: b,
+      targetColumnName: "y",
+      kind: "inner",
+    });
 
-		const groups = computeJoinGroups(store);
-		// Two distinct column pairs → two groups, each with one join.
-		expect(groups).toHaveLength(2);
-		expect(groups.every((g) => g.joins.length === 1)).toBe(true);
-	});
+    const groups = computeJoinGroups(store);
+    // Two distinct column pairs → two groups, each with one join.
+    expect(groups).toHaveLength(2);
+    expect(groups.every((g) => g.joins.length === 1)).toBe(true);
+  });
 });
 
-describe('isSemanticGroup', () => {
-	it('is true only when every join is cube-link / inferred-fk', () => {
-		const store = new SchemaCanvasStore('jg2');
-		const a = addTable(store, 'a', ['x']);
-		const b = addTable(store, 'b', ['x']);
-		store.addJoin({
-			sourceTableId: a,
-			sourceColumnName: 'x',
-			targetTableId: b,
-			targetColumnName: 'x',
-			kind: 'inner',
-			origin: 'cube-link'
-		});
-		expect(isSemanticGroup(computeJoinGroups(store)[0])).toBe(true);
+describe("isSemanticGroup", () => {
+  it("is true only when every join is cube-link / inferred-fk", () => {
+    const store = new SchemaCanvasStore("jg2");
+    const a = addTable(store, "a", ["x"]);
+    const b = addTable(store, "b", ["x"]);
+    store.addJoin({
+      sourceTableId: a,
+      sourceColumnName: "x",
+      targetTableId: b,
+      targetColumnName: "x",
+      kind: "inner",
+      origin: "cube-link",
+    });
+    expect(isSemanticGroup(computeJoinGroups(store)[0])).toBe(true);
 
-		const store2 = new SchemaCanvasStore('jg3');
-		const c = addTable(store2, 'a', ['x']);
-		const d = addTable(store2, 'b', ['x']);
-		store2.addJoin({
-			sourceTableId: c,
-			sourceColumnName: 'x',
-			targetTableId: d,
-			targetColumnName: 'x',
-			kind: 'inner',
-			origin: 'physical'
-		});
-		expect(isSemanticGroup(computeJoinGroups(store2)[0])).toBe(false);
-	});
+    const store2 = new SchemaCanvasStore("jg3");
+    const c = addTable(store2, "a", ["x"]);
+    const d = addTable(store2, "b", ["x"]);
+    store2.addJoin({
+      sourceTableId: c,
+      sourceColumnName: "x",
+      targetTableId: d,
+      targetColumnName: "x",
+      kind: "inner",
+      origin: "physical",
+    });
+    expect(isSemanticGroup(computeJoinGroups(store2)[0])).toBe(false);
+  });
 });

--- a/saiku-ui/src/lib/cube-designer/join-groups.ts
+++ b/saiku-ui/src/lib/cube-designer/join-groups.ts
@@ -4,15 +4,15 @@
  * JoinsPanel (which renders the groups). Lifted out of SchemaCanvasView.svelte
  * (audit finding #1040, template-decompose pass).
  */
-import { SchemaCanvasStore } from './state.svelte.js';
-import type { SchemaCanvasJoin } from './types.js';
+import { SchemaCanvasStore } from "./state.svelte.js";
+import type { SchemaCanvasJoin } from "./types.js";
 
 /** One rendered join group: a display label + the canonical key (so rename
  *  writes land in the right slot) + every join under that label. */
 export interface JoinGroupRender {
-	label: string;
-	canonicalKey: string;
-	joins: SchemaCanvasJoin[];
+  label: string;
+  canonicalKey: string;
+  joins: SchemaCanvasJoin[];
 }
 
 /**
@@ -20,20 +20,20 @@ export interface JoinGroupRender {
  * order = the order each group's first join appears in `store.doc.joins`.
  */
 export function computeJoinGroups(store: SchemaCanvasStore): JoinGroupRender[] {
-	const out: JoinGroupRender[] = [];
-	const byLabel = new Map<string, JoinGroupRender>();
-	for (const j of store.doc.joins) {
-		const canonicalKey = SchemaCanvasStore.joinCanonicalKey(j);
-		const label = store.joinGroupLabelFor(j);
-		let g = byLabel.get(label);
-		if (!g) {
-			g = { label, canonicalKey, joins: [] };
-			byLabel.set(label, g);
-			out.push(g);
-		}
-		g.joins.push(j);
-	}
-	return out;
+  const out: JoinGroupRender[] = [];
+  const byLabel = new Map<string, JoinGroupRender>();
+  for (const j of store.doc.joins) {
+    const canonicalKey = SchemaCanvasStore.joinCanonicalKey(j);
+    const label = store.joinGroupLabelFor(j);
+    let g = byLabel.get(label);
+    if (!g) {
+      g = { label, canonicalKey, joins: [] };
+      byLabel.set(label, g);
+      out.push(g);
+    }
+    g.joins.push(j);
+  }
+  return out;
 }
 
 /**
@@ -42,5 +42,7 @@ export function computeJoinGroups(store: SchemaCanvasStore): JoinGroupRender[] {
  * the physical bucket since the physical statement wins.
  */
 export function isSemanticGroup(g: JoinGroupRender): boolean {
-	return g.joins.every((j) => j.origin === 'cube-link' || j.origin === 'inferred-fk');
+  return g.joins.every(
+    (j) => j.origin === "cube-link" || j.origin === "inferred-fk",
+  );
 }

--- a/saiku-ui/src/lib/cube-designer/join-groups.ts
+++ b/saiku-ui/src/lib/cube-designer/join-groups.ts
@@ -1,0 +1,46 @@
+/**
+ * Join-group derivation — pure helpers shared by SchemaCanvasView (which
+ * needs the physical/semantic counts for the toolbar + canvas chip) and
+ * JoinsPanel (which renders the groups). Lifted out of SchemaCanvasView.svelte
+ * (audit finding #1040, template-decompose pass).
+ */
+import { SchemaCanvasStore } from './state.svelte.js';
+import type { SchemaCanvasJoin } from './types.js';
+
+/** One rendered join group: a display label + the canonical key (so rename
+ *  writes land in the right slot) + every join under that label. */
+export interface JoinGroupRender {
+	label: string;
+	canonicalKey: string;
+	joins: SchemaCanvasJoin[];
+}
+
+/**
+ * Group every join by its rendered label (renames applied). Stable insertion
+ * order = the order each group's first join appears in `store.doc.joins`.
+ */
+export function computeJoinGroups(store: SchemaCanvasStore): JoinGroupRender[] {
+	const out: JoinGroupRender[] = [];
+	const byLabel = new Map<string, JoinGroupRender>();
+	for (const j of store.doc.joins) {
+		const canonicalKey = SchemaCanvasStore.joinCanonicalKey(j);
+		const label = store.joinGroupLabelFor(j);
+		let g = byLabel.get(label);
+		if (!g) {
+			g = { label, canonicalKey, joins: [] };
+			byLabel.set(label, g);
+			out.push(g);
+		}
+		g.joins.push(j);
+	}
+	return out;
+}
+
+/**
+ * A group is "semantic" iff EVERY join in it is a cube-link / inferred-fk.
+ * Mixed groups (same column pair in both physical AND a cube-link) stay in
+ * the physical bucket since the physical statement wins.
+ */
+export function isSemanticGroup(g: JoinGroupRender): boolean {
+	return g.joins.every((j) => j.origin === 'cube-link' || j.origin === 'inferred-fk');
+}

--- a/saiku-ui/src/lib/cube-designer/layout.ts
+++ b/saiku-ui/src/lib/cube-designer/layout.ts
@@ -1,0 +1,333 @@
+/**
+ * Canvas schema designer — ELK auto-layout helper.
+ *
+ * Wraps elkjs with the "Arrange" button's preferred config: hierarchical
+ * layered layout, top-down (fact table sits at the top, dimensions fan
+ * below), enough breathing room that wires don't cross awkwardly.
+ *
+ * The user can still drag nodes after — ELK gives them a starting
+ * arrangement, not a constraint.
+ */
+import ELK from 'elkjs/lib/elk.bundled.js';
+import type { SchemaCanvasState, SchemaCanvasTable } from './types.js';
+
+const elk = new ELK();
+
+interface LayoutOptions {
+	/** Default node width if we don't know better. Each TableNode is roughly this wide. */
+	nodeWidth?: number;
+	/** Per-row height inside a TableNode — used to compute total node height. */
+	rowHeight?: number;
+	/** Fixed node header height. */
+	headerHeight?: number;
+	/**
+	 * Cap the visible column count when estimating a table's rendered
+	 * height. Pass `store.defaultColumnsShown`. Without this the
+	 * estimator assumed every column was visible, which over-inflated
+	 * the ring (and any other height-aware) layout by ~5×.
+	 */
+	visibleColumnsCap?: number;
+	/** Available canvas viewport in CSS px, when known. Used by the
+	 *  grid layout to size its column count to whatever the user can
+	 *  actually see, so the result fits without horizontal panning. */
+	canvasWidth?: number;
+	canvasHeight?: number;
+}
+
+const DEFAULTS: Required<LayoutOptions> = {
+	nodeWidth: 240,
+	rowHeight: 22,
+	headerHeight: 48,
+	visibleColumnsCap: Number.POSITIVE_INFINITY,
+	canvasWidth: 0,
+	canvasHeight: 0
+};
+
+export function estimateNodeHeight(table: SchemaCanvasTable, opts: LayoutOptions = {}): number {
+	const { headerHeight, rowHeight } = { ...DEFAULTS, ...opts };
+	const cap = opts.visibleColumnsCap ?? Number.POSITIVE_INFINITY;
+	// Visible-row count mirrors what TableNode actually renders:
+	//   collapsed=true  → header only (0 rows)
+	//   collapsed=false → every column
+	//   undefined       → min(cap, columns.length)
+	let visible: number;
+	if (table.collapsed === true) {
+		visible = 0;
+	} else if (table.collapsed === false) {
+		visible = table.columns.length;
+	} else {
+		visible = Math.min(cap, table.columns.length);
+	}
+	return headerHeight + Math.max(1, visible) * rowHeight + 12;
+}
+
+/**
+ * Layout modes the user can pick from the canvas toolbar.
+ *  - layered: ELK top-down hierarchical (good for snowflake / chained dims)
+ *  - star: fact at centre, dimensions in a ring around it (classic star schema)
+ *  - grid: even rows of N tables, alphabetical sort (clean reset)
+ *  - byJoins: tables most-connected to the fact first, less-connected radiating out
+ */
+export type LayoutMode = 'layered' | 'star' | 'grid' | 'byJoins';
+
+/**
+ * Dispatcher — apply whichever layout the user picked.
+ */
+export async function applyLayout(
+	state: SchemaCanvasState,
+	mode: LayoutMode,
+	opts: LayoutOptions = {}
+): Promise<SchemaCanvasState> {
+	switch (mode) {
+		case 'star':
+			return starLayout(state, opts);
+		case 'grid':
+			return gridLayout(state, opts);
+		case 'byJoins':
+			return byJoinsLayout(state, opts);
+		case 'layered':
+		default:
+			return applyAutoLayout(state, opts);
+	}
+}
+
+/**
+ * Apply ELK layered layout to the canvas. Returns a fresh state with new
+ * `position` values on every table; doesn't mutate the input. This is the
+ * historic "Arrange" behaviour — preserved as the default.
+ */
+export async function applyAutoLayout(
+	state: SchemaCanvasState,
+	opts: LayoutOptions = {}
+): Promise<SchemaCanvasState> {
+	const merged = { ...DEFAULTS, ...opts };
+	const elkGraph = {
+		id: 'root',
+		layoutOptions: {
+			'elk.algorithm': 'layered',
+			'elk.direction': 'DOWN',
+			'elk.spacing.nodeNode': '60',
+			'elk.spacing.edgeNode': '24',
+			'elk.spacing.componentComponent': '80',
+			'elk.layered.spacing.nodeNodeBetweenLayers': '80',
+			'elk.layered.spacing.edgeNodeBetweenLayers': '20',
+			'elk.layered.considerModelOrder.strategy': 'NODES_AND_EDGES'
+		},
+		children: state.tables.map((t) => ({
+			id: t.id,
+			width: merged.nodeWidth,
+			height: estimateNodeHeight(t, merged)
+		})),
+		edges: state.joins.map((j) => ({
+			id: j.id,
+			sources: [j.sourceTableId],
+			targets: [j.targetTableId]
+		}))
+	};
+	const laid = await elk.layout(elkGraph as Parameters<typeof elk.layout>[0]);
+	const positions = new Map<string, { x: number; y: number }>();
+	for (const child of laid.children ?? []) {
+		if (child.id) {
+			positions.set(child.id, { x: child.x ?? 0, y: child.y ?? 0 });
+		}
+	}
+	return {
+		...state,
+		tables: state.tables.map((t) => ({
+			...t,
+			position: positions.get(t.id) ?? t.position
+		})),
+		updatedAt: new Date().toISOString()
+	};
+}
+
+/**
+ * Star layout — fact at centre, dimensions arranged in a ring around it.
+ * The radius grows with table count so big schemas don't collapse on
+ * themselves. Dimensions are sorted alphabetically so the same schema
+ * lays out the same way every time you hit Star.
+ */
+export function starLayout(state: SchemaCanvasState, opts: LayoutOptions = {}): SchemaCanvasState {
+	const merged = { ...DEFAULTS, ...opts };
+	const fact = state.tables.find((t) => t.role === 'fact');
+	const others = state.tables
+		.filter((t) => t.role !== 'fact')
+		.slice()
+		.sort((a, b) => a.name.localeCompare(b.name));
+	// Adjacent-card chord requirement. Cards aren't rotated to face the
+	// centre — they stay axis-aligned — so the limiting dimension is
+	// the LARGER of width or height (not the diagonal). Using the
+	// diagonal was over-spacing the ring. Floor at 320 so 1–2 tables
+	// don't collapse onto each other.
+	// Generous pad so adjacent cards never sit edge-to-edge — they used to
+	// touch (gap == 0) which made overlapping-content (long names, hover
+	// shadows) visually merge two tables. 48px of breathing room each way.
+	const PAD = 48;
+	const MAX_HEIGHT_FOR_RADIUS = 400;
+	const rawMaxHeight = Math.max(...state.tables.map((t) => estimateNodeHeight(t, merged)));
+	const heightForRadius = Math.min(MAX_HEIGHT_FOR_RADIUS, rawMaxHeight);
+	const chordRequirement = Math.max(merged.nodeWidth + PAD, heightForRadius + PAD);
+	const N = others.length;
+	const minRadius = N >= 2 ? chordRequirement / (2 * Math.sin(Math.PI / N)) : 220;
+	const radius = Math.max(220, minRadius);
+	const centre = { x: radius + 80, y: radius + 80 };
+	const positions = new Map<string, { x: number; y: number }>();
+	if (fact) {
+		const factH = estimateNodeHeight(fact, merged);
+		positions.set(fact.id, {
+			x: centre.x - merged.nodeWidth / 2,
+			y: centre.y - factH / 2
+		});
+	}
+	const n = Math.max(1, others.length);
+	others.forEach((t, i) => {
+		// -π/2 puts the first dim at the top of the ring.
+		const angle = -Math.PI / 2 + (i / n) * Math.PI * 2;
+		const h = estimateNodeHeight(t, merged);
+		positions.set(t.id, {
+			x: centre.x + Math.cos(angle) * radius - merged.nodeWidth / 2,
+			y: centre.y + Math.sin(angle) * radius - h / 2
+		});
+	});
+	return applyPositions(state, positions);
+}
+
+/**
+ * Grid layout — fact in the top-left slot, everything else arranged in
+ * even rows below it. Useful when the canvas has drifted and you just
+ * want a clean reset.
+ */
+export function gridLayout(state: SchemaCanvasState, opts: LayoutOptions = {}): SchemaCanvasState {
+	const merged = { ...DEFAULTS, ...opts };
+	// Generous gaps so a join label landing at the midpoint between two
+	// cards has room to read without sitting on either card. Not the
+	// real obstacle-avoidance fix (queued), but it makes labels visually
+	// "fit" between rows / columns instead of crowding them.
+	const gapX = 160;
+	const gapY = 160;
+	// Cols default — when the caller passes a real canvasWidth, size the
+	// grid to fit that width (minus a small padding budget for the
+	// SvelteFlow chrome).  When not, fall back to a step-function on
+	// table count so a stale caller still gets something reasonable.
+	let cols: number;
+	if (merged.canvasWidth > 0) {
+		const usable = Math.max(merged.canvasWidth - 120, merged.nodeWidth);
+		cols = Math.max(1, Math.floor((usable + gapX) / (merged.nodeWidth + gapX)));
+		// Don't waste columns on a small set of tables — cap at table count.
+		cols = Math.min(cols, Math.max(1, state.tables.length));
+	} else {
+		cols = state.tables.length <= 4 ? 2 : state.tables.length <= 9 ? 3 : 4;
+	}
+	const fact = state.tables.find((t) => t.role === 'fact');
+	const rest = state.tables
+		.filter((t) => t.id !== fact?.id)
+		.slice()
+		.sort((a, b) => a.name.localeCompare(b.name));
+	const ordered = fact ? [fact, ...rest] : rest;
+	const positions = new Map<string, { x: number; y: number }>();
+	// Compute the tallest node in each row so the next row clears it.
+	let rowTopY = 60;
+	for (let row = 0; row * cols < ordered.length; row++) {
+		const rowTables = ordered.slice(row * cols, row * cols + cols);
+		const rowMaxH = rowTables.reduce((m, t) => Math.max(m, estimateNodeHeight(t, merged)), 0);
+		rowTables.forEach((t, i) => {
+			positions.set(t.id, {
+				x: 60 + i * (merged.nodeWidth + gapX),
+				y: rowTopY
+			});
+		});
+		rowTopY += rowMaxH + gapY;
+	}
+	return applyPositions(state, positions);
+}
+
+/**
+ * By-joins layout — concentric rings around the fact based on how many
+ * hops away each table sits in the join graph. Fact at centre, direct
+ * dims in the first ring, indirect (e.g. bridge → outer dim) in the next.
+ * Falls back to star semantics when there are no joins yet.
+ */
+export function byJoinsLayout(
+	state: SchemaCanvasState,
+	opts: LayoutOptions = {}
+): SchemaCanvasState {
+	const fact = state.tables.find((t) => t.role === 'fact');
+	if (!fact) return gridLayout(state, opts);
+
+	// BFS from the fact across the join graph to assign a ring number.
+	const adj = new Map<string, Set<string>>();
+	for (const t of state.tables) adj.set(t.id, new Set());
+	for (const j of state.joins) {
+		adj.get(j.sourceTableId)?.add(j.targetTableId);
+		adj.get(j.targetTableId)?.add(j.sourceTableId);
+	}
+	const ring = new Map<string, number>();
+	ring.set(fact.id, 0);
+	const queue = [fact.id];
+	while (queue.length) {
+		const cur = queue.shift()!;
+		const d = ring.get(cur)!;
+		for (const next of adj.get(cur) ?? []) {
+			if (ring.has(next)) continue;
+			ring.set(next, d + 1);
+			queue.push(next);
+		}
+	}
+	// Disconnected tables sit one ring further out than the deepest connected.
+	const maxRing = [...ring.values()].reduce((m, r) => Math.max(m, r), 0);
+	for (const t of state.tables) {
+		if (!ring.has(t.id)) ring.set(t.id, maxRing + 1);
+	}
+
+	// Place each ring around the centre.
+	const merged = { ...DEFAULTS, ...opts };
+	const centre = { x: 600, y: 400 };
+	const byRing = new Map<number, string[]>();
+	for (const [id, r] of ring) {
+		if (!byRing.has(r)) byRing.set(r, []);
+		byRing.get(r)!.push(id);
+	}
+	const positions = new Map<string, { x: number; y: number }>();
+	for (const [r, ids] of byRing) {
+		ids.sort((a, b) => {
+			const ta = state.tables.find((t) => t.id === a)!;
+			const tb = state.tables.find((t) => t.id === b)!;
+			return ta.name.localeCompare(tb.name);
+		});
+		if (r === 0) {
+			const t = state.tables.find((tt) => tt.id === ids[0])!;
+			const h = estimateNodeHeight(t, merged);
+			positions.set(ids[0], {
+				x: centre.x - merged.nodeWidth / 2,
+				y: centre.y - h / 2
+			});
+			continue;
+		}
+		const radius = 220 + r * 200;
+		const n = Math.max(1, ids.length);
+		ids.forEach((id, i) => {
+			const angle = -Math.PI / 2 + (i / n) * Math.PI * 2;
+			const t = state.tables.find((tt) => tt.id === id)!;
+			const h = estimateNodeHeight(t, merged);
+			positions.set(id, {
+				x: centre.x + Math.cos(angle) * radius - merged.nodeWidth / 2,
+				y: centre.y + Math.sin(angle) * radius - h / 2
+			});
+		});
+	}
+	return applyPositions(state, positions);
+}
+
+function applyPositions(
+	state: SchemaCanvasState,
+	positions: Map<string, { x: number; y: number }>
+): SchemaCanvasState {
+	return {
+		...state,
+		tables: state.tables.map((t) => ({
+			...t,
+			position: positions.get(t.id) ?? t.position
+		})),
+		updatedAt: new Date().toISOString()
+	};
+}

--- a/saiku-ui/src/lib/cube-designer/layout.ts
+++ b/saiku-ui/src/lib/cube-designer/layout.ts
@@ -8,57 +8,60 @@
  * The user can still drag nodes after — ELK gives them a starting
  * arrangement, not a constraint.
  */
-import ELK from 'elkjs/lib/elk.bundled.js';
-import type { SchemaCanvasState, SchemaCanvasTable } from './types.js';
+import ELK from "elkjs/lib/elk.bundled.js";
+import type { SchemaCanvasState, SchemaCanvasTable } from "./types.js";
 
 const elk = new ELK();
 
 interface LayoutOptions {
-	/** Default node width if we don't know better. Each TableNode is roughly this wide. */
-	nodeWidth?: number;
-	/** Per-row height inside a TableNode — used to compute total node height. */
-	rowHeight?: number;
-	/** Fixed node header height. */
-	headerHeight?: number;
-	/**
-	 * Cap the visible column count when estimating a table's rendered
-	 * height. Pass `store.defaultColumnsShown`. Without this the
-	 * estimator assumed every column was visible, which over-inflated
-	 * the ring (and any other height-aware) layout by ~5×.
-	 */
-	visibleColumnsCap?: number;
-	/** Available canvas viewport in CSS px, when known. Used by the
-	 *  grid layout to size its column count to whatever the user can
-	 *  actually see, so the result fits without horizontal panning. */
-	canvasWidth?: number;
-	canvasHeight?: number;
+  /** Default node width if we don't know better. Each TableNode is roughly this wide. */
+  nodeWidth?: number;
+  /** Per-row height inside a TableNode — used to compute total node height. */
+  rowHeight?: number;
+  /** Fixed node header height. */
+  headerHeight?: number;
+  /**
+   * Cap the visible column count when estimating a table's rendered
+   * height. Pass `store.defaultColumnsShown`. Without this the
+   * estimator assumed every column was visible, which over-inflated
+   * the ring (and any other height-aware) layout by ~5×.
+   */
+  visibleColumnsCap?: number;
+  /** Available canvas viewport in CSS px, when known. Used by the
+   *  grid layout to size its column count to whatever the user can
+   *  actually see, so the result fits without horizontal panning. */
+  canvasWidth?: number;
+  canvasHeight?: number;
 }
 
 const DEFAULTS: Required<LayoutOptions> = {
-	nodeWidth: 240,
-	rowHeight: 22,
-	headerHeight: 48,
-	visibleColumnsCap: Number.POSITIVE_INFINITY,
-	canvasWidth: 0,
-	canvasHeight: 0
+  nodeWidth: 240,
+  rowHeight: 22,
+  headerHeight: 48,
+  visibleColumnsCap: Number.POSITIVE_INFINITY,
+  canvasWidth: 0,
+  canvasHeight: 0,
 };
 
-export function estimateNodeHeight(table: SchemaCanvasTable, opts: LayoutOptions = {}): number {
-	const { headerHeight, rowHeight } = { ...DEFAULTS, ...opts };
-	const cap = opts.visibleColumnsCap ?? Number.POSITIVE_INFINITY;
-	// Visible-row count mirrors what TableNode actually renders:
-	//   collapsed=true  → header only (0 rows)
-	//   collapsed=false → every column
-	//   undefined       → min(cap, columns.length)
-	let visible: number;
-	if (table.collapsed === true) {
-		visible = 0;
-	} else if (table.collapsed === false) {
-		visible = table.columns.length;
-	} else {
-		visible = Math.min(cap, table.columns.length);
-	}
-	return headerHeight + Math.max(1, visible) * rowHeight + 12;
+export function estimateNodeHeight(
+  table: SchemaCanvasTable,
+  opts: LayoutOptions = {},
+): number {
+  const { headerHeight, rowHeight } = { ...DEFAULTS, ...opts };
+  const cap = opts.visibleColumnsCap ?? Number.POSITIVE_INFINITY;
+  // Visible-row count mirrors what TableNode actually renders:
+  //   collapsed=true  → header only (0 rows)
+  //   collapsed=false → every column
+  //   undefined       → min(cap, columns.length)
+  let visible: number;
+  if (table.collapsed === true) {
+    visible = 0;
+  } else if (table.collapsed === false) {
+    visible = table.columns.length;
+  } else {
+    visible = Math.min(cap, table.columns.length);
+  }
+  return headerHeight + Math.max(1, visible) * rowHeight + 12;
 }
 
 /**
@@ -68,27 +71,27 @@ export function estimateNodeHeight(table: SchemaCanvasTable, opts: LayoutOptions
  *  - grid: even rows of N tables, alphabetical sort (clean reset)
  *  - byJoins: tables most-connected to the fact first, less-connected radiating out
  */
-export type LayoutMode = 'layered' | 'star' | 'grid' | 'byJoins';
+export type LayoutMode = "layered" | "star" | "grid" | "byJoins";
 
 /**
  * Dispatcher — apply whichever layout the user picked.
  */
 export async function applyLayout(
-	state: SchemaCanvasState,
-	mode: LayoutMode,
-	opts: LayoutOptions = {}
+  state: SchemaCanvasState,
+  mode: LayoutMode,
+  opts: LayoutOptions = {},
 ): Promise<SchemaCanvasState> {
-	switch (mode) {
-		case 'star':
-			return starLayout(state, opts);
-		case 'grid':
-			return gridLayout(state, opts);
-		case 'byJoins':
-			return byJoinsLayout(state, opts);
-		case 'layered':
-		default:
-			return applyAutoLayout(state, opts);
-	}
+  switch (mode) {
+    case "star":
+      return starLayout(state, opts);
+    case "grid":
+      return gridLayout(state, opts);
+    case "byJoins":
+      return byJoinsLayout(state, opts);
+    case "layered":
+    default:
+      return applyAutoLayout(state, opts);
+  }
 }
 
 /**
@@ -97,48 +100,48 @@ export async function applyLayout(
  * historic "Arrange" behaviour — preserved as the default.
  */
 export async function applyAutoLayout(
-	state: SchemaCanvasState,
-	opts: LayoutOptions = {}
+  state: SchemaCanvasState,
+  opts: LayoutOptions = {},
 ): Promise<SchemaCanvasState> {
-	const merged = { ...DEFAULTS, ...opts };
-	const elkGraph = {
-		id: 'root',
-		layoutOptions: {
-			'elk.algorithm': 'layered',
-			'elk.direction': 'DOWN',
-			'elk.spacing.nodeNode': '60',
-			'elk.spacing.edgeNode': '24',
-			'elk.spacing.componentComponent': '80',
-			'elk.layered.spacing.nodeNodeBetweenLayers': '80',
-			'elk.layered.spacing.edgeNodeBetweenLayers': '20',
-			'elk.layered.considerModelOrder.strategy': 'NODES_AND_EDGES'
-		},
-		children: state.tables.map((t) => ({
-			id: t.id,
-			width: merged.nodeWidth,
-			height: estimateNodeHeight(t, merged)
-		})),
-		edges: state.joins.map((j) => ({
-			id: j.id,
-			sources: [j.sourceTableId],
-			targets: [j.targetTableId]
-		}))
-	};
-	const laid = await elk.layout(elkGraph as Parameters<typeof elk.layout>[0]);
-	const positions = new Map<string, { x: number; y: number }>();
-	for (const child of laid.children ?? []) {
-		if (child.id) {
-			positions.set(child.id, { x: child.x ?? 0, y: child.y ?? 0 });
-		}
-	}
-	return {
-		...state,
-		tables: state.tables.map((t) => ({
-			...t,
-			position: positions.get(t.id) ?? t.position
-		})),
-		updatedAt: new Date().toISOString()
-	};
+  const merged = { ...DEFAULTS, ...opts };
+  const elkGraph = {
+    id: "root",
+    layoutOptions: {
+      "elk.algorithm": "layered",
+      "elk.direction": "DOWN",
+      "elk.spacing.nodeNode": "60",
+      "elk.spacing.edgeNode": "24",
+      "elk.spacing.componentComponent": "80",
+      "elk.layered.spacing.nodeNodeBetweenLayers": "80",
+      "elk.layered.spacing.edgeNodeBetweenLayers": "20",
+      "elk.layered.considerModelOrder.strategy": "NODES_AND_EDGES",
+    },
+    children: state.tables.map((t) => ({
+      id: t.id,
+      width: merged.nodeWidth,
+      height: estimateNodeHeight(t, merged),
+    })),
+    edges: state.joins.map((j) => ({
+      id: j.id,
+      sources: [j.sourceTableId],
+      targets: [j.targetTableId],
+    })),
+  };
+  const laid = await elk.layout(elkGraph as Parameters<typeof elk.layout>[0]);
+  const positions = new Map<string, { x: number; y: number }>();
+  for (const child of laid.children ?? []) {
+    if (child.id) {
+      positions.set(child.id, { x: child.x ?? 0, y: child.y ?? 0 });
+    }
+  }
+  return {
+    ...state,
+    tables: state.tables.map((t) => ({
+      ...t,
+      position: positions.get(t.id) ?? t.position,
+    })),
+    updatedAt: new Date().toISOString(),
+  };
 }
 
 /**
@@ -147,49 +150,58 @@ export async function applyAutoLayout(
  * themselves. Dimensions are sorted alphabetically so the same schema
  * lays out the same way every time you hit Star.
  */
-export function starLayout(state: SchemaCanvasState, opts: LayoutOptions = {}): SchemaCanvasState {
-	const merged = { ...DEFAULTS, ...opts };
-	const fact = state.tables.find((t) => t.role === 'fact');
-	const others = state.tables
-		.filter((t) => t.role !== 'fact')
-		.slice()
-		.sort((a, b) => a.name.localeCompare(b.name));
-	// Adjacent-card chord requirement. Cards aren't rotated to face the
-	// centre — they stay axis-aligned — so the limiting dimension is
-	// the LARGER of width or height (not the diagonal). Using the
-	// diagonal was over-spacing the ring. Floor at 320 so 1–2 tables
-	// don't collapse onto each other.
-	// Generous pad so adjacent cards never sit edge-to-edge — they used to
-	// touch (gap == 0) which made overlapping-content (long names, hover
-	// shadows) visually merge two tables. 48px of breathing room each way.
-	const PAD = 48;
-	const MAX_HEIGHT_FOR_RADIUS = 400;
-	const rawMaxHeight = Math.max(...state.tables.map((t) => estimateNodeHeight(t, merged)));
-	const heightForRadius = Math.min(MAX_HEIGHT_FOR_RADIUS, rawMaxHeight);
-	const chordRequirement = Math.max(merged.nodeWidth + PAD, heightForRadius + PAD);
-	const N = others.length;
-	const minRadius = N >= 2 ? chordRequirement / (2 * Math.sin(Math.PI / N)) : 220;
-	const radius = Math.max(220, minRadius);
-	const centre = { x: radius + 80, y: radius + 80 };
-	const positions = new Map<string, { x: number; y: number }>();
-	if (fact) {
-		const factH = estimateNodeHeight(fact, merged);
-		positions.set(fact.id, {
-			x: centre.x - merged.nodeWidth / 2,
-			y: centre.y - factH / 2
-		});
-	}
-	const n = Math.max(1, others.length);
-	others.forEach((t, i) => {
-		// -π/2 puts the first dim at the top of the ring.
-		const angle = -Math.PI / 2 + (i / n) * Math.PI * 2;
-		const h = estimateNodeHeight(t, merged);
-		positions.set(t.id, {
-			x: centre.x + Math.cos(angle) * radius - merged.nodeWidth / 2,
-			y: centre.y + Math.sin(angle) * radius - h / 2
-		});
-	});
-	return applyPositions(state, positions);
+export function starLayout(
+  state: SchemaCanvasState,
+  opts: LayoutOptions = {},
+): SchemaCanvasState {
+  const merged = { ...DEFAULTS, ...opts };
+  const fact = state.tables.find((t) => t.role === "fact");
+  const others = state.tables
+    .filter((t) => t.role !== "fact")
+    .slice()
+    .sort((a, b) => a.name.localeCompare(b.name));
+  // Adjacent-card chord requirement. Cards aren't rotated to face the
+  // centre — they stay axis-aligned — so the limiting dimension is
+  // the LARGER of width or height (not the diagonal). Using the
+  // diagonal was over-spacing the ring. Floor at 320 so 1–2 tables
+  // don't collapse onto each other.
+  // Generous pad so adjacent cards never sit edge-to-edge — they used to
+  // touch (gap == 0) which made overlapping-content (long names, hover
+  // shadows) visually merge two tables. 48px of breathing room each way.
+  const PAD = 48;
+  const MAX_HEIGHT_FOR_RADIUS = 400;
+  const rawMaxHeight = Math.max(
+    ...state.tables.map((t) => estimateNodeHeight(t, merged)),
+  );
+  const heightForRadius = Math.min(MAX_HEIGHT_FOR_RADIUS, rawMaxHeight);
+  const chordRequirement = Math.max(
+    merged.nodeWidth + PAD,
+    heightForRadius + PAD,
+  );
+  const N = others.length;
+  const minRadius =
+    N >= 2 ? chordRequirement / (2 * Math.sin(Math.PI / N)) : 220;
+  const radius = Math.max(220, minRadius);
+  const centre = { x: radius + 80, y: radius + 80 };
+  const positions = new Map<string, { x: number; y: number }>();
+  if (fact) {
+    const factH = estimateNodeHeight(fact, merged);
+    positions.set(fact.id, {
+      x: centre.x - merged.nodeWidth / 2,
+      y: centre.y - factH / 2,
+    });
+  }
+  const n = Math.max(1, others.length);
+  others.forEach((t, i) => {
+    // -π/2 puts the first dim at the top of the ring.
+    const angle = -Math.PI / 2 + (i / n) * Math.PI * 2;
+    const h = estimateNodeHeight(t, merged);
+    positions.set(t.id, {
+      x: centre.x + Math.cos(angle) * radius - merged.nodeWidth / 2,
+      y: centre.y + Math.sin(angle) * radius - h / 2,
+    });
+  });
+  return applyPositions(state, positions);
 }
 
 /**
@@ -197,48 +209,54 @@ export function starLayout(state: SchemaCanvasState, opts: LayoutOptions = {}): 
  * even rows below it. Useful when the canvas has drifted and you just
  * want a clean reset.
  */
-export function gridLayout(state: SchemaCanvasState, opts: LayoutOptions = {}): SchemaCanvasState {
-	const merged = { ...DEFAULTS, ...opts };
-	// Generous gaps so a join label landing at the midpoint between two
-	// cards has room to read without sitting on either card. Not the
-	// real obstacle-avoidance fix (queued), but it makes labels visually
-	// "fit" between rows / columns instead of crowding them.
-	const gapX = 160;
-	const gapY = 160;
-	// Cols default — when the caller passes a real canvasWidth, size the
-	// grid to fit that width (minus a small padding budget for the
-	// SvelteFlow chrome).  When not, fall back to a step-function on
-	// table count so a stale caller still gets something reasonable.
-	let cols: number;
-	if (merged.canvasWidth > 0) {
-		const usable = Math.max(merged.canvasWidth - 120, merged.nodeWidth);
-		cols = Math.max(1, Math.floor((usable + gapX) / (merged.nodeWidth + gapX)));
-		// Don't waste columns on a small set of tables — cap at table count.
-		cols = Math.min(cols, Math.max(1, state.tables.length));
-	} else {
-		cols = state.tables.length <= 4 ? 2 : state.tables.length <= 9 ? 3 : 4;
-	}
-	const fact = state.tables.find((t) => t.role === 'fact');
-	const rest = state.tables
-		.filter((t) => t.id !== fact?.id)
-		.slice()
-		.sort((a, b) => a.name.localeCompare(b.name));
-	const ordered = fact ? [fact, ...rest] : rest;
-	const positions = new Map<string, { x: number; y: number }>();
-	// Compute the tallest node in each row so the next row clears it.
-	let rowTopY = 60;
-	for (let row = 0; row * cols < ordered.length; row++) {
-		const rowTables = ordered.slice(row * cols, row * cols + cols);
-		const rowMaxH = rowTables.reduce((m, t) => Math.max(m, estimateNodeHeight(t, merged)), 0);
-		rowTables.forEach((t, i) => {
-			positions.set(t.id, {
-				x: 60 + i * (merged.nodeWidth + gapX),
-				y: rowTopY
-			});
-		});
-		rowTopY += rowMaxH + gapY;
-	}
-	return applyPositions(state, positions);
+export function gridLayout(
+  state: SchemaCanvasState,
+  opts: LayoutOptions = {},
+): SchemaCanvasState {
+  const merged = { ...DEFAULTS, ...opts };
+  // Generous gaps so a join label landing at the midpoint between two
+  // cards has room to read without sitting on either card. Not the
+  // real obstacle-avoidance fix (queued), but it makes labels visually
+  // "fit" between rows / columns instead of crowding them.
+  const gapX = 160;
+  const gapY = 160;
+  // Cols default — when the caller passes a real canvasWidth, size the
+  // grid to fit that width (minus a small padding budget for the
+  // SvelteFlow chrome).  When not, fall back to a step-function on
+  // table count so a stale caller still gets something reasonable.
+  let cols: number;
+  if (merged.canvasWidth > 0) {
+    const usable = Math.max(merged.canvasWidth - 120, merged.nodeWidth);
+    cols = Math.max(1, Math.floor((usable + gapX) / (merged.nodeWidth + gapX)));
+    // Don't waste columns on a small set of tables — cap at table count.
+    cols = Math.min(cols, Math.max(1, state.tables.length));
+  } else {
+    cols = state.tables.length <= 4 ? 2 : state.tables.length <= 9 ? 3 : 4;
+  }
+  const fact = state.tables.find((t) => t.role === "fact");
+  const rest = state.tables
+    .filter((t) => t.id !== fact?.id)
+    .slice()
+    .sort((a, b) => a.name.localeCompare(b.name));
+  const ordered = fact ? [fact, ...rest] : rest;
+  const positions = new Map<string, { x: number; y: number }>();
+  // Compute the tallest node in each row so the next row clears it.
+  let rowTopY = 60;
+  for (let row = 0; row * cols < ordered.length; row++) {
+    const rowTables = ordered.slice(row * cols, row * cols + cols);
+    const rowMaxH = rowTables.reduce(
+      (m, t) => Math.max(m, estimateNodeHeight(t, merged)),
+      0,
+    );
+    rowTables.forEach((t, i) => {
+      positions.set(t.id, {
+        x: 60 + i * (merged.nodeWidth + gapX),
+        y: rowTopY,
+      });
+    });
+    rowTopY += rowMaxH + gapY;
+  }
+  return applyPositions(state, positions);
 }
 
 /**
@@ -248,86 +266,86 @@ export function gridLayout(state: SchemaCanvasState, opts: LayoutOptions = {}): 
  * Falls back to star semantics when there are no joins yet.
  */
 export function byJoinsLayout(
-	state: SchemaCanvasState,
-	opts: LayoutOptions = {}
+  state: SchemaCanvasState,
+  opts: LayoutOptions = {},
 ): SchemaCanvasState {
-	const fact = state.tables.find((t) => t.role === 'fact');
-	if (!fact) return gridLayout(state, opts);
+  const fact = state.tables.find((t) => t.role === "fact");
+  if (!fact) return gridLayout(state, opts);
 
-	// BFS from the fact across the join graph to assign a ring number.
-	const adj = new Map<string, Set<string>>();
-	for (const t of state.tables) adj.set(t.id, new Set());
-	for (const j of state.joins) {
-		adj.get(j.sourceTableId)?.add(j.targetTableId);
-		adj.get(j.targetTableId)?.add(j.sourceTableId);
-	}
-	const ring = new Map<string, number>();
-	ring.set(fact.id, 0);
-	const queue = [fact.id];
-	while (queue.length) {
-		const cur = queue.shift()!;
-		const d = ring.get(cur)!;
-		for (const next of adj.get(cur) ?? []) {
-			if (ring.has(next)) continue;
-			ring.set(next, d + 1);
-			queue.push(next);
-		}
-	}
-	// Disconnected tables sit one ring further out than the deepest connected.
-	const maxRing = [...ring.values()].reduce((m, r) => Math.max(m, r), 0);
-	for (const t of state.tables) {
-		if (!ring.has(t.id)) ring.set(t.id, maxRing + 1);
-	}
+  // BFS from the fact across the join graph to assign a ring number.
+  const adj = new Map<string, Set<string>>();
+  for (const t of state.tables) adj.set(t.id, new Set());
+  for (const j of state.joins) {
+    adj.get(j.sourceTableId)?.add(j.targetTableId);
+    adj.get(j.targetTableId)?.add(j.sourceTableId);
+  }
+  const ring = new Map<string, number>();
+  ring.set(fact.id, 0);
+  const queue = [fact.id];
+  while (queue.length) {
+    const cur = queue.shift()!;
+    const d = ring.get(cur)!;
+    for (const next of adj.get(cur) ?? []) {
+      if (ring.has(next)) continue;
+      ring.set(next, d + 1);
+      queue.push(next);
+    }
+  }
+  // Disconnected tables sit one ring further out than the deepest connected.
+  const maxRing = [...ring.values()].reduce((m, r) => Math.max(m, r), 0);
+  for (const t of state.tables) {
+    if (!ring.has(t.id)) ring.set(t.id, maxRing + 1);
+  }
 
-	// Place each ring around the centre.
-	const merged = { ...DEFAULTS, ...opts };
-	const centre = { x: 600, y: 400 };
-	const byRing = new Map<number, string[]>();
-	for (const [id, r] of ring) {
-		if (!byRing.has(r)) byRing.set(r, []);
-		byRing.get(r)!.push(id);
-	}
-	const positions = new Map<string, { x: number; y: number }>();
-	for (const [r, ids] of byRing) {
-		ids.sort((a, b) => {
-			const ta = state.tables.find((t) => t.id === a)!;
-			const tb = state.tables.find((t) => t.id === b)!;
-			return ta.name.localeCompare(tb.name);
-		});
-		if (r === 0) {
-			const t = state.tables.find((tt) => tt.id === ids[0])!;
-			const h = estimateNodeHeight(t, merged);
-			positions.set(ids[0], {
-				x: centre.x - merged.nodeWidth / 2,
-				y: centre.y - h / 2
-			});
-			continue;
-		}
-		const radius = 220 + r * 200;
-		const n = Math.max(1, ids.length);
-		ids.forEach((id, i) => {
-			const angle = -Math.PI / 2 + (i / n) * Math.PI * 2;
-			const t = state.tables.find((tt) => tt.id === id)!;
-			const h = estimateNodeHeight(t, merged);
-			positions.set(id, {
-				x: centre.x + Math.cos(angle) * radius - merged.nodeWidth / 2,
-				y: centre.y + Math.sin(angle) * radius - h / 2
-			});
-		});
-	}
-	return applyPositions(state, positions);
+  // Place each ring around the centre.
+  const merged = { ...DEFAULTS, ...opts };
+  const centre = { x: 600, y: 400 };
+  const byRing = new Map<number, string[]>();
+  for (const [id, r] of ring) {
+    if (!byRing.has(r)) byRing.set(r, []);
+    byRing.get(r)!.push(id);
+  }
+  const positions = new Map<string, { x: number; y: number }>();
+  for (const [r, ids] of byRing) {
+    ids.sort((a, b) => {
+      const ta = state.tables.find((t) => t.id === a)!;
+      const tb = state.tables.find((t) => t.id === b)!;
+      return ta.name.localeCompare(tb.name);
+    });
+    if (r === 0) {
+      const t = state.tables.find((tt) => tt.id === ids[0])!;
+      const h = estimateNodeHeight(t, merged);
+      positions.set(ids[0], {
+        x: centre.x - merged.nodeWidth / 2,
+        y: centre.y - h / 2,
+      });
+      continue;
+    }
+    const radius = 220 + r * 200;
+    const n = Math.max(1, ids.length);
+    ids.forEach((id, i) => {
+      const angle = -Math.PI / 2 + (i / n) * Math.PI * 2;
+      const t = state.tables.find((tt) => tt.id === id)!;
+      const h = estimateNodeHeight(t, merged);
+      positions.set(id, {
+        x: centre.x + Math.cos(angle) * radius - merged.nodeWidth / 2,
+        y: centre.y + Math.sin(angle) * radius - h / 2,
+      });
+    });
+  }
+  return applyPositions(state, positions);
 }
 
 function applyPositions(
-	state: SchemaCanvasState,
-	positions: Map<string, { x: number; y: number }>
+  state: SchemaCanvasState,
+  positions: Map<string, { x: number; y: number }>,
 ): SchemaCanvasState {
-	return {
-		...state,
-		tables: state.tables.map((t) => ({
-			...t,
-			position: positions.get(t.id) ?? t.position
-		})),
-		updatedAt: new Date().toISOString()
-	};
+  return {
+    ...state,
+    tables: state.tables.map((t) => ({
+      ...t,
+      position: positions.get(t.id) ?? t.position,
+    })),
+    updatedAt: new Date().toISOString(),
+  };
 }

--- a/saiku-ui/src/lib/cube-designer/mondrian-export.test.ts
+++ b/saiku-ui/src/lib/cube-designer/mondrian-export.test.ts
@@ -1,764 +1,876 @@
-import { describe, it, expect } from 'vitest';
-import { parse } from 'yaml';
-import { exportToMondrianXml, exportToMondrianYaml } from './mondrian-export.js';
-import type { SchemaCanvasState } from './types.js';
+import { describe, it, expect } from "vitest";
+import { parse } from "yaml";
+import {
+  exportToMondrianXml,
+  exportToMondrianYaml,
+} from "./mondrian-export.js";
+import type { SchemaCanvasState } from "./types.js";
 
 function baseDoc(): SchemaCanvasState {
-	return {
-		version: 1,
-		connectionId: 'conn-1',
-		label: 'My Cube',
-		tables: [],
-		joins: [],
-		groups: [],
-		updatedAt: '2026-06-18T00:00:00.000Z'
-	};
+  return {
+    version: 1,
+    connectionId: "conn-1",
+    label: "My Cube",
+    tables: [],
+    joins: [],
+    groups: [],
+    updatedAt: "2026-06-18T00:00:00.000Z",
+  };
 }
 
-describe('exportToMondrianXml', () => {
-	it('throws when no fact table is on the canvas', () => {
-		const doc = baseDoc();
-		expect(() => exportToMondrianXml(doc)).toThrow(/no fact table/);
-	});
+describe("exportToMondrianXml", () => {
+  it("throws when no fact table is on the canvas", () => {
+    const doc = baseDoc();
+    expect(() => exportToMondrianXml(doc)).toThrow(/no fact table/);
+  });
 
-	it('emits a stub Row count measure when the doc has no measures', () => {
-		const doc: SchemaCanvasState = {
-			...baseDoc(),
-			tables: [
-				{
-					id: 'f',
-					schema: 'public',
-					name: 'sales_fact',
-					role: 'fact',
-					columns: [{ name: 'amount', sqlType: 'numeric' }],
-					position: { x: 0, y: 0 },
-					groupId: null
-				}
-			]
-		};
-		const xml = exportToMondrianXml(doc);
-		expect(xml).toContain('<Schema name="My Cube" metamodelVersion="4.0">');
-		expect(xml).toContain('<Table name="sales_fact" schema="public" />');
-		expect(xml).toContain('<Measure name="Row count" aggregator="count"');
-		// M4 only — no legacy M3 shapes.
-		expect(xml).not.toContain('foreignKey=');
-		expect(xml).not.toMatch(/<Hierarchy[^>]*primaryKey=/);
-	});
+  it("emits a stub Row count measure when the doc has no measures", () => {
+    const doc: SchemaCanvasState = {
+      ...baseDoc(),
+      tables: [
+        {
+          id: "f",
+          schema: "public",
+          name: "sales_fact",
+          role: "fact",
+          columns: [{ name: "amount", sqlType: "numeric" }],
+          position: { x: 0, y: 0 },
+          groupId: null,
+        },
+      ],
+    };
+    const xml = exportToMondrianXml(doc);
+    expect(xml).toContain('<Schema name="My Cube" metamodelVersion="4.0">');
+    expect(xml).toContain('<Table name="sales_fact" schema="public" />');
+    expect(xml).toContain('<Measure name="Row count" aggregator="count"');
+    // M4 only — no legacy M3 shapes.
+    expect(xml).not.toContain("foreignKey=");
+    expect(xml).not.toMatch(/<Hierarchy[^>]*primaryKey=/);
+  });
 
-	it('emits user-authored measures instead of the Row count stub', () => {
-		const doc: SchemaCanvasState = {
-			...baseDoc(),
-			tables: [
-				{
-					id: 'f',
-					schema: 'public',
-					name: 'sales_fact',
-					role: 'fact',
-					columns: [
-						{ name: 'amount', sqlType: 'numeric' },
-						{ name: 'qty', sqlType: 'numeric' }
-					],
-					position: { x: 0, y: 0 },
-					groupId: null
-				}
-			],
-			measures: [
-				{
-					id: 'm1',
-					name: 'Sales',
-					aggregator: 'sum',
-					tableId: 'f',
-					columnName: 'amount',
-					formatString: '$#,##0'
-				},
-				{
-					id: 'm2',
-					name: 'Orders',
-					aggregator: 'count',
-					tableId: 'f',
-					columnName: 'qty'
-				}
-			]
-		};
-		const xml = exportToMondrianXml(doc);
-		expect(xml).toContain(
-			'<Measure name="Sales" column="amount" aggregator="sum" formatString="$#,##0" />'
-		);
-		expect(xml).toContain('<Measure name="Orders" column="qty" aggregator="count" />');
-		expect(xml).not.toContain('Row count');
-	});
+  it("emits user-authored measures instead of the Row count stub", () => {
+    const doc: SchemaCanvasState = {
+      ...baseDoc(),
+      tables: [
+        {
+          id: "f",
+          schema: "public",
+          name: "sales_fact",
+          role: "fact",
+          columns: [
+            { name: "amount", sqlType: "numeric" },
+            { name: "qty", sqlType: "numeric" },
+          ],
+          position: { x: 0, y: 0 },
+          groupId: null,
+        },
+      ],
+      measures: [
+        {
+          id: "m1",
+          name: "Sales",
+          aggregator: "sum",
+          tableId: "f",
+          columnName: "amount",
+          formatString: "$#,##0",
+        },
+        {
+          id: "m2",
+          name: "Orders",
+          aggregator: "count",
+          tableId: "f",
+          columnName: "qty",
+        },
+      ],
+    };
+    const xml = exportToMondrianXml(doc);
+    expect(xml).toContain(
+      '<Measure name="Sales" column="amount" aggregator="sum" formatString="$#,##0" />',
+    );
+    expect(xml).toContain(
+      '<Measure name="Orders" column="qty" aggregator="count" />',
+    );
+    expect(xml).not.toContain("Row count");
+  });
 
-	it('emits median + percentile aggregators, with percentile="N" only for percentile', () => {
-		const doc: SchemaCanvasState = {
-			...baseDoc(),
-			tables: [
-				{
-					id: 'f',
-					schema: 'public',
-					name: 'sales_fact',
-					role: 'fact',
-					columns: [
-						{ name: 'order_total', sqlType: 'numeric' },
-						{ name: 'latency_ms', sqlType: 'numeric' }
-					],
-					position: { x: 0, y: 0 },
-					groupId: null
-				}
-			],
-			measures: [
-				{
-					id: 'm1',
-					name: 'Median Order',
-					aggregator: 'median',
-					tableId: 'f',
-					columnName: 'order_total'
-				},
-				{
-					id: 'm2',
-					name: 'P90 Latency',
-					aggregator: 'percentile',
-					tableId: 'f',
-					columnName: 'latency_ms',
-					percentile: 90
-				}
-			]
-		};
-		const xml = exportToMondrianXml(doc);
-		// median: aggregator only, no percentile attribute.
-		expect(xml).toContain(
-			'<Measure name="Median Order" column="order_total" aggregator="median" />'
-		);
-		// percentile: carries the fraction.
-		expect(xml).toContain(
-			'<Measure name="P90 Latency" column="latency_ms" aggregator="percentile" percentile="90" />'
-		);
-	});
+  it('emits median + percentile aggregators, with percentile="N" only for percentile', () => {
+    const doc: SchemaCanvasState = {
+      ...baseDoc(),
+      tables: [
+        {
+          id: "f",
+          schema: "public",
+          name: "sales_fact",
+          role: "fact",
+          columns: [
+            { name: "order_total", sqlType: "numeric" },
+            { name: "latency_ms", sqlType: "numeric" },
+          ],
+          position: { x: 0, y: 0 },
+          groupId: null,
+        },
+      ],
+      measures: [
+        {
+          id: "m1",
+          name: "Median Order",
+          aggregator: "median",
+          tableId: "f",
+          columnName: "order_total",
+        },
+        {
+          id: "m2",
+          name: "P90 Latency",
+          aggregator: "percentile",
+          tableId: "f",
+          columnName: "latency_ms",
+          percentile: 90,
+        },
+      ],
+    };
+    const xml = exportToMondrianXml(doc);
+    // median: aggregator only, no percentile attribute.
+    expect(xml).toContain(
+      '<Measure name="Median Order" column="order_total" aggregator="median" />',
+    );
+    // percentile: carries the fraction.
+    expect(xml).toContain(
+      '<Measure name="P90 Latency" column="latency_ms" aggregator="percentile" percentile="90" />',
+    );
+  });
 
-	it('emits workbench-curated dimensions with their hierarchies and levels', () => {
-		const doc: SchemaCanvasState = {
-			...baseDoc(),
-			tables: [
-				{
-					id: 'f',
-					schema: 'public',
-					name: 'sales_fact',
-					role: 'fact',
-					columns: [{ name: 'customer_id', sqlType: 'int' }],
-					position: { x: 0, y: 0 },
-					groupId: null
-				},
-				{
-					id: 'c',
-					schema: 'public',
-					name: 'customer',
-					role: 'dimension',
-					columns: [
-						{ name: 'id', sqlType: 'int' },
-						{ name: 'country', sqlType: 'text' },
-						{ name: 'city', sqlType: 'text' }
-					],
-					position: { x: 100, y: 0 },
-					groupId: null
-				}
-			],
-			dimensions: [
-				{
-					id: 'd1',
-					name: 'Customer',
-					foreignKey: 'customer_id',
-					primaryKey: 'id',
-					primaryKeyTableId: 'c',
-					hierarchies: [
-						{
-							id: 'h1',
-							name: 'Geo',
-							hasAll: true,
-							levels: [
-								{
-									id: 'l1',
-									name: 'Country',
-									caption: 'Country of residence',
-									tableId: 'c',
-									columnName: 'country',
-									type: 'String'
-								},
-								{ id: 'l2', name: 'City', tableId: 'c', columnName: 'city', type: 'String' }
-							]
-						}
-					],
-					dimensionType: 'Standard'
-				}
-			]
-		};
-		const xml = exportToMondrianXml(doc);
-		// M4: PK on the physical dim table + dimension key; FK on the link.
-		expect(xml).toContain('<Table name="customer" schema="public" keyColumn="id" />');
-		expect(xml).toContain('<Dimension name="Customer" table="customer" key="Customer Key">');
-		expect(xml).toContain('<Attribute name="Customer Key" keyColumn="id" hasHierarchy="false" />');
-		expect(xml).toContain('<Hierarchy name="Geo" hasAll="true">');
-		// Levels reference attributes synthesised from the M3-style level columns.
-		expect(xml).toContain('<Attribute name="Country" keyColumn="country" />');
-		expect(xml).toContain('<Attribute name="City" keyColumn="city" />');
-		expect(xml).toContain('<Level attribute="Country" caption="Country of residence" />');
-		expect(xml).toContain('<Level attribute="City" />');
-		expect(xml).toContain('<ForeignKeyLink dimension="Customer" foreignKeyColumn="customer_id" />');
-	});
+  it("emits workbench-curated dimensions with their hierarchies and levels", () => {
+    const doc: SchemaCanvasState = {
+      ...baseDoc(),
+      tables: [
+        {
+          id: "f",
+          schema: "public",
+          name: "sales_fact",
+          role: "fact",
+          columns: [{ name: "customer_id", sqlType: "int" }],
+          position: { x: 0, y: 0 },
+          groupId: null,
+        },
+        {
+          id: "c",
+          schema: "public",
+          name: "customer",
+          role: "dimension",
+          columns: [
+            { name: "id", sqlType: "int" },
+            { name: "country", sqlType: "text" },
+            { name: "city", sqlType: "text" },
+          ],
+          position: { x: 100, y: 0 },
+          groupId: null,
+        },
+      ],
+      dimensions: [
+        {
+          id: "d1",
+          name: "Customer",
+          foreignKey: "customer_id",
+          primaryKey: "id",
+          primaryKeyTableId: "c",
+          hierarchies: [
+            {
+              id: "h1",
+              name: "Geo",
+              hasAll: true,
+              levels: [
+                {
+                  id: "l1",
+                  name: "Country",
+                  caption: "Country of residence",
+                  tableId: "c",
+                  columnName: "country",
+                  type: "String",
+                },
+                {
+                  id: "l2",
+                  name: "City",
+                  tableId: "c",
+                  columnName: "city",
+                  type: "String",
+                },
+              ],
+            },
+          ],
+          dimensionType: "Standard",
+        },
+      ],
+    };
+    const xml = exportToMondrianXml(doc);
+    // M4: PK on the physical dim table + dimension key; FK on the link.
+    expect(xml).toContain(
+      '<Table name="customer" schema="public" keyColumn="id" />',
+    );
+    expect(xml).toContain(
+      '<Dimension name="Customer" table="customer" key="Customer Key">',
+    );
+    expect(xml).toContain(
+      '<Attribute name="Customer Key" keyColumn="id" hasHierarchy="false" />',
+    );
+    expect(xml).toContain('<Hierarchy name="Geo" hasAll="true">');
+    // Levels reference attributes synthesised from the M3-style level columns.
+    expect(xml).toContain('<Attribute name="Country" keyColumn="country" />');
+    expect(xml).toContain('<Attribute name="City" keyColumn="city" />');
+    expect(xml).toContain(
+      '<Level attribute="Country" caption="Country of residence" />',
+    );
+    expect(xml).toContain('<Level attribute="City" />');
+    expect(xml).toContain(
+      '<ForeignKeyLink dimension="Customer" foreignKeyColumn="customer_id" />',
+    );
+  });
 
-	it('annotates Time dimensions with type="TIME" and per-level levelType', () => {
-		const doc: SchemaCanvasState = {
-			...baseDoc(),
-			tables: [
-				{
-					id: 'f',
-					schema: null,
-					name: 'fact',
-					role: 'fact',
-					columns: [{ name: 'date_id', sqlType: 'int' }],
-					position: { x: 0, y: 0 },
-					groupId: null
-				},
-				{
-					id: 't',
-					schema: null,
-					name: 'time_by_day',
-					role: 'dimension',
-					columns: [
-						{ name: 'id', sqlType: 'int' },
-						{ name: 'year', sqlType: 'int' }
-					],
-					position: { x: 0, y: 0 },
-					groupId: null
-				}
-			],
-			dimensions: [
-				{
-					id: 'd-time',
-					name: 'Time',
-					foreignKey: 'date_id',
-					primaryKey: 'id',
-					primaryKeyTableId: 't',
-					dimensionType: 'Time',
-					hierarchies: [
-						{
-							id: 'h-t',
-							name: 'Time',
-							hasAll: true,
-							levels: [
-								{
-									id: 'l-y',
-									name: 'Year',
-									tableId: 't',
-									columnName: 'year',
-									type: 'Integer',
-									levelType: 'TimeYears'
-								}
-							]
-						}
-					]
-				}
-			]
-		};
-		const xml = exportToMondrianXml(doc);
-		// Mondrian 4 spells it "TIME" (not the M3 "TimeDimension").
-		expect(xml).toContain('type="TIME"');
-		expect(xml).not.toContain('type="TimeDimension"');
-		// levelType rides on the level's <Attribute> (M4 shape).
-		expect(xml).toContain('levelType="TimeYears"');
-	});
+  it('annotates Time dimensions with type="TIME" and per-level levelType', () => {
+    const doc: SchemaCanvasState = {
+      ...baseDoc(),
+      tables: [
+        {
+          id: "f",
+          schema: null,
+          name: "fact",
+          role: "fact",
+          columns: [{ name: "date_id", sqlType: "int" }],
+          position: { x: 0, y: 0 },
+          groupId: null,
+        },
+        {
+          id: "t",
+          schema: null,
+          name: "time_by_day",
+          role: "dimension",
+          columns: [
+            { name: "id", sqlType: "int" },
+            { name: "year", sqlType: "int" },
+          ],
+          position: { x: 0, y: 0 },
+          groupId: null,
+        },
+      ],
+      dimensions: [
+        {
+          id: "d-time",
+          name: "Time",
+          foreignKey: "date_id",
+          primaryKey: "id",
+          primaryKeyTableId: "t",
+          dimensionType: "Time",
+          hierarchies: [
+            {
+              id: "h-t",
+              name: "Time",
+              hasAll: true,
+              levels: [
+                {
+                  id: "l-y",
+                  name: "Year",
+                  tableId: "t",
+                  columnName: "year",
+                  type: "Integer",
+                  levelType: "TimeYears",
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+    const xml = exportToMondrianXml(doc);
+    // Mondrian 4 spells it "TIME" (not the M3 "TimeDimension").
+    expect(xml).toContain('type="TIME"');
+    expect(xml).not.toContain('type="TimeDimension"');
+    // levelType rides on the level's <Attribute> (M4 shape).
+    expect(xml).toContain('levelType="TimeYears"');
+  });
 
-	it('falls back to join-inferred dimensions when no curated dims exist', () => {
-		const doc: SchemaCanvasState = {
-			...baseDoc(),
-			tables: [
-				{
-					id: 'f',
-					schema: 'public',
-					name: 'sales_fact',
-					role: 'fact',
-					columns: [{ name: 'customer_id', sqlType: 'int' }],
-					position: { x: 0, y: 0 },
-					groupId: null
-				},
-				{
-					id: 'c',
-					schema: 'public',
-					name: 'customer',
-					role: 'dimension',
-					columns: [
-						{ name: 'id', sqlType: 'int' },
-						{ name: 'country', sqlType: 'text' }
-					],
-					position: { x: 100, y: 0 },
-					groupId: null
-				}
-			],
-			joins: [
-				{
-					id: 'j1',
-					sourceTableId: 'f',
-					sourceColumnName: 'customer_id',
-					targetTableId: 'c',
-					targetColumnName: 'id',
-					kind: 'inner'
-				}
-			]
-		};
-		const xml = exportToMondrianXml(doc);
-		// Inferred dims are emitted in the SAME M4 shape as curated ones.
-		expect(xml).toContain('<Table name="customer" schema="public" keyColumn="id" />');
-		expect(xml).toContain('<Dimension name="Customer" table="customer" key="id">');
-		expect(xml).toContain('<Level attribute="country" />');
-		expect(xml).toContain('<ForeignKeyLink dimension="Customer" foreignKeyColumn="customer_id" />');
-	});
+  it("falls back to join-inferred dimensions when no curated dims exist", () => {
+    const doc: SchemaCanvasState = {
+      ...baseDoc(),
+      tables: [
+        {
+          id: "f",
+          schema: "public",
+          name: "sales_fact",
+          role: "fact",
+          columns: [{ name: "customer_id", sqlType: "int" }],
+          position: { x: 0, y: 0 },
+          groupId: null,
+        },
+        {
+          id: "c",
+          schema: "public",
+          name: "customer",
+          role: "dimension",
+          columns: [
+            { name: "id", sqlType: "int" },
+            { name: "country", sqlType: "text" },
+          ],
+          position: { x: 100, y: 0 },
+          groupId: null,
+        },
+      ],
+      joins: [
+        {
+          id: "j1",
+          sourceTableId: "f",
+          sourceColumnName: "customer_id",
+          targetTableId: "c",
+          targetColumnName: "id",
+          kind: "inner",
+        },
+      ],
+    };
+    const xml = exportToMondrianXml(doc);
+    // Inferred dims are emitted in the SAME M4 shape as curated ones.
+    expect(xml).toContain(
+      '<Table name="customer" schema="public" keyColumn="id" />',
+    );
+    expect(xml).toContain(
+      '<Dimension name="Customer" table="customer" key="id">',
+    );
+    expect(xml).toContain('<Level attribute="country" />');
+    expect(xml).toContain(
+      '<ForeignKeyLink dimension="Customer" foreignKeyColumn="customer_id" />',
+    );
+  });
 
-	it('escapes special characters in identifiers', () => {
-		const doc: SchemaCanvasState = {
-			...baseDoc(),
-			label: 'A&B<Cube>',
-			tables: [
-				{
-					id: 'f',
-					schema: null,
-					name: 'fact',
-					role: 'fact',
-					columns: [],
-					position: { x: 0, y: 0 },
-					groupId: null
-				}
-			],
-			measures: [
-				{
-					id: 'm',
-					name: 'Sales & Returns',
-					aggregator: 'sum',
-					tableId: 'f',
-					columnName: 'amount'
-				}
-			]
-		};
-		const xml = exportToMondrianXml(doc);
-		expect(xml).toContain('<Schema name="A&amp;B&lt;Cube&gt;" metamodelVersion="4.0">');
-		expect(xml).toContain('<Measure name="Sales &amp; Returns"');
-	});
+  it("escapes special characters in identifiers", () => {
+    const doc: SchemaCanvasState = {
+      ...baseDoc(),
+      label: "A&B<Cube>",
+      tables: [
+        {
+          id: "f",
+          schema: null,
+          name: "fact",
+          role: "fact",
+          columns: [],
+          position: { x: 0, y: 0 },
+          groupId: null,
+        },
+      ],
+      measures: [
+        {
+          id: "m",
+          name: "Sales & Returns",
+          aggregator: "sum",
+          tableId: "f",
+          columnName: "amount",
+        },
+      ],
+    };
+    const xml = exportToMondrianXml(doc);
+    expect(xml).toContain(
+      '<Schema name="A&amp;B&lt;Cube&gt;" metamodelVersion="4.0">',
+    );
+    expect(xml).toContain('<Measure name="Sales &amp; Returns"');
+  });
 });
 
-describe('exportToMondrianXml — cubes-based', () => {
-	function cubeDoc(): SchemaCanvasState {
-		return {
-			...baseDoc(),
-			label: 'Sales',
-			tables: [
-				{
-					id: 'f',
-					schema: 'public',
-					name: 'sales_fact',
-					role: 'fact',
-					columns: [
-						{ name: 'amount', sqlType: 'numeric' },
-						{ name: 'qty', sqlType: 'numeric' },
-						{ name: 'customer_id', sqlType: 'int' }
-					],
-					position: { x: 0, y: 0 },
-					groupId: null
-				},
-				{
-					id: 'c',
-					schema: 'public',
-					name: 'customer',
-					role: 'dimension',
-					columns: [
-						{ name: 'id', sqlType: 'int' },
-						{ name: 'country', sqlType: 'text' }
-					],
-					position: { x: 100, y: 0 },
-					groupId: null
-				}
-			],
-			dimensions: [
-				{
-					id: 'd1',
-					name: 'Customer',
-					sourceTableId: 'c',
-					primaryKeyTableId: 'c',
-					primaryKey: 'id',
-					attributes: [{ tableId: 'c', columnName: 'id' }],
-					hierarchies: [
-						{
-							id: 'h1',
-							name: 'Geo',
-							hasAll: true,
-							levels: [
-								{ id: 'l1', name: 'Country', tableId: 'c', columnName: 'country', type: 'String' }
-							]
-						}
-					]
-				}
-			],
-			measures: [
-				{
-					id: 'm1',
-					name: 'Sales',
-					aggregator: 'sum',
-					tableId: 'f',
-					columnName: 'amount',
-					formatString: '$#,##0'
-				}
-			],
-			cubes: [
-				{
-					id: 'cube-1',
-					name: 'Sales',
-					measureGroups: [
-						{
-							id: 'mg-1',
-							name: 'Sales Facts',
-							measureColumns: ['amount', 'qty'],
-							factTableId: 'f',
-							dimensionLinks: [{ dimensionId: 'd1', foreignKeyColumn: 'customer_id' }]
-						}
-					],
-					calcs: [
-						{
-							id: 'calc-1',
-							name: 'Margin',
-							tokens: [
-								{ kind: 'measure', name: 'Sales' },
-								{ kind: 'op', op: '-' },
-								{ kind: 'measure', name: 'Cost' }
-							],
-							mode: 'build'
-						}
-					]
-				}
-			]
-		};
-	}
+describe("exportToMondrianXml — cubes-based", () => {
+  function cubeDoc(): SchemaCanvasState {
+    return {
+      ...baseDoc(),
+      label: "Sales",
+      tables: [
+        {
+          id: "f",
+          schema: "public",
+          name: "sales_fact",
+          role: "fact",
+          columns: [
+            { name: "amount", sqlType: "numeric" },
+            { name: "qty", sqlType: "numeric" },
+            { name: "customer_id", sqlType: "int" },
+          ],
+          position: { x: 0, y: 0 },
+          groupId: null,
+        },
+        {
+          id: "c",
+          schema: "public",
+          name: "customer",
+          role: "dimension",
+          columns: [
+            { name: "id", sqlType: "int" },
+            { name: "country", sqlType: "text" },
+          ],
+          position: { x: 100, y: 0 },
+          groupId: null,
+        },
+      ],
+      dimensions: [
+        {
+          id: "d1",
+          name: "Customer",
+          sourceTableId: "c",
+          primaryKeyTableId: "c",
+          primaryKey: "id",
+          attributes: [{ tableId: "c", columnName: "id" }],
+          hierarchies: [
+            {
+              id: "h1",
+              name: "Geo",
+              hasAll: true,
+              levels: [
+                {
+                  id: "l1",
+                  name: "Country",
+                  tableId: "c",
+                  columnName: "country",
+                  type: "String",
+                },
+              ],
+            },
+          ],
+        },
+      ],
+      measures: [
+        {
+          id: "m1",
+          name: "Sales",
+          aggregator: "sum",
+          tableId: "f",
+          columnName: "amount",
+          formatString: "$#,##0",
+        },
+      ],
+      cubes: [
+        {
+          id: "cube-1",
+          name: "Sales",
+          measureGroups: [
+            {
+              id: "mg-1",
+              name: "Sales Facts",
+              measureColumns: ["amount", "qty"],
+              factTableId: "f",
+              dimensionLinks: [
+                { dimensionId: "d1", foreignKeyColumn: "customer_id" },
+              ],
+            },
+          ],
+          calcs: [
+            {
+              id: "calc-1",
+              name: "Margin",
+              tokens: [
+                { kind: "measure", name: "Sales" },
+                { kind: "op", op: "-" },
+                { kind: "measure", name: "Cost" },
+              ],
+              mode: "build",
+            },
+          ],
+        },
+      ],
+    };
+  }
 
-	it('emits a Cube + MeasureGroup from state.cubes (not the flat fallback)', () => {
-		const xml = exportToMondrianXml(cubeDoc());
-		expect(xml).toContain('<Cube name="Sales">');
-		expect(xml).toContain('<MeasureGroup name="Sales Facts" table="sales_fact">');
-		// Measure name is the column (matches the Code-tab preview); aggregator
-		// + formatString come from state.measures.
-		expect(xml).toContain(
-			'<Measure name="amount" column="amount" aggregator="sum" formatString="$#,##0" />'
-		);
-		// A column with no matching state.measures entry defaults to sum.
-		expect(xml).toContain('<Measure name="qty" column="qty" aggregator="sum" />');
-	});
+  it("emits a Cube + MeasureGroup from state.cubes (not the flat fallback)", () => {
+    const xml = exportToMondrianXml(cubeDoc());
+    expect(xml).toContain('<Cube name="Sales">');
+    expect(xml).toContain(
+      '<MeasureGroup name="Sales Facts" table="sales_fact">',
+    );
+    // Measure name is the column (matches the Code-tab preview); aggregator
+    // + formatString come from state.measures.
+    expect(xml).toContain(
+      '<Measure name="amount" column="amount" aggregator="sum" formatString="$#,##0" />',
+    );
+    // A column with no matching state.measures entry defaults to sum.
+    expect(xml).toContain(
+      '<Measure name="qty" column="qty" aggregator="sum" />',
+    );
+  });
 
-	it('emits the measure group dimension link', () => {
-		const xml = exportToMondrianXml(cubeDoc());
-		expect(xml).toContain('<ForeignKeyLink dimension="Customer" foreignKeyColumn="customer_id" />');
-	});
+  it("emits the measure group dimension link", () => {
+    const xml = exportToMondrianXml(cubeDoc());
+    expect(xml).toContain(
+      '<ForeignKeyLink dimension="Customer" foreignKeyColumn="customer_id" />',
+    );
+  });
 
-	it('emits cube-scope calculated members from calc tokens', () => {
-		const xml = exportToMondrianXml(cubeDoc());
-		expect(xml).toContain(
-			'<CalculatedMember name="Margin" dimension="Measures" formula="[Sales] - [Cost]"/>'
-		);
-	});
+  it("emits cube-scope calculated members from calc tokens", () => {
+    const xml = exportToMondrianXml(cubeDoc());
+    expect(xml).toContain(
+      '<CalculatedMember name="Margin" dimension="Measures" formula="[Sales] - [Cost]"/>',
+    );
+  });
 
-	it('emits <Annotations> (saiku.semantic.*) on a measure', () => {
-		const doc: SchemaCanvasState = {
-			...baseDoc(),
-			tables: [
-				{
-					id: 'f',
-					schema: 'public',
-					name: 'fact',
-					role: 'fact',
-					columns: [{ name: 'rev', sqlType: 'numeric' }],
-					position: { x: 0, y: 0 },
-					groupId: null
-				}
-			],
-			measures: [
-				{
-					id: 'm1',
-					name: 'rev',
-					aggregator: 'sum',
-					tableId: 'f',
-					columnName: 'rev',
-					annotations: { pii: 'true', unit: 'USD' }
-				}
-			],
-			cubes: [
-				{
-					id: 'c1',
-					name: 'C',
-					measureGroups: [
-						{ id: 'g1', name: 'G', measureColumns: ['rev'], factTableId: 'f', dimensionLinks: [] }
-					],
-					calcs: []
-				}
-			]
-		};
-		const xml = exportToMondrianXml(doc);
-		expect(xml).toContain('<Measure name="rev" column="rev" aggregator="sum">');
-		expect(xml).toContain('<Annotation name="saiku.semantic.pii">true</Annotation>');
-		expect(xml).toContain('<Annotation name="saiku.semantic.unit">USD</Annotation>');
-	});
+  it("emits <Annotations> (saiku.semantic.*) on a measure", () => {
+    const doc: SchemaCanvasState = {
+      ...baseDoc(),
+      tables: [
+        {
+          id: "f",
+          schema: "public",
+          name: "fact",
+          role: "fact",
+          columns: [{ name: "rev", sqlType: "numeric" }],
+          position: { x: 0, y: 0 },
+          groupId: null,
+        },
+      ],
+      measures: [
+        {
+          id: "m1",
+          name: "rev",
+          aggregator: "sum",
+          tableId: "f",
+          columnName: "rev",
+          annotations: { pii: "true", unit: "USD" },
+        },
+      ],
+      cubes: [
+        {
+          id: "c1",
+          name: "C",
+          measureGroups: [
+            {
+              id: "g1",
+              name: "G",
+              measureColumns: ["rev"],
+              factTableId: "f",
+              dimensionLinks: [],
+            },
+          ],
+          calcs: [],
+        },
+      ],
+    };
+    const xml = exportToMondrianXml(doc);
+    expect(xml).toContain('<Measure name="rev" column="rev" aggregator="sum">');
+    expect(xml).toContain(
+      '<Annotation name="saiku.semantic.pii">true</Annotation>',
+    );
+    expect(xml).toContain(
+      '<Annotation name="saiku.semantic.unit">USD</Annotation>',
+    );
+  });
 
-	it('emits <Attribute> overrides and cascades a rename to the <Level> reference', () => {
-		const doc: SchemaCanvasState = {
-			...baseDoc(),
-			tables: [
-				{
-					id: 'f',
-					schema: 'public',
-					name: 'fact',
-					role: 'fact',
-					columns: [{ name: 'cust_id', sqlType: 'int' }],
-					position: { x: 0, y: 0 },
-					groupId: null
-				},
-				{
-					id: 'c',
-					schema: 'public',
-					name: 'customer',
-					role: 'dimension',
-					columns: [
-						{ name: 'id', sqlType: 'int' },
-						{ name: 'country', sqlType: 'text' },
-						{ name: 'country_label', sqlType: 'text' },
-						{ name: 'country_sort', sqlType: 'int' }
-					],
-					position: { x: 100, y: 0 },
-					groupId: null
-				}
-			],
-			dimensions: [
-				{
-					id: 'd1',
-					name: 'Customer',
-					foreignKey: 'cust_id',
-					primaryKey: 'id',
-					primaryKeyTableId: 'c',
-					attributes: [
-						{
-							tableId: 'c',
-							columnName: 'country',
-							name: 'Country Name',
-							nameColumn: 'country_label',
-							orderByColumn: 'country_sort',
-							description: 'ISO country'
-						}
-					],
-					hierarchies: [
-						{
-							id: 'h1',
-							name: 'Geo',
-							hasAll: true,
-							// The level is stored by column; the emit must reference the
-							// attribute by its (renamed) NAME.
-							levels: [{ id: 'l1', name: 'Country', tableId: 'c', columnName: 'country' }]
-						}
-					]
-				}
-			],
-			cubes: [
-				{
-					id: 'cube1',
-					name: 'C',
-					measureGroups: [
-						{ id: 'g1', name: 'G', measureColumns: [], factTableId: 'f', dimensionLinks: [] }
-					],
-					calcs: []
-				}
-			]
-		};
-		const xml = exportToMondrianXml(doc);
-		expect(xml).toContain(
-			'<Attribute name="Country Name" keyColumn="country" nameColumn="country_label" orderByColumn="country_sort" description="ISO country" />'
-		);
-		// The rename cascaded: the level references the attribute by its new name.
-		expect(xml).toContain('<Level attribute="Country Name" />');
-	});
+  it("emits <Attribute> overrides and cascades a rename to the <Level> reference", () => {
+    const doc: SchemaCanvasState = {
+      ...baseDoc(),
+      tables: [
+        {
+          id: "f",
+          schema: "public",
+          name: "fact",
+          role: "fact",
+          columns: [{ name: "cust_id", sqlType: "int" }],
+          position: { x: 0, y: 0 },
+          groupId: null,
+        },
+        {
+          id: "c",
+          schema: "public",
+          name: "customer",
+          role: "dimension",
+          columns: [
+            { name: "id", sqlType: "int" },
+            { name: "country", sqlType: "text" },
+            { name: "country_label", sqlType: "text" },
+            { name: "country_sort", sqlType: "int" },
+          ],
+          position: { x: 100, y: 0 },
+          groupId: null,
+        },
+      ],
+      dimensions: [
+        {
+          id: "d1",
+          name: "Customer",
+          foreignKey: "cust_id",
+          primaryKey: "id",
+          primaryKeyTableId: "c",
+          attributes: [
+            {
+              tableId: "c",
+              columnName: "country",
+              name: "Country Name",
+              nameColumn: "country_label",
+              orderByColumn: "country_sort",
+              description: "ISO country",
+            },
+          ],
+          hierarchies: [
+            {
+              id: "h1",
+              name: "Geo",
+              hasAll: true,
+              // The level is stored by column; the emit must reference the
+              // attribute by its (renamed) NAME.
+              levels: [
+                {
+                  id: "l1",
+                  name: "Country",
+                  tableId: "c",
+                  columnName: "country",
+                },
+              ],
+            },
+          ],
+        },
+      ],
+      cubes: [
+        {
+          id: "cube1",
+          name: "C",
+          measureGroups: [
+            {
+              id: "g1",
+              name: "G",
+              measureColumns: [],
+              factTableId: "f",
+              dimensionLinks: [],
+            },
+          ],
+          calcs: [],
+        },
+      ],
+    };
+    const xml = exportToMondrianXml(doc);
+    expect(xml).toContain(
+      '<Attribute name="Country Name" keyColumn="country" nameColumn="country_label" orderByColumn="country_sort" description="ISO country" />',
+    );
+    // The rename cascaded: the level references the attribute by its new name.
+    expect(xml).toContain('<Level attribute="Country Name" />');
+  });
 
-	it('emits <Hierarchy> caption + allMemberName from the inspector', () => {
-		const doc: SchemaCanvasState = {
-			...baseDoc(),
-			tables: [
-				{
-					id: 'f',
-					schema: 'public',
-					name: 'fact',
-					role: 'fact',
-					columns: [{ name: 'cust_id', sqlType: 'int' }],
-					position: { x: 0, y: 0 },
-					groupId: null
-				},
-				{
-					id: 'c',
-					schema: 'public',
-					name: 'customer',
-					role: 'dimension',
-					columns: [
-						{ name: 'id', sqlType: 'int' },
-						{ name: 'country', sqlType: 'text' }
-					],
-					position: { x: 100, y: 0 },
-					groupId: null
-				}
-			],
-			dimensions: [
-				{
-					id: 'd1',
-					name: 'Customer',
-					foreignKey: 'cust_id',
-					primaryKey: 'id',
-					primaryKeyTableId: 'c',
-					hierarchies: [
-						{
-							id: 'h1',
-							name: 'Geo',
-							hasAll: true,
-							caption: 'Customer Geography',
-							allMemberName: 'All Customers',
-							levels: [
-								{ id: 'l1', name: 'Country', tableId: 'c', columnName: 'country', type: 'String' }
-							]
-						}
-					]
-				}
-			],
-			cubes: [
-				{
-					id: 'cube1',
-					name: 'C',
-					measureGroups: [
-						{ id: 'g1', name: 'G', measureColumns: [], factTableId: 'f', dimensionLinks: [] }
-					],
-					calcs: []
-				}
-			]
-		};
-		const xml = exportToMondrianXml(doc);
-		expect(xml).toContain('allMemberName="All Customers"');
-		expect(xml).toContain('caption="Customer Geography"');
-	});
+  it("emits <Hierarchy> caption + allMemberName from the inspector", () => {
+    const doc: SchemaCanvasState = {
+      ...baseDoc(),
+      tables: [
+        {
+          id: "f",
+          schema: "public",
+          name: "fact",
+          role: "fact",
+          columns: [{ name: "cust_id", sqlType: "int" }],
+          position: { x: 0, y: 0 },
+          groupId: null,
+        },
+        {
+          id: "c",
+          schema: "public",
+          name: "customer",
+          role: "dimension",
+          columns: [
+            { name: "id", sqlType: "int" },
+            { name: "country", sqlType: "text" },
+          ],
+          position: { x: 100, y: 0 },
+          groupId: null,
+        },
+      ],
+      dimensions: [
+        {
+          id: "d1",
+          name: "Customer",
+          foreignKey: "cust_id",
+          primaryKey: "id",
+          primaryKeyTableId: "c",
+          hierarchies: [
+            {
+              id: "h1",
+              name: "Geo",
+              hasAll: true,
+              caption: "Customer Geography",
+              allMemberName: "All Customers",
+              levels: [
+                {
+                  id: "l1",
+                  name: "Country",
+                  tableId: "c",
+                  columnName: "country",
+                  type: "String",
+                },
+              ],
+            },
+          ],
+        },
+      ],
+      cubes: [
+        {
+          id: "cube1",
+          name: "C",
+          measureGroups: [
+            {
+              id: "g1",
+              name: "G",
+              measureColumns: [],
+              factTableId: "f",
+              dimensionLinks: [],
+            },
+          ],
+          calcs: [],
+        },
+      ],
+    };
+    const xml = exportToMondrianXml(doc);
+    expect(xml).toContain('allMemberName="All Customers"');
+    expect(xml).toContain('caption="Customer Geography"');
+  });
 
-	it('emits <TimeCalcs> for cube-scoped time-intelligence metrics', () => {
-		const doc = cubeDoc();
-		doc.cubes![0].timeCalcs = [
-			{ id: 't1', name: 'Amount YoY', type: 'yoy', measure: 'amount', formatString: '0.0%' },
-			{
-				id: 't2',
-				name: 'Amount R3',
-				type: 'rolling',
-				measure: 'amount',
-				window: 3,
-				function: 'avg'
-			},
-			// Half-authored (no measure) — must be dropped, not emitted invalid.
-			{ id: 't3', name: 'Incomplete', type: 'ytd', measure: '' }
-		];
-		const xml = exportToMondrianXml(doc);
-		expect(xml).toContain('<TimeCalcs>');
-		expect(xml).toContain(
-			'<TimeCalc name="Amount YoY" type="yoy" measure="amount" formatString="0.0%"/>'
-		);
-		expect(xml).toContain(
-			'<TimeCalc name="Amount R3" type="rolling" measure="amount" window="3" function="avg"/>'
-		);
-		// The incomplete row (blank measure) is not emitted.
-		expect(xml).not.toContain('name="Incomplete"');
-	});
+  it("emits <TimeCalcs> for cube-scoped time-intelligence metrics", () => {
+    const doc = cubeDoc();
+    doc.cubes![0].timeCalcs = [
+      {
+        id: "t1",
+        name: "Amount YoY",
+        type: "yoy",
+        measure: "amount",
+        formatString: "0.0%",
+      },
+      {
+        id: "t2",
+        name: "Amount R3",
+        type: "rolling",
+        measure: "amount",
+        window: 3,
+        function: "avg",
+      },
+      // Half-authored (no measure) — must be dropped, not emitted invalid.
+      { id: "t3", name: "Incomplete", type: "ytd", measure: "" },
+    ];
+    const xml = exportToMondrianXml(doc);
+    expect(xml).toContain("<TimeCalcs>");
+    expect(xml).toContain(
+      '<TimeCalc name="Amount YoY" type="yoy" measure="amount" formatString="0.0%"/>',
+    );
+    expect(xml).toContain(
+      '<TimeCalc name="Amount R3" type="rolling" measure="amount" window="3" function="avg"/>',
+    );
+    // The incomplete row (blank measure) is not emitted.
+    expect(xml).not.toContain('name="Incomplete"');
+  });
 
-	it('emits the dimension table PK in PhysicalSchema + Dimension key', () => {
-		const xml = exportToMondrianXml(cubeDoc());
-		expect(xml).toContain('<Table name="customer" schema="public" keyColumn="id" />');
-		// The dim carries an explicit `id` attribute bound to the PK column, so
-		// the key resolves to that attribute (no synthetic "Customer Key").
-		expect(xml).toContain('<Dimension name="Customer" table="customer" key="id">');
-	});
+  it("emits the dimension table PK in PhysicalSchema + Dimension key", () => {
+    const xml = exportToMondrianXml(cubeDoc());
+    expect(xml).toContain(
+      '<Table name="customer" schema="public" keyColumn="id" />',
+    );
+    // The dim carries an explicit `id` attribute bound to the PK column, so
+    // the key resolves to that attribute (no synthetic "Customer Key").
+    expect(xml).toContain(
+      '<Dimension name="Customer" table="customer" key="id">',
+    );
+  });
 
-	it('falls back to the single-fact export when the doc has no cubes', () => {
-		const doc = cubeDoc();
-		doc.cubes = [];
-		const xml = exportToMondrianXml(doc);
-		// Fallback names the single MeasureGroup after the cube (title-cased
-		// fact) and emits the flat state.measures list.
-		expect(xml).toContain('<MeasureGroup name="Sales Fact" table="sales_fact">');
-		expect(xml).toContain('<Measure name="Sales" column="amount" aggregator="sum"');
-	});
+  it("falls back to the single-fact export when the doc has no cubes", () => {
+    const doc = cubeDoc();
+    doc.cubes = [];
+    const xml = exportToMondrianXml(doc);
+    // Fallback names the single MeasureGroup after the cube (title-cased
+    // fact) and emits the flat state.measures list.
+    expect(xml).toContain(
+      '<MeasureGroup name="Sales Fact" table="sales_fact">',
+    );
+    expect(xml).toContain(
+      '<Measure name="Sales" column="amount" aggregator="sum"',
+    );
+  });
 });
 
-describe('exportToMondrianYaml', () => {
-	it('derives M4 YAML from the same state as the XML export', () => {
-		const doc: SchemaCanvasState = {
-			...baseDoc(),
-			tables: [
-				{
-					id: 'f',
-					schema: 'public',
-					name: 'sales_fact',
-					role: 'fact',
-					columns: [{ name: 'customer_id', sqlType: 'int' }],
-					position: { x: 0, y: 0 },
-					groupId: null
-				},
-				{
-					id: 'c',
-					schema: 'public',
-					name: 'customer',
-					role: 'dimension',
-					columns: [
-						{ name: 'id', sqlType: 'int' },
-						{ name: 'country', sqlType: 'text' }
-					],
-					position: { x: 100, y: 0 },
-					groupId: null
-				}
-			],
-			dimensions: [
-				{
-					id: 'd1',
-					name: 'Customer',
-					foreignKey: 'customer_id',
-					primaryKey: 'id',
-					primaryKeyTableId: 'c',
-					hierarchies: [
-						{
-							id: 'h1',
-							name: 'Geo',
-							hasAll: true,
-							levels: [
-								{ id: 'l1', name: 'Country', tableId: 'c', columnName: 'country', type: 'String' }
-							]
-						}
-					],
-					dimensionType: 'Standard'
-				}
-			],
-			measures: [{ id: 'm', name: 'Sales', aggregator: 'sum', tableId: 'f', columnName: 'amount' }]
-		};
-		const parsed = parse(exportToMondrianYaml(doc));
-		expect(parsed.schema.metamodel_version).toBe('4.0');
-		expect(parsed.shared_dimensions.Customer.key).toBe('Customer Key');
-		expect(parsed.cubes['Sales Fact'].measure_groups[0].dimension_links).toEqual([
-			{ type: 'foreign_key', dimension: 'Customer', foreign_key_column: 'customer_id' }
-		]);
-	});
+describe("exportToMondrianYaml", () => {
+  it("derives M4 YAML from the same state as the XML export", () => {
+    const doc: SchemaCanvasState = {
+      ...baseDoc(),
+      tables: [
+        {
+          id: "f",
+          schema: "public",
+          name: "sales_fact",
+          role: "fact",
+          columns: [{ name: "customer_id", sqlType: "int" }],
+          position: { x: 0, y: 0 },
+          groupId: null,
+        },
+        {
+          id: "c",
+          schema: "public",
+          name: "customer",
+          role: "dimension",
+          columns: [
+            { name: "id", sqlType: "int" },
+            { name: "country", sqlType: "text" },
+          ],
+          position: { x: 100, y: 0 },
+          groupId: null,
+        },
+      ],
+      dimensions: [
+        {
+          id: "d1",
+          name: "Customer",
+          foreignKey: "customer_id",
+          primaryKey: "id",
+          primaryKeyTableId: "c",
+          hierarchies: [
+            {
+              id: "h1",
+              name: "Geo",
+              hasAll: true,
+              levels: [
+                {
+                  id: "l1",
+                  name: "Country",
+                  tableId: "c",
+                  columnName: "country",
+                  type: "String",
+                },
+              ],
+            },
+          ],
+          dimensionType: "Standard",
+        },
+      ],
+      measures: [
+        {
+          id: "m",
+          name: "Sales",
+          aggregator: "sum",
+          tableId: "f",
+          columnName: "amount",
+        },
+      ],
+    };
+    const parsed = parse(exportToMondrianYaml(doc));
+    expect(parsed.schema.metamodel_version).toBe("4.0");
+    expect(parsed.shared_dimensions.Customer.key).toBe("Customer Key");
+    expect(
+      parsed.cubes["Sales Fact"].measure_groups[0].dimension_links,
+    ).toEqual([
+      {
+        type: "foreign_key",
+        dimension: "Customer",
+        foreign_key_column: "customer_id",
+      },
+    ]);
+  });
 
-	it('never emits a Mondrian 3 marker', () => {
-		const doc: SchemaCanvasState = {
-			...baseDoc(),
-			tables: [
-				{
-					id: 'f',
-					schema: 'public',
-					name: 'sales_fact',
-					role: 'fact',
-					columns: [{ name: 'amount', sqlType: 'numeric' }],
-					position: { x: 0, y: 0 },
-					groupId: null
-				}
-			]
-		};
-		const yaml = exportToMondrianYaml(doc);
-		expect(yaml).not.toContain('foreignKey');
-		expect(yaml).not.toContain('primaryKey');
-	});
+  it("never emits a Mondrian 3 marker", () => {
+    const doc: SchemaCanvasState = {
+      ...baseDoc(),
+      tables: [
+        {
+          id: "f",
+          schema: "public",
+          name: "sales_fact",
+          role: "fact",
+          columns: [{ name: "amount", sqlType: "numeric" }],
+          position: { x: 0, y: 0 },
+          groupId: null,
+        },
+      ],
+    };
+    const yaml = exportToMondrianYaml(doc);
+    expect(yaml).not.toContain("foreignKey");
+    expect(yaml).not.toContain("primaryKey");
+  });
 });

--- a/saiku-ui/src/lib/cube-designer/mondrian-export.test.ts
+++ b/saiku-ui/src/lib/cube-designer/mondrian-export.test.ts
@@ -1,0 +1,764 @@
+import { describe, it, expect } from 'vitest';
+import { parse } from 'yaml';
+import { exportToMondrianXml, exportToMondrianYaml } from './mondrian-export.js';
+import type { SchemaCanvasState } from './types.js';
+
+function baseDoc(): SchemaCanvasState {
+	return {
+		version: 1,
+		connectionId: 'conn-1',
+		label: 'My Cube',
+		tables: [],
+		joins: [],
+		groups: [],
+		updatedAt: '2026-06-18T00:00:00.000Z'
+	};
+}
+
+describe('exportToMondrianXml', () => {
+	it('throws when no fact table is on the canvas', () => {
+		const doc = baseDoc();
+		expect(() => exportToMondrianXml(doc)).toThrow(/no fact table/);
+	});
+
+	it('emits a stub Row count measure when the doc has no measures', () => {
+		const doc: SchemaCanvasState = {
+			...baseDoc(),
+			tables: [
+				{
+					id: 'f',
+					schema: 'public',
+					name: 'sales_fact',
+					role: 'fact',
+					columns: [{ name: 'amount', sqlType: 'numeric' }],
+					position: { x: 0, y: 0 },
+					groupId: null
+				}
+			]
+		};
+		const xml = exportToMondrianXml(doc);
+		expect(xml).toContain('<Schema name="My Cube" metamodelVersion="4.0">');
+		expect(xml).toContain('<Table name="sales_fact" schema="public" />');
+		expect(xml).toContain('<Measure name="Row count" aggregator="count"');
+		// M4 only — no legacy M3 shapes.
+		expect(xml).not.toContain('foreignKey=');
+		expect(xml).not.toMatch(/<Hierarchy[^>]*primaryKey=/);
+	});
+
+	it('emits user-authored measures instead of the Row count stub', () => {
+		const doc: SchemaCanvasState = {
+			...baseDoc(),
+			tables: [
+				{
+					id: 'f',
+					schema: 'public',
+					name: 'sales_fact',
+					role: 'fact',
+					columns: [
+						{ name: 'amount', sqlType: 'numeric' },
+						{ name: 'qty', sqlType: 'numeric' }
+					],
+					position: { x: 0, y: 0 },
+					groupId: null
+				}
+			],
+			measures: [
+				{
+					id: 'm1',
+					name: 'Sales',
+					aggregator: 'sum',
+					tableId: 'f',
+					columnName: 'amount',
+					formatString: '$#,##0'
+				},
+				{
+					id: 'm2',
+					name: 'Orders',
+					aggregator: 'count',
+					tableId: 'f',
+					columnName: 'qty'
+				}
+			]
+		};
+		const xml = exportToMondrianXml(doc);
+		expect(xml).toContain(
+			'<Measure name="Sales" column="amount" aggregator="sum" formatString="$#,##0" />'
+		);
+		expect(xml).toContain('<Measure name="Orders" column="qty" aggregator="count" />');
+		expect(xml).not.toContain('Row count');
+	});
+
+	it('emits median + percentile aggregators, with percentile="N" only for percentile', () => {
+		const doc: SchemaCanvasState = {
+			...baseDoc(),
+			tables: [
+				{
+					id: 'f',
+					schema: 'public',
+					name: 'sales_fact',
+					role: 'fact',
+					columns: [
+						{ name: 'order_total', sqlType: 'numeric' },
+						{ name: 'latency_ms', sqlType: 'numeric' }
+					],
+					position: { x: 0, y: 0 },
+					groupId: null
+				}
+			],
+			measures: [
+				{
+					id: 'm1',
+					name: 'Median Order',
+					aggregator: 'median',
+					tableId: 'f',
+					columnName: 'order_total'
+				},
+				{
+					id: 'm2',
+					name: 'P90 Latency',
+					aggregator: 'percentile',
+					tableId: 'f',
+					columnName: 'latency_ms',
+					percentile: 90
+				}
+			]
+		};
+		const xml = exportToMondrianXml(doc);
+		// median: aggregator only, no percentile attribute.
+		expect(xml).toContain(
+			'<Measure name="Median Order" column="order_total" aggregator="median" />'
+		);
+		// percentile: carries the fraction.
+		expect(xml).toContain(
+			'<Measure name="P90 Latency" column="latency_ms" aggregator="percentile" percentile="90" />'
+		);
+	});
+
+	it('emits workbench-curated dimensions with their hierarchies and levels', () => {
+		const doc: SchemaCanvasState = {
+			...baseDoc(),
+			tables: [
+				{
+					id: 'f',
+					schema: 'public',
+					name: 'sales_fact',
+					role: 'fact',
+					columns: [{ name: 'customer_id', sqlType: 'int' }],
+					position: { x: 0, y: 0 },
+					groupId: null
+				},
+				{
+					id: 'c',
+					schema: 'public',
+					name: 'customer',
+					role: 'dimension',
+					columns: [
+						{ name: 'id', sqlType: 'int' },
+						{ name: 'country', sqlType: 'text' },
+						{ name: 'city', sqlType: 'text' }
+					],
+					position: { x: 100, y: 0 },
+					groupId: null
+				}
+			],
+			dimensions: [
+				{
+					id: 'd1',
+					name: 'Customer',
+					foreignKey: 'customer_id',
+					primaryKey: 'id',
+					primaryKeyTableId: 'c',
+					hierarchies: [
+						{
+							id: 'h1',
+							name: 'Geo',
+							hasAll: true,
+							levels: [
+								{
+									id: 'l1',
+									name: 'Country',
+									caption: 'Country of residence',
+									tableId: 'c',
+									columnName: 'country',
+									type: 'String'
+								},
+								{ id: 'l2', name: 'City', tableId: 'c', columnName: 'city', type: 'String' }
+							]
+						}
+					],
+					dimensionType: 'Standard'
+				}
+			]
+		};
+		const xml = exportToMondrianXml(doc);
+		// M4: PK on the physical dim table + dimension key; FK on the link.
+		expect(xml).toContain('<Table name="customer" schema="public" keyColumn="id" />');
+		expect(xml).toContain('<Dimension name="Customer" table="customer" key="Customer Key">');
+		expect(xml).toContain('<Attribute name="Customer Key" keyColumn="id" hasHierarchy="false" />');
+		expect(xml).toContain('<Hierarchy name="Geo" hasAll="true">');
+		// Levels reference attributes synthesised from the M3-style level columns.
+		expect(xml).toContain('<Attribute name="Country" keyColumn="country" />');
+		expect(xml).toContain('<Attribute name="City" keyColumn="city" />');
+		expect(xml).toContain('<Level attribute="Country" caption="Country of residence" />');
+		expect(xml).toContain('<Level attribute="City" />');
+		expect(xml).toContain('<ForeignKeyLink dimension="Customer" foreignKeyColumn="customer_id" />');
+	});
+
+	it('annotates Time dimensions with type="TIME" and per-level levelType', () => {
+		const doc: SchemaCanvasState = {
+			...baseDoc(),
+			tables: [
+				{
+					id: 'f',
+					schema: null,
+					name: 'fact',
+					role: 'fact',
+					columns: [{ name: 'date_id', sqlType: 'int' }],
+					position: { x: 0, y: 0 },
+					groupId: null
+				},
+				{
+					id: 't',
+					schema: null,
+					name: 'time_by_day',
+					role: 'dimension',
+					columns: [
+						{ name: 'id', sqlType: 'int' },
+						{ name: 'year', sqlType: 'int' }
+					],
+					position: { x: 0, y: 0 },
+					groupId: null
+				}
+			],
+			dimensions: [
+				{
+					id: 'd-time',
+					name: 'Time',
+					foreignKey: 'date_id',
+					primaryKey: 'id',
+					primaryKeyTableId: 't',
+					dimensionType: 'Time',
+					hierarchies: [
+						{
+							id: 'h-t',
+							name: 'Time',
+							hasAll: true,
+							levels: [
+								{
+									id: 'l-y',
+									name: 'Year',
+									tableId: 't',
+									columnName: 'year',
+									type: 'Integer',
+									levelType: 'TimeYears'
+								}
+							]
+						}
+					]
+				}
+			]
+		};
+		const xml = exportToMondrianXml(doc);
+		// Mondrian 4 spells it "TIME" (not the M3 "TimeDimension").
+		expect(xml).toContain('type="TIME"');
+		expect(xml).not.toContain('type="TimeDimension"');
+		// levelType rides on the level's <Attribute> (M4 shape).
+		expect(xml).toContain('levelType="TimeYears"');
+	});
+
+	it('falls back to join-inferred dimensions when no curated dims exist', () => {
+		const doc: SchemaCanvasState = {
+			...baseDoc(),
+			tables: [
+				{
+					id: 'f',
+					schema: 'public',
+					name: 'sales_fact',
+					role: 'fact',
+					columns: [{ name: 'customer_id', sqlType: 'int' }],
+					position: { x: 0, y: 0 },
+					groupId: null
+				},
+				{
+					id: 'c',
+					schema: 'public',
+					name: 'customer',
+					role: 'dimension',
+					columns: [
+						{ name: 'id', sqlType: 'int' },
+						{ name: 'country', sqlType: 'text' }
+					],
+					position: { x: 100, y: 0 },
+					groupId: null
+				}
+			],
+			joins: [
+				{
+					id: 'j1',
+					sourceTableId: 'f',
+					sourceColumnName: 'customer_id',
+					targetTableId: 'c',
+					targetColumnName: 'id',
+					kind: 'inner'
+				}
+			]
+		};
+		const xml = exportToMondrianXml(doc);
+		// Inferred dims are emitted in the SAME M4 shape as curated ones.
+		expect(xml).toContain('<Table name="customer" schema="public" keyColumn="id" />');
+		expect(xml).toContain('<Dimension name="Customer" table="customer" key="id">');
+		expect(xml).toContain('<Level attribute="country" />');
+		expect(xml).toContain('<ForeignKeyLink dimension="Customer" foreignKeyColumn="customer_id" />');
+	});
+
+	it('escapes special characters in identifiers', () => {
+		const doc: SchemaCanvasState = {
+			...baseDoc(),
+			label: 'A&B<Cube>',
+			tables: [
+				{
+					id: 'f',
+					schema: null,
+					name: 'fact',
+					role: 'fact',
+					columns: [],
+					position: { x: 0, y: 0 },
+					groupId: null
+				}
+			],
+			measures: [
+				{
+					id: 'm',
+					name: 'Sales & Returns',
+					aggregator: 'sum',
+					tableId: 'f',
+					columnName: 'amount'
+				}
+			]
+		};
+		const xml = exportToMondrianXml(doc);
+		expect(xml).toContain('<Schema name="A&amp;B&lt;Cube&gt;" metamodelVersion="4.0">');
+		expect(xml).toContain('<Measure name="Sales &amp; Returns"');
+	});
+});
+
+describe('exportToMondrianXml — cubes-based', () => {
+	function cubeDoc(): SchemaCanvasState {
+		return {
+			...baseDoc(),
+			label: 'Sales',
+			tables: [
+				{
+					id: 'f',
+					schema: 'public',
+					name: 'sales_fact',
+					role: 'fact',
+					columns: [
+						{ name: 'amount', sqlType: 'numeric' },
+						{ name: 'qty', sqlType: 'numeric' },
+						{ name: 'customer_id', sqlType: 'int' }
+					],
+					position: { x: 0, y: 0 },
+					groupId: null
+				},
+				{
+					id: 'c',
+					schema: 'public',
+					name: 'customer',
+					role: 'dimension',
+					columns: [
+						{ name: 'id', sqlType: 'int' },
+						{ name: 'country', sqlType: 'text' }
+					],
+					position: { x: 100, y: 0 },
+					groupId: null
+				}
+			],
+			dimensions: [
+				{
+					id: 'd1',
+					name: 'Customer',
+					sourceTableId: 'c',
+					primaryKeyTableId: 'c',
+					primaryKey: 'id',
+					attributes: [{ tableId: 'c', columnName: 'id' }],
+					hierarchies: [
+						{
+							id: 'h1',
+							name: 'Geo',
+							hasAll: true,
+							levels: [
+								{ id: 'l1', name: 'Country', tableId: 'c', columnName: 'country', type: 'String' }
+							]
+						}
+					]
+				}
+			],
+			measures: [
+				{
+					id: 'm1',
+					name: 'Sales',
+					aggregator: 'sum',
+					tableId: 'f',
+					columnName: 'amount',
+					formatString: '$#,##0'
+				}
+			],
+			cubes: [
+				{
+					id: 'cube-1',
+					name: 'Sales',
+					measureGroups: [
+						{
+							id: 'mg-1',
+							name: 'Sales Facts',
+							measureColumns: ['amount', 'qty'],
+							factTableId: 'f',
+							dimensionLinks: [{ dimensionId: 'd1', foreignKeyColumn: 'customer_id' }]
+						}
+					],
+					calcs: [
+						{
+							id: 'calc-1',
+							name: 'Margin',
+							tokens: [
+								{ kind: 'measure', name: 'Sales' },
+								{ kind: 'op', op: '-' },
+								{ kind: 'measure', name: 'Cost' }
+							],
+							mode: 'build'
+						}
+					]
+				}
+			]
+		};
+	}
+
+	it('emits a Cube + MeasureGroup from state.cubes (not the flat fallback)', () => {
+		const xml = exportToMondrianXml(cubeDoc());
+		expect(xml).toContain('<Cube name="Sales">');
+		expect(xml).toContain('<MeasureGroup name="Sales Facts" table="sales_fact">');
+		// Measure name is the column (matches the Code-tab preview); aggregator
+		// + formatString come from state.measures.
+		expect(xml).toContain(
+			'<Measure name="amount" column="amount" aggregator="sum" formatString="$#,##0" />'
+		);
+		// A column with no matching state.measures entry defaults to sum.
+		expect(xml).toContain('<Measure name="qty" column="qty" aggregator="sum" />');
+	});
+
+	it('emits the measure group dimension link', () => {
+		const xml = exportToMondrianXml(cubeDoc());
+		expect(xml).toContain('<ForeignKeyLink dimension="Customer" foreignKeyColumn="customer_id" />');
+	});
+
+	it('emits cube-scope calculated members from calc tokens', () => {
+		const xml = exportToMondrianXml(cubeDoc());
+		expect(xml).toContain(
+			'<CalculatedMember name="Margin" dimension="Measures" formula="[Sales] - [Cost]"/>'
+		);
+	});
+
+	it('emits <Annotations> (saiku.semantic.*) on a measure', () => {
+		const doc: SchemaCanvasState = {
+			...baseDoc(),
+			tables: [
+				{
+					id: 'f',
+					schema: 'public',
+					name: 'fact',
+					role: 'fact',
+					columns: [{ name: 'rev', sqlType: 'numeric' }],
+					position: { x: 0, y: 0 },
+					groupId: null
+				}
+			],
+			measures: [
+				{
+					id: 'm1',
+					name: 'rev',
+					aggregator: 'sum',
+					tableId: 'f',
+					columnName: 'rev',
+					annotations: { pii: 'true', unit: 'USD' }
+				}
+			],
+			cubes: [
+				{
+					id: 'c1',
+					name: 'C',
+					measureGroups: [
+						{ id: 'g1', name: 'G', measureColumns: ['rev'], factTableId: 'f', dimensionLinks: [] }
+					],
+					calcs: []
+				}
+			]
+		};
+		const xml = exportToMondrianXml(doc);
+		expect(xml).toContain('<Measure name="rev" column="rev" aggregator="sum">');
+		expect(xml).toContain('<Annotation name="saiku.semantic.pii">true</Annotation>');
+		expect(xml).toContain('<Annotation name="saiku.semantic.unit">USD</Annotation>');
+	});
+
+	it('emits <Attribute> overrides and cascades a rename to the <Level> reference', () => {
+		const doc: SchemaCanvasState = {
+			...baseDoc(),
+			tables: [
+				{
+					id: 'f',
+					schema: 'public',
+					name: 'fact',
+					role: 'fact',
+					columns: [{ name: 'cust_id', sqlType: 'int' }],
+					position: { x: 0, y: 0 },
+					groupId: null
+				},
+				{
+					id: 'c',
+					schema: 'public',
+					name: 'customer',
+					role: 'dimension',
+					columns: [
+						{ name: 'id', sqlType: 'int' },
+						{ name: 'country', sqlType: 'text' },
+						{ name: 'country_label', sqlType: 'text' },
+						{ name: 'country_sort', sqlType: 'int' }
+					],
+					position: { x: 100, y: 0 },
+					groupId: null
+				}
+			],
+			dimensions: [
+				{
+					id: 'd1',
+					name: 'Customer',
+					foreignKey: 'cust_id',
+					primaryKey: 'id',
+					primaryKeyTableId: 'c',
+					attributes: [
+						{
+							tableId: 'c',
+							columnName: 'country',
+							name: 'Country Name',
+							nameColumn: 'country_label',
+							orderByColumn: 'country_sort',
+							description: 'ISO country'
+						}
+					],
+					hierarchies: [
+						{
+							id: 'h1',
+							name: 'Geo',
+							hasAll: true,
+							// The level is stored by column; the emit must reference the
+							// attribute by its (renamed) NAME.
+							levels: [{ id: 'l1', name: 'Country', tableId: 'c', columnName: 'country' }]
+						}
+					]
+				}
+			],
+			cubes: [
+				{
+					id: 'cube1',
+					name: 'C',
+					measureGroups: [
+						{ id: 'g1', name: 'G', measureColumns: [], factTableId: 'f', dimensionLinks: [] }
+					],
+					calcs: []
+				}
+			]
+		};
+		const xml = exportToMondrianXml(doc);
+		expect(xml).toContain(
+			'<Attribute name="Country Name" keyColumn="country" nameColumn="country_label" orderByColumn="country_sort" description="ISO country" />'
+		);
+		// The rename cascaded: the level references the attribute by its new name.
+		expect(xml).toContain('<Level attribute="Country Name" />');
+	});
+
+	it('emits <Hierarchy> caption + allMemberName from the inspector', () => {
+		const doc: SchemaCanvasState = {
+			...baseDoc(),
+			tables: [
+				{
+					id: 'f',
+					schema: 'public',
+					name: 'fact',
+					role: 'fact',
+					columns: [{ name: 'cust_id', sqlType: 'int' }],
+					position: { x: 0, y: 0 },
+					groupId: null
+				},
+				{
+					id: 'c',
+					schema: 'public',
+					name: 'customer',
+					role: 'dimension',
+					columns: [
+						{ name: 'id', sqlType: 'int' },
+						{ name: 'country', sqlType: 'text' }
+					],
+					position: { x: 100, y: 0 },
+					groupId: null
+				}
+			],
+			dimensions: [
+				{
+					id: 'd1',
+					name: 'Customer',
+					foreignKey: 'cust_id',
+					primaryKey: 'id',
+					primaryKeyTableId: 'c',
+					hierarchies: [
+						{
+							id: 'h1',
+							name: 'Geo',
+							hasAll: true,
+							caption: 'Customer Geography',
+							allMemberName: 'All Customers',
+							levels: [
+								{ id: 'l1', name: 'Country', tableId: 'c', columnName: 'country', type: 'String' }
+							]
+						}
+					]
+				}
+			],
+			cubes: [
+				{
+					id: 'cube1',
+					name: 'C',
+					measureGroups: [
+						{ id: 'g1', name: 'G', measureColumns: [], factTableId: 'f', dimensionLinks: [] }
+					],
+					calcs: []
+				}
+			]
+		};
+		const xml = exportToMondrianXml(doc);
+		expect(xml).toContain('allMemberName="All Customers"');
+		expect(xml).toContain('caption="Customer Geography"');
+	});
+
+	it('emits <TimeCalcs> for cube-scoped time-intelligence metrics', () => {
+		const doc = cubeDoc();
+		doc.cubes![0].timeCalcs = [
+			{ id: 't1', name: 'Amount YoY', type: 'yoy', measure: 'amount', formatString: '0.0%' },
+			{
+				id: 't2',
+				name: 'Amount R3',
+				type: 'rolling',
+				measure: 'amount',
+				window: 3,
+				function: 'avg'
+			},
+			// Half-authored (no measure) — must be dropped, not emitted invalid.
+			{ id: 't3', name: 'Incomplete', type: 'ytd', measure: '' }
+		];
+		const xml = exportToMondrianXml(doc);
+		expect(xml).toContain('<TimeCalcs>');
+		expect(xml).toContain(
+			'<TimeCalc name="Amount YoY" type="yoy" measure="amount" formatString="0.0%"/>'
+		);
+		expect(xml).toContain(
+			'<TimeCalc name="Amount R3" type="rolling" measure="amount" window="3" function="avg"/>'
+		);
+		// The incomplete row (blank measure) is not emitted.
+		expect(xml).not.toContain('name="Incomplete"');
+	});
+
+	it('emits the dimension table PK in PhysicalSchema + Dimension key', () => {
+		const xml = exportToMondrianXml(cubeDoc());
+		expect(xml).toContain('<Table name="customer" schema="public" keyColumn="id" />');
+		// The dim carries an explicit `id` attribute bound to the PK column, so
+		// the key resolves to that attribute (no synthetic "Customer Key").
+		expect(xml).toContain('<Dimension name="Customer" table="customer" key="id">');
+	});
+
+	it('falls back to the single-fact export when the doc has no cubes', () => {
+		const doc = cubeDoc();
+		doc.cubes = [];
+		const xml = exportToMondrianXml(doc);
+		// Fallback names the single MeasureGroup after the cube (title-cased
+		// fact) and emits the flat state.measures list.
+		expect(xml).toContain('<MeasureGroup name="Sales Fact" table="sales_fact">');
+		expect(xml).toContain('<Measure name="Sales" column="amount" aggregator="sum"');
+	});
+});
+
+describe('exportToMondrianYaml', () => {
+	it('derives M4 YAML from the same state as the XML export', () => {
+		const doc: SchemaCanvasState = {
+			...baseDoc(),
+			tables: [
+				{
+					id: 'f',
+					schema: 'public',
+					name: 'sales_fact',
+					role: 'fact',
+					columns: [{ name: 'customer_id', sqlType: 'int' }],
+					position: { x: 0, y: 0 },
+					groupId: null
+				},
+				{
+					id: 'c',
+					schema: 'public',
+					name: 'customer',
+					role: 'dimension',
+					columns: [
+						{ name: 'id', sqlType: 'int' },
+						{ name: 'country', sqlType: 'text' }
+					],
+					position: { x: 100, y: 0 },
+					groupId: null
+				}
+			],
+			dimensions: [
+				{
+					id: 'd1',
+					name: 'Customer',
+					foreignKey: 'customer_id',
+					primaryKey: 'id',
+					primaryKeyTableId: 'c',
+					hierarchies: [
+						{
+							id: 'h1',
+							name: 'Geo',
+							hasAll: true,
+							levels: [
+								{ id: 'l1', name: 'Country', tableId: 'c', columnName: 'country', type: 'String' }
+							]
+						}
+					],
+					dimensionType: 'Standard'
+				}
+			],
+			measures: [{ id: 'm', name: 'Sales', aggregator: 'sum', tableId: 'f', columnName: 'amount' }]
+		};
+		const parsed = parse(exportToMondrianYaml(doc));
+		expect(parsed.schema.metamodel_version).toBe('4.0');
+		expect(parsed.shared_dimensions.Customer.key).toBe('Customer Key');
+		expect(parsed.cubes['Sales Fact'].measure_groups[0].dimension_links).toEqual([
+			{ type: 'foreign_key', dimension: 'Customer', foreign_key_column: 'customer_id' }
+		]);
+	});
+
+	it('never emits a Mondrian 3 marker', () => {
+		const doc: SchemaCanvasState = {
+			...baseDoc(),
+			tables: [
+				{
+					id: 'f',
+					schema: 'public',
+					name: 'sales_fact',
+					role: 'fact',
+					columns: [{ name: 'amount', sqlType: 'numeric' }],
+					position: { x: 0, y: 0 },
+					groupId: null
+				}
+			]
+		};
+		const yaml = exportToMondrianYaml(doc);
+		expect(yaml).not.toContain('foreignKey');
+		expect(yaml).not.toContain('primaryKey');
+	});
+});

--- a/saiku-ui/src/lib/cube-designer/mondrian-export.ts
+++ b/saiku-ui/src/lib/cube-designer/mondrian-export.ts
@@ -19,28 +19,28 @@
  * Caveats: one cube per canvas (v1); cube-scope calculated members are not
  * exported yet (that state lives in the workbench, not the canvas doc).
  */
-import { mondrianXmlToYaml } from './mondrian-xml-to-yaml.js';
+import { mondrianXmlToYaml } from "./mondrian-xml-to-yaml.js";
 import type {
-	SchemaCanvasState,
-	SchemaCanvasTable,
-	SchemaCanvasJoin,
-	SchemaCanvasDimension,
-	SchemaCanvasHierarchy,
-	SchemaCanvasMeasure,
-	SchemaCanvasCube,
-	SchemaCanvasCalc
-} from './types.js';
+  SchemaCanvasState,
+  SchemaCanvasTable,
+  SchemaCanvasJoin,
+  SchemaCanvasDimension,
+  SchemaCanvasHierarchy,
+  SchemaCanvasMeasure,
+  SchemaCanvasCube,
+  SchemaCanvasCalc,
+} from "./types.js";
 
 function escape(s: string): string {
-	return s
-		.replace(/&/g, '&amp;')
-		.replace(/</g, '&lt;')
-		.replace(/>/g, '&gt;')
-		.replace(/"/g, '&quot;');
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
 }
 
 function attr(name: string, value: string | undefined | null): string {
-	return value && value.length > 0 ? ` ${name}="${escape(value)}"` : '';
+  return value && value.length > 0 ? ` ${name}="${escape(value)}"` : "";
 }
 
 /**
@@ -50,43 +50,46 @@ function attr(name: string, value: string | undefined | null): string {
  * (e.g. `description`, `pii`) and namespaced here.
  */
 function annotationLines(
-	annotations: Record<string, string> | undefined,
-	indent: string
+  annotations: Record<string, string> | undefined,
+  indent: string,
 ): string[] {
-	if (!annotations) return [];
-	const entries = Object.entries(annotations).filter(
-		([, v]) => v != null && String(v).trim() !== ''
-	);
-	if (entries.length === 0) return [];
-	const out = [`${indent}<Annotations>`];
-	for (const [k, v] of entries) {
-		out.push(
-			`${indent}  <Annotation name="saiku.semantic.${escape(k)}">${escape(String(v))}</Annotation>`
-		);
-	}
-	out.push(`${indent}</Annotations>`);
-	return out;
+  if (!annotations) return [];
+  const entries = Object.entries(annotations).filter(
+    ([, v]) => v != null && String(v).trim() !== "",
+  );
+  if (entries.length === 0) return [];
+  const out = [`${indent}<Annotations>`];
+  for (const [k, v] of entries) {
+    out.push(
+      `${indent}  <Annotation name="saiku.semantic.${escape(k)}">${escape(String(v))}</Annotation>`,
+    );
+  }
+  out.push(`${indent}</Annotations>`);
+  return out;
 }
 
 function titleCase(s: string): string {
-	return s
-		.split(/[._]/)
-		.map((part) => part.charAt(0).toUpperCase() + part.slice(1))
-		.join(' ');
+  return s
+    .split(/[._]/)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(" ");
 }
 
-const AGGREGATOR_TO_MONDRIAN: Record<SchemaCanvasMeasure['aggregator'], string> = {
-	sum: 'sum',
-	count: 'count',
-	avg: 'avg',
-	min: 'min',
-	max: 'max',
-	'distinct-count': 'distinct-count',
-	// Non-additive leaf aggregators (mondrian-saiku #104) — pushed to SQL as
-	// PERCENTILE_CONT. `median` is the implicit 50th percentile; `percentile`
-	// carries a `percentile="0..100"` attribute (emitted below).
-	median: 'median',
-	percentile: 'percentile'
+const AGGREGATOR_TO_MONDRIAN: Record<
+  SchemaCanvasMeasure["aggregator"],
+  string
+> = {
+  sum: "sum",
+  count: "count",
+  avg: "avg",
+  min: "min",
+  max: "max",
+  "distinct-count": "distinct-count",
+  // Non-additive leaf aggregators (mondrian-saiku #104) — pushed to SQL as
+  // PERCENTILE_CONT. `median` is the implicit 50th percentile; `percentile`
+  // carries a `percentile="0..100"` attribute (emitted below).
+  median: "median",
+  percentile: "percentile",
 };
 
 /**
@@ -95,181 +98,204 @@ const AGGREGATOR_TO_MONDRIAN: Record<SchemaCanvasMeasure['aggregator'], string> 
  * when no value is set — Mondrian defaults percentile to 50.
  */
 function percentileAttr(m: SchemaCanvasMeasure | undefined): string {
-	if (!m || m.aggregator !== 'percentile') return '';
-	const v = m.percentile;
-	if (v === null || v === undefined) return '';
-	return ` percentile="${escape(String(v))}"`;
+  if (!m || m.aggregator !== "percentile") return "";
+  const v = m.percentile;
+  if (v === null || v === undefined) return "";
+  return ` percentile="${escape(String(v))}"`;
 }
 
 /** Per-dimension resolution: the tables + columns M4 needs to wire it up. */
 interface DimResolution {
-	dim: SchemaCanvasDimension;
-	table: SchemaCanvasTable | undefined;
-	/** dimension-side PK column (target of the fact's FK). */
-	pkColumn: string | null;
-	/** fact-side FK column. */
-	fkColumn: string | null;
-	/** name of the key attribute (referenced by `<Dimension key=...>`). */
-	keyAttrName: string | null;
+  dim: SchemaCanvasDimension;
+  table: SchemaCanvasTable | undefined;
+  /** dimension-side PK column (target of the fact's FK). */
+  pkColumn: string | null;
+  /** fact-side FK column. */
+  fkColumn: string | null;
+  /** name of the key attribute (referenced by `<Dimension key=...>`). */
+  keyAttrName: string | null;
 }
 
 function resolveDimension(
-	dim: SchemaCanvasDimension,
-	tables: SchemaCanvasTable[],
-	joins: SchemaCanvasJoin[],
-	factTableId: string
+  dim: SchemaCanvasDimension,
+  tables: SchemaCanvasTable[],
+  joins: SchemaCanvasJoin[],
+  factTableId: string,
 ): DimResolution {
-	const table = tables.find((t) => t.id === (dim.primaryKeyTableId ?? dim.sourceTableId));
+  const table = tables.find(
+    (t) => t.id === (dim.primaryKeyTableId ?? dim.sourceTableId),
+  );
 
-	// FK (fact side) + PK (dim side): explicit dim fields win, else derive from
-	// the canvas join between the fact and this dim's table.
-	let fkColumn = dim.foreignKey ?? null;
-	let pkColumn = resolvePkColumn(dim);
-	if ((!fkColumn || !pkColumn) && table) {
-		for (const j of joins) {
-			if (j.sourceTableId === factTableId && j.targetTableId === table.id) {
-				fkColumn = fkColumn ?? j.sourceColumnName;
-				pkColumn = pkColumn ?? j.targetColumnName;
-				break;
-			}
-			if (j.targetTableId === factTableId && j.sourceTableId === table.id) {
-				fkColumn = fkColumn ?? j.targetColumnName;
-				pkColumn = pkColumn ?? j.sourceColumnName;
-				break;
-			}
-		}
-	}
+  // FK (fact side) + PK (dim side): explicit dim fields win, else derive from
+  // the canvas join between the fact and this dim's table.
+  let fkColumn = dim.foreignKey ?? null;
+  let pkColumn = resolvePkColumn(dim);
+  if ((!fkColumn || !pkColumn) && table) {
+    for (const j of joins) {
+      if (j.sourceTableId === factTableId && j.targetTableId === table.id) {
+        fkColumn = fkColumn ?? j.sourceColumnName;
+        pkColumn = pkColumn ?? j.targetColumnName;
+        break;
+      }
+      if (j.targetTableId === factTableId && j.sourceTableId === table.id) {
+        fkColumn = fkColumn ?? j.targetColumnName;
+        pkColumn = pkColumn ?? j.sourceColumnName;
+        break;
+      }
+    }
+  }
 
-	// Key attribute: reuse an attribute already bound to the PK column, else a
-	// synthetic one gets emitted (see emitDimension).
-	const existing = pkColumn
-		? (dim.attributes ?? []).find((a) => a.columnName === pkColumn)
-		: undefined;
-	const keyAttrName = pkColumn
-		? (existing?.name ?? existing?.columnName ?? `${dim.name} Key`)
-		: null;
+  // Key attribute: reuse an attribute already bound to the PK column, else a
+  // synthetic one gets emitted (see emitDimension).
+  const existing = pkColumn
+    ? (dim.attributes ?? []).find((a) => a.columnName === pkColumn)
+    : undefined;
+  const keyAttrName = pkColumn
+    ? (existing?.name ?? existing?.columnName ?? `${dim.name} Key`)
+    : null;
 
-	return { dim, table, pkColumn, fkColumn, keyAttrName };
+  return { dim, table, pkColumn, fkColumn, keyAttrName };
 }
 
 /** `dim.primaryKey` stores an attribute's logical NAME; resolve it to a column. */
 function resolvePkColumn(dim: SchemaCanvasDimension): string | null {
-	if (!dim.primaryKey) return null;
-	const byName = (dim.attributes ?? []).find((a) => (a.name ?? a.columnName) === dim.primaryKey);
-	return byName?.columnName ?? dim.primaryKey;
+  if (!dim.primaryKey) return null;
+  const byName = (dim.attributes ?? []).find(
+    (a) => (a.name ?? a.columnName) === dim.primaryKey,
+  );
+  return byName?.columnName ?? dim.primaryKey;
 }
 
 interface SynthAttr {
-	name: string;
-	keyColumn?: string;
-	keyColumns?: string[];
-	isKey?: boolean;
+  name: string;
+  keyColumn?: string;
+  keyColumns?: string[];
+  isKey?: boolean;
 }
 
 function emitDimension(r: DimResolution): string[] {
-	const { dim, table, pkColumn, keyAttrName } = r;
-	const lines: string[] = [];
+  const { dim, table, pkColumn, keyAttrName } = r;
+  const lines: string[] = [];
 
-	// Build the full attribute set. M4 <Level attribute="X"/> references an
-	// attribute by NAME, so every hierarchy level needs a backing attribute —
-	// synthesise one for any level (or the key) not already declared.
-	const attrs = new Map<string, SynthAttr>();
-	const explicit = dim.attributes ?? [];
-	if (keyAttrName && pkColumn && !explicit.some((a) => a.columnName === pkColumn)) {
-		attrs.set(keyAttrName, { name: keyAttrName, keyColumn: pkColumn, isKey: true });
-	}
-	for (const a of explicit) {
-		const name = a.name ?? a.columnName;
-		attrs.set(name, {
-			name,
-			keyColumn: a.keyColumns && a.keyColumns.length > 1 ? undefined : a.columnName,
-			keyColumns: a.keyColumns && a.keyColumns.length > 1 ? a.keyColumns : undefined
-		});
-	}
-	// Resolve each hierarchy's levels to attribute names, synthesising as needed.
-	// Carry the level's caption alongside so the <Level> emit can round-trip it.
-	const hierarchyLevels: {
-		h: SchemaCanvasHierarchy;
-		levels: { name: string; caption?: string }[];
-	}[] = [];
-	for (const h of dim.hierarchies) {
-		const levels: { name: string; caption?: string }[] = [];
-		for (const lvl of h.levels) {
-			const fromCol = explicit.find((a) => a.columnName === lvl.columnName);
-			const name = fromCol?.name ?? fromCol?.columnName ?? lvl.name;
-			if (!attrs.has(name)) attrs.set(name, { name, keyColumn: lvl.columnName });
-			levels.push({ name, caption: lvl.caption });
-		}
-		hierarchyLevels.push({ h, levels });
-	}
+  // Build the full attribute set. M4 <Level attribute="X"/> references an
+  // attribute by NAME, so every hierarchy level needs a backing attribute —
+  // synthesise one for any level (or the key) not already declared.
+  const attrs = new Map<string, SynthAttr>();
+  const explicit = dim.attributes ?? [];
+  if (
+    keyAttrName &&
+    pkColumn &&
+    !explicit.some((a) => a.columnName === pkColumn)
+  ) {
+    attrs.set(keyAttrName, {
+      name: keyAttrName,
+      keyColumn: pkColumn,
+      isKey: true,
+    });
+  }
+  for (const a of explicit) {
+    const name = a.name ?? a.columnName;
+    attrs.set(name, {
+      name,
+      keyColumn:
+        a.keyColumns && a.keyColumns.length > 1 ? undefined : a.columnName,
+      keyColumns:
+        a.keyColumns && a.keyColumns.length > 1 ? a.keyColumns : undefined,
+    });
+  }
+  // Resolve each hierarchy's levels to attribute names, synthesising as needed.
+  // Carry the level's caption alongside so the <Level> emit can round-trip it.
+  const hierarchyLevels: {
+    h: SchemaCanvasHierarchy;
+    levels: { name: string; caption?: string }[];
+  }[] = [];
+  for (const h of dim.hierarchies) {
+    const levels: { name: string; caption?: string }[] = [];
+    for (const lvl of h.levels) {
+      const fromCol = explicit.find((a) => a.columnName === lvl.columnName);
+      const name = fromCol?.name ?? fromCol?.columnName ?? lvl.name;
+      if (!attrs.has(name))
+        attrs.set(name, { name, keyColumn: lvl.columnName });
+      levels.push({ name, caption: lvl.caption });
+    }
+    hierarchyLevels.push({ h, levels });
+  }
 
-	const tableAttr = table ? ` table="${escape(table.name)}"` : '';
-	const keyAttr = keyAttrName ? ` key="${escape(keyAttrName)}"` : '';
-	// Mondrian 4 spells a time dimension `type="TIME"` (M3 used "TimeDimension").
-	const typeAttr = dim.dimensionType === 'Time' ? ' type="TIME"' : '';
-	lines.push(
-		`  <Dimension name="${escape(dim.name)}"${tableAttr}${keyAttr}${typeAttr}` +
-			`${attr('caption', dim.caption)}${attr('description', dim.description)}>`
-	);
+  const tableAttr = table ? ` table="${escape(table.name)}"` : "";
+  const keyAttr = keyAttrName ? ` key="${escape(keyAttrName)}"` : "";
+  // Mondrian 4 spells a time dimension `type="TIME"` (M3 used "TimeDimension").
+  const typeAttr = dim.dimensionType === "Time" ? ' type="TIME"' : "";
+  lines.push(
+    `  <Dimension name="${escape(dim.name)}"${tableAttr}${keyAttr}${typeAttr}` +
+      `${attr("caption", dim.caption)}${attr("description", dim.description)}>`,
+  );
 
-	// M4 carries a level's levelType on its <Attribute>; map marked columns.
-	const legacyLevelTypeByColumn = new Map<string, string>();
-	for (const h of dim.hierarchies) {
-		for (const lvl of h.levels) {
-			if (lvl.levelType) legacyLevelTypeByColumn.set(lvl.columnName, lvl.levelType);
-		}
-	}
+  // M4 carries a level's levelType on its <Attribute>; map marked columns.
+  const legacyLevelTypeByColumn = new Map<string, string>();
+  for (const h of dim.hierarchies) {
+    for (const lvl of h.levels) {
+      if (lvl.levelType)
+        legacyLevelTypeByColumn.set(lvl.columnName, lvl.levelType);
+    }
+  }
 
-	if (attrs.size > 0) {
-		lines.push('    <Attributes>');
-		for (const a of attrs.values()) {
-			const hasHier = a.isKey ? ' hasHierarchy="false"' : '';
-			const lt = a.keyColumn ? legacyLevelTypeByColumn.get(a.keyColumn) : undefined;
-			const ltAttr = lt ? ` levelType="${escape(lt)}"` : '';
-			if (a.keyColumns) {
-				lines.push(`      <Attribute name="${escape(a.name)}"${hasHier}>`);
-				lines.push('        <Key>');
-				for (const c of a.keyColumns) lines.push(`          <Column name="${escape(c)}"/>`);
-				lines.push('        </Key>');
-				lines.push('      </Attribute>');
-			} else {
-				lines.push(
-					`      <Attribute name="${escape(a.name)}" keyColumn="${escape(a.keyColumn ?? a.name)}"${hasHier}${ltAttr} />`
-				);
-			}
-		}
-		lines.push('    </Attributes>');
-	}
+  if (attrs.size > 0) {
+    lines.push("    <Attributes>");
+    for (const a of attrs.values()) {
+      const hasHier = a.isKey ? ' hasHierarchy="false"' : "";
+      const lt = a.keyColumn
+        ? legacyLevelTypeByColumn.get(a.keyColumn)
+        : undefined;
+      const ltAttr = lt ? ` levelType="${escape(lt)}"` : "";
+      if (a.keyColumns) {
+        lines.push(`      <Attribute name="${escape(a.name)}"${hasHier}>`);
+        lines.push("        <Key>");
+        for (const c of a.keyColumns)
+          lines.push(`          <Column name="${escape(c)}"/>`);
+        lines.push("        </Key>");
+        lines.push("      </Attribute>");
+      } else {
+        lines.push(
+          `      <Attribute name="${escape(a.name)}" keyColumn="${escape(a.keyColumn ?? a.name)}"${hasHier}${ltAttr} />`,
+        );
+      }
+    }
+    lines.push("    </Attributes>");
+  }
 
-	// Hierarchies — emit authored ones; if none, synthesise a single hierarchy
-	// over the non-key attributes so the dimension is sliceable.
-	if (hierarchyLevels.length > 0) {
-		lines.push('    <Hierarchies>');
-		for (const { h, levels } of hierarchyLevels) {
-			lines.push(
-				`      <Hierarchy name="${escape(h.name)}" hasAll="${h.hasAll ? 'true' : 'false'}"` +
-					`${attr('allMemberName', h.allMemberName)}${attr('defaultMember', h.defaultMember)}>`
-			);
-			for (const l of levels)
-				lines.push(`        <Level attribute="${escape(l.name)}"${attr('caption', l.caption)} />`);
-			lines.push('      </Hierarchy>');
-		}
-		lines.push('    </Hierarchies>');
-	} else {
-		const levelNames = [...attrs.values()]
-			.filter((a) => !a.isKey && a.name !== keyAttrName)
-			.map((a) => a.name);
-		const levels = levelNames.length > 0 ? levelNames : keyAttrName ? [keyAttrName] : [];
-		if (levels.length > 0) {
-			lines.push('    <Hierarchies>');
-			lines.push(`      <Hierarchy name="${escape(dim.name)}" hasAll="true">`);
-			for (const n of levels) lines.push(`        <Level attribute="${escape(n)}" />`);
-			lines.push('      </Hierarchy>');
-			lines.push('    </Hierarchies>');
-		}
-	}
-	lines.push('  </Dimension>');
-	return lines;
+  // Hierarchies — emit authored ones; if none, synthesise a single hierarchy
+  // over the non-key attributes so the dimension is sliceable.
+  if (hierarchyLevels.length > 0) {
+    lines.push("    <Hierarchies>");
+    for (const { h, levels } of hierarchyLevels) {
+      lines.push(
+        `      <Hierarchy name="${escape(h.name)}" hasAll="${h.hasAll ? "true" : "false"}"` +
+          `${attr("allMemberName", h.allMemberName)}${attr("defaultMember", h.defaultMember)}>`,
+      );
+      for (const l of levels)
+        lines.push(
+          `        <Level attribute="${escape(l.name)}"${attr("caption", l.caption)} />`,
+        );
+      lines.push("      </Hierarchy>");
+    }
+    lines.push("    </Hierarchies>");
+  } else {
+    const levelNames = [...attrs.values()]
+      .filter((a) => !a.isKey && a.name !== keyAttrName)
+      .map((a) => a.name);
+    const levels =
+      levelNames.length > 0 ? levelNames : keyAttrName ? [keyAttrName] : [];
+    if (levels.length > 0) {
+      lines.push("    <Hierarchies>");
+      lines.push(`      <Hierarchy name="${escape(dim.name)}" hasAll="true">`);
+      for (const n of levels)
+        lines.push(`        <Level attribute="${escape(n)}" />`);
+      lines.push("      </Hierarchy>");
+      lines.push("    </Hierarchies>");
+    }
+  }
+  lines.push("  </Dimension>");
+  return lines;
 }
 
 /**
@@ -277,29 +303,29 @@ function emitDimension(r: DimResolution): string[] {
  * one per non-fact table joined to the fact. Emitted in the SAME M4 shape.
  */
 function inferDimensions(
-	fact: SchemaCanvasTable,
-	tables: SchemaCanvasTable[],
-	joins: SchemaCanvasJoin[]
+  fact: SchemaCanvasTable,
+  tables: SchemaCanvasTable[],
+  joins: SchemaCanvasJoin[],
 ): SchemaCanvasDimension[] {
-	const dims: SchemaCanvasDimension[] = [];
-	for (const t of tables) {
-		if (t.id === fact.id) continue;
-		const joined = joins.some(
-			(j) =>
-				(j.sourceTableId === fact.id && j.targetTableId === t.id) ||
-				(j.targetTableId === fact.id && j.sourceTableId === t.id)
-		);
-		if (!joined) continue;
-		dims.push({
-			id: `inferred-${t.id}`,
-			name: titleCase(t.name),
-			sourceTableId: t.id,
-			primaryKeyTableId: t.id,
-			attributes: t.columns.map((c) => ({ tableId: t.id, columnName: c.name })),
-			hierarchies: []
-		} as SchemaCanvasDimension);
-	}
-	return dims;
+  const dims: SchemaCanvasDimension[] = [];
+  for (const t of tables) {
+    if (t.id === fact.id) continue;
+    const joined = joins.some(
+      (j) =>
+        (j.sourceTableId === fact.id && j.targetTableId === t.id) ||
+        (j.targetTableId === fact.id && j.sourceTableId === t.id),
+    );
+    if (!joined) continue;
+    dims.push({
+      id: `inferred-${t.id}`,
+      name: titleCase(t.name),
+      sourceTableId: t.id,
+      primaryKeyTableId: t.id,
+      attributes: t.columns.map((c) => ({ tableId: t.id, columnName: c.name })),
+      hierarchies: [],
+    } as SchemaCanvasDimension);
+  }
+  return dims;
 }
 
 /**
@@ -308,13 +334,15 @@ function inferDimensions(
  * matches the Code-tab preview exactly.
  */
 function renderCalcFormula(c: SchemaCanvasCalc): string {
-	const mode = c.mode ?? 'build';
-	if (mode === 'expression') return (c.formula ?? '').trim();
-	return c.tokens
-		.map((t) => (t.kind === 'measure' ? `[${t.name ?? ''}]` : ` ${t.op ?? '+'} `))
-		.join('')
-		.replace(/\s+/g, ' ')
-		.trim();
+  const mode = c.mode ?? "build";
+  if (mode === "expression") return (c.formula ?? "").trim();
+  return c.tokens
+    .map((t) =>
+      t.kind === "measure" ? `[${t.name ?? ""}]` : ` ${t.op ?? "+"} `,
+    )
+    .join("")
+    .replace(/\s+/g, " ")
+    .trim();
 }
 
 /**
@@ -325,413 +353,467 @@ function renderCalcFormula(c: SchemaCanvasCalc): string {
  * `<CalculatedMembers>`.  Used whenever the doc carries cubes; otherwise
  * {@link exportSingleFactFallback} keeps the legacy single-fact behaviour.
  */
-function exportCubesBased(state: SchemaCanvasState, cubes: SchemaCanvasCube[]): string {
-	const tables = state.tables;
-	const dims = state.dimensions ?? [];
-	const measures = state.measures ?? [];
-	const schemaName = state.label.trim() || 'Untitled';
+function exportCubesBased(
+  state: SchemaCanvasState,
+  cubes: SchemaCanvasCube[],
+): string {
+  const tables = state.tables;
+  const dims = state.dimensions ?? [];
+  const measures = state.measures ?? [];
+  const schemaName = state.label.trim() || "Untitled";
 
-	// Dimension tables — one physical <Table> each (keyColumn = its PK).
-	const dimTables = new Map<string, SchemaCanvasTable>();
-	for (const d of dims) {
-		const dSrc = d.sourceTableId ?? d.primaryKeyTableId;
-		if (!dSrc) continue;
-		const t = tables.find((x) => x.id === dSrc);
-		if (t) dimTables.set(t.id, t);
-	}
+  // Dimension tables — one physical <Table> each (keyColumn = its PK).
+  const dimTables = new Map<string, SchemaCanvasTable>();
+  for (const d of dims) {
+    const dSrc = d.sourceTableId ?? d.primaryKeyTableId;
+    if (!dSrc) continue;
+    const t = tables.find((x) => x.id === dSrc);
+    if (t) dimTables.set(t.id, t);
+  }
 
-	// Per-cube fact fallback: the first MG carrying a factTableId.
-	const legacyFact = tables.find((t) => t.role === 'fact') ?? null;
-	const cubeFactOf = (c: SchemaCanvasCube): string | null =>
-		c.measureGroups.find((mg) => mg.factTableId)?.factTableId ?? legacyFact?.id ?? null;
+  // Per-cube fact fallback: the first MG carrying a factTableId.
+  const legacyFact = tables.find((t) => t.role === "fact") ?? null;
+  const cubeFactOf = (c: SchemaCanvasCube): string | null =>
+    c.measureGroups.find((mg) => mg.factTableId)?.factTableId ??
+    legacyFact?.id ??
+    null;
 
-	// Every fact table referenced by any cube / measure group.
-	const factTables = new Map<string, SchemaCanvasTable>();
-	if (legacyFact) factTables.set(legacyFact.id, legacyFact);
-	for (const c of cubes) {
-		const cf = cubeFactOf(c);
-		if (cf) {
-			const t = tables.find((x) => x.id === cf);
-			if (t) factTables.set(t.id, t);
-		}
-		for (const mg of c.measureGroups) {
-			if (mg.factTableId) {
-				const t = tables.find((x) => x.id === mg.factTableId);
-				if (t) factTables.set(t.id, t);
-			}
-		}
-	}
+  // Every fact table referenced by any cube / measure group.
+  const factTables = new Map<string, SchemaCanvasTable>();
+  if (legacyFact) factTables.set(legacyFact.id, legacyFact);
+  for (const c of cubes) {
+    const cf = cubeFactOf(c);
+    if (cf) {
+      const t = tables.find((x) => x.id === cf);
+      if (t) factTables.set(t.id, t);
+    }
+    for (const mg of c.measureGroups) {
+      if (mg.factTableId) {
+        const t = tables.find((x) => x.id === mg.factTableId);
+        if (t) factTables.set(t.id, t);
+      }
+    }
+  }
 
-	// Dimension-table PK column (#1080) — used by BOTH the PhysicalSchema
-	// keyColumn and the <Dimension key>.  Prefer explicit dim.primaryKey,
-	// else the dim-side column of a join to a fact, else an id-like guess.
-	const dimTablePk = new Map<string, string>();
-	for (const dim of dims) {
-		const bt = tables.find((t) => t.id === (dim.sourceTableId ?? dim.primaryKeyTableId));
-		if (!bt || dimTablePk.has(bt.id)) continue;
-		let pk: string | null = dim.primaryKey ?? null;
-		if (!pk) {
-			for (const j of state.joins) {
-				if (j.sourceTableId === bt.id && factTables.has(j.targetTableId)) {
-					pk = j.sourceColumnName;
-					break;
-				}
-				if (j.targetTableId === bt.id && factTables.has(j.sourceTableId)) {
-					pk = j.targetColumnName;
-					break;
-				}
-			}
-		}
-		if (!pk) {
-			const cols = bt.columns ?? [];
-			const name = bt.name.toLowerCase();
-			const idCol =
-				cols.find((c) => c.name.toLowerCase() === `${name}_id`) ??
-				cols.find((c) => c.name.toLowerCase() === 'id') ??
-				cols.find((c) => /_id$/i.test(c.name));
-			if (idCol) pk = idCol.name;
-		}
-		if (pk) dimTablePk.set(bt.id, pk);
-	}
+  // Dimension-table PK column (#1080) — used by BOTH the PhysicalSchema
+  // keyColumn and the <Dimension key>.  Prefer explicit dim.primaryKey,
+  // else the dim-side column of a join to a fact, else an id-like guess.
+  const dimTablePk = new Map<string, string>();
+  for (const dim of dims) {
+    const bt = tables.find(
+      (t) => t.id === (dim.sourceTableId ?? dim.primaryKeyTableId),
+    );
+    if (!bt || dimTablePk.has(bt.id)) continue;
+    let pk: string | null = dim.primaryKey ?? null;
+    if (!pk) {
+      for (const j of state.joins) {
+        if (j.sourceTableId === bt.id && factTables.has(j.targetTableId)) {
+          pk = j.sourceColumnName;
+          break;
+        }
+        if (j.targetTableId === bt.id && factTables.has(j.sourceTableId)) {
+          pk = j.targetColumnName;
+          break;
+        }
+      }
+    }
+    if (!pk) {
+      const cols = bt.columns ?? [];
+      const name = bt.name.toLowerCase();
+      const idCol =
+        cols.find((c) => c.name.toLowerCase() === `${name}_id`) ??
+        cols.find((c) => c.name.toLowerCase() === "id") ??
+        cols.find((c) => /_id$/i.test(c.name));
+      if (idCol) pk = idCol.name;
+    }
+    if (pk) dimTablePk.set(bt.id, pk);
+  }
 
-	const out: string[] = [];
-	out.push('<?xml version="1.0" encoding="UTF-8"?>');
-	out.push(`<Schema name="${escape(schemaName)}" metamodelVersion="4.0">`);
+  const out: string[] = [];
+  out.push('<?xml version="1.0" encoding="UTF-8"?>');
+  out.push(`<Schema name="${escape(schemaName)}" metamodelVersion="4.0">`);
 
-	// ── PhysicalSchema — facts (no key) + dim tables (keyColumn = PK) ──
-	out.push('  <PhysicalSchema>');
-	for (const ft of factTables.values()) {
-		out.push(
-			`    <Table name="${escape(ft.name)}"${ft.schema ? ` schema="${escape(ft.schema)}"` : ''} />`
-		);
-	}
-	for (const t of dimTables.values()) {
-		if (factTables.has(t.id)) continue;
-		const pk = dimTablePk.get(t.id);
-		const keyColAttr = pk ? ` keyColumn="${escape(pk)}"` : '';
-		out.push(
-			`    <Table name="${escape(t.name)}"${t.schema ? ` schema="${escape(t.schema)}"` : ''}${keyColAttr} />`
-		);
-	}
-	out.push('  </PhysicalSchema>');
+  // ── PhysicalSchema — facts (no key) + dim tables (keyColumn = PK) ──
+  out.push("  <PhysicalSchema>");
+  for (const ft of factTables.values()) {
+    out.push(
+      `    <Table name="${escape(ft.name)}"${ft.schema ? ` schema="${escape(ft.schema)}"` : ""} />`,
+    );
+  }
+  for (const t of dimTables.values()) {
+    if (factTables.has(t.id)) continue;
+    const pk = dimTablePk.get(t.id);
+    const keyColAttr = pk ? ` keyColumn="${escape(pk)}"` : "";
+    out.push(
+      `    <Table name="${escape(t.name)}"${t.schema ? ` schema="${escape(t.schema)}"` : ""}${keyColAttr} />`,
+    );
+  }
+  out.push("  </PhysicalSchema>");
 
-	// ── Shared Dimensions ──
-	for (const dim of dims) {
-		const boundTable = tables.find((t) => t.id === (dim.sourceTableId ?? dim.primaryKeyTableId));
-		const tableAttr = boundTable ? ` table="${escape(boundTable.name)}"` : '';
-		// Mondrian 4 spells a time dimension `type="TIME"` (M3 used
-		// "TimeDimension"). Only Time has a defined M4 dimension type.
-		const typeAttr =
-			dim.dimensionType === 'Time'
-				? ' type="TIME"'
-				: dim.dimensionType && dim.dimensionType !== 'Standard'
-					? ` type="${dim.dimensionType}Dimension"`
-					: '';
-		const hangerAttr = dim.hanger ? ' hanger="true"' : '';
-		// M4 carries a level's `levelType` on its <Attribute>, not the <Level>.
-		// Map each column that a hierarchy level marks (TimeYears/…) so the
-		// attribute below can inherit it — drives time intelligence.
-		const levelTypeByColumn = new Map<string, string>();
-		for (const h of dim.hierarchies) {
-			for (const lvl of h.levels) {
-				if (lvl.levelType) levelTypeByColumn.set(lvl.columnName, lvl.levelType);
-			}
-		}
-		const levelTypeAttr = (columnName: string): string => {
-			const lt = levelTypeByColumn.get(columnName);
-			return lt ? ` levelType="${escape(lt)}"` : '';
-		};
-		// Level `saiku.semantic.*` annotations ride on the level's <Attribute>,
-		// keyed by column (like levelType).
-		const annotationsByColumn = new Map<string, Record<string, string>>();
-		for (const h of dim.hierarchies) {
-			for (const lvl of h.levels) {
-				if (lvl.annotations) annotationsByColumn.set(lvl.columnName, lvl.annotations);
-			}
-		}
-		const A = dim.attributes ?? [];
-		// M4 `<Level attribute="X">` references an <Attribute> by its NAME, not by
-		// column. Resolve each level's column to the backing attribute's logical
-		// name so renaming an attribute cascades to every level that uses it
-		// (inspector #959). Falls back to the column name when unbound.
-		const attrNameByColumn = new Map<string, string>();
-		for (const a of A) attrNameByColumn.set(a.columnName, a.name ?? a.columnName);
-		const levelAttrName = (columnName: string): string =>
-			attrNameByColumn.get(columnName) ?? columnName;
-		const pkColumn: string | null = boundTable ? (dimTablePk.get(boundTable.id) ?? null) : null;
-		const existingKeyAttr = pkColumn ? A.find((a) => a.columnName === pkColumn) : undefined;
-		const keyAttrName = pkColumn
-			? (existingKeyAttr?.name ?? existingKeyAttr?.columnName ?? `${dim.name} Key`)
-			: null;
-		const needSyntheticKey = !!pkColumn && !existingKeyAttr && !dim.hanger;
-		const keyAttr = keyAttrName && !dim.hanger ? ` key="${escape(keyAttrName)}"` : '';
-		out.push(
-			`  <Dimension name="${escape(dim.name)}"${tableAttr}${keyAttr}${typeAttr}${hangerAttr}` +
-				`${attr('caption', dim.caption)}${attr('description', dim.description)}>`
-		);
-		out.push(...annotationLines(dim.annotations, '    '));
-		if (A.length > 0 || needSyntheticKey) {
-			out.push('    <Attributes>');
-			if (needSyntheticKey) {
-				out.push(
-					`      <Attribute name="${escape(keyAttrName!)}" keyColumn="${escape(pkColumn!)}" hasHierarchy="false" />`
-				);
-			}
-			for (const a of A) {
-				const attrLabel = a.name ?? a.columnName;
-				const lt = levelTypeAttr(a.columnName);
-				const anns = annotationLines(annotationsByColumn.get(a.columnName), '        ');
-				// Optional M4 attribute overrides (inspector #959): display / sort /
-				// caption columns + long-form description. Mirror the gateway's
-				// MondrianXmlEmitter spellings.
-				const overrides =
-					attr('nameColumn', a.nameColumn) +
-					attr('captionColumn', a.captionColumn) +
-					attr('orderByColumn', a.orderByColumn) +
-					attr('description', a.description);
-				if (a.keyColumns && a.keyColumns.length > 1) {
-					out.push(`      <Attribute name="${escape(attrLabel)}"${lt}${overrides}>`);
-					out.push('        <Key>');
-					for (const c of a.keyColumns) out.push(`          <Column name="${escape(c)}"/>`);
-					out.push('        </Key>');
-					out.push(...anns);
-					out.push('      </Attribute>');
-				} else if (anns.length > 0) {
-					out.push(
-						`      <Attribute name="${escape(attrLabel)}" keyColumn="${escape(a.columnName)}"${lt}${overrides}>`
-					);
-					out.push(...anns);
-					out.push('      </Attribute>');
-				} else {
-					out.push(
-						`      <Attribute name="${escape(attrLabel)}" keyColumn="${escape(a.columnName)}"${lt}${overrides} />`
-					);
-				}
-			}
-			out.push('    </Attributes>');
-		}
-		if (dim.hierarchies.length > 0) {
-			out.push('    <Hierarchies>');
-			for (const hier of dim.hierarchies) {
-				out.push(
-					`      <Hierarchy name="${escape(hier.name)}" hasAll="${hier.hasAll ? 'true' : 'false'}"` +
-						`${attr('allMemberName', hier.allMemberName)}${attr('defaultMember', hier.defaultMember)}` +
-						`${attr('caption', hier.caption)}${attr('description', hier.description)}>`
-				);
-				for (let li = 0; li < hier.levels.length; li++) {
-					const lvl = hier.levels[li];
-					if (li === 0 && hier.closure) {
-						out.push(
-							`        <Level attribute="${escape(levelAttrName(lvl.columnName))}"${attr('caption', lvl.caption)}>`
-						);
-						const cl = hier.closure;
-						out.push(
-							`          <Closure table="${escape(cl.table)}" parentColumn="${escape(cl.parentColumn)}" childColumn="${escape(cl.childColumn)}"/>`
-						);
-						out.push('        </Level>');
-					} else {
-						out.push(
-							`        <Level attribute="${escape(levelAttrName(lvl.columnName))}"${attr('caption', lvl.caption)} />`
-						);
-					}
-				}
-				out.push('      </Hierarchy>');
-			}
-			out.push('    </Hierarchies>');
-		}
-		out.push('  </Dimension>');
-	}
+  // ── Shared Dimensions ──
+  for (const dim of dims) {
+    const boundTable = tables.find(
+      (t) => t.id === (dim.sourceTableId ?? dim.primaryKeyTableId),
+    );
+    const tableAttr = boundTable ? ` table="${escape(boundTable.name)}"` : "";
+    // Mondrian 4 spells a time dimension `type="TIME"` (M3 used
+    // "TimeDimension"). Only Time has a defined M4 dimension type.
+    const typeAttr =
+      dim.dimensionType === "Time"
+        ? ' type="TIME"'
+        : dim.dimensionType && dim.dimensionType !== "Standard"
+          ? ` type="${dim.dimensionType}Dimension"`
+          : "";
+    const hangerAttr = dim.hanger ? ' hanger="true"' : "";
+    // M4 carries a level's `levelType` on its <Attribute>, not the <Level>.
+    // Map each column that a hierarchy level marks (TimeYears/…) so the
+    // attribute below can inherit it — drives time intelligence.
+    const levelTypeByColumn = new Map<string, string>();
+    for (const h of dim.hierarchies) {
+      for (const lvl of h.levels) {
+        if (lvl.levelType) levelTypeByColumn.set(lvl.columnName, lvl.levelType);
+      }
+    }
+    const levelTypeAttr = (columnName: string): string => {
+      const lt = levelTypeByColumn.get(columnName);
+      return lt ? ` levelType="${escape(lt)}"` : "";
+    };
+    // Level `saiku.semantic.*` annotations ride on the level's <Attribute>,
+    // keyed by column (like levelType).
+    const annotationsByColumn = new Map<string, Record<string, string>>();
+    for (const h of dim.hierarchies) {
+      for (const lvl of h.levels) {
+        if (lvl.annotations)
+          annotationsByColumn.set(lvl.columnName, lvl.annotations);
+      }
+    }
+    const A = dim.attributes ?? [];
+    // M4 `<Level attribute="X">` references an <Attribute> by its NAME, not by
+    // column. Resolve each level's column to the backing attribute's logical
+    // name so renaming an attribute cascades to every level that uses it
+    // (inspector #959). Falls back to the column name when unbound.
+    const attrNameByColumn = new Map<string, string>();
+    for (const a of A)
+      attrNameByColumn.set(a.columnName, a.name ?? a.columnName);
+    const levelAttrName = (columnName: string): string =>
+      attrNameByColumn.get(columnName) ?? columnName;
+    const pkColumn: string | null = boundTable
+      ? (dimTablePk.get(boundTable.id) ?? null)
+      : null;
+    const existingKeyAttr = pkColumn
+      ? A.find((a) => a.columnName === pkColumn)
+      : undefined;
+    const keyAttrName = pkColumn
+      ? (existingKeyAttr?.name ??
+        existingKeyAttr?.columnName ??
+        `${dim.name} Key`)
+      : null;
+    const needSyntheticKey = !!pkColumn && !existingKeyAttr && !dim.hanger;
+    const keyAttr =
+      keyAttrName && !dim.hanger ? ` key="${escape(keyAttrName)}"` : "";
+    out.push(
+      `  <Dimension name="${escape(dim.name)}"${tableAttr}${keyAttr}${typeAttr}${hangerAttr}` +
+        `${attr("caption", dim.caption)}${attr("description", dim.description)}>`,
+    );
+    out.push(...annotationLines(dim.annotations, "    "));
+    if (A.length > 0 || needSyntheticKey) {
+      out.push("    <Attributes>");
+      if (needSyntheticKey) {
+        out.push(
+          `      <Attribute name="${escape(keyAttrName!)}" keyColumn="${escape(pkColumn!)}" hasHierarchy="false" />`,
+        );
+      }
+      for (const a of A) {
+        const attrLabel = a.name ?? a.columnName;
+        const lt = levelTypeAttr(a.columnName);
+        const anns = annotationLines(
+          annotationsByColumn.get(a.columnName),
+          "        ",
+        );
+        // Optional M4 attribute overrides (inspector #959): display / sort /
+        // caption columns + long-form description. Mirror the gateway's
+        // MondrianXmlEmitter spellings.
+        const overrides =
+          attr("nameColumn", a.nameColumn) +
+          attr("captionColumn", a.captionColumn) +
+          attr("orderByColumn", a.orderByColumn) +
+          attr("description", a.description);
+        if (a.keyColumns && a.keyColumns.length > 1) {
+          out.push(
+            `      <Attribute name="${escape(attrLabel)}"${lt}${overrides}>`,
+          );
+          out.push("        <Key>");
+          for (const c of a.keyColumns)
+            out.push(`          <Column name="${escape(c)}"/>`);
+          out.push("        </Key>");
+          out.push(...anns);
+          out.push("      </Attribute>");
+        } else if (anns.length > 0) {
+          out.push(
+            `      <Attribute name="${escape(attrLabel)}" keyColumn="${escape(a.columnName)}"${lt}${overrides}>`,
+          );
+          out.push(...anns);
+          out.push("      </Attribute>");
+        } else {
+          out.push(
+            `      <Attribute name="${escape(attrLabel)}" keyColumn="${escape(a.columnName)}"${lt}${overrides} />`,
+          );
+        }
+      }
+      out.push("    </Attributes>");
+    }
+    if (dim.hierarchies.length > 0) {
+      out.push("    <Hierarchies>");
+      for (const hier of dim.hierarchies) {
+        out.push(
+          `      <Hierarchy name="${escape(hier.name)}" hasAll="${hier.hasAll ? "true" : "false"}"` +
+            `${attr("allMemberName", hier.allMemberName)}${attr("defaultMember", hier.defaultMember)}` +
+            `${attr("caption", hier.caption)}${attr("description", hier.description)}>`,
+        );
+        for (let li = 0; li < hier.levels.length; li++) {
+          const lvl = hier.levels[li];
+          if (li === 0 && hier.closure) {
+            out.push(
+              `        <Level attribute="${escape(levelAttrName(lvl.columnName))}"${attr("caption", lvl.caption)}>`,
+            );
+            const cl = hier.closure;
+            out.push(
+              `          <Closure table="${escape(cl.table)}" parentColumn="${escape(cl.parentColumn)}" childColumn="${escape(cl.childColumn)}"/>`,
+            );
+            out.push("        </Level>");
+          } else {
+            out.push(
+              `        <Level attribute="${escape(levelAttrName(lvl.columnName))}"${attr("caption", lvl.caption)} />`,
+            );
+          }
+        }
+        out.push("      </Hierarchy>");
+      }
+      out.push("    </Hierarchies>");
+    }
+    out.push("  </Dimension>");
+  }
 
-	// ── Cubes ──
-	for (const cube of cubes) {
-		const cubeFact = cubeFactOf(cube);
-		out.push(`  <Cube name="${escape(cube.name || 'Untitled')}">`);
-		if (dims.length > 0) {
-			out.push('    <Dimensions>');
-			for (const dim of dims) out.push(`      <Dimension source="${escape(dim.name)}" />`);
-			out.push('    </Dimensions>');
-		}
-		if (cube.measureGroups.length > 0) {
-			out.push('    <MeasureGroups>');
-			for (const mg of cube.measureGroups) {
-				const mgFactId = mg.factTableId ?? cubeFact;
-				const mgFact = mgFactId ? tables.find((t) => t.id === mgFactId) : null;
-				if (!mgFact) continue;
-				out.push(`      <MeasureGroup name="${escape(mg.name)}" table="${escape(mgFact.name)}">`);
-				if (mg.measureColumns.length > 0) {
-					out.push('        <Measures>');
-					for (const col of mg.measureColumns) {
-						const m = measures.find((mm) => mm.tableId === mgFact.id && mm.columnName === col);
-						const aggregator = m ? (AGGREGATOR_TO_MONDRIAN[m.aggregator] ?? 'sum') : 'sum';
-						const captionRaw = mg.measureCaptions?.[col]?.trim();
-						const captionAttr =
-							captionRaw && captionRaw !== col ? ` caption="${escape(captionRaw)}"` : '';
-						const attrs = `name="${escape(col)}" column="${escape(col)}" aggregator="${aggregator}"${captionAttr}${attr('formatString', m?.formatString)}${percentileAttr(m)}`;
-						const anns = annotationLines(m?.annotations, '            ');
-						if (anns.length > 0) {
-							out.push(`          <Measure ${attrs}>`);
-							out.push(...anns);
-							out.push('          </Measure>');
-						} else {
-							out.push(`          <Measure ${attrs} />`);
-						}
-					}
-					out.push('        </Measures>');
-				}
-				const links = mg.dimensionLinks ?? [];
-				if (links.length > 0) {
-					out.push('        <DimensionLinks>');
-					for (const link of links) {
-						const dim = dims.find((d) => d.id === link.dimensionId);
-						if (!dim) continue;
-						const kind = link.linkKind ?? 'foreign-key';
-						if (kind === 'fact') {
-							out.push(`          <FactLink dimension="${escape(dim.name)}" />`);
-						} else if (kind === 'reference') {
-							out.push(
-								`          <ReferenceLink dimension="${escape(dim.name)}"${attr('viaDimension', link.viaDimension)}${attr('viaAttribute', link.viaAttribute)} />`
-							);
-						} else {
-							out.push(
-								`          <ForeignKeyLink dimension="${escape(dim.name)}" foreignKeyColumn="${escape(link.foreignKeyColumn)}" />`
-							);
-						}
-					}
-					out.push('        </DimensionLinks>');
-				}
-				out.push('      </MeasureGroup>');
-			}
-			out.push('    </MeasureGroups>');
-		}
-		const liveCalcs = cube.calcs.filter((c) => renderCalcFormula(c).length > 0);
-		if (liveCalcs.length > 0) {
-			out.push('    <CalculatedMembers>');
-			for (const c of liveCalcs) {
-				const formula = renderCalcFormula(c);
-				out.push(
-					`      <CalculatedMember name="${escape(c.name || 'Untitled')}" dimension="Measures" formula="${escape(formula)}"/>`
-				);
-			}
-			out.push('    </CalculatedMembers>');
-		}
-		// Declarative time-intelligence metrics (yoy/pop/ytd/rolling). Only emit
-		// well-formed ones (name + measure; rolling needs a positive window) so a
-		// half-authored row never ships an invalid <TimeCalc> the engine rejects.
-		const liveTimeCalcs = (cube.timeCalcs ?? []).filter(
-			(t) => t.name.trim() && t.measure.trim() && (t.type !== 'rolling' || (t.window ?? 0) > 0)
-		);
-		if (liveTimeCalcs.length > 0) {
-			out.push('    <TimeCalcs>');
-			for (const t of liveTimeCalcs) {
-				const parts = [
-					`name="${escape(t.name)}"`,
-					`type="${escape(t.type)}"`,
-					`measure="${escape(t.measure)}"`
-				];
-				if (t.timeDimension) parts.push(`timeDimension="${escape(t.timeDimension)}"`);
-				if (t.type === 'rolling') {
-					if (t.window != null) parts.push(`window="${escape(String(t.window))}"`);
-					if (t.function) parts.push(`function="${escape(t.function)}"`);
-				}
-				if (t.formatString) parts.push(`formatString="${escape(t.formatString)}"`);
-				out.push(`      <TimeCalc ${parts.join(' ')}/>`);
-			}
-			out.push('    </TimeCalcs>');
-		}
-		out.push('  </Cube>');
-	}
+  // ── Cubes ──
+  for (const cube of cubes) {
+    const cubeFact = cubeFactOf(cube);
+    out.push(`  <Cube name="${escape(cube.name || "Untitled")}">`);
+    if (dims.length > 0) {
+      out.push("    <Dimensions>");
+      for (const dim of dims)
+        out.push(`      <Dimension source="${escape(dim.name)}" />`);
+      out.push("    </Dimensions>");
+    }
+    if (cube.measureGroups.length > 0) {
+      out.push("    <MeasureGroups>");
+      for (const mg of cube.measureGroups) {
+        const mgFactId = mg.factTableId ?? cubeFact;
+        const mgFact = mgFactId ? tables.find((t) => t.id === mgFactId) : null;
+        if (!mgFact) continue;
+        out.push(
+          `      <MeasureGroup name="${escape(mg.name)}" table="${escape(mgFact.name)}">`,
+        );
+        if (mg.measureColumns.length > 0) {
+          out.push("        <Measures>");
+          for (const col of mg.measureColumns) {
+            const m = measures.find(
+              (mm) => mm.tableId === mgFact.id && mm.columnName === col,
+            );
+            const aggregator = m
+              ? (AGGREGATOR_TO_MONDRIAN[m.aggregator] ?? "sum")
+              : "sum";
+            const captionRaw = mg.measureCaptions?.[col]?.trim();
+            const captionAttr =
+              captionRaw && captionRaw !== col
+                ? ` caption="${escape(captionRaw)}"`
+                : "";
+            const attrs = `name="${escape(col)}" column="${escape(col)}" aggregator="${aggregator}"${captionAttr}${attr("formatString", m?.formatString)}${percentileAttr(m)}`;
+            const anns = annotationLines(m?.annotations, "            ");
+            if (anns.length > 0) {
+              out.push(`          <Measure ${attrs}>`);
+              out.push(...anns);
+              out.push("          </Measure>");
+            } else {
+              out.push(`          <Measure ${attrs} />`);
+            }
+          }
+          out.push("        </Measures>");
+        }
+        const links = mg.dimensionLinks ?? [];
+        if (links.length > 0) {
+          out.push("        <DimensionLinks>");
+          for (const link of links) {
+            const dim = dims.find((d) => d.id === link.dimensionId);
+            if (!dim) continue;
+            const kind = link.linkKind ?? "foreign-key";
+            if (kind === "fact") {
+              out.push(
+                `          <FactLink dimension="${escape(dim.name)}" />`,
+              );
+            } else if (kind === "reference") {
+              out.push(
+                `          <ReferenceLink dimension="${escape(dim.name)}"${attr("viaDimension", link.viaDimension)}${attr("viaAttribute", link.viaAttribute)} />`,
+              );
+            } else {
+              out.push(
+                `          <ForeignKeyLink dimension="${escape(dim.name)}" foreignKeyColumn="${escape(link.foreignKeyColumn)}" />`,
+              );
+            }
+          }
+          out.push("        </DimensionLinks>");
+        }
+        out.push("      </MeasureGroup>");
+      }
+      out.push("    </MeasureGroups>");
+    }
+    const liveCalcs = cube.calcs.filter((c) => renderCalcFormula(c).length > 0);
+    if (liveCalcs.length > 0) {
+      out.push("    <CalculatedMembers>");
+      for (const c of liveCalcs) {
+        const formula = renderCalcFormula(c);
+        out.push(
+          `      <CalculatedMember name="${escape(c.name || "Untitled")}" dimension="Measures" formula="${escape(formula)}"/>`,
+        );
+      }
+      out.push("    </CalculatedMembers>");
+    }
+    // Declarative time-intelligence metrics (yoy/pop/ytd/rolling). Only emit
+    // well-formed ones (name + measure; rolling needs a positive window) so a
+    // half-authored row never ships an invalid <TimeCalc> the engine rejects.
+    const liveTimeCalcs = (cube.timeCalcs ?? []).filter(
+      (t) =>
+        t.name.trim() &&
+        t.measure.trim() &&
+        (t.type !== "rolling" || (t.window ?? 0) > 0),
+    );
+    if (liveTimeCalcs.length > 0) {
+      out.push("    <TimeCalcs>");
+      for (const t of liveTimeCalcs) {
+        const parts = [
+          `name="${escape(t.name)}"`,
+          `type="${escape(t.type)}"`,
+          `measure="${escape(t.measure)}"`,
+        ];
+        if (t.timeDimension)
+          parts.push(`timeDimension="${escape(t.timeDimension)}"`);
+        if (t.type === "rolling") {
+          if (t.window != null)
+            parts.push(`window="${escape(String(t.window))}"`);
+          if (t.function) parts.push(`function="${escape(t.function)}"`);
+        }
+        if (t.formatString)
+          parts.push(`formatString="${escape(t.formatString)}"`);
+        out.push(`      <TimeCalc ${parts.join(" ")}/>`);
+      }
+      out.push("    </TimeCalcs>");
+    }
+    out.push("  </Cube>");
+  }
 
-	out.push('</Schema>');
-	return out.join('\n');
+  out.push("</Schema>");
+  return out.join("\n");
 }
 
 export function exportToMondrianXml(state: SchemaCanvasState): string {
-	// Cubes on the doc → emit exactly what the workbench Code-tab previews.
-	// No cubes → keep the legacy single-fact fallback so nothing regresses.
-	const cubes = (state.cubes ?? []).filter((c) => c.measureGroups.length > 0 || c.calcs.length > 0);
-	if (cubes.length > 0) {
-		return exportCubesBased(state, cubes);
-	}
-	return exportSingleFactFallback(state);
+  // Cubes on the doc → emit exactly what the workbench Code-tab previews.
+  // No cubes → keep the legacy single-fact fallback so nothing regresses.
+  const cubes = (state.cubes ?? []).filter(
+    (c) => c.measureGroups.length > 0 || c.calcs.length > 0,
+  );
+  if (cubes.length > 0) {
+    return exportCubesBased(state, cubes);
+  }
+  return exportSingleFactFallback(state);
 }
 
 function exportSingleFactFallback(state: SchemaCanvasState): string {
-	const fact = state.tables.find((t) => t.role === 'fact');
-	if (!fact) {
-		throw new Error('Cannot export: no fact table designated on the canvas.');
-	}
-	const schemaName = state.label.trim() || `Schema for ${fact.name}`;
-	const cubeName = titleCase(fact.name);
+  const fact = state.tables.find((t) => t.role === "fact");
+  if (!fact) {
+    throw new Error("Cannot export: no fact table designated on the canvas.");
+  }
+  const schemaName = state.label.trim() || `Schema for ${fact.name}`;
+  const cubeName = titleCase(fact.name);
 
-	const dims = state.dimensions?.length
-		? state.dimensions
-		: inferDimensions(fact, state.tables, state.joins);
-	const resolved = dims.map((d) => resolveDimension(d, state.tables, state.joins, fact.id));
+  const dims = state.dimensions?.length
+    ? state.dimensions
+    : inferDimensions(fact, state.tables, state.joins);
+  const resolved = dims.map((d) =>
+    resolveDimension(d, state.tables, state.joins, fact.id),
+  );
 
-	const lines: string[] = [];
-	lines.push('<?xml version="1.0" encoding="UTF-8"?>');
-	lines.push(`<Schema name="${escape(schemaName)}" metamodelVersion="4.0">`);
+  const lines: string[] = [];
+  lines.push('<?xml version="1.0" encoding="UTF-8"?>');
+  lines.push(`<Schema name="${escape(schemaName)}" metamodelVersion="4.0">`);
 
-	// ── PhysicalSchema — fact (no key) + each dim table (keyColumn=PK) ──
-	lines.push('  <PhysicalSchema>');
-	lines.push(
-		`    <Table name="${escape(fact.name)}"${fact.schema ? ` schema="${escape(fact.schema)}"` : ''} />`
-	);
-	const seen = new Set<string>([fact.id]);
-	for (const r of resolved) {
-		if (!r.table || seen.has(r.table.id)) continue;
-		seen.add(r.table.id);
-		const keyColAttr = r.pkColumn ? ` keyColumn="${escape(r.pkColumn)}"` : '';
-		lines.push(
-			`    <Table name="${escape(r.table.name)}"${r.table.schema ? ` schema="${escape(r.table.schema)}"` : ''}${keyColAttr} />`
-		);
-	}
-	lines.push('  </PhysicalSchema>');
+  // ── PhysicalSchema — fact (no key) + each dim table (keyColumn=PK) ──
+  lines.push("  <PhysicalSchema>");
+  lines.push(
+    `    <Table name="${escape(fact.name)}"${fact.schema ? ` schema="${escape(fact.schema)}"` : ""} />`,
+  );
+  const seen = new Set<string>([fact.id]);
+  for (const r of resolved) {
+    if (!r.table || seen.has(r.table.id)) continue;
+    seen.add(r.table.id);
+    const keyColAttr = r.pkColumn ? ` keyColumn="${escape(r.pkColumn)}"` : "";
+    lines.push(
+      `    <Table name="${escape(r.table.name)}"${r.table.schema ? ` schema="${escape(r.table.schema)}"` : ""}${keyColAttr} />`,
+    );
+  }
+  lines.push("  </PhysicalSchema>");
 
-	// ── Shared Dimensions ──
-	for (const r of resolved) {
-		for (const line of emitDimension(r)) lines.push(line);
-	}
+  // ── Shared Dimensions ──
+  for (const r of resolved) {
+    for (const line of emitDimension(r)) lines.push(line);
+  }
 
-	// ── Cube: dimension usages + one MeasureGroup bound to the fact ──
-	lines.push(`  <Cube name="${escape(cubeName)}">`);
-	if (resolved.length > 0) {
-		lines.push('    <Dimensions>');
-		for (const r of resolved) lines.push(`      <Dimension source="${escape(r.dim.name)}" />`);
-		lines.push('    </Dimensions>');
-	}
-	lines.push('    <MeasureGroups>');
-	lines.push(`      <MeasureGroup name="${escape(cubeName)}" table="${escape(fact.name)}">`);
-	lines.push('        <Measures>');
-	const userMeasures = state.measures ?? [];
-	if (userMeasures.length > 0) {
-		for (const m of userMeasures) {
-			const aggregator = AGGREGATOR_TO_MONDRIAN[m.aggregator] ?? 'sum';
-			lines.push(
-				`          <Measure name="${escape(m.name)}" column="${escape(m.columnName)}" aggregator="${aggregator}"${attr('formatString', m.formatString)}${percentileAttr(m)} />`
-			);
-		}
-	} else {
-		// Every cube needs at least one measure; a count is the safe default.
-		lines.push('          <Measure name="Row count" aggregator="count" formatString="#,##0" />');
-	}
-	lines.push('        </Measures>');
-	if (resolved.length > 0) {
-		lines.push('        <DimensionLinks>');
-		for (const r of resolved) {
-			const fkAttr = r.fkColumn ? ` foreignKeyColumn="${escape(r.fkColumn)}"` : '';
-			lines.push(`          <ForeignKeyLink dimension="${escape(r.dim.name)}"${fkAttr} />`);
-		}
-		lines.push('        </DimensionLinks>');
-	}
-	lines.push('      </MeasureGroup>');
-	lines.push('    </MeasureGroups>');
-	lines.push('  </Cube>');
-	lines.push('</Schema>');
-	return lines.join('\n');
+  // ── Cube: dimension usages + one MeasureGroup bound to the fact ──
+  lines.push(`  <Cube name="${escape(cubeName)}">`);
+  if (resolved.length > 0) {
+    lines.push("    <Dimensions>");
+    for (const r of resolved)
+      lines.push(`      <Dimension source="${escape(r.dim.name)}" />`);
+    lines.push("    </Dimensions>");
+  }
+  lines.push("    <MeasureGroups>");
+  lines.push(
+    `      <MeasureGroup name="${escape(cubeName)}" table="${escape(fact.name)}">`,
+  );
+  lines.push("        <Measures>");
+  const userMeasures = state.measures ?? [];
+  if (userMeasures.length > 0) {
+    for (const m of userMeasures) {
+      const aggregator = AGGREGATOR_TO_MONDRIAN[m.aggregator] ?? "sum";
+      lines.push(
+        `          <Measure name="${escape(m.name)}" column="${escape(m.columnName)}" aggregator="${aggregator}"${attr("formatString", m.formatString)}${percentileAttr(m)} />`,
+      );
+    }
+  } else {
+    // Every cube needs at least one measure; a count is the safe default.
+    lines.push(
+      '          <Measure name="Row count" aggregator="count" formatString="#,##0" />',
+    );
+  }
+  lines.push("        </Measures>");
+  if (resolved.length > 0) {
+    lines.push("        <DimensionLinks>");
+    for (const r of resolved) {
+      const fkAttr = r.fkColumn
+        ? ` foreignKeyColumn="${escape(r.fkColumn)}"`
+        : "";
+      lines.push(
+        `          <ForeignKeyLink dimension="${escape(r.dim.name)}"${fkAttr} />`,
+      );
+    }
+    lines.push("        </DimensionLinks>");
+  }
+  lines.push("      </MeasureGroup>");
+  lines.push("    </MeasureGroups>");
+  lines.push("  </Cube>");
+  lines.push("</Schema>");
+  return lines.join("\n");
 }
 
 /** Same schema as {@link exportToMondrianXml}, serialised as Mondrian 4 YAML. */
 export function exportToMondrianYaml(state: SchemaCanvasState): string {
-	return mondrianXmlToYaml(exportToMondrianXml(state));
+  return mondrianXmlToYaml(exportToMondrianXml(state));
 }

--- a/saiku-ui/src/lib/cube-designer/mondrian-export.ts
+++ b/saiku-ui/src/lib/cube-designer/mondrian-export.ts
@@ -1,0 +1,737 @@
+/**
+ * Canvas schema designer — Mondrian 4 export (saiku-cloud#1080).
+ *
+ * Translates a SchemaCanvasState into a Mondrian **4** schema — as XML or, via
+ * {@link mondrianXmlToYaml}, as M4 YAML. Saiku Cloud emits Mondrian 4 only; the
+ * legacy M3 emitter (`<Dimension foreignKey>` / `<Hierarchy primaryKey>` /
+ * inline `<Table>`) has been retired.
+ *
+ * M4 shape (matches canonical `mondrian-saiku demo/FoodMart.{mondrian.xml,yaml}`
+ * and the canvas Code-tab preview):
+ *   - `<PhysicalSchema>` lists every table; dimension tables declare their PK
+ *     (`keyColumn`), fact tables declare none.
+ *   - Shared `<Dimension key="…">` elements carry `<Attributes>` (incl. the key
+ *     attribute whose `keyColumn` is the PK) + `<Hierarchies>`.
+ *   - The `<Cube>` references dimensions by `source` and binds the fact via a
+ *     `<MeasureGroup>` whose `<DimensionLinks><ForeignKeyLink foreignKeyColumn>`
+ *     resolves to the dimension key.
+ *
+ * Caveats: one cube per canvas (v1); cube-scope calculated members are not
+ * exported yet (that state lives in the workbench, not the canvas doc).
+ */
+import { mondrianXmlToYaml } from './mondrian-xml-to-yaml.js';
+import type {
+	SchemaCanvasState,
+	SchemaCanvasTable,
+	SchemaCanvasJoin,
+	SchemaCanvasDimension,
+	SchemaCanvasHierarchy,
+	SchemaCanvasMeasure,
+	SchemaCanvasCube,
+	SchemaCanvasCalc
+} from './types.js';
+
+function escape(s: string): string {
+	return s
+		.replace(/&/g, '&amp;')
+		.replace(/</g, '&lt;')
+		.replace(/>/g, '&gt;')
+		.replace(/"/g, '&quot;');
+}
+
+function attr(name: string, value: string | undefined | null): string {
+	return value && value.length > 0 ? ` ${name}="${escape(value)}"` : '';
+}
+
+/**
+ * Render a Mondrian `<Annotations>` block for the `saiku.semantic.*` keys on an
+ * element (measure / level / dimension). Returns [] when there's nothing to
+ * emit — so a callable can keep the element self-closing. Keys are stored bare
+ * (e.g. `description`, `pii`) and namespaced here.
+ */
+function annotationLines(
+	annotations: Record<string, string> | undefined,
+	indent: string
+): string[] {
+	if (!annotations) return [];
+	const entries = Object.entries(annotations).filter(
+		([, v]) => v != null && String(v).trim() !== ''
+	);
+	if (entries.length === 0) return [];
+	const out = [`${indent}<Annotations>`];
+	for (const [k, v] of entries) {
+		out.push(
+			`${indent}  <Annotation name="saiku.semantic.${escape(k)}">${escape(String(v))}</Annotation>`
+		);
+	}
+	out.push(`${indent}</Annotations>`);
+	return out;
+}
+
+function titleCase(s: string): string {
+	return s
+		.split(/[._]/)
+		.map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+		.join(' ');
+}
+
+const AGGREGATOR_TO_MONDRIAN: Record<SchemaCanvasMeasure['aggregator'], string> = {
+	sum: 'sum',
+	count: 'count',
+	avg: 'avg',
+	min: 'min',
+	max: 'max',
+	'distinct-count': 'distinct-count',
+	// Non-additive leaf aggregators (mondrian-saiku #104) — pushed to SQL as
+	// PERCENTILE_CONT. `median` is the implicit 50th percentile; `percentile`
+	// carries a `percentile="0..100"` attribute (emitted below).
+	median: 'median',
+	percentile: 'percentile'
+};
+
+/**
+ * Render the `percentile="N"` attribute for a percentile measure. Median needs
+ * none (it's the implicit 50th). Omitted when not a percentile aggregator or
+ * when no value is set — Mondrian defaults percentile to 50.
+ */
+function percentileAttr(m: SchemaCanvasMeasure | undefined): string {
+	if (!m || m.aggregator !== 'percentile') return '';
+	const v = m.percentile;
+	if (v === null || v === undefined) return '';
+	return ` percentile="${escape(String(v))}"`;
+}
+
+/** Per-dimension resolution: the tables + columns M4 needs to wire it up. */
+interface DimResolution {
+	dim: SchemaCanvasDimension;
+	table: SchemaCanvasTable | undefined;
+	/** dimension-side PK column (target of the fact's FK). */
+	pkColumn: string | null;
+	/** fact-side FK column. */
+	fkColumn: string | null;
+	/** name of the key attribute (referenced by `<Dimension key=...>`). */
+	keyAttrName: string | null;
+}
+
+function resolveDimension(
+	dim: SchemaCanvasDimension,
+	tables: SchemaCanvasTable[],
+	joins: SchemaCanvasJoin[],
+	factTableId: string
+): DimResolution {
+	const table = tables.find((t) => t.id === (dim.primaryKeyTableId ?? dim.sourceTableId));
+
+	// FK (fact side) + PK (dim side): explicit dim fields win, else derive from
+	// the canvas join between the fact and this dim's table.
+	let fkColumn = dim.foreignKey ?? null;
+	let pkColumn = resolvePkColumn(dim);
+	if ((!fkColumn || !pkColumn) && table) {
+		for (const j of joins) {
+			if (j.sourceTableId === factTableId && j.targetTableId === table.id) {
+				fkColumn = fkColumn ?? j.sourceColumnName;
+				pkColumn = pkColumn ?? j.targetColumnName;
+				break;
+			}
+			if (j.targetTableId === factTableId && j.sourceTableId === table.id) {
+				fkColumn = fkColumn ?? j.targetColumnName;
+				pkColumn = pkColumn ?? j.sourceColumnName;
+				break;
+			}
+		}
+	}
+
+	// Key attribute: reuse an attribute already bound to the PK column, else a
+	// synthetic one gets emitted (see emitDimension).
+	const existing = pkColumn
+		? (dim.attributes ?? []).find((a) => a.columnName === pkColumn)
+		: undefined;
+	const keyAttrName = pkColumn
+		? (existing?.name ?? existing?.columnName ?? `${dim.name} Key`)
+		: null;
+
+	return { dim, table, pkColumn, fkColumn, keyAttrName };
+}
+
+/** `dim.primaryKey` stores an attribute's logical NAME; resolve it to a column. */
+function resolvePkColumn(dim: SchemaCanvasDimension): string | null {
+	if (!dim.primaryKey) return null;
+	const byName = (dim.attributes ?? []).find((a) => (a.name ?? a.columnName) === dim.primaryKey);
+	return byName?.columnName ?? dim.primaryKey;
+}
+
+interface SynthAttr {
+	name: string;
+	keyColumn?: string;
+	keyColumns?: string[];
+	isKey?: boolean;
+}
+
+function emitDimension(r: DimResolution): string[] {
+	const { dim, table, pkColumn, keyAttrName } = r;
+	const lines: string[] = [];
+
+	// Build the full attribute set. M4 <Level attribute="X"/> references an
+	// attribute by NAME, so every hierarchy level needs a backing attribute —
+	// synthesise one for any level (or the key) not already declared.
+	const attrs = new Map<string, SynthAttr>();
+	const explicit = dim.attributes ?? [];
+	if (keyAttrName && pkColumn && !explicit.some((a) => a.columnName === pkColumn)) {
+		attrs.set(keyAttrName, { name: keyAttrName, keyColumn: pkColumn, isKey: true });
+	}
+	for (const a of explicit) {
+		const name = a.name ?? a.columnName;
+		attrs.set(name, {
+			name,
+			keyColumn: a.keyColumns && a.keyColumns.length > 1 ? undefined : a.columnName,
+			keyColumns: a.keyColumns && a.keyColumns.length > 1 ? a.keyColumns : undefined
+		});
+	}
+	// Resolve each hierarchy's levels to attribute names, synthesising as needed.
+	// Carry the level's caption alongside so the <Level> emit can round-trip it.
+	const hierarchyLevels: {
+		h: SchemaCanvasHierarchy;
+		levels: { name: string; caption?: string }[];
+	}[] = [];
+	for (const h of dim.hierarchies) {
+		const levels: { name: string; caption?: string }[] = [];
+		for (const lvl of h.levels) {
+			const fromCol = explicit.find((a) => a.columnName === lvl.columnName);
+			const name = fromCol?.name ?? fromCol?.columnName ?? lvl.name;
+			if (!attrs.has(name)) attrs.set(name, { name, keyColumn: lvl.columnName });
+			levels.push({ name, caption: lvl.caption });
+		}
+		hierarchyLevels.push({ h, levels });
+	}
+
+	const tableAttr = table ? ` table="${escape(table.name)}"` : '';
+	const keyAttr = keyAttrName ? ` key="${escape(keyAttrName)}"` : '';
+	// Mondrian 4 spells a time dimension `type="TIME"` (M3 used "TimeDimension").
+	const typeAttr = dim.dimensionType === 'Time' ? ' type="TIME"' : '';
+	lines.push(
+		`  <Dimension name="${escape(dim.name)}"${tableAttr}${keyAttr}${typeAttr}` +
+			`${attr('caption', dim.caption)}${attr('description', dim.description)}>`
+	);
+
+	// M4 carries a level's levelType on its <Attribute>; map marked columns.
+	const legacyLevelTypeByColumn = new Map<string, string>();
+	for (const h of dim.hierarchies) {
+		for (const lvl of h.levels) {
+			if (lvl.levelType) legacyLevelTypeByColumn.set(lvl.columnName, lvl.levelType);
+		}
+	}
+
+	if (attrs.size > 0) {
+		lines.push('    <Attributes>');
+		for (const a of attrs.values()) {
+			const hasHier = a.isKey ? ' hasHierarchy="false"' : '';
+			const lt = a.keyColumn ? legacyLevelTypeByColumn.get(a.keyColumn) : undefined;
+			const ltAttr = lt ? ` levelType="${escape(lt)}"` : '';
+			if (a.keyColumns) {
+				lines.push(`      <Attribute name="${escape(a.name)}"${hasHier}>`);
+				lines.push('        <Key>');
+				for (const c of a.keyColumns) lines.push(`          <Column name="${escape(c)}"/>`);
+				lines.push('        </Key>');
+				lines.push('      </Attribute>');
+			} else {
+				lines.push(
+					`      <Attribute name="${escape(a.name)}" keyColumn="${escape(a.keyColumn ?? a.name)}"${hasHier}${ltAttr} />`
+				);
+			}
+		}
+		lines.push('    </Attributes>');
+	}
+
+	// Hierarchies — emit authored ones; if none, synthesise a single hierarchy
+	// over the non-key attributes so the dimension is sliceable.
+	if (hierarchyLevels.length > 0) {
+		lines.push('    <Hierarchies>');
+		for (const { h, levels } of hierarchyLevels) {
+			lines.push(
+				`      <Hierarchy name="${escape(h.name)}" hasAll="${h.hasAll ? 'true' : 'false'}"` +
+					`${attr('allMemberName', h.allMemberName)}${attr('defaultMember', h.defaultMember)}>`
+			);
+			for (const l of levels)
+				lines.push(`        <Level attribute="${escape(l.name)}"${attr('caption', l.caption)} />`);
+			lines.push('      </Hierarchy>');
+		}
+		lines.push('    </Hierarchies>');
+	} else {
+		const levelNames = [...attrs.values()]
+			.filter((a) => !a.isKey && a.name !== keyAttrName)
+			.map((a) => a.name);
+		const levels = levelNames.length > 0 ? levelNames : keyAttrName ? [keyAttrName] : [];
+		if (levels.length > 0) {
+			lines.push('    <Hierarchies>');
+			lines.push(`      <Hierarchy name="${escape(dim.name)}" hasAll="true">`);
+			for (const n of levels) lines.push(`        <Level attribute="${escape(n)}" />`);
+			lines.push('      </Hierarchy>');
+			lines.push('    </Hierarchies>');
+		}
+	}
+	lines.push('  </Dimension>');
+	return lines;
+}
+
+/**
+ * Fallback dimensions for a canvas where the workbench hasn't curated any —
+ * one per non-fact table joined to the fact. Emitted in the SAME M4 shape.
+ */
+function inferDimensions(
+	fact: SchemaCanvasTable,
+	tables: SchemaCanvasTable[],
+	joins: SchemaCanvasJoin[]
+): SchemaCanvasDimension[] {
+	const dims: SchemaCanvasDimension[] = [];
+	for (const t of tables) {
+		if (t.id === fact.id) continue;
+		const joined = joins.some(
+			(j) =>
+				(j.sourceTableId === fact.id && j.targetTableId === t.id) ||
+				(j.targetTableId === fact.id && j.sourceTableId === t.id)
+		);
+		if (!joined) continue;
+		dims.push({
+			id: `inferred-${t.id}`,
+			name: titleCase(t.name),
+			sourceTableId: t.id,
+			primaryKeyTableId: t.id,
+			attributes: t.columns.map((c) => ({ tableId: t.id, columnName: c.name })),
+			hierarchies: []
+		} as SchemaCanvasDimension);
+	}
+	return dims;
+}
+
+/**
+ * Render a calculated member's Mondrian formula.  Mirrors the workbench's
+ * `renderCalcTokens` / `calcMode` so the exported `<CalculatedMember>`
+ * matches the Code-tab preview exactly.
+ */
+function renderCalcFormula(c: SchemaCanvasCalc): string {
+	const mode = c.mode ?? 'build';
+	if (mode === 'expression') return (c.formula ?? '').trim();
+	return c.tokens
+		.map((t) => (t.kind === 'measure' ? `[${t.name ?? ''}]` : ` ${t.op ?? '+'} `))
+		.join('')
+		.replace(/\s+/g, ' ')
+		.trim();
+}
+
+/**
+ * Cubes-based export (matches `workbenchToMondrianPreview`): emits one
+ * `<Cube>` per `state.cubes[]` entry, each with `<Dimensions>` refs, one
+ * `<MeasureGroup>` per group (measures resolved from `state.measures`,
+ * `<DimensionLinks>` from the group's `dimensionLinks`) and cube-scope
+ * `<CalculatedMembers>`.  Used whenever the doc carries cubes; otherwise
+ * {@link exportSingleFactFallback} keeps the legacy single-fact behaviour.
+ */
+function exportCubesBased(state: SchemaCanvasState, cubes: SchemaCanvasCube[]): string {
+	const tables = state.tables;
+	const dims = state.dimensions ?? [];
+	const measures = state.measures ?? [];
+	const schemaName = state.label.trim() || 'Untitled';
+
+	// Dimension tables — one physical <Table> each (keyColumn = its PK).
+	const dimTables = new Map<string, SchemaCanvasTable>();
+	for (const d of dims) {
+		const dSrc = d.sourceTableId ?? d.primaryKeyTableId;
+		if (!dSrc) continue;
+		const t = tables.find((x) => x.id === dSrc);
+		if (t) dimTables.set(t.id, t);
+	}
+
+	// Per-cube fact fallback: the first MG carrying a factTableId.
+	const legacyFact = tables.find((t) => t.role === 'fact') ?? null;
+	const cubeFactOf = (c: SchemaCanvasCube): string | null =>
+		c.measureGroups.find((mg) => mg.factTableId)?.factTableId ?? legacyFact?.id ?? null;
+
+	// Every fact table referenced by any cube / measure group.
+	const factTables = new Map<string, SchemaCanvasTable>();
+	if (legacyFact) factTables.set(legacyFact.id, legacyFact);
+	for (const c of cubes) {
+		const cf = cubeFactOf(c);
+		if (cf) {
+			const t = tables.find((x) => x.id === cf);
+			if (t) factTables.set(t.id, t);
+		}
+		for (const mg of c.measureGroups) {
+			if (mg.factTableId) {
+				const t = tables.find((x) => x.id === mg.factTableId);
+				if (t) factTables.set(t.id, t);
+			}
+		}
+	}
+
+	// Dimension-table PK column (#1080) — used by BOTH the PhysicalSchema
+	// keyColumn and the <Dimension key>.  Prefer explicit dim.primaryKey,
+	// else the dim-side column of a join to a fact, else an id-like guess.
+	const dimTablePk = new Map<string, string>();
+	for (const dim of dims) {
+		const bt = tables.find((t) => t.id === (dim.sourceTableId ?? dim.primaryKeyTableId));
+		if (!bt || dimTablePk.has(bt.id)) continue;
+		let pk: string | null = dim.primaryKey ?? null;
+		if (!pk) {
+			for (const j of state.joins) {
+				if (j.sourceTableId === bt.id && factTables.has(j.targetTableId)) {
+					pk = j.sourceColumnName;
+					break;
+				}
+				if (j.targetTableId === bt.id && factTables.has(j.sourceTableId)) {
+					pk = j.targetColumnName;
+					break;
+				}
+			}
+		}
+		if (!pk) {
+			const cols = bt.columns ?? [];
+			const name = bt.name.toLowerCase();
+			const idCol =
+				cols.find((c) => c.name.toLowerCase() === `${name}_id`) ??
+				cols.find((c) => c.name.toLowerCase() === 'id') ??
+				cols.find((c) => /_id$/i.test(c.name));
+			if (idCol) pk = idCol.name;
+		}
+		if (pk) dimTablePk.set(bt.id, pk);
+	}
+
+	const out: string[] = [];
+	out.push('<?xml version="1.0" encoding="UTF-8"?>');
+	out.push(`<Schema name="${escape(schemaName)}" metamodelVersion="4.0">`);
+
+	// ── PhysicalSchema — facts (no key) + dim tables (keyColumn = PK) ──
+	out.push('  <PhysicalSchema>');
+	for (const ft of factTables.values()) {
+		out.push(
+			`    <Table name="${escape(ft.name)}"${ft.schema ? ` schema="${escape(ft.schema)}"` : ''} />`
+		);
+	}
+	for (const t of dimTables.values()) {
+		if (factTables.has(t.id)) continue;
+		const pk = dimTablePk.get(t.id);
+		const keyColAttr = pk ? ` keyColumn="${escape(pk)}"` : '';
+		out.push(
+			`    <Table name="${escape(t.name)}"${t.schema ? ` schema="${escape(t.schema)}"` : ''}${keyColAttr} />`
+		);
+	}
+	out.push('  </PhysicalSchema>');
+
+	// ── Shared Dimensions ──
+	for (const dim of dims) {
+		const boundTable = tables.find((t) => t.id === (dim.sourceTableId ?? dim.primaryKeyTableId));
+		const tableAttr = boundTable ? ` table="${escape(boundTable.name)}"` : '';
+		// Mondrian 4 spells a time dimension `type="TIME"` (M3 used
+		// "TimeDimension"). Only Time has a defined M4 dimension type.
+		const typeAttr =
+			dim.dimensionType === 'Time'
+				? ' type="TIME"'
+				: dim.dimensionType && dim.dimensionType !== 'Standard'
+					? ` type="${dim.dimensionType}Dimension"`
+					: '';
+		const hangerAttr = dim.hanger ? ' hanger="true"' : '';
+		// M4 carries a level's `levelType` on its <Attribute>, not the <Level>.
+		// Map each column that a hierarchy level marks (TimeYears/…) so the
+		// attribute below can inherit it — drives time intelligence.
+		const levelTypeByColumn = new Map<string, string>();
+		for (const h of dim.hierarchies) {
+			for (const lvl of h.levels) {
+				if (lvl.levelType) levelTypeByColumn.set(lvl.columnName, lvl.levelType);
+			}
+		}
+		const levelTypeAttr = (columnName: string): string => {
+			const lt = levelTypeByColumn.get(columnName);
+			return lt ? ` levelType="${escape(lt)}"` : '';
+		};
+		// Level `saiku.semantic.*` annotations ride on the level's <Attribute>,
+		// keyed by column (like levelType).
+		const annotationsByColumn = new Map<string, Record<string, string>>();
+		for (const h of dim.hierarchies) {
+			for (const lvl of h.levels) {
+				if (lvl.annotations) annotationsByColumn.set(lvl.columnName, lvl.annotations);
+			}
+		}
+		const A = dim.attributes ?? [];
+		// M4 `<Level attribute="X">` references an <Attribute> by its NAME, not by
+		// column. Resolve each level's column to the backing attribute's logical
+		// name so renaming an attribute cascades to every level that uses it
+		// (inspector #959). Falls back to the column name when unbound.
+		const attrNameByColumn = new Map<string, string>();
+		for (const a of A) attrNameByColumn.set(a.columnName, a.name ?? a.columnName);
+		const levelAttrName = (columnName: string): string =>
+			attrNameByColumn.get(columnName) ?? columnName;
+		const pkColumn: string | null = boundTable ? (dimTablePk.get(boundTable.id) ?? null) : null;
+		const existingKeyAttr = pkColumn ? A.find((a) => a.columnName === pkColumn) : undefined;
+		const keyAttrName = pkColumn
+			? (existingKeyAttr?.name ?? existingKeyAttr?.columnName ?? `${dim.name} Key`)
+			: null;
+		const needSyntheticKey = !!pkColumn && !existingKeyAttr && !dim.hanger;
+		const keyAttr = keyAttrName && !dim.hanger ? ` key="${escape(keyAttrName)}"` : '';
+		out.push(
+			`  <Dimension name="${escape(dim.name)}"${tableAttr}${keyAttr}${typeAttr}${hangerAttr}` +
+				`${attr('caption', dim.caption)}${attr('description', dim.description)}>`
+		);
+		out.push(...annotationLines(dim.annotations, '    '));
+		if (A.length > 0 || needSyntheticKey) {
+			out.push('    <Attributes>');
+			if (needSyntheticKey) {
+				out.push(
+					`      <Attribute name="${escape(keyAttrName!)}" keyColumn="${escape(pkColumn!)}" hasHierarchy="false" />`
+				);
+			}
+			for (const a of A) {
+				const attrLabel = a.name ?? a.columnName;
+				const lt = levelTypeAttr(a.columnName);
+				const anns = annotationLines(annotationsByColumn.get(a.columnName), '        ');
+				// Optional M4 attribute overrides (inspector #959): display / sort /
+				// caption columns + long-form description. Mirror the gateway's
+				// MondrianXmlEmitter spellings.
+				const overrides =
+					attr('nameColumn', a.nameColumn) +
+					attr('captionColumn', a.captionColumn) +
+					attr('orderByColumn', a.orderByColumn) +
+					attr('description', a.description);
+				if (a.keyColumns && a.keyColumns.length > 1) {
+					out.push(`      <Attribute name="${escape(attrLabel)}"${lt}${overrides}>`);
+					out.push('        <Key>');
+					for (const c of a.keyColumns) out.push(`          <Column name="${escape(c)}"/>`);
+					out.push('        </Key>');
+					out.push(...anns);
+					out.push('      </Attribute>');
+				} else if (anns.length > 0) {
+					out.push(
+						`      <Attribute name="${escape(attrLabel)}" keyColumn="${escape(a.columnName)}"${lt}${overrides}>`
+					);
+					out.push(...anns);
+					out.push('      </Attribute>');
+				} else {
+					out.push(
+						`      <Attribute name="${escape(attrLabel)}" keyColumn="${escape(a.columnName)}"${lt}${overrides} />`
+					);
+				}
+			}
+			out.push('    </Attributes>');
+		}
+		if (dim.hierarchies.length > 0) {
+			out.push('    <Hierarchies>');
+			for (const hier of dim.hierarchies) {
+				out.push(
+					`      <Hierarchy name="${escape(hier.name)}" hasAll="${hier.hasAll ? 'true' : 'false'}"` +
+						`${attr('allMemberName', hier.allMemberName)}${attr('defaultMember', hier.defaultMember)}` +
+						`${attr('caption', hier.caption)}${attr('description', hier.description)}>`
+				);
+				for (let li = 0; li < hier.levels.length; li++) {
+					const lvl = hier.levels[li];
+					if (li === 0 && hier.closure) {
+						out.push(
+							`        <Level attribute="${escape(levelAttrName(lvl.columnName))}"${attr('caption', lvl.caption)}>`
+						);
+						const cl = hier.closure;
+						out.push(
+							`          <Closure table="${escape(cl.table)}" parentColumn="${escape(cl.parentColumn)}" childColumn="${escape(cl.childColumn)}"/>`
+						);
+						out.push('        </Level>');
+					} else {
+						out.push(
+							`        <Level attribute="${escape(levelAttrName(lvl.columnName))}"${attr('caption', lvl.caption)} />`
+						);
+					}
+				}
+				out.push('      </Hierarchy>');
+			}
+			out.push('    </Hierarchies>');
+		}
+		out.push('  </Dimension>');
+	}
+
+	// ── Cubes ──
+	for (const cube of cubes) {
+		const cubeFact = cubeFactOf(cube);
+		out.push(`  <Cube name="${escape(cube.name || 'Untitled')}">`);
+		if (dims.length > 0) {
+			out.push('    <Dimensions>');
+			for (const dim of dims) out.push(`      <Dimension source="${escape(dim.name)}" />`);
+			out.push('    </Dimensions>');
+		}
+		if (cube.measureGroups.length > 0) {
+			out.push('    <MeasureGroups>');
+			for (const mg of cube.measureGroups) {
+				const mgFactId = mg.factTableId ?? cubeFact;
+				const mgFact = mgFactId ? tables.find((t) => t.id === mgFactId) : null;
+				if (!mgFact) continue;
+				out.push(`      <MeasureGroup name="${escape(mg.name)}" table="${escape(mgFact.name)}">`);
+				if (mg.measureColumns.length > 0) {
+					out.push('        <Measures>');
+					for (const col of mg.measureColumns) {
+						const m = measures.find((mm) => mm.tableId === mgFact.id && mm.columnName === col);
+						const aggregator = m ? (AGGREGATOR_TO_MONDRIAN[m.aggregator] ?? 'sum') : 'sum';
+						const captionRaw = mg.measureCaptions?.[col]?.trim();
+						const captionAttr =
+							captionRaw && captionRaw !== col ? ` caption="${escape(captionRaw)}"` : '';
+						const attrs = `name="${escape(col)}" column="${escape(col)}" aggregator="${aggregator}"${captionAttr}${attr('formatString', m?.formatString)}${percentileAttr(m)}`;
+						const anns = annotationLines(m?.annotations, '            ');
+						if (anns.length > 0) {
+							out.push(`          <Measure ${attrs}>`);
+							out.push(...anns);
+							out.push('          </Measure>');
+						} else {
+							out.push(`          <Measure ${attrs} />`);
+						}
+					}
+					out.push('        </Measures>');
+				}
+				const links = mg.dimensionLinks ?? [];
+				if (links.length > 0) {
+					out.push('        <DimensionLinks>');
+					for (const link of links) {
+						const dim = dims.find((d) => d.id === link.dimensionId);
+						if (!dim) continue;
+						const kind = link.linkKind ?? 'foreign-key';
+						if (kind === 'fact') {
+							out.push(`          <FactLink dimension="${escape(dim.name)}" />`);
+						} else if (kind === 'reference') {
+							out.push(
+								`          <ReferenceLink dimension="${escape(dim.name)}"${attr('viaDimension', link.viaDimension)}${attr('viaAttribute', link.viaAttribute)} />`
+							);
+						} else {
+							out.push(
+								`          <ForeignKeyLink dimension="${escape(dim.name)}" foreignKeyColumn="${escape(link.foreignKeyColumn)}" />`
+							);
+						}
+					}
+					out.push('        </DimensionLinks>');
+				}
+				out.push('      </MeasureGroup>');
+			}
+			out.push('    </MeasureGroups>');
+		}
+		const liveCalcs = cube.calcs.filter((c) => renderCalcFormula(c).length > 0);
+		if (liveCalcs.length > 0) {
+			out.push('    <CalculatedMembers>');
+			for (const c of liveCalcs) {
+				const formula = renderCalcFormula(c);
+				out.push(
+					`      <CalculatedMember name="${escape(c.name || 'Untitled')}" dimension="Measures" formula="${escape(formula)}"/>`
+				);
+			}
+			out.push('    </CalculatedMembers>');
+		}
+		// Declarative time-intelligence metrics (yoy/pop/ytd/rolling). Only emit
+		// well-formed ones (name + measure; rolling needs a positive window) so a
+		// half-authored row never ships an invalid <TimeCalc> the engine rejects.
+		const liveTimeCalcs = (cube.timeCalcs ?? []).filter(
+			(t) => t.name.trim() && t.measure.trim() && (t.type !== 'rolling' || (t.window ?? 0) > 0)
+		);
+		if (liveTimeCalcs.length > 0) {
+			out.push('    <TimeCalcs>');
+			for (const t of liveTimeCalcs) {
+				const parts = [
+					`name="${escape(t.name)}"`,
+					`type="${escape(t.type)}"`,
+					`measure="${escape(t.measure)}"`
+				];
+				if (t.timeDimension) parts.push(`timeDimension="${escape(t.timeDimension)}"`);
+				if (t.type === 'rolling') {
+					if (t.window != null) parts.push(`window="${escape(String(t.window))}"`);
+					if (t.function) parts.push(`function="${escape(t.function)}"`);
+				}
+				if (t.formatString) parts.push(`formatString="${escape(t.formatString)}"`);
+				out.push(`      <TimeCalc ${parts.join(' ')}/>`);
+			}
+			out.push('    </TimeCalcs>');
+		}
+		out.push('  </Cube>');
+	}
+
+	out.push('</Schema>');
+	return out.join('\n');
+}
+
+export function exportToMondrianXml(state: SchemaCanvasState): string {
+	// Cubes on the doc → emit exactly what the workbench Code-tab previews.
+	// No cubes → keep the legacy single-fact fallback so nothing regresses.
+	const cubes = (state.cubes ?? []).filter((c) => c.measureGroups.length > 0 || c.calcs.length > 0);
+	if (cubes.length > 0) {
+		return exportCubesBased(state, cubes);
+	}
+	return exportSingleFactFallback(state);
+}
+
+function exportSingleFactFallback(state: SchemaCanvasState): string {
+	const fact = state.tables.find((t) => t.role === 'fact');
+	if (!fact) {
+		throw new Error('Cannot export: no fact table designated on the canvas.');
+	}
+	const schemaName = state.label.trim() || `Schema for ${fact.name}`;
+	const cubeName = titleCase(fact.name);
+
+	const dims = state.dimensions?.length
+		? state.dimensions
+		: inferDimensions(fact, state.tables, state.joins);
+	const resolved = dims.map((d) => resolveDimension(d, state.tables, state.joins, fact.id));
+
+	const lines: string[] = [];
+	lines.push('<?xml version="1.0" encoding="UTF-8"?>');
+	lines.push(`<Schema name="${escape(schemaName)}" metamodelVersion="4.0">`);
+
+	// ── PhysicalSchema — fact (no key) + each dim table (keyColumn=PK) ──
+	lines.push('  <PhysicalSchema>');
+	lines.push(
+		`    <Table name="${escape(fact.name)}"${fact.schema ? ` schema="${escape(fact.schema)}"` : ''} />`
+	);
+	const seen = new Set<string>([fact.id]);
+	for (const r of resolved) {
+		if (!r.table || seen.has(r.table.id)) continue;
+		seen.add(r.table.id);
+		const keyColAttr = r.pkColumn ? ` keyColumn="${escape(r.pkColumn)}"` : '';
+		lines.push(
+			`    <Table name="${escape(r.table.name)}"${r.table.schema ? ` schema="${escape(r.table.schema)}"` : ''}${keyColAttr} />`
+		);
+	}
+	lines.push('  </PhysicalSchema>');
+
+	// ── Shared Dimensions ──
+	for (const r of resolved) {
+		for (const line of emitDimension(r)) lines.push(line);
+	}
+
+	// ── Cube: dimension usages + one MeasureGroup bound to the fact ──
+	lines.push(`  <Cube name="${escape(cubeName)}">`);
+	if (resolved.length > 0) {
+		lines.push('    <Dimensions>');
+		for (const r of resolved) lines.push(`      <Dimension source="${escape(r.dim.name)}" />`);
+		lines.push('    </Dimensions>');
+	}
+	lines.push('    <MeasureGroups>');
+	lines.push(`      <MeasureGroup name="${escape(cubeName)}" table="${escape(fact.name)}">`);
+	lines.push('        <Measures>');
+	const userMeasures = state.measures ?? [];
+	if (userMeasures.length > 0) {
+		for (const m of userMeasures) {
+			const aggregator = AGGREGATOR_TO_MONDRIAN[m.aggregator] ?? 'sum';
+			lines.push(
+				`          <Measure name="${escape(m.name)}" column="${escape(m.columnName)}" aggregator="${aggregator}"${attr('formatString', m.formatString)}${percentileAttr(m)} />`
+			);
+		}
+	} else {
+		// Every cube needs at least one measure; a count is the safe default.
+		lines.push('          <Measure name="Row count" aggregator="count" formatString="#,##0" />');
+	}
+	lines.push('        </Measures>');
+	if (resolved.length > 0) {
+		lines.push('        <DimensionLinks>');
+		for (const r of resolved) {
+			const fkAttr = r.fkColumn ? ` foreignKeyColumn="${escape(r.fkColumn)}"` : '';
+			lines.push(`          <ForeignKeyLink dimension="${escape(r.dim.name)}"${fkAttr} />`);
+		}
+		lines.push('        </DimensionLinks>');
+	}
+	lines.push('      </MeasureGroup>');
+	lines.push('    </MeasureGroups>');
+	lines.push('  </Cube>');
+	lines.push('</Schema>');
+	return lines.join('\n');
+}
+
+/** Same schema as {@link exportToMondrianXml}, serialised as Mondrian 4 YAML. */
+export function exportToMondrianYaml(state: SchemaCanvasState): string {
+	return mondrianXmlToYaml(exportToMondrianXml(state));
+}

--- a/saiku-ui/src/lib/cube-designer/mondrian-import.m4-templates.test.ts
+++ b/saiku-ui/src/lib/cube-designer/mondrian-import.m4-templates.test.ts
@@ -1,6 +1,6 @@
 // @vitest-environment happy-dom
-import { describe, expect, it } from 'vitest';
-import { importFromMondrianXml } from './mondrian-import';
+import { describe, expect, it } from "vitest";
+import { importFromMondrianXml } from "./mondrian-import";
 
 /**
  * Self-contained M4 import round-trip guards for the designer's importer.
@@ -9,8 +9,8 @@ import { importFromMondrianXml } from './mondrian-import';
  * there, against that repo's cube-library.)
  */
 
-describe('M4 import round-trips a Time dimension + levelType', () => {
-	const XML = `<Schema name="t" metamodelVersion="4.0">
+describe("M4 import round-trips a Time dimension + levelType", () => {
+  const XML = `<Schema name="t" metamodelVersion="4.0">
   <PhysicalSchema>
     <Table name="dim_date"><Key name="k"><Column name="date_key"/></Key></Table>
     <Table name="fact"/>
@@ -33,20 +33,23 @@ describe('M4 import round-trips a Time dimension + levelType', () => {
   </Cube>
 </Schema>`;
 
-	it('reads type="TIME" as a Time dimension and levelType back onto the level', () => {
-		const res = importFromMondrianXml(XML, { connectionId: 'test', sourceTables: [] });
-		const dim = res.state.dimensions?.find((d) => d.name === 'Calendar');
-		expect(dim?.dimensionType).toBe('Time');
-		const year = dim?.hierarchies[0]?.levels.find((l) => l.name === 'Year');
-		expect(year?.levelType).toBe('TimeYears');
-		// A non-time level carries no levelType.
-		const date = dim?.hierarchies[0]?.levels.find((l) => l.name === 'Date');
-		expect(date?.levelType).toBeUndefined();
-	});
+  it('reads type="TIME" as a Time dimension and levelType back onto the level', () => {
+    const res = importFromMondrianXml(XML, {
+      connectionId: "test",
+      sourceTables: [],
+    });
+    const dim = res.state.dimensions?.find((d) => d.name === "Calendar");
+    expect(dim?.dimensionType).toBe("Time");
+    const year = dim?.hierarchies[0]?.levels.find((l) => l.name === "Year");
+    expect(year?.levelType).toBe("TimeYears");
+    // A non-time level carries no levelType.
+    const date = dim?.hierarchies[0]?.levels.find((l) => l.name === "Date");
+    expect(date?.levelType).toBeUndefined();
+  });
 });
 
-describe('M4 import reads <TimeCalcs> back onto the cube', () => {
-	const XML = `<Schema name="t" metamodelVersion="4.0">
+describe("M4 import reads <TimeCalcs> back onto the cube", () => {
+  const XML = `<Schema name="t" metamodelVersion="4.0">
   <PhysicalSchema><Table name="fact"/></PhysicalSchema>
   <Cube name="Revenue">
     <MeasureGroups>
@@ -61,25 +64,33 @@ describe('M4 import reads <TimeCalcs> back onto the cube', () => {
   </Cube>
 </Schema>`;
 
-	it('parses yoy + rolling TimeCalcs with their attributes', () => {
-		const res = importFromMondrianXml(XML, { connectionId: 'test', sourceTables: [] });
-		const cube = res.workbenchCubes.find((c) => c.name === 'Revenue');
-		const tcs = cube?.timeCalcs ?? [];
-		expect(tcs.length).toBe(2);
-		const yoy = tcs.find((t) => t.name === 'Revenue YoY');
-		expect(yoy).toMatchObject({
-			type: 'yoy',
-			measure: 'Revenue',
-			timeDimension: 'Calendar',
-			formatString: '0.0%'
-		});
-		const roll = tcs.find((t) => t.name === 'Revenue R3');
-		expect(roll).toMatchObject({ type: 'rolling', measure: 'Revenue', window: 3, function: 'avg' });
-	});
+  it("parses yoy + rolling TimeCalcs with their attributes", () => {
+    const res = importFromMondrianXml(XML, {
+      connectionId: "test",
+      sourceTables: [],
+    });
+    const cube = res.workbenchCubes.find((c) => c.name === "Revenue");
+    const tcs = cube?.timeCalcs ?? [];
+    expect(tcs.length).toBe(2);
+    const yoy = tcs.find((t) => t.name === "Revenue YoY");
+    expect(yoy).toMatchObject({
+      type: "yoy",
+      measure: "Revenue",
+      timeDimension: "Calendar",
+      formatString: "0.0%",
+    });
+    const roll = tcs.find((t) => t.name === "Revenue R3");
+    expect(roll).toMatchObject({
+      type: "rolling",
+      measure: "Revenue",
+      window: 3,
+      function: "avg",
+    });
+  });
 });
 
-describe('M4 import reads saiku.semantic.* annotations back', () => {
-	const XML = `<Schema name="t" metamodelVersion="4.0">
+describe("M4 import reads saiku.semantic.* annotations back", () => {
+  const XML = `<Schema name="t" metamodelVersion="4.0">
   <PhysicalSchema>
     <Table name="dim_c"><Key name="k"><Column name="cid"/></Key></Table>
     <Table name="fact"/>
@@ -111,20 +122,23 @@ describe('M4 import reads saiku.semantic.* annotations back', () => {
   </Cube>
 </Schema>`;
 
-	it('round-trips dimension, level, and measure annotations', () => {
-		const res = importFromMondrianXml(XML, { connectionId: 'test', sourceTables: [] });
-		const dim = res.state.dimensions?.find((d) => d.name === 'Customer');
-		expect(dim?.annotations?.synonyms).toBe('client, account');
-		const nameLvl = dim?.hierarchies[0]?.levels.find((l) => l.name === 'Name');
-		expect(nameLvl?.annotations?.pii).toBe('true');
-		expect(nameLvl?.annotations?.cardinality).toBe('high');
-		const rev = res.state.measures?.find((m) => m.name === 'Rev');
-		expect(rev?.annotations?.unit).toBe('USD');
-	});
+  it("round-trips dimension, level, and measure annotations", () => {
+    const res = importFromMondrianXml(XML, {
+      connectionId: "test",
+      sourceTables: [],
+    });
+    const dim = res.state.dimensions?.find((d) => d.name === "Customer");
+    expect(dim?.annotations?.synonyms).toBe("client, account");
+    const nameLvl = dim?.hierarchies[0]?.levels.find((l) => l.name === "Name");
+    expect(nameLvl?.annotations?.pii).toBe("true");
+    expect(nameLvl?.annotations?.cardinality).toBe("high");
+    const rev = res.state.measures?.find((m) => m.name === "Rev");
+    expect(rev?.annotations?.unit).toBe("USD");
+  });
 });
 
-describe('M4 import round-trips a <Level caption>', () => {
-	const XML = `<Schema name="t" metamodelVersion="4.0">
+describe("M4 import round-trips a <Level caption>", () => {
+  const XML = `<Schema name="t" metamodelVersion="4.0">
   <PhysicalSchema>
     <Table name="dim_c"><Key name="k"><Column name="cid"/></Key></Table>
     <Table name="fact"/>
@@ -150,16 +164,19 @@ describe('M4 import round-trips a <Level caption>', () => {
   </Cube>
 </Schema>`;
 
-	it('reads the level caption back onto the level', () => {
-		const res = importFromMondrianXml(XML, { connectionId: 'test', sourceTables: [] });
-		const dim = res.state.dimensions?.find((d) => d.name === 'Customer');
-		const lvl = dim?.hierarchies[0]?.levels.find((l) => l.name === 'Name');
-		expect(lvl?.caption).toBe('Customer Name');
-	});
+  it("reads the level caption back onto the level", () => {
+    const res = importFromMondrianXml(XML, {
+      connectionId: "test",
+      sourceTables: [],
+    });
+    const dim = res.state.dimensions?.find((d) => d.name === "Customer");
+    const lvl = dim?.hierarchies[0]?.levels.find((l) => l.name === "Name");
+    expect(lvl?.caption).toBe("Customer Name");
+  });
 });
 
-describe('M4 import round-trips <Hierarchy> caption + allMemberName', () => {
-	const XML = `<Schema name="t" metamodelVersion="4.0">
+describe("M4 import round-trips <Hierarchy> caption + allMemberName", () => {
+  const XML = `<Schema name="t" metamodelVersion="4.0">
   <PhysicalSchema>
     <Table name="dim_c"><Key name="k"><Column name="cid"/></Key></Table>
     <Table name="fact"/>
@@ -185,17 +202,20 @@ describe('M4 import round-trips <Hierarchy> caption + allMemberName', () => {
   </Cube>
 </Schema>`;
 
-	it('reads hierarchy caption + allMemberName back', () => {
-		const res = importFromMondrianXml(XML, { connectionId: 'test', sourceTables: [] });
-		const dim = res.state.dimensions?.find((d) => d.name === 'Customer');
-		const hier = dim?.hierarchies.find((h) => h.name === 'Geo');
-		expect(hier?.caption).toBe('Customer Geography');
-		expect(hier?.allMemberName).toBe('All Customers');
-	});
+  it("reads hierarchy caption + allMemberName back", () => {
+    const res = importFromMondrianXml(XML, {
+      connectionId: "test",
+      sourceTables: [],
+    });
+    const dim = res.state.dimensions?.find((d) => d.name === "Customer");
+    const hier = dim?.hierarchies.find((h) => h.name === "Geo");
+    expect(hier?.caption).toBe("Customer Geography");
+    expect(hier?.allMemberName).toBe("All Customers");
+  });
 });
 
-describe('M4 import round-trips <Attribute> overrides (#959)', () => {
-	const XML = `<Schema name="t" metamodelVersion="4.0">
+describe("M4 import round-trips <Attribute> overrides (#959)", () => {
+  const XML = `<Schema name="t" metamodelVersion="4.0">
   <PhysicalSchema>
     <Table name="dim_c"><Key name="k"><Column name="cid"/></Key></Table>
     <Table name="fact"/>
@@ -219,14 +239,17 @@ describe('M4 import round-trips <Attribute> overrides (#959)', () => {
   </Cube>
 </Schema>`;
 
-	it('reads name / nameColumn / orderByColumn / captionColumn / description back', () => {
-		const res = importFromMondrianXml(XML, { connectionId: 'test', sourceTables: [] });
-		const dim = res.state.dimensions?.find((d) => d.name === 'Customer');
-		const a = dim?.attributes?.find((x) => x.columnName === 'country');
-		expect(a?.name).toBe('Country Name');
-		expect(a?.nameColumn).toBe('country_label');
-		expect(a?.orderByColumn).toBe('country_sort');
-		expect(a?.captionColumn).toBe('country_caption');
-		expect(a?.description).toBe('ISO country');
-	});
+  it("reads name / nameColumn / orderByColumn / captionColumn / description back", () => {
+    const res = importFromMondrianXml(XML, {
+      connectionId: "test",
+      sourceTables: [],
+    });
+    const dim = res.state.dimensions?.find((d) => d.name === "Customer");
+    const a = dim?.attributes?.find((x) => x.columnName === "country");
+    expect(a?.name).toBe("Country Name");
+    expect(a?.nameColumn).toBe("country_label");
+    expect(a?.orderByColumn).toBe("country_sort");
+    expect(a?.captionColumn).toBe("country_caption");
+    expect(a?.description).toBe("ISO country");
+  });
 });

--- a/saiku-ui/src/lib/cube-designer/mondrian-import.m4-templates.test.ts
+++ b/saiku-ui/src/lib/cube-designer/mondrian-import.m4-templates.test.ts
@@ -1,0 +1,232 @@
+// @vitest-environment happy-dom
+import { describe, expect, it } from 'vitest';
+import { importFromMondrianXml } from './mondrian-import';
+
+/**
+ * Self-contained M4 import round-trip guards for the designer's importer.
+ * (The cube-library template fixtures — ecommerce/saas-metrics/hr-analytics/
+ * healthcare-reporting — live in saiku-cloud, so those integration tests stay
+ * there, against that repo's cube-library.)
+ */
+
+describe('M4 import round-trips a Time dimension + levelType', () => {
+	const XML = `<Schema name="t" metamodelVersion="4.0">
+  <PhysicalSchema>
+    <Table name="dim_date"><Key name="k"><Column name="date_key"/></Key></Table>
+    <Table name="fact"/>
+  </PhysicalSchema>
+  <Dimension name="Calendar" type="TIME" table="dim_date" key="Year">
+    <Attributes>
+      <Attribute name="Year" table="dim_date" keyColumn="year_num" levelType="TimeYears"/>
+      <Attribute name="Date" table="dim_date" keyColumn="date_key"/>
+    </Attributes>
+    <Hierarchies>
+      <Hierarchy name="Calendar" hasAll="true">
+        <Level attribute="Year"/>
+        <Level attribute="Date"/>
+      </Hierarchy>
+    </Hierarchies>
+  </Dimension>
+  <Cube name="C">
+    <Dimensions><Dimension source="Calendar"/></Dimensions>
+    <MeasureGroups><MeasureGroup name="G" table="fact"><Measures><Measure name="Cnt" aggregator="count"/></Measures></MeasureGroup></MeasureGroups>
+  </Cube>
+</Schema>`;
+
+	it('reads type="TIME" as a Time dimension and levelType back onto the level', () => {
+		const res = importFromMondrianXml(XML, { connectionId: 'test', sourceTables: [] });
+		const dim = res.state.dimensions?.find((d) => d.name === 'Calendar');
+		expect(dim?.dimensionType).toBe('Time');
+		const year = dim?.hierarchies[0]?.levels.find((l) => l.name === 'Year');
+		expect(year?.levelType).toBe('TimeYears');
+		// A non-time level carries no levelType.
+		const date = dim?.hierarchies[0]?.levels.find((l) => l.name === 'Date');
+		expect(date?.levelType).toBeUndefined();
+	});
+});
+
+describe('M4 import reads <TimeCalcs> back onto the cube', () => {
+	const XML = `<Schema name="t" metamodelVersion="4.0">
+  <PhysicalSchema><Table name="fact"/></PhysicalSchema>
+  <Cube name="Revenue">
+    <MeasureGroups>
+      <MeasureGroup name="G" table="fact">
+        <Measures><Measure name="Revenue" column="rev" aggregator="sum"/></Measures>
+      </MeasureGroup>
+    </MeasureGroups>
+    <TimeCalcs>
+      <TimeCalc name="Revenue YoY" type="yoy" measure="Revenue" timeDimension="Calendar" formatString="0.0%"/>
+      <TimeCalc name="Revenue R3" type="rolling" measure="Revenue" window="3" function="avg"/>
+    </TimeCalcs>
+  </Cube>
+</Schema>`;
+
+	it('parses yoy + rolling TimeCalcs with their attributes', () => {
+		const res = importFromMondrianXml(XML, { connectionId: 'test', sourceTables: [] });
+		const cube = res.workbenchCubes.find((c) => c.name === 'Revenue');
+		const tcs = cube?.timeCalcs ?? [];
+		expect(tcs.length).toBe(2);
+		const yoy = tcs.find((t) => t.name === 'Revenue YoY');
+		expect(yoy).toMatchObject({
+			type: 'yoy',
+			measure: 'Revenue',
+			timeDimension: 'Calendar',
+			formatString: '0.0%'
+		});
+		const roll = tcs.find((t) => t.name === 'Revenue R3');
+		expect(roll).toMatchObject({ type: 'rolling', measure: 'Revenue', window: 3, function: 'avg' });
+	});
+});
+
+describe('M4 import reads saiku.semantic.* annotations back', () => {
+	const XML = `<Schema name="t" metamodelVersion="4.0">
+  <PhysicalSchema>
+    <Table name="dim_c"><Key name="k"><Column name="cid"/></Key></Table>
+    <Table name="fact"/>
+  </PhysicalSchema>
+  <Dimension name="Customer" table="dim_c" key="Name">
+    <Annotations><Annotation name="saiku.semantic.synonyms">client, account</Annotation></Annotations>
+    <Attributes>
+      <Attribute name="Name" table="dim_c" keyColumn="cid">
+        <Annotations>
+          <Annotation name="saiku.semantic.pii">true</Annotation>
+          <Annotation name="saiku.semantic.cardinality">high</Annotation>
+        </Annotations>
+      </Attribute>
+    </Attributes>
+    <Hierarchies><Hierarchy name="H" hasAll="true"><Level attribute="Name"/></Hierarchy></Hierarchies>
+  </Dimension>
+  <Cube name="C">
+    <Dimensions><Dimension source="Customer"/></Dimensions>
+    <MeasureGroups>
+      <MeasureGroup name="G" table="fact">
+        <Measures>
+          <Measure name="Rev" column="rev" aggregator="sum">
+            <Annotations><Annotation name="saiku.semantic.unit">USD</Annotation></Annotations>
+          </Measure>
+        </Measures>
+        <DimensionLinks><ForeignKeyLink dimension="Customer" foreignKeyColumn="cid"/></DimensionLinks>
+      </MeasureGroup>
+    </MeasureGroups>
+  </Cube>
+</Schema>`;
+
+	it('round-trips dimension, level, and measure annotations', () => {
+		const res = importFromMondrianXml(XML, { connectionId: 'test', sourceTables: [] });
+		const dim = res.state.dimensions?.find((d) => d.name === 'Customer');
+		expect(dim?.annotations?.synonyms).toBe('client, account');
+		const nameLvl = dim?.hierarchies[0]?.levels.find((l) => l.name === 'Name');
+		expect(nameLvl?.annotations?.pii).toBe('true');
+		expect(nameLvl?.annotations?.cardinality).toBe('high');
+		const rev = res.state.measures?.find((m) => m.name === 'Rev');
+		expect(rev?.annotations?.unit).toBe('USD');
+	});
+});
+
+describe('M4 import round-trips a <Level caption>', () => {
+	const XML = `<Schema name="t" metamodelVersion="4.0">
+  <PhysicalSchema>
+    <Table name="dim_c"><Key name="k"><Column name="cid"/></Key></Table>
+    <Table name="fact"/>
+  </PhysicalSchema>
+  <Dimension name="Customer" table="dim_c" key="Name">
+    <Attributes>
+      <Attribute name="Name" table="dim_c" keyColumn="cid"/>
+    </Attributes>
+    <Hierarchies>
+      <Hierarchy name="H" hasAll="true">
+        <Level attribute="Name" caption="Customer Name"/>
+      </Hierarchy>
+    </Hierarchies>
+  </Dimension>
+  <Cube name="C">
+    <Dimensions><Dimension source="Customer"/></Dimensions>
+    <MeasureGroups>
+      <MeasureGroup name="G" table="fact">
+        <Measures><Measure name="Cnt" aggregator="count"/></Measures>
+        <DimensionLinks><ForeignKeyLink dimension="Customer" foreignKeyColumn="cid"/></DimensionLinks>
+      </MeasureGroup>
+    </MeasureGroups>
+  </Cube>
+</Schema>`;
+
+	it('reads the level caption back onto the level', () => {
+		const res = importFromMondrianXml(XML, { connectionId: 'test', sourceTables: [] });
+		const dim = res.state.dimensions?.find((d) => d.name === 'Customer');
+		const lvl = dim?.hierarchies[0]?.levels.find((l) => l.name === 'Name');
+		expect(lvl?.caption).toBe('Customer Name');
+	});
+});
+
+describe('M4 import round-trips <Hierarchy> caption + allMemberName', () => {
+	const XML = `<Schema name="t" metamodelVersion="4.0">
+  <PhysicalSchema>
+    <Table name="dim_c"><Key name="k"><Column name="cid"/></Key></Table>
+    <Table name="fact"/>
+  </PhysicalSchema>
+  <Dimension name="Customer" table="dim_c" key="Name">
+    <Attributes>
+      <Attribute name="Name" table="dim_c" keyColumn="cid"/>
+    </Attributes>
+    <Hierarchies>
+      <Hierarchy name="Geo" hasAll="true" allMemberName="All Customers" caption="Customer Geography">
+        <Level attribute="Name"/>
+      </Hierarchy>
+    </Hierarchies>
+  </Dimension>
+  <Cube name="C">
+    <Dimensions><Dimension source="Customer"/></Dimensions>
+    <MeasureGroups>
+      <MeasureGroup name="G" table="fact">
+        <Measures><Measure name="Cnt" aggregator="count"/></Measures>
+        <DimensionLinks><ForeignKeyLink dimension="Customer" foreignKeyColumn="cid"/></DimensionLinks>
+      </MeasureGroup>
+    </MeasureGroups>
+  </Cube>
+</Schema>`;
+
+	it('reads hierarchy caption + allMemberName back', () => {
+		const res = importFromMondrianXml(XML, { connectionId: 'test', sourceTables: [] });
+		const dim = res.state.dimensions?.find((d) => d.name === 'Customer');
+		const hier = dim?.hierarchies.find((h) => h.name === 'Geo');
+		expect(hier?.caption).toBe('Customer Geography');
+		expect(hier?.allMemberName).toBe('All Customers');
+	});
+});
+
+describe('M4 import round-trips <Attribute> overrides (#959)', () => {
+	const XML = `<Schema name="t" metamodelVersion="4.0">
+  <PhysicalSchema>
+    <Table name="dim_c"><Key name="k"><Column name="cid"/></Key></Table>
+    <Table name="fact"/>
+  </PhysicalSchema>
+  <Dimension name="Customer" table="dim_c" key="Country Name">
+    <Attributes>
+      <Attribute name="Country Name" table="dim_c" keyColumn="country" nameColumn="country_label" orderByColumn="country_sort" captionColumn="country_caption" description="ISO country"/>
+    </Attributes>
+    <Hierarchies>
+      <Hierarchy name="Geo" hasAll="true"><Level attribute="Country Name"/></Hierarchy>
+    </Hierarchies>
+  </Dimension>
+  <Cube name="C">
+    <Dimensions><Dimension source="Customer"/></Dimensions>
+    <MeasureGroups>
+      <MeasureGroup name="G" table="fact">
+        <Measures><Measure name="Cnt" aggregator="count"/></Measures>
+        <DimensionLinks><ForeignKeyLink dimension="Customer" foreignKeyColumn="cid"/></DimensionLinks>
+      </MeasureGroup>
+    </MeasureGroups>
+  </Cube>
+</Schema>`;
+
+	it('reads name / nameColumn / orderByColumn / captionColumn / description back', () => {
+		const res = importFromMondrianXml(XML, { connectionId: 'test', sourceTables: [] });
+		const dim = res.state.dimensions?.find((d) => d.name === 'Customer');
+		const a = dim?.attributes?.find((x) => x.columnName === 'country');
+		expect(a?.name).toBe('Country Name');
+		expect(a?.nameColumn).toBe('country_label');
+		expect(a?.orderByColumn).toBe('country_sort');
+		expect(a?.captionColumn).toBe('country_caption');
+		expect(a?.description).toBe('ISO country');
+	});
+});

--- a/saiku-ui/src/lib/cube-designer/mondrian-import.ts
+++ b/saiku-ui/src/lib/cube-designer/mondrian-import.ts
@@ -63,36 +63,40 @@
  * skipped with a warning rather than silently dropped.
  */
 import type {
-	SchemaCanvasState,
-	SchemaCanvasTable,
-	SchemaCanvasJoin,
-	SchemaCanvasColumn,
-	SchemaCanvasDimension,
-	SchemaCanvasHierarchy,
-	SchemaCanvasLevel,
-	SchemaCanvasMeasure,
-	SchemaCanvasTimeCalc,
-	SourceTableCandidate
-} from './types.js';
+  SchemaCanvasState,
+  SchemaCanvasTable,
+  SchemaCanvasJoin,
+  SchemaCanvasColumn,
+  SchemaCanvasDimension,
+  SchemaCanvasHierarchy,
+  SchemaCanvasLevel,
+  SchemaCanvasMeasure,
+  SchemaCanvasTimeCalc,
+  SourceTableCandidate,
+} from "./types.js";
 
 /**
  * Read a schema element's `saiku.semantic.*` annotations into a bare-keyed map
  * (e.g. `{ description, pii }`). Returns undefined when there are none, so the
  * caller can leave the field unset. Non-saiku annotations are ignored.
  */
-function readSemanticAnnotations(el: Element): Record<string, string> | undefined {
-	const out: Record<string, string> = {};
-	for (const aEl of Array.from(el.querySelectorAll(':scope > Annotations > Annotation'))) {
-		const name = aEl.getAttribute('name') ?? '';
-		if (!name.startsWith('saiku.semantic.')) continue;
-		const key = name.slice('saiku.semantic.'.length);
-		if (key) out[key] = aEl.textContent?.trim() ?? '';
-	}
-	return Object.keys(out).length > 0 ? out : undefined;
+function readSemanticAnnotations(
+  el: Element,
+): Record<string, string> | undefined {
+  const out: Record<string, string> = {};
+  for (const aEl of Array.from(
+    el.querySelectorAll(":scope > Annotations > Annotation"),
+  )) {
+    const name = aEl.getAttribute("name") ?? "";
+    if (!name.startsWith("saiku.semantic.")) continue;
+    const key = name.slice("saiku.semantic.".length);
+    if (key) out[key] = aEl.textContent?.trim() ?? "";
+  }
+  return Object.keys(out).length > 0 ? out : undefined;
 }
 
 function makeId(prefix: string): string {
-	return `${prefix}_${Math.random().toString(36).slice(2, 10)}`;
+  return `${prefix}_${Math.random().toString(36).slice(2, 10)}`;
 }
 
 /**
@@ -118,41 +122,41 @@ function makeId(prefix: string): string {
  * lose them on export.
  */
 export interface ImportedWorkbenchMeasureGroup {
-	id: string;
-	name: string;
-	factTableId: string | null;
-	measureColumns: string[];
-	dimensionLinks: {
-		dimensionId: string;
-		foreignKeyColumn: string;
-		linkKind?: 'foreign-key' | 'fact' | 'reference';
-		viaDimension?: string;
-		viaAttribute?: string;
-	}[];
+  id: string;
+  name: string;
+  factTableId: string | null;
+  measureColumns: string[];
+  dimensionLinks: {
+    dimensionId: string;
+    foreignKeyColumn: string;
+    linkKind?: "foreign-key" | "fact" | "reference";
+    viaDimension?: string;
+    viaAttribute?: string;
+  }[];
 }
 export interface ImportedWorkbenchCalc {
-	id: string;
-	name: string;
-	tokens: never[];
-	formula?: string;
+  id: string;
+  name: string;
+  tokens: never[];
+  formula?: string;
 }
 export interface ImportedWorkbenchCube {
-	id: string;
-	name: string;
-	measureGroups: ImportedWorkbenchMeasureGroup[];
-	factsCalcs: ImportedWorkbenchCalc[];
-	/** Declarative <TimeCalc> metrics read back from the schema. */
-	timeCalcs?: SchemaCanvasTimeCalc[];
+  id: string;
+  name: string;
+  measureGroups: ImportedWorkbenchMeasureGroup[];
+  factsCalcs: ImportedWorkbenchCalc[];
+  /** Declarative <TimeCalc> metrics read back from the schema. */
+  timeCalcs?: SchemaCanvasTimeCalc[];
 }
 
 export interface MondrianImportResult {
-	state: SchemaCanvasState;
-	warnings: string[];
-	/** Populated by the Mondrian-4 importer: one workbench cube per `<Cube>`
-	 *  in the schema, with MGs/measures/dim-links/calcs ready to seed
-	 *  the workbench.  Empty array on Mondrian-3 imports or
-	 *  PhysicalSchema-only imports. */
-	workbenchCubes: ImportedWorkbenchCube[];
+  state: SchemaCanvasState;
+  warnings: string[];
+  /** Populated by the Mondrian-4 importer: one workbench cube per `<Cube>`
+   *  in the schema, with MGs/measures/dim-links/calcs ready to seed
+   *  the workbench.  Empty array on Mondrian-3 imports or
+   *  PhysicalSchema-only imports. */
+  workbenchCubes: ImportedWorkbenchCube[];
 }
 
 /**
@@ -162,65 +166,75 @@ export interface MondrianImportResult {
  * schema per table, then re-run the import with `schemaOverrides` set.
  */
 export class AmbiguousSchemaError extends Error {
-	readonly name = 'AmbiguousSchemaError';
-	constructor(
-		public readonly ambiguities: Array<{
-			tableName: string;
-			candidateSchemas: string[];
-		}>
-	) {
-		super(`Schema is ambiguous for: ${ambiguities.map((a) => a.tableName).join(', ')}.`);
-	}
+  readonly name = "AmbiguousSchemaError";
+  constructor(
+    public readonly ambiguities: Array<{
+      tableName: string;
+      candidateSchemas: string[];
+    }>,
+  ) {
+    super(
+      `Schema is ambiguous for: ${ambiguities.map((a) => a.tableName).join(", ")}.`,
+    );
+  }
 }
 
 interface ImportOpts {
-	/** Connection id the imported doc will live under. */
-	connectionId: string;
-	/** Schema label override (defaults to the <Schema name="…"> attribute). */
-	label?: string;
-	/** Live source catalog — used to enrich columns when the XML only
-	 *  names a few. If a referenced table isn't in the catalog the
-	 *  importer falls back to whatever columns the XML mentions. */
-	sourceTables?: SourceTableCandidate[];
-	/**
-	 * Per-table schema overrides keyed by lowercased table name. Used
-	 * after the user resolves an `AmbiguousSchemaError` — the importer
-	 * applies the picked schema instead of guessing or throwing again.
-	 */
-	schemaOverrides?: Record<string, string>;
+  /** Connection id the imported doc will live under. */
+  connectionId: string;
+  /** Schema label override (defaults to the <Schema name="…"> attribute). */
+  label?: string;
+  /** Live source catalog — used to enrich columns when the XML only
+   *  names a few. If a referenced table isn't in the catalog the
+   *  importer falls back to whatever columns the XML mentions. */
+  sourceTables?: SourceTableCandidate[];
+  /**
+   * Per-table schema overrides keyed by lowercased table name. Used
+   * after the user resolves an `AmbiguousSchemaError` — the importer
+   * applies the picked schema instead of guessing or throwing again.
+   */
+  schemaOverrides?: Record<string, string>;
 }
 
-export function importFromMondrianXml(xml: string, opts: ImportOpts): MondrianImportResult {
-	if (typeof window === 'undefined') {
-		throw new Error('XML import is only available in the browser.');
-	}
-	const parser = new DOMParser();
-	const dom = parser.parseFromString(xml, 'application/xml');
-	const err = dom.querySelector('parsererror');
-	if (err) throw new Error(`XML parse error: ${err.textContent?.slice(0, 240) ?? 'unknown'}`);
+export function importFromMondrianXml(
+  xml: string,
+  opts: ImportOpts,
+): MondrianImportResult {
+  if (typeof window === "undefined") {
+    throw new Error("XML import is only available in the browser.");
+  }
+  const parser = new DOMParser();
+  const dom = parser.parseFromString(xml, "application/xml");
+  const err = dom.querySelector("parsererror");
+  if (err)
+    throw new Error(
+      `XML parse error: ${err.textContent?.slice(0, 240) ?? "unknown"}`,
+    );
 
-	// Accept either a full `<Schema>` doc OR a bare `<PhysicalSchema>`
-	// block.  The bare-PhysicalSchema route is for "I only care about the
-	// table layout" pastes; a full <Schema> ALWAYS has a <PhysicalSchema>
-	// child too, so we route by ROOT element tag, not by presence of a
-	// <PhysicalSchema> descendant.  Previously the dispatcher fell through
-	// to parsePhysicalSchemaOnly for every M4 schema, silently skipping
-	// the cube walker.
-	const rootEl = dom.documentElement;
-	if (rootEl?.tagName === 'PhysicalSchema') {
-		return parsePhysicalSchemaOnly(rootEl, opts);
-	}
+  // Accept either a full `<Schema>` doc OR a bare `<PhysicalSchema>`
+  // block.  The bare-PhysicalSchema route is for "I only care about the
+  // table layout" pastes; a full <Schema> ALWAYS has a <PhysicalSchema>
+  // child too, so we route by ROOT element tag, not by presence of a
+  // <PhysicalSchema> descendant.  Previously the dispatcher fell through
+  // to parsePhysicalSchemaOnly for every M4 schema, silently skipping
+  // the cube walker.
+  const rootEl = dom.documentElement;
+  if (rootEl?.tagName === "PhysicalSchema") {
+    return parsePhysicalSchemaOnly(rootEl, opts);
+  }
 
-	const schemaEl = dom.querySelector('Schema');
-	if (!schemaEl) {
-		throw new Error('Expected a <Schema> or <PhysicalSchema> element at the root.');
-	}
+  const schemaEl = dom.querySelector("Schema");
+  if (!schemaEl) {
+    throw new Error(
+      "Expected a <Schema> or <PhysicalSchema> element at the root.",
+    );
+  }
 
-	const isM4 =
-		schemaEl.getAttribute('metamodelVersion') === '4.0' ||
-		schemaEl.querySelector(':scope > Cube > MeasureGroups') !== null;
+  const isM4 =
+    schemaEl.getAttribute("metamodelVersion") === "4.0" ||
+    schemaEl.querySelector(":scope > Cube > MeasureGroups") !== null;
 
-	return isM4 ? parseM4(schemaEl, opts) : parseM3(schemaEl, opts);
+  return isM4 ? parseM4(schemaEl, opts) : parseM3(schemaEl, opts);
 }
 
 /**
@@ -237,21 +251,24 @@ export function importFromMondrianXml(xml: string, opts: ImportOpts): MondrianIm
  * its own clear error.
  */
 export function isMondrian3Xml(xml: string): boolean {
-	if (typeof window === 'undefined') return false;
-	let dom: Document;
-	try {
-		dom = new DOMParser().parseFromString(xml, 'application/xml');
-	} catch {
-		return false;
-	}
-	if (dom.querySelector('parsererror')) return false;
-	if (dom.documentElement?.tagName === 'PhysicalSchema') return false;
-	const schemaEl = dom.querySelector('Schema');
-	if (!schemaEl) return false;
-	const metamodelVersion = (schemaEl.getAttribute('metamodelVersion') ?? '').trim();
-	if (metamodelVersion.startsWith('4')) return false;
-	if (schemaEl.querySelector(':scope > Cube > MeasureGroups') !== null) return false;
-	return true;
+  if (typeof window === "undefined") return false;
+  let dom: Document;
+  try {
+    dom = new DOMParser().parseFromString(xml, "application/xml");
+  } catch {
+    return false;
+  }
+  if (dom.querySelector("parsererror")) return false;
+  if (dom.documentElement?.tagName === "PhysicalSchema") return false;
+  const schemaEl = dom.querySelector("Schema");
+  if (!schemaEl) return false;
+  const metamodelVersion = (
+    schemaEl.getAttribute("metamodelVersion") ?? ""
+  ).trim();
+  if (metamodelVersion.startsWith("4")) return false;
+  if (schemaEl.querySelector(":scope > Cube > MeasureGroups") !== null)
+    return false;
+  return true;
 }
 
 /**
@@ -261,10 +278,10 @@ export function isMondrian3Xml(xml: string): boolean {
  * with no column (e.g. count-of-rows measures) — the caller decides.
  */
 function measureColumnOf(measureEl: Element): string | null {
-	const attr = measureEl.getAttribute('column');
-	if (attr) return attr;
-	const argCol = measureEl.querySelector(':scope > Arguments > Column');
-	return argCol?.getAttribute('name') ?? null;
+  const attr = measureEl.getAttribute("column");
+  if (attr) return attr;
+  const argCol = measureEl.querySelector(":scope > Arguments > Column");
+  return argCol?.getAttribute("name") ?? null;
 }
 
 // ─── PhysicalSchema-only parser (peer model) ───────────────────────────────
@@ -279,181 +296,199 @@ function measureColumnOf(measureEl: Element): string | null {
  * its join column; target side uses the `<ForeignKey><Column>` named
  * column.
  */
-function parsePhysicalSchemaOnly(physEl: Element, opts: ImportOpts): MondrianImportResult {
-	const warnings: string[] = [];
-	// PhysicalSchema-only imports don't carry cube metadata — return an
-	// empty array so the +page.svelte hydration path is unchanged.
-	const workbenchCubes: ImportedWorkbenchCube[] = [];
+function parsePhysicalSchemaOnly(
+  physEl: Element,
+  opts: ImportOpts,
+): MondrianImportResult {
+  const warnings: string[] = [];
+  // PhysicalSchema-only imports don't carry cube metadata — return an
+  // empty array so the +page.svelte hydration path is unchanged.
+  const workbenchCubes: ImportedWorkbenchCube[] = [];
 
-	// Phase 1 — harvest tables.
-	interface PhysTable {
-		schema: string | null;
-		name: string;
-		columns: Set<string>;
-		keyColumn: string | null;
-	}
-	const physTables = new Map<string, PhysTable>();
-	for (const tEl of Array.from(physEl.querySelectorAll(':scope > Table'))) {
-		const name = tEl.getAttribute('name');
-		if (!name) continue;
-		const schema = tEl.getAttribute('schema');
-		const columns = new Set<string>();
-		for (const cEl of Array.from(tEl.querySelectorAll('Column'))) {
-			const col = cEl.getAttribute('name');
-			if (col) columns.add(col);
-		}
-		const keyEl = tEl.querySelector(':scope > Key > Column');
-		physTables.set(name, {
-			schema,
-			name,
-			columns,
-			keyColumn: keyEl?.getAttribute('name') ?? null
-		});
-	}
-	if (physTables.size === 0) {
-		throw new Error('<PhysicalSchema> contained no <Table> elements.');
-	}
+  // Phase 1 — harvest tables.
+  interface PhysTable {
+    schema: string | null;
+    name: string;
+    columns: Set<string>;
+    keyColumn: string | null;
+  }
+  const physTables = new Map<string, PhysTable>();
+  for (const tEl of Array.from(physEl.querySelectorAll(":scope > Table"))) {
+    const name = tEl.getAttribute("name");
+    if (!name) continue;
+    const schema = tEl.getAttribute("schema");
+    const columns = new Set<string>();
+    for (const cEl of Array.from(tEl.querySelectorAll("Column"))) {
+      const col = cEl.getAttribute("name");
+      if (col) columns.add(col);
+    }
+    const keyEl = tEl.querySelector(":scope > Key > Column");
+    physTables.set(name, {
+      schema,
+      name,
+      columns,
+      keyColumn: keyEl?.getAttribute("name") ?? null,
+    });
+  }
+  if (physTables.size === 0) {
+    throw new Error("<PhysicalSchema> contained no <Table> elements.");
+  }
 
-	// Detect ambiguous schemas — names without `schema=` (and no override)
-	// that exist in MULTIPLE schemas in the live catalog. The host has to
-	// prompt the user to pick before we can proceed.
-	const overrides = opts.schemaOverrides ?? {};
-	if (opts.sourceTables && opts.sourceTables.length > 0) {
-		const ambiguities: Array<{ tableName: string; candidateSchemas: string[] }> = [];
-		for (const [name, phys] of physTables) {
-			const lower = name.toLowerCase();
-			if (phys.schema) continue; // already qualified
-			if (overrides[lower]) continue; // user resolved it
-			const candidates: string[] = [];
-			for (const t of opts.sourceTables) {
-				if (t.name.toLowerCase() === lower) {
-					const sch = t.schema ?? '';
-					if (sch && !candidates.includes(sch)) candidates.push(sch);
-				}
-			}
-			if (candidates.length >= 2) {
-				ambiguities.push({ tableName: name, candidateSchemas: candidates.sort() });
-			}
-		}
-		if (ambiguities.length > 0) {
-			throw new AmbiguousSchemaError(ambiguities);
-		}
-	}
+  // Detect ambiguous schemas — names without `schema=` (and no override)
+  // that exist in MULTIPLE schemas in the live catalog. The host has to
+  // prompt the user to pick before we can proceed.
+  const overrides = opts.schemaOverrides ?? {};
+  if (opts.sourceTables && opts.sourceTables.length > 0) {
+    const ambiguities: Array<{
+      tableName: string;
+      candidateSchemas: string[];
+    }> = [];
+    for (const [name, phys] of physTables) {
+      const lower = name.toLowerCase();
+      if (phys.schema) continue; // already qualified
+      if (overrides[lower]) continue; // user resolved it
+      const candidates: string[] = [];
+      for (const t of opts.sourceTables) {
+        if (t.name.toLowerCase() === lower) {
+          const sch = t.schema ?? "";
+          if (sch && !candidates.includes(sch)) candidates.push(sch);
+        }
+      }
+      if (candidates.length >= 2) {
+        ambiguities.push({
+          tableName: name,
+          candidateSchemas: candidates.sort(),
+        });
+      }
+    }
+    if (ambiguities.length > 0) {
+      throw new AmbiguousSchemaError(ambiguities);
+    }
+  }
 
-	// Phase 2 — drop the tables onto the canvas. We arrange them in a
-	// loose grid so the user has somewhere to start; they can re-arrange.
-	const tables: SchemaCanvasTable[] = [];
-	const tableIdByName = new Map<string, string>();
-	const namesSorted = [...physTables.keys()].sort();
-	const cols = Math.max(1, Math.ceil(Math.sqrt(namesSorted.length)));
-	namesSorted.forEach((name, i) => {
-		const phys = physTables.get(name)!;
-		// Pre-resolve schema using the user's override (set after they
-		// resolved an AmbiguousSchemaError) before falling back to
-		// what the XML provided.
-		const overriddenSchema = overrides[name.toLowerCase()] ?? phys.schema;
-		const catalogHit = lookupTableInCatalog(opts.sourceTables, overriddenSchema, name);
-		const resolvedSchema = catalogHit?.schema ?? overriddenSchema;
-		const initialCols: SchemaCanvasColumn[] = catalogHit
-			? catalogHit.columns.map((c) => ({ name: c.name, sqlType: c.sqlType }))
-			: [...phys.columns].map((n) => ({ name: n, sqlType: 'UNKNOWN' }));
-		if (!catalogHit) {
-			warnings.push(
-				`"${name}" wasn't found in the active connection's catalog — imported with only the columns the XML referenced. Switch to the right connection to enrich it.`
-			);
-		} else if ((phys.schema ?? '') !== (catalogHit.schema ?? '') && phys.schema) {
-			warnings.push(
-				`"${name}" was schema-qualified as "${phys.schema}" in the XML but matched "${catalogHit.schema}" in the catalog. Using the catalog's schema.`
-			);
-		}
-		const id = makeId('tbl');
-		tables.push({
-			id,
-			schema: resolvedSchema,
-			name,
-			role: 'dimension',
-			columns: initialCols,
-			position: {
-				x: 120 + (i % cols) * 320,
-				y: 120 + Math.floor(i / cols) * 280
-			},
-			groupId: null
-		});
-		tableIdByName.set(name, id);
-	});
+  // Phase 2 — drop the tables onto the canvas. We arrange them in a
+  // loose grid so the user has somewhere to start; they can re-arrange.
+  const tables: SchemaCanvasTable[] = [];
+  const tableIdByName = new Map<string, string>();
+  const namesSorted = [...physTables.keys()].sort();
+  const cols = Math.max(1, Math.ceil(Math.sqrt(namesSorted.length)));
+  namesSorted.forEach((name, i) => {
+    const phys = physTables.get(name)!;
+    // Pre-resolve schema using the user's override (set after they
+    // resolved an AmbiguousSchemaError) before falling back to
+    // what the XML provided.
+    const overriddenSchema = overrides[name.toLowerCase()] ?? phys.schema;
+    const catalogHit = lookupTableInCatalog(
+      opts.sourceTables,
+      overriddenSchema,
+      name,
+    );
+    const resolvedSchema = catalogHit?.schema ?? overriddenSchema;
+    const initialCols: SchemaCanvasColumn[] = catalogHit
+      ? catalogHit.columns.map((c) => ({ name: c.name, sqlType: c.sqlType }))
+      : [...phys.columns].map((n) => ({ name: n, sqlType: "UNKNOWN" }));
+    if (!catalogHit) {
+      warnings.push(
+        `"${name}" wasn't found in the active connection's catalog — imported with only the columns the XML referenced. Switch to the right connection to enrich it.`,
+      );
+    } else if (
+      (phys.schema ?? "") !== (catalogHit.schema ?? "") &&
+      phys.schema
+    ) {
+      warnings.push(
+        `"${name}" was schema-qualified as "${phys.schema}" in the XML but matched "${catalogHit.schema}" in the catalog. Using the catalog's schema.`,
+      );
+    }
+    const id = makeId("tbl");
+    tables.push({
+      id,
+      schema: resolvedSchema,
+      name,
+      role: "dimension",
+      columns: initialCols,
+      position: {
+        x: 120 + (i % cols) * 320,
+        y: 120 + Math.floor(i / cols) * 280,
+      },
+      groupId: null,
+    });
+    tableIdByName.set(name, id);
+  });
 
-	// Phase 3 — parse <Link> rows into joins. Each Link is `source` →
-	// `target` with a `<ForeignKey><Column>` naming the FK column on
-	// the target. Source side uses its declared Key column.
-	const joins: SchemaCanvasJoin[] = [];
-	for (const linkEl of Array.from(physEl.querySelectorAll(':scope > Link'))) {
-		const sourceName = linkEl.getAttribute('source');
-		const targetName = linkEl.getAttribute('target');
-		if (!sourceName || !targetName) {
-			warnings.push('<Link> with missing source/target attribute — skipped.');
-			continue;
-		}
-		const fkColEl = linkEl.querySelector('ForeignKey > Column');
-		const fkColName = fkColEl?.getAttribute('name');
-		if (!fkColName) {
-			warnings.push(
-				`<Link source="${sourceName}" target="${targetName}"> has no <ForeignKey><Column> — skipped.`
-			);
-			continue;
-		}
-		const sourceId = tableIdByName.get(sourceName);
-		const targetId = tableIdByName.get(targetName);
-		if (!sourceId || !targetId) {
-			warnings.push(
-				`<Link source="${sourceName}" target="${targetName}"> references an undefined table — skipped.`
-			);
-			continue;
-		}
-		const sourcePhys = physTables.get(sourceName);
-		const sourceKey = sourcePhys?.keyColumn ?? 'id';
-		// Make sure both columns appear on their tables for the canvas
-		// to render the join endpoints meaningfully.
-		const sourceTable = tables.find((t) => t.id === sourceId);
-		if (sourceTable && !sourceTable.columns.some((c) => c.name === sourceKey)) {
-			sourceTable.columns.push({ name: sourceKey, sqlType: 'UNKNOWN' });
-		}
-		const targetTable = tables.find((t) => t.id === targetId);
-		if (targetTable && !targetTable.columns.some((c) => c.name === fkColName)) {
-			targetTable.columns.push({ name: fkColName, sqlType: 'UNKNOWN' });
-		}
-		joins.push({
-			id: makeId('join'),
-			sourceTableId: sourceId,
-			sourceColumnName: sourceKey,
-			targetTableId: targetId,
-			targetColumnName: fkColName,
-			kind: 'inner',
-			// PhysicalSchema-only parse — these are explicit <Link> joins.
-			origin: 'physical'
-		});
-	}
+  // Phase 3 — parse <Link> rows into joins. Each Link is `source` →
+  // `target` with a `<ForeignKey><Column>` naming the FK column on
+  // the target. Source side uses its declared Key column.
+  const joins: SchemaCanvasJoin[] = [];
+  for (const linkEl of Array.from(physEl.querySelectorAll(":scope > Link"))) {
+    const sourceName = linkEl.getAttribute("source");
+    const targetName = linkEl.getAttribute("target");
+    if (!sourceName || !targetName) {
+      warnings.push("<Link> with missing source/target attribute — skipped.");
+      continue;
+    }
+    const fkColEl = linkEl.querySelector("ForeignKey > Column");
+    const fkColName = fkColEl?.getAttribute("name");
+    if (!fkColName) {
+      warnings.push(
+        `<Link source="${sourceName}" target="${targetName}"> has no <ForeignKey><Column> — skipped.`,
+      );
+      continue;
+    }
+    const sourceId = tableIdByName.get(sourceName);
+    const targetId = tableIdByName.get(targetName);
+    if (!sourceId || !targetId) {
+      warnings.push(
+        `<Link source="${sourceName}" target="${targetName}"> references an undefined table — skipped.`,
+      );
+      continue;
+    }
+    const sourcePhys = physTables.get(sourceName);
+    const sourceKey = sourcePhys?.keyColumn ?? "id";
+    // Make sure both columns appear on their tables for the canvas
+    // to render the join endpoints meaningfully.
+    const sourceTable = tables.find((t) => t.id === sourceId);
+    if (sourceTable && !sourceTable.columns.some((c) => c.name === sourceKey)) {
+      sourceTable.columns.push({ name: sourceKey, sqlType: "UNKNOWN" });
+    }
+    const targetTable = tables.find((t) => t.id === targetId);
+    if (targetTable && !targetTable.columns.some((c) => c.name === fkColName)) {
+      targetTable.columns.push({ name: fkColName, sqlType: "UNKNOWN" });
+    }
+    joins.push({
+      id: makeId("join"),
+      sourceTableId: sourceId,
+      sourceColumnName: sourceKey,
+      targetTableId: targetId,
+      targetColumnName: fkColName,
+      kind: "inner",
+      // PhysicalSchema-only parse — these are explicit <Link> joins.
+      origin: "physical",
+    });
+  }
 
-	const state: SchemaCanvasState = {
-		version: 1,
-		connectionId: opts.connectionId,
-		label: opts.label ?? '',
-		tables,
-		joins,
-		groups: [],
-		updatedAt: new Date().toISOString()
-	};
-	return { state, warnings, workbenchCubes };
+  const state: SchemaCanvasState = {
+    version: 1,
+    connectionId: opts.connectionId,
+    label: opts.label ?? "",
+    tables,
+    joins,
+    groups: [],
+    updatedAt: new Date().toISOString(),
+  };
+  return { state, warnings, workbenchCubes };
 }
 
 // ─── shared helpers ────────────────────────────────────────────────────────
 
 function lookupColumnsFromCatalog(
-	sourceTables: SourceTableCandidate[] | undefined,
-	schema: string | null,
-	name: string
+  sourceTables: SourceTableCandidate[] | undefined,
+  schema: string | null,
+  name: string,
 ): SchemaCanvasColumn[] | null {
-	const hit = lookupTableInCatalog(sourceTables, schema, name);
-	return hit ? hit.columns.map((c) => ({ name: c.name, sqlType: c.sqlType })) : null;
+  const hit = lookupTableInCatalog(sourceTables, schema, name);
+  return hit
+    ? hit.columns.map((c) => ({ name: c.name, sqlType: c.sqlType }))
+    : null;
 }
 
 /**
@@ -472,1216 +507,1337 @@ function lookupColumnsFromCatalog(
  * present instead of just the few the XML happened to name.
  */
 function lookupTableInCatalog(
-	sourceTables: SourceTableCandidate[] | undefined,
-	schema: string | null,
-	name: string
+  sourceTables: SourceTableCandidate[] | undefined,
+  schema: string | null,
+  name: string,
 ): SourceTableCandidate | null {
-	if (!sourceTables || sourceTables.length === 0) return null;
-	const lowerName = name.toLowerCase();
-	const lowerSchema = schema?.toLowerCase() ?? null;
-	let nameOnlyHit: SourceTableCandidate | null = null;
-	for (const t of sourceTables) {
-		if (t.name.toLowerCase() !== lowerName) continue;
-		if (lowerSchema !== null && (t.schema?.toLowerCase() ?? null) === lowerSchema) {
-			return t;
-		}
-		if (nameOnlyHit === null) nameOnlyHit = t;
-	}
-	return nameOnlyHit;
+  if (!sourceTables || sourceTables.length === 0) return null;
+  const lowerName = name.toLowerCase();
+  const lowerSchema = schema?.toLowerCase() ?? null;
+  let nameOnlyHit: SourceTableCandidate | null = null;
+  for (const t of sourceTables) {
+    if (t.name.toLowerCase() !== lowerName) continue;
+    if (
+      lowerSchema !== null &&
+      (t.schema?.toLowerCase() ?? null) === lowerSchema
+    ) {
+      return t;
+    }
+    if (nameOnlyHit === null) nameOnlyHit = t;
+  }
+  return nameOnlyHit;
 }
 
 // ─── Mondrian 3 — existing path ────────────────────────────────────────────
 
 function parseM3(schemaEl: Element, opts: ImportOpts): MondrianImportResult {
-	const warnings: string[] = [];
-	const schemaName = schemaEl.getAttribute('name') ?? '';
+  const warnings: string[] = [];
+  const schemaName = schemaEl.getAttribute("name") ?? "";
 
-	const cubeEls = Array.from(schemaEl.querySelectorAll(':scope > Cube'));
-	if (cubeEls.length === 0) throw new Error('Schema has no <Cube>.');
+  const cubeEls = Array.from(schemaEl.querySelectorAll(":scope > Cube"));
+  if (cubeEls.length === 0) throw new Error("Schema has no <Cube>.");
 
-	const keyFor = (schema: string | null, name: string) =>
-		`${(schema ?? '').toLowerCase()}::${name.toLowerCase()}`;
+  const keyFor = (schema: string | null, name: string) =>
+    `${(schema ?? "").toLowerCase()}::${name.toLowerCase()}`;
 
-	// ── Phase 0 — collect schema-level shared <Dimension> blocks ──
-	// FoodMart-style: <Schema><Dimension name="Time"><Hierarchy…><Table/>
-	// </Hierarchy></Dimension>…<Cube><DimensionUsage source="Time" …/></Cube>
-	// Cubes reference shared dims via <DimensionUsage source=X foreignKey=Y>
-	// so Phase 3 has to resolve X → the shared dim's PK table + PK column.
-	interface HierarchyResolved {
-		primaryKey: string | null;
-		// PK-bearing table — where the fact's foreignKey joins.  Comes
-		// from Hierarchy@primaryKeyTable when set, otherwise the first
-		// <Table> in the hierarchy (bare or leftmost inside a <Join>).
-		pkTable: { schema: string | null; name: string } | null;
-		tables: Array<{ schema: string | null; name: string; xmlEl: Element }>;
-		// Snowflake internal joins from <Join leftKey="X" rightKey="Y">
-		// with two Tables inside.  Only the simple 2-table form is
-		// supported; deeper nesting is warned about and dropped.
-		snowflakeJoins: Array<{
-			leftTable: { schema: string | null; name: string };
-			leftCol: string;
-			rightTable: { schema: string | null; name: string };
-			rightCol: string;
-		}>;
-	}
-	function resolveHierarchy(hierEl: Element, dimNameForWarn: string): HierarchyResolved | null {
-		const primaryKey = hierEl.getAttribute('primaryKey');
-		const pkTableAttr = hierEl.getAttribute('primaryKeyTable');
-		const tables: HierarchyResolved['tables'] = [];
-		const snowflakeJoins: HierarchyResolved['snowflakeJoins'] = [];
+  // ── Phase 0 — collect schema-level shared <Dimension> blocks ──
+  // FoodMart-style: <Schema><Dimension name="Time"><Hierarchy…><Table/>
+  // </Hierarchy></Dimension>…<Cube><DimensionUsage source="Time" …/></Cube>
+  // Cubes reference shared dims via <DimensionUsage source=X foreignKey=Y>
+  // so Phase 3 has to resolve X → the shared dim's PK table + PK column.
+  interface HierarchyResolved {
+    primaryKey: string | null;
+    // PK-bearing table — where the fact's foreignKey joins.  Comes
+    // from Hierarchy@primaryKeyTable when set, otherwise the first
+    // <Table> in the hierarchy (bare or leftmost inside a <Join>).
+    pkTable: { schema: string | null; name: string } | null;
+    tables: Array<{ schema: string | null; name: string; xmlEl: Element }>;
+    // Snowflake internal joins from <Join leftKey="X" rightKey="Y">
+    // with two Tables inside.  Only the simple 2-table form is
+    // supported; deeper nesting is warned about and dropped.
+    snowflakeJoins: Array<{
+      leftTable: { schema: string | null; name: string };
+      leftCol: string;
+      rightTable: { schema: string | null; name: string };
+      rightCol: string;
+    }>;
+  }
+  function resolveHierarchy(
+    hierEl: Element,
+    dimNameForWarn: string,
+  ): HierarchyResolved | null {
+    const primaryKey = hierEl.getAttribute("primaryKey");
+    const pkTableAttr = hierEl.getAttribute("primaryKeyTable");
+    const tables: HierarchyResolved["tables"] = [];
+    const snowflakeJoins: HierarchyResolved["snowflakeJoins"] = [];
 
-		// Simple form: <Hierarchy><Table name=…/></Hierarchy>
-		const bareTableEl = hierEl.querySelector(':scope > Table');
-		if (bareTableEl) {
-			const name = bareTableEl.getAttribute('name');
-			if (name) {
-				tables.push({
-					schema: bareTableEl.getAttribute('schema'),
-					name,
-					xmlEl: bareTableEl
-				});
-			}
-		}
+    // Simple form: <Hierarchy><Table name=…/></Hierarchy>
+    const bareTableEl = hierEl.querySelector(":scope > Table");
+    if (bareTableEl) {
+      const name = bareTableEl.getAttribute("name");
+      if (name) {
+        tables.push({
+          schema: bareTableEl.getAttribute("schema"),
+          name,
+          xmlEl: bareTableEl,
+        });
+      }
+    }
 
-		// Snowflake form: <Hierarchy><Join leftKey=… rightKey=…>
-		//   <Table name="a"/><Table name="b"/></Join></Hierarchy>
-		const joinEl = hierEl.querySelector(':scope > Join');
-		if (joinEl) {
-			const leftKey = joinEl.getAttribute('leftKey');
-			const rightKey = joinEl.getAttribute('rightKey');
-			const joinTables = Array.from(joinEl.querySelectorAll(':scope > Table'));
-			const nestedJoins = Array.from(joinEl.querySelectorAll(':scope > Join'));
-			if (nestedJoins.length > 0) {
-				warnings.push(
-					`Dimension "${dimNameForWarn}" uses nested <Join> — only simple 2-table snowflakes are wired for now.`
-				);
-			}
-			if (joinTables.length >= 1) {
-				const t0 = joinTables[0];
-				const t0name = t0.getAttribute('name');
-				if (t0name) {
-					tables.push({
-						schema: t0.getAttribute('schema'),
-						name: t0name,
-						xmlEl: t0
-					});
-				}
-			}
-			if (joinTables.length >= 2 && leftKey && rightKey) {
-				const t0 = joinTables[0];
-				const t1 = joinTables[1];
-				const t0name = t0.getAttribute('name');
-				const t1name = t1.getAttribute('name');
-				if (t1name) {
-					tables.push({
-						schema: t1.getAttribute('schema'),
-						name: t1name,
-						xmlEl: t1
-					});
-				}
-				if (t0name && t1name) {
-					snowflakeJoins.push({
-						leftTable: { schema: t0.getAttribute('schema'), name: t0name },
-						leftCol: leftKey,
-						rightTable: { schema: t1.getAttribute('schema'), name: t1name },
-						rightCol: rightKey
-					});
-				}
-			}
-		}
+    // Snowflake form: <Hierarchy><Join leftKey=… rightKey=…>
+    //   <Table name="a"/><Table name="b"/></Join></Hierarchy>
+    const joinEl = hierEl.querySelector(":scope > Join");
+    if (joinEl) {
+      const leftKey = joinEl.getAttribute("leftKey");
+      const rightKey = joinEl.getAttribute("rightKey");
+      const joinTables = Array.from(joinEl.querySelectorAll(":scope > Table"));
+      const nestedJoins = Array.from(joinEl.querySelectorAll(":scope > Join"));
+      if (nestedJoins.length > 0) {
+        warnings.push(
+          `Dimension "${dimNameForWarn}" uses nested <Join> — only simple 2-table snowflakes are wired for now.`,
+        );
+      }
+      if (joinTables.length >= 1) {
+        const t0 = joinTables[0];
+        const t0name = t0.getAttribute("name");
+        if (t0name) {
+          tables.push({
+            schema: t0.getAttribute("schema"),
+            name: t0name,
+            xmlEl: t0,
+          });
+        }
+      }
+      if (joinTables.length >= 2 && leftKey && rightKey) {
+        const t0 = joinTables[0];
+        const t1 = joinTables[1];
+        const t0name = t0.getAttribute("name");
+        const t1name = t1.getAttribute("name");
+        if (t1name) {
+          tables.push({
+            schema: t1.getAttribute("schema"),
+            name: t1name,
+            xmlEl: t1,
+          });
+        }
+        if (t0name && t1name) {
+          snowflakeJoins.push({
+            leftTable: { schema: t0.getAttribute("schema"), name: t0name },
+            leftCol: leftKey,
+            rightTable: { schema: t1.getAttribute("schema"), name: t1name },
+            rightCol: rightKey,
+          });
+        }
+      }
+    }
 
-		if (tables.length === 0) return null;
+    if (tables.length === 0) return null;
 
-		// PK-bearing table — primaryKeyTable attr overrides; else first.
-		let pkTable: HierarchyResolved['pkTable'] = tables[0];
-		if (pkTableAttr) {
-			const hit = tables.find((t) => t.name.toLowerCase() === pkTableAttr.toLowerCase());
-			if (hit) pkTable = hit;
-		}
-		return { primaryKey, pkTable, tables, snowflakeJoins };
-	}
+    // PK-bearing table — primaryKeyTable attr overrides; else first.
+    let pkTable: HierarchyResolved["pkTable"] = tables[0];
+    if (pkTableAttr) {
+      const hit = tables.find(
+        (t) => t.name.toLowerCase() === pkTableAttr.toLowerCase(),
+      );
+      if (hit) pkTable = hit;
+    }
+    return { primaryKey, pkTable, tables, snowflakeJoins };
+  }
 
-	// Schema-level dims — keyed by <Dimension name="…">.
-	interface SharedDim {
-		name: string;
-		hierarchy: HierarchyResolved;
-	}
-	const sharedDims = new Map<string, SharedDim>();
-	for (const dimEl of Array.from(schemaEl.querySelectorAll(':scope > Dimension'))) {
-		const dimName = dimEl.getAttribute('name');
-		if (!dimName) continue;
-		const hierarchyEl = dimEl.querySelector(':scope > Hierarchy');
-		if (!hierarchyEl) continue;
-		const hier = resolveHierarchy(hierarchyEl, dimName);
-		if (hier) sharedDims.set(dimName, { name: dimName, hierarchy: hier });
-	}
+  // Schema-level dims — keyed by <Dimension name="…">.
+  interface SharedDim {
+    name: string;
+    hierarchy: HierarchyResolved;
+  }
+  const sharedDims = new Map<string, SharedDim>();
+  for (const dimEl of Array.from(
+    schemaEl.querySelectorAll(":scope > Dimension"),
+  )) {
+    const dimName = dimEl.getAttribute("name");
+    if (!dimName) continue;
+    const hierarchyEl = dimEl.querySelector(":scope > Hierarchy");
+    if (!hierarchyEl) continue;
+    const hier = resolveHierarchy(hierarchyEl, dimName);
+    if (hier) sharedDims.set(dimName, { name: dimName, hierarchy: hier });
+  }
 
-	// ── Phase 1 — derive the PHYSICAL SCHEMA ──
-	interface PhysDescriptor {
-		schema: string | null;
-		name: string;
-		role: 'fact' | 'dimension';
-		xmlHost: Element; // for column enrichment from XML
-	}
-	const phys = new Map<string, PhysDescriptor>();
+  // ── Phase 1 — derive the PHYSICAL SCHEMA ──
+  interface PhysDescriptor {
+    schema: string | null;
+    name: string;
+    role: "fact" | "dimension";
+    xmlHost: Element; // for column enrichment from XML
+  }
+  const phys = new Map<string, PhysDescriptor>();
 
-	function ensurePhys(
-		schema: string | null,
-		name: string,
-		role: 'fact' | 'dimension',
-		xmlHost: Element
-	) {
-		const k = keyFor(schema, name);
-		const existing = phys.get(k);
-		if (existing) {
-			if (role === 'fact') existing.role = 'fact'; // fact wins
-		} else {
-			phys.set(k, { schema, name, role, xmlHost });
-		}
-	}
+  function ensurePhys(
+    schema: string | null,
+    name: string,
+    role: "fact" | "dimension",
+    xmlHost: Element,
+  ) {
+    const k = keyFor(schema, name);
+    const existing = phys.get(k);
+    if (existing) {
+      if (role === "fact") existing.role = "fact"; // fact wins
+    } else {
+      phys.set(k, { schema, name, role, xmlHost });
+    }
+  }
 
-	for (const cubeEl of cubeEls) {
-		const cubeName = cubeEl.getAttribute('name') ?? '(unnamed)';
+  for (const cubeEl of cubeEls) {
+    const cubeName = cubeEl.getAttribute("name") ?? "(unnamed)";
 
-		const factEl = cubeEl.querySelector(':scope > Table');
-		if (!factEl) {
-			warnings.push(`Cube "${cubeName}" has no <Table> (fact); ignored.`);
-			continue;
-		}
-		const factName = factEl.getAttribute('name');
-		if (!factName) {
-			warnings.push(`Cube "${cubeName}" fact <Table> has no name attribute; ignored.`);
-			continue;
-		}
-		ensurePhys(factEl.getAttribute('schema'), factName, 'fact', cubeEl);
+    const factEl = cubeEl.querySelector(":scope > Table");
+    if (!factEl) {
+      warnings.push(`Cube "${cubeName}" has no <Table> (fact); ignored.`);
+      continue;
+    }
+    const factName = factEl.getAttribute("name");
+    if (!factName) {
+      warnings.push(
+        `Cube "${cubeName}" fact <Table> has no name attribute; ignored.`,
+      );
+      continue;
+    }
+    ensurePhys(factEl.getAttribute("schema"), factName, "fact", cubeEl);
 
-		// Inline <Dimension> in the cube (rare but possible).
-		for (const dimEl of Array.from(cubeEl.querySelectorAll(':scope > Dimension'))) {
-			const dimName = dimEl.getAttribute('name') ?? '(inline)';
-			const hierarchyEl = dimEl.querySelector(':scope > Hierarchy');
-			if (!hierarchyEl) continue;
-			const hier = resolveHierarchy(hierarchyEl, dimName);
-			if (!hier) continue;
-			for (const t of hier.tables) {
-				ensurePhys(t.schema, t.name, 'dimension', t.xmlEl);
-			}
-		}
+    // Inline <Dimension> in the cube (rare but possible).
+    for (const dimEl of Array.from(
+      cubeEl.querySelectorAll(":scope > Dimension"),
+    )) {
+      const dimName = dimEl.getAttribute("name") ?? "(inline)";
+      const hierarchyEl = dimEl.querySelector(":scope > Hierarchy");
+      if (!hierarchyEl) continue;
+      const hier = resolveHierarchy(hierarchyEl, dimName);
+      if (!hier) continue;
+      for (const t of hier.tables) {
+        ensurePhys(t.schema, t.name, "dimension", t.xmlEl);
+      }
+    }
 
-		// <DimensionUsage source="X"> → resolve to schema-level shared dim.
-		for (const usageEl of Array.from(cubeEl.querySelectorAll(':scope > DimensionUsage'))) {
-			const source = usageEl.getAttribute('source');
-			if (!source) continue;
-			const shared = sharedDims.get(source);
-			if (!shared) {
-				warnings.push(
-					`Cube "${cubeName}" references dimension "${source}" via <DimensionUsage>, but no schema-level <Dimension name="${source}"> was found.`
-				);
-				continue;
-			}
-			for (const t of shared.hierarchy.tables) {
-				ensurePhys(t.schema, t.name, 'dimension', t.xmlEl);
-			}
-		}
-	}
+    // <DimensionUsage source="X"> → resolve to schema-level shared dim.
+    for (const usageEl of Array.from(
+      cubeEl.querySelectorAll(":scope > DimensionUsage"),
+    )) {
+      const source = usageEl.getAttribute("source");
+      if (!source) continue;
+      const shared = sharedDims.get(source);
+      if (!shared) {
+        warnings.push(
+          `Cube "${cubeName}" references dimension "${source}" via <DimensionUsage>, but no schema-level <Dimension name="${source}"> was found.`,
+        );
+        continue;
+      }
+      for (const t of shared.hierarchy.tables) {
+        ensurePhys(t.schema, t.name, "dimension", t.xmlEl);
+      }
+    }
+  }
 
-	// ── Phase 2 — emit canvas tables from the physical schema ──
-	// Inherit the CATALOG's schema attribute when the XML omitted it.
-	// FoodMart-style XML writes bare `<Table name="sales_fact_1997"/>`
-	// so p.schema is null; but the catalog stores it as `public::…`.
-	// Without this inheritance the sidebar "on canvas" markers don't
-	// light up (identity mismatch), Phase-3 join lookups miss, and
-	// any downstream schema-qualified equality fails silently.
-	const tables: SchemaCanvasTable[] = [];
-	const tableIdByKey = new Map<string, string>();
-	const physKeys = [...phys.keys()];
-	const gridCols = Math.max(1, Math.ceil(Math.sqrt(physKeys.length)));
-	physKeys.forEach((k, i) => {
-		const p = phys.get(k)!;
-		const catalogHit = lookupTableInCatalog(opts.sourceTables, p.schema, p.name);
-		const resolvedSchema = catalogHit?.schema ?? p.schema;
-		const cols =
-			(catalogHit ? catalogHit.columns.map((c) => ({ name: c.name, sqlType: c.sqlType })) : null) ??
-			collectColumnsFromM3Xml(p.xmlHost, p.name, p.role, warnings);
-		const id = makeId('tbl');
-		tables.push({
-			id,
-			schema: resolvedSchema,
-			name: p.name,
-			role: p.role,
-			columns: cols,
-			position: {
-				x: 200 + (i % gridCols) * 320,
-				y: 160 + Math.floor(i / gridCols) * 280
-			},
-			groupId: null
-		});
-		// Register under BOTH the original XML key (Phase 3 lookups use
-		// the XML-declared identity) AND the catalog-resolved key (so
-		// snowflake-join lookups matching resolved schemas hit too).
-		tableIdByKey.set(k, id);
-		const resolvedKey = keyFor(resolvedSchema, p.name);
-		if (resolvedKey !== k) tableIdByKey.set(resolvedKey, id);
-	});
+  // ── Phase 2 — emit canvas tables from the physical schema ──
+  // Inherit the CATALOG's schema attribute when the XML omitted it.
+  // FoodMart-style XML writes bare `<Table name="sales_fact_1997"/>`
+  // so p.schema is null; but the catalog stores it as `public::…`.
+  // Without this inheritance the sidebar "on canvas" markers don't
+  // light up (identity mismatch), Phase-3 join lookups miss, and
+  // any downstream schema-qualified equality fails silently.
+  const tables: SchemaCanvasTable[] = [];
+  const tableIdByKey = new Map<string, string>();
+  const physKeys = [...phys.keys()];
+  const gridCols = Math.max(1, Math.ceil(Math.sqrt(physKeys.length)));
+  physKeys.forEach((k, i) => {
+    const p = phys.get(k)!;
+    const catalogHit = lookupTableInCatalog(
+      opts.sourceTables,
+      p.schema,
+      p.name,
+    );
+    const resolvedSchema = catalogHit?.schema ?? p.schema;
+    const cols =
+      (catalogHit
+        ? catalogHit.columns.map((c) => ({ name: c.name, sqlType: c.sqlType }))
+        : null) ?? collectColumnsFromM3Xml(p.xmlHost, p.name, p.role, warnings);
+    const id = makeId("tbl");
+    tables.push({
+      id,
+      schema: resolvedSchema,
+      name: p.name,
+      role: p.role,
+      columns: cols,
+      position: {
+        x: 200 + (i % gridCols) * 320,
+        y: 160 + Math.floor(i / gridCols) * 280,
+      },
+      groupId: null,
+    });
+    // Register under BOTH the original XML key (Phase 3 lookups use
+    // the XML-declared identity) AND the catalog-resolved key (so
+    // snowflake-join lookups matching resolved schemas hit too).
+    tableIdByKey.set(k, id);
+    const resolvedKey = keyFor(resolvedSchema, p.name);
+    if (resolvedKey !== k) tableIdByKey.set(resolvedKey, id);
+  });
 
-	// ── Phase 3 — walk cubes to emit joins + workbench cubes ──
-	const joins: SchemaCanvasJoin[] = [];
-	const joinKeys = new Set<string>();
-	const workbenchCubes: ImportedWorkbenchCube[] = [];
+  // ── Phase 3 — walk cubes to emit joins + workbench cubes ──
+  const joins: SchemaCanvasJoin[] = [];
+  const joinKeys = new Set<string>();
+  const workbenchCubes: ImportedWorkbenchCube[] = [];
 
-	function pushJoin(
-		sourceTableId: string,
-		sourceColumnName: string,
-		targetTableId: string,
-		targetColumnName: string
-	) {
-		const joinKey = `${sourceTableId}::${sourceColumnName}->${targetTableId}::${targetColumnName}`;
-		if (joinKeys.has(joinKey)) return;
-		joinKeys.add(joinKey);
-		joins.push({
-			id: makeId('join'),
-			sourceTableId,
-			sourceColumnName,
-			targetTableId,
-			targetColumnName,
-			kind: 'inner',
-			origin: 'physical'
-		});
-	}
+  function pushJoin(
+    sourceTableId: string,
+    sourceColumnName: string,
+    targetTableId: string,
+    targetColumnName: string,
+  ) {
+    const joinKey = `${sourceTableId}::${sourceColumnName}->${targetTableId}::${targetColumnName}`;
+    if (joinKeys.has(joinKey)) return;
+    joinKeys.add(joinKey);
+    joins.push({
+      id: makeId("join"),
+      sourceTableId,
+      sourceColumnName,
+      targetTableId,
+      targetColumnName,
+      kind: "inner",
+      origin: "physical",
+    });
+  }
 
-	// Snowflake joins from schema-level shared dims land ONCE (they're
-	// part of the physical schema, not tied to any specific cube).
-	for (const shared of sharedDims.values()) {
-		for (const sj of shared.hierarchy.snowflakeJoins) {
-			const leftId = tableIdByKey.get(keyFor(sj.leftTable.schema, sj.leftTable.name));
-			const rightId = tableIdByKey.get(keyFor(sj.rightTable.schema, sj.rightTable.name));
-			if (leftId && rightId) pushJoin(leftId, sj.leftCol, rightId, sj.rightCol);
-		}
-	}
+  // Snowflake joins from schema-level shared dims land ONCE (they're
+  // part of the physical schema, not tied to any specific cube).
+  for (const shared of sharedDims.values()) {
+    for (const sj of shared.hierarchy.snowflakeJoins) {
+      const leftId = tableIdByKey.get(
+        keyFor(sj.leftTable.schema, sj.leftTable.name),
+      );
+      const rightId = tableIdByKey.get(
+        keyFor(sj.rightTable.schema, sj.rightTable.name),
+      );
+      if (leftId && rightId) pushJoin(leftId, sj.leftCol, rightId, sj.rightCol);
+    }
+  }
 
-	for (const cubeEl of cubeEls) {
-		const cubeName = cubeEl.getAttribute('name') ?? '(unnamed)';
-		const factEl = cubeEl.querySelector(':scope > Table');
-		const factName = factEl?.getAttribute('name');
-		const factSchema = factEl?.getAttribute('schema') ?? null;
-		if (!factName) continue;
-		const factId = tableIdByKey.get(keyFor(factSchema, factName));
-		if (!factId) continue;
+  for (const cubeEl of cubeEls) {
+    const cubeName = cubeEl.getAttribute("name") ?? "(unnamed)";
+    const factEl = cubeEl.querySelector(":scope > Table");
+    const factName = factEl?.getAttribute("name");
+    const factSchema = factEl?.getAttribute("schema") ?? null;
+    if (!factName) continue;
+    const factId = tableIdByKey.get(keyFor(factSchema, factName));
+    if (!factId) continue;
 
-		const measureCols: string[] = [];
-		const dimensionLinks: ImportedWorkbenchMeasureGroup['dimensionLinks'] = [];
-		for (const measureEl of Array.from(cubeEl.querySelectorAll(':scope > Measure'))) {
-			const col = measureEl.getAttribute('column');
-			if (col) measureCols.push(col);
-		}
+    const measureCols: string[] = [];
+    const dimensionLinks: ImportedWorkbenchMeasureGroup["dimensionLinks"] = [];
+    for (const measureEl of Array.from(
+      cubeEl.querySelectorAll(":scope > Measure"),
+    )) {
+      const col = measureEl.getAttribute("column");
+      if (col) measureCols.push(col);
+    }
 
-		// Inline <Dimension> — existing path.
-		for (const dimEl of Array.from(cubeEl.querySelectorAll(':scope > Dimension'))) {
-			const fk = dimEl.getAttribute('foreignKey');
-			const dimName = dimEl.getAttribute('name') ?? '(inline)';
-			const hierarchyEl = dimEl.querySelector(':scope > Hierarchy');
-			if (!hierarchyEl) {
-				warnings.push(
-					`<Dimension name="${dimName}"> in cube "${cubeName}" has no <Hierarchy>; skipped.`
-				);
-				continue;
-			}
-			const hier = resolveHierarchy(hierarchyEl, dimName);
-			if (!hier || !hier.pkTable) continue;
-			const dimId = tableIdByKey.get(keyFor(hier.pkTable.schema, hier.pkTable.name));
-			if (!dimId) continue;
-			if (fk && hier.primaryKey) {
-				pushJoin(dimId, hier.primaryKey, factId, fk);
-				dimensionLinks.push({
-					dimensionId: dimId,
-					foreignKeyColumn: fk,
-					linkKind: 'foreign-key'
-				});
-			} else {
-				warnings.push(
-					`Dimension "${dimName}" in cube "${cubeName}" missing foreignKey/primaryKey; join skipped.`
-				);
-			}
-		}
+    // Inline <Dimension> — existing path.
+    for (const dimEl of Array.from(
+      cubeEl.querySelectorAll(":scope > Dimension"),
+    )) {
+      const fk = dimEl.getAttribute("foreignKey");
+      const dimName = dimEl.getAttribute("name") ?? "(inline)";
+      const hierarchyEl = dimEl.querySelector(":scope > Hierarchy");
+      if (!hierarchyEl) {
+        warnings.push(
+          `<Dimension name="${dimName}"> in cube "${cubeName}" has no <Hierarchy>; skipped.`,
+        );
+        continue;
+      }
+      const hier = resolveHierarchy(hierarchyEl, dimName);
+      if (!hier || !hier.pkTable) continue;
+      const dimId = tableIdByKey.get(
+        keyFor(hier.pkTable.schema, hier.pkTable.name),
+      );
+      if (!dimId) continue;
+      if (fk && hier.primaryKey) {
+        pushJoin(dimId, hier.primaryKey, factId, fk);
+        dimensionLinks.push({
+          dimensionId: dimId,
+          foreignKeyColumn: fk,
+          linkKind: "foreign-key",
+        });
+      } else {
+        warnings.push(
+          `Dimension "${dimName}" in cube "${cubeName}" missing foreignKey/primaryKey; join skipped.`,
+        );
+      }
+    }
 
-		// <DimensionUsage> — resolve source → shared dim → PK table.
-		for (const usageEl of Array.from(cubeEl.querySelectorAll(':scope > DimensionUsage'))) {
-			const usageName = usageEl.getAttribute('name') ?? usageEl.getAttribute('source') ?? '(usage)';
-			const source = usageEl.getAttribute('source');
-			const fk = usageEl.getAttribute('foreignKey');
-			if (!source) {
-				warnings.push(
-					`<DimensionUsage name="${usageName}"> in cube "${cubeName}" has no source= attribute; skipped.`
-				);
-				continue;
-			}
-			const shared = sharedDims.get(source);
-			if (!shared || !shared.hierarchy.pkTable || !shared.hierarchy.primaryKey) continue;
-			const dimId = tableIdByKey.get(
-				keyFor(shared.hierarchy.pkTable.schema, shared.hierarchy.pkTable.name)
-			);
-			if (!dimId) continue;
-			if (fk) {
-				pushJoin(dimId, shared.hierarchy.primaryKey, factId, fk);
-				dimensionLinks.push({
-					dimensionId: dimId,
-					foreignKeyColumn: fk,
-					linkKind: 'foreign-key'
-				});
-			} else {
-				warnings.push(
-					`<DimensionUsage name="${usageName}"> in cube "${cubeName}" has no foreignKey=; join skipped.`
-				);
-			}
-		}
+    // <DimensionUsage> — resolve source → shared dim → PK table.
+    for (const usageEl of Array.from(
+      cubeEl.querySelectorAll(":scope > DimensionUsage"),
+    )) {
+      const usageName =
+        usageEl.getAttribute("name") ??
+        usageEl.getAttribute("source") ??
+        "(usage)";
+      const source = usageEl.getAttribute("source");
+      const fk = usageEl.getAttribute("foreignKey");
+      if (!source) {
+        warnings.push(
+          `<DimensionUsage name="${usageName}"> in cube "${cubeName}" has no source= attribute; skipped.`,
+        );
+        continue;
+      }
+      const shared = sharedDims.get(source);
+      if (!shared || !shared.hierarchy.pkTable || !shared.hierarchy.primaryKey)
+        continue;
+      const dimId = tableIdByKey.get(
+        keyFor(shared.hierarchy.pkTable.schema, shared.hierarchy.pkTable.name),
+      );
+      if (!dimId) continue;
+      if (fk) {
+        pushJoin(dimId, shared.hierarchy.primaryKey, factId, fk);
+        dimensionLinks.push({
+          dimensionId: dimId,
+          foreignKeyColumn: fk,
+          linkKind: "foreign-key",
+        });
+      } else {
+        warnings.push(
+          `<DimensionUsage name="${usageName}"> in cube "${cubeName}" has no foreignKey=; join skipped.`,
+        );
+      }
+    }
 
-		workbenchCubes.push({
-			id: makeId('cube'),
-			name: cubeName,
-			measureGroups: [
-				{
-					id: makeId('mg'),
-					name: cubeName,
-					factTableId: factId,
-					measureColumns: measureCols,
-					dimensionLinks
-				}
-			],
-			factsCalcs: []
-		});
-	}
+    workbenchCubes.push({
+      id: makeId("cube"),
+      name: cubeName,
+      measureGroups: [
+        {
+          id: makeId("mg"),
+          name: cubeName,
+          factTableId: factId,
+          measureColumns: measureCols,
+          dimensionLinks,
+        },
+      ],
+      factsCalcs: [],
+    });
+  }
 
-	const state: SchemaCanvasState = {
-		version: 1,
-		connectionId: opts.connectionId,
-		label: opts.label ?? schemaName,
-		tables,
-		joins,
-		groups: [],
-		updatedAt: new Date().toISOString()
-	};
-	return { state, warnings, workbenchCubes };
+  const state: SchemaCanvasState = {
+    version: 1,
+    connectionId: opts.connectionId,
+    label: opts.label ?? schemaName,
+    tables,
+    joins,
+    groups: [],
+    updatedAt: new Date().toISOString(),
+  };
+  return { state, warnings, workbenchCubes };
 }
 
 function collectColumnsFromM3Xml(
-	scope: Element,
-	tableName: string,
-	role: 'fact' | 'dimension',
-	warnings: string[]
+  scope: Element,
+  tableName: string,
+  role: "fact" | "dimension",
+  warnings: string[],
 ): SchemaCanvasColumn[] {
-	const names = new Set<string>();
-	if (role === 'fact') {
-		for (const dim of Array.from(scope.querySelectorAll(':scope > Dimension'))) {
-			const fk = dim.getAttribute('foreignKey');
-			if (fk) names.add(fk);
-		}
-	} else {
-		const hier = scope.tagName === 'Hierarchy' ? scope : scope.querySelector(':scope > Hierarchy');
-		if (hier) {
-			const pk = hier.getAttribute('primaryKey');
-			if (pk) names.add(pk);
-			for (const lvl of Array.from(hier.querySelectorAll(':scope > Level'))) {
-				const col = lvl.getAttribute('column') ?? lvl.getAttribute('name');
-				if (col) names.add(col);
-			}
-		}
-	}
-	if (names.size === 0) {
-		warnings.push(
-			`No columns could be inferred for "${tableName}" from XML; canvas node will render empty.`
-		);
-	}
-	return [...names].map((name) => ({ name, sqlType: 'UNKNOWN' }));
+  const names = new Set<string>();
+  if (role === "fact") {
+    for (const dim of Array.from(
+      scope.querySelectorAll(":scope > Dimension"),
+    )) {
+      const fk = dim.getAttribute("foreignKey");
+      if (fk) names.add(fk);
+    }
+  } else {
+    const hier =
+      scope.tagName === "Hierarchy"
+        ? scope
+        : scope.querySelector(":scope > Hierarchy");
+    if (hier) {
+      const pk = hier.getAttribute("primaryKey");
+      if (pk) names.add(pk);
+      for (const lvl of Array.from(hier.querySelectorAll(":scope > Level"))) {
+        const col = lvl.getAttribute("column") ?? lvl.getAttribute("name");
+        if (col) names.add(col);
+      }
+    }
+  }
+  if (names.size === 0) {
+    warnings.push(
+      `No columns could be inferred for "${tableName}" from XML; canvas node will render empty.`,
+    );
+  }
+  return [...names].map((name) => ({ name, sqlType: "UNKNOWN" }));
 }
 
 // ─── Mondrian 4 — new path ─────────────────────────────────────────────────
 
 function parseM4(schemaEl: Element, opts: ImportOpts): MondrianImportResult {
-	const warnings: string[] = [];
-	const schemaName = schemaEl.getAttribute('name') ?? '';
-	// Populated by Phase 6 from <Cube> blocks — handed back to +page.svelte
-	// for localStorage seeding.
-	const workbenchCubes: ImportedWorkbenchCube[] = [];
+  const warnings: string[] = [];
+  const schemaName = schemaEl.getAttribute("name") ?? "";
+  // Populated by Phase 6 from <Cube> blocks — handed back to +page.svelte
+  // for localStorage seeding.
+  const workbenchCubes: ImportedWorkbenchCube[] = [];
 
-	const physSchemaEl = schemaEl.querySelector(':scope > PhysicalSchema');
+  const physSchemaEl = schemaEl.querySelector(":scope > PhysicalSchema");
 
-	// Phase 1: harvest every physical table — schema-qualified, with the
-	// columns scraped from any <Column> descendants (Key declarations,
-	// inline column defs, etc.).
-	interface PhysTable {
-		schema: string | null;
-		name: string;
-		columns: Set<string>;
-		keyColumn: string | null;
-	}
-	const physTables = new Map<string, PhysTable>();
-	if (physSchemaEl) {
-		for (const tEl of Array.from(physSchemaEl.querySelectorAll(':scope > Table'))) {
-			const name = tEl.getAttribute('name');
-			if (!name) continue;
-			const schema = tEl.getAttribute('schema');
-			const columns = new Set<string>();
-			for (const cEl of Array.from(tEl.querySelectorAll('Column'))) {
-				const col = cEl.getAttribute('name');
-				if (col) columns.add(col);
-			}
-			const keyEl = tEl.querySelector(':scope > Key > Column');
-			physTables.set(name, {
-				schema,
-				name,
-				columns,
-				keyColumn: keyEl?.getAttribute('name') ?? null
-			});
-		}
-	}
+  // Phase 1: harvest every physical table — schema-qualified, with the
+  // columns scraped from any <Column> descendants (Key declarations,
+  // inline column defs, etc.).
+  interface PhysTable {
+    schema: string | null;
+    name: string;
+    columns: Set<string>;
+    keyColumn: string | null;
+  }
+  const physTables = new Map<string, PhysTable>();
+  if (physSchemaEl) {
+    for (const tEl of Array.from(
+      physSchemaEl.querySelectorAll(":scope > Table"),
+    )) {
+      const name = tEl.getAttribute("name");
+      if (!name) continue;
+      const schema = tEl.getAttribute("schema");
+      const columns = new Set<string>();
+      for (const cEl of Array.from(tEl.querySelectorAll("Column"))) {
+        const col = cEl.getAttribute("name");
+        if (col) columns.add(col);
+      }
+      const keyEl = tEl.querySelector(":scope > Key > Column");
+      physTables.set(name, {
+        schema,
+        name,
+        columns,
+        keyColumn: keyEl?.getAttribute("name") ?? null,
+      });
+    }
+  }
 
-	// Phase 2: collect every <Cube> — the workbench needs them all.
-	const cubeEls = Array.from(schemaEl.querySelectorAll(':scope > Cube'));
-	if (cubeEls.length === 0) throw new Error('Schema has no <Cube>.');
+  // Phase 2: collect every <Cube> — the workbench needs them all.
+  const cubeEls = Array.from(schemaEl.querySelectorAll(":scope > Cube"));
+  if (cubeEls.length === 0) throw new Error("Schema has no <Cube>.");
 
-	const tables: SchemaCanvasTable[] = [];
-	const joins: SchemaCanvasJoin[] = [];
-	const tableIdByName = new Map<string, string>();
+  const tables: SchemaCanvasTable[] = [];
+  const joins: SchemaCanvasJoin[] = [];
+  const tableIdByName = new Map<string, string>();
 
-	function ensureTable(
-		tableName: string,
-		role: 'fact' | 'dimension',
-		position: { x: number; y: number }
-	): string {
-		const existing = tableIdByName.get(tableName);
-		if (existing) {
-			// Upgrade dim → fact if it gets referenced as a MeasureGroup later.
-			if (role === 'fact') {
-				const t = tables.find((tt) => tt.id === existing);
-				if (t) t.role = 'fact';
-			}
-			return existing;
-		}
-		const phys = physTables.get(tableName);
-		const fromCatalog = phys
-			? lookupColumnsFromCatalog(opts.sourceTables, phys.schema, tableName)
-			: lookupColumnsFromCatalog(opts.sourceTables, null, tableName);
-		const initialCols: SchemaCanvasColumn[] =
-			fromCatalog ?? (phys ? [...phys.columns].map((n) => ({ name: n, sqlType: 'UNKNOWN' })) : []);
-		const id = makeId('tbl');
-		tables.push({
-			id,
-			schema: phys?.schema ?? null,
-			name: tableName,
-			role,
-			columns: initialCols,
-			position,
-			groupId: null
-		});
-		tableIdByName.set(tableName, id);
-		return id;
-	}
+  function ensureTable(
+    tableName: string,
+    role: "fact" | "dimension",
+    position: { x: number; y: number },
+  ): string {
+    const existing = tableIdByName.get(tableName);
+    if (existing) {
+      // Upgrade dim → fact if it gets referenced as a MeasureGroup later.
+      if (role === "fact") {
+        const t = tables.find((tt) => tt.id === existing);
+        if (t) t.role = "fact";
+      }
+      return existing;
+    }
+    const phys = physTables.get(tableName);
+    const fromCatalog = phys
+      ? lookupColumnsFromCatalog(opts.sourceTables, phys.schema, tableName)
+      : lookupColumnsFromCatalog(opts.sourceTables, null, tableName);
+    const initialCols: SchemaCanvasColumn[] =
+      fromCatalog ??
+      (phys
+        ? [...phys.columns].map((n) => ({ name: n, sqlType: "UNKNOWN" }))
+        : []);
+    const id = makeId("tbl");
+    tables.push({
+      id,
+      schema: phys?.schema ?? null,
+      name: tableName,
+      role,
+      columns: initialCols,
+      position,
+      groupId: null,
+    });
+    tableIdByName.set(tableName, id);
+    return id;
+  }
 
-	function ensureColumn(tableId: string, colName: string) {
-		const t = tables.find((tt) => tt.id === tableId);
-		if (!t) return;
-		if (t.columns.some((c) => c.name === colName)) return;
-		t.columns.push({ name: colName, sqlType: 'UNKNOWN' });
-	}
+  function ensureColumn(tableId: string, colName: string) {
+    const t = tables.find((tt) => tt.id === tableId);
+    if (!t) return;
+    if (t.columns.some((c) => c.name === colName)) return;
+    t.columns.push({ name: colName, sqlType: "UNKNOWN" });
+  }
 
-	// Phase 3: MeasureGroups → mark fact tables, harvest measure columns.
-	// Walks EVERY cube's MGs, not just the first cube's, so multi-cube
-	// schemas (FoodMart has 6) register every fact table.  Flat `mgEls`
-	// stays around for the join-inference pass further down.
-	const mgEls: Element[] = [];
-	for (const c of cubeEls) {
-		for (const m of Array.from(c.querySelectorAll(':scope > MeasureGroups > MeasureGroup'))) {
-			mgEls.push(m);
-		}
-	}
-	mgEls.forEach((mgEl) => {
-		const tableName = mgEl.getAttribute('table');
-		if (!tableName) {
-			warnings.push(`<MeasureGroup name="${mgEl.getAttribute('name')}"> has no table; skipped.`);
-			return;
-		}
-		const factId = ensureTable(tableName, 'fact', { x: 600, y: 400 });
-		for (const mEl of Array.from(mgEl.querySelectorAll(':scope > Measures > Measure'))) {
-			const col = measureColumnOf(mEl);
-			if (col) ensureColumn(factId, col);
-		}
-	});
-	if (mgEls.length === 0) {
-		warnings.push("No <MeasureGroup> found in any cube — fact tables won't be marked.");
-	}
+  // Phase 3: MeasureGroups → mark fact tables, harvest measure columns.
+  // Walks EVERY cube's MGs, not just the first cube's, so multi-cube
+  // schemas (FoodMart has 6) register every fact table.  Flat `mgEls`
+  // stays around for the join-inference pass further down.
+  const mgEls: Element[] = [];
+  for (const c of cubeEls) {
+    for (const m of Array.from(
+      c.querySelectorAll(":scope > MeasureGroups > MeasureGroup"),
+    )) {
+      mgEls.push(m);
+    }
+  }
+  mgEls.forEach((mgEl) => {
+    const tableName = mgEl.getAttribute("table");
+    if (!tableName) {
+      warnings.push(
+        `<MeasureGroup name="${mgEl.getAttribute("name")}"> has no table; skipped.`,
+      );
+      return;
+    }
+    const factId = ensureTable(tableName, "fact", { x: 600, y: 400 });
+    for (const mEl of Array.from(
+      mgEl.querySelectorAll(":scope > Measures > Measure"),
+    )) {
+      const col = measureColumnOf(mEl);
+      if (col) ensureColumn(factId, col);
+    }
+  });
+  if (mgEls.length === 0) {
+    warnings.push(
+      "No <MeasureGroup> found in any cube — fact tables won't be marked.",
+    );
+  }
 
-	// Phase 4: Dimensions → register dim tables, harvest attribute columns.
-	// Walks SCHEMA-level <Dimension>s (Mondrian 4's shared-dim model) AND
-	// cube-private <Dimension>s, so every dim's underlying table is on the
-	// canvas before the workbench-side parser tries to resolve attributes
-	// against it.  Per-attribute `table=` overrides are also registered so
-	// cross-table dims (e.g. Customer with attributes on `customer` + dim
-	// joins to `customer_class`) get their secondary tables too.
-	const dimByName = new Map<string, string>(); // dim "logical" name → physical table name
-	const schemaDimEls = Array.from(schemaEl.querySelectorAll(':scope > Dimension'));
-	const cubeDimEls: Element[] = [];
-	for (const c of cubeEls) {
-		for (const dEl of Array.from(c.querySelectorAll(':scope > Dimensions > Dimension'))) {
-			// source='X' refers to a shared dim that's already in schemaDimEls;
-			// skip duplicate ensureTable.
-			if (dEl.getAttribute('source')) continue;
-			cubeDimEls.push(dEl);
-		}
-	}
-	const allDimEls = [...schemaDimEls, ...cubeDimEls];
-	const n = Math.max(1, allDimEls.length);
-	allDimEls.forEach((dimEl, i) => {
-		const logical = dimEl.getAttribute('name') ?? '';
-		const dimTableName = dimEl.getAttribute('table');
-		const gridCols = n <= 4 ? 2 : n <= 9 ? 3 : 4;
-		const gridRow = Math.floor(i / gridCols);
-		const gridCol = i % gridCols;
-		const posBase = { x: 320 + gridCol * 320, y: 200 + gridRow * 280 };
-		let dimTableId: string | null = null;
-		if (dimTableName) {
-			dimByName.set(logical, dimTableName);
-			dimTableId = ensureTable(dimTableName, 'dimension', posBase);
-		} else {
-			// Dim has no top-level table=; pick the FIRST attribute's table=
-			// as the canonical physical table.  Suppresses the legacy
-			// "references an undefined dimension" inference warning for dims
-			// like Store2 / Product whose tables only appear at attribute scope.
-			const firstAttrTable = dimEl
-				.querySelector(':scope > Attributes > Attribute[table]')
-				?.getAttribute('table');
-			if (firstAttrTable) dimByName.set(logical, firstAttrTable);
-		}
-		// Each Attribute may override `table=`; register every referenced
-		// table so attribute-level table refs (e.g. Product attrs on both
-		// product + product_class) resolve.
-		for (const aEl of Array.from(dimEl.querySelectorAll(':scope > Attributes > Attribute'))) {
-			const attrTable = aEl.getAttribute('table');
-			let attrTableId = dimTableId;
-			if (attrTable) {
-				attrTableId = ensureTable(attrTable, 'dimension', {
-					x: posBase.x + 40,
-					y: posBase.y + 40
-				});
-			}
-			const col =
-				aEl.getAttribute('keyColumn') ??
-				aEl.getAttribute('nameColumn') ??
-				aEl.querySelector(':scope > Key > Column')?.getAttribute('name');
-			if (attrTableId && col) ensureColumn(attrTableId, col);
-		}
-		// No warning when dimTableName is absent — the workbench parser
-		// handles per-attribute table= refs (Store2 / Product follow this
-		// pattern), and we just inferred the canonical physical table from
-		// the first attribute above for the legacy join-inference path.
-		// The previous "has no table attribute; skipped" message was
-		// misleading — the dim was NOT skipped, just registered differently.
-	});
+  // Phase 4: Dimensions → register dim tables, harvest attribute columns.
+  // Walks SCHEMA-level <Dimension>s (Mondrian 4's shared-dim model) AND
+  // cube-private <Dimension>s, so every dim's underlying table is on the
+  // canvas before the workbench-side parser tries to resolve attributes
+  // against it.  Per-attribute `table=` overrides are also registered so
+  // cross-table dims (e.g. Customer with attributes on `customer` + dim
+  // joins to `customer_class`) get their secondary tables too.
+  const dimByName = new Map<string, string>(); // dim "logical" name → physical table name
+  const schemaDimEls = Array.from(
+    schemaEl.querySelectorAll(":scope > Dimension"),
+  );
+  const cubeDimEls: Element[] = [];
+  for (const c of cubeEls) {
+    for (const dEl of Array.from(
+      c.querySelectorAll(":scope > Dimensions > Dimension"),
+    )) {
+      // source='X' refers to a shared dim that's already in schemaDimEls;
+      // skip duplicate ensureTable.
+      if (dEl.getAttribute("source")) continue;
+      cubeDimEls.push(dEl);
+    }
+  }
+  const allDimEls = [...schemaDimEls, ...cubeDimEls];
+  const n = Math.max(1, allDimEls.length);
+  allDimEls.forEach((dimEl, i) => {
+    const logical = dimEl.getAttribute("name") ?? "";
+    const dimTableName = dimEl.getAttribute("table");
+    const gridCols = n <= 4 ? 2 : n <= 9 ? 3 : 4;
+    const gridRow = Math.floor(i / gridCols);
+    const gridCol = i % gridCols;
+    const posBase = { x: 320 + gridCol * 320, y: 200 + gridRow * 280 };
+    let dimTableId: string | null = null;
+    if (dimTableName) {
+      dimByName.set(logical, dimTableName);
+      dimTableId = ensureTable(dimTableName, "dimension", posBase);
+    } else {
+      // Dim has no top-level table=; pick the FIRST attribute's table=
+      // as the canonical physical table.  Suppresses the legacy
+      // "references an undefined dimension" inference warning for dims
+      // like Store2 / Product whose tables only appear at attribute scope.
+      const firstAttrTable = dimEl
+        .querySelector(":scope > Attributes > Attribute[table]")
+        ?.getAttribute("table");
+      if (firstAttrTable) dimByName.set(logical, firstAttrTable);
+    }
+    // Each Attribute may override `table=`; register every referenced
+    // table so attribute-level table refs (e.g. Product attrs on both
+    // product + product_class) resolve.
+    for (const aEl of Array.from(
+      dimEl.querySelectorAll(":scope > Attributes > Attribute"),
+    )) {
+      const attrTable = aEl.getAttribute("table");
+      let attrTableId = dimTableId;
+      if (attrTable) {
+        attrTableId = ensureTable(attrTable, "dimension", {
+          x: posBase.x + 40,
+          y: posBase.y + 40,
+        });
+      }
+      const col =
+        aEl.getAttribute("keyColumn") ??
+        aEl.getAttribute("nameColumn") ??
+        aEl.querySelector(":scope > Key > Column")?.getAttribute("name");
+      if (attrTableId && col) ensureColumn(attrTableId, col);
+    }
+    // No warning when dimTableName is absent — the workbench parser
+    // handles per-attribute table= refs (Store2 / Product follow this
+    // pattern), and we just inferred the canonical physical table from
+    // the first attribute above for the legacy join-inference path.
+    // The previous "has no table attribute; skipped" message was
+    // misleading — the dim was NOT skipped, just registered differently.
+  });
 
-	// Phase 5: PhysicalSchema Links → table-pair joins. A Link's <ForeignKey>
-	// <Column> sits on the TARGET side; the SOURCE side uses its declared <Key>.
-	function joinExists(srcId: string, srcCol: string, tgtId: string, tgtCol: string): boolean {
-		return joins.some(
-			(j) =>
-				(j.sourceTableId === srcId &&
-					j.targetTableId === tgtId &&
-					j.sourceColumnName === srcCol &&
-					j.targetColumnName === tgtCol) ||
-				(j.sourceTableId === tgtId &&
-					j.targetTableId === srcId &&
-					j.sourceColumnName === tgtCol &&
-					j.targetColumnName === srcCol)
-		);
-	}
+  // Phase 5: PhysicalSchema Links → table-pair joins. A Link's <ForeignKey>
+  // <Column> sits on the TARGET side; the SOURCE side uses its declared <Key>.
+  function joinExists(
+    srcId: string,
+    srcCol: string,
+    tgtId: string,
+    tgtCol: string,
+  ): boolean {
+    return joins.some(
+      (j) =>
+        (j.sourceTableId === srcId &&
+          j.targetTableId === tgtId &&
+          j.sourceColumnName === srcCol &&
+          j.targetColumnName === tgtCol) ||
+        (j.sourceTableId === tgtId &&
+          j.targetTableId === srcId &&
+          j.sourceColumnName === tgtCol &&
+          j.targetColumnName === srcCol),
+    );
+  }
 
-	if (physSchemaEl) {
-		for (const linkEl of Array.from(physSchemaEl.querySelectorAll(':scope > Link'))) {
-			const sourceName = linkEl.getAttribute('source');
-			const targetName = linkEl.getAttribute('target');
-			if (!sourceName || !targetName) continue;
-			const fkColEl = linkEl.querySelector('ForeignKey > Column');
-			const fkColName = fkColEl?.getAttribute('name');
-			if (!fkColName) {
-				warnings.push(
-					`<Link source="${sourceName}" target="${targetName}"> has no <ForeignKey><Column>; skipped.`
-				);
-				continue;
-			}
-			const sourceId = ensureTable(sourceName, 'dimension', { x: 0, y: 0 });
-			const targetId = ensureTable(targetName, 'dimension', { x: 0, y: 0 });
-			const sourcePhys = physTables.get(sourceName);
-			const sourceKey = sourcePhys?.keyColumn ?? 'id';
-			ensureColumn(sourceId, sourceKey);
-			ensureColumn(targetId, fkColName);
-			if (!joinExists(sourceId, sourceKey, targetId, fkColName)) {
-				joins.push({
-					id: makeId('join'),
-					sourceTableId: sourceId,
-					sourceColumnName: sourceKey,
-					targetTableId: targetId,
-					targetColumnName: fkColName,
-					kind: 'inner',
-					// Mondrian-4 <PhysicalSchema><Link> — the canonical
-					// physical-schema statement.  Editable on canvas.
-					origin: 'physical'
-				});
-			}
-		}
-	}
+  if (physSchemaEl) {
+    for (const linkEl of Array.from(
+      physSchemaEl.querySelectorAll(":scope > Link"),
+    )) {
+      const sourceName = linkEl.getAttribute("source");
+      const targetName = linkEl.getAttribute("target");
+      if (!sourceName || !targetName) continue;
+      const fkColEl = linkEl.querySelector("ForeignKey > Column");
+      const fkColName = fkColEl?.getAttribute("name");
+      if (!fkColName) {
+        warnings.push(
+          `<Link source="${sourceName}" target="${targetName}"> has no <ForeignKey><Column>; skipped.`,
+        );
+        continue;
+      }
+      const sourceId = ensureTable(sourceName, "dimension", { x: 0, y: 0 });
+      const targetId = ensureTable(targetName, "dimension", { x: 0, y: 0 });
+      const sourcePhys = physTables.get(sourceName);
+      const sourceKey = sourcePhys?.keyColumn ?? "id";
+      ensureColumn(sourceId, sourceKey);
+      ensureColumn(targetId, fkColName);
+      if (!joinExists(sourceId, sourceKey, targetId, fkColName)) {
+        joins.push({
+          id: makeId("join"),
+          sourceTableId: sourceId,
+          sourceColumnName: sourceKey,
+          targetTableId: targetId,
+          targetColumnName: fkColName,
+          kind: "inner",
+          // Mondrian-4 <PhysicalSchema><Link> — the canonical
+          // physical-schema statement.  Editable on canvas.
+          origin: "physical",
+        });
+      }
+    }
+  }
 
-	// Phase 6 (REMOVED): cube-level <DimensionLinks><ForeignKeyLink> no
-	// longer becomes a canvas join.  The schema canvas is the *physical
-	// schema* view — it reflects only the <Link>s declared inside
-	// <PhysicalSchema>.  Cube-side FK/Fact/Reference links round-trip
-	// through the workbench cube's dimensionLinks (built separately in
-	// the per-cube walker below), so nothing is lost — they just don't
-	// pollute the canvas join count with derived edges.  Amelia's rule:
-	// "only read joins from the physical schema for the joins on the
-	// schema canvas summary, ignore all links inside the cubes."
+  // Phase 6 (REMOVED): cube-level <DimensionLinks><ForeignKeyLink> no
+  // longer becomes a canvas join.  The schema canvas is the *physical
+  // schema* view — it reflects only the <Link>s declared inside
+  // <PhysicalSchema>.  Cube-side FK/Fact/Reference links round-trip
+  // through the workbench cube's dimensionLinks (built separately in
+  // the per-cube walker below), so nothing is lost — they just don't
+  // pollute the canvas join count with derived edges.  Amelia's rule:
+  // "only read joins from the physical schema for the joins on the
+  // schema canvas summary, ignore all links inside the cubes."
 
-	// Phase 7 (removed): we deliberately DO NOT drop orphan physical tables
-	// (declared in <PhysicalSchema> but referenced by no cube) onto the
-	// canvas. A schema whose warehouse also contains leftover tables from a
-	// prior provision (e.g. a `test2_`-prefixed run) would otherwise litter
-	// the canvas with disconnected orphans the user never asked for. The
-	// canvas shows only the tables a cube actually uses (fact tables +
-	// dimension tables + their links). `physTables` still backs column
-	// enrichment for those used tables.
+  // Phase 7 (removed): we deliberately DO NOT drop orphan physical tables
+  // (declared in <PhysicalSchema> but referenced by no cube) onto the
+  // canvas. A schema whose warehouse also contains leftover tables from a
+  // prior provision (e.g. a `test2_`-prefixed run) would otherwise litter
+  // the canvas with disconnected orphans the user never asked for. The
+  // canvas shows only the tables a cube actually uses (fact tables +
+  // dimension tables + their links). `physTables` still backs column
+  // enrichment for those used tables.
 
-	if (tables.length === 0) {
-		throw new Error('Mondrian 4 schema produced no tables — check the file.');
-	}
+  if (tables.length === 0) {
+    throw new Error("Mondrian 4 schema produced no tables — check the file.");
+  }
 
-	// ── Phase 5: Schema-level <Dimension>s → SchemaCanvasDimension[].
-	// Walks every <Dimension> directly under <Schema>: each becomes a
-	// shared dim with attributes, hierarchies, levels, and a primary key
-	// derived from the `key=` attribute → matching <Attribute>'s
-	// keyColumn.  Inline Dimensions inside Cubes (Mondrian 4 lets you
-	// declare private dims there) are walked when we process Cubes
-	// below; <Dimension source='X'/> references just link the cube to
-	// the shared dim by name.
-	const dimensions: SchemaCanvasDimension[] = [];
-	const dimensionsByName = new Map<string, SchemaCanvasDimension>();
+  // ── Phase 5: Schema-level <Dimension>s → SchemaCanvasDimension[].
+  // Walks every <Dimension> directly under <Schema>: each becomes a
+  // shared dim with attributes, hierarchies, levels, and a primary key
+  // derived from the `key=` attribute → matching <Attribute>'s
+  // keyColumn.  Inline Dimensions inside Cubes (Mondrian 4 lets you
+  // declare private dims there) are walked when we process Cubes
+  // below; <Dimension source='X'/> references just link the cube to
+  // the shared dim by name.
+  const dimensions: SchemaCanvasDimension[] = [];
+  const dimensionsByName = new Map<string, SchemaCanvasDimension>();
 
-	function parseAttributes(
-		dimEl: Element,
-		fallbackTableId: string | null
-	): {
-		tableId: string;
-		columnName: string;
-		logicalName: string;
-		keyColumns?: string[];
-		levelType?: string;
-		annotations?: Record<string, string>;
-		nameColumn?: string;
-		captionColumn?: string;
-		orderByColumn?: string;
-		description?: string;
-	}[] {
-		const out: {
-			tableId: string;
-			columnName: string;
-			logicalName: string;
-			keyColumns?: string[];
-			levelType?: string;
-			annotations?: Record<string, string>;
-			nameColumn?: string;
-			captionColumn?: string;
-			orderByColumn?: string;
-			description?: string;
-		}[] = [];
-		for (const aEl of Array.from(dimEl.querySelectorAll(':scope > Attributes > Attribute'))) {
-			const logicalName = aEl.getAttribute('name') ?? '';
-			// M4 carries a level's levelType on its <Attribute> — read it so the
-			// resolved <Level> below inherits it (round-trips time intelligence).
-			const levelType = aEl.getAttribute('levelType') ?? undefined;
-			const annotations = readSemanticAnnotations(aEl);
-			const attrTable = aEl.getAttribute('table');
-			// Attribute can override the dim's table via `table=`; falls back
-			// to the dim's own table when omitted.
-			const tableName = attrTable ?? null;
-			const tableId = (tableName ? tableIdByName.get(tableName) : null) ?? fallbackTableId ?? null;
-			if (!tableId) {
-				warnings.push(`<Attribute name="${logicalName}"> couldn't resolve its table — skipped.`);
-				continue;
-			}
-			// keyColumn= is the simple case; <Key><Column/></Key> is the
-			// multi-col case.  v2: PRESERVE the full column list so composite
-			// keys round-trip (FoodMart Store City has key=(store_state,
-			// store_city) — collapsing to last column loses the parent-scope
-			// disambiguation Mondrian uses to keep CA's "Los Angeles" distinct
-			// from another state's).  `columnName` is the canonical naming
-			// column (last); `keyColumns` holds the full list when > 1.
-			let columnName = aEl.getAttribute('keyColumn');
-			let keyColumns: string[] | undefined;
-			if (!columnName) {
-				const keyEl = aEl.querySelector(':scope > Key');
-				if (keyEl) {
-					const cols = Array.from(keyEl.querySelectorAll(':scope > Column'))
-						.map((c) => c.getAttribute('name') ?? '')
-						.filter((c) => c.length > 0);
-					if (cols.length > 1) {
-						keyColumns = cols;
-					}
-					columnName = cols[cols.length - 1] ?? null;
-				}
-			}
-			// Last-resort: nameColumn (handles the FoodMart Customer.Name
-			// pattern where keyColumn=customer_id but the display is full_name).
-			if (!columnName) columnName = aEl.getAttribute('nameColumn');
-			if (!columnName) {
-				warnings.push(`<Attribute name="${logicalName}"> has no resolvable column — skipped.`);
-				continue;
-			}
-			ensureColumn(tableId, columnName);
-			// Composite-key columns also live on this table — ensure them too
-			// so the canvas card shows every referenced column.
-			if (keyColumns) {
-				for (const c of keyColumns) ensureColumn(tableId, c);
-			}
-			// Optional M4 attribute overrides (#959). `nameColumn` doubles as a
-			// column-resolution fallback above, so only treat it as a display
-			// override when it genuinely differs from the resolved key column.
-			const rawNameColumn = aEl.getAttribute('nameColumn') ?? undefined;
-			const nameColumn = rawNameColumn && rawNameColumn !== columnName ? rawNameColumn : undefined;
-			const captionColumn = aEl.getAttribute('captionColumn') ?? undefined;
-			const orderByColumn = aEl.getAttribute('orderByColumn') ?? undefined;
-			const description = aEl.getAttribute('description') ?? undefined;
-			out.push({
-				tableId,
-				columnName,
-				logicalName,
-				keyColumns,
-				levelType,
-				annotations,
-				nameColumn,
-				captionColumn,
-				orderByColumn,
-				description
-			});
-		}
-		return out;
-	}
+  function parseAttributes(
+    dimEl: Element,
+    fallbackTableId: string | null,
+  ): {
+    tableId: string;
+    columnName: string;
+    logicalName: string;
+    keyColumns?: string[];
+    levelType?: string;
+    annotations?: Record<string, string>;
+    nameColumn?: string;
+    captionColumn?: string;
+    orderByColumn?: string;
+    description?: string;
+  }[] {
+    const out: {
+      tableId: string;
+      columnName: string;
+      logicalName: string;
+      keyColumns?: string[];
+      levelType?: string;
+      annotations?: Record<string, string>;
+      nameColumn?: string;
+      captionColumn?: string;
+      orderByColumn?: string;
+      description?: string;
+    }[] = [];
+    for (const aEl of Array.from(
+      dimEl.querySelectorAll(":scope > Attributes > Attribute"),
+    )) {
+      const logicalName = aEl.getAttribute("name") ?? "";
+      // M4 carries a level's levelType on its <Attribute> — read it so the
+      // resolved <Level> below inherits it (round-trips time intelligence).
+      const levelType = aEl.getAttribute("levelType") ?? undefined;
+      const annotations = readSemanticAnnotations(aEl);
+      const attrTable = aEl.getAttribute("table");
+      // Attribute can override the dim's table via `table=`; falls back
+      // to the dim's own table when omitted.
+      const tableName = attrTable ?? null;
+      const tableId =
+        (tableName ? tableIdByName.get(tableName) : null) ??
+        fallbackTableId ??
+        null;
+      if (!tableId) {
+        warnings.push(
+          `<Attribute name="${logicalName}"> couldn't resolve its table — skipped.`,
+        );
+        continue;
+      }
+      // keyColumn= is the simple case; <Key><Column/></Key> is the
+      // multi-col case.  v2: PRESERVE the full column list so composite
+      // keys round-trip (FoodMart Store City has key=(store_state,
+      // store_city) — collapsing to last column loses the parent-scope
+      // disambiguation Mondrian uses to keep CA's "Los Angeles" distinct
+      // from another state's).  `columnName` is the canonical naming
+      // column (last); `keyColumns` holds the full list when > 1.
+      let columnName = aEl.getAttribute("keyColumn");
+      let keyColumns: string[] | undefined;
+      if (!columnName) {
+        const keyEl = aEl.querySelector(":scope > Key");
+        if (keyEl) {
+          const cols = Array.from(keyEl.querySelectorAll(":scope > Column"))
+            .map((c) => c.getAttribute("name") ?? "")
+            .filter((c) => c.length > 0);
+          if (cols.length > 1) {
+            keyColumns = cols;
+          }
+          columnName = cols[cols.length - 1] ?? null;
+        }
+      }
+      // Last-resort: nameColumn (handles the FoodMart Customer.Name
+      // pattern where keyColumn=customer_id but the display is full_name).
+      if (!columnName) columnName = aEl.getAttribute("nameColumn");
+      if (!columnName) {
+        warnings.push(
+          `<Attribute name="${logicalName}"> has no resolvable column — skipped.`,
+        );
+        continue;
+      }
+      ensureColumn(tableId, columnName);
+      // Composite-key columns also live on this table — ensure them too
+      // so the canvas card shows every referenced column.
+      if (keyColumns) {
+        for (const c of keyColumns) ensureColumn(tableId, c);
+      }
+      // Optional M4 attribute overrides (#959). `nameColumn` doubles as a
+      // column-resolution fallback above, so only treat it as a display
+      // override when it genuinely differs from the resolved key column.
+      const rawNameColumn = aEl.getAttribute("nameColumn") ?? undefined;
+      const nameColumn =
+        rawNameColumn && rawNameColumn !== columnName
+          ? rawNameColumn
+          : undefined;
+      const captionColumn = aEl.getAttribute("captionColumn") ?? undefined;
+      const orderByColumn = aEl.getAttribute("orderByColumn") ?? undefined;
+      const description = aEl.getAttribute("description") ?? undefined;
+      out.push({
+        tableId,
+        columnName,
+        logicalName,
+        keyColumns,
+        levelType,
+        annotations,
+        nameColumn,
+        captionColumn,
+        orderByColumn,
+        description,
+      });
+    }
+    return out;
+  }
 
-	function parseDimensionInto(
-		dimEl: Element,
-		opts: { fallbackTableName: string | null }
-	): SchemaCanvasDimension | null {
-		const name = dimEl.getAttribute('name') ?? '';
-		// Hanger dims (`hanger='true'`) — no underlying table, no attributes
-		// resolved from columns.  Levels are MDX expressions slicing scenario
-		// values like "Actual vs Budget".  Round-trip parses + re-emits the
-		// hanger flag but leaves attributes empty (which is what Mondrian
-		// expects for hangers).
-		const isHanger = dimEl.getAttribute('hanger') === 'true';
-		// Dim can declare a table at the top OR delegate to per-attribute
-		// `table=`.  Either path lands the dim on some table — the picked
-		// "primary" tableId is the one carrying the key attribute.
-		//
-		// The M3→M4 upgrader emits the latter shape: NO `table=` on <Dimension>,
-		// `table="store"` only on the key <Attribute>, and level-property
-		// attributes (e.g. "Store Name$Store Type") with no `table=` at all,
-		// meant to inherit the dim's table. So when <Dimension> has no `table=`,
-		// fall back to the KEY attribute's table — otherwise every property
-		// attribute resolves to null and is dropped with "couldn't resolve its
-		// table" (saiku-cloud#1133).
-		const keyAttrName = dimEl.getAttribute('key');
-		let keyAttrTable: string | null = null;
-		if (keyAttrName) {
-			for (const aEl of Array.from(dimEl.querySelectorAll(':scope > Attributes > Attribute'))) {
-				if (aEl.getAttribute('name') === keyAttrName) {
-					keyAttrTable = aEl.getAttribute('table');
-					break;
-				}
-			}
-		}
-		const dimTableName =
-			dimEl.getAttribute('table') ?? keyAttrTable ?? opts.fallbackTableName ?? null;
-		const fallbackTableId = dimTableName ? (tableIdByName.get(dimTableName) ?? null) : null;
-		const attrs = parseAttributes(dimEl, fallbackTableId);
-		if (attrs.length === 0 && !isHanger) {
-			warnings.push(`<Dimension name="${name}"> has no resolvable attributes — skipped.`);
-			return null;
-		}
+  function parseDimensionInto(
+    dimEl: Element,
+    opts: { fallbackTableName: string | null },
+  ): SchemaCanvasDimension | null {
+    const name = dimEl.getAttribute("name") ?? "";
+    // Hanger dims (`hanger='true'`) — no underlying table, no attributes
+    // resolved from columns.  Levels are MDX expressions slicing scenario
+    // values like "Actual vs Budget".  Round-trip parses + re-emits the
+    // hanger flag but leaves attributes empty (which is what Mondrian
+    // expects for hangers).
+    const isHanger = dimEl.getAttribute("hanger") === "true";
+    // Dim can declare a table at the top OR delegate to per-attribute
+    // `table=`.  Either path lands the dim on some table — the picked
+    // "primary" tableId is the one carrying the key attribute.
+    //
+    // The M3→M4 upgrader emits the latter shape: NO `table=` on <Dimension>,
+    // `table="store"` only on the key <Attribute>, and level-property
+    // attributes (e.g. "Store Name$Store Type") with no `table=` at all,
+    // meant to inherit the dim's table. So when <Dimension> has no `table=`,
+    // fall back to the KEY attribute's table — otherwise every property
+    // attribute resolves to null and is dropped with "couldn't resolve its
+    // table" (saiku-cloud#1133).
+    const keyAttrName = dimEl.getAttribute("key");
+    let keyAttrTable: string | null = null;
+    if (keyAttrName) {
+      for (const aEl of Array.from(
+        dimEl.querySelectorAll(":scope > Attributes > Attribute"),
+      )) {
+        if (aEl.getAttribute("name") === keyAttrName) {
+          keyAttrTable = aEl.getAttribute("table");
+          break;
+        }
+      }
+    }
+    const dimTableName =
+      dimEl.getAttribute("table") ??
+      keyAttrTable ??
+      opts.fallbackTableName ??
+      null;
+    const fallbackTableId = dimTableName
+      ? (tableIdByName.get(dimTableName) ?? null)
+      : null;
+    const attrs = parseAttributes(dimEl, fallbackTableId);
+    if (attrs.length === 0 && !isHanger) {
+      warnings.push(
+        `<Dimension name="${name}"> has no resolvable attributes — skipped.`,
+      );
+      return null;
+    }
 
-		// Resolve the dim's PRIMARY KEY: key='X' on <Dimension> refers to
-		// the Attribute logical name; map back to the underlying column.
-		// (keyAttrName resolved above, where it also seeds the fallback table.)
-		let primaryKey: string | undefined;
-		let primaryKeyTableId: string | undefined;
-		if (keyAttrName) {
-			const keyAttr = attrs.find((a) => a.logicalName === keyAttrName);
-			if (keyAttr) {
-				// Store the attribute's LOGICAL name (guaranteed unique per
-				// Mondrian) rather than the columnName — two attributes on the
-				// same table can share a column (FoodMart's Product has both
-				// "Product Name" and "Product Id" on product.product_id).
-				primaryKey = keyAttr.logicalName || keyAttr.columnName;
-				primaryKeyTableId = keyAttr.tableId;
-			} else {
-				warnings.push(
-					`<Dimension name="${name}"> key="${keyAttrName}" — no matching Attribute; primary key left unset.`
-				);
-			}
-		}
+    // Resolve the dim's PRIMARY KEY: key='X' on <Dimension> refers to
+    // the Attribute logical name; map back to the underlying column.
+    // (keyAttrName resolved above, where it also seeds the fallback table.)
+    let primaryKey: string | undefined;
+    let primaryKeyTableId: string | undefined;
+    if (keyAttrName) {
+      const keyAttr = attrs.find((a) => a.logicalName === keyAttrName);
+      if (keyAttr) {
+        // Store the attribute's LOGICAL name (guaranteed unique per
+        // Mondrian) rather than the columnName — two attributes on the
+        // same table can share a column (FoodMart's Product has both
+        // "Product Name" and "Product Id" on product.product_id).
+        primaryKey = keyAttr.logicalName || keyAttr.columnName;
+        primaryKeyTableId = keyAttr.tableId;
+      } else {
+        warnings.push(
+          `<Dimension name="${name}"> key="${keyAttrName}" — no matching Attribute; primary key left unset.`,
+        );
+      }
+    }
 
-		// Walk <Hierarchies>/<Hierarchy>/<Level> — each Level references
-		// an Attribute by logical name, which we resolve back to its
-		// (tableId, columnName) tuple.  Levels stay in document order.
-		// `<Closure table='employee_closure' parentColumn='supervisor_id'
-		// childColumn='employee_id'/>` on a Level marks the parent-child
-		// optimisation table; we capture it at hierarchy scope (Mondrian
-		// only allows one closure per hierarchy in practice) and round-trip
-		// it on export.  HR's Employee hierarchy uses this.
-		const hierarchies: SchemaCanvasHierarchy[] = [];
-		for (const hEl of Array.from(dimEl.querySelectorAll(':scope > Hierarchies > Hierarchy'))) {
-			const hName = hEl.getAttribute('name') ?? name;
-			const hasAllRaw = hEl.getAttribute('hasAll');
-			const hasAll = hasAllRaw === null ? true : hasAllRaw === 'true';
-			const allMemberName = hEl.getAttribute('allMemberName') ?? undefined;
-			const defaultMember = hEl.getAttribute('defaultMember') ?? undefined;
-			const caption = hEl.getAttribute('caption') ?? undefined;
-			const description = hEl.getAttribute('description') ?? undefined;
-			const levels: SchemaCanvasLevel[] = [];
-			let closure: SchemaCanvasHierarchy['closure'] | undefined;
-			for (const lEl of Array.from(hEl.querySelectorAll(':scope > Level'))) {
-				const attrName = lEl.getAttribute('attribute') ?? '';
-				const attr = attrs.find((a) => a.logicalName === attrName);
-				if (!attr) {
-					warnings.push(
-						`<Level attribute="${attrName}"> in <Hierarchy name="${hName}"> — no matching Attribute; skipped.`
-					);
-					continue;
-				}
-				levels.push({
-					id: makeId('lvl'),
-					name: lEl.getAttribute('name') ?? attr.logicalName,
-					caption: lEl.getAttribute('caption') ?? undefined,
-					tableId: attr.tableId,
-					columnName: attr.columnName,
-					// levelType round-trips from the <Attribute> (M4 carries it there).
-					levelType:
-						attr.levelType === 'TimeYears' ||
-						attr.levelType === 'TimeQuarters' ||
-						attr.levelType === 'TimeMonths' ||
-						attr.levelType === 'TimeDays'
-							? attr.levelType
-							: undefined,
-					// saiku.semantic.* annotations also ride on the <Attribute>.
-					annotations: attr.annotations
-				});
-				// Closure lives on a Level as a child element in Mondrian 4 —
-				// pull it up to hierarchy scope where round-trip and the
-				// export layer expect it.
-				const cEl = lEl.querySelector(':scope > Closure');
-				if (cEl) {
-					closure = {
-						table: cEl.getAttribute('table') ?? '',
-						parentColumn: cEl.getAttribute('parentColumn') ?? '',
-						childColumn: cEl.getAttribute('childColumn') ?? ''
-					};
-				}
-			}
-			hierarchies.push({
-				id: makeId('hier'),
-				name: hName,
-				hasAll,
-				allMemberName,
-				defaultMember,
-				caption,
-				description,
-				levels,
-				closure
-			});
-		}
+    // Walk <Hierarchies>/<Hierarchy>/<Level> — each Level references
+    // an Attribute by logical name, which we resolve back to its
+    // (tableId, columnName) tuple.  Levels stay in document order.
+    // `<Closure table='employee_closure' parentColumn='supervisor_id'
+    // childColumn='employee_id'/>` on a Level marks the parent-child
+    // optimisation table; we capture it at hierarchy scope (Mondrian
+    // only allows one closure per hierarchy in practice) and round-trip
+    // it on export.  HR's Employee hierarchy uses this.
+    const hierarchies: SchemaCanvasHierarchy[] = [];
+    for (const hEl of Array.from(
+      dimEl.querySelectorAll(":scope > Hierarchies > Hierarchy"),
+    )) {
+      const hName = hEl.getAttribute("name") ?? name;
+      const hasAllRaw = hEl.getAttribute("hasAll");
+      const hasAll = hasAllRaw === null ? true : hasAllRaw === "true";
+      const allMemberName = hEl.getAttribute("allMemberName") ?? undefined;
+      const defaultMember = hEl.getAttribute("defaultMember") ?? undefined;
+      const caption = hEl.getAttribute("caption") ?? undefined;
+      const description = hEl.getAttribute("description") ?? undefined;
+      const levels: SchemaCanvasLevel[] = [];
+      let closure: SchemaCanvasHierarchy["closure"] | undefined;
+      for (const lEl of Array.from(hEl.querySelectorAll(":scope > Level"))) {
+        const attrName = lEl.getAttribute("attribute") ?? "";
+        const attr = attrs.find((a) => a.logicalName === attrName);
+        if (!attr) {
+          warnings.push(
+            `<Level attribute="${attrName}"> in <Hierarchy name="${hName}"> — no matching Attribute; skipped.`,
+          );
+          continue;
+        }
+        levels.push({
+          id: makeId("lvl"),
+          name: lEl.getAttribute("name") ?? attr.logicalName,
+          caption: lEl.getAttribute("caption") ?? undefined,
+          tableId: attr.tableId,
+          columnName: attr.columnName,
+          // levelType round-trips from the <Attribute> (M4 carries it there).
+          levelType:
+            attr.levelType === "TimeYears" ||
+            attr.levelType === "TimeQuarters" ||
+            attr.levelType === "TimeMonths" ||
+            attr.levelType === "TimeDays"
+              ? attr.levelType
+              : undefined,
+          // saiku.semantic.* annotations also ride on the <Attribute>.
+          annotations: attr.annotations,
+        });
+        // Closure lives on a Level as a child element in Mondrian 4 —
+        // pull it up to hierarchy scope where round-trip and the
+        // export layer expect it.
+        const cEl = lEl.querySelector(":scope > Closure");
+        if (cEl) {
+          closure = {
+            table: cEl.getAttribute("table") ?? "",
+            parentColumn: cEl.getAttribute("parentColumn") ?? "",
+            childColumn: cEl.getAttribute("childColumn") ?? "",
+          };
+        }
+      }
+      hierarchies.push({
+        id: makeId("hier"),
+        name: hName,
+        hasAll,
+        allMemberName,
+        defaultMember,
+        caption,
+        description,
+        levels,
+        closure,
+      });
+    }
 
-		const typeRaw = dimEl.getAttribute('type');
-		const dimensionType =
-			typeRaw === 'TIME'
-				? ('Time' as const)
-				: typeRaw === 'StandardDimension'
-					? ('Standard' as const)
-					: typeRaw === 'TimeDimension'
-						? ('Time' as const)
-						: typeRaw === 'GeographicDimension'
-							? ('Geographic' as const)
-							: undefined;
+    const typeRaw = dimEl.getAttribute("type");
+    const dimensionType =
+      typeRaw === "TIME"
+        ? ("Time" as const)
+        : typeRaw === "StandardDimension"
+          ? ("Standard" as const)
+          : typeRaw === "TimeDimension"
+            ? ("Time" as const)
+            : typeRaw === "GeographicDimension"
+              ? ("Geographic" as const)
+              : undefined;
 
-		// Source table binding — set from <Dimension table="X"> when
-		// present, else fall back to the KEY attribute's table (matches
-		// how the workbench treats the "source table" concept).  Prior
-		// to this the parser only wrote primaryKeyTableId; sourceTableId
-		// stayed undefined even when the XML clearly declared a table,
-		// so the "No table bound" empty state fired for imported dims.
-		const sourceTableId = dimTableName
-			? (tableIdByName.get(dimTableName) ?? primaryKeyTableId)
-			: primaryKeyTableId;
+    // Source table binding — set from <Dimension table="X"> when
+    // present, else fall back to the KEY attribute's table (matches
+    // how the workbench treats the "source table" concept).  Prior
+    // to this the parser only wrote primaryKeyTableId; sourceTableId
+    // stayed undefined even when the XML clearly declared a table,
+    // so the "No table bound" empty state fired for imported dims.
+    const sourceTableId = dimTableName
+      ? (tableIdByName.get(dimTableName) ?? primaryKeyTableId)
+      : primaryKeyTableId;
 
-		const dim: SchemaCanvasDimension = {
-			id: makeId('dim'),
-			name,
-			attributes: attrs.map((a) => ({
-				tableId: a.tableId,
-				columnName: a.columnName,
-				name: a.logicalName,
-				keyColumns: a.keyColumns,
-				nameColumn: a.nameColumn,
-				captionColumn: a.captionColumn,
-				orderByColumn: a.orderByColumn,
-				description: a.description
-			})),
-			hierarchies,
-			primaryKey,
-			primaryKeyTableId,
-			sourceTableId,
-			hanger: isHanger || undefined,
-			caption: dimEl.getAttribute('caption') ?? undefined,
-			description: dimEl.getAttribute('description') ?? undefined,
-			dimensionType,
-			annotations: readSemanticAnnotations(dimEl)
-		};
-		return dim;
-	}
+    const dim: SchemaCanvasDimension = {
+      id: makeId("dim"),
+      name,
+      attributes: attrs.map((a) => ({
+        tableId: a.tableId,
+        columnName: a.columnName,
+        name: a.logicalName,
+        keyColumns: a.keyColumns,
+        nameColumn: a.nameColumn,
+        captionColumn: a.captionColumn,
+        orderByColumn: a.orderByColumn,
+        description: a.description,
+      })),
+      hierarchies,
+      primaryKey,
+      primaryKeyTableId,
+      sourceTableId,
+      hanger: isHanger || undefined,
+      caption: dimEl.getAttribute("caption") ?? undefined,
+      description: dimEl.getAttribute("description") ?? undefined,
+      dimensionType,
+      annotations: readSemanticAnnotations(dimEl),
+    };
+    return dim;
+  }
 
-	// Schema-scope shared dimensions (Mondrian 4's first-class dim model).
-	for (const dimEl of Array.from(schemaEl.querySelectorAll(':scope > Dimension'))) {
-		const dim = parseDimensionInto(dimEl, { fallbackTableName: dimEl.getAttribute('table') });
-		if (!dim) continue;
-		dimensions.push(dim);
-		dimensionsByName.set(dim.name, dim);
-	}
+  // Schema-scope shared dimensions (Mondrian 4's first-class dim model).
+  for (const dimEl of Array.from(
+    schemaEl.querySelectorAll(":scope > Dimension"),
+  )) {
+    const dim = parseDimensionInto(dimEl, {
+      fallbackTableName: dimEl.getAttribute("table"),
+    });
+    if (!dim) continue;
+    dimensions.push(dim);
+    dimensionsByName.set(dim.name, dim);
+  }
 
-	// ── Phase 6: <Cube>s → workbench cubes + measures.
-	// Measures (flat) accumulate into state.measures.  Per-cube workbench
-	// data goes into `workbenchCubes` for the localStorage seed.
-	const measures: SchemaCanvasMeasure[] = [];
-	const seenMeasureKeys = new Set<string>();
+  // ── Phase 6: <Cube>s → workbench cubes + measures.
+  // Measures (flat) accumulate into state.measures.  Per-cube workbench
+  // data goes into `workbenchCubes` for the localStorage seed.
+  const measures: SchemaCanvasMeasure[] = [];
+  const seenMeasureKeys = new Set<string>();
 
-	for (const cubeEl of cubeEls) {
-		const cubeName = cubeEl.getAttribute('name') ?? 'Cube';
-		const workCube: ImportedWorkbenchCube = {
-			id: makeId('cube'),
-			name: cubeName,
-			measureGroups: [],
-			factsCalcs: []
-		};
+  for (const cubeEl of cubeEls) {
+    const cubeName = cubeEl.getAttribute("name") ?? "Cube";
+    const workCube: ImportedWorkbenchCube = {
+      id: makeId("cube"),
+      name: cubeName,
+      measureGroups: [],
+      factsCalcs: [],
+    };
 
-		// Cube-private Dimensions (declared inline, not source='X' refs)
-		// also become shared dims — append them so DimensionLinks below
-		// can resolve.
-		for (const dimEl of Array.from(cubeEl.querySelectorAll(':scope > Dimensions > Dimension'))) {
-			// source='X' is a REFERENCE to a schema-level dim (Mondrian 4's
-			// DimensionUsage), optionally RENAMED (e.g. name="Order Date"
-			// source="Date"). Register the local name as an alias to the shared
-			// dim so DimensionLinks that reference the local name resolve.
-			const sourceRef = dimEl.getAttribute('source');
-			if (sourceRef) {
-				const localName = dimEl.getAttribute('name');
-				if (localName && localName !== sourceRef && !dimensionsByName.has(localName)) {
-					const shared = dimensionsByName.get(sourceRef);
-					if (shared) dimensionsByName.set(localName, shared);
-				}
-				continue;
-			}
-			const dim = parseDimensionInto(dimEl, { fallbackTableName: dimEl.getAttribute('table') });
-			if (!dim) continue;
-			// Avoid double-registering a dim name (e.g. a cube-private "Time"
-			// when a schema "Time" also exists — warn the user, keep the
-			// cube-private one under a synthetic name).
-			if (dimensionsByName.has(dim.name)) {
-				dim.name = `${dim.name} (${cubeName})`;
-				warnings.push(
-					`<Cube name="${cubeName}"> redefines dimension "${dimEl.getAttribute('name')}"; renamed to "${dim.name}" to avoid collision.`
-				);
-			}
-			dimensions.push(dim);
-			dimensionsByName.set(dim.name, dim);
-		}
+    // Cube-private Dimensions (declared inline, not source='X' refs)
+    // also become shared dims — append them so DimensionLinks below
+    // can resolve.
+    for (const dimEl of Array.from(
+      cubeEl.querySelectorAll(":scope > Dimensions > Dimension"),
+    )) {
+      // source='X' is a REFERENCE to a schema-level dim (Mondrian 4's
+      // DimensionUsage), optionally RENAMED (e.g. name="Order Date"
+      // source="Date"). Register the local name as an alias to the shared
+      // dim so DimensionLinks that reference the local name resolve.
+      const sourceRef = dimEl.getAttribute("source");
+      if (sourceRef) {
+        const localName = dimEl.getAttribute("name");
+        if (
+          localName &&
+          localName !== sourceRef &&
+          !dimensionsByName.has(localName)
+        ) {
+          const shared = dimensionsByName.get(sourceRef);
+          if (shared) dimensionsByName.set(localName, shared);
+        }
+        continue;
+      }
+      const dim = parseDimensionInto(dimEl, {
+        fallbackTableName: dimEl.getAttribute("table"),
+      });
+      if (!dim) continue;
+      // Avoid double-registering a dim name (e.g. a cube-private "Time"
+      // when a schema "Time" also exists — warn the user, keep the
+      // cube-private one under a synthetic name).
+      if (dimensionsByName.has(dim.name)) {
+        dim.name = `${dim.name} (${cubeName})`;
+        warnings.push(
+          `<Cube name="${cubeName}"> redefines dimension "${dimEl.getAttribute("name")}"; renamed to "${dim.name}" to avoid collision.`,
+        );
+      }
+      dimensions.push(dim);
+      dimensionsByName.set(dim.name, dim);
+    }
 
-		// MeasureGroups → workbench MGs + flat measures.
-		for (const mgEl of Array.from(
-			cubeEl.querySelectorAll(':scope > MeasureGroups > MeasureGroup')
-		)) {
-			const mgName =
-				mgEl.getAttribute('name') ??
-				mgEl.getAttribute('table') ??
-				`MG${workCube.measureGroups.length + 1}`;
-			const factTableName = mgEl.getAttribute('table');
-			const factTableId = factTableName ? (tableIdByName.get(factTableName) ?? null) : null;
-			if (factTableName && !factTableId) {
-				warnings.push(
-					`<MeasureGroup name="${mgName}"> table="${factTableName}" wasn't on the canvas — fact unlinked.`
-				);
-			}
+    // MeasureGroups → workbench MGs + flat measures.
+    for (const mgEl of Array.from(
+      cubeEl.querySelectorAll(":scope > MeasureGroups > MeasureGroup"),
+    )) {
+      const mgName =
+        mgEl.getAttribute("name") ??
+        mgEl.getAttribute("table") ??
+        `MG${workCube.measureGroups.length + 1}`;
+      const factTableName = mgEl.getAttribute("table");
+      const factTableId = factTableName
+        ? (tableIdByName.get(factTableName) ?? null)
+        : null;
+      if (factTableName && !factTableId) {
+        warnings.push(
+          `<MeasureGroup name="${mgName}"> table="${factTableName}" wasn't on the canvas — fact unlinked.`,
+        );
+      }
 
-			const measureColumns: string[] = [];
-			for (const measureEl of Array.from(mgEl.querySelectorAll(':scope > Measures > Measure'))) {
-				const measureName = measureEl.getAttribute('name') ?? '';
-				const column = measureColumnOf(measureEl);
-				const aggRaw = measureEl.getAttribute('aggregator') ?? 'sum';
-				const aggregator: SchemaCanvasMeasure['aggregator'] =
-					aggRaw === 'sum' ||
-					aggRaw === 'count' ||
-					aggRaw === 'avg' ||
-					aggRaw === 'min' ||
-					aggRaw === 'max' ||
-					aggRaw === 'distinct-count' ||
-					aggRaw === 'median' ||
-					aggRaw === 'percentile'
-						? aggRaw
-						: 'sum';
-				// Percentile fraction (mondrian-saiku #104) — only on percentile
-				// measures; a non-numeric or absent value leaves it unset (→ 50).
-				const percentileRaw =
-					aggregator === 'percentile' ? measureEl.getAttribute('percentile') : null;
-				const percentileVal =
-					percentileRaw !== null &&
-					percentileRaw.trim() !== '' &&
-					!Number.isNaN(Number(percentileRaw))
-						? Number(percentileRaw)
-						: undefined;
-				if (!column) {
-					warnings.push(`<Measure name="${measureName}"> has no column — skipped.`);
-					continue;
-				}
-				measureColumns.push(column);
-				if (factTableId) {
-					const key = `${factTableId}::${column}`;
-					if (!seenMeasureKeys.has(key)) {
-						seenMeasureKeys.add(key);
-						measures.push({
-							id: makeId('m'),
-							name: measureName || column,
-							aggregator,
-							tableId: factTableId,
-							columnName: column,
-							formatString: measureEl.getAttribute('formatString') ?? undefined,
-							percentile: percentileVal,
-							annotations: readSemanticAnnotations(measureEl)
-						});
-					}
-				}
-			}
+      const measureColumns: string[] = [];
+      for (const measureEl of Array.from(
+        mgEl.querySelectorAll(":scope > Measures > Measure"),
+      )) {
+        const measureName = measureEl.getAttribute("name") ?? "";
+        const column = measureColumnOf(measureEl);
+        const aggRaw = measureEl.getAttribute("aggregator") ?? "sum";
+        const aggregator: SchemaCanvasMeasure["aggregator"] =
+          aggRaw === "sum" ||
+          aggRaw === "count" ||
+          aggRaw === "avg" ||
+          aggRaw === "min" ||
+          aggRaw === "max" ||
+          aggRaw === "distinct-count" ||
+          aggRaw === "median" ||
+          aggRaw === "percentile"
+            ? aggRaw
+            : "sum";
+        // Percentile fraction (mondrian-saiku #104) — only on percentile
+        // measures; a non-numeric or absent value leaves it unset (→ 50).
+        const percentileRaw =
+          aggregator === "percentile"
+            ? measureEl.getAttribute("percentile")
+            : null;
+        const percentileVal =
+          percentileRaw !== null &&
+          percentileRaw.trim() !== "" &&
+          !Number.isNaN(Number(percentileRaw))
+            ? Number(percentileRaw)
+            : undefined;
+        if (!column) {
+          warnings.push(
+            `<Measure name="${measureName}"> has no column — skipped.`,
+          );
+          continue;
+        }
+        measureColumns.push(column);
+        if (factTableId) {
+          const key = `${factTableId}::${column}`;
+          if (!seenMeasureKeys.has(key)) {
+            seenMeasureKeys.add(key);
+            measures.push({
+              id: makeId("m"),
+              name: measureName || column,
+              aggregator,
+              tableId: factTableId,
+              columnName: column,
+              formatString: measureEl.getAttribute("formatString") ?? undefined,
+              percentile: percentileVal,
+              annotations: readSemanticAnnotations(measureEl),
+            });
+          }
+        }
+      }
 
-			// DimensionLinks → mg.dimensionLinks resolving dimension name
-			// to the parsed dim's id.  v2 supports all three Mondrian-4 link
-			// kinds — ForeignKeyLink (default), FactLink (degenerate dim on
-			// the fact table; no FK column), and ReferenceLink (multi-hop
-			// via another dim's attribute).  `linkKind` is preserved through
-			// round-trip so the exporter re-emits the original tag.
-			const dimensionLinks: ImportedWorkbenchMeasureGroup['dimensionLinks'] = [];
-			const linksEl = mgEl.querySelector(':scope > DimensionLinks');
-			if (linksEl) {
-				for (const linkEl of Array.from(linksEl.children)) {
-					const tag = linkEl.tagName;
-					const dimName = linkEl.getAttribute('dimension') ?? '';
-					const dim = dimensionsByName.get(dimName);
-					if (!dim) {
-						warnings.push(
-							`<${tag} dimension="${dimName}"> on cube "${cubeName}" — no matching dim; skipped.`
-						);
-						continue;
-					}
-					if (tag === 'ForeignKeyLink') {
-						let fk = linkEl.getAttribute('foreignKeyColumn') ?? '';
-						if (!fk) {
-							const colEl = linkEl.querySelector(':scope > ForeignKey > Column');
-							fk = colEl?.getAttribute('name') ?? '';
-						}
-						dimensionLinks.push({
-							dimensionId: dim.id,
-							foreignKeyColumn: fk,
-							linkKind: 'foreign-key'
-						});
-					} else if (tag === 'FactLink') {
-						// Degenerate dim — its level columns ARE on the fact
-						// table.  No FK column to carry; `factTableId` IS the
-						// dim's table.
-						dimensionLinks.push({
-							dimensionId: dim.id,
-							foreignKeyColumn: '',
-							linkKind: 'fact'
-						});
-					} else if (tag === 'ReferenceLink') {
-						// Multi-hop: dim is reached through `viaDimension`'s
-						// `viaAttribute`.  Carry both through so the export
-						// can re-emit the original.
-						dimensionLinks.push({
-							dimensionId: dim.id,
-							foreignKeyColumn: '',
-							linkKind: 'reference',
-							viaDimension: linkEl.getAttribute('viaDimension') ?? undefined,
-							viaAttribute: linkEl.getAttribute('viaAttribute') ?? undefined
-						});
-					}
-				}
-			}
+      // DimensionLinks → mg.dimensionLinks resolving dimension name
+      // to the parsed dim's id.  v2 supports all three Mondrian-4 link
+      // kinds — ForeignKeyLink (default), FactLink (degenerate dim on
+      // the fact table; no FK column), and ReferenceLink (multi-hop
+      // via another dim's attribute).  `linkKind` is preserved through
+      // round-trip so the exporter re-emits the original tag.
+      const dimensionLinks: ImportedWorkbenchMeasureGroup["dimensionLinks"] =
+        [];
+      const linksEl = mgEl.querySelector(":scope > DimensionLinks");
+      if (linksEl) {
+        for (const linkEl of Array.from(linksEl.children)) {
+          const tag = linkEl.tagName;
+          const dimName = linkEl.getAttribute("dimension") ?? "";
+          const dim = dimensionsByName.get(dimName);
+          if (!dim) {
+            warnings.push(
+              `<${tag} dimension="${dimName}"> on cube "${cubeName}" — no matching dim; skipped.`,
+            );
+            continue;
+          }
+          if (tag === "ForeignKeyLink") {
+            let fk = linkEl.getAttribute("foreignKeyColumn") ?? "";
+            if (!fk) {
+              const colEl = linkEl.querySelector(
+                ":scope > ForeignKey > Column",
+              );
+              fk = colEl?.getAttribute("name") ?? "";
+            }
+            dimensionLinks.push({
+              dimensionId: dim.id,
+              foreignKeyColumn: fk,
+              linkKind: "foreign-key",
+            });
+          } else if (tag === "FactLink") {
+            // Degenerate dim — its level columns ARE on the fact
+            // table.  No FK column to carry; `factTableId` IS the
+            // dim's table.
+            dimensionLinks.push({
+              dimensionId: dim.id,
+              foreignKeyColumn: "",
+              linkKind: "fact",
+            });
+          } else if (tag === "ReferenceLink") {
+            // Multi-hop: dim is reached through `viaDimension`'s
+            // `viaAttribute`.  Carry both through so the export
+            // can re-emit the original.
+            dimensionLinks.push({
+              dimensionId: dim.id,
+              foreignKeyColumn: "",
+              linkKind: "reference",
+              viaDimension: linkEl.getAttribute("viaDimension") ?? undefined,
+              viaAttribute: linkEl.getAttribute("viaAttribute") ?? undefined,
+            });
+          }
+        }
+      }
 
-			workCube.measureGroups.push({
-				id: makeId('mg'),
-				name: mgName,
-				factTableId,
-				measureColumns,
-				dimensionLinks
-			});
-		}
+      workCube.measureGroups.push({
+        id: makeId("mg"),
+        name: mgName,
+        factTableId,
+        measureColumns,
+        dimensionLinks,
+      });
+    }
 
-		// CalculatedMembers → factsCalcs (formula text only — chip tokens stay empty).
-		for (const calcEl of Array.from(
-			cubeEl.querySelectorAll(':scope > CalculatedMembers > CalculatedMember')
-		)) {
-			const calcName = calcEl.getAttribute('name') ?? '';
-			// Formula can be an attribute OR a child <Formula> element.
-			let formula = calcEl.getAttribute('formula') ?? '';
-			if (!formula) {
-				const formulaEl = calcEl.querySelector(':scope > Formula');
-				formula = formulaEl?.textContent?.trim() ?? '';
-			}
-			workCube.factsCalcs.push({
-				id: makeId('calc'),
-				name: calcName,
-				tokens: [],
-				formula: formula || undefined
-			});
-		}
+    // CalculatedMembers → factsCalcs (formula text only — chip tokens stay empty).
+    for (const calcEl of Array.from(
+      cubeEl.querySelectorAll(":scope > CalculatedMembers > CalculatedMember"),
+    )) {
+      const calcName = calcEl.getAttribute("name") ?? "";
+      // Formula can be an attribute OR a child <Formula> element.
+      let formula = calcEl.getAttribute("formula") ?? "";
+      if (!formula) {
+        const formulaEl = calcEl.querySelector(":scope > Formula");
+        formula = formulaEl?.textContent?.trim() ?? "";
+      }
+      workCube.factsCalcs.push({
+        id: makeId("calc"),
+        name: calcName,
+        tokens: [],
+        formula: formula || undefined,
+      });
+    }
 
-		// TimeCalcs → cube.timeCalcs (declarative time-intelligence metrics).
-		const timeCalcs: SchemaCanvasTimeCalc[] = [];
-		for (const tcEl of Array.from(cubeEl.querySelectorAll(':scope > TimeCalcs > TimeCalc'))) {
-			const rawType = tcEl.getAttribute('type') ?? '';
-			const type =
-				rawType === 'yoy' || rawType === 'pop' || rawType === 'ytd' || rawType === 'rolling'
-					? rawType
-					: 'yoy';
-			const rawWindow = tcEl.getAttribute('window');
-			const rawFn = tcEl.getAttribute('function');
-			timeCalcs.push({
-				id: makeId('timecalc'),
-				name: tcEl.getAttribute('name') ?? '',
-				type,
-				measure: tcEl.getAttribute('measure') ?? '',
-				timeDimension: tcEl.getAttribute('timeDimension') ?? undefined,
-				window:
-					type === 'rolling' && rawWindow != null && !Number.isNaN(Number(rawWindow))
-						? Number(rawWindow)
-						: undefined,
-				function: rawFn === 'avg' ? 'avg' : rawFn === 'sum' ? 'sum' : undefined,
-				formatString: tcEl.getAttribute('formatString') ?? undefined
-			});
-		}
-		if (timeCalcs.length > 0) workCube.timeCalcs = timeCalcs;
+    // TimeCalcs → cube.timeCalcs (declarative time-intelligence metrics).
+    const timeCalcs: SchemaCanvasTimeCalc[] = [];
+    for (const tcEl of Array.from(
+      cubeEl.querySelectorAll(":scope > TimeCalcs > TimeCalc"),
+    )) {
+      const rawType = tcEl.getAttribute("type") ?? "";
+      const type =
+        rawType === "yoy" ||
+        rawType === "pop" ||
+        rawType === "ytd" ||
+        rawType === "rolling"
+          ? rawType
+          : "yoy";
+      const rawWindow = tcEl.getAttribute("window");
+      const rawFn = tcEl.getAttribute("function");
+      timeCalcs.push({
+        id: makeId("timecalc"),
+        name: tcEl.getAttribute("name") ?? "",
+        type,
+        measure: tcEl.getAttribute("measure") ?? "",
+        timeDimension: tcEl.getAttribute("timeDimension") ?? undefined,
+        window:
+          type === "rolling" &&
+          rawWindow != null &&
+          !Number.isNaN(Number(rawWindow))
+            ? Number(rawWindow)
+            : undefined,
+        function: rawFn === "avg" ? "avg" : rawFn === "sum" ? "sum" : undefined,
+        formatString: tcEl.getAttribute("formatString") ?? undefined,
+      });
+    }
+    if (timeCalcs.length > 0) workCube.timeCalcs = timeCalcs;
 
-		workbenchCubes.push(workCube);
-	}
+    workbenchCubes.push(workCube);
+  }
 
-	const state: SchemaCanvasState = {
-		version: 1,
-		connectionId: opts.connectionId,
-		label: opts.label ?? schemaName,
-		tables,
-		joins,
-		groups: [],
-		dimensions,
-		measures,
-		updatedAt: new Date().toISOString()
-	};
-	return { state, warnings, workbenchCubes };
+  const state: SchemaCanvasState = {
+    version: 1,
+    connectionId: opts.connectionId,
+    label: opts.label ?? schemaName,
+    tables,
+    joins,
+    groups: [],
+    dimensions,
+    measures,
+    updatedAt: new Date().toISOString(),
+  };
+  return { state, warnings, workbenchCubes };
 }

--- a/saiku-ui/src/lib/cube-designer/mondrian-import.ts
+++ b/saiku-ui/src/lib/cube-designer/mondrian-import.ts
@@ -1,0 +1,1687 @@
+/**
+ * Canvas schema designer — Mondrian XML import.
+ *
+ * Parses a Mondrian 3- OR 4-style Schema XML back into a
+ * SchemaCanvasState so the user can round-trip a schema:
+ * canvas → Export XML → … → Import XML → canvas.
+ *
+ * Mondrian 3 (Pentaho legacy) shape — fact + dims inline in <Cube>:
+ *
+ *   <Schema name="…">
+ *     <Cube name="…">
+ *       <Table name="fact" schema="public" />
+ *       <Dimension name="…" foreignKey="…">
+ *         <Hierarchy hasAll="true" primaryKey="…">
+ *           <Table name="dim" schema="public" />
+ *           <Level name="…" column="…" />
+ *           …
+ *         </Hierarchy>
+ *       </Dimension>
+ *       <Measure … />
+ *     </Cube>
+ *   </Schema>
+ *
+ * Mondrian 4 (Saiku Cloud native) shape — physical schema + cube linkage:
+ *
+ *   <Schema name="…" metamodelVersion="4.0">
+ *     <PhysicalSchema>
+ *       <Table name="sales_fact" schema="public">
+ *         <Key name="key0"><Column name="id" /></Key>
+ *       </Table>
+ *       <Table name="customer" schema="public">
+ *         <Key name="key0"><Column name="customer_id" /></Key>
+ *       </Table>
+ *       <Link source="customer" target="sales_fact">
+ *         <ForeignKey>
+ *           <Column table="sales_fact" name="customer_id" />
+ *         </ForeignKey>
+ *       </Link>
+ *     </PhysicalSchema>
+ *     <Cube name="Sales">
+ *       <Dimensions>
+ *         <Dimension name="Customer" table="customer" key="key0">
+ *           <Attributes>
+ *             <Attribute name="Name" keyColumn="fullname" />
+ *           </Attributes>
+ *         </Dimension>
+ *       </Dimensions>
+ *       <MeasureGroups>
+ *         <MeasureGroup name="Sales" table="sales_fact">
+ *           <Measures>
+ *             <Measure name="Amount" column="amount" aggregator="sum" />
+ *           </Measures>
+ *           <DimensionLinks>
+ *             <ForeignKeyLink dimension="Customer" foreignKeyColumn="customer_id" />
+ *           </DimensionLinks>
+ *         </MeasureGroup>
+ *       </MeasureGroups>
+ *     </Cube>
+ *   </Schema>
+ *
+ * Detection: `metamodelVersion="4.0"` on <Schema>, or the presence of a
+ * <PhysicalSchema> / <MeasureGroups> child. Out-of-band shapes are
+ * skipped with a warning rather than silently dropped.
+ */
+import type {
+	SchemaCanvasState,
+	SchemaCanvasTable,
+	SchemaCanvasJoin,
+	SchemaCanvasColumn,
+	SchemaCanvasDimension,
+	SchemaCanvasHierarchy,
+	SchemaCanvasLevel,
+	SchemaCanvasMeasure,
+	SchemaCanvasTimeCalc,
+	SourceTableCandidate
+} from './types.js';
+
+/**
+ * Read a schema element's `saiku.semantic.*` annotations into a bare-keyed map
+ * (e.g. `{ description, pii }`). Returns undefined when there are none, so the
+ * caller can leave the field unset. Non-saiku annotations are ignored.
+ */
+function readSemanticAnnotations(el: Element): Record<string, string> | undefined {
+	const out: Record<string, string> = {};
+	for (const aEl of Array.from(el.querySelectorAll(':scope > Annotations > Annotation'))) {
+		const name = aEl.getAttribute('name') ?? '';
+		if (!name.startsWith('saiku.semantic.')) continue;
+		const key = name.slice('saiku.semantic.'.length);
+		if (key) out[key] = aEl.textContent?.trim() ?? '';
+	}
+	return Object.keys(out).length > 0 ? out : undefined;
+}
+
+function makeId(prefix: string): string {
+	return `${prefix}_${Math.random().toString(36).slice(2, 10)}`;
+}
+
+/**
+ * Per-cube workbench shape — serialisable mirror of `WorkbenchCube` from
+ * WorkbenchView.svelte, minus the UI-only edit flags.  Importer fills
+ * this from `<Cube>` blocks; +page.svelte maps it to the trimmed doc cube
+ * shape and writes it via `store.setCubes`, then remounts the WorkbenchView
+ * so it hydrates from `doc.cubes`.
+ */
+/**
+ * Mondrian 4 measure-group → dim link.  Three flavours:
+ *
+ *   - `foreign-key` (default) — `<ForeignKeyLink dimension='X' foreignKeyColumn='Y'/>`.
+ *     The fact-side column joining to the dim's primary key.
+ *   - `fact` — `<FactLink dimension='X'/>`.  Degenerate dim whose level
+ *     columns ARE on the fact table; no FK column needed.
+ *   - `reference` — `<ReferenceLink dimension='X' viaDimension='Y'
+ *     viaAttribute='Z'/>`.  Multi-hop: the dim is reached through another
+ *     dim's attribute (FoodMart HR's Store via Employee.store_id).
+ *
+ * v1 only modelled `foreign-key`; v2 carries the link kind through
+ * round-trip so authors who hand-author FactLink / ReferenceLink don't
+ * lose them on export.
+ */
+export interface ImportedWorkbenchMeasureGroup {
+	id: string;
+	name: string;
+	factTableId: string | null;
+	measureColumns: string[];
+	dimensionLinks: {
+		dimensionId: string;
+		foreignKeyColumn: string;
+		linkKind?: 'foreign-key' | 'fact' | 'reference';
+		viaDimension?: string;
+		viaAttribute?: string;
+	}[];
+}
+export interface ImportedWorkbenchCalc {
+	id: string;
+	name: string;
+	tokens: never[];
+	formula?: string;
+}
+export interface ImportedWorkbenchCube {
+	id: string;
+	name: string;
+	measureGroups: ImportedWorkbenchMeasureGroup[];
+	factsCalcs: ImportedWorkbenchCalc[];
+	/** Declarative <TimeCalc> metrics read back from the schema. */
+	timeCalcs?: SchemaCanvasTimeCalc[];
+}
+
+export interface MondrianImportResult {
+	state: SchemaCanvasState;
+	warnings: string[];
+	/** Populated by the Mondrian-4 importer: one workbench cube per `<Cube>`
+	 *  in the schema, with MGs/measures/dim-links/calcs ready to seed
+	 *  the workbench.  Empty array on Mondrian-3 imports or
+	 *  PhysicalSchema-only imports. */
+	workbenchCubes: ImportedWorkbenchCube[];
+}
+
+/**
+ * Thrown when the XML referenced one or more tables without a schema
+ * attribute AND those table names exist in more than one schema in the
+ * active catalog. The caller is expected to prompt the user to pick a
+ * schema per table, then re-run the import with `schemaOverrides` set.
+ */
+export class AmbiguousSchemaError extends Error {
+	readonly name = 'AmbiguousSchemaError';
+	constructor(
+		public readonly ambiguities: Array<{
+			tableName: string;
+			candidateSchemas: string[];
+		}>
+	) {
+		super(`Schema is ambiguous for: ${ambiguities.map((a) => a.tableName).join(', ')}.`);
+	}
+}
+
+interface ImportOpts {
+	/** Connection id the imported doc will live under. */
+	connectionId: string;
+	/** Schema label override (defaults to the <Schema name="…"> attribute). */
+	label?: string;
+	/** Live source catalog — used to enrich columns when the XML only
+	 *  names a few. If a referenced table isn't in the catalog the
+	 *  importer falls back to whatever columns the XML mentions. */
+	sourceTables?: SourceTableCandidate[];
+	/**
+	 * Per-table schema overrides keyed by lowercased table name. Used
+	 * after the user resolves an `AmbiguousSchemaError` — the importer
+	 * applies the picked schema instead of guessing or throwing again.
+	 */
+	schemaOverrides?: Record<string, string>;
+}
+
+export function importFromMondrianXml(xml: string, opts: ImportOpts): MondrianImportResult {
+	if (typeof window === 'undefined') {
+		throw new Error('XML import is only available in the browser.');
+	}
+	const parser = new DOMParser();
+	const dom = parser.parseFromString(xml, 'application/xml');
+	const err = dom.querySelector('parsererror');
+	if (err) throw new Error(`XML parse error: ${err.textContent?.slice(0, 240) ?? 'unknown'}`);
+
+	// Accept either a full `<Schema>` doc OR a bare `<PhysicalSchema>`
+	// block.  The bare-PhysicalSchema route is for "I only care about the
+	// table layout" pastes; a full <Schema> ALWAYS has a <PhysicalSchema>
+	// child too, so we route by ROOT element tag, not by presence of a
+	// <PhysicalSchema> descendant.  Previously the dispatcher fell through
+	// to parsePhysicalSchemaOnly for every M4 schema, silently skipping
+	// the cube walker.
+	const rootEl = dom.documentElement;
+	if (rootEl?.tagName === 'PhysicalSchema') {
+		return parsePhysicalSchemaOnly(rootEl, opts);
+	}
+
+	const schemaEl = dom.querySelector('Schema');
+	if (!schemaEl) {
+		throw new Error('Expected a <Schema> or <PhysicalSchema> element at the root.');
+	}
+
+	const isM4 =
+		schemaEl.getAttribute('metamodelVersion') === '4.0' ||
+		schemaEl.querySelector(':scope > Cube > MeasureGroups') !== null;
+
+	return isM4 ? parseM4(schemaEl, opts) : parseM3(schemaEl, opts);
+}
+
+/**
+ * True when the pasted XML is a legacy Mondrian 3 `<Schema>` — i.e. it has no
+ * Mondrian-4 marker (`metamodelVersion="4…"`) and no `<MeasureGroups>`. Used by
+ * the import flow (saiku-cloud#1133) to decide whether to upgrade the paste to
+ * faithful M4 (via the gateway) BEFORE handing it to {@link importFromMondrianXml},
+ * because the canvas editor is Mondrian-4 native and can't meaningfully open an
+ * M3 schema.
+ *
+ * Robust to any 4.x (the engine's upgrader emits `4.8`, not just `4.0`). A bare
+ * `<PhysicalSchema>` paste, a non-Schema document, or malformed XML all return
+ * `false` (not M3) — those are handled unchanged by the importer, which surfaces
+ * its own clear error.
+ */
+export function isMondrian3Xml(xml: string): boolean {
+	if (typeof window === 'undefined') return false;
+	let dom: Document;
+	try {
+		dom = new DOMParser().parseFromString(xml, 'application/xml');
+	} catch {
+		return false;
+	}
+	if (dom.querySelector('parsererror')) return false;
+	if (dom.documentElement?.tagName === 'PhysicalSchema') return false;
+	const schemaEl = dom.querySelector('Schema');
+	if (!schemaEl) return false;
+	const metamodelVersion = (schemaEl.getAttribute('metamodelVersion') ?? '').trim();
+	if (metamodelVersion.startsWith('4')) return false;
+	if (schemaEl.querySelector(':scope > Cube > MeasureGroups') !== null) return false;
+	return true;
+}
+
+/**
+ * The physical column a `<Measure>` aggregates. Mondrian 4 carries it in
+ * `<Arguments><Column name="…"/></Arguments>`; legacy/hand-written schemas
+ * may instead use a bare `column="…"` attribute. Returns null for measures
+ * with no column (e.g. count-of-rows measures) — the caller decides.
+ */
+function measureColumnOf(measureEl: Element): string | null {
+	const attr = measureEl.getAttribute('column');
+	if (attr) return attr;
+	const argCol = measureEl.querySelector(':scope > Arguments > Column');
+	return argCol?.getAttribute('name') ?? null;
+}
+
+// ─── PhysicalSchema-only parser (peer model) ───────────────────────────────
+
+/**
+ * Parses just the `<PhysicalSchema>` block — every `<Table>` becomes a
+ * peer canvas node, every `<Link>` becomes a join. No fact/dim
+ * distinction, no cube parsing. Matches the canvas's peer model where
+ * tables are equal and joins are arbitrary.
+ *
+ * Source side of each Link uses the source table's `<Key><Column>` as
+ * its join column; target side uses the `<ForeignKey><Column>` named
+ * column.
+ */
+function parsePhysicalSchemaOnly(physEl: Element, opts: ImportOpts): MondrianImportResult {
+	const warnings: string[] = [];
+	// PhysicalSchema-only imports don't carry cube metadata — return an
+	// empty array so the +page.svelte hydration path is unchanged.
+	const workbenchCubes: ImportedWorkbenchCube[] = [];
+
+	// Phase 1 — harvest tables.
+	interface PhysTable {
+		schema: string | null;
+		name: string;
+		columns: Set<string>;
+		keyColumn: string | null;
+	}
+	const physTables = new Map<string, PhysTable>();
+	for (const tEl of Array.from(physEl.querySelectorAll(':scope > Table'))) {
+		const name = tEl.getAttribute('name');
+		if (!name) continue;
+		const schema = tEl.getAttribute('schema');
+		const columns = new Set<string>();
+		for (const cEl of Array.from(tEl.querySelectorAll('Column'))) {
+			const col = cEl.getAttribute('name');
+			if (col) columns.add(col);
+		}
+		const keyEl = tEl.querySelector(':scope > Key > Column');
+		physTables.set(name, {
+			schema,
+			name,
+			columns,
+			keyColumn: keyEl?.getAttribute('name') ?? null
+		});
+	}
+	if (physTables.size === 0) {
+		throw new Error('<PhysicalSchema> contained no <Table> elements.');
+	}
+
+	// Detect ambiguous schemas — names without `schema=` (and no override)
+	// that exist in MULTIPLE schemas in the live catalog. The host has to
+	// prompt the user to pick before we can proceed.
+	const overrides = opts.schemaOverrides ?? {};
+	if (opts.sourceTables && opts.sourceTables.length > 0) {
+		const ambiguities: Array<{ tableName: string; candidateSchemas: string[] }> = [];
+		for (const [name, phys] of physTables) {
+			const lower = name.toLowerCase();
+			if (phys.schema) continue; // already qualified
+			if (overrides[lower]) continue; // user resolved it
+			const candidates: string[] = [];
+			for (const t of opts.sourceTables) {
+				if (t.name.toLowerCase() === lower) {
+					const sch = t.schema ?? '';
+					if (sch && !candidates.includes(sch)) candidates.push(sch);
+				}
+			}
+			if (candidates.length >= 2) {
+				ambiguities.push({ tableName: name, candidateSchemas: candidates.sort() });
+			}
+		}
+		if (ambiguities.length > 0) {
+			throw new AmbiguousSchemaError(ambiguities);
+		}
+	}
+
+	// Phase 2 — drop the tables onto the canvas. We arrange them in a
+	// loose grid so the user has somewhere to start; they can re-arrange.
+	const tables: SchemaCanvasTable[] = [];
+	const tableIdByName = new Map<string, string>();
+	const namesSorted = [...physTables.keys()].sort();
+	const cols = Math.max(1, Math.ceil(Math.sqrt(namesSorted.length)));
+	namesSorted.forEach((name, i) => {
+		const phys = physTables.get(name)!;
+		// Pre-resolve schema using the user's override (set after they
+		// resolved an AmbiguousSchemaError) before falling back to
+		// what the XML provided.
+		const overriddenSchema = overrides[name.toLowerCase()] ?? phys.schema;
+		const catalogHit = lookupTableInCatalog(opts.sourceTables, overriddenSchema, name);
+		const resolvedSchema = catalogHit?.schema ?? overriddenSchema;
+		const initialCols: SchemaCanvasColumn[] = catalogHit
+			? catalogHit.columns.map((c) => ({ name: c.name, sqlType: c.sqlType }))
+			: [...phys.columns].map((n) => ({ name: n, sqlType: 'UNKNOWN' }));
+		if (!catalogHit) {
+			warnings.push(
+				`"${name}" wasn't found in the active connection's catalog — imported with only the columns the XML referenced. Switch to the right connection to enrich it.`
+			);
+		} else if ((phys.schema ?? '') !== (catalogHit.schema ?? '') && phys.schema) {
+			warnings.push(
+				`"${name}" was schema-qualified as "${phys.schema}" in the XML but matched "${catalogHit.schema}" in the catalog. Using the catalog's schema.`
+			);
+		}
+		const id = makeId('tbl');
+		tables.push({
+			id,
+			schema: resolvedSchema,
+			name,
+			role: 'dimension',
+			columns: initialCols,
+			position: {
+				x: 120 + (i % cols) * 320,
+				y: 120 + Math.floor(i / cols) * 280
+			},
+			groupId: null
+		});
+		tableIdByName.set(name, id);
+	});
+
+	// Phase 3 — parse <Link> rows into joins. Each Link is `source` →
+	// `target` with a `<ForeignKey><Column>` naming the FK column on
+	// the target. Source side uses its declared Key column.
+	const joins: SchemaCanvasJoin[] = [];
+	for (const linkEl of Array.from(physEl.querySelectorAll(':scope > Link'))) {
+		const sourceName = linkEl.getAttribute('source');
+		const targetName = linkEl.getAttribute('target');
+		if (!sourceName || !targetName) {
+			warnings.push('<Link> with missing source/target attribute — skipped.');
+			continue;
+		}
+		const fkColEl = linkEl.querySelector('ForeignKey > Column');
+		const fkColName = fkColEl?.getAttribute('name');
+		if (!fkColName) {
+			warnings.push(
+				`<Link source="${sourceName}" target="${targetName}"> has no <ForeignKey><Column> — skipped.`
+			);
+			continue;
+		}
+		const sourceId = tableIdByName.get(sourceName);
+		const targetId = tableIdByName.get(targetName);
+		if (!sourceId || !targetId) {
+			warnings.push(
+				`<Link source="${sourceName}" target="${targetName}"> references an undefined table — skipped.`
+			);
+			continue;
+		}
+		const sourcePhys = physTables.get(sourceName);
+		const sourceKey = sourcePhys?.keyColumn ?? 'id';
+		// Make sure both columns appear on their tables for the canvas
+		// to render the join endpoints meaningfully.
+		const sourceTable = tables.find((t) => t.id === sourceId);
+		if (sourceTable && !sourceTable.columns.some((c) => c.name === sourceKey)) {
+			sourceTable.columns.push({ name: sourceKey, sqlType: 'UNKNOWN' });
+		}
+		const targetTable = tables.find((t) => t.id === targetId);
+		if (targetTable && !targetTable.columns.some((c) => c.name === fkColName)) {
+			targetTable.columns.push({ name: fkColName, sqlType: 'UNKNOWN' });
+		}
+		joins.push({
+			id: makeId('join'),
+			sourceTableId: sourceId,
+			sourceColumnName: sourceKey,
+			targetTableId: targetId,
+			targetColumnName: fkColName,
+			kind: 'inner',
+			// PhysicalSchema-only parse — these are explicit <Link> joins.
+			origin: 'physical'
+		});
+	}
+
+	const state: SchemaCanvasState = {
+		version: 1,
+		connectionId: opts.connectionId,
+		label: opts.label ?? '',
+		tables,
+		joins,
+		groups: [],
+		updatedAt: new Date().toISOString()
+	};
+	return { state, warnings, workbenchCubes };
+}
+
+// ─── shared helpers ────────────────────────────────────────────────────────
+
+function lookupColumnsFromCatalog(
+	sourceTables: SourceTableCandidate[] | undefined,
+	schema: string | null,
+	name: string
+): SchemaCanvasColumn[] | null {
+	const hit = lookupTableInCatalog(sourceTables, schema, name);
+	return hit ? hit.columns.map((c) => ({ name: c.name, sqlType: c.sqlType })) : null;
+}
+
+/**
+ * Resolve a (schema, name) pair against the live source-table catalog.
+ *
+ * Match precedence:
+ *   1. Exact `schema.name` (case-insensitive) — preferred.
+ *   2. Just `name` (case-insensitive) — for XML that omits `schema=`,
+ *      or names something with a different schema than what's in the
+ *      catalog. If multiple tables across schemas share the same name,
+ *      the FIRST one wins (caller gets a warning hook if it cares).
+ *
+ * Returns the matched `SourceTableCandidate` so the caller can inherit
+ * both the schema attribute AND the full column list, so an imported
+ * `product_class` becomes `public.product_class` with every column
+ * present instead of just the few the XML happened to name.
+ */
+function lookupTableInCatalog(
+	sourceTables: SourceTableCandidate[] | undefined,
+	schema: string | null,
+	name: string
+): SourceTableCandidate | null {
+	if (!sourceTables || sourceTables.length === 0) return null;
+	const lowerName = name.toLowerCase();
+	const lowerSchema = schema?.toLowerCase() ?? null;
+	let nameOnlyHit: SourceTableCandidate | null = null;
+	for (const t of sourceTables) {
+		if (t.name.toLowerCase() !== lowerName) continue;
+		if (lowerSchema !== null && (t.schema?.toLowerCase() ?? null) === lowerSchema) {
+			return t;
+		}
+		if (nameOnlyHit === null) nameOnlyHit = t;
+	}
+	return nameOnlyHit;
+}
+
+// ─── Mondrian 3 — existing path ────────────────────────────────────────────
+
+function parseM3(schemaEl: Element, opts: ImportOpts): MondrianImportResult {
+	const warnings: string[] = [];
+	const schemaName = schemaEl.getAttribute('name') ?? '';
+
+	const cubeEls = Array.from(schemaEl.querySelectorAll(':scope > Cube'));
+	if (cubeEls.length === 0) throw new Error('Schema has no <Cube>.');
+
+	const keyFor = (schema: string | null, name: string) =>
+		`${(schema ?? '').toLowerCase()}::${name.toLowerCase()}`;
+
+	// ── Phase 0 — collect schema-level shared <Dimension> blocks ──
+	// FoodMart-style: <Schema><Dimension name="Time"><Hierarchy…><Table/>
+	// </Hierarchy></Dimension>…<Cube><DimensionUsage source="Time" …/></Cube>
+	// Cubes reference shared dims via <DimensionUsage source=X foreignKey=Y>
+	// so Phase 3 has to resolve X → the shared dim's PK table + PK column.
+	interface HierarchyResolved {
+		primaryKey: string | null;
+		// PK-bearing table — where the fact's foreignKey joins.  Comes
+		// from Hierarchy@primaryKeyTable when set, otherwise the first
+		// <Table> in the hierarchy (bare or leftmost inside a <Join>).
+		pkTable: { schema: string | null; name: string } | null;
+		tables: Array<{ schema: string | null; name: string; xmlEl: Element }>;
+		// Snowflake internal joins from <Join leftKey="X" rightKey="Y">
+		// with two Tables inside.  Only the simple 2-table form is
+		// supported; deeper nesting is warned about and dropped.
+		snowflakeJoins: Array<{
+			leftTable: { schema: string | null; name: string };
+			leftCol: string;
+			rightTable: { schema: string | null; name: string };
+			rightCol: string;
+		}>;
+	}
+	function resolveHierarchy(hierEl: Element, dimNameForWarn: string): HierarchyResolved | null {
+		const primaryKey = hierEl.getAttribute('primaryKey');
+		const pkTableAttr = hierEl.getAttribute('primaryKeyTable');
+		const tables: HierarchyResolved['tables'] = [];
+		const snowflakeJoins: HierarchyResolved['snowflakeJoins'] = [];
+
+		// Simple form: <Hierarchy><Table name=…/></Hierarchy>
+		const bareTableEl = hierEl.querySelector(':scope > Table');
+		if (bareTableEl) {
+			const name = bareTableEl.getAttribute('name');
+			if (name) {
+				tables.push({
+					schema: bareTableEl.getAttribute('schema'),
+					name,
+					xmlEl: bareTableEl
+				});
+			}
+		}
+
+		// Snowflake form: <Hierarchy><Join leftKey=… rightKey=…>
+		//   <Table name="a"/><Table name="b"/></Join></Hierarchy>
+		const joinEl = hierEl.querySelector(':scope > Join');
+		if (joinEl) {
+			const leftKey = joinEl.getAttribute('leftKey');
+			const rightKey = joinEl.getAttribute('rightKey');
+			const joinTables = Array.from(joinEl.querySelectorAll(':scope > Table'));
+			const nestedJoins = Array.from(joinEl.querySelectorAll(':scope > Join'));
+			if (nestedJoins.length > 0) {
+				warnings.push(
+					`Dimension "${dimNameForWarn}" uses nested <Join> — only simple 2-table snowflakes are wired for now.`
+				);
+			}
+			if (joinTables.length >= 1) {
+				const t0 = joinTables[0];
+				const t0name = t0.getAttribute('name');
+				if (t0name) {
+					tables.push({
+						schema: t0.getAttribute('schema'),
+						name: t0name,
+						xmlEl: t0
+					});
+				}
+			}
+			if (joinTables.length >= 2 && leftKey && rightKey) {
+				const t0 = joinTables[0];
+				const t1 = joinTables[1];
+				const t0name = t0.getAttribute('name');
+				const t1name = t1.getAttribute('name');
+				if (t1name) {
+					tables.push({
+						schema: t1.getAttribute('schema'),
+						name: t1name,
+						xmlEl: t1
+					});
+				}
+				if (t0name && t1name) {
+					snowflakeJoins.push({
+						leftTable: { schema: t0.getAttribute('schema'), name: t0name },
+						leftCol: leftKey,
+						rightTable: { schema: t1.getAttribute('schema'), name: t1name },
+						rightCol: rightKey
+					});
+				}
+			}
+		}
+
+		if (tables.length === 0) return null;
+
+		// PK-bearing table — primaryKeyTable attr overrides; else first.
+		let pkTable: HierarchyResolved['pkTable'] = tables[0];
+		if (pkTableAttr) {
+			const hit = tables.find((t) => t.name.toLowerCase() === pkTableAttr.toLowerCase());
+			if (hit) pkTable = hit;
+		}
+		return { primaryKey, pkTable, tables, snowflakeJoins };
+	}
+
+	// Schema-level dims — keyed by <Dimension name="…">.
+	interface SharedDim {
+		name: string;
+		hierarchy: HierarchyResolved;
+	}
+	const sharedDims = new Map<string, SharedDim>();
+	for (const dimEl of Array.from(schemaEl.querySelectorAll(':scope > Dimension'))) {
+		const dimName = dimEl.getAttribute('name');
+		if (!dimName) continue;
+		const hierarchyEl = dimEl.querySelector(':scope > Hierarchy');
+		if (!hierarchyEl) continue;
+		const hier = resolveHierarchy(hierarchyEl, dimName);
+		if (hier) sharedDims.set(dimName, { name: dimName, hierarchy: hier });
+	}
+
+	// ── Phase 1 — derive the PHYSICAL SCHEMA ──
+	interface PhysDescriptor {
+		schema: string | null;
+		name: string;
+		role: 'fact' | 'dimension';
+		xmlHost: Element; // for column enrichment from XML
+	}
+	const phys = new Map<string, PhysDescriptor>();
+
+	function ensurePhys(
+		schema: string | null,
+		name: string,
+		role: 'fact' | 'dimension',
+		xmlHost: Element
+	) {
+		const k = keyFor(schema, name);
+		const existing = phys.get(k);
+		if (existing) {
+			if (role === 'fact') existing.role = 'fact'; // fact wins
+		} else {
+			phys.set(k, { schema, name, role, xmlHost });
+		}
+	}
+
+	for (const cubeEl of cubeEls) {
+		const cubeName = cubeEl.getAttribute('name') ?? '(unnamed)';
+
+		const factEl = cubeEl.querySelector(':scope > Table');
+		if (!factEl) {
+			warnings.push(`Cube "${cubeName}" has no <Table> (fact); ignored.`);
+			continue;
+		}
+		const factName = factEl.getAttribute('name');
+		if (!factName) {
+			warnings.push(`Cube "${cubeName}" fact <Table> has no name attribute; ignored.`);
+			continue;
+		}
+		ensurePhys(factEl.getAttribute('schema'), factName, 'fact', cubeEl);
+
+		// Inline <Dimension> in the cube (rare but possible).
+		for (const dimEl of Array.from(cubeEl.querySelectorAll(':scope > Dimension'))) {
+			const dimName = dimEl.getAttribute('name') ?? '(inline)';
+			const hierarchyEl = dimEl.querySelector(':scope > Hierarchy');
+			if (!hierarchyEl) continue;
+			const hier = resolveHierarchy(hierarchyEl, dimName);
+			if (!hier) continue;
+			for (const t of hier.tables) {
+				ensurePhys(t.schema, t.name, 'dimension', t.xmlEl);
+			}
+		}
+
+		// <DimensionUsage source="X"> → resolve to schema-level shared dim.
+		for (const usageEl of Array.from(cubeEl.querySelectorAll(':scope > DimensionUsage'))) {
+			const source = usageEl.getAttribute('source');
+			if (!source) continue;
+			const shared = sharedDims.get(source);
+			if (!shared) {
+				warnings.push(
+					`Cube "${cubeName}" references dimension "${source}" via <DimensionUsage>, but no schema-level <Dimension name="${source}"> was found.`
+				);
+				continue;
+			}
+			for (const t of shared.hierarchy.tables) {
+				ensurePhys(t.schema, t.name, 'dimension', t.xmlEl);
+			}
+		}
+	}
+
+	// ── Phase 2 — emit canvas tables from the physical schema ──
+	// Inherit the CATALOG's schema attribute when the XML omitted it.
+	// FoodMart-style XML writes bare `<Table name="sales_fact_1997"/>`
+	// so p.schema is null; but the catalog stores it as `public::…`.
+	// Without this inheritance the sidebar "on canvas" markers don't
+	// light up (identity mismatch), Phase-3 join lookups miss, and
+	// any downstream schema-qualified equality fails silently.
+	const tables: SchemaCanvasTable[] = [];
+	const tableIdByKey = new Map<string, string>();
+	const physKeys = [...phys.keys()];
+	const gridCols = Math.max(1, Math.ceil(Math.sqrt(physKeys.length)));
+	physKeys.forEach((k, i) => {
+		const p = phys.get(k)!;
+		const catalogHit = lookupTableInCatalog(opts.sourceTables, p.schema, p.name);
+		const resolvedSchema = catalogHit?.schema ?? p.schema;
+		const cols =
+			(catalogHit ? catalogHit.columns.map((c) => ({ name: c.name, sqlType: c.sqlType })) : null) ??
+			collectColumnsFromM3Xml(p.xmlHost, p.name, p.role, warnings);
+		const id = makeId('tbl');
+		tables.push({
+			id,
+			schema: resolvedSchema,
+			name: p.name,
+			role: p.role,
+			columns: cols,
+			position: {
+				x: 200 + (i % gridCols) * 320,
+				y: 160 + Math.floor(i / gridCols) * 280
+			},
+			groupId: null
+		});
+		// Register under BOTH the original XML key (Phase 3 lookups use
+		// the XML-declared identity) AND the catalog-resolved key (so
+		// snowflake-join lookups matching resolved schemas hit too).
+		tableIdByKey.set(k, id);
+		const resolvedKey = keyFor(resolvedSchema, p.name);
+		if (resolvedKey !== k) tableIdByKey.set(resolvedKey, id);
+	});
+
+	// ── Phase 3 — walk cubes to emit joins + workbench cubes ──
+	const joins: SchemaCanvasJoin[] = [];
+	const joinKeys = new Set<string>();
+	const workbenchCubes: ImportedWorkbenchCube[] = [];
+
+	function pushJoin(
+		sourceTableId: string,
+		sourceColumnName: string,
+		targetTableId: string,
+		targetColumnName: string
+	) {
+		const joinKey = `${sourceTableId}::${sourceColumnName}->${targetTableId}::${targetColumnName}`;
+		if (joinKeys.has(joinKey)) return;
+		joinKeys.add(joinKey);
+		joins.push({
+			id: makeId('join'),
+			sourceTableId,
+			sourceColumnName,
+			targetTableId,
+			targetColumnName,
+			kind: 'inner',
+			origin: 'physical'
+		});
+	}
+
+	// Snowflake joins from schema-level shared dims land ONCE (they're
+	// part of the physical schema, not tied to any specific cube).
+	for (const shared of sharedDims.values()) {
+		for (const sj of shared.hierarchy.snowflakeJoins) {
+			const leftId = tableIdByKey.get(keyFor(sj.leftTable.schema, sj.leftTable.name));
+			const rightId = tableIdByKey.get(keyFor(sj.rightTable.schema, sj.rightTable.name));
+			if (leftId && rightId) pushJoin(leftId, sj.leftCol, rightId, sj.rightCol);
+		}
+	}
+
+	for (const cubeEl of cubeEls) {
+		const cubeName = cubeEl.getAttribute('name') ?? '(unnamed)';
+		const factEl = cubeEl.querySelector(':scope > Table');
+		const factName = factEl?.getAttribute('name');
+		const factSchema = factEl?.getAttribute('schema') ?? null;
+		if (!factName) continue;
+		const factId = tableIdByKey.get(keyFor(factSchema, factName));
+		if (!factId) continue;
+
+		const measureCols: string[] = [];
+		const dimensionLinks: ImportedWorkbenchMeasureGroup['dimensionLinks'] = [];
+		for (const measureEl of Array.from(cubeEl.querySelectorAll(':scope > Measure'))) {
+			const col = measureEl.getAttribute('column');
+			if (col) measureCols.push(col);
+		}
+
+		// Inline <Dimension> — existing path.
+		for (const dimEl of Array.from(cubeEl.querySelectorAll(':scope > Dimension'))) {
+			const fk = dimEl.getAttribute('foreignKey');
+			const dimName = dimEl.getAttribute('name') ?? '(inline)';
+			const hierarchyEl = dimEl.querySelector(':scope > Hierarchy');
+			if (!hierarchyEl) {
+				warnings.push(
+					`<Dimension name="${dimName}"> in cube "${cubeName}" has no <Hierarchy>; skipped.`
+				);
+				continue;
+			}
+			const hier = resolveHierarchy(hierarchyEl, dimName);
+			if (!hier || !hier.pkTable) continue;
+			const dimId = tableIdByKey.get(keyFor(hier.pkTable.schema, hier.pkTable.name));
+			if (!dimId) continue;
+			if (fk && hier.primaryKey) {
+				pushJoin(dimId, hier.primaryKey, factId, fk);
+				dimensionLinks.push({
+					dimensionId: dimId,
+					foreignKeyColumn: fk,
+					linkKind: 'foreign-key'
+				});
+			} else {
+				warnings.push(
+					`Dimension "${dimName}" in cube "${cubeName}" missing foreignKey/primaryKey; join skipped.`
+				);
+			}
+		}
+
+		// <DimensionUsage> — resolve source → shared dim → PK table.
+		for (const usageEl of Array.from(cubeEl.querySelectorAll(':scope > DimensionUsage'))) {
+			const usageName = usageEl.getAttribute('name') ?? usageEl.getAttribute('source') ?? '(usage)';
+			const source = usageEl.getAttribute('source');
+			const fk = usageEl.getAttribute('foreignKey');
+			if (!source) {
+				warnings.push(
+					`<DimensionUsage name="${usageName}"> in cube "${cubeName}" has no source= attribute; skipped.`
+				);
+				continue;
+			}
+			const shared = sharedDims.get(source);
+			if (!shared || !shared.hierarchy.pkTable || !shared.hierarchy.primaryKey) continue;
+			const dimId = tableIdByKey.get(
+				keyFor(shared.hierarchy.pkTable.schema, shared.hierarchy.pkTable.name)
+			);
+			if (!dimId) continue;
+			if (fk) {
+				pushJoin(dimId, shared.hierarchy.primaryKey, factId, fk);
+				dimensionLinks.push({
+					dimensionId: dimId,
+					foreignKeyColumn: fk,
+					linkKind: 'foreign-key'
+				});
+			} else {
+				warnings.push(
+					`<DimensionUsage name="${usageName}"> in cube "${cubeName}" has no foreignKey=; join skipped.`
+				);
+			}
+		}
+
+		workbenchCubes.push({
+			id: makeId('cube'),
+			name: cubeName,
+			measureGroups: [
+				{
+					id: makeId('mg'),
+					name: cubeName,
+					factTableId: factId,
+					measureColumns: measureCols,
+					dimensionLinks
+				}
+			],
+			factsCalcs: []
+		});
+	}
+
+	const state: SchemaCanvasState = {
+		version: 1,
+		connectionId: opts.connectionId,
+		label: opts.label ?? schemaName,
+		tables,
+		joins,
+		groups: [],
+		updatedAt: new Date().toISOString()
+	};
+	return { state, warnings, workbenchCubes };
+}
+
+function collectColumnsFromM3Xml(
+	scope: Element,
+	tableName: string,
+	role: 'fact' | 'dimension',
+	warnings: string[]
+): SchemaCanvasColumn[] {
+	const names = new Set<string>();
+	if (role === 'fact') {
+		for (const dim of Array.from(scope.querySelectorAll(':scope > Dimension'))) {
+			const fk = dim.getAttribute('foreignKey');
+			if (fk) names.add(fk);
+		}
+	} else {
+		const hier = scope.tagName === 'Hierarchy' ? scope : scope.querySelector(':scope > Hierarchy');
+		if (hier) {
+			const pk = hier.getAttribute('primaryKey');
+			if (pk) names.add(pk);
+			for (const lvl of Array.from(hier.querySelectorAll(':scope > Level'))) {
+				const col = lvl.getAttribute('column') ?? lvl.getAttribute('name');
+				if (col) names.add(col);
+			}
+		}
+	}
+	if (names.size === 0) {
+		warnings.push(
+			`No columns could be inferred for "${tableName}" from XML; canvas node will render empty.`
+		);
+	}
+	return [...names].map((name) => ({ name, sqlType: 'UNKNOWN' }));
+}
+
+// ─── Mondrian 4 — new path ─────────────────────────────────────────────────
+
+function parseM4(schemaEl: Element, opts: ImportOpts): MondrianImportResult {
+	const warnings: string[] = [];
+	const schemaName = schemaEl.getAttribute('name') ?? '';
+	// Populated by Phase 6 from <Cube> blocks — handed back to +page.svelte
+	// for localStorage seeding.
+	const workbenchCubes: ImportedWorkbenchCube[] = [];
+
+	const physSchemaEl = schemaEl.querySelector(':scope > PhysicalSchema');
+
+	// Phase 1: harvest every physical table — schema-qualified, with the
+	// columns scraped from any <Column> descendants (Key declarations,
+	// inline column defs, etc.).
+	interface PhysTable {
+		schema: string | null;
+		name: string;
+		columns: Set<string>;
+		keyColumn: string | null;
+	}
+	const physTables = new Map<string, PhysTable>();
+	if (physSchemaEl) {
+		for (const tEl of Array.from(physSchemaEl.querySelectorAll(':scope > Table'))) {
+			const name = tEl.getAttribute('name');
+			if (!name) continue;
+			const schema = tEl.getAttribute('schema');
+			const columns = new Set<string>();
+			for (const cEl of Array.from(tEl.querySelectorAll('Column'))) {
+				const col = cEl.getAttribute('name');
+				if (col) columns.add(col);
+			}
+			const keyEl = tEl.querySelector(':scope > Key > Column');
+			physTables.set(name, {
+				schema,
+				name,
+				columns,
+				keyColumn: keyEl?.getAttribute('name') ?? null
+			});
+		}
+	}
+
+	// Phase 2: collect every <Cube> — the workbench needs them all.
+	const cubeEls = Array.from(schemaEl.querySelectorAll(':scope > Cube'));
+	if (cubeEls.length === 0) throw new Error('Schema has no <Cube>.');
+
+	const tables: SchemaCanvasTable[] = [];
+	const joins: SchemaCanvasJoin[] = [];
+	const tableIdByName = new Map<string, string>();
+
+	function ensureTable(
+		tableName: string,
+		role: 'fact' | 'dimension',
+		position: { x: number; y: number }
+	): string {
+		const existing = tableIdByName.get(tableName);
+		if (existing) {
+			// Upgrade dim → fact if it gets referenced as a MeasureGroup later.
+			if (role === 'fact') {
+				const t = tables.find((tt) => tt.id === existing);
+				if (t) t.role = 'fact';
+			}
+			return existing;
+		}
+		const phys = physTables.get(tableName);
+		const fromCatalog = phys
+			? lookupColumnsFromCatalog(opts.sourceTables, phys.schema, tableName)
+			: lookupColumnsFromCatalog(opts.sourceTables, null, tableName);
+		const initialCols: SchemaCanvasColumn[] =
+			fromCatalog ?? (phys ? [...phys.columns].map((n) => ({ name: n, sqlType: 'UNKNOWN' })) : []);
+		const id = makeId('tbl');
+		tables.push({
+			id,
+			schema: phys?.schema ?? null,
+			name: tableName,
+			role,
+			columns: initialCols,
+			position,
+			groupId: null
+		});
+		tableIdByName.set(tableName, id);
+		return id;
+	}
+
+	function ensureColumn(tableId: string, colName: string) {
+		const t = tables.find((tt) => tt.id === tableId);
+		if (!t) return;
+		if (t.columns.some((c) => c.name === colName)) return;
+		t.columns.push({ name: colName, sqlType: 'UNKNOWN' });
+	}
+
+	// Phase 3: MeasureGroups → mark fact tables, harvest measure columns.
+	// Walks EVERY cube's MGs, not just the first cube's, so multi-cube
+	// schemas (FoodMart has 6) register every fact table.  Flat `mgEls`
+	// stays around for the join-inference pass further down.
+	const mgEls: Element[] = [];
+	for (const c of cubeEls) {
+		for (const m of Array.from(c.querySelectorAll(':scope > MeasureGroups > MeasureGroup'))) {
+			mgEls.push(m);
+		}
+	}
+	mgEls.forEach((mgEl) => {
+		const tableName = mgEl.getAttribute('table');
+		if (!tableName) {
+			warnings.push(`<MeasureGroup name="${mgEl.getAttribute('name')}"> has no table; skipped.`);
+			return;
+		}
+		const factId = ensureTable(tableName, 'fact', { x: 600, y: 400 });
+		for (const mEl of Array.from(mgEl.querySelectorAll(':scope > Measures > Measure'))) {
+			const col = measureColumnOf(mEl);
+			if (col) ensureColumn(factId, col);
+		}
+	});
+	if (mgEls.length === 0) {
+		warnings.push("No <MeasureGroup> found in any cube — fact tables won't be marked.");
+	}
+
+	// Phase 4: Dimensions → register dim tables, harvest attribute columns.
+	// Walks SCHEMA-level <Dimension>s (Mondrian 4's shared-dim model) AND
+	// cube-private <Dimension>s, so every dim's underlying table is on the
+	// canvas before the workbench-side parser tries to resolve attributes
+	// against it.  Per-attribute `table=` overrides are also registered so
+	// cross-table dims (e.g. Customer with attributes on `customer` + dim
+	// joins to `customer_class`) get their secondary tables too.
+	const dimByName = new Map<string, string>(); // dim "logical" name → physical table name
+	const schemaDimEls = Array.from(schemaEl.querySelectorAll(':scope > Dimension'));
+	const cubeDimEls: Element[] = [];
+	for (const c of cubeEls) {
+		for (const dEl of Array.from(c.querySelectorAll(':scope > Dimensions > Dimension'))) {
+			// source='X' refers to a shared dim that's already in schemaDimEls;
+			// skip duplicate ensureTable.
+			if (dEl.getAttribute('source')) continue;
+			cubeDimEls.push(dEl);
+		}
+	}
+	const allDimEls = [...schemaDimEls, ...cubeDimEls];
+	const n = Math.max(1, allDimEls.length);
+	allDimEls.forEach((dimEl, i) => {
+		const logical = dimEl.getAttribute('name') ?? '';
+		const dimTableName = dimEl.getAttribute('table');
+		const gridCols = n <= 4 ? 2 : n <= 9 ? 3 : 4;
+		const gridRow = Math.floor(i / gridCols);
+		const gridCol = i % gridCols;
+		const posBase = { x: 320 + gridCol * 320, y: 200 + gridRow * 280 };
+		let dimTableId: string | null = null;
+		if (dimTableName) {
+			dimByName.set(logical, dimTableName);
+			dimTableId = ensureTable(dimTableName, 'dimension', posBase);
+		} else {
+			// Dim has no top-level table=; pick the FIRST attribute's table=
+			// as the canonical physical table.  Suppresses the legacy
+			// "references an undefined dimension" inference warning for dims
+			// like Store2 / Product whose tables only appear at attribute scope.
+			const firstAttrTable = dimEl
+				.querySelector(':scope > Attributes > Attribute[table]')
+				?.getAttribute('table');
+			if (firstAttrTable) dimByName.set(logical, firstAttrTable);
+		}
+		// Each Attribute may override `table=`; register every referenced
+		// table so attribute-level table refs (e.g. Product attrs on both
+		// product + product_class) resolve.
+		for (const aEl of Array.from(dimEl.querySelectorAll(':scope > Attributes > Attribute'))) {
+			const attrTable = aEl.getAttribute('table');
+			let attrTableId = dimTableId;
+			if (attrTable) {
+				attrTableId = ensureTable(attrTable, 'dimension', {
+					x: posBase.x + 40,
+					y: posBase.y + 40
+				});
+			}
+			const col =
+				aEl.getAttribute('keyColumn') ??
+				aEl.getAttribute('nameColumn') ??
+				aEl.querySelector(':scope > Key > Column')?.getAttribute('name');
+			if (attrTableId && col) ensureColumn(attrTableId, col);
+		}
+		// No warning when dimTableName is absent — the workbench parser
+		// handles per-attribute table= refs (Store2 / Product follow this
+		// pattern), and we just inferred the canonical physical table from
+		// the first attribute above for the legacy join-inference path.
+		// The previous "has no table attribute; skipped" message was
+		// misleading — the dim was NOT skipped, just registered differently.
+	});
+
+	// Phase 5: PhysicalSchema Links → table-pair joins. A Link's <ForeignKey>
+	// <Column> sits on the TARGET side; the SOURCE side uses its declared <Key>.
+	function joinExists(srcId: string, srcCol: string, tgtId: string, tgtCol: string): boolean {
+		return joins.some(
+			(j) =>
+				(j.sourceTableId === srcId &&
+					j.targetTableId === tgtId &&
+					j.sourceColumnName === srcCol &&
+					j.targetColumnName === tgtCol) ||
+				(j.sourceTableId === tgtId &&
+					j.targetTableId === srcId &&
+					j.sourceColumnName === tgtCol &&
+					j.targetColumnName === srcCol)
+		);
+	}
+
+	if (physSchemaEl) {
+		for (const linkEl of Array.from(physSchemaEl.querySelectorAll(':scope > Link'))) {
+			const sourceName = linkEl.getAttribute('source');
+			const targetName = linkEl.getAttribute('target');
+			if (!sourceName || !targetName) continue;
+			const fkColEl = linkEl.querySelector('ForeignKey > Column');
+			const fkColName = fkColEl?.getAttribute('name');
+			if (!fkColName) {
+				warnings.push(
+					`<Link source="${sourceName}" target="${targetName}"> has no <ForeignKey><Column>; skipped.`
+				);
+				continue;
+			}
+			const sourceId = ensureTable(sourceName, 'dimension', { x: 0, y: 0 });
+			const targetId = ensureTable(targetName, 'dimension', { x: 0, y: 0 });
+			const sourcePhys = physTables.get(sourceName);
+			const sourceKey = sourcePhys?.keyColumn ?? 'id';
+			ensureColumn(sourceId, sourceKey);
+			ensureColumn(targetId, fkColName);
+			if (!joinExists(sourceId, sourceKey, targetId, fkColName)) {
+				joins.push({
+					id: makeId('join'),
+					sourceTableId: sourceId,
+					sourceColumnName: sourceKey,
+					targetTableId: targetId,
+					targetColumnName: fkColName,
+					kind: 'inner',
+					// Mondrian-4 <PhysicalSchema><Link> — the canonical
+					// physical-schema statement.  Editable on canvas.
+					origin: 'physical'
+				});
+			}
+		}
+	}
+
+	// Phase 6 (REMOVED): cube-level <DimensionLinks><ForeignKeyLink> no
+	// longer becomes a canvas join.  The schema canvas is the *physical
+	// schema* view — it reflects only the <Link>s declared inside
+	// <PhysicalSchema>.  Cube-side FK/Fact/Reference links round-trip
+	// through the workbench cube's dimensionLinks (built separately in
+	// the per-cube walker below), so nothing is lost — they just don't
+	// pollute the canvas join count with derived edges.  Amelia's rule:
+	// "only read joins from the physical schema for the joins on the
+	// schema canvas summary, ignore all links inside the cubes."
+
+	// Phase 7 (removed): we deliberately DO NOT drop orphan physical tables
+	// (declared in <PhysicalSchema> but referenced by no cube) onto the
+	// canvas. A schema whose warehouse also contains leftover tables from a
+	// prior provision (e.g. a `test2_`-prefixed run) would otherwise litter
+	// the canvas with disconnected orphans the user never asked for. The
+	// canvas shows only the tables a cube actually uses (fact tables +
+	// dimension tables + their links). `physTables` still backs column
+	// enrichment for those used tables.
+
+	if (tables.length === 0) {
+		throw new Error('Mondrian 4 schema produced no tables — check the file.');
+	}
+
+	// ── Phase 5: Schema-level <Dimension>s → SchemaCanvasDimension[].
+	// Walks every <Dimension> directly under <Schema>: each becomes a
+	// shared dim with attributes, hierarchies, levels, and a primary key
+	// derived from the `key=` attribute → matching <Attribute>'s
+	// keyColumn.  Inline Dimensions inside Cubes (Mondrian 4 lets you
+	// declare private dims there) are walked when we process Cubes
+	// below; <Dimension source='X'/> references just link the cube to
+	// the shared dim by name.
+	const dimensions: SchemaCanvasDimension[] = [];
+	const dimensionsByName = new Map<string, SchemaCanvasDimension>();
+
+	function parseAttributes(
+		dimEl: Element,
+		fallbackTableId: string | null
+	): {
+		tableId: string;
+		columnName: string;
+		logicalName: string;
+		keyColumns?: string[];
+		levelType?: string;
+		annotations?: Record<string, string>;
+		nameColumn?: string;
+		captionColumn?: string;
+		orderByColumn?: string;
+		description?: string;
+	}[] {
+		const out: {
+			tableId: string;
+			columnName: string;
+			logicalName: string;
+			keyColumns?: string[];
+			levelType?: string;
+			annotations?: Record<string, string>;
+			nameColumn?: string;
+			captionColumn?: string;
+			orderByColumn?: string;
+			description?: string;
+		}[] = [];
+		for (const aEl of Array.from(dimEl.querySelectorAll(':scope > Attributes > Attribute'))) {
+			const logicalName = aEl.getAttribute('name') ?? '';
+			// M4 carries a level's levelType on its <Attribute> — read it so the
+			// resolved <Level> below inherits it (round-trips time intelligence).
+			const levelType = aEl.getAttribute('levelType') ?? undefined;
+			const annotations = readSemanticAnnotations(aEl);
+			const attrTable = aEl.getAttribute('table');
+			// Attribute can override the dim's table via `table=`; falls back
+			// to the dim's own table when omitted.
+			const tableName = attrTable ?? null;
+			const tableId = (tableName ? tableIdByName.get(tableName) : null) ?? fallbackTableId ?? null;
+			if (!tableId) {
+				warnings.push(`<Attribute name="${logicalName}"> couldn't resolve its table — skipped.`);
+				continue;
+			}
+			// keyColumn= is the simple case; <Key><Column/></Key> is the
+			// multi-col case.  v2: PRESERVE the full column list so composite
+			// keys round-trip (FoodMart Store City has key=(store_state,
+			// store_city) — collapsing to last column loses the parent-scope
+			// disambiguation Mondrian uses to keep CA's "Los Angeles" distinct
+			// from another state's).  `columnName` is the canonical naming
+			// column (last); `keyColumns` holds the full list when > 1.
+			let columnName = aEl.getAttribute('keyColumn');
+			let keyColumns: string[] | undefined;
+			if (!columnName) {
+				const keyEl = aEl.querySelector(':scope > Key');
+				if (keyEl) {
+					const cols = Array.from(keyEl.querySelectorAll(':scope > Column'))
+						.map((c) => c.getAttribute('name') ?? '')
+						.filter((c) => c.length > 0);
+					if (cols.length > 1) {
+						keyColumns = cols;
+					}
+					columnName = cols[cols.length - 1] ?? null;
+				}
+			}
+			// Last-resort: nameColumn (handles the FoodMart Customer.Name
+			// pattern where keyColumn=customer_id but the display is full_name).
+			if (!columnName) columnName = aEl.getAttribute('nameColumn');
+			if (!columnName) {
+				warnings.push(`<Attribute name="${logicalName}"> has no resolvable column — skipped.`);
+				continue;
+			}
+			ensureColumn(tableId, columnName);
+			// Composite-key columns also live on this table — ensure them too
+			// so the canvas card shows every referenced column.
+			if (keyColumns) {
+				for (const c of keyColumns) ensureColumn(tableId, c);
+			}
+			// Optional M4 attribute overrides (#959). `nameColumn` doubles as a
+			// column-resolution fallback above, so only treat it as a display
+			// override when it genuinely differs from the resolved key column.
+			const rawNameColumn = aEl.getAttribute('nameColumn') ?? undefined;
+			const nameColumn = rawNameColumn && rawNameColumn !== columnName ? rawNameColumn : undefined;
+			const captionColumn = aEl.getAttribute('captionColumn') ?? undefined;
+			const orderByColumn = aEl.getAttribute('orderByColumn') ?? undefined;
+			const description = aEl.getAttribute('description') ?? undefined;
+			out.push({
+				tableId,
+				columnName,
+				logicalName,
+				keyColumns,
+				levelType,
+				annotations,
+				nameColumn,
+				captionColumn,
+				orderByColumn,
+				description
+			});
+		}
+		return out;
+	}
+
+	function parseDimensionInto(
+		dimEl: Element,
+		opts: { fallbackTableName: string | null }
+	): SchemaCanvasDimension | null {
+		const name = dimEl.getAttribute('name') ?? '';
+		// Hanger dims (`hanger='true'`) — no underlying table, no attributes
+		// resolved from columns.  Levels are MDX expressions slicing scenario
+		// values like "Actual vs Budget".  Round-trip parses + re-emits the
+		// hanger flag but leaves attributes empty (which is what Mondrian
+		// expects for hangers).
+		const isHanger = dimEl.getAttribute('hanger') === 'true';
+		// Dim can declare a table at the top OR delegate to per-attribute
+		// `table=`.  Either path lands the dim on some table — the picked
+		// "primary" tableId is the one carrying the key attribute.
+		//
+		// The M3→M4 upgrader emits the latter shape: NO `table=` on <Dimension>,
+		// `table="store"` only on the key <Attribute>, and level-property
+		// attributes (e.g. "Store Name$Store Type") with no `table=` at all,
+		// meant to inherit the dim's table. So when <Dimension> has no `table=`,
+		// fall back to the KEY attribute's table — otherwise every property
+		// attribute resolves to null and is dropped with "couldn't resolve its
+		// table" (saiku-cloud#1133).
+		const keyAttrName = dimEl.getAttribute('key');
+		let keyAttrTable: string | null = null;
+		if (keyAttrName) {
+			for (const aEl of Array.from(dimEl.querySelectorAll(':scope > Attributes > Attribute'))) {
+				if (aEl.getAttribute('name') === keyAttrName) {
+					keyAttrTable = aEl.getAttribute('table');
+					break;
+				}
+			}
+		}
+		const dimTableName =
+			dimEl.getAttribute('table') ?? keyAttrTable ?? opts.fallbackTableName ?? null;
+		const fallbackTableId = dimTableName ? (tableIdByName.get(dimTableName) ?? null) : null;
+		const attrs = parseAttributes(dimEl, fallbackTableId);
+		if (attrs.length === 0 && !isHanger) {
+			warnings.push(`<Dimension name="${name}"> has no resolvable attributes — skipped.`);
+			return null;
+		}
+
+		// Resolve the dim's PRIMARY KEY: key='X' on <Dimension> refers to
+		// the Attribute logical name; map back to the underlying column.
+		// (keyAttrName resolved above, where it also seeds the fallback table.)
+		let primaryKey: string | undefined;
+		let primaryKeyTableId: string | undefined;
+		if (keyAttrName) {
+			const keyAttr = attrs.find((a) => a.logicalName === keyAttrName);
+			if (keyAttr) {
+				// Store the attribute's LOGICAL name (guaranteed unique per
+				// Mondrian) rather than the columnName — two attributes on the
+				// same table can share a column (FoodMart's Product has both
+				// "Product Name" and "Product Id" on product.product_id).
+				primaryKey = keyAttr.logicalName || keyAttr.columnName;
+				primaryKeyTableId = keyAttr.tableId;
+			} else {
+				warnings.push(
+					`<Dimension name="${name}"> key="${keyAttrName}" — no matching Attribute; primary key left unset.`
+				);
+			}
+		}
+
+		// Walk <Hierarchies>/<Hierarchy>/<Level> — each Level references
+		// an Attribute by logical name, which we resolve back to its
+		// (tableId, columnName) tuple.  Levels stay in document order.
+		// `<Closure table='employee_closure' parentColumn='supervisor_id'
+		// childColumn='employee_id'/>` on a Level marks the parent-child
+		// optimisation table; we capture it at hierarchy scope (Mondrian
+		// only allows one closure per hierarchy in practice) and round-trip
+		// it on export.  HR's Employee hierarchy uses this.
+		const hierarchies: SchemaCanvasHierarchy[] = [];
+		for (const hEl of Array.from(dimEl.querySelectorAll(':scope > Hierarchies > Hierarchy'))) {
+			const hName = hEl.getAttribute('name') ?? name;
+			const hasAllRaw = hEl.getAttribute('hasAll');
+			const hasAll = hasAllRaw === null ? true : hasAllRaw === 'true';
+			const allMemberName = hEl.getAttribute('allMemberName') ?? undefined;
+			const defaultMember = hEl.getAttribute('defaultMember') ?? undefined;
+			const caption = hEl.getAttribute('caption') ?? undefined;
+			const description = hEl.getAttribute('description') ?? undefined;
+			const levels: SchemaCanvasLevel[] = [];
+			let closure: SchemaCanvasHierarchy['closure'] | undefined;
+			for (const lEl of Array.from(hEl.querySelectorAll(':scope > Level'))) {
+				const attrName = lEl.getAttribute('attribute') ?? '';
+				const attr = attrs.find((a) => a.logicalName === attrName);
+				if (!attr) {
+					warnings.push(
+						`<Level attribute="${attrName}"> in <Hierarchy name="${hName}"> — no matching Attribute; skipped.`
+					);
+					continue;
+				}
+				levels.push({
+					id: makeId('lvl'),
+					name: lEl.getAttribute('name') ?? attr.logicalName,
+					caption: lEl.getAttribute('caption') ?? undefined,
+					tableId: attr.tableId,
+					columnName: attr.columnName,
+					// levelType round-trips from the <Attribute> (M4 carries it there).
+					levelType:
+						attr.levelType === 'TimeYears' ||
+						attr.levelType === 'TimeQuarters' ||
+						attr.levelType === 'TimeMonths' ||
+						attr.levelType === 'TimeDays'
+							? attr.levelType
+							: undefined,
+					// saiku.semantic.* annotations also ride on the <Attribute>.
+					annotations: attr.annotations
+				});
+				// Closure lives on a Level as a child element in Mondrian 4 —
+				// pull it up to hierarchy scope where round-trip and the
+				// export layer expect it.
+				const cEl = lEl.querySelector(':scope > Closure');
+				if (cEl) {
+					closure = {
+						table: cEl.getAttribute('table') ?? '',
+						parentColumn: cEl.getAttribute('parentColumn') ?? '',
+						childColumn: cEl.getAttribute('childColumn') ?? ''
+					};
+				}
+			}
+			hierarchies.push({
+				id: makeId('hier'),
+				name: hName,
+				hasAll,
+				allMemberName,
+				defaultMember,
+				caption,
+				description,
+				levels,
+				closure
+			});
+		}
+
+		const typeRaw = dimEl.getAttribute('type');
+		const dimensionType =
+			typeRaw === 'TIME'
+				? ('Time' as const)
+				: typeRaw === 'StandardDimension'
+					? ('Standard' as const)
+					: typeRaw === 'TimeDimension'
+						? ('Time' as const)
+						: typeRaw === 'GeographicDimension'
+							? ('Geographic' as const)
+							: undefined;
+
+		// Source table binding — set from <Dimension table="X"> when
+		// present, else fall back to the KEY attribute's table (matches
+		// how the workbench treats the "source table" concept).  Prior
+		// to this the parser only wrote primaryKeyTableId; sourceTableId
+		// stayed undefined even when the XML clearly declared a table,
+		// so the "No table bound" empty state fired for imported dims.
+		const sourceTableId = dimTableName
+			? (tableIdByName.get(dimTableName) ?? primaryKeyTableId)
+			: primaryKeyTableId;
+
+		const dim: SchemaCanvasDimension = {
+			id: makeId('dim'),
+			name,
+			attributes: attrs.map((a) => ({
+				tableId: a.tableId,
+				columnName: a.columnName,
+				name: a.logicalName,
+				keyColumns: a.keyColumns,
+				nameColumn: a.nameColumn,
+				captionColumn: a.captionColumn,
+				orderByColumn: a.orderByColumn,
+				description: a.description
+			})),
+			hierarchies,
+			primaryKey,
+			primaryKeyTableId,
+			sourceTableId,
+			hanger: isHanger || undefined,
+			caption: dimEl.getAttribute('caption') ?? undefined,
+			description: dimEl.getAttribute('description') ?? undefined,
+			dimensionType,
+			annotations: readSemanticAnnotations(dimEl)
+		};
+		return dim;
+	}
+
+	// Schema-scope shared dimensions (Mondrian 4's first-class dim model).
+	for (const dimEl of Array.from(schemaEl.querySelectorAll(':scope > Dimension'))) {
+		const dim = parseDimensionInto(dimEl, { fallbackTableName: dimEl.getAttribute('table') });
+		if (!dim) continue;
+		dimensions.push(dim);
+		dimensionsByName.set(dim.name, dim);
+	}
+
+	// ── Phase 6: <Cube>s → workbench cubes + measures.
+	// Measures (flat) accumulate into state.measures.  Per-cube workbench
+	// data goes into `workbenchCubes` for the localStorage seed.
+	const measures: SchemaCanvasMeasure[] = [];
+	const seenMeasureKeys = new Set<string>();
+
+	for (const cubeEl of cubeEls) {
+		const cubeName = cubeEl.getAttribute('name') ?? 'Cube';
+		const workCube: ImportedWorkbenchCube = {
+			id: makeId('cube'),
+			name: cubeName,
+			measureGroups: [],
+			factsCalcs: []
+		};
+
+		// Cube-private Dimensions (declared inline, not source='X' refs)
+		// also become shared dims — append them so DimensionLinks below
+		// can resolve.
+		for (const dimEl of Array.from(cubeEl.querySelectorAll(':scope > Dimensions > Dimension'))) {
+			// source='X' is a REFERENCE to a schema-level dim (Mondrian 4's
+			// DimensionUsage), optionally RENAMED (e.g. name="Order Date"
+			// source="Date"). Register the local name as an alias to the shared
+			// dim so DimensionLinks that reference the local name resolve.
+			const sourceRef = dimEl.getAttribute('source');
+			if (sourceRef) {
+				const localName = dimEl.getAttribute('name');
+				if (localName && localName !== sourceRef && !dimensionsByName.has(localName)) {
+					const shared = dimensionsByName.get(sourceRef);
+					if (shared) dimensionsByName.set(localName, shared);
+				}
+				continue;
+			}
+			const dim = parseDimensionInto(dimEl, { fallbackTableName: dimEl.getAttribute('table') });
+			if (!dim) continue;
+			// Avoid double-registering a dim name (e.g. a cube-private "Time"
+			// when a schema "Time" also exists — warn the user, keep the
+			// cube-private one under a synthetic name).
+			if (dimensionsByName.has(dim.name)) {
+				dim.name = `${dim.name} (${cubeName})`;
+				warnings.push(
+					`<Cube name="${cubeName}"> redefines dimension "${dimEl.getAttribute('name')}"; renamed to "${dim.name}" to avoid collision.`
+				);
+			}
+			dimensions.push(dim);
+			dimensionsByName.set(dim.name, dim);
+		}
+
+		// MeasureGroups → workbench MGs + flat measures.
+		for (const mgEl of Array.from(
+			cubeEl.querySelectorAll(':scope > MeasureGroups > MeasureGroup')
+		)) {
+			const mgName =
+				mgEl.getAttribute('name') ??
+				mgEl.getAttribute('table') ??
+				`MG${workCube.measureGroups.length + 1}`;
+			const factTableName = mgEl.getAttribute('table');
+			const factTableId = factTableName ? (tableIdByName.get(factTableName) ?? null) : null;
+			if (factTableName && !factTableId) {
+				warnings.push(
+					`<MeasureGroup name="${mgName}"> table="${factTableName}" wasn't on the canvas — fact unlinked.`
+				);
+			}
+
+			const measureColumns: string[] = [];
+			for (const measureEl of Array.from(mgEl.querySelectorAll(':scope > Measures > Measure'))) {
+				const measureName = measureEl.getAttribute('name') ?? '';
+				const column = measureColumnOf(measureEl);
+				const aggRaw = measureEl.getAttribute('aggregator') ?? 'sum';
+				const aggregator: SchemaCanvasMeasure['aggregator'] =
+					aggRaw === 'sum' ||
+					aggRaw === 'count' ||
+					aggRaw === 'avg' ||
+					aggRaw === 'min' ||
+					aggRaw === 'max' ||
+					aggRaw === 'distinct-count' ||
+					aggRaw === 'median' ||
+					aggRaw === 'percentile'
+						? aggRaw
+						: 'sum';
+				// Percentile fraction (mondrian-saiku #104) — only on percentile
+				// measures; a non-numeric or absent value leaves it unset (→ 50).
+				const percentileRaw =
+					aggregator === 'percentile' ? measureEl.getAttribute('percentile') : null;
+				const percentileVal =
+					percentileRaw !== null &&
+					percentileRaw.trim() !== '' &&
+					!Number.isNaN(Number(percentileRaw))
+						? Number(percentileRaw)
+						: undefined;
+				if (!column) {
+					warnings.push(`<Measure name="${measureName}"> has no column — skipped.`);
+					continue;
+				}
+				measureColumns.push(column);
+				if (factTableId) {
+					const key = `${factTableId}::${column}`;
+					if (!seenMeasureKeys.has(key)) {
+						seenMeasureKeys.add(key);
+						measures.push({
+							id: makeId('m'),
+							name: measureName || column,
+							aggregator,
+							tableId: factTableId,
+							columnName: column,
+							formatString: measureEl.getAttribute('formatString') ?? undefined,
+							percentile: percentileVal,
+							annotations: readSemanticAnnotations(measureEl)
+						});
+					}
+				}
+			}
+
+			// DimensionLinks → mg.dimensionLinks resolving dimension name
+			// to the parsed dim's id.  v2 supports all three Mondrian-4 link
+			// kinds — ForeignKeyLink (default), FactLink (degenerate dim on
+			// the fact table; no FK column), and ReferenceLink (multi-hop
+			// via another dim's attribute).  `linkKind` is preserved through
+			// round-trip so the exporter re-emits the original tag.
+			const dimensionLinks: ImportedWorkbenchMeasureGroup['dimensionLinks'] = [];
+			const linksEl = mgEl.querySelector(':scope > DimensionLinks');
+			if (linksEl) {
+				for (const linkEl of Array.from(linksEl.children)) {
+					const tag = linkEl.tagName;
+					const dimName = linkEl.getAttribute('dimension') ?? '';
+					const dim = dimensionsByName.get(dimName);
+					if (!dim) {
+						warnings.push(
+							`<${tag} dimension="${dimName}"> on cube "${cubeName}" — no matching dim; skipped.`
+						);
+						continue;
+					}
+					if (tag === 'ForeignKeyLink') {
+						let fk = linkEl.getAttribute('foreignKeyColumn') ?? '';
+						if (!fk) {
+							const colEl = linkEl.querySelector(':scope > ForeignKey > Column');
+							fk = colEl?.getAttribute('name') ?? '';
+						}
+						dimensionLinks.push({
+							dimensionId: dim.id,
+							foreignKeyColumn: fk,
+							linkKind: 'foreign-key'
+						});
+					} else if (tag === 'FactLink') {
+						// Degenerate dim — its level columns ARE on the fact
+						// table.  No FK column to carry; `factTableId` IS the
+						// dim's table.
+						dimensionLinks.push({
+							dimensionId: dim.id,
+							foreignKeyColumn: '',
+							linkKind: 'fact'
+						});
+					} else if (tag === 'ReferenceLink') {
+						// Multi-hop: dim is reached through `viaDimension`'s
+						// `viaAttribute`.  Carry both through so the export
+						// can re-emit the original.
+						dimensionLinks.push({
+							dimensionId: dim.id,
+							foreignKeyColumn: '',
+							linkKind: 'reference',
+							viaDimension: linkEl.getAttribute('viaDimension') ?? undefined,
+							viaAttribute: linkEl.getAttribute('viaAttribute') ?? undefined
+						});
+					}
+				}
+			}
+
+			workCube.measureGroups.push({
+				id: makeId('mg'),
+				name: mgName,
+				factTableId,
+				measureColumns,
+				dimensionLinks
+			});
+		}
+
+		// CalculatedMembers → factsCalcs (formula text only — chip tokens stay empty).
+		for (const calcEl of Array.from(
+			cubeEl.querySelectorAll(':scope > CalculatedMembers > CalculatedMember')
+		)) {
+			const calcName = calcEl.getAttribute('name') ?? '';
+			// Formula can be an attribute OR a child <Formula> element.
+			let formula = calcEl.getAttribute('formula') ?? '';
+			if (!formula) {
+				const formulaEl = calcEl.querySelector(':scope > Formula');
+				formula = formulaEl?.textContent?.trim() ?? '';
+			}
+			workCube.factsCalcs.push({
+				id: makeId('calc'),
+				name: calcName,
+				tokens: [],
+				formula: formula || undefined
+			});
+		}
+
+		// TimeCalcs → cube.timeCalcs (declarative time-intelligence metrics).
+		const timeCalcs: SchemaCanvasTimeCalc[] = [];
+		for (const tcEl of Array.from(cubeEl.querySelectorAll(':scope > TimeCalcs > TimeCalc'))) {
+			const rawType = tcEl.getAttribute('type') ?? '';
+			const type =
+				rawType === 'yoy' || rawType === 'pop' || rawType === 'ytd' || rawType === 'rolling'
+					? rawType
+					: 'yoy';
+			const rawWindow = tcEl.getAttribute('window');
+			const rawFn = tcEl.getAttribute('function');
+			timeCalcs.push({
+				id: makeId('timecalc'),
+				name: tcEl.getAttribute('name') ?? '',
+				type,
+				measure: tcEl.getAttribute('measure') ?? '',
+				timeDimension: tcEl.getAttribute('timeDimension') ?? undefined,
+				window:
+					type === 'rolling' && rawWindow != null && !Number.isNaN(Number(rawWindow))
+						? Number(rawWindow)
+						: undefined,
+				function: rawFn === 'avg' ? 'avg' : rawFn === 'sum' ? 'sum' : undefined,
+				formatString: tcEl.getAttribute('formatString') ?? undefined
+			});
+		}
+		if (timeCalcs.length > 0) workCube.timeCalcs = timeCalcs;
+
+		workbenchCubes.push(workCube);
+	}
+
+	const state: SchemaCanvasState = {
+		version: 1,
+		connectionId: opts.connectionId,
+		label: opts.label ?? schemaName,
+		tables,
+		joins,
+		groups: [],
+		dimensions,
+		measures,
+		updatedAt: new Date().toISOString()
+	};
+	return { state, warnings, workbenchCubes };
+}

--- a/saiku-ui/src/lib/cube-designer/mondrian-xml-to-yaml.test.ts
+++ b/saiku-ui/src/lib/cube-designer/mondrian-xml-to-yaml.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect } from 'vitest';
+import { parse } from 'yaml';
+import { mondrianXmlToYaml } from './mondrian-xml-to-yaml';
+
+/**
+ * The M4 XML the (fixed) canvas preview emits for the FoodMart-shaped schema
+ * from saiku-cloud#1080 — now with physical-table keys + dimension keys.
+ */
+const FOODMART_M4_XML = `<?xml version="1.0" encoding="UTF-8"?>
+<Schema name="Untitled" metamodelVersion="4.0">
+  <PhysicalSchema>
+    <Table name="sales_fact_1997" schema="public" />
+    <Table name="product" schema="public" keyColumn="product_id" />
+    <Table name="store" schema="public" keyColumn="store_id" />
+    <Table name="time_by_day" schema="public" keyColumn="time_id" />
+  </PhysicalSchema>
+  <Dimension name="product" table="product" key="product Key">
+    <Attributes>
+      <Attribute name="product Key" keyColumn="product_id" hasHierarchy="false" />
+      <Attribute name="brand_name" keyColumn="brand_name" />
+    </Attributes>
+  </Dimension>
+  <Dimension name="store" table="store" key="store Key">
+    <Attributes>
+      <Attribute name="store Key" keyColumn="store_id" hasHierarchy="false" />
+    </Attributes>
+  </Dimension>
+  <Cube name="Cube 1">
+    <Dimensions>
+      <Dimension source="product" />
+      <Dimension source="store" />
+    </Dimensions>
+    <MeasureGroups>
+      <MeasureGroup name="Group 1" table="sales_fact_1997">
+        <Measures>
+          <Measure name="store_sales" column="store_sales" aggregator="sum" />
+        </Measures>
+        <DimensionLinks>
+          <ForeignKeyLink dimension="product" foreignKeyColumn="product_id" />
+          <ForeignKeyLink dimension="store" foreignKeyColumn="store_id" />
+        </DimensionLinks>
+      </MeasureGroup>
+    </MeasureGroups>
+  </Cube>
+</Schema>`;
+
+describe('mondrianXmlToYaml', () => {
+	it('produces M4 YAML matching the canonical FoodMart shape', () => {
+		const yaml = mondrianXmlToYaml(FOODMART_M4_XML);
+		// Round-trip through the YAML parser to assert structure (not bytes).
+		// `parse` returns the library's untyped node — fine for structural asserts.
+		const doc = parse(yaml);
+
+		// schema header
+		expect(doc.schema).toEqual({ name: 'Untitled', metamodel_version: '4.0' });
+
+		// physical_schema: fact has NO key; dims carry key_column
+		const tables = doc.physical_schema.tables as Array<Record<string, unknown>>;
+		const fact = tables.find((t) => t.name === 'sales_fact_1997')!;
+		expect(fact.key_column).toBeUndefined();
+		const product = tables.find((t) => t.name === 'product')!;
+		expect(product).toMatchObject({ name: 'product', schema: 'public', key_column: 'product_id' });
+
+		// shared_dimensions: key points at the key attribute, which carries the PK column
+		expect(doc.shared_dimensions.product.key).toBe('product Key');
+		const keyAttr = doc.shared_dimensions.product.attributes.find(
+			(a: { name: string }) => a.name === 'product Key'
+		);
+		expect(keyAttr).toMatchObject({ key_column: 'product_id', has_hierarchy: false });
+
+		// cube: dimension usages + measure group + foreign_key links that RESOLVE
+		// to the dimension key (product_id ↔ product Key ↔ product.product_id).
+		const cube = doc.cubes['Cube 1'];
+		expect(cube.dimensions).toEqual([{ source: 'product' }, { source: 'store' }]);
+		const mg = cube.measure_groups[0];
+		expect(mg).toMatchObject({ name: 'Group 1', table: 'sales_fact_1997' });
+		expect(mg.measures[0]).toMatchObject({
+			name: 'store_sales',
+			column: 'store_sales',
+			aggregator: 'sum'
+		});
+		expect(mg.dimension_links).toEqual([
+			{ type: 'foreign_key', dimension: 'product', foreign_key_column: 'product_id' },
+			{ type: 'foreign_key', dimension: 'store', foreign_key_column: 'store_id' }
+		]);
+	});
+
+	it('maps composite <Key><Column/></Key> to a key list', () => {
+		const xml = `<Schema name="S" metamodelVersion="4.0">
+      <PhysicalSchema>
+        <Table name="customer"><Key><Column name="a"/><Column name="b"/></Key></Table>
+      </PhysicalSchema>
+    </Schema>`;
+		const doc = parse(mondrianXmlToYaml(xml));
+		expect(doc.physical_schema.tables[0]).toEqual({ name: 'customer', key: ['a', 'b'] });
+	});
+
+	it('never throws on incomplete / non-schema XML', () => {
+		expect(mondrianXmlToYaml('<not-a-schema/>')).toContain('#');
+		expect(mondrianXmlToYaml('garbage <<<')).toContain('#');
+	});
+});

--- a/saiku-ui/src/lib/cube-designer/mondrian-xml-to-yaml.test.ts
+++ b/saiku-ui/src/lib/cube-designer/mondrian-xml-to-yaml.test.ts
@@ -1,6 +1,6 @@
-import { describe, it, expect } from 'vitest';
-import { parse } from 'yaml';
-import { mondrianXmlToYaml } from './mondrian-xml-to-yaml';
+import { describe, it, expect } from "vitest";
+import { parse } from "yaml";
+import { mondrianXmlToYaml } from "./mondrian-xml-to-yaml";
 
 /**
  * The M4 XML the (fixed) canvas preview emits for the FoodMart-shaped schema
@@ -44,59 +44,80 @@ const FOODMART_M4_XML = `<?xml version="1.0" encoding="UTF-8"?>
   </Cube>
 </Schema>`;
 
-describe('mondrianXmlToYaml', () => {
-	it('produces M4 YAML matching the canonical FoodMart shape', () => {
-		const yaml = mondrianXmlToYaml(FOODMART_M4_XML);
-		// Round-trip through the YAML parser to assert structure (not bytes).
-		// `parse` returns the library's untyped node — fine for structural asserts.
-		const doc = parse(yaml);
+describe("mondrianXmlToYaml", () => {
+  it("produces M4 YAML matching the canonical FoodMart shape", () => {
+    const yaml = mondrianXmlToYaml(FOODMART_M4_XML);
+    // Round-trip through the YAML parser to assert structure (not bytes).
+    // `parse` returns the library's untyped node — fine for structural asserts.
+    const doc = parse(yaml);
 
-		// schema header
-		expect(doc.schema).toEqual({ name: 'Untitled', metamodel_version: '4.0' });
+    // schema header
+    expect(doc.schema).toEqual({ name: "Untitled", metamodel_version: "4.0" });
 
-		// physical_schema: fact has NO key; dims carry key_column
-		const tables = doc.physical_schema.tables as Array<Record<string, unknown>>;
-		const fact = tables.find((t) => t.name === 'sales_fact_1997')!;
-		expect(fact.key_column).toBeUndefined();
-		const product = tables.find((t) => t.name === 'product')!;
-		expect(product).toMatchObject({ name: 'product', schema: 'public', key_column: 'product_id' });
+    // physical_schema: fact has NO key; dims carry key_column
+    const tables = doc.physical_schema.tables as Array<Record<string, unknown>>;
+    const fact = tables.find((t) => t.name === "sales_fact_1997")!;
+    expect(fact.key_column).toBeUndefined();
+    const product = tables.find((t) => t.name === "product")!;
+    expect(product).toMatchObject({
+      name: "product",
+      schema: "public",
+      key_column: "product_id",
+    });
 
-		// shared_dimensions: key points at the key attribute, which carries the PK column
-		expect(doc.shared_dimensions.product.key).toBe('product Key');
-		const keyAttr = doc.shared_dimensions.product.attributes.find(
-			(a: { name: string }) => a.name === 'product Key'
-		);
-		expect(keyAttr).toMatchObject({ key_column: 'product_id', has_hierarchy: false });
+    // shared_dimensions: key points at the key attribute, which carries the PK column
+    expect(doc.shared_dimensions.product.key).toBe("product Key");
+    const keyAttr = doc.shared_dimensions.product.attributes.find(
+      (a: { name: string }) => a.name === "product Key",
+    );
+    expect(keyAttr).toMatchObject({
+      key_column: "product_id",
+      has_hierarchy: false,
+    });
 
-		// cube: dimension usages + measure group + foreign_key links that RESOLVE
-		// to the dimension key (product_id ↔ product Key ↔ product.product_id).
-		const cube = doc.cubes['Cube 1'];
-		expect(cube.dimensions).toEqual([{ source: 'product' }, { source: 'store' }]);
-		const mg = cube.measure_groups[0];
-		expect(mg).toMatchObject({ name: 'Group 1', table: 'sales_fact_1997' });
-		expect(mg.measures[0]).toMatchObject({
-			name: 'store_sales',
-			column: 'store_sales',
-			aggregator: 'sum'
-		});
-		expect(mg.dimension_links).toEqual([
-			{ type: 'foreign_key', dimension: 'product', foreign_key_column: 'product_id' },
-			{ type: 'foreign_key', dimension: 'store', foreign_key_column: 'store_id' }
-		]);
-	});
+    // cube: dimension usages + measure group + foreign_key links that RESOLVE
+    // to the dimension key (product_id ↔ product Key ↔ product.product_id).
+    const cube = doc.cubes["Cube 1"];
+    expect(cube.dimensions).toEqual([
+      { source: "product" },
+      { source: "store" },
+    ]);
+    const mg = cube.measure_groups[0];
+    expect(mg).toMatchObject({ name: "Group 1", table: "sales_fact_1997" });
+    expect(mg.measures[0]).toMatchObject({
+      name: "store_sales",
+      column: "store_sales",
+      aggregator: "sum",
+    });
+    expect(mg.dimension_links).toEqual([
+      {
+        type: "foreign_key",
+        dimension: "product",
+        foreign_key_column: "product_id",
+      },
+      {
+        type: "foreign_key",
+        dimension: "store",
+        foreign_key_column: "store_id",
+      },
+    ]);
+  });
 
-	it('maps composite <Key><Column/></Key> to a key list', () => {
-		const xml = `<Schema name="S" metamodelVersion="4.0">
+  it("maps composite <Key><Column/></Key> to a key list", () => {
+    const xml = `<Schema name="S" metamodelVersion="4.0">
       <PhysicalSchema>
         <Table name="customer"><Key><Column name="a"/><Column name="b"/></Key></Table>
       </PhysicalSchema>
     </Schema>`;
-		const doc = parse(mondrianXmlToYaml(xml));
-		expect(doc.physical_schema.tables[0]).toEqual({ name: 'customer', key: ['a', 'b'] });
-	});
+    const doc = parse(mondrianXmlToYaml(xml));
+    expect(doc.physical_schema.tables[0]).toEqual({
+      name: "customer",
+      key: ["a", "b"],
+    });
+  });
 
-	it('never throws on incomplete / non-schema XML', () => {
-		expect(mondrianXmlToYaml('<not-a-schema/>')).toContain('#');
-		expect(mondrianXmlToYaml('garbage <<<')).toContain('#');
-	});
+  it("never throws on incomplete / non-schema XML", () => {
+    expect(mondrianXmlToYaml("<not-a-schema/>")).toContain("#");
+    expect(mondrianXmlToYaml("garbage <<<")).toContain("#");
+  });
 });

--- a/saiku-ui/src/lib/cube-designer/mondrian-xml-to-yaml.ts
+++ b/saiku-ui/src/lib/cube-designer/mondrian-xml-to-yaml.ts
@@ -1,0 +1,208 @@
+/**
+ * Mondrian 4 XML → Mondrian 4 YAML (saiku-cloud#1080).
+ *
+ * The dashboard's canvas Code tab renders the schema as XML
+ * (`workbenchToMondrianPreview`); this converts that same XML into the M4 YAML
+ * the engine accepts, so the Code tab can offer an XML/YAML toggle without a
+ * second, drift-prone emitter. It mirrors the engine's own `M4XmlToYaml` and
+ * the format documented in `docs-site/.../mondrian/yaml-schemas.mdx` (canonical
+ * fixture: mondrian-saiku `demo/FoodMart.yaml`).
+ *
+ * PURE + isomorphic (browser + Node/vitest). Handles exactly the M4 constructs
+ * the canvas emits — PhysicalSchema tables/keys, shared Dimensions (attributes +
+ * hierarchies), Cubes (dimension usages, measure groups, measures, dimension
+ * links). Never throws: returns a short `# comment` string on unparseable input.
+ */
+import { stringify } from 'yaml';
+import { parseXml, childNamed, childrenNamed, type XmlNode } from './xml-parser';
+
+type Yaml = Record<string, unknown>;
+
+/** M4 XML string → M4 YAML string. */
+export function mondrianXmlToYaml(xml: string): string {
+	// The preview interleaves `<!-- ... -->` placeholder comments; strip them so
+	// the parser sees clean markup (YAML has its own `#` comments if needed).
+	const cleaned = xml.replace(/<!--[\s\S]*?-->/g, '');
+	const parsed = parseXml(cleaned);
+	if (!parsed.ok || parsed.root.name !== 'Schema') {
+		return '# Could not render YAML — the schema XML is incomplete.\n';
+	}
+	const schema = parsed.root;
+
+	const doc: Yaml = {};
+	doc.schema = {
+		name: schema.attributes.name ?? 'Untitled',
+		metamodel_version: schema.attributes.metamodelVersion ?? '4.0'
+	};
+
+	const physical = childNamed(schema, 'PhysicalSchema');
+	if (physical) {
+		const tables = childrenNamed(physical, 'Table').map(tableToYaml);
+		const links = childrenNamed(physical, 'Link').map((l) => ({
+			source: l.attributes.source,
+			target: l.attributes.target,
+			...keyOrKeyColumn(l, 'foreignKeyColumn', 'foreign_key_column', 'foreign_key')
+		}));
+		const ps: Yaml = {};
+		if (tables.length) ps.tables = tables;
+		if (links.length) ps.links = links;
+		if (Object.keys(ps).length) doc.physical_schema = ps;
+	}
+
+	// Shared dimensions are the schema-level <Dimension> elements.
+	const sharedDims = childrenNamed(schema, 'Dimension');
+	if (sharedDims.length) {
+		const map: Yaml = {};
+		for (const d of sharedDims) {
+			map[d.attributes.name ?? 'Dimension'] = dimensionBodyToYaml(d);
+		}
+		doc.shared_dimensions = map;
+	}
+
+	const cubes = childrenNamed(schema, 'Cube');
+	if (cubes.length) {
+		const map: Yaml = {};
+		for (const c of cubes) {
+			map[c.attributes.name ?? 'Cube'] = cubeToYaml(c);
+		}
+		doc.cubes = map;
+	}
+
+	return stringify(doc, {
+		lineWidth: 0,
+		defaultStringType: 'QUOTE_DOUBLE',
+		defaultKeyType: 'PLAIN'
+	});
+}
+
+function tableToYaml(t: XmlNode): Yaml {
+	const out: Yaml = { name: t.attributes.name };
+	if (t.attributes.schema) out.schema = t.attributes.schema;
+	if (t.attributes.alias) out.alias = t.attributes.alias;
+	Object.assign(out, keyOrKeyColumn(t, 'keyColumn', 'key_column', 'key'));
+	return out;
+}
+
+/**
+ * Resolve an element's single-column key (`keyColumn` attr) or composite key
+ * (`<Key><Column name=.../></Key>` children) into YAML `key_column` / `key`.
+ */
+function keyOrKeyColumn(node: XmlNode, attrName: string, singleKey: string, listKey: string): Yaml {
+	const single = node.attributes[attrName];
+	if (single) return { [singleKey]: single };
+	const key = childNamed(node, 'Key');
+	if (key) {
+		const cols = childrenNamed(key, 'Column')
+			.map((c) => c.attributes.name)
+			.filter((n): n is string => !!n);
+		if (cols.length) return { [listKey]: cols };
+	}
+	return {};
+}
+
+function dimensionBodyToYaml(d: XmlNode): Yaml {
+	const out: Yaml = {};
+	if (d.attributes.table) out.table = d.attributes.table;
+	if (d.attributes.key) out.key = d.attributes.key;
+	if (d.attributes.type) out.type = d.attributes.type.replace(/Dimension$/, '').toUpperCase();
+
+	const attrsNode = childNamed(d, 'Attributes');
+	if (attrsNode) {
+		const attrs = childrenNamed(attrsNode, 'Attribute').map(attributeToYaml);
+		if (attrs.length) out.attributes = attrs;
+	}
+	const hierNode = childNamed(d, 'Hierarchies');
+	if (hierNode) {
+		const hiers = childrenNamed(hierNode, 'Hierarchy').map(hierarchyToYaml);
+		if (hiers.length) out.hierarchies = hiers;
+	}
+	return out;
+}
+
+function attributeToYaml(a: XmlNode): Yaml {
+	const out: Yaml = { name: a.attributes.name };
+	Object.assign(out, keyOrKeyColumn(a, 'keyColumn', 'key_column', 'key'));
+	if (a.attributes.nameColumn) out.name_column = a.attributes.nameColumn;
+	if (a.attributes.levelType) out.level_type = a.attributes.levelType;
+	if (a.attributes.hasHierarchy === 'false') out.has_hierarchy = false;
+	if (a.attributes.hierarchyAllMemberName) {
+		out.hierarchy_all_member_name = a.attributes.hierarchyAllMemberName;
+	}
+	return out;
+}
+
+function hierarchyToYaml(h: XmlNode): Yaml {
+	const out: Yaml = { name: h.attributes.name };
+	if (h.attributes.allMemberName) out.all_member_name = h.attributes.allMemberName;
+	if (h.attributes.defaultMember) out.default_member = h.attributes.defaultMember;
+	if (h.attributes.hasAll) out.has_all = h.attributes.hasAll === 'true';
+	// Each <Level attribute="X"/> becomes a bare string (level name == attribute).
+	const levels = childrenNamed(h, 'Level').map((l) => l.attributes.attribute ?? l.attributes.name);
+	out.levels = levels;
+	return out;
+}
+
+function cubeToYaml(c: XmlNode): Yaml {
+	const out: Yaml = {};
+	const dimsNode = childNamed(c, 'Dimensions');
+	if (dimsNode) {
+		const dims = childrenNamed(dimsNode, 'Dimension').map((d) =>
+			d.attributes.source ? { source: d.attributes.source } : dimensionBodyToYaml(d)
+		);
+		if (dims.length) out.dimensions = dims;
+	}
+	const mgsNode = childNamed(c, 'MeasureGroups');
+	if (mgsNode) {
+		const mgs = childrenNamed(mgsNode, 'MeasureGroup').map(measureGroupToYaml);
+		if (mgs.length) out.measure_groups = mgs;
+	}
+	return out;
+}
+
+function measureGroupToYaml(mg: XmlNode): Yaml {
+	const out: Yaml = {};
+	if (mg.attributes.name) out.name = mg.attributes.name;
+	out.table = mg.attributes.table;
+
+	const measuresNode = childNamed(mg, 'Measures');
+	if (measuresNode) {
+		const measures = childrenNamed(measuresNode, 'Measure').map((m) => {
+			const mo: Yaml = { name: m.attributes.name };
+			if (m.attributes.column) mo.column = m.attributes.column;
+			mo.aggregator = m.attributes.aggregator ?? 'sum';
+			if (m.attributes.formatString) mo.format_string = m.attributes.formatString;
+			return mo;
+		});
+		if (measures.length) out.measures = measures;
+	}
+
+	const linksNode = childNamed(mg, 'DimensionLinks');
+	if (linksNode) {
+		const links = linksNode.children.map(dimensionLinkToYaml).filter((l): l is Yaml => l !== null);
+		if (links.length) out.dimension_links = links;
+	}
+	return out;
+}
+
+function dimensionLinkToYaml(link: XmlNode): Yaml | null {
+	const dimension = link.attributes.dimension;
+	if (!dimension) return null;
+	switch (link.name) {
+		case 'ForeignKeyLink':
+			return {
+				type: 'foreign_key',
+				dimension,
+				...keyOrKeyColumn(link, 'foreignKeyColumn', 'foreign_key_column', 'foreign_key')
+			};
+		case 'FactLink':
+			return { type: 'fact', dimension };
+		case 'ReferenceLink': {
+			const out: Yaml = { type: 'reference', dimension };
+			if (link.attributes.viaDimension) out.via_dimension = link.attributes.viaDimension;
+			if (link.attributes.viaAttribute) out.via_attribute = link.attributes.viaAttribute;
+			return out;
+		}
+		default:
+			return null;
+	}
+}

--- a/saiku-ui/src/lib/cube-designer/mondrian-xml-to-yaml.ts
+++ b/saiku-ui/src/lib/cube-designer/mondrian-xml-to-yaml.ts
@@ -13,196 +13,228 @@
  * hierarchies), Cubes (dimension usages, measure groups, measures, dimension
  * links). Never throws: returns a short `# comment` string on unparseable input.
  */
-import { stringify } from 'yaml';
-import { parseXml, childNamed, childrenNamed, type XmlNode } from './xml-parser';
+import { stringify } from "yaml";
+import {
+  parseXml,
+  childNamed,
+  childrenNamed,
+  type XmlNode,
+} from "./xml-parser";
 
 type Yaml = Record<string, unknown>;
 
 /** M4 XML string → M4 YAML string. */
 export function mondrianXmlToYaml(xml: string): string {
-	// The preview interleaves `<!-- ... -->` placeholder comments; strip them so
-	// the parser sees clean markup (YAML has its own `#` comments if needed).
-	const cleaned = xml.replace(/<!--[\s\S]*?-->/g, '');
-	const parsed = parseXml(cleaned);
-	if (!parsed.ok || parsed.root.name !== 'Schema') {
-		return '# Could not render YAML — the schema XML is incomplete.\n';
-	}
-	const schema = parsed.root;
+  // The preview interleaves `<!-- ... -->` placeholder comments; strip them so
+  // the parser sees clean markup (YAML has its own `#` comments if needed).
+  const cleaned = xml.replace(/<!--[\s\S]*?-->/g, "");
+  const parsed = parseXml(cleaned);
+  if (!parsed.ok || parsed.root.name !== "Schema") {
+    return "# Could not render YAML — the schema XML is incomplete.\n";
+  }
+  const schema = parsed.root;
 
-	const doc: Yaml = {};
-	doc.schema = {
-		name: schema.attributes.name ?? 'Untitled',
-		metamodel_version: schema.attributes.metamodelVersion ?? '4.0'
-	};
+  const doc: Yaml = {};
+  doc.schema = {
+    name: schema.attributes.name ?? "Untitled",
+    metamodel_version: schema.attributes.metamodelVersion ?? "4.0",
+  };
 
-	const physical = childNamed(schema, 'PhysicalSchema');
-	if (physical) {
-		const tables = childrenNamed(physical, 'Table').map(tableToYaml);
-		const links = childrenNamed(physical, 'Link').map((l) => ({
-			source: l.attributes.source,
-			target: l.attributes.target,
-			...keyOrKeyColumn(l, 'foreignKeyColumn', 'foreign_key_column', 'foreign_key')
-		}));
-		const ps: Yaml = {};
-		if (tables.length) ps.tables = tables;
-		if (links.length) ps.links = links;
-		if (Object.keys(ps).length) doc.physical_schema = ps;
-	}
+  const physical = childNamed(schema, "PhysicalSchema");
+  if (physical) {
+    const tables = childrenNamed(physical, "Table").map(tableToYaml);
+    const links = childrenNamed(physical, "Link").map((l) => ({
+      source: l.attributes.source,
+      target: l.attributes.target,
+      ...keyOrKeyColumn(
+        l,
+        "foreignKeyColumn",
+        "foreign_key_column",
+        "foreign_key",
+      ),
+    }));
+    const ps: Yaml = {};
+    if (tables.length) ps.tables = tables;
+    if (links.length) ps.links = links;
+    if (Object.keys(ps).length) doc.physical_schema = ps;
+  }
 
-	// Shared dimensions are the schema-level <Dimension> elements.
-	const sharedDims = childrenNamed(schema, 'Dimension');
-	if (sharedDims.length) {
-		const map: Yaml = {};
-		for (const d of sharedDims) {
-			map[d.attributes.name ?? 'Dimension'] = dimensionBodyToYaml(d);
-		}
-		doc.shared_dimensions = map;
-	}
+  // Shared dimensions are the schema-level <Dimension> elements.
+  const sharedDims = childrenNamed(schema, "Dimension");
+  if (sharedDims.length) {
+    const map: Yaml = {};
+    for (const d of sharedDims) {
+      map[d.attributes.name ?? "Dimension"] = dimensionBodyToYaml(d);
+    }
+    doc.shared_dimensions = map;
+  }
 
-	const cubes = childrenNamed(schema, 'Cube');
-	if (cubes.length) {
-		const map: Yaml = {};
-		for (const c of cubes) {
-			map[c.attributes.name ?? 'Cube'] = cubeToYaml(c);
-		}
-		doc.cubes = map;
-	}
+  const cubes = childrenNamed(schema, "Cube");
+  if (cubes.length) {
+    const map: Yaml = {};
+    for (const c of cubes) {
+      map[c.attributes.name ?? "Cube"] = cubeToYaml(c);
+    }
+    doc.cubes = map;
+  }
 
-	return stringify(doc, {
-		lineWidth: 0,
-		defaultStringType: 'QUOTE_DOUBLE',
-		defaultKeyType: 'PLAIN'
-	});
+  return stringify(doc, {
+    lineWidth: 0,
+    defaultStringType: "QUOTE_DOUBLE",
+    defaultKeyType: "PLAIN",
+  });
 }
 
 function tableToYaml(t: XmlNode): Yaml {
-	const out: Yaml = { name: t.attributes.name };
-	if (t.attributes.schema) out.schema = t.attributes.schema;
-	if (t.attributes.alias) out.alias = t.attributes.alias;
-	Object.assign(out, keyOrKeyColumn(t, 'keyColumn', 'key_column', 'key'));
-	return out;
+  const out: Yaml = { name: t.attributes.name };
+  if (t.attributes.schema) out.schema = t.attributes.schema;
+  if (t.attributes.alias) out.alias = t.attributes.alias;
+  Object.assign(out, keyOrKeyColumn(t, "keyColumn", "key_column", "key"));
+  return out;
 }
 
 /**
  * Resolve an element's single-column key (`keyColumn` attr) or composite key
  * (`<Key><Column name=.../></Key>` children) into YAML `key_column` / `key`.
  */
-function keyOrKeyColumn(node: XmlNode, attrName: string, singleKey: string, listKey: string): Yaml {
-	const single = node.attributes[attrName];
-	if (single) return { [singleKey]: single };
-	const key = childNamed(node, 'Key');
-	if (key) {
-		const cols = childrenNamed(key, 'Column')
-			.map((c) => c.attributes.name)
-			.filter((n): n is string => !!n);
-		if (cols.length) return { [listKey]: cols };
-	}
-	return {};
+function keyOrKeyColumn(
+  node: XmlNode,
+  attrName: string,
+  singleKey: string,
+  listKey: string,
+): Yaml {
+  const single = node.attributes[attrName];
+  if (single) return { [singleKey]: single };
+  const key = childNamed(node, "Key");
+  if (key) {
+    const cols = childrenNamed(key, "Column")
+      .map((c) => c.attributes.name)
+      .filter((n): n is string => !!n);
+    if (cols.length) return { [listKey]: cols };
+  }
+  return {};
 }
 
 function dimensionBodyToYaml(d: XmlNode): Yaml {
-	const out: Yaml = {};
-	if (d.attributes.table) out.table = d.attributes.table;
-	if (d.attributes.key) out.key = d.attributes.key;
-	if (d.attributes.type) out.type = d.attributes.type.replace(/Dimension$/, '').toUpperCase();
+  const out: Yaml = {};
+  if (d.attributes.table) out.table = d.attributes.table;
+  if (d.attributes.key) out.key = d.attributes.key;
+  if (d.attributes.type)
+    out.type = d.attributes.type.replace(/Dimension$/, "").toUpperCase();
 
-	const attrsNode = childNamed(d, 'Attributes');
-	if (attrsNode) {
-		const attrs = childrenNamed(attrsNode, 'Attribute').map(attributeToYaml);
-		if (attrs.length) out.attributes = attrs;
-	}
-	const hierNode = childNamed(d, 'Hierarchies');
-	if (hierNode) {
-		const hiers = childrenNamed(hierNode, 'Hierarchy').map(hierarchyToYaml);
-		if (hiers.length) out.hierarchies = hiers;
-	}
-	return out;
+  const attrsNode = childNamed(d, "Attributes");
+  if (attrsNode) {
+    const attrs = childrenNamed(attrsNode, "Attribute").map(attributeToYaml);
+    if (attrs.length) out.attributes = attrs;
+  }
+  const hierNode = childNamed(d, "Hierarchies");
+  if (hierNode) {
+    const hiers = childrenNamed(hierNode, "Hierarchy").map(hierarchyToYaml);
+    if (hiers.length) out.hierarchies = hiers;
+  }
+  return out;
 }
 
 function attributeToYaml(a: XmlNode): Yaml {
-	const out: Yaml = { name: a.attributes.name };
-	Object.assign(out, keyOrKeyColumn(a, 'keyColumn', 'key_column', 'key'));
-	if (a.attributes.nameColumn) out.name_column = a.attributes.nameColumn;
-	if (a.attributes.levelType) out.level_type = a.attributes.levelType;
-	if (a.attributes.hasHierarchy === 'false') out.has_hierarchy = false;
-	if (a.attributes.hierarchyAllMemberName) {
-		out.hierarchy_all_member_name = a.attributes.hierarchyAllMemberName;
-	}
-	return out;
+  const out: Yaml = { name: a.attributes.name };
+  Object.assign(out, keyOrKeyColumn(a, "keyColumn", "key_column", "key"));
+  if (a.attributes.nameColumn) out.name_column = a.attributes.nameColumn;
+  if (a.attributes.levelType) out.level_type = a.attributes.levelType;
+  if (a.attributes.hasHierarchy === "false") out.has_hierarchy = false;
+  if (a.attributes.hierarchyAllMemberName) {
+    out.hierarchy_all_member_name = a.attributes.hierarchyAllMemberName;
+  }
+  return out;
 }
 
 function hierarchyToYaml(h: XmlNode): Yaml {
-	const out: Yaml = { name: h.attributes.name };
-	if (h.attributes.allMemberName) out.all_member_name = h.attributes.allMemberName;
-	if (h.attributes.defaultMember) out.default_member = h.attributes.defaultMember;
-	if (h.attributes.hasAll) out.has_all = h.attributes.hasAll === 'true';
-	// Each <Level attribute="X"/> becomes a bare string (level name == attribute).
-	const levels = childrenNamed(h, 'Level').map((l) => l.attributes.attribute ?? l.attributes.name);
-	out.levels = levels;
-	return out;
+  const out: Yaml = { name: h.attributes.name };
+  if (h.attributes.allMemberName)
+    out.all_member_name = h.attributes.allMemberName;
+  if (h.attributes.defaultMember)
+    out.default_member = h.attributes.defaultMember;
+  if (h.attributes.hasAll) out.has_all = h.attributes.hasAll === "true";
+  // Each <Level attribute="X"/> becomes a bare string (level name == attribute).
+  const levels = childrenNamed(h, "Level").map(
+    (l) => l.attributes.attribute ?? l.attributes.name,
+  );
+  out.levels = levels;
+  return out;
 }
 
 function cubeToYaml(c: XmlNode): Yaml {
-	const out: Yaml = {};
-	const dimsNode = childNamed(c, 'Dimensions');
-	if (dimsNode) {
-		const dims = childrenNamed(dimsNode, 'Dimension').map((d) =>
-			d.attributes.source ? { source: d.attributes.source } : dimensionBodyToYaml(d)
-		);
-		if (dims.length) out.dimensions = dims;
-	}
-	const mgsNode = childNamed(c, 'MeasureGroups');
-	if (mgsNode) {
-		const mgs = childrenNamed(mgsNode, 'MeasureGroup').map(measureGroupToYaml);
-		if (mgs.length) out.measure_groups = mgs;
-	}
-	return out;
+  const out: Yaml = {};
+  const dimsNode = childNamed(c, "Dimensions");
+  if (dimsNode) {
+    const dims = childrenNamed(dimsNode, "Dimension").map((d) =>
+      d.attributes.source
+        ? { source: d.attributes.source }
+        : dimensionBodyToYaml(d),
+    );
+    if (dims.length) out.dimensions = dims;
+  }
+  const mgsNode = childNamed(c, "MeasureGroups");
+  if (mgsNode) {
+    const mgs = childrenNamed(mgsNode, "MeasureGroup").map(measureGroupToYaml);
+    if (mgs.length) out.measure_groups = mgs;
+  }
+  return out;
 }
 
 function measureGroupToYaml(mg: XmlNode): Yaml {
-	const out: Yaml = {};
-	if (mg.attributes.name) out.name = mg.attributes.name;
-	out.table = mg.attributes.table;
+  const out: Yaml = {};
+  if (mg.attributes.name) out.name = mg.attributes.name;
+  out.table = mg.attributes.table;
 
-	const measuresNode = childNamed(mg, 'Measures');
-	if (measuresNode) {
-		const measures = childrenNamed(measuresNode, 'Measure').map((m) => {
-			const mo: Yaml = { name: m.attributes.name };
-			if (m.attributes.column) mo.column = m.attributes.column;
-			mo.aggregator = m.attributes.aggregator ?? 'sum';
-			if (m.attributes.formatString) mo.format_string = m.attributes.formatString;
-			return mo;
-		});
-		if (measures.length) out.measures = measures;
-	}
+  const measuresNode = childNamed(mg, "Measures");
+  if (measuresNode) {
+    const measures = childrenNamed(measuresNode, "Measure").map((m) => {
+      const mo: Yaml = { name: m.attributes.name };
+      if (m.attributes.column) mo.column = m.attributes.column;
+      mo.aggregator = m.attributes.aggregator ?? "sum";
+      if (m.attributes.formatString)
+        mo.format_string = m.attributes.formatString;
+      return mo;
+    });
+    if (measures.length) out.measures = measures;
+  }
 
-	const linksNode = childNamed(mg, 'DimensionLinks');
-	if (linksNode) {
-		const links = linksNode.children.map(dimensionLinkToYaml).filter((l): l is Yaml => l !== null);
-		if (links.length) out.dimension_links = links;
-	}
-	return out;
+  const linksNode = childNamed(mg, "DimensionLinks");
+  if (linksNode) {
+    const links = linksNode.children
+      .map(dimensionLinkToYaml)
+      .filter((l): l is Yaml => l !== null);
+    if (links.length) out.dimension_links = links;
+  }
+  return out;
 }
 
 function dimensionLinkToYaml(link: XmlNode): Yaml | null {
-	const dimension = link.attributes.dimension;
-	if (!dimension) return null;
-	switch (link.name) {
-		case 'ForeignKeyLink':
-			return {
-				type: 'foreign_key',
-				dimension,
-				...keyOrKeyColumn(link, 'foreignKeyColumn', 'foreign_key_column', 'foreign_key')
-			};
-		case 'FactLink':
-			return { type: 'fact', dimension };
-		case 'ReferenceLink': {
-			const out: Yaml = { type: 'reference', dimension };
-			if (link.attributes.viaDimension) out.via_dimension = link.attributes.viaDimension;
-			if (link.attributes.viaAttribute) out.via_attribute = link.attributes.viaAttribute;
-			return out;
-		}
-		default:
-			return null;
-	}
+  const dimension = link.attributes.dimension;
+  if (!dimension) return null;
+  switch (link.name) {
+    case "ForeignKeyLink":
+      return {
+        type: "foreign_key",
+        dimension,
+        ...keyOrKeyColumn(
+          link,
+          "foreignKeyColumn",
+          "foreign_key_column",
+          "foreign_key",
+        ),
+      };
+    case "FactLink":
+      return { type: "fact", dimension };
+    case "ReferenceLink": {
+      const out: Yaml = { type: "reference", dimension };
+      if (link.attributes.viaDimension)
+        out.via_dimension = link.attributes.viaDimension;
+      if (link.attributes.viaAttribute)
+        out.via_attribute = link.attributes.viaAttribute;
+      return out;
+    }
+    default:
+      return null;
+  }
 }

--- a/saiku-ui/src/lib/cube-designer/oss-backend.test.ts
+++ b/saiku-ui/src/lib/cube-designer/oss-backend.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { ossCubeDesignerBackend } from "./oss-backend";
+import { parseProfileTables } from "./profile-types";
+
+/**
+ * The OSS adapter maps CubeDesignerBackend onto Saiku's REST surface and reshapes
+ * a few responses to the exact JSON the designer's client code expects. These pin
+ * the transforms + URL mapping so a rename can't silently break the wiring.
+ */
+describe("ossCubeDesignerBackend", () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+  });
+  afterEach(() => vi.unstubAllGlobals());
+
+  function jsonOk(body: unknown): Response {
+    return new Response(JSON.stringify(body), { status: 200 });
+  }
+
+  it("profileConnection introspect → the profile shape parseProfileTables consumes (type→sqlType)", async () => {
+    fetchMock.mockResolvedValueOnce(
+      jsonOk({
+        tables: [
+          {
+            schema: "public",
+            name: "customer",
+            columns: [
+              { name: "id", type: "INTEGER" },
+              { name: "name", type: "VARCHAR" },
+            ],
+          },
+        ],
+      }),
+    );
+
+    const resp = await ossCubeDesignerBackend.profileConnection("conn-1");
+    const [url] = fetchMock.mock.calls[0] as [string];
+    expect(url).toBe("/rest/saiku/admin/cube-designer/introspect/conn-1");
+
+    // The reshaped body must round-trip through the designer's own parser.
+    const tables = parseProfileTables(await resp.text());
+    expect(tables).toHaveLength(1);
+    expect(tables[0]).toMatchObject({ schema: "public", name: "customer" });
+    expect(tables[0].columns).toEqual([
+      { name: "id", sqlType: "INTEGER" },
+      { name: "name", sqlType: "VARCHAR" },
+    ]);
+  });
+
+  it("sample builds the introspect sample URL with encoded table + limit", () => {
+    fetchMock.mockResolvedValueOnce(jsonOk({ columns: [], rows: [] }));
+    ossCubeDesignerBackend.sample("c1", "public.sales", 25);
+    const [url] = fetchMock.mock.calls[0] as [string];
+    expect(url).toBe(
+      "/rest/saiku/admin/cube-designer/sample/c1?table=public.sales&limit=25",
+    );
+  });
+
+  it("convertSchema maps connectionId→dataSourceId and passes {mondrianXml}", async () => {
+    fetchMock.mockResolvedValueOnce(jsonOk({ mondrianXml: "<Schema/>" }));
+    await ossCubeDesignerBackend.convertSchema({
+      mondrianXml: "<M3/>",
+      connectionId: "c1",
+    });
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe("/rest/saiku/admin/cube-designer/convert");
+    expect(init.method).toBe("POST");
+    expect(JSON.parse(init.body as string)).toEqual({
+      mondrianXml: "<M3/>",
+      dataSourceId: "c1",
+    });
+  });
+
+  it("convertSchema wraps a 4xx failure token as { message }", async () => {
+    fetchMock.mockResolvedValueOnce(
+      new Response("tables_missing", { status: 422 }),
+    );
+    const resp = await ossCubeDesignerBackend.convertSchema({
+      mondrianXml: "<M3/>",
+      connectionId: "c1",
+    });
+    expect(resp.status).toBe(422);
+    const body = (await resp.json()) as { message: string };
+    expect(body.message).toMatch(/does not exist/i);
+  });
+
+  it("loadSchema wraps repository XML as { mondrianXml }", async () => {
+    fetchMock.mockResolvedValueOnce(
+      new Response('<Schema name="x"/>', { status: 200 }),
+    );
+    const resp = await ossCubeDesignerBackend.loadSchema(
+      "/homes/home:admin/x.xml",
+    );
+    const [url] = fetchMock.mock.calls[0] as [string];
+    expect(url).toContain("/rest/saiku/api/repository/resource?file=");
+    expect((await resp.json()) as { mondrianXml: string }).toEqual({
+      mondrianXml: '<Schema name="x"/>',
+    });
+  });
+
+  it("tryQuery is a graceful 501 (no run-against-unsaved-proposal endpoint in OSS)", async () => {
+    const resp = await ossCubeDesignerBackend.tryQuery({});
+    expect(resp.status).toBe(501);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});

--- a/saiku-ui/src/lib/cube-designer/oss-backend.ts
+++ b/saiku-ui/src/lib/cube-designer/oss-backend.ts
@@ -19,7 +19,7 @@
  *  - `tryQuery`: OSS has no run-against-an-unsaved-proposal endpoint yet, so the
  *    Try-a-query tab is unavailable in this build (graceful 501).
  */
-import type { CubeDesignerBackend } from "./backend";
+import type { CubeDesignerBackend, CubeDesignerAI } from "./backend";
 
 const REST_BASE = "/rest/saiku";
 const BASE = `${REST_BASE}/admin/cube-designer`;
@@ -121,4 +121,16 @@ export const ossCubeDesignerBackend: CubeDesignerBackend = {
     const token = await r.text().catch(() => "");
     return jsonResponse({ message: convertMessage(token) }, r.status);
   },
+};
+
+/**
+ * OSS AI adapter — points the DimSum agent turn at Saiku's schema-authoring
+ * endpoint. dimsum-agent's `postDimSumTurn` posts `{messages, canvasSummary}` to
+ * its built-in URL; the injected `fetchImpl` redirects that to
+ * `/rest/saiku/admin/cube-designer/turn` (which returns `{content: [...]}`). The
+ * server 503s when no API key is configured, and the designer surfaces that.
+ */
+export const ossCubeDesignerAI: CubeDesignerAI = {
+  fetchImpl: (_input, init) =>
+    fetch(`${BASE}/turn`, { ...(init ?? {}), ...CREDS }),
 };

--- a/saiku-ui/src/lib/cube-designer/oss-backend.ts
+++ b/saiku-ui/src/lib/cube-designer/oss-backend.ts
@@ -1,0 +1,124 @@
+/**
+ * OSS Saiku host implementation of the cube-designer backend seam.
+ *
+ * Maps each {@link CubeDesignerBackend} method onto Saiku's own REST surface —
+ * the three dedicated endpoints added for the designer
+ * (`/rest/saiku/admin/cube-designer/*`) plus the existing repository resource.
+ * Cookie-based auth (`credentials: "include"`), same as every other saiku-ui
+ * api client.
+ *
+ * A few responses are reshaped to the exact JSON the designer's client code
+ * expects (it was written against the Cloud gateway's shapes):
+ *  - `profileConnection`: introspect returns `columns[].type`; the designer's
+ *    `parseProfileTables` wants `columns[].sqlType`.
+ *  - `loadSchema`: the repository returns raw XML; the importer wants
+ *    `{ mondrianXml }`.
+ *  - `convertSchema`: the designer sends `{ mondrianXml, connectionId }`; the
+ *    OSS endpoint wants `{ mondrianXml, dataSourceId }`, and returns a plain
+ *    failure token on 4xx which we wrap as `{ message }`.
+ *  - `tryQuery`: OSS has no run-against-an-unsaved-proposal endpoint yet, so the
+ *    Try-a-query tab is unavailable in this build (graceful 501).
+ */
+import type { CubeDesignerBackend } from "./backend";
+
+const REST_BASE = "/rest/saiku";
+const BASE = `${REST_BASE}/admin/cube-designer`;
+const CREDS: RequestInit = { credentials: "include" };
+const JSON_HEADERS = { "Content-Type": "application/json" } as const;
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+/** Friendly text for the convert endpoint's typed failure tokens. */
+function convertMessage(token: string): string {
+  switch (token.trim()) {
+    case "tables_missing":
+      return "The schema references a table that does not exist in the warehouse.";
+    case "connection_failed":
+      return "Could not connect to the warehouse to upgrade the schema.";
+    case "not_upgradable":
+      return "The schema could not be upgraded to Mondrian 4.";
+    default:
+      return "The schema could not be converted.";
+  }
+}
+
+type IntrospectResponse = {
+  tables: Array<{
+    schema: string | null;
+    name: string;
+    columns: Array<{ name: string; type: string | null }>;
+  }>;
+};
+
+export const ossCubeDesignerBackend: CubeDesignerBackend = {
+  async profileConnection(connectionId) {
+    const r = await fetch(
+      `${BASE}/introspect/${encodeURIComponent(connectionId)}`,
+      CREDS,
+    );
+    if (!r.ok) return r; // let the caller surface the HTTP error
+    const data = (await r.json()) as IntrospectResponse;
+    // Reshape to the `{ tables: [{ schema, name, columns: [{ name, sqlType }] }] }`
+    // envelope parseProfileTables consumes (column `type` → `sqlType`).
+    const tables = (data.tables ?? []).map((t) => ({
+      schema: t.schema,
+      name: t.name,
+      columns: (t.columns ?? []).map((c) => ({
+        name: c.name,
+        sqlType: c.type ?? "unknown",
+      })),
+    }));
+    return jsonResponse({ tables });
+  },
+
+  sample(connectionId, table, limit) {
+    const url =
+      `${BASE}/sample/${encodeURIComponent(connectionId)}` +
+      `?table=${encodeURIComponent(table)}&limit=${limit}`;
+    return fetch(url, CREDS);
+  },
+
+  tryQuery() {
+    // No OSS endpoint runs a query against an unsaved proposal (Cloud does this
+    // gateway-side). Save the schema, then query it in Studio.
+    return Promise.resolve(
+      jsonResponse(
+        { message: "Query preview is not available in this build." },
+        501,
+      ),
+    );
+  },
+
+  async loadSchema(entryId) {
+    const r = await fetch(
+      `${REST_BASE}/api/repository/resource?file=${encodeURIComponent(entryId)}`,
+      CREDS,
+    );
+    if (!r.ok) return r;
+    const xml = await r.text();
+    return jsonResponse({ mondrianXml: xml });
+  },
+
+  async convertSchema(body) {
+    const b = (body ?? {}) as { mondrianXml?: string; connectionId?: string };
+    const r = await fetch(`${BASE}/convert`, {
+      method: "POST",
+      ...CREDS,
+      headers: JSON_HEADERS,
+      body: JSON.stringify({
+        mondrianXml: b.mondrianXml,
+        dataSourceId: b.connectionId,
+      }),
+    });
+    if (r.ok) return r; // { mondrianXml }
+    // OSS returns a plain-text failure token (e.g. "tables_missing"); wrap as
+    // JSON so the importer's `{ message }` error path shows something useful.
+    const token = await r.text().catch(() => "");
+    return jsonResponse({ message: convertMessage(token) }, r.status);
+  },
+};

--- a/saiku-ui/src/lib/cube-designer/primitives/Popover.svelte
+++ b/saiku-ui/src/lib/cube-designer/primitives/Popover.svelte
@@ -1,0 +1,59 @@
+<!--
+	Popover — a floating panel anchored to a trigger.  Wraps bits-ui
+	Popover with the design-system's border / bg / shadow contract.
+	The trigger snippet receives `props` that the caller MUST spread
+	onto their button — this is the bits-ui `child` pattern, needed
+	so click + aria attributes land on the actual interactive element
+	(a wrapper span with `display: contents` swallows the events).
+
+	Slot the trigger and content:
+
+	  <Popover>
+	    {#snippet trigger({ props })}
+	      <button {...props}>Open</button>
+	    {/snippet}
+	    {#snippet content()}
+	      <div class="p-3">…</div>
+	    {/snippet}
+	  </Popover>
+-->
+<script lang="ts">
+	import { Popover as PopoverPrimitive } from 'bits-ui';
+
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	type TriggerProps = Record<string, any>;
+
+	let {
+		side = 'bottom',
+		align = 'center',
+		sideOffset = 6,
+		open = $bindable(false),
+		trigger,
+		content
+	}: {
+		side?: 'top' | 'right' | 'bottom' | 'left';
+		align?: 'start' | 'center' | 'end';
+		sideOffset?: number;
+		open?: boolean;
+		trigger: import('svelte').Snippet<[{ props: TriggerProps }]>;
+		content: import('svelte').Snippet;
+	} = $props();
+</script>
+
+<PopoverPrimitive.Root bind:open>
+	<PopoverPrimitive.Trigger>
+		{#snippet child({ props })}
+			{@render trigger({ props })}
+		{/snippet}
+	</PopoverPrimitive.Trigger>
+	<PopoverPrimitive.Portal>
+		<PopoverPrimitive.Content
+			{side}
+			{align}
+			{sideOffset}
+			class="z-50 min-w-40 rounded-md border border-border bg-popover text-popover-foreground shadow-md outline-none"
+		>
+			{@render content()}
+		</PopoverPrimitive.Content>
+	</PopoverPrimitive.Portal>
+</PopoverPrimitive.Root>

--- a/saiku-ui/src/lib/cube-designer/primitives/SortableColumnHeader.svelte
+++ b/saiku-ui/src/lib/cube-designer/primitives/SortableColumnHeader.svelte
@@ -1,0 +1,55 @@
+<!--
+  SortableColumnHeader — clickable table column header with sort indicator.
+
+  Replaces 18-line copy-paste blocks per column. Caller owns the sort
+  state and the `onToggle` callback; this component just renders the
+  label + the appropriate arrow icon.
+
+  Usage:
+
+    <th>
+      <SortableColumnHeader
+        label="Filename"
+        sortKey="filename"
+        activeKey={sortKey}
+        direction={sortDir}
+        onToggle={toggleSort}
+      />
+    </th>
+-->
+<script lang="ts" generics="K extends string">
+	import { ArrowUp, ArrowDown, ArrowUpDown } from 'lucide-svelte';
+
+	type Direction = 'asc' | 'desc';
+
+	interface Props {
+		label: string;
+		sortKey: K;
+		activeKey: K;
+		direction: Direction;
+		onToggle: (key: K) => void;
+		testid?: string;
+	}
+
+	let { label, sortKey, activeKey, direction, onToggle, testid }: Props = $props();
+
+	const isActive = $derived(sortKey === activeKey);
+</script>
+
+<button
+	type="button"
+	onclick={() => onToggle(sortKey)}
+	class="inline-flex items-center gap-1 hover:text-foreground"
+	data-testid={testid ?? `sort-${sortKey}`}
+>
+	{label}
+	{#if isActive}
+		{#if direction === 'asc'}
+			<ArrowUp class="h-3 w-3" aria-hidden="true" />
+		{:else}
+			<ArrowDown class="h-3 w-3" aria-hidden="true" />
+		{/if}
+	{:else}
+		<ArrowUpDown class="h-3 w-3 opacity-40" aria-hidden="true" />
+	{/if}
+</button>

--- a/saiku-ui/src/lib/cube-designer/primitives/Toast.svelte
+++ b/saiku-ui/src/lib/cube-designer/primitives/Toast.svelte
@@ -1,0 +1,61 @@
+<!--
+  Toast — transient top-right notification with manual dismiss.
+
+  Tone-driven via the design-system tokens. The component is purely
+  presentational — caller owns the timeout / show / dismiss lifecycle.
+
+  Typical pattern:
+
+    let toastMessage = $state<string | null>(null);
+    function showToast(msg: string) {
+      toastMessage = msg;
+      setTimeout(() => { toastMessage = null; }, 4500);
+    }
+
+    {#if toastMessage}
+      <Toast tone="success" onDismiss={() => toastMessage = null}>
+        {toastMessage}
+      </Toast>
+    {/if}
+-->
+<script lang="ts">
+	import type { Snippet } from 'svelte';
+	import { TONE_CLASSES, type Tone } from './tokens';
+
+	interface Props {
+		tone?: Tone;
+		testid?: string;
+		dismissTestid?: string;
+		onDismiss?: () => void;
+		children: Snippet;
+	}
+
+	let { tone = 'success', testid, dismissTestid, onDismiss, children }: Props = $props();
+
+	const toneClass = $derived(TONE_CLASSES[tone]);
+	// Icon character per tone. Tiny visual rhetoric.
+	const icon = $derived(
+		tone === 'success' ? '✓' : tone === 'error' ? '✗' : tone === 'warning' ? '!' : 'ℹ'
+	);
+</script>
+
+<div
+	class="fixed top-6 right-6 z-50 flex max-w-sm items-start gap-3 rounded-lg border px-4 py-3 text-sm shadow-lg backdrop-blur {toneClass}"
+	role="status"
+	aria-live="polite"
+	data-testid={testid}
+>
+	<span aria-hidden="true" class="mt-0.5 font-bold">{icon}</span>
+	<span class="flex-1 leading-snug">{@render children()}</span>
+	{#if onDismiss}
+		<button
+			type="button"
+			class="opacity-70 hover:opacity-100"
+			aria-label="Dismiss"
+			data-testid={dismissTestid}
+			onclick={onDismiss}
+		>
+			×
+		</button>
+	{/if}
+</div>

--- a/saiku-ui/src/lib/cube-designer/primitives/button.svelte
+++ b/saiku-ui/src/lib/cube-designer/primitives/button.svelte
@@ -1,0 +1,80 @@
+<script lang="ts" module>
+	import { tv, type VariantProps } from 'tailwind-variants';
+
+	export const buttonVariants = tv({
+		// Disabled treatment: explicit muted background + muted-foreground
+		// text on the chromed variants (default / destructive / outline /
+		// secondary). Reads as unambiguously disabled, not "dim brand
+		// colour". For chromeless variants (ghost / link / text) the bg
+		// stays absent and only the foreground mutes. Replaces the
+		// shadcn-default `disabled:opacity-50`, which on saturated brand
+		// reds read as low-contrast brand button.
+		// Focus ring intentionally without ring-offset — saiku-ui's existing
+		// chrome reads as flat / single-stroke, and the shadcn-default
+		// ring-offset-2 + ring-2 combination produces a chunky "3D" outline
+		// that visually conflicts with the rest of the codebase. A flat
+		// 2px ring on the element itself is enough for keyboard a11y.
+		// `no-underline` neutralises the global `a { text-decoration }`
+		// rule for anchors styled as buttons via buttonVariants().
+		base: 'inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium no-underline transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:pointer-events-none hover:no-underline',
+		variants: {
+			variant: {
+				default:
+					'bg-primary text-primary-foreground hover:bg-primary/90 disabled:bg-muted disabled:text-muted-foreground',
+				destructive:
+					'bg-destructive text-destructive-foreground hover:bg-destructive/90 disabled:bg-muted disabled:text-muted-foreground',
+				outline:
+					'border border-input bg-background text-foreground hover:bg-accent hover:text-accent-foreground disabled:bg-muted disabled:text-muted-foreground disabled:border-transparent',
+				secondary:
+					'bg-secondary text-secondary-foreground hover:bg-secondary/80 disabled:bg-muted disabled:text-muted-foreground',
+				ghost: 'text-foreground hover:bg-accent hover:text-accent-foreground disabled:text-muted-foreground',
+				link: 'text-primary underline-offset-4 hover:underline disabled:text-muted-foreground disabled:no-underline',
+				// "text" — looks like plain text. Foreground color, no background,
+				// no border, no padding. Underlines only on hover or keyboard focus.
+				// Inherits font-medium from base; pass `class="font-bold"` to override.
+				// Pair with `size="none"` to fully strip height/padding. Use this when
+				// you want a click action that visually reads as text (e.g. "Skip for
+				// now" alongside a primary CTA).
+				text: 'appearance-none bg-transparent text-foreground shadow-none hover:underline focus-visible:underline focus-visible:ring-0 focus-visible:ring-offset-0 disabled:text-muted-foreground'
+			},
+			size: {
+				default: 'h-10 px-4 py-2',
+				sm: 'h-9 rounded-md px-3',
+				lg: 'h-11 rounded-md px-8',
+				icon: 'h-10 w-10',
+				// "none" — no height, no padding, no border-radius. For text variant
+				// or when you need a button that flows inline with surrounding text.
+				none: 'h-auto p-0 rounded-none'
+			}
+		},
+		defaultVariants: {
+			variant: 'default',
+			size: 'default'
+		}
+	});
+
+	export type ButtonVariant = VariantProps<typeof buttonVariants>['variant'];
+	export type ButtonSize = VariantProps<typeof buttonVariants>['size'];
+</script>
+
+<script lang="ts">
+	import type { HTMLButtonAttributes } from 'svelte/elements';
+	import { cn } from './cn';
+
+	interface Props extends HTMLButtonAttributes {
+		variant?: ButtonVariant;
+		size?: ButtonSize;
+	}
+
+	let {
+		variant = 'default',
+		size = 'default',
+		class: className,
+		children,
+		...restProps
+	}: Props = $props();
+</script>
+
+<button class={cn(buttonVariants({ variant, size }), className)} {...restProps}>
+	{@render children?.()}
+</button>

--- a/saiku-ui/src/lib/cube-designer/primitives/cn.ts
+++ b/saiku-ui/src/lib/cube-designer/primitives/cn.ts
@@ -1,0 +1,6 @@
+import { clsx, type ClassValue } from "clsx";
+import { twMerge } from "tailwind-merge";
+
+export function cn(...inputs: ClassValue[]): string {
+  return twMerge(clsx(inputs));
+}

--- a/saiku-ui/src/lib/cube-designer/primitives/tokens.ts
+++ b/saiku-ui/src/lib/cube-designer/primitives/tokens.ts
@@ -1,0 +1,39 @@
+/**
+ * Design-system token contract — TypeScript source of truth.
+ *
+ * Components consume these types (e.g. `FeedbackBanner` props.tone) so
+ * `tone: 'sucess'` is a compile-time error, not a runtime mystery. The
+ * underlying CSS variables (`--success`, `--success-foreground`, etc.)
+ * live in `src/routes/layout.css` and resolve to a light + dark value
+ * each — see `docs/design-system.md` for the full token map.
+ *
+ * Why types here instead of free strings inline in each component:
+ * - One place to add a new tone (e.g. 'neutral') instead of grep-and-replace.
+ * - Misuse becomes a compile error visible in CI, not a visual bug.
+ * - Auto-complete in editors surfaces the available options.
+ */
+
+/** Status tones for feedback surfaces (banners, badges, toasts). */
+export const TONES = ["success", "error", "warning", "info"] as const;
+export type Tone = (typeof TONES)[number];
+
+/** Size scale for compact / standard / generous variants of compound
+ *  components (banners, cards, etc.). Buttons use their own scale via
+ *  the `Button` primitive — see `src/lib/components/ui/button.svelte`. */
+export const SIZES = ["sm", "md", "lg"] as const;
+export type Size = (typeof SIZES)[number];
+
+/**
+ * Tailwind class map per tone. Centralised so banners, badges, and any
+ * future tone-driven component all reach for the same utility strings
+ * — no copy-pasted `border-success/40 bg-success/10 text-success` drift
+ * across consumers. Keys match the `Tone` union; values are the trio of
+ * (border, background-wash, foreground) classes that work in both
+ * light AND dark mode because they resolve to `hsl(var(--<tone>))`.
+ */
+export const TONE_CLASSES: Record<Tone, string> = {
+  success: "border-success/40 bg-success/10 text-success",
+  error: "border-destructive/40 bg-destructive/10 text-destructive",
+  warning: "border-warning/40 bg-warning/10 text-warning",
+  info: "border-info/40 bg-info/10 text-info",
+};

--- a/saiku-ui/src/lib/cube-designer/primitives/tooltip.svelte
+++ b/saiku-ui/src/lib/cube-designer/primitives/tooltip.svelte
@@ -1,0 +1,78 @@
+<!--
+  Tooltip — one-shot wrapper around bits-ui's Tooltip primitive.
+
+  Composes Provider + Root + Trigger + Content into a single
+  component so most call sites collapse to:
+
+    <Tooltip text="Open command palette">
+      <button>…</button>
+    </Tooltip>
+
+  Earlier this wrapper rendered `<TooltipPrimitive.Trigger>{children}</...>`
+  which produced `<button><button>...</button></button>` — invalid HTML
+  + the outer button's default styling bled through (the search trigger
+  in the sidebar rendered with a pink background, see bug repro
+  2026-05-23). Now uses bits-ui's `child` snippet pattern: the trigger
+  doesn't emit its own DOM element, instead spreading its event +
+  ARIA props onto a layout-invisible wrapper span (class="contents")
+  that lives directly around the user's element. The user's button
+  stays the SINGLE button and keeps its own styling intact.
+
+  The default delay (300ms) is snappier than bits-ui's 700ms default.
+  Override via `delayMs` when a slower hint is warranted (e.g. on a
+  destructive action where we want intent).
+
+  For richer compositions (controlled-open state, custom content,
+  portal target), use the sub-components directly via
+  `import { Tooltip as TooltipPrimitive } from 'bits-ui'`.
+-->
+<script lang="ts">
+	import { Tooltip as TooltipPrimitive } from 'bits-ui';
+	import type { Snippet } from 'svelte';
+
+	interface Props {
+		/** The hint text. Empty / null disables the tooltip. */
+		text?: string | null;
+		/** Open delay in ms. Default 300. */
+		delayMs?: number;
+		/** Tooltip placement relative to the trigger. */
+		side?: 'top' | 'right' | 'bottom' | 'left';
+		/** Trigger element — receives the trigger event + ARIA props via a `contents` span. */
+		children: Snippet;
+	}
+
+	let { text = null, delayMs = 300, side = 'top', children }: Props = $props();
+</script>
+
+{#if text}
+	<TooltipPrimitive.Provider delayDuration={delayMs}>
+		<TooltipPrimitive.Root>
+			<TooltipPrimitive.Trigger>
+				{#snippet child({ props })}
+					<!--
+						`class="contents"` makes this span layout-invisible:
+						its child (the user's button/anchor/whatever) lays out
+						as if the span weren't there. The trigger's hover +
+						focus + ARIA props attach to the span itself, so the
+						user's element stays untouched + keeps its own styles.
+						No nested <button>; no leaked outer styling.
+					-->
+					<span {...props} class="contents">
+						{@render children()}
+					</span>
+				{/snippet}
+			</TooltipPrimitive.Trigger>
+			<TooltipPrimitive.Portal>
+				<TooltipPrimitive.Content
+					{side}
+					sideOffset={6}
+					class="z-50 max-w-xs rounded-md border border-border bg-popover px-2.5 py-1.5 text-xs leading-snug text-popover-foreground shadow-md"
+				>
+					{text}
+				</TooltipPrimitive.Content>
+			</TooltipPrimitive.Portal>
+		</TooltipPrimitive.Root>
+	</TooltipPrimitive.Provider>
+{:else}
+	{@render children()}
+{/if}

--- a/saiku-ui/src/lib/cube-designer/profile-types.ts
+++ b/saiku-ui/src/lib/cube-designer/profile-types.ts
@@ -9,59 +9,59 @@
  */
 
 export interface SchemaProposal {
-	schemaName: string;
-	cubes: CubeProposal[];
-	/**
-	 * Composite cubes that draw from multiple base cubes.
-	 * Saiku-mondrian 4.8.x reads the M3-style {@code <VirtualCube>}
-	 * element directly. Added 2026-05-28 (#646).
-	 */
-	virtualCubes?: VirtualCubeProposal[];
-	/**
-	 * Schema-scope MDX named sets. Mondrian 4 hardens against
-	 * schema-scope; cube-scope is the canonical place. Round-trip only.
-	 */
-	namedSets?: NamedSetProposal[];
-	/**
-	 * Mondrian schema-scope access-control roles.
-	 */
-	roles?: RoleProposal[];
+  schemaName: string;
+  cubes: CubeProposal[];
+  /**
+   * Composite cubes that draw from multiple base cubes.
+   * Saiku-mondrian 4.8.x reads the M3-style {@code <VirtualCube>}
+   * element directly. Added 2026-05-28 (#646).
+   */
+  virtualCubes?: VirtualCubeProposal[];
+  /**
+   * Schema-scope MDX named sets. Mondrian 4 hardens against
+   * schema-scope; cube-scope is the canonical place. Round-trip only.
+   */
+  namedSets?: NamedSetProposal[];
+  /**
+   * Mondrian schema-scope access-control roles.
+   */
+  roles?: RoleProposal[];
 }
 
 export interface CubeProposal {
-	name: string;
-	factTableSchema: string | null;
-	factTableName: string;
-	caption?: string | null;
-	description?: string | null;
-	dimensions: DimensionProposal[];
-	measures: MeasureProposal[];
-	/**
-	 * Calculated members (Mondrian `<CalculatedMember dimension="Measures" formula="..."/>`).
-	 * Composed measures expressed as MDX formulas — `[Measures].[Profit] = [Measures].[Revenue] - [Measures].[Cost]`.
-	 * Optional — back-compat with pre-#646 IR shapes. Added 2026-05-28.
-	 */
-	calculatedMembers?: CalculatedMemberProposal[];
-	/**
-	 * Cube-scope MDX named sets. Mondrian 4 hardens cube-scope, so
-	 * this is the canonical place. Added 2026-05-28.
-	 */
-	namedSets?: NamedSetProposal[];
-	/**
-	 * Declarative time-intelligence (Mondrian 4 `<TimeCalc>`). Desugars
-	 * at engine load-time into calculated members on `[Measures]`. Optional
-	 * — back-compat with pre-#112 IR shapes. Added 2026-06-09.
-	 */
-	timeCalcs?: TimeCalcProposal[];
-	/**
-	 * Declarative currency/unit conversions (Mondrian 4
-	 * `<CurrencyConversion>`). A measure-group-level construct producing a
-	 * converted measure `SUM(measure × rate)` via an as-of rate-table band
-	 * join. The gateway IR has no measure-group node, so these attach to the
-	 * cube. Optional — back-compat with pre-#112-phase-3 IR shapes. Added
-	 * 2026-06-09.
-	 */
-	currencyConversions?: CurrencyConversionProposal[];
+  name: string;
+  factTableSchema: string | null;
+  factTableName: string;
+  caption?: string | null;
+  description?: string | null;
+  dimensions: DimensionProposal[];
+  measures: MeasureProposal[];
+  /**
+   * Calculated members (Mondrian `<CalculatedMember dimension="Measures" formula="..."/>`).
+   * Composed measures expressed as MDX formulas — `[Measures].[Profit] = [Measures].[Revenue] - [Measures].[Cost]`.
+   * Optional — back-compat with pre-#646 IR shapes. Added 2026-05-28.
+   */
+  calculatedMembers?: CalculatedMemberProposal[];
+  /**
+   * Cube-scope MDX named sets. Mondrian 4 hardens cube-scope, so
+   * this is the canonical place. Added 2026-05-28.
+   */
+  namedSets?: NamedSetProposal[];
+  /**
+   * Declarative time-intelligence (Mondrian 4 `<TimeCalc>`). Desugars
+   * at engine load-time into calculated members on `[Measures]`. Optional
+   * — back-compat with pre-#112 IR shapes. Added 2026-06-09.
+   */
+  timeCalcs?: TimeCalcProposal[];
+  /**
+   * Declarative currency/unit conversions (Mondrian 4
+   * `<CurrencyConversion>`). A measure-group-level construct producing a
+   * converted measure `SUM(measure × rate)` via an as-of rate-table band
+   * join. The gateway IR has no measure-group node, so these attach to the
+   * cube. Optional — back-compat with pre-#112-phase-3 IR shapes. Added
+   * 2026-06-09.
+   */
+  currencyConversions?: CurrencyConversionProposal[];
 }
 
 /**
@@ -70,18 +70,18 @@ export interface CubeProposal {
  * required (the gateway IR rejects a blank).
  */
 export interface CurrencyConversionProposal {
-	name: string;
-	measure: string;
-	rateTable: string;
-	rateColumn: string;
-	rateType: string;
-	rateTypeColumn: string;
-	factCurrencyColumn: string;
-	rateCurrencyColumn: string;
-	factDateColumn: string;
-	rateValidFromColumn: string;
-	rateValidToColumn: string;
-	formatString?: string | null;
+  name: string;
+  measure: string;
+  rateTable: string;
+  rateColumn: string;
+  rateType: string;
+  rateTypeColumn: string;
+  factCurrencyColumn: string;
+  rateCurrencyColumn: string;
+  factDateColumn: string;
+  rateValidFromColumn: string;
+  rateValidToColumn: string;
+  formatString?: string | null;
 }
 
 /**
@@ -90,20 +90,20 @@ export interface CurrencyConversionProposal {
  * `type === 'rolling'` (the gateway IR drops them otherwise).
  */
 export interface TimeCalcProposal {
-	name: string;
-	type: string;
-	measure: string;
-	timeDimension?: string | null;
-	window?: number | null;
-	function?: string | null;
-	formatString?: string | null;
+  name: string;
+  type: string;
+  measure: string;
+  timeDimension?: string | null;
+  window?: number | null;
+  function?: string | null;
+  formatString?: string | null;
 }
 
-export const VALID_TIME_CALC_TYPES = ['yoy', 'pop', 'ytd', 'rolling'] as const;
+export const VALID_TIME_CALC_TYPES = ["yoy", "pop", "ytd", "rolling"] as const;
 
 export type TimeCalcType = (typeof VALID_TIME_CALC_TYPES)[number];
 
-export const VALID_TIME_CALC_FUNCTIONS = ['sum', 'avg'] as const;
+export const VALID_TIME_CALC_FUNCTIONS = ["sum", "avg"] as const;
 
 export type TimeCalcFunction = (typeof VALID_TIME_CALC_FUNCTIONS)[number];
 
@@ -111,7 +111,12 @@ export type TimeCalcFunction = (typeof VALID_TIME_CALC_FUNCTIONS)[number];
  * Mondrian 4 access levels for Role / SchemaGrant / CubeGrant /
  * DimensionGrant / HierarchyGrant / MemberGrant.
  */
-export const VALID_ACCESS_LEVELS = ['all', 'none', 'custom', 'all_dimensions'] as const;
+export const VALID_ACCESS_LEVELS = [
+  "all",
+  "none",
+  "custom",
+  "all_dimensions",
+] as const;
 
 export type AccessLevel = (typeof VALID_ACCESS_LEVELS)[number];
 
@@ -119,14 +124,14 @@ export type AccessLevel = (typeof VALID_ACCESS_LEVELS)[number];
  * Mondrian 4 hierarchy rollup policy — controls how the engine
  * aggregates restricted hierarchies during query rollup.
  */
-export const VALID_ROLLUP_POLICIES = ['full', 'partial', 'hidden'] as const;
+export const VALID_ROLLUP_POLICIES = ["full", "partial", "hidden"] as const;
 
 export type RollupPolicy = (typeof VALID_ROLLUP_POLICIES)[number];
 
 export interface NamedSetProposal {
-	name: string;
-	formula: string;
-	description?: string | null;
+  name: string;
+  formula: string;
+  description?: string | null;
 }
 
 /**
@@ -135,105 +140,105 @@ export interface NamedSetProposal {
  * for editor convenience; the gateway emits M4 syntax.
  */
 export interface VirtualCubeProposal {
-	name: string;
-	defaultMeasure?: string | null;
-	cubeUsages?: CubeUsageProposal[];
-	dimensions: VirtualCubeDimensionProposal[];
-	measures: VirtualCubeMeasureProposal[];
-	calculatedMembers?: CalculatedMemberProposal[];
-	namedSets?: NamedSetProposal[];
-	caption?: string | null;
-	description?: string | null;
+  name: string;
+  defaultMeasure?: string | null;
+  cubeUsages?: CubeUsageProposal[];
+  dimensions: VirtualCubeDimensionProposal[];
+  measures: VirtualCubeMeasureProposal[];
+  calculatedMembers?: CalculatedMemberProposal[];
+  namedSets?: NamedSetProposal[];
+  caption?: string | null;
+  description?: string | null;
 }
 
 export interface CubeUsageProposal {
-	cubeName: string;
-	ignoreUnrelatedDimensions: boolean;
+  cubeName: string;
+  ignoreUnrelatedDimensions: boolean;
 }
 
 export interface VirtualCubeDimensionProposal {
-	name: string;
-	/** Source base cube (M4 `source="..."`). Null = shared dimension. */
-	cubeName?: string | null;
-	caption?: string | null;
-	description?: string | null;
+  name: string;
+  /** Source base cube (M4 `source="..."`). Null = shared dimension. */
+  cubeName?: string | null;
+  caption?: string | null;
+  description?: string | null;
 }
 
 export interface VirtualCubeMeasureProposal {
-	/** Fully-qualified MDX measure reference: `[Measures].[Foo]`. */
-	name: string;
-	cubeName: string;
-	visible: boolean;
+  /** Fully-qualified MDX measure reference: `[Measures].[Foo]`. */
+  name: string;
+  cubeName: string;
+  visible: boolean;
 }
 
 export interface RoleProposal {
-	name: string;
-	schemaGrant: SchemaGrantProposal;
-	description?: string | null;
+  name: string;
+  schemaGrant: SchemaGrantProposal;
+  description?: string | null;
 }
 
 export interface SchemaGrantProposal {
-	access: string;
-	cubeGrants?: CubeGrantProposal[];
+  access: string;
+  cubeGrants?: CubeGrantProposal[];
 }
 
 export interface CubeGrantProposal {
-	cube: string;
-	access: string;
-	dimensionGrants?: DimensionGrantProposal[];
-	hierarchyGrants?: HierarchyGrantProposal[];
+  cube: string;
+  access: string;
+  dimensionGrants?: DimensionGrantProposal[];
+  hierarchyGrants?: HierarchyGrantProposal[];
 }
 
 export interface DimensionGrantProposal {
-	dimension: string;
-	access: string;
+  dimension: string;
+  access: string;
 }
 
 export interface HierarchyGrantProposal {
-	hierarchy: string;
-	access: string;
-	topLevel?: string | null;
-	bottomLevel?: string | null;
-	rollupPolicy?: string | null;
-	memberGrants?: MemberGrantProposal[];
+  hierarchy: string;
+  access: string;
+  topLevel?: string | null;
+  bottomLevel?: string | null;
+  rollupPolicy?: string | null;
+  memberGrants?: MemberGrantProposal[];
 }
 
 export interface MemberGrantProposal {
-	member: string;
-	access: string;
+  member: string;
+  access: string;
 }
 
 export interface DimensionProposal {
-	name: string;
-	foreignKey: string;
-	tableSchema: string | null;
-	tableName: string;
-	primaryKey: string;
-	/**
-	 * Top-level levels — the legacy single-hierarchy shape. When
-	 * `hierarchies` is non-empty the emitter uses that and these are
-	 * ignored; otherwise the emitter wraps these in a default
-	 * anonymous hierarchy.
-	 */
-	levels: LevelProposal[];
-	/**
-	 * Multi-hierarchy support (Mondrian `<Hierarchy>` children). Optional
-	 * — the typical cube has a single hierarchy and the LLM proposer
-	 * emits everything via `levels` for back-compat. Added 2026-05-28.
-	 */
-	hierarchies?: HierarchyProposal[];
-	/**
-	 * Mondrian-4 derived Tier (binning) attributes (saiku-cloud#108). Each
-	 * hangs off an `<Attribute hasHierarchy="true"><Tier>` in the M4 model.
-	 * Optional — only present on dimensions that bucket a numeric column.
-	 */
-	tiers?: TierProposal[];
-	/**
-	 * Mondrian-4 derived Duration attributes (saiku-cloud#108). Each hangs
-	 * off an `<Attribute hasHierarchy="true"><Duration>` in the M4 model.
-	 * Optional — only present on dimensions with a date-pair column.
-	 */
-	durations?: DurationProposal[];
+  name: string;
+  foreignKey: string;
+  tableSchema: string | null;
+  tableName: string;
+  primaryKey: string;
+  /**
+   * Top-level levels — the legacy single-hierarchy shape. When
+   * `hierarchies` is non-empty the emitter uses that and these are
+   * ignored; otherwise the emitter wraps these in a default
+   * anonymous hierarchy.
+   */
+  levels: LevelProposal[];
+  /**
+   * Multi-hierarchy support (Mondrian `<Hierarchy>` children). Optional
+   * — the typical cube has a single hierarchy and the LLM proposer
+   * emits everything via `levels` for back-compat. Added 2026-05-28.
+   */
+  hierarchies?: HierarchyProposal[];
+  /**
+   * Mondrian-4 derived Tier (binning) attributes (saiku-cloud#108). Each
+   * hangs off an `<Attribute hasHierarchy="true"><Tier>` in the M4 model.
+   * Optional — only present on dimensions that bucket a numeric column.
+   */
+  tiers?: TierProposal[];
+  /**
+   * Mondrian-4 derived Duration attributes (saiku-cloud#108). Each hangs
+   * off an `<Attribute hasHierarchy="true"><Duration>` in the M4 model.
+   * Optional — only present on dimensions with a date-pair column.
+   */
+  durations?: DurationProposal[];
 }
 
 /**
@@ -242,9 +247,9 @@ export interface DimensionProposal {
  * omits its boundary (catch-all for everything above the last boundary).
  */
 export interface TierProposal {
-	name: string;
-	column: string;
-	bins: BinProposal[];
+  name: string;
+  column: string;
+  bins: BinProposal[];
 }
 
 /**
@@ -253,8 +258,8 @@ export interface TierProposal {
  * is always required.
  */
 export interface BinProposal {
-	boundary?: string | null;
-	label: string;
+  boundary?: string | null;
+  label: string;
 }
 
 /**
@@ -262,83 +267,89 @@ export interface BinProposal {
  * elapsed time between two date columns at a chosen unit.
  */
 export interface DurationProposal {
-	name: string;
-	startColumn: string;
-	endColumn: string;
-	unit: string;
+  name: string;
+  startColumn: string;
+  endColumn: string;
+  unit: string;
 }
 
 /** Mondrian-4 duration units (coarsest → finest). */
-export const VALID_DURATION_UNITS = ['YEAR', 'QUARTER', 'MONTH', 'WEEK', 'DAY'] as const;
+export const VALID_DURATION_UNITS = [
+  "YEAR",
+  "QUARTER",
+  "MONTH",
+  "WEEK",
+  "DAY",
+] as const;
 
 export type DurationUnit = (typeof VALID_DURATION_UNITS)[number];
 
 export interface HierarchyProposal {
-	name?: string | null;
-	hasAll: boolean;
-	allMemberName?: string | null;
-	primaryKey: string;
-	tableSchema?: string | null;
-	tableName?: string | null;
-	levels: LevelProposal[];
+  name?: string | null;
+  hasAll: boolean;
+  allMemberName?: string | null;
+  primaryKey: string;
+  tableSchema?: string | null;
+  tableName?: string | null;
+  levels: LevelProposal[];
 }
 
 export interface LevelProposal {
-	name: string;
-	column: string;
-	nameColumn?: string | null;
-	captionColumn?: string | null;
-	ordinalColumn?: string | null;
-	type: string;
-	uniqueMembers: boolean;
-	levelType?: string | null;
-	description?: string | null;
-	/**
-	 * Member properties (Mondrian `<Property>` children). Surface as
-	 * `[Dim].CurrentMember.Properties("name")` in MDX. Added 2026-05-28.
-	 */
-	properties?: PropertyProposal[];
-	annotations?: Record<string, string[]>;
+  name: string;
+  column: string;
+  nameColumn?: string | null;
+  captionColumn?: string | null;
+  ordinalColumn?: string | null;
+  type: string;
+  uniqueMembers: boolean;
+  levelType?: string | null;
+  description?: string | null;
+  /**
+   * Member properties (Mondrian `<Property>` children). Surface as
+   * `[Dim].CurrentMember.Properties("name")` in MDX. Added 2026-05-28.
+   */
+  properties?: PropertyProposal[];
+  annotations?: Record<string, string[]>;
 }
 
 export interface PropertyProposal {
-	name: string;
-	column: string;
-	type?: string | null;
-	description?: string | null;
+  name: string;
+  column: string;
+  type?: string | null;
+  description?: string | null;
 }
 
 export interface MeasureProposal {
-	name: string;
-	column: string;
-	aggregator: string;
-	/**
-	 * Integer 0–100, only meaningful when `aggregator === 'percentile'`
-	 * (median is the implicit 50th percentile and carries no value).
-	 * Mondrian-4 non-additive leaf aggregators (saiku-cloud#104).
-	 */
-	percentile?: number | null;
-	formatString?: string | null;
-	description?: string | null;
-	annotations?: Record<string, string[]>;
+  name: string;
+  column: string;
+  aggregator: string;
+  /**
+   * Integer 0–100, only meaningful when `aggregator === 'percentile'`
+   * (median is the implicit 50th percentile and carries no value).
+   * Mondrian-4 non-additive leaf aggregators (saiku-cloud#104).
+   */
+  percentile?: number | null;
+  formatString?: string | null;
+  description?: string | null;
+  annotations?: Record<string, string[]>;
 }
 
 export interface CalculatedMemberProposal {
-	name: string;
-	formula: string;
-	formatString?: string | null;
-	description?: string | null;
+  name: string;
+  formula: string;
+  formatString?: string | null;
+  description?: string | null;
 }
 
 export const VALID_AGGREGATORS = [
-	'sum',
-	'count',
-	'avg',
-	'min',
-	'max',
-	'distinct-count',
-	'median',
-	'percentile'
+  "sum",
+  "count",
+  "avg",
+  "min",
+  "max",
+  "distinct-count",
+  "median",
+  "percentile",
 ] as const;
 
 export type Aggregator = (typeof VALID_AGGREGATORS)[number];
@@ -350,13 +361,13 @@ export type Aggregator = (typeof VALID_AGGREGATORS)[number];
  * how to round-trip and the ones surfaced in the level editor.
  */
 export const VALID_LEVEL_TYPES = [
-	'String',
-	'Numeric',
-	'Integer',
-	'Boolean',
-	'Date',
-	'Time',
-	'Timestamp'
+  "String",
+  "Numeric",
+  "Integer",
+  "Boolean",
+  "Date",
+  "Time",
+  "Timestamp",
 ] as const;
 
 export type LevelType = (typeof VALID_LEVEL_TYPES)[number];
@@ -368,15 +379,15 @@ export type LevelType = (typeof VALID_LEVEL_TYPES)[number];
  * the default for non-time hierarchies.
  */
 export const VALID_LEVEL_LEVELTYPES = [
-	'Regular',
-	'TimeYears',
-	'TimeQuarters',
-	'TimeMonths',
-	'TimeWeeks',
-	'TimeDays',
-	'TimeHours',
-	'TimeMinutes',
-	'TimeSeconds'
+  "Regular",
+  "TimeYears",
+  "TimeQuarters",
+  "TimeMonths",
+  "TimeWeeks",
+  "TimeDays",
+  "TimeHours",
+  "TimeMinutes",
+  "TimeSeconds",
 ] as const;
 
 export type LevelLevelType = (typeof VALID_LEVEL_LEVELTYPES)[number];
@@ -388,67 +399,74 @@ export type LevelLevelType = (typeof VALID_LEVEL_LEVELTYPES)[number];
  * fields (gateway emits `null` or omits, dashboard reads either).
  */
 export function parseProposal(raw: unknown): SchemaProposal | null {
-	if (!raw || typeof raw !== 'object') return null;
-	const r = raw as Record<string, unknown>;
-	const schemaName = typeof r.schemaName === 'string' ? r.schemaName : null;
-	const cubesRaw = Array.isArray(r.cubes) ? r.cubes : null;
-	if (!schemaName || !cubesRaw) return null;
-	const cubes: CubeProposal[] = [];
-	for (const c of cubesRaw) {
-		const cube = parseCube(c);
-		if (!cube) return null;
-		cubes.push(cube);
-	}
-	const virtualCubes = Array.isArray(r.virtualCubes)
-		? r.virtualCubes.map(parseVirtualCube).filter(isNotNull)
-		: [];
-	const namedSets = Array.isArray(r.namedSets)
-		? r.namedSets.map(parseNamedSet).filter(isNotNull)
-		: [];
-	const roles = Array.isArray(r.roles) ? r.roles.map(parseRole).filter(isNotNull) : [];
-	if (cubes.length === 0) return null;
-	return {
-		schemaName,
-		cubes,
-		virtualCubes: virtualCubes.length > 0 ? virtualCubes : undefined,
-		namedSets: namedSets.length > 0 ? namedSets : undefined,
-		roles: roles.length > 0 ? roles : undefined
-	};
+  if (!raw || typeof raw !== "object") return null;
+  const r = raw as Record<string, unknown>;
+  const schemaName = typeof r.schemaName === "string" ? r.schemaName : null;
+  const cubesRaw = Array.isArray(r.cubes) ? r.cubes : null;
+  if (!schemaName || !cubesRaw) return null;
+  const cubes: CubeProposal[] = [];
+  for (const c of cubesRaw) {
+    const cube = parseCube(c);
+    if (!cube) return null;
+    cubes.push(cube);
+  }
+  const virtualCubes = Array.isArray(r.virtualCubes)
+    ? r.virtualCubes.map(parseVirtualCube).filter(isNotNull)
+    : [];
+  const namedSets = Array.isArray(r.namedSets)
+    ? r.namedSets.map(parseNamedSet).filter(isNotNull)
+    : [];
+  const roles = Array.isArray(r.roles)
+    ? r.roles.map(parseRole).filter(isNotNull)
+    : [];
+  if (cubes.length === 0) return null;
+  return {
+    schemaName,
+    cubes,
+    virtualCubes: virtualCubes.length > 0 ? virtualCubes : undefined,
+    namedSets: namedSets.length > 0 ? namedSets : undefined,
+    roles: roles.length > 0 ? roles : undefined,
+  };
 }
 
 function parseCube(raw: unknown): CubeProposal | null {
-	if (!raw || typeof raw !== 'object') return null;
-	const r = raw as Record<string, unknown>;
-	if (typeof r.name !== 'string' || typeof r.factTableName !== 'string') return null;
-	const measures = Array.isArray(r.measures) ? r.measures.map(parseMeasure).filter(isNotNull) : [];
-	const dimensions = Array.isArray(r.dimensions)
-		? r.dimensions.map(parseDimension).filter(isNotNull)
-		: [];
-	const calculatedMembers = Array.isArray(r.calculatedMembers)
-		? r.calculatedMembers.map(parseCalculatedMember).filter(isNotNull)
-		: [];
-	const namedSets = Array.isArray(r.namedSets)
-		? r.namedSets.map(parseNamedSet).filter(isNotNull)
-		: [];
-	const timeCalcs = Array.isArray(r.timeCalcs)
-		? r.timeCalcs.map(parseTimeCalc).filter(isNotNull)
-		: [];
-	const currencyConversions = Array.isArray(r.currencyConversions)
-		? r.currencyConversions.map(parseCurrencyConversion).filter(isNotNull)
-		: [];
-	return {
-		name: r.name,
-		factTableSchema: typeof r.factTableSchema === 'string' ? r.factTableSchema : null,
-		factTableName: r.factTableName,
-		caption: optionalString(r.caption),
-		description: optionalString(r.description),
-		dimensions,
-		measures,
-		calculatedMembers,
-		namedSets: namedSets.length > 0 ? namedSets : undefined,
-		timeCalcs: timeCalcs.length > 0 ? timeCalcs : undefined,
-		currencyConversions: currencyConversions.length > 0 ? currencyConversions : undefined
-	};
+  if (!raw || typeof raw !== "object") return null;
+  const r = raw as Record<string, unknown>;
+  if (typeof r.name !== "string" || typeof r.factTableName !== "string")
+    return null;
+  const measures = Array.isArray(r.measures)
+    ? r.measures.map(parseMeasure).filter(isNotNull)
+    : [];
+  const dimensions = Array.isArray(r.dimensions)
+    ? r.dimensions.map(parseDimension).filter(isNotNull)
+    : [];
+  const calculatedMembers = Array.isArray(r.calculatedMembers)
+    ? r.calculatedMembers.map(parseCalculatedMember).filter(isNotNull)
+    : [];
+  const namedSets = Array.isArray(r.namedSets)
+    ? r.namedSets.map(parseNamedSet).filter(isNotNull)
+    : [];
+  const timeCalcs = Array.isArray(r.timeCalcs)
+    ? r.timeCalcs.map(parseTimeCalc).filter(isNotNull)
+    : [];
+  const currencyConversions = Array.isArray(r.currencyConversions)
+    ? r.currencyConversions.map(parseCurrencyConversion).filter(isNotNull)
+    : [];
+  return {
+    name: r.name,
+    factTableSchema:
+      typeof r.factTableSchema === "string" ? r.factTableSchema : null,
+    factTableName: r.factTableName,
+    caption: optionalString(r.caption),
+    description: optionalString(r.description),
+    dimensions,
+    measures,
+    calculatedMembers,
+    namedSets: namedSets.length > 0 ? namedSets : undefined,
+    timeCalcs: timeCalcs.length > 0 ? timeCalcs : undefined,
+    currencyConversions:
+      currencyConversions.length > 0 ? currencyConversions : undefined,
+  };
 }
 
 /**
@@ -456,39 +474,42 @@ function parseCube(raw: unknown): CubeProposal | null {
  * mismatch (the caller filters nulls out). Every field except
  * `formatString` is required, mirroring the gateway IR.
  */
-export function parseCurrencyConversion(raw: unknown): CurrencyConversionProposal | null {
-	if (!raw || typeof raw !== 'object') return null;
-	const r = raw as Record<string, unknown>;
-	const required = [
-		'name',
-		'measure',
-		'rateTable',
-		'rateColumn',
-		'rateType',
-		'rateTypeColumn',
-		'factCurrencyColumn',
-		'rateCurrencyColumn',
-		'factDateColumn',
-		'rateValidFromColumn',
-		'rateValidToColumn'
-	] as const;
-	for (const key of required) {
-		if (typeof r[key] !== 'string' || (r[key] as string).length === 0) return null;
-	}
-	return {
-		name: r.name as string,
-		measure: r.measure as string,
-		rateTable: r.rateTable as string,
-		rateColumn: r.rateColumn as string,
-		rateType: r.rateType as string,
-		rateTypeColumn: r.rateTypeColumn as string,
-		factCurrencyColumn: r.factCurrencyColumn as string,
-		rateCurrencyColumn: r.rateCurrencyColumn as string,
-		factDateColumn: r.factDateColumn as string,
-		rateValidFromColumn: r.rateValidFromColumn as string,
-		rateValidToColumn: r.rateValidToColumn as string,
-		formatString: optionalString(r.formatString)
-	};
+export function parseCurrencyConversion(
+  raw: unknown,
+): CurrencyConversionProposal | null {
+  if (!raw || typeof raw !== "object") return null;
+  const r = raw as Record<string, unknown>;
+  const required = [
+    "name",
+    "measure",
+    "rateTable",
+    "rateColumn",
+    "rateType",
+    "rateTypeColumn",
+    "factCurrencyColumn",
+    "rateCurrencyColumn",
+    "factDateColumn",
+    "rateValidFromColumn",
+    "rateValidToColumn",
+  ] as const;
+  for (const key of required) {
+    if (typeof r[key] !== "string" || (r[key] as string).length === 0)
+      return null;
+  }
+  return {
+    name: r.name as string,
+    measure: r.measure as string,
+    rateTable: r.rateTable as string,
+    rateColumn: r.rateColumn as string,
+    rateType: r.rateType as string,
+    rateTypeColumn: r.rateTypeColumn as string,
+    factCurrencyColumn: r.factCurrencyColumn as string,
+    rateCurrencyColumn: r.rateCurrencyColumn as string,
+    factDateColumn: r.factDateColumn as string,
+    rateValidFromColumn: r.rateValidFromColumn as string,
+    rateValidToColumn: r.rateValidToColumn as string,
+    formatString: optionalString(r.formatString),
+  };
 }
 
 /**
@@ -497,237 +518,258 @@ export function parseCurrencyConversion(raw: unknown): CurrencyConversionProposa
  * `type === 'rolling'`, mirroring the gateway IR.
  */
 export function parseTimeCalc(raw: unknown): TimeCalcProposal | null {
-	if (!raw || typeof raw !== 'object') return null;
-	const r = raw as Record<string, unknown>;
-	if (typeof r.name !== 'string' || typeof r.type !== 'string' || typeof r.measure !== 'string')
-		return null;
-	const isRolling = r.type === 'rolling';
-	return {
-		name: r.name,
-		type: r.type,
-		measure: r.measure,
-		timeDimension: optionalString(r.timeDimension),
-		window: isRolling ? optionalInt(r.window) : null,
-		function: isRolling ? optionalString(r.function) : null,
-		formatString: optionalString(r.formatString)
-	};
+  if (!raw || typeof raw !== "object") return null;
+  const r = raw as Record<string, unknown>;
+  if (
+    typeof r.name !== "string" ||
+    typeof r.type !== "string" ||
+    typeof r.measure !== "string"
+  )
+    return null;
+  const isRolling = r.type === "rolling";
+  return {
+    name: r.name,
+    type: r.type,
+    measure: r.measure,
+    timeDimension: optionalString(r.timeDimension),
+    window: isRolling ? optionalInt(r.window) : null,
+    function: isRolling ? optionalString(r.function) : null,
+    formatString: optionalString(r.formatString),
+  };
 }
 
 function parseNamedSet(raw: unknown): NamedSetProposal | null {
-	if (!raw || typeof raw !== 'object') return null;
-	const r = raw as Record<string, unknown>;
-	if (typeof r.name !== 'string' || typeof r.formula !== 'string') return null;
-	return {
-		name: r.name,
-		formula: r.formula,
-		description: optionalString(r.description)
-	};
+  if (!raw || typeof raw !== "object") return null;
+  const r = raw as Record<string, unknown>;
+  if (typeof r.name !== "string" || typeof r.formula !== "string") return null;
+  return {
+    name: r.name,
+    formula: r.formula,
+    description: optionalString(r.description),
+  };
 }
 
 function parseVirtualCube(raw: unknown): VirtualCubeProposal | null {
-	if (!raw || typeof raw !== 'object') return null;
-	const r = raw as Record<string, unknown>;
-	if (typeof r.name !== 'string') return null;
-	const cubeUsages = Array.isArray(r.cubeUsages)
-		? r.cubeUsages
-				.map((u) => {
-					if (!u || typeof u !== 'object') return null;
-					const ur = u as Record<string, unknown>;
-					if (typeof ur.cubeName !== 'string') return null;
-					return {
-						cubeName: ur.cubeName,
-						ignoreUnrelatedDimensions: ur.ignoreUnrelatedDimensions !== false
-					};
-				})
-				.filter(isNotNull)
-		: [];
-	const dimensions: VirtualCubeDimensionProposal[] = Array.isArray(r.dimensions)
-		? r.dimensions
-				.map((d) => {
-					if (!d || typeof d !== 'object') return null;
-					const dr = d as Record<string, unknown>;
-					if (typeof dr.name !== 'string') return null;
-					return {
-						name: dr.name,
-						cubeName: optionalString(dr.cubeName),
-						caption: optionalString(dr.caption),
-						description: optionalString(dr.description)
-					};
-				})
-				.filter(isNotNull)
-		: [];
-	const measures: VirtualCubeMeasureProposal[] = Array.isArray(r.measures)
-		? r.measures
-				.map((m) => {
-					if (!m || typeof m !== 'object') return null;
-					const mr = m as Record<string, unknown>;
-					if (typeof mr.name !== 'string' || typeof mr.cubeName !== 'string') return null;
-					return { name: mr.name, cubeName: mr.cubeName, visible: mr.visible !== false };
-				})
-				.filter(isNotNull)
-		: [];
-	const calculatedMembers = Array.isArray(r.calculatedMembers)
-		? r.calculatedMembers.map(parseCalculatedMember).filter(isNotNull)
-		: [];
-	const namedSets = Array.isArray(r.namedSets)
-		? r.namedSets.map(parseNamedSet).filter(isNotNull)
-		: [];
-	return {
-		name: r.name,
-		defaultMeasure: optionalString(r.defaultMeasure),
-		cubeUsages: cubeUsages.length > 0 ? cubeUsages : undefined,
-		dimensions,
-		measures,
-		calculatedMembers: calculatedMembers.length > 0 ? calculatedMembers : undefined,
-		namedSets: namedSets.length > 0 ? namedSets : undefined,
-		caption: optionalString(r.caption),
-		description: optionalString(r.description)
-	};
+  if (!raw || typeof raw !== "object") return null;
+  const r = raw as Record<string, unknown>;
+  if (typeof r.name !== "string") return null;
+  const cubeUsages = Array.isArray(r.cubeUsages)
+    ? r.cubeUsages
+        .map((u) => {
+          if (!u || typeof u !== "object") return null;
+          const ur = u as Record<string, unknown>;
+          if (typeof ur.cubeName !== "string") return null;
+          return {
+            cubeName: ur.cubeName,
+            ignoreUnrelatedDimensions: ur.ignoreUnrelatedDimensions !== false,
+          };
+        })
+        .filter(isNotNull)
+    : [];
+  const dimensions: VirtualCubeDimensionProposal[] = Array.isArray(r.dimensions)
+    ? r.dimensions
+        .map((d) => {
+          if (!d || typeof d !== "object") return null;
+          const dr = d as Record<string, unknown>;
+          if (typeof dr.name !== "string") return null;
+          return {
+            name: dr.name,
+            cubeName: optionalString(dr.cubeName),
+            caption: optionalString(dr.caption),
+            description: optionalString(dr.description),
+          };
+        })
+        .filter(isNotNull)
+    : [];
+  const measures: VirtualCubeMeasureProposal[] = Array.isArray(r.measures)
+    ? r.measures
+        .map((m) => {
+          if (!m || typeof m !== "object") return null;
+          const mr = m as Record<string, unknown>;
+          if (typeof mr.name !== "string" || typeof mr.cubeName !== "string")
+            return null;
+          return {
+            name: mr.name,
+            cubeName: mr.cubeName,
+            visible: mr.visible !== false,
+          };
+        })
+        .filter(isNotNull)
+    : [];
+  const calculatedMembers = Array.isArray(r.calculatedMembers)
+    ? r.calculatedMembers.map(parseCalculatedMember).filter(isNotNull)
+    : [];
+  const namedSets = Array.isArray(r.namedSets)
+    ? r.namedSets.map(parseNamedSet).filter(isNotNull)
+    : [];
+  return {
+    name: r.name,
+    defaultMeasure: optionalString(r.defaultMeasure),
+    cubeUsages: cubeUsages.length > 0 ? cubeUsages : undefined,
+    dimensions,
+    measures,
+    calculatedMembers:
+      calculatedMembers.length > 0 ? calculatedMembers : undefined,
+    namedSets: namedSets.length > 0 ? namedSets : undefined,
+    caption: optionalString(r.caption),
+    description: optionalString(r.description),
+  };
 }
 
 function parseRole(raw: unknown): RoleProposal | null {
-	if (!raw || typeof raw !== 'object') return null;
-	const r = raw as Record<string, unknown>;
-	if (typeof r.name !== 'string') return null;
-	const sg = parseSchemaGrant(r.schemaGrant);
-	if (!sg) return null;
-	return {
-		name: r.name,
-		schemaGrant: sg,
-		description: optionalString(r.description)
-	};
+  if (!raw || typeof raw !== "object") return null;
+  const r = raw as Record<string, unknown>;
+  if (typeof r.name !== "string") return null;
+  const sg = parseSchemaGrant(r.schemaGrant);
+  if (!sg) return null;
+  return {
+    name: r.name,
+    schemaGrant: sg,
+    description: optionalString(r.description),
+  };
 }
 
 function parseSchemaGrant(raw: unknown): SchemaGrantProposal | null {
-	if (!raw || typeof raw !== 'object') return null;
-	const r = raw as Record<string, unknown>;
-	if (typeof r.access !== 'string') return null;
-	const cubeGrants = Array.isArray(r.cubeGrants)
-		? r.cubeGrants.map(parseCubeGrant).filter(isNotNull)
-		: [];
-	return { access: r.access, cubeGrants: cubeGrants.length > 0 ? cubeGrants : undefined };
+  if (!raw || typeof raw !== "object") return null;
+  const r = raw as Record<string, unknown>;
+  if (typeof r.access !== "string") return null;
+  const cubeGrants = Array.isArray(r.cubeGrants)
+    ? r.cubeGrants.map(parseCubeGrant).filter(isNotNull)
+    : [];
+  return {
+    access: r.access,
+    cubeGrants: cubeGrants.length > 0 ? cubeGrants : undefined,
+  };
 }
 
 function parseCubeGrant(raw: unknown): CubeGrantProposal | null {
-	if (!raw || typeof raw !== 'object') return null;
-	const r = raw as Record<string, unknown>;
-	if (typeof r.cube !== 'string' || typeof r.access !== 'string') return null;
-	const dimensionGrants = Array.isArray(r.dimensionGrants)
-		? r.dimensionGrants
-				.map((d) => {
-					if (!d || typeof d !== 'object') return null;
-					const dr = d as Record<string, unknown>;
-					if (typeof dr.dimension !== 'string' || typeof dr.access !== 'string') return null;
-					return { dimension: dr.dimension, access: dr.access };
-				})
-				.filter(isNotNull)
-		: [];
-	const hierarchyGrants = Array.isArray(r.hierarchyGrants)
-		? r.hierarchyGrants.map(parseHierarchyGrant).filter(isNotNull)
-		: [];
-	return {
-		cube: r.cube,
-		access: r.access,
-		dimensionGrants: dimensionGrants.length > 0 ? dimensionGrants : undefined,
-		hierarchyGrants: hierarchyGrants.length > 0 ? hierarchyGrants : undefined
-	};
+  if (!raw || typeof raw !== "object") return null;
+  const r = raw as Record<string, unknown>;
+  if (typeof r.cube !== "string" || typeof r.access !== "string") return null;
+  const dimensionGrants = Array.isArray(r.dimensionGrants)
+    ? r.dimensionGrants
+        .map((d) => {
+          if (!d || typeof d !== "object") return null;
+          const dr = d as Record<string, unknown>;
+          if (typeof dr.dimension !== "string" || typeof dr.access !== "string")
+            return null;
+          return { dimension: dr.dimension, access: dr.access };
+        })
+        .filter(isNotNull)
+    : [];
+  const hierarchyGrants = Array.isArray(r.hierarchyGrants)
+    ? r.hierarchyGrants.map(parseHierarchyGrant).filter(isNotNull)
+    : [];
+  return {
+    cube: r.cube,
+    access: r.access,
+    dimensionGrants: dimensionGrants.length > 0 ? dimensionGrants : undefined,
+    hierarchyGrants: hierarchyGrants.length > 0 ? hierarchyGrants : undefined,
+  };
 }
 
 function parseHierarchyGrant(raw: unknown): HierarchyGrantProposal | null {
-	if (!raw || typeof raw !== 'object') return null;
-	const r = raw as Record<string, unknown>;
-	if (typeof r.hierarchy !== 'string' || typeof r.access !== 'string') return null;
-	const memberGrants = Array.isArray(r.memberGrants)
-		? r.memberGrants
-				.map((m) => {
-					if (!m || typeof m !== 'object') return null;
-					const mr = m as Record<string, unknown>;
-					if (typeof mr.member !== 'string' || typeof mr.access !== 'string') return null;
-					return { member: mr.member, access: mr.access };
-				})
-				.filter(isNotNull)
-		: [];
-	return {
-		hierarchy: r.hierarchy,
-		access: r.access,
-		topLevel: optionalString(r.topLevel),
-		bottomLevel: optionalString(r.bottomLevel),
-		rollupPolicy: optionalString(r.rollupPolicy),
-		memberGrants: memberGrants.length > 0 ? memberGrants : undefined
-	};
+  if (!raw || typeof raw !== "object") return null;
+  const r = raw as Record<string, unknown>;
+  if (typeof r.hierarchy !== "string" || typeof r.access !== "string")
+    return null;
+  const memberGrants = Array.isArray(r.memberGrants)
+    ? r.memberGrants
+        .map((m) => {
+          if (!m || typeof m !== "object") return null;
+          const mr = m as Record<string, unknown>;
+          if (typeof mr.member !== "string" || typeof mr.access !== "string")
+            return null;
+          return { member: mr.member, access: mr.access };
+        })
+        .filter(isNotNull)
+    : [];
+  return {
+    hierarchy: r.hierarchy,
+    access: r.access,
+    topLevel: optionalString(r.topLevel),
+    bottomLevel: optionalString(r.bottomLevel),
+    rollupPolicy: optionalString(r.rollupPolicy),
+    memberGrants: memberGrants.length > 0 ? memberGrants : undefined,
+  };
 }
 
 function parseCalculatedMember(raw: unknown): CalculatedMemberProposal | null {
-	if (!raw || typeof raw !== 'object') return null;
-	const r = raw as Record<string, unknown>;
-	if (typeof r.name !== 'string' || typeof r.formula !== 'string') return null;
-	return {
-		name: r.name,
-		formula: r.formula,
-		formatString: optionalString(r.formatString),
-		description: optionalString(r.description)
-	};
+  if (!raw || typeof raw !== "object") return null;
+  const r = raw as Record<string, unknown>;
+  if (typeof r.name !== "string" || typeof r.formula !== "string") return null;
+  return {
+    name: r.name,
+    formula: r.formula,
+    formatString: optionalString(r.formatString),
+    description: optionalString(r.description),
+  };
 }
 
 function parseMeasure(raw: unknown): MeasureProposal | null {
-	if (!raw || typeof raw !== 'object') return null;
-	const r = raw as Record<string, unknown>;
-	if (
-		typeof r.name !== 'string' ||
-		typeof r.column !== 'string' ||
-		typeof r.aggregator !== 'string'
-	)
-		return null;
-	return {
-		name: r.name,
-		column: r.column,
-		aggregator: r.aggregator,
-		percentile: r.aggregator === 'percentile' ? optionalInt(r.percentile) : null,
-		formatString: optionalString(r.formatString),
-		description: optionalString(r.description),
-		annotations: parseAnnotations(r.annotations)
-	};
+  if (!raw || typeof raw !== "object") return null;
+  const r = raw as Record<string, unknown>;
+  if (
+    typeof r.name !== "string" ||
+    typeof r.column !== "string" ||
+    typeof r.aggregator !== "string"
+  )
+    return null;
+  return {
+    name: r.name,
+    column: r.column,
+    aggregator: r.aggregator,
+    percentile:
+      r.aggregator === "percentile" ? optionalInt(r.percentile) : null,
+    formatString: optionalString(r.formatString),
+    description: optionalString(r.description),
+    annotations: parseAnnotations(r.annotations),
+  };
 }
 
 function parseDimension(raw: unknown): DimensionProposal | null {
-	if (!raw || typeof raw !== 'object') return null;
-	const r = raw as Record<string, unknown>;
-	if (
-		typeof r.name !== 'string' ||
-		typeof r.foreignKey !== 'string' ||
-		typeof r.tableName !== 'string' ||
-		typeof r.primaryKey !== 'string'
-	)
-		return null;
-	const levels = Array.isArray(r.levels) ? r.levels.map(parseLevel).filter(isNotNull) : [];
-	const hierarchies = Array.isArray(r.hierarchies)
-		? r.hierarchies.map(parseHierarchy).filter(isNotNull)
-		: [];
-	const tiers = Array.isArray(r.tiers) ? r.tiers.map(parseTier).filter(isNotNull) : [];
-	const durations = Array.isArray(r.durations)
-		? r.durations.map(parseDuration).filter(isNotNull)
-		: [];
-	// A dimension must surface something queryable: levels, hierarchies, OR
-	// Mondrian-4 derived attributes (tiers/durations — the degenerate-on-fact
-	// Bank "Account" shape, saiku-cloud#108).
-	if (
-		levels.length === 0 &&
-		hierarchies.length === 0 &&
-		tiers.length === 0 &&
-		durations.length === 0
-	)
-		return null;
-	return {
-		name: r.name,
-		foreignKey: r.foreignKey,
-		tableSchema: typeof r.tableSchema === 'string' ? r.tableSchema : null,
-		tableName: r.tableName,
-		primaryKey: r.primaryKey,
-		levels,
-		hierarchies: hierarchies.length > 0 ? hierarchies : undefined,
-		tiers: tiers.length > 0 ? tiers : undefined,
-		durations: durations.length > 0 ? durations : undefined
-	};
+  if (!raw || typeof raw !== "object") return null;
+  const r = raw as Record<string, unknown>;
+  if (
+    typeof r.name !== "string" ||
+    typeof r.foreignKey !== "string" ||
+    typeof r.tableName !== "string" ||
+    typeof r.primaryKey !== "string"
+  )
+    return null;
+  const levels = Array.isArray(r.levels)
+    ? r.levels.map(parseLevel).filter(isNotNull)
+    : [];
+  const hierarchies = Array.isArray(r.hierarchies)
+    ? r.hierarchies.map(parseHierarchy).filter(isNotNull)
+    : [];
+  const tiers = Array.isArray(r.tiers)
+    ? r.tiers.map(parseTier).filter(isNotNull)
+    : [];
+  const durations = Array.isArray(r.durations)
+    ? r.durations.map(parseDuration).filter(isNotNull)
+    : [];
+  // A dimension must surface something queryable: levels, hierarchies, OR
+  // Mondrian-4 derived attributes (tiers/durations — the degenerate-on-fact
+  // Bank "Account" shape, saiku-cloud#108).
+  if (
+    levels.length === 0 &&
+    hierarchies.length === 0 &&
+    tiers.length === 0 &&
+    durations.length === 0
+  )
+    return null;
+  return {
+    name: r.name,
+    foreignKey: r.foreignKey,
+    tableSchema: typeof r.tableSchema === "string" ? r.tableSchema : null,
+    tableName: r.tableName,
+    primaryKey: r.primaryKey,
+    levels,
+    hierarchies: hierarchies.length > 0 ? hierarchies : undefined,
+    tiers: tiers.length > 0 ? tiers : undefined,
+    durations: durations.length > 0 ? durations : undefined,
+  };
 }
 
 /**
@@ -736,113 +778,115 @@ function parseDimension(raw: unknown): DimensionProposal | null {
  * boundary.
  */
 export function parseTier(raw: unknown): TierProposal | null {
-	if (!raw || typeof raw !== 'object') return null;
-	const r = raw as Record<string, unknown>;
-	if (typeof r.name !== 'string' || typeof r.column !== 'string') return null;
-	if (!Array.isArray(r.bins) || r.bins.length === 0) return null;
-	const bins: BinProposal[] = [];
-	for (const b of r.bins) {
-		if (!b || typeof b !== 'object') return null;
-		const br = b as Record<string, unknown>;
-		if (typeof br.label !== 'string' || br.label.length === 0) return null;
-		bins.push({ boundary: optionalString(br.boundary), label: br.label });
-	}
-	// Only the final bin may omit its boundary.
-	for (let i = 0; i < bins.length - 1; i++) {
-		if (!bins[i].boundary) return null;
-	}
-	return { name: r.name, column: r.column, bins };
+  if (!raw || typeof raw !== "object") return null;
+  const r = raw as Record<string, unknown>;
+  if (typeof r.name !== "string" || typeof r.column !== "string") return null;
+  if (!Array.isArray(r.bins) || r.bins.length === 0) return null;
+  const bins: BinProposal[] = [];
+  for (const b of r.bins) {
+    if (!b || typeof b !== "object") return null;
+    const br = b as Record<string, unknown>;
+    if (typeof br.label !== "string" || br.label.length === 0) return null;
+    bins.push({ boundary: optionalString(br.boundary), label: br.label });
+  }
+  // Only the final bin may omit its boundary.
+  for (let i = 0; i < bins.length - 1; i++) {
+    if (!bins[i].boundary) return null;
+  }
+  return { name: r.name, column: r.column, bins };
 }
 
 /** Parse a single Duration IR node. Returns null on a shape mismatch. */
 export function parseDuration(raw: unknown): DurationProposal | null {
-	if (!raw || typeof raw !== 'object') return null;
-	const r = raw as Record<string, unknown>;
-	if (
-		typeof r.name !== 'string' ||
-		typeof r.startColumn !== 'string' ||
-		typeof r.endColumn !== 'string' ||
-		typeof r.unit !== 'string'
-	)
-		return null;
-	return {
-		name: r.name,
-		startColumn: r.startColumn,
-		endColumn: r.endColumn,
-		unit: r.unit
-	};
+  if (!raw || typeof raw !== "object") return null;
+  const r = raw as Record<string, unknown>;
+  if (
+    typeof r.name !== "string" ||
+    typeof r.startColumn !== "string" ||
+    typeof r.endColumn !== "string" ||
+    typeof r.unit !== "string"
+  )
+    return null;
+  return {
+    name: r.name,
+    startColumn: r.startColumn,
+    endColumn: r.endColumn,
+    unit: r.unit,
+  };
 }
 
 function parseHierarchy(raw: unknown): HierarchyProposal | null {
-	if (!raw || typeof raw !== 'object') return null;
-	const r = raw as Record<string, unknown>;
-	if (typeof r.primaryKey !== 'string') return null;
-	const levels = Array.isArray(r.levels) ? r.levels.map(parseLevel).filter(isNotNull) : [];
-	if (levels.length === 0) return null;
-	return {
-		name: optionalString(r.name),
-		hasAll: r.hasAll === false ? false : true, // default true
-		allMemberName: optionalString(r.allMemberName),
-		primaryKey: r.primaryKey,
-		tableSchema: optionalString(r.tableSchema),
-		tableName: optionalString(r.tableName),
-		levels
-	};
+  if (!raw || typeof raw !== "object") return null;
+  const r = raw as Record<string, unknown>;
+  if (typeof r.primaryKey !== "string") return null;
+  const levels = Array.isArray(r.levels)
+    ? r.levels.map(parseLevel).filter(isNotNull)
+    : [];
+  if (levels.length === 0) return null;
+  return {
+    name: optionalString(r.name),
+    hasAll: r.hasAll === false ? false : true, // default true
+    allMemberName: optionalString(r.allMemberName),
+    primaryKey: r.primaryKey,
+    tableSchema: optionalString(r.tableSchema),
+    tableName: optionalString(r.tableName),
+    levels,
+  };
 }
 
 function parseLevel(raw: unknown): LevelProposal | null {
-	if (!raw || typeof raw !== 'object') return null;
-	const r = raw as Record<string, unknown>;
-	if (typeof r.name !== 'string' || typeof r.column !== 'string') return null;
-	const properties = Array.isArray(r.properties)
-		? r.properties.map(parseProperty).filter(isNotNull)
-		: [];
-	return {
-		name: r.name,
-		column: r.column,
-		nameColumn: optionalString(r.nameColumn),
-		captionColumn: optionalString(r.captionColumn),
-		ordinalColumn: optionalString(r.ordinalColumn),
-		type: typeof r.type === 'string' ? r.type : 'String',
-		uniqueMembers: !!r.uniqueMembers,
-		levelType: optionalString(r.levelType),
-		description: optionalString(r.description),
-		properties: properties.length > 0 ? properties : undefined,
-		annotations: parseAnnotations(r.annotations)
-	};
+  if (!raw || typeof raw !== "object") return null;
+  const r = raw as Record<string, unknown>;
+  if (typeof r.name !== "string" || typeof r.column !== "string") return null;
+  const properties = Array.isArray(r.properties)
+    ? r.properties.map(parseProperty).filter(isNotNull)
+    : [];
+  return {
+    name: r.name,
+    column: r.column,
+    nameColumn: optionalString(r.nameColumn),
+    captionColumn: optionalString(r.captionColumn),
+    ordinalColumn: optionalString(r.ordinalColumn),
+    type: typeof r.type === "string" ? r.type : "String",
+    uniqueMembers: !!r.uniqueMembers,
+    levelType: optionalString(r.levelType),
+    description: optionalString(r.description),
+    properties: properties.length > 0 ? properties : undefined,
+    annotations: parseAnnotations(r.annotations),
+  };
 }
 
 function parseProperty(raw: unknown): PropertyProposal | null {
-	if (!raw || typeof raw !== 'object') return null;
-	const r = raw as Record<string, unknown>;
-	if (typeof r.name !== 'string' || typeof r.column !== 'string') return null;
-	return {
-		name: r.name,
-		column: r.column,
-		type: optionalString(r.type),
-		description: optionalString(r.description)
-	};
+  if (!raw || typeof raw !== "object") return null;
+  const r = raw as Record<string, unknown>;
+  if (typeof r.name !== "string" || typeof r.column !== "string") return null;
+  return {
+    name: r.name,
+    column: r.column,
+    type: optionalString(r.type),
+    description: optionalString(r.description),
+  };
 }
 
 function parseAnnotations(raw: unknown): Record<string, string[]> | undefined {
-	if (!raw || typeof raw !== 'object') return undefined;
-	const out: Record<string, string[]> = {};
-	for (const [k, v] of Object.entries(raw as Record<string, unknown>)) {
-		if (!Array.isArray(v)) continue;
-		const stringValues = v.filter((x): x is string => typeof x === 'string');
-		if (stringValues.length === 0) continue;
-		out[k] = stringValues;
-	}
-	return Object.keys(out).length > 0 ? out : undefined;
+  if (!raw || typeof raw !== "object") return undefined;
+  const out: Record<string, string[]> = {};
+  for (const [k, v] of Object.entries(raw as Record<string, unknown>)) {
+    if (!Array.isArray(v)) continue;
+    const stringValues = v.filter((x): x is string => typeof x === "string");
+    if (stringValues.length === 0) continue;
+    out[k] = stringValues;
+  }
+  return Object.keys(out).length > 0 ? out : undefined;
 }
 
 function optionalString(value: unknown): string | null {
-	if (typeof value === 'string') return value;
-	if (value && typeof value === 'object' && 'value' in value) {
-		const v = (value as { value: unknown }).value;
-		return typeof v === 'string' ? v : null;
-	}
-	return null;
+  if (typeof value === "string") return value;
+  if (value && typeof value === "object" && "value" in value) {
+    const v = (value as { value: unknown }).value;
+    return typeof v === "string" ? v : null;
+  }
+  return null;
 }
 
 /**
@@ -852,19 +896,20 @@ function optionalString(value: unknown): string | null {
  * drops a missing/irrelevant percentile).
  */
 function optionalInt(value: unknown): number | null {
-	if (typeof value === 'number' && Number.isFinite(value)) return Math.trunc(value);
-	if (typeof value === 'string' && value.trim() !== '') {
-		const n = Number(value);
-		return Number.isFinite(n) ? Math.trunc(n) : null;
-	}
-	if (value && typeof value === 'object' && 'value' in value) {
-		return optionalInt((value as { value: unknown }).value);
-	}
-	return null;
+  if (typeof value === "number" && Number.isFinite(value))
+    return Math.trunc(value);
+  if (typeof value === "string" && value.trim() !== "") {
+    const n = Number(value);
+    return Number.isFinite(n) ? Math.trunc(n) : null;
+  }
+  if (value && typeof value === "object" && "value" in value) {
+    return optionalInt((value as { value: unknown }).value);
+  }
+  return null;
 }
 
 function isNotNull<T>(value: T | null): value is T {
-	return value !== null;
+  return value !== null;
 }
 
 /**
@@ -872,8 +917,11 @@ function isNotNull<T>(value: T | null): value is T {
  * present, just the table name otherwise. Used by the CubeCard
  * header.
  */
-export function qualifiedTable(schema: string | null | undefined, name: string): string {
-	return schema && schema.length > 0 ? `${schema}.${name}` : name;
+export function qualifiedTable(
+  schema: string | null | undefined,
+  name: string,
+): string {
+  return schema && schema.length > 0 ? `${schema}.${name}` : name;
 }
 
 /**
@@ -883,14 +931,14 @@ export function qualifiedTable(schema: string | null | undefined, name: string):
  * because the picker doesn't need sample values, cardinality, etc.
  */
 export interface ProfileTableSummary {
-	schema: string | null;
-	name: string;
-	columns: ProfileColumnSummary[];
+  schema: string | null;
+  name: string;
+  columns: ProfileColumnSummary[];
 }
 
 export interface ProfileColumnSummary {
-	name: string;
-	sqlType: string;
+  name: string;
+  sqlType: string;
 }
 
 /**
@@ -899,66 +947,72 @@ export interface ProfileColumnSummary {
  * array on any shape mismatch — picker falls back to "no tables
  * available" UI.
  */
-export function parseProfileTables(rawJson: string | null | undefined): ProfileTableSummary[] {
-	if (!rawJson || rawJson.trim().length === 0) return [];
-	let parsed: unknown;
-	try {
-		parsed = JSON.parse(rawJson);
-	} catch {
-		return [];
-	}
-	if (!parsed || typeof parsed !== 'object') return [];
-	// Two response shapes in the wild:
-	//   (a) bare SchemaProfile — `{tables: [...]}` (what the manual +page.server
-	//       extracts via `body.profile` before stringifying).
-	//   (b) the wrapped envelope the gateway returns from
-	//       `POST /me/inference/profile/connection/{id}` after #448 added
-	//       cube-library matches: `{profile: {tables: [...]}, connection, libraryMatches}`.
-	// Callers that pass the raw fetch body land on (b); accept either so a
-	// missed unwrap on the caller side doesn't silently zero the table list.
-	const top = parsed as { tables?: unknown; profile?: unknown };
-	let tablesRaw: unknown = top.tables;
-	if (!Array.isArray(tablesRaw) && top.profile && typeof top.profile === 'object') {
-		tablesRaw = (top.profile as { tables?: unknown }).tables;
-	}
-	if (!Array.isArray(tablesRaw)) {
-		// Shape drift early-warning — non-trivial JSON came in but neither
-		// `tables` nor `profile.tables` exists. Next time the gateway
-		// changes the envelope, this fires in the browser console (and
-		// the SSR dashboard container log) the moment the page loads,
-		// instead of a silent "0 tables" mystery.
-		if (rawJson.length > 16) {
-			const keys = Object.keys(top).slice(0, 8).join(',');
+export function parseProfileTables(
+  rawJson: string | null | undefined,
+): ProfileTableSummary[] {
+  if (!rawJson || rawJson.trim().length === 0) return [];
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(rawJson);
+  } catch {
+    return [];
+  }
+  if (!parsed || typeof parsed !== "object") return [];
+  // Two response shapes in the wild:
+  //   (a) bare SchemaProfile — `{tables: [...]}` (what the manual +page.server
+  //       extracts via `body.profile` before stringifying).
+  //   (b) the wrapped envelope the gateway returns from
+  //       `POST /me/inference/profile/connection/{id}` after #448 added
+  //       cube-library matches: `{profile: {tables: [...]}, connection, libraryMatches}`.
+  // Callers that pass the raw fetch body land on (b); accept either so a
+  // missed unwrap on the caller side doesn't silently zero the table list.
+  const top = parsed as { tables?: unknown; profile?: unknown };
+  let tablesRaw: unknown = top.tables;
+  if (
+    !Array.isArray(tablesRaw) &&
+    top.profile &&
+    typeof top.profile === "object"
+  ) {
+    tablesRaw = (top.profile as { tables?: unknown }).tables;
+  }
+  if (!Array.isArray(tablesRaw)) {
+    // Shape drift early-warning — non-trivial JSON came in but neither
+    // `tables` nor `profile.tables` exists. Next time the gateway
+    // changes the envelope, this fires in the browser console (and
+    // the SSR dashboard container log) the moment the page loads,
+    // instead of a silent "0 tables" mystery.
+    if (rawJson.length > 16) {
+      const keys = Object.keys(top).slice(0, 8).join(",");
 
-			console.warn(
-				`[parseProfileTables] non-empty input (${rawJson.length} chars) ` +
-					`produced 0 tables — expected \`tables\` or \`profile.tables\`, ` +
-					`got keys=[${keys}]`
-			);
-		}
-		return [];
-	}
-	const out: ProfileTableSummary[] = [];
-	for (const t of tablesRaw) {
-		if (!t || typeof t !== 'object') continue;
-		const r = t as Record<string, unknown>;
-		if (typeof r.name !== 'string') continue;
-		const colsRaw = Array.isArray(r.columns) ? r.columns : [];
-		const columns: ProfileColumnSummary[] = [];
-		for (const c of colsRaw) {
-			if (!c || typeof c !== 'object') continue;
-			const cr = c as Record<string, unknown>;
-			if (typeof cr.name !== 'string') continue;
-			columns.push({
-				name: cr.name,
-				sqlType: typeof cr.sqlType === 'string' ? cr.sqlType : 'unknown'
-			});
-		}
-		out.push({
-			schema: typeof r.schema === 'string' ? r.schema : null,
-			name: r.name,
-			columns
-		});
-	}
-	return out;
+      console.warn(
+        `[parseProfileTables] non-empty input (${rawJson.length} chars) ` +
+          `produced 0 tables — expected \`tables\` or \`profile.tables\`, ` +
+          `got keys=[${keys}]`,
+      );
+    }
+    return [];
+  }
+  const out: ProfileTableSummary[] = [];
+  for (const t of tablesRaw) {
+    if (!t || typeof t !== "object") continue;
+    const r = t as Record<string, unknown>;
+    if (typeof r.name !== "string") continue;
+    const colsRaw = Array.isArray(r.columns) ? r.columns : [];
+    const columns: ProfileColumnSummary[] = [];
+    for (const c of colsRaw) {
+      if (!c || typeof c !== "object") continue;
+      const cr = c as Record<string, unknown>;
+      if (typeof cr.name !== "string") continue;
+      columns.push({
+        name: cr.name,
+        sqlType: typeof cr.sqlType === "string" ? cr.sqlType : "unknown",
+      });
+    }
+    out.push({
+      schema: typeof r.schema === "string" ? r.schema : null,
+      name: r.name,
+      columns,
+    });
+  }
+  return out;
 }

--- a/saiku-ui/src/lib/cube-designer/profile-types.ts
+++ b/saiku-ui/src/lib/cube-designer/profile-types.ts
@@ -1,0 +1,964 @@
+/**
+ * Dashboard-side mirror of the gateway's SchemaProposal IR shape
+ * (saiku-cloud#444 — visual cube-card editor).
+ *
+ * Mirrors `bi.saiku.cloud.gateway.inference.SchemaProposal` and its
+ * nested records. Keep this in sync when the IR evolves — see
+ * `docs/decisions/ai-inference-emitter-shape.md` for the canonical
+ * contract.
+ */
+
+export interface SchemaProposal {
+	schemaName: string;
+	cubes: CubeProposal[];
+	/**
+	 * Composite cubes that draw from multiple base cubes.
+	 * Saiku-mondrian 4.8.x reads the M3-style {@code <VirtualCube>}
+	 * element directly. Added 2026-05-28 (#646).
+	 */
+	virtualCubes?: VirtualCubeProposal[];
+	/**
+	 * Schema-scope MDX named sets. Mondrian 4 hardens against
+	 * schema-scope; cube-scope is the canonical place. Round-trip only.
+	 */
+	namedSets?: NamedSetProposal[];
+	/**
+	 * Mondrian schema-scope access-control roles.
+	 */
+	roles?: RoleProposal[];
+}
+
+export interface CubeProposal {
+	name: string;
+	factTableSchema: string | null;
+	factTableName: string;
+	caption?: string | null;
+	description?: string | null;
+	dimensions: DimensionProposal[];
+	measures: MeasureProposal[];
+	/**
+	 * Calculated members (Mondrian `<CalculatedMember dimension="Measures" formula="..."/>`).
+	 * Composed measures expressed as MDX formulas — `[Measures].[Profit] = [Measures].[Revenue] - [Measures].[Cost]`.
+	 * Optional — back-compat with pre-#646 IR shapes. Added 2026-05-28.
+	 */
+	calculatedMembers?: CalculatedMemberProposal[];
+	/**
+	 * Cube-scope MDX named sets. Mondrian 4 hardens cube-scope, so
+	 * this is the canonical place. Added 2026-05-28.
+	 */
+	namedSets?: NamedSetProposal[];
+	/**
+	 * Declarative time-intelligence (Mondrian 4 `<TimeCalc>`). Desugars
+	 * at engine load-time into calculated members on `[Measures]`. Optional
+	 * — back-compat with pre-#112 IR shapes. Added 2026-06-09.
+	 */
+	timeCalcs?: TimeCalcProposal[];
+	/**
+	 * Declarative currency/unit conversions (Mondrian 4
+	 * `<CurrencyConversion>`). A measure-group-level construct producing a
+	 * converted measure `SUM(measure × rate)` via an as-of rate-table band
+	 * join. The gateway IR has no measure-group node, so these attach to the
+	 * cube. Optional — back-compat with pre-#112-phase-3 IR shapes. Added
+	 * 2026-06-09.
+	 */
+	currencyConversions?: CurrencyConversionProposal[];
+}
+
+/**
+ * Declarative currency conversion (Mondrian 4 `<CurrencyConversion>`,
+ * saiku-cloud#112 phase 3). Every field except `formatString` is
+ * required (the gateway IR rejects a blank).
+ */
+export interface CurrencyConversionProposal {
+	name: string;
+	measure: string;
+	rateTable: string;
+	rateColumn: string;
+	rateType: string;
+	rateTypeColumn: string;
+	factCurrencyColumn: string;
+	rateCurrencyColumn: string;
+	factDateColumn: string;
+	rateValidFromColumn: string;
+	rateValidToColumn: string;
+	formatString?: string | null;
+}
+
+/**
+ * Declarative time-intelligence metric (Mondrian 4 `<TimeCalc>`,
+ * saiku-cloud#112). `window` + `function` are only meaningful for
+ * `type === 'rolling'` (the gateway IR drops them otherwise).
+ */
+export interface TimeCalcProposal {
+	name: string;
+	type: string;
+	measure: string;
+	timeDimension?: string | null;
+	window?: number | null;
+	function?: string | null;
+	formatString?: string | null;
+}
+
+export const VALID_TIME_CALC_TYPES = ['yoy', 'pop', 'ytd', 'rolling'] as const;
+
+export type TimeCalcType = (typeof VALID_TIME_CALC_TYPES)[number];
+
+export const VALID_TIME_CALC_FUNCTIONS = ['sum', 'avg'] as const;
+
+export type TimeCalcFunction = (typeof VALID_TIME_CALC_FUNCTIONS)[number];
+
+/**
+ * Mondrian 4 access levels for Role / SchemaGrant / CubeGrant /
+ * DimensionGrant / HierarchyGrant / MemberGrant.
+ */
+export const VALID_ACCESS_LEVELS = ['all', 'none', 'custom', 'all_dimensions'] as const;
+
+export type AccessLevel = (typeof VALID_ACCESS_LEVELS)[number];
+
+/**
+ * Mondrian 4 hierarchy rollup policy — controls how the engine
+ * aggregates restricted hierarchies during query rollup.
+ */
+export const VALID_ROLLUP_POLICIES = ['full', 'partial', 'hidden'] as const;
+
+export type RollupPolicy = (typeof VALID_ROLLUP_POLICIES)[number];
+
+export interface NamedSetProposal {
+	name: string;
+	formula: string;
+	description?: string | null;
+}
+
+/**
+ * Mondrian 4 virtual cube (emitted as `<Cube>` with `<MeasureGroups>`
+ * per the M4 schema docs). The IR keeps the M3-style record shape
+ * for editor convenience; the gateway emits M4 syntax.
+ */
+export interface VirtualCubeProposal {
+	name: string;
+	defaultMeasure?: string | null;
+	cubeUsages?: CubeUsageProposal[];
+	dimensions: VirtualCubeDimensionProposal[];
+	measures: VirtualCubeMeasureProposal[];
+	calculatedMembers?: CalculatedMemberProposal[];
+	namedSets?: NamedSetProposal[];
+	caption?: string | null;
+	description?: string | null;
+}
+
+export interface CubeUsageProposal {
+	cubeName: string;
+	ignoreUnrelatedDimensions: boolean;
+}
+
+export interface VirtualCubeDimensionProposal {
+	name: string;
+	/** Source base cube (M4 `source="..."`). Null = shared dimension. */
+	cubeName?: string | null;
+	caption?: string | null;
+	description?: string | null;
+}
+
+export interface VirtualCubeMeasureProposal {
+	/** Fully-qualified MDX measure reference: `[Measures].[Foo]`. */
+	name: string;
+	cubeName: string;
+	visible: boolean;
+}
+
+export interface RoleProposal {
+	name: string;
+	schemaGrant: SchemaGrantProposal;
+	description?: string | null;
+}
+
+export interface SchemaGrantProposal {
+	access: string;
+	cubeGrants?: CubeGrantProposal[];
+}
+
+export interface CubeGrantProposal {
+	cube: string;
+	access: string;
+	dimensionGrants?: DimensionGrantProposal[];
+	hierarchyGrants?: HierarchyGrantProposal[];
+}
+
+export interface DimensionGrantProposal {
+	dimension: string;
+	access: string;
+}
+
+export interface HierarchyGrantProposal {
+	hierarchy: string;
+	access: string;
+	topLevel?: string | null;
+	bottomLevel?: string | null;
+	rollupPolicy?: string | null;
+	memberGrants?: MemberGrantProposal[];
+}
+
+export interface MemberGrantProposal {
+	member: string;
+	access: string;
+}
+
+export interface DimensionProposal {
+	name: string;
+	foreignKey: string;
+	tableSchema: string | null;
+	tableName: string;
+	primaryKey: string;
+	/**
+	 * Top-level levels — the legacy single-hierarchy shape. When
+	 * `hierarchies` is non-empty the emitter uses that and these are
+	 * ignored; otherwise the emitter wraps these in a default
+	 * anonymous hierarchy.
+	 */
+	levels: LevelProposal[];
+	/**
+	 * Multi-hierarchy support (Mondrian `<Hierarchy>` children). Optional
+	 * — the typical cube has a single hierarchy and the LLM proposer
+	 * emits everything via `levels` for back-compat. Added 2026-05-28.
+	 */
+	hierarchies?: HierarchyProposal[];
+	/**
+	 * Mondrian-4 derived Tier (binning) attributes (saiku-cloud#108). Each
+	 * hangs off an `<Attribute hasHierarchy="true"><Tier>` in the M4 model.
+	 * Optional — only present on dimensions that bucket a numeric column.
+	 */
+	tiers?: TierProposal[];
+	/**
+	 * Mondrian-4 derived Duration attributes (saiku-cloud#108). Each hangs
+	 * off an `<Attribute hasHierarchy="true"><Duration>` in the M4 model.
+	 * Optional — only present on dimensions with a date-pair column.
+	 */
+	durations?: DurationProposal[];
+}
+
+/**
+ * Mondrian-4 Tier (binning) derived attribute (saiku-cloud#108). Buckets a
+ * numeric column into labelled bins by ascending boundary. The FINAL bin
+ * omits its boundary (catch-all for everything above the last boundary).
+ */
+export interface TierProposal {
+	name: string;
+	column: string;
+	bins: BinProposal[];
+}
+
+/**
+ * One bin within a {@link TierProposal}. `boundary` (a numeric upper bound
+ * carried as a string) is omitted ONLY on the final catch-all bin; `label`
+ * is always required.
+ */
+export interface BinProposal {
+	boundary?: string | null;
+	label: string;
+}
+
+/**
+ * Mondrian-4 Duration derived attribute (saiku-cloud#108). Computes the
+ * elapsed time between two date columns at a chosen unit.
+ */
+export interface DurationProposal {
+	name: string;
+	startColumn: string;
+	endColumn: string;
+	unit: string;
+}
+
+/** Mondrian-4 duration units (coarsest → finest). */
+export const VALID_DURATION_UNITS = ['YEAR', 'QUARTER', 'MONTH', 'WEEK', 'DAY'] as const;
+
+export type DurationUnit = (typeof VALID_DURATION_UNITS)[number];
+
+export interface HierarchyProposal {
+	name?: string | null;
+	hasAll: boolean;
+	allMemberName?: string | null;
+	primaryKey: string;
+	tableSchema?: string | null;
+	tableName?: string | null;
+	levels: LevelProposal[];
+}
+
+export interface LevelProposal {
+	name: string;
+	column: string;
+	nameColumn?: string | null;
+	captionColumn?: string | null;
+	ordinalColumn?: string | null;
+	type: string;
+	uniqueMembers: boolean;
+	levelType?: string | null;
+	description?: string | null;
+	/**
+	 * Member properties (Mondrian `<Property>` children). Surface as
+	 * `[Dim].CurrentMember.Properties("name")` in MDX. Added 2026-05-28.
+	 */
+	properties?: PropertyProposal[];
+	annotations?: Record<string, string[]>;
+}
+
+export interface PropertyProposal {
+	name: string;
+	column: string;
+	type?: string | null;
+	description?: string | null;
+}
+
+export interface MeasureProposal {
+	name: string;
+	column: string;
+	aggregator: string;
+	/**
+	 * Integer 0–100, only meaningful when `aggregator === 'percentile'`
+	 * (median is the implicit 50th percentile and carries no value).
+	 * Mondrian-4 non-additive leaf aggregators (saiku-cloud#104).
+	 */
+	percentile?: number | null;
+	formatString?: string | null;
+	description?: string | null;
+	annotations?: Record<string, string[]>;
+}
+
+export interface CalculatedMemberProposal {
+	name: string;
+	formula: string;
+	formatString?: string | null;
+	description?: string | null;
+}
+
+export const VALID_AGGREGATORS = [
+	'sum',
+	'count',
+	'avg',
+	'min',
+	'max',
+	'distinct-count',
+	'median',
+	'percentile'
+] as const;
+
+export type Aggregator = (typeof VALID_AGGREGATORS)[number];
+
+/**
+ * Mondrian Level `type` attribute. Drives JDBC value parsing
+ * (member.getKey() coercion + ordinal comparisons). The Mondrian DTD
+ * accepts a wider set, but these are the ones our XML emitter knows
+ * how to round-trip and the ones surfaced in the level editor.
+ */
+export const VALID_LEVEL_TYPES = [
+	'String',
+	'Numeric',
+	'Integer',
+	'Boolean',
+	'Date',
+	'Time',
+	'Timestamp'
+] as const;
+
+export type LevelType = (typeof VALID_LEVEL_TYPES)[number];
+
+/**
+ * Mondrian Level `levelType` attribute. Time-* values tell Mondrian
+ * which time grain a level represents — this drives the time-related
+ * MDX functions (PARALLELPERIOD, OPENINGPERIOD, etc.). `Regular` is
+ * the default for non-time hierarchies.
+ */
+export const VALID_LEVEL_LEVELTYPES = [
+	'Regular',
+	'TimeYears',
+	'TimeQuarters',
+	'TimeMonths',
+	'TimeWeeks',
+	'TimeDays',
+	'TimeHours',
+	'TimeMinutes',
+	'TimeSeconds'
+] as const;
+
+export type LevelLevelType = (typeof VALID_LEVEL_LEVELTYPES)[number];
+
+/**
+ * Best-effort parse of a proposal JSON string. Returns null on any
+ * shape mismatch — the caller can fall back to the raw-JSON view in
+ * that case rather than crashing the page. We accept Optional-ish
+ * fields (gateway emits `null` or omits, dashboard reads either).
+ */
+export function parseProposal(raw: unknown): SchemaProposal | null {
+	if (!raw || typeof raw !== 'object') return null;
+	const r = raw as Record<string, unknown>;
+	const schemaName = typeof r.schemaName === 'string' ? r.schemaName : null;
+	const cubesRaw = Array.isArray(r.cubes) ? r.cubes : null;
+	if (!schemaName || !cubesRaw) return null;
+	const cubes: CubeProposal[] = [];
+	for (const c of cubesRaw) {
+		const cube = parseCube(c);
+		if (!cube) return null;
+		cubes.push(cube);
+	}
+	const virtualCubes = Array.isArray(r.virtualCubes)
+		? r.virtualCubes.map(parseVirtualCube).filter(isNotNull)
+		: [];
+	const namedSets = Array.isArray(r.namedSets)
+		? r.namedSets.map(parseNamedSet).filter(isNotNull)
+		: [];
+	const roles = Array.isArray(r.roles) ? r.roles.map(parseRole).filter(isNotNull) : [];
+	if (cubes.length === 0) return null;
+	return {
+		schemaName,
+		cubes,
+		virtualCubes: virtualCubes.length > 0 ? virtualCubes : undefined,
+		namedSets: namedSets.length > 0 ? namedSets : undefined,
+		roles: roles.length > 0 ? roles : undefined
+	};
+}
+
+function parseCube(raw: unknown): CubeProposal | null {
+	if (!raw || typeof raw !== 'object') return null;
+	const r = raw as Record<string, unknown>;
+	if (typeof r.name !== 'string' || typeof r.factTableName !== 'string') return null;
+	const measures = Array.isArray(r.measures) ? r.measures.map(parseMeasure).filter(isNotNull) : [];
+	const dimensions = Array.isArray(r.dimensions)
+		? r.dimensions.map(parseDimension).filter(isNotNull)
+		: [];
+	const calculatedMembers = Array.isArray(r.calculatedMembers)
+		? r.calculatedMembers.map(parseCalculatedMember).filter(isNotNull)
+		: [];
+	const namedSets = Array.isArray(r.namedSets)
+		? r.namedSets.map(parseNamedSet).filter(isNotNull)
+		: [];
+	const timeCalcs = Array.isArray(r.timeCalcs)
+		? r.timeCalcs.map(parseTimeCalc).filter(isNotNull)
+		: [];
+	const currencyConversions = Array.isArray(r.currencyConversions)
+		? r.currencyConversions.map(parseCurrencyConversion).filter(isNotNull)
+		: [];
+	return {
+		name: r.name,
+		factTableSchema: typeof r.factTableSchema === 'string' ? r.factTableSchema : null,
+		factTableName: r.factTableName,
+		caption: optionalString(r.caption),
+		description: optionalString(r.description),
+		dimensions,
+		measures,
+		calculatedMembers,
+		namedSets: namedSets.length > 0 ? namedSets : undefined,
+		timeCalcs: timeCalcs.length > 0 ? timeCalcs : undefined,
+		currencyConversions: currencyConversions.length > 0 ? currencyConversions : undefined
+	};
+}
+
+/**
+ * Parse a single currency-conversion IR node. Returns null on a shape
+ * mismatch (the caller filters nulls out). Every field except
+ * `formatString` is required, mirroring the gateway IR.
+ */
+export function parseCurrencyConversion(raw: unknown): CurrencyConversionProposal | null {
+	if (!raw || typeof raw !== 'object') return null;
+	const r = raw as Record<string, unknown>;
+	const required = [
+		'name',
+		'measure',
+		'rateTable',
+		'rateColumn',
+		'rateType',
+		'rateTypeColumn',
+		'factCurrencyColumn',
+		'rateCurrencyColumn',
+		'factDateColumn',
+		'rateValidFromColumn',
+		'rateValidToColumn'
+	] as const;
+	for (const key of required) {
+		if (typeof r[key] !== 'string' || (r[key] as string).length === 0) return null;
+	}
+	return {
+		name: r.name as string,
+		measure: r.measure as string,
+		rateTable: r.rateTable as string,
+		rateColumn: r.rateColumn as string,
+		rateType: r.rateType as string,
+		rateTypeColumn: r.rateTypeColumn as string,
+		factCurrencyColumn: r.factCurrencyColumn as string,
+		rateCurrencyColumn: r.rateCurrencyColumn as string,
+		factDateColumn: r.factDateColumn as string,
+		rateValidFromColumn: r.rateValidFromColumn as string,
+		rateValidToColumn: r.rateValidToColumn as string,
+		formatString: optionalString(r.formatString)
+	};
+}
+
+/**
+ * Parse a single time-calc IR node. Returns null on a shape mismatch
+ * (the caller filters nulls out). `window` / `function` survive only for
+ * `type === 'rolling'`, mirroring the gateway IR.
+ */
+export function parseTimeCalc(raw: unknown): TimeCalcProposal | null {
+	if (!raw || typeof raw !== 'object') return null;
+	const r = raw as Record<string, unknown>;
+	if (typeof r.name !== 'string' || typeof r.type !== 'string' || typeof r.measure !== 'string')
+		return null;
+	const isRolling = r.type === 'rolling';
+	return {
+		name: r.name,
+		type: r.type,
+		measure: r.measure,
+		timeDimension: optionalString(r.timeDimension),
+		window: isRolling ? optionalInt(r.window) : null,
+		function: isRolling ? optionalString(r.function) : null,
+		formatString: optionalString(r.formatString)
+	};
+}
+
+function parseNamedSet(raw: unknown): NamedSetProposal | null {
+	if (!raw || typeof raw !== 'object') return null;
+	const r = raw as Record<string, unknown>;
+	if (typeof r.name !== 'string' || typeof r.formula !== 'string') return null;
+	return {
+		name: r.name,
+		formula: r.formula,
+		description: optionalString(r.description)
+	};
+}
+
+function parseVirtualCube(raw: unknown): VirtualCubeProposal | null {
+	if (!raw || typeof raw !== 'object') return null;
+	const r = raw as Record<string, unknown>;
+	if (typeof r.name !== 'string') return null;
+	const cubeUsages = Array.isArray(r.cubeUsages)
+		? r.cubeUsages
+				.map((u) => {
+					if (!u || typeof u !== 'object') return null;
+					const ur = u as Record<string, unknown>;
+					if (typeof ur.cubeName !== 'string') return null;
+					return {
+						cubeName: ur.cubeName,
+						ignoreUnrelatedDimensions: ur.ignoreUnrelatedDimensions !== false
+					};
+				})
+				.filter(isNotNull)
+		: [];
+	const dimensions: VirtualCubeDimensionProposal[] = Array.isArray(r.dimensions)
+		? r.dimensions
+				.map((d) => {
+					if (!d || typeof d !== 'object') return null;
+					const dr = d as Record<string, unknown>;
+					if (typeof dr.name !== 'string') return null;
+					return {
+						name: dr.name,
+						cubeName: optionalString(dr.cubeName),
+						caption: optionalString(dr.caption),
+						description: optionalString(dr.description)
+					};
+				})
+				.filter(isNotNull)
+		: [];
+	const measures: VirtualCubeMeasureProposal[] = Array.isArray(r.measures)
+		? r.measures
+				.map((m) => {
+					if (!m || typeof m !== 'object') return null;
+					const mr = m as Record<string, unknown>;
+					if (typeof mr.name !== 'string' || typeof mr.cubeName !== 'string') return null;
+					return { name: mr.name, cubeName: mr.cubeName, visible: mr.visible !== false };
+				})
+				.filter(isNotNull)
+		: [];
+	const calculatedMembers = Array.isArray(r.calculatedMembers)
+		? r.calculatedMembers.map(parseCalculatedMember).filter(isNotNull)
+		: [];
+	const namedSets = Array.isArray(r.namedSets)
+		? r.namedSets.map(parseNamedSet).filter(isNotNull)
+		: [];
+	return {
+		name: r.name,
+		defaultMeasure: optionalString(r.defaultMeasure),
+		cubeUsages: cubeUsages.length > 0 ? cubeUsages : undefined,
+		dimensions,
+		measures,
+		calculatedMembers: calculatedMembers.length > 0 ? calculatedMembers : undefined,
+		namedSets: namedSets.length > 0 ? namedSets : undefined,
+		caption: optionalString(r.caption),
+		description: optionalString(r.description)
+	};
+}
+
+function parseRole(raw: unknown): RoleProposal | null {
+	if (!raw || typeof raw !== 'object') return null;
+	const r = raw as Record<string, unknown>;
+	if (typeof r.name !== 'string') return null;
+	const sg = parseSchemaGrant(r.schemaGrant);
+	if (!sg) return null;
+	return {
+		name: r.name,
+		schemaGrant: sg,
+		description: optionalString(r.description)
+	};
+}
+
+function parseSchemaGrant(raw: unknown): SchemaGrantProposal | null {
+	if (!raw || typeof raw !== 'object') return null;
+	const r = raw as Record<string, unknown>;
+	if (typeof r.access !== 'string') return null;
+	const cubeGrants = Array.isArray(r.cubeGrants)
+		? r.cubeGrants.map(parseCubeGrant).filter(isNotNull)
+		: [];
+	return { access: r.access, cubeGrants: cubeGrants.length > 0 ? cubeGrants : undefined };
+}
+
+function parseCubeGrant(raw: unknown): CubeGrantProposal | null {
+	if (!raw || typeof raw !== 'object') return null;
+	const r = raw as Record<string, unknown>;
+	if (typeof r.cube !== 'string' || typeof r.access !== 'string') return null;
+	const dimensionGrants = Array.isArray(r.dimensionGrants)
+		? r.dimensionGrants
+				.map((d) => {
+					if (!d || typeof d !== 'object') return null;
+					const dr = d as Record<string, unknown>;
+					if (typeof dr.dimension !== 'string' || typeof dr.access !== 'string') return null;
+					return { dimension: dr.dimension, access: dr.access };
+				})
+				.filter(isNotNull)
+		: [];
+	const hierarchyGrants = Array.isArray(r.hierarchyGrants)
+		? r.hierarchyGrants.map(parseHierarchyGrant).filter(isNotNull)
+		: [];
+	return {
+		cube: r.cube,
+		access: r.access,
+		dimensionGrants: dimensionGrants.length > 0 ? dimensionGrants : undefined,
+		hierarchyGrants: hierarchyGrants.length > 0 ? hierarchyGrants : undefined
+	};
+}
+
+function parseHierarchyGrant(raw: unknown): HierarchyGrantProposal | null {
+	if (!raw || typeof raw !== 'object') return null;
+	const r = raw as Record<string, unknown>;
+	if (typeof r.hierarchy !== 'string' || typeof r.access !== 'string') return null;
+	const memberGrants = Array.isArray(r.memberGrants)
+		? r.memberGrants
+				.map((m) => {
+					if (!m || typeof m !== 'object') return null;
+					const mr = m as Record<string, unknown>;
+					if (typeof mr.member !== 'string' || typeof mr.access !== 'string') return null;
+					return { member: mr.member, access: mr.access };
+				})
+				.filter(isNotNull)
+		: [];
+	return {
+		hierarchy: r.hierarchy,
+		access: r.access,
+		topLevel: optionalString(r.topLevel),
+		bottomLevel: optionalString(r.bottomLevel),
+		rollupPolicy: optionalString(r.rollupPolicy),
+		memberGrants: memberGrants.length > 0 ? memberGrants : undefined
+	};
+}
+
+function parseCalculatedMember(raw: unknown): CalculatedMemberProposal | null {
+	if (!raw || typeof raw !== 'object') return null;
+	const r = raw as Record<string, unknown>;
+	if (typeof r.name !== 'string' || typeof r.formula !== 'string') return null;
+	return {
+		name: r.name,
+		formula: r.formula,
+		formatString: optionalString(r.formatString),
+		description: optionalString(r.description)
+	};
+}
+
+function parseMeasure(raw: unknown): MeasureProposal | null {
+	if (!raw || typeof raw !== 'object') return null;
+	const r = raw as Record<string, unknown>;
+	if (
+		typeof r.name !== 'string' ||
+		typeof r.column !== 'string' ||
+		typeof r.aggregator !== 'string'
+	)
+		return null;
+	return {
+		name: r.name,
+		column: r.column,
+		aggregator: r.aggregator,
+		percentile: r.aggregator === 'percentile' ? optionalInt(r.percentile) : null,
+		formatString: optionalString(r.formatString),
+		description: optionalString(r.description),
+		annotations: parseAnnotations(r.annotations)
+	};
+}
+
+function parseDimension(raw: unknown): DimensionProposal | null {
+	if (!raw || typeof raw !== 'object') return null;
+	const r = raw as Record<string, unknown>;
+	if (
+		typeof r.name !== 'string' ||
+		typeof r.foreignKey !== 'string' ||
+		typeof r.tableName !== 'string' ||
+		typeof r.primaryKey !== 'string'
+	)
+		return null;
+	const levels = Array.isArray(r.levels) ? r.levels.map(parseLevel).filter(isNotNull) : [];
+	const hierarchies = Array.isArray(r.hierarchies)
+		? r.hierarchies.map(parseHierarchy).filter(isNotNull)
+		: [];
+	const tiers = Array.isArray(r.tiers) ? r.tiers.map(parseTier).filter(isNotNull) : [];
+	const durations = Array.isArray(r.durations)
+		? r.durations.map(parseDuration).filter(isNotNull)
+		: [];
+	// A dimension must surface something queryable: levels, hierarchies, OR
+	// Mondrian-4 derived attributes (tiers/durations — the degenerate-on-fact
+	// Bank "Account" shape, saiku-cloud#108).
+	if (
+		levels.length === 0 &&
+		hierarchies.length === 0 &&
+		tiers.length === 0 &&
+		durations.length === 0
+	)
+		return null;
+	return {
+		name: r.name,
+		foreignKey: r.foreignKey,
+		tableSchema: typeof r.tableSchema === 'string' ? r.tableSchema : null,
+		tableName: r.tableName,
+		primaryKey: r.primaryKey,
+		levels,
+		hierarchies: hierarchies.length > 0 ? hierarchies : undefined,
+		tiers: tiers.length > 0 ? tiers : undefined,
+		durations: durations.length > 0 ? durations : undefined
+	};
+}
+
+/**
+ * Parse a single Tier IR node. Returns null on a shape mismatch. Mirrors
+ * the gateway IR: every bin needs a label; only the final bin may omit its
+ * boundary.
+ */
+export function parseTier(raw: unknown): TierProposal | null {
+	if (!raw || typeof raw !== 'object') return null;
+	const r = raw as Record<string, unknown>;
+	if (typeof r.name !== 'string' || typeof r.column !== 'string') return null;
+	if (!Array.isArray(r.bins) || r.bins.length === 0) return null;
+	const bins: BinProposal[] = [];
+	for (const b of r.bins) {
+		if (!b || typeof b !== 'object') return null;
+		const br = b as Record<string, unknown>;
+		if (typeof br.label !== 'string' || br.label.length === 0) return null;
+		bins.push({ boundary: optionalString(br.boundary), label: br.label });
+	}
+	// Only the final bin may omit its boundary.
+	for (let i = 0; i < bins.length - 1; i++) {
+		if (!bins[i].boundary) return null;
+	}
+	return { name: r.name, column: r.column, bins };
+}
+
+/** Parse a single Duration IR node. Returns null on a shape mismatch. */
+export function parseDuration(raw: unknown): DurationProposal | null {
+	if (!raw || typeof raw !== 'object') return null;
+	const r = raw as Record<string, unknown>;
+	if (
+		typeof r.name !== 'string' ||
+		typeof r.startColumn !== 'string' ||
+		typeof r.endColumn !== 'string' ||
+		typeof r.unit !== 'string'
+	)
+		return null;
+	return {
+		name: r.name,
+		startColumn: r.startColumn,
+		endColumn: r.endColumn,
+		unit: r.unit
+	};
+}
+
+function parseHierarchy(raw: unknown): HierarchyProposal | null {
+	if (!raw || typeof raw !== 'object') return null;
+	const r = raw as Record<string, unknown>;
+	if (typeof r.primaryKey !== 'string') return null;
+	const levels = Array.isArray(r.levels) ? r.levels.map(parseLevel).filter(isNotNull) : [];
+	if (levels.length === 0) return null;
+	return {
+		name: optionalString(r.name),
+		hasAll: r.hasAll === false ? false : true, // default true
+		allMemberName: optionalString(r.allMemberName),
+		primaryKey: r.primaryKey,
+		tableSchema: optionalString(r.tableSchema),
+		tableName: optionalString(r.tableName),
+		levels
+	};
+}
+
+function parseLevel(raw: unknown): LevelProposal | null {
+	if (!raw || typeof raw !== 'object') return null;
+	const r = raw as Record<string, unknown>;
+	if (typeof r.name !== 'string' || typeof r.column !== 'string') return null;
+	const properties = Array.isArray(r.properties)
+		? r.properties.map(parseProperty).filter(isNotNull)
+		: [];
+	return {
+		name: r.name,
+		column: r.column,
+		nameColumn: optionalString(r.nameColumn),
+		captionColumn: optionalString(r.captionColumn),
+		ordinalColumn: optionalString(r.ordinalColumn),
+		type: typeof r.type === 'string' ? r.type : 'String',
+		uniqueMembers: !!r.uniqueMembers,
+		levelType: optionalString(r.levelType),
+		description: optionalString(r.description),
+		properties: properties.length > 0 ? properties : undefined,
+		annotations: parseAnnotations(r.annotations)
+	};
+}
+
+function parseProperty(raw: unknown): PropertyProposal | null {
+	if (!raw || typeof raw !== 'object') return null;
+	const r = raw as Record<string, unknown>;
+	if (typeof r.name !== 'string' || typeof r.column !== 'string') return null;
+	return {
+		name: r.name,
+		column: r.column,
+		type: optionalString(r.type),
+		description: optionalString(r.description)
+	};
+}
+
+function parseAnnotations(raw: unknown): Record<string, string[]> | undefined {
+	if (!raw || typeof raw !== 'object') return undefined;
+	const out: Record<string, string[]> = {};
+	for (const [k, v] of Object.entries(raw as Record<string, unknown>)) {
+		if (!Array.isArray(v)) continue;
+		const stringValues = v.filter((x): x is string => typeof x === 'string');
+		if (stringValues.length === 0) continue;
+		out[k] = stringValues;
+	}
+	return Object.keys(out).length > 0 ? out : undefined;
+}
+
+function optionalString(value: unknown): string | null {
+	if (typeof value === 'string') return value;
+	if (value && typeof value === 'object' && 'value' in value) {
+		const v = (value as { value: unknown }).value;
+		return typeof v === 'string' ? v : null;
+	}
+	return null;
+}
+
+/**
+ * Best-effort parse of an optional integer. Accepts a bare number, a
+ * numeric string, or the gateway's serialised `Optional` shape
+ * (`{ value: N }`). Returns null on anything else (mirrors how the IR
+ * drops a missing/irrelevant percentile).
+ */
+function optionalInt(value: unknown): number | null {
+	if (typeof value === 'number' && Number.isFinite(value)) return Math.trunc(value);
+	if (typeof value === 'string' && value.trim() !== '') {
+		const n = Number(value);
+		return Number.isFinite(n) ? Math.trunc(n) : null;
+	}
+	if (value && typeof value === 'object' && 'value' in value) {
+		return optionalInt((value as { value: unknown }).value);
+	}
+	return null;
+}
+
+function isNotNull<T>(value: T | null): value is T {
+	return value !== null;
+}
+
+/**
+ * Qualified fact-table label for display: `schema.table` when both
+ * present, just the table name otherwise. Used by the CubeCard
+ * header.
+ */
+export function qualifiedTable(schema: string | null | undefined, name: string): string {
+	return schema && schema.length > 0 ? `${schema}.${name}` : name;
+}
+
+/**
+ * Dashboard-side summary of a {@code TableProfile} — only the fields
+ * the Add-Dimension table picker (saiku-cloud#449 slice 2) needs.
+ * We deliberately don't mirror the full {@code SchemaProfile} surface
+ * because the picker doesn't need sample values, cardinality, etc.
+ */
+export interface ProfileTableSummary {
+	schema: string | null;
+	name: string;
+	columns: ProfileColumnSummary[];
+}
+
+export interface ProfileColumnSummary {
+	name: string;
+	sqlType: string;
+}
+
+/**
+ * Best-effort parse of a {@code SchemaProfile} JSON string into the
+ * minimal summary the Add-Dimension picker needs. Returns an empty
+ * array on any shape mismatch — picker falls back to "no tables
+ * available" UI.
+ */
+export function parseProfileTables(rawJson: string | null | undefined): ProfileTableSummary[] {
+	if (!rawJson || rawJson.trim().length === 0) return [];
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(rawJson);
+	} catch {
+		return [];
+	}
+	if (!parsed || typeof parsed !== 'object') return [];
+	// Two response shapes in the wild:
+	//   (a) bare SchemaProfile — `{tables: [...]}` (what the manual +page.server
+	//       extracts via `body.profile` before stringifying).
+	//   (b) the wrapped envelope the gateway returns from
+	//       `POST /me/inference/profile/connection/{id}` after #448 added
+	//       cube-library matches: `{profile: {tables: [...]}, connection, libraryMatches}`.
+	// Callers that pass the raw fetch body land on (b); accept either so a
+	// missed unwrap on the caller side doesn't silently zero the table list.
+	const top = parsed as { tables?: unknown; profile?: unknown };
+	let tablesRaw: unknown = top.tables;
+	if (!Array.isArray(tablesRaw) && top.profile && typeof top.profile === 'object') {
+		tablesRaw = (top.profile as { tables?: unknown }).tables;
+	}
+	if (!Array.isArray(tablesRaw)) {
+		// Shape drift early-warning — non-trivial JSON came in but neither
+		// `tables` nor `profile.tables` exists. Next time the gateway
+		// changes the envelope, this fires in the browser console (and
+		// the SSR dashboard container log) the moment the page loads,
+		// instead of a silent "0 tables" mystery.
+		if (rawJson.length > 16) {
+			const keys = Object.keys(top).slice(0, 8).join(',');
+
+			console.warn(
+				`[parseProfileTables] non-empty input (${rawJson.length} chars) ` +
+					`produced 0 tables — expected \`tables\` or \`profile.tables\`, ` +
+					`got keys=[${keys}]`
+			);
+		}
+		return [];
+	}
+	const out: ProfileTableSummary[] = [];
+	for (const t of tablesRaw) {
+		if (!t || typeof t !== 'object') continue;
+		const r = t as Record<string, unknown>;
+		if (typeof r.name !== 'string') continue;
+		const colsRaw = Array.isArray(r.columns) ? r.columns : [];
+		const columns: ProfileColumnSummary[] = [];
+		for (const c of colsRaw) {
+			if (!c || typeof c !== 'object') continue;
+			const cr = c as Record<string, unknown>;
+			if (typeof cr.name !== 'string') continue;
+			columns.push({
+				name: cr.name,
+				sqlType: typeof cr.sqlType === 'string' ? cr.sqlType : 'unknown'
+			});
+		}
+		out.push({
+			schema: typeof r.schema === 'string' ? r.schema : null,
+			name: r.name,
+			columns
+		});
+	}
+	return out;
+}

--- a/saiku-ui/src/lib/cube-designer/state.svelte.ts
+++ b/saiku-ui/src/lib/cube-designer/state.svelte.ts
@@ -13,77 +13,79 @@
  * separate subscribe API needed.
  */
 import type {
-	SchemaCanvasState,
-	SchemaCanvasTable,
-	SchemaCanvasJoin,
-	SchemaCanvasGroup,
-	SourceTableCandidate,
-	SchemaCanvasTableRole,
-	SchemaCanvasJoinKind,
-	SchemaCanvasDimension,
-	SchemaCanvasHierarchy,
-	SchemaCanvasLevel,
-	SchemaCanvasMeasure,
-	SchemaCanvasColumnKind,
-	SchemaCanvasCube,
-	SchemaCanvasMeasureGroup,
-	SchemaCanvasDimensionLink,
-	SchemaCanvasCalc,
-	SchemaCanvasTimeCalc
-} from './types.js';
-import { suggestJoins } from './auto-suggest.js';
+  SchemaCanvasState,
+  SchemaCanvasTable,
+  SchemaCanvasJoin,
+  SchemaCanvasGroup,
+  SourceTableCandidate,
+  SchemaCanvasTableRole,
+  SchemaCanvasJoinKind,
+  SchemaCanvasDimension,
+  SchemaCanvasHierarchy,
+  SchemaCanvasLevel,
+  SchemaCanvasMeasure,
+  SchemaCanvasColumnKind,
+  SchemaCanvasCube,
+  SchemaCanvasMeasureGroup,
+  SchemaCanvasDimensionLink,
+  SchemaCanvasCalc,
+  SchemaCanvasTimeCalc,
+} from "./types.js";
+import { suggestJoins } from "./auto-suggest.js";
 
-const STORAGE_PREFIX = 'saiku.canvas.';
+const STORAGE_PREFIX = "saiku.canvas.";
 /** Legacy localStorage key the Facts & Measures workbench used to own the
  *  cube model under before it was lifted into the doc (`doc.cubes`).  Still
  *  read once on load to migrate any state authored before the refactor. */
-const LEGACY_CUBES_STORAGE_KEY = 'saiku.workbench.cubesState';
+const LEGACY_CUBES_STORAGE_KEY = "saiku.workbench.cubesState";
 /** Per-user UI preferences (NOT per-connection — survives connection
  *  switches and applies across every cube the user authors).  Kept in
  *  its own localStorage key so doc-shape changes don't risk losing
  *  preference state. */
-const PREFS_STORAGE_KEY = 'saiku.canvas.prefs';
+const PREFS_STORAGE_KEY = "saiku.canvas.prefs";
 
-type LayoutMode = 'layered' | 'star' | 'grid' | 'byJoins';
+type LayoutMode = "layered" | "star" | "grid" | "byJoins";
 
 /** Top-level surface the schema designer renders.  `'binary'` is a
  *  historical alias for `'workbench'` (single "Cube Workbench" tab
  *  that owned dims + facts) — migrated on load. */
-export type CanvasMode = 'canvas' | 'workbench' | 'facts' | 'validate';
+export type CanvasMode = "canvas" | "workbench" | "facts" | "validate";
 
 interface CanvasPrefs {
-	defaultLayoutMode?: LayoutMode;
-	/** Which view tab the user was last on — restored on next mount so
-	 *  someone who flipped to a designer tab last session lands
-	 *  back there instead of always landing on the Schema Canvas. */
-	mode?: CanvasMode | 'binary';
+  defaultLayoutMode?: LayoutMode;
+  /** Which view tab the user was last on — restored on next mount so
+   *  someone who flipped to a designer tab last session lands
+   *  back there instead of always landing on the Schema Canvas. */
+  mode?: CanvasMode | "binary";
 }
 
-function migrateMode(mode: CanvasMode | 'binary' | undefined): CanvasMode | undefined {
-	if (!mode) return undefined;
-	if (mode === 'binary') return 'workbench';
-	return mode;
+function migrateMode(
+  mode: CanvasMode | "binary" | undefined,
+): CanvasMode | undefined {
+  if (!mode) return undefined;
+  if (mode === "binary") return "workbench";
+  return mode;
 }
 
 function loadPrefsFromStorage(): CanvasPrefs {
-	if (typeof window === 'undefined') return {};
-	try {
-		const raw = window.localStorage.getItem(PREFS_STORAGE_KEY);
-		if (!raw) return {};
-		const parsed = JSON.parse(raw) as CanvasPrefs;
-		return parsed && typeof parsed === 'object' ? parsed : {};
-	} catch {
-		return {};
-	}
+  if (typeof window === "undefined") return {};
+  try {
+    const raw = window.localStorage.getItem(PREFS_STORAGE_KEY);
+    if (!raw) return {};
+    const parsed = JSON.parse(raw) as CanvasPrefs;
+    return parsed && typeof parsed === "object" ? parsed : {};
+  } catch {
+    return {};
+  }
 }
 
 function savePrefsToStorage(prefs: CanvasPrefs): void {
-	if (typeof window === 'undefined') return;
-	try {
-		window.localStorage.setItem(PREFS_STORAGE_KEY, JSON.stringify(prefs));
-	} catch {
-		/* private browsing, quota — silently ignore */
-	}
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(PREFS_STORAGE_KEY, JSON.stringify(prefs));
+  } catch {
+    /* private browsing, quota — silently ignore */
+  }
 }
 
 /** Single source of truth for "what identifies this dim's PK column?"
@@ -97,18 +99,18 @@ function savePrefsToStorage(prefs: CanvasPrefs): void {
  *  consumer through this helper and the badge / Inspector / alert stay
  *  in sync. */
 export function dimKeyIdentity(
-	dim: Pick<SchemaCanvasDimension, 'primaryKey' | 'foreignKey'>
+  dim: Pick<SchemaCanvasDimension, "primaryKey" | "foreignKey">,
 ): string | null {
-	return dim.primaryKey ?? dim.foreignKey ?? null;
+  return dim.primaryKey ?? dim.foreignKey ?? null;
 }
 
 /** Which on-canvas table the dim's PK column lives on.  Prefers the
  *  explicit `primaryKeyTableId` (set when the PK is on a snowflake
  *  child of the source table), falls back to `sourceTableId`. */
 export function dimKeyTableId(
-	dim: Pick<SchemaCanvasDimension, 'primaryKeyTableId' | 'sourceTableId'>
+  dim: Pick<SchemaCanvasDimension, "primaryKeyTableId" | "sourceTableId">,
 ): string | undefined {
-	return dim.primaryKeyTableId ?? dim.sourceTableId;
+  return dim.primaryKeyTableId ?? dim.sourceTableId;
 }
 
 /** Resolve the key back to a SPECIFIC attribute on the dim so the KEY
@@ -127,25 +129,26 @@ export function dimKeyTableId(
  *  affordances when it's not a clean logical match.
  */
 export function resolveKeyAttribute(
-	dim: Pick<SchemaCanvasDimension, 'primaryKey' | 'foreignKey' | 'attributes'>
+  dim: Pick<SchemaCanvasDimension, "primaryKey" | "foreignKey" | "attributes">,
 ): {
-	attr: NonNullable<SchemaCanvasDimension['attributes']>[number];
-	resolution: 'logical' | 'column-fallback';
+  attr: NonNullable<SchemaCanvasDimension["attributes"]>[number];
+  resolution: "logical" | "column-fallback";
 } | null {
-	const key = dimKeyIdentity(dim);
-	if (!key) return null;
-	const attrs = dim.attributes ?? [];
-	const byLogical = attrs.find((a) => (a.name ?? a.columnName) === key);
-	if (byLogical) return { attr: byLogical, resolution: 'logical' };
-	const byColumn = attrs.filter((a) => a.columnName === key);
-	if (byColumn.length === 1) return { attr: byColumn[0], resolution: 'column-fallback' };
-	return null;
+  const key = dimKeyIdentity(dim);
+  if (!key) return null;
+  const attrs = dim.attributes ?? [];
+  const byLogical = attrs.find((a) => (a.name ?? a.columnName) === key);
+  if (byLogical) return { attr: byLogical, resolution: "logical" };
+  const byColumn = attrs.filter((a) => a.columnName === key);
+  if (byColumn.length === 1)
+    return { attr: byColumn[0], resolution: "column-fallback" };
+  return null;
 }
 
 function makeId(prefix: string): string {
-	// Local-only ids — collision-safe across a single user-session, not
-	// global. Server persistence will reissue if needed.
-	return `${prefix}_${Math.random().toString(36).slice(2, 10)}`;
+  // Local-only ids — collision-safe across a single user-session, not
+  // global. Server persistence will reissue if needed.
+  return `${prefix}_${Math.random().toString(36).slice(2, 10)}`;
 }
 
 /** Pick a name not present in `existing`.  If `desired` collides, suffix
@@ -153,28 +156,28 @@ function makeId(prefix: string): string {
  *  the cube and hierarchy names unique within a dim — set-theoretic
  *  cleanliness (two dims named "Customer" would be the same element). */
 function ensureUnique(desired: string, existing: string[]): string {
-	const set = new Set(existing);
-	if (!set.has(desired)) return desired;
-	for (let n = 2; n < 10_000; n++) {
-		const candidate = `${desired} (${n})`;
-		if (!set.has(candidate)) return candidate;
-	}
-	return `${desired} (${Date.now()})`;
+  const set = new Set(existing);
+  if (!set.has(desired)) return desired;
+  for (let n = 2; n < 10_000; n++) {
+    const candidate = `${desired} (${n})`;
+    if (!set.has(candidate)) return candidate;
+  }
+  return `${desired} (${Date.now()})`;
 }
 
 function blankState(connectionId: string): SchemaCanvasState {
-	return {
-		version: 1,
-		connectionId,
-		label: '',
-		tables: [],
-		joins: [],
-		groups: [],
-		dimensions: [],
-		measures: [],
-		cubes: [],
-		updatedAt: new Date(0).toISOString()
-	};
+  return {
+    version: 1,
+    connectionId,
+    label: "",
+    tables: [],
+    joins: [],
+    groups: [],
+    dimensions: [],
+    measures: [],
+    cubes: [],
+    updatedAt: new Date(0).toISOString(),
+  };
 }
 
 /**
@@ -186,104 +189,109 @@ function blankState(connectionId: string): SchemaCanvasState {
  * Guarded + never throws — returns `[]` on any problem.
  */
 function migrateLegacyCubes(): SchemaCanvasCube[] {
-	if (typeof localStorage === 'undefined') return [];
-	try {
-		const raw = localStorage.getItem(LEGACY_CUBES_STORAGE_KEY);
-		if (!raw) return [];
-		const parsed = JSON.parse(raw) as {
-			cubes?: Array<{
-				id?: string;
-				name?: string;
-				measureGroups?: Array<{
-					id?: string;
-					name?: string;
-					measureColumns?: string[];
-					factTableId?: string | null;
-					dimensionLinks?: SchemaCanvasDimensionLink[];
-					measureCaptions?: Record<string, string>;
-				}>;
-				factsCalcs?: SchemaCanvasCalc[];
-				timeCalcs?: SchemaCanvasTimeCalc[];
-			}>;
-		};
-		if (!Array.isArray(parsed.cubes) || parsed.cubes.length === 0) return [];
-		return parsed.cubes.map((c) => ({
-			id: c.id ?? makeId('cube'),
-			name: c.name ?? 'Cube',
-			measureGroups: (c.measureGroups ?? []).map((g) => ({
-				id: g.id ?? makeId('mg'),
-				name: g.name ?? 'Group',
-				measureColumns: Array.isArray(g.measureColumns) ? g.measureColumns : [],
-				factTableId: g.factTableId ?? null,
-				dimensionLinks: Array.isArray(g.dimensionLinks) ? g.dimensionLinks : [],
-				measureCaptions:
-					g.measureCaptions && typeof g.measureCaptions === 'object' ? g.measureCaptions : {}
-			})),
-			calcs: Array.isArray(c.factsCalcs) ? c.factsCalcs : [],
-			timeCalcs: Array.isArray(c.timeCalcs) ? c.timeCalcs : undefined
-		}));
-	} catch {
-		return [];
-	}
+  if (typeof localStorage === "undefined") return [];
+  try {
+    const raw = localStorage.getItem(LEGACY_CUBES_STORAGE_KEY);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw) as {
+      cubes?: Array<{
+        id?: string;
+        name?: string;
+        measureGroups?: Array<{
+          id?: string;
+          name?: string;
+          measureColumns?: string[];
+          factTableId?: string | null;
+          dimensionLinks?: SchemaCanvasDimensionLink[];
+          measureCaptions?: Record<string, string>;
+        }>;
+        factsCalcs?: SchemaCanvasCalc[];
+        timeCalcs?: SchemaCanvasTimeCalc[];
+      }>;
+    };
+    if (!Array.isArray(parsed.cubes) || parsed.cubes.length === 0) return [];
+    return parsed.cubes.map((c) => ({
+      id: c.id ?? makeId("cube"),
+      name: c.name ?? "Cube",
+      measureGroups: (c.measureGroups ?? []).map((g) => ({
+        id: g.id ?? makeId("mg"),
+        name: g.name ?? "Group",
+        measureColumns: Array.isArray(g.measureColumns) ? g.measureColumns : [],
+        factTableId: g.factTableId ?? null,
+        dimensionLinks: Array.isArray(g.dimensionLinks) ? g.dimensionLinks : [],
+        measureCaptions:
+          g.measureCaptions && typeof g.measureCaptions === "object"
+            ? g.measureCaptions
+            : {},
+      })),
+      calcs: Array.isArray(c.factsCalcs) ? c.factsCalcs : [],
+      timeCalcs: Array.isArray(c.timeCalcs) ? c.timeCalcs : undefined,
+    }));
+  } catch {
+    return [];
+  }
 }
 
 function loadFromStorage(connectionId: string): SchemaCanvasState {
-	if (typeof window === 'undefined') return blankState(connectionId);
-	try {
-		const raw = window.localStorage.getItem(STORAGE_PREFIX + connectionId);
-		if (!raw) return blankState(connectionId);
-		const parsed = JSON.parse(raw) as SchemaCanvasState;
-		if (parsed.version !== 1) return blankState(connectionId);
-		// Self-heal: dedupe by the EXACT (source_col, target_col) tuple
-		// so role-playing dims (multiple distinct joins between the
-		// same table pair) survive a reload. Earlier versions of this
-		// store enforced one-per-pair; that rule has since been
-		// relaxed (see addJoin).
-		const tupleMap = new Map<string, SchemaCanvasState['joins'][number]>();
-		for (const j of parsed.joins ?? []) {
-			const key = [
-				[j.sourceTableId, j.sourceColumnName].join('.'),
-				[j.targetTableId, j.targetColumnName].join('.')
-			]
-				.sort()
-				.join('::');
-			tupleMap.set(key, j);
-		}
-		parsed.joins = [...tupleMap.values()];
-		// Back-fill workbench fields for docs persisted before the
-		// Dimensions Workbench landed.  Doc version is NOT bumped — the
-		// `?? []` defaults keep old docs round-tripping cleanly.
-		if (!Array.isArray(parsed.dimensions)) parsed.dimensions = [];
-		if (!Array.isArray(parsed.measures)) parsed.measures = [];
-		// Cubes were formerly held in the workbench's own localStorage key.
-		// Back-fill an empty array for docs saved before the model moved
-		// into the doc, and one-time migrate any legacy workbench cube state
-		// so the workbench + exporter see it immediately.
-		if (!Array.isArray(parsed.cubes) || parsed.cubes.length === 0) {
-			parsed.cubes = migrateLegacyCubes();
-		}
-		// Migrate old docs that only carried `primaryKeyTableId` (which
-		// was overloaded to mean both source-binding AND PK-column-table).
-		// Split-forward: source-binding lives on `sourceTableId`; the PK
-		// column table stays on `primaryKeyTableId` only for snowflakes.
-		for (const d of parsed.dimensions) {
-			if (!d.sourceTableId && d.primaryKeyTableId) {
-				d.sourceTableId = d.primaryKeyTableId;
-			}
-		}
-		return parsed;
-	} catch {
-		return blankState(connectionId);
-	}
+  if (typeof window === "undefined") return blankState(connectionId);
+  try {
+    const raw = window.localStorage.getItem(STORAGE_PREFIX + connectionId);
+    if (!raw) return blankState(connectionId);
+    const parsed = JSON.parse(raw) as SchemaCanvasState;
+    if (parsed.version !== 1) return blankState(connectionId);
+    // Self-heal: dedupe by the EXACT (source_col, target_col) tuple
+    // so role-playing dims (multiple distinct joins between the
+    // same table pair) survive a reload. Earlier versions of this
+    // store enforced one-per-pair; that rule has since been
+    // relaxed (see addJoin).
+    const tupleMap = new Map<string, SchemaCanvasState["joins"][number]>();
+    for (const j of parsed.joins ?? []) {
+      const key = [
+        [j.sourceTableId, j.sourceColumnName].join("."),
+        [j.targetTableId, j.targetColumnName].join("."),
+      ]
+        .sort()
+        .join("::");
+      tupleMap.set(key, j);
+    }
+    parsed.joins = [...tupleMap.values()];
+    // Back-fill workbench fields for docs persisted before the
+    // Dimensions Workbench landed.  Doc version is NOT bumped — the
+    // `?? []` defaults keep old docs round-tripping cleanly.
+    if (!Array.isArray(parsed.dimensions)) parsed.dimensions = [];
+    if (!Array.isArray(parsed.measures)) parsed.measures = [];
+    // Cubes were formerly held in the workbench's own localStorage key.
+    // Back-fill an empty array for docs saved before the model moved
+    // into the doc, and one-time migrate any legacy workbench cube state
+    // so the workbench + exporter see it immediately.
+    if (!Array.isArray(parsed.cubes) || parsed.cubes.length === 0) {
+      parsed.cubes = migrateLegacyCubes();
+    }
+    // Migrate old docs that only carried `primaryKeyTableId` (which
+    // was overloaded to mean both source-binding AND PK-column-table).
+    // Split-forward: source-binding lives on `sourceTableId`; the PK
+    // column table stays on `primaryKeyTableId` only for snowflakes.
+    for (const d of parsed.dimensions) {
+      if (!d.sourceTableId && d.primaryKeyTableId) {
+        d.sourceTableId = d.primaryKeyTableId;
+      }
+    }
+    return parsed;
+  } catch {
+    return blankState(connectionId);
+  }
 }
 
 function saveToStorage(state: SchemaCanvasState): void {
-	if (typeof window === 'undefined') return;
-	try {
-		window.localStorage.setItem(STORAGE_PREFIX + state.connectionId, JSON.stringify(state));
-	} catch {
-		/* private browsing, quota — silently ignore */
-	}
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(
+      STORAGE_PREFIX + state.connectionId,
+      JSON.stringify(state),
+    );
+  } catch {
+    /* private browsing, quota — silently ignore */
+  }
 }
 
 /**
@@ -296,2076 +304,2194 @@ function saveToStorage(state: SchemaCanvasState): void {
  * "Create path joins" then wires up any virtual edges along the way.
  */
 export interface PathfinderEndpoint {
-	tableId: string;
-	columnName: string;
+  tableId: string;
+  columnName: string;
 }
 
 export interface PathfinderStep {
-	fromTableId: string;
-	fromColumnName: string;
-	toTableId: string;
-	toColumnName: string;
-	/** Existing join id when the step traverses an already-wired join;
-	 *  null when it's a name-collision virtual edge the user would still
-	 *  need to commit via Create path joins. */
-	existingJoinId: string | null;
+  fromTableId: string;
+  fromColumnName: string;
+  toTableId: string;
+  toColumnName: string;
+  /** Existing join id when the step traverses an already-wired join;
+   *  null when it's a name-collision virtual edge the user would still
+   *  need to commit via Create path joins. */
+  existingJoinId: string | null;
 }
 
 export interface PathfinderResult {
-	steps: PathfinderStep[];
-	hasGaps: boolean;
+  steps: PathfinderStep[];
+  hasGaps: boolean;
 }
 
 export class SchemaCanvasStore {
-	// Reactive ($state): consumers read `store.connectionId` in reactive
-	// template positions (e.g. AskDimSumWidget's Send-button gate). A plain
-	// field wouldn't re-run those bindings when `switchConnection` reassigns
-	// it, so a fresh-canvas → pick-a-connection flow left the DimSum Send
-	// button stuck disabled ("Pick a connection first").
-	connectionId = $state<string>('');
-
-	// Document — top-level reactive state.
-	doc = $state<SchemaCanvasState>(blankState(''));
-
-	/**
-	 * One-step undo stash.  When set, the toolbar Undo button becomes
-	 * live and `undo()` swaps this back into `doc`.  Populated
-	 * automatically by `loadDoc` before every replace (so AI Draft is
-	 * always reversible) and can be populated by other big operations
-	 * that want to be undoable.
-	 */
-	previousDoc = $state<SchemaCanvasState | null>(null);
-
-	/**
-	 * Bumped whenever an external caller (DimSum) writes to `doc.cubes` and
-	 * wants the Facts & Measures workbench to re-hydrate.  The canvas page
-	 * watches this and force-remounts `<WorkbenchView>` (which re-reads
-	 * `doc.cubes` on mount) so the change is visible.  Pure signal — not
-	 * persisted.
-	 */
-	workbenchReloadNonce = $state<number>(0);
-
-	/**
-	 * The cube currently selected in the Facts & Measures workbench. Lifted to
-	 * the store so (a) the selection survives the DimSum-triggered remount and
-	 * (b) the DimSum chat (which lives in SchemaCanvasView) can reset itself
-	 * when the user switches to a different cube. Pure UI signal — not persisted.
-	 */
-	activeCubeId = $state<string | null>(null);
-
-	/**
-	 * Bumped when a saved schema is opened (or duplicated) from the library so
-	 * the DimSum chat (SchemaCanvasView) starts a fresh conversation for it,
-	 * instead of restoring the connection's last chat. Pure signal — not persisted.
-	 */
-	chatResetNonce = $state<number>(0);
-
-	// UI state.
-	selectedTableId = $state<string | null>(null);
-	selectedJoinId = $state<string | null>(null);
-	/** Filter expression for the sidebar table catalog. */
-	sidebarQuery = $state('');
-	/** Source-table catalog from /api/inference/profile-connection. */
-	sourceTables = $state<SourceTableCandidate[]>([]);
-	/** Selected schema filter — null means "all schemas". When set, the
-	 *  sidebar list is filtered to this schema. */
-	selectedSchema = $state<string | null>(null);
-	sourceLoading = $state(false);
-	sourceError = $state<string | null>(null);
-	/** Which top-level surface the schema designer renders.
-	 *  - `canvas`     — schema canvas (tables + joins).
-	 *  - `workbench`  — dimensions / attributes / hierarchies + inspector.
-	 *  - `facts`      — measure groups + calculated measures + inspector.
-	 *  - `validate`   — cube validation (sample data / try query / linked cubes).
-	 *
-	 *  Legacy `'binary'` value is migrated to `'workbench'` on load. */
-	mode = $state<CanvasMode>('canvas');
-	/**
-	 * Globally-highlighted column name. When set, every table on the
-	 * canvas that contains a column with this name renders with a glow
-	 * — visual signal of potential join targets for what the user just
-	 * clicked. Also drives the sidebar search filter.
-	 */
-	highlightedColumn = $state<string | null>(null);
-	/** Which table the highlighted column came from — lets the sidebar
-	 *  footer chip target "link similar on canvas" against THIS column
-	 *  specifically (origin → every other on-canvas table with the same
-	 *  column name). */
-	highlightOriginTableId = $state<string | null>(null);
-	/** What drove the current highlight — a column click or the sidebar
-	 *  search box. Lets the view's search→highlight effect decide
-	 *  whether emptying the search should clear the highlight (only when
-	 *  search drove it; otherwise a click-initiated highlight survives a
-	 *  manual search clear). */
-	highlightSource = $state<'click' | 'search' | null>(null);
-	/**
-	 * Click-to-join armed source. When a user clicks a column on table A,
-	 * we stash it here; the next click on a column on table B commits a
-	 * join between the two. Clicking the same (table, column) again
-	 * cancels; clicking another column on the SAME table replaces the
-	 * pending source (you can't join a table to itself in this model).
-	 *
-	 * This is pure UI state — NOT persisted in the doc / localStorage.
-	 */
-	pendingJoinSource = $state<{ tableId: string; columnName: string } | null>(null);
-	/**
-	 * Pick mode — toggled by tapping E (no hold required). When ON,
-	 * column clicks accumulate into `eShiftPicks` instead of arming a
-	 * single click-to-join.  Commit happens via the picks-panel
-	 * "Match" button, which takes a group name and wires picks in a
-	 * STAR pattern (first pick = origin, joins to each subsequent
-	 * pick).  Lets a user group columns with DIFFERENT names
-	 * (`product_id` ↔ `prod_id` ↔ `pid`) under a single semantic
-	 * label like "Product Key". UI state; not persisted.
-	 */
-	pickModeActive = $state<boolean>(false);
-	eShiftPicks = $state<Array<{ tableId: string; columnName: string }>>([]);
-	/** Bump-counter feedback channel for the join-creation toast.  Any
-	 *  path that materialises a new join writes here; the view listens
-	 *  on the `id` and renders a toast.  A single addJoin sets a
-	 *  descriptive per-join message; batch paths (commitEShiftPicks,
-	 *  linkSimilarOnCanvas) overwrite with a summary after the loop so
-	 *  the user gets one toast, not N. */
-	lastJoinFeedback = $state<{ id: number; message: string } | null>(null);
-	private joinFeedbackCounter = 0;
-	/** Pathfinder UX state — see PathfinderEndpoint / PathfinderResult.
-	 *  When `pathfinderArmed` is non-null, the next column click on the
-	 *  canvas writes into that slot (start / end) instead of running the
-	 *  normal click-to-join flow.  Result is computed on-demand via
-	 *  `findPath()` and surfaced as `pathfinderResult`. */
-	pathfinderArmed = $state<'start' | 'end' | null>(null);
-	pathfinderStart = $state<PathfinderEndpoint | null>(null);
-	pathfinderEnd = $state<PathfinderEndpoint | null>(null);
-	pathfinderResult = $state<PathfinderResult | null>(null);
-	/** Sidebar width in px — user-draggable via the splitter handle. */
-	sidebarWidth = $state(288);
-	/** Joins panel (right rail) width in px — same splitter pattern.
-	 *  Clamped at 220-560 in the drag handler. */
-	joinsPanelWidth = $state(280);
-	/** User's preferred Arrange layout — what the main Arrange button
-	 *  applies when clicked without picking from the menu.  All
-	 *  layouts stay individually clickable in the dropdown; this just
-	 *  controls the one-click default.  Persisted to localStorage as
-	 *  a per-user preference (NOT per-connection) so the choice
-	 *  follows the user across cubes and connection switches. */
-	defaultLayoutMode = $state<LayoutMode>('star');
-	/** Multi-select state for the sidebar table list. Clicking a row
-	 *  replaces selection; Shift/Cmd-clicking toggles. Dragging any
-	 *  selected row drags the WHOLE selection at once. Identities are
-	 *  the same `schema.name` (or bare `name`) form the sidebar uses. */
-	sidebarSelectedIdentities = $state<Set<string>>(new Set());
-	/**
-	 * Default columns shown per table when the user hasn't individually
-	 * collapsed/expanded that table. 0 = headers only. Any positive
-	 * number caps the visible row count; tables with fewer columns just
-	 * show all of theirs. Per-table `collapsed` boolean (true = headers
-	 * only, false = show all) overrides this when set.
-	 */
-	defaultColumnsShown = $state<number>(8);
-	/**
-	 * When ON, dropping a new table onto the canvas silently commits
-	 * every high-confidence column-name match between the dropped table
-	 * and the fact. Friendly when starting from a blank canvas; gets in
-	 * the way when you're trying to test interactions (E, click-to-join)
-	 * because joins materialise before you can do anything. Default OFF.
-	 */
-	autoSuggestOnDrop = $state<boolean>(false);
-	/**
-	 * When ON, focusing a table or join-group ALSO highlights the actual
-	 * column rows that participate in the focused joins (green row +
-	 * auto-expand the table to show them). When OFF (default), focus
-	 * just dims unrelated stuff — the user follows the lines themselves.
-	 * Some folks want the green highlight; others prefer the cleaner
-	 * "just follow the lines" view.
-	 */
-	highlightFocusedColumns = $state<boolean>(false);
-	/** When ON, hides every join line + label so the user can see the
-	 *  bare table layout without the visual noise. Doesn't delete the
-	 *  joins — just visually hides them. UI-only state. */
-	joinsHidden = $state<boolean>(false);
-	/** When ON, also render `cube-link` / `inferred-fk` joins (the ones
-	 *  auto-inferred from Mondrian-4 MeasureGroup `<ForeignKeyLink>` —
-	 *  semantic, not physical).  Default OFF — canvas shows only
-	 *  `origin: 'physical'` joins, matching the PhysicalSchema in the
-	 *  source XML.  UI-only state. */
-	showCubeLinks = $state<boolean>(false);
-	/**
-	 * Join-line rendering style.
-	 *   - `bezier`     — smooth curves (default).
-	 *   - `smoothstep` — orthogonal segments with rounded corners.
-	 *   - `step`       — sharp right-angle segments.
-	 * UI-only; not persisted in the doc (it's a personal preference).
-	 */
-	edgeStyle = $state<'bezier' | 'smoothstep' | 'step'>('smoothstep');
-	/**
-	 * Focus dimming. When the user picks a target — a join group label
-	 * in the panel, a table on the canvas, etc. — everything else
-	 * drops opacity so the chosen thing stands out. Click the empty
-	 * canvas to clear. UI-only.
-	 */
-	focusKind = $state<'none' | 'group' | 'table'>('none');
-	focusKey = $state<string | null>(null);
-	/** Cursor for binary view: index into the non-fact tables list. */
-	binaryCursor = $state(0);
-	/** Sidebar → canvas jump request. Set by the sidebar's "on canvas"
-	 *  result link; consumed by a tiny JumpHandler inside the SvelteFlow
-	 *  tree which calls `useSvelteFlow().setCenter()` (the hook only
-	 *  works inside the flow component subtree). `ts` makes repeat
-	 *  clicks on the same row re-fire the effect. */
-	requestedJumpTarget = $state<{ tableId: string; columnName?: string; ts: number } | null>(null);
-	/** Imperative viewport actions DimSum (or other UI) can request. The
-	 *  CanvasActionHandler child inside <SvelteFlow> consumes this and
-	 *  calls the corresponding useSvelteFlow() method. `ts` re-fires
-	 *  repeat requests of the same kind. Keeps the AI-visible action
-	 *  registry decoupled from where the imperative API is available. */
-	requestedCanvasAction = $state<{
-		kind: 'zoom_in' | 'zoom_out' | 'fit_view' | 'zoom_to_100' | 'center_view';
-		ts: number;
-	} | null>(null);
-	/**
-	 * Workbench working set — table IDs the user has pulled into the
-	 * Workbench view for focused side-by-side work. UI-only; not
-	 * persisted in the doc. Empty means "Workbench shows nothing yet —
-	 * drag tables in from the sidebar." Removing a table from this set
-	 * does NOT remove it from the canvas (the canvas is the source of
-	 * truth; the workbench is a scratch surface).
-	 */
-	workbenchWorkingSet = $state<Set<string>>(new Set());
-	/** Soft-threshold warning state — flips true above 30 tables. */
-	get thresholdSoft(): boolean {
-		return this.doc.tables.length >= 30;
-	}
-
-	/**
-	 * The "active set" — phase-2's unifying primitive for column
-	 * selection. Two prior pieces of UI (highlightedColumn ↔ across-table
-	 * name match, and eShiftPicks ↔ explicit E-hold picks) reduce to
-	 * ONE concept the rest of the canvas can read uniformly: an ordered
-	 * list of `{tableId, columnName}` plus a mode tag.
-	 *
-	 * Modes:
-	 *  - `pick`  — explicit picks accumulated during E-hold (or via the
-	 *              joins-panel "picks" affordance later). Survives until
-	 *              committed or explicitly cleared.
-	 *  - `auto`  — derived from `highlightedColumn`: every column on
-	 *              canvas whose name matches.
-	 *  - `none`  — neither mode active.
-	 *
-	 * Both visual surfaces (canvas column rows + Workbench panel) read
-	 * this and apply the SAME green-glow vocabulary, replacing the
-	 * Workbench's old red-ring treatment.
-	 */
-	get activeSetMode(): 'auto' | 'pick' | 'none' {
-		if (this.eShiftPicks.length > 0) return 'pick';
-		if (this.highlightedColumn !== null) return 'auto';
-		return 'none';
-	}
-
-	get activeSet(): Array<{ tableId: string; columnName: string }> {
-		if (this.eShiftPicks.length > 0) return this.eShiftPicks;
-		if (this.highlightedColumn !== null) {
-			const colName = this.highlightedColumn;
-			const out: Array<{ tableId: string; columnName: string }> = [];
-			for (const t of this.doc.tables) {
-				if (t.columns.some((c) => c.name === colName)) {
-					out.push({ tableId: t.id, columnName: colName });
-				}
-			}
-			return out;
-		}
-		return [];
-	}
-
-	/**
-	 * `${tableId}:${columnName}` keys for fast O(1) membership tests in
-	 * render hot paths — TableNode column rows test against this Set to
-	 * decide whether to apply the green glow.
-	 */
-	get activeSetKeys(): Set<string> {
-		const out = new Set<string>();
-		for (const p of this.activeSet) {
-			out.add(`${p.tableId}:${p.columnName}`);
-		}
-		return out;
-	}
-
-	constructor(connectionId: string) {
-		this.connectionId = connectionId;
-		this.doc = loadFromStorage(connectionId);
-		// One-time migration: strip the old "implicit-default hierarchy"
-		// auto-seed that the previous addDimension code created.  Match
-		// criterion: hier.name === dim.name AND hier.levels.length === 0
-		// — those are the obvious leftovers from the convention we
-		// abandoned (hierarchies are always explicit now).  Won't strip
-		// a hier the user named the same as the dim and populated.
-		for (const d of this.doc.dimensions ?? []) {
-			d.hierarchies = d.hierarchies.filter((h) => !(h.levels.length === 0 && h.name === d.name));
-			// Sibling-unique hierarchy names per dim.  Pre-uniqueness
-			// data may have shipped duplicates; resolve by suffixing
-			// "(2)", "(3)", ….  Keep the first occurrence's name intact.
-			const seen = new Set<string>();
-			for (const h of d.hierarchies) {
-				if (seen.has(h.name)) {
-					let n = 2;
-					while (seen.has(`${h.name} (${n})`)) n++;
-					h.name = `${h.name} (${n})`;
-				}
-				seen.add(h.name);
-			}
-		}
-		// Same for dim names at the cube level.
-		const seenDimNames = new Set<string>();
-		for (const d of this.doc.dimensions ?? []) {
-			if (seenDimNames.has(d.name)) {
-				let n = 2;
-				while (seenDimNames.has(`${d.name} (${n})`)) n++;
-				d.name = `${d.name} (${n})`;
-			}
-			seenDimNames.add(d.name);
-		}
-		// Restore per-user UI preferences (NOT per-connection).
-		const prefs = loadPrefsFromStorage();
-		if (prefs.defaultLayoutMode) {
-			this.defaultLayoutMode = prefs.defaultLayoutMode;
-		}
-		const migrated = migrateMode(prefs.mode);
-		if (migrated) this.mode = migrated;
-	}
-
-	/** Update the default Arrange layout and persist it as a per-user
-	 *  preference.  Callers should use this method rather than mutating
-	 *  `defaultLayoutMode` directly so the localStorage write stays in
-	 *  one place. */
-	setDefaultLayoutMode(mode: LayoutMode): void {
-		this.defaultLayoutMode = mode;
-		const prefs = loadPrefsFromStorage();
-		prefs.defaultLayoutMode = mode;
-		savePrefsToStorage(prefs);
-	}
-
-	/** Set the active view tab and persist as a per-user preference so the
-	 *  next session lands on the same tab.  Tab toggle UI should call
-	 *  this rather than mutating `mode` directly. */
-	setMode(mode: CanvasMode): void {
-		this.mode = mode;
-		const prefs = loadPrefsFromStorage();
-		prefs.mode = mode;
-		savePrefsToStorage(prefs);
-	}
-
-	/**
-	 * Swap the active connection without recreating the store. Persists
-	 * the current doc, loads the doc for the new connection from
-	 * localStorage, and resets the UI state (selection, mode cursor).
-	 * Source-table catalog is the caller's responsibility — the
-	 * /cubes/new/canvas page kicks off a fresh fetch on connection
-	 * change.
-	 */
-	switchConnection(connectionId: string): void {
-		if (this.connectionId === connectionId) return;
-		// Persist whatever's currently in flight under the old key.
-		saveToStorage(this.doc);
-		this.connectionId = connectionId;
-		this.doc = loadFromStorage(connectionId);
-		this.selectedTableId = null;
-		this.selectedJoinId = null;
-		this.binaryCursor = 0;
-		this.sourceTables = [];
-		this.sourceLoading = false;
-		this.sourceError = null;
-		this.sidebarQuery = '';
-	}
-
-	private touch(): void {
-		this.doc.updatedAt = new Date().toISOString();
-		saveToStorage(this.doc);
-	}
-
-	/** Public setter for the cube label.  Goes through the same
-	 *  touch() → saveToStorage path as canvas mutations, so renames
-	 *  survive a reload.  The two-way `bind:value` on the title input
-	 *  used to mutate `store.doc.label` directly, which never wrote
-	 *  to localStorage. */
-	setLabel(label: string): void {
-		this.doc.label = label;
-		this.touch();
-	}
-
-	/** Add a table from the source catalog onto the canvas at the given position. */
-	addTable(candidate: SourceTableCandidate, position: { x: number; y: number }): SchemaCanvasTable {
-		this.maybeSnapshotForUndo();
-		// Dedupe (#1084) — a physical table (schema+name) may only appear
-		// once on the canvas. Every add path (drag-drop, "+ Add to canvas",
-		// DimSum's add_table_to_canvas tool) funnels through here, so this
-		// is the single guard against a second node with a fresh id being
-		// pushed for a table that's already present. If found, return the
-		// existing node untouched rather than creating a duplicate.
-		const identity = candidate.schema ? `${candidate.schema}.${candidate.name}` : candidate.name;
-		const existing = this.doc.tables.find(
-			(t) => (t.schema ? `${t.schema}.${t.name}` : t.name) === identity
-		);
-		if (existing) return existing;
-		// Peer model — every table on the canvas is equal. The `role`
-		// field stays on the data model (Mondrian export still needs a
-		// fact at the END), but the canvas itself doesn't designate one
-		// any more. New tables come in as plain dimensions.
-		const role: SchemaCanvasTableRole = 'dimension';
-		const table: SchemaCanvasTable = {
-			id: makeId('tbl'),
-			schema: candidate.schema,
-			name: candidate.name,
-			role,
-			columns: candidate.columns.map((c) => ({ name: c.name, sqlType: c.sqlType })),
-			position,
-			groupId: null
-		};
-		this.doc.tables.push(table);
-		this.touch();
-		return table;
-	}
-
-	removeTable(tableId: string): void {
-		this.maybeSnapshotForUndo();
-		this.doc.tables = this.doc.tables.filter((t) => t.id !== tableId);
-		// Cascade: drop any joins that referenced this table.
-		this.doc.joins = this.doc.joins.filter(
-			(j) => j.sourceTableId !== tableId && j.targetTableId !== tableId
-		);
-		if (this.selectedTableId === tableId) this.selectedTableId = null;
-		this.touch();
-	}
-
-	moveTable(tableId: string, position: { x: number; y: number }): void {
-		const t = this.doc.tables.find((t) => t.id === tableId);
-		if (!t) return;
-		t.position = position;
-		this.touch();
-	}
-
-	/** Force a single table to show every column (overrides the global
-	 *  default). Used by the "+ N more" footer affordance — clicking it
-	 *  is an explicit "I want to see everything in this table". The
-	 *  chevron still cycles undef ↔ true after that. */
-	expandTableFully(tableId: string): void {
-		const t = this.doc.tables.find((t) => t.id === tableId);
-		if (!t) return;
-		t.collapsed = false;
-		this.touch();
-	}
-
-	toggleTableCollapsed(tableId: string): void {
-		const t = this.doc.tables.find((t) => t.id === tableId);
-		if (!t) return;
-		// Cycle is two states: `undefined` (follow `defaultColumnsShown`)
-		// ↔ `true` (header only). The chevron NEVER sets the third state
-		// (`false` = force show-all) because that would pin the table
-		// past any future change to `defaultColumnsShown` — Amelia hit
-		// this and had to click "Reset views" to escape. "Force show all"
-		// is reachable only via the explicit "Expand all" toolbar button.
-		if (t.collapsed === true) {
-			t.collapsed = undefined;
-		} else {
-			t.collapsed = true;
-		}
-		this.touch();
-	}
-
-	/** Reset every table's per-table collapse override so they all
-	 *  follow the global `defaultColumnsShown` setting again. */
-	resetCollapseOverrides(): void {
-		for (const t of this.doc.tables) t.collapsed = undefined;
-		this.touch();
-	}
-
-	/** Force every table to show all its columns (overrides the global
-	 *  default). Companion to the toolbar's "Expand all" button. */
-	expandAllTables(): void {
-		for (const t of this.doc.tables) t.collapsed = false;
-		this.touch();
-	}
-
-	/** Force every table to collapse to header-only. */
-	collapseAllTables(): void {
-		for (const t of this.doc.tables) t.collapsed = true;
-		this.touch();
-	}
-
-	/** Add a canvas table to the workbench working set. No-op if
-	 *  already present. Doesn't touch the canvas. */
-	addToWorkbench(tableId: string): void {
-		if (this.workbenchWorkingSet.has(tableId)) return;
-		const next = new Set(this.workbenchWorkingSet);
-		next.add(tableId);
-		this.workbenchWorkingSet = next;
-	}
-
-	/** Remove a table from the workbench WITHOUT removing it from the
-	 *  canvas. */
-	removeFromWorkbench(tableId: string): void {
-		if (!this.workbenchWorkingSet.has(tableId)) return;
-		const next = new Set(this.workbenchWorkingSet);
-		next.delete(tableId);
-		this.workbenchWorkingSet = next;
-	}
-
-	clearWorkbench(): void {
-		this.workbenchWorkingSet = new Set();
-	}
-
-	/** The actual tables in the workbench's working set (canvas tables
-	 *  filtered by membership). The Set may include stale IDs from a
-	 *  prior reload; we resolve against the live canvas tables. */
-	get workbenchTables(): SchemaCanvasTable[] {
-		return this.doc.tables.filter((t) => this.workbenchWorkingSet.has(t.id));
-	}
-
-	/** `schema.name` identities of every table currently in the
-	 *  workbench's working set — used by the Workbench's TableSidebar
-	 *  to grey out tables already in focus (vs. all canvas tables). */
-	get workbenchTableIdentities(): Set<string> {
-		return new Set(this.workbenchTables.map((t) => (t.schema ? `${t.schema}.${t.name}` : t.name)));
-	}
-
-	setTableRole(tableId: string, role: SchemaCanvasTableRole): void {
-		const t = this.doc.tables.find((t) => t.id === tableId);
-		if (!t) return;
-		// Only one fact at a time — demote any prior fact to dimension when
-		// another is promoted.
-		if (role === 'fact') {
-			for (const other of this.doc.tables) {
-				if (other.id !== tableId && other.role === 'fact') other.role = 'dimension';
-			}
-		}
-		t.role = role;
-		this.touch();
-	}
-
-	addJoin(j: Omit<SchemaCanvasJoin, 'id'>): SchemaCanvasJoin {
-		this.maybeSnapshotForUndo();
-		// User-initiated joins default to `physical` — only the importer
-		// creates `cube-link` / `inferred-fk` joins, and it sets origin
-		// explicitly when it does.
-		const join: SchemaCanvasJoin = { ...j, id: makeId('join'), origin: j.origin ?? 'physical' };
-		// Multiple joins per table pair are valid for role-playing
-		// dimensions: a fact joining `date` three times via order_date_id,
-		// ship_date_id, and invoice_date_id is one classic shape. Tom's
-		// "no composite keys" rule meant a SINGLE join using multiple
-		// columns simultaneously — different from N distinct
-		// single-column joins between the same pair. We only dedupe on
-		// the exact (source_col, target_col) tuple so the same join
-		// can't be drawn twice.
-		const existingIdx = this.doc.joins.findIndex((existing) => {
-			const sameDirection =
-				existing.sourceTableId === join.sourceTableId &&
-				existing.targetTableId === join.targetTableId &&
-				existing.sourceColumnName === join.sourceColumnName &&
-				existing.targetColumnName === join.targetColumnName;
-			const swappedDirection =
-				existing.sourceTableId === join.targetTableId &&
-				existing.targetTableId === join.sourceTableId &&
-				existing.sourceColumnName === join.targetColumnName &&
-				existing.targetColumnName === join.sourceColumnName;
-			return sameDirection || swappedDirection;
-		});
-		if (existingIdx >= 0) {
-			this.doc.joins[existingIdx] = join;
-			this.touch();
-			return join;
-		}
-		// Within a given table pair, a single (source_table, source_column)
-		// endpoint can only participate in ONE join. If the same source
-		// endpoint is being paired with a DIFFERENT target column on the
-		// same target table, that's ambiguous (a "first_name" endpoint
-		// wired to both `fname` and `lname`) so replace the older join
-		// instead of accumulating semantically-inconsistent pairs.
-		// Role-playing (same target column reused via DIFFERENT source
-		// columns) stays legal because the check keys off the source
-		// endpoint, not the target.
-		const ambiguousIdx = this.doc.joins.findIndex((existing) => {
-			const sameDirection =
-				existing.sourceTableId === join.sourceTableId &&
-				existing.targetTableId === join.targetTableId &&
-				existing.sourceColumnName === join.sourceColumnName &&
-				existing.targetColumnName !== join.targetColumnName;
-			// Swapped: the incoming join's TARGET endpoint (table + column)
-			// matches the existing join's SOURCE endpoint — same conceptual
-			// "source" endpoint of the pair, written in reverse. Other-side
-			// columns must still differ, else the sameDirection dedupe (or
-			// exact-tuple dedupe above) would have caught it.
-			const swappedDirection =
-				existing.sourceTableId === join.targetTableId &&
-				existing.targetTableId === join.sourceTableId &&
-				existing.sourceColumnName === join.targetColumnName &&
-				existing.targetColumnName !== join.sourceColumnName;
-			return sameDirection || swappedDirection;
-		});
-		if (ambiguousIdx >= 0) {
-			const prior = this.doc.joins[ambiguousIdx];
-			// Both detection cases converge on: prior.sourceColumnName is
-			// the endpoint being reused, prior.targetColumnName is what it
-			// was previously paired with. (In sameDirection the incoming's
-			// source matches prior.sourceColumnName; in swappedDirection
-			// the incoming's target does. Either way, prior tells us the
-			// old story.)
-			const reusedColumn = prior.sourceColumnName;
-			const oldPairedColumn = prior.targetColumnName;
-			this.doc.joins[ambiguousIdx] = join;
-			this.touch();
-			this.pushJoinFeedback(
-				`Replaced join (${reusedColumn} was already paired with ${oldPairedColumn})`
-			);
-			return join;
-		}
-		this.doc.joins.push(join);
-		this.touch();
-		this.pushJoinFeedback(this.describeJoinCreation(join));
-		return join;
-	}
-
-	private describeJoinCreation(j: SchemaCanvasJoin): string {
-		const src = this.doc.tables.find((t) => t.id === j.sourceTableId);
-		const tgt = this.doc.tables.find((t) => t.id === j.targetTableId);
-		const srcName = src?.name ?? '?';
-		const tgtName = tgt?.name ?? '?';
-		return `Joined ${srcName}.${j.sourceColumnName} ↔ ${tgtName}.${j.targetColumnName}`;
-	}
-
-	private pushJoinFeedback(message: string): void {
-		this.lastJoinFeedback = { id: ++this.joinFeedbackCounter, message };
-	}
-
-	removeJoin(joinId: string): void {
-		this.maybeSnapshotForUndo();
-		const target = this.doc.joins.find((j) => j.id === joinId);
-		// Cube-link + inferred-fk joins are owned by the cube-side
-		// MeasureGroup ForeignKeyLink, not by the canvas.  The user must
-		// remove the FK link from the MG's dim-link checklist to make it
-		// go away; deleting it on the canvas would just have the importer
-		// recreate it.  Silently no-op so accidental clicks don't surprise.
-		if (target && (target.origin === 'cube-link' || target.origin === 'inferred-fk')) {
-			return;
-		}
-		this.doc.joins = this.doc.joins.filter((j) => j.id !== joinId);
-		if (this.selectedJoinId === joinId) this.selectedJoinId = null;
-		// If the removed join was the LAST one for its canonical key,
-		// clear the rename so a future re-creation doesn't silently
-		// inherit a stale label.  When other joins for the same key
-		// still exist (the group survives the removal), the rename
-		// stays — same group, same label.
-		if (target) {
-			const key = SchemaCanvasStore.joinCanonicalKey(target);
-			const stillHasKey = this.doc.joins.some((j) => SchemaCanvasStore.joinCanonicalKey(j) === key);
-			if (!stillHasKey && this.doc.joinGroupRenames?.[key]) {
-				const next = { ...this.doc.joinGroupRenames };
-				delete next[key];
-				this.doc.joinGroupRenames = next;
-			}
-		}
-		this.touch();
-	}
-
-	/** Remove a column from a group while keeping the rest of the
-	 *  group's equivalence intact.
-	 *
-	 *  Three cases:
-	 *  1. Removing the endpoint leaves fewer than 2 remaining → group
-	 *     dissolves (delete every join in it).
-	 *  2. Removing it leaves at least one join that DOESN'T touch
-	 *     the endpoint → just drop the joins that do.
-	 *  3. Removing it leaves 2+ endpoints but ZERO surviving joins
-	 *     (the endpoint was the star anchor) → re-anchor: pick the
-	 *     first remaining endpoint as the new anchor and rewire a
-	 *     fresh star to the rest, re-applying the group label.
-	 *
-	 *  The UI doesn't see any of this — it just calls
-	 *  `removeEndpointFromGroup` and the group's semantic "these are
-	 *  all the same" stays true, no matter which member is removed.
-	 */
-	removeEndpointFromGroup(groupLabel: string, tableId: string, columnName: string): void {
-		const groupJoins = this.doc.joins.filter((j) => this.joinGroupLabelFor(j) === groupLabel);
-		if (groupJoins.length === 0) return;
-		const touchesEndpoint = (j: SchemaCanvasJoin) =>
-			(j.sourceTableId === tableId && j.sourceColumnName === columnName) ||
-			(j.targetTableId === tableId && j.targetColumnName === columnName);
-		const joinsTouchingEp = groupJoins.filter(touchesEndpoint);
-		const remainingJoins = groupJoins.filter((j) => !touchesEndpoint(j));
-		// Build the ordered set of endpoints (excluding the one being
-		// removed) — preserve the order they first appear so the new
-		// anchor is deterministic.
-		const seen = new Set<string>();
-		const remainingEndpoints: Array<{ tableId: string; columnName: string }> = [];
-		const skipKey = `${tableId}:${columnName}`;
-		for (const j of groupJoins) {
-			for (const ep of [
-				{ tableId: j.sourceTableId, columnName: j.sourceColumnName },
-				{ tableId: j.targetTableId, columnName: j.targetColumnName }
-			]) {
-				const k = `${ep.tableId}:${ep.columnName}`;
-				if (k === skipKey || seen.has(k)) continue;
-				seen.add(k);
-				remainingEndpoints.push(ep);
-			}
-		}
-		// Case 1 — group falls under 2 members → kill it.
-		if (remainingEndpoints.length < 2) {
-			for (const j of groupJoins) this.removeJoin(j.id);
-			return;
-		}
-		// Case 2 — the endpoint wasn't the anchor; just drop the joins
-		// that touch it and leave the rest of the star intact.
-		if (remainingJoins.length > 0) {
-			for (const j of joinsTouchingEp) this.removeJoin(j.id);
-			return;
-		}
-		// Case 3 — the endpoint was the anchor; rebuild the star
-		// using the first remaining endpoint as the new anchor and
-		// re-applying the same group label.
-		for (const j of groupJoins) this.removeJoin(j.id);
-		const newAnchor = remainingEndpoints[0];
-		const peers = remainingEndpoints.slice(1);
-		const renames = { ...(this.doc.joinGroupRenames ?? {}) };
-		for (const peer of peers) {
-			if (newAnchor.tableId === peer.tableId) continue;
-			const created = this.addJoin({
-				sourceTableId: newAnchor.tableId,
-				sourceColumnName: newAnchor.columnName,
-				targetTableId: peer.tableId,
-				targetColumnName: peer.columnName,
-				kind: 'inner'
-			});
-			const canonicalKey = SchemaCanvasStore.joinCanonicalKey(created);
-			renames[canonicalKey] = groupLabel;
-		}
-		this.doc.joinGroupRenames = renames;
-		this.touch();
-	}
-
-	/** Remove every join in `joinIds`. Single pass, single save. */
-	removeJoins(joinIds: Iterable<string>): void {
-		const set = joinIds instanceof Set ? joinIds : new Set(joinIds);
-		if (set.size === 0) return;
-		this.maybeSnapshotForUndo();
-		this.doc.joins = this.doc.joins.filter((j) => !set.has(j.id));
-		if (this.selectedJoinId && set.has(this.selectedJoinId)) {
-			this.selectedJoinId = null;
-		}
-		this.touch();
-	}
-
-	focusGroup(label: string): void {
-		// `focusKey` for a group is the rendered LABEL (so
-		// joinIdsInFocus / tableIdsInFocus can match every join under
-		// that label, even when the group spans multiple canonical
-		// keys via pick-mode renames).
-		if (this.focusKind === 'group' && this.focusKey === label) {
-			this.clearFocus();
-			return;
-		}
-		this.focusKind = 'group';
-		this.focusKey = label;
-		// Auto-flip the column-highlight toggle ON when a group is
-		// focused — clicking a group means "show me the data you
-		// grouped," so the row glow + auto-expand are the natural
-		// default.  The user is still free to toggle it back off
-		// mid-focus if they prefer the cleaner line-only view.
-		this.highlightFocusedColumns = true;
-		// Drop any stale name-match highlight (from a previous column
-		// click or sidebar search) so the only thing lighting up is
-		// the group itself — otherwise the user can't tell which
-		// columns are "in the group" vs "still glowing from earlier".
-		this.highlightedColumn = null;
-		this.highlightOriginTableId = null;
-		this.highlightSource = null;
-	}
-
-	focusTableNode(tableId: string): void {
-		if (this.focusKind === 'table' && this.focusKey === tableId) {
-			this.clearFocus();
-			return;
-		}
-		this.focusKind = 'table';
-		this.focusKey = tableId;
-	}
-
-	clearFocus(): void {
-		this.focusKind = 'none';
-		this.focusKey = null;
-	}
-
-	/**
-	 * Reset every transient interaction state to neutral. Wired to
-	 * SvelteFlow's pane-click — clicking the empty canvas should clear
-	 * focus, drop the armed click-to-join, clear the green column
-	 * highlight, deselect the join, abandon any held E-shift collection,
-	 * and reset the sidebar search to neutral. The doc itself
-	 * (tables / joins / groups) is untouched.
-	 */
-	clearAllInteractions(): void {
-		this.focusKind = 'none';
-		this.focusKey = null;
-		this.highlightedColumn = null;
-		this.highlightOriginTableId = null;
-		this.highlightSource = null;
-		this.pendingJoinSource = null;
-		this.selectedJoinId = null;
-		this.selectedTableId = null;
-		this.sidebarQuery = '';
-		this.pickModeActive = false;
-		this.eShiftPicks = [];
-		// Also drop any pending jump request — otherwise the
-		// JumpHandler's $effect re-fires on the stale target after
-		// the rest of state was cleared and re-stamps selectedTableId
-		// + highlightedColumn behind the user's back.
-		this.requestedJumpTarget = null;
-	}
-
-	/** Returns the set of join ids that are IN focus for the current
-	 *  focus state. Empty set means "no focus active" — callers should
-	 *  treat that as "everything is in focus". */
-	joinIdsInFocus(): Set<string> {
-		const out = new Set<string>();
-		if (this.focusKind === 'group' && this.focusKey !== null) {
-			// Group focus filters by LABEL, not canonical key, so a
-			// user-renamed group like "Random" (which can span multiple
-			// canonical keys when picks crossed different column names)
-			// lights up every join in the rendered group — not just the
-			// ones whose canonical key happens to match the click target.
-			const label = this.focusKey;
-			for (const j of this.doc.joins) {
-				if (this.joinGroupLabelFor(j) === label) out.add(j.id);
-			}
-		} else if (this.focusKind === 'table' && this.focusKey !== null) {
-			const id = this.focusKey;
-			for (const j of this.doc.joins) {
-				if (j.sourceTableId === id || j.targetTableId === id) out.add(j.id);
-			}
-		}
-		return out;
-	}
-
-	/** Returns the set of table ids that are IN focus. */
-	tableIdsInFocus(): Set<string> {
-		const out = new Set<string>();
-		if (this.focusKind === 'group' && this.focusKey !== null) {
-			// Group focus filters by LABEL — see joinIdsInFocus() for the
-			// rationale (multi-canonical-key groups created via pick mode).
-			const label = this.focusKey;
-			for (const j of this.doc.joins) {
-				if (this.joinGroupLabelFor(j) === label) {
-					out.add(j.sourceTableId);
-					out.add(j.targetTableId);
-				}
-			}
-		} else if (this.focusKind === 'table' && this.focusKey !== null) {
-			out.add(this.focusKey);
-			for (const j of this.doc.joins) {
-				if (j.sourceTableId === this.focusKey) out.add(j.targetTableId);
-				else if (j.targetTableId === this.focusKey) out.add(j.sourceTableId);
-			}
-		}
-		return out;
-	}
-
-	/**
-	 * Run auto-suggest for one table against every OTHER table on the
-	 * canvas — commit every high-confidence column-name match as a
-	 * join. Used by the drop handler AND by the "pull-in matching
-	 * tables" feature; respects `addJoin`'s tuple-dedupe.
-	 */
-	runAutoSuggestForTable(tableId: string): void {
-		const t = this.doc.tables.find((tt) => tt.id === tableId);
-		if (!t) return;
-		for (const other of this.doc.tables) {
-			if (other.id === tableId) continue;
-			const suggestions = suggestJoins(t, other).filter((s) => s.confidence === 'high');
-			for (const s of suggestions) {
-				this.addJoin({
-					sourceTableId: tableId,
-					sourceColumnName: s.sourceColumnName,
-					targetTableId: other.id,
-					targetColumnName: s.targetColumnName,
-					kind: s.kind
-				});
-			}
-		}
-	}
-
-	/**
-	 * For the currently-highlighted column (or an explicit name),
-	 * scan the SOURCE catalog for every table containing a column with
-	 * that name and pull each one not yet on the canvas onto it. If
-	 * `autoSuggestOnDrop` is ON, every newly-added table is also wired
-	 * to its peers via runAutoSuggestForTable. Returns the count of
-	 * tables actually pulled in.
-	 */
-	/**
-	 * For an on-canvas column, find every OTHER table already on the
-	 * canvas that has a column with the same (case-insensitive) name
-	 * and commit a join from this column to each of them. Returns the
-	 * count of joins actually added (existing-tuple dedupe applies).
-	 * Companion to `pullInMatchingColumnTables` but scoped to what's
-	 * already on the canvas.
-	 */
-	linkSimilarOnCanvas(originTableId: string, columnName: string): number {
-		const needle = columnName.toLowerCase();
-		let added = 0;
-		this.withUndoBatch(() => {
-			for (const t of this.doc.tables) {
-				if (t.id === originTableId) continue;
-				const match = t.columns.find((c) => c.name.toLowerCase() === needle);
-				if (!match) continue;
-				const before = this.doc.joins.length;
-				this.addJoin({
-					sourceTableId: originTableId,
-					sourceColumnName: columnName,
-					targetTableId: t.id,
-					targetColumnName: match.name,
-					kind: 'inner'
-				});
-				if (this.doc.joins.length > before) added++;
-			}
-		});
-		// One summary toast for the batch, overwriting the per-join
-		// feedback each addJoin pushed.
-		if (added > 1) {
-			this.pushJoinFeedback(`${added} joins created (linked ${columnName})`);
-		}
-		return added;
-	}
-
-	pullInMatchingColumnTables(columnName: string): number {
-		const needle = columnName.trim().toLowerCase();
-		if (!needle) return 0;
-		const onCanvas = this.tableIdentitiesOnCanvas;
-		const candidates = this.sourceTables.filter((c) => {
-			const ident = c.schema ? `${c.schema}.${c.name}` : c.name;
-			if (onCanvas.has(ident)) return false;
-			return c.columns.some((col) => col.name.toLowerCase() === needle);
-		});
-		if (candidates.length === 0) return 0;
-		// Lay them out in a horizontal row to the right of the rightmost
-		// existing table — keeps the new ones together visually.
-		const rightmostX = this.doc.tables.reduce((m, t) => Math.max(m, t.position.x), 0);
-		const baseX = rightmostX + 320;
-		const baseY = 80;
-		const added: string[] = [];
-		// One Undo step for the whole pull-in (tables + any auto-joins).
-		this.withUndoBatch(() => {
-			candidates.forEach((cand, i) => {
-				const t = this.addTable(cand, { x: baseX, y: baseY + i * 280 });
-				added.push(t.id);
-			});
-			if (this.autoSuggestOnDrop) {
-				for (const id of added) this.runAutoSuggestForTable(id);
-			}
-		});
-		return added.length;
-	}
-
-	/** Wipe every join. Tables stay where they are.  Also clears the
-	 *  group-rename map and every piece of UI state that referenced a
-	 *  now-deleted join — otherwise recreating the same canonical pair
-	 *  silently inherits the previous label, and stale selection /
-	 *  focus / pathfinder state would point at edges that no longer
-	 *  exist. */
-	removeAllJoins(): void {
-		if (this.doc.joins.length === 0) return;
-		this.doc.joins = [];
-		this.doc.joinGroupRenames = {};
-		this.selectedJoinId = null;
-		this.pendingJoinSource = null;
-		this.pickModeActive = false;
-		this.eShiftPicks = [];
-		this.pathfinderResult = null;
-		this.highlightedColumn = null;
-		this.highlightOriginTableId = null;
-		this.highlightSource = null;
-		this.focusKind = 'none';
-		this.focusKey = null;
-		this.touch();
-	}
-
-	// ── Dimensions Workbench (Step 2) ────────────────────────────────
-	// Mondrian-shaped dimension/hierarchy/level/measure authoring sits
-	// on top of the join graph from Step 1.  Persistence rides the
-	// same touch() → saveToStorage path as everything else on the doc.
-
-	/** Read accessor with default — older docs in localStorage didn't
-	 *  carry `dimensions`. */
-	get dimensions(): SchemaCanvasDimension[] {
-		return this.doc.dimensions ?? [];
-	}
-
-	/** Read accessor with default — older docs in localStorage didn't
-	 *  carry `measures`. */
-	get measures(): SchemaCanvasMeasure[] {
-		return this.doc.measures ?? [];
-	}
-
-	/** Create a new dimension. If a column reference is supplied, the
-	 *  dimension is seeded with a first hierarchy that already holds
-	 *  that column as its sole level — matches the drop UX where a
-	 *  column dragged onto the empty zone materialises a full
-	 *  dimension in one gesture. */
-	addDimension(seed?: {
-		name?: string;
-		tableId?: string;
-		columnName?: string;
-		columnType?: SchemaCanvasColumnKind;
-	}): SchemaCanvasDimension {
-		const tableName =
-			seed?.tableId !== undefined
-				? (this.doc.tables.find((t) => t.id === seed.tableId)?.name ?? null)
-				: null;
-		const desired = seed?.name?.trim() || tableName || seed?.columnName || 'New dimension';
-		const name = ensureUnique(
-			desired,
-			(this.doc.dimensions ?? []).map((d) => d.name)
-		);
-		// Default: zero hierarchies.  The user explicitly composes
-		// hierarchies in Col 3 (Make hierarchy) or implicitly via the
-		// "singleton hierarchy for this attribute" checkbox on the
-		// Attributes pane.  Only the column-drop seed path (used by the
-		// legacy Cards/Tree drag UX) still auto-creates one hierarchy
-		// since the user dropped a specific column.
-		const hierarchies: SchemaCanvasHierarchy[] = [];
-		if (seed?.tableId && seed?.columnName) {
-			hierarchies.push({
-				id: makeId('hier'),
-				name,
-				hasAll: true,
-				levels: [
-					{
-						id: makeId('lvl'),
-						name: seed.columnName,
-						tableId: seed.tableId,
-						columnName: seed.columnName,
-						type: seed.columnType
-					}
-				]
-			});
-		}
-		const dim: SchemaCanvasDimension = {
-			id: makeId('dim'),
-			name,
-			hierarchies,
-			// Set BOTH: `sourceTableId` is the canonical binding the
-			// Workbench (Attrs count, FK selector, attribute picker)
-			// reads.  `primaryKeyTableId` kept for the snowflake case +
-			// legacy compatibility.  The types.ts split (2026-07-30ish)
-			// made `sourceTableId` primary but addDimension wasn't
-			// updated — freshly added dims read as "no table bound".
-			sourceTableId: seed?.tableId,
-			primaryKeyTableId: seed?.tableId
-		};
-		this.doc.dimensions = [...this.dimensions, dim];
-		this.touch();
-		return dim;
-	}
-
-	updateDimension(
-		dimensionId: string,
-		patch: Partial<Omit<SchemaCanvasDimension, 'id' | 'hierarchies'>>
-	): void {
-		const d = this.dimensions.find((d) => d.id === dimensionId);
-		if (!d) return;
-		Object.assign(d, patch);
-		// Note: we used to auto-rename any hierarchy whose name matched
-		// the old dim name when the dim was renamed — to keep the
-		// Mondrian "implicit-default" convention.  Dropped once the
-		// authoring model became "hierarchies are always explicit".
-		// Hierarchies are now independent of the dim's label; renaming
-		// the dim never touches them.
-		this.touch();
-	}
-
-	removeDimension(dimensionId: string): void {
-		this.doc.dimensions = this.dimensions.filter((d) => d.id !== dimensionId);
-		this.touch();
-	}
-
-	/** Add a {tableId, columnName} pair to the dim's attribute set A.
-	 *  No-op if already present.  `attributes === undefined` is the
-	 *  blank-slate state; the first add materialises it as a one-item
-	 *  array, matching the "user starts including" mode. */
-	addAttribute(dimensionId: string, tableId: string, columnName: string): void {
-		const d = this.dimensions.find((d) => d.id === dimensionId);
-		if (!d) return;
-		const list = d.attributes ?? [];
-		if (list.some((a) => a.tableId === tableId && a.columnName === columnName)) return;
-		d.attributes = [...list, { tableId, columnName }];
-		this.touch();
-	}
-
-	/** Patch one attribute's editable Mondrian-4 fields (name, display /
-	 *  sort / caption columns, description) — inspector #959. Identified by
-	 *  its {tableId, columnName} identity, which is NOT itself patched here. */
-	updateAttribute(
-		dimensionId: string,
-		tableId: string,
-		columnName: string,
-		patch: Partial<
-			Omit<NonNullable<SchemaCanvasDimension['attributes']>[number], 'tableId' | 'columnName'>
-		>
-	): void {
-		const d = this.dimensions.find((d) => d.id === dimensionId);
-		const a = d?.attributes?.find((x) => x.tableId === tableId && x.columnName === columnName);
-		if (!a) return;
-		Object.assign(a, patch);
-		this.touch();
-	}
-
-	/** Remove a {tableId, columnName} pair from the dim's attribute set
-	 *  A.  Leaves the array (even empty) in place so the dim is
-	 *  distinguishably "user has touched A" vs "user hasn't yet". */
-	removeAttribute(dimensionId: string, tableId: string, columnName: string): void {
-		const d = this.dimensions.find((d) => d.id === dimensionId);
-		if (!d?.attributes) return;
-		d.attributes = d.attributes.filter(
-			(a) => !(a.tableId === tableId && a.columnName === columnName)
-		);
-		this.touch();
-	}
-
-	/** Replace A wholesale — used by bulk include-all / exclude-all. */
-	setAttributes(dimensionId: string, attributes: { tableId: string; columnName: string }[]): void {
-		const d = this.dimensions.find((d) => d.id === dimensionId);
-		if (!d) return;
-		d.attributes = attributes;
-		this.touch();
-	}
-
-	addHierarchy(dimensionId: string, name?: string): SchemaCanvasHierarchy | null {
-		const d = this.dimensions.find((d) => d.id === dimensionId);
-		if (!d) return null;
-		const desired = name?.trim() || `Hierarchy ${d.hierarchies.length + 1}`;
-		const h: SchemaCanvasHierarchy = {
-			id: makeId('hier'),
-			name: ensureUnique(
-				desired,
-				d.hierarchies.map((x) => x.name)
-			),
-			hasAll: true,
-			levels: []
-		};
-		d.hierarchies = [...d.hierarchies, h];
-		this.touch();
-		return h;
-	}
-
-	updateHierarchy(
-		dimensionId: string,
-		hierarchyId: string,
-		patch: Partial<Omit<SchemaCanvasHierarchy, 'id' | 'levels'>>
-	): void {
-		const d = this.dimensions.find((d) => d.id === dimensionId);
-		const h = d?.hierarchies.find((h) => h.id === hierarchyId);
-		if (!h) return;
-		Object.assign(h, patch);
-		this.touch();
-	}
-
-	removeHierarchy(dimensionId: string, hierarchyId: string): void {
-		const d = this.dimensions.find((d) => d.id === dimensionId);
-		if (!d) return;
-		d.hierarchies = d.hierarchies.filter((h) => h.id !== hierarchyId);
-		this.touch();
-	}
-
-	addLevel(
-		dimensionId: string,
-		hierarchyId: string,
-		level: { tableId: string; columnName: string; name?: string; type?: SchemaCanvasColumnKind }
-	): SchemaCanvasLevel | null {
-		const d = this.dimensions.find((d) => d.id === dimensionId);
-		const h = d?.hierarchies.find((h) => h.id === hierarchyId);
-		if (!h) return null;
-		// Skip the exact same column landing twice in one hierarchy —
-		// stops a stray double-drop from creating an obviously useless
-		// duplicate row.  Different hierarchies (or different columns)
-		// are fine.
-		const dup = h.levels.find(
-			(l) => l.tableId === level.tableId && l.columnName === level.columnName
-		);
-		if (dup) return dup;
-		const lvl: SchemaCanvasLevel = {
-			id: makeId('lvl'),
-			name: level.name?.trim() || level.columnName,
-			tableId: level.tableId,
-			columnName: level.columnName,
-			type: level.type
-		};
-		h.levels = [...h.levels, lvl];
-		this.touch();
-		return lvl;
-	}
-
-	updateLevel(
-		dimensionId: string,
-		hierarchyId: string,
-		levelId: string,
-		patch: Partial<Omit<SchemaCanvasLevel, 'id'>>
-	): void {
-		const d = this.dimensions.find((d) => d.id === dimensionId);
-		const h = d?.hierarchies.find((h) => h.id === hierarchyId);
-		const l = h?.levels.find((l) => l.id === levelId);
-		if (!l) return;
-		Object.assign(l, patch);
-		this.touch();
-	}
-
-	removeLevel(dimensionId: string, hierarchyId: string, levelId: string): void {
-		const d = this.dimensions.find((d) => d.id === dimensionId);
-		const h = d?.hierarchies.find((h) => h.id === hierarchyId);
-		if (!h) return;
-		h.levels = h.levels.filter((l) => l.id !== levelId);
-		this.touch();
-	}
-
-	/** Move a level one position within its hierarchy (coarse↔fine reorder).
-	 *  `delta` is -1 (toward coarsest / up) or +1 (toward finest / down). No-op
-	 *  at the ends. Immutable swap — a new levels array is assigned. */
-	moveLevel(dimensionId: string, hierarchyId: string, levelId: string, delta: -1 | 1): void {
-		const d = this.dimensions.find((d) => d.id === dimensionId);
-		const h = d?.hierarchies.find((h) => h.id === hierarchyId);
-		if (!h) return;
-		const i = h.levels.findIndex((l) => l.id === levelId);
-		const j = i + delta;
-		if (i < 0 || j < 0 || j >= h.levels.length) return;
-		const next = [...h.levels];
-		[next[i], next[j]] = [next[j], next[i]];
-		h.levels = next;
-		this.touch();
-	}
-
-	/** Drop a measure for a numeric column. Defaults to sum. */
-	addMeasure(seed: {
-		tableId: string;
-		columnName: string;
-		name?: string;
-		aggregator?: SchemaCanvasMeasure['aggregator'];
-		/** Percentile fraction (0–100); only meaningful for aggregator 'percentile'. */
-		percentile?: number | null;
-	}): SchemaCanvasMeasure {
-		const aggregator = seed.aggregator ?? 'sum';
-		const m: SchemaCanvasMeasure = {
-			id: makeId('meas'),
-			name: seed.name?.trim() || seed.columnName,
-			aggregator,
-			tableId: seed.tableId,
-			columnName: seed.columnName,
-			percentile: aggregator === 'percentile' ? (seed.percentile ?? null) : undefined
-		};
-		this.doc.measures = [...this.measures, m];
-		this.touch();
-		return m;
-	}
-
-	updateMeasure(measureId: string, patch: Partial<Omit<SchemaCanvasMeasure, 'id'>>): void {
-		const m = this.measures.find((m) => m.id === measureId);
-		if (!m) return;
-		Object.assign(m, patch);
-		this.touch();
-	}
-
-	removeMeasure(measureId: string): void {
-		this.doc.measures = this.measures.filter((m) => m.id !== measureId);
-		this.touch();
-	}
-
-	// ── Cubes (measure groups + calculated members) ──────────────────
-	// The durable half of the Facts & Measures workbench.  Every mutator
-	// is immutable + rides the same touch() → saveToStorage path.  UI-only
-	// flags stay in WorkbenchView; the doc carries only the model an
-	// external caller (DimSum) needs to create and the exporter to emit.
-
-	/** Read accessor with default — older docs didn't carry `cubes`. */
-	get cubes(): SchemaCanvasCube[] {
-		return this.doc.cubes ?? [];
-	}
-
-	/** Replace the whole cube list.  Used by the workbench's persist path
-	 *  (mapping its live cubes back into the trimmed doc shape). */
-	setCubes(cubes: SchemaCanvasCube[]): void {
-		// Preserve cube-scoped time-intelligence metrics across a workbench
-		// write-back. The workbench maps its live cubes through `cubeToDoc`,
-		// which doesn't carry `timeCalcs` (they're edited via the inspector's
-		// store methods on the doc). Without this merge, every workbench sync
-		// would silently wipe them. Incoming timeCalcs win when present (e.g. an
-		// import); otherwise inherit the existing doc cube's by id.
-		const existingTimeCalcs = new Map((this.doc.cubes ?? []).map((c) => [c.id, c.timeCalcs]));
-		this.doc.cubes = cubes.map((c) =>
-			c.timeCalcs !== undefined ? c : { ...c, timeCalcs: existingTimeCalcs.get(c.id) }
-		);
-		this.touch();
-	}
-
-	/** Signal the canvas page to re-hydrate the workbench from `doc.cubes`
-	 *  after an external cube write. */
-	bumpWorkbenchReload(): void {
-		this.workbenchReloadNonce += 1;
-	}
-
-	addCube(seed?: { id?: string; name?: string }): SchemaCanvasCube {
-		const name = ensureUnique(
-			seed?.name?.trim() || `Cube ${this.cubes.length + 1}`,
-			this.cubes.map((c) => c.name)
-		);
-		const cube: SchemaCanvasCube = {
-			id: seed?.id ?? makeId('cube'),
-			name,
-			measureGroups: [],
-			calcs: []
-		};
-		this.doc.cubes = [...this.cubes, cube];
-		this.touch();
-		return cube;
-	}
-
-	removeCube(cubeId: string): void {
-		this.doc.cubes = this.cubes.filter((c) => c.id !== cubeId);
-		this.touch();
-	}
-
-	renameCube(cubeId: string, name: string): void {
-		const c = this.cubes.find((c) => c.id === cubeId);
-		if (!c) return;
-		c.name = name;
-		this.touch();
-	}
-
-	private findCube(cubeId: string): SchemaCanvasCube | undefined {
-		return this.cubes.find((c) => c.id === cubeId);
-	}
-
-	addMeasureGroup(
-		cubeId: string,
-		seed: { id?: string; name?: string; factTableId?: string | null }
-	): SchemaCanvasMeasureGroup | null {
-		const cube = this.findCube(cubeId);
-		if (!cube) return null;
-		const name = ensureUnique(
-			seed.name?.trim() || `Group ${cube.measureGroups.length + 1}`,
-			cube.measureGroups.map((g) => g.name)
-		);
-		const mg: SchemaCanvasMeasureGroup = {
-			id: seed.id ?? makeId('mg'),
-			name,
-			measureColumns: [],
-			factTableId: seed.factTableId ?? null,
-			dimensionLinks: []
-		};
-		cube.measureGroups = [...cube.measureGroups, mg];
-		this.touch();
-		return mg;
-	}
-
-	removeMeasureGroup(cubeId: string, mgId: string): void {
-		const cube = this.findCube(cubeId);
-		if (!cube) return;
-		cube.measureGroups = cube.measureGroups.filter((g) => g.id !== mgId);
-		this.touch();
-	}
-
-	renameMeasureGroup(cubeId: string, mgId: string, name: string): void {
-		const mg = this.findCube(cubeId)?.measureGroups.find((g) => g.id === mgId);
-		if (!mg) return;
-		mg.name = name;
-		this.touch();
-	}
-
-	setMeasureColumns(cubeId: string, mgId: string, cols: string[]): void {
-		const mg = this.findCube(cubeId)?.measureGroups.find((g) => g.id === mgId);
-		if (!mg) return;
-		mg.measureColumns = [...cols];
-		this.touch();
-	}
-
-	/** Add or remove a single measure column from a group. */
-	toggleMeasureColumn(cubeId: string, mgId: string, col: string): void {
-		const mg = this.findCube(cubeId)?.measureGroups.find((g) => g.id === mgId);
-		if (!mg) return;
-		mg.measureColumns = mg.measureColumns.includes(col)
-			? mg.measureColumns.filter((c) => c !== col)
-			: [...mg.measureColumns, col];
-		this.touch();
-	}
-
-	setMeasureGroupFactTable(cubeId: string, mgId: string, tableId: string | null): void {
-		const mg = this.findCube(cubeId)?.measureGroups.find((g) => g.id === mgId);
-		if (!mg) return;
-		mg.factTableId = tableId;
-		this.touch();
-	}
-
-	/** Upsert a dimension link on a measure group — keyed by dimensionId. */
-	setMeasureGroupDimLink(cubeId: string, mgId: string, link: SchemaCanvasDimensionLink): void {
-		const mg = this.findCube(cubeId)?.measureGroups.find((g) => g.id === mgId);
-		if (!mg) return;
-		const existing = mg.dimensionLinks ?? [];
-		const idx = existing.findIndex((l) => l.dimensionId === link.dimensionId);
-		mg.dimensionLinks =
-			idx >= 0 ? existing.map((l, i) => (i === idx ? link : l)) : [...existing, link];
-		this.touch();
-	}
-
-	removeMeasureGroupDimLink(cubeId: string, mgId: string, dimensionId: string): void {
-		const mg = this.findCube(cubeId)?.measureGroups.find((g) => g.id === mgId);
-		if (!mg?.dimensionLinks) return;
-		mg.dimensionLinks = mg.dimensionLinks.filter((l) => l.dimensionId !== dimensionId);
-		this.touch();
-	}
-
-	addCalc(
-		cubeId: string,
-		seed: { id?: string; name?: string; tokens?: SchemaCanvasCalc['tokens']; formula?: string }
-	): SchemaCanvasCalc | null {
-		const cube = this.findCube(cubeId);
-		if (!cube) return null;
-		const calc: SchemaCanvasCalc = {
-			id: seed.id ?? makeId('calc'),
-			name: seed.name ?? '',
-			tokens: seed.tokens ?? [],
-			formula: seed.formula
-		};
-		cube.calcs = [...cube.calcs, calc];
-		this.touch();
-		return calc;
-	}
-
-	removeCalc(cubeId: string, calcId: string): void {
-		const cube = this.findCube(cubeId);
-		if (!cube) return;
-		cube.calcs = cube.calcs.filter((c) => c.id !== calcId);
-		this.touch();
-	}
-
-	// ── Time-intelligence calcs (yoy/pop/ytd/rolling) — cube-scoped ──
-	addTimeCalc(cubeId: string, seed?: Partial<SchemaCanvasTimeCalc>): SchemaCanvasTimeCalc | null {
-		const cube = this.findCube(cubeId);
-		if (!cube) return null;
-		const tc: SchemaCanvasTimeCalc = {
-			id: seed?.id ?? makeId('timecalc'),
-			name: seed?.name ?? '',
-			type: seed?.type ?? 'yoy',
-			measure: seed?.measure ?? '',
-			timeDimension: seed?.timeDimension,
-			window: seed?.window,
-			function: seed?.function,
-			formatString: seed?.formatString
-		};
-		cube.timeCalcs = [...(cube.timeCalcs ?? []), tc];
-		this.touch();
-		return tc;
-	}
-
-	updateTimeCalc(
-		cubeId: string,
-		timeCalcId: string,
-		patch: Partial<Omit<SchemaCanvasTimeCalc, 'id'>>
-	): void {
-		const cube = this.findCube(cubeId);
-		if (!cube?.timeCalcs) return;
-		const tc = cube.timeCalcs.find((t) => t.id === timeCalcId);
-		if (!tc) return;
-		Object.assign(tc, patch);
-		this.touch();
-	}
-
-	removeTimeCalc(cubeId: string, timeCalcId: string): void {
-		const cube = this.findCube(cubeId);
-		if (!cube?.timeCalcs) return;
-		cube.timeCalcs = cube.timeCalcs.filter((t) => t.id !== timeCalcId);
-		this.touch();
-	}
-
-	/**
-	 * Canonical group key for a join — the shared column name when
-	 * both sides match, otherwise the alphabetised pair joined by `↔`.
-	 * Stable across direction (source ↔ target) so a swap doesn't
-	 * shuffle groups around.
-	 */
-	static joinCanonicalKey(j: SchemaCanvasJoin): string {
-		if (j.sourceColumnName === j.targetColumnName) return j.sourceColumnName;
-		return [j.sourceColumnName, j.targetColumnName].sort().join('↔');
-	}
-
-	/** Human label for a join group — falls back to the canonical key
-	 *  when nothing has been renamed. */
-	joinGroupLabelFor(j: SchemaCanvasJoin): string {
-		const key = SchemaCanvasStore.joinCanonicalKey(j);
-		return this.doc.joinGroupRenames?.[key] ?? key;
-	}
-
-	/** Rename a join group. Empty/whitespace `nextLabel` drops the
-	 *  rename so the group reverts to its canonical key. */
-	renameJoinGroup(canonicalKey: string, nextLabel: string): void {
-		const trimmed = nextLabel.trim();
-		const renames = { ...(this.doc.joinGroupRenames ?? {}) };
-		if (!trimmed || trimmed === canonicalKey) {
-			delete renames[canonicalKey];
-		} else {
-			renames[canonicalKey] = trimmed;
-		}
-		this.doc.joinGroupRenames = renames;
-		this.touch();
-	}
-
-	setJoinKind(joinId: string, kind: SchemaCanvasJoinKind): void {
-		const j = this.doc.joins.find((j) => j.id === joinId);
-		if (!j) return;
-		j.kind = kind;
-		this.touch();
-	}
-
-	createGroup(label: string): SchemaCanvasGroup {
-		const g: SchemaCanvasGroup = { id: makeId('grp'), label, collapsed: false };
-		this.doc.groups.push(g);
-		this.touch();
-		return g;
-	}
-
-	assignTableToGroup(tableId: string, groupId: string | null): void {
-		const t = this.doc.tables.find((t) => t.id === tableId);
-		if (!t) return;
-		t.groupId = groupId;
-		this.touch();
-	}
-
-	get factTable(): SchemaCanvasTable | null {
-		return this.doc.tables.find((t) => t.role === 'fact') ?? null;
-	}
-
-	get dimensionTables(): SchemaCanvasTable[] {
-		return this.doc.tables.filter((t) => t.role !== 'fact');
-	}
-
-	/** Returns the set of source-table identities (schema.name) currently on the canvas. */
-	get tableIdentitiesOnCanvas(): Set<string> {
-		return new Set(this.doc.tables.map((t) => (t.schema ? `${t.schema}.${t.name}` : t.name)));
-	}
-
-	/**
-	 * Wipe the canvas back to a blank doc for the current connection.
-	 * Clears UI state too so nothing dangles. Persistence follows — the
-	 * empty doc replaces the saved one in localStorage.
-	 */
-	resetCanvas(): void {
-		this.doc = blankState(this.connectionId);
-		this.selectedTableId = null;
-		this.selectedJoinId = null;
-		this.highlightedColumn = null;
-		this.highlightSource = null;
-		this.binaryCursor = 0;
-		this.sidebarQuery = '';
-		this.touch();
-	}
-
-	/**
-	 * Replace the current canvas doc with one loaded from elsewhere
-	 * (JSON bundle, XML import). The doc is forced onto the active
-	 * connection id so localStorage stays keyed correctly.
-	 */
-	loadDoc(doc: SchemaCanvasState): void {
-		// Snapshot the current doc BEFORE replacing so the toolbar Undo
-		// button can revert.  Structured clone to isolate the snapshot
-		// from subsequent mutations of `this.doc`.
-		// JSON round-trip because structuredClone can't clone Svelte 5
-		// `$state` proxies (DataCloneError).
-		this.previousDoc = JSON.parse(JSON.stringify(this.doc)) as SchemaCanvasState;
-		this.doc = { ...doc, connectionId: this.connectionId };
-		this.selectedTableId = null;
-		this.selectedJoinId = null;
-		this.highlightedColumn = null;
-		this.highlightSource = null;
-		this.binaryCursor = 0;
-		this.sidebarQuery = '';
-		this.touch();
-	}
-
-	/**
-	 * Restore the last `previousDoc` snapshot as the current doc.  Swaps
-	 * the snapshot forward-and-back so undo can immediately re-apply
-	 * (the current doc becomes the new snapshot).  No-op when the
-	 * snapshot is null.
-	 */
-	undo(): void {
-		if (!this.previousDoc) return;
-		const swap = this.previousDoc;
-		// JSON round-trip because structuredClone can't clone Svelte 5
-		// `$state` proxies (DataCloneError).
-		this.previousDoc = JSON.parse(JSON.stringify(this.doc)) as SchemaCanvasState;
-		this.doc = { ...swap, connectionId: this.connectionId };
-		this.selectedTableId = null;
-		this.selectedJoinId = null;
-		this.highlightedColumn = null;
-		this.highlightSource = null;
-		this.touch();
-	}
-
-	/** Discard the pending undo snapshot — e.g. after the user confirms
-	 *  an AI proposal and no longer wants to revert it. */
-	clearPreviousDoc(): void {
-		this.previousDoc = null;
-	}
-
-	/** Take a snapshot of the current doc so the next big user gesture
-	 *  is reversible via Undo.  Call at the entry point of a semantic
-	 *  action (a drag-drop, a commit, an import) rather than per-
-	 *  mutation, so N adds inside one gesture collapse to one undo
-	 *  step.  Idempotent within the same gesture: a repeat call inside
-	 *  the same tick overwrites the previous snapshot (which is what
-	 *  we want — one snapshot per user intent). */
-	snapshotForUndo(): void {
-		// JSON round-trip because structuredClone can't clone Svelte 5
-		// `$state` proxies (DataCloneError).
-		this.previousDoc = JSON.parse(JSON.stringify(this.doc)) as SchemaCanvasState;
-	}
-
-	/** When true, per-mutation snapshotForUndo is suppressed — the batch
-	 *  caller (drop, CJM commit, pullIn, linkSimilar) has already taken
-	 *  ONE snapshot at its entry and doesn't want each addJoin/addTable
-	 *  inside its loop clobbering that.  Set via `withUndoBatch()`. */
-	private undoBatchDepth = 0;
-
-	/** Run `fn` as a single Undo step — take one snapshot at entry, then
-	 *  suppress the per-mutation snapshots that base methods (addTable,
-	 *  addJoin, removeTable, removeJoin, removeJoins) would otherwise
-	 *  take.  Nesting is safe — only the outermost call snapshots. */
-	withUndoBatch<T>(fn: () => T): T {
-		if (this.undoBatchDepth === 0) this.snapshotForUndo();
-		this.undoBatchDepth++;
-		try {
-			return fn();
-		} finally {
-			this.undoBatchDepth--;
-		}
-	}
-
-	/** Take a snapshot unless we're inside a batch (in which case the
-	 *  batch already snapshotted at entry). Called from every base
-	 *  mutation so every user-visible action ends up undoable. */
-	private maybeSnapshotForUndo(): void {
-		if (this.undoBatchDepth === 0) this.snapshotForUndo();
-	}
-
-	/**
-	 * Click-to-join entry point. State machine:
-	 *  - no pending source → arm (stash this column as the source).
-	 *  - click the SAME (table, column) again → cancel (clear).
-	 *  - click a different column on the SAME table → replace the pending
-	 *    source (self-joins aren't modelled here, so silently re-arm).
-	 *  - click a column on a DIFFERENT table → commit the join via
-	 *    `addJoin` (which itself dedupes by exact tuple + touches the
-	 *    doc), then clear the pending source.
-	 *
-	 * `pendingJoinSource` is UI-only — no `touch()` here, only `addJoin`
-	 * mutates the persisted doc.
-	 */
-	/** Tap E → toggle pick mode.  When ON, column clicks accumulate
-	 *  into eShiftPicks instead of arming a single click-to-join.
-	 *  Tapping E again turns the mode OFF but does NOT clear picks —
-	 *  the panel persists until Clear or Match.  Idempotent on
-	 *  keyboard auto-repeat. */
-	togglePickMode(): void {
-		this.pickModeActive = !this.pickModeActive;
-	}
-	enterPickMode(): void {
-		this.pickModeActive = true;
-	}
-	exitPickMode(): void {
-		this.pickModeActive = false;
-	}
-
-	/** Add (or toggle off) a column to the pick set.  Enforces at most
-	 *  ONE column per table — joins are one-to-one, so picking a second
-	 *  column on a table that already has one REPLACES the previous
-	 *  pick for that table (otherwise you'd end up trying to "merge"
-	 *  two columns of the same table into a single joined thing, which
-	 *  is meaningless).  Re-clicking the same (table, column) toggles
-	 *  it off. */
-	pushEShiftPick(tableId: string, columnName: string): void {
-		const sameColIdx = this.eShiftPicks.findIndex(
-			(p) => p.tableId === tableId && p.columnName === columnName
-		);
-		if (sameColIdx >= 0) {
-			// Toggle off — user re-clicked the same pick.
-			const next = this.eShiftPicks.slice();
-			next.splice(sameColIdx, 1);
-			this.eShiftPicks = next;
-			return;
-		}
-		const sameTableIdx = this.eShiftPicks.findIndex((p) => p.tableId === tableId);
-		if (sameTableIdx >= 0) {
-			// Replace the existing pick on this table — one column per table.
-			const next = this.eShiftPicks.slice();
-			next[sameTableIdx] = { tableId, columnName };
-			this.eShiftPicks = next;
-			return;
-		}
-		// New table entirely — append.
-		this.eShiftPicks = [...this.eShiftPicks, { tableId, columnName }];
-	}
-
-	/** Commit picks → joins, using a STAR pattern (pick[0] = origin,
-	 *  wires to each subsequent pick).  The optional `groupName` is
-	 *  written into `joinGroupRenames` for every new join's canonical
-	 *  key so the joins-panel renders them all under one label —
-	 *  letting picks with DIFFERENT column names ("product_id" ↔
-	 *  "prod_id" ↔ "pid") collapse into a single semantic group like
-	 *  "Product Key".  Less than two picks → no-op.  Mesh + chain
-	 *  patterns are not exposed yet; star is the safe default. */
-	commitEShiftPicks(groupName?: string): void {
-		const picks = this.eShiftPicks;
-		this.eShiftPicks = [];
-		this.pickModeActive = false;
-		if (picks.length < 2) return;
-		const trimmedName = groupName?.trim();
-		const origin = picks[0];
-		const renames = { ...(this.doc.joinGroupRenames ?? {}) };
-		let joinsCreated = 0;
-		// One Undo step per commit — every addJoin inside skips its
-		// per-mutation snapshot via the batch guard.
-		this.withUndoBatch(() => {
-			for (let i = 1; i < picks.length; i++) {
-				const peer = picks[i];
-				if (origin.tableId === peer.tableId) continue;
-				const created = this.addJoin({
-					sourceTableId: origin.tableId,
-					sourceColumnName: origin.columnName,
-					targetTableId: peer.tableId,
-					targetColumnName: peer.columnName,
-					kind: 'inner'
-				});
-				joinsCreated++;
-				if (trimmedName) {
-					const canonicalKey = SchemaCanvasStore.joinCanonicalKey(created);
-					renames[canonicalKey] = trimmedName;
-				}
-			}
-			if (trimmedName) {
-				this.doc.joinGroupRenames = renames;
-				this.touch();
-			}
-		});
-		// Overwrite the per-join feedback with a batch summary so the
-		// user sees ONE toast, not N.
-		if (joinsCreated > 1) {
-			const label = trimmedName ? ` under "${trimmedName}"` : '';
-			this.pushJoinFeedback(`${joinsCreated} joins created${label}`);
-		} else if (joinsCreated === 1 && trimmedName) {
-			// Single join with a named group — mention the label so the
-			// user knows the rename landed.
-			this.pushJoinFeedback(`Join created as "${trimmedName}"`);
-		}
-	}
-
-	/** Clear picks + exit pick mode.  Wired to ESC and the picks-
-	 *  panel "Clear" button. */
-	cancelEShift(): void {
-		this.pickModeActive = false;
-		this.eShiftPicks = [];
-	}
-
-	/** User-typed sidebar search — updates the query AND clears the
-	 *  click-driven highlight so the sidebar and the "Pull in N
-	 *  matching tables" pill / "MATCHING X" active-set panel can't
-	 *  end up talking about different columns.  Column-click driven
-	 *  updates go through the internal `sidebarQuery = X` path (with
-	 *  the highlight set alongside) so they stay coherent. */
-	setSidebarQueryFromUser(q: string): void {
-		this.sidebarQuery = q;
-		this.highlightedColumn = null;
-		this.highlightOriginTableId = null;
-		this.highlightSource = null;
-	}
-
-	/** Sensible default label for a group of picked columns — used to
-	 *  prefill the group-name input and as the auto-name when the user
-	 *  hits Enter without typing anything.  If every pick shares the
-	 *  same column name, use it verbatim; otherwise fall back to the
-	 *  most common name across the picks (ties broken by first-seen).
-	 *  Empty string when there are no picks. */
-	autoPickGroupName(): string {
-		if (this.eShiftPicks.length === 0) return '';
-		const counts = new Map<string, number>();
-		for (const p of this.eShiftPicks) {
-			counts.set(p.columnName, (counts.get(p.columnName) ?? 0) + 1);
-		}
-		let bestName = this.eShiftPicks[0].columnName;
-		let bestCount = 0;
-		for (const [name, count] of counts) {
-			if (count > bestCount) {
-				bestName = name;
-				bestCount = count;
-			}
-		}
-		return bestName;
-	}
-
-	/** Arm a pathfinder slot — the next column click on the canvas
-	 *  writes into that slot.  Passing `null` disarms.  Clicking the
-	 *  same slot twice while armed toggles it off. */
-	armPathfinder(slot: 'start' | 'end' | null): void {
-		this.pathfinderArmed = this.pathfinderArmed === slot ? null : slot;
-		// Stale result becomes meaningless the moment endpoints might
-		// change — clear it so the UI doesn't display a path that no
-		// longer matches the inputs.
-		this.pathfinderResult = null;
-	}
-
-	/** Set an endpoint explicitly (used by tryColumnClickJoin when
-	 *  pathfinderArmed is set). Clears the armed flag once written. */
-	setPathfinderEndpoint(slot: 'start' | 'end', endpoint: PathfinderEndpoint): void {
-		if (slot === 'start') this.pathfinderStart = endpoint;
-		else this.pathfinderEnd = endpoint;
-		this.pathfinderArmed = null;
-		this.pathfinderResult = null;
-	}
-
-	/** Wipe every pathfinder bit — slots, armed flag, result.  Wired
-	 *  to the panel's Clear button. */
-	clearPathfinder(): void {
-		this.pathfinderArmed = null;
-		this.pathfinderStart = null;
-		this.pathfinderEnd = null;
-		this.pathfinderResult = null;
-	}
-
-	/**
-	 * BFS from `pathfinderStart.tableId` to `pathfinderEnd.tableId`.
-	 * First pass uses existing joins only.  If no path exists, a
-	 * second pass adds virtual edges for column-name collisions
-	 * (case-insensitive) so the result can propose missing joins for
-	 * the user to commit via `applyPathfinderJoins`.  Writes the
-	 * shortest chain (or null when no path is possible) into
-	 * `pathfinderResult`.
-	 */
-	findPath(): void {
-		const start = this.pathfinderStart;
-		const end = this.pathfinderEnd;
-		if (!start || !end) {
-			this.pathfinderResult = null;
-			return;
-		}
-		// Same-table trivial case — no path, just return an empty steps
-		// list so the UI can say "already on the same table".
-		if (start.tableId === end.tableId) {
-			this.pathfinderResult = { steps: [], hasGaps: false };
-			return;
-		}
-
-		type Edge = {
-			toTableId: string;
-			fromColumnName: string;
-			toColumnName: string;
-			joinId: string | null; // null = virtual (proposed)
-		};
-
-		// Build adjacency from existing joins first.  Joins are undirected
-		// for traversal — a path from A to B can use a join wired B→A.
-		const adj = new Map<string, Edge[]>();
-		const pushEdge = (fromId: string, edge: Edge) => {
-			const list = adj.get(fromId);
-			if (list) list.push(edge);
-			else adj.set(fromId, [edge]);
-		};
-		for (const j of this.doc.joins) {
-			pushEdge(j.sourceTableId, {
-				toTableId: j.targetTableId,
-				fromColumnName: j.sourceColumnName,
-				toColumnName: j.targetColumnName,
-				joinId: j.id
-			});
-			pushEdge(j.targetTableId, {
-				toTableId: j.sourceTableId,
-				fromColumnName: j.targetColumnName,
-				toColumnName: j.sourceColumnName,
-				joinId: j.id
-			});
-		}
-
-		const bfs = (): PathfinderStep[] | null => {
-			const prev = new Map<string, { fromId: string; edge: Edge }>();
-			const seen = new Set<string>([start.tableId]);
-			const queue: string[] = [start.tableId];
-			while (queue.length > 0) {
-				const cur = queue.shift()!;
-				if (cur === end.tableId) {
-					const steps: PathfinderStep[] = [];
-					let nodeId: string | undefined = cur;
-					while (nodeId && nodeId !== start.tableId) {
-						const back = prev.get(nodeId);
-						if (!back) break;
-						steps.unshift({
-							fromTableId: back.fromId,
-							fromColumnName: back.edge.fromColumnName,
-							toTableId: back.edge.toTableId,
-							toColumnName: back.edge.toColumnName,
-							existingJoinId: back.edge.joinId
-						});
-						nodeId = back.fromId;
-					}
-					return steps;
-				}
-				const edges = adj.get(cur) ?? [];
-				for (const edge of edges) {
-					if (seen.has(edge.toTableId)) continue;
-					seen.add(edge.toTableId);
-					prev.set(edge.toTableId, { fromId: cur, edge });
-					queue.push(edge.toTableId);
-				}
-			}
-			return null;
-		};
-
-		const existingOnly = bfs();
-		if (existingOnly && existingOnly.length > 0) {
-			this.pathfinderResult = { steps: existingOnly, hasGaps: false };
-			return;
-		}
-
-		// Fallback — re-build adjacency including virtual edges built from
-		// shared column names across on-canvas tables, then BFS again.
-		// The result will probably include gaps (virtual edges with
-		// joinId: null) that "Create path joins" can wire up.
-		const byNameLower = new Map<string, Array<{ tableId: string; columnName: string }>>();
-		for (const t of this.doc.tables) {
-			for (const c of t.columns) {
-				const key = c.name.toLowerCase();
-				const bucket = byNameLower.get(key);
-				if (bucket) bucket.push({ tableId: t.id, columnName: c.name });
-				else byNameLower.set(key, [{ tableId: t.id, columnName: c.name }]);
-			}
-		}
-		for (const bucket of byNameLower.values()) {
-			if (bucket.length < 2) continue;
-			for (let i = 0; i < bucket.length; i++) {
-				for (let k = i + 1; k < bucket.length; k++) {
-					const a = bucket[i];
-					const b = bucket[k];
-					if (a.tableId === b.tableId) continue;
-					// Skip pairs already wired in either direction — would
-					// otherwise inflate the graph with duplicate edges.
-					const already = this.doc.joins.some((j) => {
-						const f =
-							j.sourceTableId === a.tableId &&
-							j.sourceColumnName === a.columnName &&
-							j.targetTableId === b.tableId &&
-							j.targetColumnName === b.columnName;
-						const r =
-							j.sourceTableId === b.tableId &&
-							j.sourceColumnName === b.columnName &&
-							j.targetTableId === a.tableId &&
-							j.targetColumnName === a.columnName;
-						return f || r;
-					});
-					if (already) continue;
-					pushEdge(a.tableId, {
-						toTableId: b.tableId,
-						fromColumnName: a.columnName,
-						toColumnName: b.columnName,
-						joinId: null
-					});
-					pushEdge(b.tableId, {
-						toTableId: a.tableId,
-						fromColumnName: b.columnName,
-						toColumnName: a.columnName,
-						joinId: null
-					});
-				}
-			}
-		}
-		const withVirtual = bfs();
-		if (withVirtual && withVirtual.length > 0) {
-			this.pathfinderResult = {
-				steps: withVirtual,
-				hasGaps: withVirtual.some((s) => s.existingJoinId === null)
-			};
-			return;
-		}
-		this.pathfinderResult = null;
-	}
-
-	/** Wire up every virtual (gap) step in `pathfinderResult` as a real
-	 *  join.  No-op when there's no result or no gaps.  Returns the
-	 *  number actually added. */
-	applyPathfinderJoins(): number {
-		const result = this.pathfinderResult;
-		if (!result || !result.hasGaps) return 0;
-		let added = 0;
-		for (const step of result.steps) {
-			if (step.existingJoinId !== null) continue;
-			const before = this.doc.joins.length;
-			this.addJoin({
-				sourceTableId: step.fromTableId,
-				sourceColumnName: step.fromColumnName,
-				targetTableId: step.toTableId,
-				targetColumnName: step.toColumnName,
-				kind: 'inner'
-			});
-			if (this.doc.joins.length > before) added++;
-		}
-		// Re-run the search so the result reflects post-commit state —
-		// what was a virtual step is now an existing join, and hasGaps
-		// flips false.
-		if (added > 0) this.findPath();
-		return added;
-	}
-
-	tryColumnClickJoin(tableId: string, columnName: string): void {
-		// A column click is a column-level intent — not a table-focus
-		// trigger. SvelteFlow marks the node selected on any click inside
-		// it, which would otherwise fire the auto-focus $effect and
-		// light up EVERY join column on the table. Explicitly bail out
-		// of table-focus + selection so the only thing the user sees is
-		// the green column highlight.
-		this.selectedTableId = null;
-		this.focusKind = 'none';
-		this.focusKey = null;
-		// Pathfinder armed → the click captures an endpoint instead of
-		// running the normal click-to-highlight flow.
-		if (this.pathfinderArmed !== null) {
-			this.setPathfinderEndpoint(this.pathfinderArmed, { tableId, columnName });
-			return;
-		}
-		// Click-to-join (the hidden two-step where the first click armed
-		// a `pendingJoinSource` and the second click on a different
-		// table committed a join) was removed because users hit it by
-		// accident — clicking around to look at columns silently armed
-		// the next click. Joins now come from explicit gestures only:
-		// drag handle-to-handle, Create Joins Mode (⌘J), or sidebar drag with
-		// Auto-join on. Column click is highlight-only.
-		const alreadyHighlighted =
-			this.highlightedColumn === columnName && this.highlightOriginTableId === tableId;
-		if (alreadyHighlighted) {
-			this.highlightedColumn = null;
-			this.highlightOriginTableId = null;
-			this.highlightSource = null;
-			this.sidebarQuery = '';
-			return;
-		}
-		this.highlightedColumn = columnName;
-		this.highlightOriginTableId = tableId;
-		this.highlightSource = 'click';
-		this.sidebarQuery = columnName;
-	}
-
-	/**
-	 * Highlight a column name across the whole canvas + push the same
-	 * name into the sidebar search so the user sees every table that has
-	 * it. Click the same column again to clear. Switching the highlight
-	 * to a different name replaces it.
-	 */
-	highlightColumn(columnName: string): void {
-		if (this.highlightedColumn === columnName) {
-			this.highlightedColumn = null;
-			this.highlightSource = null;
-			this.sidebarQuery = '';
-			return;
-		}
-		this.highlightedColumn = columnName;
-		this.highlightSource = 'click';
-		this.sidebarQuery = columnName;
-	}
+  // Reactive ($state): consumers read `store.connectionId` in reactive
+  // template positions (e.g. AskDimSumWidget's Send-button gate). A plain
+  // field wouldn't re-run those bindings when `switchConnection` reassigns
+  // it, so a fresh-canvas → pick-a-connection flow left the DimSum Send
+  // button stuck disabled ("Pick a connection first").
+  connectionId = $state<string>("");
+
+  // Document — top-level reactive state.
+  doc = $state<SchemaCanvasState>(blankState(""));
+
+  /**
+   * One-step undo stash.  When set, the toolbar Undo button becomes
+   * live and `undo()` swaps this back into `doc`.  Populated
+   * automatically by `loadDoc` before every replace (so AI Draft is
+   * always reversible) and can be populated by other big operations
+   * that want to be undoable.
+   */
+  previousDoc = $state<SchemaCanvasState | null>(null);
+
+  /**
+   * Bumped whenever an external caller (DimSum) writes to `doc.cubes` and
+   * wants the Facts & Measures workbench to re-hydrate.  The canvas page
+   * watches this and force-remounts `<WorkbenchView>` (which re-reads
+   * `doc.cubes` on mount) so the change is visible.  Pure signal — not
+   * persisted.
+   */
+  workbenchReloadNonce = $state<number>(0);
+
+  /**
+   * The cube currently selected in the Facts & Measures workbench. Lifted to
+   * the store so (a) the selection survives the DimSum-triggered remount and
+   * (b) the DimSum chat (which lives in SchemaCanvasView) can reset itself
+   * when the user switches to a different cube. Pure UI signal — not persisted.
+   */
+  activeCubeId = $state<string | null>(null);
+
+  /**
+   * Bumped when a saved schema is opened (or duplicated) from the library so
+   * the DimSum chat (SchemaCanvasView) starts a fresh conversation for it,
+   * instead of restoring the connection's last chat. Pure signal — not persisted.
+   */
+  chatResetNonce = $state<number>(0);
+
+  // UI state.
+  selectedTableId = $state<string | null>(null);
+  selectedJoinId = $state<string | null>(null);
+  /** Filter expression for the sidebar table catalog. */
+  sidebarQuery = $state("");
+  /** Source-table catalog from /api/inference/profile-connection. */
+  sourceTables = $state<SourceTableCandidate[]>([]);
+  /** Selected schema filter — null means "all schemas". When set, the
+   *  sidebar list is filtered to this schema. */
+  selectedSchema = $state<string | null>(null);
+  sourceLoading = $state(false);
+  sourceError = $state<string | null>(null);
+  /** Which top-level surface the schema designer renders.
+   *  - `canvas`     — schema canvas (tables + joins).
+   *  - `workbench`  — dimensions / attributes / hierarchies + inspector.
+   *  - `facts`      — measure groups + calculated measures + inspector.
+   *  - `validate`   — cube validation (sample data / try query / linked cubes).
+   *
+   *  Legacy `'binary'` value is migrated to `'workbench'` on load. */
+  mode = $state<CanvasMode>("canvas");
+  /**
+   * Globally-highlighted column name. When set, every table on the
+   * canvas that contains a column with this name renders with a glow
+   * — visual signal of potential join targets for what the user just
+   * clicked. Also drives the sidebar search filter.
+   */
+  highlightedColumn = $state<string | null>(null);
+  /** Which table the highlighted column came from — lets the sidebar
+   *  footer chip target "link similar on canvas" against THIS column
+   *  specifically (origin → every other on-canvas table with the same
+   *  column name). */
+  highlightOriginTableId = $state<string | null>(null);
+  /** What drove the current highlight — a column click or the sidebar
+   *  search box. Lets the view's search→highlight effect decide
+   *  whether emptying the search should clear the highlight (only when
+   *  search drove it; otherwise a click-initiated highlight survives a
+   *  manual search clear). */
+  highlightSource = $state<"click" | "search" | null>(null);
+  /**
+   * Click-to-join armed source. When a user clicks a column on table A,
+   * we stash it here; the next click on a column on table B commits a
+   * join between the two. Clicking the same (table, column) again
+   * cancels; clicking another column on the SAME table replaces the
+   * pending source (you can't join a table to itself in this model).
+   *
+   * This is pure UI state — NOT persisted in the doc / localStorage.
+   */
+  pendingJoinSource = $state<{ tableId: string; columnName: string } | null>(
+    null,
+  );
+  /**
+   * Pick mode — toggled by tapping E (no hold required). When ON,
+   * column clicks accumulate into `eShiftPicks` instead of arming a
+   * single click-to-join.  Commit happens via the picks-panel
+   * "Match" button, which takes a group name and wires picks in a
+   * STAR pattern (first pick = origin, joins to each subsequent
+   * pick).  Lets a user group columns with DIFFERENT names
+   * (`product_id` ↔ `prod_id` ↔ `pid`) under a single semantic
+   * label like "Product Key". UI state; not persisted.
+   */
+  pickModeActive = $state<boolean>(false);
+  eShiftPicks = $state<Array<{ tableId: string; columnName: string }>>([]);
+  /** Bump-counter feedback channel for the join-creation toast.  Any
+   *  path that materialises a new join writes here; the view listens
+   *  on the `id` and renders a toast.  A single addJoin sets a
+   *  descriptive per-join message; batch paths (commitEShiftPicks,
+   *  linkSimilarOnCanvas) overwrite with a summary after the loop so
+   *  the user gets one toast, not N. */
+  lastJoinFeedback = $state<{ id: number; message: string } | null>(null);
+  private joinFeedbackCounter = 0;
+  /** Pathfinder UX state — see PathfinderEndpoint / PathfinderResult.
+   *  When `pathfinderArmed` is non-null, the next column click on the
+   *  canvas writes into that slot (start / end) instead of running the
+   *  normal click-to-join flow.  Result is computed on-demand via
+   *  `findPath()` and surfaced as `pathfinderResult`. */
+  pathfinderArmed = $state<"start" | "end" | null>(null);
+  pathfinderStart = $state<PathfinderEndpoint | null>(null);
+  pathfinderEnd = $state<PathfinderEndpoint | null>(null);
+  pathfinderResult = $state<PathfinderResult | null>(null);
+  /** Sidebar width in px — user-draggable via the splitter handle. */
+  sidebarWidth = $state(288);
+  /** Joins panel (right rail) width in px — same splitter pattern.
+   *  Clamped at 220-560 in the drag handler. */
+  joinsPanelWidth = $state(280);
+  /** User's preferred Arrange layout — what the main Arrange button
+   *  applies when clicked without picking from the menu.  All
+   *  layouts stay individually clickable in the dropdown; this just
+   *  controls the one-click default.  Persisted to localStorage as
+   *  a per-user preference (NOT per-connection) so the choice
+   *  follows the user across cubes and connection switches. */
+  defaultLayoutMode = $state<LayoutMode>("star");
+  /** Multi-select state for the sidebar table list. Clicking a row
+   *  replaces selection; Shift/Cmd-clicking toggles. Dragging any
+   *  selected row drags the WHOLE selection at once. Identities are
+   *  the same `schema.name` (or bare `name`) form the sidebar uses. */
+  sidebarSelectedIdentities = $state<Set<string>>(new Set());
+  /**
+   * Default columns shown per table when the user hasn't individually
+   * collapsed/expanded that table. 0 = headers only. Any positive
+   * number caps the visible row count; tables with fewer columns just
+   * show all of theirs. Per-table `collapsed` boolean (true = headers
+   * only, false = show all) overrides this when set.
+   */
+  defaultColumnsShown = $state<number>(8);
+  /**
+   * When ON, dropping a new table onto the canvas silently commits
+   * every high-confidence column-name match between the dropped table
+   * and the fact. Friendly when starting from a blank canvas; gets in
+   * the way when you're trying to test interactions (E, click-to-join)
+   * because joins materialise before you can do anything. Default OFF.
+   */
+  autoSuggestOnDrop = $state<boolean>(false);
+  /**
+   * When ON, focusing a table or join-group ALSO highlights the actual
+   * column rows that participate in the focused joins (green row +
+   * auto-expand the table to show them). When OFF (default), focus
+   * just dims unrelated stuff — the user follows the lines themselves.
+   * Some folks want the green highlight; others prefer the cleaner
+   * "just follow the lines" view.
+   */
+  highlightFocusedColumns = $state<boolean>(false);
+  /** When ON, hides every join line + label so the user can see the
+   *  bare table layout without the visual noise. Doesn't delete the
+   *  joins — just visually hides them. UI-only state. */
+  joinsHidden = $state<boolean>(false);
+  /** When ON, also render `cube-link` / `inferred-fk` joins (the ones
+   *  auto-inferred from Mondrian-4 MeasureGroup `<ForeignKeyLink>` —
+   *  semantic, not physical).  Default OFF — canvas shows only
+   *  `origin: 'physical'` joins, matching the PhysicalSchema in the
+   *  source XML.  UI-only state. */
+  showCubeLinks = $state<boolean>(false);
+  /**
+   * Join-line rendering style.
+   *   - `bezier`     — smooth curves (default).
+   *   - `smoothstep` — orthogonal segments with rounded corners.
+   *   - `step`       — sharp right-angle segments.
+   * UI-only; not persisted in the doc (it's a personal preference).
+   */
+  edgeStyle = $state<"bezier" | "smoothstep" | "step">("smoothstep");
+  /**
+   * Focus dimming. When the user picks a target — a join group label
+   * in the panel, a table on the canvas, etc. — everything else
+   * drops opacity so the chosen thing stands out. Click the empty
+   * canvas to clear. UI-only.
+   */
+  focusKind = $state<"none" | "group" | "table">("none");
+  focusKey = $state<string | null>(null);
+  /** Cursor for binary view: index into the non-fact tables list. */
+  binaryCursor = $state(0);
+  /** Sidebar → canvas jump request. Set by the sidebar's "on canvas"
+   *  result link; consumed by a tiny JumpHandler inside the SvelteFlow
+   *  tree which calls `useSvelteFlow().setCenter()` (the hook only
+   *  works inside the flow component subtree). `ts` makes repeat
+   *  clicks on the same row re-fire the effect. */
+  requestedJumpTarget = $state<{
+    tableId: string;
+    columnName?: string;
+    ts: number;
+  } | null>(null);
+  /** Imperative viewport actions DimSum (or other UI) can request. The
+   *  CanvasActionHandler child inside <SvelteFlow> consumes this and
+   *  calls the corresponding useSvelteFlow() method. `ts` re-fires
+   *  repeat requests of the same kind. Keeps the AI-visible action
+   *  registry decoupled from where the imperative API is available. */
+  requestedCanvasAction = $state<{
+    kind: "zoom_in" | "zoom_out" | "fit_view" | "zoom_to_100" | "center_view";
+    ts: number;
+  } | null>(null);
+  /**
+   * Workbench working set — table IDs the user has pulled into the
+   * Workbench view for focused side-by-side work. UI-only; not
+   * persisted in the doc. Empty means "Workbench shows nothing yet —
+   * drag tables in from the sidebar." Removing a table from this set
+   * does NOT remove it from the canvas (the canvas is the source of
+   * truth; the workbench is a scratch surface).
+   */
+  workbenchWorkingSet = $state<Set<string>>(new Set());
+  /** Soft-threshold warning state — flips true above 30 tables. */
+  get thresholdSoft(): boolean {
+    return this.doc.tables.length >= 30;
+  }
+
+  /**
+   * The "active set" — phase-2's unifying primitive for column
+   * selection. Two prior pieces of UI (highlightedColumn ↔ across-table
+   * name match, and eShiftPicks ↔ explicit E-hold picks) reduce to
+   * ONE concept the rest of the canvas can read uniformly: an ordered
+   * list of `{tableId, columnName}` plus a mode tag.
+   *
+   * Modes:
+   *  - `pick`  — explicit picks accumulated during E-hold (or via the
+   *              joins-panel "picks" affordance later). Survives until
+   *              committed or explicitly cleared.
+   *  - `auto`  — derived from `highlightedColumn`: every column on
+   *              canvas whose name matches.
+   *  - `none`  — neither mode active.
+   *
+   * Both visual surfaces (canvas column rows + Workbench panel) read
+   * this and apply the SAME green-glow vocabulary, replacing the
+   * Workbench's old red-ring treatment.
+   */
+  get activeSetMode(): "auto" | "pick" | "none" {
+    if (this.eShiftPicks.length > 0) return "pick";
+    if (this.highlightedColumn !== null) return "auto";
+    return "none";
+  }
+
+  get activeSet(): Array<{ tableId: string; columnName: string }> {
+    if (this.eShiftPicks.length > 0) return this.eShiftPicks;
+    if (this.highlightedColumn !== null) {
+      const colName = this.highlightedColumn;
+      const out: Array<{ tableId: string; columnName: string }> = [];
+      for (const t of this.doc.tables) {
+        if (t.columns.some((c) => c.name === colName)) {
+          out.push({ tableId: t.id, columnName: colName });
+        }
+      }
+      return out;
+    }
+    return [];
+  }
+
+  /**
+   * `${tableId}:${columnName}` keys for fast O(1) membership tests in
+   * render hot paths — TableNode column rows test against this Set to
+   * decide whether to apply the green glow.
+   */
+  get activeSetKeys(): Set<string> {
+    const out = new Set<string>();
+    for (const p of this.activeSet) {
+      out.add(`${p.tableId}:${p.columnName}`);
+    }
+    return out;
+  }
+
+  constructor(connectionId: string) {
+    this.connectionId = connectionId;
+    this.doc = loadFromStorage(connectionId);
+    // One-time migration: strip the old "implicit-default hierarchy"
+    // auto-seed that the previous addDimension code created.  Match
+    // criterion: hier.name === dim.name AND hier.levels.length === 0
+    // — those are the obvious leftovers from the convention we
+    // abandoned (hierarchies are always explicit now).  Won't strip
+    // a hier the user named the same as the dim and populated.
+    for (const d of this.doc.dimensions ?? []) {
+      d.hierarchies = d.hierarchies.filter(
+        (h) => !(h.levels.length === 0 && h.name === d.name),
+      );
+      // Sibling-unique hierarchy names per dim.  Pre-uniqueness
+      // data may have shipped duplicates; resolve by suffixing
+      // "(2)", "(3)", ….  Keep the first occurrence's name intact.
+      const seen = new Set<string>();
+      for (const h of d.hierarchies) {
+        if (seen.has(h.name)) {
+          let n = 2;
+          while (seen.has(`${h.name} (${n})`)) n++;
+          h.name = `${h.name} (${n})`;
+        }
+        seen.add(h.name);
+      }
+    }
+    // Same for dim names at the cube level.
+    const seenDimNames = new Set<string>();
+    for (const d of this.doc.dimensions ?? []) {
+      if (seenDimNames.has(d.name)) {
+        let n = 2;
+        while (seenDimNames.has(`${d.name} (${n})`)) n++;
+        d.name = `${d.name} (${n})`;
+      }
+      seenDimNames.add(d.name);
+    }
+    // Restore per-user UI preferences (NOT per-connection).
+    const prefs = loadPrefsFromStorage();
+    if (prefs.defaultLayoutMode) {
+      this.defaultLayoutMode = prefs.defaultLayoutMode;
+    }
+    const migrated = migrateMode(prefs.mode);
+    if (migrated) this.mode = migrated;
+  }
+
+  /** Update the default Arrange layout and persist it as a per-user
+   *  preference.  Callers should use this method rather than mutating
+   *  `defaultLayoutMode` directly so the localStorage write stays in
+   *  one place. */
+  setDefaultLayoutMode(mode: LayoutMode): void {
+    this.defaultLayoutMode = mode;
+    const prefs = loadPrefsFromStorage();
+    prefs.defaultLayoutMode = mode;
+    savePrefsToStorage(prefs);
+  }
+
+  /** Set the active view tab and persist as a per-user preference so the
+   *  next session lands on the same tab.  Tab toggle UI should call
+   *  this rather than mutating `mode` directly. */
+  setMode(mode: CanvasMode): void {
+    this.mode = mode;
+    const prefs = loadPrefsFromStorage();
+    prefs.mode = mode;
+    savePrefsToStorage(prefs);
+  }
+
+  /**
+   * Swap the active connection without recreating the store. Persists
+   * the current doc, loads the doc for the new connection from
+   * localStorage, and resets the UI state (selection, mode cursor).
+   * Source-table catalog is the caller's responsibility — the
+   * /cubes/new/canvas page kicks off a fresh fetch on connection
+   * change.
+   */
+  switchConnection(connectionId: string): void {
+    if (this.connectionId === connectionId) return;
+    // Persist whatever's currently in flight under the old key.
+    saveToStorage(this.doc);
+    this.connectionId = connectionId;
+    this.doc = loadFromStorage(connectionId);
+    this.selectedTableId = null;
+    this.selectedJoinId = null;
+    this.binaryCursor = 0;
+    this.sourceTables = [];
+    this.sourceLoading = false;
+    this.sourceError = null;
+    this.sidebarQuery = "";
+  }
+
+  private touch(): void {
+    this.doc.updatedAt = new Date().toISOString();
+    saveToStorage(this.doc);
+  }
+
+  /** Public setter for the cube label.  Goes through the same
+   *  touch() → saveToStorage path as canvas mutations, so renames
+   *  survive a reload.  The two-way `bind:value` on the title input
+   *  used to mutate `store.doc.label` directly, which never wrote
+   *  to localStorage. */
+  setLabel(label: string): void {
+    this.doc.label = label;
+    this.touch();
+  }
+
+  /** Add a table from the source catalog onto the canvas at the given position. */
+  addTable(
+    candidate: SourceTableCandidate,
+    position: { x: number; y: number },
+  ): SchemaCanvasTable {
+    this.maybeSnapshotForUndo();
+    // Dedupe (#1084) — a physical table (schema+name) may only appear
+    // once on the canvas. Every add path (drag-drop, "+ Add to canvas",
+    // DimSum's add_table_to_canvas tool) funnels through here, so this
+    // is the single guard against a second node with a fresh id being
+    // pushed for a table that's already present. If found, return the
+    // existing node untouched rather than creating a duplicate.
+    const identity = candidate.schema
+      ? `${candidate.schema}.${candidate.name}`
+      : candidate.name;
+    const existing = this.doc.tables.find(
+      (t) => (t.schema ? `${t.schema}.${t.name}` : t.name) === identity,
+    );
+    if (existing) return existing;
+    // Peer model — every table on the canvas is equal. The `role`
+    // field stays on the data model (Mondrian export still needs a
+    // fact at the END), but the canvas itself doesn't designate one
+    // any more. New tables come in as plain dimensions.
+    const role: SchemaCanvasTableRole = "dimension";
+    const table: SchemaCanvasTable = {
+      id: makeId("tbl"),
+      schema: candidate.schema,
+      name: candidate.name,
+      role,
+      columns: candidate.columns.map((c) => ({
+        name: c.name,
+        sqlType: c.sqlType,
+      })),
+      position,
+      groupId: null,
+    };
+    this.doc.tables.push(table);
+    this.touch();
+    return table;
+  }
+
+  removeTable(tableId: string): void {
+    this.maybeSnapshotForUndo();
+    this.doc.tables = this.doc.tables.filter((t) => t.id !== tableId);
+    // Cascade: drop any joins that referenced this table.
+    this.doc.joins = this.doc.joins.filter(
+      (j) => j.sourceTableId !== tableId && j.targetTableId !== tableId,
+    );
+    if (this.selectedTableId === tableId) this.selectedTableId = null;
+    this.touch();
+  }
+
+  moveTable(tableId: string, position: { x: number; y: number }): void {
+    const t = this.doc.tables.find((t) => t.id === tableId);
+    if (!t) return;
+    t.position = position;
+    this.touch();
+  }
+
+  /** Force a single table to show every column (overrides the global
+   *  default). Used by the "+ N more" footer affordance — clicking it
+   *  is an explicit "I want to see everything in this table". The
+   *  chevron still cycles undef ↔ true after that. */
+  expandTableFully(tableId: string): void {
+    const t = this.doc.tables.find((t) => t.id === tableId);
+    if (!t) return;
+    t.collapsed = false;
+    this.touch();
+  }
+
+  toggleTableCollapsed(tableId: string): void {
+    const t = this.doc.tables.find((t) => t.id === tableId);
+    if (!t) return;
+    // Cycle is two states: `undefined` (follow `defaultColumnsShown`)
+    // ↔ `true` (header only). The chevron NEVER sets the third state
+    // (`false` = force show-all) because that would pin the table
+    // past any future change to `defaultColumnsShown` — Amelia hit
+    // this and had to click "Reset views" to escape. "Force show all"
+    // is reachable only via the explicit "Expand all" toolbar button.
+    if (t.collapsed === true) {
+      t.collapsed = undefined;
+    } else {
+      t.collapsed = true;
+    }
+    this.touch();
+  }
+
+  /** Reset every table's per-table collapse override so they all
+   *  follow the global `defaultColumnsShown` setting again. */
+  resetCollapseOverrides(): void {
+    for (const t of this.doc.tables) t.collapsed = undefined;
+    this.touch();
+  }
+
+  /** Force every table to show all its columns (overrides the global
+   *  default). Companion to the toolbar's "Expand all" button. */
+  expandAllTables(): void {
+    for (const t of this.doc.tables) t.collapsed = false;
+    this.touch();
+  }
+
+  /** Force every table to collapse to header-only. */
+  collapseAllTables(): void {
+    for (const t of this.doc.tables) t.collapsed = true;
+    this.touch();
+  }
+
+  /** Add a canvas table to the workbench working set. No-op if
+   *  already present. Doesn't touch the canvas. */
+  addToWorkbench(tableId: string): void {
+    if (this.workbenchWorkingSet.has(tableId)) return;
+    const next = new Set(this.workbenchWorkingSet);
+    next.add(tableId);
+    this.workbenchWorkingSet = next;
+  }
+
+  /** Remove a table from the workbench WITHOUT removing it from the
+   *  canvas. */
+  removeFromWorkbench(tableId: string): void {
+    if (!this.workbenchWorkingSet.has(tableId)) return;
+    const next = new Set(this.workbenchWorkingSet);
+    next.delete(tableId);
+    this.workbenchWorkingSet = next;
+  }
+
+  clearWorkbench(): void {
+    this.workbenchWorkingSet = new Set();
+  }
+
+  /** The actual tables in the workbench's working set (canvas tables
+   *  filtered by membership). The Set may include stale IDs from a
+   *  prior reload; we resolve against the live canvas tables. */
+  get workbenchTables(): SchemaCanvasTable[] {
+    return this.doc.tables.filter((t) => this.workbenchWorkingSet.has(t.id));
+  }
+
+  /** `schema.name` identities of every table currently in the
+   *  workbench's working set — used by the Workbench's TableSidebar
+   *  to grey out tables already in focus (vs. all canvas tables). */
+  get workbenchTableIdentities(): Set<string> {
+    return new Set(
+      this.workbenchTables.map((t) =>
+        t.schema ? `${t.schema}.${t.name}` : t.name,
+      ),
+    );
+  }
+
+  setTableRole(tableId: string, role: SchemaCanvasTableRole): void {
+    const t = this.doc.tables.find((t) => t.id === tableId);
+    if (!t) return;
+    // Only one fact at a time — demote any prior fact to dimension when
+    // another is promoted.
+    if (role === "fact") {
+      for (const other of this.doc.tables) {
+        if (other.id !== tableId && other.role === "fact")
+          other.role = "dimension";
+      }
+    }
+    t.role = role;
+    this.touch();
+  }
+
+  addJoin(j: Omit<SchemaCanvasJoin, "id">): SchemaCanvasJoin {
+    this.maybeSnapshotForUndo();
+    // User-initiated joins default to `physical` — only the importer
+    // creates `cube-link` / `inferred-fk` joins, and it sets origin
+    // explicitly when it does.
+    const join: SchemaCanvasJoin = {
+      ...j,
+      id: makeId("join"),
+      origin: j.origin ?? "physical",
+    };
+    // Multiple joins per table pair are valid for role-playing
+    // dimensions: a fact joining `date` three times via order_date_id,
+    // ship_date_id, and invoice_date_id is one classic shape. Tom's
+    // "no composite keys" rule meant a SINGLE join using multiple
+    // columns simultaneously — different from N distinct
+    // single-column joins between the same pair. We only dedupe on
+    // the exact (source_col, target_col) tuple so the same join
+    // can't be drawn twice.
+    const existingIdx = this.doc.joins.findIndex((existing) => {
+      const sameDirection =
+        existing.sourceTableId === join.sourceTableId &&
+        existing.targetTableId === join.targetTableId &&
+        existing.sourceColumnName === join.sourceColumnName &&
+        existing.targetColumnName === join.targetColumnName;
+      const swappedDirection =
+        existing.sourceTableId === join.targetTableId &&
+        existing.targetTableId === join.sourceTableId &&
+        existing.sourceColumnName === join.targetColumnName &&
+        existing.targetColumnName === join.sourceColumnName;
+      return sameDirection || swappedDirection;
+    });
+    if (existingIdx >= 0) {
+      this.doc.joins[existingIdx] = join;
+      this.touch();
+      return join;
+    }
+    // Within a given table pair, a single (source_table, source_column)
+    // endpoint can only participate in ONE join. If the same source
+    // endpoint is being paired with a DIFFERENT target column on the
+    // same target table, that's ambiguous (a "first_name" endpoint
+    // wired to both `fname` and `lname`) so replace the older join
+    // instead of accumulating semantically-inconsistent pairs.
+    // Role-playing (same target column reused via DIFFERENT source
+    // columns) stays legal because the check keys off the source
+    // endpoint, not the target.
+    const ambiguousIdx = this.doc.joins.findIndex((existing) => {
+      const sameDirection =
+        existing.sourceTableId === join.sourceTableId &&
+        existing.targetTableId === join.targetTableId &&
+        existing.sourceColumnName === join.sourceColumnName &&
+        existing.targetColumnName !== join.targetColumnName;
+      // Swapped: the incoming join's TARGET endpoint (table + column)
+      // matches the existing join's SOURCE endpoint — same conceptual
+      // "source" endpoint of the pair, written in reverse. Other-side
+      // columns must still differ, else the sameDirection dedupe (or
+      // exact-tuple dedupe above) would have caught it.
+      const swappedDirection =
+        existing.sourceTableId === join.targetTableId &&
+        existing.targetTableId === join.sourceTableId &&
+        existing.sourceColumnName === join.targetColumnName &&
+        existing.targetColumnName !== join.sourceColumnName;
+      return sameDirection || swappedDirection;
+    });
+    if (ambiguousIdx >= 0) {
+      const prior = this.doc.joins[ambiguousIdx];
+      // Both detection cases converge on: prior.sourceColumnName is
+      // the endpoint being reused, prior.targetColumnName is what it
+      // was previously paired with. (In sameDirection the incoming's
+      // source matches prior.sourceColumnName; in swappedDirection
+      // the incoming's target does. Either way, prior tells us the
+      // old story.)
+      const reusedColumn = prior.sourceColumnName;
+      const oldPairedColumn = prior.targetColumnName;
+      this.doc.joins[ambiguousIdx] = join;
+      this.touch();
+      this.pushJoinFeedback(
+        `Replaced join (${reusedColumn} was already paired with ${oldPairedColumn})`,
+      );
+      return join;
+    }
+    this.doc.joins.push(join);
+    this.touch();
+    this.pushJoinFeedback(this.describeJoinCreation(join));
+    return join;
+  }
+
+  private describeJoinCreation(j: SchemaCanvasJoin): string {
+    const src = this.doc.tables.find((t) => t.id === j.sourceTableId);
+    const tgt = this.doc.tables.find((t) => t.id === j.targetTableId);
+    const srcName = src?.name ?? "?";
+    const tgtName = tgt?.name ?? "?";
+    return `Joined ${srcName}.${j.sourceColumnName} ↔ ${tgtName}.${j.targetColumnName}`;
+  }
+
+  private pushJoinFeedback(message: string): void {
+    this.lastJoinFeedback = { id: ++this.joinFeedbackCounter, message };
+  }
+
+  removeJoin(joinId: string): void {
+    this.maybeSnapshotForUndo();
+    const target = this.doc.joins.find((j) => j.id === joinId);
+    // Cube-link + inferred-fk joins are owned by the cube-side
+    // MeasureGroup ForeignKeyLink, not by the canvas.  The user must
+    // remove the FK link from the MG's dim-link checklist to make it
+    // go away; deleting it on the canvas would just have the importer
+    // recreate it.  Silently no-op so accidental clicks don't surprise.
+    if (
+      target &&
+      (target.origin === "cube-link" || target.origin === "inferred-fk")
+    ) {
+      return;
+    }
+    this.doc.joins = this.doc.joins.filter((j) => j.id !== joinId);
+    if (this.selectedJoinId === joinId) this.selectedJoinId = null;
+    // If the removed join was the LAST one for its canonical key,
+    // clear the rename so a future re-creation doesn't silently
+    // inherit a stale label.  When other joins for the same key
+    // still exist (the group survives the removal), the rename
+    // stays — same group, same label.
+    if (target) {
+      const key = SchemaCanvasStore.joinCanonicalKey(target);
+      const stillHasKey = this.doc.joins.some(
+        (j) => SchemaCanvasStore.joinCanonicalKey(j) === key,
+      );
+      if (!stillHasKey && this.doc.joinGroupRenames?.[key]) {
+        const next = { ...this.doc.joinGroupRenames };
+        delete next[key];
+        this.doc.joinGroupRenames = next;
+      }
+    }
+    this.touch();
+  }
+
+  /** Remove a column from a group while keeping the rest of the
+   *  group's equivalence intact.
+   *
+   *  Three cases:
+   *  1. Removing the endpoint leaves fewer than 2 remaining → group
+   *     dissolves (delete every join in it).
+   *  2. Removing it leaves at least one join that DOESN'T touch
+   *     the endpoint → just drop the joins that do.
+   *  3. Removing it leaves 2+ endpoints but ZERO surviving joins
+   *     (the endpoint was the star anchor) → re-anchor: pick the
+   *     first remaining endpoint as the new anchor and rewire a
+   *     fresh star to the rest, re-applying the group label.
+   *
+   *  The UI doesn't see any of this — it just calls
+   *  `removeEndpointFromGroup` and the group's semantic "these are
+   *  all the same" stays true, no matter which member is removed.
+   */
+  removeEndpointFromGroup(
+    groupLabel: string,
+    tableId: string,
+    columnName: string,
+  ): void {
+    const groupJoins = this.doc.joins.filter(
+      (j) => this.joinGroupLabelFor(j) === groupLabel,
+    );
+    if (groupJoins.length === 0) return;
+    const touchesEndpoint = (j: SchemaCanvasJoin) =>
+      (j.sourceTableId === tableId && j.sourceColumnName === columnName) ||
+      (j.targetTableId === tableId && j.targetColumnName === columnName);
+    const joinsTouchingEp = groupJoins.filter(touchesEndpoint);
+    const remainingJoins = groupJoins.filter((j) => !touchesEndpoint(j));
+    // Build the ordered set of endpoints (excluding the one being
+    // removed) — preserve the order they first appear so the new
+    // anchor is deterministic.
+    const seen = new Set<string>();
+    const remainingEndpoints: Array<{ tableId: string; columnName: string }> =
+      [];
+    const skipKey = `${tableId}:${columnName}`;
+    for (const j of groupJoins) {
+      for (const ep of [
+        { tableId: j.sourceTableId, columnName: j.sourceColumnName },
+        { tableId: j.targetTableId, columnName: j.targetColumnName },
+      ]) {
+        const k = `${ep.tableId}:${ep.columnName}`;
+        if (k === skipKey || seen.has(k)) continue;
+        seen.add(k);
+        remainingEndpoints.push(ep);
+      }
+    }
+    // Case 1 — group falls under 2 members → kill it.
+    if (remainingEndpoints.length < 2) {
+      for (const j of groupJoins) this.removeJoin(j.id);
+      return;
+    }
+    // Case 2 — the endpoint wasn't the anchor; just drop the joins
+    // that touch it and leave the rest of the star intact.
+    if (remainingJoins.length > 0) {
+      for (const j of joinsTouchingEp) this.removeJoin(j.id);
+      return;
+    }
+    // Case 3 — the endpoint was the anchor; rebuild the star
+    // using the first remaining endpoint as the new anchor and
+    // re-applying the same group label.
+    for (const j of groupJoins) this.removeJoin(j.id);
+    const newAnchor = remainingEndpoints[0];
+    const peers = remainingEndpoints.slice(1);
+    const renames = { ...(this.doc.joinGroupRenames ?? {}) };
+    for (const peer of peers) {
+      if (newAnchor.tableId === peer.tableId) continue;
+      const created = this.addJoin({
+        sourceTableId: newAnchor.tableId,
+        sourceColumnName: newAnchor.columnName,
+        targetTableId: peer.tableId,
+        targetColumnName: peer.columnName,
+        kind: "inner",
+      });
+      const canonicalKey = SchemaCanvasStore.joinCanonicalKey(created);
+      renames[canonicalKey] = groupLabel;
+    }
+    this.doc.joinGroupRenames = renames;
+    this.touch();
+  }
+
+  /** Remove every join in `joinIds`. Single pass, single save. */
+  removeJoins(joinIds: Iterable<string>): void {
+    const set = joinIds instanceof Set ? joinIds : new Set(joinIds);
+    if (set.size === 0) return;
+    this.maybeSnapshotForUndo();
+    this.doc.joins = this.doc.joins.filter((j) => !set.has(j.id));
+    if (this.selectedJoinId && set.has(this.selectedJoinId)) {
+      this.selectedJoinId = null;
+    }
+    this.touch();
+  }
+
+  focusGroup(label: string): void {
+    // `focusKey` for a group is the rendered LABEL (so
+    // joinIdsInFocus / tableIdsInFocus can match every join under
+    // that label, even when the group spans multiple canonical
+    // keys via pick-mode renames).
+    if (this.focusKind === "group" && this.focusKey === label) {
+      this.clearFocus();
+      return;
+    }
+    this.focusKind = "group";
+    this.focusKey = label;
+    // Auto-flip the column-highlight toggle ON when a group is
+    // focused — clicking a group means "show me the data you
+    // grouped," so the row glow + auto-expand are the natural
+    // default.  The user is still free to toggle it back off
+    // mid-focus if they prefer the cleaner line-only view.
+    this.highlightFocusedColumns = true;
+    // Drop any stale name-match highlight (from a previous column
+    // click or sidebar search) so the only thing lighting up is
+    // the group itself — otherwise the user can't tell which
+    // columns are "in the group" vs "still glowing from earlier".
+    this.highlightedColumn = null;
+    this.highlightOriginTableId = null;
+    this.highlightSource = null;
+  }
+
+  focusTableNode(tableId: string): void {
+    if (this.focusKind === "table" && this.focusKey === tableId) {
+      this.clearFocus();
+      return;
+    }
+    this.focusKind = "table";
+    this.focusKey = tableId;
+  }
+
+  clearFocus(): void {
+    this.focusKind = "none";
+    this.focusKey = null;
+  }
+
+  /**
+   * Reset every transient interaction state to neutral. Wired to
+   * SvelteFlow's pane-click — clicking the empty canvas should clear
+   * focus, drop the armed click-to-join, clear the green column
+   * highlight, deselect the join, abandon any held E-shift collection,
+   * and reset the sidebar search to neutral. The doc itself
+   * (tables / joins / groups) is untouched.
+   */
+  clearAllInteractions(): void {
+    this.focusKind = "none";
+    this.focusKey = null;
+    this.highlightedColumn = null;
+    this.highlightOriginTableId = null;
+    this.highlightSource = null;
+    this.pendingJoinSource = null;
+    this.selectedJoinId = null;
+    this.selectedTableId = null;
+    this.sidebarQuery = "";
+    this.pickModeActive = false;
+    this.eShiftPicks = [];
+    // Also drop any pending jump request — otherwise the
+    // JumpHandler's $effect re-fires on the stale target after
+    // the rest of state was cleared and re-stamps selectedTableId
+    // + highlightedColumn behind the user's back.
+    this.requestedJumpTarget = null;
+  }
+
+  /** Returns the set of join ids that are IN focus for the current
+   *  focus state. Empty set means "no focus active" — callers should
+   *  treat that as "everything is in focus". */
+  joinIdsInFocus(): Set<string> {
+    const out = new Set<string>();
+    if (this.focusKind === "group" && this.focusKey !== null) {
+      // Group focus filters by LABEL, not canonical key, so a
+      // user-renamed group like "Random" (which can span multiple
+      // canonical keys when picks crossed different column names)
+      // lights up every join in the rendered group — not just the
+      // ones whose canonical key happens to match the click target.
+      const label = this.focusKey;
+      for (const j of this.doc.joins) {
+        if (this.joinGroupLabelFor(j) === label) out.add(j.id);
+      }
+    } else if (this.focusKind === "table" && this.focusKey !== null) {
+      const id = this.focusKey;
+      for (const j of this.doc.joins) {
+        if (j.sourceTableId === id || j.targetTableId === id) out.add(j.id);
+      }
+    }
+    return out;
+  }
+
+  /** Returns the set of table ids that are IN focus. */
+  tableIdsInFocus(): Set<string> {
+    const out = new Set<string>();
+    if (this.focusKind === "group" && this.focusKey !== null) {
+      // Group focus filters by LABEL — see joinIdsInFocus() for the
+      // rationale (multi-canonical-key groups created via pick mode).
+      const label = this.focusKey;
+      for (const j of this.doc.joins) {
+        if (this.joinGroupLabelFor(j) === label) {
+          out.add(j.sourceTableId);
+          out.add(j.targetTableId);
+        }
+      }
+    } else if (this.focusKind === "table" && this.focusKey !== null) {
+      out.add(this.focusKey);
+      for (const j of this.doc.joins) {
+        if (j.sourceTableId === this.focusKey) out.add(j.targetTableId);
+        else if (j.targetTableId === this.focusKey) out.add(j.sourceTableId);
+      }
+    }
+    return out;
+  }
+
+  /**
+   * Run auto-suggest for one table against every OTHER table on the
+   * canvas — commit every high-confidence column-name match as a
+   * join. Used by the drop handler AND by the "pull-in matching
+   * tables" feature; respects `addJoin`'s tuple-dedupe.
+   */
+  runAutoSuggestForTable(tableId: string): void {
+    const t = this.doc.tables.find((tt) => tt.id === tableId);
+    if (!t) return;
+    for (const other of this.doc.tables) {
+      if (other.id === tableId) continue;
+      const suggestions = suggestJoins(t, other).filter(
+        (s) => s.confidence === "high",
+      );
+      for (const s of suggestions) {
+        this.addJoin({
+          sourceTableId: tableId,
+          sourceColumnName: s.sourceColumnName,
+          targetTableId: other.id,
+          targetColumnName: s.targetColumnName,
+          kind: s.kind,
+        });
+      }
+    }
+  }
+
+  /**
+   * For the currently-highlighted column (or an explicit name),
+   * scan the SOURCE catalog for every table containing a column with
+   * that name and pull each one not yet on the canvas onto it. If
+   * `autoSuggestOnDrop` is ON, every newly-added table is also wired
+   * to its peers via runAutoSuggestForTable. Returns the count of
+   * tables actually pulled in.
+   */
+  /**
+   * For an on-canvas column, find every OTHER table already on the
+   * canvas that has a column with the same (case-insensitive) name
+   * and commit a join from this column to each of them. Returns the
+   * count of joins actually added (existing-tuple dedupe applies).
+   * Companion to `pullInMatchingColumnTables` but scoped to what's
+   * already on the canvas.
+   */
+  linkSimilarOnCanvas(originTableId: string, columnName: string): number {
+    const needle = columnName.toLowerCase();
+    let added = 0;
+    this.withUndoBatch(() => {
+      for (const t of this.doc.tables) {
+        if (t.id === originTableId) continue;
+        const match = t.columns.find((c) => c.name.toLowerCase() === needle);
+        if (!match) continue;
+        const before = this.doc.joins.length;
+        this.addJoin({
+          sourceTableId: originTableId,
+          sourceColumnName: columnName,
+          targetTableId: t.id,
+          targetColumnName: match.name,
+          kind: "inner",
+        });
+        if (this.doc.joins.length > before) added++;
+      }
+    });
+    // One summary toast for the batch, overwriting the per-join
+    // feedback each addJoin pushed.
+    if (added > 1) {
+      this.pushJoinFeedback(`${added} joins created (linked ${columnName})`);
+    }
+    return added;
+  }
+
+  pullInMatchingColumnTables(columnName: string): number {
+    const needle = columnName.trim().toLowerCase();
+    if (!needle) return 0;
+    const onCanvas = this.tableIdentitiesOnCanvas;
+    const candidates = this.sourceTables.filter((c) => {
+      const ident = c.schema ? `${c.schema}.${c.name}` : c.name;
+      if (onCanvas.has(ident)) return false;
+      return c.columns.some((col) => col.name.toLowerCase() === needle);
+    });
+    if (candidates.length === 0) return 0;
+    // Lay them out in a horizontal row to the right of the rightmost
+    // existing table — keeps the new ones together visually.
+    const rightmostX = this.doc.tables.reduce(
+      (m, t) => Math.max(m, t.position.x),
+      0,
+    );
+    const baseX = rightmostX + 320;
+    const baseY = 80;
+    const added: string[] = [];
+    // One Undo step for the whole pull-in (tables + any auto-joins).
+    this.withUndoBatch(() => {
+      candidates.forEach((cand, i) => {
+        const t = this.addTable(cand, { x: baseX, y: baseY + i * 280 });
+        added.push(t.id);
+      });
+      if (this.autoSuggestOnDrop) {
+        for (const id of added) this.runAutoSuggestForTable(id);
+      }
+    });
+    return added.length;
+  }
+
+  /** Wipe every join. Tables stay where they are.  Also clears the
+   *  group-rename map and every piece of UI state that referenced a
+   *  now-deleted join — otherwise recreating the same canonical pair
+   *  silently inherits the previous label, and stale selection /
+   *  focus / pathfinder state would point at edges that no longer
+   *  exist. */
+  removeAllJoins(): void {
+    if (this.doc.joins.length === 0) return;
+    this.doc.joins = [];
+    this.doc.joinGroupRenames = {};
+    this.selectedJoinId = null;
+    this.pendingJoinSource = null;
+    this.pickModeActive = false;
+    this.eShiftPicks = [];
+    this.pathfinderResult = null;
+    this.highlightedColumn = null;
+    this.highlightOriginTableId = null;
+    this.highlightSource = null;
+    this.focusKind = "none";
+    this.focusKey = null;
+    this.touch();
+  }
+
+  // ── Dimensions Workbench (Step 2) ────────────────────────────────
+  // Mondrian-shaped dimension/hierarchy/level/measure authoring sits
+  // on top of the join graph from Step 1.  Persistence rides the
+  // same touch() → saveToStorage path as everything else on the doc.
+
+  /** Read accessor with default — older docs in localStorage didn't
+   *  carry `dimensions`. */
+  get dimensions(): SchemaCanvasDimension[] {
+    return this.doc.dimensions ?? [];
+  }
+
+  /** Read accessor with default — older docs in localStorage didn't
+   *  carry `measures`. */
+  get measures(): SchemaCanvasMeasure[] {
+    return this.doc.measures ?? [];
+  }
+
+  /** Create a new dimension. If a column reference is supplied, the
+   *  dimension is seeded with a first hierarchy that already holds
+   *  that column as its sole level — matches the drop UX where a
+   *  column dragged onto the empty zone materialises a full
+   *  dimension in one gesture. */
+  addDimension(seed?: {
+    name?: string;
+    tableId?: string;
+    columnName?: string;
+    columnType?: SchemaCanvasColumnKind;
+  }): SchemaCanvasDimension {
+    const tableName =
+      seed?.tableId !== undefined
+        ? (this.doc.tables.find((t) => t.id === seed.tableId)?.name ?? null)
+        : null;
+    const desired =
+      seed?.name?.trim() || tableName || seed?.columnName || "New dimension";
+    const name = ensureUnique(
+      desired,
+      (this.doc.dimensions ?? []).map((d) => d.name),
+    );
+    // Default: zero hierarchies.  The user explicitly composes
+    // hierarchies in Col 3 (Make hierarchy) or implicitly via the
+    // "singleton hierarchy for this attribute" checkbox on the
+    // Attributes pane.  Only the column-drop seed path (used by the
+    // legacy Cards/Tree drag UX) still auto-creates one hierarchy
+    // since the user dropped a specific column.
+    const hierarchies: SchemaCanvasHierarchy[] = [];
+    if (seed?.tableId && seed?.columnName) {
+      hierarchies.push({
+        id: makeId("hier"),
+        name,
+        hasAll: true,
+        levels: [
+          {
+            id: makeId("lvl"),
+            name: seed.columnName,
+            tableId: seed.tableId,
+            columnName: seed.columnName,
+            type: seed.columnType,
+          },
+        ],
+      });
+    }
+    const dim: SchemaCanvasDimension = {
+      id: makeId("dim"),
+      name,
+      hierarchies,
+      // Set BOTH: `sourceTableId` is the canonical binding the
+      // Workbench (Attrs count, FK selector, attribute picker)
+      // reads.  `primaryKeyTableId` kept for the snowflake case +
+      // legacy compatibility.  The types.ts split (2026-07-30ish)
+      // made `sourceTableId` primary but addDimension wasn't
+      // updated — freshly added dims read as "no table bound".
+      sourceTableId: seed?.tableId,
+      primaryKeyTableId: seed?.tableId,
+    };
+    this.doc.dimensions = [...this.dimensions, dim];
+    this.touch();
+    return dim;
+  }
+
+  updateDimension(
+    dimensionId: string,
+    patch: Partial<Omit<SchemaCanvasDimension, "id" | "hierarchies">>,
+  ): void {
+    const d = this.dimensions.find((d) => d.id === dimensionId);
+    if (!d) return;
+    Object.assign(d, patch);
+    // Note: we used to auto-rename any hierarchy whose name matched
+    // the old dim name when the dim was renamed — to keep the
+    // Mondrian "implicit-default" convention.  Dropped once the
+    // authoring model became "hierarchies are always explicit".
+    // Hierarchies are now independent of the dim's label; renaming
+    // the dim never touches them.
+    this.touch();
+  }
+
+  removeDimension(dimensionId: string): void {
+    this.doc.dimensions = this.dimensions.filter((d) => d.id !== dimensionId);
+    this.touch();
+  }
+
+  /** Add a {tableId, columnName} pair to the dim's attribute set A.
+   *  No-op if already present.  `attributes === undefined` is the
+   *  blank-slate state; the first add materialises it as a one-item
+   *  array, matching the "user starts including" mode. */
+  addAttribute(dimensionId: string, tableId: string, columnName: string): void {
+    const d = this.dimensions.find((d) => d.id === dimensionId);
+    if (!d) return;
+    const list = d.attributes ?? [];
+    if (list.some((a) => a.tableId === tableId && a.columnName === columnName))
+      return;
+    d.attributes = [...list, { tableId, columnName }];
+    this.touch();
+  }
+
+  /** Patch one attribute's editable Mondrian-4 fields (name, display /
+   *  sort / caption columns, description) — inspector #959. Identified by
+   *  its {tableId, columnName} identity, which is NOT itself patched here. */
+  updateAttribute(
+    dimensionId: string,
+    tableId: string,
+    columnName: string,
+    patch: Partial<
+      Omit<
+        NonNullable<SchemaCanvasDimension["attributes"]>[number],
+        "tableId" | "columnName"
+      >
+    >,
+  ): void {
+    const d = this.dimensions.find((d) => d.id === dimensionId);
+    const a = d?.attributes?.find(
+      (x) => x.tableId === tableId && x.columnName === columnName,
+    );
+    if (!a) return;
+    Object.assign(a, patch);
+    this.touch();
+  }
+
+  /** Remove a {tableId, columnName} pair from the dim's attribute set
+   *  A.  Leaves the array (even empty) in place so the dim is
+   *  distinguishably "user has touched A" vs "user hasn't yet". */
+  removeAttribute(
+    dimensionId: string,
+    tableId: string,
+    columnName: string,
+  ): void {
+    const d = this.dimensions.find((d) => d.id === dimensionId);
+    if (!d?.attributes) return;
+    d.attributes = d.attributes.filter(
+      (a) => !(a.tableId === tableId && a.columnName === columnName),
+    );
+    this.touch();
+  }
+
+  /** Replace A wholesale — used by bulk include-all / exclude-all. */
+  setAttributes(
+    dimensionId: string,
+    attributes: { tableId: string; columnName: string }[],
+  ): void {
+    const d = this.dimensions.find((d) => d.id === dimensionId);
+    if (!d) return;
+    d.attributes = attributes;
+    this.touch();
+  }
+
+  addHierarchy(
+    dimensionId: string,
+    name?: string,
+  ): SchemaCanvasHierarchy | null {
+    const d = this.dimensions.find((d) => d.id === dimensionId);
+    if (!d) return null;
+    const desired = name?.trim() || `Hierarchy ${d.hierarchies.length + 1}`;
+    const h: SchemaCanvasHierarchy = {
+      id: makeId("hier"),
+      name: ensureUnique(
+        desired,
+        d.hierarchies.map((x) => x.name),
+      ),
+      hasAll: true,
+      levels: [],
+    };
+    d.hierarchies = [...d.hierarchies, h];
+    this.touch();
+    return h;
+  }
+
+  updateHierarchy(
+    dimensionId: string,
+    hierarchyId: string,
+    patch: Partial<Omit<SchemaCanvasHierarchy, "id" | "levels">>,
+  ): void {
+    const d = this.dimensions.find((d) => d.id === dimensionId);
+    const h = d?.hierarchies.find((h) => h.id === hierarchyId);
+    if (!h) return;
+    Object.assign(h, patch);
+    this.touch();
+  }
+
+  removeHierarchy(dimensionId: string, hierarchyId: string): void {
+    const d = this.dimensions.find((d) => d.id === dimensionId);
+    if (!d) return;
+    d.hierarchies = d.hierarchies.filter((h) => h.id !== hierarchyId);
+    this.touch();
+  }
+
+  addLevel(
+    dimensionId: string,
+    hierarchyId: string,
+    level: {
+      tableId: string;
+      columnName: string;
+      name?: string;
+      type?: SchemaCanvasColumnKind;
+    },
+  ): SchemaCanvasLevel | null {
+    const d = this.dimensions.find((d) => d.id === dimensionId);
+    const h = d?.hierarchies.find((h) => h.id === hierarchyId);
+    if (!h) return null;
+    // Skip the exact same column landing twice in one hierarchy —
+    // stops a stray double-drop from creating an obviously useless
+    // duplicate row.  Different hierarchies (or different columns)
+    // are fine.
+    const dup = h.levels.find(
+      (l) => l.tableId === level.tableId && l.columnName === level.columnName,
+    );
+    if (dup) return dup;
+    const lvl: SchemaCanvasLevel = {
+      id: makeId("lvl"),
+      name: level.name?.trim() || level.columnName,
+      tableId: level.tableId,
+      columnName: level.columnName,
+      type: level.type,
+    };
+    h.levels = [...h.levels, lvl];
+    this.touch();
+    return lvl;
+  }
+
+  updateLevel(
+    dimensionId: string,
+    hierarchyId: string,
+    levelId: string,
+    patch: Partial<Omit<SchemaCanvasLevel, "id">>,
+  ): void {
+    const d = this.dimensions.find((d) => d.id === dimensionId);
+    const h = d?.hierarchies.find((h) => h.id === hierarchyId);
+    const l = h?.levels.find((l) => l.id === levelId);
+    if (!l) return;
+    Object.assign(l, patch);
+    this.touch();
+  }
+
+  removeLevel(dimensionId: string, hierarchyId: string, levelId: string): void {
+    const d = this.dimensions.find((d) => d.id === dimensionId);
+    const h = d?.hierarchies.find((h) => h.id === hierarchyId);
+    if (!h) return;
+    h.levels = h.levels.filter((l) => l.id !== levelId);
+    this.touch();
+  }
+
+  /** Move a level one position within its hierarchy (coarse↔fine reorder).
+   *  `delta` is -1 (toward coarsest / up) or +1 (toward finest / down). No-op
+   *  at the ends. Immutable swap — a new levels array is assigned. */
+  moveLevel(
+    dimensionId: string,
+    hierarchyId: string,
+    levelId: string,
+    delta: -1 | 1,
+  ): void {
+    const d = this.dimensions.find((d) => d.id === dimensionId);
+    const h = d?.hierarchies.find((h) => h.id === hierarchyId);
+    if (!h) return;
+    const i = h.levels.findIndex((l) => l.id === levelId);
+    const j = i + delta;
+    if (i < 0 || j < 0 || j >= h.levels.length) return;
+    const next = [...h.levels];
+    [next[i], next[j]] = [next[j], next[i]];
+    h.levels = next;
+    this.touch();
+  }
+
+  /** Drop a measure for a numeric column. Defaults to sum. */
+  addMeasure(seed: {
+    tableId: string;
+    columnName: string;
+    name?: string;
+    aggregator?: SchemaCanvasMeasure["aggregator"];
+    /** Percentile fraction (0–100); only meaningful for aggregator 'percentile'. */
+    percentile?: number | null;
+  }): SchemaCanvasMeasure {
+    const aggregator = seed.aggregator ?? "sum";
+    const m: SchemaCanvasMeasure = {
+      id: makeId("meas"),
+      name: seed.name?.trim() || seed.columnName,
+      aggregator,
+      tableId: seed.tableId,
+      columnName: seed.columnName,
+      percentile:
+        aggregator === "percentile" ? (seed.percentile ?? null) : undefined,
+    };
+    this.doc.measures = [...this.measures, m];
+    this.touch();
+    return m;
+  }
+
+  updateMeasure(
+    measureId: string,
+    patch: Partial<Omit<SchemaCanvasMeasure, "id">>,
+  ): void {
+    const m = this.measures.find((m) => m.id === measureId);
+    if (!m) return;
+    Object.assign(m, patch);
+    this.touch();
+  }
+
+  removeMeasure(measureId: string): void {
+    this.doc.measures = this.measures.filter((m) => m.id !== measureId);
+    this.touch();
+  }
+
+  // ── Cubes (measure groups + calculated members) ──────────────────
+  // The durable half of the Facts & Measures workbench.  Every mutator
+  // is immutable + rides the same touch() → saveToStorage path.  UI-only
+  // flags stay in WorkbenchView; the doc carries only the model an
+  // external caller (DimSum) needs to create and the exporter to emit.
+
+  /** Read accessor with default — older docs didn't carry `cubes`. */
+  get cubes(): SchemaCanvasCube[] {
+    return this.doc.cubes ?? [];
+  }
+
+  /** Replace the whole cube list.  Used by the workbench's persist path
+   *  (mapping its live cubes back into the trimmed doc shape). */
+  setCubes(cubes: SchemaCanvasCube[]): void {
+    // Preserve cube-scoped time-intelligence metrics across a workbench
+    // write-back. The workbench maps its live cubes through `cubeToDoc`,
+    // which doesn't carry `timeCalcs` (they're edited via the inspector's
+    // store methods on the doc). Without this merge, every workbench sync
+    // would silently wipe them. Incoming timeCalcs win when present (e.g. an
+    // import); otherwise inherit the existing doc cube's by id.
+    const existingTimeCalcs = new Map(
+      (this.doc.cubes ?? []).map((c) => [c.id, c.timeCalcs]),
+    );
+    this.doc.cubes = cubes.map((c) =>
+      c.timeCalcs !== undefined
+        ? c
+        : { ...c, timeCalcs: existingTimeCalcs.get(c.id) },
+    );
+    this.touch();
+  }
+
+  /** Signal the canvas page to re-hydrate the workbench from `doc.cubes`
+   *  after an external cube write. */
+  bumpWorkbenchReload(): void {
+    this.workbenchReloadNonce += 1;
+  }
+
+  addCube(seed?: { id?: string; name?: string }): SchemaCanvasCube {
+    const name = ensureUnique(
+      seed?.name?.trim() || `Cube ${this.cubes.length + 1}`,
+      this.cubes.map((c) => c.name),
+    );
+    const cube: SchemaCanvasCube = {
+      id: seed?.id ?? makeId("cube"),
+      name,
+      measureGroups: [],
+      calcs: [],
+    };
+    this.doc.cubes = [...this.cubes, cube];
+    this.touch();
+    return cube;
+  }
+
+  removeCube(cubeId: string): void {
+    this.doc.cubes = this.cubes.filter((c) => c.id !== cubeId);
+    this.touch();
+  }
+
+  renameCube(cubeId: string, name: string): void {
+    const c = this.cubes.find((c) => c.id === cubeId);
+    if (!c) return;
+    c.name = name;
+    this.touch();
+  }
+
+  private findCube(cubeId: string): SchemaCanvasCube | undefined {
+    return this.cubes.find((c) => c.id === cubeId);
+  }
+
+  addMeasureGroup(
+    cubeId: string,
+    seed: { id?: string; name?: string; factTableId?: string | null },
+  ): SchemaCanvasMeasureGroup | null {
+    const cube = this.findCube(cubeId);
+    if (!cube) return null;
+    const name = ensureUnique(
+      seed.name?.trim() || `Group ${cube.measureGroups.length + 1}`,
+      cube.measureGroups.map((g) => g.name),
+    );
+    const mg: SchemaCanvasMeasureGroup = {
+      id: seed.id ?? makeId("mg"),
+      name,
+      measureColumns: [],
+      factTableId: seed.factTableId ?? null,
+      dimensionLinks: [],
+    };
+    cube.measureGroups = [...cube.measureGroups, mg];
+    this.touch();
+    return mg;
+  }
+
+  removeMeasureGroup(cubeId: string, mgId: string): void {
+    const cube = this.findCube(cubeId);
+    if (!cube) return;
+    cube.measureGroups = cube.measureGroups.filter((g) => g.id !== mgId);
+    this.touch();
+  }
+
+  renameMeasureGroup(cubeId: string, mgId: string, name: string): void {
+    const mg = this.findCube(cubeId)?.measureGroups.find((g) => g.id === mgId);
+    if (!mg) return;
+    mg.name = name;
+    this.touch();
+  }
+
+  setMeasureColumns(cubeId: string, mgId: string, cols: string[]): void {
+    const mg = this.findCube(cubeId)?.measureGroups.find((g) => g.id === mgId);
+    if (!mg) return;
+    mg.measureColumns = [...cols];
+    this.touch();
+  }
+
+  /** Add or remove a single measure column from a group. */
+  toggleMeasureColumn(cubeId: string, mgId: string, col: string): void {
+    const mg = this.findCube(cubeId)?.measureGroups.find((g) => g.id === mgId);
+    if (!mg) return;
+    mg.measureColumns = mg.measureColumns.includes(col)
+      ? mg.measureColumns.filter((c) => c !== col)
+      : [...mg.measureColumns, col];
+    this.touch();
+  }
+
+  setMeasureGroupFactTable(
+    cubeId: string,
+    mgId: string,
+    tableId: string | null,
+  ): void {
+    const mg = this.findCube(cubeId)?.measureGroups.find((g) => g.id === mgId);
+    if (!mg) return;
+    mg.factTableId = tableId;
+    this.touch();
+  }
+
+  /** Upsert a dimension link on a measure group — keyed by dimensionId. */
+  setMeasureGroupDimLink(
+    cubeId: string,
+    mgId: string,
+    link: SchemaCanvasDimensionLink,
+  ): void {
+    const mg = this.findCube(cubeId)?.measureGroups.find((g) => g.id === mgId);
+    if (!mg) return;
+    const existing = mg.dimensionLinks ?? [];
+    const idx = existing.findIndex((l) => l.dimensionId === link.dimensionId);
+    mg.dimensionLinks =
+      idx >= 0
+        ? existing.map((l, i) => (i === idx ? link : l))
+        : [...existing, link];
+    this.touch();
+  }
+
+  removeMeasureGroupDimLink(
+    cubeId: string,
+    mgId: string,
+    dimensionId: string,
+  ): void {
+    const mg = this.findCube(cubeId)?.measureGroups.find((g) => g.id === mgId);
+    if (!mg?.dimensionLinks) return;
+    mg.dimensionLinks = mg.dimensionLinks.filter(
+      (l) => l.dimensionId !== dimensionId,
+    );
+    this.touch();
+  }
+
+  addCalc(
+    cubeId: string,
+    seed: {
+      id?: string;
+      name?: string;
+      tokens?: SchemaCanvasCalc["tokens"];
+      formula?: string;
+    },
+  ): SchemaCanvasCalc | null {
+    const cube = this.findCube(cubeId);
+    if (!cube) return null;
+    const calc: SchemaCanvasCalc = {
+      id: seed.id ?? makeId("calc"),
+      name: seed.name ?? "",
+      tokens: seed.tokens ?? [],
+      formula: seed.formula,
+    };
+    cube.calcs = [...cube.calcs, calc];
+    this.touch();
+    return calc;
+  }
+
+  removeCalc(cubeId: string, calcId: string): void {
+    const cube = this.findCube(cubeId);
+    if (!cube) return;
+    cube.calcs = cube.calcs.filter((c) => c.id !== calcId);
+    this.touch();
+  }
+
+  // ── Time-intelligence calcs (yoy/pop/ytd/rolling) — cube-scoped ──
+  addTimeCalc(
+    cubeId: string,
+    seed?: Partial<SchemaCanvasTimeCalc>,
+  ): SchemaCanvasTimeCalc | null {
+    const cube = this.findCube(cubeId);
+    if (!cube) return null;
+    const tc: SchemaCanvasTimeCalc = {
+      id: seed?.id ?? makeId("timecalc"),
+      name: seed?.name ?? "",
+      type: seed?.type ?? "yoy",
+      measure: seed?.measure ?? "",
+      timeDimension: seed?.timeDimension,
+      window: seed?.window,
+      function: seed?.function,
+      formatString: seed?.formatString,
+    };
+    cube.timeCalcs = [...(cube.timeCalcs ?? []), tc];
+    this.touch();
+    return tc;
+  }
+
+  updateTimeCalc(
+    cubeId: string,
+    timeCalcId: string,
+    patch: Partial<Omit<SchemaCanvasTimeCalc, "id">>,
+  ): void {
+    const cube = this.findCube(cubeId);
+    if (!cube?.timeCalcs) return;
+    const tc = cube.timeCalcs.find((t) => t.id === timeCalcId);
+    if (!tc) return;
+    Object.assign(tc, patch);
+    this.touch();
+  }
+
+  removeTimeCalc(cubeId: string, timeCalcId: string): void {
+    const cube = this.findCube(cubeId);
+    if (!cube?.timeCalcs) return;
+    cube.timeCalcs = cube.timeCalcs.filter((t) => t.id !== timeCalcId);
+    this.touch();
+  }
+
+  /**
+   * Canonical group key for a join — the shared column name when
+   * both sides match, otherwise the alphabetised pair joined by `↔`.
+   * Stable across direction (source ↔ target) so a swap doesn't
+   * shuffle groups around.
+   */
+  static joinCanonicalKey(j: SchemaCanvasJoin): string {
+    if (j.sourceColumnName === j.targetColumnName) return j.sourceColumnName;
+    return [j.sourceColumnName, j.targetColumnName].sort().join("↔");
+  }
+
+  /** Human label for a join group — falls back to the canonical key
+   *  when nothing has been renamed. */
+  joinGroupLabelFor(j: SchemaCanvasJoin): string {
+    const key = SchemaCanvasStore.joinCanonicalKey(j);
+    return this.doc.joinGroupRenames?.[key] ?? key;
+  }
+
+  /** Rename a join group. Empty/whitespace `nextLabel` drops the
+   *  rename so the group reverts to its canonical key. */
+  renameJoinGroup(canonicalKey: string, nextLabel: string): void {
+    const trimmed = nextLabel.trim();
+    const renames = { ...(this.doc.joinGroupRenames ?? {}) };
+    if (!trimmed || trimmed === canonicalKey) {
+      delete renames[canonicalKey];
+    } else {
+      renames[canonicalKey] = trimmed;
+    }
+    this.doc.joinGroupRenames = renames;
+    this.touch();
+  }
+
+  setJoinKind(joinId: string, kind: SchemaCanvasJoinKind): void {
+    const j = this.doc.joins.find((j) => j.id === joinId);
+    if (!j) return;
+    j.kind = kind;
+    this.touch();
+  }
+
+  createGroup(label: string): SchemaCanvasGroup {
+    const g: SchemaCanvasGroup = { id: makeId("grp"), label, collapsed: false };
+    this.doc.groups.push(g);
+    this.touch();
+    return g;
+  }
+
+  assignTableToGroup(tableId: string, groupId: string | null): void {
+    const t = this.doc.tables.find((t) => t.id === tableId);
+    if (!t) return;
+    t.groupId = groupId;
+    this.touch();
+  }
+
+  get factTable(): SchemaCanvasTable | null {
+    return this.doc.tables.find((t) => t.role === "fact") ?? null;
+  }
+
+  get dimensionTables(): SchemaCanvasTable[] {
+    return this.doc.tables.filter((t) => t.role !== "fact");
+  }
+
+  /** Returns the set of source-table identities (schema.name) currently on the canvas. */
+  get tableIdentitiesOnCanvas(): Set<string> {
+    return new Set(
+      this.doc.tables.map((t) => (t.schema ? `${t.schema}.${t.name}` : t.name)),
+    );
+  }
+
+  /**
+   * Wipe the canvas back to a blank doc for the current connection.
+   * Clears UI state too so nothing dangles. Persistence follows — the
+   * empty doc replaces the saved one in localStorage.
+   */
+  resetCanvas(): void {
+    this.doc = blankState(this.connectionId);
+    this.selectedTableId = null;
+    this.selectedJoinId = null;
+    this.highlightedColumn = null;
+    this.highlightSource = null;
+    this.binaryCursor = 0;
+    this.sidebarQuery = "";
+    this.touch();
+  }
+
+  /**
+   * Replace the current canvas doc with one loaded from elsewhere
+   * (JSON bundle, XML import). The doc is forced onto the active
+   * connection id so localStorage stays keyed correctly.
+   */
+  loadDoc(doc: SchemaCanvasState): void {
+    // Snapshot the current doc BEFORE replacing so the toolbar Undo
+    // button can revert.  Structured clone to isolate the snapshot
+    // from subsequent mutations of `this.doc`.
+    // JSON round-trip because structuredClone can't clone Svelte 5
+    // `$state` proxies (DataCloneError).
+    this.previousDoc = JSON.parse(
+      JSON.stringify(this.doc),
+    ) as SchemaCanvasState;
+    this.doc = { ...doc, connectionId: this.connectionId };
+    this.selectedTableId = null;
+    this.selectedJoinId = null;
+    this.highlightedColumn = null;
+    this.highlightSource = null;
+    this.binaryCursor = 0;
+    this.sidebarQuery = "";
+    this.touch();
+  }
+
+  /**
+   * Restore the last `previousDoc` snapshot as the current doc.  Swaps
+   * the snapshot forward-and-back so undo can immediately re-apply
+   * (the current doc becomes the new snapshot).  No-op when the
+   * snapshot is null.
+   */
+  undo(): void {
+    if (!this.previousDoc) return;
+    const swap = this.previousDoc;
+    // JSON round-trip because structuredClone can't clone Svelte 5
+    // `$state` proxies (DataCloneError).
+    this.previousDoc = JSON.parse(
+      JSON.stringify(this.doc),
+    ) as SchemaCanvasState;
+    this.doc = { ...swap, connectionId: this.connectionId };
+    this.selectedTableId = null;
+    this.selectedJoinId = null;
+    this.highlightedColumn = null;
+    this.highlightSource = null;
+    this.touch();
+  }
+
+  /** Discard the pending undo snapshot — e.g. after the user confirms
+   *  an AI proposal and no longer wants to revert it. */
+  clearPreviousDoc(): void {
+    this.previousDoc = null;
+  }
+
+  /** Take a snapshot of the current doc so the next big user gesture
+   *  is reversible via Undo.  Call at the entry point of a semantic
+   *  action (a drag-drop, a commit, an import) rather than per-
+   *  mutation, so N adds inside one gesture collapse to one undo
+   *  step.  Idempotent within the same gesture: a repeat call inside
+   *  the same tick overwrites the previous snapshot (which is what
+   *  we want — one snapshot per user intent). */
+  snapshotForUndo(): void {
+    // JSON round-trip because structuredClone can't clone Svelte 5
+    // `$state` proxies (DataCloneError).
+    this.previousDoc = JSON.parse(
+      JSON.stringify(this.doc),
+    ) as SchemaCanvasState;
+  }
+
+  /** When true, per-mutation snapshotForUndo is suppressed — the batch
+   *  caller (drop, CJM commit, pullIn, linkSimilar) has already taken
+   *  ONE snapshot at its entry and doesn't want each addJoin/addTable
+   *  inside its loop clobbering that.  Set via `withUndoBatch()`. */
+  private undoBatchDepth = 0;
+
+  /** Run `fn` as a single Undo step — take one snapshot at entry, then
+   *  suppress the per-mutation snapshots that base methods (addTable,
+   *  addJoin, removeTable, removeJoin, removeJoins) would otherwise
+   *  take.  Nesting is safe — only the outermost call snapshots. */
+  withUndoBatch<T>(fn: () => T): T {
+    if (this.undoBatchDepth === 0) this.snapshotForUndo();
+    this.undoBatchDepth++;
+    try {
+      return fn();
+    } finally {
+      this.undoBatchDepth--;
+    }
+  }
+
+  /** Take a snapshot unless we're inside a batch (in which case the
+   *  batch already snapshotted at entry). Called from every base
+   *  mutation so every user-visible action ends up undoable. */
+  private maybeSnapshotForUndo(): void {
+    if (this.undoBatchDepth === 0) this.snapshotForUndo();
+  }
+
+  /**
+   * Click-to-join entry point. State machine:
+   *  - no pending source → arm (stash this column as the source).
+   *  - click the SAME (table, column) again → cancel (clear).
+   *  - click a different column on the SAME table → replace the pending
+   *    source (self-joins aren't modelled here, so silently re-arm).
+   *  - click a column on a DIFFERENT table → commit the join via
+   *    `addJoin` (which itself dedupes by exact tuple + touches the
+   *    doc), then clear the pending source.
+   *
+   * `pendingJoinSource` is UI-only — no `touch()` here, only `addJoin`
+   * mutates the persisted doc.
+   */
+  /** Tap E → toggle pick mode.  When ON, column clicks accumulate
+   *  into eShiftPicks instead of arming a single click-to-join.
+   *  Tapping E again turns the mode OFF but does NOT clear picks —
+   *  the panel persists until Clear or Match.  Idempotent on
+   *  keyboard auto-repeat. */
+  togglePickMode(): void {
+    this.pickModeActive = !this.pickModeActive;
+  }
+  enterPickMode(): void {
+    this.pickModeActive = true;
+  }
+  exitPickMode(): void {
+    this.pickModeActive = false;
+  }
+
+  /** Add (or toggle off) a column to the pick set.  Enforces at most
+   *  ONE column per table — joins are one-to-one, so picking a second
+   *  column on a table that already has one REPLACES the previous
+   *  pick for that table (otherwise you'd end up trying to "merge"
+   *  two columns of the same table into a single joined thing, which
+   *  is meaningless).  Re-clicking the same (table, column) toggles
+   *  it off. */
+  pushEShiftPick(tableId: string, columnName: string): void {
+    const sameColIdx = this.eShiftPicks.findIndex(
+      (p) => p.tableId === tableId && p.columnName === columnName,
+    );
+    if (sameColIdx >= 0) {
+      // Toggle off — user re-clicked the same pick.
+      const next = this.eShiftPicks.slice();
+      next.splice(sameColIdx, 1);
+      this.eShiftPicks = next;
+      return;
+    }
+    const sameTableIdx = this.eShiftPicks.findIndex(
+      (p) => p.tableId === tableId,
+    );
+    if (sameTableIdx >= 0) {
+      // Replace the existing pick on this table — one column per table.
+      const next = this.eShiftPicks.slice();
+      next[sameTableIdx] = { tableId, columnName };
+      this.eShiftPicks = next;
+      return;
+    }
+    // New table entirely — append.
+    this.eShiftPicks = [...this.eShiftPicks, { tableId, columnName }];
+  }
+
+  /** Commit picks → joins, using a STAR pattern (pick[0] = origin,
+   *  wires to each subsequent pick).  The optional `groupName` is
+   *  written into `joinGroupRenames` for every new join's canonical
+   *  key so the joins-panel renders them all under one label —
+   *  letting picks with DIFFERENT column names ("product_id" ↔
+   *  "prod_id" ↔ "pid") collapse into a single semantic group like
+   *  "Product Key".  Less than two picks → no-op.  Mesh + chain
+   *  patterns are not exposed yet; star is the safe default. */
+  commitEShiftPicks(groupName?: string): void {
+    const picks = this.eShiftPicks;
+    this.eShiftPicks = [];
+    this.pickModeActive = false;
+    if (picks.length < 2) return;
+    const trimmedName = groupName?.trim();
+    const origin = picks[0];
+    const renames = { ...(this.doc.joinGroupRenames ?? {}) };
+    let joinsCreated = 0;
+    // One Undo step per commit — every addJoin inside skips its
+    // per-mutation snapshot via the batch guard.
+    this.withUndoBatch(() => {
+      for (let i = 1; i < picks.length; i++) {
+        const peer = picks[i];
+        if (origin.tableId === peer.tableId) continue;
+        const created = this.addJoin({
+          sourceTableId: origin.tableId,
+          sourceColumnName: origin.columnName,
+          targetTableId: peer.tableId,
+          targetColumnName: peer.columnName,
+          kind: "inner",
+        });
+        joinsCreated++;
+        if (trimmedName) {
+          const canonicalKey = SchemaCanvasStore.joinCanonicalKey(created);
+          renames[canonicalKey] = trimmedName;
+        }
+      }
+      if (trimmedName) {
+        this.doc.joinGroupRenames = renames;
+        this.touch();
+      }
+    });
+    // Overwrite the per-join feedback with a batch summary so the
+    // user sees ONE toast, not N.
+    if (joinsCreated > 1) {
+      const label = trimmedName ? ` under "${trimmedName}"` : "";
+      this.pushJoinFeedback(`${joinsCreated} joins created${label}`);
+    } else if (joinsCreated === 1 && trimmedName) {
+      // Single join with a named group — mention the label so the
+      // user knows the rename landed.
+      this.pushJoinFeedback(`Join created as "${trimmedName}"`);
+    }
+  }
+
+  /** Clear picks + exit pick mode.  Wired to ESC and the picks-
+   *  panel "Clear" button. */
+  cancelEShift(): void {
+    this.pickModeActive = false;
+    this.eShiftPicks = [];
+  }
+
+  /** User-typed sidebar search — updates the query AND clears the
+   *  click-driven highlight so the sidebar and the "Pull in N
+   *  matching tables" pill / "MATCHING X" active-set panel can't
+   *  end up talking about different columns.  Column-click driven
+   *  updates go through the internal `sidebarQuery = X` path (with
+   *  the highlight set alongside) so they stay coherent. */
+  setSidebarQueryFromUser(q: string): void {
+    this.sidebarQuery = q;
+    this.highlightedColumn = null;
+    this.highlightOriginTableId = null;
+    this.highlightSource = null;
+  }
+
+  /** Sensible default label for a group of picked columns — used to
+   *  prefill the group-name input and as the auto-name when the user
+   *  hits Enter without typing anything.  If every pick shares the
+   *  same column name, use it verbatim; otherwise fall back to the
+   *  most common name across the picks (ties broken by first-seen).
+   *  Empty string when there are no picks. */
+  autoPickGroupName(): string {
+    if (this.eShiftPicks.length === 0) return "";
+    const counts = new Map<string, number>();
+    for (const p of this.eShiftPicks) {
+      counts.set(p.columnName, (counts.get(p.columnName) ?? 0) + 1);
+    }
+    let bestName = this.eShiftPicks[0].columnName;
+    let bestCount = 0;
+    for (const [name, count] of counts) {
+      if (count > bestCount) {
+        bestName = name;
+        bestCount = count;
+      }
+    }
+    return bestName;
+  }
+
+  /** Arm a pathfinder slot — the next column click on the canvas
+   *  writes into that slot.  Passing `null` disarms.  Clicking the
+   *  same slot twice while armed toggles it off. */
+  armPathfinder(slot: "start" | "end" | null): void {
+    this.pathfinderArmed = this.pathfinderArmed === slot ? null : slot;
+    // Stale result becomes meaningless the moment endpoints might
+    // change — clear it so the UI doesn't display a path that no
+    // longer matches the inputs.
+    this.pathfinderResult = null;
+  }
+
+  /** Set an endpoint explicitly (used by tryColumnClickJoin when
+   *  pathfinderArmed is set). Clears the armed flag once written. */
+  setPathfinderEndpoint(
+    slot: "start" | "end",
+    endpoint: PathfinderEndpoint,
+  ): void {
+    if (slot === "start") this.pathfinderStart = endpoint;
+    else this.pathfinderEnd = endpoint;
+    this.pathfinderArmed = null;
+    this.pathfinderResult = null;
+  }
+
+  /** Wipe every pathfinder bit — slots, armed flag, result.  Wired
+   *  to the panel's Clear button. */
+  clearPathfinder(): void {
+    this.pathfinderArmed = null;
+    this.pathfinderStart = null;
+    this.pathfinderEnd = null;
+    this.pathfinderResult = null;
+  }
+
+  /**
+   * BFS from `pathfinderStart.tableId` to `pathfinderEnd.tableId`.
+   * First pass uses existing joins only.  If no path exists, a
+   * second pass adds virtual edges for column-name collisions
+   * (case-insensitive) so the result can propose missing joins for
+   * the user to commit via `applyPathfinderJoins`.  Writes the
+   * shortest chain (or null when no path is possible) into
+   * `pathfinderResult`.
+   */
+  findPath(): void {
+    const start = this.pathfinderStart;
+    const end = this.pathfinderEnd;
+    if (!start || !end) {
+      this.pathfinderResult = null;
+      return;
+    }
+    // Same-table trivial case — no path, just return an empty steps
+    // list so the UI can say "already on the same table".
+    if (start.tableId === end.tableId) {
+      this.pathfinderResult = { steps: [], hasGaps: false };
+      return;
+    }
+
+    type Edge = {
+      toTableId: string;
+      fromColumnName: string;
+      toColumnName: string;
+      joinId: string | null; // null = virtual (proposed)
+    };
+
+    // Build adjacency from existing joins first.  Joins are undirected
+    // for traversal — a path from A to B can use a join wired B→A.
+    const adj = new Map<string, Edge[]>();
+    const pushEdge = (fromId: string, edge: Edge) => {
+      const list = adj.get(fromId);
+      if (list) list.push(edge);
+      else adj.set(fromId, [edge]);
+    };
+    for (const j of this.doc.joins) {
+      pushEdge(j.sourceTableId, {
+        toTableId: j.targetTableId,
+        fromColumnName: j.sourceColumnName,
+        toColumnName: j.targetColumnName,
+        joinId: j.id,
+      });
+      pushEdge(j.targetTableId, {
+        toTableId: j.sourceTableId,
+        fromColumnName: j.targetColumnName,
+        toColumnName: j.sourceColumnName,
+        joinId: j.id,
+      });
+    }
+
+    const bfs = (): PathfinderStep[] | null => {
+      const prev = new Map<string, { fromId: string; edge: Edge }>();
+      const seen = new Set<string>([start.tableId]);
+      const queue: string[] = [start.tableId];
+      while (queue.length > 0) {
+        const cur = queue.shift()!;
+        if (cur === end.tableId) {
+          const steps: PathfinderStep[] = [];
+          let nodeId: string | undefined = cur;
+          while (nodeId && nodeId !== start.tableId) {
+            const back = prev.get(nodeId);
+            if (!back) break;
+            steps.unshift({
+              fromTableId: back.fromId,
+              fromColumnName: back.edge.fromColumnName,
+              toTableId: back.edge.toTableId,
+              toColumnName: back.edge.toColumnName,
+              existingJoinId: back.edge.joinId,
+            });
+            nodeId = back.fromId;
+          }
+          return steps;
+        }
+        const edges = adj.get(cur) ?? [];
+        for (const edge of edges) {
+          if (seen.has(edge.toTableId)) continue;
+          seen.add(edge.toTableId);
+          prev.set(edge.toTableId, { fromId: cur, edge });
+          queue.push(edge.toTableId);
+        }
+      }
+      return null;
+    };
+
+    const existingOnly = bfs();
+    if (existingOnly && existingOnly.length > 0) {
+      this.pathfinderResult = { steps: existingOnly, hasGaps: false };
+      return;
+    }
+
+    // Fallback — re-build adjacency including virtual edges built from
+    // shared column names across on-canvas tables, then BFS again.
+    // The result will probably include gaps (virtual edges with
+    // joinId: null) that "Create path joins" can wire up.
+    const byNameLower = new Map<
+      string,
+      Array<{ tableId: string; columnName: string }>
+    >();
+    for (const t of this.doc.tables) {
+      for (const c of t.columns) {
+        const key = c.name.toLowerCase();
+        const bucket = byNameLower.get(key);
+        if (bucket) bucket.push({ tableId: t.id, columnName: c.name });
+        else byNameLower.set(key, [{ tableId: t.id, columnName: c.name }]);
+      }
+    }
+    for (const bucket of byNameLower.values()) {
+      if (bucket.length < 2) continue;
+      for (let i = 0; i < bucket.length; i++) {
+        for (let k = i + 1; k < bucket.length; k++) {
+          const a = bucket[i];
+          const b = bucket[k];
+          if (a.tableId === b.tableId) continue;
+          // Skip pairs already wired in either direction — would
+          // otherwise inflate the graph with duplicate edges.
+          const already = this.doc.joins.some((j) => {
+            const f =
+              j.sourceTableId === a.tableId &&
+              j.sourceColumnName === a.columnName &&
+              j.targetTableId === b.tableId &&
+              j.targetColumnName === b.columnName;
+            const r =
+              j.sourceTableId === b.tableId &&
+              j.sourceColumnName === b.columnName &&
+              j.targetTableId === a.tableId &&
+              j.targetColumnName === a.columnName;
+            return f || r;
+          });
+          if (already) continue;
+          pushEdge(a.tableId, {
+            toTableId: b.tableId,
+            fromColumnName: a.columnName,
+            toColumnName: b.columnName,
+            joinId: null,
+          });
+          pushEdge(b.tableId, {
+            toTableId: a.tableId,
+            fromColumnName: b.columnName,
+            toColumnName: a.columnName,
+            joinId: null,
+          });
+        }
+      }
+    }
+    const withVirtual = bfs();
+    if (withVirtual && withVirtual.length > 0) {
+      this.pathfinderResult = {
+        steps: withVirtual,
+        hasGaps: withVirtual.some((s) => s.existingJoinId === null),
+      };
+      return;
+    }
+    this.pathfinderResult = null;
+  }
+
+  /** Wire up every virtual (gap) step in `pathfinderResult` as a real
+   *  join.  No-op when there's no result or no gaps.  Returns the
+   *  number actually added. */
+  applyPathfinderJoins(): number {
+    const result = this.pathfinderResult;
+    if (!result || !result.hasGaps) return 0;
+    let added = 0;
+    for (const step of result.steps) {
+      if (step.existingJoinId !== null) continue;
+      const before = this.doc.joins.length;
+      this.addJoin({
+        sourceTableId: step.fromTableId,
+        sourceColumnName: step.fromColumnName,
+        targetTableId: step.toTableId,
+        targetColumnName: step.toColumnName,
+        kind: "inner",
+      });
+      if (this.doc.joins.length > before) added++;
+    }
+    // Re-run the search so the result reflects post-commit state —
+    // what was a virtual step is now an existing join, and hasGaps
+    // flips false.
+    if (added > 0) this.findPath();
+    return added;
+  }
+
+  tryColumnClickJoin(tableId: string, columnName: string): void {
+    // A column click is a column-level intent — not a table-focus
+    // trigger. SvelteFlow marks the node selected on any click inside
+    // it, which would otherwise fire the auto-focus $effect and
+    // light up EVERY join column on the table. Explicitly bail out
+    // of table-focus + selection so the only thing the user sees is
+    // the green column highlight.
+    this.selectedTableId = null;
+    this.focusKind = "none";
+    this.focusKey = null;
+    // Pathfinder armed → the click captures an endpoint instead of
+    // running the normal click-to-highlight flow.
+    if (this.pathfinderArmed !== null) {
+      this.setPathfinderEndpoint(this.pathfinderArmed, { tableId, columnName });
+      return;
+    }
+    // Click-to-join (the hidden two-step where the first click armed
+    // a `pendingJoinSource` and the second click on a different
+    // table committed a join) was removed because users hit it by
+    // accident — clicking around to look at columns silently armed
+    // the next click. Joins now come from explicit gestures only:
+    // drag handle-to-handle, Create Joins Mode (⌘J), or sidebar drag with
+    // Auto-join on. Column click is highlight-only.
+    const alreadyHighlighted =
+      this.highlightedColumn === columnName &&
+      this.highlightOriginTableId === tableId;
+    if (alreadyHighlighted) {
+      this.highlightedColumn = null;
+      this.highlightOriginTableId = null;
+      this.highlightSource = null;
+      this.sidebarQuery = "";
+      return;
+    }
+    this.highlightedColumn = columnName;
+    this.highlightOriginTableId = tableId;
+    this.highlightSource = "click";
+    this.sidebarQuery = columnName;
+  }
+
+  /**
+   * Highlight a column name across the whole canvas + push the same
+   * name into the sidebar search so the user sees every table that has
+   * it. Click the same column again to clear. Switching the highlight
+   * to a different name replaces it.
+   */
+  highlightColumn(columnName: string): void {
+    if (this.highlightedColumn === columnName) {
+      this.highlightedColumn = null;
+      this.highlightSource = null;
+      this.sidebarQuery = "";
+      return;
+    }
+    this.highlightedColumn = columnName;
+    this.highlightSource = "click";
+    this.sidebarQuery = columnName;
+  }
 }

--- a/saiku-ui/src/lib/cube-designer/state.svelte.ts
+++ b/saiku-ui/src/lib/cube-designer/state.svelte.ts
@@ -1,0 +1,2371 @@
+/**
+ * Canvas schema designer — reactive state container.
+ *
+ * One `SchemaCanvasStore` per page mount. Owns the canvas document (tables /
+ * joins / groups), the active selection, and the workbench cursor.
+ * Persists every mutation to localStorage under
+ * `saiku.canvas.<connectionId>` so reloads pick up where the user left
+ * off. Server-side persistence is layered on later via the existing
+ * /me/schemas endpoint.
+ *
+ * Svelte 5 reactivity — uses the runes API (`$state` inside `.svelte.ts`
+ * classes is supported). Components consume via instance properties; no
+ * separate subscribe API needed.
+ */
+import type {
+	SchemaCanvasState,
+	SchemaCanvasTable,
+	SchemaCanvasJoin,
+	SchemaCanvasGroup,
+	SourceTableCandidate,
+	SchemaCanvasTableRole,
+	SchemaCanvasJoinKind,
+	SchemaCanvasDimension,
+	SchemaCanvasHierarchy,
+	SchemaCanvasLevel,
+	SchemaCanvasMeasure,
+	SchemaCanvasColumnKind,
+	SchemaCanvasCube,
+	SchemaCanvasMeasureGroup,
+	SchemaCanvasDimensionLink,
+	SchemaCanvasCalc,
+	SchemaCanvasTimeCalc
+} from './types.js';
+import { suggestJoins } from './auto-suggest.js';
+
+const STORAGE_PREFIX = 'saiku.canvas.';
+/** Legacy localStorage key the Facts & Measures workbench used to own the
+ *  cube model under before it was lifted into the doc (`doc.cubes`).  Still
+ *  read once on load to migrate any state authored before the refactor. */
+const LEGACY_CUBES_STORAGE_KEY = 'saiku.workbench.cubesState';
+/** Per-user UI preferences (NOT per-connection — survives connection
+ *  switches and applies across every cube the user authors).  Kept in
+ *  its own localStorage key so doc-shape changes don't risk losing
+ *  preference state. */
+const PREFS_STORAGE_KEY = 'saiku.canvas.prefs';
+
+type LayoutMode = 'layered' | 'star' | 'grid' | 'byJoins';
+
+/** Top-level surface the schema designer renders.  `'binary'` is a
+ *  historical alias for `'workbench'` (single "Cube Workbench" tab
+ *  that owned dims + facts) — migrated on load. */
+export type CanvasMode = 'canvas' | 'workbench' | 'facts' | 'validate';
+
+interface CanvasPrefs {
+	defaultLayoutMode?: LayoutMode;
+	/** Which view tab the user was last on — restored on next mount so
+	 *  someone who flipped to a designer tab last session lands
+	 *  back there instead of always landing on the Schema Canvas. */
+	mode?: CanvasMode | 'binary';
+}
+
+function migrateMode(mode: CanvasMode | 'binary' | undefined): CanvasMode | undefined {
+	if (!mode) return undefined;
+	if (mode === 'binary') return 'workbench';
+	return mode;
+}
+
+function loadPrefsFromStorage(): CanvasPrefs {
+	if (typeof window === 'undefined') return {};
+	try {
+		const raw = window.localStorage.getItem(PREFS_STORAGE_KEY);
+		if (!raw) return {};
+		const parsed = JSON.parse(raw) as CanvasPrefs;
+		return parsed && typeof parsed === 'object' ? parsed : {};
+	} catch {
+		return {};
+	}
+}
+
+function savePrefsToStorage(prefs: CanvasPrefs): void {
+	if (typeof window === 'undefined') return;
+	try {
+		window.localStorage.setItem(PREFS_STORAGE_KEY, JSON.stringify(prefs));
+	} catch {
+		/* private browsing, quota — silently ignore */
+	}
+}
+
+/** Single source of truth for "what identifies this dim's PK column?"
+ *  Three consumers read this (Attributes pane KEY badge, Tree KEY badge,
+ *  Inspector Select display + the "PK missing" alert on the Dimensions
+ *  pane row) — if they read `dim.primaryKey` or `dim.foreignKey`
+ *  directly they disagree on dims that only carry one of the two (M3
+ *  imports very often leave `primaryKey` unset because Mondrian 3's
+ *  `<Dimension foreignKey="X">` alone is enough for the engine — the
+ *  dim-side column is inferred from column-name match).  Route every
+ *  consumer through this helper and the badge / Inspector / alert stay
+ *  in sync. */
+export function dimKeyIdentity(
+	dim: Pick<SchemaCanvasDimension, 'primaryKey' | 'foreignKey'>
+): string | null {
+	return dim.primaryKey ?? dim.foreignKey ?? null;
+}
+
+/** Which on-canvas table the dim's PK column lives on.  Prefers the
+ *  explicit `primaryKeyTableId` (set when the PK is on a snowflake
+ *  child of the source table), falls back to `sourceTableId`. */
+export function dimKeyTableId(
+	dim: Pick<SchemaCanvasDimension, 'primaryKeyTableId' | 'sourceTableId'>
+): string | undefined {
+	return dim.primaryKeyTableId ?? dim.sourceTableId;
+}
+
+/** Resolve the key back to a SPECIFIC attribute on the dim so the KEY
+ *  badge, the Inspector display, and the alert all point to the same
+ *  row.  Rules:
+ *   1. Exact match on logical identity (`attr.name ?? attr.columnName`).
+ *   2. Fallback for M3 imports where `dim.primaryKey` still holds a raw
+ *      column name: match by `attr.columnName` ONLY when exactly one
+ *      attribute has that column (avoids double-badging Product where
+ *      two attributes share `columnName='product_id'`).
+ *   3. Otherwise return null — the schema is ambiguous, callers should
+ *      surface the alert and prompt the user to pick.
+ *
+ *  Returns the resolved attribute plus a `resolution` tag so callers
+ *  can display "resolved by column-name fallback — pick to confirm"
+ *  affordances when it's not a clean logical match.
+ */
+export function resolveKeyAttribute(
+	dim: Pick<SchemaCanvasDimension, 'primaryKey' | 'foreignKey' | 'attributes'>
+): {
+	attr: NonNullable<SchemaCanvasDimension['attributes']>[number];
+	resolution: 'logical' | 'column-fallback';
+} | null {
+	const key = dimKeyIdentity(dim);
+	if (!key) return null;
+	const attrs = dim.attributes ?? [];
+	const byLogical = attrs.find((a) => (a.name ?? a.columnName) === key);
+	if (byLogical) return { attr: byLogical, resolution: 'logical' };
+	const byColumn = attrs.filter((a) => a.columnName === key);
+	if (byColumn.length === 1) return { attr: byColumn[0], resolution: 'column-fallback' };
+	return null;
+}
+
+function makeId(prefix: string): string {
+	// Local-only ids — collision-safe across a single user-session, not
+	// global. Server persistence will reissue if needed.
+	return `${prefix}_${Math.random().toString(36).slice(2, 10)}`;
+}
+
+/** Pick a name not present in `existing`.  If `desired` collides, suffix
+ *  with `(2)`, `(3)`, … until clear.  Used to keep dim names unique in
+ *  the cube and hierarchy names unique within a dim — set-theoretic
+ *  cleanliness (two dims named "Customer" would be the same element). */
+function ensureUnique(desired: string, existing: string[]): string {
+	const set = new Set(existing);
+	if (!set.has(desired)) return desired;
+	for (let n = 2; n < 10_000; n++) {
+		const candidate = `${desired} (${n})`;
+		if (!set.has(candidate)) return candidate;
+	}
+	return `${desired} (${Date.now()})`;
+}
+
+function blankState(connectionId: string): SchemaCanvasState {
+	return {
+		version: 1,
+		connectionId,
+		label: '',
+		tables: [],
+		joins: [],
+		groups: [],
+		dimensions: [],
+		measures: [],
+		cubes: [],
+		updatedAt: new Date(0).toISOString()
+	};
+}
+
+/**
+ * Read the workbench's former localStorage cube model
+ * (`saiku.workbench.cubesState`) and map it to the trimmed
+ * `SchemaCanvasCube[]` doc shape — dropping every UI-only flag (edit modes,
+ * confirm flags, selection cursors, seq counters).  Used once on load to
+ * migrate any cube authored before the model was lifted into the doc.
+ * Guarded + never throws — returns `[]` on any problem.
+ */
+function migrateLegacyCubes(): SchemaCanvasCube[] {
+	if (typeof localStorage === 'undefined') return [];
+	try {
+		const raw = localStorage.getItem(LEGACY_CUBES_STORAGE_KEY);
+		if (!raw) return [];
+		const parsed = JSON.parse(raw) as {
+			cubes?: Array<{
+				id?: string;
+				name?: string;
+				measureGroups?: Array<{
+					id?: string;
+					name?: string;
+					measureColumns?: string[];
+					factTableId?: string | null;
+					dimensionLinks?: SchemaCanvasDimensionLink[];
+					measureCaptions?: Record<string, string>;
+				}>;
+				factsCalcs?: SchemaCanvasCalc[];
+				timeCalcs?: SchemaCanvasTimeCalc[];
+			}>;
+		};
+		if (!Array.isArray(parsed.cubes) || parsed.cubes.length === 0) return [];
+		return parsed.cubes.map((c) => ({
+			id: c.id ?? makeId('cube'),
+			name: c.name ?? 'Cube',
+			measureGroups: (c.measureGroups ?? []).map((g) => ({
+				id: g.id ?? makeId('mg'),
+				name: g.name ?? 'Group',
+				measureColumns: Array.isArray(g.measureColumns) ? g.measureColumns : [],
+				factTableId: g.factTableId ?? null,
+				dimensionLinks: Array.isArray(g.dimensionLinks) ? g.dimensionLinks : [],
+				measureCaptions:
+					g.measureCaptions && typeof g.measureCaptions === 'object' ? g.measureCaptions : {}
+			})),
+			calcs: Array.isArray(c.factsCalcs) ? c.factsCalcs : [],
+			timeCalcs: Array.isArray(c.timeCalcs) ? c.timeCalcs : undefined
+		}));
+	} catch {
+		return [];
+	}
+}
+
+function loadFromStorage(connectionId: string): SchemaCanvasState {
+	if (typeof window === 'undefined') return blankState(connectionId);
+	try {
+		const raw = window.localStorage.getItem(STORAGE_PREFIX + connectionId);
+		if (!raw) return blankState(connectionId);
+		const parsed = JSON.parse(raw) as SchemaCanvasState;
+		if (parsed.version !== 1) return blankState(connectionId);
+		// Self-heal: dedupe by the EXACT (source_col, target_col) tuple
+		// so role-playing dims (multiple distinct joins between the
+		// same table pair) survive a reload. Earlier versions of this
+		// store enforced one-per-pair; that rule has since been
+		// relaxed (see addJoin).
+		const tupleMap = new Map<string, SchemaCanvasState['joins'][number]>();
+		for (const j of parsed.joins ?? []) {
+			const key = [
+				[j.sourceTableId, j.sourceColumnName].join('.'),
+				[j.targetTableId, j.targetColumnName].join('.')
+			]
+				.sort()
+				.join('::');
+			tupleMap.set(key, j);
+		}
+		parsed.joins = [...tupleMap.values()];
+		// Back-fill workbench fields for docs persisted before the
+		// Dimensions Workbench landed.  Doc version is NOT bumped — the
+		// `?? []` defaults keep old docs round-tripping cleanly.
+		if (!Array.isArray(parsed.dimensions)) parsed.dimensions = [];
+		if (!Array.isArray(parsed.measures)) parsed.measures = [];
+		// Cubes were formerly held in the workbench's own localStorage key.
+		// Back-fill an empty array for docs saved before the model moved
+		// into the doc, and one-time migrate any legacy workbench cube state
+		// so the workbench + exporter see it immediately.
+		if (!Array.isArray(parsed.cubes) || parsed.cubes.length === 0) {
+			parsed.cubes = migrateLegacyCubes();
+		}
+		// Migrate old docs that only carried `primaryKeyTableId` (which
+		// was overloaded to mean both source-binding AND PK-column-table).
+		// Split-forward: source-binding lives on `sourceTableId`; the PK
+		// column table stays on `primaryKeyTableId` only for snowflakes.
+		for (const d of parsed.dimensions) {
+			if (!d.sourceTableId && d.primaryKeyTableId) {
+				d.sourceTableId = d.primaryKeyTableId;
+			}
+		}
+		return parsed;
+	} catch {
+		return blankState(connectionId);
+	}
+}
+
+function saveToStorage(state: SchemaCanvasState): void {
+	if (typeof window === 'undefined') return;
+	try {
+		window.localStorage.setItem(STORAGE_PREFIX + state.connectionId, JSON.stringify(state));
+	} catch {
+		/* private browsing, quota — silently ignore */
+	}
+}
+
+/**
+ * Pathfinder UX state — a column-to-column join-path finder anchored at
+ * the bottom of the joins panel.  The user clicks "Start" to arm the
+ * start slot, clicks a column on the canvas to set it, repeats for
+ * "End", then hits "Find path".  Pathfinder searches the join graph
+ * (existing joins first; falling back to virtual edges where two on-
+ * canvas tables share a column name) and returns the shortest chain.
+ * "Create path joins" then wires up any virtual edges along the way.
+ */
+export interface PathfinderEndpoint {
+	tableId: string;
+	columnName: string;
+}
+
+export interface PathfinderStep {
+	fromTableId: string;
+	fromColumnName: string;
+	toTableId: string;
+	toColumnName: string;
+	/** Existing join id when the step traverses an already-wired join;
+	 *  null when it's a name-collision virtual edge the user would still
+	 *  need to commit via Create path joins. */
+	existingJoinId: string | null;
+}
+
+export interface PathfinderResult {
+	steps: PathfinderStep[];
+	hasGaps: boolean;
+}
+
+export class SchemaCanvasStore {
+	// Reactive ($state): consumers read `store.connectionId` in reactive
+	// template positions (e.g. AskDimSumWidget's Send-button gate). A plain
+	// field wouldn't re-run those bindings when `switchConnection` reassigns
+	// it, so a fresh-canvas → pick-a-connection flow left the DimSum Send
+	// button stuck disabled ("Pick a connection first").
+	connectionId = $state<string>('');
+
+	// Document — top-level reactive state.
+	doc = $state<SchemaCanvasState>(blankState(''));
+
+	/**
+	 * One-step undo stash.  When set, the toolbar Undo button becomes
+	 * live and `undo()` swaps this back into `doc`.  Populated
+	 * automatically by `loadDoc` before every replace (so AI Draft is
+	 * always reversible) and can be populated by other big operations
+	 * that want to be undoable.
+	 */
+	previousDoc = $state<SchemaCanvasState | null>(null);
+
+	/**
+	 * Bumped whenever an external caller (DimSum) writes to `doc.cubes` and
+	 * wants the Facts & Measures workbench to re-hydrate.  The canvas page
+	 * watches this and force-remounts `<WorkbenchView>` (which re-reads
+	 * `doc.cubes` on mount) so the change is visible.  Pure signal — not
+	 * persisted.
+	 */
+	workbenchReloadNonce = $state<number>(0);
+
+	/**
+	 * The cube currently selected in the Facts & Measures workbench. Lifted to
+	 * the store so (a) the selection survives the DimSum-triggered remount and
+	 * (b) the DimSum chat (which lives in SchemaCanvasView) can reset itself
+	 * when the user switches to a different cube. Pure UI signal — not persisted.
+	 */
+	activeCubeId = $state<string | null>(null);
+
+	/**
+	 * Bumped when a saved schema is opened (or duplicated) from the library so
+	 * the DimSum chat (SchemaCanvasView) starts a fresh conversation for it,
+	 * instead of restoring the connection's last chat. Pure signal — not persisted.
+	 */
+	chatResetNonce = $state<number>(0);
+
+	// UI state.
+	selectedTableId = $state<string | null>(null);
+	selectedJoinId = $state<string | null>(null);
+	/** Filter expression for the sidebar table catalog. */
+	sidebarQuery = $state('');
+	/** Source-table catalog from /api/inference/profile-connection. */
+	sourceTables = $state<SourceTableCandidate[]>([]);
+	/** Selected schema filter — null means "all schemas". When set, the
+	 *  sidebar list is filtered to this schema. */
+	selectedSchema = $state<string | null>(null);
+	sourceLoading = $state(false);
+	sourceError = $state<string | null>(null);
+	/** Which top-level surface the schema designer renders.
+	 *  - `canvas`     — schema canvas (tables + joins).
+	 *  - `workbench`  — dimensions / attributes / hierarchies + inspector.
+	 *  - `facts`      — measure groups + calculated measures + inspector.
+	 *  - `validate`   — cube validation (sample data / try query / linked cubes).
+	 *
+	 *  Legacy `'binary'` value is migrated to `'workbench'` on load. */
+	mode = $state<CanvasMode>('canvas');
+	/**
+	 * Globally-highlighted column name. When set, every table on the
+	 * canvas that contains a column with this name renders with a glow
+	 * — visual signal of potential join targets for what the user just
+	 * clicked. Also drives the sidebar search filter.
+	 */
+	highlightedColumn = $state<string | null>(null);
+	/** Which table the highlighted column came from — lets the sidebar
+	 *  footer chip target "link similar on canvas" against THIS column
+	 *  specifically (origin → every other on-canvas table with the same
+	 *  column name). */
+	highlightOriginTableId = $state<string | null>(null);
+	/** What drove the current highlight — a column click or the sidebar
+	 *  search box. Lets the view's search→highlight effect decide
+	 *  whether emptying the search should clear the highlight (only when
+	 *  search drove it; otherwise a click-initiated highlight survives a
+	 *  manual search clear). */
+	highlightSource = $state<'click' | 'search' | null>(null);
+	/**
+	 * Click-to-join armed source. When a user clicks a column on table A,
+	 * we stash it here; the next click on a column on table B commits a
+	 * join between the two. Clicking the same (table, column) again
+	 * cancels; clicking another column on the SAME table replaces the
+	 * pending source (you can't join a table to itself in this model).
+	 *
+	 * This is pure UI state — NOT persisted in the doc / localStorage.
+	 */
+	pendingJoinSource = $state<{ tableId: string; columnName: string } | null>(null);
+	/**
+	 * Pick mode — toggled by tapping E (no hold required). When ON,
+	 * column clicks accumulate into `eShiftPicks` instead of arming a
+	 * single click-to-join.  Commit happens via the picks-panel
+	 * "Match" button, which takes a group name and wires picks in a
+	 * STAR pattern (first pick = origin, joins to each subsequent
+	 * pick).  Lets a user group columns with DIFFERENT names
+	 * (`product_id` ↔ `prod_id` ↔ `pid`) under a single semantic
+	 * label like "Product Key". UI state; not persisted.
+	 */
+	pickModeActive = $state<boolean>(false);
+	eShiftPicks = $state<Array<{ tableId: string; columnName: string }>>([]);
+	/** Bump-counter feedback channel for the join-creation toast.  Any
+	 *  path that materialises a new join writes here; the view listens
+	 *  on the `id` and renders a toast.  A single addJoin sets a
+	 *  descriptive per-join message; batch paths (commitEShiftPicks,
+	 *  linkSimilarOnCanvas) overwrite with a summary after the loop so
+	 *  the user gets one toast, not N. */
+	lastJoinFeedback = $state<{ id: number; message: string } | null>(null);
+	private joinFeedbackCounter = 0;
+	/** Pathfinder UX state — see PathfinderEndpoint / PathfinderResult.
+	 *  When `pathfinderArmed` is non-null, the next column click on the
+	 *  canvas writes into that slot (start / end) instead of running the
+	 *  normal click-to-join flow.  Result is computed on-demand via
+	 *  `findPath()` and surfaced as `pathfinderResult`. */
+	pathfinderArmed = $state<'start' | 'end' | null>(null);
+	pathfinderStart = $state<PathfinderEndpoint | null>(null);
+	pathfinderEnd = $state<PathfinderEndpoint | null>(null);
+	pathfinderResult = $state<PathfinderResult | null>(null);
+	/** Sidebar width in px — user-draggable via the splitter handle. */
+	sidebarWidth = $state(288);
+	/** Joins panel (right rail) width in px — same splitter pattern.
+	 *  Clamped at 220-560 in the drag handler. */
+	joinsPanelWidth = $state(280);
+	/** User's preferred Arrange layout — what the main Arrange button
+	 *  applies when clicked without picking from the menu.  All
+	 *  layouts stay individually clickable in the dropdown; this just
+	 *  controls the one-click default.  Persisted to localStorage as
+	 *  a per-user preference (NOT per-connection) so the choice
+	 *  follows the user across cubes and connection switches. */
+	defaultLayoutMode = $state<LayoutMode>('star');
+	/** Multi-select state for the sidebar table list. Clicking a row
+	 *  replaces selection; Shift/Cmd-clicking toggles. Dragging any
+	 *  selected row drags the WHOLE selection at once. Identities are
+	 *  the same `schema.name` (or bare `name`) form the sidebar uses. */
+	sidebarSelectedIdentities = $state<Set<string>>(new Set());
+	/**
+	 * Default columns shown per table when the user hasn't individually
+	 * collapsed/expanded that table. 0 = headers only. Any positive
+	 * number caps the visible row count; tables with fewer columns just
+	 * show all of theirs. Per-table `collapsed` boolean (true = headers
+	 * only, false = show all) overrides this when set.
+	 */
+	defaultColumnsShown = $state<number>(8);
+	/**
+	 * When ON, dropping a new table onto the canvas silently commits
+	 * every high-confidence column-name match between the dropped table
+	 * and the fact. Friendly when starting from a blank canvas; gets in
+	 * the way when you're trying to test interactions (E, click-to-join)
+	 * because joins materialise before you can do anything. Default OFF.
+	 */
+	autoSuggestOnDrop = $state<boolean>(false);
+	/**
+	 * When ON, focusing a table or join-group ALSO highlights the actual
+	 * column rows that participate in the focused joins (green row +
+	 * auto-expand the table to show them). When OFF (default), focus
+	 * just dims unrelated stuff — the user follows the lines themselves.
+	 * Some folks want the green highlight; others prefer the cleaner
+	 * "just follow the lines" view.
+	 */
+	highlightFocusedColumns = $state<boolean>(false);
+	/** When ON, hides every join line + label so the user can see the
+	 *  bare table layout without the visual noise. Doesn't delete the
+	 *  joins — just visually hides them. UI-only state. */
+	joinsHidden = $state<boolean>(false);
+	/** When ON, also render `cube-link` / `inferred-fk` joins (the ones
+	 *  auto-inferred from Mondrian-4 MeasureGroup `<ForeignKeyLink>` —
+	 *  semantic, not physical).  Default OFF — canvas shows only
+	 *  `origin: 'physical'` joins, matching the PhysicalSchema in the
+	 *  source XML.  UI-only state. */
+	showCubeLinks = $state<boolean>(false);
+	/**
+	 * Join-line rendering style.
+	 *   - `bezier`     — smooth curves (default).
+	 *   - `smoothstep` — orthogonal segments with rounded corners.
+	 *   - `step`       — sharp right-angle segments.
+	 * UI-only; not persisted in the doc (it's a personal preference).
+	 */
+	edgeStyle = $state<'bezier' | 'smoothstep' | 'step'>('smoothstep');
+	/**
+	 * Focus dimming. When the user picks a target — a join group label
+	 * in the panel, a table on the canvas, etc. — everything else
+	 * drops opacity so the chosen thing stands out. Click the empty
+	 * canvas to clear. UI-only.
+	 */
+	focusKind = $state<'none' | 'group' | 'table'>('none');
+	focusKey = $state<string | null>(null);
+	/** Cursor for binary view: index into the non-fact tables list. */
+	binaryCursor = $state(0);
+	/** Sidebar → canvas jump request. Set by the sidebar's "on canvas"
+	 *  result link; consumed by a tiny JumpHandler inside the SvelteFlow
+	 *  tree which calls `useSvelteFlow().setCenter()` (the hook only
+	 *  works inside the flow component subtree). `ts` makes repeat
+	 *  clicks on the same row re-fire the effect. */
+	requestedJumpTarget = $state<{ tableId: string; columnName?: string; ts: number } | null>(null);
+	/** Imperative viewport actions DimSum (or other UI) can request. The
+	 *  CanvasActionHandler child inside <SvelteFlow> consumes this and
+	 *  calls the corresponding useSvelteFlow() method. `ts` re-fires
+	 *  repeat requests of the same kind. Keeps the AI-visible action
+	 *  registry decoupled from where the imperative API is available. */
+	requestedCanvasAction = $state<{
+		kind: 'zoom_in' | 'zoom_out' | 'fit_view' | 'zoom_to_100' | 'center_view';
+		ts: number;
+	} | null>(null);
+	/**
+	 * Workbench working set — table IDs the user has pulled into the
+	 * Workbench view for focused side-by-side work. UI-only; not
+	 * persisted in the doc. Empty means "Workbench shows nothing yet —
+	 * drag tables in from the sidebar." Removing a table from this set
+	 * does NOT remove it from the canvas (the canvas is the source of
+	 * truth; the workbench is a scratch surface).
+	 */
+	workbenchWorkingSet = $state<Set<string>>(new Set());
+	/** Soft-threshold warning state — flips true above 30 tables. */
+	get thresholdSoft(): boolean {
+		return this.doc.tables.length >= 30;
+	}
+
+	/**
+	 * The "active set" — phase-2's unifying primitive for column
+	 * selection. Two prior pieces of UI (highlightedColumn ↔ across-table
+	 * name match, and eShiftPicks ↔ explicit E-hold picks) reduce to
+	 * ONE concept the rest of the canvas can read uniformly: an ordered
+	 * list of `{tableId, columnName}` plus a mode tag.
+	 *
+	 * Modes:
+	 *  - `pick`  — explicit picks accumulated during E-hold (or via the
+	 *              joins-panel "picks" affordance later). Survives until
+	 *              committed or explicitly cleared.
+	 *  - `auto`  — derived from `highlightedColumn`: every column on
+	 *              canvas whose name matches.
+	 *  - `none`  — neither mode active.
+	 *
+	 * Both visual surfaces (canvas column rows + Workbench panel) read
+	 * this and apply the SAME green-glow vocabulary, replacing the
+	 * Workbench's old red-ring treatment.
+	 */
+	get activeSetMode(): 'auto' | 'pick' | 'none' {
+		if (this.eShiftPicks.length > 0) return 'pick';
+		if (this.highlightedColumn !== null) return 'auto';
+		return 'none';
+	}
+
+	get activeSet(): Array<{ tableId: string; columnName: string }> {
+		if (this.eShiftPicks.length > 0) return this.eShiftPicks;
+		if (this.highlightedColumn !== null) {
+			const colName = this.highlightedColumn;
+			const out: Array<{ tableId: string; columnName: string }> = [];
+			for (const t of this.doc.tables) {
+				if (t.columns.some((c) => c.name === colName)) {
+					out.push({ tableId: t.id, columnName: colName });
+				}
+			}
+			return out;
+		}
+		return [];
+	}
+
+	/**
+	 * `${tableId}:${columnName}` keys for fast O(1) membership tests in
+	 * render hot paths — TableNode column rows test against this Set to
+	 * decide whether to apply the green glow.
+	 */
+	get activeSetKeys(): Set<string> {
+		const out = new Set<string>();
+		for (const p of this.activeSet) {
+			out.add(`${p.tableId}:${p.columnName}`);
+		}
+		return out;
+	}
+
+	constructor(connectionId: string) {
+		this.connectionId = connectionId;
+		this.doc = loadFromStorage(connectionId);
+		// One-time migration: strip the old "implicit-default hierarchy"
+		// auto-seed that the previous addDimension code created.  Match
+		// criterion: hier.name === dim.name AND hier.levels.length === 0
+		// — those are the obvious leftovers from the convention we
+		// abandoned (hierarchies are always explicit now).  Won't strip
+		// a hier the user named the same as the dim and populated.
+		for (const d of this.doc.dimensions ?? []) {
+			d.hierarchies = d.hierarchies.filter((h) => !(h.levels.length === 0 && h.name === d.name));
+			// Sibling-unique hierarchy names per dim.  Pre-uniqueness
+			// data may have shipped duplicates; resolve by suffixing
+			// "(2)", "(3)", ….  Keep the first occurrence's name intact.
+			const seen = new Set<string>();
+			for (const h of d.hierarchies) {
+				if (seen.has(h.name)) {
+					let n = 2;
+					while (seen.has(`${h.name} (${n})`)) n++;
+					h.name = `${h.name} (${n})`;
+				}
+				seen.add(h.name);
+			}
+		}
+		// Same for dim names at the cube level.
+		const seenDimNames = new Set<string>();
+		for (const d of this.doc.dimensions ?? []) {
+			if (seenDimNames.has(d.name)) {
+				let n = 2;
+				while (seenDimNames.has(`${d.name} (${n})`)) n++;
+				d.name = `${d.name} (${n})`;
+			}
+			seenDimNames.add(d.name);
+		}
+		// Restore per-user UI preferences (NOT per-connection).
+		const prefs = loadPrefsFromStorage();
+		if (prefs.defaultLayoutMode) {
+			this.defaultLayoutMode = prefs.defaultLayoutMode;
+		}
+		const migrated = migrateMode(prefs.mode);
+		if (migrated) this.mode = migrated;
+	}
+
+	/** Update the default Arrange layout and persist it as a per-user
+	 *  preference.  Callers should use this method rather than mutating
+	 *  `defaultLayoutMode` directly so the localStorage write stays in
+	 *  one place. */
+	setDefaultLayoutMode(mode: LayoutMode): void {
+		this.defaultLayoutMode = mode;
+		const prefs = loadPrefsFromStorage();
+		prefs.defaultLayoutMode = mode;
+		savePrefsToStorage(prefs);
+	}
+
+	/** Set the active view tab and persist as a per-user preference so the
+	 *  next session lands on the same tab.  Tab toggle UI should call
+	 *  this rather than mutating `mode` directly. */
+	setMode(mode: CanvasMode): void {
+		this.mode = mode;
+		const prefs = loadPrefsFromStorage();
+		prefs.mode = mode;
+		savePrefsToStorage(prefs);
+	}
+
+	/**
+	 * Swap the active connection without recreating the store. Persists
+	 * the current doc, loads the doc for the new connection from
+	 * localStorage, and resets the UI state (selection, mode cursor).
+	 * Source-table catalog is the caller's responsibility — the
+	 * /cubes/new/canvas page kicks off a fresh fetch on connection
+	 * change.
+	 */
+	switchConnection(connectionId: string): void {
+		if (this.connectionId === connectionId) return;
+		// Persist whatever's currently in flight under the old key.
+		saveToStorage(this.doc);
+		this.connectionId = connectionId;
+		this.doc = loadFromStorage(connectionId);
+		this.selectedTableId = null;
+		this.selectedJoinId = null;
+		this.binaryCursor = 0;
+		this.sourceTables = [];
+		this.sourceLoading = false;
+		this.sourceError = null;
+		this.sidebarQuery = '';
+	}
+
+	private touch(): void {
+		this.doc.updatedAt = new Date().toISOString();
+		saveToStorage(this.doc);
+	}
+
+	/** Public setter for the cube label.  Goes through the same
+	 *  touch() → saveToStorage path as canvas mutations, so renames
+	 *  survive a reload.  The two-way `bind:value` on the title input
+	 *  used to mutate `store.doc.label` directly, which never wrote
+	 *  to localStorage. */
+	setLabel(label: string): void {
+		this.doc.label = label;
+		this.touch();
+	}
+
+	/** Add a table from the source catalog onto the canvas at the given position. */
+	addTable(candidate: SourceTableCandidate, position: { x: number; y: number }): SchemaCanvasTable {
+		this.maybeSnapshotForUndo();
+		// Dedupe (#1084) — a physical table (schema+name) may only appear
+		// once on the canvas. Every add path (drag-drop, "+ Add to canvas",
+		// DimSum's add_table_to_canvas tool) funnels through here, so this
+		// is the single guard against a second node with a fresh id being
+		// pushed for a table that's already present. If found, return the
+		// existing node untouched rather than creating a duplicate.
+		const identity = candidate.schema ? `${candidate.schema}.${candidate.name}` : candidate.name;
+		const existing = this.doc.tables.find(
+			(t) => (t.schema ? `${t.schema}.${t.name}` : t.name) === identity
+		);
+		if (existing) return existing;
+		// Peer model — every table on the canvas is equal. The `role`
+		// field stays on the data model (Mondrian export still needs a
+		// fact at the END), but the canvas itself doesn't designate one
+		// any more. New tables come in as plain dimensions.
+		const role: SchemaCanvasTableRole = 'dimension';
+		const table: SchemaCanvasTable = {
+			id: makeId('tbl'),
+			schema: candidate.schema,
+			name: candidate.name,
+			role,
+			columns: candidate.columns.map((c) => ({ name: c.name, sqlType: c.sqlType })),
+			position,
+			groupId: null
+		};
+		this.doc.tables.push(table);
+		this.touch();
+		return table;
+	}
+
+	removeTable(tableId: string): void {
+		this.maybeSnapshotForUndo();
+		this.doc.tables = this.doc.tables.filter((t) => t.id !== tableId);
+		// Cascade: drop any joins that referenced this table.
+		this.doc.joins = this.doc.joins.filter(
+			(j) => j.sourceTableId !== tableId && j.targetTableId !== tableId
+		);
+		if (this.selectedTableId === tableId) this.selectedTableId = null;
+		this.touch();
+	}
+
+	moveTable(tableId: string, position: { x: number; y: number }): void {
+		const t = this.doc.tables.find((t) => t.id === tableId);
+		if (!t) return;
+		t.position = position;
+		this.touch();
+	}
+
+	/** Force a single table to show every column (overrides the global
+	 *  default). Used by the "+ N more" footer affordance — clicking it
+	 *  is an explicit "I want to see everything in this table". The
+	 *  chevron still cycles undef ↔ true after that. */
+	expandTableFully(tableId: string): void {
+		const t = this.doc.tables.find((t) => t.id === tableId);
+		if (!t) return;
+		t.collapsed = false;
+		this.touch();
+	}
+
+	toggleTableCollapsed(tableId: string): void {
+		const t = this.doc.tables.find((t) => t.id === tableId);
+		if (!t) return;
+		// Cycle is two states: `undefined` (follow `defaultColumnsShown`)
+		// ↔ `true` (header only). The chevron NEVER sets the third state
+		// (`false` = force show-all) because that would pin the table
+		// past any future change to `defaultColumnsShown` — Amelia hit
+		// this and had to click "Reset views" to escape. "Force show all"
+		// is reachable only via the explicit "Expand all" toolbar button.
+		if (t.collapsed === true) {
+			t.collapsed = undefined;
+		} else {
+			t.collapsed = true;
+		}
+		this.touch();
+	}
+
+	/** Reset every table's per-table collapse override so they all
+	 *  follow the global `defaultColumnsShown` setting again. */
+	resetCollapseOverrides(): void {
+		for (const t of this.doc.tables) t.collapsed = undefined;
+		this.touch();
+	}
+
+	/** Force every table to show all its columns (overrides the global
+	 *  default). Companion to the toolbar's "Expand all" button. */
+	expandAllTables(): void {
+		for (const t of this.doc.tables) t.collapsed = false;
+		this.touch();
+	}
+
+	/** Force every table to collapse to header-only. */
+	collapseAllTables(): void {
+		for (const t of this.doc.tables) t.collapsed = true;
+		this.touch();
+	}
+
+	/** Add a canvas table to the workbench working set. No-op if
+	 *  already present. Doesn't touch the canvas. */
+	addToWorkbench(tableId: string): void {
+		if (this.workbenchWorkingSet.has(tableId)) return;
+		const next = new Set(this.workbenchWorkingSet);
+		next.add(tableId);
+		this.workbenchWorkingSet = next;
+	}
+
+	/** Remove a table from the workbench WITHOUT removing it from the
+	 *  canvas. */
+	removeFromWorkbench(tableId: string): void {
+		if (!this.workbenchWorkingSet.has(tableId)) return;
+		const next = new Set(this.workbenchWorkingSet);
+		next.delete(tableId);
+		this.workbenchWorkingSet = next;
+	}
+
+	clearWorkbench(): void {
+		this.workbenchWorkingSet = new Set();
+	}
+
+	/** The actual tables in the workbench's working set (canvas tables
+	 *  filtered by membership). The Set may include stale IDs from a
+	 *  prior reload; we resolve against the live canvas tables. */
+	get workbenchTables(): SchemaCanvasTable[] {
+		return this.doc.tables.filter((t) => this.workbenchWorkingSet.has(t.id));
+	}
+
+	/** `schema.name` identities of every table currently in the
+	 *  workbench's working set — used by the Workbench's TableSidebar
+	 *  to grey out tables already in focus (vs. all canvas tables). */
+	get workbenchTableIdentities(): Set<string> {
+		return new Set(this.workbenchTables.map((t) => (t.schema ? `${t.schema}.${t.name}` : t.name)));
+	}
+
+	setTableRole(tableId: string, role: SchemaCanvasTableRole): void {
+		const t = this.doc.tables.find((t) => t.id === tableId);
+		if (!t) return;
+		// Only one fact at a time — demote any prior fact to dimension when
+		// another is promoted.
+		if (role === 'fact') {
+			for (const other of this.doc.tables) {
+				if (other.id !== tableId && other.role === 'fact') other.role = 'dimension';
+			}
+		}
+		t.role = role;
+		this.touch();
+	}
+
+	addJoin(j: Omit<SchemaCanvasJoin, 'id'>): SchemaCanvasJoin {
+		this.maybeSnapshotForUndo();
+		// User-initiated joins default to `physical` — only the importer
+		// creates `cube-link` / `inferred-fk` joins, and it sets origin
+		// explicitly when it does.
+		const join: SchemaCanvasJoin = { ...j, id: makeId('join'), origin: j.origin ?? 'physical' };
+		// Multiple joins per table pair are valid for role-playing
+		// dimensions: a fact joining `date` three times via order_date_id,
+		// ship_date_id, and invoice_date_id is one classic shape. Tom's
+		// "no composite keys" rule meant a SINGLE join using multiple
+		// columns simultaneously — different from N distinct
+		// single-column joins between the same pair. We only dedupe on
+		// the exact (source_col, target_col) tuple so the same join
+		// can't be drawn twice.
+		const existingIdx = this.doc.joins.findIndex((existing) => {
+			const sameDirection =
+				existing.sourceTableId === join.sourceTableId &&
+				existing.targetTableId === join.targetTableId &&
+				existing.sourceColumnName === join.sourceColumnName &&
+				existing.targetColumnName === join.targetColumnName;
+			const swappedDirection =
+				existing.sourceTableId === join.targetTableId &&
+				existing.targetTableId === join.sourceTableId &&
+				existing.sourceColumnName === join.targetColumnName &&
+				existing.targetColumnName === join.sourceColumnName;
+			return sameDirection || swappedDirection;
+		});
+		if (existingIdx >= 0) {
+			this.doc.joins[existingIdx] = join;
+			this.touch();
+			return join;
+		}
+		// Within a given table pair, a single (source_table, source_column)
+		// endpoint can only participate in ONE join. If the same source
+		// endpoint is being paired with a DIFFERENT target column on the
+		// same target table, that's ambiguous (a "first_name" endpoint
+		// wired to both `fname` and `lname`) so replace the older join
+		// instead of accumulating semantically-inconsistent pairs.
+		// Role-playing (same target column reused via DIFFERENT source
+		// columns) stays legal because the check keys off the source
+		// endpoint, not the target.
+		const ambiguousIdx = this.doc.joins.findIndex((existing) => {
+			const sameDirection =
+				existing.sourceTableId === join.sourceTableId &&
+				existing.targetTableId === join.targetTableId &&
+				existing.sourceColumnName === join.sourceColumnName &&
+				existing.targetColumnName !== join.targetColumnName;
+			// Swapped: the incoming join's TARGET endpoint (table + column)
+			// matches the existing join's SOURCE endpoint — same conceptual
+			// "source" endpoint of the pair, written in reverse. Other-side
+			// columns must still differ, else the sameDirection dedupe (or
+			// exact-tuple dedupe above) would have caught it.
+			const swappedDirection =
+				existing.sourceTableId === join.targetTableId &&
+				existing.targetTableId === join.sourceTableId &&
+				existing.sourceColumnName === join.targetColumnName &&
+				existing.targetColumnName !== join.sourceColumnName;
+			return sameDirection || swappedDirection;
+		});
+		if (ambiguousIdx >= 0) {
+			const prior = this.doc.joins[ambiguousIdx];
+			// Both detection cases converge on: prior.sourceColumnName is
+			// the endpoint being reused, prior.targetColumnName is what it
+			// was previously paired with. (In sameDirection the incoming's
+			// source matches prior.sourceColumnName; in swappedDirection
+			// the incoming's target does. Either way, prior tells us the
+			// old story.)
+			const reusedColumn = prior.sourceColumnName;
+			const oldPairedColumn = prior.targetColumnName;
+			this.doc.joins[ambiguousIdx] = join;
+			this.touch();
+			this.pushJoinFeedback(
+				`Replaced join (${reusedColumn} was already paired with ${oldPairedColumn})`
+			);
+			return join;
+		}
+		this.doc.joins.push(join);
+		this.touch();
+		this.pushJoinFeedback(this.describeJoinCreation(join));
+		return join;
+	}
+
+	private describeJoinCreation(j: SchemaCanvasJoin): string {
+		const src = this.doc.tables.find((t) => t.id === j.sourceTableId);
+		const tgt = this.doc.tables.find((t) => t.id === j.targetTableId);
+		const srcName = src?.name ?? '?';
+		const tgtName = tgt?.name ?? '?';
+		return `Joined ${srcName}.${j.sourceColumnName} ↔ ${tgtName}.${j.targetColumnName}`;
+	}
+
+	private pushJoinFeedback(message: string): void {
+		this.lastJoinFeedback = { id: ++this.joinFeedbackCounter, message };
+	}
+
+	removeJoin(joinId: string): void {
+		this.maybeSnapshotForUndo();
+		const target = this.doc.joins.find((j) => j.id === joinId);
+		// Cube-link + inferred-fk joins are owned by the cube-side
+		// MeasureGroup ForeignKeyLink, not by the canvas.  The user must
+		// remove the FK link from the MG's dim-link checklist to make it
+		// go away; deleting it on the canvas would just have the importer
+		// recreate it.  Silently no-op so accidental clicks don't surprise.
+		if (target && (target.origin === 'cube-link' || target.origin === 'inferred-fk')) {
+			return;
+		}
+		this.doc.joins = this.doc.joins.filter((j) => j.id !== joinId);
+		if (this.selectedJoinId === joinId) this.selectedJoinId = null;
+		// If the removed join was the LAST one for its canonical key,
+		// clear the rename so a future re-creation doesn't silently
+		// inherit a stale label.  When other joins for the same key
+		// still exist (the group survives the removal), the rename
+		// stays — same group, same label.
+		if (target) {
+			const key = SchemaCanvasStore.joinCanonicalKey(target);
+			const stillHasKey = this.doc.joins.some((j) => SchemaCanvasStore.joinCanonicalKey(j) === key);
+			if (!stillHasKey && this.doc.joinGroupRenames?.[key]) {
+				const next = { ...this.doc.joinGroupRenames };
+				delete next[key];
+				this.doc.joinGroupRenames = next;
+			}
+		}
+		this.touch();
+	}
+
+	/** Remove a column from a group while keeping the rest of the
+	 *  group's equivalence intact.
+	 *
+	 *  Three cases:
+	 *  1. Removing the endpoint leaves fewer than 2 remaining → group
+	 *     dissolves (delete every join in it).
+	 *  2. Removing it leaves at least one join that DOESN'T touch
+	 *     the endpoint → just drop the joins that do.
+	 *  3. Removing it leaves 2+ endpoints but ZERO surviving joins
+	 *     (the endpoint was the star anchor) → re-anchor: pick the
+	 *     first remaining endpoint as the new anchor and rewire a
+	 *     fresh star to the rest, re-applying the group label.
+	 *
+	 *  The UI doesn't see any of this — it just calls
+	 *  `removeEndpointFromGroup` and the group's semantic "these are
+	 *  all the same" stays true, no matter which member is removed.
+	 */
+	removeEndpointFromGroup(groupLabel: string, tableId: string, columnName: string): void {
+		const groupJoins = this.doc.joins.filter((j) => this.joinGroupLabelFor(j) === groupLabel);
+		if (groupJoins.length === 0) return;
+		const touchesEndpoint = (j: SchemaCanvasJoin) =>
+			(j.sourceTableId === tableId && j.sourceColumnName === columnName) ||
+			(j.targetTableId === tableId && j.targetColumnName === columnName);
+		const joinsTouchingEp = groupJoins.filter(touchesEndpoint);
+		const remainingJoins = groupJoins.filter((j) => !touchesEndpoint(j));
+		// Build the ordered set of endpoints (excluding the one being
+		// removed) — preserve the order they first appear so the new
+		// anchor is deterministic.
+		const seen = new Set<string>();
+		const remainingEndpoints: Array<{ tableId: string; columnName: string }> = [];
+		const skipKey = `${tableId}:${columnName}`;
+		for (const j of groupJoins) {
+			for (const ep of [
+				{ tableId: j.sourceTableId, columnName: j.sourceColumnName },
+				{ tableId: j.targetTableId, columnName: j.targetColumnName }
+			]) {
+				const k = `${ep.tableId}:${ep.columnName}`;
+				if (k === skipKey || seen.has(k)) continue;
+				seen.add(k);
+				remainingEndpoints.push(ep);
+			}
+		}
+		// Case 1 — group falls under 2 members → kill it.
+		if (remainingEndpoints.length < 2) {
+			for (const j of groupJoins) this.removeJoin(j.id);
+			return;
+		}
+		// Case 2 — the endpoint wasn't the anchor; just drop the joins
+		// that touch it and leave the rest of the star intact.
+		if (remainingJoins.length > 0) {
+			for (const j of joinsTouchingEp) this.removeJoin(j.id);
+			return;
+		}
+		// Case 3 — the endpoint was the anchor; rebuild the star
+		// using the first remaining endpoint as the new anchor and
+		// re-applying the same group label.
+		for (const j of groupJoins) this.removeJoin(j.id);
+		const newAnchor = remainingEndpoints[0];
+		const peers = remainingEndpoints.slice(1);
+		const renames = { ...(this.doc.joinGroupRenames ?? {}) };
+		for (const peer of peers) {
+			if (newAnchor.tableId === peer.tableId) continue;
+			const created = this.addJoin({
+				sourceTableId: newAnchor.tableId,
+				sourceColumnName: newAnchor.columnName,
+				targetTableId: peer.tableId,
+				targetColumnName: peer.columnName,
+				kind: 'inner'
+			});
+			const canonicalKey = SchemaCanvasStore.joinCanonicalKey(created);
+			renames[canonicalKey] = groupLabel;
+		}
+		this.doc.joinGroupRenames = renames;
+		this.touch();
+	}
+
+	/** Remove every join in `joinIds`. Single pass, single save. */
+	removeJoins(joinIds: Iterable<string>): void {
+		const set = joinIds instanceof Set ? joinIds : new Set(joinIds);
+		if (set.size === 0) return;
+		this.maybeSnapshotForUndo();
+		this.doc.joins = this.doc.joins.filter((j) => !set.has(j.id));
+		if (this.selectedJoinId && set.has(this.selectedJoinId)) {
+			this.selectedJoinId = null;
+		}
+		this.touch();
+	}
+
+	focusGroup(label: string): void {
+		// `focusKey` for a group is the rendered LABEL (so
+		// joinIdsInFocus / tableIdsInFocus can match every join under
+		// that label, even when the group spans multiple canonical
+		// keys via pick-mode renames).
+		if (this.focusKind === 'group' && this.focusKey === label) {
+			this.clearFocus();
+			return;
+		}
+		this.focusKind = 'group';
+		this.focusKey = label;
+		// Auto-flip the column-highlight toggle ON when a group is
+		// focused — clicking a group means "show me the data you
+		// grouped," so the row glow + auto-expand are the natural
+		// default.  The user is still free to toggle it back off
+		// mid-focus if they prefer the cleaner line-only view.
+		this.highlightFocusedColumns = true;
+		// Drop any stale name-match highlight (from a previous column
+		// click or sidebar search) so the only thing lighting up is
+		// the group itself — otherwise the user can't tell which
+		// columns are "in the group" vs "still glowing from earlier".
+		this.highlightedColumn = null;
+		this.highlightOriginTableId = null;
+		this.highlightSource = null;
+	}
+
+	focusTableNode(tableId: string): void {
+		if (this.focusKind === 'table' && this.focusKey === tableId) {
+			this.clearFocus();
+			return;
+		}
+		this.focusKind = 'table';
+		this.focusKey = tableId;
+	}
+
+	clearFocus(): void {
+		this.focusKind = 'none';
+		this.focusKey = null;
+	}
+
+	/**
+	 * Reset every transient interaction state to neutral. Wired to
+	 * SvelteFlow's pane-click — clicking the empty canvas should clear
+	 * focus, drop the armed click-to-join, clear the green column
+	 * highlight, deselect the join, abandon any held E-shift collection,
+	 * and reset the sidebar search to neutral. The doc itself
+	 * (tables / joins / groups) is untouched.
+	 */
+	clearAllInteractions(): void {
+		this.focusKind = 'none';
+		this.focusKey = null;
+		this.highlightedColumn = null;
+		this.highlightOriginTableId = null;
+		this.highlightSource = null;
+		this.pendingJoinSource = null;
+		this.selectedJoinId = null;
+		this.selectedTableId = null;
+		this.sidebarQuery = '';
+		this.pickModeActive = false;
+		this.eShiftPicks = [];
+		// Also drop any pending jump request — otherwise the
+		// JumpHandler's $effect re-fires on the stale target after
+		// the rest of state was cleared and re-stamps selectedTableId
+		// + highlightedColumn behind the user's back.
+		this.requestedJumpTarget = null;
+	}
+
+	/** Returns the set of join ids that are IN focus for the current
+	 *  focus state. Empty set means "no focus active" — callers should
+	 *  treat that as "everything is in focus". */
+	joinIdsInFocus(): Set<string> {
+		const out = new Set<string>();
+		if (this.focusKind === 'group' && this.focusKey !== null) {
+			// Group focus filters by LABEL, not canonical key, so a
+			// user-renamed group like "Random" (which can span multiple
+			// canonical keys when picks crossed different column names)
+			// lights up every join in the rendered group — not just the
+			// ones whose canonical key happens to match the click target.
+			const label = this.focusKey;
+			for (const j of this.doc.joins) {
+				if (this.joinGroupLabelFor(j) === label) out.add(j.id);
+			}
+		} else if (this.focusKind === 'table' && this.focusKey !== null) {
+			const id = this.focusKey;
+			for (const j of this.doc.joins) {
+				if (j.sourceTableId === id || j.targetTableId === id) out.add(j.id);
+			}
+		}
+		return out;
+	}
+
+	/** Returns the set of table ids that are IN focus. */
+	tableIdsInFocus(): Set<string> {
+		const out = new Set<string>();
+		if (this.focusKind === 'group' && this.focusKey !== null) {
+			// Group focus filters by LABEL — see joinIdsInFocus() for the
+			// rationale (multi-canonical-key groups created via pick mode).
+			const label = this.focusKey;
+			for (const j of this.doc.joins) {
+				if (this.joinGroupLabelFor(j) === label) {
+					out.add(j.sourceTableId);
+					out.add(j.targetTableId);
+				}
+			}
+		} else if (this.focusKind === 'table' && this.focusKey !== null) {
+			out.add(this.focusKey);
+			for (const j of this.doc.joins) {
+				if (j.sourceTableId === this.focusKey) out.add(j.targetTableId);
+				else if (j.targetTableId === this.focusKey) out.add(j.sourceTableId);
+			}
+		}
+		return out;
+	}
+
+	/**
+	 * Run auto-suggest for one table against every OTHER table on the
+	 * canvas — commit every high-confidence column-name match as a
+	 * join. Used by the drop handler AND by the "pull-in matching
+	 * tables" feature; respects `addJoin`'s tuple-dedupe.
+	 */
+	runAutoSuggestForTable(tableId: string): void {
+		const t = this.doc.tables.find((tt) => tt.id === tableId);
+		if (!t) return;
+		for (const other of this.doc.tables) {
+			if (other.id === tableId) continue;
+			const suggestions = suggestJoins(t, other).filter((s) => s.confidence === 'high');
+			for (const s of suggestions) {
+				this.addJoin({
+					sourceTableId: tableId,
+					sourceColumnName: s.sourceColumnName,
+					targetTableId: other.id,
+					targetColumnName: s.targetColumnName,
+					kind: s.kind
+				});
+			}
+		}
+	}
+
+	/**
+	 * For the currently-highlighted column (or an explicit name),
+	 * scan the SOURCE catalog for every table containing a column with
+	 * that name and pull each one not yet on the canvas onto it. If
+	 * `autoSuggestOnDrop` is ON, every newly-added table is also wired
+	 * to its peers via runAutoSuggestForTable. Returns the count of
+	 * tables actually pulled in.
+	 */
+	/**
+	 * For an on-canvas column, find every OTHER table already on the
+	 * canvas that has a column with the same (case-insensitive) name
+	 * and commit a join from this column to each of them. Returns the
+	 * count of joins actually added (existing-tuple dedupe applies).
+	 * Companion to `pullInMatchingColumnTables` but scoped to what's
+	 * already on the canvas.
+	 */
+	linkSimilarOnCanvas(originTableId: string, columnName: string): number {
+		const needle = columnName.toLowerCase();
+		let added = 0;
+		this.withUndoBatch(() => {
+			for (const t of this.doc.tables) {
+				if (t.id === originTableId) continue;
+				const match = t.columns.find((c) => c.name.toLowerCase() === needle);
+				if (!match) continue;
+				const before = this.doc.joins.length;
+				this.addJoin({
+					sourceTableId: originTableId,
+					sourceColumnName: columnName,
+					targetTableId: t.id,
+					targetColumnName: match.name,
+					kind: 'inner'
+				});
+				if (this.doc.joins.length > before) added++;
+			}
+		});
+		// One summary toast for the batch, overwriting the per-join
+		// feedback each addJoin pushed.
+		if (added > 1) {
+			this.pushJoinFeedback(`${added} joins created (linked ${columnName})`);
+		}
+		return added;
+	}
+
+	pullInMatchingColumnTables(columnName: string): number {
+		const needle = columnName.trim().toLowerCase();
+		if (!needle) return 0;
+		const onCanvas = this.tableIdentitiesOnCanvas;
+		const candidates = this.sourceTables.filter((c) => {
+			const ident = c.schema ? `${c.schema}.${c.name}` : c.name;
+			if (onCanvas.has(ident)) return false;
+			return c.columns.some((col) => col.name.toLowerCase() === needle);
+		});
+		if (candidates.length === 0) return 0;
+		// Lay them out in a horizontal row to the right of the rightmost
+		// existing table — keeps the new ones together visually.
+		const rightmostX = this.doc.tables.reduce((m, t) => Math.max(m, t.position.x), 0);
+		const baseX = rightmostX + 320;
+		const baseY = 80;
+		const added: string[] = [];
+		// One Undo step for the whole pull-in (tables + any auto-joins).
+		this.withUndoBatch(() => {
+			candidates.forEach((cand, i) => {
+				const t = this.addTable(cand, { x: baseX, y: baseY + i * 280 });
+				added.push(t.id);
+			});
+			if (this.autoSuggestOnDrop) {
+				for (const id of added) this.runAutoSuggestForTable(id);
+			}
+		});
+		return added.length;
+	}
+
+	/** Wipe every join. Tables stay where they are.  Also clears the
+	 *  group-rename map and every piece of UI state that referenced a
+	 *  now-deleted join — otherwise recreating the same canonical pair
+	 *  silently inherits the previous label, and stale selection /
+	 *  focus / pathfinder state would point at edges that no longer
+	 *  exist. */
+	removeAllJoins(): void {
+		if (this.doc.joins.length === 0) return;
+		this.doc.joins = [];
+		this.doc.joinGroupRenames = {};
+		this.selectedJoinId = null;
+		this.pendingJoinSource = null;
+		this.pickModeActive = false;
+		this.eShiftPicks = [];
+		this.pathfinderResult = null;
+		this.highlightedColumn = null;
+		this.highlightOriginTableId = null;
+		this.highlightSource = null;
+		this.focusKind = 'none';
+		this.focusKey = null;
+		this.touch();
+	}
+
+	// ── Dimensions Workbench (Step 2) ────────────────────────────────
+	// Mondrian-shaped dimension/hierarchy/level/measure authoring sits
+	// on top of the join graph from Step 1.  Persistence rides the
+	// same touch() → saveToStorage path as everything else on the doc.
+
+	/** Read accessor with default — older docs in localStorage didn't
+	 *  carry `dimensions`. */
+	get dimensions(): SchemaCanvasDimension[] {
+		return this.doc.dimensions ?? [];
+	}
+
+	/** Read accessor with default — older docs in localStorage didn't
+	 *  carry `measures`. */
+	get measures(): SchemaCanvasMeasure[] {
+		return this.doc.measures ?? [];
+	}
+
+	/** Create a new dimension. If a column reference is supplied, the
+	 *  dimension is seeded with a first hierarchy that already holds
+	 *  that column as its sole level — matches the drop UX where a
+	 *  column dragged onto the empty zone materialises a full
+	 *  dimension in one gesture. */
+	addDimension(seed?: {
+		name?: string;
+		tableId?: string;
+		columnName?: string;
+		columnType?: SchemaCanvasColumnKind;
+	}): SchemaCanvasDimension {
+		const tableName =
+			seed?.tableId !== undefined
+				? (this.doc.tables.find((t) => t.id === seed.tableId)?.name ?? null)
+				: null;
+		const desired = seed?.name?.trim() || tableName || seed?.columnName || 'New dimension';
+		const name = ensureUnique(
+			desired,
+			(this.doc.dimensions ?? []).map((d) => d.name)
+		);
+		// Default: zero hierarchies.  The user explicitly composes
+		// hierarchies in Col 3 (Make hierarchy) or implicitly via the
+		// "singleton hierarchy for this attribute" checkbox on the
+		// Attributes pane.  Only the column-drop seed path (used by the
+		// legacy Cards/Tree drag UX) still auto-creates one hierarchy
+		// since the user dropped a specific column.
+		const hierarchies: SchemaCanvasHierarchy[] = [];
+		if (seed?.tableId && seed?.columnName) {
+			hierarchies.push({
+				id: makeId('hier'),
+				name,
+				hasAll: true,
+				levels: [
+					{
+						id: makeId('lvl'),
+						name: seed.columnName,
+						tableId: seed.tableId,
+						columnName: seed.columnName,
+						type: seed.columnType
+					}
+				]
+			});
+		}
+		const dim: SchemaCanvasDimension = {
+			id: makeId('dim'),
+			name,
+			hierarchies,
+			// Set BOTH: `sourceTableId` is the canonical binding the
+			// Workbench (Attrs count, FK selector, attribute picker)
+			// reads.  `primaryKeyTableId` kept for the snowflake case +
+			// legacy compatibility.  The types.ts split (2026-07-30ish)
+			// made `sourceTableId` primary but addDimension wasn't
+			// updated — freshly added dims read as "no table bound".
+			sourceTableId: seed?.tableId,
+			primaryKeyTableId: seed?.tableId
+		};
+		this.doc.dimensions = [...this.dimensions, dim];
+		this.touch();
+		return dim;
+	}
+
+	updateDimension(
+		dimensionId: string,
+		patch: Partial<Omit<SchemaCanvasDimension, 'id' | 'hierarchies'>>
+	): void {
+		const d = this.dimensions.find((d) => d.id === dimensionId);
+		if (!d) return;
+		Object.assign(d, patch);
+		// Note: we used to auto-rename any hierarchy whose name matched
+		// the old dim name when the dim was renamed — to keep the
+		// Mondrian "implicit-default" convention.  Dropped once the
+		// authoring model became "hierarchies are always explicit".
+		// Hierarchies are now independent of the dim's label; renaming
+		// the dim never touches them.
+		this.touch();
+	}
+
+	removeDimension(dimensionId: string): void {
+		this.doc.dimensions = this.dimensions.filter((d) => d.id !== dimensionId);
+		this.touch();
+	}
+
+	/** Add a {tableId, columnName} pair to the dim's attribute set A.
+	 *  No-op if already present.  `attributes === undefined` is the
+	 *  blank-slate state; the first add materialises it as a one-item
+	 *  array, matching the "user starts including" mode. */
+	addAttribute(dimensionId: string, tableId: string, columnName: string): void {
+		const d = this.dimensions.find((d) => d.id === dimensionId);
+		if (!d) return;
+		const list = d.attributes ?? [];
+		if (list.some((a) => a.tableId === tableId && a.columnName === columnName)) return;
+		d.attributes = [...list, { tableId, columnName }];
+		this.touch();
+	}
+
+	/** Patch one attribute's editable Mondrian-4 fields (name, display /
+	 *  sort / caption columns, description) — inspector #959. Identified by
+	 *  its {tableId, columnName} identity, which is NOT itself patched here. */
+	updateAttribute(
+		dimensionId: string,
+		tableId: string,
+		columnName: string,
+		patch: Partial<
+			Omit<NonNullable<SchemaCanvasDimension['attributes']>[number], 'tableId' | 'columnName'>
+		>
+	): void {
+		const d = this.dimensions.find((d) => d.id === dimensionId);
+		const a = d?.attributes?.find((x) => x.tableId === tableId && x.columnName === columnName);
+		if (!a) return;
+		Object.assign(a, patch);
+		this.touch();
+	}
+
+	/** Remove a {tableId, columnName} pair from the dim's attribute set
+	 *  A.  Leaves the array (even empty) in place so the dim is
+	 *  distinguishably "user has touched A" vs "user hasn't yet". */
+	removeAttribute(dimensionId: string, tableId: string, columnName: string): void {
+		const d = this.dimensions.find((d) => d.id === dimensionId);
+		if (!d?.attributes) return;
+		d.attributes = d.attributes.filter(
+			(a) => !(a.tableId === tableId && a.columnName === columnName)
+		);
+		this.touch();
+	}
+
+	/** Replace A wholesale — used by bulk include-all / exclude-all. */
+	setAttributes(dimensionId: string, attributes: { tableId: string; columnName: string }[]): void {
+		const d = this.dimensions.find((d) => d.id === dimensionId);
+		if (!d) return;
+		d.attributes = attributes;
+		this.touch();
+	}
+
+	addHierarchy(dimensionId: string, name?: string): SchemaCanvasHierarchy | null {
+		const d = this.dimensions.find((d) => d.id === dimensionId);
+		if (!d) return null;
+		const desired = name?.trim() || `Hierarchy ${d.hierarchies.length + 1}`;
+		const h: SchemaCanvasHierarchy = {
+			id: makeId('hier'),
+			name: ensureUnique(
+				desired,
+				d.hierarchies.map((x) => x.name)
+			),
+			hasAll: true,
+			levels: []
+		};
+		d.hierarchies = [...d.hierarchies, h];
+		this.touch();
+		return h;
+	}
+
+	updateHierarchy(
+		dimensionId: string,
+		hierarchyId: string,
+		patch: Partial<Omit<SchemaCanvasHierarchy, 'id' | 'levels'>>
+	): void {
+		const d = this.dimensions.find((d) => d.id === dimensionId);
+		const h = d?.hierarchies.find((h) => h.id === hierarchyId);
+		if (!h) return;
+		Object.assign(h, patch);
+		this.touch();
+	}
+
+	removeHierarchy(dimensionId: string, hierarchyId: string): void {
+		const d = this.dimensions.find((d) => d.id === dimensionId);
+		if (!d) return;
+		d.hierarchies = d.hierarchies.filter((h) => h.id !== hierarchyId);
+		this.touch();
+	}
+
+	addLevel(
+		dimensionId: string,
+		hierarchyId: string,
+		level: { tableId: string; columnName: string; name?: string; type?: SchemaCanvasColumnKind }
+	): SchemaCanvasLevel | null {
+		const d = this.dimensions.find((d) => d.id === dimensionId);
+		const h = d?.hierarchies.find((h) => h.id === hierarchyId);
+		if (!h) return null;
+		// Skip the exact same column landing twice in one hierarchy —
+		// stops a stray double-drop from creating an obviously useless
+		// duplicate row.  Different hierarchies (or different columns)
+		// are fine.
+		const dup = h.levels.find(
+			(l) => l.tableId === level.tableId && l.columnName === level.columnName
+		);
+		if (dup) return dup;
+		const lvl: SchemaCanvasLevel = {
+			id: makeId('lvl'),
+			name: level.name?.trim() || level.columnName,
+			tableId: level.tableId,
+			columnName: level.columnName,
+			type: level.type
+		};
+		h.levels = [...h.levels, lvl];
+		this.touch();
+		return lvl;
+	}
+
+	updateLevel(
+		dimensionId: string,
+		hierarchyId: string,
+		levelId: string,
+		patch: Partial<Omit<SchemaCanvasLevel, 'id'>>
+	): void {
+		const d = this.dimensions.find((d) => d.id === dimensionId);
+		const h = d?.hierarchies.find((h) => h.id === hierarchyId);
+		const l = h?.levels.find((l) => l.id === levelId);
+		if (!l) return;
+		Object.assign(l, patch);
+		this.touch();
+	}
+
+	removeLevel(dimensionId: string, hierarchyId: string, levelId: string): void {
+		const d = this.dimensions.find((d) => d.id === dimensionId);
+		const h = d?.hierarchies.find((h) => h.id === hierarchyId);
+		if (!h) return;
+		h.levels = h.levels.filter((l) => l.id !== levelId);
+		this.touch();
+	}
+
+	/** Move a level one position within its hierarchy (coarse↔fine reorder).
+	 *  `delta` is -1 (toward coarsest / up) or +1 (toward finest / down). No-op
+	 *  at the ends. Immutable swap — a new levels array is assigned. */
+	moveLevel(dimensionId: string, hierarchyId: string, levelId: string, delta: -1 | 1): void {
+		const d = this.dimensions.find((d) => d.id === dimensionId);
+		const h = d?.hierarchies.find((h) => h.id === hierarchyId);
+		if (!h) return;
+		const i = h.levels.findIndex((l) => l.id === levelId);
+		const j = i + delta;
+		if (i < 0 || j < 0 || j >= h.levels.length) return;
+		const next = [...h.levels];
+		[next[i], next[j]] = [next[j], next[i]];
+		h.levels = next;
+		this.touch();
+	}
+
+	/** Drop a measure for a numeric column. Defaults to sum. */
+	addMeasure(seed: {
+		tableId: string;
+		columnName: string;
+		name?: string;
+		aggregator?: SchemaCanvasMeasure['aggregator'];
+		/** Percentile fraction (0–100); only meaningful for aggregator 'percentile'. */
+		percentile?: number | null;
+	}): SchemaCanvasMeasure {
+		const aggregator = seed.aggregator ?? 'sum';
+		const m: SchemaCanvasMeasure = {
+			id: makeId('meas'),
+			name: seed.name?.trim() || seed.columnName,
+			aggregator,
+			tableId: seed.tableId,
+			columnName: seed.columnName,
+			percentile: aggregator === 'percentile' ? (seed.percentile ?? null) : undefined
+		};
+		this.doc.measures = [...this.measures, m];
+		this.touch();
+		return m;
+	}
+
+	updateMeasure(measureId: string, patch: Partial<Omit<SchemaCanvasMeasure, 'id'>>): void {
+		const m = this.measures.find((m) => m.id === measureId);
+		if (!m) return;
+		Object.assign(m, patch);
+		this.touch();
+	}
+
+	removeMeasure(measureId: string): void {
+		this.doc.measures = this.measures.filter((m) => m.id !== measureId);
+		this.touch();
+	}
+
+	// ── Cubes (measure groups + calculated members) ──────────────────
+	// The durable half of the Facts & Measures workbench.  Every mutator
+	// is immutable + rides the same touch() → saveToStorage path.  UI-only
+	// flags stay in WorkbenchView; the doc carries only the model an
+	// external caller (DimSum) needs to create and the exporter to emit.
+
+	/** Read accessor with default — older docs didn't carry `cubes`. */
+	get cubes(): SchemaCanvasCube[] {
+		return this.doc.cubes ?? [];
+	}
+
+	/** Replace the whole cube list.  Used by the workbench's persist path
+	 *  (mapping its live cubes back into the trimmed doc shape). */
+	setCubes(cubes: SchemaCanvasCube[]): void {
+		// Preserve cube-scoped time-intelligence metrics across a workbench
+		// write-back. The workbench maps its live cubes through `cubeToDoc`,
+		// which doesn't carry `timeCalcs` (they're edited via the inspector's
+		// store methods on the doc). Without this merge, every workbench sync
+		// would silently wipe them. Incoming timeCalcs win when present (e.g. an
+		// import); otherwise inherit the existing doc cube's by id.
+		const existingTimeCalcs = new Map((this.doc.cubes ?? []).map((c) => [c.id, c.timeCalcs]));
+		this.doc.cubes = cubes.map((c) =>
+			c.timeCalcs !== undefined ? c : { ...c, timeCalcs: existingTimeCalcs.get(c.id) }
+		);
+		this.touch();
+	}
+
+	/** Signal the canvas page to re-hydrate the workbench from `doc.cubes`
+	 *  after an external cube write. */
+	bumpWorkbenchReload(): void {
+		this.workbenchReloadNonce += 1;
+	}
+
+	addCube(seed?: { id?: string; name?: string }): SchemaCanvasCube {
+		const name = ensureUnique(
+			seed?.name?.trim() || `Cube ${this.cubes.length + 1}`,
+			this.cubes.map((c) => c.name)
+		);
+		const cube: SchemaCanvasCube = {
+			id: seed?.id ?? makeId('cube'),
+			name,
+			measureGroups: [],
+			calcs: []
+		};
+		this.doc.cubes = [...this.cubes, cube];
+		this.touch();
+		return cube;
+	}
+
+	removeCube(cubeId: string): void {
+		this.doc.cubes = this.cubes.filter((c) => c.id !== cubeId);
+		this.touch();
+	}
+
+	renameCube(cubeId: string, name: string): void {
+		const c = this.cubes.find((c) => c.id === cubeId);
+		if (!c) return;
+		c.name = name;
+		this.touch();
+	}
+
+	private findCube(cubeId: string): SchemaCanvasCube | undefined {
+		return this.cubes.find((c) => c.id === cubeId);
+	}
+
+	addMeasureGroup(
+		cubeId: string,
+		seed: { id?: string; name?: string; factTableId?: string | null }
+	): SchemaCanvasMeasureGroup | null {
+		const cube = this.findCube(cubeId);
+		if (!cube) return null;
+		const name = ensureUnique(
+			seed.name?.trim() || `Group ${cube.measureGroups.length + 1}`,
+			cube.measureGroups.map((g) => g.name)
+		);
+		const mg: SchemaCanvasMeasureGroup = {
+			id: seed.id ?? makeId('mg'),
+			name,
+			measureColumns: [],
+			factTableId: seed.factTableId ?? null,
+			dimensionLinks: []
+		};
+		cube.measureGroups = [...cube.measureGroups, mg];
+		this.touch();
+		return mg;
+	}
+
+	removeMeasureGroup(cubeId: string, mgId: string): void {
+		const cube = this.findCube(cubeId);
+		if (!cube) return;
+		cube.measureGroups = cube.measureGroups.filter((g) => g.id !== mgId);
+		this.touch();
+	}
+
+	renameMeasureGroup(cubeId: string, mgId: string, name: string): void {
+		const mg = this.findCube(cubeId)?.measureGroups.find((g) => g.id === mgId);
+		if (!mg) return;
+		mg.name = name;
+		this.touch();
+	}
+
+	setMeasureColumns(cubeId: string, mgId: string, cols: string[]): void {
+		const mg = this.findCube(cubeId)?.measureGroups.find((g) => g.id === mgId);
+		if (!mg) return;
+		mg.measureColumns = [...cols];
+		this.touch();
+	}
+
+	/** Add or remove a single measure column from a group. */
+	toggleMeasureColumn(cubeId: string, mgId: string, col: string): void {
+		const mg = this.findCube(cubeId)?.measureGroups.find((g) => g.id === mgId);
+		if (!mg) return;
+		mg.measureColumns = mg.measureColumns.includes(col)
+			? mg.measureColumns.filter((c) => c !== col)
+			: [...mg.measureColumns, col];
+		this.touch();
+	}
+
+	setMeasureGroupFactTable(cubeId: string, mgId: string, tableId: string | null): void {
+		const mg = this.findCube(cubeId)?.measureGroups.find((g) => g.id === mgId);
+		if (!mg) return;
+		mg.factTableId = tableId;
+		this.touch();
+	}
+
+	/** Upsert a dimension link on a measure group — keyed by dimensionId. */
+	setMeasureGroupDimLink(cubeId: string, mgId: string, link: SchemaCanvasDimensionLink): void {
+		const mg = this.findCube(cubeId)?.measureGroups.find((g) => g.id === mgId);
+		if (!mg) return;
+		const existing = mg.dimensionLinks ?? [];
+		const idx = existing.findIndex((l) => l.dimensionId === link.dimensionId);
+		mg.dimensionLinks =
+			idx >= 0 ? existing.map((l, i) => (i === idx ? link : l)) : [...existing, link];
+		this.touch();
+	}
+
+	removeMeasureGroupDimLink(cubeId: string, mgId: string, dimensionId: string): void {
+		const mg = this.findCube(cubeId)?.measureGroups.find((g) => g.id === mgId);
+		if (!mg?.dimensionLinks) return;
+		mg.dimensionLinks = mg.dimensionLinks.filter((l) => l.dimensionId !== dimensionId);
+		this.touch();
+	}
+
+	addCalc(
+		cubeId: string,
+		seed: { id?: string; name?: string; tokens?: SchemaCanvasCalc['tokens']; formula?: string }
+	): SchemaCanvasCalc | null {
+		const cube = this.findCube(cubeId);
+		if (!cube) return null;
+		const calc: SchemaCanvasCalc = {
+			id: seed.id ?? makeId('calc'),
+			name: seed.name ?? '',
+			tokens: seed.tokens ?? [],
+			formula: seed.formula
+		};
+		cube.calcs = [...cube.calcs, calc];
+		this.touch();
+		return calc;
+	}
+
+	removeCalc(cubeId: string, calcId: string): void {
+		const cube = this.findCube(cubeId);
+		if (!cube) return;
+		cube.calcs = cube.calcs.filter((c) => c.id !== calcId);
+		this.touch();
+	}
+
+	// ── Time-intelligence calcs (yoy/pop/ytd/rolling) — cube-scoped ──
+	addTimeCalc(cubeId: string, seed?: Partial<SchemaCanvasTimeCalc>): SchemaCanvasTimeCalc | null {
+		const cube = this.findCube(cubeId);
+		if (!cube) return null;
+		const tc: SchemaCanvasTimeCalc = {
+			id: seed?.id ?? makeId('timecalc'),
+			name: seed?.name ?? '',
+			type: seed?.type ?? 'yoy',
+			measure: seed?.measure ?? '',
+			timeDimension: seed?.timeDimension,
+			window: seed?.window,
+			function: seed?.function,
+			formatString: seed?.formatString
+		};
+		cube.timeCalcs = [...(cube.timeCalcs ?? []), tc];
+		this.touch();
+		return tc;
+	}
+
+	updateTimeCalc(
+		cubeId: string,
+		timeCalcId: string,
+		patch: Partial<Omit<SchemaCanvasTimeCalc, 'id'>>
+	): void {
+		const cube = this.findCube(cubeId);
+		if (!cube?.timeCalcs) return;
+		const tc = cube.timeCalcs.find((t) => t.id === timeCalcId);
+		if (!tc) return;
+		Object.assign(tc, patch);
+		this.touch();
+	}
+
+	removeTimeCalc(cubeId: string, timeCalcId: string): void {
+		const cube = this.findCube(cubeId);
+		if (!cube?.timeCalcs) return;
+		cube.timeCalcs = cube.timeCalcs.filter((t) => t.id !== timeCalcId);
+		this.touch();
+	}
+
+	/**
+	 * Canonical group key for a join — the shared column name when
+	 * both sides match, otherwise the alphabetised pair joined by `↔`.
+	 * Stable across direction (source ↔ target) so a swap doesn't
+	 * shuffle groups around.
+	 */
+	static joinCanonicalKey(j: SchemaCanvasJoin): string {
+		if (j.sourceColumnName === j.targetColumnName) return j.sourceColumnName;
+		return [j.sourceColumnName, j.targetColumnName].sort().join('↔');
+	}
+
+	/** Human label for a join group — falls back to the canonical key
+	 *  when nothing has been renamed. */
+	joinGroupLabelFor(j: SchemaCanvasJoin): string {
+		const key = SchemaCanvasStore.joinCanonicalKey(j);
+		return this.doc.joinGroupRenames?.[key] ?? key;
+	}
+
+	/** Rename a join group. Empty/whitespace `nextLabel` drops the
+	 *  rename so the group reverts to its canonical key. */
+	renameJoinGroup(canonicalKey: string, nextLabel: string): void {
+		const trimmed = nextLabel.trim();
+		const renames = { ...(this.doc.joinGroupRenames ?? {}) };
+		if (!trimmed || trimmed === canonicalKey) {
+			delete renames[canonicalKey];
+		} else {
+			renames[canonicalKey] = trimmed;
+		}
+		this.doc.joinGroupRenames = renames;
+		this.touch();
+	}
+
+	setJoinKind(joinId: string, kind: SchemaCanvasJoinKind): void {
+		const j = this.doc.joins.find((j) => j.id === joinId);
+		if (!j) return;
+		j.kind = kind;
+		this.touch();
+	}
+
+	createGroup(label: string): SchemaCanvasGroup {
+		const g: SchemaCanvasGroup = { id: makeId('grp'), label, collapsed: false };
+		this.doc.groups.push(g);
+		this.touch();
+		return g;
+	}
+
+	assignTableToGroup(tableId: string, groupId: string | null): void {
+		const t = this.doc.tables.find((t) => t.id === tableId);
+		if (!t) return;
+		t.groupId = groupId;
+		this.touch();
+	}
+
+	get factTable(): SchemaCanvasTable | null {
+		return this.doc.tables.find((t) => t.role === 'fact') ?? null;
+	}
+
+	get dimensionTables(): SchemaCanvasTable[] {
+		return this.doc.tables.filter((t) => t.role !== 'fact');
+	}
+
+	/** Returns the set of source-table identities (schema.name) currently on the canvas. */
+	get tableIdentitiesOnCanvas(): Set<string> {
+		return new Set(this.doc.tables.map((t) => (t.schema ? `${t.schema}.${t.name}` : t.name)));
+	}
+
+	/**
+	 * Wipe the canvas back to a blank doc for the current connection.
+	 * Clears UI state too so nothing dangles. Persistence follows — the
+	 * empty doc replaces the saved one in localStorage.
+	 */
+	resetCanvas(): void {
+		this.doc = blankState(this.connectionId);
+		this.selectedTableId = null;
+		this.selectedJoinId = null;
+		this.highlightedColumn = null;
+		this.highlightSource = null;
+		this.binaryCursor = 0;
+		this.sidebarQuery = '';
+		this.touch();
+	}
+
+	/**
+	 * Replace the current canvas doc with one loaded from elsewhere
+	 * (JSON bundle, XML import). The doc is forced onto the active
+	 * connection id so localStorage stays keyed correctly.
+	 */
+	loadDoc(doc: SchemaCanvasState): void {
+		// Snapshot the current doc BEFORE replacing so the toolbar Undo
+		// button can revert.  Structured clone to isolate the snapshot
+		// from subsequent mutations of `this.doc`.
+		// JSON round-trip because structuredClone can't clone Svelte 5
+		// `$state` proxies (DataCloneError).
+		this.previousDoc = JSON.parse(JSON.stringify(this.doc)) as SchemaCanvasState;
+		this.doc = { ...doc, connectionId: this.connectionId };
+		this.selectedTableId = null;
+		this.selectedJoinId = null;
+		this.highlightedColumn = null;
+		this.highlightSource = null;
+		this.binaryCursor = 0;
+		this.sidebarQuery = '';
+		this.touch();
+	}
+
+	/**
+	 * Restore the last `previousDoc` snapshot as the current doc.  Swaps
+	 * the snapshot forward-and-back so undo can immediately re-apply
+	 * (the current doc becomes the new snapshot).  No-op when the
+	 * snapshot is null.
+	 */
+	undo(): void {
+		if (!this.previousDoc) return;
+		const swap = this.previousDoc;
+		// JSON round-trip because structuredClone can't clone Svelte 5
+		// `$state` proxies (DataCloneError).
+		this.previousDoc = JSON.parse(JSON.stringify(this.doc)) as SchemaCanvasState;
+		this.doc = { ...swap, connectionId: this.connectionId };
+		this.selectedTableId = null;
+		this.selectedJoinId = null;
+		this.highlightedColumn = null;
+		this.highlightSource = null;
+		this.touch();
+	}
+
+	/** Discard the pending undo snapshot — e.g. after the user confirms
+	 *  an AI proposal and no longer wants to revert it. */
+	clearPreviousDoc(): void {
+		this.previousDoc = null;
+	}
+
+	/** Take a snapshot of the current doc so the next big user gesture
+	 *  is reversible via Undo.  Call at the entry point of a semantic
+	 *  action (a drag-drop, a commit, an import) rather than per-
+	 *  mutation, so N adds inside one gesture collapse to one undo
+	 *  step.  Idempotent within the same gesture: a repeat call inside
+	 *  the same tick overwrites the previous snapshot (which is what
+	 *  we want — one snapshot per user intent). */
+	snapshotForUndo(): void {
+		// JSON round-trip because structuredClone can't clone Svelte 5
+		// `$state` proxies (DataCloneError).
+		this.previousDoc = JSON.parse(JSON.stringify(this.doc)) as SchemaCanvasState;
+	}
+
+	/** When true, per-mutation snapshotForUndo is suppressed — the batch
+	 *  caller (drop, CJM commit, pullIn, linkSimilar) has already taken
+	 *  ONE snapshot at its entry and doesn't want each addJoin/addTable
+	 *  inside its loop clobbering that.  Set via `withUndoBatch()`. */
+	private undoBatchDepth = 0;
+
+	/** Run `fn` as a single Undo step — take one snapshot at entry, then
+	 *  suppress the per-mutation snapshots that base methods (addTable,
+	 *  addJoin, removeTable, removeJoin, removeJoins) would otherwise
+	 *  take.  Nesting is safe — only the outermost call snapshots. */
+	withUndoBatch<T>(fn: () => T): T {
+		if (this.undoBatchDepth === 0) this.snapshotForUndo();
+		this.undoBatchDepth++;
+		try {
+			return fn();
+		} finally {
+			this.undoBatchDepth--;
+		}
+	}
+
+	/** Take a snapshot unless we're inside a batch (in which case the
+	 *  batch already snapshotted at entry). Called from every base
+	 *  mutation so every user-visible action ends up undoable. */
+	private maybeSnapshotForUndo(): void {
+		if (this.undoBatchDepth === 0) this.snapshotForUndo();
+	}
+
+	/**
+	 * Click-to-join entry point. State machine:
+	 *  - no pending source → arm (stash this column as the source).
+	 *  - click the SAME (table, column) again → cancel (clear).
+	 *  - click a different column on the SAME table → replace the pending
+	 *    source (self-joins aren't modelled here, so silently re-arm).
+	 *  - click a column on a DIFFERENT table → commit the join via
+	 *    `addJoin` (which itself dedupes by exact tuple + touches the
+	 *    doc), then clear the pending source.
+	 *
+	 * `pendingJoinSource` is UI-only — no `touch()` here, only `addJoin`
+	 * mutates the persisted doc.
+	 */
+	/** Tap E → toggle pick mode.  When ON, column clicks accumulate
+	 *  into eShiftPicks instead of arming a single click-to-join.
+	 *  Tapping E again turns the mode OFF but does NOT clear picks —
+	 *  the panel persists until Clear or Match.  Idempotent on
+	 *  keyboard auto-repeat. */
+	togglePickMode(): void {
+		this.pickModeActive = !this.pickModeActive;
+	}
+	enterPickMode(): void {
+		this.pickModeActive = true;
+	}
+	exitPickMode(): void {
+		this.pickModeActive = false;
+	}
+
+	/** Add (or toggle off) a column to the pick set.  Enforces at most
+	 *  ONE column per table — joins are one-to-one, so picking a second
+	 *  column on a table that already has one REPLACES the previous
+	 *  pick for that table (otherwise you'd end up trying to "merge"
+	 *  two columns of the same table into a single joined thing, which
+	 *  is meaningless).  Re-clicking the same (table, column) toggles
+	 *  it off. */
+	pushEShiftPick(tableId: string, columnName: string): void {
+		const sameColIdx = this.eShiftPicks.findIndex(
+			(p) => p.tableId === tableId && p.columnName === columnName
+		);
+		if (sameColIdx >= 0) {
+			// Toggle off — user re-clicked the same pick.
+			const next = this.eShiftPicks.slice();
+			next.splice(sameColIdx, 1);
+			this.eShiftPicks = next;
+			return;
+		}
+		const sameTableIdx = this.eShiftPicks.findIndex((p) => p.tableId === tableId);
+		if (sameTableIdx >= 0) {
+			// Replace the existing pick on this table — one column per table.
+			const next = this.eShiftPicks.slice();
+			next[sameTableIdx] = { tableId, columnName };
+			this.eShiftPicks = next;
+			return;
+		}
+		// New table entirely — append.
+		this.eShiftPicks = [...this.eShiftPicks, { tableId, columnName }];
+	}
+
+	/** Commit picks → joins, using a STAR pattern (pick[0] = origin,
+	 *  wires to each subsequent pick).  The optional `groupName` is
+	 *  written into `joinGroupRenames` for every new join's canonical
+	 *  key so the joins-panel renders them all under one label —
+	 *  letting picks with DIFFERENT column names ("product_id" ↔
+	 *  "prod_id" ↔ "pid") collapse into a single semantic group like
+	 *  "Product Key".  Less than two picks → no-op.  Mesh + chain
+	 *  patterns are not exposed yet; star is the safe default. */
+	commitEShiftPicks(groupName?: string): void {
+		const picks = this.eShiftPicks;
+		this.eShiftPicks = [];
+		this.pickModeActive = false;
+		if (picks.length < 2) return;
+		const trimmedName = groupName?.trim();
+		const origin = picks[0];
+		const renames = { ...(this.doc.joinGroupRenames ?? {}) };
+		let joinsCreated = 0;
+		// One Undo step per commit — every addJoin inside skips its
+		// per-mutation snapshot via the batch guard.
+		this.withUndoBatch(() => {
+			for (let i = 1; i < picks.length; i++) {
+				const peer = picks[i];
+				if (origin.tableId === peer.tableId) continue;
+				const created = this.addJoin({
+					sourceTableId: origin.tableId,
+					sourceColumnName: origin.columnName,
+					targetTableId: peer.tableId,
+					targetColumnName: peer.columnName,
+					kind: 'inner'
+				});
+				joinsCreated++;
+				if (trimmedName) {
+					const canonicalKey = SchemaCanvasStore.joinCanonicalKey(created);
+					renames[canonicalKey] = trimmedName;
+				}
+			}
+			if (trimmedName) {
+				this.doc.joinGroupRenames = renames;
+				this.touch();
+			}
+		});
+		// Overwrite the per-join feedback with a batch summary so the
+		// user sees ONE toast, not N.
+		if (joinsCreated > 1) {
+			const label = trimmedName ? ` under "${trimmedName}"` : '';
+			this.pushJoinFeedback(`${joinsCreated} joins created${label}`);
+		} else if (joinsCreated === 1 && trimmedName) {
+			// Single join with a named group — mention the label so the
+			// user knows the rename landed.
+			this.pushJoinFeedback(`Join created as "${trimmedName}"`);
+		}
+	}
+
+	/** Clear picks + exit pick mode.  Wired to ESC and the picks-
+	 *  panel "Clear" button. */
+	cancelEShift(): void {
+		this.pickModeActive = false;
+		this.eShiftPicks = [];
+	}
+
+	/** User-typed sidebar search — updates the query AND clears the
+	 *  click-driven highlight so the sidebar and the "Pull in N
+	 *  matching tables" pill / "MATCHING X" active-set panel can't
+	 *  end up talking about different columns.  Column-click driven
+	 *  updates go through the internal `sidebarQuery = X` path (with
+	 *  the highlight set alongside) so they stay coherent. */
+	setSidebarQueryFromUser(q: string): void {
+		this.sidebarQuery = q;
+		this.highlightedColumn = null;
+		this.highlightOriginTableId = null;
+		this.highlightSource = null;
+	}
+
+	/** Sensible default label for a group of picked columns — used to
+	 *  prefill the group-name input and as the auto-name when the user
+	 *  hits Enter without typing anything.  If every pick shares the
+	 *  same column name, use it verbatim; otherwise fall back to the
+	 *  most common name across the picks (ties broken by first-seen).
+	 *  Empty string when there are no picks. */
+	autoPickGroupName(): string {
+		if (this.eShiftPicks.length === 0) return '';
+		const counts = new Map<string, number>();
+		for (const p of this.eShiftPicks) {
+			counts.set(p.columnName, (counts.get(p.columnName) ?? 0) + 1);
+		}
+		let bestName = this.eShiftPicks[0].columnName;
+		let bestCount = 0;
+		for (const [name, count] of counts) {
+			if (count > bestCount) {
+				bestName = name;
+				bestCount = count;
+			}
+		}
+		return bestName;
+	}
+
+	/** Arm a pathfinder slot — the next column click on the canvas
+	 *  writes into that slot.  Passing `null` disarms.  Clicking the
+	 *  same slot twice while armed toggles it off. */
+	armPathfinder(slot: 'start' | 'end' | null): void {
+		this.pathfinderArmed = this.pathfinderArmed === slot ? null : slot;
+		// Stale result becomes meaningless the moment endpoints might
+		// change — clear it so the UI doesn't display a path that no
+		// longer matches the inputs.
+		this.pathfinderResult = null;
+	}
+
+	/** Set an endpoint explicitly (used by tryColumnClickJoin when
+	 *  pathfinderArmed is set). Clears the armed flag once written. */
+	setPathfinderEndpoint(slot: 'start' | 'end', endpoint: PathfinderEndpoint): void {
+		if (slot === 'start') this.pathfinderStart = endpoint;
+		else this.pathfinderEnd = endpoint;
+		this.pathfinderArmed = null;
+		this.pathfinderResult = null;
+	}
+
+	/** Wipe every pathfinder bit — slots, armed flag, result.  Wired
+	 *  to the panel's Clear button. */
+	clearPathfinder(): void {
+		this.pathfinderArmed = null;
+		this.pathfinderStart = null;
+		this.pathfinderEnd = null;
+		this.pathfinderResult = null;
+	}
+
+	/**
+	 * BFS from `pathfinderStart.tableId` to `pathfinderEnd.tableId`.
+	 * First pass uses existing joins only.  If no path exists, a
+	 * second pass adds virtual edges for column-name collisions
+	 * (case-insensitive) so the result can propose missing joins for
+	 * the user to commit via `applyPathfinderJoins`.  Writes the
+	 * shortest chain (or null when no path is possible) into
+	 * `pathfinderResult`.
+	 */
+	findPath(): void {
+		const start = this.pathfinderStart;
+		const end = this.pathfinderEnd;
+		if (!start || !end) {
+			this.pathfinderResult = null;
+			return;
+		}
+		// Same-table trivial case — no path, just return an empty steps
+		// list so the UI can say "already on the same table".
+		if (start.tableId === end.tableId) {
+			this.pathfinderResult = { steps: [], hasGaps: false };
+			return;
+		}
+
+		type Edge = {
+			toTableId: string;
+			fromColumnName: string;
+			toColumnName: string;
+			joinId: string | null; // null = virtual (proposed)
+		};
+
+		// Build adjacency from existing joins first.  Joins are undirected
+		// for traversal — a path from A to B can use a join wired B→A.
+		const adj = new Map<string, Edge[]>();
+		const pushEdge = (fromId: string, edge: Edge) => {
+			const list = adj.get(fromId);
+			if (list) list.push(edge);
+			else adj.set(fromId, [edge]);
+		};
+		for (const j of this.doc.joins) {
+			pushEdge(j.sourceTableId, {
+				toTableId: j.targetTableId,
+				fromColumnName: j.sourceColumnName,
+				toColumnName: j.targetColumnName,
+				joinId: j.id
+			});
+			pushEdge(j.targetTableId, {
+				toTableId: j.sourceTableId,
+				fromColumnName: j.targetColumnName,
+				toColumnName: j.sourceColumnName,
+				joinId: j.id
+			});
+		}
+
+		const bfs = (): PathfinderStep[] | null => {
+			const prev = new Map<string, { fromId: string; edge: Edge }>();
+			const seen = new Set<string>([start.tableId]);
+			const queue: string[] = [start.tableId];
+			while (queue.length > 0) {
+				const cur = queue.shift()!;
+				if (cur === end.tableId) {
+					const steps: PathfinderStep[] = [];
+					let nodeId: string | undefined = cur;
+					while (nodeId && nodeId !== start.tableId) {
+						const back = prev.get(nodeId);
+						if (!back) break;
+						steps.unshift({
+							fromTableId: back.fromId,
+							fromColumnName: back.edge.fromColumnName,
+							toTableId: back.edge.toTableId,
+							toColumnName: back.edge.toColumnName,
+							existingJoinId: back.edge.joinId
+						});
+						nodeId = back.fromId;
+					}
+					return steps;
+				}
+				const edges = adj.get(cur) ?? [];
+				for (const edge of edges) {
+					if (seen.has(edge.toTableId)) continue;
+					seen.add(edge.toTableId);
+					prev.set(edge.toTableId, { fromId: cur, edge });
+					queue.push(edge.toTableId);
+				}
+			}
+			return null;
+		};
+
+		const existingOnly = bfs();
+		if (existingOnly && existingOnly.length > 0) {
+			this.pathfinderResult = { steps: existingOnly, hasGaps: false };
+			return;
+		}
+
+		// Fallback — re-build adjacency including virtual edges built from
+		// shared column names across on-canvas tables, then BFS again.
+		// The result will probably include gaps (virtual edges with
+		// joinId: null) that "Create path joins" can wire up.
+		const byNameLower = new Map<string, Array<{ tableId: string; columnName: string }>>();
+		for (const t of this.doc.tables) {
+			for (const c of t.columns) {
+				const key = c.name.toLowerCase();
+				const bucket = byNameLower.get(key);
+				if (bucket) bucket.push({ tableId: t.id, columnName: c.name });
+				else byNameLower.set(key, [{ tableId: t.id, columnName: c.name }]);
+			}
+		}
+		for (const bucket of byNameLower.values()) {
+			if (bucket.length < 2) continue;
+			for (let i = 0; i < bucket.length; i++) {
+				for (let k = i + 1; k < bucket.length; k++) {
+					const a = bucket[i];
+					const b = bucket[k];
+					if (a.tableId === b.tableId) continue;
+					// Skip pairs already wired in either direction — would
+					// otherwise inflate the graph with duplicate edges.
+					const already = this.doc.joins.some((j) => {
+						const f =
+							j.sourceTableId === a.tableId &&
+							j.sourceColumnName === a.columnName &&
+							j.targetTableId === b.tableId &&
+							j.targetColumnName === b.columnName;
+						const r =
+							j.sourceTableId === b.tableId &&
+							j.sourceColumnName === b.columnName &&
+							j.targetTableId === a.tableId &&
+							j.targetColumnName === a.columnName;
+						return f || r;
+					});
+					if (already) continue;
+					pushEdge(a.tableId, {
+						toTableId: b.tableId,
+						fromColumnName: a.columnName,
+						toColumnName: b.columnName,
+						joinId: null
+					});
+					pushEdge(b.tableId, {
+						toTableId: a.tableId,
+						fromColumnName: b.columnName,
+						toColumnName: a.columnName,
+						joinId: null
+					});
+				}
+			}
+		}
+		const withVirtual = bfs();
+		if (withVirtual && withVirtual.length > 0) {
+			this.pathfinderResult = {
+				steps: withVirtual,
+				hasGaps: withVirtual.some((s) => s.existingJoinId === null)
+			};
+			return;
+		}
+		this.pathfinderResult = null;
+	}
+
+	/** Wire up every virtual (gap) step in `pathfinderResult` as a real
+	 *  join.  No-op when there's no result or no gaps.  Returns the
+	 *  number actually added. */
+	applyPathfinderJoins(): number {
+		const result = this.pathfinderResult;
+		if (!result || !result.hasGaps) return 0;
+		let added = 0;
+		for (const step of result.steps) {
+			if (step.existingJoinId !== null) continue;
+			const before = this.doc.joins.length;
+			this.addJoin({
+				sourceTableId: step.fromTableId,
+				sourceColumnName: step.fromColumnName,
+				targetTableId: step.toTableId,
+				targetColumnName: step.toColumnName,
+				kind: 'inner'
+			});
+			if (this.doc.joins.length > before) added++;
+		}
+		// Re-run the search so the result reflects post-commit state —
+		// what was a virtual step is now an existing join, and hasGaps
+		// flips false.
+		if (added > 0) this.findPath();
+		return added;
+	}
+
+	tryColumnClickJoin(tableId: string, columnName: string): void {
+		// A column click is a column-level intent — not a table-focus
+		// trigger. SvelteFlow marks the node selected on any click inside
+		// it, which would otherwise fire the auto-focus $effect and
+		// light up EVERY join column on the table. Explicitly bail out
+		// of table-focus + selection so the only thing the user sees is
+		// the green column highlight.
+		this.selectedTableId = null;
+		this.focusKind = 'none';
+		this.focusKey = null;
+		// Pathfinder armed → the click captures an endpoint instead of
+		// running the normal click-to-highlight flow.
+		if (this.pathfinderArmed !== null) {
+			this.setPathfinderEndpoint(this.pathfinderArmed, { tableId, columnName });
+			return;
+		}
+		// Click-to-join (the hidden two-step where the first click armed
+		// a `pendingJoinSource` and the second click on a different
+		// table committed a join) was removed because users hit it by
+		// accident — clicking around to look at columns silently armed
+		// the next click. Joins now come from explicit gestures only:
+		// drag handle-to-handle, Create Joins Mode (⌘J), or sidebar drag with
+		// Auto-join on. Column click is highlight-only.
+		const alreadyHighlighted =
+			this.highlightedColumn === columnName && this.highlightOriginTableId === tableId;
+		if (alreadyHighlighted) {
+			this.highlightedColumn = null;
+			this.highlightOriginTableId = null;
+			this.highlightSource = null;
+			this.sidebarQuery = '';
+			return;
+		}
+		this.highlightedColumn = columnName;
+		this.highlightOriginTableId = tableId;
+		this.highlightSource = 'click';
+		this.sidebarQuery = columnName;
+	}
+
+	/**
+	 * Highlight a column name across the whole canvas + push the same
+	 * name into the sidebar search so the user sees every table that has
+	 * it. Click the same column again to clear. Switching the highlight
+	 * to a different name replaces it.
+	 */
+	highlightColumn(columnName: string): void {
+		if (this.highlightedColumn === columnName) {
+			this.highlightedColumn = null;
+			this.highlightSource = null;
+			this.sidebarQuery = '';
+			return;
+		}
+		this.highlightedColumn = columnName;
+		this.highlightSource = 'click';
+		this.sidebarQuery = columnName;
+	}
+}

--- a/saiku-ui/src/lib/cube-designer/state.test.ts
+++ b/saiku-ui/src/lib/cube-designer/state.test.ts
@@ -1,0 +1,999 @@
+import { describe, it, expect } from 'vitest';
+import { SchemaCanvasStore } from './state.svelte.js';
+
+describe('SchemaCanvasStore cubes', () => {
+	it('addCube + addMeasureGroup + toggleMeasureColumn build a cube on the doc', () => {
+		// Arrange
+		const store = new SchemaCanvasStore('conn-1');
+
+		// Act
+		const cube = store.addCube({ name: 'Sales' });
+		const mg = store.addMeasureGroup(cube.id, { name: 'Facts', factTableId: 'f' });
+		store.toggleMeasureColumn(cube.id, mg!.id, 'amount');
+		store.toggleMeasureColumn(cube.id, mg!.id, 'qty');
+		store.toggleMeasureColumn(cube.id, mg!.id, 'amount'); // toggles amount back off
+
+		// Assert
+		expect(mg).not.toBeNull();
+		expect(store.cubes).toHaveLength(1);
+		const group = store.cubes[0].measureGroups[0];
+		expect(group.measureColumns).toEqual(['qty']);
+		expect(group.factTableId).toBe('f');
+	});
+
+	it('setMeasureGroupDimLink upserts by dimensionId', () => {
+		// Arrange
+		const store = new SchemaCanvasStore('conn-2');
+		const cube = store.addCube({});
+		const mg = store.addMeasureGroup(cube.id, { factTableId: 'f' })!;
+
+		// Act
+		store.setMeasureGroupDimLink(cube.id, mg.id, { dimensionId: 'd1', foreignKeyColumn: 'a' });
+		store.setMeasureGroupDimLink(cube.id, mg.id, { dimensionId: 'd1', foreignKeyColumn: 'b' });
+		store.setMeasureGroupDimLink(cube.id, mg.id, { dimensionId: 'd2', foreignKeyColumn: 'c' });
+
+		// Assert
+		const links = store.cubes[0].measureGroups[0].dimensionLinks ?? [];
+		expect(links).toHaveLength(2);
+		expect(links.find((l) => l.dimensionId === 'd1')?.foreignKeyColumn).toBe('b');
+	});
+
+	it('bumpWorkbenchReload increments the reload nonce', () => {
+		// Arrange
+		const store = new SchemaCanvasStore('conn-3');
+		const before = store.workbenchReloadNonce;
+
+		// Act
+		store.bumpWorkbenchReload();
+
+		// Assert
+		expect(store.workbenchReloadNonce).toBe(before + 1);
+	});
+});
+
+// A stand-in candidate for addTable: minimal shape the tests rely on.
+function candidate(schema: string, name: string, columns: string[]) {
+	return {
+		schema,
+		name,
+		onCanvas: false,
+		columns: columns.map((n) => ({ name: n, sqlType: 'VARCHAR' as const }))
+	};
+}
+
+describe('Create Joins Mode — pushEShiftPick (one column per table)', () => {
+	it('appends a pick for a new table', () => {
+		const store = new SchemaCanvasStore('conn-picks-1');
+		store.pushEShiftPick('t1', 'a');
+		expect(store.eShiftPicks).toEqual([{ tableId: 't1', columnName: 'a' }]);
+	});
+
+	it('appends a second pick when it is a different table', () => {
+		const store = new SchemaCanvasStore('conn-picks-2');
+		store.pushEShiftPick('t1', 'a');
+		store.pushEShiftPick('t2', 'b');
+		expect(store.eShiftPicks).toEqual([
+			{ tableId: 't1', columnName: 'a' },
+			{ tableId: 't2', columnName: 'b' }
+		]);
+	});
+
+	it('REPLACES the existing pick when a different column is picked on the same table', () => {
+		const store = new SchemaCanvasStore('conn-picks-3');
+		store.pushEShiftPick('t1', 'a');
+		store.pushEShiftPick('t2', 'x');
+		// Second pick on t1 — should REPLACE `a`, not append.
+		store.pushEShiftPick('t1', 'b');
+		expect(store.eShiftPicks).toEqual([
+			{ tableId: 't1', columnName: 'b' },
+			{ tableId: 't2', columnName: 'x' }
+		]);
+	});
+
+	it('toggles off when the exact same (table, column) is re-clicked', () => {
+		const store = new SchemaCanvasStore('conn-picks-4');
+		store.pushEShiftPick('t1', 'a');
+		store.pushEShiftPick('t1', 'a');
+		expect(store.eShiftPicks).toEqual([]);
+	});
+
+	it('never allows two picks on the same table across many rapid clicks', () => {
+		const store = new SchemaCanvasStore('conn-picks-5');
+		store.pushEShiftPick('t1', 'a');
+		store.pushEShiftPick('t1', 'b');
+		store.pushEShiftPick('t1', 'c');
+		store.pushEShiftPick('t1', 'd');
+		// Only the most-recent pick per table survives.
+		expect(store.eShiftPicks).toEqual([{ tableId: 't1', columnName: 'd' }]);
+	});
+});
+
+describe('Create Joins Mode — autoPickGroupName', () => {
+	it('returns empty string when there are no picks', () => {
+		const store = new SchemaCanvasStore('conn-auto-1');
+		expect(store.autoPickGroupName()).toBe('');
+	});
+
+	it('uses the shared column name when every pick has the same name', () => {
+		const store = new SchemaCanvasStore('conn-auto-2');
+		store.pushEShiftPick('t1', 'customer_id');
+		store.pushEShiftPick('t2', 'customer_id');
+		store.pushEShiftPick('t3', 'customer_id');
+		expect(store.autoPickGroupName()).toBe('customer_id');
+	});
+
+	it('falls back to the most common column name when picks differ', () => {
+		const store = new SchemaCanvasStore('conn-auto-3');
+		store.pushEShiftPick('t1', 'customer_id');
+		store.pushEShiftPick('t2', 'customer_id');
+		store.pushEShiftPick('t3', 'cust_id');
+		expect(store.autoPickGroupName()).toBe('customer_id');
+	});
+
+	it('uses the first-seen column name when there is no majority', () => {
+		const store = new SchemaCanvasStore('conn-auto-4');
+		store.pushEShiftPick('t1', 'foo');
+		store.pushEShiftPick('t2', 'bar');
+		// bar and foo tied at 1 each — first-seen (foo) wins.
+		expect(store.autoPickGroupName()).toBe('foo');
+	});
+});
+
+describe('Create Joins Mode — commitEShiftPicks', () => {
+	function makeStoreWithTables() {
+		const store = new SchemaCanvasStore('conn-commit');
+		const a = store.addTable(candidate('public', 'a', ['id', 'name']), { x: 0, y: 0 });
+		const b = store.addTable(candidate('public', 'b', ['id', 'a_id']), { x: 200, y: 0 });
+		const c = store.addTable(candidate('public', 'c', ['id', 'a_id']), { x: 400, y: 0 });
+		return { store, a, b, c };
+	}
+
+	it('is a no-op when fewer than 2 picks exist', () => {
+		const { store, a } = makeStoreWithTables();
+		store.pushEShiftPick(a.id, 'id');
+		const joinsBefore = store.doc.joins.length;
+		store.commitEShiftPicks();
+		expect(store.doc.joins.length).toBe(joinsBefore);
+	});
+
+	it('creates N-1 joins in a star pattern from pick[0] to each peer', () => {
+		const { store, a, b, c } = makeStoreWithTables();
+		store.pushEShiftPick(a.id, 'id');
+		store.pushEShiftPick(b.id, 'a_id');
+		store.pushEShiftPick(c.id, 'a_id');
+		const joinsBefore = store.doc.joins.length;
+		store.commitEShiftPicks();
+		// 3 picks → 2 joins (a→b, a→c).
+		expect(store.doc.joins.length - joinsBefore).toBe(2);
+		const created = store.doc.joins.slice(joinsBefore);
+		expect(created.every((j) => j.sourceTableId === a.id)).toBe(true);
+		expect(created.map((j) => j.targetTableId).sort()).toEqual([b.id, c.id].sort());
+	});
+
+	it('clears the pick set and exits Create Joins Mode after commit', () => {
+		const { store, a, b } = makeStoreWithTables();
+		store.enterPickMode();
+		store.pushEShiftPick(a.id, 'id');
+		store.pushEShiftPick(b.id, 'a_id');
+		store.commitEShiftPicks();
+		expect(store.eShiftPicks).toEqual([]);
+		expect(store.pickModeActive).toBe(false);
+	});
+
+	it('applies groupName to every created join via joinGroupRenames', () => {
+		const { store, a, b, c } = makeStoreWithTables();
+		store.pushEShiftPick(a.id, 'id');
+		store.pushEShiftPick(b.id, 'a_id');
+		store.pushEShiftPick(c.id, 'a_id');
+		store.commitEShiftPicks('Account Key');
+		const renames = store.doc.joinGroupRenames ?? {};
+		// Every join added on this commit shares the same custom group label.
+		const labels = new Set(Object.values(renames));
+		expect(labels.has('Account Key')).toBe(true);
+	});
+
+	it('leaves joinGroupRenames untouched when no groupName supplied', () => {
+		const { store, a, b } = makeStoreWithTables();
+		store.pushEShiftPick(a.id, 'id');
+		store.pushEShiftPick(b.id, 'a_id');
+		const before = { ...(store.doc.joinGroupRenames ?? {}) };
+		store.commitEShiftPicks();
+		expect(store.doc.joinGroupRenames ?? {}).toEqual(before);
+	});
+});
+
+describe('Create Joins Mode — undo covers CJM commit', () => {
+	it('one Undo removes every join created by a single commitEShiftPicks batch', () => {
+		const store = new SchemaCanvasStore('conn-undo-commit');
+		const a = store.addTable(candidate('public', 'a', ['id']), { x: 0, y: 0 });
+		const b = store.addTable(candidate('public', 'b', ['a_id']), { x: 200, y: 0 });
+		const c = store.addTable(candidate('public', 'c', ['a_id']), { x: 400, y: 0 });
+		const joinsBefore = store.doc.joins.length;
+		store.pushEShiftPick(a.id, 'id');
+		store.pushEShiftPick(b.id, 'a_id');
+		store.pushEShiftPick(c.id, 'a_id');
+		store.commitEShiftPicks();
+		// 2 joins created.
+		expect(store.doc.joins.length).toBe(joinsBefore + 2);
+		// One undo reverts the whole batch.
+		store.undo();
+		expect(store.doc.joins.length).toBe(joinsBefore);
+	});
+});
+
+describe('addJoin — single-source-endpoint invariant', () => {
+	// Amelia hit this: `reserve_employee.first_name` had two joins in one
+	// group, one to `customer.fname` and one to `customer.lname`. A single
+	// source endpoint can only participate in ONE join per target table.
+	// Role-playing (SAME target column, DIFFERENT source columns) must
+	// still be legal.
+
+	function makePair() {
+		const store = new SchemaCanvasStore('conn-invariant');
+		const emp = store.addTable(
+			candidate('public', 'reserve_employee', ['first_name', 'last_name']),
+			{ x: 0, y: 0 }
+		);
+		const cust = store.addTable(candidate('public', 'customer', ['fname', 'lname']), {
+			x: 300,
+			y: 0
+		});
+		return { store, emp, cust };
+	}
+
+	it('replaces the existing join when the same source endpoint is repointed to a different target column', () => {
+		const { store, emp, cust } = makePair();
+		store.addJoin({
+			sourceTableId: emp.id,
+			sourceColumnName: 'first_name',
+			targetTableId: cust.id,
+			targetColumnName: 'fname',
+			kind: 'inner'
+		});
+		store.addJoin({
+			sourceTableId: emp.id,
+			sourceColumnName: 'first_name',
+			targetTableId: cust.id,
+			targetColumnName: 'lname',
+			kind: 'inner'
+		});
+		expect(store.doc.joins).toHaveLength(1);
+		expect(store.doc.joins[0].targetColumnName).toBe('lname');
+		expect(store.lastJoinFeedback?.message).toMatch(/Replaced join/i);
+		expect(store.lastJoinFeedback?.message).toContain('first_name');
+		expect(store.lastJoinFeedback?.message).toContain('fname');
+	});
+
+	it('also replaces when the tables are swapped (source ↔ target in the incoming join)', () => {
+		const { store, emp, cust } = makePair();
+		// Existing: emp.first_name → customer.fname
+		store.addJoin({
+			sourceTableId: emp.id,
+			sourceColumnName: 'first_name',
+			targetTableId: cust.id,
+			targetColumnName: 'fname',
+			kind: 'inner'
+		});
+		// Incoming, swapped: customer.lname → emp.first_name (same emp endpoint,
+		// different customer column) — treat as ambiguous, replace.
+		store.addJoin({
+			sourceTableId: cust.id,
+			sourceColumnName: 'lname',
+			targetTableId: emp.id,
+			targetColumnName: 'first_name',
+			kind: 'inner'
+		});
+		expect(store.doc.joins).toHaveLength(1);
+		const only = store.doc.joins[0];
+		expect(only.sourceTableId).toBe(cust.id);
+		expect(only.sourceColumnName).toBe('lname');
+		expect(only.targetTableId).toBe(emp.id);
+		expect(only.targetColumnName).toBe('first_name');
+	});
+
+	it('preserves role-playing (different source columns joined to the same target column)', () => {
+		const store = new SchemaCanvasStore('conn-role-play');
+		const fact = store.addTable(
+			candidate('public', 'sales', ['order_date', 'ship_date', 'invoice_date']),
+			{ x: 0, y: 0 }
+		);
+		const date = store.addTable(candidate('public', 'date_dim', ['date_id']), { x: 300, y: 0 });
+		store.addJoin({
+			sourceTableId: fact.id,
+			sourceColumnName: 'order_date',
+			targetTableId: date.id,
+			targetColumnName: 'date_id',
+			kind: 'inner'
+		});
+		store.addJoin({
+			sourceTableId: fact.id,
+			sourceColumnName: 'ship_date',
+			targetTableId: date.id,
+			targetColumnName: 'date_id',
+			kind: 'inner'
+		});
+		store.addJoin({
+			sourceTableId: fact.id,
+			sourceColumnName: 'invoice_date',
+			targetTableId: date.id,
+			targetColumnName: 'date_id',
+			kind: 'inner'
+		});
+		expect(store.doc.joins).toHaveLength(3);
+		expect(store.doc.joins.map((j) => j.sourceColumnName).sort()).toEqual([
+			'invoice_date',
+			'order_date',
+			'ship_date'
+		]);
+	});
+
+	it('still dedupes an exact tuple duplicate (no-op replace)', () => {
+		const { store, emp, cust } = makePair();
+		const first = store.addJoin({
+			sourceTableId: emp.id,
+			sourceColumnName: 'first_name',
+			targetTableId: cust.id,
+			targetColumnName: 'fname',
+			kind: 'inner'
+		});
+		const second = store.addJoin({
+			sourceTableId: emp.id,
+			sourceColumnName: 'first_name',
+			targetTableId: cust.id,
+			targetColumnName: 'fname',
+			kind: 'inner'
+		});
+		expect(store.doc.joins).toHaveLength(1);
+		// It's the second call's id that survives (existing tuple dedupe replaces).
+		expect(store.doc.joins[0].id).toBe(second.id);
+		expect(first.id).not.toBe(second.id);
+	});
+});
+
+// ── Undo primitives (issue #1180, bucket 1) ─────────────────────────────────
+// The undo model is a single-level swap: base mutations (addTable, addJoin,
+// removeTable, removeJoin, removeJoins) snapshot the PRE-mutation doc into
+// `previousDoc` via maybeSnapshotForUndo, unless a withUndoBatch is active — in
+// which case only the batch's entry snapshot is kept so N mutations collapse to
+// one Undo step. undo() swaps previousDoc↔doc so it doubles as redo. Amelia's
+// #1144 pushed the snapshot into base mutations; this locks the invariants.
+describe('SchemaCanvasStore — undo primitives (#1180)', () => {
+	function storeWith(...names: string[]): SchemaCanvasStore {
+		const store = new SchemaCanvasStore('conn-undo');
+		names.forEach((n, i) => store.addTable(candidate('public', n, ['id']), { x: i * 10, y: 0 }));
+		return store;
+	}
+
+	it('a base mutation is a single undoable step', () => {
+		const store = new SchemaCanvasStore('conn-undo');
+		store.addTable(candidate('public', 't1', ['id']), { x: 0, y: 0 });
+		expect(store.doc.tables).toHaveLength(1);
+
+		store.undo();
+		expect(store.doc.tables).toHaveLength(0);
+	});
+
+	it('undo is single-level — reverts only the most recent action', () => {
+		const store = storeWith('t1', 't2');
+		expect(store.doc.tables).toHaveLength(2);
+
+		store.undo(); // reverts the t2 add only
+		expect(store.doc.tables.map((t) => t.name)).toEqual(['t1']);
+	});
+
+	it('withUndoBatch collapses N mutations into ONE undo step', () => {
+		const store = new SchemaCanvasStore('conn-undo');
+		store.withUndoBatch(() => {
+			store.addTable(candidate('public', 't1', ['id']), { x: 0, y: 0 });
+			store.addTable(candidate('public', 't2', ['id']), { x: 10, y: 0 });
+			store.addTable(candidate('public', 't3', ['id']), { x: 20, y: 0 });
+		});
+		expect(store.doc.tables).toHaveLength(3);
+
+		store.undo(); // one snapshot at batch entry (empty) → all three revert
+		expect(store.doc.tables).toHaveLength(0);
+	});
+
+	it('nested withUndoBatch only snapshots at the outermost entry', () => {
+		const store = storeWith('t0'); // pre-existing table before the batch
+		store.withUndoBatch(() => {
+			store.addTable(candidate('public', 't1', ['id']), { x: 10, y: 0 });
+			store.withUndoBatch(() => {
+				store.addTable(candidate('public', 't2', ['id']), { x: 20, y: 0 });
+			});
+		});
+		expect(store.doc.tables).toHaveLength(3);
+
+		store.undo(); // reverts to the outer-batch entry state (just t0)
+		expect(store.doc.tables.map((t) => t.name)).toEqual(['t0']);
+	});
+
+	it('undo doubles as redo — a second undo re-applies', () => {
+		const store = new SchemaCanvasStore('conn-undo');
+		store.addTable(candidate('public', 't1', ['id']), { x: 0, y: 0 });
+
+		store.undo(); // remove t1
+		expect(store.doc.tables).toHaveLength(0);
+		store.undo(); // swap back — redo
+		expect(store.doc.tables.map((t) => t.name)).toEqual(['t1']);
+	});
+
+	it('clearPreviousDoc drops the pending snapshot so undo is a no-op', () => {
+		const store = new SchemaCanvasStore('conn-undo');
+		store.addTable(candidate('public', 't1', ['id']), { x: 0, y: 0 });
+
+		store.clearPreviousDoc();
+		store.undo();
+		expect(store.doc.tables).toHaveLength(1);
+	});
+
+	it('undo is a no-op on a fresh store with nothing to revert', () => {
+		const store = new SchemaCanvasStore('conn-undo');
+		expect(() => store.undo()).not.toThrow();
+		expect(store.doc.tables).toHaveLength(0);
+	});
+
+	it('removeJoins under a batch reverts in one undo', () => {
+		const store = storeWith('a', 'b');
+		const [a, b] = store.doc.tables;
+		store.addJoin({
+			sourceTableId: a.id,
+			sourceColumnName: 'id',
+			targetTableId: b.id,
+			targetColumnName: 'id',
+			kind: 'inner'
+		});
+		expect(store.doc.joins).toHaveLength(1);
+
+		store.removeJoins([store.doc.joins[0].id]);
+		expect(store.doc.joins).toHaveLength(0);
+
+		store.undo(); // the join comes back
+		expect(store.doc.joins).toHaveLength(1);
+	});
+});
+
+// ── Table lifecycle (issue #1180, bucket 3) ─────────────────────────────────
+describe('SchemaCanvasStore — table lifecycle (#1180)', () => {
+	function twoTables(): { store: SchemaCanvasStore; a: string; b: string } {
+		const store = new SchemaCanvasStore('conn-tbl');
+		const a = store.addTable(candidate('public', 'a', ['id', 'k']), { x: 0, y: 0 });
+		const b = store.addTable(candidate('public', 'b', ['id', 'k']), { x: 100, y: 0 });
+		return { store, a: a.id, b: b.id };
+	}
+
+	it('removeTable drops the table and cascades its joins', () => {
+		const { store, a, b } = twoTables();
+		store.addJoin({
+			sourceTableId: a,
+			sourceColumnName: 'k',
+			targetTableId: b,
+			targetColumnName: 'k',
+			kind: 'inner'
+		});
+		expect(store.doc.joins).toHaveLength(1);
+
+		store.removeTable(a);
+		expect(store.doc.tables.map((t) => t.name)).toEqual(['b']);
+		expect(store.doc.joins).toHaveLength(0); // join referencing `a` cascaded
+	});
+
+	it('removeTable clears the selection when the removed table was selected', () => {
+		const { store, a } = twoTables();
+		store.selectedTableId = a;
+		store.removeTable(a);
+		expect(store.selectedTableId).toBeNull();
+	});
+
+	it('moveTable updates position and is a no-op for an unknown id', () => {
+		const { store, a } = twoTables();
+		store.moveTable(a, { x: 42, y: 99 });
+		expect(store.doc.tables.find((t) => t.id === a)?.position).toEqual({ x: 42, y: 99 });
+		expect(() => store.moveTable('nope', { x: 1, y: 1 })).not.toThrow();
+	});
+
+	it('setTableRole enforces a single fact — promoting one demotes the prior fact', () => {
+		const { store, a, b } = twoTables();
+		store.setTableRole(a, 'fact');
+		expect(store.doc.tables.find((t) => t.id === a)?.role).toBe('fact');
+
+		store.setTableRole(b, 'fact');
+		expect(store.doc.tables.find((t) => t.id === b)?.role).toBe('fact');
+		expect(store.doc.tables.find((t) => t.id === a)?.role).toBe('dimension');
+	});
+
+	it('toggleTableCollapsed cycles undefined ↔ true (never the force-show-all state)', () => {
+		const { store, a } = twoTables();
+		const t = () => store.doc.tables.find((x) => x.id === a)!;
+		expect(t().collapsed).toBeUndefined();
+		store.toggleTableCollapsed(a);
+		expect(t().collapsed).toBe(true);
+		store.toggleTableCollapsed(a);
+		expect(t().collapsed).toBeUndefined();
+	});
+
+	it('expand/collapse-all + resetCollapseOverrides drive every table together', () => {
+		const { store } = twoTables();
+		store.collapseAllTables();
+		expect(store.doc.tables.every((t) => t.collapsed === true)).toBe(true);
+		store.expandAllTables();
+		expect(store.doc.tables.every((t) => t.collapsed === false)).toBe(true);
+		store.resetCollapseOverrides();
+		expect(store.doc.tables.every((t) => t.collapsed === undefined)).toBe(true);
+	});
+});
+
+// ── Join lifecycle (issue #1180, bucket 2) ──────────────────────────────────
+describe('SchemaCanvasStore — join lifecycle (#1180)', () => {
+	function joined(): { store: SchemaCanvasStore; a: string; b: string; joinId: string } {
+		const store = new SchemaCanvasStore('conn-join');
+		const a = store.addTable(candidate('public', 'a', ['id', 'k']), { x: 0, y: 0 });
+		const b = store.addTable(candidate('public', 'b', ['id', 'k']), { x: 100, y: 0 });
+		store.addJoin({
+			sourceTableId: a.id,
+			sourceColumnName: 'k',
+			targetTableId: b.id,
+			targetColumnName: 'k',
+			kind: 'inner'
+		});
+		return { store, a: a.id, b: b.id, joinId: store.doc.joins[0].id };
+	}
+
+	it('removeJoin drops a physical join and clears its selection', () => {
+		const { store, joinId } = joined();
+		store.selectedJoinId = joinId;
+		store.removeJoin(joinId);
+		expect(store.doc.joins).toHaveLength(0);
+		expect(store.selectedJoinId).toBeNull();
+	});
+
+	it('removeJoin is a no-op for cube-link joins (owned by the MeasureGroup FK)', () => {
+		const { store, joinId } = joined();
+		store.doc.joins[0].origin = 'cube-link';
+		store.removeJoin(joinId);
+		expect(store.doc.joins).toHaveLength(1); // untouched
+	});
+
+	it('removeAllJoins wipes joins + resets related state; no-op when already empty', () => {
+		const { store } = joined();
+		store.removeAllJoins();
+		expect(store.doc.joins).toHaveLength(0);
+		expect(store.selectedJoinId).toBeNull();
+		expect(() => store.removeAllJoins()).not.toThrow();
+	});
+
+	it('setJoinKind changes the kind in place', () => {
+		const { store, joinId } = joined();
+		store.setJoinKind(joinId, 'left');
+		expect(store.doc.joins[0].kind).toBe('left');
+	});
+
+	it('renameJoinGroup + joinGroupLabelFor round-trip; empty label reverts to the key', () => {
+		const { store } = joined();
+		const j = store.doc.joins[0];
+		const key = store.joinGroupLabelFor(j); // canonical key (no rename yet)
+
+		store.renameJoinGroup(key, 'Geography');
+		expect(store.joinGroupLabelFor(j)).toBe('Geography');
+
+		store.renameJoinGroup(key, '   ');
+		expect(store.joinGroupLabelFor(j)).toBe(key);
+	});
+
+	it('createGroup + assignTableToGroup wire a table into a group and back out', () => {
+		const { store, a } = joined();
+		const g = store.createGroup('Dims');
+		expect(store.doc.groups.map((x) => x.label)).toContain('Dims');
+
+		store.assignTableToGroup(a, g.id);
+		expect(store.doc.tables.find((t) => t.id === a)?.groupId).toBe(g.id);
+		store.assignTableToGroup(a, null);
+		expect(store.doc.tables.find((t) => t.id === a)?.groupId).toBeNull();
+	});
+
+	it('linkSimilarOnCanvas joins every other table sharing the column (one undo step)', () => {
+		const store = new SchemaCanvasStore('conn-link');
+		const origin = store.addTable(candidate('public', 'fact', ['sales_id', 'cust_id']), {
+			x: 0,
+			y: 0
+		});
+		store.addTable(candidate('public', 'd1', ['cust_id']), { x: 100, y: 0 });
+		store.addTable(candidate('public', 'd2', ['cust_id']), { x: 200, y: 0 });
+		store.addTable(candidate('public', 'other', ['zzz']), { x: 300, y: 0 });
+
+		const added = store.linkSimilarOnCanvas(origin.id, 'cust_id');
+		expect(added).toBe(2); // d1 + d2, not `other`
+		expect(store.doc.joins).toHaveLength(2);
+
+		store.undo(); // one batch → all links revert together
+		expect(store.doc.joins).toHaveLength(0);
+	});
+
+	it('tryColumnClickJoin is highlight-only — it never creates a join', () => {
+		const { store, a } = joined();
+		const before = store.doc.joins.length;
+		store.tryColumnClickJoin(a, 'k');
+		expect(store.highlightedColumn).toBe('k');
+		expect(store.highlightOriginTableId).toBe(a);
+		expect(store.doc.joins).toHaveLength(before); // no join created
+		// Clicking the same column again clears the highlight.
+		store.tryColumnClickJoin(a, 'k');
+		expect(store.highlightedColumn).toBeNull();
+	});
+});
+
+// ── Workbench: dimensions / hierarchies / levels / attributes (#1180 bucket 4)
+describe('SchemaCanvasStore — dimensions / hierarchies / levels / attributes (#1180)', () => {
+	it('addDimension names uniquely, sets primaryKeyTableId, and stays hierarchy-less without a column seed', () => {
+		const store = new SchemaCanvasStore('conn-dim');
+		const d1 = store.addDimension({ name: 'Customer', tableId: 't1' });
+		const d2 = store.addDimension({ name: 'Customer' });
+		expect(d1.name).toBe('Customer');
+		expect(d1.primaryKeyTableId).toBe('t1');
+		expect(d1.hierarchies).toHaveLength(0);
+		expect(d2.name).not.toBe('Customer'); // deduped
+	});
+
+	it('addDimension with a column seed auto-creates one hierarchy + level', () => {
+		const store = new SchemaCanvasStore('conn-dim');
+		const d = store.addDimension({ name: 'Time', tableId: 't1', columnName: 'the_year' });
+		expect(d.hierarchies).toHaveLength(1);
+		expect(d.hierarchies[0].levels[0].columnName).toBe('the_year');
+	});
+
+	it('updateDimension patches + removeDimension drops it', () => {
+		const store = new SchemaCanvasStore('conn-dim');
+		const d = store.addDimension({ name: 'D' });
+		store.updateDimension(d.id, { caption: 'Display D' });
+		expect(store.dimensions.find((x) => x.id === d.id)?.caption).toBe('Display D');
+		store.removeDimension(d.id);
+		expect(store.dimensions).toHaveLength(0);
+	});
+
+	it('hierarchy + level lifecycle: add, dedupe same column, move, update, remove', () => {
+		const store = new SchemaCanvasStore('conn-dim');
+		const d = store.addDimension({ name: 'Geo' });
+		const h = store.addHierarchy(d.id, 'Region')!;
+		expect(h).not.toBeNull();
+
+		const l1 = store.addLevel(d.id, h.id, { tableId: 't', columnName: 'country' });
+		const dup = store.addLevel(d.id, h.id, { tableId: 't', columnName: 'country' });
+		expect(dup).toBe(l1); // same column returns the existing level, no duplicate
+		store.addLevel(d.id, h.id, { tableId: 't', columnName: 'city' });
+		const levels = () => store.dimensions[0].hierarchies[0].levels;
+		expect(levels().map((l) => l.columnName)).toEqual(['country', 'city']);
+
+		store.moveLevel(d.id, h.id, levels()[1].id, -1); // city up
+		expect(levels().map((l) => l.columnName)).toEqual(['city', 'country']);
+
+		store.updateLevel(d.id, h.id, levels()[0].id, { caption: 'Municipality' });
+		expect(levels()[0].caption).toBe('Municipality');
+
+		store.removeLevel(d.id, h.id, levels()[0].id);
+		expect(levels().map((l) => l.columnName)).toEqual(['country']);
+
+		store.removeHierarchy(d.id, h.id);
+		expect(store.dimensions[0].hierarchies).toHaveLength(0);
+	});
+
+	it('attribute lifecycle: add (idempotent), update, setAttributes replace, remove', () => {
+		const store = new SchemaCanvasStore('conn-dim');
+		const d = store.addDimension({ name: 'Product' });
+		store.addAttribute(d.id, 't', 'name');
+		store.addAttribute(d.id, 't', 'name'); // no-op
+		expect(store.dimensions[0].attributes).toHaveLength(1);
+
+		store.updateAttribute(d.id, 't', 'name', { nameColumn: 'display_name' });
+		expect(store.dimensions[0].attributes?.[0].nameColumn).toBe('display_name');
+
+		store.setAttributes(d.id, [
+			{ tableId: 't', columnName: 'a' },
+			{ tableId: 't', columnName: 'b' }
+		]);
+		expect(store.dimensions[0].attributes?.map((a) => a.columnName)).toEqual(['a', 'b']);
+
+		store.removeAttribute(d.id, 't', 'a');
+		expect(store.dimensions[0].attributes?.map((a) => a.columnName)).toEqual(['b']);
+	});
+});
+
+// ── Workbench: measures (#1180 bucket 4) ─────────────────────────────────────
+describe('SchemaCanvasStore — measures (#1180)', () => {
+	it('addMeasure defaults to sum and only carries percentile for a percentile aggregator', () => {
+		const store = new SchemaCanvasStore('conn-meas');
+		const sum = store.addMeasure({ tableId: 'f', columnName: 'amount' });
+		expect(sum.aggregator).toBe('sum');
+		expect(sum.percentile).toBeUndefined();
+
+		const p90 = store.addMeasure({
+			tableId: 'f',
+			columnName: 'latency',
+			aggregator: 'percentile',
+			percentile: 90
+		});
+		expect(p90.percentile).toBe(90);
+	});
+
+	it('updateMeasure patches + removeMeasure drops it', () => {
+		const store = new SchemaCanvasStore('conn-meas');
+		const m = store.addMeasure({ tableId: 'f', columnName: 'amount' });
+		store.updateMeasure(m.id, { name: 'Revenue' });
+		expect(store.measures[0].name).toBe('Revenue');
+		store.removeMeasure(m.id);
+		expect(store.measures).toHaveLength(0);
+	});
+});
+
+// ── Workbench: cubes / measure groups / calcs / time-calcs (#1180 bucket 4) ──
+describe('SchemaCanvasStore — cubes / groups / calcs / timeCalcs (#1180)', () => {
+	function cubeWithGroup() {
+		const store = new SchemaCanvasStore('conn-cube');
+		const cube = store.addCube({ name: 'Sales' });
+		const mg = store.addMeasureGroup(cube.id, { name: 'Facts', factTableId: 'f' })!;
+		return { store, cubeId: cube.id, mgId: mg.id };
+	}
+
+	it('renameCube + removeCube', () => {
+		const { store, cubeId } = cubeWithGroup();
+		store.renameCube(cubeId, 'Orders');
+		expect(store.cubes[0].name).toBe('Orders');
+		store.removeCube(cubeId);
+		expect(store.cubes).toHaveLength(0);
+	});
+
+	it('measure-group edits: rename, setMeasureColumns, setMeasureGroupFactTable, remove', () => {
+		const { store, cubeId, mgId } = cubeWithGroup();
+		store.renameMeasureGroup(cubeId, mgId, 'Renamed');
+		store.setMeasureColumns(cubeId, mgId, ['amount', 'qty']);
+		store.setMeasureGroupFactTable(cubeId, mgId, 'fact2');
+		const mg = store.cubes[0].measureGroups[0];
+		expect(mg.name).toBe('Renamed');
+		expect(mg.measureColumns).toEqual(['amount', 'qty']);
+		expect(mg.factTableId).toBe('fact2');
+
+		store.removeMeasureGroup(cubeId, mgId);
+		expect(store.cubes[0].measureGroups).toHaveLength(0);
+	});
+
+	it('dim-link upsert + removeMeasureGroupDimLink', () => {
+		const { store, cubeId, mgId } = cubeWithGroup();
+		store.setMeasureGroupDimLink(cubeId, mgId, { dimensionId: 'd1', foreignKeyColumn: 'a' });
+		store.setMeasureGroupDimLink(cubeId, mgId, { dimensionId: 'd2', foreignKeyColumn: 'b' });
+		expect(store.cubes[0].measureGroups[0].dimensionLinks).toHaveLength(2);
+		store.removeMeasureGroupDimLink(cubeId, mgId, 'd1');
+		expect(store.cubes[0].measureGroups[0].dimensionLinks?.map((l) => l.dimensionId)).toEqual([
+			'd2'
+		]);
+	});
+
+	it('addCalc + removeCalc', () => {
+		const { store, cubeId } = cubeWithGroup();
+		const calc = store.addCalc(cubeId, { name: 'Margin', formula: '[a]-[b]' })!;
+		expect(store.cubes[0].calcs.map((c) => c.name)).toEqual(['Margin']);
+		store.removeCalc(cubeId, calc.id);
+		expect(store.cubes[0].calcs).toHaveLength(0);
+	});
+
+	it('timeCalc lifecycle: add, update, remove', () => {
+		const { store, cubeId } = cubeWithGroup();
+		const tc = store.addTimeCalc(cubeId, { name: 'Rev YoY', type: 'yoy', measure: 'Revenue' })!;
+		expect(store.cubes[0].timeCalcs?.[0].type).toBe('yoy');
+		store.updateTimeCalc(cubeId, tc.id, { type: 'rolling', window: 3, function: 'avg' });
+		expect(store.cubes[0].timeCalcs?.[0]).toMatchObject({ type: 'rolling', window: 3 });
+		store.removeTimeCalc(cubeId, tc.id);
+		expect(store.cubes[0].timeCalcs).toHaveLength(0);
+	});
+
+	it('setCubes preserves cube-scoped timeCalcs by id (workbench write-back cannot wipe them)', () => {
+		const { store, cubeId } = cubeWithGroup();
+		store.addTimeCalc(cubeId, { name: 'Rev YoY', type: 'yoy', measure: 'Revenue' });
+		// Simulate the workbench persisting via cubeToDoc (which drops timeCalcs).
+		store.setCubes([{ id: cubeId, name: 'Sales', measureGroups: [], calcs: [] }]);
+		expect(store.cubes[0].timeCalcs).toHaveLength(1); // preserved by id
+		expect(store.cubes[0].timeCalcs?.[0].name).toBe('Rev YoY');
+	});
+});
+
+// ── Focus + interaction (issue #1180, bucket 6) ─────────────────────────────
+describe('SchemaCanvasStore — focus + interaction (#1180)', () => {
+	function joined() {
+		const store = new SchemaCanvasStore('conn-focus');
+		const a = store.addTable(candidate('public', 'a', ['k']), { x: 0, y: 0 });
+		const b = store.addTable(candidate('public', 'b', ['k']), { x: 100, y: 0 });
+		store.addJoin({
+			sourceTableId: a.id,
+			sourceColumnName: 'k',
+			targetTableId: b.id,
+			targetColumnName: 'k',
+			kind: 'inner'
+		});
+		return { store, a: a.id, b: b.id, joinId: store.doc.joins[0].id };
+	}
+
+	it('focusTableNode toggles table focus and drives tableIdsInFocus / joinIdsInFocus', () => {
+		const { store, a, b, joinId } = joined();
+		store.focusTableNode(a);
+		expect(store.focusKind).toBe('table');
+		expect([...store.tableIdsInFocus()].sort()).toEqual([a, b].sort()); // a + its neighbour
+		expect([...store.joinIdsInFocus()]).toEqual([joinId]);
+
+		store.focusTableNode(a); // toggle off
+		expect(store.focusKind).toBe('none');
+		expect(store.tableIdsInFocus().size).toBe(0);
+	});
+
+	it('focusGroup focuses by label and turns on column highlighting', () => {
+		const { store } = joined();
+		const label = store.joinGroupLabelFor(store.doc.joins[0]);
+		store.focusGroup(label);
+		expect(store.focusKind).toBe('group');
+		expect(store.focusKey).toBe(label);
+		expect(store.highlightFocusedColumns).toBe(true);
+		expect(store.joinIdsInFocus().size).toBe(1);
+	});
+
+	it('clearFocus + clearAllInteractions reset transient state (doc untouched)', () => {
+		const { store, a } = joined();
+		store.focusTableNode(a);
+		store.highlightColumn('k');
+		store.selectedTableId = a;
+		store.clearAllInteractions();
+		expect(store.focusKind).toBe('none');
+		expect(store.highlightedColumn).toBeNull();
+		expect(store.selectedTableId).toBeNull();
+		expect(store.doc.tables).toHaveLength(2); // doc intact
+	});
+
+	it('highlightColumn toggles the name highlight + sidebar query', () => {
+		const { store } = joined();
+		store.highlightColumn('k');
+		expect(store.highlightedColumn).toBe('k');
+		expect(store.sidebarQuery).toBe('k');
+		store.highlightColumn('k');
+		expect(store.highlightedColumn).toBeNull();
+	});
+});
+
+// ── Pathfinder (issue #1180, bucket 5) ──────────────────────────────────────
+describe('SchemaCanvasStore — pathfinder (#1180)', () => {
+	it('arm/setEndpoint/clear manage the pathfinder slots + result', () => {
+		const store = new SchemaCanvasStore('conn-pf');
+		store.armPathfinder('start');
+		expect(store.pathfinderArmed).toBe('start');
+		store.armPathfinder('start'); // toggle off
+		expect(store.pathfinderArmed).toBeNull();
+
+		store.setPathfinderEndpoint('start', { tableId: 'a', columnName: 'k' });
+		expect(store.pathfinderStart).toEqual({ tableId: 'a', columnName: 'k' });
+		store.clearPathfinder();
+		expect(store.pathfinderStart).toBeNull();
+		expect(store.pathfinderResult).toBeNull();
+	});
+
+	it('findPath walks existing joins A→B→C with no gaps', () => {
+		const store = new SchemaCanvasStore('conn-pf');
+		const a = store.addTable(candidate('public', 'a', ['k']), { x: 0, y: 0 });
+		const b = store.addTable(candidate('public', 'b', ['k', 'm']), { x: 100, y: 0 });
+		const c = store.addTable(candidate('public', 'c', ['m']), { x: 200, y: 0 });
+		store.addJoin({
+			sourceTableId: a.id,
+			sourceColumnName: 'k',
+			targetTableId: b.id,
+			targetColumnName: 'k',
+			kind: 'inner'
+		});
+		store.addJoin({
+			sourceTableId: b.id,
+			sourceColumnName: 'm',
+			targetTableId: c.id,
+			targetColumnName: 'm',
+			kind: 'inner'
+		});
+
+		store.setPathfinderEndpoint('start', { tableId: a.id, columnName: 'k' });
+		store.setPathfinderEndpoint('end', { tableId: c.id, columnName: 'm' });
+		store.findPath();
+		expect(store.pathfinderResult?.hasGaps).toBe(false);
+		expect(store.pathfinderResult?.steps).toHaveLength(2);
+	});
+
+	it('findPath proposes a virtual edge across a gap; applyPathfinderJoins commits it', () => {
+		const store = new SchemaCanvasStore('conn-pf');
+		const a = store.addTable(candidate('public', 'a', ['shared']), { x: 0, y: 0 });
+		const c = store.addTable(candidate('public', 'c', ['shared']), { x: 200, y: 0 });
+		store.setPathfinderEndpoint('start', { tableId: a.id, columnName: 'shared' });
+		store.setPathfinderEndpoint('end', { tableId: c.id, columnName: 'shared' });
+		store.findPath();
+		expect(store.pathfinderResult?.hasGaps).toBe(true);
+		expect(store.doc.joins).toHaveLength(0);
+
+		const added = store.applyPathfinderJoins();
+		expect(added).toBe(1);
+		expect(store.doc.joins).toHaveLength(1);
+	});
+});
+
+// ── Session lifecycle (issue #1180, bucket 7) ───────────────────────────────
+describe('SchemaCanvasStore — session lifecycle (#1180)', () => {
+	it('setLabel writes the cube label', () => {
+		const store = new SchemaCanvasStore('conn-sess');
+		store.setLabel('Q3 Revenue');
+		expect(store.doc.label).toBe('Q3 Revenue');
+	});
+
+	it('setMode + setDefaultLayoutMode update the fields', () => {
+		const store = new SchemaCanvasStore('conn-sess');
+		store.setMode('workbench');
+		expect(store.mode).toBe('workbench');
+		store.setDefaultLayoutMode('star');
+		expect(store.defaultLayoutMode).toBe('star');
+	});
+
+	it('switchConnection swaps the doc and resets UI state; same-connection is a no-op', () => {
+		const store = new SchemaCanvasStore('conn-A');
+		store.addTable(candidate('public', 't', ['id']), { x: 0, y: 0 });
+		store.selectedTableId = store.doc.tables[0].id;
+
+		store.switchConnection('conn-B');
+		expect(store.connectionId).toBe('conn-B');
+		expect(store.doc.tables).toHaveLength(0); // fresh doc for conn-B
+		expect(store.selectedTableId).toBeNull();
+	});
+
+	it('resetCanvas blanks the doc for the current connection', () => {
+		const store = new SchemaCanvasStore('conn-sess');
+		store.addTable(candidate('public', 't', ['id']), { x: 0, y: 0 });
+		store.resetCanvas();
+		expect(store.doc.tables).toHaveLength(0);
+		expect(store.connectionId).toBe('conn-sess');
+	});
+
+	it('loadDoc replaces the doc and is undoable', () => {
+		const store = new SchemaCanvasStore('conn-sess');
+		store.addTable(candidate('public', 'orig', ['id']), { x: 0, y: 0 });
+		const snapshot = JSON.parse(JSON.stringify(store.doc));
+		store.loadDoc({ ...snapshot, label: 'Imported', tables: [] });
+		expect(store.doc.label).toBe('Imported');
+		expect(store.doc.tables).toHaveLength(0);
+		store.undo();
+		expect(store.doc.tables.map((t) => t.name)).toEqual(['orig']);
+	});
+
+	it('setSidebarQueryFromUser sets the query and clears the click highlight', () => {
+		const store = new SchemaCanvasStore('conn-sess');
+		store.highlightColumn('k');
+		store.setSidebarQueryFromUser('cust');
+		expect(store.sidebarQuery).toBe('cust');
+		expect(store.highlightedColumn).toBeNull();
+	});
+
+	it('togglePickMode / exitPickMode / cancelEShift drive pick-mode state', () => {
+		const store = new SchemaCanvasStore('conn-sess');
+		store.togglePickMode();
+		expect(store.pickModeActive).toBe(true);
+		store.exitPickMode();
+		expect(store.pickModeActive).toBe(false);
+		store.togglePickMode();
+		store.cancelEShift();
+		expect(store.pickModeActive).toBe(false);
+		expect(store.eShiftPicks).toHaveLength(0);
+	});
+});
+
+// ── Workbench working set (issue #1180, bucket 8) ───────────────────────────
+describe('SchemaCanvasStore — workbench working set (#1180)', () => {
+	it('addToWorkbench (idempotent) / removeFromWorkbench / clearWorkbench', () => {
+		const store = new SchemaCanvasStore('conn-wb');
+		const t = store.addTable(candidate('public', 't', ['id']), { x: 0, y: 0 });
+		store.addToWorkbench(t.id);
+		store.addToWorkbench(t.id); // no-op
+		expect(store.workbenchTables.map((x) => x.name)).toEqual(['t']);
+
+		store.removeFromWorkbench(t.id);
+		expect(store.workbenchTables).toHaveLength(0);
+
+		store.addToWorkbench(t.id);
+		store.clearWorkbench();
+		expect(store.workbenchTables).toHaveLength(0);
+	});
+});

--- a/saiku-ui/src/lib/cube-designer/state.test.ts
+++ b/saiku-ui/src/lib/cube-designer/state.test.ts
@@ -1,353 +1,390 @@
-import { describe, it, expect } from 'vitest';
-import { SchemaCanvasStore } from './state.svelte.js';
+import { describe, it, expect } from "vitest";
+import { SchemaCanvasStore } from "./state.svelte.js";
 
-describe('SchemaCanvasStore cubes', () => {
-	it('addCube + addMeasureGroup + toggleMeasureColumn build a cube on the doc', () => {
-		// Arrange
-		const store = new SchemaCanvasStore('conn-1');
+describe("SchemaCanvasStore cubes", () => {
+  it("addCube + addMeasureGroup + toggleMeasureColumn build a cube on the doc", () => {
+    // Arrange
+    const store = new SchemaCanvasStore("conn-1");
 
-		// Act
-		const cube = store.addCube({ name: 'Sales' });
-		const mg = store.addMeasureGroup(cube.id, { name: 'Facts', factTableId: 'f' });
-		store.toggleMeasureColumn(cube.id, mg!.id, 'amount');
-		store.toggleMeasureColumn(cube.id, mg!.id, 'qty');
-		store.toggleMeasureColumn(cube.id, mg!.id, 'amount'); // toggles amount back off
+    // Act
+    const cube = store.addCube({ name: "Sales" });
+    const mg = store.addMeasureGroup(cube.id, {
+      name: "Facts",
+      factTableId: "f",
+    });
+    store.toggleMeasureColumn(cube.id, mg!.id, "amount");
+    store.toggleMeasureColumn(cube.id, mg!.id, "qty");
+    store.toggleMeasureColumn(cube.id, mg!.id, "amount"); // toggles amount back off
 
-		// Assert
-		expect(mg).not.toBeNull();
-		expect(store.cubes).toHaveLength(1);
-		const group = store.cubes[0].measureGroups[0];
-		expect(group.measureColumns).toEqual(['qty']);
-		expect(group.factTableId).toBe('f');
-	});
+    // Assert
+    expect(mg).not.toBeNull();
+    expect(store.cubes).toHaveLength(1);
+    const group = store.cubes[0].measureGroups[0];
+    expect(group.measureColumns).toEqual(["qty"]);
+    expect(group.factTableId).toBe("f");
+  });
 
-	it('setMeasureGroupDimLink upserts by dimensionId', () => {
-		// Arrange
-		const store = new SchemaCanvasStore('conn-2');
-		const cube = store.addCube({});
-		const mg = store.addMeasureGroup(cube.id, { factTableId: 'f' })!;
+  it("setMeasureGroupDimLink upserts by dimensionId", () => {
+    // Arrange
+    const store = new SchemaCanvasStore("conn-2");
+    const cube = store.addCube({});
+    const mg = store.addMeasureGroup(cube.id, { factTableId: "f" })!;
 
-		// Act
-		store.setMeasureGroupDimLink(cube.id, mg.id, { dimensionId: 'd1', foreignKeyColumn: 'a' });
-		store.setMeasureGroupDimLink(cube.id, mg.id, { dimensionId: 'd1', foreignKeyColumn: 'b' });
-		store.setMeasureGroupDimLink(cube.id, mg.id, { dimensionId: 'd2', foreignKeyColumn: 'c' });
+    // Act
+    store.setMeasureGroupDimLink(cube.id, mg.id, {
+      dimensionId: "d1",
+      foreignKeyColumn: "a",
+    });
+    store.setMeasureGroupDimLink(cube.id, mg.id, {
+      dimensionId: "d1",
+      foreignKeyColumn: "b",
+    });
+    store.setMeasureGroupDimLink(cube.id, mg.id, {
+      dimensionId: "d2",
+      foreignKeyColumn: "c",
+    });
 
-		// Assert
-		const links = store.cubes[0].measureGroups[0].dimensionLinks ?? [];
-		expect(links).toHaveLength(2);
-		expect(links.find((l) => l.dimensionId === 'd1')?.foreignKeyColumn).toBe('b');
-	});
+    // Assert
+    const links = store.cubes[0].measureGroups[0].dimensionLinks ?? [];
+    expect(links).toHaveLength(2);
+    expect(links.find((l) => l.dimensionId === "d1")?.foreignKeyColumn).toBe(
+      "b",
+    );
+  });
 
-	it('bumpWorkbenchReload increments the reload nonce', () => {
-		// Arrange
-		const store = new SchemaCanvasStore('conn-3');
-		const before = store.workbenchReloadNonce;
+  it("bumpWorkbenchReload increments the reload nonce", () => {
+    // Arrange
+    const store = new SchemaCanvasStore("conn-3");
+    const before = store.workbenchReloadNonce;
 
-		// Act
-		store.bumpWorkbenchReload();
+    // Act
+    store.bumpWorkbenchReload();
 
-		// Assert
-		expect(store.workbenchReloadNonce).toBe(before + 1);
-	});
+    // Assert
+    expect(store.workbenchReloadNonce).toBe(before + 1);
+  });
 });
 
 // A stand-in candidate for addTable: minimal shape the tests rely on.
 function candidate(schema: string, name: string, columns: string[]) {
-	return {
-		schema,
-		name,
-		onCanvas: false,
-		columns: columns.map((n) => ({ name: n, sqlType: 'VARCHAR' as const }))
-	};
+  return {
+    schema,
+    name,
+    onCanvas: false,
+    columns: columns.map((n) => ({ name: n, sqlType: "VARCHAR" as const })),
+  };
 }
 
-describe('Create Joins Mode — pushEShiftPick (one column per table)', () => {
-	it('appends a pick for a new table', () => {
-		const store = new SchemaCanvasStore('conn-picks-1');
-		store.pushEShiftPick('t1', 'a');
-		expect(store.eShiftPicks).toEqual([{ tableId: 't1', columnName: 'a' }]);
-	});
+describe("Create Joins Mode — pushEShiftPick (one column per table)", () => {
+  it("appends a pick for a new table", () => {
+    const store = new SchemaCanvasStore("conn-picks-1");
+    store.pushEShiftPick("t1", "a");
+    expect(store.eShiftPicks).toEqual([{ tableId: "t1", columnName: "a" }]);
+  });
 
-	it('appends a second pick when it is a different table', () => {
-		const store = new SchemaCanvasStore('conn-picks-2');
-		store.pushEShiftPick('t1', 'a');
-		store.pushEShiftPick('t2', 'b');
-		expect(store.eShiftPicks).toEqual([
-			{ tableId: 't1', columnName: 'a' },
-			{ tableId: 't2', columnName: 'b' }
-		]);
-	});
+  it("appends a second pick when it is a different table", () => {
+    const store = new SchemaCanvasStore("conn-picks-2");
+    store.pushEShiftPick("t1", "a");
+    store.pushEShiftPick("t2", "b");
+    expect(store.eShiftPicks).toEqual([
+      { tableId: "t1", columnName: "a" },
+      { tableId: "t2", columnName: "b" },
+    ]);
+  });
 
-	it('REPLACES the existing pick when a different column is picked on the same table', () => {
-		const store = new SchemaCanvasStore('conn-picks-3');
-		store.pushEShiftPick('t1', 'a');
-		store.pushEShiftPick('t2', 'x');
-		// Second pick on t1 — should REPLACE `a`, not append.
-		store.pushEShiftPick('t1', 'b');
-		expect(store.eShiftPicks).toEqual([
-			{ tableId: 't1', columnName: 'b' },
-			{ tableId: 't2', columnName: 'x' }
-		]);
-	});
+  it("REPLACES the existing pick when a different column is picked on the same table", () => {
+    const store = new SchemaCanvasStore("conn-picks-3");
+    store.pushEShiftPick("t1", "a");
+    store.pushEShiftPick("t2", "x");
+    // Second pick on t1 — should REPLACE `a`, not append.
+    store.pushEShiftPick("t1", "b");
+    expect(store.eShiftPicks).toEqual([
+      { tableId: "t1", columnName: "b" },
+      { tableId: "t2", columnName: "x" },
+    ]);
+  });
 
-	it('toggles off when the exact same (table, column) is re-clicked', () => {
-		const store = new SchemaCanvasStore('conn-picks-4');
-		store.pushEShiftPick('t1', 'a');
-		store.pushEShiftPick('t1', 'a');
-		expect(store.eShiftPicks).toEqual([]);
-	});
+  it("toggles off when the exact same (table, column) is re-clicked", () => {
+    const store = new SchemaCanvasStore("conn-picks-4");
+    store.pushEShiftPick("t1", "a");
+    store.pushEShiftPick("t1", "a");
+    expect(store.eShiftPicks).toEqual([]);
+  });
 
-	it('never allows two picks on the same table across many rapid clicks', () => {
-		const store = new SchemaCanvasStore('conn-picks-5');
-		store.pushEShiftPick('t1', 'a');
-		store.pushEShiftPick('t1', 'b');
-		store.pushEShiftPick('t1', 'c');
-		store.pushEShiftPick('t1', 'd');
-		// Only the most-recent pick per table survives.
-		expect(store.eShiftPicks).toEqual([{ tableId: 't1', columnName: 'd' }]);
-	});
+  it("never allows two picks on the same table across many rapid clicks", () => {
+    const store = new SchemaCanvasStore("conn-picks-5");
+    store.pushEShiftPick("t1", "a");
+    store.pushEShiftPick("t1", "b");
+    store.pushEShiftPick("t1", "c");
+    store.pushEShiftPick("t1", "d");
+    // Only the most-recent pick per table survives.
+    expect(store.eShiftPicks).toEqual([{ tableId: "t1", columnName: "d" }]);
+  });
 });
 
-describe('Create Joins Mode — autoPickGroupName', () => {
-	it('returns empty string when there are no picks', () => {
-		const store = new SchemaCanvasStore('conn-auto-1');
-		expect(store.autoPickGroupName()).toBe('');
-	});
+describe("Create Joins Mode — autoPickGroupName", () => {
+  it("returns empty string when there are no picks", () => {
+    const store = new SchemaCanvasStore("conn-auto-1");
+    expect(store.autoPickGroupName()).toBe("");
+  });
 
-	it('uses the shared column name when every pick has the same name', () => {
-		const store = new SchemaCanvasStore('conn-auto-2');
-		store.pushEShiftPick('t1', 'customer_id');
-		store.pushEShiftPick('t2', 'customer_id');
-		store.pushEShiftPick('t3', 'customer_id');
-		expect(store.autoPickGroupName()).toBe('customer_id');
-	});
+  it("uses the shared column name when every pick has the same name", () => {
+    const store = new SchemaCanvasStore("conn-auto-2");
+    store.pushEShiftPick("t1", "customer_id");
+    store.pushEShiftPick("t2", "customer_id");
+    store.pushEShiftPick("t3", "customer_id");
+    expect(store.autoPickGroupName()).toBe("customer_id");
+  });
 
-	it('falls back to the most common column name when picks differ', () => {
-		const store = new SchemaCanvasStore('conn-auto-3');
-		store.pushEShiftPick('t1', 'customer_id');
-		store.pushEShiftPick('t2', 'customer_id');
-		store.pushEShiftPick('t3', 'cust_id');
-		expect(store.autoPickGroupName()).toBe('customer_id');
-	});
+  it("falls back to the most common column name when picks differ", () => {
+    const store = new SchemaCanvasStore("conn-auto-3");
+    store.pushEShiftPick("t1", "customer_id");
+    store.pushEShiftPick("t2", "customer_id");
+    store.pushEShiftPick("t3", "cust_id");
+    expect(store.autoPickGroupName()).toBe("customer_id");
+  });
 
-	it('uses the first-seen column name when there is no majority', () => {
-		const store = new SchemaCanvasStore('conn-auto-4');
-		store.pushEShiftPick('t1', 'foo');
-		store.pushEShiftPick('t2', 'bar');
-		// bar and foo tied at 1 each — first-seen (foo) wins.
-		expect(store.autoPickGroupName()).toBe('foo');
-	});
+  it("uses the first-seen column name when there is no majority", () => {
+    const store = new SchemaCanvasStore("conn-auto-4");
+    store.pushEShiftPick("t1", "foo");
+    store.pushEShiftPick("t2", "bar");
+    // bar and foo tied at 1 each — first-seen (foo) wins.
+    expect(store.autoPickGroupName()).toBe("foo");
+  });
 });
 
-describe('Create Joins Mode — commitEShiftPicks', () => {
-	function makeStoreWithTables() {
-		const store = new SchemaCanvasStore('conn-commit');
-		const a = store.addTable(candidate('public', 'a', ['id', 'name']), { x: 0, y: 0 });
-		const b = store.addTable(candidate('public', 'b', ['id', 'a_id']), { x: 200, y: 0 });
-		const c = store.addTable(candidate('public', 'c', ['id', 'a_id']), { x: 400, y: 0 });
-		return { store, a, b, c };
-	}
+describe("Create Joins Mode — commitEShiftPicks", () => {
+  function makeStoreWithTables() {
+    const store = new SchemaCanvasStore("conn-commit");
+    const a = store.addTable(candidate("public", "a", ["id", "name"]), {
+      x: 0,
+      y: 0,
+    });
+    const b = store.addTable(candidate("public", "b", ["id", "a_id"]), {
+      x: 200,
+      y: 0,
+    });
+    const c = store.addTable(candidate("public", "c", ["id", "a_id"]), {
+      x: 400,
+      y: 0,
+    });
+    return { store, a, b, c };
+  }
 
-	it('is a no-op when fewer than 2 picks exist', () => {
-		const { store, a } = makeStoreWithTables();
-		store.pushEShiftPick(a.id, 'id');
-		const joinsBefore = store.doc.joins.length;
-		store.commitEShiftPicks();
-		expect(store.doc.joins.length).toBe(joinsBefore);
-	});
+  it("is a no-op when fewer than 2 picks exist", () => {
+    const { store, a } = makeStoreWithTables();
+    store.pushEShiftPick(a.id, "id");
+    const joinsBefore = store.doc.joins.length;
+    store.commitEShiftPicks();
+    expect(store.doc.joins.length).toBe(joinsBefore);
+  });
 
-	it('creates N-1 joins in a star pattern from pick[0] to each peer', () => {
-		const { store, a, b, c } = makeStoreWithTables();
-		store.pushEShiftPick(a.id, 'id');
-		store.pushEShiftPick(b.id, 'a_id');
-		store.pushEShiftPick(c.id, 'a_id');
-		const joinsBefore = store.doc.joins.length;
-		store.commitEShiftPicks();
-		// 3 picks → 2 joins (a→b, a→c).
-		expect(store.doc.joins.length - joinsBefore).toBe(2);
-		const created = store.doc.joins.slice(joinsBefore);
-		expect(created.every((j) => j.sourceTableId === a.id)).toBe(true);
-		expect(created.map((j) => j.targetTableId).sort()).toEqual([b.id, c.id].sort());
-	});
+  it("creates N-1 joins in a star pattern from pick[0] to each peer", () => {
+    const { store, a, b, c } = makeStoreWithTables();
+    store.pushEShiftPick(a.id, "id");
+    store.pushEShiftPick(b.id, "a_id");
+    store.pushEShiftPick(c.id, "a_id");
+    const joinsBefore = store.doc.joins.length;
+    store.commitEShiftPicks();
+    // 3 picks → 2 joins (a→b, a→c).
+    expect(store.doc.joins.length - joinsBefore).toBe(2);
+    const created = store.doc.joins.slice(joinsBefore);
+    expect(created.every((j) => j.sourceTableId === a.id)).toBe(true);
+    expect(created.map((j) => j.targetTableId).sort()).toEqual(
+      [b.id, c.id].sort(),
+    );
+  });
 
-	it('clears the pick set and exits Create Joins Mode after commit', () => {
-		const { store, a, b } = makeStoreWithTables();
-		store.enterPickMode();
-		store.pushEShiftPick(a.id, 'id');
-		store.pushEShiftPick(b.id, 'a_id');
-		store.commitEShiftPicks();
-		expect(store.eShiftPicks).toEqual([]);
-		expect(store.pickModeActive).toBe(false);
-	});
+  it("clears the pick set and exits Create Joins Mode after commit", () => {
+    const { store, a, b } = makeStoreWithTables();
+    store.enterPickMode();
+    store.pushEShiftPick(a.id, "id");
+    store.pushEShiftPick(b.id, "a_id");
+    store.commitEShiftPicks();
+    expect(store.eShiftPicks).toEqual([]);
+    expect(store.pickModeActive).toBe(false);
+  });
 
-	it('applies groupName to every created join via joinGroupRenames', () => {
-		const { store, a, b, c } = makeStoreWithTables();
-		store.pushEShiftPick(a.id, 'id');
-		store.pushEShiftPick(b.id, 'a_id');
-		store.pushEShiftPick(c.id, 'a_id');
-		store.commitEShiftPicks('Account Key');
-		const renames = store.doc.joinGroupRenames ?? {};
-		// Every join added on this commit shares the same custom group label.
-		const labels = new Set(Object.values(renames));
-		expect(labels.has('Account Key')).toBe(true);
-	});
+  it("applies groupName to every created join via joinGroupRenames", () => {
+    const { store, a, b, c } = makeStoreWithTables();
+    store.pushEShiftPick(a.id, "id");
+    store.pushEShiftPick(b.id, "a_id");
+    store.pushEShiftPick(c.id, "a_id");
+    store.commitEShiftPicks("Account Key");
+    const renames = store.doc.joinGroupRenames ?? {};
+    // Every join added on this commit shares the same custom group label.
+    const labels = new Set(Object.values(renames));
+    expect(labels.has("Account Key")).toBe(true);
+  });
 
-	it('leaves joinGroupRenames untouched when no groupName supplied', () => {
-		const { store, a, b } = makeStoreWithTables();
-		store.pushEShiftPick(a.id, 'id');
-		store.pushEShiftPick(b.id, 'a_id');
-		const before = { ...(store.doc.joinGroupRenames ?? {}) };
-		store.commitEShiftPicks();
-		expect(store.doc.joinGroupRenames ?? {}).toEqual(before);
-	});
+  it("leaves joinGroupRenames untouched when no groupName supplied", () => {
+    const { store, a, b } = makeStoreWithTables();
+    store.pushEShiftPick(a.id, "id");
+    store.pushEShiftPick(b.id, "a_id");
+    const before = { ...(store.doc.joinGroupRenames ?? {}) };
+    store.commitEShiftPicks();
+    expect(store.doc.joinGroupRenames ?? {}).toEqual(before);
+  });
 });
 
-describe('Create Joins Mode — undo covers CJM commit', () => {
-	it('one Undo removes every join created by a single commitEShiftPicks batch', () => {
-		const store = new SchemaCanvasStore('conn-undo-commit');
-		const a = store.addTable(candidate('public', 'a', ['id']), { x: 0, y: 0 });
-		const b = store.addTable(candidate('public', 'b', ['a_id']), { x: 200, y: 0 });
-		const c = store.addTable(candidate('public', 'c', ['a_id']), { x: 400, y: 0 });
-		const joinsBefore = store.doc.joins.length;
-		store.pushEShiftPick(a.id, 'id');
-		store.pushEShiftPick(b.id, 'a_id');
-		store.pushEShiftPick(c.id, 'a_id');
-		store.commitEShiftPicks();
-		// 2 joins created.
-		expect(store.doc.joins.length).toBe(joinsBefore + 2);
-		// One undo reverts the whole batch.
-		store.undo();
-		expect(store.doc.joins.length).toBe(joinsBefore);
-	});
+describe("Create Joins Mode — undo covers CJM commit", () => {
+  it("one Undo removes every join created by a single commitEShiftPicks batch", () => {
+    const store = new SchemaCanvasStore("conn-undo-commit");
+    const a = store.addTable(candidate("public", "a", ["id"]), { x: 0, y: 0 });
+    const b = store.addTable(candidate("public", "b", ["a_id"]), {
+      x: 200,
+      y: 0,
+    });
+    const c = store.addTable(candidate("public", "c", ["a_id"]), {
+      x: 400,
+      y: 0,
+    });
+    const joinsBefore = store.doc.joins.length;
+    store.pushEShiftPick(a.id, "id");
+    store.pushEShiftPick(b.id, "a_id");
+    store.pushEShiftPick(c.id, "a_id");
+    store.commitEShiftPicks();
+    // 2 joins created.
+    expect(store.doc.joins.length).toBe(joinsBefore + 2);
+    // One undo reverts the whole batch.
+    store.undo();
+    expect(store.doc.joins.length).toBe(joinsBefore);
+  });
 });
 
-describe('addJoin — single-source-endpoint invariant', () => {
-	// Amelia hit this: `reserve_employee.first_name` had two joins in one
-	// group, one to `customer.fname` and one to `customer.lname`. A single
-	// source endpoint can only participate in ONE join per target table.
-	// Role-playing (SAME target column, DIFFERENT source columns) must
-	// still be legal.
+describe("addJoin — single-source-endpoint invariant", () => {
+  // Amelia hit this: `reserve_employee.first_name` had two joins in one
+  // group, one to `customer.fname` and one to `customer.lname`. A single
+  // source endpoint can only participate in ONE join per target table.
+  // Role-playing (SAME target column, DIFFERENT source columns) must
+  // still be legal.
 
-	function makePair() {
-		const store = new SchemaCanvasStore('conn-invariant');
-		const emp = store.addTable(
-			candidate('public', 'reserve_employee', ['first_name', 'last_name']),
-			{ x: 0, y: 0 }
-		);
-		const cust = store.addTable(candidate('public', 'customer', ['fname', 'lname']), {
-			x: 300,
-			y: 0
-		});
-		return { store, emp, cust };
-	}
+  function makePair() {
+    const store = new SchemaCanvasStore("conn-invariant");
+    const emp = store.addTable(
+      candidate("public", "reserve_employee", ["first_name", "last_name"]),
+      { x: 0, y: 0 },
+    );
+    const cust = store.addTable(
+      candidate("public", "customer", ["fname", "lname"]),
+      {
+        x: 300,
+        y: 0,
+      },
+    );
+    return { store, emp, cust };
+  }
 
-	it('replaces the existing join when the same source endpoint is repointed to a different target column', () => {
-		const { store, emp, cust } = makePair();
-		store.addJoin({
-			sourceTableId: emp.id,
-			sourceColumnName: 'first_name',
-			targetTableId: cust.id,
-			targetColumnName: 'fname',
-			kind: 'inner'
-		});
-		store.addJoin({
-			sourceTableId: emp.id,
-			sourceColumnName: 'first_name',
-			targetTableId: cust.id,
-			targetColumnName: 'lname',
-			kind: 'inner'
-		});
-		expect(store.doc.joins).toHaveLength(1);
-		expect(store.doc.joins[0].targetColumnName).toBe('lname');
-		expect(store.lastJoinFeedback?.message).toMatch(/Replaced join/i);
-		expect(store.lastJoinFeedback?.message).toContain('first_name');
-		expect(store.lastJoinFeedback?.message).toContain('fname');
-	});
+  it("replaces the existing join when the same source endpoint is repointed to a different target column", () => {
+    const { store, emp, cust } = makePair();
+    store.addJoin({
+      sourceTableId: emp.id,
+      sourceColumnName: "first_name",
+      targetTableId: cust.id,
+      targetColumnName: "fname",
+      kind: "inner",
+    });
+    store.addJoin({
+      sourceTableId: emp.id,
+      sourceColumnName: "first_name",
+      targetTableId: cust.id,
+      targetColumnName: "lname",
+      kind: "inner",
+    });
+    expect(store.doc.joins).toHaveLength(1);
+    expect(store.doc.joins[0].targetColumnName).toBe("lname");
+    expect(store.lastJoinFeedback?.message).toMatch(/Replaced join/i);
+    expect(store.lastJoinFeedback?.message).toContain("first_name");
+    expect(store.lastJoinFeedback?.message).toContain("fname");
+  });
 
-	it('also replaces when the tables are swapped (source ↔ target in the incoming join)', () => {
-		const { store, emp, cust } = makePair();
-		// Existing: emp.first_name → customer.fname
-		store.addJoin({
-			sourceTableId: emp.id,
-			sourceColumnName: 'first_name',
-			targetTableId: cust.id,
-			targetColumnName: 'fname',
-			kind: 'inner'
-		});
-		// Incoming, swapped: customer.lname → emp.first_name (same emp endpoint,
-		// different customer column) — treat as ambiguous, replace.
-		store.addJoin({
-			sourceTableId: cust.id,
-			sourceColumnName: 'lname',
-			targetTableId: emp.id,
-			targetColumnName: 'first_name',
-			kind: 'inner'
-		});
-		expect(store.doc.joins).toHaveLength(1);
-		const only = store.doc.joins[0];
-		expect(only.sourceTableId).toBe(cust.id);
-		expect(only.sourceColumnName).toBe('lname');
-		expect(only.targetTableId).toBe(emp.id);
-		expect(only.targetColumnName).toBe('first_name');
-	});
+  it("also replaces when the tables are swapped (source ↔ target in the incoming join)", () => {
+    const { store, emp, cust } = makePair();
+    // Existing: emp.first_name → customer.fname
+    store.addJoin({
+      sourceTableId: emp.id,
+      sourceColumnName: "first_name",
+      targetTableId: cust.id,
+      targetColumnName: "fname",
+      kind: "inner",
+    });
+    // Incoming, swapped: customer.lname → emp.first_name (same emp endpoint,
+    // different customer column) — treat as ambiguous, replace.
+    store.addJoin({
+      sourceTableId: cust.id,
+      sourceColumnName: "lname",
+      targetTableId: emp.id,
+      targetColumnName: "first_name",
+      kind: "inner",
+    });
+    expect(store.doc.joins).toHaveLength(1);
+    const only = store.doc.joins[0];
+    expect(only.sourceTableId).toBe(cust.id);
+    expect(only.sourceColumnName).toBe("lname");
+    expect(only.targetTableId).toBe(emp.id);
+    expect(only.targetColumnName).toBe("first_name");
+  });
 
-	it('preserves role-playing (different source columns joined to the same target column)', () => {
-		const store = new SchemaCanvasStore('conn-role-play');
-		const fact = store.addTable(
-			candidate('public', 'sales', ['order_date', 'ship_date', 'invoice_date']),
-			{ x: 0, y: 0 }
-		);
-		const date = store.addTable(candidate('public', 'date_dim', ['date_id']), { x: 300, y: 0 });
-		store.addJoin({
-			sourceTableId: fact.id,
-			sourceColumnName: 'order_date',
-			targetTableId: date.id,
-			targetColumnName: 'date_id',
-			kind: 'inner'
-		});
-		store.addJoin({
-			sourceTableId: fact.id,
-			sourceColumnName: 'ship_date',
-			targetTableId: date.id,
-			targetColumnName: 'date_id',
-			kind: 'inner'
-		});
-		store.addJoin({
-			sourceTableId: fact.id,
-			sourceColumnName: 'invoice_date',
-			targetTableId: date.id,
-			targetColumnName: 'date_id',
-			kind: 'inner'
-		});
-		expect(store.doc.joins).toHaveLength(3);
-		expect(store.doc.joins.map((j) => j.sourceColumnName).sort()).toEqual([
-			'invoice_date',
-			'order_date',
-			'ship_date'
-		]);
-	});
+  it("preserves role-playing (different source columns joined to the same target column)", () => {
+    const store = new SchemaCanvasStore("conn-role-play");
+    const fact = store.addTable(
+      candidate("public", "sales", ["order_date", "ship_date", "invoice_date"]),
+      { x: 0, y: 0 },
+    );
+    const date = store.addTable(candidate("public", "date_dim", ["date_id"]), {
+      x: 300,
+      y: 0,
+    });
+    store.addJoin({
+      sourceTableId: fact.id,
+      sourceColumnName: "order_date",
+      targetTableId: date.id,
+      targetColumnName: "date_id",
+      kind: "inner",
+    });
+    store.addJoin({
+      sourceTableId: fact.id,
+      sourceColumnName: "ship_date",
+      targetTableId: date.id,
+      targetColumnName: "date_id",
+      kind: "inner",
+    });
+    store.addJoin({
+      sourceTableId: fact.id,
+      sourceColumnName: "invoice_date",
+      targetTableId: date.id,
+      targetColumnName: "date_id",
+      kind: "inner",
+    });
+    expect(store.doc.joins).toHaveLength(3);
+    expect(store.doc.joins.map((j) => j.sourceColumnName).sort()).toEqual([
+      "invoice_date",
+      "order_date",
+      "ship_date",
+    ]);
+  });
 
-	it('still dedupes an exact tuple duplicate (no-op replace)', () => {
-		const { store, emp, cust } = makePair();
-		const first = store.addJoin({
-			sourceTableId: emp.id,
-			sourceColumnName: 'first_name',
-			targetTableId: cust.id,
-			targetColumnName: 'fname',
-			kind: 'inner'
-		});
-		const second = store.addJoin({
-			sourceTableId: emp.id,
-			sourceColumnName: 'first_name',
-			targetTableId: cust.id,
-			targetColumnName: 'fname',
-			kind: 'inner'
-		});
-		expect(store.doc.joins).toHaveLength(1);
-		// It's the second call's id that survives (existing tuple dedupe replaces).
-		expect(store.doc.joins[0].id).toBe(second.id);
-		expect(first.id).not.toBe(second.id);
-	});
+  it("still dedupes an exact tuple duplicate (no-op replace)", () => {
+    const { store, emp, cust } = makePair();
+    const first = store.addJoin({
+      sourceTableId: emp.id,
+      sourceColumnName: "first_name",
+      targetTableId: cust.id,
+      targetColumnName: "fname",
+      kind: "inner",
+    });
+    const second = store.addJoin({
+      sourceTableId: emp.id,
+      sourceColumnName: "first_name",
+      targetTableId: cust.id,
+      targetColumnName: "fname",
+      kind: "inner",
+    });
+    expect(store.doc.joins).toHaveLength(1);
+    // It's the second call's id that survives (existing tuple dedupe replaces).
+    expect(store.doc.joins[0].id).toBe(second.id);
+    expect(first.id).not.toBe(second.id);
+  });
 });
 
 // ── Undo primitives (issue #1180, bucket 1) ─────────────────────────────────
@@ -357,643 +394,723 @@ describe('addJoin — single-source-endpoint invariant', () => {
 // which case only the batch's entry snapshot is kept so N mutations collapse to
 // one Undo step. undo() swaps previousDoc↔doc so it doubles as redo. Amelia's
 // #1144 pushed the snapshot into base mutations; this locks the invariants.
-describe('SchemaCanvasStore — undo primitives (#1180)', () => {
-	function storeWith(...names: string[]): SchemaCanvasStore {
-		const store = new SchemaCanvasStore('conn-undo');
-		names.forEach((n, i) => store.addTable(candidate('public', n, ['id']), { x: i * 10, y: 0 }));
-		return store;
-	}
+describe("SchemaCanvasStore — undo primitives (#1180)", () => {
+  function storeWith(...names: string[]): SchemaCanvasStore {
+    const store = new SchemaCanvasStore("conn-undo");
+    names.forEach((n, i) =>
+      store.addTable(candidate("public", n, ["id"]), { x: i * 10, y: 0 }),
+    );
+    return store;
+  }
 
-	it('a base mutation is a single undoable step', () => {
-		const store = new SchemaCanvasStore('conn-undo');
-		store.addTable(candidate('public', 't1', ['id']), { x: 0, y: 0 });
-		expect(store.doc.tables).toHaveLength(1);
+  it("a base mutation is a single undoable step", () => {
+    const store = new SchemaCanvasStore("conn-undo");
+    store.addTable(candidate("public", "t1", ["id"]), { x: 0, y: 0 });
+    expect(store.doc.tables).toHaveLength(1);
 
-		store.undo();
-		expect(store.doc.tables).toHaveLength(0);
-	});
+    store.undo();
+    expect(store.doc.tables).toHaveLength(0);
+  });
 
-	it('undo is single-level — reverts only the most recent action', () => {
-		const store = storeWith('t1', 't2');
-		expect(store.doc.tables).toHaveLength(2);
+  it("undo is single-level — reverts only the most recent action", () => {
+    const store = storeWith("t1", "t2");
+    expect(store.doc.tables).toHaveLength(2);
 
-		store.undo(); // reverts the t2 add only
-		expect(store.doc.tables.map((t) => t.name)).toEqual(['t1']);
-	});
+    store.undo(); // reverts the t2 add only
+    expect(store.doc.tables.map((t) => t.name)).toEqual(["t1"]);
+  });
 
-	it('withUndoBatch collapses N mutations into ONE undo step', () => {
-		const store = new SchemaCanvasStore('conn-undo');
-		store.withUndoBatch(() => {
-			store.addTable(candidate('public', 't1', ['id']), { x: 0, y: 0 });
-			store.addTable(candidate('public', 't2', ['id']), { x: 10, y: 0 });
-			store.addTable(candidate('public', 't3', ['id']), { x: 20, y: 0 });
-		});
-		expect(store.doc.tables).toHaveLength(3);
+  it("withUndoBatch collapses N mutations into ONE undo step", () => {
+    const store = new SchemaCanvasStore("conn-undo");
+    store.withUndoBatch(() => {
+      store.addTable(candidate("public", "t1", ["id"]), { x: 0, y: 0 });
+      store.addTable(candidate("public", "t2", ["id"]), { x: 10, y: 0 });
+      store.addTable(candidate("public", "t3", ["id"]), { x: 20, y: 0 });
+    });
+    expect(store.doc.tables).toHaveLength(3);
 
-		store.undo(); // one snapshot at batch entry (empty) → all three revert
-		expect(store.doc.tables).toHaveLength(0);
-	});
+    store.undo(); // one snapshot at batch entry (empty) → all three revert
+    expect(store.doc.tables).toHaveLength(0);
+  });
 
-	it('nested withUndoBatch only snapshots at the outermost entry', () => {
-		const store = storeWith('t0'); // pre-existing table before the batch
-		store.withUndoBatch(() => {
-			store.addTable(candidate('public', 't1', ['id']), { x: 10, y: 0 });
-			store.withUndoBatch(() => {
-				store.addTable(candidate('public', 't2', ['id']), { x: 20, y: 0 });
-			});
-		});
-		expect(store.doc.tables).toHaveLength(3);
+  it("nested withUndoBatch only snapshots at the outermost entry", () => {
+    const store = storeWith("t0"); // pre-existing table before the batch
+    store.withUndoBatch(() => {
+      store.addTable(candidate("public", "t1", ["id"]), { x: 10, y: 0 });
+      store.withUndoBatch(() => {
+        store.addTable(candidate("public", "t2", ["id"]), { x: 20, y: 0 });
+      });
+    });
+    expect(store.doc.tables).toHaveLength(3);
 
-		store.undo(); // reverts to the outer-batch entry state (just t0)
-		expect(store.doc.tables.map((t) => t.name)).toEqual(['t0']);
-	});
+    store.undo(); // reverts to the outer-batch entry state (just t0)
+    expect(store.doc.tables.map((t) => t.name)).toEqual(["t0"]);
+  });
 
-	it('undo doubles as redo — a second undo re-applies', () => {
-		const store = new SchemaCanvasStore('conn-undo');
-		store.addTable(candidate('public', 't1', ['id']), { x: 0, y: 0 });
+  it("undo doubles as redo — a second undo re-applies", () => {
+    const store = new SchemaCanvasStore("conn-undo");
+    store.addTable(candidate("public", "t1", ["id"]), { x: 0, y: 0 });
 
-		store.undo(); // remove t1
-		expect(store.doc.tables).toHaveLength(0);
-		store.undo(); // swap back — redo
-		expect(store.doc.tables.map((t) => t.name)).toEqual(['t1']);
-	});
+    store.undo(); // remove t1
+    expect(store.doc.tables).toHaveLength(0);
+    store.undo(); // swap back — redo
+    expect(store.doc.tables.map((t) => t.name)).toEqual(["t1"]);
+  });
 
-	it('clearPreviousDoc drops the pending snapshot so undo is a no-op', () => {
-		const store = new SchemaCanvasStore('conn-undo');
-		store.addTable(candidate('public', 't1', ['id']), { x: 0, y: 0 });
+  it("clearPreviousDoc drops the pending snapshot so undo is a no-op", () => {
+    const store = new SchemaCanvasStore("conn-undo");
+    store.addTable(candidate("public", "t1", ["id"]), { x: 0, y: 0 });
 
-		store.clearPreviousDoc();
-		store.undo();
-		expect(store.doc.tables).toHaveLength(1);
-	});
+    store.clearPreviousDoc();
+    store.undo();
+    expect(store.doc.tables).toHaveLength(1);
+  });
 
-	it('undo is a no-op on a fresh store with nothing to revert', () => {
-		const store = new SchemaCanvasStore('conn-undo');
-		expect(() => store.undo()).not.toThrow();
-		expect(store.doc.tables).toHaveLength(0);
-	});
+  it("undo is a no-op on a fresh store with nothing to revert", () => {
+    const store = new SchemaCanvasStore("conn-undo");
+    expect(() => store.undo()).not.toThrow();
+    expect(store.doc.tables).toHaveLength(0);
+  });
 
-	it('removeJoins under a batch reverts in one undo', () => {
-		const store = storeWith('a', 'b');
-		const [a, b] = store.doc.tables;
-		store.addJoin({
-			sourceTableId: a.id,
-			sourceColumnName: 'id',
-			targetTableId: b.id,
-			targetColumnName: 'id',
-			kind: 'inner'
-		});
-		expect(store.doc.joins).toHaveLength(1);
+  it("removeJoins under a batch reverts in one undo", () => {
+    const store = storeWith("a", "b");
+    const [a, b] = store.doc.tables;
+    store.addJoin({
+      sourceTableId: a.id,
+      sourceColumnName: "id",
+      targetTableId: b.id,
+      targetColumnName: "id",
+      kind: "inner",
+    });
+    expect(store.doc.joins).toHaveLength(1);
 
-		store.removeJoins([store.doc.joins[0].id]);
-		expect(store.doc.joins).toHaveLength(0);
+    store.removeJoins([store.doc.joins[0].id]);
+    expect(store.doc.joins).toHaveLength(0);
 
-		store.undo(); // the join comes back
-		expect(store.doc.joins).toHaveLength(1);
-	});
+    store.undo(); // the join comes back
+    expect(store.doc.joins).toHaveLength(1);
+  });
 });
 
 // ── Table lifecycle (issue #1180, bucket 3) ─────────────────────────────────
-describe('SchemaCanvasStore — table lifecycle (#1180)', () => {
-	function twoTables(): { store: SchemaCanvasStore; a: string; b: string } {
-		const store = new SchemaCanvasStore('conn-tbl');
-		const a = store.addTable(candidate('public', 'a', ['id', 'k']), { x: 0, y: 0 });
-		const b = store.addTable(candidate('public', 'b', ['id', 'k']), { x: 100, y: 0 });
-		return { store, a: a.id, b: b.id };
-	}
+describe("SchemaCanvasStore — table lifecycle (#1180)", () => {
+  function twoTables(): { store: SchemaCanvasStore; a: string; b: string } {
+    const store = new SchemaCanvasStore("conn-tbl");
+    const a = store.addTable(candidate("public", "a", ["id", "k"]), {
+      x: 0,
+      y: 0,
+    });
+    const b = store.addTable(candidate("public", "b", ["id", "k"]), {
+      x: 100,
+      y: 0,
+    });
+    return { store, a: a.id, b: b.id };
+  }
 
-	it('removeTable drops the table and cascades its joins', () => {
-		const { store, a, b } = twoTables();
-		store.addJoin({
-			sourceTableId: a,
-			sourceColumnName: 'k',
-			targetTableId: b,
-			targetColumnName: 'k',
-			kind: 'inner'
-		});
-		expect(store.doc.joins).toHaveLength(1);
+  it("removeTable drops the table and cascades its joins", () => {
+    const { store, a, b } = twoTables();
+    store.addJoin({
+      sourceTableId: a,
+      sourceColumnName: "k",
+      targetTableId: b,
+      targetColumnName: "k",
+      kind: "inner",
+    });
+    expect(store.doc.joins).toHaveLength(1);
 
-		store.removeTable(a);
-		expect(store.doc.tables.map((t) => t.name)).toEqual(['b']);
-		expect(store.doc.joins).toHaveLength(0); // join referencing `a` cascaded
-	});
+    store.removeTable(a);
+    expect(store.doc.tables.map((t) => t.name)).toEqual(["b"]);
+    expect(store.doc.joins).toHaveLength(0); // join referencing `a` cascaded
+  });
 
-	it('removeTable clears the selection when the removed table was selected', () => {
-		const { store, a } = twoTables();
-		store.selectedTableId = a;
-		store.removeTable(a);
-		expect(store.selectedTableId).toBeNull();
-	});
+  it("removeTable clears the selection when the removed table was selected", () => {
+    const { store, a } = twoTables();
+    store.selectedTableId = a;
+    store.removeTable(a);
+    expect(store.selectedTableId).toBeNull();
+  });
 
-	it('moveTable updates position and is a no-op for an unknown id', () => {
-		const { store, a } = twoTables();
-		store.moveTable(a, { x: 42, y: 99 });
-		expect(store.doc.tables.find((t) => t.id === a)?.position).toEqual({ x: 42, y: 99 });
-		expect(() => store.moveTable('nope', { x: 1, y: 1 })).not.toThrow();
-	});
+  it("moveTable updates position and is a no-op for an unknown id", () => {
+    const { store, a } = twoTables();
+    store.moveTable(a, { x: 42, y: 99 });
+    expect(store.doc.tables.find((t) => t.id === a)?.position).toEqual({
+      x: 42,
+      y: 99,
+    });
+    expect(() => store.moveTable("nope", { x: 1, y: 1 })).not.toThrow();
+  });
 
-	it('setTableRole enforces a single fact — promoting one demotes the prior fact', () => {
-		const { store, a, b } = twoTables();
-		store.setTableRole(a, 'fact');
-		expect(store.doc.tables.find((t) => t.id === a)?.role).toBe('fact');
+  it("setTableRole enforces a single fact — promoting one demotes the prior fact", () => {
+    const { store, a, b } = twoTables();
+    store.setTableRole(a, "fact");
+    expect(store.doc.tables.find((t) => t.id === a)?.role).toBe("fact");
 
-		store.setTableRole(b, 'fact');
-		expect(store.doc.tables.find((t) => t.id === b)?.role).toBe('fact');
-		expect(store.doc.tables.find((t) => t.id === a)?.role).toBe('dimension');
-	});
+    store.setTableRole(b, "fact");
+    expect(store.doc.tables.find((t) => t.id === b)?.role).toBe("fact");
+    expect(store.doc.tables.find((t) => t.id === a)?.role).toBe("dimension");
+  });
 
-	it('toggleTableCollapsed cycles undefined ↔ true (never the force-show-all state)', () => {
-		const { store, a } = twoTables();
-		const t = () => store.doc.tables.find((x) => x.id === a)!;
-		expect(t().collapsed).toBeUndefined();
-		store.toggleTableCollapsed(a);
-		expect(t().collapsed).toBe(true);
-		store.toggleTableCollapsed(a);
-		expect(t().collapsed).toBeUndefined();
-	});
+  it("toggleTableCollapsed cycles undefined ↔ true (never the force-show-all state)", () => {
+    const { store, a } = twoTables();
+    const t = () => store.doc.tables.find((x) => x.id === a)!;
+    expect(t().collapsed).toBeUndefined();
+    store.toggleTableCollapsed(a);
+    expect(t().collapsed).toBe(true);
+    store.toggleTableCollapsed(a);
+    expect(t().collapsed).toBeUndefined();
+  });
 
-	it('expand/collapse-all + resetCollapseOverrides drive every table together', () => {
-		const { store } = twoTables();
-		store.collapseAllTables();
-		expect(store.doc.tables.every((t) => t.collapsed === true)).toBe(true);
-		store.expandAllTables();
-		expect(store.doc.tables.every((t) => t.collapsed === false)).toBe(true);
-		store.resetCollapseOverrides();
-		expect(store.doc.tables.every((t) => t.collapsed === undefined)).toBe(true);
-	});
+  it("expand/collapse-all + resetCollapseOverrides drive every table together", () => {
+    const { store } = twoTables();
+    store.collapseAllTables();
+    expect(store.doc.tables.every((t) => t.collapsed === true)).toBe(true);
+    store.expandAllTables();
+    expect(store.doc.tables.every((t) => t.collapsed === false)).toBe(true);
+    store.resetCollapseOverrides();
+    expect(store.doc.tables.every((t) => t.collapsed === undefined)).toBe(true);
+  });
 });
 
 // ── Join lifecycle (issue #1180, bucket 2) ──────────────────────────────────
-describe('SchemaCanvasStore — join lifecycle (#1180)', () => {
-	function joined(): { store: SchemaCanvasStore; a: string; b: string; joinId: string } {
-		const store = new SchemaCanvasStore('conn-join');
-		const a = store.addTable(candidate('public', 'a', ['id', 'k']), { x: 0, y: 0 });
-		const b = store.addTable(candidate('public', 'b', ['id', 'k']), { x: 100, y: 0 });
-		store.addJoin({
-			sourceTableId: a.id,
-			sourceColumnName: 'k',
-			targetTableId: b.id,
-			targetColumnName: 'k',
-			kind: 'inner'
-		});
-		return { store, a: a.id, b: b.id, joinId: store.doc.joins[0].id };
-	}
+describe("SchemaCanvasStore — join lifecycle (#1180)", () => {
+  function joined(): {
+    store: SchemaCanvasStore;
+    a: string;
+    b: string;
+    joinId: string;
+  } {
+    const store = new SchemaCanvasStore("conn-join");
+    const a = store.addTable(candidate("public", "a", ["id", "k"]), {
+      x: 0,
+      y: 0,
+    });
+    const b = store.addTable(candidate("public", "b", ["id", "k"]), {
+      x: 100,
+      y: 0,
+    });
+    store.addJoin({
+      sourceTableId: a.id,
+      sourceColumnName: "k",
+      targetTableId: b.id,
+      targetColumnName: "k",
+      kind: "inner",
+    });
+    return { store, a: a.id, b: b.id, joinId: store.doc.joins[0].id };
+  }
 
-	it('removeJoin drops a physical join and clears its selection', () => {
-		const { store, joinId } = joined();
-		store.selectedJoinId = joinId;
-		store.removeJoin(joinId);
-		expect(store.doc.joins).toHaveLength(0);
-		expect(store.selectedJoinId).toBeNull();
-	});
+  it("removeJoin drops a physical join and clears its selection", () => {
+    const { store, joinId } = joined();
+    store.selectedJoinId = joinId;
+    store.removeJoin(joinId);
+    expect(store.doc.joins).toHaveLength(0);
+    expect(store.selectedJoinId).toBeNull();
+  });
 
-	it('removeJoin is a no-op for cube-link joins (owned by the MeasureGroup FK)', () => {
-		const { store, joinId } = joined();
-		store.doc.joins[0].origin = 'cube-link';
-		store.removeJoin(joinId);
-		expect(store.doc.joins).toHaveLength(1); // untouched
-	});
+  it("removeJoin is a no-op for cube-link joins (owned by the MeasureGroup FK)", () => {
+    const { store, joinId } = joined();
+    store.doc.joins[0].origin = "cube-link";
+    store.removeJoin(joinId);
+    expect(store.doc.joins).toHaveLength(1); // untouched
+  });
 
-	it('removeAllJoins wipes joins + resets related state; no-op when already empty', () => {
-		const { store } = joined();
-		store.removeAllJoins();
-		expect(store.doc.joins).toHaveLength(0);
-		expect(store.selectedJoinId).toBeNull();
-		expect(() => store.removeAllJoins()).not.toThrow();
-	});
+  it("removeAllJoins wipes joins + resets related state; no-op when already empty", () => {
+    const { store } = joined();
+    store.removeAllJoins();
+    expect(store.doc.joins).toHaveLength(0);
+    expect(store.selectedJoinId).toBeNull();
+    expect(() => store.removeAllJoins()).not.toThrow();
+  });
 
-	it('setJoinKind changes the kind in place', () => {
-		const { store, joinId } = joined();
-		store.setJoinKind(joinId, 'left');
-		expect(store.doc.joins[0].kind).toBe('left');
-	});
+  it("setJoinKind changes the kind in place", () => {
+    const { store, joinId } = joined();
+    store.setJoinKind(joinId, "left");
+    expect(store.doc.joins[0].kind).toBe("left");
+  });
 
-	it('renameJoinGroup + joinGroupLabelFor round-trip; empty label reverts to the key', () => {
-		const { store } = joined();
-		const j = store.doc.joins[0];
-		const key = store.joinGroupLabelFor(j); // canonical key (no rename yet)
+  it("renameJoinGroup + joinGroupLabelFor round-trip; empty label reverts to the key", () => {
+    const { store } = joined();
+    const j = store.doc.joins[0];
+    const key = store.joinGroupLabelFor(j); // canonical key (no rename yet)
 
-		store.renameJoinGroup(key, 'Geography');
-		expect(store.joinGroupLabelFor(j)).toBe('Geography');
+    store.renameJoinGroup(key, "Geography");
+    expect(store.joinGroupLabelFor(j)).toBe("Geography");
 
-		store.renameJoinGroup(key, '   ');
-		expect(store.joinGroupLabelFor(j)).toBe(key);
-	});
+    store.renameJoinGroup(key, "   ");
+    expect(store.joinGroupLabelFor(j)).toBe(key);
+  });
 
-	it('createGroup + assignTableToGroup wire a table into a group and back out', () => {
-		const { store, a } = joined();
-		const g = store.createGroup('Dims');
-		expect(store.doc.groups.map((x) => x.label)).toContain('Dims');
+  it("createGroup + assignTableToGroup wire a table into a group and back out", () => {
+    const { store, a } = joined();
+    const g = store.createGroup("Dims");
+    expect(store.doc.groups.map((x) => x.label)).toContain("Dims");
 
-		store.assignTableToGroup(a, g.id);
-		expect(store.doc.tables.find((t) => t.id === a)?.groupId).toBe(g.id);
-		store.assignTableToGroup(a, null);
-		expect(store.doc.tables.find((t) => t.id === a)?.groupId).toBeNull();
-	});
+    store.assignTableToGroup(a, g.id);
+    expect(store.doc.tables.find((t) => t.id === a)?.groupId).toBe(g.id);
+    store.assignTableToGroup(a, null);
+    expect(store.doc.tables.find((t) => t.id === a)?.groupId).toBeNull();
+  });
 
-	it('linkSimilarOnCanvas joins every other table sharing the column (one undo step)', () => {
-		const store = new SchemaCanvasStore('conn-link');
-		const origin = store.addTable(candidate('public', 'fact', ['sales_id', 'cust_id']), {
-			x: 0,
-			y: 0
-		});
-		store.addTable(candidate('public', 'd1', ['cust_id']), { x: 100, y: 0 });
-		store.addTable(candidate('public', 'd2', ['cust_id']), { x: 200, y: 0 });
-		store.addTable(candidate('public', 'other', ['zzz']), { x: 300, y: 0 });
+  it("linkSimilarOnCanvas joins every other table sharing the column (one undo step)", () => {
+    const store = new SchemaCanvasStore("conn-link");
+    const origin = store.addTable(
+      candidate("public", "fact", ["sales_id", "cust_id"]),
+      {
+        x: 0,
+        y: 0,
+      },
+    );
+    store.addTable(candidate("public", "d1", ["cust_id"]), { x: 100, y: 0 });
+    store.addTable(candidate("public", "d2", ["cust_id"]), { x: 200, y: 0 });
+    store.addTable(candidate("public", "other", ["zzz"]), { x: 300, y: 0 });
 
-		const added = store.linkSimilarOnCanvas(origin.id, 'cust_id');
-		expect(added).toBe(2); // d1 + d2, not `other`
-		expect(store.doc.joins).toHaveLength(2);
+    const added = store.linkSimilarOnCanvas(origin.id, "cust_id");
+    expect(added).toBe(2); // d1 + d2, not `other`
+    expect(store.doc.joins).toHaveLength(2);
 
-		store.undo(); // one batch → all links revert together
-		expect(store.doc.joins).toHaveLength(0);
-	});
+    store.undo(); // one batch → all links revert together
+    expect(store.doc.joins).toHaveLength(0);
+  });
 
-	it('tryColumnClickJoin is highlight-only — it never creates a join', () => {
-		const { store, a } = joined();
-		const before = store.doc.joins.length;
-		store.tryColumnClickJoin(a, 'k');
-		expect(store.highlightedColumn).toBe('k');
-		expect(store.highlightOriginTableId).toBe(a);
-		expect(store.doc.joins).toHaveLength(before); // no join created
-		// Clicking the same column again clears the highlight.
-		store.tryColumnClickJoin(a, 'k');
-		expect(store.highlightedColumn).toBeNull();
-	});
+  it("tryColumnClickJoin is highlight-only — it never creates a join", () => {
+    const { store, a } = joined();
+    const before = store.doc.joins.length;
+    store.tryColumnClickJoin(a, "k");
+    expect(store.highlightedColumn).toBe("k");
+    expect(store.highlightOriginTableId).toBe(a);
+    expect(store.doc.joins).toHaveLength(before); // no join created
+    // Clicking the same column again clears the highlight.
+    store.tryColumnClickJoin(a, "k");
+    expect(store.highlightedColumn).toBeNull();
+  });
 });
 
 // ── Workbench: dimensions / hierarchies / levels / attributes (#1180 bucket 4)
-describe('SchemaCanvasStore — dimensions / hierarchies / levels / attributes (#1180)', () => {
-	it('addDimension names uniquely, sets primaryKeyTableId, and stays hierarchy-less without a column seed', () => {
-		const store = new SchemaCanvasStore('conn-dim');
-		const d1 = store.addDimension({ name: 'Customer', tableId: 't1' });
-		const d2 = store.addDimension({ name: 'Customer' });
-		expect(d1.name).toBe('Customer');
-		expect(d1.primaryKeyTableId).toBe('t1');
-		expect(d1.hierarchies).toHaveLength(0);
-		expect(d2.name).not.toBe('Customer'); // deduped
-	});
+describe("SchemaCanvasStore — dimensions / hierarchies / levels / attributes (#1180)", () => {
+  it("addDimension names uniquely, sets primaryKeyTableId, and stays hierarchy-less without a column seed", () => {
+    const store = new SchemaCanvasStore("conn-dim");
+    const d1 = store.addDimension({ name: "Customer", tableId: "t1" });
+    const d2 = store.addDimension({ name: "Customer" });
+    expect(d1.name).toBe("Customer");
+    expect(d1.primaryKeyTableId).toBe("t1");
+    expect(d1.hierarchies).toHaveLength(0);
+    expect(d2.name).not.toBe("Customer"); // deduped
+  });
 
-	it('addDimension with a column seed auto-creates one hierarchy + level', () => {
-		const store = new SchemaCanvasStore('conn-dim');
-		const d = store.addDimension({ name: 'Time', tableId: 't1', columnName: 'the_year' });
-		expect(d.hierarchies).toHaveLength(1);
-		expect(d.hierarchies[0].levels[0].columnName).toBe('the_year');
-	});
+  it("addDimension with a column seed auto-creates one hierarchy + level", () => {
+    const store = new SchemaCanvasStore("conn-dim");
+    const d = store.addDimension({
+      name: "Time",
+      tableId: "t1",
+      columnName: "the_year",
+    });
+    expect(d.hierarchies).toHaveLength(1);
+    expect(d.hierarchies[0].levels[0].columnName).toBe("the_year");
+  });
 
-	it('updateDimension patches + removeDimension drops it', () => {
-		const store = new SchemaCanvasStore('conn-dim');
-		const d = store.addDimension({ name: 'D' });
-		store.updateDimension(d.id, { caption: 'Display D' });
-		expect(store.dimensions.find((x) => x.id === d.id)?.caption).toBe('Display D');
-		store.removeDimension(d.id);
-		expect(store.dimensions).toHaveLength(0);
-	});
+  it("updateDimension patches + removeDimension drops it", () => {
+    const store = new SchemaCanvasStore("conn-dim");
+    const d = store.addDimension({ name: "D" });
+    store.updateDimension(d.id, { caption: "Display D" });
+    expect(store.dimensions.find((x) => x.id === d.id)?.caption).toBe(
+      "Display D",
+    );
+    store.removeDimension(d.id);
+    expect(store.dimensions).toHaveLength(0);
+  });
 
-	it('hierarchy + level lifecycle: add, dedupe same column, move, update, remove', () => {
-		const store = new SchemaCanvasStore('conn-dim');
-		const d = store.addDimension({ name: 'Geo' });
-		const h = store.addHierarchy(d.id, 'Region')!;
-		expect(h).not.toBeNull();
+  it("hierarchy + level lifecycle: add, dedupe same column, move, update, remove", () => {
+    const store = new SchemaCanvasStore("conn-dim");
+    const d = store.addDimension({ name: "Geo" });
+    const h = store.addHierarchy(d.id, "Region")!;
+    expect(h).not.toBeNull();
 
-		const l1 = store.addLevel(d.id, h.id, { tableId: 't', columnName: 'country' });
-		const dup = store.addLevel(d.id, h.id, { tableId: 't', columnName: 'country' });
-		expect(dup).toBe(l1); // same column returns the existing level, no duplicate
-		store.addLevel(d.id, h.id, { tableId: 't', columnName: 'city' });
-		const levels = () => store.dimensions[0].hierarchies[0].levels;
-		expect(levels().map((l) => l.columnName)).toEqual(['country', 'city']);
+    const l1 = store.addLevel(d.id, h.id, {
+      tableId: "t",
+      columnName: "country",
+    });
+    const dup = store.addLevel(d.id, h.id, {
+      tableId: "t",
+      columnName: "country",
+    });
+    expect(dup).toBe(l1); // same column returns the existing level, no duplicate
+    store.addLevel(d.id, h.id, { tableId: "t", columnName: "city" });
+    const levels = () => store.dimensions[0].hierarchies[0].levels;
+    expect(levels().map((l) => l.columnName)).toEqual(["country", "city"]);
 
-		store.moveLevel(d.id, h.id, levels()[1].id, -1); // city up
-		expect(levels().map((l) => l.columnName)).toEqual(['city', 'country']);
+    store.moveLevel(d.id, h.id, levels()[1].id, -1); // city up
+    expect(levels().map((l) => l.columnName)).toEqual(["city", "country"]);
 
-		store.updateLevel(d.id, h.id, levels()[0].id, { caption: 'Municipality' });
-		expect(levels()[0].caption).toBe('Municipality');
+    store.updateLevel(d.id, h.id, levels()[0].id, { caption: "Municipality" });
+    expect(levels()[0].caption).toBe("Municipality");
 
-		store.removeLevel(d.id, h.id, levels()[0].id);
-		expect(levels().map((l) => l.columnName)).toEqual(['country']);
+    store.removeLevel(d.id, h.id, levels()[0].id);
+    expect(levels().map((l) => l.columnName)).toEqual(["country"]);
 
-		store.removeHierarchy(d.id, h.id);
-		expect(store.dimensions[0].hierarchies).toHaveLength(0);
-	});
+    store.removeHierarchy(d.id, h.id);
+    expect(store.dimensions[0].hierarchies).toHaveLength(0);
+  });
 
-	it('attribute lifecycle: add (idempotent), update, setAttributes replace, remove', () => {
-		const store = new SchemaCanvasStore('conn-dim');
-		const d = store.addDimension({ name: 'Product' });
-		store.addAttribute(d.id, 't', 'name');
-		store.addAttribute(d.id, 't', 'name'); // no-op
-		expect(store.dimensions[0].attributes).toHaveLength(1);
+  it("attribute lifecycle: add (idempotent), update, setAttributes replace, remove", () => {
+    const store = new SchemaCanvasStore("conn-dim");
+    const d = store.addDimension({ name: "Product" });
+    store.addAttribute(d.id, "t", "name");
+    store.addAttribute(d.id, "t", "name"); // no-op
+    expect(store.dimensions[0].attributes).toHaveLength(1);
 
-		store.updateAttribute(d.id, 't', 'name', { nameColumn: 'display_name' });
-		expect(store.dimensions[0].attributes?.[0].nameColumn).toBe('display_name');
+    store.updateAttribute(d.id, "t", "name", { nameColumn: "display_name" });
+    expect(store.dimensions[0].attributes?.[0].nameColumn).toBe("display_name");
 
-		store.setAttributes(d.id, [
-			{ tableId: 't', columnName: 'a' },
-			{ tableId: 't', columnName: 'b' }
-		]);
-		expect(store.dimensions[0].attributes?.map((a) => a.columnName)).toEqual(['a', 'b']);
+    store.setAttributes(d.id, [
+      { tableId: "t", columnName: "a" },
+      { tableId: "t", columnName: "b" },
+    ]);
+    expect(store.dimensions[0].attributes?.map((a) => a.columnName)).toEqual([
+      "a",
+      "b",
+    ]);
 
-		store.removeAttribute(d.id, 't', 'a');
-		expect(store.dimensions[0].attributes?.map((a) => a.columnName)).toEqual(['b']);
-	});
+    store.removeAttribute(d.id, "t", "a");
+    expect(store.dimensions[0].attributes?.map((a) => a.columnName)).toEqual([
+      "b",
+    ]);
+  });
 });
 
 // ── Workbench: measures (#1180 bucket 4) ─────────────────────────────────────
-describe('SchemaCanvasStore — measures (#1180)', () => {
-	it('addMeasure defaults to sum and only carries percentile for a percentile aggregator', () => {
-		const store = new SchemaCanvasStore('conn-meas');
-		const sum = store.addMeasure({ tableId: 'f', columnName: 'amount' });
-		expect(sum.aggregator).toBe('sum');
-		expect(sum.percentile).toBeUndefined();
+describe("SchemaCanvasStore — measures (#1180)", () => {
+  it("addMeasure defaults to sum and only carries percentile for a percentile aggregator", () => {
+    const store = new SchemaCanvasStore("conn-meas");
+    const sum = store.addMeasure({ tableId: "f", columnName: "amount" });
+    expect(sum.aggregator).toBe("sum");
+    expect(sum.percentile).toBeUndefined();
 
-		const p90 = store.addMeasure({
-			tableId: 'f',
-			columnName: 'latency',
-			aggregator: 'percentile',
-			percentile: 90
-		});
-		expect(p90.percentile).toBe(90);
-	});
+    const p90 = store.addMeasure({
+      tableId: "f",
+      columnName: "latency",
+      aggregator: "percentile",
+      percentile: 90,
+    });
+    expect(p90.percentile).toBe(90);
+  });
 
-	it('updateMeasure patches + removeMeasure drops it', () => {
-		const store = new SchemaCanvasStore('conn-meas');
-		const m = store.addMeasure({ tableId: 'f', columnName: 'amount' });
-		store.updateMeasure(m.id, { name: 'Revenue' });
-		expect(store.measures[0].name).toBe('Revenue');
-		store.removeMeasure(m.id);
-		expect(store.measures).toHaveLength(0);
-	});
+  it("updateMeasure patches + removeMeasure drops it", () => {
+    const store = new SchemaCanvasStore("conn-meas");
+    const m = store.addMeasure({ tableId: "f", columnName: "amount" });
+    store.updateMeasure(m.id, { name: "Revenue" });
+    expect(store.measures[0].name).toBe("Revenue");
+    store.removeMeasure(m.id);
+    expect(store.measures).toHaveLength(0);
+  });
 });
 
 // ── Workbench: cubes / measure groups / calcs / time-calcs (#1180 bucket 4) ──
-describe('SchemaCanvasStore — cubes / groups / calcs / timeCalcs (#1180)', () => {
-	function cubeWithGroup() {
-		const store = new SchemaCanvasStore('conn-cube');
-		const cube = store.addCube({ name: 'Sales' });
-		const mg = store.addMeasureGroup(cube.id, { name: 'Facts', factTableId: 'f' })!;
-		return { store, cubeId: cube.id, mgId: mg.id };
-	}
+describe("SchemaCanvasStore — cubes / groups / calcs / timeCalcs (#1180)", () => {
+  function cubeWithGroup() {
+    const store = new SchemaCanvasStore("conn-cube");
+    const cube = store.addCube({ name: "Sales" });
+    const mg = store.addMeasureGroup(cube.id, {
+      name: "Facts",
+      factTableId: "f",
+    })!;
+    return { store, cubeId: cube.id, mgId: mg.id };
+  }
 
-	it('renameCube + removeCube', () => {
-		const { store, cubeId } = cubeWithGroup();
-		store.renameCube(cubeId, 'Orders');
-		expect(store.cubes[0].name).toBe('Orders');
-		store.removeCube(cubeId);
-		expect(store.cubes).toHaveLength(0);
-	});
+  it("renameCube + removeCube", () => {
+    const { store, cubeId } = cubeWithGroup();
+    store.renameCube(cubeId, "Orders");
+    expect(store.cubes[0].name).toBe("Orders");
+    store.removeCube(cubeId);
+    expect(store.cubes).toHaveLength(0);
+  });
 
-	it('measure-group edits: rename, setMeasureColumns, setMeasureGroupFactTable, remove', () => {
-		const { store, cubeId, mgId } = cubeWithGroup();
-		store.renameMeasureGroup(cubeId, mgId, 'Renamed');
-		store.setMeasureColumns(cubeId, mgId, ['amount', 'qty']);
-		store.setMeasureGroupFactTable(cubeId, mgId, 'fact2');
-		const mg = store.cubes[0].measureGroups[0];
-		expect(mg.name).toBe('Renamed');
-		expect(mg.measureColumns).toEqual(['amount', 'qty']);
-		expect(mg.factTableId).toBe('fact2');
+  it("measure-group edits: rename, setMeasureColumns, setMeasureGroupFactTable, remove", () => {
+    const { store, cubeId, mgId } = cubeWithGroup();
+    store.renameMeasureGroup(cubeId, mgId, "Renamed");
+    store.setMeasureColumns(cubeId, mgId, ["amount", "qty"]);
+    store.setMeasureGroupFactTable(cubeId, mgId, "fact2");
+    const mg = store.cubes[0].measureGroups[0];
+    expect(mg.name).toBe("Renamed");
+    expect(mg.measureColumns).toEqual(["amount", "qty"]);
+    expect(mg.factTableId).toBe("fact2");
 
-		store.removeMeasureGroup(cubeId, mgId);
-		expect(store.cubes[0].measureGroups).toHaveLength(0);
-	});
+    store.removeMeasureGroup(cubeId, mgId);
+    expect(store.cubes[0].measureGroups).toHaveLength(0);
+  });
 
-	it('dim-link upsert + removeMeasureGroupDimLink', () => {
-		const { store, cubeId, mgId } = cubeWithGroup();
-		store.setMeasureGroupDimLink(cubeId, mgId, { dimensionId: 'd1', foreignKeyColumn: 'a' });
-		store.setMeasureGroupDimLink(cubeId, mgId, { dimensionId: 'd2', foreignKeyColumn: 'b' });
-		expect(store.cubes[0].measureGroups[0].dimensionLinks).toHaveLength(2);
-		store.removeMeasureGroupDimLink(cubeId, mgId, 'd1');
-		expect(store.cubes[0].measureGroups[0].dimensionLinks?.map((l) => l.dimensionId)).toEqual([
-			'd2'
-		]);
-	});
+  it("dim-link upsert + removeMeasureGroupDimLink", () => {
+    const { store, cubeId, mgId } = cubeWithGroup();
+    store.setMeasureGroupDimLink(cubeId, mgId, {
+      dimensionId: "d1",
+      foreignKeyColumn: "a",
+    });
+    store.setMeasureGroupDimLink(cubeId, mgId, {
+      dimensionId: "d2",
+      foreignKeyColumn: "b",
+    });
+    expect(store.cubes[0].measureGroups[0].dimensionLinks).toHaveLength(2);
+    store.removeMeasureGroupDimLink(cubeId, mgId, "d1");
+    expect(
+      store.cubes[0].measureGroups[0].dimensionLinks?.map((l) => l.dimensionId),
+    ).toEqual(["d2"]);
+  });
 
-	it('addCalc + removeCalc', () => {
-		const { store, cubeId } = cubeWithGroup();
-		const calc = store.addCalc(cubeId, { name: 'Margin', formula: '[a]-[b]' })!;
-		expect(store.cubes[0].calcs.map((c) => c.name)).toEqual(['Margin']);
-		store.removeCalc(cubeId, calc.id);
-		expect(store.cubes[0].calcs).toHaveLength(0);
-	});
+  it("addCalc + removeCalc", () => {
+    const { store, cubeId } = cubeWithGroup();
+    const calc = store.addCalc(cubeId, { name: "Margin", formula: "[a]-[b]" })!;
+    expect(store.cubes[0].calcs.map((c) => c.name)).toEqual(["Margin"]);
+    store.removeCalc(cubeId, calc.id);
+    expect(store.cubes[0].calcs).toHaveLength(0);
+  });
 
-	it('timeCalc lifecycle: add, update, remove', () => {
-		const { store, cubeId } = cubeWithGroup();
-		const tc = store.addTimeCalc(cubeId, { name: 'Rev YoY', type: 'yoy', measure: 'Revenue' })!;
-		expect(store.cubes[0].timeCalcs?.[0].type).toBe('yoy');
-		store.updateTimeCalc(cubeId, tc.id, { type: 'rolling', window: 3, function: 'avg' });
-		expect(store.cubes[0].timeCalcs?.[0]).toMatchObject({ type: 'rolling', window: 3 });
-		store.removeTimeCalc(cubeId, tc.id);
-		expect(store.cubes[0].timeCalcs).toHaveLength(0);
-	});
+  it("timeCalc lifecycle: add, update, remove", () => {
+    const { store, cubeId } = cubeWithGroup();
+    const tc = store.addTimeCalc(cubeId, {
+      name: "Rev YoY",
+      type: "yoy",
+      measure: "Revenue",
+    })!;
+    expect(store.cubes[0].timeCalcs?.[0].type).toBe("yoy");
+    store.updateTimeCalc(cubeId, tc.id, {
+      type: "rolling",
+      window: 3,
+      function: "avg",
+    });
+    expect(store.cubes[0].timeCalcs?.[0]).toMatchObject({
+      type: "rolling",
+      window: 3,
+    });
+    store.removeTimeCalc(cubeId, tc.id);
+    expect(store.cubes[0].timeCalcs).toHaveLength(0);
+  });
 
-	it('setCubes preserves cube-scoped timeCalcs by id (workbench write-back cannot wipe them)', () => {
-		const { store, cubeId } = cubeWithGroup();
-		store.addTimeCalc(cubeId, { name: 'Rev YoY', type: 'yoy', measure: 'Revenue' });
-		// Simulate the workbench persisting via cubeToDoc (which drops timeCalcs).
-		store.setCubes([{ id: cubeId, name: 'Sales', measureGroups: [], calcs: [] }]);
-		expect(store.cubes[0].timeCalcs).toHaveLength(1); // preserved by id
-		expect(store.cubes[0].timeCalcs?.[0].name).toBe('Rev YoY');
-	});
+  it("setCubes preserves cube-scoped timeCalcs by id (workbench write-back cannot wipe them)", () => {
+    const { store, cubeId } = cubeWithGroup();
+    store.addTimeCalc(cubeId, {
+      name: "Rev YoY",
+      type: "yoy",
+      measure: "Revenue",
+    });
+    // Simulate the workbench persisting via cubeToDoc (which drops timeCalcs).
+    store.setCubes([
+      { id: cubeId, name: "Sales", measureGroups: [], calcs: [] },
+    ]);
+    expect(store.cubes[0].timeCalcs).toHaveLength(1); // preserved by id
+    expect(store.cubes[0].timeCalcs?.[0].name).toBe("Rev YoY");
+  });
 });
 
 // ── Focus + interaction (issue #1180, bucket 6) ─────────────────────────────
-describe('SchemaCanvasStore — focus + interaction (#1180)', () => {
-	function joined() {
-		const store = new SchemaCanvasStore('conn-focus');
-		const a = store.addTable(candidate('public', 'a', ['k']), { x: 0, y: 0 });
-		const b = store.addTable(candidate('public', 'b', ['k']), { x: 100, y: 0 });
-		store.addJoin({
-			sourceTableId: a.id,
-			sourceColumnName: 'k',
-			targetTableId: b.id,
-			targetColumnName: 'k',
-			kind: 'inner'
-		});
-		return { store, a: a.id, b: b.id, joinId: store.doc.joins[0].id };
-	}
+describe("SchemaCanvasStore — focus + interaction (#1180)", () => {
+  function joined() {
+    const store = new SchemaCanvasStore("conn-focus");
+    const a = store.addTable(candidate("public", "a", ["k"]), { x: 0, y: 0 });
+    const b = store.addTable(candidate("public", "b", ["k"]), { x: 100, y: 0 });
+    store.addJoin({
+      sourceTableId: a.id,
+      sourceColumnName: "k",
+      targetTableId: b.id,
+      targetColumnName: "k",
+      kind: "inner",
+    });
+    return { store, a: a.id, b: b.id, joinId: store.doc.joins[0].id };
+  }
 
-	it('focusTableNode toggles table focus and drives tableIdsInFocus / joinIdsInFocus', () => {
-		const { store, a, b, joinId } = joined();
-		store.focusTableNode(a);
-		expect(store.focusKind).toBe('table');
-		expect([...store.tableIdsInFocus()].sort()).toEqual([a, b].sort()); // a + its neighbour
-		expect([...store.joinIdsInFocus()]).toEqual([joinId]);
+  it("focusTableNode toggles table focus and drives tableIdsInFocus / joinIdsInFocus", () => {
+    const { store, a, b, joinId } = joined();
+    store.focusTableNode(a);
+    expect(store.focusKind).toBe("table");
+    expect([...store.tableIdsInFocus()].sort()).toEqual([a, b].sort()); // a + its neighbour
+    expect([...store.joinIdsInFocus()]).toEqual([joinId]);
 
-		store.focusTableNode(a); // toggle off
-		expect(store.focusKind).toBe('none');
-		expect(store.tableIdsInFocus().size).toBe(0);
-	});
+    store.focusTableNode(a); // toggle off
+    expect(store.focusKind).toBe("none");
+    expect(store.tableIdsInFocus().size).toBe(0);
+  });
 
-	it('focusGroup focuses by label and turns on column highlighting', () => {
-		const { store } = joined();
-		const label = store.joinGroupLabelFor(store.doc.joins[0]);
-		store.focusGroup(label);
-		expect(store.focusKind).toBe('group');
-		expect(store.focusKey).toBe(label);
-		expect(store.highlightFocusedColumns).toBe(true);
-		expect(store.joinIdsInFocus().size).toBe(1);
-	});
+  it("focusGroup focuses by label and turns on column highlighting", () => {
+    const { store } = joined();
+    const label = store.joinGroupLabelFor(store.doc.joins[0]);
+    store.focusGroup(label);
+    expect(store.focusKind).toBe("group");
+    expect(store.focusKey).toBe(label);
+    expect(store.highlightFocusedColumns).toBe(true);
+    expect(store.joinIdsInFocus().size).toBe(1);
+  });
 
-	it('clearFocus + clearAllInteractions reset transient state (doc untouched)', () => {
-		const { store, a } = joined();
-		store.focusTableNode(a);
-		store.highlightColumn('k');
-		store.selectedTableId = a;
-		store.clearAllInteractions();
-		expect(store.focusKind).toBe('none');
-		expect(store.highlightedColumn).toBeNull();
-		expect(store.selectedTableId).toBeNull();
-		expect(store.doc.tables).toHaveLength(2); // doc intact
-	});
+  it("clearFocus + clearAllInteractions reset transient state (doc untouched)", () => {
+    const { store, a } = joined();
+    store.focusTableNode(a);
+    store.highlightColumn("k");
+    store.selectedTableId = a;
+    store.clearAllInteractions();
+    expect(store.focusKind).toBe("none");
+    expect(store.highlightedColumn).toBeNull();
+    expect(store.selectedTableId).toBeNull();
+    expect(store.doc.tables).toHaveLength(2); // doc intact
+  });
 
-	it('highlightColumn toggles the name highlight + sidebar query', () => {
-		const { store } = joined();
-		store.highlightColumn('k');
-		expect(store.highlightedColumn).toBe('k');
-		expect(store.sidebarQuery).toBe('k');
-		store.highlightColumn('k');
-		expect(store.highlightedColumn).toBeNull();
-	});
+  it("highlightColumn toggles the name highlight + sidebar query", () => {
+    const { store } = joined();
+    store.highlightColumn("k");
+    expect(store.highlightedColumn).toBe("k");
+    expect(store.sidebarQuery).toBe("k");
+    store.highlightColumn("k");
+    expect(store.highlightedColumn).toBeNull();
+  });
 });
 
 // ── Pathfinder (issue #1180, bucket 5) ──────────────────────────────────────
-describe('SchemaCanvasStore — pathfinder (#1180)', () => {
-	it('arm/setEndpoint/clear manage the pathfinder slots + result', () => {
-		const store = new SchemaCanvasStore('conn-pf');
-		store.armPathfinder('start');
-		expect(store.pathfinderArmed).toBe('start');
-		store.armPathfinder('start'); // toggle off
-		expect(store.pathfinderArmed).toBeNull();
+describe("SchemaCanvasStore — pathfinder (#1180)", () => {
+  it("arm/setEndpoint/clear manage the pathfinder slots + result", () => {
+    const store = new SchemaCanvasStore("conn-pf");
+    store.armPathfinder("start");
+    expect(store.pathfinderArmed).toBe("start");
+    store.armPathfinder("start"); // toggle off
+    expect(store.pathfinderArmed).toBeNull();
 
-		store.setPathfinderEndpoint('start', { tableId: 'a', columnName: 'k' });
-		expect(store.pathfinderStart).toEqual({ tableId: 'a', columnName: 'k' });
-		store.clearPathfinder();
-		expect(store.pathfinderStart).toBeNull();
-		expect(store.pathfinderResult).toBeNull();
-	});
+    store.setPathfinderEndpoint("start", { tableId: "a", columnName: "k" });
+    expect(store.pathfinderStart).toEqual({ tableId: "a", columnName: "k" });
+    store.clearPathfinder();
+    expect(store.pathfinderStart).toBeNull();
+    expect(store.pathfinderResult).toBeNull();
+  });
 
-	it('findPath walks existing joins A→B→C with no gaps', () => {
-		const store = new SchemaCanvasStore('conn-pf');
-		const a = store.addTable(candidate('public', 'a', ['k']), { x: 0, y: 0 });
-		const b = store.addTable(candidate('public', 'b', ['k', 'm']), { x: 100, y: 0 });
-		const c = store.addTable(candidate('public', 'c', ['m']), { x: 200, y: 0 });
-		store.addJoin({
-			sourceTableId: a.id,
-			sourceColumnName: 'k',
-			targetTableId: b.id,
-			targetColumnName: 'k',
-			kind: 'inner'
-		});
-		store.addJoin({
-			sourceTableId: b.id,
-			sourceColumnName: 'm',
-			targetTableId: c.id,
-			targetColumnName: 'm',
-			kind: 'inner'
-		});
+  it("findPath walks existing joins A→B→C with no gaps", () => {
+    const store = new SchemaCanvasStore("conn-pf");
+    const a = store.addTable(candidate("public", "a", ["k"]), { x: 0, y: 0 });
+    const b = store.addTable(candidate("public", "b", ["k", "m"]), {
+      x: 100,
+      y: 0,
+    });
+    const c = store.addTable(candidate("public", "c", ["m"]), { x: 200, y: 0 });
+    store.addJoin({
+      sourceTableId: a.id,
+      sourceColumnName: "k",
+      targetTableId: b.id,
+      targetColumnName: "k",
+      kind: "inner",
+    });
+    store.addJoin({
+      sourceTableId: b.id,
+      sourceColumnName: "m",
+      targetTableId: c.id,
+      targetColumnName: "m",
+      kind: "inner",
+    });
 
-		store.setPathfinderEndpoint('start', { tableId: a.id, columnName: 'k' });
-		store.setPathfinderEndpoint('end', { tableId: c.id, columnName: 'm' });
-		store.findPath();
-		expect(store.pathfinderResult?.hasGaps).toBe(false);
-		expect(store.pathfinderResult?.steps).toHaveLength(2);
-	});
+    store.setPathfinderEndpoint("start", { tableId: a.id, columnName: "k" });
+    store.setPathfinderEndpoint("end", { tableId: c.id, columnName: "m" });
+    store.findPath();
+    expect(store.pathfinderResult?.hasGaps).toBe(false);
+    expect(store.pathfinderResult?.steps).toHaveLength(2);
+  });
 
-	it('findPath proposes a virtual edge across a gap; applyPathfinderJoins commits it', () => {
-		const store = new SchemaCanvasStore('conn-pf');
-		const a = store.addTable(candidate('public', 'a', ['shared']), { x: 0, y: 0 });
-		const c = store.addTable(candidate('public', 'c', ['shared']), { x: 200, y: 0 });
-		store.setPathfinderEndpoint('start', { tableId: a.id, columnName: 'shared' });
-		store.setPathfinderEndpoint('end', { tableId: c.id, columnName: 'shared' });
-		store.findPath();
-		expect(store.pathfinderResult?.hasGaps).toBe(true);
-		expect(store.doc.joins).toHaveLength(0);
+  it("findPath proposes a virtual edge across a gap; applyPathfinderJoins commits it", () => {
+    const store = new SchemaCanvasStore("conn-pf");
+    const a = store.addTable(candidate("public", "a", ["shared"]), {
+      x: 0,
+      y: 0,
+    });
+    const c = store.addTable(candidate("public", "c", ["shared"]), {
+      x: 200,
+      y: 0,
+    });
+    store.setPathfinderEndpoint("start", {
+      tableId: a.id,
+      columnName: "shared",
+    });
+    store.setPathfinderEndpoint("end", { tableId: c.id, columnName: "shared" });
+    store.findPath();
+    expect(store.pathfinderResult?.hasGaps).toBe(true);
+    expect(store.doc.joins).toHaveLength(0);
 
-		const added = store.applyPathfinderJoins();
-		expect(added).toBe(1);
-		expect(store.doc.joins).toHaveLength(1);
-	});
+    const added = store.applyPathfinderJoins();
+    expect(added).toBe(1);
+    expect(store.doc.joins).toHaveLength(1);
+  });
 });
 
 // ── Session lifecycle (issue #1180, bucket 7) ───────────────────────────────
-describe('SchemaCanvasStore — session lifecycle (#1180)', () => {
-	it('setLabel writes the cube label', () => {
-		const store = new SchemaCanvasStore('conn-sess');
-		store.setLabel('Q3 Revenue');
-		expect(store.doc.label).toBe('Q3 Revenue');
-	});
+describe("SchemaCanvasStore — session lifecycle (#1180)", () => {
+  it("setLabel writes the cube label", () => {
+    const store = new SchemaCanvasStore("conn-sess");
+    store.setLabel("Q3 Revenue");
+    expect(store.doc.label).toBe("Q3 Revenue");
+  });
 
-	it('setMode + setDefaultLayoutMode update the fields', () => {
-		const store = new SchemaCanvasStore('conn-sess');
-		store.setMode('workbench');
-		expect(store.mode).toBe('workbench');
-		store.setDefaultLayoutMode('star');
-		expect(store.defaultLayoutMode).toBe('star');
-	});
+  it("setMode + setDefaultLayoutMode update the fields", () => {
+    const store = new SchemaCanvasStore("conn-sess");
+    store.setMode("workbench");
+    expect(store.mode).toBe("workbench");
+    store.setDefaultLayoutMode("star");
+    expect(store.defaultLayoutMode).toBe("star");
+  });
 
-	it('switchConnection swaps the doc and resets UI state; same-connection is a no-op', () => {
-		const store = new SchemaCanvasStore('conn-A');
-		store.addTable(candidate('public', 't', ['id']), { x: 0, y: 0 });
-		store.selectedTableId = store.doc.tables[0].id;
+  it("switchConnection swaps the doc and resets UI state; same-connection is a no-op", () => {
+    const store = new SchemaCanvasStore("conn-A");
+    store.addTable(candidate("public", "t", ["id"]), { x: 0, y: 0 });
+    store.selectedTableId = store.doc.tables[0].id;
 
-		store.switchConnection('conn-B');
-		expect(store.connectionId).toBe('conn-B');
-		expect(store.doc.tables).toHaveLength(0); // fresh doc for conn-B
-		expect(store.selectedTableId).toBeNull();
-	});
+    store.switchConnection("conn-B");
+    expect(store.connectionId).toBe("conn-B");
+    expect(store.doc.tables).toHaveLength(0); // fresh doc for conn-B
+    expect(store.selectedTableId).toBeNull();
+  });
 
-	it('resetCanvas blanks the doc for the current connection', () => {
-		const store = new SchemaCanvasStore('conn-sess');
-		store.addTable(candidate('public', 't', ['id']), { x: 0, y: 0 });
-		store.resetCanvas();
-		expect(store.doc.tables).toHaveLength(0);
-		expect(store.connectionId).toBe('conn-sess');
-	});
+  it("resetCanvas blanks the doc for the current connection", () => {
+    const store = new SchemaCanvasStore("conn-sess");
+    store.addTable(candidate("public", "t", ["id"]), { x: 0, y: 0 });
+    store.resetCanvas();
+    expect(store.doc.tables).toHaveLength(0);
+    expect(store.connectionId).toBe("conn-sess");
+  });
 
-	it('loadDoc replaces the doc and is undoable', () => {
-		const store = new SchemaCanvasStore('conn-sess');
-		store.addTable(candidate('public', 'orig', ['id']), { x: 0, y: 0 });
-		const snapshot = JSON.parse(JSON.stringify(store.doc));
-		store.loadDoc({ ...snapshot, label: 'Imported', tables: [] });
-		expect(store.doc.label).toBe('Imported');
-		expect(store.doc.tables).toHaveLength(0);
-		store.undo();
-		expect(store.doc.tables.map((t) => t.name)).toEqual(['orig']);
-	});
+  it("loadDoc replaces the doc and is undoable", () => {
+    const store = new SchemaCanvasStore("conn-sess");
+    store.addTable(candidate("public", "orig", ["id"]), { x: 0, y: 0 });
+    const snapshot = JSON.parse(JSON.stringify(store.doc));
+    store.loadDoc({ ...snapshot, label: "Imported", tables: [] });
+    expect(store.doc.label).toBe("Imported");
+    expect(store.doc.tables).toHaveLength(0);
+    store.undo();
+    expect(store.doc.tables.map((t) => t.name)).toEqual(["orig"]);
+  });
 
-	it('setSidebarQueryFromUser sets the query and clears the click highlight', () => {
-		const store = new SchemaCanvasStore('conn-sess');
-		store.highlightColumn('k');
-		store.setSidebarQueryFromUser('cust');
-		expect(store.sidebarQuery).toBe('cust');
-		expect(store.highlightedColumn).toBeNull();
-	});
+  it("setSidebarQueryFromUser sets the query and clears the click highlight", () => {
+    const store = new SchemaCanvasStore("conn-sess");
+    store.highlightColumn("k");
+    store.setSidebarQueryFromUser("cust");
+    expect(store.sidebarQuery).toBe("cust");
+    expect(store.highlightedColumn).toBeNull();
+  });
 
-	it('togglePickMode / exitPickMode / cancelEShift drive pick-mode state', () => {
-		const store = new SchemaCanvasStore('conn-sess');
-		store.togglePickMode();
-		expect(store.pickModeActive).toBe(true);
-		store.exitPickMode();
-		expect(store.pickModeActive).toBe(false);
-		store.togglePickMode();
-		store.cancelEShift();
-		expect(store.pickModeActive).toBe(false);
-		expect(store.eShiftPicks).toHaveLength(0);
-	});
+  it("togglePickMode / exitPickMode / cancelEShift drive pick-mode state", () => {
+    const store = new SchemaCanvasStore("conn-sess");
+    store.togglePickMode();
+    expect(store.pickModeActive).toBe(true);
+    store.exitPickMode();
+    expect(store.pickModeActive).toBe(false);
+    store.togglePickMode();
+    store.cancelEShift();
+    expect(store.pickModeActive).toBe(false);
+    expect(store.eShiftPicks).toHaveLength(0);
+  });
 });
 
 // ── Workbench working set (issue #1180, bucket 8) ───────────────────────────
-describe('SchemaCanvasStore — workbench working set (#1180)', () => {
-	it('addToWorkbench (idempotent) / removeFromWorkbench / clearWorkbench', () => {
-		const store = new SchemaCanvasStore('conn-wb');
-		const t = store.addTable(candidate('public', 't', ['id']), { x: 0, y: 0 });
-		store.addToWorkbench(t.id);
-		store.addToWorkbench(t.id); // no-op
-		expect(store.workbenchTables.map((x) => x.name)).toEqual(['t']);
+describe("SchemaCanvasStore — workbench working set (#1180)", () => {
+  it("addToWorkbench (idempotent) / removeFromWorkbench / clearWorkbench", () => {
+    const store = new SchemaCanvasStore("conn-wb");
+    const t = store.addTable(candidate("public", "t", ["id"]), { x: 0, y: 0 });
+    store.addToWorkbench(t.id);
+    store.addToWorkbench(t.id); // no-op
+    expect(store.workbenchTables.map((x) => x.name)).toEqual(["t"]);
 
-		store.removeFromWorkbench(t.id);
-		expect(store.workbenchTables).toHaveLength(0);
+    store.removeFromWorkbench(t.id);
+    expect(store.workbenchTables).toHaveLength(0);
 
-		store.addToWorkbench(t.id);
-		store.clearWorkbench();
-		expect(store.workbenchTables).toHaveLength(0);
-	});
+    store.addToWorkbench(t.id);
+    store.clearWorkbench();
+    expect(store.workbenchTables).toHaveLength(0);
+  });
 });

--- a/saiku-ui/src/lib/cube-designer/types.ts
+++ b/saiku-ui/src/lib/cube-designer/types.ts
@@ -15,68 +15,71 @@
  * the existing /api/inference/profile-connection endpoint and isn't part
  * of this document.
  */
-import type { ProfileTableSummary, ProfileColumnSummary } from './profile-types';
+import type {
+  ProfileTableSummary,
+  ProfileColumnSummary,
+} from "./profile-types";
 
-export type SchemaCanvasTableRole = 'fact' | 'dimension' | 'bridge';
+export type SchemaCanvasTableRole = "fact" | "dimension" | "bridge";
 
 export interface SchemaCanvasTable {
-	/** Unique within a canvas document. Generated locally. */
-	id: string;
-	/** Schema-qualified name from the source warehouse — e.g. `public.sales_fact_1997`. */
-	schema: string | null;
-	name: string;
-	role: SchemaCanvasTableRole;
-	/** Columns mirrored from the source-table catalog at the moment of pull-in. */
-	columns: SchemaCanvasColumn[];
-	/** Canvas position. ELK auto-layout writes here; manual drag also writes here. */
-	position: { x: number; y: number };
-	/** Group id this table belongs to, or null for ungrouped. */
-	groupId: string | null;
-	/** Collapsed = header only (no column list). Defaults to expanded. */
-	collapsed?: boolean;
+  /** Unique within a canvas document. Generated locally. */
+  id: string;
+  /** Schema-qualified name from the source warehouse — e.g. `public.sales_fact_1997`. */
+  schema: string | null;
+  name: string;
+  role: SchemaCanvasTableRole;
+  /** Columns mirrored from the source-table catalog at the moment of pull-in. */
+  columns: SchemaCanvasColumn[];
+  /** Canvas position. ELK auto-layout writes here; manual drag also writes here. */
+  position: { x: number; y: number };
+  /** Group id this table belongs to, or null for ungrouped. */
+  groupId: string | null;
+  /** Collapsed = header only (no column list). Defaults to expanded. */
+  collapsed?: boolean;
 }
 
 export interface SchemaCanvasColumn {
-	name: string;
-	sqlType: string;
-	/** Inferred by name-match against other tables; user can override. */
-	isPrimaryKey?: boolean;
-	/** Used by the validation pass — "this column is required but isn't joined to anything." */
-	required?: boolean;
+  name: string;
+  sqlType: string;
+  /** Inferred by name-match against other tables; user can override. */
+  isPrimaryKey?: boolean;
+  /** Used by the validation pass — "this column is required but isn't joined to anything." */
+  required?: boolean;
 }
 
-export type SchemaCanvasJoinKind = 'inner' | 'left' | 'right' | 'full';
+export type SchemaCanvasJoinKind = "inner" | "left" | "right" | "full";
 
 export interface SchemaCanvasJoin {
-	id: string;
-	/** Always references SchemaCanvasTable.id, not the source-warehouse name. */
-	sourceTableId: string;
-	sourceColumnName: string;
-	targetTableId: string;
-	targetColumnName: string;
-	kind: SchemaCanvasJoinKind;
-	/**
-	 * Where this join came from.  Drives canvas visibility + editability:
-	 *  - `physical` (default) — user-authored OR imported from Mondrian-4
-	 *    `<PhysicalSchema><Link>` / Mondrian-3 nested `<Hierarchy><Table>`.
-	 *    Editable, always rendered.
-	 *  - `cube-link` — auto-inferred from a Mondrian-4 `<MeasureGroup>`'s
-	 *    `<ForeignKeyLink>`.  Cube-side semantic link, NOT a physical-schema
-	 *    statement.  Hidden by default; rendered dashed when shown; not
-	 *    user-editable (delete the FK link on the MG instead).
-	 *  - `inferred-fk` — legacy fallback when nothing explicit existed.
-	 *    Same treatment as cube-link.
-	 *  Undefined is treated as `physical` for back-compat with older docs.
-	 */
-	origin?: 'physical' | 'cube-link' | 'inferred-fk';
+  id: string;
+  /** Always references SchemaCanvasTable.id, not the source-warehouse name. */
+  sourceTableId: string;
+  sourceColumnName: string;
+  targetTableId: string;
+  targetColumnName: string;
+  kind: SchemaCanvasJoinKind;
+  /**
+   * Where this join came from.  Drives canvas visibility + editability:
+   *  - `physical` (default) — user-authored OR imported from Mondrian-4
+   *    `<PhysicalSchema><Link>` / Mondrian-3 nested `<Hierarchy><Table>`.
+   *    Editable, always rendered.
+   *  - `cube-link` — auto-inferred from a Mondrian-4 `<MeasureGroup>`'s
+   *    `<ForeignKeyLink>`.  Cube-side semantic link, NOT a physical-schema
+   *    statement.  Hidden by default; rendered dashed when shown; not
+   *    user-editable (delete the FK link on the MG instead).
+   *  - `inferred-fk` — legacy fallback when nothing explicit existed.
+   *    Same treatment as cube-link.
+   *  Undefined is treated as `physical` for back-compat with older docs.
+   */
+  origin?: "physical" | "cube-link" | "inferred-fk";
 }
 
 export interface SchemaCanvasGroup {
-	id: string;
-	label: string;
-	/** Optional colour token override; otherwise the default group palette is used. */
-	color?: string;
-	collapsed: boolean;
+  id: string;
+  label: string;
+  /** Optional colour token override; otherwise the default group palette is used. */
+  color?: string;
+  collapsed: boolean;
 }
 
 /**
@@ -85,7 +88,8 @@ export interface SchemaCanvasGroup {
  * as a measure with `sum` by default; a string column drops in as a
  * level). Mirrors a Mondrian `Level type` attribute when present.
  */
-export type SchemaCanvasColumnKind = 'String' | 'Numeric' | 'Integer' | 'Boolean' | 'Date';
+export type SchemaCanvasColumnKind =
+  "String" | "Numeric" | "Integer" | "Boolean" | "Date";
 
 /**
  * One Mondrian-style level inside a hierarchy. Levels are ordered
@@ -93,33 +97,33 @@ export type SchemaCanvasColumnKind = 'String' | 'Numeric' | 'Integer' | 'Boolean
  * convention and what the workbench renders top-to-bottom.
  */
 export interface SchemaCanvasLevel {
-	id: string;
-	/** User-visible label, e.g. "Year". Defaults to the column name. */
-	name: string;
-	/** Mondrian 4 `caption` — display label shown to end users, distinct from
-	 *  the logical `name`. Optional; when unset the engine falls back to `name`. */
-	caption?: string;
-	/** Canvas table id the column lives on. */
-	tableId: string;
-	/** Column referenced — the level's `column` attribute in Mondrian. */
-	columnName: string;
-	/** Coarse type bucket — drives downstream Mondrian export. */
-	type?: SchemaCanvasColumnKind;
-	/**
-	 * Mondrian-4 `levelType` — marks a level as a time grain so the engine can
-	 * drive time-intelligence (`<TimeCalc>` requires a `TimeYears` level).
-	 * Only meaningful on a Time dimension; emitted onto the M4 `<Attribute>`.
-	 * See docs.saiku.bi/mondrian/time-intelligence.
-	 */
-	levelType?: 'TimeYears' | 'TimeQuarters' | 'TimeMonths' | 'TimeDays';
-	/**
-	 * Optional `saiku.semantic.*` annotations (description, synonyms, cardinality,
-	 * grain, required_filters, pii) — drive the AI Ask layer + PII protection.
-	 * Keyed by the bare suffix (e.g. `description`, `pii`); emitted as
-	 * `<Annotation name="saiku.semantic.<key>">`. See
-	 * docs.saiku.bi/mondrian/semantic-annotations.
-	 */
-	annotations?: Record<string, string>;
+  id: string;
+  /** User-visible label, e.g. "Year". Defaults to the column name. */
+  name: string;
+  /** Mondrian 4 `caption` — display label shown to end users, distinct from
+   *  the logical `name`. Optional; when unset the engine falls back to `name`. */
+  caption?: string;
+  /** Canvas table id the column lives on. */
+  tableId: string;
+  /** Column referenced — the level's `column` attribute in Mondrian. */
+  columnName: string;
+  /** Coarse type bucket — drives downstream Mondrian export. */
+  type?: SchemaCanvasColumnKind;
+  /**
+   * Mondrian-4 `levelType` — marks a level as a time grain so the engine can
+   * drive time-intelligence (`<TimeCalc>` requires a `TimeYears` level).
+   * Only meaningful on a Time dimension; emitted onto the M4 `<Attribute>`.
+   * See docs.saiku.bi/mondrian/time-intelligence.
+   */
+  levelType?: "TimeYears" | "TimeQuarters" | "TimeMonths" | "TimeDays";
+  /**
+   * Optional `saiku.semantic.*` annotations (description, synonyms, cardinality,
+   * grain, required_filters, pii) — drive the AI Ask layer + PII protection.
+   * Keyed by the bare suffix (e.g. `description`, `pii`); emitted as
+   * `<Annotation name="saiku.semantic.<key>">`. See
+   * docs.saiku.bi/mondrian/semantic-annotations.
+   */
+  annotations?: Record<string, string>;
 }
 
 /**
@@ -129,34 +133,34 @@ export interface SchemaCanvasLevel {
  * dimension card.
  */
 export interface SchemaCanvasHierarchy {
-	id: string;
-	/** User-visible label. Defaults to the dimension name on creation. */
-	name: string;
-	/** Mondrian `hasAll` attribute — default true. */
-	hasAll: boolean;
-	/** Mondrian 4 `allMemberName` — overrides "All" with a custom label
-	 *  for the synthetic top member.  Optional. */
-	allMemberName?: string;
-	/** Mondrian 4 `defaultMember` — MDX-style member reference that
-	 *  becomes the default when this hierarchy is queried without an
-	 *  explicit member.  Optional. */
-	defaultMember?: string;
-	/** Mondrian 4 `caption` — display label distinct from `name`.
-	 *  Optional. */
-	caption?: string;
-	/** Mondrian 4 `description` — long-form documentation.  Optional. */
-	description?: string;
-	/** Ordered coarse → fine. */
-	levels: SchemaCanvasLevel[];
-	/** Mondrian `<Closure>` — parent-child hierarchy optimisation that
-	 *  pre-materialises (ancestor, descendant) pairs so MDX queries don't
-	 *  have to walk the parent chain at query time.  Used by FoodMart's
-	 *  HR Employee hierarchy. */
-	closure?: {
-		table: string;
-		parentColumn: string;
-		childColumn: string;
-	};
+  id: string;
+  /** User-visible label. Defaults to the dimension name on creation. */
+  name: string;
+  /** Mondrian `hasAll` attribute — default true. */
+  hasAll: boolean;
+  /** Mondrian 4 `allMemberName` — overrides "All" with a custom label
+   *  for the synthetic top member.  Optional. */
+  allMemberName?: string;
+  /** Mondrian 4 `defaultMember` — MDX-style member reference that
+   *  becomes the default when this hierarchy is queried without an
+   *  explicit member.  Optional. */
+  defaultMember?: string;
+  /** Mondrian 4 `caption` — display label distinct from `name`.
+   *  Optional. */
+  caption?: string;
+  /** Mondrian 4 `description` — long-form documentation.  Optional. */
+  description?: string;
+  /** Ordered coarse → fine. */
+  levels: SchemaCanvasLevel[];
+  /** Mondrian `<Closure>` — parent-child hierarchy optimisation that
+   *  pre-materialises (ancestor, descendant) pairs so MDX queries don't
+   *  have to walk the parent chain at query time.  Used by FoodMart's
+   *  HR Employee hierarchy. */
+  closure?: {
+    table: string;
+    parentColumn: string;
+    childColumn: string;
+  };
 }
 
 /**
@@ -166,81 +170,81 @@ export interface SchemaCanvasHierarchy {
  * fact) leave foreignKey/primaryKey unset.
  */
 export interface SchemaCanvasDimension {
-	id: string;
-	/** User-visible label, e.g. "Customer". */
-	name: string;
-	/** Column on the fact table linking to this dimension. Undefined
-	 *  for degenerate dimensions. */
-	foreignKey?: string;
-	/** The physical table this dim is authored against — pick it FIRST
-	 *  in the Dimensions pane before choosing attributes.  Every non-hanger
-	 *  dim needs one; the Attributes pane shows this table's columns.
-	 *  Historical note: previously conflated with `primaryKeyTableId`; the
-	 *  import + store hydration both back-fill from `primaryKeyTableId` for
-	 *  old docs that only carried the merged field. */
-	sourceTableId?: string;
-	/** PK column on the dim's source table. Undefined for degenerate dims.
-	 *  Chosen from the attributes AFTER `sourceTableId` is set. */
-	primaryKey?: string;
-	/** Which on-canvas table holds the PK column.  ONLY set explicitly
-	 *  when the dim is a snowflake (attribute lives on a table other than
-	 *  `sourceTableId`).  For normal dims, treat as `sourceTableId`. */
-	primaryKeyTableId?: string;
-	/** Ordered hierarchies. */
-	hierarchies: SchemaCanvasHierarchy[];
-	/** Set theory: A ⊆ T.  The user-chosen subset of the source's
-	 *  columns that this dim is allowed to draw from when composing
-	 *  hierarchies.  Each attribute is a {tableId, columnName} pair so
-	 *  the same data can come from any of the source's tables (for
-	 *  join-group sources).
-	 *  - `name` is the Mondrian `<Attribute name="...">` logical label;
-	 *    used by `<Level attribute="X"/>` references inside hierarchies.
-	 *  - `keyColumns` (optional) carries composite-key columns when the
-	 *    Mondrian `<Key><Column/><Column/></Key>` had more than one column.
-	 *    Empty / absent → use `columnName` alone.  Round-trip preserved.
-	 *  Undefined means "no attributes picked yet" — distinct from the
-	 *  empty array, which means "all excluded". */
-	attributes?: {
-		tableId: string;
-		columnName: string;
-		name?: string;
-		keyColumns?: string[];
-		/** Mondrian 4 `nameColumn` — the column whose value is DISPLAYED for a
-		 *  member, when it differs from the key column (e.g. key on `product_id`,
-		 *  display `product_name`). Optional. */
-		nameColumn?: string;
-		/** Mondrian 4 `captionColumn` — column supplying a per-member caption.
-		 *  Optional. */
-		captionColumn?: string;
-		/** Mondrian 4 `orderByColumn` — column members are sorted by, when it
-		 *  differs from the key. Optional. */
-		orderByColumn?: string;
-		/** Mondrian 4 `description` — long-form documentation. Optional. */
-		description?: string;
-	}[];
-	/** Mondrian 4 `hanger='true'` — a dim with no underlying table whose
-	 *  members are sliced via MDX expressions ("Actual vs Budget" style).
-	 *  No primaryKey / no FK link to a fact.  Cube authors use these for
-	 *  scenario filters that aren't backed by data. */
-	hanger?: boolean;
-	/** When the dim was sourced from a join group (rather than a single
-	 *  table), this is the group's key — used to label the dim as a
-	 *  join-source in UIs even after the user renames it. */
-	sourceJoinGroupKey?: string;
-	/** Mondrian 4 `caption` — display label distinct from `name`. */
-	caption?: string;
-	/** Mondrian 4 `description` — long-form documentation. */
-	description?: string;
-	/** Mondrian 4 `type` — Standard | Time | Geographic.  Default
-	 *  Standard.  Drives engine-side semantics (Time dimensions get
-	 *  special MDX functions like ParallelPeriod). */
-	dimensionType?: 'Standard' | 'Time' | 'Geographic';
-	/**
-	 * Optional `saiku.semantic.*` annotations (description, synonyms) — business
-	 * context for the AI Ask layer. Keyed by bare suffix; emitted as
-	 * `<Annotation name="saiku.semantic.<key>">`.
-	 */
-	annotations?: Record<string, string>;
+  id: string;
+  /** User-visible label, e.g. "Customer". */
+  name: string;
+  /** Column on the fact table linking to this dimension. Undefined
+   *  for degenerate dimensions. */
+  foreignKey?: string;
+  /** The physical table this dim is authored against — pick it FIRST
+   *  in the Dimensions pane before choosing attributes.  Every non-hanger
+   *  dim needs one; the Attributes pane shows this table's columns.
+   *  Historical note: previously conflated with `primaryKeyTableId`; the
+   *  import + store hydration both back-fill from `primaryKeyTableId` for
+   *  old docs that only carried the merged field. */
+  sourceTableId?: string;
+  /** PK column on the dim's source table. Undefined for degenerate dims.
+   *  Chosen from the attributes AFTER `sourceTableId` is set. */
+  primaryKey?: string;
+  /** Which on-canvas table holds the PK column.  ONLY set explicitly
+   *  when the dim is a snowflake (attribute lives on a table other than
+   *  `sourceTableId`).  For normal dims, treat as `sourceTableId`. */
+  primaryKeyTableId?: string;
+  /** Ordered hierarchies. */
+  hierarchies: SchemaCanvasHierarchy[];
+  /** Set theory: A ⊆ T.  The user-chosen subset of the source's
+   *  columns that this dim is allowed to draw from when composing
+   *  hierarchies.  Each attribute is a {tableId, columnName} pair so
+   *  the same data can come from any of the source's tables (for
+   *  join-group sources).
+   *  - `name` is the Mondrian `<Attribute name="...">` logical label;
+   *    used by `<Level attribute="X"/>` references inside hierarchies.
+   *  - `keyColumns` (optional) carries composite-key columns when the
+   *    Mondrian `<Key><Column/><Column/></Key>` had more than one column.
+   *    Empty / absent → use `columnName` alone.  Round-trip preserved.
+   *  Undefined means "no attributes picked yet" — distinct from the
+   *  empty array, which means "all excluded". */
+  attributes?: {
+    tableId: string;
+    columnName: string;
+    name?: string;
+    keyColumns?: string[];
+    /** Mondrian 4 `nameColumn` — the column whose value is DISPLAYED for a
+     *  member, when it differs from the key column (e.g. key on `product_id`,
+     *  display `product_name`). Optional. */
+    nameColumn?: string;
+    /** Mondrian 4 `captionColumn` — column supplying a per-member caption.
+     *  Optional. */
+    captionColumn?: string;
+    /** Mondrian 4 `orderByColumn` — column members are sorted by, when it
+     *  differs from the key. Optional. */
+    orderByColumn?: string;
+    /** Mondrian 4 `description` — long-form documentation. Optional. */
+    description?: string;
+  }[];
+  /** Mondrian 4 `hanger='true'` — a dim with no underlying table whose
+   *  members are sliced via MDX expressions ("Actual vs Budget" style).
+   *  No primaryKey / no FK link to a fact.  Cube authors use these for
+   *  scenario filters that aren't backed by data. */
+  hanger?: boolean;
+  /** When the dim was sourced from a join group (rather than a single
+   *  table), this is the group's key — used to label the dim as a
+   *  join-source in UIs even after the user renames it. */
+  sourceJoinGroupKey?: string;
+  /** Mondrian 4 `caption` — display label distinct from `name`. */
+  caption?: string;
+  /** Mondrian 4 `description` — long-form documentation. */
+  description?: string;
+  /** Mondrian 4 `type` — Standard | Time | Geographic.  Default
+   *  Standard.  Drives engine-side semantics (Time dimensions get
+   *  special MDX functions like ParallelPeriod). */
+  dimensionType?: "Standard" | "Time" | "Geographic";
+  /**
+   * Optional `saiku.semantic.*` annotations (description, synonyms) — business
+   * context for the AI Ask layer. Keyed by bare suffix; emitted as
+   * `<Annotation name="saiku.semantic.<key>">`.
+   */
+  annotations?: Record<string, string>;
 }
 
 /**
@@ -249,30 +253,38 @@ export interface SchemaCanvasDimension {
  * an on-canvas table; promoting one to the fact role is Step 1's job.
  */
 export interface SchemaCanvasMeasure {
-	id: string;
-	/** User-visible label, e.g. "Sales". */
-	name: string;
-	aggregator: 'sum' | 'count' | 'avg' | 'min' | 'max' | 'distinct-count' | 'median' | 'percentile';
-	/** Canvas table id the column lives on (typically the fact). */
-	tableId: string;
-	/** Column to aggregate. */
-	columnName: string;
-	/** Mondrian formatString, e.g. "$#,##0". */
-	formatString?: string;
-	/**
-	 * Percentile fraction (0–100). Only meaningful when
-	 * {@link aggregator} === 'percentile' — median is the implicit 50th
-	 * percentile and carries no value. Emitted as `percentile="N"`; defaults
-	 * to 50 when omitted.
-	 */
-	percentile?: number | null;
-	/**
-	 * Optional `saiku.semantic.*` annotations (description, synonyms, unit,
-	 * currency, aggregation_kind, pii) — drive the AI Ask layer + PII
-	 * protection. Keyed by bare suffix; emitted as
-	 * `<Annotation name="saiku.semantic.<key>">`.
-	 */
-	annotations?: Record<string, string>;
+  id: string;
+  /** User-visible label, e.g. "Sales". */
+  name: string;
+  aggregator:
+    | "sum"
+    | "count"
+    | "avg"
+    | "min"
+    | "max"
+    | "distinct-count"
+    | "median"
+    | "percentile";
+  /** Canvas table id the column lives on (typically the fact). */
+  tableId: string;
+  /** Column to aggregate. */
+  columnName: string;
+  /** Mondrian formatString, e.g. "$#,##0". */
+  formatString?: string;
+  /**
+   * Percentile fraction (0–100). Only meaningful when
+   * {@link aggregator} === 'percentile' — median is the implicit 50th
+   * percentile and carries no value. Emitted as `percentile="N"`; defaults
+   * to 50 when omitted.
+   */
+  percentile?: number | null;
+  /**
+   * Optional `saiku.semantic.*` annotations (description, synonyms, unit,
+   * currency, aggregation_kind, pii) — drive the AI Ask layer + PII
+   * protection. Keyed by bare suffix; emitted as
+   * `<Annotation name="saiku.semantic.<key>">`.
+   */
+  annotations?: Record<string, string>;
 }
 
 /**
@@ -288,36 +300,36 @@ export interface SchemaCanvasMeasure {
  * (tableId === factTableId, columnName === col) — NOT by id.
  */
 export interface SchemaCanvasDimensionLink {
-	dimensionId: string;
-	foreignKeyColumn: string;
-	/** Undefined ≡ 'foreign-key' (the v1 default). */
-	linkKind?: 'foreign-key' | 'fact' | 'reference';
-	viaDimension?: string;
-	viaAttribute?: string;
+  dimensionId: string;
+  foreignKeyColumn: string;
+  /** Undefined ≡ 'foreign-key' (the v1 default). */
+  linkKind?: "foreign-key" | "fact" | "reference";
+  viaDimension?: string;
+  viaAttribute?: string;
 }
 
 export interface SchemaCanvasCalcToken {
-	kind: 'measure' | 'op';
-	/** Present for `kind === 'measure'`. */
-	name?: string;
-	/**
-	 * Whether a measure token references a whole measure GROUP rather than a
-	 * single measure.  Boolean to match the workbench's calc builder — the
-	 * chip highlights differently and the group expands to its members on
-	 * emit.
-	 */
-	fromGroup?: boolean;
-	/** Present for `kind === 'op'`. */
-	op?: '+' | '-' | '*' | '/';
+  kind: "measure" | "op";
+  /** Present for `kind === 'measure'`. */
+  name?: string;
+  /**
+   * Whether a measure token references a whole measure GROUP rather than a
+   * single measure.  Boolean to match the workbench's calc builder — the
+   * chip highlights differently and the group expands to its members on
+   * emit.
+   */
+  fromGroup?: boolean;
+  /** Present for `kind === 'op'`. */
+  op?: "+" | "-" | "*" | "/";
 }
 
 export interface SchemaCanvasCalc {
-	id: string;
-	name: string;
-	tokens: SchemaCanvasCalcToken[];
-	/** Free-text formula for `mode === 'expression'`. */
-	formula?: string;
-	mode?: 'build' | 'expression';
+  id: string;
+  name: string;
+  tokens: SchemaCanvasCalcToken[];
+  /** Free-text formula for `mode === 'expression'`. */
+  formula?: string;
+  mode?: "build" | "expression";
 }
 
 /**
@@ -327,99 +339,99 @@ export interface SchemaCanvasCalc {
  * docs.saiku.bi/mondrian/time-intelligence.
  */
 export interface SchemaCanvasTimeCalc {
-	id: string;
-	/** Generated calculated-member name, e.g. "Revenue YoY". */
-	name: string;
-	/** Metric type. */
-	type: 'yoy' | 'pop' | 'ytd' | 'rolling';
-	/** Name of an existing measure in the cube. */
-	measure: string;
-	/** Time dimension name — required only when the cube has >1 Time dimension. */
-	timeDimension?: string;
-	/** Rolling only: number of periods in the window (> 0). */
-	window?: number;
-	/** Rolling only: aggregation over the window (default sum). */
-	function?: 'sum' | 'avg';
-	/** MDX format string, e.g. "0.0%". */
-	formatString?: string;
+  id: string;
+  /** Generated calculated-member name, e.g. "Revenue YoY". */
+  name: string;
+  /** Metric type. */
+  type: "yoy" | "pop" | "ytd" | "rolling";
+  /** Name of an existing measure in the cube. */
+  measure: string;
+  /** Time dimension name — required only when the cube has >1 Time dimension. */
+  timeDimension?: string;
+  /** Rolling only: number of periods in the window (> 0). */
+  window?: number;
+  /** Rolling only: aggregation over the window (default sum). */
+  function?: "sum" | "avg";
+  /** MDX format string, e.g. "0.0%". */
+  formatString?: string;
 }
 
 export interface SchemaCanvasMeasureGroup {
-	id: string;
-	name: string;
-	/** Fact-table column names this group aggregates.  Resolve aggregator /
-	 *  format from `SchemaCanvasState.measures` by (factTableId, column). */
-	measureColumns: string[];
-	/** Canvas table id this group's measures live on. */
-	factTableId?: string | null;
-	dimensionLinks?: SchemaCanvasDimensionLink[];
-	/** Human captions per measure column — emitted as `<Measure caption>`. */
-	measureCaptions?: Record<string, string>;
+  id: string;
+  name: string;
+  /** Fact-table column names this group aggregates.  Resolve aggregator /
+   *  format from `SchemaCanvasState.measures` by (factTableId, column). */
+  measureColumns: string[];
+  /** Canvas table id this group's measures live on. */
+  factTableId?: string | null;
+  dimensionLinks?: SchemaCanvasDimensionLink[];
+  /** Human captions per measure column — emitted as `<Measure caption>`. */
+  measureCaptions?: Record<string, string>;
 }
 
 export interface SchemaCanvasCube {
-	id: string;
-	name: string;
-	measureGroups: SchemaCanvasMeasureGroup[];
-	calcs: SchemaCanvasCalc[];
-	/** Declarative time-intelligence metrics (yoy/pop/ytd/rolling), #time-intel. */
-	timeCalcs?: SchemaCanvasTimeCalc[];
+  id: string;
+  name: string;
+  measureGroups: SchemaCanvasMeasureGroup[];
+  calcs: SchemaCanvasCalc[];
+  /** Declarative time-intelligence metrics (yoy/pop/ytd/rolling), #time-intel. */
+  timeCalcs?: SchemaCanvasTimeCalc[];
 }
 
 export interface SchemaCanvasState {
-	/** Persistence schema version — bump when shape changes. */
-	version: 1;
-	/** Connection id this canvas is being authored against. */
-	connectionId: string;
-	/** Optional human label for the in-progress schema. */
-	label: string;
-	/**
-	 * Lineage id of the schema this canvas is refining (#877 sibling).
-	 * Set when the author picks "Open" on an existing library entry so
-	 * the next Save action bumps THAT lineage's version rather than
-	 * minting a new one.  Null / undefined when the canvas is a fresh
-	 * cube or a duplicate.
-	 */
-	lineageId?: string | null;
-	tables: SchemaCanvasTable[];
-	joins: SchemaCanvasJoin[];
-	groups: SchemaCanvasGroup[];
-	/**
-	 * Human-renamed labels for join groups, keyed by the join's
-	 * canonical key (shared column name when source.col === target.col,
-	 * otherwise the sorted column-pair). Lets Amelia rename a
-	 * `customer_id` group to "Customer" and have every existing AND
-	 * future join with that canonical key inherit the label.
-	 */
-	joinGroupRenames?: Record<string, string>;
-	/**
-	 * Dimensions Workbench output — the Mondrian-shaped dimensions
-	 * authored against the join graph in Step 1. Optional for
-	 * back-compat with older docs in localStorage; the store fills
-	 * in an empty array on load.
-	 */
-	dimensions?: SchemaCanvasDimension[];
-	/** Mondrian measures — fact-side aggregations. Optional for
-	 *  back-compat with older docs. */
-	measures?: SchemaCanvasMeasure[];
-	/**
-	 * Cubes — measure groups + calculated members authored in the Facts &
-	 * Measures workbench.  Optional for back-compat with older docs; the
-	 * store fills in an empty array on load (and migrates the workbench's
-	 * former localStorage `saiku.workbench.cubesState` on first load).
-	 */
-	cubes?: SchemaCanvasCube[];
-	/** ISO timestamp; bumped on every mutation so we can show "last edited X minutes ago". */
-	updatedAt: string;
+  /** Persistence schema version — bump when shape changes. */
+  version: 1;
+  /** Connection id this canvas is being authored against. */
+  connectionId: string;
+  /** Optional human label for the in-progress schema. */
+  label: string;
+  /**
+   * Lineage id of the schema this canvas is refining (#877 sibling).
+   * Set when the author picks "Open" on an existing library entry so
+   * the next Save action bumps THAT lineage's version rather than
+   * minting a new one.  Null / undefined when the canvas is a fresh
+   * cube or a duplicate.
+   */
+  lineageId?: string | null;
+  tables: SchemaCanvasTable[];
+  joins: SchemaCanvasJoin[];
+  groups: SchemaCanvasGroup[];
+  /**
+   * Human-renamed labels for join groups, keyed by the join's
+   * canonical key (shared column name when source.col === target.col,
+   * otherwise the sorted column-pair). Lets Amelia rename a
+   * `customer_id` group to "Customer" and have every existing AND
+   * future join with that canonical key inherit the label.
+   */
+  joinGroupRenames?: Record<string, string>;
+  /**
+   * Dimensions Workbench output — the Mondrian-shaped dimensions
+   * authored against the join graph in Step 1. Optional for
+   * back-compat with older docs in localStorage; the store fills
+   * in an empty array on load.
+   */
+  dimensions?: SchemaCanvasDimension[];
+  /** Mondrian measures — fact-side aggregations. Optional for
+   *  back-compat with older docs. */
+  measures?: SchemaCanvasMeasure[];
+  /**
+   * Cubes — measure groups + calculated members authored in the Facts &
+   * Measures workbench.  Optional for back-compat with older docs; the
+   * store fills in an empty array on load (and migrates the workbench's
+   * former localStorage `saiku.workbench.cubesState` on first load).
+   */
+  cubes?: SchemaCanvasCube[];
+  /** ISO timestamp; bumped on every mutation so we can show "last edited X minutes ago". */
+  updatedAt: string;
 }
 
 /** A row in the sidebar's source-table catalog — a candidate the user can drag onto the canvas. */
 export interface SourceTableCandidate {
-	schema: string | null;
-	name: string;
-	columns: ProfileColumnSummary[];
-	/** True if the user has already pulled this onto the canvas (drives the sidebar's "on canvas" indicator). */
-	onCanvas: boolean;
+  schema: string | null;
+  name: string;
+  columns: ProfileColumnSummary[];
+  /** True if the user has already pulled this onto the canvas (drives the sidebar's "on canvas" indicator). */
+  onCanvas: boolean;
 }
 
 /** Re-export for convenience. */

--- a/saiku-ui/src/lib/cube-designer/types.ts
+++ b/saiku-ui/src/lib/cube-designer/types.ts
@@ -1,0 +1,426 @@
+/**
+ * Canvas schema designer — data model.
+ *
+ * The user picks a fact table + a set of dimension/bridge tables, visually
+ * positions them on a canvas, and wires column-to-column joins between
+ * them. Result is serialisable to localStorage and ultimately exportable
+ * to a Mondrian schema.
+ *
+ * Glossary:
+ *   - SchemaCanvasTable — a table the user has pulled onto the canvas.
+ *   - SchemaCanvasJoin  — an edge between two columns on two tables.
+ *   - SchemaCanvasState — the whole document for one in-progress schema.
+ *
+ * Source-table catalog (the sidebar contents) is loaded separately from
+ * the existing /api/inference/profile-connection endpoint and isn't part
+ * of this document.
+ */
+import type { ProfileTableSummary, ProfileColumnSummary } from './profile-types';
+
+export type SchemaCanvasTableRole = 'fact' | 'dimension' | 'bridge';
+
+export interface SchemaCanvasTable {
+	/** Unique within a canvas document. Generated locally. */
+	id: string;
+	/** Schema-qualified name from the source warehouse — e.g. `public.sales_fact_1997`. */
+	schema: string | null;
+	name: string;
+	role: SchemaCanvasTableRole;
+	/** Columns mirrored from the source-table catalog at the moment of pull-in. */
+	columns: SchemaCanvasColumn[];
+	/** Canvas position. ELK auto-layout writes here; manual drag also writes here. */
+	position: { x: number; y: number };
+	/** Group id this table belongs to, or null for ungrouped. */
+	groupId: string | null;
+	/** Collapsed = header only (no column list). Defaults to expanded. */
+	collapsed?: boolean;
+}
+
+export interface SchemaCanvasColumn {
+	name: string;
+	sqlType: string;
+	/** Inferred by name-match against other tables; user can override. */
+	isPrimaryKey?: boolean;
+	/** Used by the validation pass — "this column is required but isn't joined to anything." */
+	required?: boolean;
+}
+
+export type SchemaCanvasJoinKind = 'inner' | 'left' | 'right' | 'full';
+
+export interface SchemaCanvasJoin {
+	id: string;
+	/** Always references SchemaCanvasTable.id, not the source-warehouse name. */
+	sourceTableId: string;
+	sourceColumnName: string;
+	targetTableId: string;
+	targetColumnName: string;
+	kind: SchemaCanvasJoinKind;
+	/**
+	 * Where this join came from.  Drives canvas visibility + editability:
+	 *  - `physical` (default) — user-authored OR imported from Mondrian-4
+	 *    `<PhysicalSchema><Link>` / Mondrian-3 nested `<Hierarchy><Table>`.
+	 *    Editable, always rendered.
+	 *  - `cube-link` — auto-inferred from a Mondrian-4 `<MeasureGroup>`'s
+	 *    `<ForeignKeyLink>`.  Cube-side semantic link, NOT a physical-schema
+	 *    statement.  Hidden by default; rendered dashed when shown; not
+	 *    user-editable (delete the FK link on the MG instead).
+	 *  - `inferred-fk` — legacy fallback when nothing explicit existed.
+	 *    Same treatment as cube-link.
+	 *  Undefined is treated as `physical` for back-compat with older docs.
+	 */
+	origin?: 'physical' | 'cube-link' | 'inferred-fk';
+}
+
+export interface SchemaCanvasGroup {
+	id: string;
+	label: string;
+	/** Optional colour token override; otherwise the default group palette is used. */
+	color?: string;
+	collapsed: boolean;
+}
+
+/**
+ * Coarse column-type bucket used by the Dimensions Workbench to decide
+ * how a dragged column wants to be wired up (a numeric column drops in
+ * as a measure with `sum` by default; a string column drops in as a
+ * level). Mirrors a Mondrian `Level type` attribute when present.
+ */
+export type SchemaCanvasColumnKind = 'String' | 'Numeric' | 'Integer' | 'Boolean' | 'Date';
+
+/**
+ * One Mondrian-style level inside a hierarchy. Levels are ordered
+ * coarse → fine (Year → Quarter → Month) — that's the Mondrian
+ * convention and what the workbench renders top-to-bottom.
+ */
+export interface SchemaCanvasLevel {
+	id: string;
+	/** User-visible label, e.g. "Year". Defaults to the column name. */
+	name: string;
+	/** Mondrian 4 `caption` — display label shown to end users, distinct from
+	 *  the logical `name`. Optional; when unset the engine falls back to `name`. */
+	caption?: string;
+	/** Canvas table id the column lives on. */
+	tableId: string;
+	/** Column referenced — the level's `column` attribute in Mondrian. */
+	columnName: string;
+	/** Coarse type bucket — drives downstream Mondrian export. */
+	type?: SchemaCanvasColumnKind;
+	/**
+	 * Mondrian-4 `levelType` — marks a level as a time grain so the engine can
+	 * drive time-intelligence (`<TimeCalc>` requires a `TimeYears` level).
+	 * Only meaningful on a Time dimension; emitted onto the M4 `<Attribute>`.
+	 * See docs.saiku.bi/mondrian/time-intelligence.
+	 */
+	levelType?: 'TimeYears' | 'TimeQuarters' | 'TimeMonths' | 'TimeDays';
+	/**
+	 * Optional `saiku.semantic.*` annotations (description, synonyms, cardinality,
+	 * grain, required_filters, pii) — drive the AI Ask layer + PII protection.
+	 * Keyed by the bare suffix (e.g. `description`, `pii`); emitted as
+	 * `<Annotation name="saiku.semantic.<key>">`. See
+	 * docs.saiku.bi/mondrian/semantic-annotations.
+	 */
+	annotations?: Record<string, string>;
+}
+
+/**
+ * One Mondrian hierarchy inside a dimension. A dimension always has
+ * at least one hierarchy (Mondrian requires it); the workbench
+ * auto-creates a first hierarchy whenever a level is dropped onto a
+ * dimension card.
+ */
+export interface SchemaCanvasHierarchy {
+	id: string;
+	/** User-visible label. Defaults to the dimension name on creation. */
+	name: string;
+	/** Mondrian `hasAll` attribute — default true. */
+	hasAll: boolean;
+	/** Mondrian 4 `allMemberName` — overrides "All" with a custom label
+	 *  for the synthetic top member.  Optional. */
+	allMemberName?: string;
+	/** Mondrian 4 `defaultMember` — MDX-style member reference that
+	 *  becomes the default when this hierarchy is queried without an
+	 *  explicit member.  Optional. */
+	defaultMember?: string;
+	/** Mondrian 4 `caption` — display label distinct from `name`.
+	 *  Optional. */
+	caption?: string;
+	/** Mondrian 4 `description` — long-form documentation.  Optional. */
+	description?: string;
+	/** Ordered coarse → fine. */
+	levels: SchemaCanvasLevel[];
+	/** Mondrian `<Closure>` — parent-child hierarchy optimisation that
+	 *  pre-materialises (ancestor, descendant) pairs so MDX queries don't
+	 *  have to walk the parent chain at query time.  Used by FoodMart's
+	 *  HR Employee hierarchy. */
+	closure?: {
+		table: string;
+		parentColumn: string;
+		childColumn: string;
+	};
+}
+
+/**
+ * One Mondrian dimension. A dimension corresponds to one column on
+ * the fact table (the `foreignKey`) joining to a `primaryKey` column
+ * on a dimension table. Degenerate dimensions (no FK, lives on the
+ * fact) leave foreignKey/primaryKey unset.
+ */
+export interface SchemaCanvasDimension {
+	id: string;
+	/** User-visible label, e.g. "Customer". */
+	name: string;
+	/** Column on the fact table linking to this dimension. Undefined
+	 *  for degenerate dimensions. */
+	foreignKey?: string;
+	/** The physical table this dim is authored against — pick it FIRST
+	 *  in the Dimensions pane before choosing attributes.  Every non-hanger
+	 *  dim needs one; the Attributes pane shows this table's columns.
+	 *  Historical note: previously conflated with `primaryKeyTableId`; the
+	 *  import + store hydration both back-fill from `primaryKeyTableId` for
+	 *  old docs that only carried the merged field. */
+	sourceTableId?: string;
+	/** PK column on the dim's source table. Undefined for degenerate dims.
+	 *  Chosen from the attributes AFTER `sourceTableId` is set. */
+	primaryKey?: string;
+	/** Which on-canvas table holds the PK column.  ONLY set explicitly
+	 *  when the dim is a snowflake (attribute lives on a table other than
+	 *  `sourceTableId`).  For normal dims, treat as `sourceTableId`. */
+	primaryKeyTableId?: string;
+	/** Ordered hierarchies. */
+	hierarchies: SchemaCanvasHierarchy[];
+	/** Set theory: A ⊆ T.  The user-chosen subset of the source's
+	 *  columns that this dim is allowed to draw from when composing
+	 *  hierarchies.  Each attribute is a {tableId, columnName} pair so
+	 *  the same data can come from any of the source's tables (for
+	 *  join-group sources).
+	 *  - `name` is the Mondrian `<Attribute name="...">` logical label;
+	 *    used by `<Level attribute="X"/>` references inside hierarchies.
+	 *  - `keyColumns` (optional) carries composite-key columns when the
+	 *    Mondrian `<Key><Column/><Column/></Key>` had more than one column.
+	 *    Empty / absent → use `columnName` alone.  Round-trip preserved.
+	 *  Undefined means "no attributes picked yet" — distinct from the
+	 *  empty array, which means "all excluded". */
+	attributes?: {
+		tableId: string;
+		columnName: string;
+		name?: string;
+		keyColumns?: string[];
+		/** Mondrian 4 `nameColumn` — the column whose value is DISPLAYED for a
+		 *  member, when it differs from the key column (e.g. key on `product_id`,
+		 *  display `product_name`). Optional. */
+		nameColumn?: string;
+		/** Mondrian 4 `captionColumn` — column supplying a per-member caption.
+		 *  Optional. */
+		captionColumn?: string;
+		/** Mondrian 4 `orderByColumn` — column members are sorted by, when it
+		 *  differs from the key. Optional. */
+		orderByColumn?: string;
+		/** Mondrian 4 `description` — long-form documentation. Optional. */
+		description?: string;
+	}[];
+	/** Mondrian 4 `hanger='true'` — a dim with no underlying table whose
+	 *  members are sliced via MDX expressions ("Actual vs Budget" style).
+	 *  No primaryKey / no FK link to a fact.  Cube authors use these for
+	 *  scenario filters that aren't backed by data. */
+	hanger?: boolean;
+	/** When the dim was sourced from a join group (rather than a single
+	 *  table), this is the group's key — used to label the dim as a
+	 *  join-source in UIs even after the user renames it. */
+	sourceJoinGroupKey?: string;
+	/** Mondrian 4 `caption` — display label distinct from `name`. */
+	caption?: string;
+	/** Mondrian 4 `description` — long-form documentation. */
+	description?: string;
+	/** Mondrian 4 `type` — Standard | Time | Geographic.  Default
+	 *  Standard.  Drives engine-side semantics (Time dimensions get
+	 *  special MDX functions like ParallelPeriod). */
+	dimensionType?: 'Standard' | 'Time' | 'Geographic';
+	/**
+	 * Optional `saiku.semantic.*` annotations (description, synonyms) — business
+	 * context for the AI Ask layer. Keyed by bare suffix; emitted as
+	 * `<Annotation name="saiku.semantic.<key>">`.
+	 */
+	annotations?: Record<string, string>;
+}
+
+/**
+ * One Mondrian measure. Measures aggregate a numeric column on the
+ * fact table — the workbench enforces only that `tableId` references
+ * an on-canvas table; promoting one to the fact role is Step 1's job.
+ */
+export interface SchemaCanvasMeasure {
+	id: string;
+	/** User-visible label, e.g. "Sales". */
+	name: string;
+	aggregator: 'sum' | 'count' | 'avg' | 'min' | 'max' | 'distinct-count' | 'median' | 'percentile';
+	/** Canvas table id the column lives on (typically the fact). */
+	tableId: string;
+	/** Column to aggregate. */
+	columnName: string;
+	/** Mondrian formatString, e.g. "$#,##0". */
+	formatString?: string;
+	/**
+	 * Percentile fraction (0–100). Only meaningful when
+	 * {@link aggregator} === 'percentile' — median is the implicit 50th
+	 * percentile and carries no value. Emitted as `percentile="N"`; defaults
+	 * to 50 when omitted.
+	 */
+	percentile?: number | null;
+	/**
+	 * Optional `saiku.semantic.*` annotations (description, synonyms, unit,
+	 * currency, aggregation_kind, pii) — drive the AI Ask layer + PII
+	 * protection. Keyed by bare suffix; emitted as
+	 * `<Annotation name="saiku.semantic.<key>">`.
+	 */
+	annotations?: Record<string, string>;
+}
+
+/**
+ * Cube model — the serialisable half of the Facts & Measures workbench.
+ *
+ * The workbench (`WorkbenchView.svelte`) owns a richer per-cube state that
+ * also carries UI-only flags (edit modes, confirm flags, selection cursors,
+ * search text, seq counters).  Those stay component-local.  What lives in the
+ * doc is only the durable model an external caller (e.g. DimSum) needs to
+ * create and the exporter needs to emit: cubes → measure groups → measure
+ * columns + dimension links + calculated members.  A measure group's
+ * `measureColumns` map to `SchemaCanvasState.measures` by
+ * (tableId === factTableId, columnName === col) — NOT by id.
+ */
+export interface SchemaCanvasDimensionLink {
+	dimensionId: string;
+	foreignKeyColumn: string;
+	/** Undefined ≡ 'foreign-key' (the v1 default). */
+	linkKind?: 'foreign-key' | 'fact' | 'reference';
+	viaDimension?: string;
+	viaAttribute?: string;
+}
+
+export interface SchemaCanvasCalcToken {
+	kind: 'measure' | 'op';
+	/** Present for `kind === 'measure'`. */
+	name?: string;
+	/**
+	 * Whether a measure token references a whole measure GROUP rather than a
+	 * single measure.  Boolean to match the workbench's calc builder — the
+	 * chip highlights differently and the group expands to its members on
+	 * emit.
+	 */
+	fromGroup?: boolean;
+	/** Present for `kind === 'op'`. */
+	op?: '+' | '-' | '*' | '/';
+}
+
+export interface SchemaCanvasCalc {
+	id: string;
+	name: string;
+	tokens: SchemaCanvasCalcToken[];
+	/** Free-text formula for `mode === 'expression'`. */
+	formula?: string;
+	mode?: 'build' | 'expression';
+}
+
+/**
+ * One Mondrian-4 declarative `<TimeCalc>` — a cube-scoped time-intelligence
+ * metric that the engine desugars into a `<CalculatedMember>` on `[Measures]`.
+ * Requires a typed Time dimension with a `TimeYears` level in the cube. See
+ * docs.saiku.bi/mondrian/time-intelligence.
+ */
+export interface SchemaCanvasTimeCalc {
+	id: string;
+	/** Generated calculated-member name, e.g. "Revenue YoY". */
+	name: string;
+	/** Metric type. */
+	type: 'yoy' | 'pop' | 'ytd' | 'rolling';
+	/** Name of an existing measure in the cube. */
+	measure: string;
+	/** Time dimension name — required only when the cube has >1 Time dimension. */
+	timeDimension?: string;
+	/** Rolling only: number of periods in the window (> 0). */
+	window?: number;
+	/** Rolling only: aggregation over the window (default sum). */
+	function?: 'sum' | 'avg';
+	/** MDX format string, e.g. "0.0%". */
+	formatString?: string;
+}
+
+export interface SchemaCanvasMeasureGroup {
+	id: string;
+	name: string;
+	/** Fact-table column names this group aggregates.  Resolve aggregator /
+	 *  format from `SchemaCanvasState.measures` by (factTableId, column). */
+	measureColumns: string[];
+	/** Canvas table id this group's measures live on. */
+	factTableId?: string | null;
+	dimensionLinks?: SchemaCanvasDimensionLink[];
+	/** Human captions per measure column — emitted as `<Measure caption>`. */
+	measureCaptions?: Record<string, string>;
+}
+
+export interface SchemaCanvasCube {
+	id: string;
+	name: string;
+	measureGroups: SchemaCanvasMeasureGroup[];
+	calcs: SchemaCanvasCalc[];
+	/** Declarative time-intelligence metrics (yoy/pop/ytd/rolling), #time-intel. */
+	timeCalcs?: SchemaCanvasTimeCalc[];
+}
+
+export interface SchemaCanvasState {
+	/** Persistence schema version — bump when shape changes. */
+	version: 1;
+	/** Connection id this canvas is being authored against. */
+	connectionId: string;
+	/** Optional human label for the in-progress schema. */
+	label: string;
+	/**
+	 * Lineage id of the schema this canvas is refining (#877 sibling).
+	 * Set when the author picks "Open" on an existing library entry so
+	 * the next Save action bumps THAT lineage's version rather than
+	 * minting a new one.  Null / undefined when the canvas is a fresh
+	 * cube or a duplicate.
+	 */
+	lineageId?: string | null;
+	tables: SchemaCanvasTable[];
+	joins: SchemaCanvasJoin[];
+	groups: SchemaCanvasGroup[];
+	/**
+	 * Human-renamed labels for join groups, keyed by the join's
+	 * canonical key (shared column name when source.col === target.col,
+	 * otherwise the sorted column-pair). Lets Amelia rename a
+	 * `customer_id` group to "Customer" and have every existing AND
+	 * future join with that canonical key inherit the label.
+	 */
+	joinGroupRenames?: Record<string, string>;
+	/**
+	 * Dimensions Workbench output — the Mondrian-shaped dimensions
+	 * authored against the join graph in Step 1. Optional for
+	 * back-compat with older docs in localStorage; the store fills
+	 * in an empty array on load.
+	 */
+	dimensions?: SchemaCanvasDimension[];
+	/** Mondrian measures — fact-side aggregations. Optional for
+	 *  back-compat with older docs. */
+	measures?: SchemaCanvasMeasure[];
+	/**
+	 * Cubes — measure groups + calculated members authored in the Facts &
+	 * Measures workbench.  Optional for back-compat with older docs; the
+	 * store fills in an empty array on load (and migrates the workbench's
+	 * former localStorage `saiku.workbench.cubesState` on first load).
+	 */
+	cubes?: SchemaCanvasCube[];
+	/** ISO timestamp; bumped on every mutation so we can show "last edited X minutes ago". */
+	updatedAt: string;
+}
+
+/** A row in the sidebar's source-table catalog — a candidate the user can drag onto the canvas. */
+export interface SourceTableCandidate {
+	schema: string | null;
+	name: string;
+	columns: ProfileColumnSummary[];
+	/** True if the user has already pulled this onto the canvas (drives the sidebar's "on canvas" indicator). */
+	onCanvas: boolean;
+}
+
+/** Re-export for convenience. */
+export type { ProfileTableSummary, ProfileColumnSummary };

--- a/saiku-ui/src/lib/cube-designer/workbench-columns.test.ts
+++ b/saiku-ui/src/lib/cube-designer/workbench-columns.test.ts
@@ -1,54 +1,69 @@
-import { describe, it, expect } from 'vitest';
-import { classifyColumn, isNumericKind } from './workbench-columns.js';
+import { describe, it, expect } from "vitest";
+import { classifyColumn, isNumericKind } from "./workbench-columns.js";
 
-describe('classifyColumn', () => {
-	it('returns undefined for a missing sqlType', () => {
-		expect(classifyColumn(undefined)).toBeUndefined();
-		expect(classifyColumn('')).toBeUndefined();
-	});
+describe("classifyColumn", () => {
+  it("returns undefined for a missing sqlType", () => {
+    expect(classifyColumn(undefined)).toBeUndefined();
+    expect(classifyColumn("")).toBeUndefined();
+  });
 
-	it('maps integer-family types to Integer', () => {
-		for (const t of ['int', 'integer', 'bigint', 'smallint', 'tinyint', 'serial', 'BIGSERIAL']) {
-			expect(classifyColumn(t)).toBe('Integer');
-		}
-	});
+  it("maps integer-family types to Integer", () => {
+    for (const t of [
+      "int",
+      "integer",
+      "bigint",
+      "smallint",
+      "tinyint",
+      "serial",
+      "BIGSERIAL",
+    ]) {
+      expect(classifyColumn(t)).toBe("Integer");
+    }
+  });
 
-	it('maps real/decimal-family types to Numeric', () => {
-		for (const t of ['numeric', 'decimal(10,2)', 'float', 'double precision', 'real', 'money']) {
-			expect(classifyColumn(t)).toBe('Numeric');
-		}
-	});
+  it("maps real/decimal-family types to Numeric", () => {
+    for (const t of [
+      "numeric",
+      "decimal(10,2)",
+      "float",
+      "double precision",
+      "real",
+      "money",
+    ]) {
+      expect(classifyColumn(t)).toBe("Numeric");
+    }
+  });
 
-	it('maps boolean types to Boolean', () => {
-		expect(classifyColumn('boolean')).toBe('Boolean');
-		expect(classifyColumn('bool')).toBe('Boolean');
-	});
+  it("maps boolean types to Boolean", () => {
+    expect(classifyColumn("boolean")).toBe("Boolean");
+    expect(classifyColumn("bool")).toBe("Boolean");
+  });
 
-	it('maps date/time types to Date', () => {
-		for (const t of ['date', 'timestamp', 'timestamptz', 'time']) {
-			expect(classifyColumn(t)).toBe('Date');
-		}
-	});
+  it("maps date/time types to Date", () => {
+    for (const t of ["date", "timestamp", "timestamptz", "time"]) {
+      expect(classifyColumn(t)).toBe("Date");
+    }
+  });
 
-	it('falls back to String for text-like types', () => {
-		for (const t of ['text', 'varchar(255)', 'char', 'uuid']) {
-			expect(classifyColumn(t)).toBe('String');
-		}
-	});
+  it("falls back to String for text-like types", () => {
+    for (const t of ["text", "varchar(255)", "char", "uuid"]) {
+      expect(classifyColumn(t)).toBe("String");
+    }
+  });
 
-	it('is case-insensitive', () => {
-		expect(classifyColumn('INTEGER')).toBe('Integer');
-		expect(classifyColumn('Numeric')).toBe('Numeric');
-	});
+  it("is case-insensitive", () => {
+    expect(classifyColumn("INTEGER")).toBe("Integer");
+    expect(classifyColumn("Numeric")).toBe("Numeric");
+  });
 });
 
-describe('isNumericKind', () => {
-	it('is true only for Numeric and Integer', () => {
-		expect(isNumericKind('Numeric')).toBe(true);
-		expect(isNumericKind('Integer')).toBe(true);
-		expect(isNumericKind('String')).toBe(false);
-		expect(isNumericKind('Date')).toBe(false);
-		expect(isNumericKind('Boolean')).toBe(false);
-		expect(isNumericKind(undefined)).toBe(false);
-	});
+describe("isNumericKind", () => {
+  it("is true only for Numeric and Integer", () => {
+    expect(isNumericKind("Numeric")).toBe(true);
+    expect(isNumericKind("Integer")).toBe(true);
+    expect(isNumericKind("String")).toBe(false);
+    expect(isNumericKind("Date")).toBe(false);
+    expect(isNumericKind("Boolean")).toBe(false);
+    expect(isNumericKind(undefined)).toBe(false);
+  });
 });

--- a/saiku-ui/src/lib/cube-designer/workbench-columns.test.ts
+++ b/saiku-ui/src/lib/cube-designer/workbench-columns.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from 'vitest';
+import { classifyColumn, isNumericKind } from './workbench-columns.js';
+
+describe('classifyColumn', () => {
+	it('returns undefined for a missing sqlType', () => {
+		expect(classifyColumn(undefined)).toBeUndefined();
+		expect(classifyColumn('')).toBeUndefined();
+	});
+
+	it('maps integer-family types to Integer', () => {
+		for (const t of ['int', 'integer', 'bigint', 'smallint', 'tinyint', 'serial', 'BIGSERIAL']) {
+			expect(classifyColumn(t)).toBe('Integer');
+		}
+	});
+
+	it('maps real/decimal-family types to Numeric', () => {
+		for (const t of ['numeric', 'decimal(10,2)', 'float', 'double precision', 'real', 'money']) {
+			expect(classifyColumn(t)).toBe('Numeric');
+		}
+	});
+
+	it('maps boolean types to Boolean', () => {
+		expect(classifyColumn('boolean')).toBe('Boolean');
+		expect(classifyColumn('bool')).toBe('Boolean');
+	});
+
+	it('maps date/time types to Date', () => {
+		for (const t of ['date', 'timestamp', 'timestamptz', 'time']) {
+			expect(classifyColumn(t)).toBe('Date');
+		}
+	});
+
+	it('falls back to String for text-like types', () => {
+		for (const t of ['text', 'varchar(255)', 'char', 'uuid']) {
+			expect(classifyColumn(t)).toBe('String');
+		}
+	});
+
+	it('is case-insensitive', () => {
+		expect(classifyColumn('INTEGER')).toBe('Integer');
+		expect(classifyColumn('Numeric')).toBe('Numeric');
+	});
+});
+
+describe('isNumericKind', () => {
+	it('is true only for Numeric and Integer', () => {
+		expect(isNumericKind('Numeric')).toBe(true);
+		expect(isNumericKind('Integer')).toBe(true);
+		expect(isNumericKind('String')).toBe(false);
+		expect(isNumericKind('Date')).toBe(false);
+		expect(isNumericKind('Boolean')).toBe(false);
+		expect(isNumericKind(undefined)).toBe(false);
+	});
+});

--- a/saiku-ui/src/lib/cube-designer/workbench-columns.ts
+++ b/saiku-ui/src/lib/cube-designer/workbench-columns.ts
@@ -6,18 +6,22 @@
  * across PG / MySQL / DuckDB / Snowflake without tracking every dialect's
  * spelling. Extracted from `WorkbenchView.svelte` so it is unit-testable.
  */
-import type { SchemaCanvasColumnKind } from './types.js';
+import type { SchemaCanvasColumnKind } from "./types.js";
 
-export function classifyColumn(sqlType: string | undefined): SchemaCanvasColumnKind | undefined {
-	if (!sqlType) return undefined;
-	const t = sqlType.toLowerCase();
-	if (/int|serial|bigint|smallint|tinyint/.test(t)) return 'Integer';
-	if (/numeric|decimal|float|double|real|money/.test(t)) return 'Numeric';
-	if (/bool/.test(t)) return 'Boolean';
-	if (/date|time|timestamp/.test(t)) return 'Date';
-	return 'String';
+export function classifyColumn(
+  sqlType: string | undefined,
+): SchemaCanvasColumnKind | undefined {
+  if (!sqlType) return undefined;
+  const t = sqlType.toLowerCase();
+  if (/int|serial|bigint|smallint|tinyint/.test(t)) return "Integer";
+  if (/numeric|decimal|float|double|real|money/.test(t)) return "Numeric";
+  if (/bool/.test(t)) return "Boolean";
+  if (/date|time|timestamp/.test(t)) return "Date";
+  return "String";
 }
 
-export function isNumericKind(kind: SchemaCanvasColumnKind | undefined): boolean {
-	return kind === 'Numeric' || kind === 'Integer';
+export function isNumericKind(
+  kind: SchemaCanvasColumnKind | undefined,
+): boolean {
+  return kind === "Numeric" || kind === "Integer";
 }

--- a/saiku-ui/src/lib/cube-designer/workbench-columns.ts
+++ b/saiku-ui/src/lib/cube-designer/workbench-columns.ts
@@ -1,0 +1,23 @@
+/**
+ * SQL type → coarse Mondrian column kind (saiku-cloud#1039 split).
+ *
+ * Mondrian only really cares about Numeric vs everything else for level +
+ * measure typing. We do a string-contains check so the rule stays portable
+ * across PG / MySQL / DuckDB / Snowflake without tracking every dialect's
+ * spelling. Extracted from `WorkbenchView.svelte` so it is unit-testable.
+ */
+import type { SchemaCanvasColumnKind } from './types.js';
+
+export function classifyColumn(sqlType: string | undefined): SchemaCanvasColumnKind | undefined {
+	if (!sqlType) return undefined;
+	const t = sqlType.toLowerCase();
+	if (/int|serial|bigint|smallint|tinyint/.test(t)) return 'Integer';
+	if (/numeric|decimal|float|double|real|money/.test(t)) return 'Numeric';
+	if (/bool/.test(t)) return 'Boolean';
+	if (/date|time|timestamp/.test(t)) return 'Date';
+	return 'String';
+}
+
+export function isNumericKind(kind: SchemaCanvasColumnKind | undefined): boolean {
+	return kind === 'Numeric' || kind === 'Integer';
+}

--- a/saiku-ui/src/lib/cube-designer/workbench-cubes.test.ts
+++ b/saiku-ui/src/lib/cube-designer/workbench-cubes.test.ts
@@ -1,0 +1,296 @@
+import { describe, it, expect } from 'vitest';
+import {
+	maxSeq,
+	blankCube,
+	cubeToDoc,
+	cubeFromDoc,
+	mgFromDoc,
+	calcFromDoc,
+	renderCalcTokens,
+	calcMode,
+	type WorkbenchCube
+} from './workbench-cubes.js';
+import { exportToMondrianXml } from './mondrian-export.js';
+import type { SchemaCanvasState, SchemaCanvasCube } from './types.js';
+
+describe('maxSeq', () => {
+	it('returns the highest captured number, or 0 when none match', () => {
+		expect(maxSeq(['mg-1', 'mg-4', 'mg-2'], /mg-(\d+)/)).toBe(4);
+		expect(maxSeq([], /mg-(\d+)/)).toBe(0);
+		expect(maxSeq(['dim-x', 'other'], /mg-(\d+)/)).toBe(0);
+	});
+});
+
+describe('blankCube', () => {
+	it('creates an empty edit-mode cube with the given id + name', () => {
+		const c = blankCube('cube-1', 'Cube 1');
+		expect(c.id).toBe('cube-1');
+		expect(c.name).toBe('Cube 1');
+		expect(c.editMode).toBe(true);
+		expect(c.measureGroups).toEqual([]);
+		expect(c.factsCalcs).toEqual([]);
+	});
+});
+
+describe('renderCalcTokens / calcMode', () => {
+	it('renders chip tokens as a Mondrian bracket formula', () => {
+		expect(
+			renderCalcTokens({
+				id: 'c1',
+				name: 'Margin',
+				tokens: [
+					{ kind: 'measure', name: 'Sales' },
+					{ kind: 'op', op: '-' },
+					{ kind: 'measure', name: 'Cost' }
+				]
+			})
+		).toBe('[Sales] - [Cost]');
+	});
+
+	it('defaults calcMode to build when unset', () => {
+		expect(calcMode({ id: 'c', name: 'x', tokens: [] })).toBe('build');
+		expect(calcMode({ id: 'c', name: 'x', tokens: [], mode: 'expression' })).toBe('expression');
+	});
+});
+
+describe('cubeToDoc ⇄ cubeFromDoc', () => {
+	function richWorkbenchCube(): WorkbenchCube {
+		return {
+			id: 'cube-1',
+			name: 'Sales',
+			editMode: false,
+			selectedTableId: 'f',
+			tableConfirmed: true,
+			selectedMeasures: ['amount'],
+			tableSearch: 'sea',
+			measureGroups: [
+				{
+					id: 'mg-1',
+					name: 'Sales Facts',
+					measureColumns: ['amount', 'qty'],
+					factTableId: 'f',
+					dimensionLinks: [{ dimensionId: 'd1', foreignKeyColumn: 'customer_id' }],
+					measureCaptions: { amount: 'Revenue' },
+					factConfirmed: true,
+					measuresConfirmed: true,
+					dimsConfirmed: true
+				}
+			],
+			selectedGroupId: 'mg-1',
+			groupsEditMode: false,
+			groupSeq: 1,
+			factsCalcs: [
+				{
+					id: 'calc-1',
+					name: 'Margin',
+					tokens: [
+						{ kind: 'measure', name: 'Sales' },
+						{ kind: 'op', op: '-' },
+						{ kind: 'measure', name: 'Cost' }
+					],
+					mode: 'build'
+				}
+			],
+			selectedCalcId: 'calc-1',
+			calcsEditMode: false,
+			calcSeq: 1
+		};
+	}
+
+	it('strips UI-only flags to the durable doc shape', () => {
+		const doc = cubeToDoc(richWorkbenchCube());
+		expect(doc).toEqual({
+			id: 'cube-1',
+			name: 'Sales',
+			measureGroups: [
+				{
+					id: 'mg-1',
+					name: 'Sales Facts',
+					measureColumns: ['amount', 'qty'],
+					factTableId: 'f',
+					dimensionLinks: [{ dimensionId: 'd1', foreignKeyColumn: 'customer_id' }],
+					measureCaptions: { amount: 'Revenue' }
+				}
+			],
+			calcs: [
+				{
+					id: 'calc-1',
+					name: 'Margin',
+					tokens: [
+						{ kind: 'measure', name: 'Sales' },
+						{ kind: 'op', op: '-' },
+						{ kind: 'measure', name: 'Cost' }
+					],
+					formula: undefined,
+					mode: 'build'
+				}
+			]
+		});
+	});
+
+	it('does not share nested references with its source (immutable copy)', () => {
+		const wb = richWorkbenchCube();
+		const doc = cubeToDoc(wb);
+		expect(doc.measureGroups[0].measureColumns).not.toBe(wb.measureGroups[0].measureColumns);
+		expect(doc.measureGroups[0].dimensionLinks?.[0]).not.toBe(
+			wb.measureGroups[0].dimensionLinks?.[0]
+		);
+	});
+
+	it('re-derives UI flags from content on the way back', () => {
+		const doc = cubeToDoc(richWorkbenchCube());
+		const wb = cubeFromDoc(doc);
+		expect(wb.selectedTableId).toBe('f'); // first MG fact
+		expect(wb.tableConfirmed).toBe(true);
+		expect(wb.groupsEditMode).toBe(false); // has groups
+		expect(wb.calcsEditMode).toBe(false); // has calcs
+		expect(wb.groupSeq).toBe(1);
+		expect(wb.calcSeq).toBe(1);
+		expect(wb.measureGroups[0].factConfirmed).toBe(true);
+		expect(wb.measureGroups[0].measuresConfirmed).toBe(true);
+		expect(wb.measureGroups[0].dimsConfirmed).toBe(true);
+	});
+
+	it('mgFromDoc opens a blank group in edit mode', () => {
+		const mg = mgFromDoc({ id: 'mg-9', name: 'Empty', measureColumns: [] });
+		expect(mg.factConfirmed).toBe(false);
+		expect(mg.measuresConfirmed).toBe(false);
+		expect(mg.dimsConfirmed).toBe(false);
+	});
+
+	it('calcFromDoc defaults an op token op to +', () => {
+		const calc = calcFromDoc({ id: 'c', name: 'x', tokens: [{ kind: 'op' }] });
+		expect(calc.tokens[0]).toEqual({ kind: 'op', op: '+' });
+	});
+});
+
+/**
+ * #1038 — preview == export. The inspector Code-tab preview and the
+ * save/export path both funnel the workbench cubes through
+ * `cubeToDoc` → `exportToMondrianXml`. This pins that the two paths emit
+ * byte-identical Mondrian 4 for a representative workbench cube (previously
+ * the Code tab used a second, drift-prone inline emitter).
+ */
+describe('preview == export parity (#1038)', () => {
+	function representativeState(): {
+		base: SchemaCanvasState;
+		wbCube: WorkbenchCube;
+	} {
+		const base: SchemaCanvasState = {
+			version: 1,
+			connectionId: 'conn-1',
+			label: 'Sales',
+			tables: [
+				{
+					id: 'f',
+					schema: 'public',
+					name: 'sales_fact',
+					role: 'fact',
+					columns: [
+						{ name: 'amount', sqlType: 'numeric' },
+						{ name: 'qty', sqlType: 'numeric' },
+						{ name: 'customer_id', sqlType: 'int' }
+					],
+					position: { x: 0, y: 0 },
+					groupId: null
+				},
+				{
+					id: 'c',
+					schema: 'public',
+					name: 'customer',
+					role: 'dimension',
+					columns: [
+						{ name: 'id', sqlType: 'int' },
+						{ name: 'country', sqlType: 'text' }
+					],
+					position: { x: 100, y: 0 },
+					groupId: null
+				}
+			],
+			joins: [],
+			groups: [],
+			updatedAt: '2026-07-24T00:00:00.000Z',
+			dimensions: [
+				{
+					id: 'd1',
+					name: 'Customer',
+					sourceTableId: 'c',
+					primaryKeyTableId: 'c',
+					primaryKey: 'id',
+					attributes: [{ tableId: 'c', columnName: 'id' }],
+					hierarchies: [
+						{
+							id: 'h1',
+							name: 'Geo',
+							hasAll: true,
+							levels: [
+								{ id: 'l1', name: 'Country', tableId: 'c', columnName: 'country', type: 'String' }
+							]
+						}
+					]
+				}
+			],
+			measures: [
+				{
+					id: 'm1',
+					name: 'Sales',
+					aggregator: 'sum',
+					tableId: 'f',
+					columnName: 'amount',
+					formatString: '$#,##0'
+				}
+			]
+		};
+		const wbCube: WorkbenchCube = {
+			...blankCube('cube-1', 'Sales'),
+			measureGroups: [
+				{
+					id: 'mg-1',
+					name: 'Sales Facts',
+					measureColumns: ['amount', 'qty'],
+					factTableId: 'f',
+					dimensionLinks: [{ dimensionId: 'd1', foreignKeyColumn: 'customer_id' }]
+				}
+			],
+			factsCalcs: [
+				{
+					id: 'calc-1',
+					name: 'Margin',
+					tokens: [
+						{ kind: 'measure', name: 'Sales' },
+						{ kind: 'op', op: '-' },
+						{ kind: 'measure', name: 'Cost' }
+					],
+					mode: 'build'
+				}
+			]
+		};
+		return { base, wbCube };
+	}
+
+	it('the preview and export paths emit identical XML', () => {
+		const { base, wbCube } = representativeState();
+		const docCubes: SchemaCanvasCube[] = [wbCube].map(cubeToDoc);
+
+		// Export/save path: persist writes docCubes onto the doc, export reads it.
+		const exported = exportToMondrianXml({ ...base, cubes: docCubes });
+		// Preview path: builds the same docCubes live and exports on the fly.
+		const previewed = exportToMondrianXml({ ...base, cubes: [wbCube].map(cubeToDoc) });
+
+		expect(previewed).toBe(exported);
+	});
+
+	it('emits structurally valid Mondrian 4', () => {
+		const { base, wbCube } = representativeState();
+		const xml = exportToMondrianXml({ ...base, cubes: [wbCube].map(cubeToDoc) });
+		expect(xml).toContain('metamodelVersion="4.0"');
+		expect(xml).toContain('<Cube name="Sales">');
+		expect(xml).toContain('<MeasureGroup name="Sales Facts" table="sales_fact">');
+		expect(xml).toContain('<ForeignKeyLink dimension="Customer" foreignKeyColumn="customer_id" />');
+		expect(xml).toContain(
+			'<CalculatedMember name="Margin" dimension="Measures" formula="[Sales] - [Cost]"/>'
+		);
+		// M4 only — never the legacy M3 markers.
+		expect(xml).not.toContain('foreignKey=');
+	});
+});

--- a/saiku-ui/src/lib/cube-designer/workbench-cubes.test.ts
+++ b/saiku-ui/src/lib/cube-designer/workbench-cubes.test.ts
@@ -1,167 +1,175 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect } from "vitest";
 import {
-	maxSeq,
-	blankCube,
-	cubeToDoc,
-	cubeFromDoc,
-	mgFromDoc,
-	calcFromDoc,
-	renderCalcTokens,
-	calcMode,
-	type WorkbenchCube
-} from './workbench-cubes.js';
-import { exportToMondrianXml } from './mondrian-export.js';
-import type { SchemaCanvasState, SchemaCanvasCube } from './types.js';
+  maxSeq,
+  blankCube,
+  cubeToDoc,
+  cubeFromDoc,
+  mgFromDoc,
+  calcFromDoc,
+  renderCalcTokens,
+  calcMode,
+  type WorkbenchCube,
+} from "./workbench-cubes.js";
+import { exportToMondrianXml } from "./mondrian-export.js";
+import type { SchemaCanvasState, SchemaCanvasCube } from "./types.js";
 
-describe('maxSeq', () => {
-	it('returns the highest captured number, or 0 when none match', () => {
-		expect(maxSeq(['mg-1', 'mg-4', 'mg-2'], /mg-(\d+)/)).toBe(4);
-		expect(maxSeq([], /mg-(\d+)/)).toBe(0);
-		expect(maxSeq(['dim-x', 'other'], /mg-(\d+)/)).toBe(0);
-	});
+describe("maxSeq", () => {
+  it("returns the highest captured number, or 0 when none match", () => {
+    expect(maxSeq(["mg-1", "mg-4", "mg-2"], /mg-(\d+)/)).toBe(4);
+    expect(maxSeq([], /mg-(\d+)/)).toBe(0);
+    expect(maxSeq(["dim-x", "other"], /mg-(\d+)/)).toBe(0);
+  });
 });
 
-describe('blankCube', () => {
-	it('creates an empty edit-mode cube with the given id + name', () => {
-		const c = blankCube('cube-1', 'Cube 1');
-		expect(c.id).toBe('cube-1');
-		expect(c.name).toBe('Cube 1');
-		expect(c.editMode).toBe(true);
-		expect(c.measureGroups).toEqual([]);
-		expect(c.factsCalcs).toEqual([]);
-	});
+describe("blankCube", () => {
+  it("creates an empty edit-mode cube with the given id + name", () => {
+    const c = blankCube("cube-1", "Cube 1");
+    expect(c.id).toBe("cube-1");
+    expect(c.name).toBe("Cube 1");
+    expect(c.editMode).toBe(true);
+    expect(c.measureGroups).toEqual([]);
+    expect(c.factsCalcs).toEqual([]);
+  });
 });
 
-describe('renderCalcTokens / calcMode', () => {
-	it('renders chip tokens as a Mondrian bracket formula', () => {
-		expect(
-			renderCalcTokens({
-				id: 'c1',
-				name: 'Margin',
-				tokens: [
-					{ kind: 'measure', name: 'Sales' },
-					{ kind: 'op', op: '-' },
-					{ kind: 'measure', name: 'Cost' }
-				]
-			})
-		).toBe('[Sales] - [Cost]');
-	});
+describe("renderCalcTokens / calcMode", () => {
+  it("renders chip tokens as a Mondrian bracket formula", () => {
+    expect(
+      renderCalcTokens({
+        id: "c1",
+        name: "Margin",
+        tokens: [
+          { kind: "measure", name: "Sales" },
+          { kind: "op", op: "-" },
+          { kind: "measure", name: "Cost" },
+        ],
+      }),
+    ).toBe("[Sales] - [Cost]");
+  });
 
-	it('defaults calcMode to build when unset', () => {
-		expect(calcMode({ id: 'c', name: 'x', tokens: [] })).toBe('build');
-		expect(calcMode({ id: 'c', name: 'x', tokens: [], mode: 'expression' })).toBe('expression');
-	});
+  it("defaults calcMode to build when unset", () => {
+    expect(calcMode({ id: "c", name: "x", tokens: [] })).toBe("build");
+    expect(
+      calcMode({ id: "c", name: "x", tokens: [], mode: "expression" }),
+    ).toBe("expression");
+  });
 });
 
-describe('cubeToDoc ⇄ cubeFromDoc', () => {
-	function richWorkbenchCube(): WorkbenchCube {
-		return {
-			id: 'cube-1',
-			name: 'Sales',
-			editMode: false,
-			selectedTableId: 'f',
-			tableConfirmed: true,
-			selectedMeasures: ['amount'],
-			tableSearch: 'sea',
-			measureGroups: [
-				{
-					id: 'mg-1',
-					name: 'Sales Facts',
-					measureColumns: ['amount', 'qty'],
-					factTableId: 'f',
-					dimensionLinks: [{ dimensionId: 'd1', foreignKeyColumn: 'customer_id' }],
-					measureCaptions: { amount: 'Revenue' },
-					factConfirmed: true,
-					measuresConfirmed: true,
-					dimsConfirmed: true
-				}
-			],
-			selectedGroupId: 'mg-1',
-			groupsEditMode: false,
-			groupSeq: 1,
-			factsCalcs: [
-				{
-					id: 'calc-1',
-					name: 'Margin',
-					tokens: [
-						{ kind: 'measure', name: 'Sales' },
-						{ kind: 'op', op: '-' },
-						{ kind: 'measure', name: 'Cost' }
-					],
-					mode: 'build'
-				}
-			],
-			selectedCalcId: 'calc-1',
-			calcsEditMode: false,
-			calcSeq: 1
-		};
-	}
+describe("cubeToDoc ⇄ cubeFromDoc", () => {
+  function richWorkbenchCube(): WorkbenchCube {
+    return {
+      id: "cube-1",
+      name: "Sales",
+      editMode: false,
+      selectedTableId: "f",
+      tableConfirmed: true,
+      selectedMeasures: ["amount"],
+      tableSearch: "sea",
+      measureGroups: [
+        {
+          id: "mg-1",
+          name: "Sales Facts",
+          measureColumns: ["amount", "qty"],
+          factTableId: "f",
+          dimensionLinks: [
+            { dimensionId: "d1", foreignKeyColumn: "customer_id" },
+          ],
+          measureCaptions: { amount: "Revenue" },
+          factConfirmed: true,
+          measuresConfirmed: true,
+          dimsConfirmed: true,
+        },
+      ],
+      selectedGroupId: "mg-1",
+      groupsEditMode: false,
+      groupSeq: 1,
+      factsCalcs: [
+        {
+          id: "calc-1",
+          name: "Margin",
+          tokens: [
+            { kind: "measure", name: "Sales" },
+            { kind: "op", op: "-" },
+            { kind: "measure", name: "Cost" },
+          ],
+          mode: "build",
+        },
+      ],
+      selectedCalcId: "calc-1",
+      calcsEditMode: false,
+      calcSeq: 1,
+    };
+  }
 
-	it('strips UI-only flags to the durable doc shape', () => {
-		const doc = cubeToDoc(richWorkbenchCube());
-		expect(doc).toEqual({
-			id: 'cube-1',
-			name: 'Sales',
-			measureGroups: [
-				{
-					id: 'mg-1',
-					name: 'Sales Facts',
-					measureColumns: ['amount', 'qty'],
-					factTableId: 'f',
-					dimensionLinks: [{ dimensionId: 'd1', foreignKeyColumn: 'customer_id' }],
-					measureCaptions: { amount: 'Revenue' }
-				}
-			],
-			calcs: [
-				{
-					id: 'calc-1',
-					name: 'Margin',
-					tokens: [
-						{ kind: 'measure', name: 'Sales' },
-						{ kind: 'op', op: '-' },
-						{ kind: 'measure', name: 'Cost' }
-					],
-					formula: undefined,
-					mode: 'build'
-				}
-			]
-		});
-	});
+  it("strips UI-only flags to the durable doc shape", () => {
+    const doc = cubeToDoc(richWorkbenchCube());
+    expect(doc).toEqual({
+      id: "cube-1",
+      name: "Sales",
+      measureGroups: [
+        {
+          id: "mg-1",
+          name: "Sales Facts",
+          measureColumns: ["amount", "qty"],
+          factTableId: "f",
+          dimensionLinks: [
+            { dimensionId: "d1", foreignKeyColumn: "customer_id" },
+          ],
+          measureCaptions: { amount: "Revenue" },
+        },
+      ],
+      calcs: [
+        {
+          id: "calc-1",
+          name: "Margin",
+          tokens: [
+            { kind: "measure", name: "Sales" },
+            { kind: "op", op: "-" },
+            { kind: "measure", name: "Cost" },
+          ],
+          formula: undefined,
+          mode: "build",
+        },
+      ],
+    });
+  });
 
-	it('does not share nested references with its source (immutable copy)', () => {
-		const wb = richWorkbenchCube();
-		const doc = cubeToDoc(wb);
-		expect(doc.measureGroups[0].measureColumns).not.toBe(wb.measureGroups[0].measureColumns);
-		expect(doc.measureGroups[0].dimensionLinks?.[0]).not.toBe(
-			wb.measureGroups[0].dimensionLinks?.[0]
-		);
-	});
+  it("does not share nested references with its source (immutable copy)", () => {
+    const wb = richWorkbenchCube();
+    const doc = cubeToDoc(wb);
+    expect(doc.measureGroups[0].measureColumns).not.toBe(
+      wb.measureGroups[0].measureColumns,
+    );
+    expect(doc.measureGroups[0].dimensionLinks?.[0]).not.toBe(
+      wb.measureGroups[0].dimensionLinks?.[0],
+    );
+  });
 
-	it('re-derives UI flags from content on the way back', () => {
-		const doc = cubeToDoc(richWorkbenchCube());
-		const wb = cubeFromDoc(doc);
-		expect(wb.selectedTableId).toBe('f'); // first MG fact
-		expect(wb.tableConfirmed).toBe(true);
-		expect(wb.groupsEditMode).toBe(false); // has groups
-		expect(wb.calcsEditMode).toBe(false); // has calcs
-		expect(wb.groupSeq).toBe(1);
-		expect(wb.calcSeq).toBe(1);
-		expect(wb.measureGroups[0].factConfirmed).toBe(true);
-		expect(wb.measureGroups[0].measuresConfirmed).toBe(true);
-		expect(wb.measureGroups[0].dimsConfirmed).toBe(true);
-	});
+  it("re-derives UI flags from content on the way back", () => {
+    const doc = cubeToDoc(richWorkbenchCube());
+    const wb = cubeFromDoc(doc);
+    expect(wb.selectedTableId).toBe("f"); // first MG fact
+    expect(wb.tableConfirmed).toBe(true);
+    expect(wb.groupsEditMode).toBe(false); // has groups
+    expect(wb.calcsEditMode).toBe(false); // has calcs
+    expect(wb.groupSeq).toBe(1);
+    expect(wb.calcSeq).toBe(1);
+    expect(wb.measureGroups[0].factConfirmed).toBe(true);
+    expect(wb.measureGroups[0].measuresConfirmed).toBe(true);
+    expect(wb.measureGroups[0].dimsConfirmed).toBe(true);
+  });
 
-	it('mgFromDoc opens a blank group in edit mode', () => {
-		const mg = mgFromDoc({ id: 'mg-9', name: 'Empty', measureColumns: [] });
-		expect(mg.factConfirmed).toBe(false);
-		expect(mg.measuresConfirmed).toBe(false);
-		expect(mg.dimsConfirmed).toBe(false);
-	});
+  it("mgFromDoc opens a blank group in edit mode", () => {
+    const mg = mgFromDoc({ id: "mg-9", name: "Empty", measureColumns: [] });
+    expect(mg.factConfirmed).toBe(false);
+    expect(mg.measuresConfirmed).toBe(false);
+    expect(mg.dimsConfirmed).toBe(false);
+  });
 
-	it('calcFromDoc defaults an op token op to +', () => {
-		const calc = calcFromDoc({ id: 'c', name: 'x', tokens: [{ kind: 'op' }] });
-		expect(calc.tokens[0]).toEqual({ kind: 'op', op: '+' });
-	});
+  it("calcFromDoc defaults an op token op to +", () => {
+    const calc = calcFromDoc({ id: "c", name: "x", tokens: [{ kind: "op" }] });
+    expect(calc.tokens[0]).toEqual({ kind: "op", op: "+" });
+  });
 });
 
 /**
@@ -171,126 +179,144 @@ describe('cubeToDoc ⇄ cubeFromDoc', () => {
  * byte-identical Mondrian 4 for a representative workbench cube (previously
  * the Code tab used a second, drift-prone inline emitter).
  */
-describe('preview == export parity (#1038)', () => {
-	function representativeState(): {
-		base: SchemaCanvasState;
-		wbCube: WorkbenchCube;
-	} {
-		const base: SchemaCanvasState = {
-			version: 1,
-			connectionId: 'conn-1',
-			label: 'Sales',
-			tables: [
-				{
-					id: 'f',
-					schema: 'public',
-					name: 'sales_fact',
-					role: 'fact',
-					columns: [
-						{ name: 'amount', sqlType: 'numeric' },
-						{ name: 'qty', sqlType: 'numeric' },
-						{ name: 'customer_id', sqlType: 'int' }
-					],
-					position: { x: 0, y: 0 },
-					groupId: null
-				},
-				{
-					id: 'c',
-					schema: 'public',
-					name: 'customer',
-					role: 'dimension',
-					columns: [
-						{ name: 'id', sqlType: 'int' },
-						{ name: 'country', sqlType: 'text' }
-					],
-					position: { x: 100, y: 0 },
-					groupId: null
-				}
-			],
-			joins: [],
-			groups: [],
-			updatedAt: '2026-07-24T00:00:00.000Z',
-			dimensions: [
-				{
-					id: 'd1',
-					name: 'Customer',
-					sourceTableId: 'c',
-					primaryKeyTableId: 'c',
-					primaryKey: 'id',
-					attributes: [{ tableId: 'c', columnName: 'id' }],
-					hierarchies: [
-						{
-							id: 'h1',
-							name: 'Geo',
-							hasAll: true,
-							levels: [
-								{ id: 'l1', name: 'Country', tableId: 'c', columnName: 'country', type: 'String' }
-							]
-						}
-					]
-				}
-			],
-			measures: [
-				{
-					id: 'm1',
-					name: 'Sales',
-					aggregator: 'sum',
-					tableId: 'f',
-					columnName: 'amount',
-					formatString: '$#,##0'
-				}
-			]
-		};
-		const wbCube: WorkbenchCube = {
-			...blankCube('cube-1', 'Sales'),
-			measureGroups: [
-				{
-					id: 'mg-1',
-					name: 'Sales Facts',
-					measureColumns: ['amount', 'qty'],
-					factTableId: 'f',
-					dimensionLinks: [{ dimensionId: 'd1', foreignKeyColumn: 'customer_id' }]
-				}
-			],
-			factsCalcs: [
-				{
-					id: 'calc-1',
-					name: 'Margin',
-					tokens: [
-						{ kind: 'measure', name: 'Sales' },
-						{ kind: 'op', op: '-' },
-						{ kind: 'measure', name: 'Cost' }
-					],
-					mode: 'build'
-				}
-			]
-		};
-		return { base, wbCube };
-	}
+describe("preview == export parity (#1038)", () => {
+  function representativeState(): {
+    base: SchemaCanvasState;
+    wbCube: WorkbenchCube;
+  } {
+    const base: SchemaCanvasState = {
+      version: 1,
+      connectionId: "conn-1",
+      label: "Sales",
+      tables: [
+        {
+          id: "f",
+          schema: "public",
+          name: "sales_fact",
+          role: "fact",
+          columns: [
+            { name: "amount", sqlType: "numeric" },
+            { name: "qty", sqlType: "numeric" },
+            { name: "customer_id", sqlType: "int" },
+          ],
+          position: { x: 0, y: 0 },
+          groupId: null,
+        },
+        {
+          id: "c",
+          schema: "public",
+          name: "customer",
+          role: "dimension",
+          columns: [
+            { name: "id", sqlType: "int" },
+            { name: "country", sqlType: "text" },
+          ],
+          position: { x: 100, y: 0 },
+          groupId: null,
+        },
+      ],
+      joins: [],
+      groups: [],
+      updatedAt: "2026-07-24T00:00:00.000Z",
+      dimensions: [
+        {
+          id: "d1",
+          name: "Customer",
+          sourceTableId: "c",
+          primaryKeyTableId: "c",
+          primaryKey: "id",
+          attributes: [{ tableId: "c", columnName: "id" }],
+          hierarchies: [
+            {
+              id: "h1",
+              name: "Geo",
+              hasAll: true,
+              levels: [
+                {
+                  id: "l1",
+                  name: "Country",
+                  tableId: "c",
+                  columnName: "country",
+                  type: "String",
+                },
+              ],
+            },
+          ],
+        },
+      ],
+      measures: [
+        {
+          id: "m1",
+          name: "Sales",
+          aggregator: "sum",
+          tableId: "f",
+          columnName: "amount",
+          formatString: "$#,##0",
+        },
+      ],
+    };
+    const wbCube: WorkbenchCube = {
+      ...blankCube("cube-1", "Sales"),
+      measureGroups: [
+        {
+          id: "mg-1",
+          name: "Sales Facts",
+          measureColumns: ["amount", "qty"],
+          factTableId: "f",
+          dimensionLinks: [
+            { dimensionId: "d1", foreignKeyColumn: "customer_id" },
+          ],
+        },
+      ],
+      factsCalcs: [
+        {
+          id: "calc-1",
+          name: "Margin",
+          tokens: [
+            { kind: "measure", name: "Sales" },
+            { kind: "op", op: "-" },
+            { kind: "measure", name: "Cost" },
+          ],
+          mode: "build",
+        },
+      ],
+    };
+    return { base, wbCube };
+  }
 
-	it('the preview and export paths emit identical XML', () => {
-		const { base, wbCube } = representativeState();
-		const docCubes: SchemaCanvasCube[] = [wbCube].map(cubeToDoc);
+  it("the preview and export paths emit identical XML", () => {
+    const { base, wbCube } = representativeState();
+    const docCubes: SchemaCanvasCube[] = [wbCube].map(cubeToDoc);
 
-		// Export/save path: persist writes docCubes onto the doc, export reads it.
-		const exported = exportToMondrianXml({ ...base, cubes: docCubes });
-		// Preview path: builds the same docCubes live and exports on the fly.
-		const previewed = exportToMondrianXml({ ...base, cubes: [wbCube].map(cubeToDoc) });
+    // Export/save path: persist writes docCubes onto the doc, export reads it.
+    const exported = exportToMondrianXml({ ...base, cubes: docCubes });
+    // Preview path: builds the same docCubes live and exports on the fly.
+    const previewed = exportToMondrianXml({
+      ...base,
+      cubes: [wbCube].map(cubeToDoc),
+    });
 
-		expect(previewed).toBe(exported);
-	});
+    expect(previewed).toBe(exported);
+  });
 
-	it('emits structurally valid Mondrian 4', () => {
-		const { base, wbCube } = representativeState();
-		const xml = exportToMondrianXml({ ...base, cubes: [wbCube].map(cubeToDoc) });
-		expect(xml).toContain('metamodelVersion="4.0"');
-		expect(xml).toContain('<Cube name="Sales">');
-		expect(xml).toContain('<MeasureGroup name="Sales Facts" table="sales_fact">');
-		expect(xml).toContain('<ForeignKeyLink dimension="Customer" foreignKeyColumn="customer_id" />');
-		expect(xml).toContain(
-			'<CalculatedMember name="Margin" dimension="Measures" formula="[Sales] - [Cost]"/>'
-		);
-		// M4 only — never the legacy M3 markers.
-		expect(xml).not.toContain('foreignKey=');
-	});
+  it("emits structurally valid Mondrian 4", () => {
+    const { base, wbCube } = representativeState();
+    const xml = exportToMondrianXml({
+      ...base,
+      cubes: [wbCube].map(cubeToDoc),
+    });
+    expect(xml).toContain('metamodelVersion="4.0"');
+    expect(xml).toContain('<Cube name="Sales">');
+    expect(xml).toContain(
+      '<MeasureGroup name="Sales Facts" table="sales_fact">',
+    );
+    expect(xml).toContain(
+      '<ForeignKeyLink dimension="Customer" foreignKeyColumn="customer_id" />',
+    );
+    expect(xml).toContain(
+      '<CalculatedMember name="Margin" dimension="Measures" formula="[Sales] - [Cost]"/>',
+    );
+    // M4 only — never the legacy M3 markers.
+    expect(xml).not.toContain("foreignKey=");
+  });
 });

--- a/saiku-ui/src/lib/cube-designer/workbench-cubes.ts
+++ b/saiku-ui/src/lib/cube-designer/workbench-cubes.ts
@@ -1,0 +1,212 @@
+/**
+ * Workbench ⇄ doc cube model (saiku-cloud#1039 split).
+ *
+ * The durable cube model lives on the doc (`SchemaCanvasCube` — a trimmed
+ * shape of measure groups + calcs). The workbench keeps a richer live
+ * `WorkbenchCube` carrying UI-only flags (edit modes, sequences, confirm
+ * state). These pure helpers translate between the two shapes and render a
+ * calculated member's chip tokens back to a Mondrian formula.
+ *
+ * Extracted from `WorkbenchView.svelte` so the mapping is unit-testable in
+ * the node-env vitest (no Svelte render harness). The component imports
+ * these; nothing here touches Svelte reactivity.
+ */
+import type {
+	SchemaCanvasCube,
+	SchemaCanvasMeasureGroup as DocMeasureGroup,
+	SchemaCanvasCalc as DocCalc
+} from './types.js';
+
+// ── Calculated members ──────────────────────────────────────────────
+//   - `build`      — drag/click chips: alternating measure / op tokens
+//                    that always stay well-formed.
+//   - `expression` — free-text formula for anything the chip builder
+//                    can't express (CASE, IIF, ratios with constants).
+export type FactsCalcToken =
+	| { kind: 'measure'; name: string; fromGroup?: boolean }
+	| { kind: 'op'; op: '+' | '-' | '*' | '/' };
+export type FactsCalcMode = 'build' | 'expression';
+export type FactsCalc = {
+	id: string;
+	name: string;
+	tokens: FactsCalcToken[];
+	formula?: string;
+	mode?: FactsCalcMode;
+};
+
+export type FactsMeasureGroup = {
+	id: string;
+	name: string;
+	measureColumns: string[];
+};
+
+// v2: FactLink (degenerate dim on the fact table) + ReferenceLink
+// (multi-hop dim via another dim's attribute) round-trip support.
+// `linkKind` undefined ≡ 'foreign-key' (the v1 default).
+export type MeasureGroupDimLink = {
+	dimensionId: string;
+	foreignKeyColumn: string;
+	linkKind?: 'foreign-key' | 'fact' | 'reference';
+	viaDimension?: string;
+	viaAttribute?: string;
+};
+
+export type WorkbenchMeasureGroup = FactsMeasureGroup & {
+	factTableId?: string | null;
+	dimensionLinks?: MeasureGroupDimLink[];
+	// Per-section commit flags — the per-MG editor collapses into a
+	// summary once each section is confirmed (fact → measures → dims).
+	factConfirmed?: boolean;
+	measuresConfirmed?: boolean;
+	dimsConfirmed?: boolean;
+	// Human captions for measures — round-trip into Mondrian 4 as
+	// `<Measure caption="Unit Sales" ...>`. Keyed by column name.
+	measureCaptions?: Record<string, string>;
+};
+
+export type WorkbenchCube = {
+	id: string;
+	name: string;
+	// All per-cube live state. Mirrors the persisted facts shape minus
+	// workbench-wide UI prefs (slots / collapse / inspector tab).
+	editMode: boolean;
+	selectedTableId: string | null;
+	tableConfirmed: boolean;
+	selectedMeasures: string[];
+	tableSearch: string;
+	measureGroups: WorkbenchMeasureGroup[];
+	selectedGroupId: string | null;
+	groupsEditMode: boolean;
+	groupSeq: number;
+	factsCalcs: FactsCalc[];
+	selectedCalcId: string | null;
+	calcsEditMode: boolean;
+	calcSeq: number;
+};
+
+/** Highest `<n>` matched by `re` (capture group 1) across `ids`, or 0. */
+export function maxSeq(ids: string[], re: RegExp): number {
+	let max = 0;
+	for (const id of ids) {
+		const m = re.exec(id);
+		if (m) max = Math.max(max, parseInt(m[1], 10));
+	}
+	return max;
+}
+
+export function blankCube(id: string, name: string): WorkbenchCube {
+	return {
+		id,
+		name,
+		editMode: true,
+		selectedTableId: null,
+		tableConfirmed: false,
+		selectedMeasures: [],
+		tableSearch: '',
+		measureGroups: [],
+		selectedGroupId: null,
+		groupsEditMode: true,
+		groupSeq: 0,
+		factsCalcs: [],
+		selectedCalcId: null,
+		calcsEditMode: true,
+		calcSeq: 0
+	};
+}
+
+export function calcFromDoc(c: DocCalc): FactsCalc {
+	return {
+		id: c.id,
+		name: c.name,
+		tokens: c.tokens.map((t) =>
+			t.kind === 'op'
+				? { kind: 'op', op: t.op ?? '+' }
+				: { kind: 'measure', name: t.name ?? '', fromGroup: t.fromGroup }
+		),
+		formula: c.formula,
+		mode: c.mode
+	};
+}
+
+export function mgFromDoc(g: DocMeasureGroup): WorkbenchMeasureGroup {
+	return {
+		id: g.id,
+		name: g.name,
+		measureColumns: [...g.measureColumns],
+		factTableId: g.factTableId ?? null,
+		dimensionLinks: (g.dimensionLinks ?? []).map((l) => ({ ...l })),
+		measureCaptions: g.measureCaptions ? { ...g.measureCaptions } : {},
+		// Re-derive the confirm flags from content: an imported / DimSum
+		// cube that already has a fact + measures + links reads as
+		// confirmed; a blank group opens in edit mode.
+		factConfirmed: !!g.factTableId,
+		measuresConfirmed: g.measureColumns.length > 0,
+		dimsConfirmed: (g.dimensionLinks?.length ?? 0) > 0
+	};
+}
+
+export function cubeFromDoc(sc: SchemaCanvasCube): WorkbenchCube {
+	const measureGroups = sc.measureGroups.map(mgFromDoc);
+	const factsCalcs = sc.calcs.map(calcFromDoc);
+	const firstFact = measureGroups.find((g) => g.factTableId)?.factTableId ?? null;
+	return {
+		id: sc.id,
+		name: sc.name,
+		editMode: true,
+		selectedTableId: firstFact,
+		tableConfirmed: !!firstFact,
+		selectedMeasures: [],
+		tableSearch: '',
+		measureGroups,
+		selectedGroupId: measureGroups[0]?.id ?? null,
+		groupsEditMode: measureGroups.length === 0,
+		groupSeq: maxSeq(
+			measureGroups.map((g) => g.id),
+			/mg-(\d+)/
+		),
+		factsCalcs,
+		selectedCalcId: factsCalcs[0]?.id ?? null,
+		calcsEditMode: factsCalcs.length === 0,
+		calcSeq: maxSeq(
+			factsCalcs.map((c) => c.id),
+			/calc-(\d+)/
+		)
+	};
+}
+
+export function cubeToDoc(c: WorkbenchCube): SchemaCanvasCube {
+	return {
+		id: c.id,
+		name: c.name,
+		measureGroups: c.measureGroups.map((g) => ({
+			id: g.id,
+			name: g.name,
+			measureColumns: [...g.measureColumns],
+			factTableId: g.factTableId ?? null,
+			dimensionLinks: (g.dimensionLinks ?? []).map((l) => ({ ...l })),
+			measureCaptions: g.measureCaptions ? { ...g.measureCaptions } : {}
+		})),
+		calcs: c.factsCalcs.map((calc) => ({
+			id: calc.id,
+			name: calc.name,
+			tokens: calc.tokens.map((t) => ({ ...t })),
+			formula: calc.formula,
+			mode: calc.mode
+		}))
+	};
+}
+
+/** Render token chips back to a textual formula so a build→expression
+ *  switch loses nothing. Uses Mondrian-flavoured square-bracket member
+ *  refs. Matches `mondrian-export.ts`'s `renderCalcFormula` build branch. */
+export function renderCalcTokens(c: FactsCalc): string {
+	return c.tokens
+		.map((t) => (t.kind === 'measure' ? `[${t.name}]` : ` ${t.op} `))
+		.join('')
+		.replace(/\s+/g, ' ')
+		.trim();
+}
+
+export function calcMode(c: FactsCalc): FactsCalcMode {
+	return c.mode ?? 'build';
+}

--- a/saiku-ui/src/lib/cube-designer/workbench-cubes.ts
+++ b/saiku-ui/src/lib/cube-designer/workbench-cubes.ts
@@ -12,10 +12,10 @@
  * these; nothing here touches Svelte reactivity.
  */
 import type {
-	SchemaCanvasCube,
-	SchemaCanvasMeasureGroup as DocMeasureGroup,
-	SchemaCanvasCalc as DocCalc
-} from './types.js';
+  SchemaCanvasCube,
+  SchemaCanvasMeasureGroup as DocMeasureGroup,
+  SchemaCanvasCalc as DocCalc,
+} from "./types.js";
 
 // ── Calculated members ──────────────────────────────────────────────
 //   - `build`      — drag/click chips: alternating measure / op tokens
@@ -23,190 +23,191 @@ import type {
 //   - `expression` — free-text formula for anything the chip builder
 //                    can't express (CASE, IIF, ratios with constants).
 export type FactsCalcToken =
-	| { kind: 'measure'; name: string; fromGroup?: boolean }
-	| { kind: 'op'; op: '+' | '-' | '*' | '/' };
-export type FactsCalcMode = 'build' | 'expression';
+  | { kind: "measure"; name: string; fromGroup?: boolean }
+  | { kind: "op"; op: "+" | "-" | "*" | "/" };
+export type FactsCalcMode = "build" | "expression";
 export type FactsCalc = {
-	id: string;
-	name: string;
-	tokens: FactsCalcToken[];
-	formula?: string;
-	mode?: FactsCalcMode;
+  id: string;
+  name: string;
+  tokens: FactsCalcToken[];
+  formula?: string;
+  mode?: FactsCalcMode;
 };
 
 export type FactsMeasureGroup = {
-	id: string;
-	name: string;
-	measureColumns: string[];
+  id: string;
+  name: string;
+  measureColumns: string[];
 };
 
 // v2: FactLink (degenerate dim on the fact table) + ReferenceLink
 // (multi-hop dim via another dim's attribute) round-trip support.
 // `linkKind` undefined ≡ 'foreign-key' (the v1 default).
 export type MeasureGroupDimLink = {
-	dimensionId: string;
-	foreignKeyColumn: string;
-	linkKind?: 'foreign-key' | 'fact' | 'reference';
-	viaDimension?: string;
-	viaAttribute?: string;
+  dimensionId: string;
+  foreignKeyColumn: string;
+  linkKind?: "foreign-key" | "fact" | "reference";
+  viaDimension?: string;
+  viaAttribute?: string;
 };
 
 export type WorkbenchMeasureGroup = FactsMeasureGroup & {
-	factTableId?: string | null;
-	dimensionLinks?: MeasureGroupDimLink[];
-	// Per-section commit flags — the per-MG editor collapses into a
-	// summary once each section is confirmed (fact → measures → dims).
-	factConfirmed?: boolean;
-	measuresConfirmed?: boolean;
-	dimsConfirmed?: boolean;
-	// Human captions for measures — round-trip into Mondrian 4 as
-	// `<Measure caption="Unit Sales" ...>`. Keyed by column name.
-	measureCaptions?: Record<string, string>;
+  factTableId?: string | null;
+  dimensionLinks?: MeasureGroupDimLink[];
+  // Per-section commit flags — the per-MG editor collapses into a
+  // summary once each section is confirmed (fact → measures → dims).
+  factConfirmed?: boolean;
+  measuresConfirmed?: boolean;
+  dimsConfirmed?: boolean;
+  // Human captions for measures — round-trip into Mondrian 4 as
+  // `<Measure caption="Unit Sales" ...>`. Keyed by column name.
+  measureCaptions?: Record<string, string>;
 };
 
 export type WorkbenchCube = {
-	id: string;
-	name: string;
-	// All per-cube live state. Mirrors the persisted facts shape minus
-	// workbench-wide UI prefs (slots / collapse / inspector tab).
-	editMode: boolean;
-	selectedTableId: string | null;
-	tableConfirmed: boolean;
-	selectedMeasures: string[];
-	tableSearch: string;
-	measureGroups: WorkbenchMeasureGroup[];
-	selectedGroupId: string | null;
-	groupsEditMode: boolean;
-	groupSeq: number;
-	factsCalcs: FactsCalc[];
-	selectedCalcId: string | null;
-	calcsEditMode: boolean;
-	calcSeq: number;
+  id: string;
+  name: string;
+  // All per-cube live state. Mirrors the persisted facts shape minus
+  // workbench-wide UI prefs (slots / collapse / inspector tab).
+  editMode: boolean;
+  selectedTableId: string | null;
+  tableConfirmed: boolean;
+  selectedMeasures: string[];
+  tableSearch: string;
+  measureGroups: WorkbenchMeasureGroup[];
+  selectedGroupId: string | null;
+  groupsEditMode: boolean;
+  groupSeq: number;
+  factsCalcs: FactsCalc[];
+  selectedCalcId: string | null;
+  calcsEditMode: boolean;
+  calcSeq: number;
 };
 
 /** Highest `<n>` matched by `re` (capture group 1) across `ids`, or 0. */
 export function maxSeq(ids: string[], re: RegExp): number {
-	let max = 0;
-	for (const id of ids) {
-		const m = re.exec(id);
-		if (m) max = Math.max(max, parseInt(m[1], 10));
-	}
-	return max;
+  let max = 0;
+  for (const id of ids) {
+    const m = re.exec(id);
+    if (m) max = Math.max(max, parseInt(m[1], 10));
+  }
+  return max;
 }
 
 export function blankCube(id: string, name: string): WorkbenchCube {
-	return {
-		id,
-		name,
-		editMode: true,
-		selectedTableId: null,
-		tableConfirmed: false,
-		selectedMeasures: [],
-		tableSearch: '',
-		measureGroups: [],
-		selectedGroupId: null,
-		groupsEditMode: true,
-		groupSeq: 0,
-		factsCalcs: [],
-		selectedCalcId: null,
-		calcsEditMode: true,
-		calcSeq: 0
-	};
+  return {
+    id,
+    name,
+    editMode: true,
+    selectedTableId: null,
+    tableConfirmed: false,
+    selectedMeasures: [],
+    tableSearch: "",
+    measureGroups: [],
+    selectedGroupId: null,
+    groupsEditMode: true,
+    groupSeq: 0,
+    factsCalcs: [],
+    selectedCalcId: null,
+    calcsEditMode: true,
+    calcSeq: 0,
+  };
 }
 
 export function calcFromDoc(c: DocCalc): FactsCalc {
-	return {
-		id: c.id,
-		name: c.name,
-		tokens: c.tokens.map((t) =>
-			t.kind === 'op'
-				? { kind: 'op', op: t.op ?? '+' }
-				: { kind: 'measure', name: t.name ?? '', fromGroup: t.fromGroup }
-		),
-		formula: c.formula,
-		mode: c.mode
-	};
+  return {
+    id: c.id,
+    name: c.name,
+    tokens: c.tokens.map((t) =>
+      t.kind === "op"
+        ? { kind: "op", op: t.op ?? "+" }
+        : { kind: "measure", name: t.name ?? "", fromGroup: t.fromGroup },
+    ),
+    formula: c.formula,
+    mode: c.mode,
+  };
 }
 
 export function mgFromDoc(g: DocMeasureGroup): WorkbenchMeasureGroup {
-	return {
-		id: g.id,
-		name: g.name,
-		measureColumns: [...g.measureColumns],
-		factTableId: g.factTableId ?? null,
-		dimensionLinks: (g.dimensionLinks ?? []).map((l) => ({ ...l })),
-		measureCaptions: g.measureCaptions ? { ...g.measureCaptions } : {},
-		// Re-derive the confirm flags from content: an imported / DimSum
-		// cube that already has a fact + measures + links reads as
-		// confirmed; a blank group opens in edit mode.
-		factConfirmed: !!g.factTableId,
-		measuresConfirmed: g.measureColumns.length > 0,
-		dimsConfirmed: (g.dimensionLinks?.length ?? 0) > 0
-	};
+  return {
+    id: g.id,
+    name: g.name,
+    measureColumns: [...g.measureColumns],
+    factTableId: g.factTableId ?? null,
+    dimensionLinks: (g.dimensionLinks ?? []).map((l) => ({ ...l })),
+    measureCaptions: g.measureCaptions ? { ...g.measureCaptions } : {},
+    // Re-derive the confirm flags from content: an imported / DimSum
+    // cube that already has a fact + measures + links reads as
+    // confirmed; a blank group opens in edit mode.
+    factConfirmed: !!g.factTableId,
+    measuresConfirmed: g.measureColumns.length > 0,
+    dimsConfirmed: (g.dimensionLinks?.length ?? 0) > 0,
+  };
 }
 
 export function cubeFromDoc(sc: SchemaCanvasCube): WorkbenchCube {
-	const measureGroups = sc.measureGroups.map(mgFromDoc);
-	const factsCalcs = sc.calcs.map(calcFromDoc);
-	const firstFact = measureGroups.find((g) => g.factTableId)?.factTableId ?? null;
-	return {
-		id: sc.id,
-		name: sc.name,
-		editMode: true,
-		selectedTableId: firstFact,
-		tableConfirmed: !!firstFact,
-		selectedMeasures: [],
-		tableSearch: '',
-		measureGroups,
-		selectedGroupId: measureGroups[0]?.id ?? null,
-		groupsEditMode: measureGroups.length === 0,
-		groupSeq: maxSeq(
-			measureGroups.map((g) => g.id),
-			/mg-(\d+)/
-		),
-		factsCalcs,
-		selectedCalcId: factsCalcs[0]?.id ?? null,
-		calcsEditMode: factsCalcs.length === 0,
-		calcSeq: maxSeq(
-			factsCalcs.map((c) => c.id),
-			/calc-(\d+)/
-		)
-	};
+  const measureGroups = sc.measureGroups.map(mgFromDoc);
+  const factsCalcs = sc.calcs.map(calcFromDoc);
+  const firstFact =
+    measureGroups.find((g) => g.factTableId)?.factTableId ?? null;
+  return {
+    id: sc.id,
+    name: sc.name,
+    editMode: true,
+    selectedTableId: firstFact,
+    tableConfirmed: !!firstFact,
+    selectedMeasures: [],
+    tableSearch: "",
+    measureGroups,
+    selectedGroupId: measureGroups[0]?.id ?? null,
+    groupsEditMode: measureGroups.length === 0,
+    groupSeq: maxSeq(
+      measureGroups.map((g) => g.id),
+      /mg-(\d+)/,
+    ),
+    factsCalcs,
+    selectedCalcId: factsCalcs[0]?.id ?? null,
+    calcsEditMode: factsCalcs.length === 0,
+    calcSeq: maxSeq(
+      factsCalcs.map((c) => c.id),
+      /calc-(\d+)/,
+    ),
+  };
 }
 
 export function cubeToDoc(c: WorkbenchCube): SchemaCanvasCube {
-	return {
-		id: c.id,
-		name: c.name,
-		measureGroups: c.measureGroups.map((g) => ({
-			id: g.id,
-			name: g.name,
-			measureColumns: [...g.measureColumns],
-			factTableId: g.factTableId ?? null,
-			dimensionLinks: (g.dimensionLinks ?? []).map((l) => ({ ...l })),
-			measureCaptions: g.measureCaptions ? { ...g.measureCaptions } : {}
-		})),
-		calcs: c.factsCalcs.map((calc) => ({
-			id: calc.id,
-			name: calc.name,
-			tokens: calc.tokens.map((t) => ({ ...t })),
-			formula: calc.formula,
-			mode: calc.mode
-		}))
-	};
+  return {
+    id: c.id,
+    name: c.name,
+    measureGroups: c.measureGroups.map((g) => ({
+      id: g.id,
+      name: g.name,
+      measureColumns: [...g.measureColumns],
+      factTableId: g.factTableId ?? null,
+      dimensionLinks: (g.dimensionLinks ?? []).map((l) => ({ ...l })),
+      measureCaptions: g.measureCaptions ? { ...g.measureCaptions } : {},
+    })),
+    calcs: c.factsCalcs.map((calc) => ({
+      id: calc.id,
+      name: calc.name,
+      tokens: calc.tokens.map((t) => ({ ...t })),
+      formula: calc.formula,
+      mode: calc.mode,
+    })),
+  };
 }
 
 /** Render token chips back to a textual formula so a build→expression
  *  switch loses nothing. Uses Mondrian-flavoured square-bracket member
  *  refs. Matches `mondrian-export.ts`'s `renderCalcFormula` build branch. */
 export function renderCalcTokens(c: FactsCalc): string {
-	return c.tokens
-		.map((t) => (t.kind === 'measure' ? `[${t.name}]` : ` ${t.op} `))
-		.join('')
-		.replace(/\s+/g, ' ')
-		.trim();
+  return c.tokens
+    .map((t) => (t.kind === "measure" ? `[${t.name}]` : ` ${t.op} `))
+    .join("")
+    .replace(/\s+/g, " ")
+    .trim();
 }
 
 export function calcMode(c: FactsCalc): FactsCalcMode {
-	return c.mode ?? 'build';
+  return c.mode ?? "build";
 }

--- a/saiku-ui/src/lib/cube-designer/workbench-dnd.test.ts
+++ b/saiku-ui/src/lib/cube-designer/workbench-dnd.test.ts
@@ -1,0 +1,138 @@
+import { describe, it, expect } from 'vitest';
+import {
+	COLUMN_MIME,
+	TABLE_MIME,
+	JOINGROUP_MIME,
+	FACTS_MEASURE_MIME,
+	ATTRIBUTE_MIME,
+	LEVEL_MOVE_MIME,
+	PANE_REORDER_MIME,
+	FACTS_PANE_REORDER_MIME,
+	readColumnPayload,
+	readTablePayload,
+	readJoinGroupPayload,
+	readAttributeDrag,
+	readLevelMoveDrag,
+	readFactsMeasureDrag,
+	isColumnDrag,
+	isAnyWorkbenchDrag,
+	isContentDrag,
+	isPaneReorderDrag,
+	isFactsPaneReorderDrag
+} from './workbench-dnd.js';
+
+/** Minimal DataTransfer stand-in — the parsers only read `.types` +
+ *  `.getData()`. */
+function dragEvent(data: Record<string, string>): DragEvent {
+	return {
+		dataTransfer: {
+			types: Object.keys(data),
+			getData: (mime: string) => data[mime] ?? ''
+		}
+	} as unknown as DragEvent;
+}
+
+/** A DragEvent with no dataTransfer at all. */
+const emptyEvent = {} as unknown as DragEvent;
+
+describe('column payload', () => {
+	it('round-trips a JSON column payload', () => {
+		const e = dragEvent({
+			[COLUMN_MIME]: JSON.stringify({ tableId: 't', columnName: 'c', columnType: 'Numeric' })
+		});
+		expect(readColumnPayload(e)).toEqual({ tableId: 't', columnName: 'c', columnType: 'Numeric' });
+		expect(isColumnDrag(e)).toBe(true);
+	});
+
+	it('returns null for a missing or malformed payload', () => {
+		expect(readColumnPayload(dragEvent({}))).toBeNull();
+		expect(readColumnPayload(emptyEvent)).toBeNull();
+		expect(readColumnPayload(dragEvent({ [COLUMN_MIME]: 'not json' }))).toBeNull();
+	});
+});
+
+describe('table + join-group payloads', () => {
+	it('parses a table payload', () => {
+		const e = dragEvent({ [TABLE_MIME]: JSON.stringify({ tableId: 't1' }) });
+		expect(readTablePayload(e)).toEqual({ tableId: 't1' });
+	});
+
+	it('parses a join-group payload', () => {
+		const e = dragEvent({
+			[JOINGROUP_MIME]: JSON.stringify({ key: 'k', tableIds: ['a', 'b'] })
+		});
+		expect(readJoinGroupPayload(e)).toEqual({ key: 'k', tableIds: ['a', 'b'] });
+	});
+
+	it('return null on malformed JSON', () => {
+		expect(readTablePayload(dragEvent({ [TABLE_MIME]: '{' }))).toBeNull();
+		expect(readJoinGroupPayload(dragEvent({ [JOINGROUP_MIME]: '{' }))).toBeNull();
+	});
+});
+
+describe('attribute + level-move payloads', () => {
+	it('parses an attribute drag', () => {
+		const e = dragEvent({ [ATTRIBUTE_MIME]: JSON.stringify({ tableId: 't', columnName: 'c' }) });
+		expect(readAttributeDrag(e)).toEqual({ tableId: 't', columnName: 'c' });
+	});
+
+	it('parses a level-move drag', () => {
+		const e = dragEvent({
+			[LEVEL_MOVE_MIME]: JSON.stringify({ dimId: 'd', hierId: 'h', levelId: 'l' })
+		});
+		expect(readLevelMoveDrag(e)).toEqual({ dimId: 'd', hierId: 'h', levelId: 'l' });
+	});
+
+	it('returns null when the MIME is absent', () => {
+		expect(readAttributeDrag(dragEvent({}))).toBeNull();
+		expect(readLevelMoveDrag(dragEvent({}))).toBeNull();
+	});
+});
+
+describe('facts-measure drag', () => {
+	it('returns the raw column-name string payload', () => {
+		expect(readFactsMeasureDrag(dragEvent({ [FACTS_MEASURE_MIME]: 'unit_sales' }))).toBe(
+			'unit_sales'
+		);
+	});
+
+	it('returns null when the facts-measure MIME is absent', () => {
+		expect(readFactsMeasureDrag(dragEvent({}))).toBeNull();
+	});
+});
+
+describe('drag-kind predicates', () => {
+	it('isAnyWorkbenchDrag matches column / table / join-group drags only', () => {
+		expect(isAnyWorkbenchDrag(dragEvent({ [COLUMN_MIME]: '{}' }))).toBe(true);
+		expect(isAnyWorkbenchDrag(dragEvent({ [TABLE_MIME]: '{}' }))).toBe(true);
+		expect(isAnyWorkbenchDrag(dragEvent({ [JOINGROUP_MIME]: '{}' }))).toBe(true);
+		expect(isAnyWorkbenchDrag(dragEvent({ [ATTRIBUTE_MIME]: '{}' }))).toBe(false);
+	});
+
+	it('isContentDrag matches attribute or level-move drags', () => {
+		expect(isContentDrag(dragEvent({ [ATTRIBUTE_MIME]: '{}' }))).toBe(true);
+		expect(isContentDrag(dragEvent({ [LEVEL_MOVE_MIME]: '{}' }))).toBe(true);
+		expect(isContentDrag(dragEvent({ [COLUMN_MIME]: '{}' }))).toBe(false);
+	});
+
+	it('pane-reorder predicates are side-specific', () => {
+		expect(isPaneReorderDrag(dragEvent({ [PANE_REORDER_MIME]: '0' }))).toBe(true);
+		expect(isPaneReorderDrag(dragEvent({ [FACTS_PANE_REORDER_MIME]: '0' }))).toBe(false);
+		expect(isFactsPaneReorderDrag(dragEvent({ [FACTS_PANE_REORDER_MIME]: '0' }))).toBe(true);
+		expect(isFactsPaneReorderDrag(dragEvent({ [PANE_REORDER_MIME]: '0' }))).toBe(false);
+	});
+
+	it('all MIME strings are distinct', () => {
+		const mimes = [
+			COLUMN_MIME,
+			TABLE_MIME,
+			JOINGROUP_MIME,
+			FACTS_MEASURE_MIME,
+			ATTRIBUTE_MIME,
+			LEVEL_MOVE_MIME,
+			PANE_REORDER_MIME,
+			FACTS_PANE_REORDER_MIME
+		];
+		expect(new Set(mimes).size).toBe(mimes.length);
+	});
+});

--- a/saiku-ui/src/lib/cube-designer/workbench-dnd.test.ts
+++ b/saiku-ui/src/lib/cube-designer/workbench-dnd.test.ts
@@ -1,138 +1,172 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect } from "vitest";
 import {
-	COLUMN_MIME,
-	TABLE_MIME,
-	JOINGROUP_MIME,
-	FACTS_MEASURE_MIME,
-	ATTRIBUTE_MIME,
-	LEVEL_MOVE_MIME,
-	PANE_REORDER_MIME,
-	FACTS_PANE_REORDER_MIME,
-	readColumnPayload,
-	readTablePayload,
-	readJoinGroupPayload,
-	readAttributeDrag,
-	readLevelMoveDrag,
-	readFactsMeasureDrag,
-	isColumnDrag,
-	isAnyWorkbenchDrag,
-	isContentDrag,
-	isPaneReorderDrag,
-	isFactsPaneReorderDrag
-} from './workbench-dnd.js';
+  COLUMN_MIME,
+  TABLE_MIME,
+  JOINGROUP_MIME,
+  FACTS_MEASURE_MIME,
+  ATTRIBUTE_MIME,
+  LEVEL_MOVE_MIME,
+  PANE_REORDER_MIME,
+  FACTS_PANE_REORDER_MIME,
+  readColumnPayload,
+  readTablePayload,
+  readJoinGroupPayload,
+  readAttributeDrag,
+  readLevelMoveDrag,
+  readFactsMeasureDrag,
+  isColumnDrag,
+  isAnyWorkbenchDrag,
+  isContentDrag,
+  isPaneReorderDrag,
+  isFactsPaneReorderDrag,
+} from "./workbench-dnd.js";
 
 /** Minimal DataTransfer stand-in — the parsers only read `.types` +
  *  `.getData()`. */
 function dragEvent(data: Record<string, string>): DragEvent {
-	return {
-		dataTransfer: {
-			types: Object.keys(data),
-			getData: (mime: string) => data[mime] ?? ''
-		}
-	} as unknown as DragEvent;
+  return {
+    dataTransfer: {
+      types: Object.keys(data),
+      getData: (mime: string) => data[mime] ?? "",
+    },
+  } as unknown as DragEvent;
 }
 
 /** A DragEvent with no dataTransfer at all. */
 const emptyEvent = {} as unknown as DragEvent;
 
-describe('column payload', () => {
-	it('round-trips a JSON column payload', () => {
-		const e = dragEvent({
-			[COLUMN_MIME]: JSON.stringify({ tableId: 't', columnName: 'c', columnType: 'Numeric' })
-		});
-		expect(readColumnPayload(e)).toEqual({ tableId: 't', columnName: 'c', columnType: 'Numeric' });
-		expect(isColumnDrag(e)).toBe(true);
-	});
+describe("column payload", () => {
+  it("round-trips a JSON column payload", () => {
+    const e = dragEvent({
+      [COLUMN_MIME]: JSON.stringify({
+        tableId: "t",
+        columnName: "c",
+        columnType: "Numeric",
+      }),
+    });
+    expect(readColumnPayload(e)).toEqual({
+      tableId: "t",
+      columnName: "c",
+      columnType: "Numeric",
+    });
+    expect(isColumnDrag(e)).toBe(true);
+  });
 
-	it('returns null for a missing or malformed payload', () => {
-		expect(readColumnPayload(dragEvent({}))).toBeNull();
-		expect(readColumnPayload(emptyEvent)).toBeNull();
-		expect(readColumnPayload(dragEvent({ [COLUMN_MIME]: 'not json' }))).toBeNull();
-	});
+  it("returns null for a missing or malformed payload", () => {
+    expect(readColumnPayload(dragEvent({}))).toBeNull();
+    expect(readColumnPayload(emptyEvent)).toBeNull();
+    expect(
+      readColumnPayload(dragEvent({ [COLUMN_MIME]: "not json" })),
+    ).toBeNull();
+  });
 });
 
-describe('table + join-group payloads', () => {
-	it('parses a table payload', () => {
-		const e = dragEvent({ [TABLE_MIME]: JSON.stringify({ tableId: 't1' }) });
-		expect(readTablePayload(e)).toEqual({ tableId: 't1' });
-	});
+describe("table + join-group payloads", () => {
+  it("parses a table payload", () => {
+    const e = dragEvent({ [TABLE_MIME]: JSON.stringify({ tableId: "t1" }) });
+    expect(readTablePayload(e)).toEqual({ tableId: "t1" });
+  });
 
-	it('parses a join-group payload', () => {
-		const e = dragEvent({
-			[JOINGROUP_MIME]: JSON.stringify({ key: 'k', tableIds: ['a', 'b'] })
-		});
-		expect(readJoinGroupPayload(e)).toEqual({ key: 'k', tableIds: ['a', 'b'] });
-	});
+  it("parses a join-group payload", () => {
+    const e = dragEvent({
+      [JOINGROUP_MIME]: JSON.stringify({ key: "k", tableIds: ["a", "b"] }),
+    });
+    expect(readJoinGroupPayload(e)).toEqual({ key: "k", tableIds: ["a", "b"] });
+  });
 
-	it('return null on malformed JSON', () => {
-		expect(readTablePayload(dragEvent({ [TABLE_MIME]: '{' }))).toBeNull();
-		expect(readJoinGroupPayload(dragEvent({ [JOINGROUP_MIME]: '{' }))).toBeNull();
-	});
+  it("return null on malformed JSON", () => {
+    expect(readTablePayload(dragEvent({ [TABLE_MIME]: "{" }))).toBeNull();
+    expect(
+      readJoinGroupPayload(dragEvent({ [JOINGROUP_MIME]: "{" })),
+    ).toBeNull();
+  });
 });
 
-describe('attribute + level-move payloads', () => {
-	it('parses an attribute drag', () => {
-		const e = dragEvent({ [ATTRIBUTE_MIME]: JSON.stringify({ tableId: 't', columnName: 'c' }) });
-		expect(readAttributeDrag(e)).toEqual({ tableId: 't', columnName: 'c' });
-	});
+describe("attribute + level-move payloads", () => {
+  it("parses an attribute drag", () => {
+    const e = dragEvent({
+      [ATTRIBUTE_MIME]: JSON.stringify({ tableId: "t", columnName: "c" }),
+    });
+    expect(readAttributeDrag(e)).toEqual({ tableId: "t", columnName: "c" });
+  });
 
-	it('parses a level-move drag', () => {
-		const e = dragEvent({
-			[LEVEL_MOVE_MIME]: JSON.stringify({ dimId: 'd', hierId: 'h', levelId: 'l' })
-		});
-		expect(readLevelMoveDrag(e)).toEqual({ dimId: 'd', hierId: 'h', levelId: 'l' });
-	});
+  it("parses a level-move drag", () => {
+    const e = dragEvent({
+      [LEVEL_MOVE_MIME]: JSON.stringify({
+        dimId: "d",
+        hierId: "h",
+        levelId: "l",
+      }),
+    });
+    expect(readLevelMoveDrag(e)).toEqual({
+      dimId: "d",
+      hierId: "h",
+      levelId: "l",
+    });
+  });
 
-	it('returns null when the MIME is absent', () => {
-		expect(readAttributeDrag(dragEvent({}))).toBeNull();
-		expect(readLevelMoveDrag(dragEvent({}))).toBeNull();
-	});
+  it("returns null when the MIME is absent", () => {
+    expect(readAttributeDrag(dragEvent({}))).toBeNull();
+    expect(readLevelMoveDrag(dragEvent({}))).toBeNull();
+  });
 });
 
-describe('facts-measure drag', () => {
-	it('returns the raw column-name string payload', () => {
-		expect(readFactsMeasureDrag(dragEvent({ [FACTS_MEASURE_MIME]: 'unit_sales' }))).toBe(
-			'unit_sales'
-		);
-	});
+describe("facts-measure drag", () => {
+  it("returns the raw column-name string payload", () => {
+    expect(
+      readFactsMeasureDrag(dragEvent({ [FACTS_MEASURE_MIME]: "unit_sales" })),
+    ).toBe("unit_sales");
+  });
 
-	it('returns null when the facts-measure MIME is absent', () => {
-		expect(readFactsMeasureDrag(dragEvent({}))).toBeNull();
-	});
+  it("returns null when the facts-measure MIME is absent", () => {
+    expect(readFactsMeasureDrag(dragEvent({}))).toBeNull();
+  });
 });
 
-describe('drag-kind predicates', () => {
-	it('isAnyWorkbenchDrag matches column / table / join-group drags only', () => {
-		expect(isAnyWorkbenchDrag(dragEvent({ [COLUMN_MIME]: '{}' }))).toBe(true);
-		expect(isAnyWorkbenchDrag(dragEvent({ [TABLE_MIME]: '{}' }))).toBe(true);
-		expect(isAnyWorkbenchDrag(dragEvent({ [JOINGROUP_MIME]: '{}' }))).toBe(true);
-		expect(isAnyWorkbenchDrag(dragEvent({ [ATTRIBUTE_MIME]: '{}' }))).toBe(false);
-	});
+describe("drag-kind predicates", () => {
+  it("isAnyWorkbenchDrag matches column / table / join-group drags only", () => {
+    expect(isAnyWorkbenchDrag(dragEvent({ [COLUMN_MIME]: "{}" }))).toBe(true);
+    expect(isAnyWorkbenchDrag(dragEvent({ [TABLE_MIME]: "{}" }))).toBe(true);
+    expect(isAnyWorkbenchDrag(dragEvent({ [JOINGROUP_MIME]: "{}" }))).toBe(
+      true,
+    );
+    expect(isAnyWorkbenchDrag(dragEvent({ [ATTRIBUTE_MIME]: "{}" }))).toBe(
+      false,
+    );
+  });
 
-	it('isContentDrag matches attribute or level-move drags', () => {
-		expect(isContentDrag(dragEvent({ [ATTRIBUTE_MIME]: '{}' }))).toBe(true);
-		expect(isContentDrag(dragEvent({ [LEVEL_MOVE_MIME]: '{}' }))).toBe(true);
-		expect(isContentDrag(dragEvent({ [COLUMN_MIME]: '{}' }))).toBe(false);
-	});
+  it("isContentDrag matches attribute or level-move drags", () => {
+    expect(isContentDrag(dragEvent({ [ATTRIBUTE_MIME]: "{}" }))).toBe(true);
+    expect(isContentDrag(dragEvent({ [LEVEL_MOVE_MIME]: "{}" }))).toBe(true);
+    expect(isContentDrag(dragEvent({ [COLUMN_MIME]: "{}" }))).toBe(false);
+  });
 
-	it('pane-reorder predicates are side-specific', () => {
-		expect(isPaneReorderDrag(dragEvent({ [PANE_REORDER_MIME]: '0' }))).toBe(true);
-		expect(isPaneReorderDrag(dragEvent({ [FACTS_PANE_REORDER_MIME]: '0' }))).toBe(false);
-		expect(isFactsPaneReorderDrag(dragEvent({ [FACTS_PANE_REORDER_MIME]: '0' }))).toBe(true);
-		expect(isFactsPaneReorderDrag(dragEvent({ [PANE_REORDER_MIME]: '0' }))).toBe(false);
-	});
+  it("pane-reorder predicates are side-specific", () => {
+    expect(isPaneReorderDrag(dragEvent({ [PANE_REORDER_MIME]: "0" }))).toBe(
+      true,
+    );
+    expect(
+      isPaneReorderDrag(dragEvent({ [FACTS_PANE_REORDER_MIME]: "0" })),
+    ).toBe(false);
+    expect(
+      isFactsPaneReorderDrag(dragEvent({ [FACTS_PANE_REORDER_MIME]: "0" })),
+    ).toBe(true);
+    expect(
+      isFactsPaneReorderDrag(dragEvent({ [PANE_REORDER_MIME]: "0" })),
+    ).toBe(false);
+  });
 
-	it('all MIME strings are distinct', () => {
-		const mimes = [
-			COLUMN_MIME,
-			TABLE_MIME,
-			JOINGROUP_MIME,
-			FACTS_MEASURE_MIME,
-			ATTRIBUTE_MIME,
-			LEVEL_MOVE_MIME,
-			PANE_REORDER_MIME,
-			FACTS_PANE_REORDER_MIME
-		];
-		expect(new Set(mimes).size).toBe(mimes.length);
-	});
+  it("all MIME strings are distinct", () => {
+    const mimes = [
+      COLUMN_MIME,
+      TABLE_MIME,
+      JOINGROUP_MIME,
+      FACTS_MEASURE_MIME,
+      ATTRIBUTE_MIME,
+      LEVEL_MOVE_MIME,
+      PANE_REORDER_MIME,
+      FACTS_PANE_REORDER_MIME,
+    ];
+    expect(new Set(mimes).size).toBe(mimes.length);
+  });
 });

--- a/saiku-ui/src/lib/cube-designer/workbench-dnd.ts
+++ b/saiku-ui/src/lib/cube-designer/workbench-dnd.ts
@@ -8,137 +8,146 @@
  * (a fake DataTransfer is all that's needed) — the drag *handlers* that
  * mutate component state stay in the component and import these.
  */
-import type { SchemaCanvasColumnKind } from './types.js';
+import type { SchemaCanvasColumnKind } from "./types.js";
 
 // Left-rail drag sources.
 //   column     — a single column → adds one level.
 //   table      — a table → adds a hierarchy with all its columns as levels.
 //   join-group — every column from every participating table.
-export const COLUMN_MIME = 'application/x-saiku-column';
-export const TABLE_MIME = 'application/x-saiku-table';
-export const JOINGROUP_MIME = 'application/x-saiku-joingroup';
+export const COLUMN_MIME = "application/x-saiku-column";
+export const TABLE_MIME = "application/x-saiku-table";
+export const JOINGROUP_MIME = "application/x-saiku-joingroup";
 // Fact-side: picked measure columns drop into a measure group's Content
 // column. Plain column-name string payload.
-export const FACTS_MEASURE_MIME = 'application/x-saiku-facts-measure';
+export const FACTS_MEASURE_MIME = "application/x-saiku-facts-measure";
 // Pane-reorder MIMEs — separate per side so a dim-pane drag can't drop on a
 // facts pane and vice versa.
-export const FACTS_PANE_REORDER_MIME = 'application/x-saiku-facts-pane-index';
-export const PANE_REORDER_MIME = 'application/x-saiku-pane-index';
+export const FACTS_PANE_REORDER_MIME = "application/x-saiku-facts-pane-index";
+export const PANE_REORDER_MIME = "application/x-saiku-pane-index";
 // Whole measure group dragged into a calc formula — payload is the group id.
-export const FACTS_MEASURE_GROUP_MIME = 'application/x-saiku-facts-measure-group';
+export const FACTS_MEASURE_GROUP_MIME =
+  "application/x-saiku-facts-measure-group";
 // Attribute / level drags (Col 2 → Col 4, Col 4 → Col 4). Distinct so they
 // don't collide with the column / table / join-group / pane-reorder MIMEs.
-export const ATTRIBUTE_MIME = 'application/x-saiku-attribute';
-export const LEVEL_MOVE_MIME = 'application/x-saiku-level-move';
+export const ATTRIBUTE_MIME = "application/x-saiku-attribute";
+export const LEVEL_MOVE_MIME = "application/x-saiku-level-move";
 
 export interface ColumnDragPayload {
-	tableId: string;
-	columnName: string;
-	columnType?: SchemaCanvasColumnKind;
+  tableId: string;
+  columnName: string;
+  columnType?: SchemaCanvasColumnKind;
 }
 export interface TableDragPayload {
-	tableId: string;
+  tableId: string;
 }
 export interface JoinGroupDragPayload {
-	key: string;
-	tableIds: string[];
+  key: string;
+  tableIds: string[];
 }
 export interface AttributeDragPayload {
-	tableId: string;
-	columnName: string;
+  tableId: string;
+  columnName: string;
 }
 export interface LevelMoveDragPayload {
-	dimId: string;
-	hierId: string;
-	levelId: string;
+  dimId: string;
+  hierId: string;
+  levelId: string;
 }
 
 function dragTypes(e: DragEvent): readonly string[] {
-	return Array.from(e.dataTransfer?.types ?? []);
+  return Array.from(e.dataTransfer?.types ?? []);
 }
 
 // ── Parsers ─────────────────────────────────────────────────────────
 export function readColumnPayload(e: DragEvent): ColumnDragPayload | null {
-	if (!e.dataTransfer) return null;
-	const raw = e.dataTransfer.getData(COLUMN_MIME);
-	if (!raw) return null;
-	try {
-		return JSON.parse(raw) as ColumnDragPayload;
-	} catch {
-		return null;
-	}
+  if (!e.dataTransfer) return null;
+  const raw = e.dataTransfer.getData(COLUMN_MIME);
+  if (!raw) return null;
+  try {
+    return JSON.parse(raw) as ColumnDragPayload;
+  } catch {
+    return null;
+  }
 }
 
 export function readTablePayload(e: DragEvent): TableDragPayload | null {
-	if (!e.dataTransfer) return null;
-	const raw = e.dataTransfer.getData(TABLE_MIME);
-	if (!raw) return null;
-	try {
-		return JSON.parse(raw) as TableDragPayload;
-	} catch {
-		return null;
-	}
+  if (!e.dataTransfer) return null;
+  const raw = e.dataTransfer.getData(TABLE_MIME);
+  if (!raw) return null;
+  try {
+    return JSON.parse(raw) as TableDragPayload;
+  } catch {
+    return null;
+  }
 }
 
-export function readJoinGroupPayload(e: DragEvent): JoinGroupDragPayload | null {
-	if (!e.dataTransfer) return null;
-	const raw = e.dataTransfer.getData(JOINGROUP_MIME);
-	if (!raw) return null;
-	try {
-		return JSON.parse(raw) as JoinGroupDragPayload;
-	} catch {
-		return null;
-	}
+export function readJoinGroupPayload(
+  e: DragEvent,
+): JoinGroupDragPayload | null {
+  if (!e.dataTransfer) return null;
+  const raw = e.dataTransfer.getData(JOINGROUP_MIME);
+  if (!raw) return null;
+  try {
+    return JSON.parse(raw) as JoinGroupDragPayload;
+  } catch {
+    return null;
+  }
 }
 
 export function readAttributeDrag(e: DragEvent): AttributeDragPayload | null {
-	if (!e.dataTransfer?.types.includes(ATTRIBUTE_MIME)) return null;
-	try {
-		return JSON.parse(e.dataTransfer.getData(ATTRIBUTE_MIME)) as AttributeDragPayload;
-	} catch {
-		return null;
-	}
+  if (!e.dataTransfer?.types.includes(ATTRIBUTE_MIME)) return null;
+  try {
+    return JSON.parse(
+      e.dataTransfer.getData(ATTRIBUTE_MIME),
+    ) as AttributeDragPayload;
+  } catch {
+    return null;
+  }
 }
 
 export function readLevelMoveDrag(e: DragEvent): LevelMoveDragPayload | null {
-	if (!e.dataTransfer?.types.includes(LEVEL_MOVE_MIME)) return null;
-	try {
-		return JSON.parse(e.dataTransfer.getData(LEVEL_MOVE_MIME)) as LevelMoveDragPayload;
-	} catch {
-		return null;
-	}
+  if (!e.dataTransfer?.types.includes(LEVEL_MOVE_MIME)) return null;
+  try {
+    return JSON.parse(
+      e.dataTransfer.getData(LEVEL_MOVE_MIME),
+    ) as LevelMoveDragPayload;
+  } catch {
+    return null;
+  }
 }
 
 export function readFactsMeasureDrag(e: DragEvent): string | null {
-	if (dragTypes(e).includes(FACTS_MEASURE_MIME)) {
-		return e.dataTransfer!.getData(FACTS_MEASURE_MIME);
-	}
-	return null;
+  if (dragTypes(e).includes(FACTS_MEASURE_MIME)) {
+    return e.dataTransfer!.getData(FACTS_MEASURE_MIME);
+  }
+  return null;
 }
 
 // ── Drag-kind predicates ────────────────────────────────────────────
 export function isColumnDrag(e: DragEvent): boolean {
-	return dragTypes(e).includes(COLUMN_MIME);
+  return dragTypes(e).includes(COLUMN_MIME);
 }
 
 export function isAnyWorkbenchDrag(e: DragEvent): boolean {
-	const types = dragTypes(e);
-	return (
-		types.includes(COLUMN_MIME) || types.includes(TABLE_MIME) || types.includes(JOINGROUP_MIME)
-	);
+  const types = dragTypes(e);
+  return (
+    types.includes(COLUMN_MIME) ||
+    types.includes(TABLE_MIME) ||
+    types.includes(JOINGROUP_MIME)
+  );
 }
 
 export function isContentDrag(e: DragEvent): boolean {
-	return (
-		(e.dataTransfer?.types.includes(ATTRIBUTE_MIME) ?? false) ||
-		(e.dataTransfer?.types.includes(LEVEL_MOVE_MIME) ?? false)
-	);
+  return (
+    (e.dataTransfer?.types.includes(ATTRIBUTE_MIME) ?? false) ||
+    (e.dataTransfer?.types.includes(LEVEL_MOVE_MIME) ?? false)
+  );
 }
 
 export function isPaneReorderDrag(e: DragEvent): boolean {
-	return e.dataTransfer?.types.includes(PANE_REORDER_MIME) ?? false;
+  return e.dataTransfer?.types.includes(PANE_REORDER_MIME) ?? false;
 }
 
 export function isFactsPaneReorderDrag(e: DragEvent): boolean {
-	return e.dataTransfer?.types.includes(FACTS_PANE_REORDER_MIME) ?? false;
+  return e.dataTransfer?.types.includes(FACTS_PANE_REORDER_MIME) ?? false;
 }

--- a/saiku-ui/src/lib/cube-designer/workbench-dnd.ts
+++ b/saiku-ui/src/lib/cube-designer/workbench-dnd.ts
@@ -1,0 +1,144 @@
+/**
+ * Workbench drag-and-drop payload contract (saiku-cloud#1039 split).
+ *
+ * Single source of truth for the MIME types the left rail (producer) and
+ * the dimension / measure / hierarchy drop zones (consumers) agree on, plus
+ * the pure payload parsers and drag-kind predicates. Extracted from
+ * `WorkbenchView.svelte` so the serialise/parse contract is unit-testable
+ * (a fake DataTransfer is all that's needed) — the drag *handlers* that
+ * mutate component state stay in the component and import these.
+ */
+import type { SchemaCanvasColumnKind } from './types.js';
+
+// Left-rail drag sources.
+//   column     — a single column → adds one level.
+//   table      — a table → adds a hierarchy with all its columns as levels.
+//   join-group — every column from every participating table.
+export const COLUMN_MIME = 'application/x-saiku-column';
+export const TABLE_MIME = 'application/x-saiku-table';
+export const JOINGROUP_MIME = 'application/x-saiku-joingroup';
+// Fact-side: picked measure columns drop into a measure group's Content
+// column. Plain column-name string payload.
+export const FACTS_MEASURE_MIME = 'application/x-saiku-facts-measure';
+// Pane-reorder MIMEs — separate per side so a dim-pane drag can't drop on a
+// facts pane and vice versa.
+export const FACTS_PANE_REORDER_MIME = 'application/x-saiku-facts-pane-index';
+export const PANE_REORDER_MIME = 'application/x-saiku-pane-index';
+// Whole measure group dragged into a calc formula — payload is the group id.
+export const FACTS_MEASURE_GROUP_MIME = 'application/x-saiku-facts-measure-group';
+// Attribute / level drags (Col 2 → Col 4, Col 4 → Col 4). Distinct so they
+// don't collide with the column / table / join-group / pane-reorder MIMEs.
+export const ATTRIBUTE_MIME = 'application/x-saiku-attribute';
+export const LEVEL_MOVE_MIME = 'application/x-saiku-level-move';
+
+export interface ColumnDragPayload {
+	tableId: string;
+	columnName: string;
+	columnType?: SchemaCanvasColumnKind;
+}
+export interface TableDragPayload {
+	tableId: string;
+}
+export interface JoinGroupDragPayload {
+	key: string;
+	tableIds: string[];
+}
+export interface AttributeDragPayload {
+	tableId: string;
+	columnName: string;
+}
+export interface LevelMoveDragPayload {
+	dimId: string;
+	hierId: string;
+	levelId: string;
+}
+
+function dragTypes(e: DragEvent): readonly string[] {
+	return Array.from(e.dataTransfer?.types ?? []);
+}
+
+// ── Parsers ─────────────────────────────────────────────────────────
+export function readColumnPayload(e: DragEvent): ColumnDragPayload | null {
+	if (!e.dataTransfer) return null;
+	const raw = e.dataTransfer.getData(COLUMN_MIME);
+	if (!raw) return null;
+	try {
+		return JSON.parse(raw) as ColumnDragPayload;
+	} catch {
+		return null;
+	}
+}
+
+export function readTablePayload(e: DragEvent): TableDragPayload | null {
+	if (!e.dataTransfer) return null;
+	const raw = e.dataTransfer.getData(TABLE_MIME);
+	if (!raw) return null;
+	try {
+		return JSON.parse(raw) as TableDragPayload;
+	} catch {
+		return null;
+	}
+}
+
+export function readJoinGroupPayload(e: DragEvent): JoinGroupDragPayload | null {
+	if (!e.dataTransfer) return null;
+	const raw = e.dataTransfer.getData(JOINGROUP_MIME);
+	if (!raw) return null;
+	try {
+		return JSON.parse(raw) as JoinGroupDragPayload;
+	} catch {
+		return null;
+	}
+}
+
+export function readAttributeDrag(e: DragEvent): AttributeDragPayload | null {
+	if (!e.dataTransfer?.types.includes(ATTRIBUTE_MIME)) return null;
+	try {
+		return JSON.parse(e.dataTransfer.getData(ATTRIBUTE_MIME)) as AttributeDragPayload;
+	} catch {
+		return null;
+	}
+}
+
+export function readLevelMoveDrag(e: DragEvent): LevelMoveDragPayload | null {
+	if (!e.dataTransfer?.types.includes(LEVEL_MOVE_MIME)) return null;
+	try {
+		return JSON.parse(e.dataTransfer.getData(LEVEL_MOVE_MIME)) as LevelMoveDragPayload;
+	} catch {
+		return null;
+	}
+}
+
+export function readFactsMeasureDrag(e: DragEvent): string | null {
+	if (dragTypes(e).includes(FACTS_MEASURE_MIME)) {
+		return e.dataTransfer!.getData(FACTS_MEASURE_MIME);
+	}
+	return null;
+}
+
+// ── Drag-kind predicates ────────────────────────────────────────────
+export function isColumnDrag(e: DragEvent): boolean {
+	return dragTypes(e).includes(COLUMN_MIME);
+}
+
+export function isAnyWorkbenchDrag(e: DragEvent): boolean {
+	const types = dragTypes(e);
+	return (
+		types.includes(COLUMN_MIME) || types.includes(TABLE_MIME) || types.includes(JOINGROUP_MIME)
+	);
+}
+
+export function isContentDrag(e: DragEvent): boolean {
+	return (
+		(e.dataTransfer?.types.includes(ATTRIBUTE_MIME) ?? false) ||
+		(e.dataTransfer?.types.includes(LEVEL_MOVE_MIME) ?? false)
+	);
+}
+
+export function isPaneReorderDrag(e: DragEvent): boolean {
+	return e.dataTransfer?.types.includes(PANE_REORDER_MIME) ?? false;
+}
+
+export function isFactsPaneReorderDrag(e: DragEvent): boolean {
+	return e.dataTransfer?.types.includes(FACTS_PANE_REORDER_MIME) ?? false;
+}

--- a/saiku-ui/src/lib/cube-designer/xml-parser.ts
+++ b/saiku-ui/src/lib/cube-designer/xml-parser.ts
@@ -25,26 +25,26 @@
 
 /** A parsed XML element node. Text-only content is collected in `text`. */
 export interface XmlNode {
-	/** Tag name, e.g. `"Cube"`. */
-	readonly name: string;
-	/** Attribute map; values are entity-decoded. */
-	readonly attributes: Readonly<Record<string, string>>;
-	/** Child element nodes, in document order. */
-	readonly children: readonly XmlNode[];
-	/** Concatenated, entity-decoded text content (trimmed). */
-	readonly text: string;
+  /** Tag name, e.g. `"Cube"`. */
+  readonly name: string;
+  /** Attribute map; values are entity-decoded. */
+  readonly attributes: Readonly<Record<string, string>>;
+  /** Child element nodes, in document order. */
+  readonly children: readonly XmlNode[];
+  /** Concatenated, entity-decoded text content (trimmed). */
+  readonly text: string;
 }
 
 export type XmlParseResult =
-	| { readonly ok: true; readonly root: XmlNode }
-	| { readonly ok: false; readonly reason: string };
+  | { readonly ok: true; readonly root: XmlNode }
+  | { readonly ok: false; readonly reason: string };
 
 const ENTITY_MAP: Readonly<Record<string, string>> = {
-	lt: '<',
-	gt: '>',
-	amp: '&',
-	quot: '"',
-	apos: "'"
+  lt: "<",
+  gt: ">",
+  amp: "&",
+  quot: '"',
+  apos: "'",
 };
 
 /**
@@ -52,30 +52,33 @@ const ENTITY_MAP: Readonly<Record<string, string>> = {
  * Unknown entities are left verbatim (best-effort, never throws).
  */
 function decodeEntities(input: string): string {
-	if (input.indexOf('&') === -1) return input;
-	return input.replace(/&(#x?[0-9a-fA-F]+|[a-zA-Z]+);/g, (match, body: string) => {
-		if (body[0] === '#') {
-			const isHex = body[1] === 'x' || body[1] === 'X';
-			const code = parseInt(body.slice(isHex ? 2 : 1), isHex ? 16 : 10);
-			if (Number.isNaN(code)) return match;
-			return String.fromCodePoint(code);
-		}
-		const replacement = ENTITY_MAP[body];
-		return replacement ?? match;
-	});
+  if (input.indexOf("&") === -1) return input;
+  return input.replace(
+    /&(#x?[0-9a-fA-F]+|[a-zA-Z]+);/g,
+    (match, body: string) => {
+      if (body[0] === "#") {
+        const isHex = body[1] === "x" || body[1] === "X";
+        const code = parseInt(body.slice(isHex ? 2 : 1), isHex ? 16 : 10);
+        if (Number.isNaN(code)) return match;
+        return String.fromCodePoint(code);
+      }
+      const replacement = ENTITY_MAP[body];
+      return replacement ?? match;
+    },
+  );
 }
 
 interface Cursor {
-	readonly s: string;
-	pos: number;
+  readonly s: string;
+  pos: number;
 }
 
 function isWhitespace(ch: string): boolean {
-	return ch === ' ' || ch === '\t' || ch === '\n' || ch === '\r';
+  return ch === " " || ch === "\t" || ch === "\n" || ch === "\r";
 }
 
 function skipWhitespace(c: Cursor): void {
-	while (c.pos < c.s.length && isWhitespace(c.s[c.pos])) c.pos++;
+  while (c.pos < c.s.length && isWhitespace(c.s[c.pos])) c.pos++;
 }
 
 /**
@@ -83,54 +86,57 @@ function skipWhitespace(c: Cursor): void {
  * declaration. Returns false if it hit unterminated markup.
  */
 function skipProlog(c: Cursor): boolean {
-	for (;;) {
-		skipWhitespace(c);
-		if (c.s.startsWith('<?', c.pos)) {
-			const end = c.s.indexOf('?>', c.pos);
-			if (end === -1) return false;
-			c.pos = end + 2;
-			continue;
-		}
-		if (c.s.startsWith('<!--', c.pos)) {
-			const end = c.s.indexOf('-->', c.pos);
-			if (end === -1) return false;
-			c.pos = end + 3;
-			continue;
-		}
-		return true;
-	}
+  for (;;) {
+    skipWhitespace(c);
+    if (c.s.startsWith("<?", c.pos)) {
+      const end = c.s.indexOf("?>", c.pos);
+      if (end === -1) return false;
+      c.pos = end + 2;
+      continue;
+    }
+    if (c.s.startsWith("<!--", c.pos)) {
+      const end = c.s.indexOf("-->", c.pos);
+      if (end === -1) return false;
+      c.pos = end + 3;
+      continue;
+    }
+    return true;
+  }
 }
 
-const NAME_TERMINATORS = new Set([' ', '\t', '\n', '\r', '>', '/', '=']);
+const NAME_TERMINATORS = new Set([" ", "\t", "\n", "\r", ">", "/", "="]);
 
 function readName(c: Cursor): string {
-	const start = c.pos;
-	while (c.pos < c.s.length && !NAME_TERMINATORS.has(c.s[c.pos])) c.pos++;
-	return c.s.slice(start, c.pos);
+  const start = c.pos;
+  while (c.pos < c.s.length && !NAME_TERMINATORS.has(c.s[c.pos])) c.pos++;
+  return c.s.slice(start, c.pos);
 }
 
 /** Parse attributes up to the closing `>` or `/>`. Throws on malformed. */
 function readAttributes(c: Cursor): Record<string, string> {
-	const attributes: Record<string, string> = {};
-	for (;;) {
-		skipWhitespace(c);
-		const ch = c.s[c.pos];
-		if (ch === undefined) throw new Error('unterminated start tag');
-		if (ch === '>' || ch === '/') return attributes;
-		const attrName = readName(c);
-		if (attrName.length === 0) throw new Error('expected attribute name');
-		skipWhitespace(c);
-		if (c.s[c.pos] !== '=') throw new Error(`attribute '${attrName}' missing '='`);
-		c.pos++;
-		skipWhitespace(c);
-		if (c.s[c.pos] !== '"') throw new Error(`attribute '${attrName}' value must be double-quoted`);
-		c.pos++;
-		const valStart = c.pos;
-		const valEnd = c.s.indexOf('"', c.pos);
-		if (valEnd === -1) throw new Error(`attribute '${attrName}' value unterminated`);
-		attributes[attrName] = decodeEntities(c.s.slice(valStart, valEnd));
-		c.pos = valEnd + 1;
-	}
+  const attributes: Record<string, string> = {};
+  for (;;) {
+    skipWhitespace(c);
+    const ch = c.s[c.pos];
+    if (ch === undefined) throw new Error("unterminated start tag");
+    if (ch === ">" || ch === "/") return attributes;
+    const attrName = readName(c);
+    if (attrName.length === 0) throw new Error("expected attribute name");
+    skipWhitespace(c);
+    if (c.s[c.pos] !== "=")
+      throw new Error(`attribute '${attrName}' missing '='`);
+    c.pos++;
+    skipWhitespace(c);
+    if (c.s[c.pos] !== '"')
+      throw new Error(`attribute '${attrName}' value must be double-quoted`);
+    c.pos++;
+    const valStart = c.pos;
+    const valEnd = c.s.indexOf('"', c.pos);
+    if (valEnd === -1)
+      throw new Error(`attribute '${attrName}' value unterminated`);
+    attributes[attrName] = decodeEntities(c.s.slice(valStart, valEnd));
+    c.pos = valEnd + 1;
+  }
 }
 
 /**
@@ -138,46 +144,49 @@ function readAttributes(c: Cursor): Record<string, string> {
  * parses children. Throws on malformed markup (caught at the top).
  */
 function parseElement(c: Cursor): XmlNode {
-	if (c.s[c.pos] !== '<') throw new Error('expected element start');
-	c.pos++;
-	const name = readName(c);
-	if (name.length === 0) throw new Error('empty tag name');
-	const attributes = readAttributes(c);
-	skipWhitespace(c);
-	if (c.s.startsWith('/>', c.pos)) {
-		c.pos += 2;
-		return { name, attributes, children: [], text: '' };
-	}
-	if (c.s[c.pos] !== '>') throw new Error(`tag '${name}' not closed`);
-	c.pos++;
+  if (c.s[c.pos] !== "<") throw new Error("expected element start");
+  c.pos++;
+  const name = readName(c);
+  if (name.length === 0) throw new Error("empty tag name");
+  const attributes = readAttributes(c);
+  skipWhitespace(c);
+  if (c.s.startsWith("/>", c.pos)) {
+    c.pos += 2;
+    return { name, attributes, children: [], text: "" };
+  }
+  if (c.s[c.pos] !== ">") throw new Error(`tag '${name}' not closed`);
+  c.pos++;
 
-	const children: XmlNode[] = [];
-	let text = '';
-	for (;;) {
-		const lt = c.s.indexOf('<', c.pos);
-		if (lt === -1) throw new Error(`tag '${name}' has no closing tag`);
-		text += decodeEntities(c.s.slice(c.pos, lt));
-		c.pos = lt;
-		if (c.s.startsWith('<!--', c.pos)) {
-			const end = c.s.indexOf('-->', c.pos);
-			if (end === -1) throw new Error('unterminated comment');
-			c.pos = end + 3;
-			continue;
-		}
-		if (c.s.startsWith('</', c.pos)) {
-			c.pos += 2;
-			const closeName = readName(c);
-			skipWhitespace(c);
-			if (c.s[c.pos] !== '>') throw new Error(`closing tag '${closeName}' not closed`);
-			c.pos++;
-			if (closeName !== name) {
-				throw new Error(`mismatched tag: expected </${name}>, got </${closeName}>`);
-			}
-			break;
-		}
-		children.push(parseElement(c));
-	}
-	return { name, attributes, children, text: text.trim() };
+  const children: XmlNode[] = [];
+  let text = "";
+  for (;;) {
+    const lt = c.s.indexOf("<", c.pos);
+    if (lt === -1) throw new Error(`tag '${name}' has no closing tag`);
+    text += decodeEntities(c.s.slice(c.pos, lt));
+    c.pos = lt;
+    if (c.s.startsWith("<!--", c.pos)) {
+      const end = c.s.indexOf("-->", c.pos);
+      if (end === -1) throw new Error("unterminated comment");
+      c.pos = end + 3;
+      continue;
+    }
+    if (c.s.startsWith("</", c.pos)) {
+      c.pos += 2;
+      const closeName = readName(c);
+      skipWhitespace(c);
+      if (c.s[c.pos] !== ">")
+        throw new Error(`closing tag '${closeName}' not closed`);
+      c.pos++;
+      if (closeName !== name) {
+        throw new Error(
+          `mismatched tag: expected </${name}>, got </${closeName}>`,
+        );
+      }
+      break;
+    }
+    children.push(parseElement(c));
+  }
+  return { name, attributes, children, text: text.trim() };
 }
 
 /**
@@ -185,32 +194,42 @@ function parseElement(c: Cursor): XmlNode {
  * failure on any malformed input.
  */
 export function parseXml(xml: string): XmlParseResult {
-	if (typeof xml !== 'string' || xml.trim().length === 0) {
-		return { ok: false, reason: 'empty or non-string XML' };
-	}
-	const c: Cursor = { s: xml, pos: 0 };
-	try {
-		if (!skipProlog(c))
-			return { ok: false, reason: 'unterminated prolog (declaration or comment)' };
-		if (c.s[c.pos] !== '<') return { ok: false, reason: 'no root element found' };
-		const root = parseElement(c);
-		// Trailing content after the root (other than comments/whitespace)
-		// means the document is not a single well-formed tree.
-		if (!skipProlog(c) || c.pos < c.s.length) {
-			return { ok: false, reason: 'unexpected trailing content after root element' };
-		}
-		return { ok: true, root };
-	} catch (err) {
-		return { ok: false, reason: err instanceof Error ? err.message : 'malformed XML' };
-	}
+  if (typeof xml !== "string" || xml.trim().length === 0) {
+    return { ok: false, reason: "empty or non-string XML" };
+  }
+  const c: Cursor = { s: xml, pos: 0 };
+  try {
+    if (!skipProlog(c))
+      return {
+        ok: false,
+        reason: "unterminated prolog (declaration or comment)",
+      };
+    if (c.s[c.pos] !== "<")
+      return { ok: false, reason: "no root element found" };
+    const root = parseElement(c);
+    // Trailing content after the root (other than comments/whitespace)
+    // means the document is not a single well-formed tree.
+    if (!skipProlog(c) || c.pos < c.s.length) {
+      return {
+        ok: false,
+        reason: "unexpected trailing content after root element",
+      };
+    }
+    return { ok: true, root };
+  } catch (err) {
+    return {
+      ok: false,
+      reason: err instanceof Error ? err.message : "malformed XML",
+    };
+  }
 }
 
 /** First direct child with the given tag name, or undefined. */
 export function childNamed(node: XmlNode, name: string): XmlNode | undefined {
-	return node.children.find((child) => child.name === name);
+  return node.children.find((child) => child.name === name);
 }
 
 /** All direct children with the given tag name, in document order. */
 export function childrenNamed(node: XmlNode, name: string): XmlNode[] {
-	return node.children.filter((child) => child.name === name);
+  return node.children.filter((child) => child.name === name);
 }

--- a/saiku-ui/src/lib/cube-designer/xml-parser.ts
+++ b/saiku-ui/src/lib/cube-designer/xml-parser.ts
@@ -1,0 +1,216 @@
+/**
+ * Minimal, dependency-free, isomorphic XML parser (saiku-cloud#710).
+ *
+ * The dashboard's vitest `server` project runs in a Node environment
+ * where the global {@link DOMParser} is unavailable, and we deliberately
+ * do NOT add an XML-parser npm dependency (keeps the dashboard bundle +
+ * SSR surface lean — see the PR for the rationale). This hand-rolled
+ * recursive-descent parser handles exactly the subset of XML the
+ * gateway's `MondrianXmlEmitter` produces:
+ *
+ * - An optional `<?xml ... ?>` declaration.
+ * - Comments (`<!-- ... -->`), skipped.
+ * - Elements with double-quoted attribute values.
+ * - Text content (with the five standard entity references).
+ * - Self-closing (`<Foo/>`) and container (`<Foo>...</Foo>`) elements.
+ *
+ * It intentionally does NOT support: DOCTYPE, processing instructions
+ * other than the XML declaration, CDATA, namespaces, single-quoted
+ * attribute values, or custom entities. The emitter emits none of
+ * those, and refusing them keeps the parser small + auditable.
+ *
+ * The parser never throws: malformed input yields `{ ok: false }` so
+ * the caller can fall back to a raw-XML editing surface.
+ */
+
+/** A parsed XML element node. Text-only content is collected in `text`. */
+export interface XmlNode {
+	/** Tag name, e.g. `"Cube"`. */
+	readonly name: string;
+	/** Attribute map; values are entity-decoded. */
+	readonly attributes: Readonly<Record<string, string>>;
+	/** Child element nodes, in document order. */
+	readonly children: readonly XmlNode[];
+	/** Concatenated, entity-decoded text content (trimmed). */
+	readonly text: string;
+}
+
+export type XmlParseResult =
+	| { readonly ok: true; readonly root: XmlNode }
+	| { readonly ok: false; readonly reason: string };
+
+const ENTITY_MAP: Readonly<Record<string, string>> = {
+	lt: '<',
+	gt: '>',
+	amp: '&',
+	quot: '"',
+	apos: "'"
+};
+
+/**
+ * Decode the five standard XML entity references plus numeric ones.
+ * Unknown entities are left verbatim (best-effort, never throws).
+ */
+function decodeEntities(input: string): string {
+	if (input.indexOf('&') === -1) return input;
+	return input.replace(/&(#x?[0-9a-fA-F]+|[a-zA-Z]+);/g, (match, body: string) => {
+		if (body[0] === '#') {
+			const isHex = body[1] === 'x' || body[1] === 'X';
+			const code = parseInt(body.slice(isHex ? 2 : 1), isHex ? 16 : 10);
+			if (Number.isNaN(code)) return match;
+			return String.fromCodePoint(code);
+		}
+		const replacement = ENTITY_MAP[body];
+		return replacement ?? match;
+	});
+}
+
+interface Cursor {
+	readonly s: string;
+	pos: number;
+}
+
+function isWhitespace(ch: string): boolean {
+	return ch === ' ' || ch === '\t' || ch === '\n' || ch === '\r';
+}
+
+function skipWhitespace(c: Cursor): void {
+	while (c.pos < c.s.length && isWhitespace(c.s[c.pos])) c.pos++;
+}
+
+/**
+ * Skip any number of leading comments / whitespace / the XML
+ * declaration. Returns false if it hit unterminated markup.
+ */
+function skipProlog(c: Cursor): boolean {
+	for (;;) {
+		skipWhitespace(c);
+		if (c.s.startsWith('<?', c.pos)) {
+			const end = c.s.indexOf('?>', c.pos);
+			if (end === -1) return false;
+			c.pos = end + 2;
+			continue;
+		}
+		if (c.s.startsWith('<!--', c.pos)) {
+			const end = c.s.indexOf('-->', c.pos);
+			if (end === -1) return false;
+			c.pos = end + 3;
+			continue;
+		}
+		return true;
+	}
+}
+
+const NAME_TERMINATORS = new Set([' ', '\t', '\n', '\r', '>', '/', '=']);
+
+function readName(c: Cursor): string {
+	const start = c.pos;
+	while (c.pos < c.s.length && !NAME_TERMINATORS.has(c.s[c.pos])) c.pos++;
+	return c.s.slice(start, c.pos);
+}
+
+/** Parse attributes up to the closing `>` or `/>`. Throws on malformed. */
+function readAttributes(c: Cursor): Record<string, string> {
+	const attributes: Record<string, string> = {};
+	for (;;) {
+		skipWhitespace(c);
+		const ch = c.s[c.pos];
+		if (ch === undefined) throw new Error('unterminated start tag');
+		if (ch === '>' || ch === '/') return attributes;
+		const attrName = readName(c);
+		if (attrName.length === 0) throw new Error('expected attribute name');
+		skipWhitespace(c);
+		if (c.s[c.pos] !== '=') throw new Error(`attribute '${attrName}' missing '='`);
+		c.pos++;
+		skipWhitespace(c);
+		if (c.s[c.pos] !== '"') throw new Error(`attribute '${attrName}' value must be double-quoted`);
+		c.pos++;
+		const valStart = c.pos;
+		const valEnd = c.s.indexOf('"', c.pos);
+		if (valEnd === -1) throw new Error(`attribute '${attrName}' value unterminated`);
+		attributes[attrName] = decodeEntities(c.s.slice(valStart, valEnd));
+		c.pos = valEnd + 1;
+	}
+}
+
+/**
+ * Parse a single element starting at the current `<`. Recursively
+ * parses children. Throws on malformed markup (caught at the top).
+ */
+function parseElement(c: Cursor): XmlNode {
+	if (c.s[c.pos] !== '<') throw new Error('expected element start');
+	c.pos++;
+	const name = readName(c);
+	if (name.length === 0) throw new Error('empty tag name');
+	const attributes = readAttributes(c);
+	skipWhitespace(c);
+	if (c.s.startsWith('/>', c.pos)) {
+		c.pos += 2;
+		return { name, attributes, children: [], text: '' };
+	}
+	if (c.s[c.pos] !== '>') throw new Error(`tag '${name}' not closed`);
+	c.pos++;
+
+	const children: XmlNode[] = [];
+	let text = '';
+	for (;;) {
+		const lt = c.s.indexOf('<', c.pos);
+		if (lt === -1) throw new Error(`tag '${name}' has no closing tag`);
+		text += decodeEntities(c.s.slice(c.pos, lt));
+		c.pos = lt;
+		if (c.s.startsWith('<!--', c.pos)) {
+			const end = c.s.indexOf('-->', c.pos);
+			if (end === -1) throw new Error('unterminated comment');
+			c.pos = end + 3;
+			continue;
+		}
+		if (c.s.startsWith('</', c.pos)) {
+			c.pos += 2;
+			const closeName = readName(c);
+			skipWhitespace(c);
+			if (c.s[c.pos] !== '>') throw new Error(`closing tag '${closeName}' not closed`);
+			c.pos++;
+			if (closeName !== name) {
+				throw new Error(`mismatched tag: expected </${name}>, got </${closeName}>`);
+			}
+			break;
+		}
+		children.push(parseElement(c));
+	}
+	return { name, attributes, children, text: text.trim() };
+}
+
+/**
+ * Parse an XML string into a tree. Never throws — returns a structured
+ * failure on any malformed input.
+ */
+export function parseXml(xml: string): XmlParseResult {
+	if (typeof xml !== 'string' || xml.trim().length === 0) {
+		return { ok: false, reason: 'empty or non-string XML' };
+	}
+	const c: Cursor = { s: xml, pos: 0 };
+	try {
+		if (!skipProlog(c))
+			return { ok: false, reason: 'unterminated prolog (declaration or comment)' };
+		if (c.s[c.pos] !== '<') return { ok: false, reason: 'no root element found' };
+		const root = parseElement(c);
+		// Trailing content after the root (other than comments/whitespace)
+		// means the document is not a single well-formed tree.
+		if (!skipProlog(c) || c.pos < c.s.length) {
+			return { ok: false, reason: 'unexpected trailing content after root element' };
+		}
+		return { ok: true, root };
+	} catch (err) {
+		return { ok: false, reason: err instanceof Error ? err.message : 'malformed XML' };
+	}
+}
+
+/** First direct child with the given tag name, or undefined. */
+export function childNamed(node: XmlNode, name: string): XmlNode | undefined {
+	return node.children.find((child) => child.name === name);
+}
+
+/** All direct children with the given tag name, in document order. */
+export function childrenNamed(node: XmlNode, name: string): XmlNode[] {
+	return node.children.filter((child) => child.name === name);
+}

--- a/saiku-ui/src/lib/design-system/primitives/Popover.svelte
+++ b/saiku-ui/src/lib/design-system/primitives/Popover.svelte
@@ -1,0 +1,59 @@
+<!--
+	Popover — a floating panel anchored to a trigger.  Wraps bits-ui
+	Popover with the design-system's border / bg / shadow contract.
+	The trigger snippet receives `props` that the caller MUST spread
+	onto their button — this is the bits-ui `child` pattern, needed
+	so click + aria attributes land on the actual interactive element
+	(a wrapper span with `display: contents` swallows the events).
+
+	Slot the trigger and content:
+
+	  <Popover>
+	    {#snippet trigger({ props })}
+	      <button {...props}>Open</button>
+	    {/snippet}
+	    {#snippet content()}
+	      <div class="p-3">…</div>
+	    {/snippet}
+	  </Popover>
+-->
+<script lang="ts">
+	import { Popover as PopoverPrimitive } from 'bits-ui';
+
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	type TriggerProps = Record<string, any>;
+
+	let {
+		side = 'bottom',
+		align = 'center',
+		sideOffset = 6,
+		open = $bindable(false),
+		trigger,
+		content
+	}: {
+		side?: 'top' | 'right' | 'bottom' | 'left';
+		align?: 'start' | 'center' | 'end';
+		sideOffset?: number;
+		open?: boolean;
+		trigger: import('svelte').Snippet<[{ props: TriggerProps }]>;
+		content: import('svelte').Snippet;
+	} = $props();
+</script>
+
+<PopoverPrimitive.Root bind:open>
+	<PopoverPrimitive.Trigger>
+		{#snippet child({ props })}
+			{@render trigger({ props })}
+		{/snippet}
+	</PopoverPrimitive.Trigger>
+	<PopoverPrimitive.Portal>
+		<PopoverPrimitive.Content
+			{side}
+			{align}
+			{sideOffset}
+			class="z-50 min-w-40 rounded-md border border-border bg-popover text-popover-foreground shadow-md outline-none"
+		>
+			{@render content()}
+		</PopoverPrimitive.Content>
+	</PopoverPrimitive.Portal>
+</PopoverPrimitive.Root>

--- a/saiku-ui/src/lib/views/admin/dataSourceActions.test.ts
+++ b/saiku-ui/src/lib/views/admin/dataSourceActions.test.ts
@@ -39,36 +39,36 @@ describe("canGenerateSchema", () => {
 });
 
 describe("generateSchemaLabel", () => {
-  it("returns 'Generate schema' when the data source has no schema", () => {
-    expect(generateSchemaLabel({ id: "ds-1" })).toBe("Generate schema");
+  it("returns 'Design cube' when the data source has no schema", () => {
+    expect(generateSchemaLabel({ id: "ds-1" })).toBe("Design cube");
     expect(generateSchemaLabel({ id: "ds-1", schemaName: null })).toBe(
-      "Generate schema",
+      "Design cube",
     );
     expect(generateSchemaLabel({ id: "ds-1", schemaName: "" })).toBe(
-      "Generate schema",
+      "Design cube",
     );
     expect(generateSchemaLabel({ id: "ds-1", schemaName: "   " })).toBe(
-      "Generate schema",
+      "Design cube",
     );
   });
 
-  it("returns 'Regenerate / check for drift' when a schema is attached", () => {
+  it("returns 'Edit cube schema' when a schema is attached", () => {
     expect(generateSchemaLabel({ id: "ds-1", schemaName: "SteelWheels" })).toBe(
-      "Regenerate / check for drift",
+      "Edit cube schema",
     );
   });
 });
 
 describe("generateSchemaHref", () => {
-  it("links to the schema-generator route for the data source id", () => {
+  it("links to the cube-designer route for the data source id", () => {
     expect(generateSchemaHref({ id: "ds-1" })).toBe(
-      "/admin/schema-generator/ds-1",
+      "/admin/cube-designer/ds-1",
     );
   });
 
   it("percent-encodes ids that contain URL-unsafe characters", () => {
     const href = generateSchemaHref({ id: "foo bar/baz?x" });
-    expect(href).toBe("/admin/schema-generator/foo%20bar%2Fbaz%3Fx");
+    expect(href).toBe("/admin/cube-designer/foo%20bar%2Fbaz%3Fx");
     // the raw id must not leak through
     expect(href).not.toContain(" ");
     expect(href).not.toContain("?");

--- a/saiku-ui/src/lib/views/admin/dataSourceActions.ts
+++ b/saiku-ui/src/lib/views/admin/dataSourceActions.ts
@@ -24,19 +24,13 @@ export function canGenerateSchema(ds: GenerateSchemaTarget): boolean {
 export function generateSchemaHref(
   ds: Pick<GenerateSchemaTarget, "id">,
 ): string {
-  return `/admin/schema-generator/${encodeURIComponent(ds.id)}`;
+  return `/admin/cube-designer/${encodeURIComponent(ds.id)}`;
 }
 
 /**
- * Label for the schema-generator entry-point button.
- *
- * When the data source already has a Mondrian schema attached, the button
- * enters re-run / drift-detection mode — the backend will reconcile the fresh
- * introspection against the stored sidecar and the UI will surface any
- * detected changes. Otherwise the button kicks off a first-run generation.
+ * Label for the cube-designer entry-point button. First-run when the data
+ * source has no Mondrian schema yet; edit mode when one is attached.
  */
 export function generateSchemaLabel(ds: GenerateSchemaTarget): string {
-  return canGenerateSchema(ds)
-    ? "Generate schema"
-    : "Regenerate / check for drift";
+  return canGenerateSchema(ds) ? "Design cube" : "Edit cube schema";
 }

--- a/saiku-ui/src/routes/admin/cube-designer/[dataSourceId]/+page.svelte
+++ b/saiku-ui/src/routes/admin/cube-designer/[dataSourceId]/+page.svelte
@@ -1,0 +1,151 @@
+<!--
+  Admin › Cube Designer — the OSS home for the visual cube/schema designer
+  ported from saiku-cloud. Dedicated dynamic route (mirrors the schema-generator)
+  so the heavy canvas app gets a full page + a datasource context.
+
+  This route is the HOST: it creates the store, provides the OSS backend via
+  context (setCubeDesignerBackend), profiles the datasource into the source
+  sidebar, and owns Save (emit Mondrian 4 XML → admin schema upload). The
+  designer components themselves are host-agnostic.
+-->
+<script lang="ts">
+  import { onMount } from "svelte";
+  import { goto } from "$app/navigation";
+  import { SchemaCanvasStore } from "$lib/cube-designer/state.svelte";
+  import SchemaCanvasView from "$lib/cube-designer/SchemaCanvasView.svelte";
+  import WorkbenchView from "$lib/cube-designer/WorkbenchView.svelte";
+  import { setCubeDesignerBackend } from "$lib/cube-designer/backend";
+  import { ossCubeDesignerBackend } from "$lib/cube-designer/oss-backend";
+  import { exportToMondrianXml } from "$lib/cube-designer/mondrian-export";
+  import { parseProfileTables } from "$lib/cube-designer/profile-types";
+  import type { SourceTableCandidate } from "$lib/cube-designer/types";
+  import { adminSchemas } from "$lib/api/admin";
+  import Button from "$lib/components/ui/button.svelte";
+  import FeedbackBanner from "$lib/design-system/FeedbackBanner.svelte";
+  import type { PageData } from "./$types";
+
+  let { data }: { data: PageData } = $props();
+  const dataSourceId = data.dataSourceId;
+
+  // Store keyed on the datasource; provide the OSS backend to the designer subtree.
+  const store = new SchemaCanvasStore(dataSourceId);
+  setCubeDesignerBackend(ossCubeDesignerBackend);
+
+  let sourceError = $state<string | null>(null);
+  let saving = $state(false);
+  let saveMsg = $state<{ tone: "success" | "error"; text: string } | null>(null);
+
+  const MODES = [
+    { m: "canvas", label: "Schema Canvas" },
+    { m: "workbench", label: "Dimensions & Hierarchies" },
+    { m: "facts", label: "Facts & Measures" },
+    { m: "validate", label: "Confirm cube" },
+  ] as const;
+
+  onMount(async () => {
+    store.switchConnection(dataSourceId);
+    store.sourceLoading = true;
+    store.sourceError = null;
+    try {
+      const r = await ossCubeDesignerBackend.profileConnection(dataSourceId);
+      if (!r.ok) {
+        throw new Error(`could not profile the datasource (HTTP ${r.status})`);
+      }
+      const profiled = parseProfileTables(await r.text());
+      const onCanvas = store.tableIdentitiesOnCanvas;
+      store.sourceTables = profiled.map(
+        (t): SourceTableCandidate => ({
+          schema: t.schema,
+          name: t.name,
+          columns: t.columns,
+          onCanvas: onCanvas.has(t.schema ? `${t.schema}.${t.name}` : t.name),
+        }),
+      );
+    } catch (e) {
+      sourceError = e instanceof Error ? e.message : "could not profile the datasource";
+    } finally {
+      store.sourceLoading = false;
+    }
+  });
+
+  async function save() {
+    saving = true;
+    saveMsg = null;
+    let xml: string;
+    try {
+      xml = exportToMondrianXml(store.doc);
+    } catch (e) {
+      saveMsg = {
+        tone: "error",
+        text: e instanceof Error ? e.message : "The cube is not ready to save yet.",
+      };
+      saving = false;
+      return;
+    }
+    const name = store.doc.label?.trim() || `${dataSourceId}-cube`;
+    try {
+      await adminSchemas.upload(name, xml);
+      store.doc.lineageId = name; // mark saved for the workbench's saved/dirty state
+      saveMsg = { tone: "success", text: `Saved schema "${name}".` };
+    } catch (e) {
+      saveMsg = { tone: "error", text: e instanceof Error ? e.message : "Save failed." };
+    } finally {
+      saving = false;
+    }
+  }
+</script>
+
+<div class="flex h-svh flex-col overflow-hidden">
+  <header class="flex shrink-0 flex-wrap items-center gap-2 border-b border-border px-3 py-2">
+    <h1 class="mr-2 text-sm font-semibold text-foreground">
+      Cube Designer <span class="text-muted-foreground">· {dataSourceId}</span>
+    </h1>
+    <nav class="flex items-center gap-1" role="tablist" aria-label="Designer mode">
+      {#each MODES as { m, label } (m)}
+        {@const active = store.mode === m}
+        <button
+          type="button"
+          role="tab"
+          aria-selected={active}
+          class="rounded px-2 py-1 text-[11px] font-medium {active
+            ? 'bg-primary text-primary-foreground'
+            : 'text-muted-foreground hover:bg-accent hover:text-accent-foreground'}"
+          onclick={() => store.setMode(m)}
+        >
+          {label}
+        </button>
+      {/each}
+    </nav>
+    <div class="ml-auto flex items-center gap-2">
+      <Button size="sm" onclick={save} disabled={saving}>
+        {saving ? "Saving…" : "Save"}
+      </Button>
+      <Button
+        size="sm"
+        variant="ghost"
+        onclick={() => goto("/admin?tab=datasources")}
+      >
+        Back
+      </Button>
+    </div>
+  </header>
+
+  {#if saveMsg}
+    <div class="shrink-0 px-3 pt-2">
+      <FeedbackBanner tone={saveMsg.tone} size="sm">{saveMsg.text}</FeedbackBanner>
+    </div>
+  {/if}
+  {#if sourceError}
+    <div class="shrink-0 px-3 pt-2">
+      <FeedbackBanner tone="error" size="sm">{sourceError}</FeedbackBanner>
+    </div>
+  {/if}
+
+  <div class="flex min-h-0 flex-1 flex-col overflow-hidden">
+    {#if store.mode === "canvas"}
+      <SchemaCanvasView {store} />
+    {:else}
+      <WorkbenchView {store} isSchemaSaved={!!store.doc.lineageId} />
+    {/if}
+  </div>
+</div>

--- a/saiku-ui/src/routes/admin/cube-designer/[dataSourceId]/+page.svelte
+++ b/saiku-ui/src/routes/admin/cube-designer/[dataSourceId]/+page.svelte
@@ -14,8 +14,14 @@
   import { SchemaCanvasStore } from "$lib/cube-designer/state.svelte";
   import SchemaCanvasView from "$lib/cube-designer/SchemaCanvasView.svelte";
   import WorkbenchView from "$lib/cube-designer/WorkbenchView.svelte";
-  import { setCubeDesignerBackend } from "$lib/cube-designer/backend";
-  import { ossCubeDesignerBackend } from "$lib/cube-designer/oss-backend";
+  import {
+    setCubeDesignerBackend,
+    setCubeDesignerAI,
+  } from "$lib/cube-designer/backend";
+  import {
+    ossCubeDesignerBackend,
+    ossCubeDesignerAI,
+  } from "$lib/cube-designer/oss-backend";
   import { exportToMondrianXml } from "$lib/cube-designer/mondrian-export";
   import { parseProfileTables } from "$lib/cube-designer/profile-types";
   import type { SourceTableCandidate } from "$lib/cube-designer/types";
@@ -30,6 +36,7 @@
   // Store keyed on the datasource; provide the OSS backend to the designer subtree.
   const store = new SchemaCanvasStore(dataSourceId);
   setCubeDesignerBackend(ossCubeDesignerBackend);
+  setCubeDesignerAI(ossCubeDesignerAI);
 
   let sourceError = $state<string | null>(null);
   let saving = $state(false);

--- a/saiku-ui/src/routes/admin/cube-designer/[dataSourceId]/+page.ts
+++ b/saiku-ui/src/routes/admin/cube-designer/[dataSourceId]/+page.ts
@@ -1,0 +1,12 @@
+/*
+ * SvelteKit load: extract the :dataSourceId route param so the cube-designer
+ * page can profile + author a schema against the right datasource.
+ */
+import type { PageLoad } from "./$types";
+
+// Dynamic param — opt out of the root layout's default prerender.
+export const prerender = false;
+
+export const load: PageLoad = ({ params }) => {
+  return { dataSourceId: params.dataSourceId };
+};

--- a/saiku-webapp/src/main/webapp/WEB-INF/saiku-beans.xml
+++ b/saiku-webapp/src/main/webapp/WEB-INF/saiku-beans.xml
@@ -890,11 +890,20 @@
     <!-- Cube/schema designer backend (saiku-ui/src/lib/cube-designer). Reuses the
          schema-generator's JDBC connection provider + the datasource service;
          auto-registered as a JAX-RS resource by SaikuJerseyApplication's @Path scan. -->
+    <bean id="cubeDesignerAiService"
+          class="org.saiku.service.olap.ai.cubedesigner.CubeDesignerAiService">
+        <constructor-arg value="${saiku.ai.ask.apiKey:}"/>
+        <constructor-arg value="${saiku.ai.ask.model:}"/>
+        <constructor-arg value="${saiku.ai.ask.endpoint:}"/>
+        <constructor-arg value="${saiku.ai.ask.timeoutSeconds:60}"/>
+    </bean>
+
     <bean id="cubeDesignerResource"
           class="org.saiku.web.rest.resources.cubedesigner.CubeDesignerResource">
         <constructor-arg ref="schemaGenConnectionProvider"/>
         <constructor-arg ref="datasourceServiceBean"/>
         <property name="userService" ref="userServiceBean"/>
+        <property name="aiService" ref="cubeDesignerAiService"/>
     </bean>
 
 </beans>

--- a/saiku-webapp/src/main/webapp/WEB-INF/saiku-beans.xml
+++ b/saiku-webapp/src/main/webapp/WEB-INF/saiku-beans.xml
@@ -887,4 +887,14 @@
         <property name="userService" ref="userServiceBean"/>
     </bean>
 
+    <!-- Cube/schema designer backend (saiku-ui/src/lib/cube-designer). Reuses the
+         schema-generator's JDBC connection provider + the datasource service;
+         auto-registered as a JAX-RS resource by SaikuJerseyApplication's @Path scan. -->
+    <bean id="cubeDesignerResource"
+          class="org.saiku.web.rest.resources.cubedesigner.CubeDesignerResource">
+        <constructor-arg ref="schemaGenConnectionProvider"/>
+        <constructor-arg ref="datasourceServiceBean"/>
+        <property name="userService" ref="userServiceBean"/>
+    </bean>
+
 </beans>


### PR DESCRIPTION
## What

Ports the visual **cube/schema designer** (SvelteKit canvas + inspector + workbench, ~25k LOC) from the closed saiku-cloud dashboard into OSS Saiku, wires it into the admin panel, and gives it real backend endpoints + a schema-authoring AI — so Saiku ships the designer natively.

Reachable at **`/ui/admin/cube-designer/<dataSourceId>`** (launched from the Datasources admin action).

## How (by phase)

- **Designer** → `saiku-ui/src/lib/cube-designer/` — the whole canvas/inspector/workbench + store + Mondrian emit/import, host-agnostic behind an injected `CubeDesignerBackend` (+ optional `CubeDesignerAI`). Bundles its own primitives → the package is `$lib`-free and self-contained (a public-API barrel + primitives it can be published from later). Deps added: `@xyflow/svelte`, `elkjs`, `yaml` (`bits-ui`/`tailwind-variants` already matched); `@lucide/svelte → lucide-svelte`.
- **Backend** → 3 endpoints under `/rest/saiku/admin/cube-designer` (`CubeDesignerResource`): **introspect** (JdbcIntrospector), **sample** (setMaxRows preview), **convert** (M3→M4 — the `M3ToM4Converter` ported into `saiku-service` `mondrian.rolap`, wrapping the fork's own `RolapSchemaUpgrader.upgrade`). Reuses the schema-generator's connection provider — **zero changes to schemagen code**.
- **AI (DimSum)** → `CubeDesignerAiService` + `POST /…/cube-designer/turn`: replicates the Anthropic transport (JDK HttpClient, like `AnthropicNlAskProvider`) with the designer's own 16-tool contract + prompt, returning raw `content[]` for the client to execute. Config reuses `saiku.ai.ask.*` / `ANTHROPIC_API_KEY`.
- **Admin route** → `/admin/cube-designer/[dataSourceId]` — creates the store, provides the OSS backend/AI via context, profiles the datasource, renders the mode-switched designer, and Saves (Mondrian 4 → admin schema upload). The Datasources action now launches this.

## Tests

- **saiku-ui:** 199 unit tests (store + emit/import + adapter), svelte-check 0 errors, eslint + token-check clean.
- **Java:** `CubeDesignerResourceTest` (7, H2 end-to-end) + `CubeDesignerAiServiceTest` (5) — `BUILD SUCCESS`; spotless clean.

## Notes

- The old server-driven **schema-generator is NOT deleted** here — only the launch action is repointed. Its wholesale retirement is a separate, coordinated follow-up so `development` is never designer-less.
- DimSum 503s without an API key; the manual designer (profile → design → save) works without it.
- Follow-up: publish `@concepttocloud/saiku-cube-designer` so the saiku-cloud dashboard consumes this one source of truth (no duplication).

Plan doc: `docs/plans/2026-07-31-cube-designer-migration.md`.