### PR TITLE
fix(cube-designer): entry link (base + name) + full-width layout

### DIFF
--- a/saiku-ui/src/lib/views/admin/DatasourcesAdmin.svelte
+++ b/saiku-ui/src/lib/views/admin/DatasourcesAdmin.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { onMount } from "svelte";
+  import { base } from "$app/paths";
   import { Button, buttonVariants } from "$lib/components/ui";
   import { adminDatasources, type AdminDatasource } from "$lib/api/admin";
   import { toasts } from "$lib/stores/toasts.svelte";
@@ -145,7 +146,7 @@
               <a
                 class={buttonVariants({ variant: "outline" })}
                 data-testid="generate-schema-link"
-                href={generateSchemaHref(ds)}
+                href={`${base}${generateSchemaHref(ds)}`}
               >
                 {generateSchemaLabel(ds)}
               </a>

--- a/saiku-ui/src/lib/views/admin/dataSourceActions.test.ts
+++ b/saiku-ui/src/lib/views/admin/dataSourceActions.test.ts
@@ -73,4 +73,12 @@ describe("generateSchemaHref", () => {
     expect(href).not.toContain(" ");
     expect(href).not.toContain("?");
   });
+
+  it("uses the datasource NAME (the backend resolves by name), not the UUID id", () => {
+    // Regression: passing ds.id (a UUID) 500s server-side because
+    // getDatasource keys on name. The link must carry the name.
+    expect(
+      generateSchemaHref({ id: "4432dd20-fcae-11e3-a3ac-0800200c9a66", name: "foodmart" }),
+    ).toBe("/admin/cube-designer/foodmart");
+  });
 });

--- a/saiku-ui/src/lib/views/admin/dataSourceActions.ts
+++ b/saiku-ui/src/lib/views/admin/dataSourceActions.ts
@@ -12,6 +12,10 @@
 
 export interface GenerateSchemaTarget {
   id: string;
+  /** Datasource NAME — the key the backend resolves (getDatasource keys by
+   *  name, not id), so the cube-designer route must carry the name. Optional
+   *  here only so tests can omit it; real AdminDatasource always has one. */
+  name?: string;
   schemaName?: string | null;
 }
 
@@ -21,10 +25,17 @@ export function canGenerateSchema(ds: GenerateSchemaTarget): boolean {
   return name.trim().length === 0;
 }
 
+/**
+ * App-relative (base-less) href for the cube-designer entry. The datasource
+ * NAME — not the id — is used as the route param because the backend resolves
+ * datasources by name (DatasourceService.getDatasource keys the map on name);
+ * passing the UUID id yields a 500 "no Saiku datasource named …". The caller
+ * must prefix the SvelteKit `base` (the app is served under `/ui`).
+ */
 export function generateSchemaHref(
-  ds: Pick<GenerateSchemaTarget, "id">,
+  ds: Pick<GenerateSchemaTarget, "id" | "name">,
 ): string {
-  return `/admin/cube-designer/${encodeURIComponent(ds.id)}`;
+  return `/admin/cube-designer/${encodeURIComponent(ds.name ?? ds.id)}`;
 }
 
 /**

--- a/saiku-ui/src/routes/admin/cube-designer/[dataSourceId]/+page.svelte
+++ b/saiku-ui/src/routes/admin/cube-designer/[dataSourceId]/+page.svelte
@@ -102,7 +102,10 @@
   }
 </script>
 
-<div class="flex h-svh flex-col overflow-hidden">
+<!-- flex-1 + min-w/h-0 so the designer fills the layout's <main> (a flex row)
+     across the full width AND height, instead of h-svh (which sized to the
+     viewport and left a right-hand gap / overran the topbar). -->
+<div class="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden">
   <header class="flex shrink-0 flex-wrap items-center gap-2 border-b border-border px-3 py-2">
     <h1 class="mr-2 text-sm font-semibold text-foreground">
       Cube Designer <span class="text-muted-foreground">· {dataSourceId}</span>


### PR DESCRIPTION
Fixes the 'Design cube' entry into the cube designer — three host-side bugs, all in saiku-ui admin glue (the shared `@concepttocloud/saiku-cube-designer` components are untouched, so saiku-cloud stays compatible):

- **403** — the link was base-less (`/admin/cube-designer/…`), bypassing the app served under `/ui` → Jetty root → Forbidden. Now `base`-prefixed.
- **500 'could not profile the datasource'** — the link passed the datasource **UUID id**, but the backend resolves by **name** (`getDatasource` keys on name). `generateSchemaHref` now uses `ds.name`.
- **Not full-width** — route wrapper had no `flex-1`/`w-full` inside the flex-row `<main>`; now fills width + height.

Regression test added for name-over-id. Verified on demo.saiku.bi after diagnosing the 403/500 from the container logs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)