### PR TITLE
#1634 - Cube Designer: edit-existing-cube, datasource parse, drag coords (+ #1633 entry fix)

### DIFF
--- a/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/objects/DataSourceMapper.java
+++ b/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/objects/DataSourceMapper.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.Properties;
 import java.util.UUID;
 import org.saiku.datasources.datasource.SaikuDatasource;
+import org.saiku.web.rest.util.MondrianLocation;
 
 /**
  * Map from SaikuDatasources to JSON variants.
@@ -80,26 +81,26 @@ public class DataSourceMapper {
                         && ds.getProperties().getProperty("advanced").equals("false"))) {
             String location = ds.getProperties().getProperty("location");
 
-            String[] loc = location.split(";");
-
-            String[] url = loc[0].split("=", 2);
             if (ds.getProperties().getProperty("driver").equals("mondrian.olap4j.MondrianOlap4jDriver")) {
-                String[] cat = loc[1].split("=");
-                String[] drv = loc[2].split("=");
-                if (cat.length > 1) {
-                    this.schema = cat[1];
-                }
-                if (drv.length > 1) {
-                    this.driver = drv[1];
-                }
+                // saiku#1634: parse by key, not by positional ';' split. An inner Jdbc= URL that
+                // carries its own ;params (e.g. H2's ;MODE=MySQL) used to shift the Catalog and
+                // JdbcDrivers slots — the catalog leaked into 'driver' and a stray param into
+                // 'schema'. MondrianLocation anchors on the known keys instead, so ordering and
+                // embedded params no longer matter.
+                MondrianLocation parsed = MondrianLocation.parse(location);
+                this.jdbcurl = parsed.jdbc();
+                this.schema = parsed.catalog();
+                this.driver = parsed.jdbcDrivers();
                 this.connectiontype = "MONDRIAN";
             } else {
+                // XMLA: location is `jdbc:xmla:Server=<url>` — split the server URL off the head.
+                String[] url = location.split(";", 2)[0].split("=", 2);
+                if (url.length > 1) {
+                    this.jdbcurl = url[1];
+                }
                 this.connectiontype = "XMLA";
             }
             this.connectionname = ds.getName();
-            if (url.length > 1) {
-                this.jdbcurl = url[1];
-            }
             this.username = ds.getProperties().getProperty("username");
             this.password = ds.getProperties().getProperty("password");
             this.path = ds.getProperties().getProperty("path");

--- a/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/cubedesigner/CubeDesignerResource.java
+++ b/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/cubedesigner/CubeDesignerResource.java
@@ -19,6 +19,9 @@ import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.ResultSetMetaData;
@@ -39,6 +42,7 @@ import org.saiku.service.schema.generate.model.DbModel;
 import org.saiku.service.schema.generate.model.DbTable;
 import org.saiku.service.user.UserService;
 import org.saiku.web.rest.resources.schemagen.DatasourceJdbcConnectionProvider;
+import org.saiku.web.rest.util.MondrianLocation;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -49,6 +53,7 @@ import org.slf4j.LoggerFactory;
  * <ul>
  *   <li>{@code GET  /introspect/{dataSourceId}} — the datasource's tables + columns (source sidebar)</li>
  *   <li>{@code GET  /sample/{dataSourceId}?table=&amp;schema=&amp;limit=} — preview rows for a table</li>
+ *   <li>{@code GET  /schema/{dataSourceId}} — the datasource's existing Mondrian schema XML (edit mode)</li>
  *   <li>{@code POST /convert} — upgrade a Mondrian-3 schema XML to Mondrian-4</li>
  * </ul>
  *
@@ -61,7 +66,6 @@ import org.slf4j.LoggerFactory;
 public class CubeDesignerResource {
 
     private static final Logger LOG = LoggerFactory.getLogger(CubeDesignerResource.class);
-    private static final String MONDRIAN_PREFIX = "jdbc:mondrian:";
     private static final int DEFAULT_SAMPLE_LIMIT = 25;
     private static final int MAX_SAMPLE_LIMIT = 500;
 
@@ -98,6 +102,8 @@ public class CubeDesignerResource {
     public record ConvertRequest(String mondrianXml, String dataSourceId) {}
 
     public record ConvertResult(String mondrianXml) {}
+
+    public record SchemaResult(String mondrianXml, String label) {}
 
     public record TurnRequest(JsonNode messages, String canvasSummary) {}
 
@@ -193,7 +199,63 @@ public class CubeDesignerResource {
         }
     }
 
-    // ── (3) convert (Mondrian 3 → 4) ──────────────────────────────────────────
+    // ── (3) schema (existing Mondrian XML for edit mode) ──────────────────────
+    /**
+     * saiku#1634: return the datasource's already-attached Mondrian schema XML so the designer can
+     * hydrate the canvas in edit mode (rather than opening blank). The catalog reference is parsed
+     * out of the Mondrian {@code location} ({@code Catalog=...}) and resolved three ways:
+     *
+     * <ul>
+     *   <li>{@code file:/path/Foo.xml} — read from the filesystem (the launcher's foodmart/bank use
+     *       this: {@code Catalog=file:.../FoodMart4.xml});</li>
+     *   <li>{@code res:Foo.xml} — read from the classpath (bundled schemas);</li>
+     *   <li>{@code mondrian://Name} or a bare repository path — read from the Saiku repository.</li>
+     * </ul>
+     *
+     * <p>404 when the datasource carries no catalog (plain JDBC / a fresh design target) or the
+     * referenced schema can't be found — the host treats that as "new cube, start blank". Admin-only;
+     * the {@code file:} path is already admin-authored via the datasource config, so this exposes no
+     * file an admin couldn't already reach.
+     */
+    @GET
+    @Path("/schema/{dataSourceId}")
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response schema(@PathParam("dataSourceId") String dataSourceId) {
+        Response forbidden = adminGuard();
+        if (forbidden != null) {
+            return forbidden;
+        }
+        SaikuDatasource ds = datasourceService.getDatasource(dataSourceId);
+        if (ds == null || ds.getProperties() == null) {
+            return Response.status(Response.Status.NOT_FOUND)
+                    .entity("unknown datasource")
+                    .build();
+        }
+        String location = ds.getProperties().getProperty(ISaikuConnection.URL_KEY);
+        String catalog = MondrianLocation.parse(location).catalog();
+        if (catalog == null || catalog.isBlank()) {
+            return Response.status(Response.Status.NOT_FOUND)
+                    .entity("no schema attached to this datasource")
+                    .build();
+        }
+        String xml;
+        try {
+            xml = resolveSchemaXml(catalog);
+        } catch (IOException e) {
+            LOG.warn("cube-designer schema read failed for '{}' catalog '{}'", dataSourceId, catalog, e);
+            return Response.status(Response.Status.INTERNAL_SERVER_ERROR)
+                    .entity("could not read the schema")
+                    .build();
+        }
+        if (xml == null || xml.isBlank()) {
+            return Response.status(Response.Status.NOT_FOUND)
+                    .entity("schema not found")
+                    .build();
+        }
+        return Response.ok(new SchemaResult(xml, ds.getName())).build();
+    }
+
+    // ── (4) convert (Mondrian 3 → 4) ──────────────────────────────────────────
     @POST
     @Path("/convert")
     @Consumes(MediaType.APPLICATION_JSON)
@@ -226,7 +288,7 @@ public class CubeDesignerResource {
         }
     }
 
-    // ── (4) DimSum AI turn ─────────────────────────────────────────────────────
+    // ── (5) DimSum AI turn ─────────────────────────────────────────────────────
     @POST
     @Path("/turn")
     @Consumes(MediaType.APPLICATION_JSON)
@@ -300,7 +362,9 @@ public class CubeDesignerResource {
         if (location == null || location.isEmpty()) {
             throw new SQLException("datasource '" + dataSourceId + "' has no location");
         }
-        String jdbcUrl = location.startsWith(MONDRIAN_PREFIX) ? extractJdbc(location) : location;
+        // Mondrian locations wrap the real JDBC URL as `Jdbc=...`; plain locations are the URL itself.
+        String parsedJdbc = MondrianLocation.parse(location).jdbc();
+        String jdbcUrl = parsedJdbc != null ? parsedJdbc.trim() : location;
         if (jdbcUrl == null || !jdbcUrl.startsWith("jdbc:")) {
             throw new SQLException("datasource '" + dataSourceId + "' has no resolvable JDBC URL");
         }
@@ -311,22 +375,41 @@ public class CubeDesignerResource {
     }
 
     /**
-     * Pull the inner {@code Jdbc=} URL out of a Mondrian location string
-     * ({@code jdbc:mondrian:Jdbc=jdbc:...;JdbcDrivers=...}). The inner value is a
-     * {@code jdbc:} URL that may contain {@code =} but, by Mondrian convention, no {@code ;}.
+     * Resolve a Mondrian {@code Catalog=} reference to its schema XML. Handles {@code file:} paths
+     * (filesystem), {@code res:} (classpath), and {@code mondrian://Name} / bare repository paths
+     * (Saiku repository). Returns null when the referenced schema can't be found.
      */
-    private static String extractJdbc(String location) {
-        String body = location.substring(MONDRIAN_PREFIX.length());
-        String needle = "Jdbc=";
-        int idx = body.indexOf(needle);
-        while (idx > 0 && body.charAt(idx - 1) != ';') {
-            idx = body.indexOf(needle, idx + 1);
+    private String resolveSchemaXml(String catalog) throws IOException {
+        String c = catalog.trim();
+        if (c.startsWith("file:")) {
+            return Files.readString(java.nio.file.Path.of(stripFileScheme(c)), StandardCharsets.UTF_8);
         }
-        if (idx < 0) {
-            return null;
+        if (c.startsWith("res:")) {
+            String resource = c.substring("res:".length());
+            try (InputStream in = getClass().getClassLoader().getResourceAsStream(resource)) {
+                return in == null ? null : new String(in.readAllBytes(), StandardCharsets.UTF_8);
+            }
         }
-        int start = idx + needle.length();
-        int end = body.indexOf(';', start);
-        return (end < 0 ? body.substring(start) : body.substring(start, end)).trim();
+        // Repository-stored schema. addSchema writes it at `/datasources/<name>.xml`, so try the
+        // reference verbatim first, then the conventional path for a `mondrian://Name` catalog.
+        String name = c.startsWith("mondrian://") ? c.substring("mondrian://".length()) : c;
+        String data = datasourceService.getInternalFileData(name);
+        if (data == null) {
+            data = datasourceService.getInternalFileData("/datasources/" + name + ".xml");
+        }
+        return data;
+    }
+
+    /**
+     * Strip the {@code file:} scheme (and any {@code //authority}) off a file URL, leaving the path.
+     * Handles {@code file:/p}, {@code file:///p}, and {@code file://host/p}.
+     */
+    private static String stripFileScheme(String fileUrl) {
+        String path = fileUrl.substring("file:".length());
+        if (path.startsWith("//")) {
+            int slash = path.indexOf('/', 2);
+            path = slash >= 0 ? path.substring(slash) : path.substring(2);
+        }
+        return path;
     }
 }

--- a/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/util/MondrianLocation.java
+++ b/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/util/MondrianLocation.java
@@ -1,0 +1,112 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package org.saiku.web.rest.util;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Key-based parser for a Mondrian {@code location} connect string:
+ *
+ * <pre>jdbc:mondrian:Jdbc=&lt;jdbcUrl&gt;;Catalog=&lt;catalog&gt;;JdbcDrivers=&lt;drivers&gt;</pre>
+ *
+ * <p>The naive {@code location.split(";")} positional parse this replaces broke whenever the inner
+ * {@code Jdbc=} value carried its own {@code ;}-separated JDBC parameters — e.g. the launcher's
+ * FoodMart datasource {@code jdbc:mondrian:Jdbc=jdbc:h2:.../foodmart;MODE=MySQL;Catalog=file:...
+ * FoodMart4.xml;JdbcDrivers=org.h2.Driver}. There the {@code ;MODE=MySQL} param shifted the
+ * positional segments so {@code Catalog} was read as the driver and {@code MODE=MySQL} as the
+ * catalog (saiku#1634).
+ *
+ * <p>This parser instead anchors on the three known Mondrian keys ({@code Jdbc}, {@code Catalog},
+ * {@code JdbcDrivers}) wherever they appear, treating each value as running up to the next known
+ * key — so unknown {@code ;key=value} params (like H2's {@code MODE}) stay part of the value they
+ * belong to, and key ordering does not matter. Values are otherwise returned verbatim (no
+ * unescaping), matching the previous behaviour for the fields it feeds.
+ */
+public final class MondrianLocation {
+
+    /** Mondrian location URLs start with this scheme prefix. */
+    public static final String MONDRIAN_PREFIX = "jdbc:mondrian:";
+
+    // A known key either opens the body (^) or follows a ';'. The value runs to the next such key.
+    private static final Pattern KEY = Pattern.compile("(?:^|;)(Jdbc|Catalog|JdbcDrivers)=");
+
+    private final String jdbc;
+    private final String catalog;
+    private final String jdbcDrivers;
+
+    private MondrianLocation(String jdbc, String catalog, String jdbcDrivers) {
+        this.jdbc = jdbc;
+        this.catalog = catalog;
+        this.jdbcDrivers = jdbcDrivers;
+    }
+
+    /**
+     * Parse a Mondrian location string. Non-Mondrian or blank input yields an all-null result
+     * (callers treat that as "no Mondrian coordinates"). Missing individual keys are null.
+     */
+    public static MondrianLocation parse(String location) {
+        if (location == null || !location.startsWith(MONDRIAN_PREFIX)) {
+            return new MondrianLocation(null, null, null);
+        }
+        String body = location.substring(MONDRIAN_PREFIX.length());
+        Matcher m = KEY.matcher(body);
+
+        // First pass: collect each key, the index its value starts at, and the index the whole
+        // "(^|;)Key=" match starts at (used as the previous value's end so the ';' is dropped).
+        java.util.List<String> keys = new java.util.ArrayList<>(3);
+        java.util.List<Integer> valueStarts = new java.util.ArrayList<>(3);
+        java.util.List<Integer> matchStarts = new java.util.ArrayList<>(3);
+        while (m.find()) {
+            keys.add(m.group(1));
+            valueStarts.add(m.end());
+            matchStarts.add(m.start());
+        }
+
+        String jdbc = null;
+        String catalog = null;
+        String jdbcDrivers = null;
+        for (int i = 0; i < keys.size(); i++) {
+            int end = (i + 1 < keys.size()) ? matchStarts.get(i + 1) : body.length();
+            String value = body.substring(valueStarts.get(i), end);
+            switch (keys.get(i)) {
+                case "Jdbc" -> jdbc = value;
+                case "Catalog" -> catalog = value;
+                case "JdbcDrivers" -> jdbcDrivers = value;
+                default -> {
+                    /* pattern only matches the three known keys */
+                }
+            }
+        }
+        return new MondrianLocation(jdbc, catalog, jdbcDrivers);
+    }
+
+    /** The inner {@code Jdbc=} JDBC URL (may itself contain {@code ;}-separated params), or null. */
+    public String jdbc() {
+        return jdbc;
+    }
+
+    /** The {@code Catalog=} value verbatim — e.g. {@code file:/path/Foo.xml}, {@code res:Foo.xml},
+     *  or {@code mondrian://Foo} — or null when absent. */
+    public String catalog() {
+        return catalog;
+    }
+
+    /** The {@code JdbcDrivers=} value (driver class name), or null when absent. */
+    public String jdbcDrivers() {
+        return jdbcDrivers;
+    }
+}

--- a/saiku-core/saiku-web/src/test/java/org/saiku/web/rest/objects/DataSourceMapperMondrianTest.java
+++ b/saiku-core/saiku-web/src/test/java/org/saiku/web/rest/objects/DataSourceMapperMondrianTest.java
@@ -1,0 +1,51 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.web.rest.objects;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.Properties;
+import org.junit.Test;
+import org.saiku.datasources.datasource.SaikuDatasource;
+
+/**
+ * saiku#1634 — a Mondrian datasource whose inner {@code Jdbc=} URL carries its own {@code ;}params
+ * (H2 {@code ;MODE=MySQL}) must still map to the right driver / schema / jdbcurl display fields.
+ * Before the key-based parse, FoodMart showed driver = the Catalog file and schema = "MySQL".
+ */
+public class DataSourceMapperMondrianTest {
+
+    private static SaikuDatasource mondrianDs(String name, String location) {
+        Properties props = new Properties();
+        props.setProperty("driver", "mondrian.olap4j.MondrianOlap4jDriver");
+        props.setProperty("location", location);
+        props.setProperty("username", "sa");
+        return new SaikuDatasource(name, SaikuDatasource.Type.OLAP, props);
+    }
+
+    @Test
+    public void foodmartWithEmbeddedH2ModeParamMapsCorrectly() {
+        DataSourceMapper m = new DataSourceMapper(mondrianDs(
+                "foodmart",
+                "jdbc:mondrian:Jdbc=jdbc:h2:/data/foodmart;MODE=MySQL;"
+                        + "Catalog=file:/data/FoodMart4.xml;JdbcDrivers=org.h2.Driver"));
+        assertEquals("MONDRIAN", m.getConnectiontype());
+        assertEquals("jdbc:h2:/data/foodmart;MODE=MySQL", m.getJdbcurl());
+        assertEquals("file:/data/FoodMart4.xml", m.getSchema());
+        assertEquals("org.h2.Driver", m.getDriver());
+    }
+
+    @Test
+    public void bankWithoutEmbeddedParamMapsCorrectly() {
+        DataSourceMapper m = new DataSourceMapper(mondrianDs(
+                "bank",
+                "jdbc:mondrian:Jdbc=jdbc:h2:/data/foodmart;"
+                        + "Catalog=file:/data/Bank.xml;JdbcDrivers=org.h2.Driver"));
+        assertEquals("MONDRIAN", m.getConnectiontype());
+        assertEquals("jdbc:h2:/data/foodmart", m.getJdbcurl());
+        assertEquals("file:/data/Bank.xml", m.getSchema());
+        assertEquals("org.h2.Driver", m.getDriver());
+    }
+}

--- a/saiku-core/saiku-web/src/test/java/org/saiku/web/rest/resources/cubedesigner/CubeDesignerResourceTest.java
+++ b/saiku-core/saiku-web/src/test/java/org/saiku/web/rest/resources/cubedesigner/CubeDesignerResourceTest.java
@@ -11,10 +11,14 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 import jakarta.ws.rs.core.Response;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.Statement;
 import java.util.List;
+import java.util.Map;
 import java.util.Properties;
 import org.junit.After;
 import org.junit.Before;
@@ -24,6 +28,7 @@ import org.saiku.datasources.datasource.SaikuDatasource;
 import org.saiku.service.datasource.DatasourceService;
 import org.saiku.web.rest.resources.cubedesigner.CubeDesignerResource.IntrospectResult;
 import org.saiku.web.rest.resources.cubedesigner.CubeDesignerResource.SampleResult;
+import org.saiku.web.rest.resources.cubedesigner.CubeDesignerResource.SchemaResult;
 import org.saiku.web.rest.resources.cubedesigner.CubeDesignerResource.TableView;
 import org.saiku.web.rest.resources.schemagen.DatasourceJdbcConnectionProvider;
 
@@ -63,20 +68,43 @@ public class CubeDesignerResourceTest {
         resource = new CubeDesignerResource(provider, datasourceService);
     }
 
-    /** Hand-rolled stub (house pattern — saiku-web has no Mockito), serving one datasource by id. */
+    /** Hand-rolled stub (house pattern — saiku-web has no Mockito), serving one datasource by id
+     *  plus an optional in-memory repository (path → file content) for the schema endpoint. */
     private static final class StubDatasourceService extends DatasourceService {
         private final String id;
         private final SaikuDatasource ds;
+        private final Map<String, String> repoFiles;
 
         StubDatasourceService(String id, SaikuDatasource ds) {
+            this(id, ds, Map.of());
+        }
+
+        StubDatasourceService(String id, SaikuDatasource ds, Map<String, String> repoFiles) {
             this.id = id;
             this.ds = ds;
+            this.repoFiles = repoFiles;
         }
 
         @Override
         public SaikuDatasource getDatasource(String datasourceName) {
             return id.equals(datasourceName) ? ds : null;
         }
+
+        @Override
+        public String getInternalFileData(String path) {
+            return repoFiles.get(path);
+        }
+    }
+
+    /** Build a resource whose single datasource has the given Mondrian location + optional repo. */
+    private static CubeDesignerResource resourceFor(String location, Map<String, String> repoFiles) {
+        Properties props = new Properties();
+        props.setProperty(ISaikuConnection.URL_KEY, location);
+        props.setProperty(ISaikuConnection.USERNAME_KEY, "sa");
+        props.setProperty(ISaikuConnection.PASSWORD_KEY, "");
+        SaikuDatasource ds = new SaikuDatasource(DATA_SOURCE_ID, SaikuDatasource.Type.OLAP, props);
+        StubDatasourceService svc = new StubDatasourceService(DATA_SOURCE_ID, ds, repoFiles);
+        return new CubeDesignerResource(new DatasourceJdbcConnectionProvider(svc), svc);
     }
 
     @After
@@ -140,7 +168,59 @@ public class CubeDesignerResourceTest {
         assertEquals(400, r.getStatus());
     }
 
-    // -- (3) convert ------------------------------------------------------------
+    // -- (3) schema (edit mode) -------------------------------------------------
+
+    @Test
+    public void schema_readsExternalFileCatalog() throws Exception {
+        // The launcher's foodmart/bank pattern: Catalog=file:/abs/path/Schema.xml
+        Path tmp = Files.createTempFile("cube-designer-schema", ".xml");
+        tmp.toFile().deleteOnExit();
+        String xml = "<Schema name=\"FoodMart\"/>";
+        Files.writeString(tmp, xml, StandardCharsets.UTF_8);
+        String location =
+                "jdbc:mondrian:Jdbc=" + JDBC_URL + ";MODE=MySQL;Catalog=file:" + tmp + ";JdbcDrivers=org.h2.Driver";
+
+        Response r = resourceFor(location, Map.of()).schema(DATA_SOURCE_ID);
+        assertEquals(200, r.getStatus());
+        SchemaResult body = (SchemaResult) r.getEntity();
+        assertEquals(xml, body.mondrianXml());
+        assertEquals(DATA_SOURCE_ID, body.label());
+    }
+
+    @Test
+    public void schema_readsRepositoryCatalog() {
+        // A UI-created datasource: Catalog=mondrian://Name → /datasources/Name.xml in the repo.
+        String xml = "<Schema name=\"Sales\"/>";
+        String location = "jdbc:mondrian:Jdbc=" + JDBC_URL + ";Catalog=mondrian://Sales;JdbcDrivers=org.h2.Driver";
+
+        Response r =
+                resourceFor(location, Map.of("/datasources/Sales.xml", xml)).schema(DATA_SOURCE_ID);
+        assertEquals(200, r.getStatus());
+        SchemaResult body = (SchemaResult) r.getEntity();
+        assertEquals(xml, body.mondrianXml());
+    }
+
+    @Test
+    public void schema_noCatalogIs404() {
+        // Plain JDBC datasource (no Mondrian wrapper) → new-cube target, host stays blank.
+        Response r = resourceFor(JDBC_URL, Map.of()).schema(DATA_SOURCE_ID);
+        assertEquals(404, r.getStatus());
+    }
+
+    @Test
+    public void schema_missingRepositoryFileIs404() {
+        String location = "jdbc:mondrian:Jdbc=" + JDBC_URL + ";Catalog=mondrian://Absent;JdbcDrivers=org.h2.Driver";
+        Response r = resourceFor(location, Map.of()).schema(DATA_SOURCE_ID);
+        assertEquals(404, r.getStatus());
+    }
+
+    @Test
+    public void schema_unknownDatasourceIs404() {
+        Response r = resource.schema("no-such-ds");
+        assertEquals(404, r.getStatus());
+    }
+
+    // -- (4) convert ------------------------------------------------------------
 
     @Test
     public void convert_missingXmlIs400() {

--- a/saiku-core/saiku-web/src/test/java/org/saiku/web/rest/util/MondrianLocationTest.java
+++ b/saiku-core/saiku-web/src/test/java/org/saiku/web/rest/util/MondrianLocationTest.java
@@ -1,0 +1,78 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.web.rest.util;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import org.junit.Test;
+
+/**
+ * saiku#1634 — key-based parsing of the Mondrian {@code location} connect string. The regression
+ * this guards: an inner {@code Jdbc=} URL carrying its own {@code ;}-separated params must not shift
+ * the {@code Catalog} / {@code JdbcDrivers} slots.
+ */
+public class MondrianLocationTest {
+
+    @Test
+    public void innerJdbcParamsDoNotShiftTheOtherKeys() {
+        // The launcher's FoodMart datasource: H2 ;MODE=MySQL rides inside the Jdbc value.
+        MondrianLocation p = MondrianLocation.parse("jdbc:mondrian:Jdbc=jdbc:h2:/data/foodmart;MODE=MySQL;"
+                + "Catalog=file:/data/FoodMart4.xml;JdbcDrivers=org.h2.Driver");
+        assertEquals("jdbc:h2:/data/foodmart;MODE=MySQL", p.jdbc());
+        assertEquals("file:/data/FoodMart4.xml", p.catalog());
+        assertEquals("org.h2.Driver", p.jdbcDrivers());
+    }
+
+    @Test
+    public void plainThreeKeyLocation() {
+        // The Bank datasource: no embedded params — parses cleanly (and did under the old code).
+        MondrianLocation p = MondrianLocation.parse(
+                "jdbc:mondrian:Jdbc=jdbc:h2:/data/foodmart;" + "Catalog=file:/data/Bank.xml;JdbcDrivers=org.h2.Driver");
+        assertEquals("jdbc:h2:/data/foodmart", p.jdbc());
+        assertEquals("file:/data/Bank.xml", p.catalog());
+        assertEquals("org.h2.Driver", p.jdbcDrivers());
+    }
+
+    @Test
+    public void keyOrderDoesNotMatter() {
+        MondrianLocation p = MondrianLocation.parse(
+                "jdbc:mondrian:Catalog=res:FoodMart4.xml;JdbcDrivers=org.h2.Driver;Jdbc=jdbc:h2:mem:x");
+        assertEquals("jdbc:h2:mem:x", p.jdbc());
+        assertEquals("res:FoodMart4.xml", p.catalog());
+        assertEquals("org.h2.Driver", p.jdbcDrivers());
+    }
+
+    @Test
+    public void mondrianRepositoryCatalog() {
+        // The UI write path emits Catalog=mondrian://<schema>; must round-trip verbatim.
+        MondrianLocation p = MondrianLocation.parse("jdbc:mondrian:Jdbc=jdbc:postgresql://db/foodmart;"
+                + "Catalog=mondrian://FoodMart;JdbcDrivers=org.postgresql.Driver");
+        assertEquals("jdbc:postgresql://db/foodmart", p.jdbc());
+        assertEquals("mondrian://FoodMart", p.catalog());
+        assertEquals("org.postgresql.Driver", p.jdbcDrivers());
+    }
+
+    @Test
+    public void missingKeysAreNull() {
+        MondrianLocation p = MondrianLocation.parse("jdbc:mondrian:Jdbc=jdbc:h2:mem:x");
+        assertEquals("jdbc:h2:mem:x", p.jdbc());
+        assertNull(p.catalog());
+        assertNull(p.jdbcDrivers());
+    }
+
+    @Test
+    public void nonMondrianOrNullYieldsAllNull() {
+        MondrianLocation xmla = MondrianLocation.parse("jdbc:xmla:Server=http://host/xmla");
+        assertNull(xmla.jdbc());
+        assertNull(xmla.catalog());
+        assertNull(xmla.jdbcDrivers());
+
+        MondrianLocation nul = MondrianLocation.parse(null);
+        assertNull(nul.jdbc());
+        assertNull(nul.catalog());
+        assertNull(nul.jdbcDrivers());
+    }
+}

--- a/saiku-ui/src/lib/cube-designer/CanvasPane.svelte
+++ b/saiku-ui/src/lib/cube-designer/CanvasPane.svelte
@@ -29,7 +29,11 @@
 	import JumpHandler from './JumpHandler.svelte';
 	import TableSidebar from './TableSidebar.svelte';
 	import type { SchemaCanvasStore } from './state.svelte.js';
-	import { parseConnectionJoin, parseDroppedTableCandidates } from './canvas-dnd.js';
+	import {
+		parseConnectionJoin,
+		parseDroppedTableCandidates,
+		resolveDropOrigin
+	} from './canvas-dnd.js';
 
 	interface Props {
 		store: SchemaCanvasStore;
@@ -110,8 +114,16 @@
 		const candidates = parseDroppedTableCandidates(arrayPayload, singlePayload);
 		if (candidates.length === 0) return;
 		const rect = (e.currentTarget as HTMLElement).getBoundingClientRect();
-		const baseX = e.clientX - rect.left;
-		const baseY = e.clientY - rect.top;
+		// saiku#1634 #3: map the pointer's viewport coords into FLOW space via the
+		// converter JumpHandler published, so a panned/zoomed canvas drops the node
+		// under the cursor rather than off-screen. Falls back to pane-relative
+		// pixels (identity-viewport behaviour) when the converter isn't available.
+		const { x: baseX, y: baseY } = resolveDropOrigin(
+			store.screenToFlowPosition,
+			e.clientX,
+			e.clientY,
+			rect
+		);
 		// Each addTable / addJoin snapshots on its own so Undo peels the
 		// drop off one table at a time (last-in-first-out).  Batching used
 		// to wrap this in withUndoBatch — one snapshot for the whole drop

--- a/saiku-ui/src/lib/cube-designer/JumpHandler.svelte
+++ b/saiku-ui/src/lib/cube-designer/JumpHandler.svelte
@@ -19,6 +19,16 @@
 	let { store }: Props = $props();
 	const flow = useSvelteFlow();
 
+	// Publish the screen→flow converter for the (out-of-context) pane drop
+	// handler — saiku#1634 #3. Wrapped in an arrow so `flow`'s method keeps its
+	// binding; cleared on destroy so a stale reference can't outlive the flow.
+	$effect(() => {
+		store.screenToFlowPosition = (screen) => flow.screenToFlowPosition(screen);
+		return () => {
+			store.screenToFlowPosition = null;
+		};
+	});
+
 	// Approx node dims used to centre on the card's middle, not its
 	// top-left corner. The table cards have a fixed width in TableNode
 	// and a variable height depending on visible columns — using the

--- a/saiku-ui/src/lib/cube-designer/canvas-dnd.test.ts
+++ b/saiku-ui/src/lib/cube-designer/canvas-dnd.test.ts
@@ -5,6 +5,7 @@ import { describe, it, expect } from "vitest";
 import {
   parseConnectionJoin,
   parseDroppedTableCandidates,
+  resolveDropOrigin,
 } from "./canvas-dnd.js";
 import type { SourceTableCandidate } from "./types.js";
 
@@ -77,5 +78,27 @@ describe("parseDroppedTableCandidates", () => {
 
   it("returns [] on malformed JSON instead of throwing", () => {
     expect(parseDroppedTableCandidates("{not json", null)).toEqual([]);
+  });
+});
+
+describe("resolveDropOrigin (saiku#1634 #3)", () => {
+  const rect = { left: 100, top: 50 };
+
+  it("maps viewport coords through the converter when the flow is mounted", () => {
+    // A panned/zoomed viewport: the converter returns coords far from the
+    // naive pane-relative fallback, proving we honour pan/zoom.
+    const screenToFlow = ({ x, y }: { x: number; y: number }) => ({
+      x: (x - 100) * 2 + 500,
+      y: (y - 50) * 2 + 300,
+    });
+    expect(resolveDropOrigin(screenToFlow, 300, 250, rect)).toEqual({
+      x: (300 - 100) * 2 + 500,
+      y: (250 - 50) * 2 + 300,
+    });
+  });
+
+  it("falls back to pane-relative pixels when no converter is available", () => {
+    expect(resolveDropOrigin(null, 300, 250, rect)).toEqual({ x: 200, y: 200 });
+    expect(resolveDropOrigin(undefined, 300, 250, rect)).toEqual({ x: 200, y: 200 });
   });
 });

--- a/saiku-ui/src/lib/cube-designer/canvas-dnd.ts
+++ b/saiku-ui/src/lib/cube-designer/canvas-dnd.ts
@@ -46,6 +46,37 @@ export function parseConnectionJoin(
   };
 }
 
+/** A point in the flow coordinate space (post-pan/zoom). */
+export interface FlowPoint {
+  x: number;
+  y: number;
+}
+
+/** SvelteFlow's `screenToFlowPosition`, or null when the flow isn't mounted. */
+export type ScreenToFlow = ((screen: FlowPoint) => FlowPoint) | null | undefined;
+
+/**
+ * Resolve where a dropped node should land, in FLOW coordinates.
+ *
+ * saiku#1634 (#3): the drop handler lives on the pane wrapper, OUTSIDE the
+ * SvelteFlow provider, so it can't call `useSvelteFlow().screenToFlowPosition`
+ * directly. An in-flow child (JumpHandler) publishes that converter onto the
+ * store; when present we map the pointer's viewport coords through it so a
+ * panned/zoomed canvas drops the node under the cursor rather than off-screen.
+ * When absent (SSR / tests / before the flow mounts) we fall back to
+ * pane-relative pixels, which equal flow coords only at the identity viewport —
+ * the exact stale behaviour this fixes, kept as a safe default.
+ */
+export function resolveDropOrigin(
+  screenToFlow: ScreenToFlow,
+  clientX: number,
+  clientY: number,
+  rect: { left: number; top: number },
+): FlowPoint {
+  if (screenToFlow) return screenToFlow({ x: clientX, y: clientY });
+  return { x: clientX - rect.left, y: clientY - rect.top };
+}
+
 /**
  * Parse the table candidates from a pane-drop's dataTransfer payloads.
  * Prefers the multi-table payload (`application/x-saiku-tables`), falling back

--- a/saiku-ui/src/lib/cube-designer/oss-backend.ts
+++ b/saiku-ui/src/lib/cube-designer/oss-backend.ts
@@ -55,6 +55,18 @@ type IntrospectResponse = {
   }>;
 };
 
+/**
+ * OSS edit mode (saiku#1634): fetch a datasource's already-attached Mondrian schema XML so the host
+ * can hydrate the canvas instead of opening blank. Returns the raw Response — 200 `{ mondrianXml,
+ * label }` when a schema is attached and resolvable, 404 otherwise (⇒ new-cube target, stay blank).
+ *
+ * Deliberately NOT part of the shared {@link CubeDesignerBackend} seam: Cloud has its own
+ * library-based edit flow (`ImportController`), so this stays OSS host glue.
+ */
+export function fetchDatasourceSchema(dataSourceId: string): Promise<Response> {
+  return fetch(`${BASE}/schema/${encodeURIComponent(dataSourceId)}`, CREDS);
+}
+
 export const ossCubeDesignerBackend: CubeDesignerBackend = {
   async profileConnection(connectionId) {
     const r = await fetch(

--- a/saiku-ui/src/lib/cube-designer/state.svelte.ts
+++ b/saiku-ui/src/lib/cube-designer/state.svelte.ts
@@ -536,6 +536,19 @@ export class SchemaCanvasStore {
     kind: "zoom_in" | "zoom_out" | "fit_view" | "zoom_to_100" | "center_view";
     ts: number;
   } | null>(null);
+
+  /**
+   * Screen→flow coordinate converter, published by the in-flow JumpHandler
+   * (which can call `useSvelteFlow()`) so the pane drop handler — mounted
+   * OUTSIDE the SvelteFlow provider — can map a drop's viewport coords into
+   * flow space (saiku#1634 #3). Null until the flow mounts / in SSR + tests;
+   * consumers fall back to pane-relative pixels. Plain field (not `$state`):
+   * only read imperatively inside the drop event handler, never in a reactive
+   * position, so it needs no reactivity (and functions don't proxy cleanly).
+   */
+  screenToFlowPosition:
+    | ((screen: { x: number; y: number }) => { x: number; y: number })
+    | null = null;
   /**
    * Workbench working set — table IDs the user has pulled into the
    * Workbench view for focused side-by-side work. UI-only; not

--- a/saiku-ui/src/routes/admin/cube-designer/[dataSourceId]/+page.svelte
+++ b/saiku-ui/src/routes/admin/cube-designer/[dataSourceId]/+page.svelte
@@ -21,7 +21,9 @@
   import {
     ossCubeDesignerBackend,
     ossCubeDesignerAI,
+    fetchDatasourceSchema,
   } from "$lib/cube-designer/oss-backend";
+  import { hydrateFromMondrianXml } from "./edit-load";
   import { exportToMondrianXml } from "$lib/cube-designer/mondrian-export";
   import { parseProfileTables } from "$lib/cube-designer/profile-types";
   import type { SourceTableCandidate } from "$lib/cube-designer/types";
@@ -73,7 +75,33 @@
     } finally {
       store.sourceLoading = false;
     }
+    // saiku#1634 edit mode: if this datasource already has a Mondrian schema,
+    // hydrate the canvas from it. Runs after profiling so the importer can
+    // enrich imported tables against the live source catalog.
+    await loadExistingSchema();
   });
+
+  /**
+   * Fetch the datasource's attached Mondrian schema (if any) and load it onto
+   * the canvas. A 404 (no schema attached) is the new-cube path — leave the
+   * canvas blank. A parse/read error surfaces in the source-error banner.
+   */
+  async function loadExistingSchema() {
+    try {
+      const r = await fetchDatasourceSchema(dataSourceId);
+      if (!r.ok) return; // 404 ⇒ no schema attached: start a new cube, blank canvas
+      const body = (await r.json()) as { mondrianXml?: string; label?: string };
+      const xml = body.mondrianXml ?? "";
+      if (!xml) return;
+      hydrateFromMondrianXml(store, xml, dataSourceId);
+      // Mark the canvas as editing a saved schema so the workbench shows saved
+      // (not draft) state; Save then writes back under this name.
+      store.doc.lineageId = body.label?.trim() || dataSourceId;
+    } catch (e) {
+      sourceError =
+        e instanceof Error ? e.message : "could not load the existing schema";
+    }
+  }
 
   async function save() {
     saving = true;

--- a/saiku-ui/src/routes/admin/cube-designer/[dataSourceId]/edit-load.test.ts
+++ b/saiku-ui/src/routes/admin/cube-designer/[dataSourceId]/edit-load.test.ts
@@ -1,0 +1,58 @@
+// @vitest-environment happy-dom
+import { describe, expect, it } from "vitest";
+import { SchemaCanvasStore } from "$lib/cube-designer/state.svelte";
+import { hydrateFromMondrianXml } from "./edit-load";
+
+/**
+ * saiku#1634 — the edit-existing-cube hydration path. Parsing an attached
+ * Mondrian-4 schema must populate the canvas doc, seed the workbench cubes, and
+ * recenter the viewport (so the loaded nodes aren't off-screen).
+ */
+
+const SCHEMA_XML = `<Schema name="Sales" metamodelVersion="4.0">
+  <PhysicalSchema>
+    <Table name="dim_date"><Key name="k"><Column name="date_key"/></Key></Table>
+    <Table name="fact"/>
+  </PhysicalSchema>
+  <Dimension name="Calendar" type="TIME" table="dim_date" key="Year">
+    <Attributes>
+      <Attribute name="Year" table="dim_date" keyColumn="year_num" levelType="TimeYears"/>
+    </Attributes>
+    <Hierarchies>
+      <Hierarchy name="Calendar" hasAll="true"><Level attribute="Year"/></Hierarchy>
+    </Hierarchies>
+  </Dimension>
+  <Cube name="C">
+    <Dimensions><Dimension source="Calendar"/></Dimensions>
+    <MeasureGroups>
+      <MeasureGroup name="G" table="fact">
+        <Measures><Measure name="Cnt" aggregator="count"/></Measures>
+      </MeasureGroup>
+    </MeasureGroups>
+  </Cube>
+</Schema>`;
+
+describe("hydrateFromMondrianXml", () => {
+  it("loads tables onto the canvas and recenters the viewport", () => {
+    const store = new SchemaCanvasStore("test-ds");
+    const result = hydrateFromMondrianXml(store, SCHEMA_XML, "test-ds", () => 4242);
+
+    expect(result.tableCount).toBe(2);
+    expect(store.doc.tables.map((t) => t.name).sort()).toEqual(["dim_date", "fact"]);
+    // Recenter so the freshly-loaded nodes are visible, not off in the corner.
+    expect(store.requestedCanvasAction).toEqual({ kind: "fit_view", ts: 4242 });
+  });
+
+  it("seeds the workbench cubes from the imported schema", () => {
+    const store = new SchemaCanvasStore("test-ds-2");
+    hydrateFromMondrianXml(store, SCHEMA_XML, "test-ds-2");
+
+    expect(store.cubes.map((c) => c.name)).toEqual(["C"]);
+    expect(store.cubes[0]?.measureGroups.map((mg) => mg.name)).toEqual(["G"]);
+  });
+
+  it("throws on malformed XML so the caller can surface it", () => {
+    const store = new SchemaCanvasStore("test-ds-3");
+    expect(() => hydrateFromMondrianXml(store, "not xml at all", "test-ds-3")).toThrow();
+  });
+});

--- a/saiku-ui/src/routes/admin/cube-designer/[dataSourceId]/edit-load.ts
+++ b/saiku-ui/src/routes/admin/cube-designer/[dataSourceId]/edit-load.ts
@@ -1,0 +1,56 @@
+/**
+ * OSS edit-existing-cube hydration (saiku#1634).
+ *
+ * When the Cube Designer is opened for a datasource that already has a Mondrian
+ * schema attached, the host fetches that schema's XML (see
+ * `oss-backend.ts#fetchDatasourceSchema`) and calls this helper to parse it and
+ * populate the canvas + workbench — mirroring saiku-cloud's
+ * `ImportController.loadFromLibrary` commit path, minus the library modal UI.
+ *
+ * Kept as host glue (not a shared `$lib/cube-designer` component) so saiku-cloud,
+ * which has its own library-based edit flow, is unaffected. Extracted from the
+ * route's `onMount` so the parse → hydrate transform is unit-testable.
+ */
+import type { SchemaCanvasStore } from "$lib/cube-designer/state.svelte";
+import { importFromMondrianXml } from "$lib/cube-designer/mondrian-import";
+import { mapWorkbenchDocCubes } from "./workbench-seed";
+
+export interface HydrateResult {
+  tableCount: number;
+  joinCount: number;
+  warnings: string[];
+}
+
+/**
+ * Parse `xml` and load it into the store as the canvas doc + workbench cubes,
+ * recentering the viewport on the freshly-loaded nodes. `connectionId` is the
+ * datasource the canvas is authoring against; `now` is injectable for tests.
+ *
+ * Throws whatever `importFromMondrianXml` throws (malformed XML,
+ * `AmbiguousSchemaError`) so the caller can surface a message.
+ */
+export function hydrateFromMondrianXml(
+  store: SchemaCanvasStore,
+  xml: string,
+  connectionId: string,
+  now: () => number = Date.now,
+): HydrateResult {
+  const { state, warnings, workbenchCubes } = importFromMondrianXml(xml, {
+    connectionId,
+    sourceTables: store.sourceTables,
+  });
+  store.loadDoc(state);
+  if (workbenchCubes.length > 0) {
+    store.setCubes(mapWorkbenchDocCubes(workbenchCubes));
+  }
+  if (state.tables.length > 0) {
+    // Recenter so the loaded nodes aren't rendered off-screen with only a
+    // minimap dot (saiku-cloud#1035 keeps fit_view on every import path).
+    store.requestedCanvasAction = { kind: "fit_view", ts: now() };
+  }
+  return {
+    tableCount: state.tables.length,
+    joinCount: state.joins.length,
+    warnings,
+  };
+}

--- a/saiku-ui/src/routes/admin/cube-designer/[dataSourceId]/workbench-seed.ts
+++ b/saiku-ui/src/routes/admin/cube-designer/[dataSourceId]/workbench-seed.ts
@@ -1,0 +1,47 @@
+/**
+ * Map freshly parsed Mondrian-4 import cubes into the trimmed `doc.cubes`
+ * model the workbench hydrates from (measure groups, factTableId,
+ * measureColumns, dimensionLinks, calcs, time-intelligence metrics). UI-only
+ * flags are re-derived when the workbench mounts.
+ *
+ * OSS host-glue mirror of saiku-cloud's
+ * `routes/schemas/new/canvas/workbench-seed.ts` — kept structurally identical
+ * so the edit-existing-cube flow behaves the same on both hosts (saiku#1634).
+ * Extracted from the route so the transform is unit-testable.
+ */
+import type { importFromMondrianXml } from "$lib/cube-designer/mondrian-import";
+import type { SchemaCanvasCube } from "$lib/cube-designer/types";
+
+type WorkbenchImportCubes = ReturnType<typeof importFromMondrianXml>["workbenchCubes"];
+
+export function mapWorkbenchDocCubes(cubes: WorkbenchImportCubes): SchemaCanvasCube[] {
+  return cubes.map((c) => ({
+    id: c.id,
+    name: c.name,
+    measureGroups: c.measureGroups.map((mg) => ({
+      id: mg.id,
+      name: mg.name,
+      measureColumns: mg.measureColumns,
+      factTableId: mg.factTableId,
+      // Preserve linkKind / viaDimension / viaAttribute so FactLink and
+      // ReferenceLink round-trip through the workbench → export.
+      dimensionLinks: mg.dimensionLinks.map((l) => ({
+        dimensionId: l.dimensionId,
+        foreignKeyColumn: l.foreignKeyColumn,
+        linkKind: l.linkKind,
+        viaDimension: l.viaDimension,
+        viaAttribute: l.viaAttribute,
+      })),
+      measureCaptions: {},
+    })),
+    calcs: c.factsCalcs.map((cc) => ({
+      id: cc.id,
+      name: cc.name,
+      tokens: [],
+      formula: cc.formula,
+    })),
+    // Carry declarative time-intelligence metrics onto the doc cube so they
+    // survive import (and setCubes preserves them across workbench syncs).
+    timeCalcs: c.timeCalcs,
+  }));
+}


### PR DESCRIPTION
Rolls the Cube Designer hotfix branch onto `development` so the fixes reach the demo (`demo.saiku.bi` runs `:development`). Carries two commits:

## #1633 — entry link + full-width layout (`4c2375cf8`)
Host-side fixes to the "Design cube" entry (saiku-ui admin glue only; shared components untouched → saiku-cloud unaffected): base-prefixed link (403 fix), resolve datasource by **name** not UUID (500 fix), full-width route layout.

## #1634 — edit-existing-cube, datasource parse, drag coords (`d32a0c519`)

**#2 Datasource field mis-parse** — a Mondrian `location` whose inner `Jdbc=` URL carries its own `;`params (H2 `;MODE=MySQL`) shifted the positional Catalog/JdbcDrivers segments (FoodMart showed driver=the Catalog file, schema=MySQL). New key-based `MondrianLocation` parser, shared with the endpoint below.

**#1 Edit-existing-cube opened blank** — new `GET /saiku/admin/cube-designer/schema/{dataSourceId}` resolves the `Catalog=` reference (`file:` / `res:` / `mondrian://` repo) to schema XML; OSS host glue (`edit-load.ts` + `workbench-seed.ts`) fetches on mount and hydrates canvas + workbench. 404 ⇒ new-cube, stay blank. Shared `CubeDesignerBackend` seam unchanged → saiku-cloud unaffected.

**#3 Drag-to-canvas dropped off-screen after pan/zoom** — `handlePaneDrop` used pane-local pixels as flow coords. In-flow `JumpHandler` now publishes `screenToFlowPosition` onto the store; `resolveDropOrigin` maps the pointer into flow space (fallback to pane-relative). Portable to saiku-cloud verbatim.

## Test plan
- [x] `saiku-web`: 646 tests green (new `MondrianLocationTest`, `DataSourceMapperMondrianTest`, `CubeDesignerResourceTest` schema cases)
- [x] cube-designer vitest: 202 green (new `edit-load.test.ts`, `resolveDropOrigin`)
- [x] `npm run check`: 0 errors
- [ ] Post-merge: verify on `demo.saiku.bi` — Admin › Datasources shows correct driver/schema for foodmart; "Edit cube schema" loads foodmart/bank into the canvas; drag-a-table lands under the cursor after panning.

Note: unrelated pre-existing failure `OssieYamlWriterTest` in saiku-service (PII vendor extensions) — not touched by this branch.