### PR TITLE
#1636 - Port saiku-cloud's CSS theme to saiku-ui (red brand, subtle borders, layered dark)

### DIFF
--- a/saiku-ui/src/lib/components/ContextMenu.svelte
+++ b/saiku-ui/src/lib/components/ContextMenu.svelte
@@ -51,8 +51,8 @@
   .ctx-menu {
     position: fixed;
     min-width: 180px;
-    background: var(--bg);
-    border: 1px solid var(--border);
+    background: hsl(var(--bg));
+    border: 1px solid hsl(var(--border));
     border-radius: 6px;
     box-shadow: var(--shadow-lg);
     padding: 4px;
@@ -67,13 +67,13 @@
     padding: 6px 10px;
     background: transparent;
     border: 0;
-    color: var(--fg);
+    color: hsl(var(--fg));
     font: inherit;
     cursor: pointer;
     border-radius: 4px;
   }
-  .ctx-menu__item:hover:not(:disabled) { background: var(--bg-subtle); }
-  .ctx-menu__item:disabled { color: var(--fg-subtle); cursor: default; }
-  .ctx-menu__item.danger { color: var(--danger); }
-  .ctx-menu__sep { height: 1px; background: var(--border); margin: 3px 0; }
+  .ctx-menu__item:hover:not(:disabled) { background: hsl(var(--bg-subtle)); }
+  .ctx-menu__item:disabled { color: hsl(var(--fg-subtle)); cursor: default; }
+  .ctx-menu__item.danger { color: hsl(var(--danger)); }
+  .ctx-menu__sep { height: 1px; background: hsl(var(--border)); margin: 3px 0; }
 </style>

--- a/saiku-ui/src/lib/components/EmptyState.svelte
+++ b/saiku-ui/src/lib/components/EmptyState.svelte
@@ -58,7 +58,7 @@
     text-align: center;
     gap: var(--space-3);
     padding: var(--space-8) var(--space-5);
-    color: var(--fg);
+    color: hsl(var(--fg));
   }
   .empty-state--compact {
     padding: var(--space-5) var(--space-3);
@@ -71,8 +71,8 @@
     width: 64px;
     height: 64px;
     border-radius: 50%;
-    background: var(--bg-muted);
-    color: var(--fg-subtle);
+    background: hsl(var(--bg-muted));
+    color: hsl(var(--fg-subtle));
   }
   .empty-state--compact .empty-state__icon {
     width: 48px;
@@ -81,7 +81,7 @@
   .empty-state__description {
     margin: 0;
     max-width: 32ch;
-    color: var(--fg-muted);
+    color: hsl(var(--fg-muted));
     font-size: var(--fs-sm);
     line-height: var(--lh-normal);
   }

--- a/saiku-ui/src/lib/components/PrefsMenu.svelte
+++ b/saiku-ui/src/lib/components/PrefsMenu.svelte
@@ -66,8 +66,8 @@
     bottom: calc(100% + 6px);
     left: 0;
     z-index: 30;
-    background: var(--bg);
-    border: 1px solid var(--border);
+    background: hsl(var(--bg));
+    border: 1px solid hsl(var(--border));
     border-radius: var(--radius);
     box-shadow: var(--shadow);
     padding: var(--space-3);

--- a/saiku-ui/src/lib/components/RepositoryBrowser.svelte
+++ b/saiku-ui/src/lib/components/RepositoryBrowser.svelte
@@ -288,15 +288,15 @@
     background: transparent;
     border: 0;
     border-radius: 3px;
-    color: var(--fg-muted);
+    color: hsl(var(--fg-muted));
     cursor: pointer;
     font: inherit;
   }
-  .repo-browser__crumb:hover { background: var(--bg-hover); color: var(--fg); }
-  .repo-browser__crumb.is-current { color: var(--fg); font-weight: var(--weight-medium); }
+  .repo-browser__crumb:hover { background: hsl(var(--bg-hover)); color: hsl(var(--fg)); }
+  .repo-browser__crumb.is-current { color: hsl(var(--fg)); font-weight: var(--weight-medium); }
   /* Applied via class={} on a lucide-svelte icon — needs :global so the
      scoped-style hash doesn't suppress it on the child component's root. */
-  :global(.repo-browser__crumb-sep) { color: var(--fg-subtle); }
+  :global(.repo-browser__crumb-sep) { color: hsl(var(--fg-subtle)); }
   .repo-browser__list {
     flex: 1;
     list-style: none;
@@ -304,9 +304,9 @@
     padding: 0;
     max-height: 40vh;
     overflow-y: auto;
-    border: 1px solid var(--border);
+    border: 1px solid hsl(var(--border));
     border-radius: var(--radius-sm);
-    background: var(--bg);
+    background: hsl(var(--bg));
   }
   .repo-browser__row {
     display: flex;
@@ -316,35 +316,35 @@
     padding: var(--space-2) var(--space-3);
     background: transparent;
     border: 0;
-    border-bottom: 1px solid var(--border);
-    color: var(--fg);
+    border-bottom: 1px solid hsl(var(--border));
+    color: hsl(var(--fg));
     cursor: pointer;
     font: inherit;
     font-size: var(--fs-sm);
     text-align: left;
   }
   .repo-browser__row:last-child { border-bottom: 0; }
-  .repo-browser__row:hover { background: var(--bg-hover); }
+  .repo-browser__row:hover { background: hsl(var(--bg-hover)); }
   .repo-browser__row.is-selected {
-    background: var(--accent-soft);
-    color: var(--accent-strong);
+    background: hsl(var(--accent));
+    color: hsl(var(--primary-strong));
   }
   .repo-browser__new-folder {
     display: flex;
     align-items: center;
     gap: var(--space-2);
     padding: var(--space-2);
-    background: var(--bg-muted);
-    border: 1px solid var(--border);
+    background: hsl(var(--bg-muted));
+    border: 1px solid hsl(var(--border));
     border-radius: var(--radius-sm);
-    color: var(--fg-muted);
+    color: hsl(var(--fg-muted));
   }
   .repo-browser__new-folder-input {
     flex: 1;
     padding: 6px var(--space-2);
-    background: var(--bg);
-    color: var(--fg);
-    border: 1px solid var(--border);
+    background: hsl(var(--bg));
+    color: hsl(var(--fg));
+    border: 1px solid hsl(var(--border));
     border-radius: var(--radius-sm);
     font: inherit;
     font-size: var(--fs-sm);

--- a/saiku-ui/src/lib/components/SessionExpiredBanner.svelte
+++ b/saiku-ui/src/lib/components/SessionExpiredBanner.svelte
@@ -175,9 +175,9 @@
     z-index: 2100; /* above ToastStack (2000), below explicit modals. */
     margin: 0 auto;
     max-width: 960px;
-    background: var(--bg);
-    color: var(--fg);
-    border: 1px solid var(--danger);
+    background: hsl(var(--bg));
+    color: hsl(var(--fg));
+    border: 1px solid hsl(var(--danger));
     border-top: 0;
     border-radius: 0 0 var(--radius-md) var(--radius-md);
     box-shadow: var(--shadow-md);
@@ -192,10 +192,10 @@
     /* High-contrast left bar so the banner reads as urgent without
        borrowing the toast pattern (which is dismissible-info, not
        attention-required). */
-    border-left: 4px solid var(--danger);
+    border-left: 4px solid hsl(var(--danger));
   }
   .session-banner :global(.session-banner__icon) {
-    color: var(--danger);
+    color: hsl(var(--danger));
     flex-shrink: 0;
   }
   .session-banner__form {
@@ -203,14 +203,14 @@
     flex-direction: column;
     gap: var(--space-2);
     padding: var(--space-3);
-    border-top: 1px solid var(--border);
-    background: var(--bg-muted);
+    border-top: 1px solid hsl(var(--border));
+    background: hsl(var(--bg-muted));
   }
   .session-banner__err {
     margin: 0;
     padding: var(--space-2);
     background: var(--danger-soft, rgba(220, 38, 38, 0.1));
-    color: var(--danger);
+    color: hsl(var(--danger));
     border-radius: var(--radius-sm);
   }
   .session-banner__fields {

--- a/saiku-ui/src/lib/components/Skeleton.svelte
+++ b/saiku-ui/src/lib/components/Skeleton.svelte
@@ -58,9 +58,9 @@
     border-radius: var(--radius-sm);
     background: linear-gradient(
       90deg,
-      var(--bg-muted) 0%,
-      var(--bg-subtle) 50%,
-      var(--bg-muted) 100%
+      hsl(var(--bg-muted)) 0%,
+      hsl(var(--bg-subtle)) 50%,
+      hsl(var(--bg-muted)) 100%
     );
     background-size: 200% 100%;
     animation: skeleton-shimmer 1.4s ease-in-out infinite;
@@ -74,7 +74,7 @@
   @media (prefers-reduced-motion: reduce) {
     .skeleton-bar {
       animation: none;
-      background: var(--bg-subtle);
+      background: hsl(var(--bg-subtle));
     }
   }
 </style>

--- a/saiku-ui/src/lib/components/Tour.svelte
+++ b/saiku-ui/src/lib/components/Tour.svelte
@@ -153,7 +153,7 @@
   .tour { position: fixed; inset: 0; z-index: 3000; pointer-events: none; }
   .tour__highlight {
     position: absolute;
-    border: 2px solid var(--accent);
+    border: 2px solid hsl(var(--primary));
     border-radius: var(--radius-sm);
     box-shadow: 0 0 0 9999px rgba(0, 0, 0, 0.45);
     transition: all var(--duration-normal) ease;
@@ -163,9 +163,9 @@
     position: absolute;
     width: 360px;
     max-width: calc(100vw - 24px);
-    background: var(--bg);
-    color: var(--fg);
-    border: 1px solid var(--border);
+    background: hsl(var(--bg));
+    color: hsl(var(--fg));
+    border: 1px solid hsl(var(--border));
     border-radius: var(--radius-md);
     box-shadow: var(--shadow-lg);
     padding: var(--space-4);
@@ -177,8 +177,8 @@
     align-items: baseline;
     margin-bottom: var(--space-2);
   }
-  .tour__bubble .step { color: var(--fg-subtle); font-size: var(--fs-xs); }
-  .tour__bubble p { margin: 0 0 var(--space-3); color: var(--fg-muted); font-size: var(--fs-sm); }
+  .tour__bubble .step { color: hsl(var(--fg-subtle)); font-size: var(--fs-xs); }
+  .tour__bubble p { margin: 0 0 var(--space-3); color: hsl(var(--fg-muted)); font-size: var(--fs-sm); }
   .tour__bubble footer {
     display: flex;
     justify-content: flex-end;

--- a/saiku-ui/src/lib/components/schemagen/NodeDrawer.svelte
+++ b/saiku-ui/src/lib/components/schemagen/NodeDrawer.svelte
@@ -118,7 +118,7 @@
 .drawer {
     font-family: var(--font-sans);
     font-size: var(--fs-sm);
-    color: var(--fg);
+    color: hsl(var(--fg));
     padding: var(--space-4);
     display: flex;
     flex-direction: column;
@@ -127,7 +127,7 @@
   }
   .drawer__kind {
     margin: 0;
-    color: var(--fg-muted);
+    color: hsl(var(--fg-muted));
     font-size: var(--fs-xs);
     text-transform: uppercase;
     letter-spacing: 0.05em;
@@ -143,25 +143,25 @@
     font-weight: var(--weight-semibold);
     text-transform: uppercase;
     letter-spacing: 0.03em;
-    background: var(--fg-subtle);
-    color: var(--accent-fg);
+    background: hsl(var(--fg-subtle));
+    color: hsl(var(--primary-foreground));
   }
   .drawer__badge--user {
-    background: var(--success);
+    background: hsl(var(--success));
     color: #fff;
   }
   .drawer__label {
     font-size: var(--fs-xs);
-    color: var(--fg-muted);
+    color: hsl(var(--fg-muted));
     text-transform: uppercase;
     letter-spacing: 0.05em;
   }
   .drawer__input,
   .drawer__textarea {
     font: inherit;
-    color: var(--fg);
-    background: var(--bg);
-    border: 1px solid var(--border);
+    color: hsl(var(--fg));
+    background: hsl(var(--bg));
+    border: 1px solid hsl(var(--border));
     border-radius: var(--radius-sm);
     padding: var(--space-2) var(--space-3);
   }
@@ -169,7 +169,7 @@
   .drawer__textarea:focus {
     outline: none;
     box-shadow: var(--focus-ring);
-    border-color: var(--accent);
+    border-color: hsl(var(--primary));
   }
   .drawer__textarea {
     resize: vertical;
@@ -181,9 +181,9 @@
     gap: 2px var(--space-3);
     margin: 0;
     padding-top: var(--space-2);
-    border-top: 1px solid var(--border);
+    border-top: 1px solid hsl(var(--border));
     font-size: var(--fs-xs);
-    color: var(--fg-muted);
+    color: hsl(var(--fg-muted));
   }
   .drawer__meta dt {
     font-weight: var(--weight-semibold);

--- a/saiku-ui/src/lib/components/schemagen/SchemaTree.svelte
+++ b/saiku-ui/src/lib/components/schemagen/SchemaTree.svelte
@@ -80,14 +80,14 @@
 .tree {
     font-family: var(--font-sans);
     font-size: var(--fs-sm);
-    color: var(--fg);
+    color: hsl(var(--fg));
     padding: var(--space-2);
     overflow: auto;
   }
   .tree__root,
   .tree__children {
     padding-left: var(--space-4);
-    border-left: 1px dashed var(--border);
+    border-left: 1px dashed hsl(var(--border));
     margin-left: var(--space-2);
   }
   .tree__item {
@@ -108,7 +108,7 @@
     font: inherit;
   }
   .tree__row:hover {
-    background: var(--bg-muted);
+    background: hsl(var(--bg-muted));
   }
   .tree__row:focus-visible {
     outline: none;
@@ -122,11 +122,11 @@
     font-weight: var(--weight-semibold);
     letter-spacing: 0.03em;
     text-transform: uppercase;
-    color: var(--accent-fg);
-    background: var(--fg-subtle);
+    color: hsl(var(--primary-foreground));
+    background: hsl(var(--fg-subtle));
   }
   .tree__badge--user {
-    background: var(--success);
+    background: hsl(var(--success));
     color: #fff;
   }
 </style>

--- a/saiku-ui/src/lib/components/schemagen/SuggestionCard.svelte
+++ b/saiku-ui/src/lib/components/schemagen/SuggestionCard.svelte
@@ -73,15 +73,15 @@
     flex-direction: column;
     gap: var(--space-2);
     padding: var(--space-3);
-    border: 1px solid var(--border);
+    border: 1px solid hsl(var(--border));
     border-radius: var(--radius-sm);
-    background: var(--bg);
+    background: hsl(var(--bg));
     font-size: var(--fs-sm);
   }
   .card__path {
     font-family: var(--font-mono);
     font-size: var(--fs-xs);
-    color: var(--fg-muted);
+    color: hsl(var(--fg-muted));
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
@@ -94,15 +94,15 @@
     font-weight: var(--weight-semibold);
     letter-spacing: 0.03em;
     text-transform: uppercase;
-    color: var(--accent-fg);
-    background: var(--fg-subtle);
+    color: hsl(var(--primary-foreground));
+    background: hsl(var(--fg-subtle));
   }
   .card__tier--high {
-    background: var(--success);
+    background: hsl(var(--success));
     color: #fff;
   }
   .card__before {
-    color: var(--fg-muted);
+    color: hsl(var(--fg-muted));
     text-decoration: line-through;
   }
   .card__btn {
@@ -112,25 +112,25 @@
     font: inherit;
     font-size: var(--fs-xs);
     padding: 4px var(--space-3);
-    border: 1px solid var(--border);
+    border: 1px solid hsl(var(--border));
     border-radius: var(--radius-sm);
-    background: var(--bg);
-    color: var(--fg);
+    background: hsl(var(--bg));
+    color: hsl(var(--fg));
     cursor: pointer;
   }
   .card__btn:hover {
-    background: var(--bg-muted);
+    background: hsl(var(--bg-muted));
   }
   .card__btn:focus-visible {
     outline: none;
     box-shadow: var(--focus-ring);
   }
   .card__btn--accept {
-    color: var(--success);
-    border-color: var(--success);
+    color: hsl(var(--success));
+    border-color: hsl(var(--success));
   }
   .card__btn--accept:hover {
-    background: var(--success);
+    background: hsl(var(--success));
     color: #fff;
   }
 </style>

--- a/saiku-ui/src/lib/components/schemagen/SuggestionsFeed.svelte
+++ b/saiku-ui/src/lib/components/schemagen/SuggestionsFeed.svelte
@@ -120,14 +120,14 @@
     padding: var(--space-3);
     font-family: var(--font-sans);
     font-size: var(--fs-sm);
-    color: var(--fg);
+    color: hsl(var(--fg));
     overflow: auto;
   }
   .feed__banner {
     padding: var(--space-2) var(--space-3);
-    border: 1px solid var(--warning, var(--border-strong));
-    background: var(--bg-muted);
-    color: var(--fg);
+    border: 1px solid var(--warning, hsl(var(--border-strong)));
+    background: hsl(var(--bg-muted));
+    color: hsl(var(--fg));
     border-radius: var(--radius-sm);
     font-size: var(--fs-xs);
   }
@@ -140,14 +140,14 @@
     font: inherit;
     font-size: var(--fs-xs);
     padding: 3px var(--space-2);
-    border: 1px solid var(--border);
+    border: 1px solid hsl(var(--border));
     border-radius: var(--radius-sm);
-    background: var(--bg);
-    color: var(--fg);
+    background: hsl(var(--bg));
+    color: hsl(var(--fg));
     cursor: pointer;
   }
   .feed__bulk:hover {
-    background: var(--bg-muted);
+    background: hsl(var(--bg-muted));
   }
   .feed__bulk:focus-visible {
     outline: none;

--- a/saiku-ui/src/lib/dashboard/cssSanitiser.test.ts
+++ b/saiku-ui/src/lib/dashboard/cssSanitiser.test.ts
@@ -41,7 +41,7 @@ describe("sanitiseAndScopeCss", () => {
   // with no Url child, so the Url walk never saw them.
   test("strips remote url() hidden in a custom property (var weaponisation)", () => {
     const out = sanitiseAndScopeCss(
-      ".a{--bg:url(https://evil/track.png)} .b{background:var(--bg)}",
+      ".a{--bg:url(https://evil/track.png)} .b{background:hsl(var(--bg))}",
       ROOT,
     );
     expect(out).not.toContain("evil");

--- a/saiku-ui/src/lib/modals/AddFolderModal.svelte
+++ b/saiku-ui/src/lib/modals/AddFolderModal.svelte
@@ -36,9 +36,9 @@
 </Modal>
 
 <style>
-  .hint { color: var(--fg-muted); font-size: var(--fs-sm); margin: 0 0 var(--space-3); }
+  .hint { color: hsl(var(--fg-muted)); font-size: var(--fs-sm); margin: 0 0 var(--space-3); }
   code {
-    background: var(--bg-subtle);
+    background: hsl(var(--bg-subtle));
     padding: 0 var(--space-1);
     border-radius: var(--radius-sm);
     font-family: var(--font-mono);

--- a/saiku-ui/src/lib/modals/CalculatedMemberModal.svelte
+++ b/saiku-ui/src/lib/modals/CalculatedMemberModal.svelte
@@ -243,54 +243,54 @@ SELECT …</pre>
   }
   .format-row { display: flex; gap: var(--space-2); }
   .preview {
-    background: var(--bg-muted);
-    border: 1px solid var(--border);
+    background: hsl(var(--bg-muted));
+    border: 1px solid hsl(var(--border));
     border-radius: var(--radius-sm);
     padding: var(--space-2) var(--space-3);
   }
-  .preview__label { font-size: var(--fs-xs); color: var(--fg-subtle); text-transform: uppercase; letter-spacing: 0.06em; margin-bottom: 4px; }
+  .preview__label { font-size: var(--fs-xs); color: hsl(var(--fg-subtle)); text-transform: uppercase; letter-spacing: 0.06em; margin-bottom: 4px; }
   .preview pre {
     margin: 0;
     font-size: var(--fs-xs);
     white-space: pre-wrap;
-    color: var(--fg-muted);
+    color: hsl(var(--fg-muted));
   }
   .palette {
-    border: 1px solid var(--border);
+    border: 1px solid hsl(var(--border));
     border-radius: var(--radius-sm);
-    background: var(--bg-muted);
+    background: hsl(var(--bg-muted));
     padding: var(--space-2);
     display: flex;
     flex-direction: column;
     gap: var(--space-1);
   }
-  .palette__title { font-size: var(--fs-xs); color: var(--fg-subtle); text-transform: uppercase; letter-spacing: 0.06em; }
+  .palette__title { font-size: var(--fs-xs); color: hsl(var(--fg-subtle)); text-transform: uppercase; letter-spacing: 0.06em; }
   .palette__btn {
     width: 100%;
     text-align: left;
     background: transparent;
     border: 0;
-    color: var(--fg);
+    color: hsl(var(--fg));
     padding: 3px 6px;
     border-radius: var(--radius-sm);
     cursor: pointer;
     font: inherit;
   }
-  .palette__btn:hover { background: var(--bg-subtle); }
-  .palette__empty { color: var(--fg-subtle); padding: 3px 6px; font-size: var(--fs-xs); }
+  .palette__btn:hover { background: hsl(var(--bg-subtle)); }
+  .palette__empty { color: hsl(var(--fg-subtle)); padding: 3px 6px; font-size: var(--fs-xs); }
   .palette__grid {
     display: grid;
     grid-template-columns: repeat(6, minmax(0, 1fr));
     gap: 4px;
   }
   .palette__chip {
-    background: var(--bg);
-    border: 1px solid var(--border);
+    background: hsl(var(--bg));
+    border: 1px solid hsl(var(--border));
     border-radius: var(--radius-sm);
     padding: 2px 0;
-    color: var(--fg);
+    color: hsl(var(--fg));
     font: inherit;
     cursor: pointer;
   }
-  .palette__chip:hover { background: var(--bg-subtle); }
+  .palette__chip:hover { background: hsl(var(--bg-subtle)); }
 </style>

--- a/saiku-ui/src/lib/modals/ChartEditorModal.svelte
+++ b/saiku-ui/src/lib/modals/ChartEditorModal.svelte
@@ -738,23 +738,23 @@
 </Modal>
 
 <style>
-.map-opts { display: flex; flex-direction: column; gap: var(--space-2); padding: var(--space-2) var(--space-3); background: var(--bg-subtle); border-radius: var(--radius-sm); }
-  .series-axis { display: flex; flex-direction: column; gap: var(--space-2); padding: var(--space-2) var(--space-3); background: var(--bg-subtle); border-radius: var(--radius-sm); }
+.map-opts { display: flex; flex-direction: column; gap: var(--space-2); padding: var(--space-2) var(--space-3); background: hsl(var(--bg-subtle)); border-radius: var(--radius-sm); }
+  .series-axis { display: flex; flex-direction: column; gap: var(--space-2); padding: var(--space-2) var(--space-3); background: hsl(var(--bg-subtle)); border-radius: var(--radius-sm); }
   .series-axis__pick { width: 8rem; flex: 0 0 auto; }
-  .number-format { display: flex; flex-direction: column; gap: var(--space-2); padding: var(--space-2) var(--space-3); background: var(--bg-subtle); border-radius: var(--radius-sm); }
-  .colours { display: flex; flex-direction: column; gap: var(--space-2); padding: var(--space-2) var(--space-3); background: var(--bg-subtle); border-radius: var(--radius-sm); }
-  .colours__pick { flex: 0 0 auto; width: 2.5rem; height: 1.75rem; padding: 0; border: 1px solid var(--border); border-radius: var(--radius-sm); background: none; cursor: pointer; }
+  .number-format { display: flex; flex-direction: column; gap: var(--space-2); padding: var(--space-2) var(--space-3); background: hsl(var(--bg-subtle)); border-radius: var(--radius-sm); }
+  .colours { display: flex; flex-direction: column; gap: var(--space-2); padding: var(--space-2) var(--space-3); background: hsl(var(--bg-subtle)); border-radius: var(--radius-sm); }
+  .colours__pick { flex: 0 0 auto; width: 2.5rem; height: 1.75rem; padding: 0; border: 1px solid hsl(var(--border)); border-radius: var(--radius-sm); background: none; cursor: pointer; }
   .colours__reset { flex: 0 0 auto; font-size: var(--fs-xs); }
   .colours__reset:disabled { opacity: 0.4; cursor: default; }
-  .ref { display: flex; flex-direction: column; gap: var(--space-2); padding: var(--space-2) var(--space-3); background: var(--bg-subtle); border-radius: var(--radius-sm); }
+  .ref { display: flex; flex-direction: column; gap: var(--space-2); padding: var(--space-2) var(--space-3); background: hsl(var(--bg-subtle)); border-radius: var(--radius-sm); }
   .ref__axis { width: 8.5rem; flex: 0 0 auto; }
   .ref__value { width: 6rem; flex: 0 0 auto; }
   .ref__label { flex: 1; min-width: 4rem; }
-  .ref__color { width: 2.25rem; height: 2rem; flex: 0 0 auto; padding: 0; border: 1px solid var(--border); border-radius: var(--radius-sm); background: none; }
+  .ref__color { width: 2.25rem; height: 2rem; flex: 0 0 auto; padding: 0; border: 1px solid hsl(var(--border)); border-radius: var(--radius-sm); background: none; }
   /* #1084: conditional formatting */
-  .cond { display: flex; flex-direction: column; gap: var(--space-2); padding: var(--space-2) var(--space-3); background: var(--bg-subtle); border-radius: var(--radius-sm); }
-  .cond__measure { display: flex; flex-direction: column; gap: var(--space-2); padding-top: var(--space-2); border-top: 1px solid var(--border); }
+  .cond { display: flex; flex-direction: column; gap: var(--space-2); padding: var(--space-2) var(--space-3); background: hsl(var(--bg-subtle)); border-radius: var(--radius-sm); }
+  .cond__measure { display: flex; flex-direction: column; gap: var(--space-2); padding-top: var(--space-2); border-top: 1px solid hsl(var(--border)); }
   .cond__op { width: 7rem; flex: 0 0 auto; }
   .cond__num { width: 5.5rem; flex: 0 0 auto; }
-  .cond__color { width: 2.25rem; height: 2rem; flex: 0 0 auto; padding: 0; border: 1px solid var(--border); border-radius: var(--radius-sm); background: none; cursor: pointer; }
+  .cond__color { width: 2.25rem; height: 2rem; flex: 0 0 auto; padding: 0; border: 1px solid hsl(var(--border)); border-radius: var(--radius-sm); background: none; cursor: pointer; }
 </style>

--- a/saiku-ui/src/lib/modals/DataSourcesModal.svelte
+++ b/saiku-ui/src/lib/modals/DataSourcesModal.svelte
@@ -56,6 +56,6 @@
 
 <style>
 .grid { width: 100%; border-collapse: collapse; font-size: var(--fs-sm); }
-  .grid th, .grid td { border: 1px solid var(--border); padding: var(--space-1) var(--space-2); text-align: left; }
-  .grid th { background: var(--bg-muted); }
+  .grid th, .grid td { border: 1px solid hsl(var(--border)); padding: var(--space-1) var(--space-2); text-align: left; }
+  .grid th { background: hsl(var(--bg-muted)); }
 </style>

--- a/saiku-ui/src/lib/modals/DateFilterModal.svelte
+++ b/saiku-ui/src/lib/modals/DateFilterModal.svelte
@@ -358,7 +358,7 @@
 .tabs {
     display: flex;
     gap: var(--space-1);
-    border-bottom: 1px solid var(--border);
+    border-bottom: 1px solid hsl(var(--border));
     margin-bottom: var(--space-3);
   }
   .tabs button {
@@ -368,24 +368,24 @@
     padding: var(--space-2) var(--space-3);
     cursor: pointer;
     font: inherit;
-    color: var(--fg-muted);
+    color: hsl(var(--fg-muted));
   }
   .tabs button.active {
-    color: var(--accent);
-    border-bottom-color: var(--accent);
+    color: hsl(var(--primary));
+    border-bottom-color: hsl(var(--primary));
   }
-  .hint { display: block; font-size: var(--fs-xs); margin-top: 4px; color: var(--fg-subtle); }
+  .hint { display: block; font-size: var(--fs-xs); margin-top: 4px; color: hsl(var(--fg-subtle)); }
   .preview {
     margin-top: var(--space-3);
     padding: var(--space-2);
-    background: var(--bg-subtle);
-    border: 1px solid var(--border);
+    background: hsl(var(--bg-subtle));
+    border: 1px solid hsl(var(--border));
     border-radius: var(--radius-sm);
   }
   .preview__label {
     display: block;
     font-size: var(--fs-xs);
-    color: var(--fg-muted);
+    color: hsl(var(--fg-muted));
     text-transform: uppercase;
     letter-spacing: 0.06em;
     margin-bottom: 4px;
@@ -396,18 +396,18 @@
     font-size: var(--fs-xs);
     white-space: pre-wrap;
     word-break: break-all;
-    color: var(--fg);
+    color: hsl(var(--fg));
   }
   .timecalcs {
     margin-top: var(--space-3);
     padding-top: var(--space-2);
-    border-top: 1px solid var(--border);
+    border-top: 1px solid hsl(var(--border));
   }
   .timecalcs__label {
     font-size: var(--fs-xs);
     text-transform: uppercase;
     letter-spacing: 0.06em;
-    color: var(--fg-muted);
+    color: hsl(var(--fg-muted));
     margin-bottom: 4px;
   }
 </style>

--- a/saiku-ui/src/lib/modals/DrillthroughModal.svelte
+++ b/saiku-ui/src/lib/modals/DrillthroughModal.svelte
@@ -92,22 +92,22 @@
 
 <style>
   .cols { display: grid; grid-template-columns: 1fr 1fr; gap: var(--space-3); margin-bottom: var(--space-4); }
-  h3 { margin: 0 0 var(--space-2); font-size: var(--fs-sm); color: var(--fg-muted); text-transform: uppercase; letter-spacing: 0.04em; }
+  h3 { margin: 0 0 var(--space-2); font-size: var(--fs-sm); color: hsl(var(--fg-muted)); text-transform: uppercase; letter-spacing: 0.04em; }
   .list {
     list-style: none;
     margin: 0;
     padding: 0;
     max-height: 40vh;
     overflow: auto;
-    border: 1px solid var(--border);
+    border: 1px solid hsl(var(--border));
     border-radius: var(--radius-sm);
   }
-  .list li + li { border-top: 1px solid var(--border); }
+  .list li + li { border-top: 1px solid hsl(var(--border)); }
   .list label {
     display: flex;
     gap: var(--space-2);
     padding: var(--space-1) var(--space-3);
     cursor: pointer;
   }
-  .list label:hover { background: var(--bg-subtle); }
+  .list label:hover { background: hsl(var(--bg-subtle)); }
 </style>

--- a/saiku-ui/src/lib/modals/DrillthroughResultModal.svelte
+++ b/saiku-ui/src/lib/modals/DrillthroughResultModal.svelte
@@ -54,9 +54,9 @@
 </Modal>
 
 <style>
-.scroll { max-height: 60vh; overflow: auto; border: 1px solid var(--border); border-radius: var(--radius-sm); }
+.scroll { max-height: 60vh; overflow: auto; border: 1px solid hsl(var(--border)); border-radius: var(--radius-sm); }
   .dt { border-collapse: separate; border-spacing: 0; width: 100%; font-size: var(--fs-sm); }
-  .dt th, .dt td { padding: 3px 9px; border-right: 1px solid var(--border); border-bottom: 1px solid var(--border); white-space: nowrap; text-align: left; }
+  .dt th, .dt td { padding: 3px 9px; border-right: 1px solid hsl(var(--border)); border-bottom: 1px solid hsl(var(--border)); white-space: nowrap; text-align: left; }
   .dt td.n { text-align: right; font-variant-numeric: tabular-nums; }
-  .dt th { position: sticky; top: 0; background: var(--bg-muted); color: var(--fg); font-weight: var(--weight-semibold); z-index: 1; }
+  .dt th { position: sticky; top: 0; background: hsl(var(--bg-muted)); color: hsl(var(--fg)); font-weight: var(--weight-semibold); z-index: 1; }
 </style>

--- a/saiku-ui/src/lib/modals/EmailMeThisModal.svelte
+++ b/saiku-ui/src/lib/modals/EmailMeThisModal.svelte
@@ -214,15 +214,15 @@
   .recipient {
     margin: 0;
     padding: var(--space-2) var(--space-3);
-    background: var(--bg-subtle);
-    border: 1px solid var(--border);
+    background: hsl(var(--bg-subtle));
+    border: 1px solid hsl(var(--border));
     border-radius: var(--radius-sm);
-    color: var(--fg);
+    color: hsl(var(--fg));
     font-size: var(--fs-sm);
     word-break: break-all;
   }
 
   .recipient--muted {
-    color: var(--fg-subtle);
+    color: hsl(var(--fg-subtle));
   }
 </style>

--- a/saiku-ui/src/lib/modals/MeasuresModal.svelte
+++ b/saiku-ui/src/lib/modals/MeasuresModal.svelte
@@ -109,10 +109,10 @@
     padding: 0;
     max-height: 50vh;
     overflow: auto;
-    border: 1px solid var(--border);
+    border: 1px solid hsl(var(--border));
     border-radius: var(--radius-sm);
   }
-  .list li + li { border-top: 1px solid var(--border); }
+  .list li + li { border-top: 1px solid hsl(var(--border)); }
   .list label {
     display: flex;
     align-items: center;
@@ -120,17 +120,17 @@
     padding: var(--space-2) var(--space-3);
     cursor: pointer;
   }
-  .list label:hover { background: var(--bg-subtle); }
+  .list label:hover { background: hsl(var(--bg-subtle)); }
   .badge {
     font-size: var(--fs-xs);
-    color: var(--accent);
+    color: hsl(var(--primary));
     padding: 0 var(--space-1);
-    border: 1px solid var(--accent);
+    border: 1px solid hsl(var(--primary));
     border-radius: var(--radius-sm);
   }
   .badge--hidden {
-    color: var(--fg-muted);
-    border-color: var(--fg-muted);
+    color: hsl(var(--fg-muted));
+    border-color: hsl(var(--fg-muted));
   }
   .hidden-toggle {
     display: grid;
@@ -140,15 +140,15 @@
     align-items: center;
     margin-top: var(--space-3);
     padding: var(--space-2) var(--space-3);
-    border: 1px dashed var(--border);
+    border: 1px dashed hsl(var(--border));
     border-radius: var(--radius-sm);
     cursor: pointer;
   }
-  .hidden-toggle:hover { background: var(--bg-subtle); }
+  .hidden-toggle:hover { background: hsl(var(--bg-subtle)); }
   .hidden-toggle input { grid-row: 1 / span 2; }
   .hidden-toggle__loading {
     margin: var(--space-2) 0 0;
     font-size: var(--fs-xs);
-    color: var(--fg-muted);
+    color: hsl(var(--fg-muted));
   }
 </style>

--- a/saiku-ui/src/lib/modals/MoveRepositoryObject.svelte
+++ b/saiku-ui/src/lib/modals/MoveRepositoryObject.svelte
@@ -34,9 +34,9 @@
 </Modal>
 
 <style>
-  .hint { color: var(--fg-muted); font-size: var(--fs-sm); margin: 0 0 var(--space-3); }
+  .hint { color: hsl(var(--fg-muted)); font-size: var(--fs-sm); margin: 0 0 var(--space-3); }
   code {
-    background: var(--bg-subtle);
+    background: hsl(var(--bg-subtle));
     padding: 0 var(--space-1);
     border-radius: var(--radius-sm);
     font-family: var(--font-mono);

--- a/saiku-ui/src/lib/modals/NewAppModal.svelte
+++ b/saiku-ui/src/lib/modals/NewAppModal.svelte
@@ -94,22 +94,22 @@
   .import-badge {
     margin: 0 0 var(--space-3);
     padding: var(--space-2) var(--space-3);
-    background: var(--bg-muted);
-    border: 1px solid var(--border);
+    background: hsl(var(--bg-muted));
+    border: 1px solid hsl(var(--border));
     border-radius: var(--radius-sm);
-    color: var(--fg-muted);
+    color: hsl(var(--fg-muted));
     font-size: var(--fs-sm);
   }
   .path-preview {
     margin: var(--space-3) 0 0;
-    color: var(--fg-muted);
+    color: hsl(var(--fg-muted));
     font-size: var(--fs-sm);
   }
   .path-preview code {
-    background: var(--bg-muted);
+    background: hsl(var(--bg-muted));
     padding: 2px 6px;
     border-radius: var(--radius-sm);
-    color: var(--fg);
+    color: hsl(var(--fg));
     font-family: var(--font-mono);
     font-size: var(--fs-xs);
   }

--- a/saiku-ui/src/lib/modals/NewDashboardModal.svelte
+++ b/saiku-ui/src/lib/modals/NewDashboardModal.svelte
@@ -158,29 +158,29 @@
     gap: var(--space-1);
     text-align: left;
     padding: var(--space-3);
-    border: 1px solid var(--border);
+    border: 1px solid hsl(var(--border));
     border-radius: var(--radius-md);
-    background: var(--bg);
-    color: var(--fg);
+    background: hsl(var(--bg));
+    color: hsl(var(--fg));
     cursor: pointer;
   }
   .template-card:hover {
-    background: var(--bg-muted);
+    background: hsl(var(--bg-muted));
   }
   .template-card--on {
-    border-color: var(--accent);
-    box-shadow: 0 0 0 1px var(--accent);
+    border-color: hsl(var(--primary));
+    box-shadow: 0 0 0 1px hsl(var(--primary));
   }
   .path-preview {
     margin: var(--space-3) 0 0;
-    color: var(--fg-muted);
+    color: hsl(var(--fg-muted));
     font-size: var(--fs-sm);
   }
   .path-preview code {
-    background: var(--bg-muted);
+    background: hsl(var(--bg-muted));
     padding: 2px 6px;
     border-radius: var(--radius-sm);
-    color: var(--fg);
+    color: hsl(var(--fg));
     font-family: var(--font-mono);
     font-size: var(--fs-xs);
   }

--- a/saiku-ui/src/lib/modals/OpenDialogModal.svelte
+++ b/saiku-ui/src/lib/modals/OpenDialogModal.svelte
@@ -71,17 +71,17 @@
 </Modal>
 
 <style>
-.hint { color: var(--fg-muted); font-size: var(--fs-sm); margin: var(--space-2) 0; }
+.hint { color: hsl(var(--fg-muted)); font-size: var(--fs-sm); margin: var(--space-2) 0; }
   .repo {
     list-style: none;
     margin: 0;
     padding: 0;
     max-height: 40vh;
     overflow: auto;
-    border: 1px solid var(--border);
+    border: 1px solid hsl(var(--border));
     border-radius: var(--radius-sm);
   }
-  .repo__entry + .repo__entry { border-top: 1px solid var(--border); }
+  .repo__entry + .repo__entry { border-top: 1px solid hsl(var(--border)); }
   .repo__row {
     display: flex;
     align-items: center;
@@ -90,11 +90,11 @@
     padding: var(--space-2) var(--space-3);
     background: transparent;
     border: 0;
-    color: var(--fg);
+    color: hsl(var(--fg));
     font: inherit;
     cursor: pointer;
     text-align: left;
   }
-  .repo__row:hover:not(:disabled) { background: var(--bg-subtle); }
-  .repo__row:disabled { color: var(--fg-muted); cursor: default; }
+  .repo__row:hover:not(:disabled) { background: hsl(var(--bg-subtle)); }
+  .repo__row:disabled { color: hsl(var(--fg-muted)); cursor: default; }
 </style>

--- a/saiku-ui/src/lib/modals/OssieAskAiModal.svelte
+++ b/saiku-ui/src/lib/modals/OssieAskAiModal.svelte
@@ -158,22 +158,22 @@
   }
   .ossie-ask__scope {
     margin: 0;
-    color: var(--fg-muted);
+    color: hsl(var(--fg-muted));
     font-size: var(--fs-sm);
   }
   .ossie-ask__history {
     max-height: 320px;
     overflow-y: auto;
     padding: var(--space-2);
-    background: var(--bg-subtle, var(--bg-hover));
-    border: 1px solid var(--border);
+    background: var(--bg-subtle, hsl(var(--bg-hover)));
+    border: 1px solid hsl(var(--border));
     border-radius: 4px;
     display: flex;
     flex-direction: column;
     gap: var(--space-2);
   }
   .ossie-ask__empty {
-    color: var(--fg-muted);
+    color: hsl(var(--fg-muted));
     font-size: var(--fs-sm);
     text-align: center;
     padding: var(--space-4) 0;
@@ -183,14 +183,14 @@
     gap: var(--space-2);
     padding: 6px 10px;
     border-radius: 4px;
-    background: var(--bg);
+    background: hsl(var(--bg));
   }
   .ossie-ask__turn--user {
-    background: color-mix(in srgb, var(--accent) 8%, var(--bg));
+    background: color-mix(in srgb, hsl(var(--primary)) 8%, hsl(var(--bg)));
   }
   .ossie-ask__role {
     font-weight: var(--weight-semibold);
-    color: var(--fg-muted);
+    color: hsl(var(--fg-muted));
     min-width: 40px;
   }
   .ossie-ask__content {
@@ -211,10 +211,10 @@
   }
   .ossie-ask__input {
     padding: 8px 10px;
-    border: 1px solid var(--border-strong);
+    border: 1px solid hsl(var(--border-strong));
     border-radius: 4px;
-    background: var(--bg);
-    color: var(--fg);
+    background: hsl(var(--bg));
+    color: hsl(var(--fg));
     font-family: inherit;
     font-size: var(--fs-sm);
     resize: vertical;

--- a/saiku-ui/src/lib/modals/OssieLoadModal.svelte
+++ b/saiku-ui/src/lib/modals/OssieLoadModal.svelte
@@ -53,7 +53,7 @@
 <style>
   .intro {
     margin: 0 0 var(--space-3);
-    color: var(--fg-muted);
+    color: hsl(var(--fg-muted));
     font-size: var(--fs-sm);
   }
 </style>

--- a/saiku-ui/src/lib/modals/ParentMemberSelectorModal.svelte
+++ b/saiku-ui/src/lib/modals/ParentMemberSelectorModal.svelte
@@ -47,10 +47,10 @@
     padding: 0;
     max-height: 50vh;
     overflow: auto;
-    border: 1px solid var(--border);
+    border: 1px solid hsl(var(--border));
     border-radius: var(--radius-sm);
   }
-  .list li + li { border-top: 1px solid var(--border); }
+  .list li + li { border-top: 1px solid hsl(var(--border)); }
   .row {
     display: flex;
     flex-direction: column;
@@ -59,11 +59,11 @@
     padding: var(--space-2) var(--space-3);
     background: transparent;
     border: 0;
-    color: var(--fg);
+    color: hsl(var(--fg));
     font: inherit;
     cursor: pointer;
     text-align: left;
   }
-  .row:hover { background: var(--bg-subtle); }
-  .un { font-family: var(--font-mono); font-size: var(--fs-xs); color: var(--fg-subtle); }
+  .row:hover { background: hsl(var(--bg-subtle)); }
+  .un { font-family: var(--font-mono); font-size: var(--fs-xs); color: hsl(var(--fg-subtle)); }
 </style>

--- a/saiku-ui/src/lib/modals/PermissionsModal.svelte
+++ b/saiku-ui/src/lib/modals/PermissionsModal.svelte
@@ -68,6 +68,6 @@
 
 <style>
 .grid { width: 100%; border-collapse: collapse; margin-top: var(--space-2); font-size: var(--fs-sm); }
-  .grid th, .grid td { border: 1px solid var(--border); padding: var(--space-1) var(--space-2); text-align: left; }
-  .grid th { background: var(--bg-muted); }
+  .grid th, .grid td { border: 1px solid hsl(var(--border)); padding: var(--space-1) var(--space-2); text-align: left; }
+  .grid th { background: hsl(var(--bg-muted)); }
 </style>

--- a/saiku-ui/src/lib/modals/RenameFolderModal.svelte
+++ b/saiku-ui/src/lib/modals/RenameFolderModal.svelte
@@ -60,19 +60,19 @@
 
 <style>
   .hint {
-    color: var(--fg-muted);
+    color: hsl(var(--fg-muted));
     font-size: var(--fs-sm);
     margin: 0 0 var(--space-3);
   }
   code {
-    background: var(--bg-subtle);
+    background: hsl(var(--bg-subtle));
     padding: 0 var(--space-1);
     border-radius: var(--radius-sm);
     font-family: var(--font-mono);
     font-size: 12px;
   }
   .err {
-    color: var(--danger);
+    color: hsl(var(--danger));
     font-size: var(--fs-sm);
     margin: var(--space-2) 0 0;
   }

--- a/saiku-ui/src/lib/modals/SaveQueryModal.svelte
+++ b/saiku-ui/src/lib/modals/SaveQueryModal.svelte
@@ -101,7 +101,7 @@
 <style>
 .save-modal__intro {
     margin: 0 0 var(--space-3);
-    color: var(--fg-muted);
+    color: hsl(var(--fg-muted));
     font-size: var(--fs-sm);
   }
 </style>

--- a/saiku-ui/src/lib/modals/SavedQueriesModal.svelte
+++ b/saiku-ui/src/lib/modals/SavedQueriesModal.svelte
@@ -430,7 +430,7 @@
 {/if}
 
 <style>
-.hint { color: var(--fg-muted); font-size: var(--fs-sm); margin: var(--space-2) 0; }
+.hint { color: hsl(var(--fg-muted)); font-size: var(--fs-sm); margin: var(--space-2) 0; }
   .saved__crumb {
     display: inline-flex;
     align-items: center;
@@ -439,31 +439,31 @@
     background: transparent;
     border: 0;
     border-radius: 3px;
-    color: var(--fg-muted);
+    color: hsl(var(--fg-muted));
     cursor: pointer;
     font: inherit;
   }
-  .saved__crumb:hover { background: var(--bg-hover); color: var(--fg); }
-  .saved__crumb.is-current { color: var(--fg); font-weight: var(--weight-medium); }
+  .saved__crumb:hover { background: hsl(var(--bg-hover)); color: hsl(var(--fg)); }
+  .saved__crumb.is-current { color: hsl(var(--fg)); font-weight: var(--weight-medium); }
   /* Applied via class={} on a lucide-svelte icon — needs :global so the
      scoped-style hash doesn't suppress it on the child component's root. */
-  :global(.saved__crumb-sep) { color: var(--fg-subtle); }
+  :global(.saved__crumb-sep) { color: hsl(var(--fg-subtle)); }
   .saved__search {
     display: flex;
     align-items: center;
     gap: var(--space-2);
     padding: 6px 10px;
     margin-bottom: var(--space-2);
-    border: 1px solid var(--border);
+    border: 1px solid hsl(var(--border));
     border-radius: var(--radius-sm);
-    background: var(--bg-subtle);
-    color: var(--fg-muted);
+    background: hsl(var(--bg-subtle));
+    color: hsl(var(--fg-muted));
   }
   .saved__search-input {
     flex: 1;
     background: transparent;
     border: 0;
-    color: var(--fg);
+    color: hsl(var(--fg));
     font: inherit;
     outline: none;
   }
@@ -473,7 +473,7 @@
     margin: 0;
     max-height: 50vh;
     overflow-y: auto;
-    border: 1px solid var(--border);
+    border: 1px solid hsl(var(--border));
     border-radius: var(--radius-sm);
   }
   .saved__row {
@@ -482,8 +482,8 @@
     gap: var(--space-2);
     padding: var(--space-2) var(--space-3);
   }
-  .saved__row + .saved__row { border-top: 1px solid var(--border); }
-  .saved__row:hover { background: var(--bg-hover); }
+  .saved__row + .saved__row { border-top: 1px solid hsl(var(--border)); }
+  .saved__row:hover { background: hsl(var(--bg-hover)); }
   .saved__main {
     flex: 1;
     display: flex;
@@ -492,7 +492,7 @@
     text-align: left;
     background: transparent;
     border: 0;
-    color: var(--fg);
+    color: hsl(var(--fg));
     cursor: pointer;
     font: inherit;
     padding: 0;
@@ -508,17 +508,17 @@
   .saved__rename-input {
     flex: 1;
     padding: 4px 8px;
-    background: var(--bg);
-    border: 1px solid var(--border-strong);
+    background: hsl(var(--bg));
+    border: 1px solid hsl(var(--border-strong));
     border-radius: var(--radius-sm);
-    color: var(--fg);
+    color: hsl(var(--fg));
     font: inherit;
   }
   .saved__confirm {
     margin-top: var(--space-3);
     padding: var(--space-3);
-    border: 1px solid var(--danger);
+    border: 1px solid hsl(var(--danger));
     border-radius: var(--radius-sm);
-    background: color-mix(in srgb, var(--danger) 10%, var(--bg));
+    background: color-mix(in srgb, hsl(var(--danger)) 10%, hsl(var(--bg)));
   }
 </style>

--- a/saiku-ui/src/lib/modals/SelectionsModal.svelte
+++ b/saiku-ui/src/lib/modals/SelectionsModal.svelte
@@ -338,13 +338,13 @@
     display: flex;
     flex-wrap: wrap;
     gap: 2px;
-    border-bottom: 1px solid var(--border);
+    border-bottom: 1px solid hsl(var(--border));
     margin-bottom: var(--space-3);
   }
   .tabs__btn {
     background: transparent;
     border: 0;
-    color: var(--fg-muted);
+    color: hsl(var(--fg-muted));
     padding: var(--space-2) var(--space-3);
     font: inherit;
     font-size: var(--fs-sm);
@@ -355,15 +355,15 @@
     align-items: center;
     gap: var(--space-2);
   }
-  .tabs__btn:hover { color: var(--fg); }
+  .tabs__btn:hover { color: hsl(var(--fg)); }
   .tabs__btn.is-active {
-    color: var(--fg);
-    border-bottom-color: var(--accent);
+    color: hsl(var(--fg));
+    border-bottom-color: hsl(var(--primary));
     font-weight: var(--weight-semibold);
   }
   .tabs__count {
-    background: var(--accent-soft);
-    color: var(--accent-strong);
+    background: hsl(var(--accent));
+    color: hsl(var(--primary-strong));
     border-radius: 999px;
     padding: 1px 6px;
     font-size: 11px;
@@ -383,11 +383,11 @@
     padding: 0;
     max-height: 45vh;
     overflow: auto;
-    border: 1px solid var(--border);
+    border: 1px solid hsl(var(--border));
     border-radius: var(--radius-sm);
   }
-  .members li + li { border-top: 1px solid var(--border); }
-  .members li.empty { padding: var(--space-4); color: var(--fg-muted); text-align: center; }
+  .members li + li { border-top: 1px solid hsl(var(--border)); }
+  .members li.empty { padding: var(--space-4); color: hsl(var(--fg-muted)); text-align: center; }
   .members label {
     display: flex;
     align-items: center;
@@ -395,5 +395,5 @@
     padding: var(--space-2) var(--space-3);
     cursor: pointer;
   }
-  .members label:hover { background: var(--bg-subtle); }
+  .members label:hover { background: hsl(var(--bg-subtle)); }
 </style>

--- a/saiku-ui/src/lib/modals/TopBottomCountModal.svelte
+++ b/saiku-ui/src/lib/modals/TopBottomCountModal.svelte
@@ -135,7 +135,7 @@
 <style>
   .field__hint {
     margin: var(--space-1) 0 0;
-    color: var(--fg-subtle);
+    color: hsl(var(--fg-subtle));
     font-size: var(--fs-xs);
   }
 </style>

--- a/saiku-ui/src/lib/modals/parts/ModalModeSwitch.svelte
+++ b/saiku-ui/src/lib/modals/parts/ModalModeSwitch.svelte
@@ -58,8 +58,8 @@
   .mode-switch {
     display: inline-flex;
     margin-bottom: var(--space-3);
-    background: var(--bg-muted);
-    border: 1px solid var(--border);
+    background: hsl(var(--bg-muted));
+    border: 1px solid hsl(var(--border));
     border-radius: var(--radius-sm);
     padding: 2px;
   }
@@ -68,17 +68,17 @@
     background: transparent;
     border: 0;
     border-radius: 3px;
-    color: var(--fg-muted);
+    color: hsl(var(--fg-muted));
     font: inherit;
     font-size: var(--fs-sm);
     cursor: pointer;
   }
   .mode-switch__btn:hover {
-    color: var(--fg);
+    color: hsl(var(--fg));
   }
   .mode-switch__btn.active {
-    background: var(--bg);
-    color: var(--fg);
+    background: hsl(var(--bg));
+    color: hsl(var(--fg));
     font-weight: var(--weight-medium);
     box-shadow: var(--shadow-sm);
   }

--- a/saiku-ui/src/lib/styles/app.css
+++ b/saiku-ui/src/lib/styles/app.css
@@ -7,8 +7,8 @@
  * Without this wrapper, unlayered type-selector rules ALWAYS beat
  * layered utility classes — the layering algorithm prioritises
  * unlayered rules above ALL layers regardless of specificity. That's
- * what made `<a class={buttonVariants()}>` render text in `var(--accent)`
- * (the global a color) instead of `var(--accent-fg)` (the Tailwind
+ * what made `<a class={buttonVariants()}>` render text in `hsl(var(--primary))`
+ * (the global a color) instead of `hsl(var(--primary-foreground))` (the Tailwind
  * `text-primary-foreground` class) — the anchor was invisible against
  * its primary background.
  *
@@ -30,8 +30,8 @@ body {
 
 @layer base {
   body {
-    background: var(--bg);
-    color: var(--fg);
+    background: hsl(var(--bg));
+    color: hsl(var(--fg));
     font-family: var(--font-sans);
     font-size: var(--fs-md);
     font-weight: var(--weight-normal);
@@ -44,7 +44,7 @@ body {
      space token grid so heading-followed-by-body has consistent rhythm. */
   h1, h2, h3, h4, h5, h6 {
     margin: 0 0 var(--space-3);
-    color: var(--fg);
+    color: hsl(var(--fg));
     font-weight: var(--weight-semibold);
     line-height: var(--lh-tight);
   }
@@ -80,7 +80,7 @@ body {
   }
 
   a {
-    color: var(--accent);
+    color: hsl(var(--primary));
     text-decoration: none;
   }
 
@@ -100,9 +100,9 @@ body {
   align-items: center;
   gap: var(--space-2);
   padding: var(--space-2) var(--space-3);
-  background: var(--bg-muted);
-  color: var(--fg);
-  border: 1px solid var(--border-strong);
+  background: hsl(var(--bg-muted));
+  color: hsl(var(--fg));
+  border: 1px solid hsl(var(--border-strong));
   border-radius: var(--radius-sm);
   cursor: pointer;
   transition:
@@ -112,7 +112,7 @@ body {
 }
 
 .btn:hover:not(:disabled) {
-  background: var(--bg-hover);
+  background: hsl(var(--bg-hover));
 }
 
 .btn:disabled {
@@ -138,7 +138,7 @@ body {
   background: transparent;
   border: 1px solid transparent;
   border-radius: var(--radius-sm);
-  color: var(--fg-muted);
+  color: hsl(var(--fg-muted));
   cursor: pointer;
   transition:
     background var(--duration-fast),
@@ -147,9 +147,9 @@ body {
 }
 
 .icon-btn:hover:not(:disabled) {
-  background: var(--bg-hover);
-  border-color: var(--border);
-  color: var(--fg);
+  background: hsl(var(--bg-hover));
+  border-color: hsl(var(--border));
+  color: hsl(var(--fg));
 }
 
 .icon-btn:disabled {
@@ -158,7 +158,7 @@ body {
 }
 
 .icon-btn--danger:hover:not(:disabled) {
-  color: var(--danger);
+  color: hsl(var(--danger));
 }
 
 /* ----------------------------------------------------------------- *
@@ -186,13 +186,13 @@ body {
 .data-grid td {
   padding: var(--space-3);
   text-align: left;
-  border-bottom: 1px solid var(--border);
+  border-bottom: 1px solid hsl(var(--border));
 }
 
 .data-grid th {
-  background: var(--bg-muted);
+  background: hsl(var(--bg-muted));
   font-weight: var(--weight-semibold);
-  color: var(--fg);
+  color: hsl(var(--fg));
 }
 
 .data-grid tbody tr {
@@ -200,11 +200,11 @@ body {
 }
 
 .data-grid tbody tr:nth-child(even) {
-  background: var(--bg-subtle);
+  background: hsl(var(--bg-subtle));
 }
 
 .data-grid tbody tr:hover {
-  background: var(--bg-hover);
+  background: hsl(var(--bg-hover));
 }
 
 .data-grid__actions {
@@ -215,25 +215,25 @@ body {
 
 .data-grid__empty {
   text-align: center;
-  color: var(--fg-muted);
+  color: hsl(var(--fg-muted));
   padding: var(--space-5);
 }
 
 .btn--primary {
-  background: var(--accent);
-  color: var(--accent-fg);
-  border-color: var(--accent);
+  background: hsl(var(--primary));
+  color: hsl(var(--primary-foreground));
+  border-color: hsl(var(--primary));
   font-weight: var(--weight-semibold);
 }
 
 .btn--primary:hover:not(:disabled) {
-  background: var(--accent-hover);
+  background: hsl(var(--primary-hover));
 }
 
 .btn--danger {
-  background: var(--danger);
+  background: hsl(var(--danger));
   color: #fff;
-  border-color: var(--danger);
+  border-color: hsl(var(--danger));
 }
 
 .field {
@@ -244,16 +244,16 @@ body {
 .field__label {
   display: block;
   margin-bottom: var(--space-1);
-  color: var(--fg-muted);
+  color: hsl(var(--fg-muted));
   font-size: var(--fs-sm);
 }
 
 .field__input {
   width: 100%;
   padding: var(--space-2) var(--space-3);
-  background: var(--bg);
-  color: var(--fg);
-  border: 1px solid var(--border-strong);
+  background: hsl(var(--bg));
+  color: hsl(var(--fg));
+  border: 1px solid hsl(var(--border-strong));
   border-radius: var(--radius-sm);
   transition:
     border-color var(--duration-fast),
@@ -261,7 +261,7 @@ body {
 }
 
 .field__input:focus-visible {
-  border-color: var(--accent);
+  border-color: hsl(var(--primary));
 }
 
 /* Invalid form-field state. Set the .field--invalid modifier on the
@@ -269,12 +269,12 @@ body {
    below renders with an alert icon. Centralized so every form modal
    communicates validation the same way. */
 .field--invalid .field__input {
-  border-color: var(--danger);
+  border-color: hsl(var(--danger));
 }
 
 .field--invalid .field__input:focus-visible {
-  box-shadow: 0 0 0 2px var(--bg), 0 0 0 4px var(--danger);
-  border-color: var(--danger);
+  box-shadow: 0 0 0 2px hsl(var(--bg)), 0 0 0 4px hsl(var(--danger));
+  border-color: hsl(var(--danger));
 }
 
 .field__error {
@@ -282,7 +282,7 @@ body {
   gap: var(--space-1);
   align-items: center;
   margin-top: var(--space-1);
-  color: var(--danger);
+  color: hsl(var(--danger));
   font-size: var(--fs-sm);
 }
 
@@ -293,13 +293,13 @@ body {
 .callout {
   padding: var(--space-3);
   border-radius: var(--radius-sm);
-  background: var(--bg-subtle);
-  border-left: 3px solid var(--accent);
+  background: hsl(var(--bg-subtle));
+  border-left: 3px solid hsl(var(--primary));
 }
 
 .callout--danger {
-  border-left-color: var(--danger);
-  color: var(--danger);
+  border-left-color: hsl(var(--danger));
+  color: hsl(var(--danger));
 }
 
 .callout__text {
@@ -309,7 +309,7 @@ body {
 
 .callout__details {
   margin-top: var(--space-2);
-  color: var(--fg-muted);
+  color: hsl(var(--fg-muted));
   font-weight: var(--weight-normal);
 }
 
@@ -322,13 +322,13 @@ body {
 .callout__detail-text {
   margin: var(--space-2) 0 0;
   padding: var(--space-2);
-  background: var(--bg-muted);
+  background: hsl(var(--bg-muted));
   border-radius: var(--radius-sm);
   font-family: var(--font-mono, ui-monospace, monospace);
   font-size: var(--fs-xs);
   white-space: pre-wrap;
   word-break: break-word;
-  color: var(--fg);
+  color: hsl(var(--fg));
 }
 
 /* Motion baseline. Modals, context menus, and toasts appear instantly

--- a/saiku-ui/src/lib/styles/tailwind.css
+++ b/saiku-ui/src/lib/styles/tailwind.css
@@ -1,103 +1,101 @@
 /*
- * Tailwind v4 entry — saiku-ui side.
+ * Tailwind v4 entry — saiku-ui side (saiku#1636: aligned with saiku-cloud).
  *
- * Why this file exists separately from `tokens.css` + `app.css`:
- *
- *   - `tokens.css` defines the 133 CSS custom properties this codebase
- *     has used as the single source of design truth since the Svelte
- *     port. Every `<style>` block in the codebase resolves
- *     `var(--fg)`, `var(--space-2)`, `var(--accent)` etc. against it.
+ *   - `tokens.css` defines the design tokens as HSL triples (three-tier system
+ *     ported from saiku-cloud). Colour tokens are bare `H S% L%` triples.
  *   - `app.css` is the global base layer (body, headings, button reset,
- *     scrollbar styling) — pre-existing vanilla CSS, NOT a Tailwind
- *     preflight.
- *   - This file (`tailwind.css`) is the new Tailwind v4 surface. We
- *     import the `theme` + `utilities` layers but DELIBERATELY SKIP
- *     `preflight` to avoid clobbering the existing base reset and
- *     the BEM-style component styles. New components reach for
- *     Tailwind utilities; legacy components keep working unchanged.
+ *     scrollbar) — vanilla CSS, NOT a Tailwind preflight.
+ *   - This file is the Tailwind v4 surface. We import `theme` + `utilities`
+ *     but DELIBERATELY SKIP `preflight` so the existing base reset and
+ *     BEM-style component styles are preserved.
  *
- * Compatibility bridge: `@theme inline { --color-fg: var(--fg) }` aliases
- * every existing token onto the Tailwind token namespace so
- * `text-fg`, `bg-bg-subtle`, `p-2`, `rounded-md` all resolve via the
- * same `var(--*)` chain as `var(--fg)`, `var(--bg-subtle)`,
- * `var(--space-2)`, `var(--radius-md)`. Light + dark themes already
- * flip the underlying tokens; Tailwind classes inherit that for free.
- *
- * For API consistency with saiku-cloud-dashboard's design-system
- * primitives, we ALSO alias the canonical names that codebase uses
- * (`destructive`, `foreground`, `background`, `card`, `muted`,
- * `border`, `input`, `ring`) onto saiku-ui's existing tokens. A `Badge`
- * ported verbatim from saiku-cloud needing `text-destructive` will
- * resolve to `var(--danger)` here; consumers can write either idiom.
+ * Bridge: `@theme inline { --color-x: hsl(var(--token)) }` resolves every
+ * `bg-*`/`text-*`/`border-*` utility through the same `hsl(var(--token))` chain
+ * that inline `<style>` blocks use — so utilities and inline styles agree, and
+ * opacity modifiers (`bg-primary/10`) compose correctly. Both the shadcn-shaped
+ * names (`foreground`, `card`, `primary`, `border`, …) and saiku-ui's legacy
+ * names (`fg`, `bg-muted`, `border`, …) resolve to the same tokens.
  */
 @layer theme, base, components, utilities;
 @import "tailwindcss/theme.css" layer(theme);
 @import "tailwindcss/utilities.css" layer(utilities);
 
+/* Tailwind v4 `dark:` variant bound to OUR theme system (explicit
+   [data-theme] override + system pref with the light guard), matching
+   saiku-cloud so ported `dark:` utilities behave identically. */
+@custom-variant dark {
+  &:where(:root[data-theme="dark"], :root[data-theme="dark"] *) {
+    @slot;
+  }
+  @media (prefers-color-scheme: dark) {
+    &:where(:root:not([data-theme="light"]), :root:not([data-theme="light"]) *) {
+      @slot;
+    }
+  }
+}
+
 @theme inline {
-  /* ---- Foreground / background surfaces ---- */
-  --color-fg: var(--fg);
-  --color-fg-muted: var(--fg-muted);
-  --color-fg-subtle: var(--fg-subtle);
-  --color-bg: var(--bg);
-  --color-bg-muted: var(--bg-muted);
-  --color-bg-subtle: var(--bg-subtle);
-  --color-bg-hover: var(--bg-hover);
+  /* ---- Foreground / background surfaces (legacy names) ---- */
+  --color-fg: hsl(var(--fg));
+  --color-fg-muted: hsl(var(--fg-muted));
+  --color-fg-subtle: hsl(var(--fg-subtle));
+  --color-bg: hsl(var(--bg));
+  --color-bg-muted: hsl(var(--bg-muted));
+  --color-bg-subtle: hsl(var(--bg-subtle));
+  --color-bg-hover: hsl(var(--bg-hover));
   --color-bg-overlay: var(--bg-overlay);
 
-  /* ---- Saiku-cloud naming aliases (API parity for shared primitives) ---- */
-  --color-foreground: var(--fg);
-  --color-background: var(--bg);
-  --color-card: var(--bg-muted);
-  --color-card-foreground: var(--fg);
-  --color-popover: var(--bg);
-  --color-popover-foreground: var(--fg);
-  --color-muted: var(--bg-subtle);
-  --color-muted-foreground: var(--fg-muted);
-  --color-input: var(--border);
-  --color-ring: var(--accent);
+  /* ---- shadcn-shaped names (cube-designer + shared primitives) ---- */
+  --color-foreground: hsl(var(--foreground));
+  --color-background: hsl(var(--background));
+  --color-card: hsl(var(--card));
+  --color-card-foreground: hsl(var(--card-foreground));
+  --color-popover: hsl(var(--popover));
+  --color-popover-foreground: hsl(var(--popover-foreground));
+  --color-muted: hsl(var(--muted));
+  --color-muted-foreground: hsl(var(--muted-foreground));
+  --color-input: hsl(var(--input));
+  --color-ring: hsl(var(--ring));
 
   /* ---- Borders ---- */
-  --color-border: var(--border);
-  --color-border-strong: var(--border-strong);
+  --color-border: hsl(var(--border));
+  --color-border-strong: hsl(var(--border-strong));
 
-  /* ---- Brand / accent ---- */
-  --color-accent: var(--accent);
-  --color-accent-hover: var(--accent-hover);
-  --color-accent-foreground: var(--accent-fg);
-  --color-accent-soft: var(--accent-soft);
-  --color-accent-strong: var(--accent-strong);
-  --color-primary: var(--accent);
-  --color-primary-foreground: var(--accent-fg);
-  --color-secondary: var(--bg-muted);
-  --color-secondary-foreground: var(--fg);
+  /* ---- Brand (primary) + pale accent surface ---- */
+  --color-primary: hsl(var(--primary));
+  --color-primary-foreground: hsl(var(--primary-foreground));
+  --color-primary-hover: hsl(var(--primary-hover));
+  --color-primary-strong: hsl(var(--primary-strong));
+  --color-secondary: hsl(var(--secondary));
+  --color-secondary-foreground: hsl(var(--secondary-foreground));
+
+  --color-accent: hsl(var(--accent));
+  --color-accent-foreground: hsl(var(--accent-foreground));
+  /* legacy accent-* Tailwind names → brand family (kept for any stragglers) */
+  --color-accent-hover: hsl(var(--primary-hover));
+  --color-accent-fg: hsl(var(--primary-foreground));
+  --color-accent-soft: hsl(var(--accent));
+  --color-accent-strong: hsl(var(--primary-strong));
 
   /* ---- Status tones ---- */
-  --color-success: var(--success);
-  --color-success-soft: var(--success-soft);
-  --color-success-strong: var(--success-strong);
+  --color-success: hsl(var(--success));
+  --color-success-soft: hsl(var(--success-soft));
+  --color-success-strong: hsl(var(--success-strong));
   --color-success-foreground: #ffffff;
-  --color-warning: var(--warning);
-  --color-warning-soft: var(--warning-soft);
-  --color-warning-strong: var(--warning-strong);
+  --color-warning: hsl(var(--warning));
+  --color-warning-soft: hsl(var(--warning-soft));
+  --color-warning-strong: hsl(var(--warning-strong));
   --color-warning-foreground: #ffffff;
-  --color-info: var(--accent);
-  --color-info-foreground: var(--accent-fg);
-  /* Saiku-ui calls it danger; saiku-cloud calls it destructive. Both
-     resolve to the same value so either idiom works in shared
-     primitives. */
-  --color-danger: var(--danger);
-  --color-danger-soft: var(--danger-soft);
-  --color-danger-strong: var(--danger-strong);
+  --color-info: hsl(var(--info-action));
+  --color-info-foreground: #ffffff;
+  --color-danger: hsl(var(--danger));
+  --color-danger-soft: hsl(var(--danger-soft));
+  --color-danger-strong: hsl(var(--danger-strong));
   --color-danger-foreground: #ffffff;
-  --color-destructive: var(--danger);
+  --color-destructive: hsl(var(--destructive));
   --color-destructive-foreground: #ffffff;
 
-  /* ---- Spacing scale ----
-     Tailwind v4 multiplies the spacing scale by integer + fraction
-     keys against `--spacing` (1 unit = `--spacing`). Mapping our
-     existing 4/8/12/16/24/32/48 ramp to 1/2/3/4/6/8/12 keeps the
-     `p-2` = 8px shape the rest of the world expects. */
+  /* ---- Spacing scale (1 unit = --spacing) ---- */
   --spacing: 4px;
 
   /* ---- Radii ---- */
@@ -109,7 +107,7 @@
   --font-sans: var(--font-sans);
   --font-mono: var(--font-mono);
 
-  /* ---- Type scale (matches saiku-ui's existing token names) ---- */
+  /* ---- Type scale ---- */
   --text-xs: var(--fs-xs);
   --text-sm: var(--fs-sm);
   --text-md: var(--fs-md);

--- a/saiku-ui/src/lib/styles/tokens.css
+++ b/saiku-ui/src/lib/styles/tokens.css
@@ -1,4 +1,36 @@
+/*
+  =============================================================================
+  Saiku Design System — Tokens  (ported from saiku-cloud, saiku#1636)
+  =============================================================================
+
+  Three-tier token architecture, adopted verbatim from saiku-cloud's
+  `dashboard/src/routes/layout.css` so the two products share one visual
+  language:
+
+    1. PRIMITIVES  — raw HSL-triple paint chips (cardinal/clay/slate/…).
+    2. SEMANTIC    — role ramps (primary/neutral/error/success/…), neutral
+                     swaps clay→slate in dark.
+    3. MAPPED      — purpose tokens (page/surface/text/border/action/…), the
+                     only tier components should bind to.
+
+  All colour tokens are BARE HSL TRIPLES (`H S% L%`); consumers wrap them in
+  `hsl(var(--x))` (and can add alpha via `hsl(var(--x) / N)`). The Tailwind
+  bridge (`tailwind.css`) resolves `bg-*`/`text-*`/`border-*` utilities through
+  the same tokens.
+
+  LEGACY COMPAT: saiku-ui shipped a flat, hex-valued token set (`--bg`, `--fg`,
+  `--border`, `--accent`, …). Those names are preserved at the bottom as TRIPLE
+  aliases into the mapped tier, and every `var(--legacy)` consumer was migrated
+  to `hsl(var(--legacy))` — so the whole app renders through one system while
+  existing components keep their token names. The brand action moved from
+  `--accent` (now the pale shadcn "accent" hover surface) to `--primary`.
+
+  Non-colour tokens (spacing/radii/fonts/type/icons/charts/shadows/durations)
+  are saiku-ui's own and stay as plain values.
+*/
+
 :root {
+  /* ── Non-colour scale (saiku-ui) ─────────────────────────────────────── */
   --space-1: 4px;
   --space-2: 8px;
   --space-3: 12px;
@@ -10,12 +42,14 @@
   --radius-sm: 4px;
   --radius-md: 8px;
   --radius-lg: 12px;
+  --radius: 0.5rem; /* shadcn-style default (cube-designer primitives) */
 
   --font-sans:
-    ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+    "Inter", ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto,
+    sans-serif;
   --font-mono:
-    ui-monospace, "SF Mono", Menlo, Monaco, Consolas, "Liberation Mono",
-    "Courier New", monospace;
+    "JetBrains Mono", ui-monospace, "SF Mono", Menlo, Monaco, Consolas,
+    "Liberation Mono", "Courier New", monospace;
 
   --fs-xs: 12px;
   --fs-sm: 13px;
@@ -27,198 +61,482 @@
   --lh-tight: 1.25;
   --lh-normal: 1.5;
 
-  /* Font weight scale. Keep usage to these four steps so weight choices
-     stay deliberate instead of drifting across components. */
   --weight-normal: 400;
   --weight-medium: 500;
   --weight-semibold: 600;
   --weight-bold: 700;
 
-  /* Icon sizes for lucide-svelte components. Keep usage to these four steps.
-     - xs (12px): tree twisties, inline cues
-     - sm (14px): list-row actions, form-field affordances
-     - md (16px): button content, modal close
-     - lg (20px): topbar primary actions, KPI accents */
   --icon-xs: 12px;
   --icon-sm: 14px;
   --icon-md: 16px;
   --icon-lg: 20px;
 
-  /* Categorical chart palette read by ChartView.svelte at runtime and
-     handed to ECharts as the `color: [...]` array. Anchored on the
-     primary --accent so charts feel cohesive with the surrounding UI
-     chrome. Dark theme overrides these below with brighter, lower-
-     saturation variants tuned for legibility on the dark background. */
-  --chart-1: #4f46e5;
-  --chart-2: #0ea5e9;
-  --chart-3: #10b981;
-  --chart-4: #f59e0b;
-  --chart-5: #ef4444;
-  --chart-6: #a855f7;
-  --chart-7: #ec4899;
-  --chart-8: #14b8a6;
+  --duration-fast: 120ms;
+  --duration-normal: 200ms;
 
   --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.06);
   --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.08);
   --shadow-lg: 0 12px 32px rgba(0, 0, 0, 0.16);
 
-  --duration-fast: 120ms;
-  --duration-normal: 200ms;
+  /* Categorical chart palette (ECharts). Kept as-is — consumed as full
+     colours via `var(--chart-N)`, not through the hsl() token chain. */
+  --chart-1: #b0182a; /* saiku red — re-anchored to the new brand */
+  --chart-2: #0ea5e9;
+  --chart-3: #10b981;
+  --chart-4: #f59e0b;
+  --chart-5: #a855f7;
+  --chart-6: #ec4899;
+  --chart-7: #14b8a6;
+  --chart-8: #6366f1;
 
   color-scheme: light;
 
-  --bg: #ffffff;
-  --bg-muted: #f6f7f9;
-  --bg-subtle: #eef0f3;
-  --bg-hover: #e2e6ec;
-  --bg-overlay: rgba(15, 23, 42, 0.32);
-  --fg: #0f172a;
-  --fg-muted: #475569;
-  --fg-subtle: #556378;
-  --border: #e2e8f0;
-  --border-strong: #cbd5e1;
+  /* =====================================================================
+     TIER 1 — PRIMITIVES (single mode; HSL triples)
+     ================================================================== */
+  --cardinal-25: 353 60% 98%;
+  --cardinal-50: 353 65% 96%;
+  --cardinal-100: 353 68% 90%;
+  --cardinal-200: 353 72% 80%;
+  --cardinal-300: 353 75% 68%;
+  --cardinal-400: 353 76% 58%;
+  --cardinal-500: 353 76% 48%;
+  --cardinal-600: 353 76% 42%;
+  --cardinal-700: 353 76% 39%; /* saiku red canonical */
+  --cardinal-800: 353 72% 30%;
+  --cardinal-900: 353 65% 22%;
+  --cardinal-950: 353 55% 12%;
 
-  --accent: #4f46e5;
-  --accent-hover: #4338ca;
-  --accent-fg: #ffffff;
-  --accent-soft: #eef2ff;
-  --accent-strong: #3730a3;
-  --danger: #dc2626;
-  --danger-soft: #fef2f2;
-  --danger-strong: #991b1b;
-  --success: #16a34a;
-  --success-soft: #ecfdf5;
-  --success-strong: #047857;
-  --warning: #d97706;
-  --warning-soft: #fffbeb;
-  --warning-strong: #b45309;
+  --clay-25: 36 24% 99%;
+  --clay-50: 36 22% 96%;
+  --clay-100: 36 20% 92%;
+  --clay-200: 36 18% 84%;
+  --clay-300: 36 15% 72%;
+  --clay-400: 32 12% 58%;
+  --clay-500: 28 10% 46%;
+  --clay-600: 24 10% 36%;
+  --clay-700: 20 12% 26%;
+  --clay-800: 20 14% 18%;
+  --clay-900: 20 16% 12%;
+  --clay-950: 20 18% 6%;
 
-  --focus-ring: 0 0 0 2px var(--bg), 0 0 0 4px var(--accent);
+  --slate-25: 220 15% 99%;
+  --slate-50: 220 15% 96%;
+  --slate-100: 220 14% 88%;
+  --slate-200: 220 12% 76%;
+  --slate-300: 220 10% 62%;
+  --slate-400: 220 10% 50%;
+  --slate-500: 220 10% 40%;
+  --slate-600: 220 12% 30%;
+  --slate-700: 220 13% 22%;
+  --slate-800: 220 14% 16%;
+  --slate-900: 220 15% 10%;
+  --slate-950: 220 15% 6%;
+
+  --meadow-25: 158 40% 98%;
+  --meadow-50: 158 45% 94%;
+  --meadow-100: 158 50% 88%;
+  --meadow-200: 158 55% 76%;
+  --meadow-300: 158 60% 60%;
+  --meadow-400: 158 62% 46%;
+  --meadow-500: 158 64% 38%;
+  --meadow-600: 158 64% 30%;
+  --meadow-700: 158 66% 24%;
+  --meadow-800: 158 68% 18%;
+  --meadow-900: 158 70% 12%;
+  --meadow-950: 158 72% 6%;
+
+  --honey-25: 32 65% 98%;
+  --honey-50: 32 70% 94%;
+  --honey-100: 32 75% 88%;
+  --honey-200: 32 80% 76%;
+  --honey-300: 32 85% 62%;
+  --honey-400: 32 88% 52%;
+  --honey-500: 32 90% 44%;
+  --honey-600: 32 90% 38%;
+  --honey-700: 32 90% 30%;
+  --honey-800: 32 90% 22%;
+  --honey-900: 32 90% 14%;
+  --honey-950: 32 90% 8%;
+
+  --rose-25: 0 60% 98%;
+  --rose-50: 0 65% 96%;
+  --rose-100: 0 70% 90%;
+  --rose-200: 0 72% 82%;
+  --rose-300: 0 74% 70%;
+  --rose-400: 0 75% 60%;
+  --rose-500: 0 75% 50%;
+  --rose-600: 0 72% 42%;
+  --rose-700: 0 70% 34%;
+  --rose-800: 0 68% 26%;
+  --rose-900: 0 65% 18%;
+  --rose-950: 0 55% 10%;
+
+  --azure-25: 217 65% 98%;
+  --azure-50: 217 70% 94%;
+  --azure-100: 217 75% 88%;
+  --azure-200: 217 78% 76%;
+  --azure-300: 217 80% 62%;
+  --azure-400: 217 80% 55%;
+  --azure-500: 217 80% 45%;
+  --azure-600: 217 82% 38%;
+  --azure-700: 217 84% 30%;
+  --azure-800: 217 86% 22%;
+  --azure-900: 217 88% 14%;
+  --azure-950: 217 90% 8%;
+
+  --white: 0 0% 100%;
+  --black: 0 0% 0%;
+
+  /* =====================================================================
+     TIER 2 — SEMANTIC (roles, Light values)
+     ================================================================== */
+  --primary-25: var(--cardinal-25);
+  --primary-50: var(--cardinal-50);
+  --primary-100: var(--cardinal-100);
+  --primary-200: var(--cardinal-200);
+  --primary-300: var(--cardinal-300);
+  --primary-400: var(--cardinal-400);
+  --primary-500: var(--cardinal-500);
+  --primary-600: var(--cardinal-600);
+  --primary-700: var(--cardinal-700);
+  --primary-800: var(--cardinal-800);
+  --primary-900: var(--cardinal-900);
+
+  --neutral-25: var(--clay-25);
+  --neutral-50: var(--clay-50);
+  --neutral-100: var(--clay-100);
+  --neutral-200: var(--clay-200);
+  --neutral-300: var(--clay-300);
+  --neutral-400: var(--clay-400);
+  --neutral-500: var(--clay-500);
+  --neutral-600: var(--clay-600);
+  --neutral-700: var(--clay-700);
+  --neutral-800: var(--clay-800);
+  --neutral-900: var(--clay-900);
+
+  --error-25: var(--rose-25);
+  --error-50: var(--rose-50);
+  --error-100: var(--rose-100);
+  --error-200: var(--rose-200);
+  --error-300: var(--rose-300);
+  --error-400: var(--rose-400);
+  --error-500: var(--rose-500);
+  --error-600: var(--rose-600);
+  --error-700: var(--rose-700);
+  --error-800: var(--rose-800);
+  --error-900: var(--rose-900);
+
+  --success-25: var(--meadow-25);
+  --success-50: var(--meadow-50);
+  --success-100: var(--meadow-100);
+  --success-200: var(--meadow-200);
+  --success-300: var(--meadow-300);
+  --success-400: var(--meadow-400);
+  --success-500: var(--meadow-500);
+  --success-600: var(--meadow-600);
+  --success-700: var(--meadow-700);
+  --success-800: var(--meadow-800);
+  --success-900: var(--meadow-900);
+
+  --warning-25: var(--honey-25);
+  --warning-50: var(--honey-50);
+  --warning-100: var(--honey-100);
+  --warning-200: var(--honey-200);
+  --warning-300: var(--honey-300);
+  --warning-400: var(--honey-400);
+  --warning-500: var(--honey-500);
+  --warning-600: var(--honey-600);
+  --warning-700: var(--honey-700);
+  --warning-800: var(--honey-800);
+  --warning-900: var(--honey-900);
+
+  --info-25: var(--azure-25);
+  --info-50: var(--azure-50);
+  --info-100: var(--azure-100);
+  --info-200: var(--azure-200);
+  --info-300: var(--azure-300);
+  --info-400: var(--azure-400);
+  --info-500: var(--azure-500);
+  --info-600: var(--azure-600);
+  --info-700: var(--azure-700);
+  --info-800: var(--azure-800);
+  --info-900: var(--azure-900);
+
+  /* =====================================================================
+     TIER 3 — MAPPED (purpose tokens, Light values)
+     ================================================================== */
+  --page: var(--neutral-25);
+  --surface-raised: var(--neutral-50);
+  --surface-elevated: var(--neutral-25);
+  --surface-inverse: var(--neutral-900);
+
+  --text-primary: var(--neutral-900);
+  --text-secondary: var(--neutral-700);
+  --text-muted: var(--neutral-500);
+  --text-inverse: var(--white);
+
+  --action-a: var(--primary-700);
+  --action-a-hover: var(--primary-800);
+  --action-a-pressed: var(--primary-800);
+  --focus-a: var(--primary-500);
+  --on-action-a: var(--white);
+
+  --action-b: var(--neutral-100);
+  --action-b-hover: var(--neutral-200);
+  --action-b-pressed: var(--neutral-300);
+  --on-action-b: var(--neutral-900);
+
+  --error-action: var(--error-500);
+  --error-action-hover: var(--error-600);
+  --error-pale: var(--error-50);
+  --on-error-action: var(--white);
+  --error-text: var(--error-600);
+
+  --success-action: var(--success-500);
+  --success-pale: var(--success-50);
+  --success-text: var(--success-600);
+  --on-success-action: var(--white);
+
+  --warning-action: var(--warning-500);
+  --warning-pale: var(--warning-50);
+  --warning-text: var(--warning-600);
+  --on-warning-action: var(--white);
+
+  --info-action: var(--info-500);
+  --info-pale: var(--info-50);
+  --info-text: var(--info-600);
+  --on-info-action: var(--white);
+
+  --border-subtle: var(--neutral-200);
+  --border-default: var(--neutral-300);
+  --border-emphasis: var(--neutral-400);
+  --border-focus: var(--primary-500);
+
+  --accent-surface: var(--primary-50);
+  --on-accent-surface: var(--neutral-900);
+
+  --elevation-0: var(--neutral-25);
+  --elevation-1: var(--neutral-50);
+  --elevation-2: var(--white);
+  --elevation-3: var(--neutral-50);
+  --elevation-4: var(--white);
+
+  /* =====================================================================
+     BRIDGE — shadcn-shaped names (used by cube-designer + shared primitives)
+     ================================================================== */
+  --background: var(--page);
+  --foreground: var(--text-primary);
+  --card: var(--surface-raised);
+  --card-foreground: var(--text-primary);
+  --popover: var(--surface-elevated);
+  --popover-foreground: var(--text-primary);
+
+  --primary: var(--action-a);
+  --primary-foreground: var(--on-action-a);
+  --ring: var(--focus-a);
+
+  --secondary: var(--action-b);
+  --secondary-foreground: var(--on-action-b);
+  --muted: var(--action-b);
+  --muted-foreground: var(--text-muted);
+
+  --accent: var(--accent-surface);
+  --accent-foreground: var(--on-accent-surface);
+
+  --destructive: var(--error-action);
+  --destructive-foreground: var(--on-error-action);
+
+  --input: var(--border-subtle);
+
+  --elev-0: var(--elevation-0);
+  --elev-1: var(--elevation-1);
+  --elev-2: var(--elevation-2);
+  --elev-3: var(--elevation-3);
+  --elev-4: var(--elevation-4);
+
+  /* =====================================================================
+     LEGACY COMPAT — saiku-ui's original flat names → mapped tier (triples).
+     Consumers were migrated to hsl(var(--x)). Brand action is --primary now;
+     legacy --accent* brand usages were migrated to --primary*.
+     ================================================================== */
+  --bg: var(--page);
+  --bg-muted: var(--surface-raised);
+  --bg-subtle: var(--action-b);
+  --bg-hover: var(--action-b-hover);
+  --fg: var(--text-primary);
+  --fg-muted: var(--text-secondary);
+  --fg-subtle: var(--text-muted);
+  --border: var(--border-subtle);
+  --border-strong: var(--border-default);
+
+  /* brand (was --accent; now split from the pale shadcn accent surface) */
+  --primary-hover: var(--action-a-hover);
+  --primary-strong: var(--action-a-pressed);
+
+  --danger: var(--error-action);
+  --danger-soft: var(--error-pale);
+  --danger-strong: var(--error-text);
+  --success: var(--success-action);
+  --success-soft: var(--success-pale);
+  --success-strong: var(--success-text);
+  --warning: var(--warning-action);
+  --warning-soft: var(--warning-pale);
+  --warning-strong: var(--warning-text);
+
+  /* Full-value colour tokens (NOT triples — consumed directly). */
+  --bg-overlay: hsl(20 16% 12% / 0.32);
+  --focus-ring:
+    0 0 0 2px hsl(var(--bg)), 0 0 0 4px hsl(var(--primary));
 }
 
+/* ============================================================================
+   DARK MODE — explicit override AND system pref (with :not([data-theme=light])
+   guard so a user's light pick beats the OS). Mirrors saiku-cloud exactly.
+   ========================================================================= */
 @media (prefers-color-scheme: dark) {
-  :root {
+  :root:not([data-theme="light"]) {
     color-scheme: dark;
 
-    --bg: #0b0d12;
-    --bg-muted: #11141b;
-    --bg-subtle: #1a1e27;
-    --bg-hover: #242935;
-    --bg-overlay: rgba(0, 0, 0, 0.6);
-    --fg: #e6e8ec;
-    --fg-muted: #a8aeba;
-    --fg-subtle: #8b94a3;
-    --border: #242935;
-    --border-strong: #333a49;
+    --neutral-25: var(--slate-25);
+    --neutral-50: var(--slate-50);
+    --neutral-100: var(--slate-100);
+    --neutral-200: var(--slate-200);
+    --neutral-300: var(--slate-300);
+    --neutral-400: var(--slate-400);
+    --neutral-500: var(--slate-500);
+    --neutral-600: var(--slate-600);
+    --neutral-700: var(--slate-700);
+    --neutral-800: var(--slate-800);
+    --neutral-900: var(--slate-900);
 
-    --accent: #818cf8;
-    --accent-hover: #a5b4fc;
-    --accent-fg: #0b0d12;
-    --accent-soft: #1e1b4b;
-    --accent-strong: #c7d2fe;
-    --danger: #ef4444;
-    --danger-soft: #2a1212;
-    --danger-strong: #fca5a5;
-    --success: #22c55e;
-    --success-soft: #0d2a1a;
-    --success-strong: #86efac;
-    --warning: #f59e0b;
-    --warning-soft: #2b1d09;
-    --warning-strong: #fcd34d;
+    --page: var(--neutral-900);
+    --surface-raised: var(--neutral-800);
+    --surface-elevated: var(--neutral-800);
+    --surface-inverse: var(--neutral-25);
 
-    --chart-1: #818cf8;
-    --chart-2: #38bdf8;
-    --chart-3: #34d399;
-    --chart-4: #fbbf24;
-    --chart-5: #f87171;
-    --chart-6: #c084fc;
-    --chart-7: #f472b6;
-    --chart-8: #2dd4bf;
+    --text-primary: var(--neutral-25);
+    --text-secondary: var(--neutral-200);
+    --text-muted: var(--neutral-400);
+    --text-inverse: var(--neutral-900);
 
-    --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.5);
-    --shadow-md: 0 4px 16px rgba(0, 0, 0, 0.6);
-    --shadow-lg: 0 12px 40px rgba(0, 0, 0, 0.7);
+    --action-a: var(--primary-400);
+    --action-a-hover: var(--primary-300);
+    --action-a-pressed: var(--primary-300);
+    --focus-a: var(--primary-400);
+
+    --action-b: var(--neutral-700);
+    --action-b-hover: var(--neutral-600);
+    --action-b-pressed: var(--neutral-500);
+    --on-action-b: var(--neutral-25);
+
+    --error-action: var(--error-400);
+    --error-action-hover: var(--error-300);
+    --error-pale: var(--error-800);
+    --error-text: var(--error-300);
+
+    --success-action: var(--success-400);
+    --success-pale: var(--success-800);
+    --success-text: var(--success-300);
+
+    --warning-action: var(--warning-400);
+    --warning-pale: var(--warning-800);
+    --warning-text: var(--warning-300);
+
+    --info-action: var(--info-400);
+    --info-pale: var(--info-800);
+    --info-text: var(--info-300);
+
+    --border-subtle: var(--neutral-700);
+    --border-default: var(--neutral-600);
+    --border-emphasis: var(--neutral-500);
+
+    --accent-surface: var(--primary-900);
+    --on-accent-surface: var(--neutral-25);
+
+    --elevation-0: var(--neutral-900);
+    --elevation-1: var(--neutral-800);
+    --elevation-2: 220 14% 20%;
+    --elevation-3: var(--neutral-700);
+    --elevation-4: 220 14% 20%;
+
+    --bg-overlay: hsl(0 0% 0% / 0.6);
   }
 }
 
 :root[data-theme="dark"] {
   color-scheme: dark;
 
-  --bg: #0b0d12;
-  --bg-muted: #11141b;
-  --bg-subtle: #1a1e27;
-  --bg-hover: #242935;
-  --bg-overlay: rgba(0, 0, 0, 0.6);
-  --fg: #e6e8ec;
-  --fg-muted: #a8aeba;
-  --fg-subtle: #8b94a3;
-  --border: #242935;
-  --border-strong: #333a49;
+  --neutral-25: var(--slate-25);
+  --neutral-50: var(--slate-50);
+  --neutral-100: var(--slate-100);
+  --neutral-200: var(--slate-200);
+  --neutral-300: var(--slate-300);
+  --neutral-400: var(--slate-400);
+  --neutral-500: var(--slate-500);
+  --neutral-600: var(--slate-600);
+  --neutral-700: var(--slate-700);
+  --neutral-800: var(--slate-800);
+  --neutral-900: var(--slate-900);
 
-  --accent: #818cf8;
-  --accent-hover: #a5b4fc;
-  --accent-fg: #0b0d12;
-  --accent-soft: #1e1b4b;
-  --accent-strong: #c7d2fe;
-  --danger: #ef4444;
-  --danger-soft: #2a1212;
-  --danger-strong: #fca5a5;
-  --success: #22c55e;
-  --success-soft: #0d2a1a;
-  --success-strong: #86efac;
-  --warning: #f59e0b;
-  --warning-soft: #2b1d09;
-  --warning-strong: #fcd34d;
+  --page: var(--neutral-900);
+  --surface-raised: var(--neutral-800);
+  --surface-elevated: var(--neutral-800);
+  --surface-inverse: var(--neutral-25);
 
-  --chart-1: #818cf8;
+  --text-primary: var(--neutral-25);
+  --text-secondary: var(--neutral-200);
+  --text-muted: var(--neutral-400);
+  --text-inverse: var(--neutral-900);
+
+  --action-a: var(--primary-400);
+  --action-a-hover: var(--primary-300);
+  --action-a-pressed: var(--primary-300);
+  --focus-a: var(--primary-400);
+
+  --action-b: var(--neutral-700);
+  --action-b-hover: var(--neutral-600);
+  --action-b-pressed: var(--neutral-500);
+  --on-action-b: var(--neutral-25);
+
+  --error-action: var(--error-400);
+  --error-action-hover: var(--error-300);
+  --error-pale: var(--error-800);
+  --error-text: var(--error-300);
+
+  --success-action: var(--success-400);
+  --success-pale: var(--success-800);
+  --success-text: var(--success-300);
+
+  --warning-action: var(--warning-400);
+  --warning-pale: var(--warning-800);
+  --warning-text: var(--warning-300);
+
+  --info-action: var(--info-400);
+  --info-pale: var(--info-800);
+  --info-text: var(--info-300);
+
+  --border-subtle: var(--neutral-700);
+  --border-default: var(--neutral-600);
+  --border-emphasis: var(--neutral-500);
+
+  --accent-surface: var(--primary-900);
+  --on-accent-surface: var(--neutral-25);
+
+  --elevation-0: var(--neutral-900);
+  --elevation-1: var(--neutral-800);
+  --elevation-2: 220 14% 20%;
+  --elevation-3: var(--neutral-700);
+  --elevation-4: 220 14% 20%;
+
+  --bg-overlay: hsl(0 0% 0% / 0.6);
+
+  --chart-1: #ef5a6b;
   --chart-2: #38bdf8;
   --chart-3: #34d399;
   --chart-4: #fbbf24;
-  --chart-5: #f87171;
-  --chart-6: #c084fc;
-  --chart-7: #f472b6;
-  --chart-8: #2dd4bf;
-
-  --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.5);
-  --shadow-md: 0 4px 16px rgba(0, 0, 0, 0.6);
-  --shadow-lg: 0 12px 40px rgba(0, 0, 0, 0.7);
-}
-
-:root[data-theme="light"] {
-  color-scheme: light;
-
-  --bg: #ffffff;
-  --bg-muted: #f6f7f9;
-  --bg-subtle: #eef0f3;
-  --bg-hover: #e2e6ec;
-  --bg-overlay: rgba(15, 23, 42, 0.32);
-  --fg: #0f172a;
-  --fg-muted: #475569;
-  --fg-subtle: #556378;
-  --border: #e2e8f0;
-  --border-strong: #cbd5e1;
-
-  --accent: #4f46e5;
-  --accent-hover: #4338ca;
-  --accent-fg: #ffffff;
-  --accent-soft: #eef2ff;
-  --accent-strong: #3730a3;
-  --danger: #dc2626;
-  --danger-soft: #fef2f2;
-  --danger-strong: #991b1b;
-  --success: #16a34a;
-  --success-soft: #ecfdf5;
-  --success-strong: #047857;
-  --warning: #d97706;
-  --warning-soft: #fffbeb;
-  --warning-strong: #b45309;
-
-  --chart-1: #4f46e5;
-  --chart-2: #0ea5e9;
-  --chart-3: #10b981;
-  --chart-4: #f59e0b;
-  --chart-5: #ef4444;
-  --chart-6: #a855f7;
-  --chart-7: #ec4899;
-  --chart-8: #14b8a6;
+  --chart-5: #c084fc;
+  --chart-6: #f472b6;
+  --chart-7: #2dd4bf;
+  --chart-8: #818cf8;
 }

--- a/saiku-ui/src/lib/views/AiDashboardBuildingOverlay.svelte
+++ b/saiku-ui/src/lib/views/AiDashboardBuildingOverlay.svelte
@@ -48,7 +48,7 @@
     <div
       class="flex w-[420px] max-w-[90vw] flex-col items-center gap-4 rounded-lg border border-border bg-bg px-8 py-7 text-center shadow-lg"
     >
-      <Loader2 size={32} class="animate-spin text-accent" aria-hidden="true" />
+      <Loader2 size={32} class="animate-spin text-primary" aria-hidden="true" />
       <div class="text-lg font-semibold text-fg">
         {i18n.t("workspace.aiDashboard.buildingTitle", "Building your dashboard…")}
       </div>

--- a/saiku-ui/src/lib/views/AiEmailPreparingPopup.svelte
+++ b/saiku-ui/src/lib/views/AiEmailPreparingPopup.svelte
@@ -25,7 +25,7 @@
     <div
       class="flex items-center gap-3 rounded-lg border border-border bg-bg px-6 py-4 text-fg shadow-lg"
     >
-      <Loader2 size={20} class="animate-spin text-accent" aria-hidden="true" />
+      <Loader2 size={20} class="animate-spin text-primary" aria-hidden="true" />
       <span class="text-sm font-medium">
         {i18n.t("workspace.aiEmail.preparing", "Preparing your email…")}
       </span>

--- a/saiku-ui/src/lib/views/AiQueryDrawer.svelte
+++ b/saiku-ui/src/lib/views/AiQueryDrawer.svelte
@@ -1077,15 +1077,15 @@
        caps at the viewport so a misclick dragging past the left edge can't
        eat the canvas entirely. */
     max-width: 100vw;
-    background: var(--bg);
-    border-left: 1px solid var(--border);
+    background: hsl(var(--bg));
+    border-left: 1px solid hsl(var(--border));
     box-shadow: -8px 0 24px rgba(0, 0, 0, 0.08);
     display: flex;
     flex-direction: column;
     transform: translateX(100%);
     transition: transform 0.18s ease-out;
     z-index: 100;
-    color: var(--fg);
+    color: hsl(var(--fg));
   }
   /* Suspend the slide-in transition while resizing so the width change
      follows the cursor 1:1 instead of easing per-frame. */
@@ -1111,15 +1111,15 @@
   }
   .ai-drawer__resize:hover,
   .ai-drawer--resizing .ai-drawer__resize {
-    background: color-mix(in srgb, var(--accent) 40%, transparent);
+    background: color-mix(in srgb, hsl(var(--primary)) 40%, transparent);
   }
   .ai-drawer__header {
     display: flex;
     align-items: center;
     gap: 8px;
     padding: 12px 14px;
-    border-bottom: 1px solid var(--border);
-    background: var(--bg-muted);
+    border-bottom: 1px solid hsl(var(--border));
+    background: hsl(var(--bg-muted));
     /* Pin header + footer against any squeeze when `messages` swells —
        previously a tall conversation could nudge the footer below the
        viewport on short windows. */
@@ -1136,15 +1136,15 @@
     justify-content: center;
     background: transparent;
     border: 1px solid transparent;
-    color: var(--fg-muted);
+    color: hsl(var(--fg-muted));
     border-radius: 6px;
     padding: 5px;
     cursor: pointer;
   }
   .ai-drawer__icon-btn:hover {
-    background: var(--bg);
-    border-color: var(--border);
-    color: var(--fg);
+    background: hsl(var(--bg));
+    border-color: hsl(var(--border));
+    color: hsl(var(--fg));
   }
   .ai-drawer__banner {
     margin: 12px 14px 0;
@@ -1160,10 +1160,10 @@
   }
   .ai-drawer__banner p {
     margin: 0;
-    color: var(--fg-muted);
+    color: hsl(var(--fg-muted));
   }
   .ai-drawer__empty {
-    color: var(--fg-muted);
+    color: hsl(var(--fg-muted));
     font-size: 0.9rem;
     line-height: 1.5;
   }
@@ -1172,7 +1172,7 @@
   }
   .ai-drawer__empty-cube {
     font-size: 0.8rem;
-    color: var(--fg-muted);
+    color: hsl(var(--fg-muted));
   }
   .ai-drawer__empty-cube--warn {
     color: #b45309;
@@ -1185,23 +1185,23 @@
   }
   .ai-drawer__examples-label {
     font-size: 0.78rem;
-    color: var(--fg-muted);
+    color: hsl(var(--fg-muted));
     margin-bottom: 2px;
   }
   .ai-drawer__example {
     text-align: left;
-    background: var(--bg);
-    border: 1px solid var(--border);
+    background: hsl(var(--bg));
+    border: 1px solid hsl(var(--border));
     border-radius: 6px;
     padding: 8px 10px;
     font-size: 0.85rem;
-    color: var(--fg);
+    color: hsl(var(--fg));
     cursor: pointer;
     font-family: inherit;
   }
   .ai-drawer__example:hover {
-    border-color: var(--accent);
-    background: var(--bg-muted);
+    border-color: hsl(var(--primary));
+    background: hsl(var(--bg-muted));
   }
   .ai-drawer__turn {
     display: flex;
@@ -1222,7 +1222,7 @@
     word-break: break-word;
   }
   .ai-drawer__bubble--user {
-    background: var(--accent);
+    background: hsl(var(--primary));
     color: white;
   }
   .ai-drawer__bubble--error {
@@ -1235,25 +1235,25 @@
   }
   .ai-drawer__candidates-label {
     font-size: 0.8rem;
-    color: var(--fg-muted);
+    color: hsl(var(--fg-muted));
     margin-bottom: 4px;
   }
   .ai-drawer__chip {
-    background: var(--bg);
-    border: 1px solid var(--border);
+    background: hsl(var(--bg));
+    border: 1px solid hsl(var(--border));
     border-radius: 999px;
     padding: 3px 9px;
     font-size: 0.78rem;
-    color: var(--fg);
+    color: hsl(var(--fg));
     cursor: pointer;
   }
   .ai-drawer__chip:hover {
-    background: var(--bg-muted);
-    border-color: var(--accent);
+    background: hsl(var(--bg-muted));
+    border-color: hsl(var(--primary));
   }
   .ai-drawer__mdx {
     margin-top: 10px;
-    border-top: 1px solid var(--border);
+    border-top: 1px solid hsl(var(--border));
     padding-top: 8px;
   }
   .ai-drawer__mdx-toggle {
@@ -1262,19 +1262,19 @@
     gap: 4px;
     background: transparent;
     border: 0;
-    color: var(--fg-muted);
+    color: hsl(var(--fg-muted));
     font-size: 0.78rem;
     cursor: pointer;
     padding: 2px 4px;
   }
   .ai-drawer__mdx-toggle:hover {
-    color: var(--fg);
+    color: hsl(var(--fg));
   }
   .ai-drawer__mdx-pre {
     margin: 6px 0;
     padding: 8px;
-    background: var(--bg);
-    border: 1px solid var(--border);
+    background: hsl(var(--bg));
+    border: 1px solid hsl(var(--border));
     border-radius: 6px;
     font-size: 0.75rem;
     overflow-x: auto;
@@ -1285,30 +1285,30 @@
     display: inline-flex;
     align-items: center;
     gap: 4px;
-    background: var(--bg);
-    border: 1px solid var(--border);
-    color: var(--fg);
+    background: hsl(var(--bg));
+    border: 1px solid hsl(var(--border));
+    color: hsl(var(--fg));
     border-radius: 6px;
     padding: 4px 9px;
     font-size: 0.78rem;
     cursor: pointer;
   }
   .ai-drawer__small-btn:hover {
-    background: var(--bg-muted);
+    background: hsl(var(--bg-muted));
   }
   .ai-drawer__small-btn--primary {
-    background: var(--accent);
-    border-color: var(--accent);
+    background: hsl(var(--primary));
+    border-color: hsl(var(--primary));
     color: white;
   }
   .ai-drawer__small-btn--primary:hover {
     filter: brightness(0.95);
-    background: var(--accent);
+    background: hsl(var(--primary));
   }
   .ai-drawer__model {
     margin-top: 6px;
     font-size: 0.72rem;
-    color: var(--fg-muted);
+    color: hsl(var(--fg-muted));
     font-style: italic;
   }
   /* Insight / view-change badges sit above the bubble title so the user can
@@ -1320,7 +1320,7 @@
     font-size: 0.68rem;
     text-transform: uppercase;
     letter-spacing: 0.06em;
-    color: var(--accent);
+    color: hsl(var(--primary));
     margin-bottom: 4px;
     font-weight: 600;
   }
@@ -1333,7 +1333,7 @@
   .ai-drawer__insight-body {
     font-size: 0.85rem;
     line-height: 1.5;
-    color: var(--fg);
+    color: hsl(var(--fg));
   }
   .ai-drawer__insight-body :global(h3),
   .ai-drawer__insight-body :global(h4),
@@ -1341,13 +1341,13 @@
   .ai-drawer__insight-body :global(h6) {
     font-weight: 600;
     margin: 12px 0 4px;
-    color: var(--fg);
+    color: hsl(var(--fg));
     line-height: 1.3;
   }
   .ai-drawer__insight-body :global(h3) { font-size: 0.95rem; }
   .ai-drawer__insight-body :global(h4) { font-size: 0.9rem; }
   .ai-drawer__insight-body :global(h5),
-  .ai-drawer__insight-body :global(h6) { font-size: 0.85rem; color: var(--fg-muted); }
+  .ai-drawer__insight-body :global(h6) { font-size: 0.85rem; color: hsl(var(--fg-muted)); }
   .ai-drawer__insight-body :global(h3:first-child),
   .ai-drawer__insight-body :global(h4:first-child) { margin-top: 0; }
   .ai-drawer__insight-body :global(p) {
@@ -1363,17 +1363,17 @@
   }
   .ai-drawer__insight-body :global(strong) {
     font-weight: 600;
-    color: var(--fg);
+    color: hsl(var(--fg));
   }
   .ai-drawer__insight-body :global(code) {
     font-family: ui-monospace, SFMono-Regular, monospace;
     font-size: 0.8rem;
-    background: var(--bg-subtle);
+    background: hsl(var(--bg-subtle));
     padding: 1px 4px;
     border-radius: 3px;
   }
   .ai-drawer__insight-body :global(a) {
-    color: var(--accent);
+    color: hsl(var(--primary));
     text-decoration: underline;
   }
   /* Mode picker — segmented control above the textarea. Pill row, active gets
@@ -1388,8 +1388,8 @@
     flex: 1 1 auto;
     min-width: 0;
     background: transparent;
-    color: var(--fg-muted);
-    border: 1px solid var(--border);
+    color: hsl(var(--fg-muted));
+    border: 1px solid hsl(var(--border));
     border-radius: 999px;
     padding: 3px 10px;
     font-size: 0.72rem;
@@ -1397,17 +1397,17 @@
     transition: background 120ms ease, color 120ms ease, border-color 120ms ease;
   }
   .ai-drawer__mode-btn:hover:not(:disabled) {
-    background: var(--bg-subtle);
-    color: var(--fg);
+    background: hsl(var(--bg-subtle));
+    color: hsl(var(--fg));
   }
   .ai-drawer__mode-btn:disabled {
     opacity: 0.5;
     cursor: not-allowed;
   }
   .ai-drawer__mode-btn--active {
-    background: color-mix(in srgb, var(--accent) 14%, transparent);
-    color: var(--accent);
-    border-color: var(--accent);
+    background: color-mix(in srgb, hsl(var(--primary)) 14%, transparent);
+    color: hsl(var(--primary));
+    border-color: hsl(var(--primary));
     font-weight: 600;
   }
   /* "Build & report" opt-in toggle — sits between the mode bar and the input row. Plain
@@ -1426,15 +1426,15 @@
     gap: 6px;
     width: fit-content;
     font-size: 0.78rem;
-    color: var(--fg-muted);
+    color: hsl(var(--fg-muted));
     cursor: pointer;
   }
   .ai-drawer__chain-toggle input {
-    accent-color: var(--accent);
+    accent-color: hsl(var(--primary));
     cursor: pointer;
   }
   .ai-drawer__chain-toggle:has(input:checked) {
-    color: var(--fg);
+    color: hsl(var(--fg));
     font-weight: 600;
   }
   .ai-drawer__chain-toggle:has(input:disabled) {
@@ -1445,14 +1445,14 @@
      short successful turns don't flash it. */
   .ai-drawer__elapsed {
     font-size: 0.72rem;
-    color: var(--fg-muted);
+    color: hsl(var(--fg-muted));
     margin-left: 6px;
   }
   .ai-drawer__dot {
     width: 6px;
     height: 6px;
     border-radius: 50%;
-    background: var(--fg-muted);
+    background: hsl(var(--fg-muted));
     animation: ai-drawer-pulse 1.2s ease-in-out infinite;
   }
   .ai-drawer__dot:nth-child(2) {
@@ -1481,24 +1481,24 @@
     min-height: 72px;
     max-height: 200px;
     padding: 8px 10px;
-    border: 1px solid var(--border);
+    border: 1px solid hsl(var(--border));
     border-radius: 6px;
-    background: var(--bg);
-    color: var(--fg);
+    background: hsl(var(--bg));
+    color: hsl(var(--fg));
     font-family: inherit;
     font-size: 0.9rem;
   }
   .ai-drawer__input:focus {
-    outline: 2px solid var(--accent);
+    outline: 2px solid hsl(var(--primary));
     outline-offset: -1px;
-    border-color: var(--accent);
+    border-color: hsl(var(--primary));
   }
   .ai-drawer__submit {
     display: inline-flex;
     align-items: center;
     gap: 6px;
-    background: var(--accent);
-    border: 1px solid var(--accent);
+    background: hsl(var(--primary));
+    border: 1px solid hsl(var(--primary));
     color: white;
     border-radius: 6px;
     padding: 0 14px;

--- a/saiku-ui/src/lib/views/CellsetTable.svelte
+++ b/saiku-ui/src/lib/views/CellsetTable.svelte
@@ -681,10 +681,10 @@
               <td class="data spark-cell" role="gridcell" aria-colindex={parsed.rowHeaderColCount + (parsed.dataRows[r]?.length ?? 0) + 1}>
                 <svg viewBox={`0 0 ${SPARK_W} ${SPARK_H}`} width={SPARK_W} height={SPARK_H} aria-hidden="true">
                   {#if spark === "line"}
-                    <path d={linePath(vals, range.min, range.max, SPARK_W, SPARK_H)} stroke="var(--accent)" stroke-width="1.5" fill="none" />
+                    <path d={linePath(vals, range.min, range.max, SPARK_W, SPARK_H)} stroke="hsl(var(--primary))" stroke-width="1.5" fill="none" />
                   {:else}
                     {#each barRects(vals, range.min, range.max, SPARK_W, SPARK_H) as b}
-                      <rect x={b.x} y={b.y} width={b.w} height={b.h} fill="var(--accent)" />
+                      <rect x={b.x} y={b.y} width={b.w} height={b.h} fill="hsl(var(--primary))" />
                     {/each}
                   {/if}
                 </svg>
@@ -778,8 +778,8 @@
     flex: 1;
     min-height: 0;
     overflow: auto;
-    border: 1px solid var(--border);
-    background: var(--bg);
+    border: 1px solid hsl(var(--border));
+    background: hsl(var(--bg));
     /* Disable scroll-snap and smooth scroll-behavior. Without this, a single
        wheel-tick can carry the viewport multiple screens due to macOS
        momentum interacting with the table's tall scroll height — visible as
@@ -797,34 +797,34 @@
   .cellset th,
   .cellset td {
     padding: 3px 9px 3px 6px;
-    border-right: 1px solid var(--border);
-    border-bottom: 1px solid var(--border);
+    border-right: 1px solid hsl(var(--border));
+    border-bottom: 1px solid hsl(var(--border));
     vertical-align: top;
   }
   .cellset thead th {
     position: sticky;
     top: 0;
     z-index: 2;
-    background: var(--bg-muted);
+    background: hsl(var(--bg-muted));
     font-weight: var(--weight-semibold);
     text-align: left;
     white-space: nowrap;
   }
   .cellset th.all_null {
-    background: var(--bg-muted);
-    border-right: 1px solid var(--border);
+    background: hsl(var(--bg-muted));
+    border-right: 1px solid hsl(var(--border));
   }
   .cellset th.col {
     cursor: context-menu;
   }
   .cellset th.col:hover {
-    background: var(--bg-subtle);
+    background: hsl(var(--bg-subtle));
   }
   .cellset th.col_null {
-    background: var(--bg-muted);
+    background: hsl(var(--bg-muted));
   }
   .cellset tbody th.row {
-    background: var(--bg-muted);
+    background: hsl(var(--bg-muted));
     text-align: left;
     white-space: nowrap;
     cursor: context-menu;
@@ -842,18 +842,18 @@
     left: 0;
     z-index: 1;
   }
-  .cellset tbody th.row--nested { font-weight: var(--weight-medium); color: var(--fg-muted); }
+  .cellset tbody th.row--nested { font-weight: var(--weight-medium); color: hsl(var(--fg-muted)); }
   .cellset tbody th.row:hover {
-    background: var(--bg-subtle);
+    background: hsl(var(--bg-subtle));
   }
   .cellset tbody th.row_null {
-    background: var(--bg-muted);
+    background: hsl(var(--bg-muted));
     position: sticky;
     left: 0;
     z-index: 1;
   }
   .cellset td.data {
-    color: var(--fg);
+    color: hsl(var(--fg));
     text-align: left;
   }
   .cellset td.data-num {
@@ -861,22 +861,22 @@
     font-variant-numeric: tabular-nums;
   }
   .cellset td.data { cursor: cell; user-select: none; }
-  .cellset td.data--selected { background: color-mix(in srgb, var(--accent) 28%, transparent); }
+  .cellset td.data--selected { background: color-mix(in srgb, hsl(var(--primary)) 28%, transparent); }
   .cellset tr.virt-spacer td {
     background: transparent;
     border: 0;
     padding: 0;
   }
   .cellset td.data--focused {
-    box-shadow: inset 0 0 0 2px var(--accent);
+    box-shadow: inset 0 0 0 2px hsl(var(--primary));
     position: relative;
   }
   .cellset-wrap:focus {
-    outline: 2px solid color-mix(in srgb, var(--accent) 50%, transparent);
+    outline: 2px solid color-mix(in srgb, hsl(var(--primary)) 50%, transparent);
     outline-offset: -2px;
   }
   .cellset-wrap:focus-visible {
-    outline: 2px solid var(--accent);
+    outline: 2px solid hsl(var(--primary));
     outline-offset: -2px;
   }
   .sel-stats {
@@ -885,26 +885,26 @@
     align-items: center;
     gap: var(--space-4);
     padding: 6px 12px;
-    border: 1px solid var(--border);
+    border: 1px solid hsl(var(--border));
     border-top: 0;
-    background: var(--bg-muted);
-    color: var(--fg-muted);
+    background: hsl(var(--bg-muted));
+    color: hsl(var(--fg-muted));
     font-size: var(--fs-sm);
     font-variant-numeric: tabular-nums;
   }
-  .sel-stats strong { color: var(--fg); font-weight: var(--weight-semibold); }
+  .sel-stats strong { color: hsl(var(--fg)); font-weight: var(--weight-semibold); }
   .sel-stats__clear {
     margin-left: auto;
     border: none;
     background: transparent;
-    color: var(--fg-muted);
+    color: hsl(var(--fg-muted));
     cursor: pointer;
     font-size: 16px;
     line-height: 1;
     padding: 2px 6px;
     border-radius: var(--radius-sm);
   }
-  .sel-stats__clear:hover { color: var(--danger); background: var(--bg-subtle); }
+  .sel-stats__clear:hover { color: hsl(var(--danger)); background: hsl(var(--bg-subtle)); }
   .cellset th.spark-col {
     min-width: 140px;
   }
@@ -916,10 +916,10 @@
   }
   .cellset tbody tr:hover td.data,
   .cellset tbody tr:hover th.row {
-    background: var(--bg-subtle);
+    background: hsl(var(--bg-subtle));
   }
   .runtime {
-    color: var(--fg-subtle);
+    color: hsl(var(--fg-subtle));
     font-size: var(--fs-xs);
     margin: var(--space-2) 0 0;
     flex: 0 0 auto;
@@ -927,8 +927,8 @@
   .cellset-ctx-menu {
     position: fixed;
     min-width: 180px;
-    background: var(--bg);
-    border: 1px solid var(--border);
+    background: hsl(var(--bg));
+    border: 1px solid hsl(var(--border));
     border-radius: var(--radius-sm);
     box-shadow: 0 8px 24px rgba(0, 0, 0, 0.35);
     padding: var(--space-1) 0;
@@ -937,7 +937,7 @@
   }
   .cellset-ctx-menu__sep {
     height: 1px;
-    background: var(--border);
+    background: hsl(var(--border));
     margin: 2px 0;
   }
   .cellset-ctx-menu__item {
@@ -947,16 +947,16 @@
     padding: 4px var(--space-3);
     background: transparent;
     border: 0;
-    color: var(--fg);
+    color: hsl(var(--fg));
     font: inherit;
     cursor: pointer;
   }
   .cellset-ctx-menu__item:hover:not(:disabled),
   .cellset-ctx-menu__item--parent > button:hover {
-    background: var(--bg-subtle);
+    background: hsl(var(--bg-subtle));
   }
   .cellset-ctx-menu__item:disabled {
-    color: var(--fg-subtle);
+    color: hsl(var(--fg-subtle));
     cursor: default;
   }
   .cellset-ctx-menu__item--parent {
@@ -969,13 +969,13 @@
     padding: 4px var(--space-3);
     background: transparent;
     border: 0;
-    color: var(--fg);
+    color: hsl(var(--fg));
     font: inherit;
     cursor: pointer;
   }
   .cellset-ctx-menu__sub {
     margin-left: var(--space-2);
-    border-left: 2px solid var(--border);
-    background: var(--bg-muted);
+    border-left: 2px solid hsl(var(--border));
+    background: hsl(var(--bg-muted));
   }
 </style>

--- a/saiku-ui/src/lib/views/ChartView.svelte
+++ b/saiku-ui/src/lib/views/ChartView.svelte
@@ -335,8 +335,8 @@
     min-height: 320px;
     overflow-y: hidden;
     overflow-x: hidden;
-    background: var(--bg);
-    border: 1px solid var(--border);
+    background: hsl(var(--bg));
+    border: 1px solid hsl(var(--border));
     border-radius: var(--radius-sm);
   }
   /* Only show the scrollbar when small-multiples actually overflow. */

--- a/saiku-ui/src/lib/views/CubePicker.svelte
+++ b/saiku-ui/src/lib/views/CubePicker.svelte
@@ -155,7 +155,7 @@
     font-weight: var(--weight-semibold);
     text-transform: uppercase;
     letter-spacing: 0.06em;
-    color: var(--fg-muted);
+    color: hsl(var(--fg-muted));
   }
   .cube-picker__refresh {
     /* match the select's vertical footprint so they line up at the same height */

--- a/saiku-ui/src/lib/views/DimensionList.svelte
+++ b/saiku-ui/src/lib/views/DimensionList.svelte
@@ -669,13 +669,13 @@
     margin-top: var(--space-4);
   }
   .panels__hint {
-    color: var(--fg-subtle);
+    color: hsl(var(--fg-subtle));
     font-size: var(--fs-sm);
     margin: var(--space-3) 0 0;
   }
   .panel {
-    background: var(--bg);
-    border-top: 1px solid var(--border);
+    background: hsl(var(--bg));
+    border-top: 1px solid hsl(var(--border));
     padding-top: var(--space-3);
   }
   .panel__header {
@@ -683,7 +683,7 @@
     font-weight: var(--weight-semibold);
     text-transform: uppercase;
     letter-spacing: 0.06em;
-    color: var(--fg-muted);
+    color: hsl(var(--fg-muted));
     margin-bottom: var(--space-2);
   }
   .panel__action {
@@ -692,12 +692,12 @@
     justify-content: center;
     background: transparent;
     border: 1px solid transparent;
-    color: var(--fg-muted);
+    color: hsl(var(--fg-muted));
     padding: 4px;
     border-radius: 4px;
     cursor: pointer;
   }
-  .panel__action:hover { background: var(--bg-subtle); color: var(--fg); }
+  .panel__action:hover { background: hsl(var(--bg-subtle)); color: hsl(var(--fg)); }
   .tree__drag {
     flex: 1;
     display: inline-flex;
@@ -718,14 +718,14 @@
     justify-content: center;
     background: transparent;
     border: 0;
-    color: var(--fg-subtle);
+    color: hsl(var(--fg-subtle));
     cursor: pointer;
     padding: 2px 6px;
     border-radius: 3px;
     transition: opacity 120ms ease;
   }
   .tree__row--level:hover .tree__gear { opacity: 1; }
-  .tree__gear:hover { color: var(--fg); }
+  .tree__gear:hover { color: hsl(var(--fg)); }
   .tree {
     list-style: none;
     margin: 0;
@@ -737,7 +737,7 @@
        stay readable without consuming the whole sidebar width. */
     padding-left: var(--space-3);
     margin-left: var(--space-2);
-    border-left: 1px solid var(--border);
+    border-left: 1px solid hsl(var(--border));
   }
   .tree__row {
     display: flex;
@@ -747,26 +747,26 @@
     padding: 2px var(--space-1);
     background: transparent;
     border: 0;
-    color: var(--fg);
+    color: hsl(var(--fg));
     cursor: pointer;
     font: inherit;
     text-align: left;
     border-radius: var(--radius-sm);
   }
-  .tree__row:hover { background: var(--bg-subtle); }
+  .tree__row:hover { background: hsl(var(--bg-subtle)); }
   .tree__row--measure {
-    color: var(--accent);
+    color: hsl(var(--primary));
     cursor: grab;
   }
-  .tree__row--measure .tree__icon--measure { color: var(--accent); }
-  .tree__row--level { color: var(--fg-muted); }
+  .tree__row--measure .tree__icon--measure { color: hsl(var(--primary)); }
+  .tree__row--level { color: hsl(var(--fg-muted)); }
   .tree__row--level .tree__drag { cursor: grab; }
   .tree__twisty {
     display: inline-flex;
     align-items: center;
     justify-content: center;
     width: 14px;
-    color: var(--fg-subtle);
+    color: hsl(var(--fg-subtle));
   }
   .tree__twisty :global(svg) {
     transition: transform var(--duration-fast) ease;
@@ -779,7 +779,7 @@
     align-items: center;
     justify-content: center;
     width: 16px;
-    color: var(--fg-subtle);
+    color: hsl(var(--fg-subtle));
   }
   /* Dim-applicability hint for virtual cubes. When a measure from a fact
      table that doesn't join the dim is selected, the dim row (and its

--- a/saiku-ui/src/lib/views/EmailGateForm.svelte
+++ b/saiku-ui/src/lib/views/EmailGateForm.svelte
@@ -153,8 +153,8 @@
     padding: var(--space-6);
     max-width: 380px;
     width: 100%;
-    background: var(--bg-muted);
-    border: 1px solid var(--border);
+    background: hsl(var(--bg-muted));
+    border: 1px solid hsl(var(--border));
     border-radius: var(--radius-lg);
     box-shadow: var(--shadow-md);
   }
@@ -164,7 +164,7 @@
   }
   .gate__intro {
     margin: 0 0 var(--space-4);
-    color: var(--fg-muted);
+    color: hsl(var(--fg-muted));
     font-size: var(--fs-sm);
     line-height: var(--lh-normal);
   }
@@ -176,7 +176,7 @@
   .gate__sent {
     margin: 0 0 var(--space-3);
     font-size: var(--fs-sm);
-    color: var(--fg-muted);
+    color: hsl(var(--fg-muted));
   }
   .gate__code {
     letter-spacing: 0.4em;
@@ -186,7 +186,7 @@
   .gate__privacy {
     margin: var(--space-4) 0 0;
     font-size: var(--fs-xs);
-    color: var(--fg-muted);
+    color: hsl(var(--fg-muted));
     line-height: var(--lh-normal);
   }
 </style>

--- a/saiku-ui/src/lib/views/LoginForm.svelte
+++ b/saiku-ui/src/lib/views/LoginForm.svelte
@@ -166,8 +166,8 @@
     padding: var(--space-6);
     max-width: 380px;
     width: 100%;
-    background: var(--bg-muted);
-    border: 1px solid var(--border);
+    background: hsl(var(--bg-muted));
+    border: 1px solid hsl(var(--border));
     border-radius: var(--radius-lg);
     box-shadow: var(--shadow-md);
   }
@@ -177,7 +177,7 @@
   }
   .login__tagline {
     margin: 0 0 var(--space-4);
-    color: var(--fg-muted);
+    color: hsl(var(--fg-muted));
     font-size: var(--fs-sm);
     line-height: var(--lh-normal);
   }
@@ -187,9 +187,9 @@
     align-items: flex-start;
     margin: 0 0 var(--space-3);
     padding: var(--space-3);
-    background: var(--success-soft);
-    color: var(--success-strong);
-    border-left: 3px solid var(--success);
+    background: hsl(var(--success-soft));
+    color: hsl(var(--success-strong));
+    border-left: 3px solid hsl(var(--success));
     border-radius: var(--radius-sm);
     font-size: var(--fs-sm);
     line-height: var(--lh-normal);

--- a/saiku-ui/src/lib/views/OssieQueryCanvas.svelte
+++ b/saiku-ui/src/lib/views/OssieQueryCanvas.svelte
@@ -1684,16 +1684,16 @@
     align-items: center;
     gap: 6px;
     padding: 6px 10px;
-    border-bottom: 1px solid var(--border);
-    background: var(--bg-muted);
+    border-bottom: 1px solid hsl(var(--border));
+    background: hsl(var(--bg-muted));
     flex-wrap: wrap;
   }
   .toolbar__dropdown {
     position: absolute;
     top: calc(100% + 6px);
     left: 0;
-    background: var(--bg);
-    border: 1px solid var(--border);
+    background: hsl(var(--bg));
+    border: 1px solid hsl(var(--border));
     border-radius: 6px;
     box-shadow: 0 12px 32px rgba(0, 0, 0, 0.35);
     padding: 4px;
@@ -1716,12 +1716,12 @@
     background: transparent;
     border: 0;
     border-radius: 4px;
-    color: var(--fg);
+    color: hsl(var(--fg));
     font: inherit;
     cursor: pointer;
   }
   .toolbar__item:hover {
-    background: var(--bg-hover);
+    background: hsl(var(--bg-hover));
   }
   .toolbar__item:disabled {
     opacity: 0.5;
@@ -1730,7 +1730,7 @@
   .toolbar__sep {
     width: 1px;
     height: 22px;
-    background: var(--border);
+    background: hsl(var(--border));
     margin: 0 4px;
   }
   .tb-btn {
@@ -1741,14 +1741,14 @@
     background: transparent;
     border: 1px solid transparent;
     border-radius: 5px;
-    color: var(--fg-muted);
+    color: hsl(var(--fg-muted));
     cursor: pointer;
     font: inherit;
     transition: background var(--duration-fast), color var(--duration-fast);
   }
   .tb-btn:hover {
-    background: var(--bg-hover);
-    color: var(--fg);
+    background: hsl(var(--bg-hover));
+    color: hsl(var(--fg));
   }
   .tb-btn:active {
     transform: translateY(1px);
@@ -1758,20 +1758,20 @@
     cursor: not-allowed;
   }
   .tb-btn--primary {
-    background: var(--accent);
-    color: var(--bg);
-    border-color: var(--accent);
+    background: hsl(var(--primary));
+    color: hsl(var(--bg));
+    border-color: hsl(var(--primary));
   }
   .tb-btn--primary:hover {
     filter: brightness(1.1);
-    background: var(--accent);
-    color: var(--bg);
+    background: hsl(var(--primary));
+    color: hsl(var(--bg));
   }
   .tb-btn--disabled-shape,
   .tb-btn--disabled-shape:hover {
-    background: var(--bg-muted);
-    color: var(--fg-muted);
-    border-color: var(--border);
+    background: hsl(var(--bg-muted));
+    color: hsl(var(--fg-muted));
+    border-color: hsl(var(--border));
     filter: none;
     cursor: not-allowed;
   }
@@ -1780,12 +1780,12 @@
     font-size: var(--fs-sm);
   }
   .ossie-canvas__runtime {
-    color: var(--fg-subtle);
+    color: hsl(var(--fg-subtle));
     font-size: var(--fs-xs);
     margin-left: auto;
   }
   .ossie-canvas__saved-name {
-    color: var(--fg-muted);
+    color: hsl(var(--fg-muted));
     font-size: var(--fs-xs);
     font-family: monospace;
   }
@@ -1794,21 +1794,21 @@
     align-items: center;
     gap: 6px;
     padding: 0 8px;
-    border: 1px solid var(--border);
+    border: 1px solid hsl(var(--border));
     border-radius: 5px;
     background: transparent;
     height: 32px;
   }
   .ossie-canvas__limit-label {
     font-size: var(--fs-xs);
-    color: var(--fg-muted);
+    color: hsl(var(--fg-muted));
     text-transform: uppercase;
     letter-spacing: 0.06em;
   }
   .ossie-canvas__limit-input {
     background: transparent;
     border: none;
-    color: var(--fg);
+    color: hsl(var(--fg));
     font-size: var(--fs-sm);
     width: 60px;
     padding: 0;
@@ -1834,17 +1834,17 @@
     text-align: left;
   }
   .ossie-result__sort-btn:hover {
-    color: var(--fg);
+    color: hsl(var(--fg));
   }
   .ossie-result__sort-btn--active {
-    color: var(--accent);
+    color: hsl(var(--primary));
   }
   .ossie-canvas__charttype {
     padding: 6px 8px;
     background: transparent;
-    border: 1px solid var(--border);
+    border: 1px solid hsl(var(--border));
     border-radius: 5px;
-    color: var(--fg);
+    color: hsl(var(--fg));
     font-size: var(--fs-sm);
     height: 32px;
   }
@@ -1852,8 +1852,8 @@
     position: fixed;
     z-index: 1000;
     min-width: 220px;
-    background: var(--bg);
-    border: 1px solid var(--border);
+    background: hsl(var(--bg));
+    border: 1px solid hsl(var(--border));
     border-radius: 6px;
     box-shadow: 0 12px 32px rgba(0, 0, 0, 0.35);
     padding: 4px;
@@ -1861,7 +1861,7 @@
   .ossie-ctx-menu__header {
     padding: 6px 12px;
     font-size: var(--fs-xs);
-    color: var(--fg-muted);
+    color: hsl(var(--fg-muted));
     font-weight: var(--weight-semibold);
     max-width: 260px;
     overflow: hidden;
@@ -1878,21 +1878,21 @@
     background: transparent;
     border: 0;
     border-radius: 4px;
-    color: var(--fg);
+    color: hsl(var(--fg));
     font: inherit;
     cursor: pointer;
   }
   .ossie-ctx-menu__item:hover {
-    background: var(--bg-hover);
+    background: hsl(var(--bg-hover));
   }
   .ossie-ctx-menu__item em {
     font-style: normal;
     font-weight: var(--weight-semibold);
-    color: var(--accent);
+    color: hsl(var(--primary));
   }
   .ossie-ctx-menu__sep {
     height: 1px;
-    background: var(--border);
+    background: hsl(var(--border));
     margin: 4px 0;
   }
   .ossie-ctx-menu__header--sub {
@@ -1902,23 +1902,23 @@
     padding-bottom: 2px;
   }
   .ossie-ctx-menu__item--active {
-    background: color-mix(in srgb, var(--accent) 12%, transparent);
-    color: var(--accent);
+    background: color-mix(in srgb, hsl(var(--primary)) 12%, transparent);
+    color: hsl(var(--primary));
   }
   .ossie-canvas__sql {
-    background: var(--bg-hover);
+    background: hsl(var(--bg-hover));
     padding: 12px;
     border-radius: 4px;
     font-family: monospace;
     font-size: var(--fs-sm);
-    color: var(--fg);
+    color: hsl(var(--fg));
     white-space: pre-wrap;
     max-height: 60vh;
     overflow: auto;
     margin: 0;
   }
   .ossie-chip__and {
-    color: var(--fg-subtle);
+    color: hsl(var(--fg-subtle));
     font-size: var(--fs-xs);
     padding: 0 2px;
   }
@@ -1929,16 +1929,16 @@
   }
   .ossie-chip__add-value {
     background: transparent;
-    border: 1px dashed var(--border);
-    color: var(--fg-subtle);
+    border: 1px dashed hsl(var(--border));
+    color: hsl(var(--fg-subtle));
     border-radius: 3px;
     padding: 1px 6px;
     font-size: var(--fs-xs);
     cursor: pointer;
   }
   .ossie-chip__add-value:hover {
-    color: var(--fg);
-    border-color: var(--border-strong);
+    color: hsl(var(--fg));
+    border-color: hsl(var(--border-strong));
   }
   .ossie-canvas__shelves {
     display: flex;
@@ -1953,8 +1953,8 @@
     gap: 6px;
     min-height: 42px;
     padding: 8px 12px;
-    background: var(--bg-subtle, var(--bg-hover));
-    border: 1px dashed var(--border-strong);
+    background: var(--bg-subtle, hsl(var(--bg-hover)));
+    border: 1px dashed hsl(var(--border-strong));
     border-radius: 4px;
     transition:
       background var(--duration-fast),
@@ -1965,16 +1965,16 @@
      and a 2px accent shadow ring so hovered shelves stand out at a glance. */
   .ossie-shelf--dragover {
     border-style: solid;
-    border-color: var(--accent);
-    background: color-mix(in srgb, var(--accent) 12%, var(--bg-subtle, var(--bg-hover)));
-    box-shadow: 0 0 0 2px color-mix(in srgb, var(--accent) 30%, transparent);
+    border-color: hsl(var(--primary));
+    background: color-mix(in srgb, hsl(var(--primary)) 12%, var(--bg-subtle, hsl(var(--bg-hover))));
+    box-shadow: 0 0 0 2px color-mix(in srgb, hsl(var(--primary)) 30%, transparent);
   }
   .ossie-shelf__label {
     font-size: var(--fs-xs);
     font-weight: var(--weight-semibold);
     text-transform: uppercase;
     letter-spacing: 0.06em;
-    color: var(--fg-muted);
+    color: hsl(var(--fg-muted));
     margin-right: 8px;
     min-width: 60px;
   }
@@ -1983,13 +1983,13 @@
     align-items: center;
     gap: 4px;
     padding: 4px 8px;
-    background: var(--bg);
-    border: 1px solid var(--border-strong);
+    background: hsl(var(--bg));
+    border: 1px solid hsl(var(--border-strong));
     border-radius: 4px;
     font-size: var(--fs-sm);
   }
   .ossie-chip--metric {
-    background: var(--bg-accent-subtle, var(--bg-hover));
+    background: var(--bg-accent-subtle, hsl(var(--bg-hover)));
   }
   .ossie-chip--filter {
     gap: 6px;
@@ -2000,14 +2000,14 @@
   }
   .ossie-chip__op {
     background: transparent;
-    border: 1px solid var(--border);
+    border: 1px solid hsl(var(--border));
     border-radius: 3px;
     padding: 1px 4px;
     font-size: var(--fs-xs);
   }
   .ossie-chip__value {
     background: transparent;
-    border: 1px solid var(--border);
+    border: 1px solid hsl(var(--border));
     border-radius: 3px;
     padding: 2px 6px;
     font-size: var(--fs-xs);
@@ -2019,19 +2019,19 @@
     justify-content: center;
     background: transparent;
     border: none;
-    color: var(--fg-subtle);
+    color: hsl(var(--fg-subtle));
     cursor: pointer;
     padding: 0;
     margin-left: 2px;
   }
   .ossie-chip__x:hover {
-    color: var(--fg);
+    color: hsl(var(--fg));
   }
   .ossie-canvas__result {
     flex: 1;
     min-height: 0;
     overflow: auto;
-    border: 1px solid var(--border);
+    border: 1px solid hsl(var(--border));
     border-radius: 4px;
     padding: var(--space-2);
     margin: var(--space-3);
@@ -2045,11 +2045,11 @@
   .ossie-result th,
   .ossie-result td {
     padding: 6px 10px;
-    border-bottom: 1px solid var(--border);
+    border-bottom: 1px solid hsl(var(--border));
     text-align: left;
   }
   .ossie-result th {
-    background: var(--bg-hover);
+    background: hsl(var(--bg-hover));
     font-weight: var(--weight-semibold);
     position: sticky;
     top: 0;
@@ -2066,7 +2066,7 @@
   }
   .ossie-canvas__hint,
   .ossie-canvas__empty {
-    color: var(--fg-subtle);
+    color: hsl(var(--fg-subtle));
     font-size: var(--fs-sm);
   }
 </style>

--- a/saiku-ui/src/lib/views/OssieSchemaTree.svelte
+++ b/saiku-ui/src/lib/views/OssieSchemaTree.svelte
@@ -173,7 +173,7 @@
     font-weight: var(--weight-semibold);
     text-transform: uppercase;
     letter-spacing: 0.06em;
-    color: var(--fg-muted);
+    color: hsl(var(--fg-muted));
     padding-bottom: var(--space-1);
   }
   .ossie-tree__info {
@@ -183,25 +183,25 @@
     padding: 0;
     border: 0;
     background: transparent;
-    color: var(--fg-subtle);
+    color: hsl(var(--fg-subtle));
     cursor: help;
     line-height: 0;
   }
   .ossie-tree__info:hover,
   .ossie-tree__info:focus-visible {
-    color: var(--fg);
+    color: hsl(var(--fg));
   }
   .ossie-tree__select {
     padding: 6px 8px;
-    background: var(--bg);
-    color: var(--fg);
-    border: 1px solid var(--border-strong);
+    background: hsl(var(--bg));
+    color: hsl(var(--fg));
+    border: 1px solid hsl(var(--border-strong));
     border-radius: 4px;
     font-size: var(--fs-sm);
   }
   .ossie-tree__hint {
     font-size: var(--fs-xs);
-    color: var(--fg-subtle);
+    color: hsl(var(--fg-subtle));
     margin: 0;
   }
   .ossie-tree__list {
@@ -213,7 +213,7 @@
     gap: 2px;
   }
   .ossie-tree__list--dim {
-    color: var(--fg-subtle);
+    color: hsl(var(--fg-subtle));
   }
   .ossie-tree__group {
     display: flex;
@@ -232,7 +232,7 @@
   }
   .ossie-tree__group-count {
     font-size: var(--fs-xs);
-    color: var(--fg-subtle);
+    color: hsl(var(--fg-subtle));
   }
   .ossie-tree__children {
     list-style: none;
@@ -255,7 +255,7 @@
   }
   .ossie-tree__field:hover,
   .ossie-tree__metric:hover {
-    background: var(--bg-hover);
+    background: hsl(var(--bg-hover));
   }
   .ossie-tree__field:active,
   .ossie-tree__metric:active {
@@ -266,8 +266,8 @@
     font-size: 10px;
     padding: 1px 6px;
     border-radius: 10px;
-    background: var(--bg-accent-subtle, var(--bg-hover));
-    color: var(--fg-muted);
+    background: var(--bg-accent-subtle, hsl(var(--bg-hover)));
+    color: hsl(var(--fg-muted));
     text-transform: uppercase;
     letter-spacing: 0.04em;
   }
@@ -278,11 +278,11 @@
     padding: 3px 6px;
   }
   .ossie-tree__arrow {
-    color: var(--fg-subtle);
+    color: hsl(var(--fg-subtle));
   }
   .ossie-tree__empty {
     font-size: var(--fs-xs);
-    color: var(--fg-subtle);
+    color: hsl(var(--fg-subtle));
     padding-left: 22px;
   }
 </style>

--- a/saiku-ui/src/lib/views/QueryCanvas.svelte
+++ b/saiku-ui/src/lib/views/QueryCanvas.svelte
@@ -1563,10 +1563,10 @@
     gap: 6px;
     padding: 2px 8px 2px 2px;
     background: transparent;
-    border: 1px solid var(--border);
+    border: 1px solid hsl(var(--border));
     border-radius: 999px;
     font-size: 0.75rem;
-    color: var(--fg-muted);
+    color: hsl(var(--fg-muted));
     align-self: flex-start;
     max-width: 100%;
     white-space: nowrap;
@@ -1574,7 +1574,7 @@
     text-overflow: ellipsis;
   }
   .canvas__mdx-badge {
-    background: var(--accent);
+    background: hsl(var(--primary));
     color: white;
     border-radius: 999px;
     padding: 1px 7px;
@@ -1589,16 +1589,16 @@
     justify-content: center;
     gap: var(--space-2);
     min-height: 360px;
-    color: var(--fg-muted);
-    border: 1px dashed var(--border-strong);
+    color: hsl(var(--fg-muted));
+    border: 1px dashed hsl(var(--border-strong));
     border-radius: var(--radius-md);
   }
   .dropzone {
-    border: 1px dashed var(--border-strong);
+    border: 1px dashed hsl(var(--border-strong));
     border-radius: var(--radius-md);
     padding: var(--space-2) var(--space-3);
     min-height: 54px;
-    background: var(--bg-muted);
+    background: hsl(var(--bg-muted));
     /* The aside above is `display: flex; flex-direction: column` with
        `overflow-y-auto`, which makes each dropzone a flex item. Flex
        items default to `flex: 0 1 auto`, so they can shrink when the
@@ -1615,9 +1615,9 @@
   }
   .dropzone.is-dragover {
     border-style: solid;
-    border-color: var(--accent);
-    background: color-mix(in srgb, var(--accent) 12%, var(--bg-muted));
-    box-shadow: 0 0 0 2px color-mix(in srgb, var(--accent) 30%, transparent);
+    border-color: hsl(var(--primary));
+    background: color-mix(in srgb, hsl(var(--primary)) 12%, hsl(var(--bg-muted)));
+    box-shadow: 0 0 0 2px color-mix(in srgb, hsl(var(--primary)) 30%, transparent);
   }
   /* Keep pointer events enabled on chips so chip-to-chip reorder drops still fire. */
   .dropzone header {
@@ -1628,13 +1628,13 @@
     font-weight: var(--weight-semibold);
     text-transform: uppercase;
     letter-spacing: 0.06em;
-    color: var(--fg-muted);
+    color: hsl(var(--fg-muted));
     margin-bottom: var(--space-1);
   }
   .dropzone__menu {
     background: transparent;
     border: 0;
-    color: var(--fg-subtle);
+    color: hsl(var(--fg-subtle));
     cursor: pointer;
     padding: 2px 4px;
     border-radius: 3px;
@@ -1644,7 +1644,7 @@
     transition: opacity 120ms ease;
   }
   .dropzone:hover .dropzone__menu { opacity: 1; }
-  .dropzone__menu:hover { background: var(--bg-subtle); color: var(--fg); }
+  .dropzone__menu:hover { background: hsl(var(--bg-subtle)); color: hsl(var(--fg)); }
   .chips {
     display: flex;
     flex-wrap: wrap;
@@ -1655,7 +1655,7 @@
     align-items: center;
     justify-content: center;
     min-height: 32px;
-    color: var(--fg-subtle);
+    color: hsl(var(--fg-subtle));
     font-size: var(--fs-sm);
     font-style: italic;
   }
@@ -1664,21 +1664,21 @@
     align-items: center;
     gap: var(--space-1);
     padding: 0;
-    background: var(--bg);
-    color: var(--fg);
-    border: 1px solid var(--border-strong);
+    background: hsl(var(--bg));
+    color: hsl(var(--fg));
+    border: 1px solid hsl(var(--border-strong));
     border-radius: var(--radius-sm);
     font-size: var(--fs-xs);
     overflow: hidden;
   }
-  .chip:hover { background: var(--bg-subtle); }
+  .chip:hover { background: hsl(var(--bg-subtle)); }
   .chip.is-drop-before {
-    box-shadow: inset 0 3px 0 0 var(--accent), 0 0 0 1px var(--accent);
-    border-color: var(--accent);
+    box-shadow: inset 0 3px 0 0 hsl(var(--primary)), 0 0 0 1px hsl(var(--primary));
+    border-color: hsl(var(--primary));
   }
   .chip.is-drop-after {
-    box-shadow: inset 0 -3px 0 0 var(--accent), 0 0 0 1px var(--accent);
-    border-color: var(--accent);
+    box-shadow: inset 0 -3px 0 0 hsl(var(--primary)), 0 0 0 1px hsl(var(--primary));
+    border-color: hsl(var(--primary));
   }
   /* chip-group — vertical stack used for hierarchy chips on ROWS /
      COLUMNS / PAGES. Always-visible × per level, predictable width
@@ -1694,20 +1694,20 @@
        against the dropzone's content width in the same situation. */
     min-width: min(140px, 100%);
     max-width: 100%;
-    background: var(--bg-muted);
-    border: 1px solid var(--border);
+    background: hsl(var(--bg-muted));
+    border: 1px solid hsl(var(--border));
     border-radius: var(--radius-md);
     overflow: hidden;
     cursor: grab;
   }
   .chip-group:active { cursor: grabbing; }
   .chip-group.is-drop-before {
-    box-shadow: 0 -2px 0 0 var(--accent), 0 0 0 1px var(--accent);
-    border-color: var(--accent);
+    box-shadow: 0 -2px 0 0 hsl(var(--primary)), 0 0 0 1px hsl(var(--primary));
+    border-color: hsl(var(--primary));
   }
   .chip-group.is-drop-after {
-    box-shadow: 0 2px 0 0 var(--accent), 0 0 0 1px var(--accent);
-    border-color: var(--accent);
+    box-shadow: 0 2px 0 0 hsl(var(--primary)), 0 0 0 1px hsl(var(--primary));
+    border-color: hsl(var(--primary));
   }
   .chip-group__head {
     display: flex;
@@ -1715,11 +1715,11 @@
     justify-content: space-between;
     gap: var(--space-2);
     padding: 4px 4px 4px var(--space-2);
-    background: var(--bg-subtle);
+    background: hsl(var(--bg-subtle));
     font-size: var(--fs-xs);
     font-weight: var(--weight-semibold);
-    color: var(--fg);
-    border-bottom: 1px solid var(--border);
+    color: hsl(var(--fg));
+    border-bottom: 1px solid hsl(var(--border));
   }
   .chip-group__title {
     background: transparent;
@@ -1738,7 +1738,7 @@
   .chip-group__x,
   .chip-group__level-x {
     background: transparent;
-    color: var(--fg-subtle);
+    color: hsl(var(--fg-subtle));
     border: 0;
     padding: 0 6px;
     font-size: 14px;
@@ -1749,8 +1749,8 @@
   }
   .chip-group__x:hover,
   .chip-group__level-x:hover {
-    color: var(--danger);
-    background: var(--bg-hover);
+    color: hsl(var(--danger));
+    background: hsl(var(--bg-hover));
   }
   .chip-group__levels {
     list-style: none;
@@ -1764,10 +1764,10 @@
     gap: var(--space-2);
     padding: 4px var(--space-2);
     font-size: var(--fs-xs);
-    color: var(--fg-muted);
+    color: hsl(var(--fg-muted));
   }
   .chip-group__level + .chip-group__level {
-    border-top: 1px dashed var(--border);
+    border-top: 1px dashed hsl(var(--border));
   }
   .chip-group__level-name {
     overflow: hidden;
@@ -1785,15 +1785,15 @@
   }
   .chip__x {
     background: transparent;
-    color: var(--fg-subtle);
+    color: hsl(var(--fg-subtle));
     border: 0;
-    border-left: 1px solid var(--border);
+    border-left: 1px solid hsl(var(--border));
     padding: 0 var(--space-1);
     font-size: 14px;
     line-height: 1;
     cursor: pointer;
   }
-  .chip__x:hover { color: var(--danger); background: var(--bg-muted); }
+  .chip__x:hover { color: hsl(var(--danger)); background: hsl(var(--bg-muted)); }
   .result-host { flex: 1; min-height: 0; display: flex; flex-direction: column; overflow: hidden; }
   .result-host :global(.runtime) { flex: 0 0 auto; }
   .view-toggle {
@@ -1808,16 +1808,16 @@
   .view-toggle button {
     padding: var(--space-1) var(--space-3);
     background: transparent;
-    border: 1px solid var(--border-strong);
-    color: var(--fg-muted);
+    border: 1px solid hsl(var(--border-strong));
+    color: hsl(var(--fg-muted));
     border-radius: var(--radius-sm);
     cursor: pointer;
     font: inherit;
   }
   .view-toggle button.active {
-    background: var(--accent);
-    color: var(--accent-fg);
-    border-color: var(--accent);
+    background: hsl(var(--primary));
+    color: hsl(var(--primary-foreground));
+    border-color: hsl(var(--primary));
   }
   .view-more { position: relative; display: inline-flex; }
   .view-more > button {
@@ -1830,8 +1830,8 @@
     top: calc(100% + 4px);
     left: 0;
     min-width: 140px;
-    background: var(--bg);
-    border: 1px solid var(--border-strong);
+    background: hsl(var(--bg));
+    border: 1px solid hsl(var(--border-strong));
     border-radius: var(--radius-sm);
     box-shadow: 0 4px 12px rgba(0, 0, 0, 0.25);
     padding: var(--space-1) 0;
@@ -1844,17 +1844,17 @@
     padding: var(--space-1) var(--space-3);
     background: transparent;
     border: none;
-    color: var(--fg);
+    color: hsl(var(--fg));
     cursor: pointer;
     font: inherit;
   }
-  .view-more__menu button:hover { background: var(--bg-subtle); }
-  .view-more__menu button.active { background: var(--accent); color: var(--accent-fg); }
+  .view-more__menu button:hover { background: hsl(var(--bg-subtle)); }
+  .view-more__menu button.active { background: hsl(var(--primary)); color: hsl(var(--primary-foreground)); }
   .chart-pick select {
     padding: var(--space-1) var(--space-2);
-    background: var(--bg);
-    color: var(--fg);
-    border: 1px solid var(--border-strong);
+    background: hsl(var(--bg));
+    color: hsl(var(--fg));
+    border: 1px solid hsl(var(--border-strong));
     border-radius: var(--radius-sm);
   }
   .run-progress {
@@ -1862,10 +1862,10 @@
     align-items: center;
     gap: var(--space-2);
     padding: var(--space-1) var(--space-2);
-    border: 1px solid var(--border);
+    border: 1px solid hsl(var(--border));
     border-radius: var(--radius-sm);
-    background: var(--bg-muted);
-    color: var(--fg-muted);
+    background: hsl(var(--bg-muted));
+    color: hsl(var(--fg-muted));
     font-size: var(--fs-sm);
   }
   .run-progress :global(.spin) {
@@ -1878,13 +1878,13 @@
     gap: 4px;
     padding: 2px 8px;
     background: transparent;
-    border: 1px solid var(--border-strong);
+    border: 1px solid hsl(var(--border-strong));
     border-radius: var(--radius-sm);
-    color: var(--fg);
+    color: hsl(var(--fg));
     cursor: pointer;
     font: inherit;
   }
-  .run-progress button:hover { background: var(--bg-subtle); }
+  .run-progress button:hover { background: hsl(var(--bg-subtle)); }
   @keyframes spin {
     from { transform: rotate(0deg); }
     to { transform: rotate(360deg); }

--- a/saiku-ui/src/lib/views/StatsView.svelte
+++ b/saiku-ui/src/lib/views/StatsView.svelte
@@ -79,8 +79,8 @@
 
 <style>
 .stats { border-collapse: separate; border-spacing: 0; width: 100%; font-size: var(--fs-sm); }
-  .stats th, .stats td { padding: 6px 12px; border-bottom: 1px solid var(--border); text-align: left; white-space: nowrap; }
-  .stats thead th { position: sticky; top: 0; background: var(--bg-muted); color: var(--fg); font-weight: var(--weight-semibold); }
-  .stats tbody th { background: var(--bg-muted); font-weight: var(--weight-medium); color: var(--fg); }
+  .stats th, .stats td { padding: 6px 12px; border-bottom: 1px solid hsl(var(--border)); text-align: left; white-space: nowrap; }
+  .stats thead th { position: sticky; top: 0; background: hsl(var(--bg-muted)); color: hsl(var(--fg)); font-weight: var(--weight-semibold); }
+  .stats tbody th { background: hsl(var(--bg-muted)); font-weight: var(--weight-medium); color: hsl(var(--fg)); }
   .stats td.n { text-align: right; font-variant-numeric: tabular-nums; }
 </style>

--- a/saiku-ui/src/lib/views/Workspace.svelte
+++ b/saiku-ui/src/lib/views/Workspace.svelte
@@ -483,7 +483,7 @@
               oncontextmenu={(e) => openTabMenu(i, e)}
             >
               <span class="tab__label">{tabLabelFor(i)}</span>
-              {#if tabDirtyFor(i)}<span class="text-accent" aria-label="unsaved changes">•</span>{/if}
+              {#if tabDirtyFor(i)}<span class="text-primary" aria-label="unsaved changes">•</span>{/if}
               {#if tabs.list.length > 1}
                 <span
                   class="tab__close"
@@ -592,7 +592,7 @@
        (#1176). */
     grid-template-columns: 300px minmax(0, 1fr);
     gap: 1px;
-    background: var(--border);
+    background: hsl(var(--border));
     overflow: hidden;
   }
   .workspace--embed {
@@ -601,7 +601,7 @@
   }
   .workspace__sidebar,
   .workspace__main {
-    background: var(--bg);
+    background: hsl(var(--bg));
     min-height: 0;
     min-width: 0;
     overflow: hidden;
@@ -612,8 +612,8 @@
   }
   .workspace__sidebar-footer {
     padding: var(--space-3) var(--space-4);
-    border-top: 1px solid var(--border-strong);
-    background: var(--bg-subtle);
+    border-top: 1px solid hsl(var(--border-strong));
+    background: hsl(var(--bg-subtle));
     display: flex;
     align-items: center;
     gap: var(--space-2);
@@ -626,8 +626,8 @@
     display: flex;
     align-items: stretch;
     padding: 0 var(--space-2);
-    border-bottom: 1px solid var(--border);
-    background: var(--bg-muted);
+    border-bottom: 1px solid hsl(var(--border));
+    background: hsl(var(--bg-muted));
     /* .workspace__main has overflow:hidden; without horizontal scroll
        here a third (or further) tab gets clipped past the right edge
        and the "+" button becomes unreachable, which presents to the
@@ -643,7 +643,7 @@
     align-items: center;
     gap: var(--space-2);
     padding: var(--space-2) var(--space-3);
-    color: var(--fg-muted);
+    color: hsl(var(--fg-muted));
     border-bottom: 2px solid transparent;
     background: transparent;
     border-top: 0;
@@ -656,12 +656,12 @@
     flex-shrink: 0;
   }
   .tab:hover:not(.tab--active) {
-    color: var(--fg);
-    background: color-mix(in srgb, var(--bg) 60%, transparent);
+    color: hsl(var(--fg));
+    background: color-mix(in srgb, hsl(var(--bg)) 60%, transparent);
   }
   .tab--active {
-    color: var(--fg);
-    border-bottom-color: var(--accent);
+    color: hsl(var(--fg));
+    border-bottom-color: hsl(var(--primary));
   }
   .tab__label {
     white-space: nowrap;
@@ -678,16 +678,16 @@
     width: 10rem;
     max-width: 12rem;
     padding: 2px 4px;
-    background: var(--bg);
-    border: 1px solid var(--border-strong);
+    background: hsl(var(--bg));
+    border: 1px solid hsl(var(--border-strong));
     border-radius: var(--radius-sm);
-    color: var(--fg);
+    color: hsl(var(--fg));
     font: inherit;
     font-size: var(--fs-sm);
     outline: none;
   }
   .tab__rename-input:focus {
-    border-color: var(--accent);
+    border-color: hsl(var(--primary));
   }
   .tab__close {
     display: inline-flex;
@@ -696,13 +696,13 @@
     width: 1.25rem;
     height: 1.25rem;
     border-radius: 50%;
-    color: var(--fg-muted);
+    color: hsl(var(--fg-muted));
     font-size: 1rem;
     line-height: 1;
     user-select: none;
   }
   .tab__close:hover {
-    background: color-mix(in srgb, var(--danger) 18%, transparent);
-    color: var(--danger);
+    background: color-mix(in srgb, hsl(var(--danger)) 18%, transparent);
+    color: hsl(var(--danger));
   }
 </style>

--- a/saiku-ui/src/lib/views/WorkspaceToolbar.svelte
+++ b/saiku-ui/src/lib/views/WorkspaceToolbar.svelte
@@ -638,16 +638,16 @@
     align-items: center;
     gap: 6px;
     padding: 6px 10px;
-    border-bottom: 1px solid var(--border);
-    background: var(--bg-muted);
+    border-bottom: 1px solid hsl(var(--border));
+    background: hsl(var(--bg-muted));
     flex-wrap: wrap;
   }
   .toolbar__dropdown {
     position: absolute;
     top: calc(100% + 6px);
     left: 0;
-    background: var(--bg);
-    border: 1px solid var(--border);
+    background: hsl(var(--bg));
+    border: 1px solid hsl(var(--border));
     border-radius: 6px;
     box-shadow: 0 12px 32px rgba(0,0,0,0.35);
     padding: 4px;
@@ -664,15 +664,15 @@
     background: transparent;
     border: 0;
     border-radius: 4px;
-    color: var(--fg);
+    color: hsl(var(--fg));
     font: inherit;
     cursor: pointer;
   }
-  .toolbar__item:hover { background: var(--bg-hover); }
+  .toolbar__item:hover { background: hsl(var(--bg-hover)); }
   .toolbar__sep {
     width: 1px;
     height: 22px;
-    background: var(--border);
+    background: hsl(var(--border));
     margin: 0 4px;
   }
   .tb-btn {
@@ -683,26 +683,26 @@
     background: transparent;
     border: 1px solid transparent;
     border-radius: 5px;
-    color: var(--fg-muted);
+    color: hsl(var(--fg-muted));
     cursor: pointer;
     font: inherit;
   }
   .tb-btn { transition: background var(--duration-fast), color var(--duration-fast); }
-  .tb-btn:hover { background: var(--bg-hover); color: var(--fg); }
+  .tb-btn:hover { background: hsl(var(--bg-hover)); color: hsl(var(--fg)); }
   .tb-btn:active { transform: translateY(1px); }
   .tb-btn--primary {
-    background: var(--accent);
-    color: var(--bg);
-    border-color: var(--accent);
+    background: hsl(var(--primary));
+    color: hsl(var(--bg));
+    border-color: hsl(var(--primary));
   }
-  .tb-btn--primary:hover { filter: brightness(1.1); background: var(--accent); color: var(--bg); }
+  .tb-btn--primary:hover { filter: brightness(1.1); background: hsl(var(--primary)); color: hsl(var(--bg)); }
   .tb-btn--ai {
-    background: linear-gradient(135deg, var(--accent) 0%, color-mix(in srgb, var(--accent) 60%, #8b5cf6) 100%);
-    color: var(--bg);
-    border-color: var(--accent);
+    background: linear-gradient(135deg, hsl(var(--primary)) 0%, color-mix(in srgb, hsl(var(--primary)) 60%, #8b5cf6) 100%);
+    color: hsl(var(--bg));
+    border-color: hsl(var(--primary));
   }
   .tb-btn--ai:hover {
-    color: var(--accent);
+    color: hsl(var(--primary));
   }
   /*
    * saiku-cloud#612 — visual cue that the query shape isn't runnable yet
@@ -712,9 +712,9 @@
    */
   .tb-btn--disabled-shape,
   .tb-btn--disabled-shape:hover {
-    background: var(--bg-muted);
-    color: var(--fg-muted);
-    border-color: var(--border);
+    background: hsl(var(--bg-muted));
+    color: hsl(var(--fg-muted));
+    border-color: hsl(var(--border));
     filter: none;
     cursor: not-allowed;
   }
@@ -724,9 +724,9 @@
     right: 4px;
     width: 7px;
     height: 7px;
-    background: var(--accent);
+    background: hsl(var(--primary));
     border-radius: 50%;
-    box-shadow: 0 0 0 2px var(--bg-muted);
+    box-shadow: 0 0 0 2px hsl(var(--bg-muted));
   }
   .split-btn {
     display: inline-flex;
@@ -750,9 +750,9 @@
     gap: 10px;
     padding: 6px 12px;
     cursor: pointer;
-    color: var(--fg);
+    color: hsl(var(--fg));
     font: inherit;
     border-radius: 4px;
   }
-  .toolbar__check:hover { background: var(--bg-subtle); }
+  .toolbar__check:hover { background: hsl(var(--bg-subtle)); }
 </style>

--- a/saiku-ui/src/lib/views/admin/AgentSpacesAdmin.svelte
+++ b/saiku-ui/src/lib/views/admin/AgentSpacesAdmin.svelte
@@ -203,28 +203,28 @@
 <style>
   .pane { display: flex; flex-direction: column; gap: var(--space-4); }
   h2 { margin: 0; }
-  code { font-family: var(--font-mono, monospace); font-size: var(--fs-xs); background: var(--bg-subtle); padding: 1px 5px; border-radius: 4px; }
+  code { font-family: var(--font-mono, monospace); font-size: var(--fs-xs); background: hsl(var(--bg-subtle)); padding: 1px 5px; border-radius: 4px; }
 
   .layout { display: grid; grid-template-columns: 240px 1fr; gap: var(--space-4); align-items: start; }
-  .list { display: flex; flex-direction: column; gap: 2px; border: 1px solid var(--border); border-radius: var(--radius); padding: var(--space-2); background: var(--bg-muted); }
-  .row { display: flex; flex-direction: column; align-items: flex-start; gap: 1px; text-align: left; border: 0; background: transparent; color: var(--fg-muted); cursor: pointer; padding: var(--space-2) var(--space-3); border-radius: var(--radius); font: inherit; }
-  .row:hover { color: var(--fg); background: var(--bg-hover); }
-  .row.active { color: var(--fg); background: var(--bg-hover); box-shadow: inset 2px 0 0 var(--accent); }
+  .list { display: flex; flex-direction: column; gap: 2px; border: 1px solid hsl(var(--border)); border-radius: var(--radius); padding: var(--space-2); background: hsl(var(--bg-muted)); }
+  .row { display: flex; flex-direction: column; align-items: flex-start; gap: 1px; text-align: left; border: 0; background: transparent; color: hsl(var(--fg-muted)); cursor: pointer; padding: var(--space-2) var(--space-3); border-radius: var(--radius); font: inherit; }
+  .row:hover { color: hsl(var(--fg)); background: hsl(var(--bg-hover)); }
+  .row.active { color: hsl(var(--fg)); background: hsl(var(--bg-hover)); box-shadow: inset 2px 0 0 hsl(var(--primary)); }
   .row .nm { font-weight: var(--weight-medium); }
-  .row .meta { font-size: var(--fs-xs); color: var(--fg-subtle); }
+  .row .meta { font-size: var(--fs-xs); color: hsl(var(--fg-subtle)); }
 
   .editor { display: flex; flex-direction: column; gap: var(--space-3); min-width: 0; }
-  .editor.empty { border: 1px dashed var(--border); border-radius: var(--radius); padding: var(--space-6); text-align: center; }
+  .editor.empty { border: 1px dashed hsl(var(--border)); border-radius: var(--radius); padding: var(--space-6); text-align: center; }
   .grid2 { display: grid; grid-template-columns: 1fr 1fr; gap: var(--space-3); }
   .field { display: flex; flex-direction: column; gap: 4px; }
   .field > span { font-size: var(--fs-sm); font-weight: var(--weight-medium); }
-  .field small { font-weight: 400; color: var(--fg-muted); }
-  input, textarea { font: inherit; font-size: var(--fs-sm); padding: 7px 10px; border: 1px solid var(--border); border-radius: var(--radius); background: var(--bg); color: var(--fg); width: 100%; }
+  .field small { font-weight: 400; color: hsl(var(--fg-muted)); }
+  input, textarea { font: inherit; font-size: var(--fs-sm); padding: 7px 10px; border: 1px solid hsl(var(--border)); border-radius: var(--radius); background: hsl(var(--bg)); color: hsl(var(--fg)); width: 100%; }
   textarea { resize: vertical; }
-  input:disabled { color: var(--fg-muted); background: var(--bg-muted); }
-  input.invalid { border-color: var(--danger); }
+  input:disabled { color: hsl(var(--fg-muted)); background: hsl(var(--bg-muted)); }
+  input.invalid { border-color: hsl(var(--danger)); }
 
-  .cubes { display: grid; grid-template-columns: repeat(auto-fill, minmax(220px, 1fr)); gap: 4px; border: 1px solid var(--border); border-radius: var(--radius); padding: var(--space-3); max-height: 200px; overflow: auto; background: var(--bg-muted); }
+  .cubes { display: grid; grid-template-columns: repeat(auto-fill, minmax(220px, 1fr)); gap: 4px; border: 1px solid hsl(var(--border)); border-radius: var(--radius); padding: var(--space-3); max-height: 200px; overflow: auto; background: hsl(var(--bg-muted)); }
   .cube { display: flex; align-items: center; gap: 8px; font-size: var(--fs-sm); cursor: pointer; }
 
   .actions { display: flex; gap: var(--space-2); margin-top: var(--space-2); }

--- a/saiku-ui/src/lib/views/admin/ApiAccessAdmin.svelte
+++ b/saiku-ui/src/lib/views/admin/ApiAccessAdmin.svelte
@@ -173,8 +173,8 @@
   }
   .small { font-size: 0.85rem; }
   .card {
-    background: var(--bg);
-    border: 1px solid var(--border);
+    background: hsl(var(--bg));
+    border: 1px solid hsl(var(--border));
     border-radius: var(--radius-md, 0.5rem);
     padding: var(--space-4);
   }
@@ -189,7 +189,7 @@
     display: inline-block;
     margin-right: var(--space-2);
     transition: transform 120ms ease;
-    color: var(--fg-muted);
+    color: hsl(var(--fg-muted));
   }
   .card[open] > summary::before { transform: rotate(90deg); }
   /* The summary owns the click target; the heading itself stays inline
@@ -221,9 +221,9 @@
     align-items: baseline;
     gap: var(--space-2);
   }
-  .kv__key { color: var(--fg-muted); font-size: 0.85rem; }
+  .kv__key { color: hsl(var(--fg-muted)); font-size: 0.85rem; }
   .kv__val {
-    background: var(--bg-muted);
+    background: hsl(var(--bg-muted));
     padding: 0.1rem 0.4rem;
     border-radius: 0.25rem;
     font-size: 0.85rem;
@@ -232,7 +232,7 @@
   .recipe { margin: var(--space-3) 0; }
   .recipe summary { cursor: pointer; user-select: none; }
   .recipe pre {
-    background: var(--bg-muted);
+    background: hsl(var(--bg-muted));
     padding: var(--space-3);
     border-radius: var(--radius-sm, 0.25rem);
     overflow: auto;
@@ -242,8 +242,8 @@
     margin-left: var(--space-2);
     font-size: 0.75rem;
     padding: 0.15rem 0.5rem;
-    background: var(--bg-muted);
-    border: 1px solid var(--border);
+    background: hsl(var(--bg-muted));
+    border: 1px solid hsl(var(--border));
     border-radius: 0.25rem;
     cursor: pointer;
   }
@@ -253,7 +253,7 @@
     gap: var(--space-2);
     margin: var(--space-3) 0;
     padding: var(--space-3);
-    background: var(--accent-soft);
+    background: hsl(var(--accent));
     border-radius: var(--radius-sm);
   }
   .install-row .btn {

--- a/saiku-ui/src/lib/views/admin/EvalsAdmin.svelte
+++ b/saiku-ui/src/lib/views/admin/EvalsAdmin.svelte
@@ -94,7 +94,7 @@
 
   {#if loaded && suites.length === 0}
     <div class="empty">
-      <h3 style="text-transform:none;color:var(--fg);font-size:var(--fs-md)">No eval runs recorded yet</h3>
+      <h3 style="text-transform:none;color:hsl(var(--fg));font-size:var(--fs-md)">No eval runs recorded yet</h3>
       <p class="text-fg-muted text-sm">
         This monitor plots agent accuracy over time from suites in <code>saiku-home/evals/</code>.
         Nothing has run against this deployment yet.
@@ -156,8 +156,8 @@
           <svg viewBox="0 0 {W} {H}" width="100%" preserveAspectRatio="xMidYMid meet">
             <defs>
               <linearGradient id="evalArea" x1="0" y1="0" x2="0" y2="1">
-                <stop offset="0" stop-color="var(--accent)" stop-opacity="0.18" />
-                <stop offset="1" stop-color="var(--accent)" stop-opacity="0" />
+                <stop offset="0" stop-color="hsl(var(--primary))" stop-opacity="0.18" />
+                <stop offset="1" stop-color="hsl(var(--primary))" stop-opacity="0" />
               </linearGradient>
             </defs>
             {#each gridLines as f (f)}
@@ -165,7 +165,7 @@
               <text class="axt" x={PL - 8} y={PT + IH * (1 - f) + 3} text-anchor="end">{(f * 100) | 0}%</text>
             {/each}
             <polygon points={areaPts} fill="url(#evalArea)" />
-            <polyline points={linePts} fill="none" stroke="var(--accent)" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" />
+            <polyline points={linePts} fill="none" stroke="hsl(var(--primary))" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" />
             {#each trend as t, i (i)}
               <circle class="dot-{band(t.passRate)}" cx={xAt(i, trend.length)} cy={yAt(t.passRate)} r={i === trend.length - 1 ? 4 : 2.6}>
                 <title>{pct(t.passRate)} · {t.total} cases · {fmtTs(t.startedAt)}</title>
@@ -219,53 +219,53 @@
 <style>
   .pane { display: flex; flex-direction: column; gap: var(--space-4); }
   h2 { margin: 0; }
-  h3 { margin: 0 0 var(--space-2); font-size: var(--fs-sm); text-transform: uppercase; letter-spacing: 0.04em; color: var(--fg-muted); }
+  h3 { margin: 0 0 var(--space-2); font-size: var(--fs-sm); text-transform: uppercase; letter-spacing: 0.04em; color: hsl(var(--fg-muted)); }
 
   .empty {
     padding: var(--space-6);
-    background: var(--bg-muted);
-    border: 1px solid var(--border);
+    background: hsl(var(--bg-muted));
+    border: 1px solid hsl(var(--border));
     border-radius: var(--radius);
     display: flex;
     flex-direction: column;
     gap: var(--space-2);
   }
-  .empty code { font-family: var(--font-mono, monospace); font-size: var(--fs-xs); background: var(--bg-subtle); padding: 1px 5px; border-radius: 4px; }
+  .empty code { font-family: var(--font-mono, monospace); font-size: var(--fs-xs); background: hsl(var(--bg-subtle)); padding: 1px 5px; border-radius: 4px; }
 
   .suite-bar { display: flex; flex-wrap: wrap; gap: var(--space-2); }
   .suite-chip {
     display: inline-flex; align-items: center; gap: var(--space-2);
     padding: var(--space-2) var(--space-3);
-    background: var(--bg-muted); border: 1px solid var(--border); border-radius: var(--radius);
-    color: var(--fg-muted); font: inherit; cursor: pointer;
+    background: hsl(var(--bg-muted)); border: 1px solid hsl(var(--border)); border-radius: var(--radius);
+    color: hsl(var(--fg-muted)); font: inherit; cursor: pointer;
   }
-  .suite-chip:hover { color: var(--fg); }
-  .suite-chip.active { color: var(--fg); border-color: var(--accent); box-shadow: inset 0 -2px 0 var(--accent); }
+  .suite-chip:hover { color: hsl(var(--fg)); }
+  .suite-chip.active { color: hsl(var(--fg)); border-color: hsl(var(--primary)); box-shadow: inset 0 -2px 0 hsl(var(--primary)); }
   .suite-chip .nm { font-weight: var(--weight-medium); }
   .suite-chip .pc { font-variant-numeric: tabular-nums; font-size: var(--fs-xs); }
-  .suite-chip .dot { width: 8px; height: 8px; border-radius: 50%; background: var(--fg-subtle); }
-  .suite-chip .dot.good { background: var(--success); }
-  .suite-chip .dot.warn { background: var(--warning); }
-  .suite-chip .dot.bad { background: var(--danger); }
+  .suite-chip .dot { width: 8px; height: 8px; border-radius: 50%; background: hsl(var(--fg-subtle)); }
+  .suite-chip .dot.good { background: hsl(var(--success)); }
+  .suite-chip .dot.warn { background: hsl(var(--warning)); }
+  .suite-chip .dot.bad { background: hsl(var(--danger)); }
 
   .kpis { display: grid; grid-template-columns: repeat(auto-fit, minmax(180px, 1fr)); gap: var(--space-3); }
-  .kpi { display: flex; flex-direction: column; gap: 2px; padding: var(--space-3); background: var(--bg-muted); border: 1px solid var(--border); border-radius: var(--radius); }
-  .kpi__label { font-size: var(--fs-xs); color: var(--fg-muted); text-transform: uppercase; letter-spacing: 0.05em; }
+  .kpi { display: flex; flex-direction: column; gap: 2px; padding: var(--space-3); background: hsl(var(--bg-muted)); border: 1px solid hsl(var(--border)); border-radius: var(--radius); }
+  .kpi__label { font-size: var(--fs-xs); color: hsl(var(--fg-muted)); text-transform: uppercase; letter-spacing: 0.05em; }
 
   .rate { font-variant-numeric: tabular-nums; }
-  .rate.good { color: var(--success); }
-  .rate.warn { color: var(--warning); }
-  .rate.bad { color: var(--danger); }
+  .rate.good { color: hsl(var(--success)); }
+  .rate.warn { color: hsl(var(--warning)); }
+  .rate.bad { color: hsl(var(--danger)); }
 
-  .chart-wrap { background: var(--bg-muted); border: 1px solid var(--border); border-radius: var(--radius); padding: var(--space-3); }
-  svg .grid { stroke: var(--border); stroke-width: 1; }
-  svg .axt { fill: var(--fg-muted); font-size: 10px; font-variant-numeric: tabular-nums; }
-  svg .dot-good { fill: var(--success); }
-  svg .dot-warn { fill: var(--warning); }
-  svg .dot-bad { fill: var(--danger); }
+  .chart-wrap { background: hsl(var(--bg-muted)); border: 1px solid hsl(var(--border)); border-radius: var(--radius); padding: var(--space-3); }
+  svg .grid { stroke: hsl(var(--border)); stroke-width: 1; }
+  svg .axt { fill: hsl(var(--fg-muted)); font-size: 10px; font-variant-numeric: tabular-nums; }
+  svg .dot-good { fill: hsl(var(--success)); }
+  svg .dot-warn { fill: hsl(var(--warning)); }
+  svg .dot-bad { fill: hsl(var(--danger)); }
 
   table { width: 100%; border-collapse: collapse; font-size: var(--fs-sm); }
-  th, td { padding: 6px 10px; text-align: left; white-space: nowrap; border-bottom: 1px solid var(--border); font-variant-numeric: tabular-nums; }
-  th { background: var(--bg-muted); font-weight: var(--weight-semibold); }
+  th, td { padding: 6px 10px; text-align: left; white-space: nowrap; border-bottom: 1px solid hsl(var(--border)); font-variant-numeric: tabular-nums; }
+  th { background: hsl(var(--bg-muted)); font-weight: var(--weight-semibold); }
   tr:last-child td { border-bottom: 0; }
 </style>

--- a/saiku-ui/src/lib/views/admin/LogsAdmin.svelte
+++ b/saiku-ui/src/lib/views/admin/LogsAdmin.svelte
@@ -47,9 +47,9 @@ h2 { margin: 0; }
   .log {
     margin: 0;
     padding: var(--space-3);
-    background: var(--bg-muted);
-    color: var(--fg);
-    border: 1px solid var(--border);
+    background: hsl(var(--bg-muted));
+    color: hsl(var(--fg));
+    border: 1px solid hsl(var(--border));
     border-radius: var(--radius-sm);
     font-family: var(--font-mono);
     font-size: var(--fs-xs);

--- a/saiku-ui/src/lib/views/admin/StatsAdmin.svelte
+++ b/saiku-ui/src/lib/views/admin/StatsAdmin.svelte
@@ -252,7 +252,7 @@
 <style>
 .pane { display: flex; flex-direction: column; gap: var(--space-4); }
   h2 { margin: 0; }
-  h3 { margin: 0 0 var(--space-2); font-size: var(--fs-sm); text-transform: uppercase; letter-spacing: 0.04em; color: var(--fg-muted); }
+  h3 { margin: 0 0 var(--space-2); font-size: var(--fs-sm); text-transform: uppercase; letter-spacing: 0.04em; color: hsl(var(--fg-muted)); }
   .kpis {
     display: grid;
     grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
@@ -263,14 +263,14 @@
     flex-direction: column;
     gap: 2px;
     padding: var(--space-3);
-    background: var(--bg-muted);
-    border: 1px solid var(--border);
+    background: hsl(var(--bg-muted));
+    border: 1px solid hsl(var(--border));
     border-radius: var(--radius);
   }
-  .kpi__label { font-size: var(--fs-xs); color: var(--fg-muted); text-transform: uppercase; letter-spacing: 0.05em; }
+  .kpi__label { font-size: var(--fs-xs); color: hsl(var(--fg-muted)); text-transform: uppercase; letter-spacing: 0.05em; }
   table { width: 100%; border-collapse: collapse; font-size: var(--fs-sm); }
-  th, td { padding: 6px 10px; text-align: left; white-space: nowrap; border-bottom: 1px solid var(--border); }
-  th { background: var(--bg-muted); font-weight: var(--weight-semibold); }
+  th, td { padding: 6px 10px; text-align: left; white-space: nowrap; border-bottom: 1px solid hsl(var(--border)); }
+  th { background: hsl(var(--bg-muted)); font-weight: var(--weight-semibold); }
   tr:last-child td { border-bottom: 0; }
   /* .mdx selector dropped — Mondrian StatementInfo doesn't surface
      the source MDX, so the column was removed in the 2026-06 rework. */

--- a/saiku-ui/src/lib/views/admin/UsersAdmin.svelte
+++ b/saiku-ui/src/lib/views/admin/UsersAdmin.svelte
@@ -168,7 +168,7 @@ h2 { margin: 0; }
   /* .field__hint is a local convention rather than a global — mirrors TopBottomCountModal.svelte. */
   .field__hint {
     margin: var(--space-1) 0 0;
-    color: var(--fg-subtle);
+    color: hsl(var(--fg-subtle));
     font-size: var(--fs-xs);
   }
   .field__hint code {

--- a/saiku-ui/src/lib/views/app/AppEditor.svelte
+++ b/saiku-ui/src/lib/views/app/AppEditor.svelte
@@ -148,7 +148,7 @@
     display: flex;
     align-items: center;
     justify-content: center;
-    color: var(--fg-muted);
+    color: hsl(var(--fg-muted));
     font-size: var(--fs-md);
   }
   /* Brand & Theme inspector — a right-edge overlay so it floats above the app

--- a/saiku-ui/src/lib/views/app/AppHeader.svelte
+++ b/saiku-ui/src/lib/views/app/AppHeader.svelte
@@ -85,9 +85,9 @@
     padding: 0.5rem 1rem;
     min-height: 3rem;
     box-sizing: border-box;
-    background: var(--saiku-app-bg, var(--bg));
-    color: var(--saiku-app-fg, var(--fg));
-    border-bottom: 1px solid var(--border);
+    background: var(--saiku-app-bg, hsl(var(--bg)));
+    color: var(--saiku-app-fg, hsl(var(--fg)));
+    border-bottom: 1px solid hsl(var(--border));
     font-family: var(--saiku-app-font, inherit);
   }
   .saiku-app__brand {
@@ -116,7 +116,7 @@
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
-    color: var(--saiku-app-primary, var(--saiku-app-fg, var(--fg)));
+    color: var(--saiku-app-primary, var(--saiku-app-fg, hsl(var(--fg))));
   }
   .saiku-app__name-accent {
     color: var(--saiku-app-accent-2, var(--saiku-app-accent, #c85a3a));

--- a/saiku-ui/src/lib/views/app/AppIndex.svelte
+++ b/saiku-ui/src/lib/views/app/AppIndex.svelte
@@ -266,8 +266,8 @@
   }
   .error {
     padding: 0.5rem 0.75rem;
-    background: color-mix(in srgb, var(--danger) 14%, transparent);
-    color: var(--danger);
+    background: color-mix(in srgb, hsl(var(--danger)) 14%, transparent);
+    color: hsl(var(--danger));
     border-radius: 4px;
     font-size: 0.875rem;
   }
@@ -284,12 +284,12 @@
     align-items: center;
     gap: 0.75rem;
     padding: 0.5rem 0.75rem;
-    border: 1px solid var(--border);
+    border: 1px solid hsl(var(--border));
     border-radius: 6px;
-    background: var(--bg);
+    background: hsl(var(--bg));
   }
   .row:hover {
-    background: var(--bg-subtle);
+    background: hsl(var(--bg-subtle));
   }
   .link {
     flex: 1;

--- a/saiku-ui/src/lib/views/app/AppNavRail.svelte
+++ b/saiku-ui/src/lib/views/app/AppNavRail.svelte
@@ -206,8 +206,8 @@
     flex-shrink: 0;
     padding: 0.5rem;
     box-sizing: border-box;
-    background: var(--saiku-app-bg, var(--bg-subtle, var(--bg)));
-    border-right: 1px solid var(--border);
+    background: var(--saiku-app-bg, var(--bg-subtle, hsl(var(--bg))));
+    border-right: 1px solid hsl(var(--border));
     overflow-y: auto;
     font-family: var(--saiku-app-font, inherit);
   }
@@ -255,7 +255,7 @@
     border: none;
     border-radius: 6px;
     background: transparent;
-    color: var(--saiku-app-fg, var(--fg-muted));
+    color: var(--saiku-app-fg, hsl(var(--fg-muted)));
     font: inherit;
     text-align: left;
     cursor: pointer;
@@ -263,12 +263,12 @@
     overflow: hidden;
   }
   .saiku-app__rail-item:hover {
-    background: var(--bg-hover);
-    color: var(--saiku-app-fg, var(--fg));
+    background: hsl(var(--bg-hover));
+    color: var(--saiku-app-fg, hsl(var(--fg)));
   }
   .saiku-app__rail-item.is-active {
-    background: var(--saiku-app-accent, var(--accent-soft));
-    color: var(--saiku-app-primary, var(--accent));
+    background: var(--saiku-app-accent, hsl(var(--accent)));
+    color: var(--saiku-app-primary, hsl(var(--primary)));
     font-weight: 600;
   }
   .saiku-app__rail-label {
@@ -279,15 +279,15 @@
     display: none;
   }
   .saiku-app__rail-add {
-    color: var(--fg-muted);
+    color: hsl(var(--fg-muted));
   }
   .saiku-app__rail-rename {
     width: 100%;
     padding: 0.4375rem 0.5rem;
-    border: 1px solid var(--border-strong);
+    border: 1px solid hsl(var(--border-strong));
     border-radius: 6px;
-    background: var(--bg);
-    color: var(--fg);
+    background: hsl(var(--bg));
+    color: hsl(var(--fg));
     font: inherit;
     box-sizing: border-box;
   }
@@ -339,12 +339,12 @@
     border: none;
     border-radius: 6px;
     background: transparent;
-    color: var(--fg-muted);
+    color: hsl(var(--fg-muted));
     cursor: pointer;
   }
   .saiku-app__rail-collapse:hover {
-    background: var(--bg-hover);
-    color: var(--fg);
+    background: hsl(var(--bg-hover));
+    color: hsl(var(--fg));
   }
 
   /* Narrow viewport: horizontal bottom bar pinned to the foot of the shell. */
@@ -352,7 +352,7 @@
     flex-direction: row;
     width: 100%;
     border-right: none;
-    border-top: 1px solid var(--border);
+    border-top: 1px solid hsl(var(--border));
     overflow-x: auto;
     overflow-y: hidden;
   }

--- a/saiku-ui/src/lib/views/app/AppShell.svelte
+++ b/saiku-ui/src/lib/views/app/AppShell.svelte
@@ -197,8 +197,8 @@
     width: 100%;
     min-width: 0;
     box-sizing: border-box;
-    background: var(--saiku-app-bg, var(--bg));
-    color: var(--saiku-app-fg, var(--fg));
+    background: var(--saiku-app-bg, hsl(var(--bg)));
+    color: var(--saiku-app-fg, hsl(var(--fg)));
     font-family: var(--saiku-app-font, inherit);
   }
   .saiku-app__body {

--- a/saiku-ui/src/lib/views/app/AppTopNav.svelte
+++ b/saiku-ui/src/lib/views/app/AppTopNav.svelte
@@ -105,8 +105,8 @@
     display: flex;
     align-items: stretch;
     padding: 0 0.75rem;
-    background: var(--saiku-app-bg, var(--bg-subtle, var(--bg)));
-    border-bottom: 1px solid var(--border);
+    background: var(--saiku-app-bg, var(--bg-subtle, hsl(var(--bg))));
+    border-bottom: 1px solid hsl(var(--border));
     overflow-x: auto;
     font-family: var(--saiku-app-font, inherit);
   }
@@ -126,29 +126,29 @@
     border: none;
     border-bottom: 2px solid transparent;
     background: transparent;
-    color: var(--saiku-app-fg, var(--fg-muted));
+    color: var(--saiku-app-fg, hsl(var(--fg-muted)));
     font: inherit;
     white-space: nowrap;
     cursor: pointer;
   }
   .saiku-app__topnav-tab:hover {
-    color: var(--saiku-app-fg, var(--fg));
+    color: var(--saiku-app-fg, hsl(var(--fg)));
   }
   .saiku-app__topnav-tab.is-active {
-    color: var(--saiku-app-primary, var(--accent));
-    border-bottom-color: var(--saiku-app-primary, var(--accent));
+    color: var(--saiku-app-primary, hsl(var(--primary)));
+    border-bottom-color: var(--saiku-app-primary, hsl(var(--primary)));
     font-weight: 600;
   }
   .saiku-app__topnav-add {
-    color: var(--fg-muted);
+    color: hsl(var(--fg-muted));
   }
   .saiku-app__topnav-rename {
     margin: 0.375rem 0;
     padding: 0.375rem 0.5rem;
-    border: 1px solid var(--border-strong);
+    border: 1px solid hsl(var(--border-strong));
     border-radius: 6px;
-    background: var(--bg);
-    color: var(--fg);
+    background: hsl(var(--bg));
+    color: hsl(var(--fg));
     font: inherit;
   }
 </style>

--- a/saiku-ui/src/lib/views/app/appSkin.ts
+++ b/saiku-ui/src/lib/views/app/appSkin.ts
@@ -21,7 +21,7 @@ export function appSkinCss(scope: string): string {
   const s = scope;
   return `
 ${s} .saiku-app__body, ${s} .saiku-app__main, ${s} .app-page {
-  background: var(--saiku-app-ground, var(--bg));
+  background: var(--saiku-app-ground, hsl(var(--bg)));
 }
 ${s} { font-family: var(--saiku-app-font-body, inherit); }
 
@@ -87,7 +87,7 @@ ${s} tbody th { font-weight: 500; text-align: left; }
 ${s} tbody td { text-align: right; font-weight: 650; color: var(--saiku-app-fg, #1f3529); }
 
 /* ---- nav rail ---- */
-${s} .saiku-app__rail { background: var(--saiku-app-rail-bg, var(--bg-subtle)); border-right: none; padding-top: 14px; }
+${s} .saiku-app__rail { background: var(--saiku-app-rail-bg, hsl(var(--bg-subtle))); border-right: none; padding-top: 14px; }
 ${s} .saiku-app__rail-brand { background: var(--saiku-app-accent-2, var(--saiku-app-accent, #2e5e43)); }
 ${s} .saiku-app__rail-item { color: var(--saiku-app-rail-fg, #9fb4a5); border-radius: 10px; }
 ${s} .saiku-app__rail-item.is-active { background: var(--saiku-app-accent, #2e5e43); color: #fff; }

--- a/saiku-ui/src/lib/views/app/inspector/AppInspector.svelte
+++ b/saiku-ui/src/lib/views/app/inspector/AppInspector.svelte
@@ -80,8 +80,8 @@
     flex-direction: column;
     min-height: 0;
     height: 100%;
-    background: var(--bg);
-    border-left: 1px solid var(--border);
+    background: hsl(var(--bg));
+    border-left: 1px solid hsl(var(--border));
     box-sizing: border-box;
   }
   .insp__head {
@@ -90,7 +90,7 @@
     justify-content: space-between;
     gap: 0.5rem;
     padding: 0.5rem 0.5rem 0.5rem 0.75rem;
-    border-bottom: 1px solid var(--border);
+    border-bottom: 1px solid hsl(var(--border));
   }
   .insp__tabs {
     display: flex;
@@ -100,7 +100,7 @@
   .insp__tab {
     border: 0;
     background: transparent;
-    color: var(--fg-muted);
+    color: hsl(var(--fg-muted));
     font-size: 0.78rem;
     font-weight: 600;
     padding: 0.35rem 0.5rem;
@@ -109,13 +109,13 @@
     white-space: nowrap;
   }
   .insp__tab.is-active {
-    background: var(--bg-subtle);
-    color: var(--fg);
+    background: hsl(var(--bg-subtle));
+    color: hsl(var(--fg));
   }
   .insp__close {
     border: 0;
     background: transparent;
-    color: var(--fg-muted);
+    color: hsl(var(--fg-muted));
     cursor: pointer;
     display: inline-flex;
     padding: 4px;
@@ -123,7 +123,7 @@
     flex-shrink: 0;
   }
   .insp__close:hover {
-    background: var(--bg-hover);
+    background: hsl(var(--bg-hover));
   }
   .insp__body {
     flex: 1;
@@ -144,7 +144,7 @@
     font-weight: 700;
     letter-spacing: 0.08em;
     text-transform: uppercase;
-    color: var(--fg-muted);
+    color: hsl(var(--fg-muted));
   }
   :global(.insp .insp-row) {
     display: flex;
@@ -154,7 +154,7 @@
     font-size: 0.82rem;
   }
   :global(.insp .insp-row > span) {
-    color: var(--fg);
+    color: hsl(var(--fg));
   }
   :global(.insp .insp-input),
   :global(.insp .insp-select) {
@@ -162,10 +162,10 @@
     min-width: 0;
     max-width: 62%;
     padding: 0.32rem 0.45rem;
-    border: 1px solid var(--border);
+    border: 1px solid hsl(var(--border));
     border-radius: 6px;
-    background: var(--bg);
-    color: var(--fg);
+    background: hsl(var(--bg));
+    color: hsl(var(--fg));
     font: inherit;
     font-size: 0.8rem;
     box-sizing: border-box;
@@ -178,10 +178,10 @@
     width: 100%;
     box-sizing: border-box;
     padding: 0.5rem;
-    border: 1px solid var(--border);
+    border: 1px solid hsl(var(--border));
     border-radius: 6px;
-    background: var(--bg);
-    color: var(--fg);
+    background: hsl(var(--bg));
+    color: hsl(var(--fg));
     font: inherit;
     font-size: 0.8rem;
     resize: vertical;
@@ -189,31 +189,31 @@
   :global(.insp .insp-hint) {
     margin: 0;
     font-size: 0.72rem;
-    color: var(--fg-muted);
+    color: hsl(var(--fg-muted));
     line-height: 1.4;
   }
   :global(.insp .insp-seg) {
     display: inline-flex;
-    border: 1px solid var(--border);
+    border: 1px solid hsl(var(--border));
     border-radius: 6px;
     overflow: hidden;
     flex-shrink: 0;
   }
   :global(.insp .insp-seg button) {
     border: 0;
-    background: var(--bg);
-    color: var(--fg-muted);
+    background: hsl(var(--bg));
+    color: hsl(var(--fg-muted));
     padding: 0.28rem 0.55rem;
     font-size: 0.72rem;
     text-transform: capitalize;
     cursor: pointer;
-    border-left: 1px solid var(--border);
+    border-left: 1px solid hsl(var(--border));
   }
   :global(.insp .insp-seg button:first-child) {
     border-left: 0;
   }
   :global(.insp .insp-seg button.is-active) {
-    background: var(--accent);
+    background: hsl(var(--primary));
     color: var(--accent-fg, #fff);
   }
   :global(.insp .insp-toggle) {
@@ -233,9 +233,9 @@
     max-width: none;
   }
   :global(.insp .insp-iconbtn) {
-    border: 1px solid var(--border);
-    background: var(--bg);
-    color: var(--fg-muted);
+    border: 1px solid hsl(var(--border));
+    background: hsl(var(--bg));
+    color: hsl(var(--fg-muted));
     border-radius: 6px;
     padding: 0.3rem 0.45rem;
     cursor: pointer;
@@ -244,21 +244,21 @@
     flex-shrink: 0;
   }
   :global(.insp .insp-iconbtn:hover) {
-    background: var(--bg-hover);
-    color: var(--fg);
+    background: hsl(var(--bg-hover));
+    color: hsl(var(--fg));
   }
   :global(.insp .insp-addbtn) {
     align-self: flex-start;
-    border: 1px dashed var(--border-strong, var(--border));
+    border: 1px dashed var(--border-strong, hsl(var(--border)));
     background: transparent;
-    color: var(--fg-muted);
+    color: hsl(var(--fg-muted));
     border-radius: 6px;
     padding: 0.3rem 0.6rem;
     font-size: 0.76rem;
     cursor: pointer;
   }
   :global(.insp .insp-addbtn:hover) {
-    color: var(--fg);
-    border-color: var(--accent);
+    color: hsl(var(--fg));
+    border-color: hsl(var(--primary));
   }
 </style>

--- a/saiku-ui/src/lib/views/app/inspector/PagesSection.svelte
+++ b/saiku-ui/src/lib/views/app/inspector/PagesSection.svelte
@@ -44,13 +44,13 @@
 </div>
 
 <style>
-  .page { border: 1px solid var(--border); border-radius: 8px; margin-bottom: 0.4rem; overflow: hidden; }
-  .page.is-active { border-color: var(--accent); }
+  .page { border: 1px solid hsl(var(--border)); border-radius: 8px; margin-bottom: 0.4rem; overflow: hidden; }
+  .page.is-active { border-color: hsl(var(--primary)); }
   .page-head {
-    width: 100%; text-align: left; border: 0; background: var(--bg-subtle);
-    padding: 0.45rem 0.6rem; font-size: 0.82rem; font-weight: 600; color: var(--fg);
+    width: 100%; text-align: left; border: 0; background: hsl(var(--bg-subtle));
+    padding: 0.45rem 0.6rem; font-size: 0.82rem; font-weight: 600; color: hsl(var(--fg));
     cursor: pointer; display: flex; align-items: center; gap: 0.4rem;
   }
-  .dot { color: var(--accent); font-size: 0.6rem; margin-left: auto; }
+  .dot { color: hsl(var(--primary)); font-size: 0.6rem; margin-left: auto; }
   .page-fields { display: flex; flex-direction: column; gap: 0.4rem; padding: 0.5rem 0.6rem 0.7rem; }
 </style>

--- a/saiku-ui/src/lib/views/app/inspector/ThemeSection.svelte
+++ b/saiku-ui/src/lib/views/app/inspector/ThemeSection.svelte
@@ -140,28 +140,28 @@
   .presets { display: grid; grid-template-columns: 1fr 1fr; gap: 0.5rem; }
   .preset {
     display: flex; flex-direction: column; gap: 0.4rem; padding: 0.5rem;
-    border: 1px solid var(--border); border-radius: 8px; background: var(--bg-subtle);
+    border: 1px solid hsl(var(--border)); border-radius: 8px; background: hsl(var(--bg-subtle));
     cursor: pointer; text-align: left;
   }
-  .preset.is-active { border-color: var(--accent); box-shadow: 0 0 0 1px var(--accent); }
+  .preset.is-active { border-color: hsl(var(--primary)); box-shadow: 0 0 0 1px hsl(var(--primary)); }
   .swatches { display: flex; height: 22px; border-radius: 5px; overflow: hidden; }
   .swatches span { flex: 1; }
   .preset-name { font-size: 0.8rem; font-weight: 600; }
   .colours { display: grid; grid-template-columns: 1fr 1fr; gap: 0.5rem 0.75rem; }
   .colour { display: flex; align-items: center; gap: 0.5rem; font-size: 0.8rem; }
   .colour input[type="color"] {
-    width: 28px; height: 24px; padding: 0; border: 1px solid var(--border);
+    width: 28px; height: 24px; padding: 0; border: 1px solid hsl(var(--border));
     border-radius: 5px; background: none; cursor: pointer; flex-shrink: 0;
   }
   .disclosure {
-    border: 0; background: transparent; color: var(--fg-muted);
+    border: 0; background: transparent; color: hsl(var(--fg-muted));
     font-size: 0.78rem; font-weight: 600; text-align: left; padding: 0; cursor: pointer;
   }
   .brief-btn {
     align-self: flex-start;
     display: inline-flex; align-items: center; gap: 6px;
     border: 0; border-radius: 6px; padding: 0.35rem 0.7rem;
-    background: var(--accent); color: var(--accent-fg, #fff);
+    background: hsl(var(--primary)); color: var(--accent-fg, #fff);
     font-size: 0.78rem; font-weight: 600; cursor: pointer;
   }
   .brief-btn:disabled { opacity: 0.5; cursor: default; }

--- a/saiku-ui/src/lib/views/dashboard/AddTileMenu.svelte
+++ b/saiku-ui/src/lib/views/dashboard/AddTileMenu.svelte
@@ -138,8 +138,8 @@
     position: absolute;
     top: calc(100% + 4px);
     right: 0;
-    background: var(--bg);
-    border: 1px solid var(--border);
+    background: hsl(var(--bg));
+    border: 1px solid hsl(var(--border));
     border-radius: 6px;
     box-shadow: 0 8px 24px rgba(0, 0, 0, 0.08);
     padding: 0.25rem;
@@ -164,7 +164,7 @@
     font-size: 0.875rem;
   }
   .menu-item:hover, .menu-item:focus {
-    background: var(--bg-subtle);
+    background: hsl(var(--bg-subtle));
     outline: none;
   }
   .menu-item:disabled {
@@ -182,7 +182,7 @@
   .hint {
     display: block;
     font-size: 0.75rem;
-    color: var(--fg-muted);
+    color: hsl(var(--fg-muted));
     margin-top: 0.125rem;
   }
 </style>

--- a/saiku-ui/src/lib/views/dashboard/CommentsPanel.svelte
+++ b/saiku-ui/src/lib/views/dashboard/CommentsPanel.svelte
@@ -243,7 +243,7 @@
     gap: var(--space-3);
   }
   .cmts__state {
-    color: var(--fg-muted);
+    color: hsl(var(--fg-muted));
     font-size: var(--fs-sm);
     padding: var(--space-2) 0;
   }
@@ -259,18 +259,18 @@
   }
   .cmts__date {
     font-size: var(--fs-xs, 0.75rem);
-    color: var(--fg-muted);
+    color: hsl(var(--fg-muted));
   }
   .cmts__del {
     margin-left: auto;
     background: none;
     border: none;
-    color: var(--fg-muted);
+    color: hsl(var(--fg-muted));
     cursor: pointer;
     padding: 2px;
   }
   .cmts__del:hover {
-    color: var(--danger);
+    color: hsl(var(--danger));
   }
   .cmts__body {
     margin: var(--space-1) 0 0;
@@ -293,8 +293,8 @@
     margin: 0;
     padding: 4px;
     list-style: none;
-    background: var(--bg);
-    border: 1px solid var(--border);
+    background: hsl(var(--bg));
+    border: 1px solid hsl(var(--border));
     border-radius: var(--radius-sm);
     box-shadow: var(--shadow-md, 0 4px 12px rgba(0, 0, 0, 0.15));
     max-height: 12rem;
@@ -311,6 +311,6 @@
     border-radius: 4px;
     cursor: pointer;
     font: inherit;
-    color: var(--fg);
+    color: hsl(var(--fg));
   }
 </style>

--- a/saiku-ui/src/lib/views/dashboard/DashboardBulkActionsBar.svelte
+++ b/saiku-ui/src/lib/views/dashboard/DashboardBulkActionsBar.svelte
@@ -69,9 +69,9 @@
     align-items: center;
     gap: 0.5rem;
     padding: 0.375rem 0.5rem 0.375rem 0.75rem;
-    border: 1px solid var(--border-strong);
+    border: 1px solid hsl(var(--border-strong));
     border-radius: 999px;
-    background: var(--bg);
+    background: hsl(var(--bg));
     box-shadow: 0 8px 24px rgba(0, 0, 0, 0.18);
     /* Float above the grid, centred near the bottom so it doesn't cover
        the toolbar or the tile a user is reaching for at the top. */
@@ -86,29 +86,29 @@
     align-items: center;
     gap: 0.375rem;
     padding: 0.3125rem 0.625rem;
-    border: 1px solid var(--border-strong);
-    background: var(--bg);
-    color: var(--fg);
+    border: 1px solid hsl(var(--border-strong));
+    background: hsl(var(--bg));
+    color: hsl(var(--fg));
     border-radius: 999px;
     cursor: pointer;
     font-size: 0.8125rem;
   }
   .bulk-bar__btn:hover {
-    background: var(--bg-subtle);
+    background: hsl(var(--bg-subtle));
   }
   .bulk-bar__btn--danger {
-    color: var(--danger);
-    border-color: color-mix(in srgb, var(--danger) 50%, var(--border-strong));
+    color: hsl(var(--danger));
+    border-color: color-mix(in srgb, hsl(var(--danger)) 50%, hsl(var(--border-strong)));
   }
   .bulk-bar__btn--danger:hover {
-    background: color-mix(in srgb, var(--danger) 12%, transparent);
+    background: color-mix(in srgb, hsl(var(--danger)) 12%, transparent);
   }
   .bulk-bar__btn--ghost {
     padding: 0.3125rem;
     border-color: transparent;
-    color: var(--fg-muted);
+    color: hsl(var(--fg-muted));
   }
   .bulk-bar__btn--ghost:hover {
-    color: var(--fg);
+    color: hsl(var(--fg));
   }
 </style>

--- a/saiku-ui/src/lib/views/dashboard/DashboardCataloguePinned.svelte
+++ b/saiku-ui/src/lib/views/dashboard/DashboardCataloguePinned.svelte
@@ -95,7 +95,7 @@
     font-size: 0.6875rem;
     text-transform: uppercase;
     letter-spacing: 0.06em;
-    color: var(--fg-muted);
+    color: hsl(var(--fg-muted));
     font-weight: var(--weight-semibold);
     margin: 0 0 0.25rem;
     display: inline-flex;
@@ -107,20 +107,20 @@
     align-items: center;
     gap: 0.5rem;
     padding: 0.5rem 0.625rem;
-    border: 1px solid var(--border);
+    border: 1px solid hsl(var(--border));
     border-radius: 6px;
-    background: var(--bg);
+    background: hsl(var(--bg));
   }
   .link {
     flex: 1;
     display: flex;
     flex-direction: column;
     text-decoration: none;
-    color: var(--fg);
+    color: hsl(var(--fg));
     min-width: 0;
   }
   .link:hover .name {
-    color: var(--accent);
+    color: hsl(var(--primary));
   }
   .name {
     font-weight: var(--weight-semibold);

--- a/saiku-ui/src/lib/views/dashboard/DashboardCatalogueTree.svelte
+++ b/saiku-ui/src/lib/views/dashboard/DashboardCatalogueTree.svelte
@@ -244,20 +244,20 @@
     align-items: center;
     gap: 0.5rem;
     padding: 0.5rem 0.625rem;
-    border: 1px solid var(--border);
+    border: 1px solid hsl(var(--border));
     border-radius: 6px;
-    background: var(--bg);
+    background: hsl(var(--bg));
   }
   .link {
     flex: 1;
     display: flex;
     flex-direction: column;
     text-decoration: none;
-    color: var(--fg);
+    color: hsl(var(--fg));
     min-width: 0;
   }
   .link:hover .name {
-    color: var(--accent);
+    color: hsl(var(--primary));
   }
   .name {
     font-weight: var(--weight-semibold);
@@ -284,10 +284,10 @@
     user-select: none;
   }
   .tree-folder-head:hover {
-    background: var(--bg-subtle);
+    background: hsl(var(--bg-subtle));
   }
   .tree-folder-head:focus-visible {
-    outline: 2px solid var(--accent);
+    outline: 2px solid hsl(var(--primary));
     outline-offset: -2px;
   }
   .tree-folder-head:hover .tree-folder-actions,
@@ -295,13 +295,13 @@
     opacity: 1;
   }
   .tree-folder-head > :global(svg) {
-    color: var(--accent);
+    color: hsl(var(--primary));
     flex: 0 0 auto;
   }
   .tree-folder-count {
     font-size: 0.6875rem;
-    color: var(--fg-muted);
-    background: var(--bg-subtle);
+    color: hsl(var(--fg-muted));
+    background: hsl(var(--bg-subtle));
     border-radius: 999px;
     padding: 0.0625rem 0.4375rem;
   }
@@ -318,7 +318,7 @@
   .tree-empty {
     list-style: none;
     font-size: 0.8125rem;
-    color: var(--fg-muted);
+    color: hsl(var(--fg-muted));
     font-style: italic;
     padding: 0.375rem 0.5rem;
     padding-left: calc(0.5rem + var(--depth, 0) * 1.25rem);

--- a/saiku-ui/src/lib/views/dashboard/DashboardEditor.svelte
+++ b/saiku-ui/src/lib/views/dashboard/DashboardEditor.svelte
@@ -257,8 +257,8 @@
   }
   .error {
     padding: 0.5rem 0.75rem;
-    background: color-mix(in srgb, var(--danger) 14%, transparent);
-    color: var(--danger);
+    background: color-mix(in srgb, hsl(var(--danger)) 14%, transparent);
+    color: hsl(var(--danger));
     border-radius: 4px;
     font-size: 0.875rem;
   }
@@ -289,10 +289,10 @@
     align-items: center;
     gap: 0.375rem;
     padding: 0.375rem 0.625rem;
-    border: 1px solid var(--border-strong);
+    border: 1px solid hsl(var(--border-strong));
     border-radius: 4px;
-    background: color-mix(in srgb, var(--bg) 80%, transparent);
-    color: var(--fg);
+    background: color-mix(in srgb, hsl(var(--bg)) 80%, transparent);
+    color: hsl(var(--fg));
     font-size: 0.8125rem;
     cursor: pointer;
     opacity: 0.35;

--- a/saiku-ui/src/lib/views/dashboard/DashboardFilterBar.svelte
+++ b/saiku-ui/src/lib/views/dashboard/DashboardFilterBar.svelte
@@ -72,18 +72,18 @@
     align-items: center;
     gap: 0.25rem;
     padding: 0.25rem 0.5rem;
-    background: var(--bg-subtle);
+    background: hsl(var(--bg-subtle));
     border-radius: 999px;
     font-size: 0.8125rem;
-    color: var(--fg);
+    color: hsl(var(--fg));
   }
   /* Subtle source affordance — click filters look slightly bolder so users
      see which chips came from their interaction vs the dashboard's defaults. */
   .chip[data-source="click"] {
-    background: color-mix(in srgb, var(--accent) 18%, transparent);
+    background: color-mix(in srgb, hsl(var(--primary)) 18%, transparent);
   }
   .chip[data-source="panel"] {
-    background: var(--bg-subtle);
+    background: hsl(var(--bg-subtle));
   }
   .chip-x {
     border: none;
@@ -92,6 +92,6 @@
     font-size: 1rem;
     line-height: 1;
     padding: 0 0.125rem;
-    color: var(--fg-muted);
+    color: hsl(var(--fg-muted));
   }
 </style>

--- a/saiku-ui/src/lib/views/dashboard/DashboardFilterPanel.svelte
+++ b/saiku-ui/src/lib/views/dashboard/DashboardFilterPanel.svelte
@@ -887,9 +887,9 @@
 
 <style>
 .panel {
-    border: 1px solid var(--border);
+    border: 1px solid hsl(var(--border));
     border-radius: 6px;
-    background: var(--bg);
+    background: hsl(var(--bg));
     display: flex;
     flex-direction: column;
   }
@@ -898,8 +898,8 @@
     align-items: center;
     gap: 0.5rem;
     padding: 0.375rem 0.5rem;
-    border-bottom: 1px solid var(--border);
-    background: var(--bg-muted);
+    border-bottom: 1px solid hsl(var(--border));
+    background: hsl(var(--bg-muted));
     font-size: 0.8125rem;
   }
   .collapse-toggle {
@@ -910,7 +910,7 @@
     border: none;
     padding: 0.125rem 0.25rem;
     cursor: pointer;
-    color: var(--fg);
+    color: hsl(var(--fg));
     font-size: inherit;
     flex: 1;
     text-align: left;
@@ -919,14 +919,14 @@
     font-weight: var(--weight-medium, 500);
   }
   .count {
-    color: var(--fg-muted);
+    color: hsl(var(--fg-muted));
     font-weight: 400;
     margin-left: 0.125rem;
   }
   .add-btn {
     padding: 0.25rem 0.5rem;
-    border: 1px solid var(--border-strong, var(--border));
-    background: var(--bg);
+    border: 1px solid var(--border-strong, hsl(var(--border)));
+    background: hsl(var(--bg));
     border-radius: 4px;
     cursor: pointer;
     font-size: 0.75rem;
@@ -934,7 +934,7 @@
   .empty {
     margin: 0;
     padding: 0.5rem 0.75rem;
-    color: var(--fg-muted);
+    color: hsl(var(--fg-muted));
     font-size: 0.8125rem;
     font-style: italic;
   }
@@ -951,17 +951,17 @@
     align-items: center;
     gap: 0.25rem;
     padding: 0.25rem 0.375rem;
-    border: 1px solid var(--border);
+    border: 1px solid hsl(var(--border));
     border-radius: 4px;
-    background: var(--bg);
+    background: hsl(var(--bg));
     user-select: none;
   }
   .picker--hover {
-    box-shadow: 0 0 0 2px var(--accent, color-mix(in srgb, var(--fg) 30%, transparent));
+    box-shadow: 0 0 0 2px var(--accent, color-mix(in srgb, hsl(var(--fg)) 30%, transparent));
   }
   .grip {
     cursor: grab;
-    color: var(--fg-muted);
+    color: hsl(var(--fg-muted));
     display: inline-flex;
   }
   .grip:active {
@@ -971,7 +971,7 @@
     font-size: 0.75rem;
     text-transform: uppercase;
     letter-spacing: 0.04em;
-    color: var(--fg-muted);
+    color: hsl(var(--fg-muted));
   }
   /* issue #924: "affects N of M tiles" hover badge. */
   .affects-badge {
@@ -979,15 +979,15 @@
     line-height: 1;
     padding: 0.125rem 0.375rem;
     border-radius: 999px;
-    background: var(--accent);
+    background: hsl(var(--primary));
     color: var(--accent-fg, #fff);
     white-space: nowrap;
   }
   .picker-select {
     padding: 0.125rem 0.25rem;
-    border: 1px solid var(--border-strong, var(--border));
+    border: 1px solid var(--border-strong, hsl(var(--border)));
     border-radius: 4px;
-    background: var(--bg);
+    background: hsl(var(--bg));
     font-size: 0.8125rem;
     max-width: 200px;
   }
@@ -995,9 +995,9 @@
      (saiku#1230); its styles live alongside the markup there. */
   .picker-date {
     padding: 0.125rem 0.25rem;
-    border: 1px solid var(--border-strong, var(--border));
+    border: 1px solid var(--border-strong, hsl(var(--border)));
     border-radius: 4px;
-    background: var(--bg);
+    background: hsl(var(--bg));
     font-size: 0.8125rem;
     font-family: inherit;
   }
@@ -1011,21 +1011,21 @@
   .picker-num {
     width: 3.5rem;
     padding: 0.125rem 0.25rem;
-    border: 1px solid var(--border-strong, var(--border));
+    border: 1px solid var(--border-strong, hsl(var(--border)));
     border-radius: 4px;
-    background: var(--bg);
+    background: hsl(var(--bg));
     font-size: 0.8125rem;
     font-family: inherit;
   }
   .topn-state {
     font-size: 0.75rem;
-    color: var(--fg-muted);
+    color: hsl(var(--fg-muted));
   }
   .picker-remove {
     background: transparent;
     border: none;
     cursor: pointer;
-    color: var(--fg-muted);
+    color: hsl(var(--fg-muted));
     padding: 0.125rem;
     display: inline-flex;
   }
@@ -1039,15 +1039,15 @@
     font-size: 0.75rem;
   }
   .add-field > span:first-child {
-    color: var(--fg-muted);
+    color: hsl(var(--fg-muted));
     text-transform: uppercase;
     letter-spacing: 0.04em;
   }
   .add-field select {
     padding: 0.25rem 0.375rem;
-    border: 1px solid var(--border-strong, var(--border));
+    border: 1px solid var(--border-strong, hsl(var(--border)));
     border-radius: 4px;
-    background: var(--bg);
+    background: hsl(var(--bg));
     font-size: 0.8125rem;
     min-width: 8rem;
   }

--- a/saiku-ui/src/lib/views/dashboard/DashboardGrid.svelte
+++ b/saiku-ui/src/lib/views/dashboard/DashboardGrid.svelte
@@ -393,16 +393,16 @@
       135deg,
       transparent 0,
       transparent 6px,
-      var(--fg-muted) 6px,
-      var(--fg-muted) 7px,
+      hsl(var(--fg-muted)) 6px,
+      hsl(var(--fg-muted)) 7px,
       transparent 7px,
       transparent 9px,
-      var(--fg-muted) 9px,
-      var(--fg-muted) 10px,
+      hsl(var(--fg-muted)) 9px,
+      hsl(var(--fg-muted)) 10px,
       transparent 10px,
       transparent 12px,
-      var(--fg-muted) 12px,
-      var(--fg-muted) 13px,
+      hsl(var(--fg-muted)) 12px,
+      hsl(var(--fg-muted)) 13px,
       transparent 13px
     );
     opacity: 0.5;
@@ -413,8 +413,8 @@
     opacity: 1;
   }
   .ghost {
-    border: 2px dashed var(--accent, color-mix(in srgb, var(--fg) 30%, transparent));
-    background: color-mix(in srgb, var(--accent, var(--fg)) 12%, transparent);
+    border: 2px dashed var(--accent, color-mix(in srgb, hsl(var(--fg)) 30%, transparent));
+    background: color-mix(in srgb, var(--accent, hsl(var(--fg))) 12%, transparent);
     border-radius: 6px;
     pointer-events: none;
     z-index: 2;
@@ -454,8 +454,8 @@
   .empty {
     padding: 3rem 1rem;
     text-align: center;
-    color: var(--fg-muted);
-    border: 2px dashed var(--border);
+    color: hsl(var(--fg-muted));
+    border: 2px dashed hsl(var(--border));
     border-radius: 8px;
   }
   .empty p { margin: 0.25rem 0; }

--- a/saiku-ui/src/lib/views/dashboard/DashboardIndex.svelte
+++ b/saiku-ui/src/lib/views/dashboard/DashboardIndex.svelte
@@ -836,8 +836,8 @@
   }
   .error {
     padding: 0.5rem 0.75rem;
-    background: color-mix(in srgb, var(--danger) 14%, transparent);
-    color: var(--danger);
+    background: color-mix(in srgb, hsl(var(--danger)) 14%, transparent);
+    color: hsl(var(--danger));
     border-radius: 4px;
     font-size: 0.875rem;
   }
@@ -854,12 +854,12 @@
     align-items: center;
     gap: 0.75rem;
     padding: 0.5rem 0.75rem;
-    border: 1px solid var(--border);
+    border: 1px solid hsl(var(--border));
     border-radius: 6px;
-    background: var(--bg);
+    background: hsl(var(--bg));
   }
   .row:hover {
-    background: var(--bg-subtle);
+    background: hsl(var(--bg-subtle));
   }
   .link {
     flex: 1;
@@ -892,29 +892,29 @@
     font-size: 0.6875rem;
     text-transform: uppercase;
     letter-spacing: 0.04em;
-    color: var(--fg-muted);
+    color: hsl(var(--fg-muted));
     font-weight: var(--weight-medium);
     margin-right: 0.25rem;
   }
   .chip {
     padding: 0.25rem 0.625rem;
-    border: 1px solid var(--border);
+    border: 1px solid hsl(var(--border));
     border-radius: 999px;
-    background: var(--bg);
+    background: hsl(var(--bg));
     cursor: pointer;
     font-size: 0.75rem;
-    color: var(--fg);
+    color: hsl(var(--fg));
   }
   .chip:hover {
-    background: var(--bg-subtle);
+    background: hsl(var(--bg-subtle));
   }
   .chip--on {
-    background: var(--accent);
+    background: hsl(var(--primary));
     color: white;
-    border-color: var(--accent);
+    border-color: hsl(var(--primary));
   }
   .chip--on:hover {
-    background: var(--accent);
+    background: hsl(var(--primary));
   }
   /* #937 folder tree + #1234 pinned styles moved into their delegates
      (DashboardCatalogueTree / DashboardCataloguePinned). */

--- a/saiku-ui/src/lib/views/dashboard/DashboardIndexFilters.svelte
+++ b/saiku-ui/src/lib/views/dashboard/DashboardIndexFilters.svelte
@@ -84,9 +84,9 @@
     flex: 1;
     min-width: 12rem;
     padding: 0.5rem 0.75rem;
-    border: 1px solid var(--border-strong);
+    border: 1px solid hsl(var(--border-strong));
     border-radius: 4px;
-    background: var(--bg);
+    background: hsl(var(--bg));
     font-size: 0.875rem;
   }
   .catalogue-filters .sort {
@@ -94,13 +94,13 @@
     align-items: center;
     gap: 0.375rem;
     font-size: 0.8125rem;
-    color: var(--fg-muted);
+    color: hsl(var(--fg-muted));
   }
   .catalogue-filters select {
     padding: 0.375rem 0.5rem;
-    border: 1px solid var(--border-strong);
+    border: 1px solid hsl(var(--border-strong));
     border-radius: 4px;
-    background: var(--bg);
+    background: hsl(var(--bg));
     font-size: 0.8125rem;
   }
 </style>

--- a/saiku-ui/src/lib/views/dashboard/DashboardShareModal.svelte
+++ b/saiku-ui/src/lib/views/dashboard/DashboardShareModal.svelte
@@ -156,7 +156,7 @@
     flex-direction: column;
     gap: var(--space-1);
     font-size: var(--fs-sm);
-    color: var(--fg-muted);
+    color: hsl(var(--fg-muted));
   }
   .share__ttl input {
     width: 6rem;
@@ -170,7 +170,7 @@
     display: flex;
     flex-direction: column;
     gap: var(--space-2);
-    border-top: 1px solid var(--border);
+    border-top: 1px solid hsl(var(--border));
     padding-top: var(--space-2);
   }
   .share__row {

--- a/saiku-ui/src/lib/views/dashboard/DashboardToolbar.svelte
+++ b/saiku-ui/src/lib/views/dashboard/DashboardToolbar.svelte
@@ -520,7 +520,7 @@
     align-items: flex-start;
     gap: 0.75rem;
     padding: 0.5rem 0.25rem;
-    border-bottom: 1px solid var(--border);
+    border-bottom: 1px solid hsl(var(--border));
   }
   /* #1604: the title block absorbs the toolbar's free space (it replaces the
      old flex spacer) so the editable name / heading has room to show the full
@@ -550,8 +550,8 @@
     overflow-wrap: anywhere;
   }
   .name:hover, .name:focus {
-    border-color: var(--border-strong);
-    background: var(--bg);
+    border-color: hsl(var(--border-strong));
+    background: hsl(var(--bg));
     outline: none;
   }
   .tag-chip {
@@ -560,8 +560,8 @@
     gap: 0.25rem;
     padding: 0.125rem 0.5rem;
     border-radius: 999px;
-    background: var(--bg-subtle);
-    color: var(--fg);
+    background: hsl(var(--bg-subtle));
+    color: hsl(var(--fg));
     font-size: 0.6875rem;
     line-height: 1.4;
   }
@@ -569,13 +569,13 @@
     background: none;
     border: none;
     padding: 0;
-    color: var(--fg-muted);
+    color: hsl(var(--fg-muted));
     cursor: pointer;
     display: inline-flex;
     align-items: center;
   }
   .tag-remove:hover {
-    color: var(--danger);
+    color: hsl(var(--danger));
   }
   .tag-input {
     border: 1px dashed transparent;
@@ -583,10 +583,10 @@
     padding: 0.125rem 0.375rem;
     font-size: 0.6875rem;
     min-width: 6rem;
-    color: var(--fg);
+    color: hsl(var(--fg));
   }
   .tag-input:hover, .tag-input:focus {
-    border-color: var(--border-strong);
+    border-color: hsl(var(--border-strong));
     outline: none;
   }
   .actions {
@@ -609,8 +609,8 @@
     gap: 0.25rem;
     min-width: 12rem;
     padding: 0.375rem;
-    background: var(--bg);
-    border: 1px solid var(--border);
+    background: hsl(var(--bg));
+    border: 1px solid hsl(var(--border));
     border-radius: 6px;
     box-shadow: 0 8px 24px rgba(0, 0, 0, 0.18);
     z-index: 60;
@@ -651,8 +651,8 @@
     gap: 0.25rem;
     min-width: 10rem;
     padding: 0.375rem;
-    background: var(--bg);
-    border: 1px solid var(--border);
+    background: hsl(var(--bg));
+    border: 1px solid hsl(var(--border));
     border-radius: 6px;
     box-shadow: 0 8px 24px rgba(0, 0, 0, 0.18);
     z-index: 70;
@@ -667,9 +667,9 @@
     gap: 0.5rem;
     max-width: 24rem;
     padding: 0.5rem 0.75rem;
-    background: color-mix(in srgb, var(--danger) 14%, var(--bg));
-    color: var(--danger);
-    border: 1px solid var(--danger);
+    background: color-mix(in srgb, hsl(var(--danger)) 14%, hsl(var(--bg)));
+    color: hsl(var(--danger));
+    border: 1px solid hsl(var(--danger));
     border-radius: 6px;
     font-size: 0.8125rem;
   }

--- a/saiku-ui/src/lib/views/dashboard/EmptyDashboardGuidance.svelte
+++ b/saiku-ui/src/lib/views/dashboard/EmptyDashboardGuidance.svelte
@@ -44,7 +44,7 @@
         onclick={() => onAddTile("chart")}
         aria-label="Add a chart tile"
       >
-        <span class="inline-flex items-center justify-center text-accent mb-1" aria-hidden="true">
+        <span class="inline-flex items-center justify-center text-primary mb-1" aria-hidden="true">
           <BarChart3 size={28} strokeWidth={1.75} />
         </span>
         <span class="font-semibold text-base">Chart</span>
@@ -57,7 +57,7 @@
         onclick={() => onAddTile("table")}
         aria-label="Add a table tile"
       >
-        <span class="inline-flex items-center justify-center text-accent mb-1" aria-hidden="true">
+        <span class="inline-flex items-center justify-center text-primary mb-1" aria-hidden="true">
           <Table2 size={28} strokeWidth={1.75} />
         </span>
         <span class="font-semibold text-base">Table</span>
@@ -70,7 +70,7 @@
         onclick={() => onAddTile("kpi")}
         aria-label="Add a KPI tile"
       >
-        <span class="inline-flex items-center justify-center text-accent mb-1" aria-hidden="true">
+        <span class="inline-flex items-center justify-center text-primary mb-1" aria-hidden="true">
           <Gauge size={28} strokeWidth={1.75} />
         </span>
         <span class="font-semibold text-base">KPI</span>
@@ -94,15 +94,15 @@
     max-width: 56rem;
     width: 100%;
     padding: 2rem 1.5rem;
-    border: 1px dashed var(--border-strong);
+    border: 1px dashed hsl(var(--border-strong));
     border-radius: 8px;
-    background: var(--bg-subtle);
+    background: hsl(var(--bg-subtle));
     text-align: center;
   }
   .subtitle {
     margin: 0;
     max-width: 36rem;
-    color: var(--fg-muted);
+    color: hsl(var(--fg-muted));
     font-size: 0.875rem;
     line-height: 1.5;
   }
@@ -124,20 +124,20 @@
     align-items: center;
     gap: 0.375rem;
     padding: 1.25rem 1rem;
-    background: var(--bg);
-    border: 1px solid var(--border-strong);
+    background: hsl(var(--bg));
+    border: 1px solid hsl(var(--border-strong));
     border-radius: 6px;
     cursor: pointer;
-    color: var(--fg);
+    color: hsl(var(--fg));
     font-family: inherit;
     transition: border-color 120ms ease, background 120ms ease, transform 120ms ease;
   }
   .cta:hover {
-    border-color: var(--accent);
-    background: color-mix(in srgb, var(--accent) 6%, var(--bg));
+    border-color: hsl(var(--primary));
+    background: color-mix(in srgb, hsl(var(--primary)) 6%, hsl(var(--bg)));
   }
   .cta:focus-visible {
-    outline: 2px solid var(--accent);
+    outline: 2px solid hsl(var(--primary));
     outline-offset: 2px;
   }
   .cta:active {
@@ -145,16 +145,16 @@
   }
   .cta-hint {
     font-size: 0.75rem;
-    color: var(--fg-muted);
+    color: hsl(var(--fg-muted));
     line-height: 1.4;
   }
   .more {
     margin: 0.25rem 0 0;
-    color: var(--fg-muted);
+    color: hsl(var(--fg-muted));
     font-size: 0.8125rem;
   }
   .more strong {
     font-weight: var(--weight-medium);
-    color: var(--fg);
+    color: hsl(var(--fg));
   }
 </style>

--- a/saiku-ui/src/lib/views/dashboard/FilterSuggestionsModal.svelte
+++ b/saiku-ui/src/lib/views/dashboard/FilterSuggestionsModal.svelte
@@ -190,8 +190,8 @@
     left: 50%;
     transform: translate(-50%, -50%);
     z-index: 101;
-    background: var(--bg);
-    border: 1px solid var(--border);
+    background: hsl(var(--bg));
+    border: 1px solid hsl(var(--border));
     border-radius: 8px;
     box-shadow: 0 12px 40px rgba(0, 0, 0, 0.2);
     width: min(540px, 90vw);
@@ -204,7 +204,7 @@
     align-items: center;
     justify-content: space-between;
     padding: 0.75rem 1rem;
-    border-bottom: 1px solid var(--border);
+    border-bottom: 1px solid hsl(var(--border));
   }
   .head h2 {
     margin: 0;
@@ -213,19 +213,19 @@
   }
   .hint, .empty {
     padding: 0.75rem 1rem 0;
-    color: var(--fg-muted);
+    color: hsl(var(--fg-muted));
     font-size: 0.8125rem;
     margin: 0;
   }
   .bulk {
     padding: 0.5rem 1rem 0;
     font-size: 0.8125rem;
-    color: var(--fg-muted);
+    color: hsl(var(--fg-muted));
   }
   .link {
     border: none;
     background: transparent;
-    color: var(--accent);
+    color: hsl(var(--primary));
     cursor: pointer;
     padding: 0;
     font: inherit;
@@ -253,6 +253,6 @@
   }
   .path, .meta {
     font-size: 0.75rem;
-    color: var(--fg-muted);
+    color: hsl(var(--fg-muted));
   }
 </style>

--- a/saiku-ui/src/lib/views/dashboard/HistoryPanel.svelte
+++ b/saiku-ui/src/lib/views/dashboard/HistoryPanel.svelte
@@ -116,12 +116,12 @@
     flex-direction: column;
   }
   .hist__state {
-    color: var(--fg-muted);
+    color: hsl(var(--fg-muted));
     font-size: var(--fs-sm);
     padding: var(--space-3) 0;
   }
   .hist__author {
     font-size: var(--fs-xs, 0.75rem);
-    color: var(--fg-muted);
+    color: hsl(var(--fg-muted));
   }
 </style>

--- a/saiku-ui/src/lib/views/dashboard/Tile.svelte
+++ b/saiku-ui/src/lib/views/dashboard/Tile.svelte
@@ -362,9 +362,9 @@
     display: flex;
     flex-direction: column;
     height: 100%;
-    border: 1px solid var(--border);
+    border: 1px solid hsl(var(--border));
     border-radius: 6px;
-    background: var(--bg);
+    background: hsl(var(--bg));
     overflow: hidden;
     /* issue #924: smooth the highlight/dim when a filter is hovered. */
     transition:
@@ -375,8 +375,8 @@
      tiles get a 1px accent ring (inset, so layout doesn't shift), tiles
      it won't touch fade back. Purely transient; clears on mouse-out. */
   .tile--filter-hit {
-    box-shadow: inset 0 0 0 1px var(--accent);
-    border-color: var(--accent);
+    box-shadow: inset 0 0 0 1px hsl(var(--primary));
+    border-color: hsl(var(--primary));
   }
   /* issue #915: multi-select outline. A 2px accent ring drawn with
      box-shadow (not border) so it never shifts the tile's layout, plus a
@@ -384,8 +384,8 @@
      ring naturally — both use box-shadow, last-declared wins on overlap,
      and a selected tile reads as selected first. */
   .tile--selected {
-    box-shadow: inset 0 0 0 2px var(--accent);
-    border-color: var(--accent);
+    box-shadow: inset 0 0 0 2px hsl(var(--primary));
+    border-color: hsl(var(--primary));
   }
   /* #942: comment badge sits between the title and the edit actions. */
   .tile-comment-badge {
@@ -403,7 +403,7 @@
     height: 14px;
     padding: 0 3px;
     border-radius: 999px;
-    background: var(--accent);
+    background: hsl(var(--primary));
     color: #fff;
     font-size: 0.625rem;
     line-height: 14px;
@@ -414,8 +414,8 @@
     display: flex;
     align-items: center;
     padding: 0.375rem 0.5rem;
-    border-bottom: 1px solid var(--border);
-    background: var(--bg-muted);
+    border-bottom: 1px solid hsl(var(--border));
+    background: hsl(var(--bg-muted));
     font-size: 0.8125rem;
     /* Hint that the header doubles as the drag handle in edit mode.
        Read-only dashboards opt out via .tile-header--draggable. */
@@ -437,8 +437,8 @@
   .tile-menu {
     position: fixed;
     min-width: 10rem;
-    background: var(--bg);
-    border: 1px solid var(--border);
+    background: hsl(var(--bg));
+    border: 1px solid hsl(var(--border));
     border-radius: 6px;
     box-shadow: 0 8px 24px rgba(0, 0, 0, 0.18);
     padding: 0.25rem;
@@ -455,13 +455,13 @@
     text-align: left;
     cursor: pointer;
     border-radius: 4px;
-    color: var(--fg);
+    color: hsl(var(--fg));
     font: inherit;
     font-size: 0.8125rem;
   }
   .tile-menu__item:hover,
   .tile-menu__item:focus {
-    background: var(--bg-subtle);
+    background: hsl(var(--bg-subtle));
     outline: none;
   }
   /* #932/#1175: height stepper row. */
@@ -477,14 +477,14 @@
     justify-content: center;
     width: 1.5rem;
     height: 1.5rem;
-    border: 1px solid var(--border-strong, var(--border));
-    background: var(--bg);
+    border: 1px solid var(--border-strong, hsl(var(--border)));
+    background: hsl(var(--bg));
     border-radius: 4px;
-    color: var(--fg);
+    color: hsl(var(--fg));
     cursor: pointer;
   }
   .tile-menu__step:hover:not(:disabled) {
-    background: var(--bg-subtle);
+    background: hsl(var(--bg-subtle));
   }
   .tile-menu__step:disabled {
     opacity: 0.4;
@@ -494,7 +494,7 @@
     min-width: 1.25rem;
     text-align: center;
     font-size: 0.8125rem;
-    color: var(--fg);
+    color: hsl(var(--fg));
     font-variant-numeric: tabular-nums;
   }
 </style>

--- a/saiku-ui/src/lib/views/dashboard/TileEditorModal.svelte
+++ b/saiku-ui/src/lib/views/dashboard/TileEditorModal.svelte
@@ -1498,7 +1498,7 @@
     z-index: 50;
   }
   .modal {
-    background: var(--bg);
+    background: hsl(var(--bg));
     border-radius: 8px;
     box-shadow: 0 16px 48px rgba(0, 0, 0, 0.2);
     width: min(560px, 92vw);
@@ -1518,7 +1518,7 @@
     display: flex;
     align-items: center;
     padding: 0.75rem 1rem;
-    border-bottom: 1px solid var(--border);
+    border-bottom: 1px solid hsl(var(--border));
   }
   .modal-header h2 {
     margin: 0;
@@ -1535,7 +1535,7 @@
   }
   .field span:first-child {
     font-size: 0.75rem;
-    color: var(--fg-muted);
+    color: hsl(var(--fg-muted));
     text-transform: uppercase;
     letter-spacing: 0.04em;
   }
@@ -1543,14 +1543,14 @@
     display: flex;
     gap: 0.5rem;
     align-items: flex-end;
-    border: 1px solid var(--border);
+    border: 1px solid hsl(var(--border));
     border-radius: 4px;
     padding: 0.5rem 0.75rem;
     margin: 0;
   }
   .size legend {
     font-size: 0.75rem;
-    color: var(--fg-muted);
+    color: hsl(var(--fg-muted));
     text-transform: uppercase;
     letter-spacing: 0.04em;
     padding: 0 0.25rem;
@@ -1563,14 +1563,14 @@
     display: flex;
     gap: 1rem;
     align-items: center;
-    border: 1px solid var(--border);
+    border: 1px solid hsl(var(--border));
     border-radius: 4px;
     padding: 0.5rem 0.75rem;
     margin: 0;
   }
   .mode legend {
     font-size: 0.75rem;
-    color: var(--fg-muted);
+    color: hsl(var(--fg-muted));
     text-transform: uppercase;
     letter-spacing: 0.04em;
     padding: 0 0.25rem;
@@ -1580,14 +1580,14 @@
     display: flex;
     flex-direction: column;
     gap: 0.5rem;
-    border: 1px solid var(--border);
+    border: 1px solid hsl(var(--border));
     border-radius: 4px;
     padding: 0.5rem 0.75rem;
     margin: 0;
   }
   .anomaly legend {
     font-size: 0.75rem;
-    color: var(--fg-muted);
+    color: hsl(var(--fg-muted));
     text-transform: uppercase;
     letter-spacing: 0.04em;
     padding: 0 0.25rem;
@@ -1602,8 +1602,8 @@
   }
   .position-error {
     padding: 0.5rem 0.75rem;
-    background: color-mix(in srgb, var(--danger) 14%, transparent);
-    color: var(--danger);
+    background: color-mix(in srgb, hsl(var(--danger)) 14%, transparent);
+    color: hsl(var(--danger));
     border-radius: 4px;
     font-size: 0.8125rem;
   }
@@ -1612,7 +1612,7 @@
   }
   input, select, textarea {
     padding: 0.375rem 0.5rem;
-    border: 1px solid var(--border-strong);
+    border: 1px solid hsl(var(--border-strong));
     border-radius: 4px;
     font-size: 0.875rem;
     font-family: inherit;
@@ -1624,10 +1624,10 @@
   }
   .hint {
     font-size: 0.75rem;
-    color: var(--fg-muted);
+    color: hsl(var(--fg-muted));
   }
-  .hint.error { color: var(--danger); }
-  .hint.ok { color: var(--success, var(--accent)); }
+  .hint.error { color: hsl(var(--danger)); }
+  .hint.ok { color: var(--success, hsl(var(--primary))); }
   /* #1077, #919: chart-options + conditional-formatting styles moved
      into TileEditorChart / TileEditorTableConditional / TileEditorKpi /
      TileEditorTableSparkline (per saiku#1229). Svelte's scoped CSS
@@ -1648,7 +1648,7 @@
     display: flex;
     flex-direction: column;
     gap: 0.5rem;
-    border: 1px solid var(--border);
+    border: 1px solid hsl(var(--border));
     border-radius: 4px;
     padding: 0.5rem 0.75rem;
     margin: 0;
@@ -1658,7 +1658,7 @@
   }
   .qe-section legend {
     font-size: 0.75rem;
-    color: var(--fg-muted);
+    color: hsl(var(--fg-muted));
     text-transform: uppercase;
     letter-spacing: 0.04em;
     padding: 0 0.25rem;
@@ -1673,7 +1673,7 @@
     /* A floor so the drop zones + result preview are usable even before the
        modal's flex height resolves. */
     min-height: 360px;
-    border: 1px solid var(--border);
+    border: 1px solid hsl(var(--border));
     border-radius: 4px;
     overflow: hidden;
   }

--- a/saiku-ui/src/lib/views/dashboard/TileEditorTableConditional.svelte
+++ b/saiku-ui/src/lib/views/dashboard/TileEditorTableConditional.svelte
@@ -194,14 +194,14 @@
     display: flex;
     flex-direction: column;
     gap: 0.5rem;
-    border: 1px solid var(--border);
+    border: 1px solid hsl(var(--border));
     border-radius: 4px;
     padding: 0.5rem 0.75rem;
     margin: 0;
   }
   .cf-section legend {
     font-size: 0.75rem;
-    color: var(--fg-muted);
+    color: hsl(var(--fg-muted));
     text-transform: uppercase;
     letter-spacing: 0.04em;
     padding: 0 0.25rem;
@@ -210,14 +210,14 @@
     display: flex;
     flex-direction: column;
     gap: 0.5rem;
-    border: 1px solid var(--border);
+    border: 1px solid hsl(var(--border));
     border-radius: 4px;
     padding: 0.5rem 0.625rem;
-    background: var(--bg-subtle);
+    background: hsl(var(--bg-subtle));
   }
   .cf-rule-label {
     font-size: 0.75rem;
-    color: var(--fg-muted);
+    color: hsl(var(--fg-muted));
     text-transform: uppercase;
     letter-spacing: 0.04em;
   }

--- a/saiku-ui/src/lib/views/dashboard/TileEditorTableSparkline.svelte
+++ b/saiku-ui/src/lib/views/dashboard/TileEditorTableSparkline.svelte
@@ -49,14 +49,14 @@
     display: flex;
     flex-direction: column;
     gap: 0.5rem;
-    border: 1px solid var(--border);
+    border: 1px solid hsl(var(--border));
     border-radius: 4px;
     padding: 0.5rem 0.75rem;
     margin: 0;
   }
   .cf-section legend {
     font-size: 0.75rem;
-    color: var(--fg-muted);
+    color: hsl(var(--fg-muted));
     text-transform: uppercase;
     letter-spacing: 0.04em;
     padding: 0 0.25rem;

--- a/saiku-ui/src/lib/views/dashboard/tiles/ChartTile.svelte
+++ b/saiku-ui/src/lib/views/dashboard/tiles/ChartTile.svelte
@@ -835,8 +835,8 @@
     display: flex;
     align-items: center;
     justify-content: center;
-    background: color-mix(in srgb, var(--bg) 75%, transparent);
-    color: var(--fg-muted);
+    background: color-mix(in srgb, hsl(var(--bg)) 75%, transparent);
+    color: hsl(var(--fg-muted));
     font-size: 0.875rem;
     z-index: 1;
     pointer-events: none;
@@ -846,7 +846,7 @@
   /* Opaque, interactive overlay for the loading skeleton / error / empty
      states (which carry Retry / Reset buttons). #933 */
   .overlay.solid {
-    background: var(--bg);
+    background: hsl(var(--bg));
     pointer-events: auto;
     padding: 0;
   }
@@ -858,14 +858,14 @@
     right: 0.25rem;
     top: 0.25rem;
     z-index: 2;
-    background: color-mix(in srgb, var(--bg) 80%, transparent);
+    background: color-mix(in srgb, hsl(var(--bg)) 80%, transparent);
     border-radius: 4px;
     padding: 0.0625rem 0.25rem;
     pointer-events: none;
     max-width: calc(100% - 0.5rem);
   }
   code {
-    background: var(--bg-subtle);
+    background: hsl(var(--bg-subtle));
     padding: 0.0625em 0.25em;
     border-radius: 3px;
     font-size: 0.85em;

--- a/saiku-ui/src/lib/views/dashboard/tiles/ImageTile.svelte
+++ b/saiku-ui/src/lib/views/dashboard/tiles/ImageTile.svelte
@@ -81,7 +81,7 @@
     flex-shrink: 0;
     padding: 0.25rem 0.5rem;
     font-size: 0.75rem;
-    color: var(--fg-muted);
+    color: hsl(var(--fg-muted));
     text-align: center;
     overflow-wrap: anywhere;
   }
@@ -96,7 +96,7 @@
     gap: 0.5rem;
     padding: 0.75rem;
     text-align: center;
-    color: var(--fg-muted);
+    color: hsl(var(--fg-muted));
     font-size: 0.8125rem;
   }
   /* Render the real edit-button icon (lucide Settings2) inline so the
@@ -104,6 +104,6 @@
   .image-placeholder :global(.inline-gear) {
     display: inline-block;
     vertical-align: -2px;
-    color: var(--fg-subtle);
+    color: hsl(var(--fg-subtle));
   }
 </style>

--- a/saiku-ui/src/lib/views/dashboard/tiles/KpiTile.svelte
+++ b/saiku-ui/src/lib/views/dashboard/tiles/KpiTile.svelte
@@ -535,7 +535,7 @@
     font-weight: 600;
     line-height: 1.1;
     letter-spacing: -0.01em;
-    color: var(--fg);
+    color: hsl(var(--fg));
     text-align: center;
   }
   .delta {
@@ -543,7 +543,7 @@
     align-items: center;
     gap: 0.25rem;
     font-size: 0.8125rem;
-    color: var(--fg-muted);
+    color: hsl(var(--fg-muted));
   }
   .delta[data-tone="positive"] {
     color: var(--success, #1b8a3a);
@@ -552,13 +552,13 @@
     color: var(--danger, #c00);
   }
   .delta.delta--empty {
-    color: var(--fg-muted);
+    color: hsl(var(--fg-muted));
     font-style: italic;
     cursor: help;
   }
   .caption {
     font-size: 0.75rem;
-    color: var(--fg-muted);
+    color: hsl(var(--fg-muted));
     text-transform: uppercase;
     letter-spacing: 0.04em;
   }
@@ -571,7 +571,7 @@
     right: 0.25rem;
     top: 0.25rem;
     z-index: 2;
-    background: color-mix(in srgb, var(--bg) 80%, transparent);
+    background: color-mix(in srgb, hsl(var(--bg)) 80%, transparent);
     border-radius: 4px;
     padding: 0.0625rem 0.25rem;
     pointer-events: none;
@@ -579,13 +579,13 @@
   }
   .placeholder {
     padding: 0.75rem 1rem;
-    color: var(--fg-muted);
+    color: hsl(var(--fg-muted));
     font-size: 0.8125rem;
     text-align: center;
   }
   .placeholder :global(.placeholder__icon) {
     display: inline-block;
     vertical-align: -2px;
-    color: var(--fg-subtle);
+    color: hsl(var(--fg-subtle));
   }
 </style>

--- a/saiku-ui/src/lib/views/dashboard/tiles/TableTile.svelte
+++ b/saiku-ui/src/lib/views/dashboard/tiles/TableTile.svelte
@@ -465,21 +465,21 @@
                               y={bar.y}
                               width={bar.width}
                               height={bar.height}
-                              fill="var(--accent)"
+                              fill="hsl(var(--primary))"
                             />
                           {/each}
                         {:else}
                           <polyline
                             points={g.polyline}
                             fill="none"
-                            stroke="var(--accent)"
+                            stroke="hsl(var(--primary))"
                             stroke-width="1.25"
                             stroke-linejoin="round"
                             stroke-linecap="round"
                             vector-effect="non-scaling-stroke"
                           />
                           {#if g.last}
-                            <circle cx={g.last.x} cy={g.last.y} r="1.5" fill="var(--accent)" />
+                            <circle cx={g.last.x} cy={g.last.y} r="1.5" fill="hsl(var(--primary))" />
                           {/if}
                         {/if}
                       </svg>
@@ -521,7 +521,7 @@
     float: right;
     margin-right: 0.25rem;
     z-index: 2;
-    background: color-mix(in srgb, var(--bg) 80%, transparent);
+    background: color-mix(in srgb, hsl(var(--bg)) 80%, transparent);
     border-radius: 4px;
     padding: 0.0625rem 0.25rem;
     pointer-events: none;
@@ -535,10 +535,10 @@
   th, td {
     padding: 0.25rem 0.5rem;
     text-align: right;
-    border-bottom: 1px solid var(--border);
+    border-bottom: 1px solid hsl(var(--border));
   }
   th {
-    background: var(--bg-muted);
+    background: hsl(var(--bg-muted));
     font-weight: var(--weight-semibold);
     position: sticky;
     top: 0;
@@ -551,10 +551,10 @@
     cursor: pointer;
   }
   td.clickable:hover {
-    background: var(--bg-subtle);
+    background: hsl(var(--bg-subtle));
   }
   td.clickable:focus {
-    outline: 2px solid var(--accent);
+    outline: 2px solid hsl(var(--primary));
     outline-offset: -2px;
   }
   /* Issue #919 — conditional-format icon glyph prepended to a cell. */
@@ -571,6 +571,6 @@
     display: block;
     width: 64px;
     height: 18px;
-    color: var(--accent);
+    color: hsl(var(--primary));
   }
 </style>

--- a/saiku-ui/src/lib/views/dashboard/tiles/TextTile.svelte
+++ b/saiku-ui/src/lib/views/dashboard/tiles/TextTile.svelte
@@ -61,7 +61,7 @@
     padding: 0.25rem 0.5rem;
     font-size: 0.875rem;
     line-height: 1.5;
-    color: var(--fg);
+    color: hsl(var(--fg));
   }
   /* Heading / paragraph / list resets so analyst-written text doesn't
      inherit weird vertical rhythm from the surrounding tile chrome. */
@@ -80,13 +80,13 @@
     padding-left: 1.25rem;
   }
   .text-tile :global(code) {
-    background: var(--bg-subtle);
+    background: hsl(var(--bg-subtle));
     padding: 0.0625em 0.25em;
     border-radius: 3px;
     font-size: 0.85em;
   }
   .text-tile :global(a) {
-    color: var(--accent);
+    color: hsl(var(--primary));
     text-decoration: underline;
   }
 </style>

--- a/saiku-ui/src/lib/views/dashboard/tiles/TileEmpty.svelte
+++ b/saiku-ui/src/lib/views/dashboard/tiles/TileEmpty.svelte
@@ -49,17 +49,17 @@
     gap: 0.35rem;
     padding: 0.25rem 0.6rem;
     font-size: 0.8125rem;
-    color: var(--fg);
-    background: var(--bg-subtle);
-    border: 1px solid var(--border);
+    color: hsl(var(--fg));
+    background: hsl(var(--bg-subtle));
+    border: 1px solid hsl(var(--border));
     border-radius: 4px;
     cursor: pointer;
   }
   .reset:hover {
-    background: var(--bg-muted);
+    background: hsl(var(--bg-muted));
   }
   .reset:focus-visible {
-    outline: 2px solid var(--accent);
+    outline: 2px solid hsl(var(--primary));
     outline-offset: 1px;
   }
 </style>

--- a/saiku-ui/src/lib/views/dashboard/tiles/TileError.svelte
+++ b/saiku-ui/src/lib/views/dashboard/tiles/TileError.svelte
@@ -35,7 +35,7 @@
     /* Long backend errors shouldn't blow out the tile. */
     max-width: 100%;
     overflow-wrap: anywhere;
-    color: var(--danger);
+    color: hsl(var(--danger));
   }
   .retry {
     display: inline-flex;
@@ -43,17 +43,17 @@
     gap: 0.35rem;
     padding: 0.25rem 0.6rem;
     font-size: 0.8125rem;
-    color: var(--fg);
-    background: var(--bg-subtle);
-    border: 1px solid var(--border);
+    color: hsl(var(--fg));
+    background: hsl(var(--bg-subtle));
+    border: 1px solid hsl(var(--border));
     border-radius: 4px;
     cursor: pointer;
   }
   .retry:hover {
-    background: var(--bg-muted);
+    background: hsl(var(--bg-muted));
   }
   .retry:focus-visible {
-    outline: 2px solid var(--accent);
+    outline: 2px solid hsl(var(--primary));
     outline-offset: 1px;
   }
 </style>

--- a/saiku-ui/src/lib/views/dashboard/tiles/TileLoading.svelte
+++ b/saiku-ui/src/lib/views/dashboard/tiles/TileLoading.svelte
@@ -52,7 +52,7 @@
 <style>
 /* Shared shimmer fill. */
   .sk {
-    background: var(--bg-subtle);
+    background: hsl(var(--bg-subtle));
     border-radius: 4px;
     position: relative;
     overflow: hidden;
@@ -64,7 +64,7 @@
     background: linear-gradient(
       90deg,
       transparent 0%,
-      color-mix(in srgb, var(--fg) 8%, transparent) 50%,
+      color-mix(in srgb, hsl(var(--fg)) 8%, transparent) 50%,
       transparent 100%
     );
     transform: translateX(-100%);
@@ -108,7 +108,7 @@
   }
   .sk-row--head .skeleton-cell {
     height: 1.05rem;
-    background: var(--bg-muted);
+    background: hsl(var(--bg-muted));
   }
   /* KPI: a big number block + a small caption block. */
   .sk-kpi {

--- a/saiku-ui/src/lib/views/dashboard/tiles/TileRefreshIndicator.svelte
+++ b/saiku-ui/src/lib/views/dashboard/tiles/TileRefreshIndicator.svelte
@@ -46,7 +46,7 @@
     align-items: center;
     gap: 0.25rem;
     font-size: 0.6875rem;
-    color: var(--fg-muted);
+    color: hsl(var(--fg-muted));
     line-height: 1;
     pointer-events: none;
     max-width: 100%;

--- a/saiku-ui/src/lib/views/dashboard/tiles/custom/EChartsOptionTile.svelte
+++ b/saiku-ui/src/lib/views/dashboard/tiles/custom/EChartsOptionTile.svelte
@@ -302,8 +302,8 @@
     display: flex;
     align-items: center;
     justify-content: center;
-    background: var(--bg);
-    color: var(--fg-muted);
+    background: hsl(var(--bg));
+    color: hsl(var(--fg-muted));
     z-index: 1;
   }
   .overlay.solid {

--- a/saiku-ui/src/lib/views/dashboard/tiles/custom/GraphTile.svelte
+++ b/saiku-ui/src/lib/views/dashboard/tiles/custom/GraphTile.svelte
@@ -246,8 +246,8 @@
     display: flex;
     align-items: center;
     justify-content: center;
-    background: var(--bg);
-    color: var(--fg-muted);
+    background: hsl(var(--bg));
+    color: hsl(var(--fg-muted));
     z-index: 1;
   }
   .overlay.solid {

--- a/saiku-ui/src/lib/views/dashboard/tiles/custom/PluginTile.svelte
+++ b/saiku-ui/src/lib/views/dashboard/tiles/custom/PluginTile.svelte
@@ -332,7 +332,7 @@
     width: 100%;
     min-height: 40px;
     border: 0;
-    background: var(--bg);
+    background: hsl(var(--bg));
   }
   .plugin-error {
     position: absolute;
@@ -342,7 +342,7 @@
     padding: 4px 8px;
     font-size: 12px;
     color: var(--danger, #b91c1c);
-    background: var(--bg);
+    background: hsl(var(--bg));
     border-top: 1px solid var(--border, #e5e7eb);
     z-index: 2;
     white-space: pre-wrap;
@@ -354,8 +354,8 @@
     display: flex;
     align-items: center;
     justify-content: center;
-    background: var(--bg);
-    color: var(--fg-muted);
+    background: hsl(var(--bg));
+    color: hsl(var(--fg-muted));
     z-index: 1;
   }
   .overlay.solid {

--- a/saiku-ui/src/lib/views/dashboard/widgets/CascadingFilterPicker.svelte
+++ b/saiku-ui/src/lib/views/dashboard/widgets/CascadingFilterPicker.svelte
@@ -209,9 +209,9 @@
   }
   .picker-select {
     padding: 0.125rem 0.25rem;
-    border: 1px solid var(--border-strong, var(--border));
+    border: 1px solid var(--border-strong, hsl(var(--border)));
     border-radius: 4px;
-    background: var(--bg);
+    background: hsl(var(--bg));
     font-size: 0.8125rem;
     max-width: 200px;
   }

--- a/saiku-ui/src/routes/+layout.svelte
+++ b/saiku-ui/src/routes/+layout.svelte
@@ -179,14 +179,14 @@
     justify-content: space-between;
     gap: var(--space-3);
     padding: var(--space-3) var(--space-5);
-    background: var(--bg-muted);
-    border-bottom: 1px solid var(--border);
+    background: hsl(var(--bg-muted));
+    border-bottom: 1px solid hsl(var(--border));
   }
   .topbar__brand {
     display: flex;
     align-items: center;
     gap: var(--space-2);
-    color: var(--fg);
+    color: hsl(var(--fg));
     text-decoration: none;
   }
   .topbar__brand:hover { text-decoration: none; }
@@ -224,11 +224,11 @@
     align-items: center;
     gap: var(--space-1);
     padding: 4px var(--space-2);
-    background: var(--bg-subtle);
-    border: 1px solid var(--border);
+    background: hsl(var(--bg-subtle));
+    border: 1px solid hsl(var(--border));
     border-radius: 999px;
-    color: var(--fg-muted);
+    color: hsl(var(--fg-muted));
     font-size: var(--fs-sm);
   }
-  .topbar__user :global(svg) { color: var(--fg-subtle); }
+  .topbar__user :global(svg) { color: hsl(var(--fg-subtle)); }
 </style>

--- a/saiku-ui/src/routes/admin/+page.svelte
+++ b/saiku-ui/src/routes/admin/+page.svelte
@@ -68,20 +68,20 @@
     display: flex;
     gap: var(--space-2);
     padding: var(--space-2) var(--space-5);
-    background: var(--bg-muted);
-    border-bottom: 1px solid var(--border);
+    background: hsl(var(--bg-muted));
+    border-bottom: 1px solid hsl(var(--border));
   }
   .admin__tabs button {
     padding: var(--space-2) var(--space-3);
     background: transparent;
     border: 0;
-    color: var(--fg-muted);
+    color: hsl(var(--fg-muted));
     font: inherit;
     cursor: pointer;
     border-bottom: 2px solid transparent;
   }
   .admin__tabs .active {
-    color: var(--fg);
-    border-bottom-color: var(--accent);
+    color: hsl(var(--fg));
+    border-bottom-color: hsl(var(--primary));
   }
 </style>

--- a/saiku-ui/src/routes/admin/schema-generator/[dataSourceId]/+page.svelte
+++ b/saiku-ui/src/routes/admin/schema-generator/[dataSourceId]/+page.svelte
@@ -288,8 +288,8 @@
     flex: 1;
     min-height: 0;
     font-family: var(--font-sans);
-    color: var(--fg);
-    background: var(--bg);
+    color: hsl(var(--fg));
+    background: hsl(var(--bg));
   }
   .schemagen__title {
     display: flex;
@@ -304,7 +304,7 @@
   .schemagen__dsid {
     font-family: var(--font-mono);
     font-size: var(--fs-xs);
-    color: var(--fg-muted);
+    color: hsl(var(--fg-muted));
   }
   .schemagen__actions {
     display: flex;
@@ -314,14 +314,14 @@
   .schemagen__actions button {
     font: inherit;
     padding: var(--space-2) var(--space-3);
-    border: 1px solid var(--border);
+    border: 1px solid hsl(var(--border));
     border-radius: var(--radius-sm);
-    background: var(--bg);
-    color: var(--fg);
+    background: hsl(var(--bg));
+    color: hsl(var(--fg));
     cursor: pointer;
   }
   .schemagen__actions button:hover:not(:disabled) {
-    background: var(--bg-subtle);
+    background: hsl(var(--bg-subtle));
   }
   .schemagen__actions button:disabled {
     opacity: 0.5;
@@ -334,19 +334,19 @@
     border-radius: 999px;
     text-transform: uppercase;
     letter-spacing: 0.03em;
-    background: var(--fg-subtle);
-    color: var(--accent-fg);
+    background: hsl(var(--fg-subtle));
+    color: hsl(var(--primary-foreground));
   }
   .schemagen__pill[data-color="muted"] {
-    background: var(--border-strong);
-    color: var(--fg);
+    background: hsl(var(--border-strong));
+    color: hsl(var(--fg));
   }
   .schemagen__pill[data-color="info"] {
-    background: var(--accent);
-    color: var(--accent-fg);
+    background: hsl(var(--primary));
+    color: hsl(var(--primary-foreground));
   }
   .schemagen__pill[data-color="success"] {
-    background: var(--success);
+    background: hsl(var(--success));
     color: #fff;
   }
   .schemagen__pill[data-color="danger"] {
@@ -360,15 +360,15 @@
     justify-content: space-between;
     gap: var(--space-3);
     padding: var(--space-2) var(--space-5);
-    border-bottom: 1px solid var(--border);
+    border-bottom: 1px solid hsl(var(--border));
   }
   .schemagen__failure {
     background: var(--danger, #c0392b);
     color: #fff;
   }
   .schemagen__error {
-    background: var(--bg-muted);
-    color: var(--fg);
+    background: hsl(var(--bg-muted));
+    color: hsl(var(--fg));
   }
   .schemagen__delta {
     display: flex;
@@ -377,7 +377,7 @@
     padding: var(--space-2) var(--space-5);
     background: var(--accent, #2b6cb0);
     color: var(--accent-fg, #fff);
-    border-bottom: 1px solid var(--border);
+    border-bottom: 1px solid hsl(var(--border));
     font-size: var(--fs-sm);
   }
   .schemagen__error button {
@@ -407,8 +407,8 @@
     right: 0;
     bottom: 0;
     width: min(420px, 50%);
-    background: var(--bg);
-    border-left: 1px solid var(--border);
+    background: hsl(var(--bg));
+    border-left: 1px solid hsl(var(--border));
     box-shadow: -8px 0 16px -12px rgb(0 0 0 / 0.25);
     transform: translateX(100%);
     transition: transform 180ms ease;
@@ -431,9 +431,9 @@
     line-height: 1;
     padding: var(--space-1) var(--space-2);
     cursor: pointer;
-    color: var(--fg-muted);
+    color: hsl(var(--fg-muted));
   }
   .schemagen__drawer-close:hover {
-    color: var(--fg);
+    color: hsl(var(--fg));
   }
 </style>

--- a/saiku-ui/src/routes/preview/+page.svelte
+++ b/saiku-ui/src/routes/preview/+page.svelte
@@ -64,22 +64,22 @@
     min-height: 0;
     display: flex;
     flex-direction: column;
-    background: var(--bg);
+    background: hsl(var(--bg));
   }
   .preview__badge {
     font-size: var(--fs-sm);
-    color: var(--fg-muted);
+    color: hsl(var(--fg-muted));
     padding: 2px var(--space-2);
-    border: 1px solid var(--border);
+    border: 1px solid hsl(var(--border));
     border-radius: 999px;
-    background: var(--bg-subtle);
+    background: hsl(var(--bg-subtle));
   }
   .preview__state {
     flex: 1;
     display: flex;
     align-items: center;
     justify-content: center;
-    color: var(--fg-muted);
+    color: hsl(var(--fg-muted));
     font-size: var(--fs-md);
   }
 </style>

--- a/saiku-ui/src/routes/share/+page.svelte
+++ b/saiku-ui/src/routes/share/+page.svelte
@@ -77,22 +77,22 @@
     min-height: 0;
     display: flex;
     flex-direction: column;
-    background: var(--bg);
+    background: hsl(var(--bg));
   }
   .share-view__badge {
     font-size: var(--fs-sm);
-    color: var(--fg-muted);
+    color: hsl(var(--fg-muted));
     padding: 2px var(--space-2);
-    border: 1px solid var(--border);
+    border: 1px solid hsl(var(--border));
     border-radius: 999px;
-    background: var(--bg-subtle);
+    background: hsl(var(--bg-subtle));
   }
   .share-view__state {
     flex: 1;
     display: flex;
     align-items: center;
     justify-content: center;
-    color: var(--fg-muted);
+    color: hsl(var(--fg-muted));
     font-size: var(--fs-md);
   }
 </style>


### PR DESCRIPTION
saiku-ui shipped a flat, hex-valued token set — indigo accent, near-black dark surfaces, harsh mid-grey borders. The cube-designer (ported from saiku-cloud) expects saiku-cloud's **triple**-based tokens (`hsl(var(--x))`, incl. alpha `hsl(var(--primary) / .15)`), so its inline styles resolved to invalid CSS and fell back — the reported "borders and stuff are a bit shit."

Adopts saiku-cloud's three-tier token system as the single source of truth.

## Changes
- **tokens.css** — saiku-cloud's HSL-triple palette verbatim: saiku red brand (cardinal), warm clay neutrals (light) / cool slate (dark), subtle border ramp + layered elevation. saiku-ui's non-colour tokens kept. Legacy flat names (`--bg`/`--fg`/`--border`/…) preserved as triple aliases.
- **tailwind.css** — bridge now resolves utilities through `hsl(var(--token))` (utilities + inline styles agree; opacity modifiers compose), plus the `data-theme`-bound `dark:` custom variant.
- **~105 component files** — bare `var(--colourToken)` → `hsl(var(--token))` (guarded against double-wrap). Brand split from the pale shadcn "accent" surface per saiku-cloud: inline `var(--accent*)` brand usages → `--primary*`; `text-accent` brand text → `text-primary`; the 300+ `hover:bg-accent` utilities now render subtle pale hovers.
- **cube-designer components unchanged** (already triple-idiom → stay byte-compatible with saiku-cloud).

## Verification
- `npm run check`: 0 errors. `npx vitest run`: **1640/1640** passing.
- Playwright computed-style checks (light + dark) on real rendered elements: subtle slate borders (`rgb(49,54,63)`), saiku-red brand (`rgb(229,67,85)`), layered card surfaces — no invalid fallbacks, no residual indigo/`#242935`.
- Visually confirmed on cube-designer, Query Editor, admin.

## Test plan
- [ ] Eyeball on demo after merge (light + dark): borders subtle, brand red, hovers pale, nothing unstyled.