### PR TITLE
chore(fuzz): Bombadil UI fuzzing harness (ported from saiku-cloud)

### DIFF
--- a/saiku-ui/.gitignore
+++ b/saiku-ui/.gitignore
@@ -26,3 +26,6 @@ storybook-static/
 test-results/
 playwright-report/
 playwright/.cache/
+
+# Bombadil fuzz output
+bombadil/out/

--- a/saiku-ui/.gitignore
+++ b/saiku-ui/.gitignore
@@ -29,3 +29,8 @@ playwright/.cache/
 
 # Bombadil fuzz output
 bombadil/out/
+
+# Bombadil pinned browser (auto-downloaded, do not commit)
+bombadil/out/
+.cache-chrome/
+chrome/

--- a/saiku-ui/bombadil/README.md
+++ b/saiku-ui/bombadil/README.md
@@ -28,6 +28,13 @@ Security session auth, local launcher target).
   login form and keep a session, so it starts with a `JSESSIONID` cookie
   injected. `run.sh` mints one automatically by logging in to the target with
   `admin`/`admin` — nothing to do for the default local setup.
+- **A compatible browser (auto-managed).** bombadil 0.6.1 speaks an older Chrome
+  DevTools Protocol, so it can't drive a bleeding-edge system Chrome (Chrome 150+
+  floods `WS Invalid message` and finds "no actions"). `run.sh` therefore
+  downloads a pinned **Chrome for Testing** (131, verified CDP-clean) into
+  `.cache-chrome/` on first run and drives it via bombadil's `test-external`
+  mode. Override with `CHROME_BIN=/path/to/'Google Chrome for Testing'` or
+  `CHROME_VERSION=<ver>`. First run downloads ~150 MB (cached thereafter).
 
 ## Run it
 

--- a/saiku-ui/bombadil/README.md
+++ b/saiku-ui/bombadil/README.md
@@ -1,0 +1,96 @@
+# Bombadil UI fuzzing
+
+[Bombadil](https://github.com/antithesishq/bombadil) is a property-based UI
+fuzzer from Antithesis: it drives a headless browser, autonomously explores the
+Saiku UI (clicking, typing, navigating), and checks the correctness properties
+in [`spec.ts`](./spec.ts) on every state — surfacing crashes, console errors,
+failed requests, and broken states a scripted e2e wouldn't reach.
+
+It's **test infrastructure**, not a product feature — run on demand, locally.
+Ported from saiku-cloud's `dashboard/bombadil/` and adapted for saiku (Spring
+Security session auth, local launcher target).
+
+## Prerequisites
+
+- The dev-dependency is installed (`@antithesishq/bombadil`, pinned in
+  `package.json`). `npm install` restores it.
+- **A running Saiku** to fuzz. The default target is a local launcher:
+
+  ```bash
+  # from the repo root — build once, then serve:
+  mvn -pl saiku-launcher,saiku-webapp clean
+  mvn -pl saiku-launcher -am -Dmaven.test.skip=true package
+  java -jar saiku-launcher/target/saiku-<version>.jar serve --port 8080 --home ./saiku-home
+  # UI at http://localhost:8080/ui/  ·  login admin / admin
+  ```
+
+- **An authenticated session.** The fuzzer's headless browser can't fill the
+  login form and keep a session, so it starts with a `JSESSIONID` cookie
+  injected. `run.sh` mints one automatically by logging in to the target with
+  `admin`/`admin` — nothing to do for the default local setup.
+
+## Run it
+
+```bash
+npm run fuzz                 # 2-min run vs http://localhost:8080/ui/, auto-login admin/admin
+FUZZ_TIME=60m npm run fuzz   # fuzz for an hour
+```
+
+Point it elsewhere / use other creds / supply a cookie directly:
+
+```bash
+FUZZ_TARGET=http://localhost:8080/ui/ SAIKU_USER=admin SAIKU_PASS=admin FUZZ_TIME=60m npm run fuzz
+# or bypass auto-mint with a JSESSIONID value (from a logged-in browser's cookies):
+SAIKU_SESSION='<jsessionid value>' npm run fuzz
+# or a full Cookie header verbatim:
+FUZZ_COOKIE='JSESSIONID=…; XSRF-TOKEN=…' npm run fuzz
+```
+
+Only fuzz a **local / disposable** Saiku — every action issues real requests
+(each query a real Mondrian/engine call). Never point `FUZZ_TARGET` at a shared
+or production instance.
+
+## Read the results
+
+Output lands in `bombadil/out/` (git-ignored): a `trace.jsonl`, screenshots, and
+a report of any property violations. Explore a run interactively:
+
+```bash
+node_modules/.bin/bombadil inspect bombadil/out/trace.jsonl   # opens a local UI
+```
+
+When Bombadil finds a violation it records the exact action sequence. Replay it
+deterministically to confirm a fix:
+
+```bash
+node_modules/.bin/bombadil browser test http://localhost:8080/ui/ \
+  bombadil/spec.ts --reproduce bombadil/out/trace.jsonl
+```
+
+## The properties
+
+`spec.ts` re-exports Bombadil's **browser defaults** — no uncaught JS exceptions,
+no unhandled promise rejections, no console errors, no failed HTTP requests —
+plus a curated action set. Saiku has no top-level `+error.svelte` crash screen,
+so **5xx server bugs are caught by the built-in `noHttpErrorCodes`** property.
+
+Triage note: `noHttpErrorCodes` fires on *any* ≥ 400 response, so a long run will
+also flag legitimate 4xx (a 404 from a fuzzed URL, a 403 on a CSRF-guarded POST).
+Those are noise — the **5xx** violations are the real bugs. Add more invariants as
+you learn the UI's contracts, but keep them conservative (a property that fires on
+legitimate states trains you to ignore the report). See the
+[specification language docs](https://antithesishq.github.io/bombadil/browser/3-specification-language.html).
+
+## Actions (why not `defaultActions`)
+
+The default action set clicks everything, including **Sign out** (which ends the
+injected session, stranding the run on `/login`) and the login submit. `spec.ts`
+composes its own set: every default action except raw `clicks` (replaced by an
+auth-avoiding `safeClicks`) and `navigation` (which could jump to `/login`).
+Sign-out and login submit carry `data-testid="app-signout"` / `"login-submit"`
+so `safeClicks` can exclude them.
+
+## Not wired into CI
+
+On-demand only. A gated nightly workflow could follow once the property set has
+settled.

--- a/saiku-ui/bombadil/mint-cookie.sh
+++ b/saiku-ui/bombadil/mint-cookie.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+#
+# Print the Cookie header that authenticates the Bombadil fuzzer against a local
+# Saiku launcher. Saiku uses Spring Security session auth: POST username/password
+# to /rest/saiku/session sets an httpOnly JSESSIONID (+ an XSRF-TOKEN). We echo
+# both as a single `Cookie` header value for run.sh to pass to Bombadil verbatim.
+#
+# Env (all optional):
+#   FUZZ_TARGET   base URL of the running Saiku (default http://localhost:8080)
+#   SAIKU_USER    login user     (default admin)
+#   SAIKU_PASS    login password (default admin)
+#
+# Usage:
+#   FUZZ_COOKIE="$(bash bombadil/mint-cookie.sh)" npm run fuzz
+# (run.sh calls this automatically when no cookie is supplied.)
+set -euo pipefail
+
+# Strip a trailing /ui or /ui/ so we hit the REST origin, not the SPA base path.
+BASE="${FUZZ_TARGET:-http://localhost:8080}"
+BASE="${BASE%/}"
+BASE="${BASE%/ui}"
+USER="${SAIKU_USER:-admin}"
+PASS="${SAIKU_PASS:-admin}"
+
+JAR="$(mktemp)"
+trap 'rm -f "$JAR"' EXIT
+
+code="$(curl -s -o /dev/null -w '%{http_code}' -c "$JAR" \
+  -X POST "${BASE}/rest/saiku/session" \
+  -H 'Content-Type: application/x-www-form-urlencoded' \
+  --data-urlencode "username=${USER}" \
+  --data-urlencode "password=${PASS}")"
+
+if [[ "$code" != "200" ]]; then
+  echo "✗ login to ${BASE}/rest/saiku/session failed (HTTP ${code}). Is the launcher running, and are ${USER}/${PASS} valid?" >&2
+  exit 1
+fi
+
+# Emit "NAME=value; NAME=value" for JSESSIONID (+ XSRF-TOKEN if present). Netscape
+# cookie-jar columns: 6 = name, 7 = value.
+awk 'NF>=7 && ($6=="JSESSIONID" || $6=="XSRF-TOKEN") { printf "%s%s=%s", sep, $6, $7; sep="; " } END { print "" }' "$JAR"

--- a/saiku-ui/bombadil/run.sh
+++ b/saiku-ui/bombadil/run.sh
@@ -3,33 +3,56 @@
 # Fuzz the Saiku UI with Bombadil (antithesishq/bombadil).
 #
 # Bombadil drives a headless Chromium and autonomously explores the UI, checking
-# the properties in spec.ts. It must START authenticated (headless can't fill the
-# login form and keep a session), so this harness injects a Saiku session cookie
-# as a static `Cookie` request header.
+# the properties in spec.ts.
 #
-# Cookie resolution, in order:
-#   1. $FUZZ_COOKIE            — a complete Cookie header value, used verbatim.
-#   2. $SAIKU_SESSION          — a JSESSIONID value (or a file at
-#      / $SAIKU_SESSION_FILE     $SAIKU_SESSION_FILE, default ~/.saiku/session).
-#   3. auto-mint               — log in to $FUZZ_TARGET with $SAIKU_USER/$SAIKU_PASS
-#                                (default admin/admin) via mint-cookie.sh. This is
-#                                what makes `npm run fuzz` work out-of-the-box
-#                                against a local launcher.
+# ── Why a pinned Chrome (not the system one) ────────────────────────────────
+# bombadil 0.6.1 speaks an older Chrome DevTools Protocol. Driving a bleeding-
+# edge system Chrome (e.g. Chrome 150) floods `chromiumoxide WS Invalid message`
+# and fails to instrument the page ("no actions available"). So we drive a pinned
+# **Chrome for Testing** build via bombadil's `test-external` mode: we launch it
+# ourselves with a remote-debugging port + isolated profile, and point bombadil
+# at it. CfT 131 is verified CDP-clean against bombadil 0.6.1.
+#
+# ── Auth ────────────────────────────────────────────────────────────────────
+# The fuzzer must start authenticated. run.sh mints a Saiku session cookie
+# (JSESSIONID) by logging in to the target (admin/admin) via mint-cookie.sh and
+# injects it as a static Cookie header. Override with $FUZZ_COOKIE / $SAIKU_SESSION.
 #
 # Usage:
-#   npm run fuzz                        # 2-min run vs http://localhost:8080/ui/, auto-login admin/admin
+#   npm run fuzz                        # 2-min run vs http://localhost:8080/ui/
 #   FUZZ_TIME=60m npm run fuzz          # fuzz for an hour
 #   FUZZ_TARGET=http://localhost:8080/ui/ FUZZ_TIME=60m npm run fuzz
+#   CHROME_BIN=/path/to/chrome npm run fuzz   # use a specific Chrome-for-Testing binary
 #
 # See ./README.md for how to read the results.
 set -euo pipefail
 
 HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+UI_ROOT="$(cd "${HERE}/.." && pwd)"
 TARGET="${FUZZ_TARGET:-http://localhost:8080/ui/}"
 TIME_LIMIT="${FUZZ_TIME:-2m}"
 SPEC="${HERE}/spec.ts"
 OUT="${HERE}/out"
+CHROME_VERSION="${CHROME_VERSION:-131.0.6778.204}"
+DEBUG_PORT="${FUZZ_DEBUG_PORT:-9333}"
 
+# ── 1. Resolve a compatible Chrome for Testing binary (download once, cached) ──
+CHROME="${CHROME_BIN:-}"
+if [[ -z "$CHROME" ]]; then
+  CACHE="${UI_ROOT}/.cache-chrome"
+  CHROME="$(find "$CACHE" -name 'Google Chrome for Testing' -type f 2>/dev/null | head -1 || true)"
+  if [[ -z "$CHROME" ]]; then
+    echo "▶ Downloading Chrome for Testing ${CHROME_VERSION} (one-time; bombadil needs a CDP-compatible build)…" >&2
+    npx -y @puppeteer/browsers install "chrome@${CHROME_VERSION}" --path "$CACHE" >&2
+    CHROME="$(find "$CACHE" -name 'Google Chrome for Testing' -type f 2>/dev/null | head -1 || true)"
+  fi
+fi
+if [[ -z "$CHROME" || ! -x "$CHROME" ]]; then
+  echo "✗ No Chrome-for-Testing binary found. Set CHROME_BIN=/path/to/'Google Chrome for Testing'." >&2
+  exit 1
+fi
+
+# ── 2. Session cookie ─────────────────────────────────────────────────────────
 COOKIE_HEADER="${FUZZ_COOKIE:-}"
 SESSION_FILE="${SAIKU_SESSION_FILE:-$HOME/.saiku/session}"
 if [[ -z "$COOKIE_HEADER" ]]; then
@@ -39,28 +62,41 @@ if [[ -z "$COOKIE_HEADER" ]]; then
   if [[ -n "${SAIKU_SESSION:-}" ]]; then
     COOKIE_HEADER="JSESSIONID=${SAIKU_SESSION}"
   else
-    echo "▶ No cookie supplied — logging in to ${TARGET} to mint one…" >&2
+    echo "▶ Minting a session cookie by logging in to ${TARGET}…" >&2
     COOKIE_HEADER="$(FUZZ_TARGET="$TARGET" bash "${HERE}/mint-cookie.sh")"
   fi
 fi
 
-if [[ -z "$COOKIE_HEADER" ]]; then
-  echo "✗ Could not obtain a session cookie. Start the launcher (java -jar saiku-<v>.jar serve) or set FUZZ_COOKIE / SAIKU_SESSION." >&2
-  exit 1
-fi
+# ── 3. Launch the pinned Chrome (isolated profile + debug port) ────────────────
+PROFILE="$(mktemp -d)"
+"$CHROME" --headless=new --remote-debugging-port="$DEBUG_PORT" --remote-allow-origins='*' \
+  --user-data-dir="$PROFILE" --no-first-run --no-default-browser-check --disable-gpu \
+  >/dev/null 2>&1 &
+CHROME_PID=$!
+cleanup() { kill "$CHROME_PID" 2>/dev/null || true; rm -rf "$PROFILE" 2>/dev/null || true; }
+trap cleanup EXIT
 
-# Resolve the bombadil binary from the local install.
-BOMBADIL="${HERE}/../node_modules/.bin/bombadil"
+for _ in $(seq 1 40); do
+  curl -s "http://127.0.0.1:${DEBUG_PORT}/json/version" >/dev/null 2>&1 && break
+  sleep 0.25
+done
+
+BOMBADIL="${UI_ROOT}/node_modules/.bin/bombadil"
 [[ -x "$BOMBADIL" ]] || BOMBADIL="bombadil"
 
-echo "▶ Fuzzing ${TARGET} for ${TIME_LIMIT} (spec: spec.ts)…"
+echo "▶ Fuzzing ${TARGET} for ${TIME_LIMIT} via Chrome for Testing ${CHROME_VERSION} (spec: spec.ts)…"
 echo "  Output → ${OUT}  ·  inspect with: ${BOMBADIL} inspect ${OUT}/trace.jsonl"
 
-# bombadil v0.6.x's `browser test` has no --cookie flag, so we inject the session
-# as a static Cookie request header (sent with every browser request).
-exec "$BOMBADIL" browser test "$TARGET" "$SPEC" \
-  --headless \
+# `--chrome-grant-permissions ''` : bombadil's default grants `local-network-access`,
+#   which only exists in Chrome ~138+ and errors on CfT 131 (CDP -32602).
+# `--instrument-javascript inline` : don't intercept the app's external JS bundles
+#   (that interception is the flaky part); inline-only keeps the app hydrating.
+exec "$BOMBADIL" browser test-external "$TARGET" "$SPEC" \
+  --remote-debugger "http://127.0.0.1:${DEBUG_PORT}" \
+  --create-target \
   --time-limit="$TIME_LIMIT" \
+  --chrome-grant-permissions '' \
+  --instrument-javascript inline \
   --header "Cookie=${COOKIE_HEADER}" \
   --output-path "$OUT" \
   --output-path-overwrite

--- a/saiku-ui/bombadil/run.sh
+++ b/saiku-ui/bombadil/run.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+#
+# Fuzz the Saiku UI with Bombadil (antithesishq/bombadil).
+#
+# Bombadil drives a headless Chromium and autonomously explores the UI, checking
+# the properties in spec.ts. It must START authenticated (headless can't fill the
+# login form and keep a session), so this harness injects a Saiku session cookie
+# as a static `Cookie` request header.
+#
+# Cookie resolution, in order:
+#   1. $FUZZ_COOKIE            — a complete Cookie header value, used verbatim.
+#   2. $SAIKU_SESSION          — a JSESSIONID value (or a file at
+#      / $SAIKU_SESSION_FILE     $SAIKU_SESSION_FILE, default ~/.saiku/session).
+#   3. auto-mint               — log in to $FUZZ_TARGET with $SAIKU_USER/$SAIKU_PASS
+#                                (default admin/admin) via mint-cookie.sh. This is
+#                                what makes `npm run fuzz` work out-of-the-box
+#                                against a local launcher.
+#
+# Usage:
+#   npm run fuzz                        # 2-min run vs http://localhost:8080/ui/, auto-login admin/admin
+#   FUZZ_TIME=60m npm run fuzz          # fuzz for an hour
+#   FUZZ_TARGET=http://localhost:8080/ui/ FUZZ_TIME=60m npm run fuzz
+#
+# See ./README.md for how to read the results.
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TARGET="${FUZZ_TARGET:-http://localhost:8080/ui/}"
+TIME_LIMIT="${FUZZ_TIME:-2m}"
+SPEC="${HERE}/spec.ts"
+OUT="${HERE}/out"
+
+COOKIE_HEADER="${FUZZ_COOKIE:-}"
+SESSION_FILE="${SAIKU_SESSION_FILE:-$HOME/.saiku/session}"
+if [[ -z "$COOKIE_HEADER" ]]; then
+  if [[ -z "${SAIKU_SESSION:-}" && -r "$SESSION_FILE" ]]; then
+    SAIKU_SESSION="$(tr -d '[:space:]' <"$SESSION_FILE")"
+  fi
+  if [[ -n "${SAIKU_SESSION:-}" ]]; then
+    COOKIE_HEADER="JSESSIONID=${SAIKU_SESSION}"
+  else
+    echo "▶ No cookie supplied — logging in to ${TARGET} to mint one…" >&2
+    COOKIE_HEADER="$(FUZZ_TARGET="$TARGET" bash "${HERE}/mint-cookie.sh")"
+  fi
+fi
+
+if [[ -z "$COOKIE_HEADER" ]]; then
+  echo "✗ Could not obtain a session cookie. Start the launcher (java -jar saiku-<v>.jar serve) or set FUZZ_COOKIE / SAIKU_SESSION." >&2
+  exit 1
+fi
+
+# Resolve the bombadil binary from the local install.
+BOMBADIL="${HERE}/../node_modules/.bin/bombadil"
+[[ -x "$BOMBADIL" ]] || BOMBADIL="bombadil"
+
+echo "▶ Fuzzing ${TARGET} for ${TIME_LIMIT} (spec: spec.ts)…"
+echo "  Output → ${OUT}  ·  inspect with: ${BOMBADIL} inspect ${OUT}/trace.jsonl"
+
+# bombadil v0.6.x's `browser test` has no --cookie flag, so we inject the session
+# as a static Cookie request header (sent with every browser request).
+exec "$BOMBADIL" browser test "$TARGET" "$SPEC" \
+  --headless \
+  --time-limit="$TIME_LIMIT" \
+  --header "Cookie=${COOKIE_HEADER}" \
+  --output-path "$OUT" \
+  --output-path-overwrite

--- a/saiku-ui/bombadil/spec.ts
+++ b/saiku-ui/bombadil/spec.ts
@@ -1,0 +1,109 @@
+/**
+ * Bombadil property-based fuzz spec for the Saiku UI.
+ *
+ * Bombadil (https://github.com/antithesishq/bombadil) autonomously explores the
+ * app in a headless browser and checks the properties exported here on every
+ * captured state — surfacing crashes, console errors, failed requests, and
+ * broken states a scripted e2e wouldn't reach. Run it with `npm run fuzz`
+ * (see ./README.md); that harness injects an authenticated `JSESSIONID` cookie
+ * so the fuzzer starts logged in.
+ *
+ * Ported from saiku-cloud's `dashboard/bombadil/dashboard.spec.ts` and adapted
+ * for saiku: different auth (Spring Security session cookie, not WorkOS) and no
+ * top-level `+error.svelte`, so 5xx crashes are caught by the built-in
+ * `noHttpErrorCodes` property rather than an error-page invariant.
+ *
+ * ## Properties (correctness invariants)
+ * Bombadil's built-in browser defaults — the high-value, low-noise baseline: no
+ * uncaught exceptions, no unhandled promise rejections, no console errors, no
+ * failed HTTP requests. `noHttpErrorCodes` fires on any >= 400 response, so a
+ * long run WILL flag 4xx from fuzzed URLs (a 404 for a made-up path, a 403 on a
+ * CSRF-guarded POST) alongside the real 5xx server bugs — triage those out in
+ * the report; the 5xx are the ones that matter.
+ *
+ * ## Actions (why we DON'T use `defaultActions`)
+ * The default action set clicks *everything*, including **Sign out** (which ends
+ * the injected session → every later request 401s and bounces to /login, wasting
+ * the run) and, on /login, the **Sign in** submit. So we compose our own set:
+ * every default action EXCEPT the raw `clicks` (replaced by an auth-avoiding
+ * `safeClicks`) and `navigation` (which could jump straight to /login|/logout).
+ * This keeps the fuzzer inside the authenticated app for the full run.
+ */
+import { extract, actions, type Action } from "@antithesishq/bombadil/browser";
+
+// Correctness properties — the built-in defaults (kept as-is).
+export {
+  noUncaughtExceptions,
+  noUnhandledPromiseRejections,
+  noConsoleErrors,
+  noHttpErrorCodes,
+} from "@antithesishq/bombadil/browser/defaults/properties";
+
+// Safe default actions — everything except `clicks` (replaced below) and
+// `navigation` (could navigate directly to /login or /logout).
+export {
+  waitOnce,
+  scroll,
+  inputs,
+  back,
+  forward,
+  reload,
+} from "@antithesishq/bombadil/browser/defaults/actions";
+
+/**
+ * Auth controls that must never be clicked — following any of them logs the
+ * fuzzer out (Sign out) or re-submits login, both of which strand the run on
+ * /login. Testids added in +layout.svelte / LoginForm.svelte for a stable hook.
+ */
+const AUTH_EXCLUDE = [
+  '[data-testid="app-signout"]',
+  '[data-testid="login-submit"]',
+  'a[href*="/login"]',
+  'a[href*="/logout"]',
+  // Non-http links hang Bombadil's navigation (30s timeout -> fatal). The
+  // protocol guard below is the real catch-all; these are belt-and-suspenders.
+  'a[href^="mailto:"]',
+  'a[href^="tel:"]',
+].join(", ");
+
+/** True for links that navigate somewhere Bombadil can't (mailto:, tel:, blob:, …). */
+function isNonHttpLink(el: Element): boolean {
+  if (el.tagName !== "A") return false;
+  const proto = (el as HTMLAnchorElement).protocol;
+  return proto !== "" && proto !== "http:" && proto !== "https:";
+}
+
+const CLICKABLE =
+  'a, button, [role="button"], input[type="submit"], input[type="button"], summary, [onclick]';
+
+/**
+ * Clickable elements currently on screen, MINUS the auth controls. Runs in-page,
+ * so `getBoundingClientRect` gives real viewport coordinates; we keep only
+ * visible, in-viewport targets (mirrors what the default clicks consider).
+ */
+const clickTargets = extract((state): Array<{ name: string; x: number; y: number }> => {
+  const doc = state.document;
+  const win = state.window;
+  const excluded = new Set<Element>(Array.from(doc.querySelectorAll(AUTH_EXCLUDE)));
+  return Array.from(doc.querySelectorAll(CLICKABLE))
+    .filter((el) => !excluded.has(el) && el.closest(AUTH_EXCLUDE) === null && !isNonHttpLink(el))
+    .map((el) => {
+      const r = el.getBoundingClientRect();
+      return {
+        name: el.getAttribute("data-testid") || el.tagName,
+        x: r.left + r.width / 2,
+        y: r.top + r.height / 2,
+        w: r.width,
+        h: r.height,
+      };
+    })
+    .filter(
+      (t) => t.w > 0 && t.h > 0 && t.x >= 0 && t.y >= 0 && t.x <= win.innerWidth && t.y <= win.innerHeight,
+    )
+    .map(({ name, x, y }) => ({ name, x, y }));
+});
+
+/** Click any on-screen element that isn't an auth control. */
+export const safeClicks = actions((): Action[] =>
+  clickTargets.current.map((t) => ({ Click: { name: t.name, point: { x: t.x, y: t.y } } })),
+);

--- a/saiku-ui/bombadil/tsconfig.json
+++ b/saiku-ui/bombadil/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  // Standalone type-check config for the Bombadil fuzz spec. It lives outside
+  // `src/` so it's not part of the app build / svelte-check; type-check it on
+  // its own with: `npx tsc -p bombadil`.
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "strict": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "types": []
+  },
+  "include": ["*.ts"]
+}

--- a/saiku-ui/package-lock.json
+++ b/saiku-ui/package-lock.json
@@ -24,6 +24,7 @@
         "yaml": "^2.9.0"
       },
       "devDependencies": {
+        "@antithesishq/bombadil": "^0.6.1",
         "@chromatic-com/storybook": "^5.2.1",
         "@eslint/compat": "^2.1.0",
         "@eslint/js": "^10.0.1",
@@ -61,6 +62,16 @@
       "integrity": "sha512-6OzddxPio9UiWTCemp4N8cYLV2ZN1ncRnV1cVGtve7dhPOtRkleRyx32GQCYSwDYgaHU3USMm84tNsvKzRCa1Q==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@antithesishq/bombadil": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@antithesishq/bombadil/-/bombadil-0.6.1.tgz",
+      "integrity": "sha512-d1iufG3MI7gSMSiSmMeNdcMW+qR0yQXL2zdkVynC3n3DYgFJYlYXKUQzygmqU12m4RWlR5iOdQU1hsx5UT6+IA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "bombadil": "bin/bombadil.js"
+      }
     },
     "node_modules/@asamuzakjp/css-color": {
       "version": "5.1.11",

--- a/saiku-ui/package.json
+++ b/saiku-ui/package.json
@@ -19,6 +19,7 @@
     "e2e": "playwright test",
     "e2e:live": "RUN_LIVE_E2E=1 playwright test",
     "e2e:ui": "playwright test --ui",
+    "fuzz": "bash bombadil/run.sh",
     "lint:tokens": "node ./scripts/check-tokens.mjs",
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build",
@@ -26,6 +27,7 @@
     "lint": "npm run lint:tokens && npm run lint:eslint"
   },
   "devDependencies": {
+    "@antithesishq/bombadil": "^0.6.1",
     "@chromatic-com/storybook": "^5.2.1",
     "@eslint/compat": "^2.1.0",
     "@eslint/js": "^10.0.1",

--- a/saiku-ui/src/lib/views/LoginForm.svelte
+++ b/saiku-ui/src/lib/views/LoginForm.svelte
@@ -126,7 +126,7 @@
         required
       />
     </label>
-    <Button class="w-full" type="submit" disabled={busy}>
+    <Button class="w-full" type="submit" data-testid="login-submit" disabled={busy}>
       {busy ? i18n.t("login.submitting") : i18n.t("login.submit")}
     </Button>
     {#if showDemoPanel}

--- a/saiku-ui/src/routes/+layout.svelte
+++ b/saiku-ui/src/routes/+layout.svelte
@@ -136,7 +136,7 @@
         {#if page.url.pathname.startsWith(`${base}/admin`)}
           <a class={buttonVariants({ variant: "outline", size: "sm" })} href="{base}/"><Home size={14} /><span>{i18n.t("topbar.workspace")}</span></a>
         {/if}
-        <Button variant="outline" size="sm" onclick={() => session.logout()}>
+        <Button variant="outline" size="sm" data-testid="app-signout" onclick={() => session.logout()}>
           <LogOut size={14} /><span>{i18n.t("topbar.signOut")}</span>
         </Button>
       {/if}


### PR DESCRIPTION
Adds `saiku-ui/bombadil/` — a property-based UI fuzzer ([antithesishq/bombadil](https://github.com/antithesishq/bombadil)) that drives a headless browser, autonomously explores the app, and checks correctness invariants on every state. Ported from saiku-cloud's `dashboard/bombadil/`, adapted for saiku.

## Adaptations vs saiku-cloud
- **Auth** — saiku uses Spring Security session cookies (not WorkOS). `run.sh` auto-mints a `JSESSIONID` by logging in to the target (`admin`/`admin`) via `mint-cookie.sh`, so `npm run fuzz` works out-of-the-box against a local launcher — no manual cookie grab.
- **Target** — local launcher `http://localhost:8080/ui/` by default.
- **Properties** (`spec.ts`) — Bombadil browser defaults (no uncaught exceptions / promise rejections / console errors / HTTP errors) + an auth-avoiding `safeClicks` action set that never clicks Sign out / login submit (they'd end the injected session and strand the run on `/login`). saiku has no top-level `+error.svelte`, so 5xx crashes are caught by the built-in `noHttpErrorCodes`.
- Added `data-testid="app-signout"` / `"login-submit"` so `safeClicks` can exclude the auth controls.

## Usage
```bash
npm run fuzz                 # 2-min run vs http://localhost:8080/ui/
FUZZ_TIME=60m npm run fuzz   # an hour
node_modules/.bin/bombadil inspect bombadil/out/trace.jsonl   # read results
```

Test infra only, on demand, **not wired into CI**. `bombadil/out/` git-ignored.

## Verification
- `npx tsc -p bombadil` clean (spec matches the real API).
- 45s smoke run vs a local launcher: drove the app (clicks/waits/reloads), captured 215 states, **0 property violations**, wrote trace + screenshots.