### PR TITLE
fix(ui): reset raw <button> so bare buttons render flat (#1636 follow-up)

### DIFF
--- a/saiku-ui/src/lib/styles/app.css
+++ b/saiku-ui/src/lib/styles/app.css
@@ -69,6 +69,23 @@ body {
   button {
     font-family: inherit;
     font-size: inherit;
+    /* Tailwind preflight is deliberately skipped (see tailwind.css), so raw
+       <button>s otherwise fall back to the UA default — a 2px outset white
+       border on a grey face. Replicate preflight's button normalisation here
+       so bare buttons (mode tabs, inspector tabs, the Button primitive's
+       default variant) render flat; `border-*` / `bg-*` utilities in the
+       utilities layer still override this base reset. (saiku#1636) */
+    appearance: none;
+    -webkit-appearance: none;
+    background-color: transparent;
+    background-image: none;
+    border: 0 solid transparent;
+    color: inherit;
+    cursor: pointer;
+  }
+
+  button:disabled {
+    cursor: default;
   }
 
   input,


### PR DESCRIPTION
Follow-up to the saiku-cloud theme port (#1636). Reported junk: the cube-designer mode tabs, inspector Properties/Code tabs, and filled buttons (login **Sign in**, **Save**) had a boxed/grey look.

**Cause:** Tailwind preflight is deliberately skipped (see `tailwind.css`), and the base `button {}` rule only set font — so every raw `<button>` without an explicit bg/border fell back to the browser UA default: a **2px outset white border on a grey face** (`rgb(107,107,107)`). Playwright confirmed **11 of 12** buttons carried it.

**Fix:** replicate preflight's button normalisation in `@layer base` — `appearance:none`, transparent background, zero border, inherited colour, pointer cursor. `border-*`/`bg-*` utilities (utilities layer) still override it, so intentionally styled buttons are unaffected.

**Verified (Playwright, dark):** UA-outset buttons 11→**0**; Confirm-cube & Facts&Measures views now show only subtle slate borders + the red active-tab underline. Resolves the border junk in the cube-designer + login screenshots.