### PR TITLE
feat(ui): match cube-designer header to saiku-cloud + lock datasources in demo mode

### DIFF
--- a/saiku-ui/src/lib/views/admin/DatasourcesAdmin.svelte
+++ b/saiku-ui/src/lib/views/admin/DatasourcesAdmin.svelte
@@ -5,6 +5,7 @@
   import { adminDatasources, type AdminDatasource } from "$lib/api/admin";
   import { toasts } from "$lib/stores/toasts.svelte";
   import { i18n } from "$lib/stores/i18n.svelte";
+  import { platform } from "$lib/stores/platform.svelte";
   import ConfirmModal from "$lib/modals/ConfirmModal.svelte";
   import Modal from "$lib/components/Modal.svelte";
   import Skeleton from "$lib/components/Skeleton.svelte";
@@ -15,6 +16,12 @@
   let error = $state<string | null>(null);
   let editing = $state<AdminDatasource | null>(null);
   let deleting = $state<AdminDatasource | null>(null);
+
+  // saiku#1636: on a public demo (SAIKU_DEMO), visitors must not be able to
+  // create / edit / delete datasources — a broken connection string takes down
+  // the shared instance for everyone. Hide every mutating control; the
+  // cube-designer link + Refresh (read-only re-introspect) stay available.
+  const demoMode = $derived(platform.capabilities?.demoMode === true);
 
   async function refresh() {
     loading = true;
@@ -28,7 +35,10 @@
     }
   }
 
-  onMount(refresh);
+  onMount(async () => {
+    if (!platform.capabilities) await platform.loadCapabilities();
+    await refresh();
+  });
 
   function startNew() {
     editing = {
@@ -89,7 +99,7 @@
   }
 
   async function save() {
-    if (!editing) return;
+    if (!editing || demoMode) return; // mutations disabled in demo mode
     try {
       if (!editing.id) await adminDatasources.create(editing);
       else await adminDatasources.update(editing);
@@ -102,7 +112,7 @@
   }
 
   async function doDelete() {
-    if (!deleting) return;
+    if (!deleting || demoMode) return; // mutations disabled in demo mode
     try {
       await adminDatasources.remove(deleting.id);
       toasts.success("Deleted", deleting.name);
@@ -127,7 +137,11 @@
 <div class="pane">
   <header class="flex justify-between items-center mb-3">
     <h2>{i18n.t("admin.tabs.datasources")}</h2>
-    <Button onclick={startNew}>{i18n.t("admin.addDatasource")}</Button>
+    {#if demoMode}
+      <span class="text-xs text-fg-muted">Read-only in demo mode</span>
+    {:else}
+      <Button onclick={startNew}>{i18n.t("admin.addDatasource")}</Button>
+    {/if}
   </header>
   {#if error}<p class="callout callout--danger">{error}</p>{/if}
   {#if loading}
@@ -151,8 +165,10 @@
                 {generateSchemaLabel(ds)}
               </a>
               <Button variant="outline" onclick={() => refreshDs(ds)}>{i18n.t("admin.refresh")}</Button>
-              <Button variant="outline" onclick={() => (editing = openForEdit(ds))}>{i18n.t("admin.edit")}</Button>
-              <Button variant="destructive" onclick={() => (deleting = ds)}>{i18n.t("admin.delete")}</Button>
+              {#if !demoMode}
+                <Button variant="outline" onclick={() => (editing = openForEdit(ds))}>{i18n.t("admin.edit")}</Button>
+                <Button variant="destructive" onclick={() => (deleting = ds)}>{i18n.t("admin.delete")}</Button>
+              {/if}
             </td>
           </tr>
         {/each}

--- a/saiku-ui/src/routes/admin/cube-designer/[dataSourceId]/+page.svelte
+++ b/saiku-ui/src/routes/admin/cube-designer/[dataSourceId]/+page.svelte
@@ -28,8 +28,15 @@
   import { parseProfileTables } from "$lib/cube-designer/profile-types";
   import type { SourceTableCandidate } from "$lib/cube-designer/types";
   import { adminSchemas } from "$lib/api/admin";
+  import { platform } from "$lib/stores/platform.svelte";
   import Button from "$lib/components/ui/button.svelte";
   import FeedbackBanner from "$lib/design-system/FeedbackBanner.svelte";
+  import {
+    LayoutGrid,
+    ArrowLeftRight,
+    Sigma,
+    CheckCircle2,
+  } from "lucide-svelte";
   import type { PageData } from "./$types";
 
   let { data }: { data: PageData } = $props();
@@ -44,14 +51,19 @@
   let saving = $state(false);
   let saveMsg = $state<{ tone: "success" | "error"; text: string } | null>(null);
 
+  // saiku#1636: on a public demo, don't let visitors persist a (possibly broken)
+  // schema that would take cubes down for everyone. Save is disabled in demo mode.
+  const demoMode = $derived(platform.capabilities?.demoMode === true);
+
   const MODES = [
-    { m: "canvas", label: "Schema Canvas" },
-    { m: "workbench", label: "Dimensions & Hierarchies" },
-    { m: "facts", label: "Facts & Measures" },
-    { m: "validate", label: "Confirm cube" },
+    { m: "canvas", label: "Schema Canvas", Icon: LayoutGrid },
+    { m: "workbench", label: "Dimensions & Hierarchies", Icon: ArrowLeftRight },
+    { m: "facts", label: "Facts & Measures", Icon: Sigma },
+    { m: "validate", label: "Confirm cube", Icon: CheckCircle2 },
   ] as const;
 
   onMount(async () => {
+    if (!platform.capabilities) await platform.loadCapabilities();
     store.switchConnection(dataSourceId);
     store.sourceLoading = true;
     store.sourceError = null;
@@ -104,6 +116,7 @@
   }
 
   async function save() {
+    if (demoMode) return; // saving disabled in demo mode
     saving = true;
     saveMsg = null;
     let xml: string;
@@ -138,24 +151,38 @@
     <h1 class="mr-2 text-sm font-semibold text-foreground">
       Cube Designer <span class="text-muted-foreground">· {dataSourceId}</span>
     </h1>
-    <nav class="flex items-center gap-1" role="tablist" aria-label="Designer mode">
-      {#each MODES as { m, label } (m)}
+    <!-- Segmented mode tabs — one outer border, siblings share edges; active
+         tab is an inset red ring + glow (matches saiku-cloud's CanvasHeader). -->
+    <nav
+      class="flex items-stretch overflow-hidden rounded border border-border bg-background"
+      role="tablist"
+      aria-label="Designer mode"
+    >
+      {#each MODES as { m, label, Icon } (m)}
         {@const active = store.mode === m}
         <button
           type="button"
           role="tab"
           aria-selected={active}
-          class="rounded px-2 py-1 text-[11px] font-medium {active
-            ? 'bg-primary text-primary-foreground'
+          aria-label={label}
+          title={label}
+          class="relative inline-flex h-9 items-center justify-center gap-1.5 border-l border-border px-3 text-xs font-medium transition-colors first:border-l-0 {active
+            ? 'z-10 bg-card text-primary shadow-[0_0_12px_hsl(var(--primary)/0.35)] ring-2 ring-primary/60 ring-inset'
             : 'text-muted-foreground hover:bg-accent hover:text-accent-foreground'}"
           onclick={() => store.setMode(m)}
         >
-          {label}
+          <Icon class="h-3.5 w-3.5" aria-hidden="true" />
+          <span>{label}</span>
         </button>
       {/each}
     </nav>
     <div class="ml-auto flex items-center gap-2">
-      <Button size="sm" onclick={save} disabled={saving}>
+      <Button
+        size="sm"
+        onclick={save}
+        disabled={saving || demoMode}
+        title={demoMode ? "Saving is disabled in demo mode" : undefined}
+      >
         {saving ? "Saving…" : "Save"}
       </Button>
       <Button


### PR DESCRIPTION
From the demo review (screenshots vs `staging.saiku.bi`).

## 1. Cube-designer header parity
The OSS route's mode tabs were red-*filled* pills; saiku-cloud's `CanvasHeader` uses a **segmented group** (one outer border, `border-l` dividers, per-mode icons) with the active tab as an **inset red ring + glow** (outline, not fill). Ported that styling into `routes/admin/cube-designer/[dataSourceId]/+page.svelte`. Uses `bg-card` (token-based, mode-safe) instead of saiku-cloud's `bg-white dark:bg-neutral-900`.

## 2. Demo lockdown (`SAIKU_DEMO`)
Visitors on the public demo must not break the shared instance:
- **Datasources admin** — Add/Edit/Delete hidden (shows "Read-only in demo mode"); Refresh + the cube-designer link (read-only) stay.
- **Cube-designer Save** — disabled with a tooltip.
- Handler-level guards too (`save()`/`doDelete()` no-op in demo), not just hidden buttons.
- Gated on `platform.capabilities.demoMode`.

Client-side gating (removes the UI path). Server-side rejection of datasource/schema writes in demo mode would be a further hardening step.

## Verification
- `npm run check`: 0 errors.
- Playwright: active mode tab renders the red ring + glow + red text (was a filled pill). Demo gating verified after deploy.