### PR TITLE
release: 4.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,44 @@
 All notable changes to Saiku are documented here. This project follows
 [Semantic Versioning](https://semver.org/).
 
+## 4.7.1 — 2026-08-02
+
+Patch release — Cube Designer fixes, a UI theme refresh aligned with Saiku
+Cloud, and a demo-mode lockdown.
+
+### Fixed
+- **Cube Designer — edit an existing cube.** Opening the designer on a datasource
+  that already has a Mondrian schema now loads that schema onto the canvas
+  instead of showing a blank one. A new `GET /rest/saiku/admin/cube-designer/
+  schema/{dataSourceId}` endpoint resolves the attached catalog (external
+  `file:`, classpath `res:`, or repository) to its XML. (saiku#1634)
+- **Datasources admin — correct driver/schema/JDBC URL.** Mondrian datasources
+  whose inner `Jdbc=` URL carries its own `;`-params (e.g. H2 `;MODE=MySQL`) were
+  mis-parsed, showing the catalog file as the driver and a stray param as the
+  schema. Parsing is now key-based and order/param tolerant. (saiku#1634)
+- **Cube Designer — drag-to-canvas.** Dropping a table now lands it under the
+  cursor after the canvas has been panned or zoomed (drop coordinates are mapped
+  into flow space). (saiku#1634)
+- **UI — flat buttons.** Raw `<button>`s no longer fall back to the browser
+  default (a 2px outset border on a grey face); the base reset that Tailwind
+  preflight would apply is now in place.
+
+### Changed
+- **UI theme aligned with Saiku Cloud.** Adopted the shared three-tier design
+  tokens: Saiku-red brand, warm-neutral light / cool-neutral dark surfaces,
+  subtle border ramp, and layered dark elevation — replacing the previous
+  indigo-accented, harsh-bordered theme.
+- **Cube Designer header.** Mode tabs restyled to a segmented group with a
+  ringed active tab, matching the Cloud designer.
+
+### Added
+- **Demo-mode lockdown (`SAIKU_DEMO`).** On a public demo, visitors can no longer
+  create/edit/delete datasources or save a schema from the Cube Designer, so a
+  broken connection or schema can't take the shared instance down. Read-only
+  actions (Refresh, opening the designer) still work.
+- **Bombadil UI fuzz harness** (`saiku-ui/bombadil/`, dev-only, not shipped in
+  the runtime) — property-based headless-browser fuzzing of the UI.
+
 ## 4.7.0 — 2026-08-01
 
 Feature release.

--- a/docs/superpowers/plans/2026-07-31-app-builder-plugins-plan.md
+++ b/docs/superpowers/plans/2026-07-31-app-builder-plugins-plan.md
@@ -1,0 +1,185 @@
+# App Builder Phase 2 — Custom-Tile / Plugin Framework — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans. Steps use checkbox (`- [ ]`) syntax.
+
+**Goal:** Open the tile system to custom visualisations — a **renderer registry**, a **config-driven tier** (ECharts `graph` + validated `echarts-option`, no code), and a **sandboxed arbitrary-JS tier** (iframe + postMessage, admin-installed plugins) for Cytoscape/deck.gl. Prove the whole flow (empty → built-out → embed) with **real-backend integration tests, built first**.
+
+**Architecture:** A `tileRegistry` (renderer id → `{component, editor, embedComponent, isQueryable, validateOptions}`) replaces the hardcoded `{#if}` dispatch in `Tile.svelte` + `EmbedGrid.svelte`. A new `type:"custom"` tile carries `{ renderer, options, query, cube }`. Config renderers feed validated config to the ECharts engine Saiku ships. The plugin renderer runs author code in an `<iframe sandbox="allow-scripts">` (opaque origin, `srcdoc`, strict CSP), exchanging only `postMessage` — host never trusts the plugin. Plugins are admin-installed bundles under `${saiku.home}/tile-plugins/`.
+
+**Tech stack:** Svelte 5 + TS + Vite; Zod for option validation; ECharts (already shipped); Java 21 (JAX-RS) for the plugin registry + embed mint fix; Playwright (live tier) + Maven failsafe (`SaikuItHarness`) for integration tests. Build requires **JDK 22** (reactor has `saiku-proptest`); main artifacts still target release 21.
+
+**Design spec:** `docs/superpowers/specs/2026-07-31-app-builder-plugins-design.md` (read it — esp. §5 the sandbox security model).
+
+**Reference patterns (read before starting):**
+- Tile dispatch: `saiku-ui/src/lib/views/dashboard/Tile.svelte` (`{#if tile.type…}`), `AddTileMenu.svelte`, `dashboards.ts` (`TileType`, `DashboardTile`).
+- Embed dispatch: `saiku-ui/src/embed/EmbedGrid.svelte`, `embed/types.ts`, `EmbedChart.svelte`.
+- Data + query: `saiku-ui/src/lib/hooks/useTileQuery.svelte`, `$lib/dashboard/effectiveQuery`, `aiQuery.ts` (`AiQueryResponse`), `$lib/dashboard/clickFilterMember` (the filter-event validation model to mirror in the sandbox).
+- Chart engine: `tiles/ChartTile.svelte`, `$lib/charts/build.ts` (`buildChartOption`).
+- Embed backend: `EmbedViewResource.java`, `EmbedAuthFilter.java`, `EmbedTokenStore.java`, `EmbedTokenResource.java`.
+- IT harness: `saiku-launcher/src/test/java/org/saiku/launcher/it/SaikuItHarness.java`, `RepositoryIT.java`; `saiku-launcher/pom.xml` (`integration` profile). e2e: `saiku-ui/playwright.config.ts`, `e2e/ossie-workbench.live.spec.ts`, `e2e/app-builder.spec.ts`.
+- Admin-content precedent: how skills/agent-spaces registries load from `${saiku.home}` (`agentSkillRegistryBean` in `saiku-beans.xml`).
+
+**Conventions:** branch `feature/app-builder-plugins` off `development`. `mvn spotless:apply` before Java commits; `npm run check` + `npm run lint` before UI commits. Commit per task. JDK 22 for builds.
+
+---
+
+## PHASE A — Integration harness FIRST (covers Phase 1 end-to-end)
+
+## Task 0: Branch
+- [ ] `git checkout development && git pull && git checkout -b feature/app-builder-plugins`
+
+## Task 1: Fix the embed `app` token-mint gap (+ test)
+
+**Files:** Modify `saiku-core/saiku-web/src/main/java/org/saiku/web/embed/EmbedTokenStore.java`; modify/add `EmbedTokenStoreTest` / `EmbedTokenResourceTest`.
+
+`EmbedTokenStore.ALLOWED_KINDS = Set.of("query","dashboard")` rejects `"app"`, so app embeds can't mint tokens. The view side (`kind="app"`) already exists.
+
+- [ ] **Step 1: Write the failing test** — in `EmbedTokenStoreTest` (or `EmbedTokenResourceTest`), assert minting a token with `resourceKind="app"`, `resourcePath="…/x.saikuapp"` SUCCEEDS (today it throws/400). Run it → FAIL.
+- [ ] **Step 2: Fix** — `ALLOWED_KINDS = Set.of("query", "dashboard", "app");`
+- [ ] **Step 3: Run** the test → PASS. Also run `EmbedTokenResourceTest`, `EmbedTokenStoreTest`, `EmbedAuthFilterTest` (JDK 22): `export JAVA_HOME=/Users/tombarber/Library/Java/JavaVirtualMachines/openjdk-22.0.1/Contents/Home; mvn -pl saiku-core/saiku-web -am test -Dtest='EmbedTokenStoreTest,EmbedTokenResourceTest,EmbedAuthFilterTest' -Dsurefire.failIfNoSpecifiedTests=false` → all green.
+- [ ] **Step 4:** spotless:apply; commit `fix(embed): allow minting 'app' embed tokens (kind=app)`.
+
+## Task 2: `AppBuilderIT` — REST + embed contract round-trip (real backend)
+
+**Files:** Create `saiku-launcher/src/test/java/org/saiku/launcher/it/AppBuilderIT.java`.
+
+Model on `RepositoryIT.java`; uses `SaikuItHarness.shared()` (real in-process Jetty + seeded FoodMart, `admin:admin`). Prove empty → built-out → embed at the REST layer.
+
+- [ ] **Step 1:** Read `RepositoryIT.java` + `SaikuItHarness.java` for the auth helpers (`postAuthJson`/`getAuth`/`parse`) and how a `.saiku`/repo path round-trips.
+- [ ] **Step 2: Write the IT** (it's inherently the test — no separate RED needed, but assert hard):
+  - Build a `.saikuapp` JSON with nav + one page whose `grid.tiles[0]` is a table/chart bound to the seeded FoodMart cube (an inline `AiQueryRequest` for a simple measure-by-dimension — copy a known-good body shape from an existing `AiQuery*IT`).
+  - `POST /rest/saiku/api/apps/{path}` (save) → assert 2xx.
+  - `GET /rest/saiku/api/apps/{path}` → assert the returned JSON **round-trips verbatim** (deep-equal the tile grid — guards opaque-doc field loss).
+  - `GET /rest/saiku/api/apps` (list) → includes the saved app.
+  - **Embed leg:** `POST /rest/saiku/api/embed/tokens` with `{resourceKind:"app", resourcePath:<path>}` → assert a token is minted (proves Task 1). `GET /rest/saiku/api/embed/app/{path}` with the token header → returns the app doc. `POST /rest/saiku/api/embed/app/{path}/page/{pageId}/tile/{tileId}/query` → assert real FoodMart cells come back (non-empty `data`/`matrix`).
+  - `DELETE` the app → assert gone.
+- [ ] **Step 3: Run** under the integration profile (JDK 22): `mvn -pl saiku-launcher -am verify -P integration -Dit.test=AppBuilderIT -DfailIfNoTests=false` → green. (First confirm the `integration` profile flag name in `saiku-launcher/pom.xml`; the plan's `-Dit.test` may need to be `-Dtest`/failsafe's include — match the pom.)
+- [ ] **Step 4:** spotless:apply; commit `test(app-builder): AppBuilderIT — REST + embed round-trip against FoodMart`.
+
+## Task 3: `app-builder.live.spec.ts` — UI empty → built-out → embed (Playwright live tier)
+
+**Files:** Create `saiku-ui/e2e/app-builder.live.spec.ts`.
+
+Model on `e2e/ossie-workbench.live.spec.ts` (real login, tolerant data assertions). Live tier (`RUN_LIVE_E2E=1`) hits a launcher on :8080 that the runner starts out-of-band.
+
+- [ ] **Step 1:** Read `ossie-workbench.live.spec.ts` (login helper, how it asserts real rows) and `app-builder.spec.ts` (the create/add-page flow to reuse).
+- [ ] **Step 2: Write the spec:** log in (`admin/admin`) → `/apps` → New app → add a page → **open AddTileMenu → add a chart or table tile → in TileEditorModal bind it to the FoodMart cube (pick connection/catalog/schema/cube + a measure + a dimension) → Save** → reload `/apps/<path>` → **assert the tile renders real numbers** (tolerant: assert ≥1 data cell/row, not exact values). Then a light **embed leg** if feasible (mint via API or a public grant, load `<saiku-embed kind="app">` in a second context, assert the tile renders) — if the embed leg is fiddly in-browser, cover it in `AppBuilderIT` (Task 2) and keep the live spec focused on authoring.
+- [ ] **Step 3: Run** (needs a launcher on :8080): `npx playwright install chromium`; start `java -jar saiku-launcher/target/saiku-4.6.4.jar serve --home /tmp/saiku-e2e` (with `SAIKU_ALLOW_DEFAULT_ADMIN=true`) in the background; `RUN_LIVE_E2E=1 npx playwright test app-builder.live` → green. If the launcher jar isn't built, `mvn -pl saiku-launcher -am -Dmaven.test.skip=true package` first. Report if the environment can't run the live tier (then this spec is authored + committed but validated in CI's integration job).
+- [ ] **Step 4:** commit `test(app-builder): live e2e — empty → tile bound to FoodMart → save → reload → renders`.
+
+---
+
+## PHASE B — The plugin framework
+
+## Task 4: Renderer registry (refactor dispatch — no behaviour change)
+
+**Files:** Create `saiku-ui/src/lib/dashboard/tileRegistry.ts` (+ test); modify `Tile.svelte`, `EmbedGrid.svelte`, `AddTileMenu.svelte`; extend `dashboards.ts` (`TileType` gains `"custom"`; `DashboardTile.custom?: CustomTileConfig`).
+
+- [ ] **Step 1: Types + registry** — `tileRegistry.ts`:
+```ts
+import type { Component } from "svelte";
+export interface CustomTileConfig { renderer: string; options: Record<string, unknown>; }
+export interface TileRenderer {
+  id: string; label: string; icon?: string;
+  component: Component;            // in-app body
+  embedComponent?: Component;      // embed body (token-scoped); omit → "Unsupported" in embed
+  isQueryable: boolean;
+  validateOptions: (o: unknown) => { ok: true; value: Record<string, unknown> } | { ok: false; error: string };
+}
+const REGISTRY = new Map<string, TileRenderer>();
+export function registerTileRenderer(r: TileRenderer): void { REGISTRY.set(r.id, r); }
+export function getTileRenderer(id: string): TileRenderer | undefined { return REGISTRY.get(id); }
+export function listTileRenderers(): TileRenderer[] { return [...REGISTRY.values()]; }
+```
+- [ ] **Step 2: Test** `tileRegistry.test.ts` — register/get/list; unknown id → undefined; `validateOptions` rejects bad options. RED→GREEN.
+- [ ] **Step 3: Wire dispatch** — in `Tile.svelte`, keep the built-in `{#if}` branches; add `{:else if tile.type === "custom"}` → look up `getTileRenderer(tile.custom.renderer)`; if found render `<svelte:component this={r.component} {tile} data={…}/>`, else an "Unknown renderer" placeholder. Same in `EmbedGrid.svelte` using `embedComponent` (fallback to its existing "Unsupported tile"). Add `"custom"` to `TileType` and `AddTileMenu` (a "Custom…" entry that opens a renderer picker — the picker lists `listTileRenderers()`).
+- [ ] **Step 4:** `npm run check` + `npm run lint`; the existing dashboard/app/embed tests still pass (no behaviour change for built-ins). Commit `feat(app-builder): tile renderer registry (open the tile dispatch)`.
+
+## Task 5: Tier 1 — `echarts-option` renderer (validated, no code)
+
+**Files:** Create `saiku-ui/src/lib/views/dashboard/tiles/custom/EChartsOptionTile.svelte`, `echartsOption.ts` (Zod validation + allowlist), `echartsOption.test.ts`, its editor, an `EmbedEChartsOptionTile.svelte`; register in `tileRegistry`.
+
+- [ ] **Step 1: Validator** `echartsOption.ts` — a Zod schema for a *safe subset* of ECharts `option`, **rejecting** function-valued props (`formatter`, event handlers), remote `url`s, and anything not in the allowlist (mirror the CSS-sanitiser reject-hostile posture). Property tests (fast-check) that no function/remote-url survives. RED→GREEN.
+- [ ] **Step 2: Renderer** — `EChartsOptionTile.svelte`: takes `(tile, records, metadata)`, merges the validated author `option` with data mapped from `records` (reuse `$lib/charts` projection helpers), feeds the shared ECharts instance. Uses `useTileQuery` for data/filter/refresh.
+- [ ] **Step 3: Editor + embed** — a `TileEditorModal` block (JSON editor + live validation errors) and `EmbedEChartsOptionTile.svelte` (same, token-scoped fetch). Register both.
+- [ ] **Step 4:** checks; commit `feat(app-builder): echarts-option custom tile (validated, no code)`.
+
+## Task 6: Tier 1 — `graph` renderer (ECharts graph series → ownership-graph viz)
+
+**Files:** `tiles/custom/GraphTile.svelte`, `graphTile.ts` (records → nodes/edges), test, editor, `EmbedGraphTile.svelte`; register.
+
+- [ ] **Step 1:** `graphTile.ts` — pure `recordsToGraph(records, { idCol, labelCol, sourceCol, targetCol, valueCol })` → `{nodes, links}` for an ECharts `graph` series. Unit tests (dedup nodes, edge mapping, empty). RED→GREEN.
+- [ ] **Step 2:** `GraphTile.svelte` renders the graph series (force/circular layout option) via the shared ECharts engine; click on a node emits a cross-filter (reuse `clickFilterMember`).
+- [ ] **Step 3:** editor (column pickers + layout) + `EmbedGraphTile.svelte`; register.
+- [ ] **Step 4:** checks; extend `app-builder.live.spec.ts` (or a new spec) to add a `graph` tile bound to a self-referential FoodMart dimension and assert it renders. Commit `feat(app-builder): graph custom tile (ECharts graph series)`.
+
+## Task 7: Tier 2 — sandboxed arbitrary-JS `plugin` renderer (SECURITY CORE)
+
+**Files:** `tiles/custom/PluginTile.svelte`, `pluginBridge.ts` (+ tests), `EmbedPluginTile.svelte`; register. This is the security-critical task — full adversarial review after.
+
+- [ ] **Step 1: The bridge contract** `pluginBridge.ts` — pure, testable message handling (no DOM), the host side of the protocol:
+```ts
+export const PLUGIN_MIN_H = 40, PLUGIN_MAX_H = 4000;
+export interface HostToPlugin { type: "init"|"data"|"theme"|"resize"; nonce: string; payload: unknown; }
+export type PluginToHost =
+  | { type: "ready"; nonce: string }
+  | { type: "resize"; nonce: string; height: number }
+  | { type: "filter"; nonce: string; dimension: string; hierarchy: string; level: string; members: string[] }
+  | { type: "error"; nonce: string; message: string };
+
+/** Accept a raw message from the iframe. Returns a validated action or null (dropped). Never trusts input. */
+export function handlePluginMessage(
+  raw: unknown, expectNonce: string,
+): { kind: "ready" } | { kind: "resize"; height: number } | { kind: "filter"; sel: FilterSel } | { kind: "error"; message: string } | null {
+  if (!raw || typeof raw !== "object") return null;
+  const m = raw as Record<string, unknown>;
+  if (m.nonce !== expectNonce) return null;                       // authenticate (origin is "null" for sandboxed frames)
+  switch (m.type) {
+    case "ready": return { kind: "ready" };
+    case "resize": {
+      const h = Number(m.height);
+      if (!Number.isFinite(h)) return null;
+      return { kind: "resize", height: Math.min(PLUGIN_MAX_H, Math.max(PLUGIN_MIN_H, Math.round(h))) }; // clamp
+    }
+    case "filter": {
+      if (typeof m.dimension !== "string" || typeof m.hierarchy !== "string" || typeof m.level !== "string") return null;
+      const members = Array.isArray(m.members) ? m.members.filter((x): x is string => typeof x === "string").slice(0, 500) : [];
+      return { kind: "filter", sel: { dimension: m.dimension, hierarchy: m.hierarchy, level: m.level, members } };
+    }
+    case "error": return { kind: "error", message: String(m.message ?? "").slice(0, 500) };
+    default: return null;                                          // unknown → dropped
+  }
+}
+```
+- [ ] **Step 2: Tests + property test** — `pluginBridge.test.ts`: wrong-nonce dropped; non-object dropped; resize clamped to `[MIN,MAX]`; NaN/Infinity resize dropped; filter with non-string fields dropped; members capped + non-strings filtered; error length-capped; unknown type dropped. A fast-check property: for ANY input + wrong nonce → `null`; and no returned `resize.height` is ever outside `[MIN,MAX]`. RED→GREEN.
+- [ ] **Step 3: `PluginTile.svelte`** — renders `<iframe sandbox="allow-scripts" srcdoc={buildSrcdoc(plugin.html, nonce, csp)}>`. `sandbox` MUST be exactly `allow-scripts` (NO `allow-same-origin`, forms, popups, top-navigation). `srcdoc` embeds: a strict CSP `<meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'unsafe-inline'; style-src 'unsafe-inline'; img-src data:; connect-src 'none'">`, the nonce, and the plugin's self-contained HTML. The host: on `message`, guard `event.source === iframe.contentWindow` then `handlePluginMessage`; apply resize (set iframe height), route `filter` through `clickFilterMember`-style validation against the tile's cube (resolve to real MDX unique names; drop unresolvable), show `error` in the tile chrome. postMessage `init`/`data`(records)/`theme` INTO the iframe with `targetOrigin="*"` (opaque frame). Never `{@html}` plugin output; the iframe is the only surface it draws on.
+- [ ] **Step 4: Embed** — `EmbedPluginTile.svelte`: same iframe, data via the token-scoped fetch (already RLS/PII-filtered). Register with `embedComponent`.
+- [ ] **Step 5:** checks; commit `feat(app-builder): sandboxed arbitrary-JS plugin tile (iframe + postMessage)`.
+- [ ] **Step 6: ADVERSARIAL SECURITY REVIEW** (controller dispatches a dedicated reviewer): try to escape the sandbox — read parent DOM/cookies/token, make network calls, inflate height past clamp, inject MDX via a `filter` message, XSS the host via a message payload, spoof the nonce, break out of the iframe. Any leak is CRITICAL → fix + re-review before this task is "done".
+
+## Task 8: Admin plugin registry (install + serve bundles)
+
+**Files:** Backend `TilePluginRegistry` + a resource under `saiku-core/.../resources/apps/` (or admin) serving installed plugins; wiring in `saiku-beans.xml` (root `${saiku.home}/tile-plugins`, mirror `agentSkillRegistryBean`); seed one example plugin; UI: the renderer picker lists installed plugins; `saiku-ui` fetches a plugin's `plugin.html` for the `srcdoc`.
+
+- [ ] **Step 1:** Backend registry scans `${saiku.home}/tile-plugins/<id>/` for `plugin.json` (`{id, label, optionSchema?}`) + `plugin.html` (the self-contained srcdoc). `GET /rest/saiku/api/tile-plugins` (list manifests) + `GET /rest/saiku/api/tile-plugins/{id}/html` (the bundle). Admin-gated for install; read for authoring. Mirror how `agentSkillRegistryBean` loads + is exposed. Tests: list + fetch + a parse-error surfaces safely.
+- [ ] **Step 2:** UI — the custom-tile renderer picker includes installed plugins (`GET /tile-plugins`); `PluginTile` fetches the `html` for its `srcdoc`. Seed a tiny example plugin (self-contained, e.g. a minimal Cytoscape-or-canvas graph) under `saiku-launcher/src/main/resources/seed/tile-plugins/` staged on first boot (mirror seed skills).
+- [ ] **Step 3:** checks (JDK 22 backend + UI); commit `feat(app-builder): admin-installed tile-plugin registry + seed example`.
+
+## Task 9: Extend integration tests to custom + plugin tiles
+
+- [ ] Extend `app-builder.live.spec.ts`: add an `echarts-option` (or `graph`) tile and the seed **plugin** tile to the built-out app; assert each renders (the plugin renders inside its iframe — assert the iframe is present + emits `ready`), and the app **embeds** with the plugin tile rendering token-scoped data.
+- [ ] Extend `AppBuilderIT`: a built-out app whose page includes a `type:"custom"` tile round-trips verbatim and its tile-query resolves through the embed path.
+- [ ] Commit `test(app-builder): integration coverage for custom + plugin tiles`.
+
+## Task 10: Back-compat, floors, final
+- [ ] Existing dashboards/apps unaffected (registry refactor is behaviour-preserving for built-ins) — confirm the full UI suite + `saiku-web` module tests green (JDK 22). Bump `.github/test-floors.json` saiku-web floor for new tests. Full UI `npm run check && npm test && npm run lint`.
+- [ ] Final commit + PR to `development`. PR body: the framework, the security model + review outcome, screenshots of a graph + plugin tile, the integration-test coverage.
+
+## Deferred (later)
+Inline-`srcdoc` author paste; plugin `connect-src` allowlist; plugin versioning/signing/marketplace; inputs/forms/write-back (Phase 3/4); AI-assistant panel (Phase 5).
+
+## Test strategy summary
+- **Integration (real backend), built first:** `AppBuilderIT` (REST + embed round-trip, FoodMart) + `app-builder.live.spec.ts` (UI empty→built-out→embed).
+- **Unit/property:** the ECharts-option validator + the plugin-bridge message handler (fast-check: wrong-nonce always dropped, resize always clamped, no function/remote-url survives validation).
+- **Adversarial security review:** the iframe sandbox (Task 7.6) — must prove no escape/leak before done.
+- **Regression:** built-in tiles unchanged through the registry; existing dashboards/apps/embeds green.

--- a/docs/superpowers/specs/2026-07-31-app-builder-plugins-design.md
+++ b/docs/superpowers/specs/2026-07-31-app-builder-plugins-design.md
@@ -172,7 +172,11 @@ Plugin `connect-src` network allowlist; a public plugin marketplace; plugin
 versioning/signing; inputs/forms/write-back (Phase 3/4); the AI-assistant panel
 (Phase 5).
 
-## 10. Open questions for review
+## 10. Resolved decisions (confirmed 2026-07-31)
+> All three confirmed per the leanings: (1) **both** config-graph and plugin-graph;
+> (2) **admin-installed registry only** in Phase 2; (3) **render** plugin tiles in
+> embeds (re-confirmed by the security review).
+
 1. **Config `graph` vs plugin `graph`:** ship both an ECharts-`graph` config
    renderer (safe, no install) AND allow a Cytoscape *plugin* (arbitrary JS,
    admin-installed)? Leaning: yes — config for the common case, plugin for the

--- a/docs/superpowers/specs/2026-07-31-app-builder-plugins-design.md
+++ b/docs/superpowers/specs/2026-07-31-app-builder-plugins-design.md
@@ -1,0 +1,196 @@
+# Saiku App Builder — Phase 2: Custom-Tile / Plugin Framework — Design
+
+**Status:** Draft for review · **Date:** 2026-07-31 · **Owner:** Tom Barber
+
+## 1. Why
+
+Phase 1 shipped the branded multi-page app shell (reusing the fixed 6-tile
+palette). Phase 2 opens the tile system so authors can add **custom
+visualisations** the palette can't express — the enigma-class need: ownership
+graphs (Cytoscape), flow maps (deck.gl), bespoke charts. Chosen scope: the
+**full framework** — a config-driven tier *and* a sandboxed arbitrary-JS tier.
+
+**Cross-cutting requirement (this phase):** integration tests that drive the app
+**from empty to a built-out example** end-to-end (create → pages → tiles → real
+data → save → reload → embed) against a real backend. Built FIRST (§7).
+
+## 2. Findings (from the codebase)
+
+- **Tiles are a closed union** with hardcoded `{#if}` dispatch in `Tile.svelte`
+  and a *separate* forked dispatch in `EmbedGrid.svelte`. No plugin API exists.
+- **App pages render through `Tile.svelte`** (via the store), so a new tile type
+  works in the App Builder for free — but the **embed renderer is forked** and
+  needs custom tiles added explicitly (else it degrades to "Unsupported tile").
+- **Data contract is clean:** a renderer receives `(tile, AiQueryResponse.records,
+  metadata)` — the exact projection charts/tables already get, so a custom tile
+  inherits filters/refresh/drill/share.
+- **No JS-sandbox primitive exists.** DOMPurify (TextTile) deliberately blocks
+  `iframe`/`object`/`script`; the embed shadow-root is style-isolation only.
+- **Embed mint gap (Phase-1 loose end):** `EmbedTokenStore.ALLOWED_KINDS =
+  {"query","dashboard"}` — `"app"` is not mintable. Fixed here.
+
+## 3. The enabling change — a renderer registry
+
+Replace the hardcoded `{#if}` dispatch (app **and** embed) with a lookup:
+
+```ts
+// saiku-ui/src/lib/dashboard/tileRegistry.ts
+interface TileRenderer {
+  id: string;                    // e.g. "graph", "echarts-option", "plugin"
+  label: string;
+  component: Component;          // in-app body (Svelte)
+  editor?: Component;            // options editor for TileEditorModal
+  embedComponent?: Component;    // embed-surface body (token-scoped)
+  isQueryable: boolean;          // does it bind a cube/query?
+  validateOptions(opts: unknown): Result; // Zod-gated (repo rule)
+}
+```
+
+- A new tile `type:"custom"` carries `{ renderer: string, options: unknown,
+  query?: TileQuery, cube?: CubeRef }` on `DashboardTile` (mirrors the
+  `kpi?`/`image?` config pattern).
+- `Tile.svelte` and `EmbedGrid.svelte` both dispatch built-in types as today,
+  and for `type:"custom"` look up `tileRegistry[tile.custom.renderer]` and render
+  its `component` / `embedComponent`. `AddTileMenu` lists registered renderers.
+- **The registry is the open surface.** Everything else composes onto it.
+
+## 4. Tier 1 — config-driven renderers (no sandbox)
+
+Built-in renderers that take a **validated config** + the query data, fed to
+engines Saiku already ships. Zero arbitrary code.
+
+- **`graph`** — maps records → an ECharts `graph` series (nodes/edges from
+  configured columns). Covers ownership-graph-style viz. Author configures
+  node/edge/id columns + layout; no raw JS.
+- **`echarts-option`** — the author supplies an ECharts `option` object; it is
+  **Zod-schema-validated and property-allowlisted** (reject event handlers,
+  `formatter` functions, remote `url`s — same reject-hostile posture as the CSS
+  sanitiser), then fed to the existing ECharts instance with the tile's records.
+- Both reuse `useTileQuery`/`effectiveQuery` → inherit filters, refresh, drill,
+  theme, share, and embed for free (they're in the registry with an
+  `embedComponent` that uses the token-scoped fetchers).
+
+## 5. Tier 2 — sandboxed arbitrary-JS plugin (the security core)
+
+For true bespoke viz (Cytoscape, deck.gl). A `plugin` renderer that runs the
+author's code in a **maximally-isolated iframe**, never trusting it.
+
+### Runtime
+- `<iframe sandbox="allow-scripts">` — **NO `allow-same-origin`**, so the frame
+  has an **opaque origin**: it cannot read the parent DOM, cookies,
+  `localStorage`, the embed token, or same-origin network. No `allow-forms`,
+  `allow-popups`, `allow-top-navigation`.
+- Content via **`srcdoc`** (a self-contained HTML/JS bundle) — not a remote
+  `src`. A strict CSP inside the srcdoc: `default-src 'none'; script-src
+  'unsafe-inline'; style-src 'unsafe-inline'; connect-src 'none'; img-src data:`
+  — the plugin is **self-contained and network-less** (its viz lib is bundled).
+  (A future opt-in `connect-src` allowlist is out of scope here.)
+
+### Host ↔ plugin protocol (postMessage only, host never trusts the plugin)
+- A per-mount **random nonce** is embedded in the srcdoc; every message is
+  tagged with it. Because a sandboxed frame's `origin` is `"null"`, the host
+  authenticates messages by **nonce + `event.source === iframe.contentWindow`**,
+  not origin.
+- **Host → plugin:** `init` (nonce, theme tokens, size), `data`
+  (`AiQueryResponse.records` + metadata — already RLS/PII-filtered upstream),
+  `theme`, `resize`.
+- **Plugin → host (ALL validated/clamped):**
+  - `ready` — plugin mounted.
+  - `resize {height}` — clamped to `[MIN, MAX]` px; never trusted verbatim.
+  - `filter {dimension, hierarchy, level, members}` — **validated against the
+    tile's cube exactly like `clickFilterMember`** (resolve to real MDX unique
+    names); an unresolvable/oversize claim is dropped. A plugin can only *narrow*
+    within the cube, never inject arbitrary MDX.
+  - `error {message}` — surfaced in the tile chrome (message length-capped, no
+    HTML).
+  - Any unknown/oversize message → dropped.
+
+### Threat model + guarantees
+Author with JCR write access is the adversary (same as TextTile's model). The
+plugin: cannot reach the host DOM/cookies/token (opaque origin), cannot make
+network requests (CSP `connect-src 'none'`), cannot navigate the top frame,
+cannot inflate the page (height clamped), cannot inject MDX or widen RLS
+(filter events validated), cannot XSS the host (postMessage payloads are data,
+rendered as text). Data reaches the plugin only *after* RLS/PII filtering. This
+is the one place untrusted code runs, so it gets a full **adversarial security
+review** (as the CSS sanitiser and embed RLS did) before it's "done".
+
+## 6. Plugin distribution + authoring
+
+- **Distribution: an admin-installed plugin registry**, mirroring Saiku's
+  existing governed-content pattern (skills / agent-spaces under `saiku-home`).
+  A plugin is a **self-contained bundle** (`plugin.json` manifest + a single
+  self-contained `plugin.html` used as the iframe `srcdoc`) under
+  `${saiku.home}/tile-plugins/<id>/`. Admin-authored/vetted; served to the
+  designer as an installed-renderer catalogue. This keeps arbitrary JS behind an
+  admin gate (not any analyst) while still letting a customer add Cytoscape/deck.gl.
+- **Authoring UX:** *Add tile → Custom →* pick a registered renderer (config
+  renderers *and* installed plugins) → bind a cube/query → configure options
+  (config tier: a form; plugin tier: the plugin's declared option schema).
+- Config-tier renderers (`graph`, `echarts-option`) are built-in registry
+  entries, available to any author (no install, no arbitrary code).
+
+## 7. Integration tests — "empty → built-out → embed" (built FIRST)
+
+Two layers, matching the existing harnesses; these land **before** the Phase-2
+feature code so the feature is built on a proven end-to-end, and they cover the
+**Phase-1** flow too (the "test all of this" ask):
+
+1. **`saiku-ui/e2e/app-builder.live.spec.ts`** (Playwright *live* tier,
+   `RUN_LIVE_E2E=1`, against a running launcher + seeded FoodMart): log in →
+   create app from empty → add a page → **add a tile → bind to the FoodMart cube
+   → Save → reload `/apps/<path>` → assert real FoodMart numbers render** → then
+   the **embed leg** (mint/grant a credential, load `<saiku-embed kind="app">`,
+   assert the same tile renders). Extended in the feature work to add a custom
+   (config) tile and a sandboxed plugin tile.
+2. **`saiku-launcher/.../it/AppBuilderIT.java`** (in-process `SaikuItHarness`,
+   `mvn verify -P integration`): POST a built-out `.saikuapp` (nav + page + tiles
+   binding FoodMart MDX) → GET verbatim round-trip → mint an **app** embed token
+   (this is where the `ALLOWED_KINDS` fix is proven) → GET `/embed/app/{path}` +
+   POST the tile-query endpoint → assert real FoodMart cells + RLS/PII behaviour.
+
+Plus: the mocked `app-builder.spec.ts` stays as the narrow effect-regression
+guard.
+
+## 8. Phasing within Phase 2 (dependency order)
+
+1. **Embed `app` mint fix** + `AppBuilderIT` + `app-builder.live.spec.ts` (the
+   integration harness, covering Phase 1 end-to-end).
+2. **Renderer registry** (refactor `Tile.svelte` + `EmbedGrid.svelte` dispatch
+   to a lookup; no behaviour change — all existing types via the registry).
+3. **Tier 1** — `graph` + `echarts-option` config renderers (+ Zod validation,
+   + editor, + embed component). Extend the integration tests to a custom tile.
+4. **Tier 2** — the iframe-sandbox `plugin` renderer + the postMessage bridge +
+   the admin plugin registry (`tile-plugins/`). **Adversarial security review**
+   before done. Extend the integration tests to a sandboxed plugin tile.
+
+Each step is a spec-compliant, review-gated task; §5 (the sandbox) gets the full
+adversarial treatment.
+
+## 9. Out of scope (later)
+Plugin `connect-src` network allowlist; a public plugin marketplace; plugin
+versioning/signing; inputs/forms/write-back (Phase 3/4); the AI-assistant panel
+(Phase 5).
+
+## 10. Open questions for review
+1. **Config `graph` vs plugin `graph`:** ship both an ECharts-`graph` config
+   renderer (safe, no install) AND allow a Cytoscape *plugin* (arbitrary JS,
+   admin-installed)? Leaning: yes — config for the common case, plugin for the
+   bespoke.
+2. **Plugin author gate:** admin-only install (recommended, matches
+   skills/agent-spaces) vs. any-author inline `srcdoc` paste? Leaning:
+   admin-installed registry only in Phase 2 (inline paste is a bigger blast
+   radius; defer).
+3. **Embed of a plugin tile:** render the sandboxed iframe inside the embed too
+   (data via the token-scoped path), or degrade plugin tiles to a placeholder in
+   embeds for Phase 2? Leaning: render it (the opaque-origin iframe can't reach
+   the embed token, and data is already RLS/PII-filtered) — but confirm in the
+   security review.
+
+## 11. Definition of done (Phase 2)
+An author can add a **custom-viz tile** to an app page — a built-in config
+renderer (graph / custom ECharts) with no code, or an **admin-installed
+sandboxed plugin** running arbitrary JS (Cytoscape/deck.gl) that renders real
+cube data, cross-filters, and embeds — with the sandbox proven (adversarial
+review) to leak nothing. And the whole flow (empty → built-out → embed) is
+covered by real-backend integration tests.

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <groupId>org.saikuanalytics</groupId>
     <artifactId>saiku</artifactId>
     <packaging>pom</packaging>
-    <version>4.7.0</version>
+    <version>4.7.1</version>
     <name>Saiku Module Project</name>
     <scm>
         <developerConnection>

--- a/saiku-bom/pom.xml
+++ b/saiku-bom/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.saikuanalytics</groupId>
     <artifactId>saiku-bom</artifactId>
-    <version>4.7.0</version>
+    <version>4.7.1</version>
     <packaging>pom</packaging>
     <name>Saiku BOM</name>
     <description>Central dependency-version catalogue for Saiku modules.</description>

--- a/saiku-core/pom.xml
+++ b/saiku-core/pom.xml
@@ -2,14 +2,14 @@
     <parent>
         <artifactId>saiku</artifactId>
         <groupId>org.saikuanalytics</groupId>
-        <version>4.7.0</version>
+        <version>4.7.1</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>
     <artifactId>saiku-core</artifactId>
     <packaging>pom</packaging>
     <name>saiku - core libraries</name>
-    <version>4.7.0</version>
+    <version>4.7.1</version>
 
     <modules>
         <module>saiku-olap-util</module>

--- a/saiku-core/saiku-olap-util/pom.xml
+++ b/saiku-core/saiku-olap-util/pom.xml
@@ -3,11 +3,11 @@
     <parent>
         <artifactId>saiku-core</artifactId>
         <groupId>org.saikuanalytics</groupId>
-        <version>4.7.0</version>
+        <version>4.7.1</version>
     </parent>
 	<artifactId>saiku-olap-util</artifactId>
 	<packaging>jar</packaging>
-	<version>4.7.0</version>
+	<version>4.7.1</version>
 	<name>saiku olap util</name>
 	<properties>
 		<maven.compiler.source>1.8</maven.compiler.source>

--- a/saiku-core/saiku-semantic/pom.xml
+++ b/saiku-core/saiku-semantic/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <artifactId>saiku-core</artifactId>
         <groupId>org.saikuanalytics</groupId>
-        <version>4.7.0</version>
+        <version>4.7.1</version>
     </parent>
 
     <artifactId>saiku-semantic</artifactId>

--- a/saiku-core/saiku-service/pom.xml
+++ b/saiku-core/saiku-service/pom.xml
@@ -2,12 +2,12 @@
     <parent>
         <artifactId>saiku-core</artifactId>
         <groupId>org.saikuanalytics</groupId>
-        <version>4.7.0</version>
+        <version>4.7.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>jar</packaging>
     <artifactId>saiku-service</artifactId>
-    <version>4.7.0</version>
+    <version>4.7.1</version>
     <name>saiku - services</name>
     <build>
         <plugins>

--- a/saiku-core/saiku-sql/pom.xml
+++ b/saiku-core/saiku-sql/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.saikuanalytics</groupId>
         <artifactId>saiku-core</artifactId>
-        <version>4.7.0</version>
+        <version>4.7.1</version>
     </parent>
 
     <artifactId>saiku-sql</artifactId>

--- a/saiku-core/saiku-web/pom.xml
+++ b/saiku-core/saiku-web/pom.xml
@@ -2,11 +2,11 @@
     <parent>
         <artifactId>saiku-core</artifactId>
         <groupId>org.saikuanalytics</groupId>
-        <version>4.7.0</version>
+        <version>4.7.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>saiku-web</artifactId>
-    <version>4.7.0</version>
+    <version>4.7.1</version>
     <name>saiku - web</name>
     <packaging>jar</packaging>
 

--- a/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/objects/DataSourceMapper.java
+++ b/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/objects/DataSourceMapper.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.Properties;
 import java.util.UUID;
 import org.saiku.datasources.datasource.SaikuDatasource;
+import org.saiku.web.rest.util.MondrianLocation;
 
 /**
  * Map from SaikuDatasources to JSON variants.
@@ -80,26 +81,26 @@ public class DataSourceMapper {
                         && ds.getProperties().getProperty("advanced").equals("false"))) {
             String location = ds.getProperties().getProperty("location");
 
-            String[] loc = location.split(";");
-
-            String[] url = loc[0].split("=", 2);
             if (ds.getProperties().getProperty("driver").equals("mondrian.olap4j.MondrianOlap4jDriver")) {
-                String[] cat = loc[1].split("=");
-                String[] drv = loc[2].split("=");
-                if (cat.length > 1) {
-                    this.schema = cat[1];
-                }
-                if (drv.length > 1) {
-                    this.driver = drv[1];
-                }
+                // saiku#1634: parse by key, not by positional ';' split. An inner Jdbc= URL that
+                // carries its own ;params (e.g. H2's ;MODE=MySQL) used to shift the Catalog and
+                // JdbcDrivers slots — the catalog leaked into 'driver' and a stray param into
+                // 'schema'. MondrianLocation anchors on the known keys instead, so ordering and
+                // embedded params no longer matter.
+                MondrianLocation parsed = MondrianLocation.parse(location);
+                this.jdbcurl = parsed.jdbc();
+                this.schema = parsed.catalog();
+                this.driver = parsed.jdbcDrivers();
                 this.connectiontype = "MONDRIAN";
             } else {
+                // XMLA: location is `jdbc:xmla:Server=<url>` — split the server URL off the head.
+                String[] url = location.split(";", 2)[0].split("=", 2);
+                if (url.length > 1) {
+                    this.jdbcurl = url[1];
+                }
                 this.connectiontype = "XMLA";
             }
             this.connectionname = ds.getName();
-            if (url.length > 1) {
-                this.jdbcurl = url[1];
-            }
             this.username = ds.getProperties().getProperty("username");
             this.password = ds.getProperties().getProperty("password");
             this.path = ds.getProperties().getProperty("path");

--- a/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/cubedesigner/CubeDesignerResource.java
+++ b/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/cubedesigner/CubeDesignerResource.java
@@ -19,6 +19,9 @@ import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.ResultSetMetaData;
@@ -39,6 +42,7 @@ import org.saiku.service.schema.generate.model.DbModel;
 import org.saiku.service.schema.generate.model.DbTable;
 import org.saiku.service.user.UserService;
 import org.saiku.web.rest.resources.schemagen.DatasourceJdbcConnectionProvider;
+import org.saiku.web.rest.util.MondrianLocation;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -49,6 +53,7 @@ import org.slf4j.LoggerFactory;
  * <ul>
  *   <li>{@code GET  /introspect/{dataSourceId}} — the datasource's tables + columns (source sidebar)</li>
  *   <li>{@code GET  /sample/{dataSourceId}?table=&amp;schema=&amp;limit=} — preview rows for a table</li>
+ *   <li>{@code GET  /schema/{dataSourceId}} — the datasource's existing Mondrian schema XML (edit mode)</li>
  *   <li>{@code POST /convert} — upgrade a Mondrian-3 schema XML to Mondrian-4</li>
  * </ul>
  *
@@ -61,7 +66,6 @@ import org.slf4j.LoggerFactory;
 public class CubeDesignerResource {
 
     private static final Logger LOG = LoggerFactory.getLogger(CubeDesignerResource.class);
-    private static final String MONDRIAN_PREFIX = "jdbc:mondrian:";
     private static final int DEFAULT_SAMPLE_LIMIT = 25;
     private static final int MAX_SAMPLE_LIMIT = 500;
 
@@ -98,6 +102,8 @@ public class CubeDesignerResource {
     public record ConvertRequest(String mondrianXml, String dataSourceId) {}
 
     public record ConvertResult(String mondrianXml) {}
+
+    public record SchemaResult(String mondrianXml, String label) {}
 
     public record TurnRequest(JsonNode messages, String canvasSummary) {}
 
@@ -193,7 +199,63 @@ public class CubeDesignerResource {
         }
     }
 
-    // ── (3) convert (Mondrian 3 → 4) ──────────────────────────────────────────
+    // ── (3) schema (existing Mondrian XML for edit mode) ──────────────────────
+    /**
+     * saiku#1634: return the datasource's already-attached Mondrian schema XML so the designer can
+     * hydrate the canvas in edit mode (rather than opening blank). The catalog reference is parsed
+     * out of the Mondrian {@code location} ({@code Catalog=...}) and resolved three ways:
+     *
+     * <ul>
+     *   <li>{@code file:/path/Foo.xml} — read from the filesystem (the launcher's foodmart/bank use
+     *       this: {@code Catalog=file:.../FoodMart4.xml});</li>
+     *   <li>{@code res:Foo.xml} — read from the classpath (bundled schemas);</li>
+     *   <li>{@code mondrian://Name} or a bare repository path — read from the Saiku repository.</li>
+     * </ul>
+     *
+     * <p>404 when the datasource carries no catalog (plain JDBC / a fresh design target) or the
+     * referenced schema can't be found — the host treats that as "new cube, start blank". Admin-only;
+     * the {@code file:} path is already admin-authored via the datasource config, so this exposes no
+     * file an admin couldn't already reach.
+     */
+    @GET
+    @Path("/schema/{dataSourceId}")
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response schema(@PathParam("dataSourceId") String dataSourceId) {
+        Response forbidden = adminGuard();
+        if (forbidden != null) {
+            return forbidden;
+        }
+        SaikuDatasource ds = datasourceService.getDatasource(dataSourceId);
+        if (ds == null || ds.getProperties() == null) {
+            return Response.status(Response.Status.NOT_FOUND)
+                    .entity("unknown datasource")
+                    .build();
+        }
+        String location = ds.getProperties().getProperty(ISaikuConnection.URL_KEY);
+        String catalog = MondrianLocation.parse(location).catalog();
+        if (catalog == null || catalog.isBlank()) {
+            return Response.status(Response.Status.NOT_FOUND)
+                    .entity("no schema attached to this datasource")
+                    .build();
+        }
+        String xml;
+        try {
+            xml = resolveSchemaXml(catalog);
+        } catch (IOException e) {
+            LOG.warn("cube-designer schema read failed for '{}' catalog '{}'", dataSourceId, catalog, e);
+            return Response.status(Response.Status.INTERNAL_SERVER_ERROR)
+                    .entity("could not read the schema")
+                    .build();
+        }
+        if (xml == null || xml.isBlank()) {
+            return Response.status(Response.Status.NOT_FOUND)
+                    .entity("schema not found")
+                    .build();
+        }
+        return Response.ok(new SchemaResult(xml, ds.getName())).build();
+    }
+
+    // ── (4) convert (Mondrian 3 → 4) ──────────────────────────────────────────
     @POST
     @Path("/convert")
     @Consumes(MediaType.APPLICATION_JSON)
@@ -226,7 +288,7 @@ public class CubeDesignerResource {
         }
     }
 
-    // ── (4) DimSum AI turn ─────────────────────────────────────────────────────
+    // ── (5) DimSum AI turn ─────────────────────────────────────────────────────
     @POST
     @Path("/turn")
     @Consumes(MediaType.APPLICATION_JSON)
@@ -300,7 +362,9 @@ public class CubeDesignerResource {
         if (location == null || location.isEmpty()) {
             throw new SQLException("datasource '" + dataSourceId + "' has no location");
         }
-        String jdbcUrl = location.startsWith(MONDRIAN_PREFIX) ? extractJdbc(location) : location;
+        // Mondrian locations wrap the real JDBC URL as `Jdbc=...`; plain locations are the URL itself.
+        String parsedJdbc = MondrianLocation.parse(location).jdbc();
+        String jdbcUrl = parsedJdbc != null ? parsedJdbc.trim() : location;
         if (jdbcUrl == null || !jdbcUrl.startsWith("jdbc:")) {
             throw new SQLException("datasource '" + dataSourceId + "' has no resolvable JDBC URL");
         }
@@ -311,22 +375,41 @@ public class CubeDesignerResource {
     }
 
     /**
-     * Pull the inner {@code Jdbc=} URL out of a Mondrian location string
-     * ({@code jdbc:mondrian:Jdbc=jdbc:...;JdbcDrivers=...}). The inner value is a
-     * {@code jdbc:} URL that may contain {@code =} but, by Mondrian convention, no {@code ;}.
+     * Resolve a Mondrian {@code Catalog=} reference to its schema XML. Handles {@code file:} paths
+     * (filesystem), {@code res:} (classpath), and {@code mondrian://Name} / bare repository paths
+     * (Saiku repository). Returns null when the referenced schema can't be found.
      */
-    private static String extractJdbc(String location) {
-        String body = location.substring(MONDRIAN_PREFIX.length());
-        String needle = "Jdbc=";
-        int idx = body.indexOf(needle);
-        while (idx > 0 && body.charAt(idx - 1) != ';') {
-            idx = body.indexOf(needle, idx + 1);
+    private String resolveSchemaXml(String catalog) throws IOException {
+        String c = catalog.trim();
+        if (c.startsWith("file:")) {
+            return Files.readString(java.nio.file.Path.of(stripFileScheme(c)), StandardCharsets.UTF_8);
         }
-        if (idx < 0) {
-            return null;
+        if (c.startsWith("res:")) {
+            String resource = c.substring("res:".length());
+            try (InputStream in = getClass().getClassLoader().getResourceAsStream(resource)) {
+                return in == null ? null : new String(in.readAllBytes(), StandardCharsets.UTF_8);
+            }
         }
-        int start = idx + needle.length();
-        int end = body.indexOf(';', start);
-        return (end < 0 ? body.substring(start) : body.substring(start, end)).trim();
+        // Repository-stored schema. addSchema writes it at `/datasources/<name>.xml`, so try the
+        // reference verbatim first, then the conventional path for a `mondrian://Name` catalog.
+        String name = c.startsWith("mondrian://") ? c.substring("mondrian://".length()) : c;
+        String data = datasourceService.getInternalFileData(name);
+        if (data == null) {
+            data = datasourceService.getInternalFileData("/datasources/" + name + ".xml");
+        }
+        return data;
+    }
+
+    /**
+     * Strip the {@code file:} scheme (and any {@code //authority}) off a file URL, leaving the path.
+     * Handles {@code file:/p}, {@code file:///p}, and {@code file://host/p}.
+     */
+    private static String stripFileScheme(String fileUrl) {
+        String path = fileUrl.substring("file:".length());
+        if (path.startsWith("//")) {
+            int slash = path.indexOf('/', 2);
+            path = slash >= 0 ? path.substring(slash) : path.substring(2);
+        }
+        return path;
     }
 }

--- a/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/util/MondrianLocation.java
+++ b/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/util/MondrianLocation.java
@@ -1,0 +1,112 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package org.saiku.web.rest.util;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Key-based parser for a Mondrian {@code location} connect string:
+ *
+ * <pre>jdbc:mondrian:Jdbc=&lt;jdbcUrl&gt;;Catalog=&lt;catalog&gt;;JdbcDrivers=&lt;drivers&gt;</pre>
+ *
+ * <p>The naive {@code location.split(";")} positional parse this replaces broke whenever the inner
+ * {@code Jdbc=} value carried its own {@code ;}-separated JDBC parameters — e.g. the launcher's
+ * FoodMart datasource {@code jdbc:mondrian:Jdbc=jdbc:h2:.../foodmart;MODE=MySQL;Catalog=file:...
+ * FoodMart4.xml;JdbcDrivers=org.h2.Driver}. There the {@code ;MODE=MySQL} param shifted the
+ * positional segments so {@code Catalog} was read as the driver and {@code MODE=MySQL} as the
+ * catalog (saiku#1634).
+ *
+ * <p>This parser instead anchors on the three known Mondrian keys ({@code Jdbc}, {@code Catalog},
+ * {@code JdbcDrivers}) wherever they appear, treating each value as running up to the next known
+ * key — so unknown {@code ;key=value} params (like H2's {@code MODE}) stay part of the value they
+ * belong to, and key ordering does not matter. Values are otherwise returned verbatim (no
+ * unescaping), matching the previous behaviour for the fields it feeds.
+ */
+public final class MondrianLocation {
+
+    /** Mondrian location URLs start with this scheme prefix. */
+    public static final String MONDRIAN_PREFIX = "jdbc:mondrian:";
+
+    // A known key either opens the body (^) or follows a ';'. The value runs to the next such key.
+    private static final Pattern KEY = Pattern.compile("(?:^|;)(Jdbc|Catalog|JdbcDrivers)=");
+
+    private final String jdbc;
+    private final String catalog;
+    private final String jdbcDrivers;
+
+    private MondrianLocation(String jdbc, String catalog, String jdbcDrivers) {
+        this.jdbc = jdbc;
+        this.catalog = catalog;
+        this.jdbcDrivers = jdbcDrivers;
+    }
+
+    /**
+     * Parse a Mondrian location string. Non-Mondrian or blank input yields an all-null result
+     * (callers treat that as "no Mondrian coordinates"). Missing individual keys are null.
+     */
+    public static MondrianLocation parse(String location) {
+        if (location == null || !location.startsWith(MONDRIAN_PREFIX)) {
+            return new MondrianLocation(null, null, null);
+        }
+        String body = location.substring(MONDRIAN_PREFIX.length());
+        Matcher m = KEY.matcher(body);
+
+        // First pass: collect each key, the index its value starts at, and the index the whole
+        // "(^|;)Key=" match starts at (used as the previous value's end so the ';' is dropped).
+        java.util.List<String> keys = new java.util.ArrayList<>(3);
+        java.util.List<Integer> valueStarts = new java.util.ArrayList<>(3);
+        java.util.List<Integer> matchStarts = new java.util.ArrayList<>(3);
+        while (m.find()) {
+            keys.add(m.group(1));
+            valueStarts.add(m.end());
+            matchStarts.add(m.start());
+        }
+
+        String jdbc = null;
+        String catalog = null;
+        String jdbcDrivers = null;
+        for (int i = 0; i < keys.size(); i++) {
+            int end = (i + 1 < keys.size()) ? matchStarts.get(i + 1) : body.length();
+            String value = body.substring(valueStarts.get(i), end);
+            switch (keys.get(i)) {
+                case "Jdbc" -> jdbc = value;
+                case "Catalog" -> catalog = value;
+                case "JdbcDrivers" -> jdbcDrivers = value;
+                default -> {
+                    /* pattern only matches the three known keys */
+                }
+            }
+        }
+        return new MondrianLocation(jdbc, catalog, jdbcDrivers);
+    }
+
+    /** The inner {@code Jdbc=} JDBC URL (may itself contain {@code ;}-separated params), or null. */
+    public String jdbc() {
+        return jdbc;
+    }
+
+    /** The {@code Catalog=} value verbatim — e.g. {@code file:/path/Foo.xml}, {@code res:Foo.xml},
+     *  or {@code mondrian://Foo} — or null when absent. */
+    public String catalog() {
+        return catalog;
+    }
+
+    /** The {@code JdbcDrivers=} value (driver class name), or null when absent. */
+    public String jdbcDrivers() {
+        return jdbcDrivers;
+    }
+}

--- a/saiku-core/saiku-web/src/test/java/org/saiku/web/rest/objects/DataSourceMapperMondrianTest.java
+++ b/saiku-core/saiku-web/src/test/java/org/saiku/web/rest/objects/DataSourceMapperMondrianTest.java
@@ -1,0 +1,51 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.web.rest.objects;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.Properties;
+import org.junit.Test;
+import org.saiku.datasources.datasource.SaikuDatasource;
+
+/**
+ * saiku#1634 — a Mondrian datasource whose inner {@code Jdbc=} URL carries its own {@code ;}params
+ * (H2 {@code ;MODE=MySQL}) must still map to the right driver / schema / jdbcurl display fields.
+ * Before the key-based parse, FoodMart showed driver = the Catalog file and schema = "MySQL".
+ */
+public class DataSourceMapperMondrianTest {
+
+    private static SaikuDatasource mondrianDs(String name, String location) {
+        Properties props = new Properties();
+        props.setProperty("driver", "mondrian.olap4j.MondrianOlap4jDriver");
+        props.setProperty("location", location);
+        props.setProperty("username", "sa");
+        return new SaikuDatasource(name, SaikuDatasource.Type.OLAP, props);
+    }
+
+    @Test
+    public void foodmartWithEmbeddedH2ModeParamMapsCorrectly() {
+        DataSourceMapper m = new DataSourceMapper(mondrianDs(
+                "foodmart",
+                "jdbc:mondrian:Jdbc=jdbc:h2:/data/foodmart;MODE=MySQL;"
+                        + "Catalog=file:/data/FoodMart4.xml;JdbcDrivers=org.h2.Driver"));
+        assertEquals("MONDRIAN", m.getConnectiontype());
+        assertEquals("jdbc:h2:/data/foodmart;MODE=MySQL", m.getJdbcurl());
+        assertEquals("file:/data/FoodMart4.xml", m.getSchema());
+        assertEquals("org.h2.Driver", m.getDriver());
+    }
+
+    @Test
+    public void bankWithoutEmbeddedParamMapsCorrectly() {
+        DataSourceMapper m = new DataSourceMapper(mondrianDs(
+                "bank",
+                "jdbc:mondrian:Jdbc=jdbc:h2:/data/foodmart;"
+                        + "Catalog=file:/data/Bank.xml;JdbcDrivers=org.h2.Driver"));
+        assertEquals("MONDRIAN", m.getConnectiontype());
+        assertEquals("jdbc:h2:/data/foodmart", m.getJdbcurl());
+        assertEquals("file:/data/Bank.xml", m.getSchema());
+        assertEquals("org.h2.Driver", m.getDriver());
+    }
+}

--- a/saiku-core/saiku-web/src/test/java/org/saiku/web/rest/resources/cubedesigner/CubeDesignerResourceTest.java
+++ b/saiku-core/saiku-web/src/test/java/org/saiku/web/rest/resources/cubedesigner/CubeDesignerResourceTest.java
@@ -11,10 +11,14 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 import jakarta.ws.rs.core.Response;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.Statement;
 import java.util.List;
+import java.util.Map;
 import java.util.Properties;
 import org.junit.After;
 import org.junit.Before;
@@ -24,6 +28,7 @@ import org.saiku.datasources.datasource.SaikuDatasource;
 import org.saiku.service.datasource.DatasourceService;
 import org.saiku.web.rest.resources.cubedesigner.CubeDesignerResource.IntrospectResult;
 import org.saiku.web.rest.resources.cubedesigner.CubeDesignerResource.SampleResult;
+import org.saiku.web.rest.resources.cubedesigner.CubeDesignerResource.SchemaResult;
 import org.saiku.web.rest.resources.cubedesigner.CubeDesignerResource.TableView;
 import org.saiku.web.rest.resources.schemagen.DatasourceJdbcConnectionProvider;
 
@@ -63,20 +68,43 @@ public class CubeDesignerResourceTest {
         resource = new CubeDesignerResource(provider, datasourceService);
     }
 
-    /** Hand-rolled stub (house pattern — saiku-web has no Mockito), serving one datasource by id. */
+    /** Hand-rolled stub (house pattern — saiku-web has no Mockito), serving one datasource by id
+     *  plus an optional in-memory repository (path → file content) for the schema endpoint. */
     private static final class StubDatasourceService extends DatasourceService {
         private final String id;
         private final SaikuDatasource ds;
+        private final Map<String, String> repoFiles;
 
         StubDatasourceService(String id, SaikuDatasource ds) {
+            this(id, ds, Map.of());
+        }
+
+        StubDatasourceService(String id, SaikuDatasource ds, Map<String, String> repoFiles) {
             this.id = id;
             this.ds = ds;
+            this.repoFiles = repoFiles;
         }
 
         @Override
         public SaikuDatasource getDatasource(String datasourceName) {
             return id.equals(datasourceName) ? ds : null;
         }
+
+        @Override
+        public String getInternalFileData(String path) {
+            return repoFiles.get(path);
+        }
+    }
+
+    /** Build a resource whose single datasource has the given Mondrian location + optional repo. */
+    private static CubeDesignerResource resourceFor(String location, Map<String, String> repoFiles) {
+        Properties props = new Properties();
+        props.setProperty(ISaikuConnection.URL_KEY, location);
+        props.setProperty(ISaikuConnection.USERNAME_KEY, "sa");
+        props.setProperty(ISaikuConnection.PASSWORD_KEY, "");
+        SaikuDatasource ds = new SaikuDatasource(DATA_SOURCE_ID, SaikuDatasource.Type.OLAP, props);
+        StubDatasourceService svc = new StubDatasourceService(DATA_SOURCE_ID, ds, repoFiles);
+        return new CubeDesignerResource(new DatasourceJdbcConnectionProvider(svc), svc);
     }
 
     @After
@@ -140,7 +168,59 @@ public class CubeDesignerResourceTest {
         assertEquals(400, r.getStatus());
     }
 
-    // -- (3) convert ------------------------------------------------------------
+    // -- (3) schema (edit mode) -------------------------------------------------
+
+    @Test
+    public void schema_readsExternalFileCatalog() throws Exception {
+        // The launcher's foodmart/bank pattern: Catalog=file:/abs/path/Schema.xml
+        Path tmp = Files.createTempFile("cube-designer-schema", ".xml");
+        tmp.toFile().deleteOnExit();
+        String xml = "<Schema name=\"FoodMart\"/>";
+        Files.writeString(tmp, xml, StandardCharsets.UTF_8);
+        String location =
+                "jdbc:mondrian:Jdbc=" + JDBC_URL + ";MODE=MySQL;Catalog=file:" + tmp + ";JdbcDrivers=org.h2.Driver";
+
+        Response r = resourceFor(location, Map.of()).schema(DATA_SOURCE_ID);
+        assertEquals(200, r.getStatus());
+        SchemaResult body = (SchemaResult) r.getEntity();
+        assertEquals(xml, body.mondrianXml());
+        assertEquals(DATA_SOURCE_ID, body.label());
+    }
+
+    @Test
+    public void schema_readsRepositoryCatalog() {
+        // A UI-created datasource: Catalog=mondrian://Name → /datasources/Name.xml in the repo.
+        String xml = "<Schema name=\"Sales\"/>";
+        String location = "jdbc:mondrian:Jdbc=" + JDBC_URL + ";Catalog=mondrian://Sales;JdbcDrivers=org.h2.Driver";
+
+        Response r =
+                resourceFor(location, Map.of("/datasources/Sales.xml", xml)).schema(DATA_SOURCE_ID);
+        assertEquals(200, r.getStatus());
+        SchemaResult body = (SchemaResult) r.getEntity();
+        assertEquals(xml, body.mondrianXml());
+    }
+
+    @Test
+    public void schema_noCatalogIs404() {
+        // Plain JDBC datasource (no Mondrian wrapper) → new-cube target, host stays blank.
+        Response r = resourceFor(JDBC_URL, Map.of()).schema(DATA_SOURCE_ID);
+        assertEquals(404, r.getStatus());
+    }
+
+    @Test
+    public void schema_missingRepositoryFileIs404() {
+        String location = "jdbc:mondrian:Jdbc=" + JDBC_URL + ";Catalog=mondrian://Absent;JdbcDrivers=org.h2.Driver";
+        Response r = resourceFor(location, Map.of()).schema(DATA_SOURCE_ID);
+        assertEquals(404, r.getStatus());
+    }
+
+    @Test
+    public void schema_unknownDatasourceIs404() {
+        Response r = resource.schema("no-such-ds");
+        assertEquals(404, r.getStatus());
+    }
+
+    // -- (4) convert ------------------------------------------------------------
 
     @Test
     public void convert_missingXmlIs400() {

--- a/saiku-core/saiku-web/src/test/java/org/saiku/web/rest/util/MondrianLocationTest.java
+++ b/saiku-core/saiku-web/src/test/java/org/saiku/web/rest/util/MondrianLocationTest.java
@@ -1,0 +1,78 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.web.rest.util;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import org.junit.Test;
+
+/**
+ * saiku#1634 — key-based parsing of the Mondrian {@code location} connect string. The regression
+ * this guards: an inner {@code Jdbc=} URL carrying its own {@code ;}-separated params must not shift
+ * the {@code Catalog} / {@code JdbcDrivers} slots.
+ */
+public class MondrianLocationTest {
+
+    @Test
+    public void innerJdbcParamsDoNotShiftTheOtherKeys() {
+        // The launcher's FoodMart datasource: H2 ;MODE=MySQL rides inside the Jdbc value.
+        MondrianLocation p = MondrianLocation.parse("jdbc:mondrian:Jdbc=jdbc:h2:/data/foodmart;MODE=MySQL;"
+                + "Catalog=file:/data/FoodMart4.xml;JdbcDrivers=org.h2.Driver");
+        assertEquals("jdbc:h2:/data/foodmart;MODE=MySQL", p.jdbc());
+        assertEquals("file:/data/FoodMart4.xml", p.catalog());
+        assertEquals("org.h2.Driver", p.jdbcDrivers());
+    }
+
+    @Test
+    public void plainThreeKeyLocation() {
+        // The Bank datasource: no embedded params — parses cleanly (and did under the old code).
+        MondrianLocation p = MondrianLocation.parse(
+                "jdbc:mondrian:Jdbc=jdbc:h2:/data/foodmart;" + "Catalog=file:/data/Bank.xml;JdbcDrivers=org.h2.Driver");
+        assertEquals("jdbc:h2:/data/foodmart", p.jdbc());
+        assertEquals("file:/data/Bank.xml", p.catalog());
+        assertEquals("org.h2.Driver", p.jdbcDrivers());
+    }
+
+    @Test
+    public void keyOrderDoesNotMatter() {
+        MondrianLocation p = MondrianLocation.parse(
+                "jdbc:mondrian:Catalog=res:FoodMart4.xml;JdbcDrivers=org.h2.Driver;Jdbc=jdbc:h2:mem:x");
+        assertEquals("jdbc:h2:mem:x", p.jdbc());
+        assertEquals("res:FoodMart4.xml", p.catalog());
+        assertEquals("org.h2.Driver", p.jdbcDrivers());
+    }
+
+    @Test
+    public void mondrianRepositoryCatalog() {
+        // The UI write path emits Catalog=mondrian://<schema>; must round-trip verbatim.
+        MondrianLocation p = MondrianLocation.parse("jdbc:mondrian:Jdbc=jdbc:postgresql://db/foodmart;"
+                + "Catalog=mondrian://FoodMart;JdbcDrivers=org.postgresql.Driver");
+        assertEquals("jdbc:postgresql://db/foodmart", p.jdbc());
+        assertEquals("mondrian://FoodMart", p.catalog());
+        assertEquals("org.postgresql.Driver", p.jdbcDrivers());
+    }
+
+    @Test
+    public void missingKeysAreNull() {
+        MondrianLocation p = MondrianLocation.parse("jdbc:mondrian:Jdbc=jdbc:h2:mem:x");
+        assertEquals("jdbc:h2:mem:x", p.jdbc());
+        assertNull(p.catalog());
+        assertNull(p.jdbcDrivers());
+    }
+
+    @Test
+    public void nonMondrianOrNullYieldsAllNull() {
+        MondrianLocation xmla = MondrianLocation.parse("jdbc:xmla:Server=http://host/xmla");
+        assertNull(xmla.jdbc());
+        assertNull(xmla.catalog());
+        assertNull(xmla.jdbcDrivers());
+
+        MondrianLocation nul = MondrianLocation.parse(null);
+        assertNull(nul.jdbc());
+        assertNull(nul.catalog());
+        assertNull(nul.jdbcDrivers());
+    }
+}

--- a/saiku-launcher/pom.xml
+++ b/saiku-launcher/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.saikuanalytics</groupId>
         <artifactId>saiku</artifactId>
-        <version>4.7.0</version>
+        <version>4.7.1</version>
     </parent>
 
     <artifactId>saiku-launcher</artifactId>

--- a/saiku-proptest/pom.xml
+++ b/saiku-proptest/pom.xml
@@ -7,11 +7,11 @@
   <parent>
     <groupId>org.saikuanalytics</groupId>
     <artifactId>saiku</artifactId>
-    <version>4.7.0</version>
+    <version>4.7.1</version>
   </parent>
 
   <artifactId>saiku-proptest</artifactId>
-  <version>4.7.0</version>
+  <version>4.7.1</version>
   <packaging>jar</packaging>
   <name>saiku-proptest</name>
   <description>
@@ -31,7 +31,7 @@
       <dependency>
         <groupId>org.saikuanalytics</groupId>
         <artifactId>saiku-bom</artifactId>
-        <version>4.7.0</version>
+        <version>4.7.1</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/saiku-ui/.gitignore
+++ b/saiku-ui/.gitignore
@@ -26,3 +26,6 @@ storybook-static/
 test-results/
 playwright-report/
 playwright/.cache/
+
+# Bombadil fuzz output
+bombadil/out/

--- a/saiku-ui/.gitignore
+++ b/saiku-ui/.gitignore
@@ -29,3 +29,8 @@ playwright/.cache/
 
 # Bombadil fuzz output
 bombadil/out/
+
+# Bombadil pinned browser (auto-downloaded, do not commit)
+bombadil/out/
+.cache-chrome/
+chrome/

--- a/saiku-ui/bombadil/README.md
+++ b/saiku-ui/bombadil/README.md
@@ -28,6 +28,13 @@ Security session auth, local launcher target).
   login form and keep a session, so it starts with a `JSESSIONID` cookie
   injected. `run.sh` mints one automatically by logging in to the target with
   `admin`/`admin` — nothing to do for the default local setup.
+- **A compatible browser (auto-managed).** bombadil 0.6.1 speaks an older Chrome
+  DevTools Protocol, so it can't drive a bleeding-edge system Chrome (Chrome 150+
+  floods `WS Invalid message` and finds "no actions"). `run.sh` therefore
+  downloads a pinned **Chrome for Testing** (131, verified CDP-clean) into
+  `.cache-chrome/` on first run and drives it via bombadil's `test-external`
+  mode. Override with `CHROME_BIN=/path/to/'Google Chrome for Testing'` or
+  `CHROME_VERSION=<ver>`. First run downloads ~150 MB (cached thereafter).
 
 ## Run it
 

--- a/saiku-ui/bombadil/README.md
+++ b/saiku-ui/bombadil/README.md
@@ -1,0 +1,96 @@
+# Bombadil UI fuzzing
+
+[Bombadil](https://github.com/antithesishq/bombadil) is a property-based UI
+fuzzer from Antithesis: it drives a headless browser, autonomously explores the
+Saiku UI (clicking, typing, navigating), and checks the correctness properties
+in [`spec.ts`](./spec.ts) on every state — surfacing crashes, console errors,
+failed requests, and broken states a scripted e2e wouldn't reach.
+
+It's **test infrastructure**, not a product feature — run on demand, locally.
+Ported from saiku-cloud's `dashboard/bombadil/` and adapted for saiku (Spring
+Security session auth, local launcher target).
+
+## Prerequisites
+
+- The dev-dependency is installed (`@antithesishq/bombadil`, pinned in
+  `package.json`). `npm install` restores it.
+- **A running Saiku** to fuzz. The default target is a local launcher:
+
+  ```bash
+  # from the repo root — build once, then serve:
+  mvn -pl saiku-launcher,saiku-webapp clean
+  mvn -pl saiku-launcher -am -Dmaven.test.skip=true package
+  java -jar saiku-launcher/target/saiku-<version>.jar serve --port 8080 --home ./saiku-home
+  # UI at http://localhost:8080/ui/  ·  login admin / admin
+  ```
+
+- **An authenticated session.** The fuzzer's headless browser can't fill the
+  login form and keep a session, so it starts with a `JSESSIONID` cookie
+  injected. `run.sh` mints one automatically by logging in to the target with
+  `admin`/`admin` — nothing to do for the default local setup.
+
+## Run it
+
+```bash
+npm run fuzz                 # 2-min run vs http://localhost:8080/ui/, auto-login admin/admin
+FUZZ_TIME=60m npm run fuzz   # fuzz for an hour
+```
+
+Point it elsewhere / use other creds / supply a cookie directly:
+
+```bash
+FUZZ_TARGET=http://localhost:8080/ui/ SAIKU_USER=admin SAIKU_PASS=admin FUZZ_TIME=60m npm run fuzz
+# or bypass auto-mint with a JSESSIONID value (from a logged-in browser's cookies):
+SAIKU_SESSION='<jsessionid value>' npm run fuzz
+# or a full Cookie header verbatim:
+FUZZ_COOKIE='JSESSIONID=…; XSRF-TOKEN=…' npm run fuzz
+```
+
+Only fuzz a **local / disposable** Saiku — every action issues real requests
+(each query a real Mondrian/engine call). Never point `FUZZ_TARGET` at a shared
+or production instance.
+
+## Read the results
+
+Output lands in `bombadil/out/` (git-ignored): a `trace.jsonl`, screenshots, and
+a report of any property violations. Explore a run interactively:
+
+```bash
+node_modules/.bin/bombadil inspect bombadil/out/trace.jsonl   # opens a local UI
+```
+
+When Bombadil finds a violation it records the exact action sequence. Replay it
+deterministically to confirm a fix:
+
+```bash
+node_modules/.bin/bombadil browser test http://localhost:8080/ui/ \
+  bombadil/spec.ts --reproduce bombadil/out/trace.jsonl
+```
+
+## The properties
+
+`spec.ts` re-exports Bombadil's **browser defaults** — no uncaught JS exceptions,
+no unhandled promise rejections, no console errors, no failed HTTP requests —
+plus a curated action set. Saiku has no top-level `+error.svelte` crash screen,
+so **5xx server bugs are caught by the built-in `noHttpErrorCodes`** property.
+
+Triage note: `noHttpErrorCodes` fires on *any* ≥ 400 response, so a long run will
+also flag legitimate 4xx (a 404 from a fuzzed URL, a 403 on a CSRF-guarded POST).
+Those are noise — the **5xx** violations are the real bugs. Add more invariants as
+you learn the UI's contracts, but keep them conservative (a property that fires on
+legitimate states trains you to ignore the report). See the
+[specification language docs](https://antithesishq.github.io/bombadil/browser/3-specification-language.html).
+
+## Actions (why not `defaultActions`)
+
+The default action set clicks everything, including **Sign out** (which ends the
+injected session, stranding the run on `/login`) and the login submit. `spec.ts`
+composes its own set: every default action except raw `clicks` (replaced by an
+auth-avoiding `safeClicks`) and `navigation` (which could jump to `/login`).
+Sign-out and login submit carry `data-testid="app-signout"` / `"login-submit"`
+so `safeClicks` can exclude them.
+
+## Not wired into CI
+
+On-demand only. A gated nightly workflow could follow once the property set has
+settled.

--- a/saiku-ui/bombadil/mint-cookie.sh
+++ b/saiku-ui/bombadil/mint-cookie.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+#
+# Print the Cookie header that authenticates the Bombadil fuzzer against a local
+# Saiku launcher. Saiku uses Spring Security session auth: POST username/password
+# to /rest/saiku/session sets an httpOnly JSESSIONID (+ an XSRF-TOKEN). We echo
+# both as a single `Cookie` header value for run.sh to pass to Bombadil verbatim.
+#
+# Env (all optional):
+#   FUZZ_TARGET   base URL of the running Saiku (default http://localhost:8080)
+#   SAIKU_USER    login user     (default admin)
+#   SAIKU_PASS    login password (default admin)
+#
+# Usage:
+#   FUZZ_COOKIE="$(bash bombadil/mint-cookie.sh)" npm run fuzz
+# (run.sh calls this automatically when no cookie is supplied.)
+set -euo pipefail
+
+# Strip a trailing /ui or /ui/ so we hit the REST origin, not the SPA base path.
+BASE="${FUZZ_TARGET:-http://localhost:8080}"
+BASE="${BASE%/}"
+BASE="${BASE%/ui}"
+USER="${SAIKU_USER:-admin}"
+PASS="${SAIKU_PASS:-admin}"
+
+JAR="$(mktemp)"
+trap 'rm -f "$JAR"' EXIT
+
+code="$(curl -s -o /dev/null -w '%{http_code}' -c "$JAR" \
+  -X POST "${BASE}/rest/saiku/session" \
+  -H 'Content-Type: application/x-www-form-urlencoded' \
+  --data-urlencode "username=${USER}" \
+  --data-urlencode "password=${PASS}")"
+
+if [[ "$code" != "200" ]]; then
+  echo "✗ login to ${BASE}/rest/saiku/session failed (HTTP ${code}). Is the launcher running, and are ${USER}/${PASS} valid?" >&2
+  exit 1
+fi
+
+# Emit "NAME=value; NAME=value" for JSESSIONID (+ XSRF-TOKEN if present). Netscape
+# cookie-jar columns: 6 = name, 7 = value.
+awk 'NF>=7 && ($6=="JSESSIONID" || $6=="XSRF-TOKEN") { printf "%s%s=%s", sep, $6, $7; sep="; " } END { print "" }' "$JAR"

--- a/saiku-ui/bombadil/run.sh
+++ b/saiku-ui/bombadil/run.sh
@@ -3,33 +3,56 @@
 # Fuzz the Saiku UI with Bombadil (antithesishq/bombadil).
 #
 # Bombadil drives a headless Chromium and autonomously explores the UI, checking
-# the properties in spec.ts. It must START authenticated (headless can't fill the
-# login form and keep a session), so this harness injects a Saiku session cookie
-# as a static `Cookie` request header.
+# the properties in spec.ts.
 #
-# Cookie resolution, in order:
-#   1. $FUZZ_COOKIE            — a complete Cookie header value, used verbatim.
-#   2. $SAIKU_SESSION          — a JSESSIONID value (or a file at
-#      / $SAIKU_SESSION_FILE     $SAIKU_SESSION_FILE, default ~/.saiku/session).
-#   3. auto-mint               — log in to $FUZZ_TARGET with $SAIKU_USER/$SAIKU_PASS
-#                                (default admin/admin) via mint-cookie.sh. This is
-#                                what makes `npm run fuzz` work out-of-the-box
-#                                against a local launcher.
+# ── Why a pinned Chrome (not the system one) ────────────────────────────────
+# bombadil 0.6.1 speaks an older Chrome DevTools Protocol. Driving a bleeding-
+# edge system Chrome (e.g. Chrome 150) floods `chromiumoxide WS Invalid message`
+# and fails to instrument the page ("no actions available"). So we drive a pinned
+# **Chrome for Testing** build via bombadil's `test-external` mode: we launch it
+# ourselves with a remote-debugging port + isolated profile, and point bombadil
+# at it. CfT 131 is verified CDP-clean against bombadil 0.6.1.
+#
+# ── Auth ────────────────────────────────────────────────────────────────────
+# The fuzzer must start authenticated. run.sh mints a Saiku session cookie
+# (JSESSIONID) by logging in to the target (admin/admin) via mint-cookie.sh and
+# injects it as a static Cookie header. Override with $FUZZ_COOKIE / $SAIKU_SESSION.
 #
 # Usage:
-#   npm run fuzz                        # 2-min run vs http://localhost:8080/ui/, auto-login admin/admin
+#   npm run fuzz                        # 2-min run vs http://localhost:8080/ui/
 #   FUZZ_TIME=60m npm run fuzz          # fuzz for an hour
 #   FUZZ_TARGET=http://localhost:8080/ui/ FUZZ_TIME=60m npm run fuzz
+#   CHROME_BIN=/path/to/chrome npm run fuzz   # use a specific Chrome-for-Testing binary
 #
 # See ./README.md for how to read the results.
 set -euo pipefail
 
 HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+UI_ROOT="$(cd "${HERE}/.." && pwd)"
 TARGET="${FUZZ_TARGET:-http://localhost:8080/ui/}"
 TIME_LIMIT="${FUZZ_TIME:-2m}"
 SPEC="${HERE}/spec.ts"
 OUT="${HERE}/out"
+CHROME_VERSION="${CHROME_VERSION:-131.0.6778.204}"
+DEBUG_PORT="${FUZZ_DEBUG_PORT:-9333}"
 
+# ── 1. Resolve a compatible Chrome for Testing binary (download once, cached) ──
+CHROME="${CHROME_BIN:-}"
+if [[ -z "$CHROME" ]]; then
+  CACHE="${UI_ROOT}/.cache-chrome"
+  CHROME="$(find "$CACHE" -name 'Google Chrome for Testing' -type f 2>/dev/null | head -1 || true)"
+  if [[ -z "$CHROME" ]]; then
+    echo "▶ Downloading Chrome for Testing ${CHROME_VERSION} (one-time; bombadil needs a CDP-compatible build)…" >&2
+    npx -y @puppeteer/browsers install "chrome@${CHROME_VERSION}" --path "$CACHE" >&2
+    CHROME="$(find "$CACHE" -name 'Google Chrome for Testing' -type f 2>/dev/null | head -1 || true)"
+  fi
+fi
+if [[ -z "$CHROME" || ! -x "$CHROME" ]]; then
+  echo "✗ No Chrome-for-Testing binary found. Set CHROME_BIN=/path/to/'Google Chrome for Testing'." >&2
+  exit 1
+fi
+
+# ── 2. Session cookie ─────────────────────────────────────────────────────────
 COOKIE_HEADER="${FUZZ_COOKIE:-}"
 SESSION_FILE="${SAIKU_SESSION_FILE:-$HOME/.saiku/session}"
 if [[ -z "$COOKIE_HEADER" ]]; then
@@ -39,28 +62,41 @@ if [[ -z "$COOKIE_HEADER" ]]; then
   if [[ -n "${SAIKU_SESSION:-}" ]]; then
     COOKIE_HEADER="JSESSIONID=${SAIKU_SESSION}"
   else
-    echo "▶ No cookie supplied — logging in to ${TARGET} to mint one…" >&2
+    echo "▶ Minting a session cookie by logging in to ${TARGET}…" >&2
     COOKIE_HEADER="$(FUZZ_TARGET="$TARGET" bash "${HERE}/mint-cookie.sh")"
   fi
 fi
 
-if [[ -z "$COOKIE_HEADER" ]]; then
-  echo "✗ Could not obtain a session cookie. Start the launcher (java -jar saiku-<v>.jar serve) or set FUZZ_COOKIE / SAIKU_SESSION." >&2
-  exit 1
-fi
+# ── 3. Launch the pinned Chrome (isolated profile + debug port) ────────────────
+PROFILE="$(mktemp -d)"
+"$CHROME" --headless=new --remote-debugging-port="$DEBUG_PORT" --remote-allow-origins='*' \
+  --user-data-dir="$PROFILE" --no-first-run --no-default-browser-check --disable-gpu \
+  >/dev/null 2>&1 &
+CHROME_PID=$!
+cleanup() { kill "$CHROME_PID" 2>/dev/null || true; rm -rf "$PROFILE" 2>/dev/null || true; }
+trap cleanup EXIT
 
-# Resolve the bombadil binary from the local install.
-BOMBADIL="${HERE}/../node_modules/.bin/bombadil"
+for _ in $(seq 1 40); do
+  curl -s "http://127.0.0.1:${DEBUG_PORT}/json/version" >/dev/null 2>&1 && break
+  sleep 0.25
+done
+
+BOMBADIL="${UI_ROOT}/node_modules/.bin/bombadil"
 [[ -x "$BOMBADIL" ]] || BOMBADIL="bombadil"
 
-echo "▶ Fuzzing ${TARGET} for ${TIME_LIMIT} (spec: spec.ts)…"
+echo "▶ Fuzzing ${TARGET} for ${TIME_LIMIT} via Chrome for Testing ${CHROME_VERSION} (spec: spec.ts)…"
 echo "  Output → ${OUT}  ·  inspect with: ${BOMBADIL} inspect ${OUT}/trace.jsonl"
 
-# bombadil v0.6.x's `browser test` has no --cookie flag, so we inject the session
-# as a static Cookie request header (sent with every browser request).
-exec "$BOMBADIL" browser test "$TARGET" "$SPEC" \
-  --headless \
+# `--chrome-grant-permissions ''` : bombadil's default grants `local-network-access`,
+#   which only exists in Chrome ~138+ and errors on CfT 131 (CDP -32602).
+# `--instrument-javascript inline` : don't intercept the app's external JS bundles
+#   (that interception is the flaky part); inline-only keeps the app hydrating.
+exec "$BOMBADIL" browser test-external "$TARGET" "$SPEC" \
+  --remote-debugger "http://127.0.0.1:${DEBUG_PORT}" \
+  --create-target \
   --time-limit="$TIME_LIMIT" \
+  --chrome-grant-permissions '' \
+  --instrument-javascript inline \
   --header "Cookie=${COOKIE_HEADER}" \
   --output-path "$OUT" \
   --output-path-overwrite

--- a/saiku-ui/bombadil/run.sh
+++ b/saiku-ui/bombadil/run.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+#
+# Fuzz the Saiku UI with Bombadil (antithesishq/bombadil).
+#
+# Bombadil drives a headless Chromium and autonomously explores the UI, checking
+# the properties in spec.ts. It must START authenticated (headless can't fill the
+# login form and keep a session), so this harness injects a Saiku session cookie
+# as a static `Cookie` request header.
+#
+# Cookie resolution, in order:
+#   1. $FUZZ_COOKIE            — a complete Cookie header value, used verbatim.
+#   2. $SAIKU_SESSION          — a JSESSIONID value (or a file at
+#      / $SAIKU_SESSION_FILE     $SAIKU_SESSION_FILE, default ~/.saiku/session).
+#   3. auto-mint               — log in to $FUZZ_TARGET with $SAIKU_USER/$SAIKU_PASS
+#                                (default admin/admin) via mint-cookie.sh. This is
+#                                what makes `npm run fuzz` work out-of-the-box
+#                                against a local launcher.
+#
+# Usage:
+#   npm run fuzz                        # 2-min run vs http://localhost:8080/ui/, auto-login admin/admin
+#   FUZZ_TIME=60m npm run fuzz          # fuzz for an hour
+#   FUZZ_TARGET=http://localhost:8080/ui/ FUZZ_TIME=60m npm run fuzz
+#
+# See ./README.md for how to read the results.
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TARGET="${FUZZ_TARGET:-http://localhost:8080/ui/}"
+TIME_LIMIT="${FUZZ_TIME:-2m}"
+SPEC="${HERE}/spec.ts"
+OUT="${HERE}/out"
+
+COOKIE_HEADER="${FUZZ_COOKIE:-}"
+SESSION_FILE="${SAIKU_SESSION_FILE:-$HOME/.saiku/session}"
+if [[ -z "$COOKIE_HEADER" ]]; then
+  if [[ -z "${SAIKU_SESSION:-}" && -r "$SESSION_FILE" ]]; then
+    SAIKU_SESSION="$(tr -d '[:space:]' <"$SESSION_FILE")"
+  fi
+  if [[ -n "${SAIKU_SESSION:-}" ]]; then
+    COOKIE_HEADER="JSESSIONID=${SAIKU_SESSION}"
+  else
+    echo "▶ No cookie supplied — logging in to ${TARGET} to mint one…" >&2
+    COOKIE_HEADER="$(FUZZ_TARGET="$TARGET" bash "${HERE}/mint-cookie.sh")"
+  fi
+fi
+
+if [[ -z "$COOKIE_HEADER" ]]; then
+  echo "✗ Could not obtain a session cookie. Start the launcher (java -jar saiku-<v>.jar serve) or set FUZZ_COOKIE / SAIKU_SESSION." >&2
+  exit 1
+fi
+
+# Resolve the bombadil binary from the local install.
+BOMBADIL="${HERE}/../node_modules/.bin/bombadil"
+[[ -x "$BOMBADIL" ]] || BOMBADIL="bombadil"
+
+echo "▶ Fuzzing ${TARGET} for ${TIME_LIMIT} (spec: spec.ts)…"
+echo "  Output → ${OUT}  ·  inspect with: ${BOMBADIL} inspect ${OUT}/trace.jsonl"
+
+# bombadil v0.6.x's `browser test` has no --cookie flag, so we inject the session
+# as a static Cookie request header (sent with every browser request).
+exec "$BOMBADIL" browser test "$TARGET" "$SPEC" \
+  --headless \
+  --time-limit="$TIME_LIMIT" \
+  --header "Cookie=${COOKIE_HEADER}" \
+  --output-path "$OUT" \
+  --output-path-overwrite

--- a/saiku-ui/bombadil/spec.ts
+++ b/saiku-ui/bombadil/spec.ts
@@ -1,0 +1,109 @@
+/**
+ * Bombadil property-based fuzz spec for the Saiku UI.
+ *
+ * Bombadil (https://github.com/antithesishq/bombadil) autonomously explores the
+ * app in a headless browser and checks the properties exported here on every
+ * captured state — surfacing crashes, console errors, failed requests, and
+ * broken states a scripted e2e wouldn't reach. Run it with `npm run fuzz`
+ * (see ./README.md); that harness injects an authenticated `JSESSIONID` cookie
+ * so the fuzzer starts logged in.
+ *
+ * Ported from saiku-cloud's `dashboard/bombadil/dashboard.spec.ts` and adapted
+ * for saiku: different auth (Spring Security session cookie, not WorkOS) and no
+ * top-level `+error.svelte`, so 5xx crashes are caught by the built-in
+ * `noHttpErrorCodes` property rather than an error-page invariant.
+ *
+ * ## Properties (correctness invariants)
+ * Bombadil's built-in browser defaults — the high-value, low-noise baseline: no
+ * uncaught exceptions, no unhandled promise rejections, no console errors, no
+ * failed HTTP requests. `noHttpErrorCodes` fires on any >= 400 response, so a
+ * long run WILL flag 4xx from fuzzed URLs (a 404 for a made-up path, a 403 on a
+ * CSRF-guarded POST) alongside the real 5xx server bugs — triage those out in
+ * the report; the 5xx are the ones that matter.
+ *
+ * ## Actions (why we DON'T use `defaultActions`)
+ * The default action set clicks *everything*, including **Sign out** (which ends
+ * the injected session → every later request 401s and bounces to /login, wasting
+ * the run) and, on /login, the **Sign in** submit. So we compose our own set:
+ * every default action EXCEPT the raw `clicks` (replaced by an auth-avoiding
+ * `safeClicks`) and `navigation` (which could jump straight to /login|/logout).
+ * This keeps the fuzzer inside the authenticated app for the full run.
+ */
+import { extract, actions, type Action } from "@antithesishq/bombadil/browser";
+
+// Correctness properties — the built-in defaults (kept as-is).
+export {
+  noUncaughtExceptions,
+  noUnhandledPromiseRejections,
+  noConsoleErrors,
+  noHttpErrorCodes,
+} from "@antithesishq/bombadil/browser/defaults/properties";
+
+// Safe default actions — everything except `clicks` (replaced below) and
+// `navigation` (could navigate directly to /login or /logout).
+export {
+  waitOnce,
+  scroll,
+  inputs,
+  back,
+  forward,
+  reload,
+} from "@antithesishq/bombadil/browser/defaults/actions";
+
+/**
+ * Auth controls that must never be clicked — following any of them logs the
+ * fuzzer out (Sign out) or re-submits login, both of which strand the run on
+ * /login. Testids added in +layout.svelte / LoginForm.svelte for a stable hook.
+ */
+const AUTH_EXCLUDE = [
+  '[data-testid="app-signout"]',
+  '[data-testid="login-submit"]',
+  'a[href*="/login"]',
+  'a[href*="/logout"]',
+  // Non-http links hang Bombadil's navigation (30s timeout -> fatal). The
+  // protocol guard below is the real catch-all; these are belt-and-suspenders.
+  'a[href^="mailto:"]',
+  'a[href^="tel:"]',
+].join(", ");
+
+/** True for links that navigate somewhere Bombadil can't (mailto:, tel:, blob:, …). */
+function isNonHttpLink(el: Element): boolean {
+  if (el.tagName !== "A") return false;
+  const proto = (el as HTMLAnchorElement).protocol;
+  return proto !== "" && proto !== "http:" && proto !== "https:";
+}
+
+const CLICKABLE =
+  'a, button, [role="button"], input[type="submit"], input[type="button"], summary, [onclick]';
+
+/**
+ * Clickable elements currently on screen, MINUS the auth controls. Runs in-page,
+ * so `getBoundingClientRect` gives real viewport coordinates; we keep only
+ * visible, in-viewport targets (mirrors what the default clicks consider).
+ */
+const clickTargets = extract((state): Array<{ name: string; x: number; y: number }> => {
+  const doc = state.document;
+  const win = state.window;
+  const excluded = new Set<Element>(Array.from(doc.querySelectorAll(AUTH_EXCLUDE)));
+  return Array.from(doc.querySelectorAll(CLICKABLE))
+    .filter((el) => !excluded.has(el) && el.closest(AUTH_EXCLUDE) === null && !isNonHttpLink(el))
+    .map((el) => {
+      const r = el.getBoundingClientRect();
+      return {
+        name: el.getAttribute("data-testid") || el.tagName,
+        x: r.left + r.width / 2,
+        y: r.top + r.height / 2,
+        w: r.width,
+        h: r.height,
+      };
+    })
+    .filter(
+      (t) => t.w > 0 && t.h > 0 && t.x >= 0 && t.y >= 0 && t.x <= win.innerWidth && t.y <= win.innerHeight,
+    )
+    .map(({ name, x, y }) => ({ name, x, y }));
+});
+
+/** Click any on-screen element that isn't an auth control. */
+export const safeClicks = actions((): Action[] =>
+  clickTargets.current.map((t) => ({ Click: { name: t.name, point: { x: t.x, y: t.y } } })),
+);

--- a/saiku-ui/bombadil/tsconfig.json
+++ b/saiku-ui/bombadil/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  // Standalone type-check config for the Bombadil fuzz spec. It lives outside
+  // `src/` so it's not part of the app build / svelte-check; type-check it on
+  // its own with: `npx tsc -p bombadil`.
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "strict": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "types": []
+  },
+  "include": ["*.ts"]
+}

--- a/saiku-ui/package-lock.json
+++ b/saiku-ui/package-lock.json
@@ -24,6 +24,7 @@
         "yaml": "^2.9.0"
       },
       "devDependencies": {
+        "@antithesishq/bombadil": "^0.6.1",
         "@chromatic-com/storybook": "^5.2.1",
         "@eslint/compat": "^2.1.0",
         "@eslint/js": "^10.0.1",
@@ -61,6 +62,16 @@
       "integrity": "sha512-6OzddxPio9UiWTCemp4N8cYLV2ZN1ncRnV1cVGtve7dhPOtRkleRyx32GQCYSwDYgaHU3USMm84tNsvKzRCa1Q==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@antithesishq/bombadil": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@antithesishq/bombadil/-/bombadil-0.6.1.tgz",
+      "integrity": "sha512-d1iufG3MI7gSMSiSmMeNdcMW+qR0yQXL2zdkVynC3n3DYgFJYlYXKUQzygmqU12m4RWlR5iOdQU1hsx5UT6+IA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "bombadil": "bin/bombadil.js"
+      }
     },
     "node_modules/@asamuzakjp/css-color": {
       "version": "5.1.11",

--- a/saiku-ui/package.json
+++ b/saiku-ui/package.json
@@ -19,6 +19,7 @@
     "e2e": "playwright test",
     "e2e:live": "RUN_LIVE_E2E=1 playwright test",
     "e2e:ui": "playwright test --ui",
+    "fuzz": "bash bombadil/run.sh",
     "lint:tokens": "node ./scripts/check-tokens.mjs",
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build",
@@ -26,6 +27,7 @@
     "lint": "npm run lint:tokens && npm run lint:eslint"
   },
   "devDependencies": {
+    "@antithesishq/bombadil": "^0.6.1",
     "@chromatic-com/storybook": "^5.2.1",
     "@eslint/compat": "^2.1.0",
     "@eslint/js": "^10.0.1",

--- a/saiku-ui/src/lib/components/ContextMenu.svelte
+++ b/saiku-ui/src/lib/components/ContextMenu.svelte
@@ -51,8 +51,8 @@
   .ctx-menu {
     position: fixed;
     min-width: 180px;
-    background: var(--bg);
-    border: 1px solid var(--border);
+    background: hsl(var(--bg));
+    border: 1px solid hsl(var(--border));
     border-radius: 6px;
     box-shadow: var(--shadow-lg);
     padding: 4px;
@@ -67,13 +67,13 @@
     padding: 6px 10px;
     background: transparent;
     border: 0;
-    color: var(--fg);
+    color: hsl(var(--fg));
     font: inherit;
     cursor: pointer;
     border-radius: 4px;
   }
-  .ctx-menu__item:hover:not(:disabled) { background: var(--bg-subtle); }
-  .ctx-menu__item:disabled { color: var(--fg-subtle); cursor: default; }
-  .ctx-menu__item.danger { color: var(--danger); }
-  .ctx-menu__sep { height: 1px; background: var(--border); margin: 3px 0; }
+  .ctx-menu__item:hover:not(:disabled) { background: hsl(var(--bg-subtle)); }
+  .ctx-menu__item:disabled { color: hsl(var(--fg-subtle)); cursor: default; }
+  .ctx-menu__item.danger { color: hsl(var(--danger)); }
+  .ctx-menu__sep { height: 1px; background: hsl(var(--border)); margin: 3px 0; }
 </style>

--- a/saiku-ui/src/lib/components/EmptyState.svelte
+++ b/saiku-ui/src/lib/components/EmptyState.svelte
@@ -58,7 +58,7 @@
     text-align: center;
     gap: var(--space-3);
     padding: var(--space-8) var(--space-5);
-    color: var(--fg);
+    color: hsl(var(--fg));
   }
   .empty-state--compact {
     padding: var(--space-5) var(--space-3);
@@ -71,8 +71,8 @@
     width: 64px;
     height: 64px;
     border-radius: 50%;
-    background: var(--bg-muted);
-    color: var(--fg-subtle);
+    background: hsl(var(--bg-muted));
+    color: hsl(var(--fg-subtle));
   }
   .empty-state--compact .empty-state__icon {
     width: 48px;
@@ -81,7 +81,7 @@
   .empty-state__description {
     margin: 0;
     max-width: 32ch;
-    color: var(--fg-muted);
+    color: hsl(var(--fg-muted));
     font-size: var(--fs-sm);
     line-height: var(--lh-normal);
   }

--- a/saiku-ui/src/lib/components/PrefsMenu.svelte
+++ b/saiku-ui/src/lib/components/PrefsMenu.svelte
@@ -66,8 +66,8 @@
     bottom: calc(100% + 6px);
     left: 0;
     z-index: 30;
-    background: var(--bg);
-    border: 1px solid var(--border);
+    background: hsl(var(--bg));
+    border: 1px solid hsl(var(--border));
     border-radius: var(--radius);
     box-shadow: var(--shadow);
     padding: var(--space-3);

--- a/saiku-ui/src/lib/components/RepositoryBrowser.svelte
+++ b/saiku-ui/src/lib/components/RepositoryBrowser.svelte
@@ -288,15 +288,15 @@
     background: transparent;
     border: 0;
     border-radius: 3px;
-    color: var(--fg-muted);
+    color: hsl(var(--fg-muted));
     cursor: pointer;
     font: inherit;
   }
-  .repo-browser__crumb:hover { background: var(--bg-hover); color: var(--fg); }
-  .repo-browser__crumb.is-current { color: var(--fg); font-weight: var(--weight-medium); }
+  .repo-browser__crumb:hover { background: hsl(var(--bg-hover)); color: hsl(var(--fg)); }
+  .repo-browser__crumb.is-current { color: hsl(var(--fg)); font-weight: var(--weight-medium); }
   /* Applied via class={} on a lucide-svelte icon — needs :global so the
      scoped-style hash doesn't suppress it on the child component's root. */
-  :global(.repo-browser__crumb-sep) { color: var(--fg-subtle); }
+  :global(.repo-browser__crumb-sep) { color: hsl(var(--fg-subtle)); }
   .repo-browser__list {
     flex: 1;
     list-style: none;
@@ -304,9 +304,9 @@
     padding: 0;
     max-height: 40vh;
     overflow-y: auto;
-    border: 1px solid var(--border);
+    border: 1px solid hsl(var(--border));
     border-radius: var(--radius-sm);
-    background: var(--bg);
+    background: hsl(var(--bg));
   }
   .repo-browser__row {
     display: flex;
@@ -316,35 +316,35 @@
     padding: var(--space-2) var(--space-3);
     background: transparent;
     border: 0;
-    border-bottom: 1px solid var(--border);
-    color: var(--fg);
+    border-bottom: 1px solid hsl(var(--border));
+    color: hsl(var(--fg));
     cursor: pointer;
     font: inherit;
     font-size: var(--fs-sm);
     text-align: left;
   }
   .repo-browser__row:last-child { border-bottom: 0; }
-  .repo-browser__row:hover { background: var(--bg-hover); }
+  .repo-browser__row:hover { background: hsl(var(--bg-hover)); }
   .repo-browser__row.is-selected {
-    background: var(--accent-soft);
-    color: var(--accent-strong);
+    background: hsl(var(--accent));
+    color: hsl(var(--primary-strong));
   }
   .repo-browser__new-folder {
     display: flex;
     align-items: center;
     gap: var(--space-2);
     padding: var(--space-2);
-    background: var(--bg-muted);
-    border: 1px solid var(--border);
+    background: hsl(var(--bg-muted));
+    border: 1px solid hsl(var(--border));
     border-radius: var(--radius-sm);
-    color: var(--fg-muted);
+    color: hsl(var(--fg-muted));
   }
   .repo-browser__new-folder-input {
     flex: 1;
     padding: 6px var(--space-2);
-    background: var(--bg);
-    color: var(--fg);
-    border: 1px solid var(--border);
+    background: hsl(var(--bg));
+    color: hsl(var(--fg));
+    border: 1px solid hsl(var(--border));
     border-radius: var(--radius-sm);
     font: inherit;
     font-size: var(--fs-sm);

--- a/saiku-ui/src/lib/components/SessionExpiredBanner.svelte
+++ b/saiku-ui/src/lib/components/SessionExpiredBanner.svelte
@@ -175,9 +175,9 @@
     z-index: 2100; /* above ToastStack (2000), below explicit modals. */
     margin: 0 auto;
     max-width: 960px;
-    background: var(--bg);
-    color: var(--fg);
-    border: 1px solid var(--danger);
+    background: hsl(var(--bg));
+    color: hsl(var(--fg));
+    border: 1px solid hsl(var(--danger));
     border-top: 0;
     border-radius: 0 0 var(--radius-md) var(--radius-md);
     box-shadow: var(--shadow-md);
@@ -192,10 +192,10 @@
     /* High-contrast left bar so the banner reads as urgent without
        borrowing the toast pattern (which is dismissible-info, not
        attention-required). */
-    border-left: 4px solid var(--danger);
+    border-left: 4px solid hsl(var(--danger));
   }
   .session-banner :global(.session-banner__icon) {
-    color: var(--danger);
+    color: hsl(var(--danger));
     flex-shrink: 0;
   }
   .session-banner__form {
@@ -203,14 +203,14 @@
     flex-direction: column;
     gap: var(--space-2);
     padding: var(--space-3);
-    border-top: 1px solid var(--border);
-    background: var(--bg-muted);
+    border-top: 1px solid hsl(var(--border));
+    background: hsl(var(--bg-muted));
   }
   .session-banner__err {
     margin: 0;
     padding: var(--space-2);
     background: var(--danger-soft, rgba(220, 38, 38, 0.1));
-    color: var(--danger);
+    color: hsl(var(--danger));
     border-radius: var(--radius-sm);
   }
   .session-banner__fields {

--- a/saiku-ui/src/lib/components/Skeleton.svelte
+++ b/saiku-ui/src/lib/components/Skeleton.svelte
@@ -58,9 +58,9 @@
     border-radius: var(--radius-sm);
     background: linear-gradient(
       90deg,
-      var(--bg-muted) 0%,
-      var(--bg-subtle) 50%,
-      var(--bg-muted) 100%
+      hsl(var(--bg-muted)) 0%,
+      hsl(var(--bg-subtle)) 50%,
+      hsl(var(--bg-muted)) 100%
     );
     background-size: 200% 100%;
     animation: skeleton-shimmer 1.4s ease-in-out infinite;
@@ -74,7 +74,7 @@
   @media (prefers-reduced-motion: reduce) {
     .skeleton-bar {
       animation: none;
-      background: var(--bg-subtle);
+      background: hsl(var(--bg-subtle));
     }
   }
 </style>

--- a/saiku-ui/src/lib/components/Tour.svelte
+++ b/saiku-ui/src/lib/components/Tour.svelte
@@ -153,7 +153,7 @@
   .tour { position: fixed; inset: 0; z-index: 3000; pointer-events: none; }
   .tour__highlight {
     position: absolute;
-    border: 2px solid var(--accent);
+    border: 2px solid hsl(var(--primary));
     border-radius: var(--radius-sm);
     box-shadow: 0 0 0 9999px rgba(0, 0, 0, 0.45);
     transition: all var(--duration-normal) ease;
@@ -163,9 +163,9 @@
     position: absolute;
     width: 360px;
     max-width: calc(100vw - 24px);
-    background: var(--bg);
-    color: var(--fg);
-    border: 1px solid var(--border);
+    background: hsl(var(--bg));
+    color: hsl(var(--fg));
+    border: 1px solid hsl(var(--border));
     border-radius: var(--radius-md);
     box-shadow: var(--shadow-lg);
     padding: var(--space-4);
@@ -177,8 +177,8 @@
     align-items: baseline;
     margin-bottom: var(--space-2);
   }
-  .tour__bubble .step { color: var(--fg-subtle); font-size: var(--fs-xs); }
-  .tour__bubble p { margin: 0 0 var(--space-3); color: var(--fg-muted); font-size: var(--fs-sm); }
+  .tour__bubble .step { color: hsl(var(--fg-subtle)); font-size: var(--fs-xs); }
+  .tour__bubble p { margin: 0 0 var(--space-3); color: hsl(var(--fg-muted)); font-size: var(--fs-sm); }
   .tour__bubble footer {
     display: flex;
     justify-content: flex-end;

--- a/saiku-ui/src/lib/components/schemagen/NodeDrawer.svelte
+++ b/saiku-ui/src/lib/components/schemagen/NodeDrawer.svelte
@@ -118,7 +118,7 @@
 .drawer {
     font-family: var(--font-sans);
     font-size: var(--fs-sm);
-    color: var(--fg);
+    color: hsl(var(--fg));
     padding: var(--space-4);
     display: flex;
     flex-direction: column;
@@ -127,7 +127,7 @@
   }
   .drawer__kind {
     margin: 0;
-    color: var(--fg-muted);
+    color: hsl(var(--fg-muted));
     font-size: var(--fs-xs);
     text-transform: uppercase;
     letter-spacing: 0.05em;
@@ -143,25 +143,25 @@
     font-weight: var(--weight-semibold);
     text-transform: uppercase;
     letter-spacing: 0.03em;
-    background: var(--fg-subtle);
-    color: var(--accent-fg);
+    background: hsl(var(--fg-subtle));
+    color: hsl(var(--primary-foreground));
   }
   .drawer__badge--user {
-    background: var(--success);
+    background: hsl(var(--success));
     color: #fff;
   }
   .drawer__label {
     font-size: var(--fs-xs);
-    color: var(--fg-muted);
+    color: hsl(var(--fg-muted));
     text-transform: uppercase;
     letter-spacing: 0.05em;
   }
   .drawer__input,
   .drawer__textarea {
     font: inherit;
-    color: var(--fg);
-    background: var(--bg);
-    border: 1px solid var(--border);
+    color: hsl(var(--fg));
+    background: hsl(var(--bg));
+    border: 1px solid hsl(var(--border));
     border-radius: var(--radius-sm);
     padding: var(--space-2) var(--space-3);
   }
@@ -169,7 +169,7 @@
   .drawer__textarea:focus {
     outline: none;
     box-shadow: var(--focus-ring);
-    border-color: var(--accent);
+    border-color: hsl(var(--primary));
   }
   .drawer__textarea {
     resize: vertical;
@@ -181,9 +181,9 @@
     gap: 2px var(--space-3);
     margin: 0;
     padding-top: var(--space-2);
-    border-top: 1px solid var(--border);
+    border-top: 1px solid hsl(var(--border));
     font-size: var(--fs-xs);
-    color: var(--fg-muted);
+    color: hsl(var(--fg-muted));
   }
   .drawer__meta dt {
     font-weight: var(--weight-semibold);

--- a/saiku-ui/src/lib/components/schemagen/SchemaTree.svelte
+++ b/saiku-ui/src/lib/components/schemagen/SchemaTree.svelte
@@ -80,14 +80,14 @@
 .tree {
     font-family: var(--font-sans);
     font-size: var(--fs-sm);
-    color: var(--fg);
+    color: hsl(var(--fg));
     padding: var(--space-2);
     overflow: auto;
   }
   .tree__root,
   .tree__children {
     padding-left: var(--space-4);
-    border-left: 1px dashed var(--border);
+    border-left: 1px dashed hsl(var(--border));
     margin-left: var(--space-2);
   }
   .tree__item {
@@ -108,7 +108,7 @@
     font: inherit;
   }
   .tree__row:hover {
-    background: var(--bg-muted);
+    background: hsl(var(--bg-muted));
   }
   .tree__row:focus-visible {
     outline: none;
@@ -122,11 +122,11 @@
     font-weight: var(--weight-semibold);
     letter-spacing: 0.03em;
     text-transform: uppercase;
-    color: var(--accent-fg);
-    background: var(--fg-subtle);
+    color: hsl(var(--primary-foreground));
+    background: hsl(var(--fg-subtle));
   }
   .tree__badge--user {
-    background: var(--success);
+    background: hsl(var(--success));
     color: #fff;
   }
 </style>

--- a/saiku-ui/src/lib/components/schemagen/SuggestionCard.svelte
+++ b/saiku-ui/src/lib/components/schemagen/SuggestionCard.svelte
@@ -73,15 +73,15 @@
     flex-direction: column;
     gap: var(--space-2);
     padding: var(--space-3);
-    border: 1px solid var(--border);
+    border: 1px solid hsl(var(--border));
     border-radius: var(--radius-sm);
-    background: var(--bg);
+    background: hsl(var(--bg));
     font-size: var(--fs-sm);
   }
   .card__path {
     font-family: var(--font-mono);
     font-size: var(--fs-xs);
-    color: var(--fg-muted);
+    color: hsl(var(--fg-muted));
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
@@ -94,15 +94,15 @@
     font-weight: var(--weight-semibold);
     letter-spacing: 0.03em;
     text-transform: uppercase;
-    color: var(--accent-fg);
-    background: var(--fg-subtle);
+    color: hsl(var(--primary-foreground));
+    background: hsl(var(--fg-subtle));
   }
   .card__tier--high {
-    background: var(--success);
+    background: hsl(var(--success));
     color: #fff;
   }
   .card__before {
-    color: var(--fg-muted);
+    color: hsl(var(--fg-muted));
     text-decoration: line-through;
   }
   .card__btn {
@@ -112,25 +112,25 @@
     font: inherit;
     font-size: var(--fs-xs);
     padding: 4px var(--space-3);
-    border: 1px solid var(--border);
+    border: 1px solid hsl(var(--border));
     border-radius: var(--radius-sm);
-    background: var(--bg);
-    color: var(--fg);
+    background: hsl(var(--bg));
+    color: hsl(var(--fg));
     cursor: pointer;
   }
   .card__btn:hover {
-    background: var(--bg-muted);
+    background: hsl(var(--bg-muted));
   }
   .card__btn:focus-visible {
     outline: none;
     box-shadow: var(--focus-ring);
   }
   .card__btn--accept {
-    color: var(--success);
-    border-color: var(--success);
+    color: hsl(var(--success));
+    border-color: hsl(var(--success));
   }
   .card__btn--accept:hover {
-    background: var(--success);
+    background: hsl(var(--success));
     color: #fff;
   }
 </style>

--- a/saiku-ui/src/lib/components/schemagen/SuggestionsFeed.svelte
+++ b/saiku-ui/src/lib/components/schemagen/SuggestionsFeed.svelte
@@ -120,14 +120,14 @@
     padding: var(--space-3);
     font-family: var(--font-sans);
     font-size: var(--fs-sm);
-    color: var(--fg);
+    color: hsl(var(--fg));
     overflow: auto;
   }
   .feed__banner {
     padding: var(--space-2) var(--space-3);
-    border: 1px solid var(--warning, var(--border-strong));
-    background: var(--bg-muted);
-    color: var(--fg);
+    border: 1px solid var(--warning, hsl(var(--border-strong)));
+    background: hsl(var(--bg-muted));
+    color: hsl(var(--fg));
     border-radius: var(--radius-sm);
     font-size: var(--fs-xs);
   }
@@ -140,14 +140,14 @@
     font: inherit;
     font-size: var(--fs-xs);
     padding: 3px var(--space-2);
-    border: 1px solid var(--border);
+    border: 1px solid hsl(var(--border));
     border-radius: var(--radius-sm);
-    background: var(--bg);
-    color: var(--fg);
+    background: hsl(var(--bg));
+    color: hsl(var(--fg));
     cursor: pointer;
   }
   .feed__bulk:hover {
-    background: var(--bg-muted);
+    background: hsl(var(--bg-muted));
   }
   .feed__bulk:focus-visible {
     outline: none;

--- a/saiku-ui/src/lib/cube-designer/CanvasPane.svelte
+++ b/saiku-ui/src/lib/cube-designer/CanvasPane.svelte
@@ -29,7 +29,11 @@
 	import JumpHandler from './JumpHandler.svelte';
 	import TableSidebar from './TableSidebar.svelte';
 	import type { SchemaCanvasStore } from './state.svelte.js';
-	import { parseConnectionJoin, parseDroppedTableCandidates } from './canvas-dnd.js';
+	import {
+		parseConnectionJoin,
+		parseDroppedTableCandidates,
+		resolveDropOrigin
+	} from './canvas-dnd.js';
 
 	interface Props {
 		store: SchemaCanvasStore;
@@ -110,8 +114,16 @@
 		const candidates = parseDroppedTableCandidates(arrayPayload, singlePayload);
 		if (candidates.length === 0) return;
 		const rect = (e.currentTarget as HTMLElement).getBoundingClientRect();
-		const baseX = e.clientX - rect.left;
-		const baseY = e.clientY - rect.top;
+		// saiku#1634 #3: map the pointer's viewport coords into FLOW space via the
+		// converter JumpHandler published, so a panned/zoomed canvas drops the node
+		// under the cursor rather than off-screen. Falls back to pane-relative
+		// pixels (identity-viewport behaviour) when the converter isn't available.
+		const { x: baseX, y: baseY } = resolveDropOrigin(
+			store.screenToFlowPosition,
+			e.clientX,
+			e.clientY,
+			rect
+		);
 		// Each addTable / addJoin snapshots on its own so Undo peels the
 		// drop off one table at a time (last-in-first-out).  Batching used
 		// to wrap this in withUndoBatch — one snapshot for the whole drop

--- a/saiku-ui/src/lib/cube-designer/JumpHandler.svelte
+++ b/saiku-ui/src/lib/cube-designer/JumpHandler.svelte
@@ -19,6 +19,16 @@
 	let { store }: Props = $props();
 	const flow = useSvelteFlow();
 
+	// Publish the screen→flow converter for the (out-of-context) pane drop
+	// handler — saiku#1634 #3. Wrapped in an arrow so `flow`'s method keeps its
+	// binding; cleared on destroy so a stale reference can't outlive the flow.
+	$effect(() => {
+		store.screenToFlowPosition = (screen) => flow.screenToFlowPosition(screen);
+		return () => {
+			store.screenToFlowPosition = null;
+		};
+	});
+
 	// Approx node dims used to centre on the card's middle, not its
 	// top-left corner. The table cards have a fixed width in TableNode
 	// and a variable height depending on visible columns — using the

--- a/saiku-ui/src/lib/cube-designer/canvas-dnd.test.ts
+++ b/saiku-ui/src/lib/cube-designer/canvas-dnd.test.ts
@@ -5,6 +5,7 @@ import { describe, it, expect } from "vitest";
 import {
   parseConnectionJoin,
   parseDroppedTableCandidates,
+  resolveDropOrigin,
 } from "./canvas-dnd.js";
 import type { SourceTableCandidate } from "./types.js";
 
@@ -77,5 +78,27 @@ describe("parseDroppedTableCandidates", () => {
 
   it("returns [] on malformed JSON instead of throwing", () => {
     expect(parseDroppedTableCandidates("{not json", null)).toEqual([]);
+  });
+});
+
+describe("resolveDropOrigin (saiku#1634 #3)", () => {
+  const rect = { left: 100, top: 50 };
+
+  it("maps viewport coords through the converter when the flow is mounted", () => {
+    // A panned/zoomed viewport: the converter returns coords far from the
+    // naive pane-relative fallback, proving we honour pan/zoom.
+    const screenToFlow = ({ x, y }: { x: number; y: number }) => ({
+      x: (x - 100) * 2 + 500,
+      y: (y - 50) * 2 + 300,
+    });
+    expect(resolveDropOrigin(screenToFlow, 300, 250, rect)).toEqual({
+      x: (300 - 100) * 2 + 500,
+      y: (250 - 50) * 2 + 300,
+    });
+  });
+
+  it("falls back to pane-relative pixels when no converter is available", () => {
+    expect(resolveDropOrigin(null, 300, 250, rect)).toEqual({ x: 200, y: 200 });
+    expect(resolveDropOrigin(undefined, 300, 250, rect)).toEqual({ x: 200, y: 200 });
   });
 });

--- a/saiku-ui/src/lib/cube-designer/canvas-dnd.ts
+++ b/saiku-ui/src/lib/cube-designer/canvas-dnd.ts
@@ -46,6 +46,37 @@ export function parseConnectionJoin(
   };
 }
 
+/** A point in the flow coordinate space (post-pan/zoom). */
+export interface FlowPoint {
+  x: number;
+  y: number;
+}
+
+/** SvelteFlow's `screenToFlowPosition`, or null when the flow isn't mounted. */
+export type ScreenToFlow = ((screen: FlowPoint) => FlowPoint) | null | undefined;
+
+/**
+ * Resolve where a dropped node should land, in FLOW coordinates.
+ *
+ * saiku#1634 (#3): the drop handler lives on the pane wrapper, OUTSIDE the
+ * SvelteFlow provider, so it can't call `useSvelteFlow().screenToFlowPosition`
+ * directly. An in-flow child (JumpHandler) publishes that converter onto the
+ * store; when present we map the pointer's viewport coords through it so a
+ * panned/zoomed canvas drops the node under the cursor rather than off-screen.
+ * When absent (SSR / tests / before the flow mounts) we fall back to
+ * pane-relative pixels, which equal flow coords only at the identity viewport —
+ * the exact stale behaviour this fixes, kept as a safe default.
+ */
+export function resolveDropOrigin(
+  screenToFlow: ScreenToFlow,
+  clientX: number,
+  clientY: number,
+  rect: { left: number; top: number },
+): FlowPoint {
+  if (screenToFlow) return screenToFlow({ x: clientX, y: clientY });
+  return { x: clientX - rect.left, y: clientY - rect.top };
+}
+
 /**
  * Parse the table candidates from a pane-drop's dataTransfer payloads.
  * Prefers the multi-table payload (`application/x-saiku-tables`), falling back

--- a/saiku-ui/src/lib/cube-designer/oss-backend.ts
+++ b/saiku-ui/src/lib/cube-designer/oss-backend.ts
@@ -55,6 +55,18 @@ type IntrospectResponse = {
   }>;
 };
 
+/**
+ * OSS edit mode (saiku#1634): fetch a datasource's already-attached Mondrian schema XML so the host
+ * can hydrate the canvas instead of opening blank. Returns the raw Response — 200 `{ mondrianXml,
+ * label }` when a schema is attached and resolvable, 404 otherwise (⇒ new-cube target, stay blank).
+ *
+ * Deliberately NOT part of the shared {@link CubeDesignerBackend} seam: Cloud has its own
+ * library-based edit flow (`ImportController`), so this stays OSS host glue.
+ */
+export function fetchDatasourceSchema(dataSourceId: string): Promise<Response> {
+  return fetch(`${BASE}/schema/${encodeURIComponent(dataSourceId)}`, CREDS);
+}
+
 export const ossCubeDesignerBackend: CubeDesignerBackend = {
   async profileConnection(connectionId) {
     const r = await fetch(

--- a/saiku-ui/src/lib/cube-designer/state.svelte.ts
+++ b/saiku-ui/src/lib/cube-designer/state.svelte.ts
@@ -536,6 +536,19 @@ export class SchemaCanvasStore {
     kind: "zoom_in" | "zoom_out" | "fit_view" | "zoom_to_100" | "center_view";
     ts: number;
   } | null>(null);
+
+  /**
+   * Screen→flow coordinate converter, published by the in-flow JumpHandler
+   * (which can call `useSvelteFlow()`) so the pane drop handler — mounted
+   * OUTSIDE the SvelteFlow provider — can map a drop's viewport coords into
+   * flow space (saiku#1634 #3). Null until the flow mounts / in SSR + tests;
+   * consumers fall back to pane-relative pixels. Plain field (not `$state`):
+   * only read imperatively inside the drop event handler, never in a reactive
+   * position, so it needs no reactivity (and functions don't proxy cleanly).
+   */
+  screenToFlowPosition:
+    | ((screen: { x: number; y: number }) => { x: number; y: number })
+    | null = null;
   /**
    * Workbench working set — table IDs the user has pulled into the
    * Workbench view for focused side-by-side work. UI-only; not

--- a/saiku-ui/src/lib/dashboard/cssSanitiser.test.ts
+++ b/saiku-ui/src/lib/dashboard/cssSanitiser.test.ts
@@ -41,7 +41,7 @@ describe("sanitiseAndScopeCss", () => {
   // with no Url child, so the Url walk never saw them.
   test("strips remote url() hidden in a custom property (var weaponisation)", () => {
     const out = sanitiseAndScopeCss(
-      ".a{--bg:url(https://evil/track.png)} .b{background:var(--bg)}",
+      ".a{--bg:url(https://evil/track.png)} .b{background:hsl(var(--bg))}",
       ROOT,
     );
     expect(out).not.toContain("evil");

--- a/saiku-ui/src/lib/modals/AddFolderModal.svelte
+++ b/saiku-ui/src/lib/modals/AddFolderModal.svelte
@@ -36,9 +36,9 @@
 </Modal>
 
 <style>
-  .hint { color: var(--fg-muted); font-size: var(--fs-sm); margin: 0 0 var(--space-3); }
+  .hint { color: hsl(var(--fg-muted)); font-size: var(--fs-sm); margin: 0 0 var(--space-3); }
   code {
-    background: var(--bg-subtle);
+    background: hsl(var(--bg-subtle));
     padding: 0 var(--space-1);
     border-radius: var(--radius-sm);
     font-family: var(--font-mono);

--- a/saiku-ui/src/lib/modals/CalculatedMemberModal.svelte
+++ b/saiku-ui/src/lib/modals/CalculatedMemberModal.svelte
@@ -243,54 +243,54 @@ SELECT …</pre>
   }
   .format-row { display: flex; gap: var(--space-2); }
   .preview {
-    background: var(--bg-muted);
-    border: 1px solid var(--border);
+    background: hsl(var(--bg-muted));
+    border: 1px solid hsl(var(--border));
     border-radius: var(--radius-sm);
     padding: var(--space-2) var(--space-3);
   }
-  .preview__label { font-size: var(--fs-xs); color: var(--fg-subtle); text-transform: uppercase; letter-spacing: 0.06em; margin-bottom: 4px; }
+  .preview__label { font-size: var(--fs-xs); color: hsl(var(--fg-subtle)); text-transform: uppercase; letter-spacing: 0.06em; margin-bottom: 4px; }
   .preview pre {
     margin: 0;
     font-size: var(--fs-xs);
     white-space: pre-wrap;
-    color: var(--fg-muted);
+    color: hsl(var(--fg-muted));
   }
   .palette {
-    border: 1px solid var(--border);
+    border: 1px solid hsl(var(--border));
     border-radius: var(--radius-sm);
-    background: var(--bg-muted);
+    background: hsl(var(--bg-muted));
     padding: var(--space-2);
     display: flex;
     flex-direction: column;
     gap: var(--space-1);
   }
-  .palette__title { font-size: var(--fs-xs); color: var(--fg-subtle); text-transform: uppercase; letter-spacing: 0.06em; }
+  .palette__title { font-size: var(--fs-xs); color: hsl(var(--fg-subtle)); text-transform: uppercase; letter-spacing: 0.06em; }
   .palette__btn {
     width: 100%;
     text-align: left;
     background: transparent;
     border: 0;
-    color: var(--fg);
+    color: hsl(var(--fg));
     padding: 3px 6px;
     border-radius: var(--radius-sm);
     cursor: pointer;
     font: inherit;
   }
-  .palette__btn:hover { background: var(--bg-subtle); }
-  .palette__empty { color: var(--fg-subtle); padding: 3px 6px; font-size: var(--fs-xs); }
+  .palette__btn:hover { background: hsl(var(--bg-subtle)); }
+  .palette__empty { color: hsl(var(--fg-subtle)); padding: 3px 6px; font-size: var(--fs-xs); }
   .palette__grid {
     display: grid;
     grid-template-columns: repeat(6, minmax(0, 1fr));
     gap: 4px;
   }
   .palette__chip {
-    background: var(--bg);
-    border: 1px solid var(--border);
+    background: hsl(var(--bg));
+    border: 1px solid hsl(var(--border));
     border-radius: var(--radius-sm);
     padding: 2px 0;
-    color: var(--fg);
+    color: hsl(var(--fg));
     font: inherit;
     cursor: pointer;
   }
-  .palette__chip:hover { background: var(--bg-subtle); }
+  .palette__chip:hover { background: hsl(var(--bg-subtle)); }
 </style>

--- a/saiku-ui/src/lib/modals/ChartEditorModal.svelte
+++ b/saiku-ui/src/lib/modals/ChartEditorModal.svelte
@@ -738,23 +738,23 @@
 </Modal>
 
 <style>
-.map-opts { display: flex; flex-direction: column; gap: var(--space-2); padding: var(--space-2) var(--space-3); background: var(--bg-subtle); border-radius: var(--radius-sm); }
-  .series-axis { display: flex; flex-direction: column; gap: var(--space-2); padding: var(--space-2) var(--space-3); background: var(--bg-subtle); border-radius: var(--radius-sm); }
+.map-opts { display: flex; flex-direction: column; gap: var(--space-2); padding: var(--space-2) var(--space-3); background: hsl(var(--bg-subtle)); border-radius: var(--radius-sm); }
+  .series-axis { display: flex; flex-direction: column; gap: var(--space-2); padding: var(--space-2) var(--space-3); background: hsl(var(--bg-subtle)); border-radius: var(--radius-sm); }
   .series-axis__pick { width: 8rem; flex: 0 0 auto; }
-  .number-format { display: flex; flex-direction: column; gap: var(--space-2); padding: var(--space-2) var(--space-3); background: var(--bg-subtle); border-radius: var(--radius-sm); }
-  .colours { display: flex; flex-direction: column; gap: var(--space-2); padding: var(--space-2) var(--space-3); background: var(--bg-subtle); border-radius: var(--radius-sm); }
-  .colours__pick { flex: 0 0 auto; width: 2.5rem; height: 1.75rem; padding: 0; border: 1px solid var(--border); border-radius: var(--radius-sm); background: none; cursor: pointer; }
+  .number-format { display: flex; flex-direction: column; gap: var(--space-2); padding: var(--space-2) var(--space-3); background: hsl(var(--bg-subtle)); border-radius: var(--radius-sm); }
+  .colours { display: flex; flex-direction: column; gap: var(--space-2); padding: var(--space-2) var(--space-3); background: hsl(var(--bg-subtle)); border-radius: var(--radius-sm); }
+  .colours__pick { flex: 0 0 auto; width: 2.5rem; height: 1.75rem; padding: 0; border: 1px solid hsl(var(--border)); border-radius: var(--radius-sm); background: none; cursor: pointer; }
   .colours__reset { flex: 0 0 auto; font-size: var(--fs-xs); }
   .colours__reset:disabled { opacity: 0.4; cursor: default; }
-  .ref { display: flex; flex-direction: column; gap: var(--space-2); padding: var(--space-2) var(--space-3); background: var(--bg-subtle); border-radius: var(--radius-sm); }
+  .ref { display: flex; flex-direction: column; gap: var(--space-2); padding: var(--space-2) var(--space-3); background: hsl(var(--bg-subtle)); border-radius: var(--radius-sm); }
   .ref__axis { width: 8.5rem; flex: 0 0 auto; }
   .ref__value { width: 6rem; flex: 0 0 auto; }
   .ref__label { flex: 1; min-width: 4rem; }
-  .ref__color { width: 2.25rem; height: 2rem; flex: 0 0 auto; padding: 0; border: 1px solid var(--border); border-radius: var(--radius-sm); background: none; }
+  .ref__color { width: 2.25rem; height: 2rem; flex: 0 0 auto; padding: 0; border: 1px solid hsl(var(--border)); border-radius: var(--radius-sm); background: none; }
   /* #1084: conditional formatting */
-  .cond { display: flex; flex-direction: column; gap: var(--space-2); padding: var(--space-2) var(--space-3); background: var(--bg-subtle); border-radius: var(--radius-sm); }
-  .cond__measure { display: flex; flex-direction: column; gap: var(--space-2); padding-top: var(--space-2); border-top: 1px solid var(--border); }
+  .cond { display: flex; flex-direction: column; gap: var(--space-2); padding: var(--space-2) var(--space-3); background: hsl(var(--bg-subtle)); border-radius: var(--radius-sm); }
+  .cond__measure { display: flex; flex-direction: column; gap: var(--space-2); padding-top: var(--space-2); border-top: 1px solid hsl(var(--border)); }
   .cond__op { width: 7rem; flex: 0 0 auto; }
   .cond__num { width: 5.5rem; flex: 0 0 auto; }
-  .cond__color { width: 2.25rem; height: 2rem; flex: 0 0 auto; padding: 0; border: 1px solid var(--border); border-radius: var(--radius-sm); background: none; cursor: pointer; }
+  .cond__color { width: 2.25rem; height: 2rem; flex: 0 0 auto; padding: 0; border: 1px solid hsl(var(--border)); border-radius: var(--radius-sm); background: none; cursor: pointer; }
 </style>

--- a/saiku-ui/src/lib/modals/DataSourcesModal.svelte
+++ b/saiku-ui/src/lib/modals/DataSourcesModal.svelte
@@ -56,6 +56,6 @@
 
 <style>
 .grid { width: 100%; border-collapse: collapse; font-size: var(--fs-sm); }
-  .grid th, .grid td { border: 1px solid var(--border); padding: var(--space-1) var(--space-2); text-align: left; }
-  .grid th { background: var(--bg-muted); }
+  .grid th, .grid td { border: 1px solid hsl(var(--border)); padding: var(--space-1) var(--space-2); text-align: left; }
+  .grid th { background: hsl(var(--bg-muted)); }
 </style>

--- a/saiku-ui/src/lib/modals/DateFilterModal.svelte
+++ b/saiku-ui/src/lib/modals/DateFilterModal.svelte
@@ -358,7 +358,7 @@
 .tabs {
     display: flex;
     gap: var(--space-1);
-    border-bottom: 1px solid var(--border);
+    border-bottom: 1px solid hsl(var(--border));
     margin-bottom: var(--space-3);
   }
   .tabs button {
@@ -368,24 +368,24 @@
     padding: var(--space-2) var(--space-3);
     cursor: pointer;
     font: inherit;
-    color: var(--fg-muted);
+    color: hsl(var(--fg-muted));
   }
   .tabs button.active {
-    color: var(--accent);
-    border-bottom-color: var(--accent);
+    color: hsl(var(--primary));
+    border-bottom-color: hsl(var(--primary));
   }
-  .hint { display: block; font-size: var(--fs-xs); margin-top: 4px; color: var(--fg-subtle); }
+  .hint { display: block; font-size: var(--fs-xs); margin-top: 4px; color: hsl(var(--fg-subtle)); }
   .preview {
     margin-top: var(--space-3);
     padding: var(--space-2);
-    background: var(--bg-subtle);
-    border: 1px solid var(--border);
+    background: hsl(var(--bg-subtle));
+    border: 1px solid hsl(var(--border));
     border-radius: var(--radius-sm);
   }
   .preview__label {
     display: block;
     font-size: var(--fs-xs);
-    color: var(--fg-muted);
+    color: hsl(var(--fg-muted));
     text-transform: uppercase;
     letter-spacing: 0.06em;
     margin-bottom: 4px;
@@ -396,18 +396,18 @@
     font-size: var(--fs-xs);
     white-space: pre-wrap;
     word-break: break-all;
-    color: var(--fg);
+    color: hsl(var(--fg));
   }
   .timecalcs {
     margin-top: var(--space-3);
     padding-top: var(--space-2);
-    border-top: 1px solid var(--border);
+    border-top: 1px solid hsl(var(--border));
   }
   .timecalcs__label {
     font-size: var(--fs-xs);
     text-transform: uppercase;
     letter-spacing: 0.06em;
-    color: var(--fg-muted);
+    color: hsl(var(--fg-muted));
     margin-bottom: 4px;
   }
 </style>

--- a/saiku-ui/src/lib/modals/DrillthroughModal.svelte
+++ b/saiku-ui/src/lib/modals/DrillthroughModal.svelte
@@ -92,22 +92,22 @@
 
 <style>
   .cols { display: grid; grid-template-columns: 1fr 1fr; gap: var(--space-3); margin-bottom: var(--space-4); }
-  h3 { margin: 0 0 var(--space-2); font-size: var(--fs-sm); color: var(--fg-muted); text-transform: uppercase; letter-spacing: 0.04em; }
+  h3 { margin: 0 0 var(--space-2); font-size: var(--fs-sm); color: hsl(var(--fg-muted)); text-transform: uppercase; letter-spacing: 0.04em; }
   .list {
     list-style: none;
     margin: 0;
     padding: 0;
     max-height: 40vh;
     overflow: auto;
-    border: 1px solid var(--border);
+    border: 1px solid hsl(var(--border));
     border-radius: var(--radius-sm);
   }
-  .list li + li { border-top: 1px solid var(--border); }
+  .list li + li { border-top: 1px solid hsl(var(--border)); }
   .list label {
     display: flex;
     gap: var(--space-2);
     padding: var(--space-1) var(--space-3);
     cursor: pointer;
   }
-  .list label:hover { background: var(--bg-subtle); }
+  .list label:hover { background: hsl(var(--bg-subtle)); }
 </style>

--- a/saiku-ui/src/lib/modals/DrillthroughResultModal.svelte
+++ b/saiku-ui/src/lib/modals/DrillthroughResultModal.svelte
@@ -54,9 +54,9 @@
 </Modal>
 
 <style>
-.scroll { max-height: 60vh; overflow: auto; border: 1px solid var(--border); border-radius: var(--radius-sm); }
+.scroll { max-height: 60vh; overflow: auto; border: 1px solid hsl(var(--border)); border-radius: var(--radius-sm); }
   .dt { border-collapse: separate; border-spacing: 0; width: 100%; font-size: var(--fs-sm); }
-  .dt th, .dt td { padding: 3px 9px; border-right: 1px solid var(--border); border-bottom: 1px solid var(--border); white-space: nowrap; text-align: left; }
+  .dt th, .dt td { padding: 3px 9px; border-right: 1px solid hsl(var(--border)); border-bottom: 1px solid hsl(var(--border)); white-space: nowrap; text-align: left; }
   .dt td.n { text-align: right; font-variant-numeric: tabular-nums; }
-  .dt th { position: sticky; top: 0; background: var(--bg-muted); color: var(--fg); font-weight: var(--weight-semibold); z-index: 1; }
+  .dt th { position: sticky; top: 0; background: hsl(var(--bg-muted)); color: hsl(var(--fg)); font-weight: var(--weight-semibold); z-index: 1; }
 </style>

--- a/saiku-ui/src/lib/modals/EmailMeThisModal.svelte
+++ b/saiku-ui/src/lib/modals/EmailMeThisModal.svelte
@@ -214,15 +214,15 @@
   .recipient {
     margin: 0;
     padding: var(--space-2) var(--space-3);
-    background: var(--bg-subtle);
-    border: 1px solid var(--border);
+    background: hsl(var(--bg-subtle));
+    border: 1px solid hsl(var(--border));
     border-radius: var(--radius-sm);
-    color: var(--fg);
+    color: hsl(var(--fg));
     font-size: var(--fs-sm);
     word-break: break-all;
   }
 
   .recipient--muted {
-    color: var(--fg-subtle);
+    color: hsl(var(--fg-subtle));
   }
 </style>

--- a/saiku-ui/src/lib/modals/MeasuresModal.svelte
+++ b/saiku-ui/src/lib/modals/MeasuresModal.svelte
@@ -109,10 +109,10 @@
     padding: 0;
     max-height: 50vh;
     overflow: auto;
-    border: 1px solid var(--border);
+    border: 1px solid hsl(var(--border));
     border-radius: var(--radius-sm);
   }
-  .list li + li { border-top: 1px solid var(--border); }
+  .list li + li { border-top: 1px solid hsl(var(--border)); }
   .list label {
     display: flex;
     align-items: center;
@@ -120,17 +120,17 @@
     padding: var(--space-2) var(--space-3);
     cursor: pointer;
   }
-  .list label:hover { background: var(--bg-subtle); }
+  .list label:hover { background: hsl(var(--bg-subtle)); }
   .badge {
     font-size: var(--fs-xs);
-    color: var(--accent);
+    color: hsl(var(--primary));
     padding: 0 var(--space-1);
-    border: 1px solid var(--accent);
+    border: 1px solid hsl(var(--primary));
     border-radius: var(--radius-sm);
   }
   .badge--hidden {
-    color: var(--fg-muted);
-    border-color: var(--fg-muted);
+    color: hsl(var(--fg-muted));
+    border-color: hsl(var(--fg-muted));
   }
   .hidden-toggle {
     display: grid;
@@ -140,15 +140,15 @@
     align-items: center;
     margin-top: var(--space-3);
     padding: var(--space-2) var(--space-3);
-    border: 1px dashed var(--border);
+    border: 1px dashed hsl(var(--border));
     border-radius: var(--radius-sm);
     cursor: pointer;
   }
-  .hidden-toggle:hover { background: var(--bg-subtle); }
+  .hidden-toggle:hover { background: hsl(var(--bg-subtle)); }
   .hidden-toggle input { grid-row: 1 / span 2; }
   .hidden-toggle__loading {
     margin: var(--space-2) 0 0;
     font-size: var(--fs-xs);
-    color: var(--fg-muted);
+    color: hsl(var(--fg-muted));
   }
 </style>

--- a/saiku-ui/src/lib/modals/MoveRepositoryObject.svelte
+++ b/saiku-ui/src/lib/modals/MoveRepositoryObject.svelte
@@ -34,9 +34,9 @@
 </Modal>
 
 <style>
-  .hint { color: var(--fg-muted); font-size: var(--fs-sm); margin: 0 0 var(--space-3); }
+  .hint { color: hsl(var(--fg-muted)); font-size: var(--fs-sm); margin: 0 0 var(--space-3); }
   code {
-    background: var(--bg-subtle);
+    background: hsl(var(--bg-subtle));
     padding: 0 var(--space-1);
     border-radius: var(--radius-sm);
     font-family: var(--font-mono);

--- a/saiku-ui/src/lib/modals/NewAppModal.svelte
+++ b/saiku-ui/src/lib/modals/NewAppModal.svelte
@@ -94,22 +94,22 @@
   .import-badge {
     margin: 0 0 var(--space-3);
     padding: var(--space-2) var(--space-3);
-    background: var(--bg-muted);
-    border: 1px solid var(--border);
+    background: hsl(var(--bg-muted));
+    border: 1px solid hsl(var(--border));
     border-radius: var(--radius-sm);
-    color: var(--fg-muted);
+    color: hsl(var(--fg-muted));
     font-size: var(--fs-sm);
   }
   .path-preview {
     margin: var(--space-3) 0 0;
-    color: var(--fg-muted);
+    color: hsl(var(--fg-muted));
     font-size: var(--fs-sm);
   }
   .path-preview code {
-    background: var(--bg-muted);
+    background: hsl(var(--bg-muted));
     padding: 2px 6px;
     border-radius: var(--radius-sm);
-    color: var(--fg);
+    color: hsl(var(--fg));
     font-family: var(--font-mono);
     font-size: var(--fs-xs);
   }

--- a/saiku-ui/src/lib/modals/NewDashboardModal.svelte
+++ b/saiku-ui/src/lib/modals/NewDashboardModal.svelte
@@ -158,29 +158,29 @@
     gap: var(--space-1);
     text-align: left;
     padding: var(--space-3);
-    border: 1px solid var(--border);
+    border: 1px solid hsl(var(--border));
     border-radius: var(--radius-md);
-    background: var(--bg);
-    color: var(--fg);
+    background: hsl(var(--bg));
+    color: hsl(var(--fg));
     cursor: pointer;
   }
   .template-card:hover {
-    background: var(--bg-muted);
+    background: hsl(var(--bg-muted));
   }
   .template-card--on {
-    border-color: var(--accent);
-    box-shadow: 0 0 0 1px var(--accent);
+    border-color: hsl(var(--primary));
+    box-shadow: 0 0 0 1px hsl(var(--primary));
   }
   .path-preview {
     margin: var(--space-3) 0 0;
-    color: var(--fg-muted);
+    color: hsl(var(--fg-muted));
     font-size: var(--fs-sm);
   }
   .path-preview code {
-    background: var(--bg-muted);
+    background: hsl(var(--bg-muted));
     padding: 2px 6px;
     border-radius: var(--radius-sm);
-    color: var(--fg);
+    color: hsl(var(--fg));
     font-family: var(--font-mono);
     font-size: var(--fs-xs);
   }

--- a/saiku-ui/src/lib/modals/OpenDialogModal.svelte
+++ b/saiku-ui/src/lib/modals/OpenDialogModal.svelte
@@ -71,17 +71,17 @@
 </Modal>
 
 <style>
-.hint { color: var(--fg-muted); font-size: var(--fs-sm); margin: var(--space-2) 0; }
+.hint { color: hsl(var(--fg-muted)); font-size: var(--fs-sm); margin: var(--space-2) 0; }
   .repo {
     list-style: none;
     margin: 0;
     padding: 0;
     max-height: 40vh;
     overflow: auto;
-    border: 1px solid var(--border);
+    border: 1px solid hsl(var(--border));
     border-radius: var(--radius-sm);
   }
-  .repo__entry + .repo__entry { border-top: 1px solid var(--border); }
+  .repo__entry + .repo__entry { border-top: 1px solid hsl(var(--border)); }
   .repo__row {
     display: flex;
     align-items: center;
@@ -90,11 +90,11 @@
     padding: var(--space-2) var(--space-3);
     background: transparent;
     border: 0;
-    color: var(--fg);
+    color: hsl(var(--fg));
     font: inherit;
     cursor: pointer;
     text-align: left;
   }
-  .repo__row:hover:not(:disabled) { background: var(--bg-subtle); }
-  .repo__row:disabled { color: var(--fg-muted); cursor: default; }
+  .repo__row:hover:not(:disabled) { background: hsl(var(--bg-subtle)); }
+  .repo__row:disabled { color: hsl(var(--fg-muted)); cursor: default; }
 </style>

--- a/saiku-ui/src/lib/modals/OssieAskAiModal.svelte
+++ b/saiku-ui/src/lib/modals/OssieAskAiModal.svelte
@@ -158,22 +158,22 @@
   }
   .ossie-ask__scope {
     margin: 0;
-    color: var(--fg-muted);
+    color: hsl(var(--fg-muted));
     font-size: var(--fs-sm);
   }
   .ossie-ask__history {
     max-height: 320px;
     overflow-y: auto;
     padding: var(--space-2);
-    background: var(--bg-subtle, var(--bg-hover));
-    border: 1px solid var(--border);
+    background: var(--bg-subtle, hsl(var(--bg-hover)));
+    border: 1px solid hsl(var(--border));
     border-radius: 4px;
     display: flex;
     flex-direction: column;
     gap: var(--space-2);
   }
   .ossie-ask__empty {
-    color: var(--fg-muted);
+    color: hsl(var(--fg-muted));
     font-size: var(--fs-sm);
     text-align: center;
     padding: var(--space-4) 0;
@@ -183,14 +183,14 @@
     gap: var(--space-2);
     padding: 6px 10px;
     border-radius: 4px;
-    background: var(--bg);
+    background: hsl(var(--bg));
   }
   .ossie-ask__turn--user {
-    background: color-mix(in srgb, var(--accent) 8%, var(--bg));
+    background: color-mix(in srgb, hsl(var(--primary)) 8%, hsl(var(--bg)));
   }
   .ossie-ask__role {
     font-weight: var(--weight-semibold);
-    color: var(--fg-muted);
+    color: hsl(var(--fg-muted));
     min-width: 40px;
   }
   .ossie-ask__content {
@@ -211,10 +211,10 @@
   }
   .ossie-ask__input {
     padding: 8px 10px;
-    border: 1px solid var(--border-strong);
+    border: 1px solid hsl(var(--border-strong));
     border-radius: 4px;
-    background: var(--bg);
-    color: var(--fg);
+    background: hsl(var(--bg));
+    color: hsl(var(--fg));
     font-family: inherit;
     font-size: var(--fs-sm);
     resize: vertical;

--- a/saiku-ui/src/lib/modals/OssieLoadModal.svelte
+++ b/saiku-ui/src/lib/modals/OssieLoadModal.svelte
@@ -53,7 +53,7 @@
 <style>
   .intro {
     margin: 0 0 var(--space-3);
-    color: var(--fg-muted);
+    color: hsl(var(--fg-muted));
     font-size: var(--fs-sm);
   }
 </style>

--- a/saiku-ui/src/lib/modals/ParentMemberSelectorModal.svelte
+++ b/saiku-ui/src/lib/modals/ParentMemberSelectorModal.svelte
@@ -47,10 +47,10 @@
     padding: 0;
     max-height: 50vh;
     overflow: auto;
-    border: 1px solid var(--border);
+    border: 1px solid hsl(var(--border));
     border-radius: var(--radius-sm);
   }
-  .list li + li { border-top: 1px solid var(--border); }
+  .list li + li { border-top: 1px solid hsl(var(--border)); }
   .row {
     display: flex;
     flex-direction: column;
@@ -59,11 +59,11 @@
     padding: var(--space-2) var(--space-3);
     background: transparent;
     border: 0;
-    color: var(--fg);
+    color: hsl(var(--fg));
     font: inherit;
     cursor: pointer;
     text-align: left;
   }
-  .row:hover { background: var(--bg-subtle); }
-  .un { font-family: var(--font-mono); font-size: var(--fs-xs); color: var(--fg-subtle); }
+  .row:hover { background: hsl(var(--bg-subtle)); }
+  .un { font-family: var(--font-mono); font-size: var(--fs-xs); color: hsl(var(--fg-subtle)); }
 </style>

--- a/saiku-ui/src/lib/modals/PermissionsModal.svelte
+++ b/saiku-ui/src/lib/modals/PermissionsModal.svelte
@@ -68,6 +68,6 @@
 
 <style>
 .grid { width: 100%; border-collapse: collapse; margin-top: var(--space-2); font-size: var(--fs-sm); }
-  .grid th, .grid td { border: 1px solid var(--border); padding: var(--space-1) var(--space-2); text-align: left; }
-  .grid th { background: var(--bg-muted); }
+  .grid th, .grid td { border: 1px solid hsl(var(--border)); padding: var(--space-1) var(--space-2); text-align: left; }
+  .grid th { background: hsl(var(--bg-muted)); }
 </style>

--- a/saiku-ui/src/lib/modals/RenameFolderModal.svelte
+++ b/saiku-ui/src/lib/modals/RenameFolderModal.svelte
@@ -60,19 +60,19 @@
 
 <style>
   .hint {
-    color: var(--fg-muted);
+    color: hsl(var(--fg-muted));
     font-size: var(--fs-sm);
     margin: 0 0 var(--space-3);
   }
   code {
-    background: var(--bg-subtle);
+    background: hsl(var(--bg-subtle));
     padding: 0 var(--space-1);
     border-radius: var(--radius-sm);
     font-family: var(--font-mono);
     font-size: 12px;
   }
   .err {
-    color: var(--danger);
+    color: hsl(var(--danger));
     font-size: var(--fs-sm);
     margin: var(--space-2) 0 0;
   }

--- a/saiku-ui/src/lib/modals/SaveQueryModal.svelte
+++ b/saiku-ui/src/lib/modals/SaveQueryModal.svelte
@@ -101,7 +101,7 @@
 <style>
 .save-modal__intro {
     margin: 0 0 var(--space-3);
-    color: var(--fg-muted);
+    color: hsl(var(--fg-muted));
     font-size: var(--fs-sm);
   }
 </style>

--- a/saiku-ui/src/lib/modals/SavedQueriesModal.svelte
+++ b/saiku-ui/src/lib/modals/SavedQueriesModal.svelte
@@ -430,7 +430,7 @@
 {/if}
 
 <style>
-.hint { color: var(--fg-muted); font-size: var(--fs-sm); margin: var(--space-2) 0; }
+.hint { color: hsl(var(--fg-muted)); font-size: var(--fs-sm); margin: var(--space-2) 0; }
   .saved__crumb {
     display: inline-flex;
     align-items: center;
@@ -439,31 +439,31 @@
     background: transparent;
     border: 0;
     border-radius: 3px;
-    color: var(--fg-muted);
+    color: hsl(var(--fg-muted));
     cursor: pointer;
     font: inherit;
   }
-  .saved__crumb:hover { background: var(--bg-hover); color: var(--fg); }
-  .saved__crumb.is-current { color: var(--fg); font-weight: var(--weight-medium); }
+  .saved__crumb:hover { background: hsl(var(--bg-hover)); color: hsl(var(--fg)); }
+  .saved__crumb.is-current { color: hsl(var(--fg)); font-weight: var(--weight-medium); }
   /* Applied via class={} on a lucide-svelte icon — needs :global so the
      scoped-style hash doesn't suppress it on the child component's root. */
-  :global(.saved__crumb-sep) { color: var(--fg-subtle); }
+  :global(.saved__crumb-sep) { color: hsl(var(--fg-subtle)); }
   .saved__search {
     display: flex;
     align-items: center;
     gap: var(--space-2);
     padding: 6px 10px;
     margin-bottom: var(--space-2);
-    border: 1px solid var(--border);
+    border: 1px solid hsl(var(--border));
     border-radius: var(--radius-sm);
-    background: var(--bg-subtle);
-    color: var(--fg-muted);
+    background: hsl(var(--bg-subtle));
+    color: hsl(var(--fg-muted));
   }
   .saved__search-input {
     flex: 1;
     background: transparent;
     border: 0;
-    color: var(--fg);
+    color: hsl(var(--fg));
     font: inherit;
     outline: none;
   }
@@ -473,7 +473,7 @@
     margin: 0;
     max-height: 50vh;
     overflow-y: auto;
-    border: 1px solid var(--border);
+    border: 1px solid hsl(var(--border));
     border-radius: var(--radius-sm);
   }
   .saved__row {
@@ -482,8 +482,8 @@
     gap: var(--space-2);
     padding: var(--space-2) var(--space-3);
   }
-  .saved__row + .saved__row { border-top: 1px solid var(--border); }
-  .saved__row:hover { background: var(--bg-hover); }
+  .saved__row + .saved__row { border-top: 1px solid hsl(var(--border)); }
+  .saved__row:hover { background: hsl(var(--bg-hover)); }
   .saved__main {
     flex: 1;
     display: flex;
@@ -492,7 +492,7 @@
     text-align: left;
     background: transparent;
     border: 0;
-    color: var(--fg);
+    color: hsl(var(--fg));
     cursor: pointer;
     font: inherit;
     padding: 0;
@@ -508,17 +508,17 @@
   .saved__rename-input {
     flex: 1;
     padding: 4px 8px;
-    background: var(--bg);
-    border: 1px solid var(--border-strong);
+    background: hsl(var(--bg));
+    border: 1px solid hsl(var(--border-strong));
     border-radius: var(--radius-sm);
-    color: var(--fg);
+    color: hsl(var(--fg));
     font: inherit;
   }
   .saved__confirm {
     margin-top: var(--space-3);
     padding: var(--space-3);
-    border: 1px solid var(--danger);
+    border: 1px solid hsl(var(--danger));
     border-radius: var(--radius-sm);
-    background: color-mix(in srgb, var(--danger) 10%, var(--bg));
+    background: color-mix(in srgb, hsl(var(--danger)) 10%, hsl(var(--bg)));
   }
 </style>

--- a/saiku-ui/src/lib/modals/SelectionsModal.svelte
+++ b/saiku-ui/src/lib/modals/SelectionsModal.svelte
@@ -338,13 +338,13 @@
     display: flex;
     flex-wrap: wrap;
     gap: 2px;
-    border-bottom: 1px solid var(--border);
+    border-bottom: 1px solid hsl(var(--border));
     margin-bottom: var(--space-3);
   }
   .tabs__btn {
     background: transparent;
     border: 0;
-    color: var(--fg-muted);
+    color: hsl(var(--fg-muted));
     padding: var(--space-2) var(--space-3);
     font: inherit;
     font-size: var(--fs-sm);
@@ -355,15 +355,15 @@
     align-items: center;
     gap: var(--space-2);
   }
-  .tabs__btn:hover { color: var(--fg); }
+  .tabs__btn:hover { color: hsl(var(--fg)); }
   .tabs__btn.is-active {
-    color: var(--fg);
-    border-bottom-color: var(--accent);
+    color: hsl(var(--fg));
+    border-bottom-color: hsl(var(--primary));
     font-weight: var(--weight-semibold);
   }
   .tabs__count {
-    background: var(--accent-soft);
-    color: var(--accent-strong);
+    background: hsl(var(--accent));
+    color: hsl(var(--primary-strong));
     border-radius: 999px;
     padding: 1px 6px;
     font-size: 11px;
@@ -383,11 +383,11 @@
     padding: 0;
     max-height: 45vh;
     overflow: auto;
-    border: 1px solid var(--border);
+    border: 1px solid hsl(var(--border));
     border-radius: var(--radius-sm);
   }
-  .members li + li { border-top: 1px solid var(--border); }
-  .members li.empty { padding: var(--space-4); color: var(--fg-muted); text-align: center; }
+  .members li + li { border-top: 1px solid hsl(var(--border)); }
+  .members li.empty { padding: var(--space-4); color: hsl(var(--fg-muted)); text-align: center; }
   .members label {
     display: flex;
     align-items: center;
@@ -395,5 +395,5 @@
     padding: var(--space-2) var(--space-3);
     cursor: pointer;
   }
-  .members label:hover { background: var(--bg-subtle); }
+  .members label:hover { background: hsl(var(--bg-subtle)); }
 </style>

--- a/saiku-ui/src/lib/modals/TopBottomCountModal.svelte
+++ b/saiku-ui/src/lib/modals/TopBottomCountModal.svelte
@@ -135,7 +135,7 @@
 <style>
   .field__hint {
     margin: var(--space-1) 0 0;
-    color: var(--fg-subtle);
+    color: hsl(var(--fg-subtle));
     font-size: var(--fs-xs);
   }
 </style>

--- a/saiku-ui/src/lib/modals/parts/ModalModeSwitch.svelte
+++ b/saiku-ui/src/lib/modals/parts/ModalModeSwitch.svelte
@@ -58,8 +58,8 @@
   .mode-switch {
     display: inline-flex;
     margin-bottom: var(--space-3);
-    background: var(--bg-muted);
-    border: 1px solid var(--border);
+    background: hsl(var(--bg-muted));
+    border: 1px solid hsl(var(--border));
     border-radius: var(--radius-sm);
     padding: 2px;
   }
@@ -68,17 +68,17 @@
     background: transparent;
     border: 0;
     border-radius: 3px;
-    color: var(--fg-muted);
+    color: hsl(var(--fg-muted));
     font: inherit;
     font-size: var(--fs-sm);
     cursor: pointer;
   }
   .mode-switch__btn:hover {
-    color: var(--fg);
+    color: hsl(var(--fg));
   }
   .mode-switch__btn.active {
-    background: var(--bg);
-    color: var(--fg);
+    background: hsl(var(--bg));
+    color: hsl(var(--fg));
     font-weight: var(--weight-medium);
     box-shadow: var(--shadow-sm);
   }

--- a/saiku-ui/src/lib/styles/app.css
+++ b/saiku-ui/src/lib/styles/app.css
@@ -69,6 +69,23 @@ body {
   button {
     font-family: inherit;
     font-size: inherit;
+    /* Tailwind preflight is deliberately skipped (see tailwind.css), so raw
+       <button>s otherwise fall back to the UA default — a 2px outset white
+       border on a grey face. Replicate preflight's button normalisation here
+       so bare buttons (mode tabs, inspector tabs, the Button primitive's
+       default variant) render flat; `border-*` / `bg-*` utilities in the
+       utilities layer still override this base reset. (saiku#1636) */
+    appearance: none;
+    -webkit-appearance: none;
+    background-color: transparent;
+    background-image: none;
+    border: 0 solid transparent;
+    color: inherit;
+    cursor: pointer;
+  }
+
+  button:disabled {
+    cursor: default;
   }
 
   input,

--- a/saiku-ui/src/lib/styles/app.css
+++ b/saiku-ui/src/lib/styles/app.css
@@ -7,8 +7,8 @@
  * Without this wrapper, unlayered type-selector rules ALWAYS beat
  * layered utility classes — the layering algorithm prioritises
  * unlayered rules above ALL layers regardless of specificity. That's
- * what made `<a class={buttonVariants()}>` render text in `var(--accent)`
- * (the global a color) instead of `var(--accent-fg)` (the Tailwind
+ * what made `<a class={buttonVariants()}>` render text in `hsl(var(--primary))`
+ * (the global a color) instead of `hsl(var(--primary-foreground))` (the Tailwind
  * `text-primary-foreground` class) — the anchor was invisible against
  * its primary background.
  *
@@ -30,8 +30,8 @@ body {
 
 @layer base {
   body {
-    background: var(--bg);
-    color: var(--fg);
+    background: hsl(var(--bg));
+    color: hsl(var(--fg));
     font-family: var(--font-sans);
     font-size: var(--fs-md);
     font-weight: var(--weight-normal);
@@ -44,7 +44,7 @@ body {
      space token grid so heading-followed-by-body has consistent rhythm. */
   h1, h2, h3, h4, h5, h6 {
     margin: 0 0 var(--space-3);
-    color: var(--fg);
+    color: hsl(var(--fg));
     font-weight: var(--weight-semibold);
     line-height: var(--lh-tight);
   }
@@ -80,7 +80,7 @@ body {
   }
 
   a {
-    color: var(--accent);
+    color: hsl(var(--primary));
     text-decoration: none;
   }
 
@@ -100,9 +100,9 @@ body {
   align-items: center;
   gap: var(--space-2);
   padding: var(--space-2) var(--space-3);
-  background: var(--bg-muted);
-  color: var(--fg);
-  border: 1px solid var(--border-strong);
+  background: hsl(var(--bg-muted));
+  color: hsl(var(--fg));
+  border: 1px solid hsl(var(--border-strong));
   border-radius: var(--radius-sm);
   cursor: pointer;
   transition:
@@ -112,7 +112,7 @@ body {
 }
 
 .btn:hover:not(:disabled) {
-  background: var(--bg-hover);
+  background: hsl(var(--bg-hover));
 }
 
 .btn:disabled {
@@ -138,7 +138,7 @@ body {
   background: transparent;
   border: 1px solid transparent;
   border-radius: var(--radius-sm);
-  color: var(--fg-muted);
+  color: hsl(var(--fg-muted));
   cursor: pointer;
   transition:
     background var(--duration-fast),
@@ -147,9 +147,9 @@ body {
 }
 
 .icon-btn:hover:not(:disabled) {
-  background: var(--bg-hover);
-  border-color: var(--border);
-  color: var(--fg);
+  background: hsl(var(--bg-hover));
+  border-color: hsl(var(--border));
+  color: hsl(var(--fg));
 }
 
 .icon-btn:disabled {
@@ -158,7 +158,7 @@ body {
 }
 
 .icon-btn--danger:hover:not(:disabled) {
-  color: var(--danger);
+  color: hsl(var(--danger));
 }
 
 /* ----------------------------------------------------------------- *
@@ -186,13 +186,13 @@ body {
 .data-grid td {
   padding: var(--space-3);
   text-align: left;
-  border-bottom: 1px solid var(--border);
+  border-bottom: 1px solid hsl(var(--border));
 }
 
 .data-grid th {
-  background: var(--bg-muted);
+  background: hsl(var(--bg-muted));
   font-weight: var(--weight-semibold);
-  color: var(--fg);
+  color: hsl(var(--fg));
 }
 
 .data-grid tbody tr {
@@ -200,11 +200,11 @@ body {
 }
 
 .data-grid tbody tr:nth-child(even) {
-  background: var(--bg-subtle);
+  background: hsl(var(--bg-subtle));
 }
 
 .data-grid tbody tr:hover {
-  background: var(--bg-hover);
+  background: hsl(var(--bg-hover));
 }
 
 .data-grid__actions {
@@ -215,25 +215,25 @@ body {
 
 .data-grid__empty {
   text-align: center;
-  color: var(--fg-muted);
+  color: hsl(var(--fg-muted));
   padding: var(--space-5);
 }
 
 .btn--primary {
-  background: var(--accent);
-  color: var(--accent-fg);
-  border-color: var(--accent);
+  background: hsl(var(--primary));
+  color: hsl(var(--primary-foreground));
+  border-color: hsl(var(--primary));
   font-weight: var(--weight-semibold);
 }
 
 .btn--primary:hover:not(:disabled) {
-  background: var(--accent-hover);
+  background: hsl(var(--primary-hover));
 }
 
 .btn--danger {
-  background: var(--danger);
+  background: hsl(var(--danger));
   color: #fff;
-  border-color: var(--danger);
+  border-color: hsl(var(--danger));
 }
 
 .field {
@@ -244,16 +244,16 @@ body {
 .field__label {
   display: block;
   margin-bottom: var(--space-1);
-  color: var(--fg-muted);
+  color: hsl(var(--fg-muted));
   font-size: var(--fs-sm);
 }
 
 .field__input {
   width: 100%;
   padding: var(--space-2) var(--space-3);
-  background: var(--bg);
-  color: var(--fg);
-  border: 1px solid var(--border-strong);
+  background: hsl(var(--bg));
+  color: hsl(var(--fg));
+  border: 1px solid hsl(var(--border-strong));
   border-radius: var(--radius-sm);
   transition:
     border-color var(--duration-fast),
@@ -261,7 +261,7 @@ body {
 }
 
 .field__input:focus-visible {
-  border-color: var(--accent);
+  border-color: hsl(var(--primary));
 }
 
 /* Invalid form-field state. Set the .field--invalid modifier on the
@@ -269,12 +269,12 @@ body {
    below renders with an alert icon. Centralized so every form modal
    communicates validation the same way. */
 .field--invalid .field__input {
-  border-color: var(--danger);
+  border-color: hsl(var(--danger));
 }
 
 .field--invalid .field__input:focus-visible {
-  box-shadow: 0 0 0 2px var(--bg), 0 0 0 4px var(--danger);
-  border-color: var(--danger);
+  box-shadow: 0 0 0 2px hsl(var(--bg)), 0 0 0 4px hsl(var(--danger));
+  border-color: hsl(var(--danger));
 }
 
 .field__error {
@@ -282,7 +282,7 @@ body {
   gap: var(--space-1);
   align-items: center;
   margin-top: var(--space-1);
-  color: var(--danger);
+  color: hsl(var(--danger));
   font-size: var(--fs-sm);
 }
 
@@ -293,13 +293,13 @@ body {
 .callout {
   padding: var(--space-3);
   border-radius: var(--radius-sm);
-  background: var(--bg-subtle);
-  border-left: 3px solid var(--accent);
+  background: hsl(var(--bg-subtle));
+  border-left: 3px solid hsl(var(--primary));
 }
 
 .callout--danger {
-  border-left-color: var(--danger);
-  color: var(--danger);
+  border-left-color: hsl(var(--danger));
+  color: hsl(var(--danger));
 }
 
 .callout__text {
@@ -309,7 +309,7 @@ body {
 
 .callout__details {
   margin-top: var(--space-2);
-  color: var(--fg-muted);
+  color: hsl(var(--fg-muted));
   font-weight: var(--weight-normal);
 }
 
@@ -322,13 +322,13 @@ body {
 .callout__detail-text {
   margin: var(--space-2) 0 0;
   padding: var(--space-2);
-  background: var(--bg-muted);
+  background: hsl(var(--bg-muted));
   border-radius: var(--radius-sm);
   font-family: var(--font-mono, ui-monospace, monospace);
   font-size: var(--fs-xs);
   white-space: pre-wrap;
   word-break: break-word;
-  color: var(--fg);
+  color: hsl(var(--fg));
 }
 
 /* Motion baseline. Modals, context menus, and toasts appear instantly

--- a/saiku-ui/src/lib/styles/tailwind.css
+++ b/saiku-ui/src/lib/styles/tailwind.css
@@ -1,103 +1,101 @@
 /*
- * Tailwind v4 entry — saiku-ui side.
+ * Tailwind v4 entry — saiku-ui side (saiku#1636: aligned with saiku-cloud).
  *
- * Why this file exists separately from `tokens.css` + `app.css`:
- *
- *   - `tokens.css` defines the 133 CSS custom properties this codebase
- *     has used as the single source of design truth since the Svelte
- *     port. Every `<style>` block in the codebase resolves
- *     `var(--fg)`, `var(--space-2)`, `var(--accent)` etc. against it.
+ *   - `tokens.css` defines the design tokens as HSL triples (three-tier system
+ *     ported from saiku-cloud). Colour tokens are bare `H S% L%` triples.
  *   - `app.css` is the global base layer (body, headings, button reset,
- *     scrollbar styling) — pre-existing vanilla CSS, NOT a Tailwind
- *     preflight.
- *   - This file (`tailwind.css`) is the new Tailwind v4 surface. We
- *     import the `theme` + `utilities` layers but DELIBERATELY SKIP
- *     `preflight` to avoid clobbering the existing base reset and
- *     the BEM-style component styles. New components reach for
- *     Tailwind utilities; legacy components keep working unchanged.
+ *     scrollbar) — vanilla CSS, NOT a Tailwind preflight.
+ *   - This file is the Tailwind v4 surface. We import `theme` + `utilities`
+ *     but DELIBERATELY SKIP `preflight` so the existing base reset and
+ *     BEM-style component styles are preserved.
  *
- * Compatibility bridge: `@theme inline { --color-fg: var(--fg) }` aliases
- * every existing token onto the Tailwind token namespace so
- * `text-fg`, `bg-bg-subtle`, `p-2`, `rounded-md` all resolve via the
- * same `var(--*)` chain as `var(--fg)`, `var(--bg-subtle)`,
- * `var(--space-2)`, `var(--radius-md)`. Light + dark themes already
- * flip the underlying tokens; Tailwind classes inherit that for free.
- *
- * For API consistency with saiku-cloud-dashboard's design-system
- * primitives, we ALSO alias the canonical names that codebase uses
- * (`destructive`, `foreground`, `background`, `card`, `muted`,
- * `border`, `input`, `ring`) onto saiku-ui's existing tokens. A `Badge`
- * ported verbatim from saiku-cloud needing `text-destructive` will
- * resolve to `var(--danger)` here; consumers can write either idiom.
+ * Bridge: `@theme inline { --color-x: hsl(var(--token)) }` resolves every
+ * `bg-*`/`text-*`/`border-*` utility through the same `hsl(var(--token))` chain
+ * that inline `<style>` blocks use — so utilities and inline styles agree, and
+ * opacity modifiers (`bg-primary/10`) compose correctly. Both the shadcn-shaped
+ * names (`foreground`, `card`, `primary`, `border`, …) and saiku-ui's legacy
+ * names (`fg`, `bg-muted`, `border`, …) resolve to the same tokens.
  */
 @layer theme, base, components, utilities;
 @import "tailwindcss/theme.css" layer(theme);
 @import "tailwindcss/utilities.css" layer(utilities);
 
+/* Tailwind v4 `dark:` variant bound to OUR theme system (explicit
+   [data-theme] override + system pref with the light guard), matching
+   saiku-cloud so ported `dark:` utilities behave identically. */
+@custom-variant dark {
+  &:where(:root[data-theme="dark"], :root[data-theme="dark"] *) {
+    @slot;
+  }
+  @media (prefers-color-scheme: dark) {
+    &:where(:root:not([data-theme="light"]), :root:not([data-theme="light"]) *) {
+      @slot;
+    }
+  }
+}
+
 @theme inline {
-  /* ---- Foreground / background surfaces ---- */
-  --color-fg: var(--fg);
-  --color-fg-muted: var(--fg-muted);
-  --color-fg-subtle: var(--fg-subtle);
-  --color-bg: var(--bg);
-  --color-bg-muted: var(--bg-muted);
-  --color-bg-subtle: var(--bg-subtle);
-  --color-bg-hover: var(--bg-hover);
+  /* ---- Foreground / background surfaces (legacy names) ---- */
+  --color-fg: hsl(var(--fg));
+  --color-fg-muted: hsl(var(--fg-muted));
+  --color-fg-subtle: hsl(var(--fg-subtle));
+  --color-bg: hsl(var(--bg));
+  --color-bg-muted: hsl(var(--bg-muted));
+  --color-bg-subtle: hsl(var(--bg-subtle));
+  --color-bg-hover: hsl(var(--bg-hover));
   --color-bg-overlay: var(--bg-overlay);
 
-  /* ---- Saiku-cloud naming aliases (API parity for shared primitives) ---- */
-  --color-foreground: var(--fg);
-  --color-background: var(--bg);
-  --color-card: var(--bg-muted);
-  --color-card-foreground: var(--fg);
-  --color-popover: var(--bg);
-  --color-popover-foreground: var(--fg);
-  --color-muted: var(--bg-subtle);
-  --color-muted-foreground: var(--fg-muted);
-  --color-input: var(--border);
-  --color-ring: var(--accent);
+  /* ---- shadcn-shaped names (cube-designer + shared primitives) ---- */
+  --color-foreground: hsl(var(--foreground));
+  --color-background: hsl(var(--background));
+  --color-card: hsl(var(--card));
+  --color-card-foreground: hsl(var(--card-foreground));
+  --color-popover: hsl(var(--popover));
+  --color-popover-foreground: hsl(var(--popover-foreground));
+  --color-muted: hsl(var(--muted));
+  --color-muted-foreground: hsl(var(--muted-foreground));
+  --color-input: hsl(var(--input));
+  --color-ring: hsl(var(--ring));
 
   /* ---- Borders ---- */
-  --color-border: var(--border);
-  --color-border-strong: var(--border-strong);
+  --color-border: hsl(var(--border));
+  --color-border-strong: hsl(var(--border-strong));
 
-  /* ---- Brand / accent ---- */
-  --color-accent: var(--accent);
-  --color-accent-hover: var(--accent-hover);
-  --color-accent-foreground: var(--accent-fg);
-  --color-accent-soft: var(--accent-soft);
-  --color-accent-strong: var(--accent-strong);
-  --color-primary: var(--accent);
-  --color-primary-foreground: var(--accent-fg);
-  --color-secondary: var(--bg-muted);
-  --color-secondary-foreground: var(--fg);
+  /* ---- Brand (primary) + pale accent surface ---- */
+  --color-primary: hsl(var(--primary));
+  --color-primary-foreground: hsl(var(--primary-foreground));
+  --color-primary-hover: hsl(var(--primary-hover));
+  --color-primary-strong: hsl(var(--primary-strong));
+  --color-secondary: hsl(var(--secondary));
+  --color-secondary-foreground: hsl(var(--secondary-foreground));
+
+  --color-accent: hsl(var(--accent));
+  --color-accent-foreground: hsl(var(--accent-foreground));
+  /* legacy accent-* Tailwind names → brand family (kept for any stragglers) */
+  --color-accent-hover: hsl(var(--primary-hover));
+  --color-accent-fg: hsl(var(--primary-foreground));
+  --color-accent-soft: hsl(var(--accent));
+  --color-accent-strong: hsl(var(--primary-strong));
 
   /* ---- Status tones ---- */
-  --color-success: var(--success);
-  --color-success-soft: var(--success-soft);
-  --color-success-strong: var(--success-strong);
+  --color-success: hsl(var(--success));
+  --color-success-soft: hsl(var(--success-soft));
+  --color-success-strong: hsl(var(--success-strong));
   --color-success-foreground: #ffffff;
-  --color-warning: var(--warning);
-  --color-warning-soft: var(--warning-soft);
-  --color-warning-strong: var(--warning-strong);
+  --color-warning: hsl(var(--warning));
+  --color-warning-soft: hsl(var(--warning-soft));
+  --color-warning-strong: hsl(var(--warning-strong));
   --color-warning-foreground: #ffffff;
-  --color-info: var(--accent);
-  --color-info-foreground: var(--accent-fg);
-  /* Saiku-ui calls it danger; saiku-cloud calls it destructive. Both
-     resolve to the same value so either idiom works in shared
-     primitives. */
-  --color-danger: var(--danger);
-  --color-danger-soft: var(--danger-soft);
-  --color-danger-strong: var(--danger-strong);
+  --color-info: hsl(var(--info-action));
+  --color-info-foreground: #ffffff;
+  --color-danger: hsl(var(--danger));
+  --color-danger-soft: hsl(var(--danger-soft));
+  --color-danger-strong: hsl(var(--danger-strong));
   --color-danger-foreground: #ffffff;
-  --color-destructive: var(--danger);
+  --color-destructive: hsl(var(--destructive));
   --color-destructive-foreground: #ffffff;
 
-  /* ---- Spacing scale ----
-     Tailwind v4 multiplies the spacing scale by integer + fraction
-     keys against `--spacing` (1 unit = `--spacing`). Mapping our
-     existing 4/8/12/16/24/32/48 ramp to 1/2/3/4/6/8/12 keeps the
-     `p-2` = 8px shape the rest of the world expects. */
+  /* ---- Spacing scale (1 unit = --spacing) ---- */
   --spacing: 4px;
 
   /* ---- Radii ---- */
@@ -109,7 +107,7 @@
   --font-sans: var(--font-sans);
   --font-mono: var(--font-mono);
 
-  /* ---- Type scale (matches saiku-ui's existing token names) ---- */
+  /* ---- Type scale ---- */
   --text-xs: var(--fs-xs);
   --text-sm: var(--fs-sm);
   --text-md: var(--fs-md);

--- a/saiku-ui/src/lib/styles/tokens.css
+++ b/saiku-ui/src/lib/styles/tokens.css
@@ -1,4 +1,36 @@
+/*
+  =============================================================================
+  Saiku Design System — Tokens  (ported from saiku-cloud, saiku#1636)
+  =============================================================================
+
+  Three-tier token architecture, adopted verbatim from saiku-cloud's
+  `dashboard/src/routes/layout.css` so the two products share one visual
+  language:
+
+    1. PRIMITIVES  — raw HSL-triple paint chips (cardinal/clay/slate/…).
+    2. SEMANTIC    — role ramps (primary/neutral/error/success/…), neutral
+                     swaps clay→slate in dark.
+    3. MAPPED      — purpose tokens (page/surface/text/border/action/…), the
+                     only tier components should bind to.
+
+  All colour tokens are BARE HSL TRIPLES (`H S% L%`); consumers wrap them in
+  `hsl(var(--x))` (and can add alpha via `hsl(var(--x) / N)`). The Tailwind
+  bridge (`tailwind.css`) resolves `bg-*`/`text-*`/`border-*` utilities through
+  the same tokens.
+
+  LEGACY COMPAT: saiku-ui shipped a flat, hex-valued token set (`--bg`, `--fg`,
+  `--border`, `--accent`, …). Those names are preserved at the bottom as TRIPLE
+  aliases into the mapped tier, and every `var(--legacy)` consumer was migrated
+  to `hsl(var(--legacy))` — so the whole app renders through one system while
+  existing components keep their token names. The brand action moved from
+  `--accent` (now the pale shadcn "accent" hover surface) to `--primary`.
+
+  Non-colour tokens (spacing/radii/fonts/type/icons/charts/shadows/durations)
+  are saiku-ui's own and stay as plain values.
+*/
+
 :root {
+  /* ── Non-colour scale (saiku-ui) ─────────────────────────────────────── */
   --space-1: 4px;
   --space-2: 8px;
   --space-3: 12px;
@@ -10,12 +42,14 @@
   --radius-sm: 4px;
   --radius-md: 8px;
   --radius-lg: 12px;
+  --radius: 0.5rem; /* shadcn-style default (cube-designer primitives) */
 
   --font-sans:
-    ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+    "Inter", ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto,
+    sans-serif;
   --font-mono:
-    ui-monospace, "SF Mono", Menlo, Monaco, Consolas, "Liberation Mono",
-    "Courier New", monospace;
+    "JetBrains Mono", ui-monospace, "SF Mono", Menlo, Monaco, Consolas,
+    "Liberation Mono", "Courier New", monospace;
 
   --fs-xs: 12px;
   --fs-sm: 13px;
@@ -27,198 +61,482 @@
   --lh-tight: 1.25;
   --lh-normal: 1.5;
 
-  /* Font weight scale. Keep usage to these four steps so weight choices
-     stay deliberate instead of drifting across components. */
   --weight-normal: 400;
   --weight-medium: 500;
   --weight-semibold: 600;
   --weight-bold: 700;
 
-  /* Icon sizes for lucide-svelte components. Keep usage to these four steps.
-     - xs (12px): tree twisties, inline cues
-     - sm (14px): list-row actions, form-field affordances
-     - md (16px): button content, modal close
-     - lg (20px): topbar primary actions, KPI accents */
   --icon-xs: 12px;
   --icon-sm: 14px;
   --icon-md: 16px;
   --icon-lg: 20px;
 
-  /* Categorical chart palette read by ChartView.svelte at runtime and
-     handed to ECharts as the `color: [...]` array. Anchored on the
-     primary --accent so charts feel cohesive with the surrounding UI
-     chrome. Dark theme overrides these below with brighter, lower-
-     saturation variants tuned for legibility on the dark background. */
-  --chart-1: #4f46e5;
-  --chart-2: #0ea5e9;
-  --chart-3: #10b981;
-  --chart-4: #f59e0b;
-  --chart-5: #ef4444;
-  --chart-6: #a855f7;
-  --chart-7: #ec4899;
-  --chart-8: #14b8a6;
+  --duration-fast: 120ms;
+  --duration-normal: 200ms;
 
   --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.06);
   --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.08);
   --shadow-lg: 0 12px 32px rgba(0, 0, 0, 0.16);
 
-  --duration-fast: 120ms;
-  --duration-normal: 200ms;
+  /* Categorical chart palette (ECharts). Kept as-is — consumed as full
+     colours via `var(--chart-N)`, not through the hsl() token chain. */
+  --chart-1: #b0182a; /* saiku red — re-anchored to the new brand */
+  --chart-2: #0ea5e9;
+  --chart-3: #10b981;
+  --chart-4: #f59e0b;
+  --chart-5: #a855f7;
+  --chart-6: #ec4899;
+  --chart-7: #14b8a6;
+  --chart-8: #6366f1;
 
   color-scheme: light;
 
-  --bg: #ffffff;
-  --bg-muted: #f6f7f9;
-  --bg-subtle: #eef0f3;
-  --bg-hover: #e2e6ec;
-  --bg-overlay: rgba(15, 23, 42, 0.32);
-  --fg: #0f172a;
-  --fg-muted: #475569;
-  --fg-subtle: #556378;
-  --border: #e2e8f0;
-  --border-strong: #cbd5e1;
+  /* =====================================================================
+     TIER 1 — PRIMITIVES (single mode; HSL triples)
+     ================================================================== */
+  --cardinal-25: 353 60% 98%;
+  --cardinal-50: 353 65% 96%;
+  --cardinal-100: 353 68% 90%;
+  --cardinal-200: 353 72% 80%;
+  --cardinal-300: 353 75% 68%;
+  --cardinal-400: 353 76% 58%;
+  --cardinal-500: 353 76% 48%;
+  --cardinal-600: 353 76% 42%;
+  --cardinal-700: 353 76% 39%; /* saiku red canonical */
+  --cardinal-800: 353 72% 30%;
+  --cardinal-900: 353 65% 22%;
+  --cardinal-950: 353 55% 12%;
 
-  --accent: #4f46e5;
-  --accent-hover: #4338ca;
-  --accent-fg: #ffffff;
-  --accent-soft: #eef2ff;
-  --accent-strong: #3730a3;
-  --danger: #dc2626;
-  --danger-soft: #fef2f2;
-  --danger-strong: #991b1b;
-  --success: #16a34a;
-  --success-soft: #ecfdf5;
-  --success-strong: #047857;
-  --warning: #d97706;
-  --warning-soft: #fffbeb;
-  --warning-strong: #b45309;
+  --clay-25: 36 24% 99%;
+  --clay-50: 36 22% 96%;
+  --clay-100: 36 20% 92%;
+  --clay-200: 36 18% 84%;
+  --clay-300: 36 15% 72%;
+  --clay-400: 32 12% 58%;
+  --clay-500: 28 10% 46%;
+  --clay-600: 24 10% 36%;
+  --clay-700: 20 12% 26%;
+  --clay-800: 20 14% 18%;
+  --clay-900: 20 16% 12%;
+  --clay-950: 20 18% 6%;
 
-  --focus-ring: 0 0 0 2px var(--bg), 0 0 0 4px var(--accent);
+  --slate-25: 220 15% 99%;
+  --slate-50: 220 15% 96%;
+  --slate-100: 220 14% 88%;
+  --slate-200: 220 12% 76%;
+  --slate-300: 220 10% 62%;
+  --slate-400: 220 10% 50%;
+  --slate-500: 220 10% 40%;
+  --slate-600: 220 12% 30%;
+  --slate-700: 220 13% 22%;
+  --slate-800: 220 14% 16%;
+  --slate-900: 220 15% 10%;
+  --slate-950: 220 15% 6%;
+
+  --meadow-25: 158 40% 98%;
+  --meadow-50: 158 45% 94%;
+  --meadow-100: 158 50% 88%;
+  --meadow-200: 158 55% 76%;
+  --meadow-300: 158 60% 60%;
+  --meadow-400: 158 62% 46%;
+  --meadow-500: 158 64% 38%;
+  --meadow-600: 158 64% 30%;
+  --meadow-700: 158 66% 24%;
+  --meadow-800: 158 68% 18%;
+  --meadow-900: 158 70% 12%;
+  --meadow-950: 158 72% 6%;
+
+  --honey-25: 32 65% 98%;
+  --honey-50: 32 70% 94%;
+  --honey-100: 32 75% 88%;
+  --honey-200: 32 80% 76%;
+  --honey-300: 32 85% 62%;
+  --honey-400: 32 88% 52%;
+  --honey-500: 32 90% 44%;
+  --honey-600: 32 90% 38%;
+  --honey-700: 32 90% 30%;
+  --honey-800: 32 90% 22%;
+  --honey-900: 32 90% 14%;
+  --honey-950: 32 90% 8%;
+
+  --rose-25: 0 60% 98%;
+  --rose-50: 0 65% 96%;
+  --rose-100: 0 70% 90%;
+  --rose-200: 0 72% 82%;
+  --rose-300: 0 74% 70%;
+  --rose-400: 0 75% 60%;
+  --rose-500: 0 75% 50%;
+  --rose-600: 0 72% 42%;
+  --rose-700: 0 70% 34%;
+  --rose-800: 0 68% 26%;
+  --rose-900: 0 65% 18%;
+  --rose-950: 0 55% 10%;
+
+  --azure-25: 217 65% 98%;
+  --azure-50: 217 70% 94%;
+  --azure-100: 217 75% 88%;
+  --azure-200: 217 78% 76%;
+  --azure-300: 217 80% 62%;
+  --azure-400: 217 80% 55%;
+  --azure-500: 217 80% 45%;
+  --azure-600: 217 82% 38%;
+  --azure-700: 217 84% 30%;
+  --azure-800: 217 86% 22%;
+  --azure-900: 217 88% 14%;
+  --azure-950: 217 90% 8%;
+
+  --white: 0 0% 100%;
+  --black: 0 0% 0%;
+
+  /* =====================================================================
+     TIER 2 — SEMANTIC (roles, Light values)
+     ================================================================== */
+  --primary-25: var(--cardinal-25);
+  --primary-50: var(--cardinal-50);
+  --primary-100: var(--cardinal-100);
+  --primary-200: var(--cardinal-200);
+  --primary-300: var(--cardinal-300);
+  --primary-400: var(--cardinal-400);
+  --primary-500: var(--cardinal-500);
+  --primary-600: var(--cardinal-600);
+  --primary-700: var(--cardinal-700);
+  --primary-800: var(--cardinal-800);
+  --primary-900: var(--cardinal-900);
+
+  --neutral-25: var(--clay-25);
+  --neutral-50: var(--clay-50);
+  --neutral-100: var(--clay-100);
+  --neutral-200: var(--clay-200);
+  --neutral-300: var(--clay-300);
+  --neutral-400: var(--clay-400);
+  --neutral-500: var(--clay-500);
+  --neutral-600: var(--clay-600);
+  --neutral-700: var(--clay-700);
+  --neutral-800: var(--clay-800);
+  --neutral-900: var(--clay-900);
+
+  --error-25: var(--rose-25);
+  --error-50: var(--rose-50);
+  --error-100: var(--rose-100);
+  --error-200: var(--rose-200);
+  --error-300: var(--rose-300);
+  --error-400: var(--rose-400);
+  --error-500: var(--rose-500);
+  --error-600: var(--rose-600);
+  --error-700: var(--rose-700);
+  --error-800: var(--rose-800);
+  --error-900: var(--rose-900);
+
+  --success-25: var(--meadow-25);
+  --success-50: var(--meadow-50);
+  --success-100: var(--meadow-100);
+  --success-200: var(--meadow-200);
+  --success-300: var(--meadow-300);
+  --success-400: var(--meadow-400);
+  --success-500: var(--meadow-500);
+  --success-600: var(--meadow-600);
+  --success-700: var(--meadow-700);
+  --success-800: var(--meadow-800);
+  --success-900: var(--meadow-900);
+
+  --warning-25: var(--honey-25);
+  --warning-50: var(--honey-50);
+  --warning-100: var(--honey-100);
+  --warning-200: var(--honey-200);
+  --warning-300: var(--honey-300);
+  --warning-400: var(--honey-400);
+  --warning-500: var(--honey-500);
+  --warning-600: var(--honey-600);
+  --warning-700: var(--honey-700);
+  --warning-800: var(--honey-800);
+  --warning-900: var(--honey-900);
+
+  --info-25: var(--azure-25);
+  --info-50: var(--azure-50);
+  --info-100: var(--azure-100);
+  --info-200: var(--azure-200);
+  --info-300: var(--azure-300);
+  --info-400: var(--azure-400);
+  --info-500: var(--azure-500);
+  --info-600: var(--azure-600);
+  --info-700: var(--azure-700);
+  --info-800: var(--azure-800);
+  --info-900: var(--azure-900);
+
+  /* =====================================================================
+     TIER 3 — MAPPED (purpose tokens, Light values)
+     ================================================================== */
+  --page: var(--neutral-25);
+  --surface-raised: var(--neutral-50);
+  --surface-elevated: var(--neutral-25);
+  --surface-inverse: var(--neutral-900);
+
+  --text-primary: var(--neutral-900);
+  --text-secondary: var(--neutral-700);
+  --text-muted: var(--neutral-500);
+  --text-inverse: var(--white);
+
+  --action-a: var(--primary-700);
+  --action-a-hover: var(--primary-800);
+  --action-a-pressed: var(--primary-800);
+  --focus-a: var(--primary-500);
+  --on-action-a: var(--white);
+
+  --action-b: var(--neutral-100);
+  --action-b-hover: var(--neutral-200);
+  --action-b-pressed: var(--neutral-300);
+  --on-action-b: var(--neutral-900);
+
+  --error-action: var(--error-500);
+  --error-action-hover: var(--error-600);
+  --error-pale: var(--error-50);
+  --on-error-action: var(--white);
+  --error-text: var(--error-600);
+
+  --success-action: var(--success-500);
+  --success-pale: var(--success-50);
+  --success-text: var(--success-600);
+  --on-success-action: var(--white);
+
+  --warning-action: var(--warning-500);
+  --warning-pale: var(--warning-50);
+  --warning-text: var(--warning-600);
+  --on-warning-action: var(--white);
+
+  --info-action: var(--info-500);
+  --info-pale: var(--info-50);
+  --info-text: var(--info-600);
+  --on-info-action: var(--white);
+
+  --border-subtle: var(--neutral-200);
+  --border-default: var(--neutral-300);
+  --border-emphasis: var(--neutral-400);
+  --border-focus: var(--primary-500);
+
+  --accent-surface: var(--primary-50);
+  --on-accent-surface: var(--neutral-900);
+
+  --elevation-0: var(--neutral-25);
+  --elevation-1: var(--neutral-50);
+  --elevation-2: var(--white);
+  --elevation-3: var(--neutral-50);
+  --elevation-4: var(--white);
+
+  /* =====================================================================
+     BRIDGE — shadcn-shaped names (used by cube-designer + shared primitives)
+     ================================================================== */
+  --background: var(--page);
+  --foreground: var(--text-primary);
+  --card: var(--surface-raised);
+  --card-foreground: var(--text-primary);
+  --popover: var(--surface-elevated);
+  --popover-foreground: var(--text-primary);
+
+  --primary: var(--action-a);
+  --primary-foreground: var(--on-action-a);
+  --ring: var(--focus-a);
+
+  --secondary: var(--action-b);
+  --secondary-foreground: var(--on-action-b);
+  --muted: var(--action-b);
+  --muted-foreground: var(--text-muted);
+
+  --accent: var(--accent-surface);
+  --accent-foreground: var(--on-accent-surface);
+
+  --destructive: var(--error-action);
+  --destructive-foreground: var(--on-error-action);
+
+  --input: var(--border-subtle);
+
+  --elev-0: var(--elevation-0);
+  --elev-1: var(--elevation-1);
+  --elev-2: var(--elevation-2);
+  --elev-3: var(--elevation-3);
+  --elev-4: var(--elevation-4);
+
+  /* =====================================================================
+     LEGACY COMPAT — saiku-ui's original flat names → mapped tier (triples).
+     Consumers were migrated to hsl(var(--x)). Brand action is --primary now;
+     legacy --accent* brand usages were migrated to --primary*.
+     ================================================================== */
+  --bg: var(--page);
+  --bg-muted: var(--surface-raised);
+  --bg-subtle: var(--action-b);
+  --bg-hover: var(--action-b-hover);
+  --fg: var(--text-primary);
+  --fg-muted: var(--text-secondary);
+  --fg-subtle: var(--text-muted);
+  --border: var(--border-subtle);
+  --border-strong: var(--border-default);
+
+  /* brand (was --accent; now split from the pale shadcn accent surface) */
+  --primary-hover: var(--action-a-hover);
+  --primary-strong: var(--action-a-pressed);
+
+  --danger: var(--error-action);
+  --danger-soft: var(--error-pale);
+  --danger-strong: var(--error-text);
+  --success: var(--success-action);
+  --success-soft: var(--success-pale);
+  --success-strong: var(--success-text);
+  --warning: var(--warning-action);
+  --warning-soft: var(--warning-pale);
+  --warning-strong: var(--warning-text);
+
+  /* Full-value colour tokens (NOT triples — consumed directly). */
+  --bg-overlay: hsl(20 16% 12% / 0.32);
+  --focus-ring:
+    0 0 0 2px hsl(var(--bg)), 0 0 0 4px hsl(var(--primary));
 }
 
+/* ============================================================================
+   DARK MODE — explicit override AND system pref (with :not([data-theme=light])
+   guard so a user's light pick beats the OS). Mirrors saiku-cloud exactly.
+   ========================================================================= */
 @media (prefers-color-scheme: dark) {
-  :root {
+  :root:not([data-theme="light"]) {
     color-scheme: dark;
 
-    --bg: #0b0d12;
-    --bg-muted: #11141b;
-    --bg-subtle: #1a1e27;
-    --bg-hover: #242935;
-    --bg-overlay: rgba(0, 0, 0, 0.6);
-    --fg: #e6e8ec;
-    --fg-muted: #a8aeba;
-    --fg-subtle: #8b94a3;
-    --border: #242935;
-    --border-strong: #333a49;
+    --neutral-25: var(--slate-25);
+    --neutral-50: var(--slate-50);
+    --neutral-100: var(--slate-100);
+    --neutral-200: var(--slate-200);
+    --neutral-300: var(--slate-300);
+    --neutral-400: var(--slate-400);
+    --neutral-500: var(--slate-500);
+    --neutral-600: var(--slate-600);
+    --neutral-700: var(--slate-700);
+    --neutral-800: var(--slate-800);
+    --neutral-900: var(--slate-900);
 
-    --accent: #818cf8;
-    --accent-hover: #a5b4fc;
-    --accent-fg: #0b0d12;
-    --accent-soft: #1e1b4b;
-    --accent-strong: #c7d2fe;
-    --danger: #ef4444;
-    --danger-soft: #2a1212;
-    --danger-strong: #fca5a5;
-    --success: #22c55e;
-    --success-soft: #0d2a1a;
-    --success-strong: #86efac;
-    --warning: #f59e0b;
-    --warning-soft: #2b1d09;
-    --warning-strong: #fcd34d;
+    --page: var(--neutral-900);
+    --surface-raised: var(--neutral-800);
+    --surface-elevated: var(--neutral-800);
+    --surface-inverse: var(--neutral-25);
 
-    --chart-1: #818cf8;
-    --chart-2: #38bdf8;
-    --chart-3: #34d399;
-    --chart-4: #fbbf24;
-    --chart-5: #f87171;
-    --chart-6: #c084fc;
-    --chart-7: #f472b6;
-    --chart-8: #2dd4bf;
+    --text-primary: var(--neutral-25);
+    --text-secondary: var(--neutral-200);
+    --text-muted: var(--neutral-400);
+    --text-inverse: var(--neutral-900);
 
-    --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.5);
-    --shadow-md: 0 4px 16px rgba(0, 0, 0, 0.6);
-    --shadow-lg: 0 12px 40px rgba(0, 0, 0, 0.7);
+    --action-a: var(--primary-400);
+    --action-a-hover: var(--primary-300);
+    --action-a-pressed: var(--primary-300);
+    --focus-a: var(--primary-400);
+
+    --action-b: var(--neutral-700);
+    --action-b-hover: var(--neutral-600);
+    --action-b-pressed: var(--neutral-500);
+    --on-action-b: var(--neutral-25);
+
+    --error-action: var(--error-400);
+    --error-action-hover: var(--error-300);
+    --error-pale: var(--error-800);
+    --error-text: var(--error-300);
+
+    --success-action: var(--success-400);
+    --success-pale: var(--success-800);
+    --success-text: var(--success-300);
+
+    --warning-action: var(--warning-400);
+    --warning-pale: var(--warning-800);
+    --warning-text: var(--warning-300);
+
+    --info-action: var(--info-400);
+    --info-pale: var(--info-800);
+    --info-text: var(--info-300);
+
+    --border-subtle: var(--neutral-700);
+    --border-default: var(--neutral-600);
+    --border-emphasis: var(--neutral-500);
+
+    --accent-surface: var(--primary-900);
+    --on-accent-surface: var(--neutral-25);
+
+    --elevation-0: var(--neutral-900);
+    --elevation-1: var(--neutral-800);
+    --elevation-2: 220 14% 20%;
+    --elevation-3: var(--neutral-700);
+    --elevation-4: 220 14% 20%;
+
+    --bg-overlay: hsl(0 0% 0% / 0.6);
   }
 }
 
 :root[data-theme="dark"] {
   color-scheme: dark;
 
-  --bg: #0b0d12;
-  --bg-muted: #11141b;
-  --bg-subtle: #1a1e27;
-  --bg-hover: #242935;
-  --bg-overlay: rgba(0, 0, 0, 0.6);
-  --fg: #e6e8ec;
-  --fg-muted: #a8aeba;
-  --fg-subtle: #8b94a3;
-  --border: #242935;
-  --border-strong: #333a49;
+  --neutral-25: var(--slate-25);
+  --neutral-50: var(--slate-50);
+  --neutral-100: var(--slate-100);
+  --neutral-200: var(--slate-200);
+  --neutral-300: var(--slate-300);
+  --neutral-400: var(--slate-400);
+  --neutral-500: var(--slate-500);
+  --neutral-600: var(--slate-600);
+  --neutral-700: var(--slate-700);
+  --neutral-800: var(--slate-800);
+  --neutral-900: var(--slate-900);
 
-  --accent: #818cf8;
-  --accent-hover: #a5b4fc;
-  --accent-fg: #0b0d12;
-  --accent-soft: #1e1b4b;
-  --accent-strong: #c7d2fe;
-  --danger: #ef4444;
-  --danger-soft: #2a1212;
-  --danger-strong: #fca5a5;
-  --success: #22c55e;
-  --success-soft: #0d2a1a;
-  --success-strong: #86efac;
-  --warning: #f59e0b;
-  --warning-soft: #2b1d09;
-  --warning-strong: #fcd34d;
+  --page: var(--neutral-900);
+  --surface-raised: var(--neutral-800);
+  --surface-elevated: var(--neutral-800);
+  --surface-inverse: var(--neutral-25);
 
-  --chart-1: #818cf8;
+  --text-primary: var(--neutral-25);
+  --text-secondary: var(--neutral-200);
+  --text-muted: var(--neutral-400);
+  --text-inverse: var(--neutral-900);
+
+  --action-a: var(--primary-400);
+  --action-a-hover: var(--primary-300);
+  --action-a-pressed: var(--primary-300);
+  --focus-a: var(--primary-400);
+
+  --action-b: var(--neutral-700);
+  --action-b-hover: var(--neutral-600);
+  --action-b-pressed: var(--neutral-500);
+  --on-action-b: var(--neutral-25);
+
+  --error-action: var(--error-400);
+  --error-action-hover: var(--error-300);
+  --error-pale: var(--error-800);
+  --error-text: var(--error-300);
+
+  --success-action: var(--success-400);
+  --success-pale: var(--success-800);
+  --success-text: var(--success-300);
+
+  --warning-action: var(--warning-400);
+  --warning-pale: var(--warning-800);
+  --warning-text: var(--warning-300);
+
+  --info-action: var(--info-400);
+  --info-pale: var(--info-800);
+  --info-text: var(--info-300);
+
+  --border-subtle: var(--neutral-700);
+  --border-default: var(--neutral-600);
+  --border-emphasis: var(--neutral-500);
+
+  --accent-surface: var(--primary-900);
+  --on-accent-surface: var(--neutral-25);
+
+  --elevation-0: var(--neutral-900);
+  --elevation-1: var(--neutral-800);
+  --elevation-2: 220 14% 20%;
+  --elevation-3: var(--neutral-700);
+  --elevation-4: 220 14% 20%;
+
+  --bg-overlay: hsl(0 0% 0% / 0.6);
+
+  --chart-1: #ef5a6b;
   --chart-2: #38bdf8;
   --chart-3: #34d399;
   --chart-4: #fbbf24;
-  --chart-5: #f87171;
-  --chart-6: #c084fc;
-  --chart-7: #f472b6;
-  --chart-8: #2dd4bf;
-
-  --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.5);
-  --shadow-md: 0 4px 16px rgba(0, 0, 0, 0.6);
-  --shadow-lg: 0 12px 40px rgba(0, 0, 0, 0.7);
-}
-
-:root[data-theme="light"] {
-  color-scheme: light;
-
-  --bg: #ffffff;
-  --bg-muted: #f6f7f9;
-  --bg-subtle: #eef0f3;
-  --bg-hover: #e2e6ec;
-  --bg-overlay: rgba(15, 23, 42, 0.32);
-  --fg: #0f172a;
-  --fg-muted: #475569;
-  --fg-subtle: #556378;
-  --border: #e2e8f0;
-  --border-strong: #cbd5e1;
-
-  --accent: #4f46e5;
-  --accent-hover: #4338ca;
-  --accent-fg: #ffffff;
-  --accent-soft: #eef2ff;
-  --accent-strong: #3730a3;
-  --danger: #dc2626;
-  --danger-soft: #fef2f2;
-  --danger-strong: #991b1b;
-  --success: #16a34a;
-  --success-soft: #ecfdf5;
-  --success-strong: #047857;
-  --warning: #d97706;
-  --warning-soft: #fffbeb;
-  --warning-strong: #b45309;
-
-  --chart-1: #4f46e5;
-  --chart-2: #0ea5e9;
-  --chart-3: #10b981;
-  --chart-4: #f59e0b;
-  --chart-5: #ef4444;
-  --chart-6: #a855f7;
-  --chart-7: #ec4899;
-  --chart-8: #14b8a6;
+  --chart-5: #c084fc;
+  --chart-6: #f472b6;
+  --chart-7: #2dd4bf;
+  --chart-8: #818cf8;
 }

--- a/saiku-ui/src/lib/views/AiDashboardBuildingOverlay.svelte
+++ b/saiku-ui/src/lib/views/AiDashboardBuildingOverlay.svelte
@@ -48,7 +48,7 @@
     <div
       class="flex w-[420px] max-w-[90vw] flex-col items-center gap-4 rounded-lg border border-border bg-bg px-8 py-7 text-center shadow-lg"
     >
-      <Loader2 size={32} class="animate-spin text-accent" aria-hidden="true" />
+      <Loader2 size={32} class="animate-spin text-primary" aria-hidden="true" />
       <div class="text-lg font-semibold text-fg">
         {i18n.t("workspace.aiDashboard.buildingTitle", "Building your dashboard…")}
       </div>

--- a/saiku-ui/src/lib/views/AiEmailPreparingPopup.svelte
+++ b/saiku-ui/src/lib/views/AiEmailPreparingPopup.svelte
@@ -25,7 +25,7 @@
     <div
       class="flex items-center gap-3 rounded-lg border border-border bg-bg px-6 py-4 text-fg shadow-lg"
     >
-      <Loader2 size={20} class="animate-spin text-accent" aria-hidden="true" />
+      <Loader2 size={20} class="animate-spin text-primary" aria-hidden="true" />
       <span class="text-sm font-medium">
         {i18n.t("workspace.aiEmail.preparing", "Preparing your email…")}
       </span>

--- a/saiku-ui/src/lib/views/AiQueryDrawer.svelte
+++ b/saiku-ui/src/lib/views/AiQueryDrawer.svelte
@@ -1077,15 +1077,15 @@
        caps at the viewport so a misclick dragging past the left edge can't
        eat the canvas entirely. */
     max-width: 100vw;
-    background: var(--bg);
-    border-left: 1px solid var(--border);
+    background: hsl(var(--bg));
+    border-left: 1px solid hsl(var(--border));
     box-shadow: -8px 0 24px rgba(0, 0, 0, 0.08);
     display: flex;
     flex-direction: column;
     transform: translateX(100%);
     transition: transform 0.18s ease-out;
     z-index: 100;
-    color: var(--fg);
+    color: hsl(var(--fg));
   }
   /* Suspend the slide-in transition while resizing so the width change
      follows the cursor 1:1 instead of easing per-frame. */
@@ -1111,15 +1111,15 @@
   }
   .ai-drawer__resize:hover,
   .ai-drawer--resizing .ai-drawer__resize {
-    background: color-mix(in srgb, var(--accent) 40%, transparent);
+    background: color-mix(in srgb, hsl(var(--primary)) 40%, transparent);
   }
   .ai-drawer__header {
     display: flex;
     align-items: center;
     gap: 8px;
     padding: 12px 14px;
-    border-bottom: 1px solid var(--border);
-    background: var(--bg-muted);
+    border-bottom: 1px solid hsl(var(--border));
+    background: hsl(var(--bg-muted));
     /* Pin header + footer against any squeeze when `messages` swells —
        previously a tall conversation could nudge the footer below the
        viewport on short windows. */
@@ -1136,15 +1136,15 @@
     justify-content: center;
     background: transparent;
     border: 1px solid transparent;
-    color: var(--fg-muted);
+    color: hsl(var(--fg-muted));
     border-radius: 6px;
     padding: 5px;
     cursor: pointer;
   }
   .ai-drawer__icon-btn:hover {
-    background: var(--bg);
-    border-color: var(--border);
-    color: var(--fg);
+    background: hsl(var(--bg));
+    border-color: hsl(var(--border));
+    color: hsl(var(--fg));
   }
   .ai-drawer__banner {
     margin: 12px 14px 0;
@@ -1160,10 +1160,10 @@
   }
   .ai-drawer__banner p {
     margin: 0;
-    color: var(--fg-muted);
+    color: hsl(var(--fg-muted));
   }
   .ai-drawer__empty {
-    color: var(--fg-muted);
+    color: hsl(var(--fg-muted));
     font-size: 0.9rem;
     line-height: 1.5;
   }
@@ -1172,7 +1172,7 @@
   }
   .ai-drawer__empty-cube {
     font-size: 0.8rem;
-    color: var(--fg-muted);
+    color: hsl(var(--fg-muted));
   }
   .ai-drawer__empty-cube--warn {
     color: #b45309;
@@ -1185,23 +1185,23 @@
   }
   .ai-drawer__examples-label {
     font-size: 0.78rem;
-    color: var(--fg-muted);
+    color: hsl(var(--fg-muted));
     margin-bottom: 2px;
   }
   .ai-drawer__example {
     text-align: left;
-    background: var(--bg);
-    border: 1px solid var(--border);
+    background: hsl(var(--bg));
+    border: 1px solid hsl(var(--border));
     border-radius: 6px;
     padding: 8px 10px;
     font-size: 0.85rem;
-    color: var(--fg);
+    color: hsl(var(--fg));
     cursor: pointer;
     font-family: inherit;
   }
   .ai-drawer__example:hover {
-    border-color: var(--accent);
-    background: var(--bg-muted);
+    border-color: hsl(var(--primary));
+    background: hsl(var(--bg-muted));
   }
   .ai-drawer__turn {
     display: flex;
@@ -1222,7 +1222,7 @@
     word-break: break-word;
   }
   .ai-drawer__bubble--user {
-    background: var(--accent);
+    background: hsl(var(--primary));
     color: white;
   }
   .ai-drawer__bubble--error {
@@ -1235,25 +1235,25 @@
   }
   .ai-drawer__candidates-label {
     font-size: 0.8rem;
-    color: var(--fg-muted);
+    color: hsl(var(--fg-muted));
     margin-bottom: 4px;
   }
   .ai-drawer__chip {
-    background: var(--bg);
-    border: 1px solid var(--border);
+    background: hsl(var(--bg));
+    border: 1px solid hsl(var(--border));
     border-radius: 999px;
     padding: 3px 9px;
     font-size: 0.78rem;
-    color: var(--fg);
+    color: hsl(var(--fg));
     cursor: pointer;
   }
   .ai-drawer__chip:hover {
-    background: var(--bg-muted);
-    border-color: var(--accent);
+    background: hsl(var(--bg-muted));
+    border-color: hsl(var(--primary));
   }
   .ai-drawer__mdx {
     margin-top: 10px;
-    border-top: 1px solid var(--border);
+    border-top: 1px solid hsl(var(--border));
     padding-top: 8px;
   }
   .ai-drawer__mdx-toggle {
@@ -1262,19 +1262,19 @@
     gap: 4px;
     background: transparent;
     border: 0;
-    color: var(--fg-muted);
+    color: hsl(var(--fg-muted));
     font-size: 0.78rem;
     cursor: pointer;
     padding: 2px 4px;
   }
   .ai-drawer__mdx-toggle:hover {
-    color: var(--fg);
+    color: hsl(var(--fg));
   }
   .ai-drawer__mdx-pre {
     margin: 6px 0;
     padding: 8px;
-    background: var(--bg);
-    border: 1px solid var(--border);
+    background: hsl(var(--bg));
+    border: 1px solid hsl(var(--border));
     border-radius: 6px;
     font-size: 0.75rem;
     overflow-x: auto;
@@ -1285,30 +1285,30 @@
     display: inline-flex;
     align-items: center;
     gap: 4px;
-    background: var(--bg);
-    border: 1px solid var(--border);
-    color: var(--fg);
+    background: hsl(var(--bg));
+    border: 1px solid hsl(var(--border));
+    color: hsl(var(--fg));
     border-radius: 6px;
     padding: 4px 9px;
     font-size: 0.78rem;
     cursor: pointer;
   }
   .ai-drawer__small-btn:hover {
-    background: var(--bg-muted);
+    background: hsl(var(--bg-muted));
   }
   .ai-drawer__small-btn--primary {
-    background: var(--accent);
-    border-color: var(--accent);
+    background: hsl(var(--primary));
+    border-color: hsl(var(--primary));
     color: white;
   }
   .ai-drawer__small-btn--primary:hover {
     filter: brightness(0.95);
-    background: var(--accent);
+    background: hsl(var(--primary));
   }
   .ai-drawer__model {
     margin-top: 6px;
     font-size: 0.72rem;
-    color: var(--fg-muted);
+    color: hsl(var(--fg-muted));
     font-style: italic;
   }
   /* Insight / view-change badges sit above the bubble title so the user can
@@ -1320,7 +1320,7 @@
     font-size: 0.68rem;
     text-transform: uppercase;
     letter-spacing: 0.06em;
-    color: var(--accent);
+    color: hsl(var(--primary));
     margin-bottom: 4px;
     font-weight: 600;
   }
@@ -1333,7 +1333,7 @@
   .ai-drawer__insight-body {
     font-size: 0.85rem;
     line-height: 1.5;
-    color: var(--fg);
+    color: hsl(var(--fg));
   }
   .ai-drawer__insight-body :global(h3),
   .ai-drawer__insight-body :global(h4),
@@ -1341,13 +1341,13 @@
   .ai-drawer__insight-body :global(h6) {
     font-weight: 600;
     margin: 12px 0 4px;
-    color: var(--fg);
+    color: hsl(var(--fg));
     line-height: 1.3;
   }
   .ai-drawer__insight-body :global(h3) { font-size: 0.95rem; }
   .ai-drawer__insight-body :global(h4) { font-size: 0.9rem; }
   .ai-drawer__insight-body :global(h5),
-  .ai-drawer__insight-body :global(h6) { font-size: 0.85rem; color: var(--fg-muted); }
+  .ai-drawer__insight-body :global(h6) { font-size: 0.85rem; color: hsl(var(--fg-muted)); }
   .ai-drawer__insight-body :global(h3:first-child),
   .ai-drawer__insight-body :global(h4:first-child) { margin-top: 0; }
   .ai-drawer__insight-body :global(p) {
@@ -1363,17 +1363,17 @@
   }
   .ai-drawer__insight-body :global(strong) {
     font-weight: 600;
-    color: var(--fg);
+    color: hsl(var(--fg));
   }
   .ai-drawer__insight-body :global(code) {
     font-family: ui-monospace, SFMono-Regular, monospace;
     font-size: 0.8rem;
-    background: var(--bg-subtle);
+    background: hsl(var(--bg-subtle));
     padding: 1px 4px;
     border-radius: 3px;
   }
   .ai-drawer__insight-body :global(a) {
-    color: var(--accent);
+    color: hsl(var(--primary));
     text-decoration: underline;
   }
   /* Mode picker — segmented control above the textarea. Pill row, active gets
@@ -1388,8 +1388,8 @@
     flex: 1 1 auto;
     min-width: 0;
     background: transparent;
-    color: var(--fg-muted);
-    border: 1px solid var(--border);
+    color: hsl(var(--fg-muted));
+    border: 1px solid hsl(var(--border));
     border-radius: 999px;
     padding: 3px 10px;
     font-size: 0.72rem;
@@ -1397,17 +1397,17 @@
     transition: background 120ms ease, color 120ms ease, border-color 120ms ease;
   }
   .ai-drawer__mode-btn:hover:not(:disabled) {
-    background: var(--bg-subtle);
-    color: var(--fg);
+    background: hsl(var(--bg-subtle));
+    color: hsl(var(--fg));
   }
   .ai-drawer__mode-btn:disabled {
     opacity: 0.5;
     cursor: not-allowed;
   }
   .ai-drawer__mode-btn--active {
-    background: color-mix(in srgb, var(--accent) 14%, transparent);
-    color: var(--accent);
-    border-color: var(--accent);
+    background: color-mix(in srgb, hsl(var(--primary)) 14%, transparent);
+    color: hsl(var(--primary));
+    border-color: hsl(var(--primary));
     font-weight: 600;
   }
   /* "Build & report" opt-in toggle — sits between the mode bar and the input row. Plain
@@ -1426,15 +1426,15 @@
     gap: 6px;
     width: fit-content;
     font-size: 0.78rem;
-    color: var(--fg-muted);
+    color: hsl(var(--fg-muted));
     cursor: pointer;
   }
   .ai-drawer__chain-toggle input {
-    accent-color: var(--accent);
+    accent-color: hsl(var(--primary));
     cursor: pointer;
   }
   .ai-drawer__chain-toggle:has(input:checked) {
-    color: var(--fg);
+    color: hsl(var(--fg));
     font-weight: 600;
   }
   .ai-drawer__chain-toggle:has(input:disabled) {
@@ -1445,14 +1445,14 @@
      short successful turns don't flash it. */
   .ai-drawer__elapsed {
     font-size: 0.72rem;
-    color: var(--fg-muted);
+    color: hsl(var(--fg-muted));
     margin-left: 6px;
   }
   .ai-drawer__dot {
     width: 6px;
     height: 6px;
     border-radius: 50%;
-    background: var(--fg-muted);
+    background: hsl(var(--fg-muted));
     animation: ai-drawer-pulse 1.2s ease-in-out infinite;
   }
   .ai-drawer__dot:nth-child(2) {
@@ -1481,24 +1481,24 @@
     min-height: 72px;
     max-height: 200px;
     padding: 8px 10px;
-    border: 1px solid var(--border);
+    border: 1px solid hsl(var(--border));
     border-radius: 6px;
-    background: var(--bg);
-    color: var(--fg);
+    background: hsl(var(--bg));
+    color: hsl(var(--fg));
     font-family: inherit;
     font-size: 0.9rem;
   }
   .ai-drawer__input:focus {
-    outline: 2px solid var(--accent);
+    outline: 2px solid hsl(var(--primary));
     outline-offset: -1px;
-    border-color: var(--accent);
+    border-color: hsl(var(--primary));
   }
   .ai-drawer__submit {
     display: inline-flex;
     align-items: center;
     gap: 6px;
-    background: var(--accent);
-    border: 1px solid var(--accent);
+    background: hsl(var(--primary));
+    border: 1px solid hsl(var(--primary));
     color: white;
     border-radius: 6px;
     padding: 0 14px;

--- a/saiku-ui/src/lib/views/CellsetTable.svelte
+++ b/saiku-ui/src/lib/views/CellsetTable.svelte
@@ -681,10 +681,10 @@
               <td class="data spark-cell" role="gridcell" aria-colindex={parsed.rowHeaderColCount + (parsed.dataRows[r]?.length ?? 0) + 1}>
                 <svg viewBox={`0 0 ${SPARK_W} ${SPARK_H}`} width={SPARK_W} height={SPARK_H} aria-hidden="true">
                   {#if spark === "line"}
-                    <path d={linePath(vals, range.min, range.max, SPARK_W, SPARK_H)} stroke="var(--accent)" stroke-width="1.5" fill="none" />
+                    <path d={linePath(vals, range.min, range.max, SPARK_W, SPARK_H)} stroke="hsl(var(--primary))" stroke-width="1.5" fill="none" />
                   {:else}
                     {#each barRects(vals, range.min, range.max, SPARK_W, SPARK_H) as b}
-                      <rect x={b.x} y={b.y} width={b.w} height={b.h} fill="var(--accent)" />
+                      <rect x={b.x} y={b.y} width={b.w} height={b.h} fill="hsl(var(--primary))" />
                     {/each}
                   {/if}
                 </svg>
@@ -778,8 +778,8 @@
     flex: 1;
     min-height: 0;
     overflow: auto;
-    border: 1px solid var(--border);
-    background: var(--bg);
+    border: 1px solid hsl(var(--border));
+    background: hsl(var(--bg));
     /* Disable scroll-snap and smooth scroll-behavior. Without this, a single
        wheel-tick can carry the viewport multiple screens due to macOS
        momentum interacting with the table's tall scroll height — visible as
@@ -797,34 +797,34 @@
   .cellset th,
   .cellset td {
     padding: 3px 9px 3px 6px;
-    border-right: 1px solid var(--border);
-    border-bottom: 1px solid var(--border);
+    border-right: 1px solid hsl(var(--border));
+    border-bottom: 1px solid hsl(var(--border));
     vertical-align: top;
   }
   .cellset thead th {
     position: sticky;
     top: 0;
     z-index: 2;
-    background: var(--bg-muted);
+    background: hsl(var(--bg-muted));
     font-weight: var(--weight-semibold);
     text-align: left;
     white-space: nowrap;
   }
   .cellset th.all_null {
-    background: var(--bg-muted);
-    border-right: 1px solid var(--border);
+    background: hsl(var(--bg-muted));
+    border-right: 1px solid hsl(var(--border));
   }
   .cellset th.col {
     cursor: context-menu;
   }
   .cellset th.col:hover {
-    background: var(--bg-subtle);
+    background: hsl(var(--bg-subtle));
   }
   .cellset th.col_null {
-    background: var(--bg-muted);
+    background: hsl(var(--bg-muted));
   }
   .cellset tbody th.row {
-    background: var(--bg-muted);
+    background: hsl(var(--bg-muted));
     text-align: left;
     white-space: nowrap;
     cursor: context-menu;
@@ -842,18 +842,18 @@
     left: 0;
     z-index: 1;
   }
-  .cellset tbody th.row--nested { font-weight: var(--weight-medium); color: var(--fg-muted); }
+  .cellset tbody th.row--nested { font-weight: var(--weight-medium); color: hsl(var(--fg-muted)); }
   .cellset tbody th.row:hover {
-    background: var(--bg-subtle);
+    background: hsl(var(--bg-subtle));
   }
   .cellset tbody th.row_null {
-    background: var(--bg-muted);
+    background: hsl(var(--bg-muted));
     position: sticky;
     left: 0;
     z-index: 1;
   }
   .cellset td.data {
-    color: var(--fg);
+    color: hsl(var(--fg));
     text-align: left;
   }
   .cellset td.data-num {
@@ -861,22 +861,22 @@
     font-variant-numeric: tabular-nums;
   }
   .cellset td.data { cursor: cell; user-select: none; }
-  .cellset td.data--selected { background: color-mix(in srgb, var(--accent) 28%, transparent); }
+  .cellset td.data--selected { background: color-mix(in srgb, hsl(var(--primary)) 28%, transparent); }
   .cellset tr.virt-spacer td {
     background: transparent;
     border: 0;
     padding: 0;
   }
   .cellset td.data--focused {
-    box-shadow: inset 0 0 0 2px var(--accent);
+    box-shadow: inset 0 0 0 2px hsl(var(--primary));
     position: relative;
   }
   .cellset-wrap:focus {
-    outline: 2px solid color-mix(in srgb, var(--accent) 50%, transparent);
+    outline: 2px solid color-mix(in srgb, hsl(var(--primary)) 50%, transparent);
     outline-offset: -2px;
   }
   .cellset-wrap:focus-visible {
-    outline: 2px solid var(--accent);
+    outline: 2px solid hsl(var(--primary));
     outline-offset: -2px;
   }
   .sel-stats {
@@ -885,26 +885,26 @@
     align-items: center;
     gap: var(--space-4);
     padding: 6px 12px;
-    border: 1px solid var(--border);
+    border: 1px solid hsl(var(--border));
     border-top: 0;
-    background: var(--bg-muted);
-    color: var(--fg-muted);
+    background: hsl(var(--bg-muted));
+    color: hsl(var(--fg-muted));
     font-size: var(--fs-sm);
     font-variant-numeric: tabular-nums;
   }
-  .sel-stats strong { color: var(--fg); font-weight: var(--weight-semibold); }
+  .sel-stats strong { color: hsl(var(--fg)); font-weight: var(--weight-semibold); }
   .sel-stats__clear {
     margin-left: auto;
     border: none;
     background: transparent;
-    color: var(--fg-muted);
+    color: hsl(var(--fg-muted));
     cursor: pointer;
     font-size: 16px;
     line-height: 1;
     padding: 2px 6px;
     border-radius: var(--radius-sm);
   }
-  .sel-stats__clear:hover { color: var(--danger); background: var(--bg-subtle); }
+  .sel-stats__clear:hover { color: hsl(var(--danger)); background: hsl(var(--bg-subtle)); }
   .cellset th.spark-col {
     min-width: 140px;
   }
@@ -916,10 +916,10 @@
   }
   .cellset tbody tr:hover td.data,
   .cellset tbody tr:hover th.row {
-    background: var(--bg-subtle);
+    background: hsl(var(--bg-subtle));
   }
   .runtime {
-    color: var(--fg-subtle);
+    color: hsl(var(--fg-subtle));
     font-size: var(--fs-xs);
     margin: var(--space-2) 0 0;
     flex: 0 0 auto;
@@ -927,8 +927,8 @@
   .cellset-ctx-menu {
     position: fixed;
     min-width: 180px;
-    background: var(--bg);
-    border: 1px solid var(--border);
+    background: hsl(var(--bg));
+    border: 1px solid hsl(var(--border));
     border-radius: var(--radius-sm);
     box-shadow: 0 8px 24px rgba(0, 0, 0, 0.35);
     padding: var(--space-1) 0;
@@ -937,7 +937,7 @@
   }
   .cellset-ctx-menu__sep {
     height: 1px;
-    background: var(--border);
+    background: hsl(var(--border));
     margin: 2px 0;
   }
   .cellset-ctx-menu__item {
@@ -947,16 +947,16 @@
     padding: 4px var(--space-3);
     background: transparent;
     border: 0;
-    color: var(--fg);
+    color: hsl(var(--fg));
     font: inherit;
     cursor: pointer;
   }
   .cellset-ctx-menu__item:hover:not(:disabled),
   .cellset-ctx-menu__item--parent > button:hover {
-    background: var(--bg-subtle);
+    background: hsl(var(--bg-subtle));
   }
   .cellset-ctx-menu__item:disabled {
-    color: var(--fg-subtle);
+    color: hsl(var(--fg-subtle));
     cursor: default;
   }
   .cellset-ctx-menu__item--parent {
@@ -969,13 +969,13 @@
     padding: 4px var(--space-3);
     background: transparent;
     border: 0;
-    color: var(--fg);
+    color: hsl(var(--fg));
     font: inherit;
     cursor: pointer;
   }
   .cellset-ctx-menu__sub {
     margin-left: var(--space-2);
-    border-left: 2px solid var(--border);
-    background: var(--bg-muted);
+    border-left: 2px solid hsl(var(--border));
+    background: hsl(var(--bg-muted));
   }
 </style>

--- a/saiku-ui/src/lib/views/ChartView.svelte
+++ b/saiku-ui/src/lib/views/ChartView.svelte
@@ -335,8 +335,8 @@
     min-height: 320px;
     overflow-y: hidden;
     overflow-x: hidden;
-    background: var(--bg);
-    border: 1px solid var(--border);
+    background: hsl(var(--bg));
+    border: 1px solid hsl(var(--border));
     border-radius: var(--radius-sm);
   }
   /* Only show the scrollbar when small-multiples actually overflow. */

--- a/saiku-ui/src/lib/views/CubePicker.svelte
+++ b/saiku-ui/src/lib/views/CubePicker.svelte
@@ -155,7 +155,7 @@
     font-weight: var(--weight-semibold);
     text-transform: uppercase;
     letter-spacing: 0.06em;
-    color: var(--fg-muted);
+    color: hsl(var(--fg-muted));
   }
   .cube-picker__refresh {
     /* match the select's vertical footprint so they line up at the same height */

--- a/saiku-ui/src/lib/views/DimensionList.svelte
+++ b/saiku-ui/src/lib/views/DimensionList.svelte
@@ -669,13 +669,13 @@
     margin-top: var(--space-4);
   }
   .panels__hint {
-    color: var(--fg-subtle);
+    color: hsl(var(--fg-subtle));
     font-size: var(--fs-sm);
     margin: var(--space-3) 0 0;
   }
   .panel {
-    background: var(--bg);
-    border-top: 1px solid var(--border);
+    background: hsl(var(--bg));
+    border-top: 1px solid hsl(var(--border));
     padding-top: var(--space-3);
   }
   .panel__header {
@@ -683,7 +683,7 @@
     font-weight: var(--weight-semibold);
     text-transform: uppercase;
     letter-spacing: 0.06em;
-    color: var(--fg-muted);
+    color: hsl(var(--fg-muted));
     margin-bottom: var(--space-2);
   }
   .panel__action {
@@ -692,12 +692,12 @@
     justify-content: center;
     background: transparent;
     border: 1px solid transparent;
-    color: var(--fg-muted);
+    color: hsl(var(--fg-muted));
     padding: 4px;
     border-radius: 4px;
     cursor: pointer;
   }
-  .panel__action:hover { background: var(--bg-subtle); color: var(--fg); }
+  .panel__action:hover { background: hsl(var(--bg-subtle)); color: hsl(var(--fg)); }
   .tree__drag {
     flex: 1;
     display: inline-flex;
@@ -718,14 +718,14 @@
     justify-content: center;
     background: transparent;
     border: 0;
-    color: var(--fg-subtle);
+    color: hsl(var(--fg-subtle));
     cursor: pointer;
     padding: 2px 6px;
     border-radius: 3px;
     transition: opacity 120ms ease;
   }
   .tree__row--level:hover .tree__gear { opacity: 1; }
-  .tree__gear:hover { color: var(--fg); }
+  .tree__gear:hover { color: hsl(var(--fg)); }
   .tree {
     list-style: none;
     margin: 0;
@@ -737,7 +737,7 @@
        stay readable without consuming the whole sidebar width. */
     padding-left: var(--space-3);
     margin-left: var(--space-2);
-    border-left: 1px solid var(--border);
+    border-left: 1px solid hsl(var(--border));
   }
   .tree__row {
     display: flex;
@@ -747,26 +747,26 @@
     padding: 2px var(--space-1);
     background: transparent;
     border: 0;
-    color: var(--fg);
+    color: hsl(var(--fg));
     cursor: pointer;
     font: inherit;
     text-align: left;
     border-radius: var(--radius-sm);
   }
-  .tree__row:hover { background: var(--bg-subtle); }
+  .tree__row:hover { background: hsl(var(--bg-subtle)); }
   .tree__row--measure {
-    color: var(--accent);
+    color: hsl(var(--primary));
     cursor: grab;
   }
-  .tree__row--measure .tree__icon--measure { color: var(--accent); }
-  .tree__row--level { color: var(--fg-muted); }
+  .tree__row--measure .tree__icon--measure { color: hsl(var(--primary)); }
+  .tree__row--level { color: hsl(var(--fg-muted)); }
   .tree__row--level .tree__drag { cursor: grab; }
   .tree__twisty {
     display: inline-flex;
     align-items: center;
     justify-content: center;
     width: 14px;
-    color: var(--fg-subtle);
+    color: hsl(var(--fg-subtle));
   }
   .tree__twisty :global(svg) {
     transition: transform var(--duration-fast) ease;
@@ -779,7 +779,7 @@
     align-items: center;
     justify-content: center;
     width: 16px;
-    color: var(--fg-subtle);
+    color: hsl(var(--fg-subtle));
   }
   /* Dim-applicability hint for virtual cubes. When a measure from a fact
      table that doesn't join the dim is selected, the dim row (and its

--- a/saiku-ui/src/lib/views/EmailGateForm.svelte
+++ b/saiku-ui/src/lib/views/EmailGateForm.svelte
@@ -153,8 +153,8 @@
     padding: var(--space-6);
     max-width: 380px;
     width: 100%;
-    background: var(--bg-muted);
-    border: 1px solid var(--border);
+    background: hsl(var(--bg-muted));
+    border: 1px solid hsl(var(--border));
     border-radius: var(--radius-lg);
     box-shadow: var(--shadow-md);
   }
@@ -164,7 +164,7 @@
   }
   .gate__intro {
     margin: 0 0 var(--space-4);
-    color: var(--fg-muted);
+    color: hsl(var(--fg-muted));
     font-size: var(--fs-sm);
     line-height: var(--lh-normal);
   }
@@ -176,7 +176,7 @@
   .gate__sent {
     margin: 0 0 var(--space-3);
     font-size: var(--fs-sm);
-    color: var(--fg-muted);
+    color: hsl(var(--fg-muted));
   }
   .gate__code {
     letter-spacing: 0.4em;
@@ -186,7 +186,7 @@
   .gate__privacy {
     margin: var(--space-4) 0 0;
     font-size: var(--fs-xs);
-    color: var(--fg-muted);
+    color: hsl(var(--fg-muted));
     line-height: var(--lh-normal);
   }
 </style>

--- a/saiku-ui/src/lib/views/LoginForm.svelte
+++ b/saiku-ui/src/lib/views/LoginForm.svelte
@@ -126,7 +126,7 @@
         required
       />
     </label>
-    <Button class="w-full" type="submit" disabled={busy}>
+    <Button class="w-full" type="submit" data-testid="login-submit" disabled={busy}>
       {busy ? i18n.t("login.submitting") : i18n.t("login.submit")}
     </Button>
     {#if showDemoPanel}

--- a/saiku-ui/src/lib/views/LoginForm.svelte
+++ b/saiku-ui/src/lib/views/LoginForm.svelte
@@ -166,8 +166,8 @@
     padding: var(--space-6);
     max-width: 380px;
     width: 100%;
-    background: var(--bg-muted);
-    border: 1px solid var(--border);
+    background: hsl(var(--bg-muted));
+    border: 1px solid hsl(var(--border));
     border-radius: var(--radius-lg);
     box-shadow: var(--shadow-md);
   }
@@ -177,7 +177,7 @@
   }
   .login__tagline {
     margin: 0 0 var(--space-4);
-    color: var(--fg-muted);
+    color: hsl(var(--fg-muted));
     font-size: var(--fs-sm);
     line-height: var(--lh-normal);
   }
@@ -187,9 +187,9 @@
     align-items: flex-start;
     margin: 0 0 var(--space-3);
     padding: var(--space-3);
-    background: var(--success-soft);
-    color: var(--success-strong);
-    border-left: 3px solid var(--success);
+    background: hsl(var(--success-soft));
+    color: hsl(var(--success-strong));
+    border-left: 3px solid hsl(var(--success));
     border-radius: var(--radius-sm);
     font-size: var(--fs-sm);
     line-height: var(--lh-normal);

--- a/saiku-ui/src/lib/views/OssieQueryCanvas.svelte
+++ b/saiku-ui/src/lib/views/OssieQueryCanvas.svelte
@@ -1684,16 +1684,16 @@
     align-items: center;
     gap: 6px;
     padding: 6px 10px;
-    border-bottom: 1px solid var(--border);
-    background: var(--bg-muted);
+    border-bottom: 1px solid hsl(var(--border));
+    background: hsl(var(--bg-muted));
     flex-wrap: wrap;
   }
   .toolbar__dropdown {
     position: absolute;
     top: calc(100% + 6px);
     left: 0;
-    background: var(--bg);
-    border: 1px solid var(--border);
+    background: hsl(var(--bg));
+    border: 1px solid hsl(var(--border));
     border-radius: 6px;
     box-shadow: 0 12px 32px rgba(0, 0, 0, 0.35);
     padding: 4px;
@@ -1716,12 +1716,12 @@
     background: transparent;
     border: 0;
     border-radius: 4px;
-    color: var(--fg);
+    color: hsl(var(--fg));
     font: inherit;
     cursor: pointer;
   }
   .toolbar__item:hover {
-    background: var(--bg-hover);
+    background: hsl(var(--bg-hover));
   }
   .toolbar__item:disabled {
     opacity: 0.5;
@@ -1730,7 +1730,7 @@
   .toolbar__sep {
     width: 1px;
     height: 22px;
-    background: var(--border);
+    background: hsl(var(--border));
     margin: 0 4px;
   }
   .tb-btn {
@@ -1741,14 +1741,14 @@
     background: transparent;
     border: 1px solid transparent;
     border-radius: 5px;
-    color: var(--fg-muted);
+    color: hsl(var(--fg-muted));
     cursor: pointer;
     font: inherit;
     transition: background var(--duration-fast), color var(--duration-fast);
   }
   .tb-btn:hover {
-    background: var(--bg-hover);
-    color: var(--fg);
+    background: hsl(var(--bg-hover));
+    color: hsl(var(--fg));
   }
   .tb-btn:active {
     transform: translateY(1px);
@@ -1758,20 +1758,20 @@
     cursor: not-allowed;
   }
   .tb-btn--primary {
-    background: var(--accent);
-    color: var(--bg);
-    border-color: var(--accent);
+    background: hsl(var(--primary));
+    color: hsl(var(--bg));
+    border-color: hsl(var(--primary));
   }
   .tb-btn--primary:hover {
     filter: brightness(1.1);
-    background: var(--accent);
-    color: var(--bg);
+    background: hsl(var(--primary));
+    color: hsl(var(--bg));
   }
   .tb-btn--disabled-shape,
   .tb-btn--disabled-shape:hover {
-    background: var(--bg-muted);
-    color: var(--fg-muted);
-    border-color: var(--border);
+    background: hsl(var(--bg-muted));
+    color: hsl(var(--fg-muted));
+    border-color: hsl(var(--border));
     filter: none;
     cursor: not-allowed;
   }
@@ -1780,12 +1780,12 @@
     font-size: var(--fs-sm);
   }
   .ossie-canvas__runtime {
-    color: var(--fg-subtle);
+    color: hsl(var(--fg-subtle));
     font-size: var(--fs-xs);
     margin-left: auto;
   }
   .ossie-canvas__saved-name {
-    color: var(--fg-muted);
+    color: hsl(var(--fg-muted));
     font-size: var(--fs-xs);
     font-family: monospace;
   }
@@ -1794,21 +1794,21 @@
     align-items: center;
     gap: 6px;
     padding: 0 8px;
-    border: 1px solid var(--border);
+    border: 1px solid hsl(var(--border));
     border-radius: 5px;
     background: transparent;
     height: 32px;
   }
   .ossie-canvas__limit-label {
     font-size: var(--fs-xs);
-    color: var(--fg-muted);
+    color: hsl(var(--fg-muted));
     text-transform: uppercase;
     letter-spacing: 0.06em;
   }
   .ossie-canvas__limit-input {
     background: transparent;
     border: none;
-    color: var(--fg);
+    color: hsl(var(--fg));
     font-size: var(--fs-sm);
     width: 60px;
     padding: 0;
@@ -1834,17 +1834,17 @@
     text-align: left;
   }
   .ossie-result__sort-btn:hover {
-    color: var(--fg);
+    color: hsl(var(--fg));
   }
   .ossie-result__sort-btn--active {
-    color: var(--accent);
+    color: hsl(var(--primary));
   }
   .ossie-canvas__charttype {
     padding: 6px 8px;
     background: transparent;
-    border: 1px solid var(--border);
+    border: 1px solid hsl(var(--border));
     border-radius: 5px;
-    color: var(--fg);
+    color: hsl(var(--fg));
     font-size: var(--fs-sm);
     height: 32px;
   }
@@ -1852,8 +1852,8 @@
     position: fixed;
     z-index: 1000;
     min-width: 220px;
-    background: var(--bg);
-    border: 1px solid var(--border);
+    background: hsl(var(--bg));
+    border: 1px solid hsl(var(--border));
     border-radius: 6px;
     box-shadow: 0 12px 32px rgba(0, 0, 0, 0.35);
     padding: 4px;
@@ -1861,7 +1861,7 @@
   .ossie-ctx-menu__header {
     padding: 6px 12px;
     font-size: var(--fs-xs);
-    color: var(--fg-muted);
+    color: hsl(var(--fg-muted));
     font-weight: var(--weight-semibold);
     max-width: 260px;
     overflow: hidden;
@@ -1878,21 +1878,21 @@
     background: transparent;
     border: 0;
     border-radius: 4px;
-    color: var(--fg);
+    color: hsl(var(--fg));
     font: inherit;
     cursor: pointer;
   }
   .ossie-ctx-menu__item:hover {
-    background: var(--bg-hover);
+    background: hsl(var(--bg-hover));
   }
   .ossie-ctx-menu__item em {
     font-style: normal;
     font-weight: var(--weight-semibold);
-    color: var(--accent);
+    color: hsl(var(--primary));
   }
   .ossie-ctx-menu__sep {
     height: 1px;
-    background: var(--border);
+    background: hsl(var(--border));
     margin: 4px 0;
   }
   .ossie-ctx-menu__header--sub {
@@ -1902,23 +1902,23 @@
     padding-bottom: 2px;
   }
   .ossie-ctx-menu__item--active {
-    background: color-mix(in srgb, var(--accent) 12%, transparent);
-    color: var(--accent);
+    background: color-mix(in srgb, hsl(var(--primary)) 12%, transparent);
+    color: hsl(var(--primary));
   }
   .ossie-canvas__sql {
-    background: var(--bg-hover);
+    background: hsl(var(--bg-hover));
     padding: 12px;
     border-radius: 4px;
     font-family: monospace;
     font-size: var(--fs-sm);
-    color: var(--fg);
+    color: hsl(var(--fg));
     white-space: pre-wrap;
     max-height: 60vh;
     overflow: auto;
     margin: 0;
   }
   .ossie-chip__and {
-    color: var(--fg-subtle);
+    color: hsl(var(--fg-subtle));
     font-size: var(--fs-xs);
     padding: 0 2px;
   }
@@ -1929,16 +1929,16 @@
   }
   .ossie-chip__add-value {
     background: transparent;
-    border: 1px dashed var(--border);
-    color: var(--fg-subtle);
+    border: 1px dashed hsl(var(--border));
+    color: hsl(var(--fg-subtle));
     border-radius: 3px;
     padding: 1px 6px;
     font-size: var(--fs-xs);
     cursor: pointer;
   }
   .ossie-chip__add-value:hover {
-    color: var(--fg);
-    border-color: var(--border-strong);
+    color: hsl(var(--fg));
+    border-color: hsl(var(--border-strong));
   }
   .ossie-canvas__shelves {
     display: flex;
@@ -1953,8 +1953,8 @@
     gap: 6px;
     min-height: 42px;
     padding: 8px 12px;
-    background: var(--bg-subtle, var(--bg-hover));
-    border: 1px dashed var(--border-strong);
+    background: var(--bg-subtle, hsl(var(--bg-hover)));
+    border: 1px dashed hsl(var(--border-strong));
     border-radius: 4px;
     transition:
       background var(--duration-fast),
@@ -1965,16 +1965,16 @@
      and a 2px accent shadow ring so hovered shelves stand out at a glance. */
   .ossie-shelf--dragover {
     border-style: solid;
-    border-color: var(--accent);
-    background: color-mix(in srgb, var(--accent) 12%, var(--bg-subtle, var(--bg-hover)));
-    box-shadow: 0 0 0 2px color-mix(in srgb, var(--accent) 30%, transparent);
+    border-color: hsl(var(--primary));
+    background: color-mix(in srgb, hsl(var(--primary)) 12%, var(--bg-subtle, hsl(var(--bg-hover))));
+    box-shadow: 0 0 0 2px color-mix(in srgb, hsl(var(--primary)) 30%, transparent);
   }
   .ossie-shelf__label {
     font-size: var(--fs-xs);
     font-weight: var(--weight-semibold);
     text-transform: uppercase;
     letter-spacing: 0.06em;
-    color: var(--fg-muted);
+    color: hsl(var(--fg-muted));
     margin-right: 8px;
     min-width: 60px;
   }
@@ -1983,13 +1983,13 @@
     align-items: center;
     gap: 4px;
     padding: 4px 8px;
-    background: var(--bg);
-    border: 1px solid var(--border-strong);
+    background: hsl(var(--bg));
+    border: 1px solid hsl(var(--border-strong));
     border-radius: 4px;
     font-size: var(--fs-sm);
   }
   .ossie-chip--metric {
-    background: var(--bg-accent-subtle, var(--bg-hover));
+    background: var(--bg-accent-subtle, hsl(var(--bg-hover)));
   }
   .ossie-chip--filter {
     gap: 6px;
@@ -2000,14 +2000,14 @@
   }
   .ossie-chip__op {
     background: transparent;
-    border: 1px solid var(--border);
+    border: 1px solid hsl(var(--border));
     border-radius: 3px;
     padding: 1px 4px;
     font-size: var(--fs-xs);
   }
   .ossie-chip__value {
     background: transparent;
-    border: 1px solid var(--border);
+    border: 1px solid hsl(var(--border));
     border-radius: 3px;
     padding: 2px 6px;
     font-size: var(--fs-xs);
@@ -2019,19 +2019,19 @@
     justify-content: center;
     background: transparent;
     border: none;
-    color: var(--fg-subtle);
+    color: hsl(var(--fg-subtle));
     cursor: pointer;
     padding: 0;
     margin-left: 2px;
   }
   .ossie-chip__x:hover {
-    color: var(--fg);
+    color: hsl(var(--fg));
   }
   .ossie-canvas__result {
     flex: 1;
     min-height: 0;
     overflow: auto;
-    border: 1px solid var(--border);
+    border: 1px solid hsl(var(--border));
     border-radius: 4px;
     padding: var(--space-2);
     margin: var(--space-3);
@@ -2045,11 +2045,11 @@
   .ossie-result th,
   .ossie-result td {
     padding: 6px 10px;
-    border-bottom: 1px solid var(--border);
+    border-bottom: 1px solid hsl(var(--border));
     text-align: left;
   }
   .ossie-result th {
-    background: var(--bg-hover);
+    background: hsl(var(--bg-hover));
     font-weight: var(--weight-semibold);
     position: sticky;
     top: 0;
@@ -2066,7 +2066,7 @@
   }
   .ossie-canvas__hint,
   .ossie-canvas__empty {
-    color: var(--fg-subtle);
+    color: hsl(var(--fg-subtle));
     font-size: var(--fs-sm);
   }
 </style>

--- a/saiku-ui/src/lib/views/OssieSchemaTree.svelte
+++ b/saiku-ui/src/lib/views/OssieSchemaTree.svelte
@@ -173,7 +173,7 @@
     font-weight: var(--weight-semibold);
     text-transform: uppercase;
     letter-spacing: 0.06em;
-    color: var(--fg-muted);
+    color: hsl(var(--fg-muted));
     padding-bottom: var(--space-1);
   }
   .ossie-tree__info {
@@ -183,25 +183,25 @@
     padding: 0;
     border: 0;
     background: transparent;
-    color: var(--fg-subtle);
+    color: hsl(var(--fg-subtle));
     cursor: help;
     line-height: 0;
   }
   .ossie-tree__info:hover,
   .ossie-tree__info:focus-visible {
-    color: var(--fg);
+    color: hsl(var(--fg));
   }
   .ossie-tree__select {
     padding: 6px 8px;
-    background: var(--bg);
-    color: var(--fg);
-    border: 1px solid var(--border-strong);
+    background: hsl(var(--bg));
+    color: hsl(var(--fg));
+    border: 1px solid hsl(var(--border-strong));
     border-radius: 4px;
     font-size: var(--fs-sm);
   }
   .ossie-tree__hint {
     font-size: var(--fs-xs);
-    color: var(--fg-subtle);
+    color: hsl(var(--fg-subtle));
     margin: 0;
   }
   .ossie-tree__list {
@@ -213,7 +213,7 @@
     gap: 2px;
   }
   .ossie-tree__list--dim {
-    color: var(--fg-subtle);
+    color: hsl(var(--fg-subtle));
   }
   .ossie-tree__group {
     display: flex;
@@ -232,7 +232,7 @@
   }
   .ossie-tree__group-count {
     font-size: var(--fs-xs);
-    color: var(--fg-subtle);
+    color: hsl(var(--fg-subtle));
   }
   .ossie-tree__children {
     list-style: none;
@@ -255,7 +255,7 @@
   }
   .ossie-tree__field:hover,
   .ossie-tree__metric:hover {
-    background: var(--bg-hover);
+    background: hsl(var(--bg-hover));
   }
   .ossie-tree__field:active,
   .ossie-tree__metric:active {
@@ -266,8 +266,8 @@
     font-size: 10px;
     padding: 1px 6px;
     border-radius: 10px;
-    background: var(--bg-accent-subtle, var(--bg-hover));
-    color: var(--fg-muted);
+    background: var(--bg-accent-subtle, hsl(var(--bg-hover)));
+    color: hsl(var(--fg-muted));
     text-transform: uppercase;
     letter-spacing: 0.04em;
   }
@@ -278,11 +278,11 @@
     padding: 3px 6px;
   }
   .ossie-tree__arrow {
-    color: var(--fg-subtle);
+    color: hsl(var(--fg-subtle));
   }
   .ossie-tree__empty {
     font-size: var(--fs-xs);
-    color: var(--fg-subtle);
+    color: hsl(var(--fg-subtle));
     padding-left: 22px;
   }
 </style>

--- a/saiku-ui/src/lib/views/QueryCanvas.svelte
+++ b/saiku-ui/src/lib/views/QueryCanvas.svelte
@@ -1563,10 +1563,10 @@
     gap: 6px;
     padding: 2px 8px 2px 2px;
     background: transparent;
-    border: 1px solid var(--border);
+    border: 1px solid hsl(var(--border));
     border-radius: 999px;
     font-size: 0.75rem;
-    color: var(--fg-muted);
+    color: hsl(var(--fg-muted));
     align-self: flex-start;
     max-width: 100%;
     white-space: nowrap;
@@ -1574,7 +1574,7 @@
     text-overflow: ellipsis;
   }
   .canvas__mdx-badge {
-    background: var(--accent);
+    background: hsl(var(--primary));
     color: white;
     border-radius: 999px;
     padding: 1px 7px;
@@ -1589,16 +1589,16 @@
     justify-content: center;
     gap: var(--space-2);
     min-height: 360px;
-    color: var(--fg-muted);
-    border: 1px dashed var(--border-strong);
+    color: hsl(var(--fg-muted));
+    border: 1px dashed hsl(var(--border-strong));
     border-radius: var(--radius-md);
   }
   .dropzone {
-    border: 1px dashed var(--border-strong);
+    border: 1px dashed hsl(var(--border-strong));
     border-radius: var(--radius-md);
     padding: var(--space-2) var(--space-3);
     min-height: 54px;
-    background: var(--bg-muted);
+    background: hsl(var(--bg-muted));
     /* The aside above is `display: flex; flex-direction: column` with
        `overflow-y-auto`, which makes each dropzone a flex item. Flex
        items default to `flex: 0 1 auto`, so they can shrink when the
@@ -1615,9 +1615,9 @@
   }
   .dropzone.is-dragover {
     border-style: solid;
-    border-color: var(--accent);
-    background: color-mix(in srgb, var(--accent) 12%, var(--bg-muted));
-    box-shadow: 0 0 0 2px color-mix(in srgb, var(--accent) 30%, transparent);
+    border-color: hsl(var(--primary));
+    background: color-mix(in srgb, hsl(var(--primary)) 12%, hsl(var(--bg-muted)));
+    box-shadow: 0 0 0 2px color-mix(in srgb, hsl(var(--primary)) 30%, transparent);
   }
   /* Keep pointer events enabled on chips so chip-to-chip reorder drops still fire. */
   .dropzone header {
@@ -1628,13 +1628,13 @@
     font-weight: var(--weight-semibold);
     text-transform: uppercase;
     letter-spacing: 0.06em;
-    color: var(--fg-muted);
+    color: hsl(var(--fg-muted));
     margin-bottom: var(--space-1);
   }
   .dropzone__menu {
     background: transparent;
     border: 0;
-    color: var(--fg-subtle);
+    color: hsl(var(--fg-subtle));
     cursor: pointer;
     padding: 2px 4px;
     border-radius: 3px;
@@ -1644,7 +1644,7 @@
     transition: opacity 120ms ease;
   }
   .dropzone:hover .dropzone__menu { opacity: 1; }
-  .dropzone__menu:hover { background: var(--bg-subtle); color: var(--fg); }
+  .dropzone__menu:hover { background: hsl(var(--bg-subtle)); color: hsl(var(--fg)); }
   .chips {
     display: flex;
     flex-wrap: wrap;
@@ -1655,7 +1655,7 @@
     align-items: center;
     justify-content: center;
     min-height: 32px;
-    color: var(--fg-subtle);
+    color: hsl(var(--fg-subtle));
     font-size: var(--fs-sm);
     font-style: italic;
   }
@@ -1664,21 +1664,21 @@
     align-items: center;
     gap: var(--space-1);
     padding: 0;
-    background: var(--bg);
-    color: var(--fg);
-    border: 1px solid var(--border-strong);
+    background: hsl(var(--bg));
+    color: hsl(var(--fg));
+    border: 1px solid hsl(var(--border-strong));
     border-radius: var(--radius-sm);
     font-size: var(--fs-xs);
     overflow: hidden;
   }
-  .chip:hover { background: var(--bg-subtle); }
+  .chip:hover { background: hsl(var(--bg-subtle)); }
   .chip.is-drop-before {
-    box-shadow: inset 0 3px 0 0 var(--accent), 0 0 0 1px var(--accent);
-    border-color: var(--accent);
+    box-shadow: inset 0 3px 0 0 hsl(var(--primary)), 0 0 0 1px hsl(var(--primary));
+    border-color: hsl(var(--primary));
   }
   .chip.is-drop-after {
-    box-shadow: inset 0 -3px 0 0 var(--accent), 0 0 0 1px var(--accent);
-    border-color: var(--accent);
+    box-shadow: inset 0 -3px 0 0 hsl(var(--primary)), 0 0 0 1px hsl(var(--primary));
+    border-color: hsl(var(--primary));
   }
   /* chip-group — vertical stack used for hierarchy chips on ROWS /
      COLUMNS / PAGES. Always-visible × per level, predictable width
@@ -1694,20 +1694,20 @@
        against the dropzone's content width in the same situation. */
     min-width: min(140px, 100%);
     max-width: 100%;
-    background: var(--bg-muted);
-    border: 1px solid var(--border);
+    background: hsl(var(--bg-muted));
+    border: 1px solid hsl(var(--border));
     border-radius: var(--radius-md);
     overflow: hidden;
     cursor: grab;
   }
   .chip-group:active { cursor: grabbing; }
   .chip-group.is-drop-before {
-    box-shadow: 0 -2px 0 0 var(--accent), 0 0 0 1px var(--accent);
-    border-color: var(--accent);
+    box-shadow: 0 -2px 0 0 hsl(var(--primary)), 0 0 0 1px hsl(var(--primary));
+    border-color: hsl(var(--primary));
   }
   .chip-group.is-drop-after {
-    box-shadow: 0 2px 0 0 var(--accent), 0 0 0 1px var(--accent);
-    border-color: var(--accent);
+    box-shadow: 0 2px 0 0 hsl(var(--primary)), 0 0 0 1px hsl(var(--primary));
+    border-color: hsl(var(--primary));
   }
   .chip-group__head {
     display: flex;
@@ -1715,11 +1715,11 @@
     justify-content: space-between;
     gap: var(--space-2);
     padding: 4px 4px 4px var(--space-2);
-    background: var(--bg-subtle);
+    background: hsl(var(--bg-subtle));
     font-size: var(--fs-xs);
     font-weight: var(--weight-semibold);
-    color: var(--fg);
-    border-bottom: 1px solid var(--border);
+    color: hsl(var(--fg));
+    border-bottom: 1px solid hsl(var(--border));
   }
   .chip-group__title {
     background: transparent;
@@ -1738,7 +1738,7 @@
   .chip-group__x,
   .chip-group__level-x {
     background: transparent;
-    color: var(--fg-subtle);
+    color: hsl(var(--fg-subtle));
     border: 0;
     padding: 0 6px;
     font-size: 14px;
@@ -1749,8 +1749,8 @@
   }
   .chip-group__x:hover,
   .chip-group__level-x:hover {
-    color: var(--danger);
-    background: var(--bg-hover);
+    color: hsl(var(--danger));
+    background: hsl(var(--bg-hover));
   }
   .chip-group__levels {
     list-style: none;
@@ -1764,10 +1764,10 @@
     gap: var(--space-2);
     padding: 4px var(--space-2);
     font-size: var(--fs-xs);
-    color: var(--fg-muted);
+    color: hsl(var(--fg-muted));
   }
   .chip-group__level + .chip-group__level {
-    border-top: 1px dashed var(--border);
+    border-top: 1px dashed hsl(var(--border));
   }
   .chip-group__level-name {
     overflow: hidden;
@@ -1785,15 +1785,15 @@
   }
   .chip__x {
     background: transparent;
-    color: var(--fg-subtle);
+    color: hsl(var(--fg-subtle));
     border: 0;
-    border-left: 1px solid var(--border);
+    border-left: 1px solid hsl(var(--border));
     padding: 0 var(--space-1);
     font-size: 14px;
     line-height: 1;
     cursor: pointer;
   }
-  .chip__x:hover { color: var(--danger); background: var(--bg-muted); }
+  .chip__x:hover { color: hsl(var(--danger)); background: hsl(var(--bg-muted)); }
   .result-host { flex: 1; min-height: 0; display: flex; flex-direction: column; overflow: hidden; }
   .result-host :global(.runtime) { flex: 0 0 auto; }
   .view-toggle {
@@ -1808,16 +1808,16 @@
   .view-toggle button {
     padding: var(--space-1) var(--space-3);
     background: transparent;
-    border: 1px solid var(--border-strong);
-    color: var(--fg-muted);
+    border: 1px solid hsl(var(--border-strong));
+    color: hsl(var(--fg-muted));
     border-radius: var(--radius-sm);
     cursor: pointer;
     font: inherit;
   }
   .view-toggle button.active {
-    background: var(--accent);
-    color: var(--accent-fg);
-    border-color: var(--accent);
+    background: hsl(var(--primary));
+    color: hsl(var(--primary-foreground));
+    border-color: hsl(var(--primary));
   }
   .view-more { position: relative; display: inline-flex; }
   .view-more > button {
@@ -1830,8 +1830,8 @@
     top: calc(100% + 4px);
     left: 0;
     min-width: 140px;
-    background: var(--bg);
-    border: 1px solid var(--border-strong);
+    background: hsl(var(--bg));
+    border: 1px solid hsl(var(--border-strong));
     border-radius: var(--radius-sm);
     box-shadow: 0 4px 12px rgba(0, 0, 0, 0.25);
     padding: var(--space-1) 0;
@@ -1844,17 +1844,17 @@
     padding: var(--space-1) var(--space-3);
     background: transparent;
     border: none;
-    color: var(--fg);
+    color: hsl(var(--fg));
     cursor: pointer;
     font: inherit;
   }
-  .view-more__menu button:hover { background: var(--bg-subtle); }
-  .view-more__menu button.active { background: var(--accent); color: var(--accent-fg); }
+  .view-more__menu button:hover { background: hsl(var(--bg-subtle)); }
+  .view-more__menu button.active { background: hsl(var(--primary)); color: hsl(var(--primary-foreground)); }
   .chart-pick select {
     padding: var(--space-1) var(--space-2);
-    background: var(--bg);
-    color: var(--fg);
-    border: 1px solid var(--border-strong);
+    background: hsl(var(--bg));
+    color: hsl(var(--fg));
+    border: 1px solid hsl(var(--border-strong));
     border-radius: var(--radius-sm);
   }
   .run-progress {
@@ -1862,10 +1862,10 @@
     align-items: center;
     gap: var(--space-2);
     padding: var(--space-1) var(--space-2);
-    border: 1px solid var(--border);
+    border: 1px solid hsl(var(--border));
     border-radius: var(--radius-sm);
-    background: var(--bg-muted);
-    color: var(--fg-muted);
+    background: hsl(var(--bg-muted));
+    color: hsl(var(--fg-muted));
     font-size: var(--fs-sm);
   }
   .run-progress :global(.spin) {
@@ -1878,13 +1878,13 @@
     gap: 4px;
     padding: 2px 8px;
     background: transparent;
-    border: 1px solid var(--border-strong);
+    border: 1px solid hsl(var(--border-strong));
     border-radius: var(--radius-sm);
-    color: var(--fg);
+    color: hsl(var(--fg));
     cursor: pointer;
     font: inherit;
   }
-  .run-progress button:hover { background: var(--bg-subtle); }
+  .run-progress button:hover { background: hsl(var(--bg-subtle)); }
   @keyframes spin {
     from { transform: rotate(0deg); }
     to { transform: rotate(360deg); }

--- a/saiku-ui/src/lib/views/StatsView.svelte
+++ b/saiku-ui/src/lib/views/StatsView.svelte
@@ -79,8 +79,8 @@
 
 <style>
 .stats { border-collapse: separate; border-spacing: 0; width: 100%; font-size: var(--fs-sm); }
-  .stats th, .stats td { padding: 6px 12px; border-bottom: 1px solid var(--border); text-align: left; white-space: nowrap; }
-  .stats thead th { position: sticky; top: 0; background: var(--bg-muted); color: var(--fg); font-weight: var(--weight-semibold); }
-  .stats tbody th { background: var(--bg-muted); font-weight: var(--weight-medium); color: var(--fg); }
+  .stats th, .stats td { padding: 6px 12px; border-bottom: 1px solid hsl(var(--border)); text-align: left; white-space: nowrap; }
+  .stats thead th { position: sticky; top: 0; background: hsl(var(--bg-muted)); color: hsl(var(--fg)); font-weight: var(--weight-semibold); }
+  .stats tbody th { background: hsl(var(--bg-muted)); font-weight: var(--weight-medium); color: hsl(var(--fg)); }
   .stats td.n { text-align: right; font-variant-numeric: tabular-nums; }
 </style>

--- a/saiku-ui/src/lib/views/Workspace.svelte
+++ b/saiku-ui/src/lib/views/Workspace.svelte
@@ -483,7 +483,7 @@
               oncontextmenu={(e) => openTabMenu(i, e)}
             >
               <span class="tab__label">{tabLabelFor(i)}</span>
-              {#if tabDirtyFor(i)}<span class="text-accent" aria-label="unsaved changes">•</span>{/if}
+              {#if tabDirtyFor(i)}<span class="text-primary" aria-label="unsaved changes">•</span>{/if}
               {#if tabs.list.length > 1}
                 <span
                   class="tab__close"
@@ -592,7 +592,7 @@
        (#1176). */
     grid-template-columns: 300px minmax(0, 1fr);
     gap: 1px;
-    background: var(--border);
+    background: hsl(var(--border));
     overflow: hidden;
   }
   .workspace--embed {
@@ -601,7 +601,7 @@
   }
   .workspace__sidebar,
   .workspace__main {
-    background: var(--bg);
+    background: hsl(var(--bg));
     min-height: 0;
     min-width: 0;
     overflow: hidden;
@@ -612,8 +612,8 @@
   }
   .workspace__sidebar-footer {
     padding: var(--space-3) var(--space-4);
-    border-top: 1px solid var(--border-strong);
-    background: var(--bg-subtle);
+    border-top: 1px solid hsl(var(--border-strong));
+    background: hsl(var(--bg-subtle));
     display: flex;
     align-items: center;
     gap: var(--space-2);
@@ -626,8 +626,8 @@
     display: flex;
     align-items: stretch;
     padding: 0 var(--space-2);
-    border-bottom: 1px solid var(--border);
-    background: var(--bg-muted);
+    border-bottom: 1px solid hsl(var(--border));
+    background: hsl(var(--bg-muted));
     /* .workspace__main has overflow:hidden; without horizontal scroll
        here a third (or further) tab gets clipped past the right edge
        and the "+" button becomes unreachable, which presents to the
@@ -643,7 +643,7 @@
     align-items: center;
     gap: var(--space-2);
     padding: var(--space-2) var(--space-3);
-    color: var(--fg-muted);
+    color: hsl(var(--fg-muted));
     border-bottom: 2px solid transparent;
     background: transparent;
     border-top: 0;
@@ -656,12 +656,12 @@
     flex-shrink: 0;
   }
   .tab:hover:not(.tab--active) {
-    color: var(--fg);
-    background: color-mix(in srgb, var(--bg) 60%, transparent);
+    color: hsl(var(--fg));
+    background: color-mix(in srgb, hsl(var(--bg)) 60%, transparent);
   }
   .tab--active {
-    color: var(--fg);
-    border-bottom-color: var(--accent);
+    color: hsl(var(--fg));
+    border-bottom-color: hsl(var(--primary));
   }
   .tab__label {
     white-space: nowrap;
@@ -678,16 +678,16 @@
     width: 10rem;
     max-width: 12rem;
     padding: 2px 4px;
-    background: var(--bg);
-    border: 1px solid var(--border-strong);
+    background: hsl(var(--bg));
+    border: 1px solid hsl(var(--border-strong));
     border-radius: var(--radius-sm);
-    color: var(--fg);
+    color: hsl(var(--fg));
     font: inherit;
     font-size: var(--fs-sm);
     outline: none;
   }
   .tab__rename-input:focus {
-    border-color: var(--accent);
+    border-color: hsl(var(--primary));
   }
   .tab__close {
     display: inline-flex;
@@ -696,13 +696,13 @@
     width: 1.25rem;
     height: 1.25rem;
     border-radius: 50%;
-    color: var(--fg-muted);
+    color: hsl(var(--fg-muted));
     font-size: 1rem;
     line-height: 1;
     user-select: none;
   }
   .tab__close:hover {
-    background: color-mix(in srgb, var(--danger) 18%, transparent);
-    color: var(--danger);
+    background: color-mix(in srgb, hsl(var(--danger)) 18%, transparent);
+    color: hsl(var(--danger));
   }
 </style>

--- a/saiku-ui/src/lib/views/WorkspaceToolbar.svelte
+++ b/saiku-ui/src/lib/views/WorkspaceToolbar.svelte
@@ -638,16 +638,16 @@
     align-items: center;
     gap: 6px;
     padding: 6px 10px;
-    border-bottom: 1px solid var(--border);
-    background: var(--bg-muted);
+    border-bottom: 1px solid hsl(var(--border));
+    background: hsl(var(--bg-muted));
     flex-wrap: wrap;
   }
   .toolbar__dropdown {
     position: absolute;
     top: calc(100% + 6px);
     left: 0;
-    background: var(--bg);
-    border: 1px solid var(--border);
+    background: hsl(var(--bg));
+    border: 1px solid hsl(var(--border));
     border-radius: 6px;
     box-shadow: 0 12px 32px rgba(0,0,0,0.35);
     padding: 4px;
@@ -664,15 +664,15 @@
     background: transparent;
     border: 0;
     border-radius: 4px;
-    color: var(--fg);
+    color: hsl(var(--fg));
     font: inherit;
     cursor: pointer;
   }
-  .toolbar__item:hover { background: var(--bg-hover); }
+  .toolbar__item:hover { background: hsl(var(--bg-hover)); }
   .toolbar__sep {
     width: 1px;
     height: 22px;
-    background: var(--border);
+    background: hsl(var(--border));
     margin: 0 4px;
   }
   .tb-btn {
@@ -683,26 +683,26 @@
     background: transparent;
     border: 1px solid transparent;
     border-radius: 5px;
-    color: var(--fg-muted);
+    color: hsl(var(--fg-muted));
     cursor: pointer;
     font: inherit;
   }
   .tb-btn { transition: background var(--duration-fast), color var(--duration-fast); }
-  .tb-btn:hover { background: var(--bg-hover); color: var(--fg); }
+  .tb-btn:hover { background: hsl(var(--bg-hover)); color: hsl(var(--fg)); }
   .tb-btn:active { transform: translateY(1px); }
   .tb-btn--primary {
-    background: var(--accent);
-    color: var(--bg);
-    border-color: var(--accent);
+    background: hsl(var(--primary));
+    color: hsl(var(--bg));
+    border-color: hsl(var(--primary));
   }
-  .tb-btn--primary:hover { filter: brightness(1.1); background: var(--accent); color: var(--bg); }
+  .tb-btn--primary:hover { filter: brightness(1.1); background: hsl(var(--primary)); color: hsl(var(--bg)); }
   .tb-btn--ai {
-    background: linear-gradient(135deg, var(--accent) 0%, color-mix(in srgb, var(--accent) 60%, #8b5cf6) 100%);
-    color: var(--bg);
-    border-color: var(--accent);
+    background: linear-gradient(135deg, hsl(var(--primary)) 0%, color-mix(in srgb, hsl(var(--primary)) 60%, #8b5cf6) 100%);
+    color: hsl(var(--bg));
+    border-color: hsl(var(--primary));
   }
   .tb-btn--ai:hover {
-    color: var(--accent);
+    color: hsl(var(--primary));
   }
   /*
    * saiku-cloud#612 — visual cue that the query shape isn't runnable yet
@@ -712,9 +712,9 @@
    */
   .tb-btn--disabled-shape,
   .tb-btn--disabled-shape:hover {
-    background: var(--bg-muted);
-    color: var(--fg-muted);
-    border-color: var(--border);
+    background: hsl(var(--bg-muted));
+    color: hsl(var(--fg-muted));
+    border-color: hsl(var(--border));
     filter: none;
     cursor: not-allowed;
   }
@@ -724,9 +724,9 @@
     right: 4px;
     width: 7px;
     height: 7px;
-    background: var(--accent);
+    background: hsl(var(--primary));
     border-radius: 50%;
-    box-shadow: 0 0 0 2px var(--bg-muted);
+    box-shadow: 0 0 0 2px hsl(var(--bg-muted));
   }
   .split-btn {
     display: inline-flex;
@@ -750,9 +750,9 @@
     gap: 10px;
     padding: 6px 12px;
     cursor: pointer;
-    color: var(--fg);
+    color: hsl(var(--fg));
     font: inherit;
     border-radius: 4px;
   }
-  .toolbar__check:hover { background: var(--bg-subtle); }
+  .toolbar__check:hover { background: hsl(var(--bg-subtle)); }
 </style>

--- a/saiku-ui/src/lib/views/admin/AgentSpacesAdmin.svelte
+++ b/saiku-ui/src/lib/views/admin/AgentSpacesAdmin.svelte
@@ -203,28 +203,28 @@
 <style>
   .pane { display: flex; flex-direction: column; gap: var(--space-4); }
   h2 { margin: 0; }
-  code { font-family: var(--font-mono, monospace); font-size: var(--fs-xs); background: var(--bg-subtle); padding: 1px 5px; border-radius: 4px; }
+  code { font-family: var(--font-mono, monospace); font-size: var(--fs-xs); background: hsl(var(--bg-subtle)); padding: 1px 5px; border-radius: 4px; }
 
   .layout { display: grid; grid-template-columns: 240px 1fr; gap: var(--space-4); align-items: start; }
-  .list { display: flex; flex-direction: column; gap: 2px; border: 1px solid var(--border); border-radius: var(--radius); padding: var(--space-2); background: var(--bg-muted); }
-  .row { display: flex; flex-direction: column; align-items: flex-start; gap: 1px; text-align: left; border: 0; background: transparent; color: var(--fg-muted); cursor: pointer; padding: var(--space-2) var(--space-3); border-radius: var(--radius); font: inherit; }
-  .row:hover { color: var(--fg); background: var(--bg-hover); }
-  .row.active { color: var(--fg); background: var(--bg-hover); box-shadow: inset 2px 0 0 var(--accent); }
+  .list { display: flex; flex-direction: column; gap: 2px; border: 1px solid hsl(var(--border)); border-radius: var(--radius); padding: var(--space-2); background: hsl(var(--bg-muted)); }
+  .row { display: flex; flex-direction: column; align-items: flex-start; gap: 1px; text-align: left; border: 0; background: transparent; color: hsl(var(--fg-muted)); cursor: pointer; padding: var(--space-2) var(--space-3); border-radius: var(--radius); font: inherit; }
+  .row:hover { color: hsl(var(--fg)); background: hsl(var(--bg-hover)); }
+  .row.active { color: hsl(var(--fg)); background: hsl(var(--bg-hover)); box-shadow: inset 2px 0 0 hsl(var(--primary)); }
   .row .nm { font-weight: var(--weight-medium); }
-  .row .meta { font-size: var(--fs-xs); color: var(--fg-subtle); }
+  .row .meta { font-size: var(--fs-xs); color: hsl(var(--fg-subtle)); }
 
   .editor { display: flex; flex-direction: column; gap: var(--space-3); min-width: 0; }
-  .editor.empty { border: 1px dashed var(--border); border-radius: var(--radius); padding: var(--space-6); text-align: center; }
+  .editor.empty { border: 1px dashed hsl(var(--border)); border-radius: var(--radius); padding: var(--space-6); text-align: center; }
   .grid2 { display: grid; grid-template-columns: 1fr 1fr; gap: var(--space-3); }
   .field { display: flex; flex-direction: column; gap: 4px; }
   .field > span { font-size: var(--fs-sm); font-weight: var(--weight-medium); }
-  .field small { font-weight: 400; color: var(--fg-muted); }
-  input, textarea { font: inherit; font-size: var(--fs-sm); padding: 7px 10px; border: 1px solid var(--border); border-radius: var(--radius); background: var(--bg); color: var(--fg); width: 100%; }
+  .field small { font-weight: 400; color: hsl(var(--fg-muted)); }
+  input, textarea { font: inherit; font-size: var(--fs-sm); padding: 7px 10px; border: 1px solid hsl(var(--border)); border-radius: var(--radius); background: hsl(var(--bg)); color: hsl(var(--fg)); width: 100%; }
   textarea { resize: vertical; }
-  input:disabled { color: var(--fg-muted); background: var(--bg-muted); }
-  input.invalid { border-color: var(--danger); }
+  input:disabled { color: hsl(var(--fg-muted)); background: hsl(var(--bg-muted)); }
+  input.invalid { border-color: hsl(var(--danger)); }
 
-  .cubes { display: grid; grid-template-columns: repeat(auto-fill, minmax(220px, 1fr)); gap: 4px; border: 1px solid var(--border); border-radius: var(--radius); padding: var(--space-3); max-height: 200px; overflow: auto; background: var(--bg-muted); }
+  .cubes { display: grid; grid-template-columns: repeat(auto-fill, minmax(220px, 1fr)); gap: 4px; border: 1px solid hsl(var(--border)); border-radius: var(--radius); padding: var(--space-3); max-height: 200px; overflow: auto; background: hsl(var(--bg-muted)); }
   .cube { display: flex; align-items: center; gap: 8px; font-size: var(--fs-sm); cursor: pointer; }
 
   .actions { display: flex; gap: var(--space-2); margin-top: var(--space-2); }

--- a/saiku-ui/src/lib/views/admin/ApiAccessAdmin.svelte
+++ b/saiku-ui/src/lib/views/admin/ApiAccessAdmin.svelte
@@ -173,8 +173,8 @@
   }
   .small { font-size: 0.85rem; }
   .card {
-    background: var(--bg);
-    border: 1px solid var(--border);
+    background: hsl(var(--bg));
+    border: 1px solid hsl(var(--border));
     border-radius: var(--radius-md, 0.5rem);
     padding: var(--space-4);
   }
@@ -189,7 +189,7 @@
     display: inline-block;
     margin-right: var(--space-2);
     transition: transform 120ms ease;
-    color: var(--fg-muted);
+    color: hsl(var(--fg-muted));
   }
   .card[open] > summary::before { transform: rotate(90deg); }
   /* The summary owns the click target; the heading itself stays inline
@@ -221,9 +221,9 @@
     align-items: baseline;
     gap: var(--space-2);
   }
-  .kv__key { color: var(--fg-muted); font-size: 0.85rem; }
+  .kv__key { color: hsl(var(--fg-muted)); font-size: 0.85rem; }
   .kv__val {
-    background: var(--bg-muted);
+    background: hsl(var(--bg-muted));
     padding: 0.1rem 0.4rem;
     border-radius: 0.25rem;
     font-size: 0.85rem;
@@ -232,7 +232,7 @@
   .recipe { margin: var(--space-3) 0; }
   .recipe summary { cursor: pointer; user-select: none; }
   .recipe pre {
-    background: var(--bg-muted);
+    background: hsl(var(--bg-muted));
     padding: var(--space-3);
     border-radius: var(--radius-sm, 0.25rem);
     overflow: auto;
@@ -242,8 +242,8 @@
     margin-left: var(--space-2);
     font-size: 0.75rem;
     padding: 0.15rem 0.5rem;
-    background: var(--bg-muted);
-    border: 1px solid var(--border);
+    background: hsl(var(--bg-muted));
+    border: 1px solid hsl(var(--border));
     border-radius: 0.25rem;
     cursor: pointer;
   }
@@ -253,7 +253,7 @@
     gap: var(--space-2);
     margin: var(--space-3) 0;
     padding: var(--space-3);
-    background: var(--accent-soft);
+    background: hsl(var(--accent));
     border-radius: var(--radius-sm);
   }
   .install-row .btn {

--- a/saiku-ui/src/lib/views/admin/DatasourcesAdmin.svelte
+++ b/saiku-ui/src/lib/views/admin/DatasourcesAdmin.svelte
@@ -5,6 +5,7 @@
   import { adminDatasources, type AdminDatasource } from "$lib/api/admin";
   import { toasts } from "$lib/stores/toasts.svelte";
   import { i18n } from "$lib/stores/i18n.svelte";
+  import { platform } from "$lib/stores/platform.svelte";
   import ConfirmModal from "$lib/modals/ConfirmModal.svelte";
   import Modal from "$lib/components/Modal.svelte";
   import Skeleton from "$lib/components/Skeleton.svelte";
@@ -15,6 +16,12 @@
   let error = $state<string | null>(null);
   let editing = $state<AdminDatasource | null>(null);
   let deleting = $state<AdminDatasource | null>(null);
+
+  // saiku#1636: on a public demo (SAIKU_DEMO), visitors must not be able to
+  // create / edit / delete datasources — a broken connection string takes down
+  // the shared instance for everyone. Hide every mutating control; the
+  // cube-designer link + Refresh (read-only re-introspect) stay available.
+  const demoMode = $derived(platform.capabilities?.demoMode === true);
 
   async function refresh() {
     loading = true;
@@ -28,7 +35,10 @@
     }
   }
 
-  onMount(refresh);
+  onMount(async () => {
+    if (!platform.capabilities) await platform.loadCapabilities();
+    await refresh();
+  });
 
   function startNew() {
     editing = {
@@ -89,7 +99,7 @@
   }
 
   async function save() {
-    if (!editing) return;
+    if (!editing || demoMode) return; // mutations disabled in demo mode
     try {
       if (!editing.id) await adminDatasources.create(editing);
       else await adminDatasources.update(editing);
@@ -102,7 +112,7 @@
   }
 
   async function doDelete() {
-    if (!deleting) return;
+    if (!deleting || demoMode) return; // mutations disabled in demo mode
     try {
       await adminDatasources.remove(deleting.id);
       toasts.success("Deleted", deleting.name);
@@ -127,7 +137,11 @@
 <div class="pane">
   <header class="flex justify-between items-center mb-3">
     <h2>{i18n.t("admin.tabs.datasources")}</h2>
-    <Button onclick={startNew}>{i18n.t("admin.addDatasource")}</Button>
+    {#if demoMode}
+      <span class="text-xs text-fg-muted">Read-only in demo mode</span>
+    {:else}
+      <Button onclick={startNew}>{i18n.t("admin.addDatasource")}</Button>
+    {/if}
   </header>
   {#if error}<p class="callout callout--danger">{error}</p>{/if}
   {#if loading}
@@ -151,8 +165,10 @@
                 {generateSchemaLabel(ds)}
               </a>
               <Button variant="outline" onclick={() => refreshDs(ds)}>{i18n.t("admin.refresh")}</Button>
-              <Button variant="outline" onclick={() => (editing = openForEdit(ds))}>{i18n.t("admin.edit")}</Button>
-              <Button variant="destructive" onclick={() => (deleting = ds)}>{i18n.t("admin.delete")}</Button>
+              {#if !demoMode}
+                <Button variant="outline" onclick={() => (editing = openForEdit(ds))}>{i18n.t("admin.edit")}</Button>
+                <Button variant="destructive" onclick={() => (deleting = ds)}>{i18n.t("admin.delete")}</Button>
+              {/if}
             </td>
           </tr>
         {/each}

--- a/saiku-ui/src/lib/views/admin/DatasourcesAdmin.svelte
+++ b/saiku-ui/src/lib/views/admin/DatasourcesAdmin.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { onMount } from "svelte";
+  import { base } from "$app/paths";
   import { Button, buttonVariants } from "$lib/components/ui";
   import { adminDatasources, type AdminDatasource } from "$lib/api/admin";
   import { toasts } from "$lib/stores/toasts.svelte";
@@ -145,7 +146,7 @@
               <a
                 class={buttonVariants({ variant: "outline" })}
                 data-testid="generate-schema-link"
-                href={generateSchemaHref(ds)}
+                href={`${base}${generateSchemaHref(ds)}`}
               >
                 {generateSchemaLabel(ds)}
               </a>

--- a/saiku-ui/src/lib/views/admin/EvalsAdmin.svelte
+++ b/saiku-ui/src/lib/views/admin/EvalsAdmin.svelte
@@ -94,7 +94,7 @@
 
   {#if loaded && suites.length === 0}
     <div class="empty">
-      <h3 style="text-transform:none;color:var(--fg);font-size:var(--fs-md)">No eval runs recorded yet</h3>
+      <h3 style="text-transform:none;color:hsl(var(--fg));font-size:var(--fs-md)">No eval runs recorded yet</h3>
       <p class="text-fg-muted text-sm">
         This monitor plots agent accuracy over time from suites in <code>saiku-home/evals/</code>.
         Nothing has run against this deployment yet.
@@ -156,8 +156,8 @@
           <svg viewBox="0 0 {W} {H}" width="100%" preserveAspectRatio="xMidYMid meet">
             <defs>
               <linearGradient id="evalArea" x1="0" y1="0" x2="0" y2="1">
-                <stop offset="0" stop-color="var(--accent)" stop-opacity="0.18" />
-                <stop offset="1" stop-color="var(--accent)" stop-opacity="0" />
+                <stop offset="0" stop-color="hsl(var(--primary))" stop-opacity="0.18" />
+                <stop offset="1" stop-color="hsl(var(--primary))" stop-opacity="0" />
               </linearGradient>
             </defs>
             {#each gridLines as f (f)}
@@ -165,7 +165,7 @@
               <text class="axt" x={PL - 8} y={PT + IH * (1 - f) + 3} text-anchor="end">{(f * 100) | 0}%</text>
             {/each}
             <polygon points={areaPts} fill="url(#evalArea)" />
-            <polyline points={linePts} fill="none" stroke="var(--accent)" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" />
+            <polyline points={linePts} fill="none" stroke="hsl(var(--primary))" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" />
             {#each trend as t, i (i)}
               <circle class="dot-{band(t.passRate)}" cx={xAt(i, trend.length)} cy={yAt(t.passRate)} r={i === trend.length - 1 ? 4 : 2.6}>
                 <title>{pct(t.passRate)} · {t.total} cases · {fmtTs(t.startedAt)}</title>
@@ -219,53 +219,53 @@
 <style>
   .pane { display: flex; flex-direction: column; gap: var(--space-4); }
   h2 { margin: 0; }
-  h3 { margin: 0 0 var(--space-2); font-size: var(--fs-sm); text-transform: uppercase; letter-spacing: 0.04em; color: var(--fg-muted); }
+  h3 { margin: 0 0 var(--space-2); font-size: var(--fs-sm); text-transform: uppercase; letter-spacing: 0.04em; color: hsl(var(--fg-muted)); }
 
   .empty {
     padding: var(--space-6);
-    background: var(--bg-muted);
-    border: 1px solid var(--border);
+    background: hsl(var(--bg-muted));
+    border: 1px solid hsl(var(--border));
     border-radius: var(--radius);
     display: flex;
     flex-direction: column;
     gap: var(--space-2);
   }
-  .empty code { font-family: var(--font-mono, monospace); font-size: var(--fs-xs); background: var(--bg-subtle); padding: 1px 5px; border-radius: 4px; }
+  .empty code { font-family: var(--font-mono, monospace); font-size: var(--fs-xs); background: hsl(var(--bg-subtle)); padding: 1px 5px; border-radius: 4px; }
 
   .suite-bar { display: flex; flex-wrap: wrap; gap: var(--space-2); }
   .suite-chip {
     display: inline-flex; align-items: center; gap: var(--space-2);
     padding: var(--space-2) var(--space-3);
-    background: var(--bg-muted); border: 1px solid var(--border); border-radius: var(--radius);
-    color: var(--fg-muted); font: inherit; cursor: pointer;
+    background: hsl(var(--bg-muted)); border: 1px solid hsl(var(--border)); border-radius: var(--radius);
+    color: hsl(var(--fg-muted)); font: inherit; cursor: pointer;
   }
-  .suite-chip:hover { color: var(--fg); }
-  .suite-chip.active { color: var(--fg); border-color: var(--accent); box-shadow: inset 0 -2px 0 var(--accent); }
+  .suite-chip:hover { color: hsl(var(--fg)); }
+  .suite-chip.active { color: hsl(var(--fg)); border-color: hsl(var(--primary)); box-shadow: inset 0 -2px 0 hsl(var(--primary)); }
   .suite-chip .nm { font-weight: var(--weight-medium); }
   .suite-chip .pc { font-variant-numeric: tabular-nums; font-size: var(--fs-xs); }
-  .suite-chip .dot { width: 8px; height: 8px; border-radius: 50%; background: var(--fg-subtle); }
-  .suite-chip .dot.good { background: var(--success); }
-  .suite-chip .dot.warn { background: var(--warning); }
-  .suite-chip .dot.bad { background: var(--danger); }
+  .suite-chip .dot { width: 8px; height: 8px; border-radius: 50%; background: hsl(var(--fg-subtle)); }
+  .suite-chip .dot.good { background: hsl(var(--success)); }
+  .suite-chip .dot.warn { background: hsl(var(--warning)); }
+  .suite-chip .dot.bad { background: hsl(var(--danger)); }
 
   .kpis { display: grid; grid-template-columns: repeat(auto-fit, minmax(180px, 1fr)); gap: var(--space-3); }
-  .kpi { display: flex; flex-direction: column; gap: 2px; padding: var(--space-3); background: var(--bg-muted); border: 1px solid var(--border); border-radius: var(--radius); }
-  .kpi__label { font-size: var(--fs-xs); color: var(--fg-muted); text-transform: uppercase; letter-spacing: 0.05em; }
+  .kpi { display: flex; flex-direction: column; gap: 2px; padding: var(--space-3); background: hsl(var(--bg-muted)); border: 1px solid hsl(var(--border)); border-radius: var(--radius); }
+  .kpi__label { font-size: var(--fs-xs); color: hsl(var(--fg-muted)); text-transform: uppercase; letter-spacing: 0.05em; }
 
   .rate { font-variant-numeric: tabular-nums; }
-  .rate.good { color: var(--success); }
-  .rate.warn { color: var(--warning); }
-  .rate.bad { color: var(--danger); }
+  .rate.good { color: hsl(var(--success)); }
+  .rate.warn { color: hsl(var(--warning)); }
+  .rate.bad { color: hsl(var(--danger)); }
 
-  .chart-wrap { background: var(--bg-muted); border: 1px solid var(--border); border-radius: var(--radius); padding: var(--space-3); }
-  svg .grid { stroke: var(--border); stroke-width: 1; }
-  svg .axt { fill: var(--fg-muted); font-size: 10px; font-variant-numeric: tabular-nums; }
-  svg .dot-good { fill: var(--success); }
-  svg .dot-warn { fill: var(--warning); }
-  svg .dot-bad { fill: var(--danger); }
+  .chart-wrap { background: hsl(var(--bg-muted)); border: 1px solid hsl(var(--border)); border-radius: var(--radius); padding: var(--space-3); }
+  svg .grid { stroke: hsl(var(--border)); stroke-width: 1; }
+  svg .axt { fill: hsl(var(--fg-muted)); font-size: 10px; font-variant-numeric: tabular-nums; }
+  svg .dot-good { fill: hsl(var(--success)); }
+  svg .dot-warn { fill: hsl(var(--warning)); }
+  svg .dot-bad { fill: hsl(var(--danger)); }
 
   table { width: 100%; border-collapse: collapse; font-size: var(--fs-sm); }
-  th, td { padding: 6px 10px; text-align: left; white-space: nowrap; border-bottom: 1px solid var(--border); font-variant-numeric: tabular-nums; }
-  th { background: var(--bg-muted); font-weight: var(--weight-semibold); }
+  th, td { padding: 6px 10px; text-align: left; white-space: nowrap; border-bottom: 1px solid hsl(var(--border)); font-variant-numeric: tabular-nums; }
+  th { background: hsl(var(--bg-muted)); font-weight: var(--weight-semibold); }
   tr:last-child td { border-bottom: 0; }
 </style>

--- a/saiku-ui/src/lib/views/admin/LogsAdmin.svelte
+++ b/saiku-ui/src/lib/views/admin/LogsAdmin.svelte
@@ -47,9 +47,9 @@ h2 { margin: 0; }
   .log {
     margin: 0;
     padding: var(--space-3);
-    background: var(--bg-muted);
-    color: var(--fg);
-    border: 1px solid var(--border);
+    background: hsl(var(--bg-muted));
+    color: hsl(var(--fg));
+    border: 1px solid hsl(var(--border));
     border-radius: var(--radius-sm);
     font-family: var(--font-mono);
     font-size: var(--fs-xs);

--- a/saiku-ui/src/lib/views/admin/StatsAdmin.svelte
+++ b/saiku-ui/src/lib/views/admin/StatsAdmin.svelte
@@ -252,7 +252,7 @@
 <style>
 .pane { display: flex; flex-direction: column; gap: var(--space-4); }
   h2 { margin: 0; }
-  h3 { margin: 0 0 var(--space-2); font-size: var(--fs-sm); text-transform: uppercase; letter-spacing: 0.04em; color: var(--fg-muted); }
+  h3 { margin: 0 0 var(--space-2); font-size: var(--fs-sm); text-transform: uppercase; letter-spacing: 0.04em; color: hsl(var(--fg-muted)); }
   .kpis {
     display: grid;
     grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
@@ -263,14 +263,14 @@
     flex-direction: column;
     gap: 2px;
     padding: var(--space-3);
-    background: var(--bg-muted);
-    border: 1px solid var(--border);
+    background: hsl(var(--bg-muted));
+    border: 1px solid hsl(var(--border));
     border-radius: var(--radius);
   }
-  .kpi__label { font-size: var(--fs-xs); color: var(--fg-muted); text-transform: uppercase; letter-spacing: 0.05em; }
+  .kpi__label { font-size: var(--fs-xs); color: hsl(var(--fg-muted)); text-transform: uppercase; letter-spacing: 0.05em; }
   table { width: 100%; border-collapse: collapse; font-size: var(--fs-sm); }
-  th, td { padding: 6px 10px; text-align: left; white-space: nowrap; border-bottom: 1px solid var(--border); }
-  th { background: var(--bg-muted); font-weight: var(--weight-semibold); }
+  th, td { padding: 6px 10px; text-align: left; white-space: nowrap; border-bottom: 1px solid hsl(var(--border)); }
+  th { background: hsl(var(--bg-muted)); font-weight: var(--weight-semibold); }
   tr:last-child td { border-bottom: 0; }
   /* .mdx selector dropped — Mondrian StatementInfo doesn't surface
      the source MDX, so the column was removed in the 2026-06 rework. */

--- a/saiku-ui/src/lib/views/admin/UsersAdmin.svelte
+++ b/saiku-ui/src/lib/views/admin/UsersAdmin.svelte
@@ -168,7 +168,7 @@ h2 { margin: 0; }
   /* .field__hint is a local convention rather than a global — mirrors TopBottomCountModal.svelte. */
   .field__hint {
     margin: var(--space-1) 0 0;
-    color: var(--fg-subtle);
+    color: hsl(var(--fg-subtle));
     font-size: var(--fs-xs);
   }
   .field__hint code {

--- a/saiku-ui/src/lib/views/admin/dataSourceActions.test.ts
+++ b/saiku-ui/src/lib/views/admin/dataSourceActions.test.ts
@@ -73,4 +73,12 @@ describe("generateSchemaHref", () => {
     expect(href).not.toContain(" ");
     expect(href).not.toContain("?");
   });
+
+  it("uses the datasource NAME (the backend resolves by name), not the UUID id", () => {
+    // Regression: passing ds.id (a UUID) 500s server-side because
+    // getDatasource keys on name. The link must carry the name.
+    expect(
+      generateSchemaHref({ id: "4432dd20-fcae-11e3-a3ac-0800200c9a66", name: "foodmart" }),
+    ).toBe("/admin/cube-designer/foodmart");
+  });
 });

--- a/saiku-ui/src/lib/views/admin/dataSourceActions.ts
+++ b/saiku-ui/src/lib/views/admin/dataSourceActions.ts
@@ -12,6 +12,10 @@
 
 export interface GenerateSchemaTarget {
   id: string;
+  /** Datasource NAME — the key the backend resolves (getDatasource keys by
+   *  name, not id), so the cube-designer route must carry the name. Optional
+   *  here only so tests can omit it; real AdminDatasource always has one. */
+  name?: string;
   schemaName?: string | null;
 }
 
@@ -21,10 +25,17 @@ export function canGenerateSchema(ds: GenerateSchemaTarget): boolean {
   return name.trim().length === 0;
 }
 
+/**
+ * App-relative (base-less) href for the cube-designer entry. The datasource
+ * NAME — not the id — is used as the route param because the backend resolves
+ * datasources by name (DatasourceService.getDatasource keys the map on name);
+ * passing the UUID id yields a 500 "no Saiku datasource named …". The caller
+ * must prefix the SvelteKit `base` (the app is served under `/ui`).
+ */
 export function generateSchemaHref(
-  ds: Pick<GenerateSchemaTarget, "id">,
+  ds: Pick<GenerateSchemaTarget, "id" | "name">,
 ): string {
-  return `/admin/cube-designer/${encodeURIComponent(ds.id)}`;
+  return `/admin/cube-designer/${encodeURIComponent(ds.name ?? ds.id)}`;
 }
 
 /**

--- a/saiku-ui/src/lib/views/app/AppEditor.svelte
+++ b/saiku-ui/src/lib/views/app/AppEditor.svelte
@@ -148,7 +148,7 @@
     display: flex;
     align-items: center;
     justify-content: center;
-    color: var(--fg-muted);
+    color: hsl(var(--fg-muted));
     font-size: var(--fs-md);
   }
   /* Brand & Theme inspector — a right-edge overlay so it floats above the app

--- a/saiku-ui/src/lib/views/app/AppHeader.svelte
+++ b/saiku-ui/src/lib/views/app/AppHeader.svelte
@@ -85,9 +85,9 @@
     padding: 0.5rem 1rem;
     min-height: 3rem;
     box-sizing: border-box;
-    background: var(--saiku-app-bg, var(--bg));
-    color: var(--saiku-app-fg, var(--fg));
-    border-bottom: 1px solid var(--border);
+    background: var(--saiku-app-bg, hsl(var(--bg)));
+    color: var(--saiku-app-fg, hsl(var(--fg)));
+    border-bottom: 1px solid hsl(var(--border));
     font-family: var(--saiku-app-font, inherit);
   }
   .saiku-app__brand {
@@ -116,7 +116,7 @@
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
-    color: var(--saiku-app-primary, var(--saiku-app-fg, var(--fg)));
+    color: var(--saiku-app-primary, var(--saiku-app-fg, hsl(var(--fg))));
   }
   .saiku-app__name-accent {
     color: var(--saiku-app-accent-2, var(--saiku-app-accent, #c85a3a));

--- a/saiku-ui/src/lib/views/app/AppIndex.svelte
+++ b/saiku-ui/src/lib/views/app/AppIndex.svelte
@@ -266,8 +266,8 @@
   }
   .error {
     padding: 0.5rem 0.75rem;
-    background: color-mix(in srgb, var(--danger) 14%, transparent);
-    color: var(--danger);
+    background: color-mix(in srgb, hsl(var(--danger)) 14%, transparent);
+    color: hsl(var(--danger));
     border-radius: 4px;
     font-size: 0.875rem;
   }
@@ -284,12 +284,12 @@
     align-items: center;
     gap: 0.75rem;
     padding: 0.5rem 0.75rem;
-    border: 1px solid var(--border);
+    border: 1px solid hsl(var(--border));
     border-radius: 6px;
-    background: var(--bg);
+    background: hsl(var(--bg));
   }
   .row:hover {
-    background: var(--bg-subtle);
+    background: hsl(var(--bg-subtle));
   }
   .link {
     flex: 1;

--- a/saiku-ui/src/lib/views/app/AppNavRail.svelte
+++ b/saiku-ui/src/lib/views/app/AppNavRail.svelte
@@ -206,8 +206,8 @@
     flex-shrink: 0;
     padding: 0.5rem;
     box-sizing: border-box;
-    background: var(--saiku-app-bg, var(--bg-subtle, var(--bg)));
-    border-right: 1px solid var(--border);
+    background: var(--saiku-app-bg, var(--bg-subtle, hsl(var(--bg))));
+    border-right: 1px solid hsl(var(--border));
     overflow-y: auto;
     font-family: var(--saiku-app-font, inherit);
   }
@@ -255,7 +255,7 @@
     border: none;
     border-radius: 6px;
     background: transparent;
-    color: var(--saiku-app-fg, var(--fg-muted));
+    color: var(--saiku-app-fg, hsl(var(--fg-muted)));
     font: inherit;
     text-align: left;
     cursor: pointer;
@@ -263,12 +263,12 @@
     overflow: hidden;
   }
   .saiku-app__rail-item:hover {
-    background: var(--bg-hover);
-    color: var(--saiku-app-fg, var(--fg));
+    background: hsl(var(--bg-hover));
+    color: var(--saiku-app-fg, hsl(var(--fg)));
   }
   .saiku-app__rail-item.is-active {
-    background: var(--saiku-app-accent, var(--accent-soft));
-    color: var(--saiku-app-primary, var(--accent));
+    background: var(--saiku-app-accent, hsl(var(--accent)));
+    color: var(--saiku-app-primary, hsl(var(--primary)));
     font-weight: 600;
   }
   .saiku-app__rail-label {
@@ -279,15 +279,15 @@
     display: none;
   }
   .saiku-app__rail-add {
-    color: var(--fg-muted);
+    color: hsl(var(--fg-muted));
   }
   .saiku-app__rail-rename {
     width: 100%;
     padding: 0.4375rem 0.5rem;
-    border: 1px solid var(--border-strong);
+    border: 1px solid hsl(var(--border-strong));
     border-radius: 6px;
-    background: var(--bg);
-    color: var(--fg);
+    background: hsl(var(--bg));
+    color: hsl(var(--fg));
     font: inherit;
     box-sizing: border-box;
   }
@@ -339,12 +339,12 @@
     border: none;
     border-radius: 6px;
     background: transparent;
-    color: var(--fg-muted);
+    color: hsl(var(--fg-muted));
     cursor: pointer;
   }
   .saiku-app__rail-collapse:hover {
-    background: var(--bg-hover);
-    color: var(--fg);
+    background: hsl(var(--bg-hover));
+    color: hsl(var(--fg));
   }
 
   /* Narrow viewport: horizontal bottom bar pinned to the foot of the shell. */
@@ -352,7 +352,7 @@
     flex-direction: row;
     width: 100%;
     border-right: none;
-    border-top: 1px solid var(--border);
+    border-top: 1px solid hsl(var(--border));
     overflow-x: auto;
     overflow-y: hidden;
   }

--- a/saiku-ui/src/lib/views/app/AppShell.svelte
+++ b/saiku-ui/src/lib/views/app/AppShell.svelte
@@ -197,8 +197,8 @@
     width: 100%;
     min-width: 0;
     box-sizing: border-box;
-    background: var(--saiku-app-bg, var(--bg));
-    color: var(--saiku-app-fg, var(--fg));
+    background: var(--saiku-app-bg, hsl(var(--bg)));
+    color: var(--saiku-app-fg, hsl(var(--fg)));
     font-family: var(--saiku-app-font, inherit);
   }
   .saiku-app__body {

--- a/saiku-ui/src/lib/views/app/AppTopNav.svelte
+++ b/saiku-ui/src/lib/views/app/AppTopNav.svelte
@@ -105,8 +105,8 @@
     display: flex;
     align-items: stretch;
     padding: 0 0.75rem;
-    background: var(--saiku-app-bg, var(--bg-subtle, var(--bg)));
-    border-bottom: 1px solid var(--border);
+    background: var(--saiku-app-bg, var(--bg-subtle, hsl(var(--bg))));
+    border-bottom: 1px solid hsl(var(--border));
     overflow-x: auto;
     font-family: var(--saiku-app-font, inherit);
   }
@@ -126,29 +126,29 @@
     border: none;
     border-bottom: 2px solid transparent;
     background: transparent;
-    color: var(--saiku-app-fg, var(--fg-muted));
+    color: var(--saiku-app-fg, hsl(var(--fg-muted)));
     font: inherit;
     white-space: nowrap;
     cursor: pointer;
   }
   .saiku-app__topnav-tab:hover {
-    color: var(--saiku-app-fg, var(--fg));
+    color: var(--saiku-app-fg, hsl(var(--fg)));
   }
   .saiku-app__topnav-tab.is-active {
-    color: var(--saiku-app-primary, var(--accent));
-    border-bottom-color: var(--saiku-app-primary, var(--accent));
+    color: var(--saiku-app-primary, hsl(var(--primary)));
+    border-bottom-color: var(--saiku-app-primary, hsl(var(--primary)));
     font-weight: 600;
   }
   .saiku-app__topnav-add {
-    color: var(--fg-muted);
+    color: hsl(var(--fg-muted));
   }
   .saiku-app__topnav-rename {
     margin: 0.375rem 0;
     padding: 0.375rem 0.5rem;
-    border: 1px solid var(--border-strong);
+    border: 1px solid hsl(var(--border-strong));
     border-radius: 6px;
-    background: var(--bg);
-    color: var(--fg);
+    background: hsl(var(--bg));
+    color: hsl(var(--fg));
     font: inherit;
   }
 </style>

--- a/saiku-ui/src/lib/views/app/appSkin.ts
+++ b/saiku-ui/src/lib/views/app/appSkin.ts
@@ -21,7 +21,7 @@ export function appSkinCss(scope: string): string {
   const s = scope;
   return `
 ${s} .saiku-app__body, ${s} .saiku-app__main, ${s} .app-page {
-  background: var(--saiku-app-ground, var(--bg));
+  background: var(--saiku-app-ground, hsl(var(--bg)));
 }
 ${s} { font-family: var(--saiku-app-font-body, inherit); }
 
@@ -87,7 +87,7 @@ ${s} tbody th { font-weight: 500; text-align: left; }
 ${s} tbody td { text-align: right; font-weight: 650; color: var(--saiku-app-fg, #1f3529); }
 
 /* ---- nav rail ---- */
-${s} .saiku-app__rail { background: var(--saiku-app-rail-bg, var(--bg-subtle)); border-right: none; padding-top: 14px; }
+${s} .saiku-app__rail { background: var(--saiku-app-rail-bg, hsl(var(--bg-subtle))); border-right: none; padding-top: 14px; }
 ${s} .saiku-app__rail-brand { background: var(--saiku-app-accent-2, var(--saiku-app-accent, #2e5e43)); }
 ${s} .saiku-app__rail-item { color: var(--saiku-app-rail-fg, #9fb4a5); border-radius: 10px; }
 ${s} .saiku-app__rail-item.is-active { background: var(--saiku-app-accent, #2e5e43); color: #fff; }

--- a/saiku-ui/src/lib/views/app/inspector/AppInspector.svelte
+++ b/saiku-ui/src/lib/views/app/inspector/AppInspector.svelte
@@ -80,8 +80,8 @@
     flex-direction: column;
     min-height: 0;
     height: 100%;
-    background: var(--bg);
-    border-left: 1px solid var(--border);
+    background: hsl(var(--bg));
+    border-left: 1px solid hsl(var(--border));
     box-sizing: border-box;
   }
   .insp__head {
@@ -90,7 +90,7 @@
     justify-content: space-between;
     gap: 0.5rem;
     padding: 0.5rem 0.5rem 0.5rem 0.75rem;
-    border-bottom: 1px solid var(--border);
+    border-bottom: 1px solid hsl(var(--border));
   }
   .insp__tabs {
     display: flex;
@@ -100,7 +100,7 @@
   .insp__tab {
     border: 0;
     background: transparent;
-    color: var(--fg-muted);
+    color: hsl(var(--fg-muted));
     font-size: 0.78rem;
     font-weight: 600;
     padding: 0.35rem 0.5rem;
@@ -109,13 +109,13 @@
     white-space: nowrap;
   }
   .insp__tab.is-active {
-    background: var(--bg-subtle);
-    color: var(--fg);
+    background: hsl(var(--bg-subtle));
+    color: hsl(var(--fg));
   }
   .insp__close {
     border: 0;
     background: transparent;
-    color: var(--fg-muted);
+    color: hsl(var(--fg-muted));
     cursor: pointer;
     display: inline-flex;
     padding: 4px;
@@ -123,7 +123,7 @@
     flex-shrink: 0;
   }
   .insp__close:hover {
-    background: var(--bg-hover);
+    background: hsl(var(--bg-hover));
   }
   .insp__body {
     flex: 1;
@@ -144,7 +144,7 @@
     font-weight: 700;
     letter-spacing: 0.08em;
     text-transform: uppercase;
-    color: var(--fg-muted);
+    color: hsl(var(--fg-muted));
   }
   :global(.insp .insp-row) {
     display: flex;
@@ -154,7 +154,7 @@
     font-size: 0.82rem;
   }
   :global(.insp .insp-row > span) {
-    color: var(--fg);
+    color: hsl(var(--fg));
   }
   :global(.insp .insp-input),
   :global(.insp .insp-select) {
@@ -162,10 +162,10 @@
     min-width: 0;
     max-width: 62%;
     padding: 0.32rem 0.45rem;
-    border: 1px solid var(--border);
+    border: 1px solid hsl(var(--border));
     border-radius: 6px;
-    background: var(--bg);
-    color: var(--fg);
+    background: hsl(var(--bg));
+    color: hsl(var(--fg));
     font: inherit;
     font-size: 0.8rem;
     box-sizing: border-box;
@@ -178,10 +178,10 @@
     width: 100%;
     box-sizing: border-box;
     padding: 0.5rem;
-    border: 1px solid var(--border);
+    border: 1px solid hsl(var(--border));
     border-radius: 6px;
-    background: var(--bg);
-    color: var(--fg);
+    background: hsl(var(--bg));
+    color: hsl(var(--fg));
     font: inherit;
     font-size: 0.8rem;
     resize: vertical;
@@ -189,31 +189,31 @@
   :global(.insp .insp-hint) {
     margin: 0;
     font-size: 0.72rem;
-    color: var(--fg-muted);
+    color: hsl(var(--fg-muted));
     line-height: 1.4;
   }
   :global(.insp .insp-seg) {
     display: inline-flex;
-    border: 1px solid var(--border);
+    border: 1px solid hsl(var(--border));
     border-radius: 6px;
     overflow: hidden;
     flex-shrink: 0;
   }
   :global(.insp .insp-seg button) {
     border: 0;
-    background: var(--bg);
-    color: var(--fg-muted);
+    background: hsl(var(--bg));
+    color: hsl(var(--fg-muted));
     padding: 0.28rem 0.55rem;
     font-size: 0.72rem;
     text-transform: capitalize;
     cursor: pointer;
-    border-left: 1px solid var(--border);
+    border-left: 1px solid hsl(var(--border));
   }
   :global(.insp .insp-seg button:first-child) {
     border-left: 0;
   }
   :global(.insp .insp-seg button.is-active) {
-    background: var(--accent);
+    background: hsl(var(--primary));
     color: var(--accent-fg, #fff);
   }
   :global(.insp .insp-toggle) {
@@ -233,9 +233,9 @@
     max-width: none;
   }
   :global(.insp .insp-iconbtn) {
-    border: 1px solid var(--border);
-    background: var(--bg);
-    color: var(--fg-muted);
+    border: 1px solid hsl(var(--border));
+    background: hsl(var(--bg));
+    color: hsl(var(--fg-muted));
     border-radius: 6px;
     padding: 0.3rem 0.45rem;
     cursor: pointer;
@@ -244,21 +244,21 @@
     flex-shrink: 0;
   }
   :global(.insp .insp-iconbtn:hover) {
-    background: var(--bg-hover);
-    color: var(--fg);
+    background: hsl(var(--bg-hover));
+    color: hsl(var(--fg));
   }
   :global(.insp .insp-addbtn) {
     align-self: flex-start;
-    border: 1px dashed var(--border-strong, var(--border));
+    border: 1px dashed var(--border-strong, hsl(var(--border)));
     background: transparent;
-    color: var(--fg-muted);
+    color: hsl(var(--fg-muted));
     border-radius: 6px;
     padding: 0.3rem 0.6rem;
     font-size: 0.76rem;
     cursor: pointer;
   }
   :global(.insp .insp-addbtn:hover) {
-    color: var(--fg);
-    border-color: var(--accent);
+    color: hsl(var(--fg));
+    border-color: hsl(var(--primary));
   }
 </style>

--- a/saiku-ui/src/lib/views/app/inspector/PagesSection.svelte
+++ b/saiku-ui/src/lib/views/app/inspector/PagesSection.svelte
@@ -44,13 +44,13 @@
 </div>
 
 <style>
-  .page { border: 1px solid var(--border); border-radius: 8px; margin-bottom: 0.4rem; overflow: hidden; }
-  .page.is-active { border-color: var(--accent); }
+  .page { border: 1px solid hsl(var(--border)); border-radius: 8px; margin-bottom: 0.4rem; overflow: hidden; }
+  .page.is-active { border-color: hsl(var(--primary)); }
   .page-head {
-    width: 100%; text-align: left; border: 0; background: var(--bg-subtle);
-    padding: 0.45rem 0.6rem; font-size: 0.82rem; font-weight: 600; color: var(--fg);
+    width: 100%; text-align: left; border: 0; background: hsl(var(--bg-subtle));
+    padding: 0.45rem 0.6rem; font-size: 0.82rem; font-weight: 600; color: hsl(var(--fg));
     cursor: pointer; display: flex; align-items: center; gap: 0.4rem;
   }
-  .dot { color: var(--accent); font-size: 0.6rem; margin-left: auto; }
+  .dot { color: hsl(var(--primary)); font-size: 0.6rem; margin-left: auto; }
   .page-fields { display: flex; flex-direction: column; gap: 0.4rem; padding: 0.5rem 0.6rem 0.7rem; }
 </style>

--- a/saiku-ui/src/lib/views/app/inspector/ThemeSection.svelte
+++ b/saiku-ui/src/lib/views/app/inspector/ThemeSection.svelte
@@ -140,28 +140,28 @@
   .presets { display: grid; grid-template-columns: 1fr 1fr; gap: 0.5rem; }
   .preset {
     display: flex; flex-direction: column; gap: 0.4rem; padding: 0.5rem;
-    border: 1px solid var(--border); border-radius: 8px; background: var(--bg-subtle);
+    border: 1px solid hsl(var(--border)); border-radius: 8px; background: hsl(var(--bg-subtle));
     cursor: pointer; text-align: left;
   }
-  .preset.is-active { border-color: var(--accent); box-shadow: 0 0 0 1px var(--accent); }
+  .preset.is-active { border-color: hsl(var(--primary)); box-shadow: 0 0 0 1px hsl(var(--primary)); }
   .swatches { display: flex; height: 22px; border-radius: 5px; overflow: hidden; }
   .swatches span { flex: 1; }
   .preset-name { font-size: 0.8rem; font-weight: 600; }
   .colours { display: grid; grid-template-columns: 1fr 1fr; gap: 0.5rem 0.75rem; }
   .colour { display: flex; align-items: center; gap: 0.5rem; font-size: 0.8rem; }
   .colour input[type="color"] {
-    width: 28px; height: 24px; padding: 0; border: 1px solid var(--border);
+    width: 28px; height: 24px; padding: 0; border: 1px solid hsl(var(--border));
     border-radius: 5px; background: none; cursor: pointer; flex-shrink: 0;
   }
   .disclosure {
-    border: 0; background: transparent; color: var(--fg-muted);
+    border: 0; background: transparent; color: hsl(var(--fg-muted));
     font-size: 0.78rem; font-weight: 600; text-align: left; padding: 0; cursor: pointer;
   }
   .brief-btn {
     align-self: flex-start;
     display: inline-flex; align-items: center; gap: 6px;
     border: 0; border-radius: 6px; padding: 0.35rem 0.7rem;
-    background: var(--accent); color: var(--accent-fg, #fff);
+    background: hsl(var(--primary)); color: var(--accent-fg, #fff);
     font-size: 0.78rem; font-weight: 600; cursor: pointer;
   }
   .brief-btn:disabled { opacity: 0.5; cursor: default; }

--- a/saiku-ui/src/lib/views/dashboard/AddTileMenu.svelte
+++ b/saiku-ui/src/lib/views/dashboard/AddTileMenu.svelte
@@ -138,8 +138,8 @@
     position: absolute;
     top: calc(100% + 4px);
     right: 0;
-    background: var(--bg);
-    border: 1px solid var(--border);
+    background: hsl(var(--bg));
+    border: 1px solid hsl(var(--border));
     border-radius: 6px;
     box-shadow: 0 8px 24px rgba(0, 0, 0, 0.08);
     padding: 0.25rem;
@@ -164,7 +164,7 @@
     font-size: 0.875rem;
   }
   .menu-item:hover, .menu-item:focus {
-    background: var(--bg-subtle);
+    background: hsl(var(--bg-subtle));
     outline: none;
   }
   .menu-item:disabled {
@@ -182,7 +182,7 @@
   .hint {
     display: block;
     font-size: 0.75rem;
-    color: var(--fg-muted);
+    color: hsl(var(--fg-muted));
     margin-top: 0.125rem;
   }
 </style>

--- a/saiku-ui/src/lib/views/dashboard/CommentsPanel.svelte
+++ b/saiku-ui/src/lib/views/dashboard/CommentsPanel.svelte
@@ -243,7 +243,7 @@
     gap: var(--space-3);
   }
   .cmts__state {
-    color: var(--fg-muted);
+    color: hsl(var(--fg-muted));
     font-size: var(--fs-sm);
     padding: var(--space-2) 0;
   }
@@ -259,18 +259,18 @@
   }
   .cmts__date {
     font-size: var(--fs-xs, 0.75rem);
-    color: var(--fg-muted);
+    color: hsl(var(--fg-muted));
   }
   .cmts__del {
     margin-left: auto;
     background: none;
     border: none;
-    color: var(--fg-muted);
+    color: hsl(var(--fg-muted));
     cursor: pointer;
     padding: 2px;
   }
   .cmts__del:hover {
-    color: var(--danger);
+    color: hsl(var(--danger));
   }
   .cmts__body {
     margin: var(--space-1) 0 0;
@@ -293,8 +293,8 @@
     margin: 0;
     padding: 4px;
     list-style: none;
-    background: var(--bg);
-    border: 1px solid var(--border);
+    background: hsl(var(--bg));
+    border: 1px solid hsl(var(--border));
     border-radius: var(--radius-sm);
     box-shadow: var(--shadow-md, 0 4px 12px rgba(0, 0, 0, 0.15));
     max-height: 12rem;
@@ -311,6 +311,6 @@
     border-radius: 4px;
     cursor: pointer;
     font: inherit;
-    color: var(--fg);
+    color: hsl(var(--fg));
   }
 </style>

--- a/saiku-ui/src/lib/views/dashboard/DashboardBulkActionsBar.svelte
+++ b/saiku-ui/src/lib/views/dashboard/DashboardBulkActionsBar.svelte
@@ -69,9 +69,9 @@
     align-items: center;
     gap: 0.5rem;
     padding: 0.375rem 0.5rem 0.375rem 0.75rem;
-    border: 1px solid var(--border-strong);
+    border: 1px solid hsl(var(--border-strong));
     border-radius: 999px;
-    background: var(--bg);
+    background: hsl(var(--bg));
     box-shadow: 0 8px 24px rgba(0, 0, 0, 0.18);
     /* Float above the grid, centred near the bottom so it doesn't cover
        the toolbar or the tile a user is reaching for at the top. */
@@ -86,29 +86,29 @@
     align-items: center;
     gap: 0.375rem;
     padding: 0.3125rem 0.625rem;
-    border: 1px solid var(--border-strong);
-    background: var(--bg);
-    color: var(--fg);
+    border: 1px solid hsl(var(--border-strong));
+    background: hsl(var(--bg));
+    color: hsl(var(--fg));
     border-radius: 999px;
     cursor: pointer;
     font-size: 0.8125rem;
   }
   .bulk-bar__btn:hover {
-    background: var(--bg-subtle);
+    background: hsl(var(--bg-subtle));
   }
   .bulk-bar__btn--danger {
-    color: var(--danger);
-    border-color: color-mix(in srgb, var(--danger) 50%, var(--border-strong));
+    color: hsl(var(--danger));
+    border-color: color-mix(in srgb, hsl(var(--danger)) 50%, hsl(var(--border-strong)));
   }
   .bulk-bar__btn--danger:hover {
-    background: color-mix(in srgb, var(--danger) 12%, transparent);
+    background: color-mix(in srgb, hsl(var(--danger)) 12%, transparent);
   }
   .bulk-bar__btn--ghost {
     padding: 0.3125rem;
     border-color: transparent;
-    color: var(--fg-muted);
+    color: hsl(var(--fg-muted));
   }
   .bulk-bar__btn--ghost:hover {
-    color: var(--fg);
+    color: hsl(var(--fg));
   }
 </style>

--- a/saiku-ui/src/lib/views/dashboard/DashboardCataloguePinned.svelte
+++ b/saiku-ui/src/lib/views/dashboard/DashboardCataloguePinned.svelte
@@ -95,7 +95,7 @@
     font-size: 0.6875rem;
     text-transform: uppercase;
     letter-spacing: 0.06em;
-    color: var(--fg-muted);
+    color: hsl(var(--fg-muted));
     font-weight: var(--weight-semibold);
     margin: 0 0 0.25rem;
     display: inline-flex;
@@ -107,20 +107,20 @@
     align-items: center;
     gap: 0.5rem;
     padding: 0.5rem 0.625rem;
-    border: 1px solid var(--border);
+    border: 1px solid hsl(var(--border));
     border-radius: 6px;
-    background: var(--bg);
+    background: hsl(var(--bg));
   }
   .link {
     flex: 1;
     display: flex;
     flex-direction: column;
     text-decoration: none;
-    color: var(--fg);
+    color: hsl(var(--fg));
     min-width: 0;
   }
   .link:hover .name {
-    color: var(--accent);
+    color: hsl(var(--primary));
   }
   .name {
     font-weight: var(--weight-semibold);

--- a/saiku-ui/src/lib/views/dashboard/DashboardCatalogueTree.svelte
+++ b/saiku-ui/src/lib/views/dashboard/DashboardCatalogueTree.svelte
@@ -244,20 +244,20 @@
     align-items: center;
     gap: 0.5rem;
     padding: 0.5rem 0.625rem;
-    border: 1px solid var(--border);
+    border: 1px solid hsl(var(--border));
     border-radius: 6px;
-    background: var(--bg);
+    background: hsl(var(--bg));
   }
   .link {
     flex: 1;
     display: flex;
     flex-direction: column;
     text-decoration: none;
-    color: var(--fg);
+    color: hsl(var(--fg));
     min-width: 0;
   }
   .link:hover .name {
-    color: var(--accent);
+    color: hsl(var(--primary));
   }
   .name {
     font-weight: var(--weight-semibold);
@@ -284,10 +284,10 @@
     user-select: none;
   }
   .tree-folder-head:hover {
-    background: var(--bg-subtle);
+    background: hsl(var(--bg-subtle));
   }
   .tree-folder-head:focus-visible {
-    outline: 2px solid var(--accent);
+    outline: 2px solid hsl(var(--primary));
     outline-offset: -2px;
   }
   .tree-folder-head:hover .tree-folder-actions,
@@ -295,13 +295,13 @@
     opacity: 1;
   }
   .tree-folder-head > :global(svg) {
-    color: var(--accent);
+    color: hsl(var(--primary));
     flex: 0 0 auto;
   }
   .tree-folder-count {
     font-size: 0.6875rem;
-    color: var(--fg-muted);
-    background: var(--bg-subtle);
+    color: hsl(var(--fg-muted));
+    background: hsl(var(--bg-subtle));
     border-radius: 999px;
     padding: 0.0625rem 0.4375rem;
   }
@@ -318,7 +318,7 @@
   .tree-empty {
     list-style: none;
     font-size: 0.8125rem;
-    color: var(--fg-muted);
+    color: hsl(var(--fg-muted));
     font-style: italic;
     padding: 0.375rem 0.5rem;
     padding-left: calc(0.5rem + var(--depth, 0) * 1.25rem);

--- a/saiku-ui/src/lib/views/dashboard/DashboardEditor.svelte
+++ b/saiku-ui/src/lib/views/dashboard/DashboardEditor.svelte
@@ -257,8 +257,8 @@
   }
   .error {
     padding: 0.5rem 0.75rem;
-    background: color-mix(in srgb, var(--danger) 14%, transparent);
-    color: var(--danger);
+    background: color-mix(in srgb, hsl(var(--danger)) 14%, transparent);
+    color: hsl(var(--danger));
     border-radius: 4px;
     font-size: 0.875rem;
   }
@@ -289,10 +289,10 @@
     align-items: center;
     gap: 0.375rem;
     padding: 0.375rem 0.625rem;
-    border: 1px solid var(--border-strong);
+    border: 1px solid hsl(var(--border-strong));
     border-radius: 4px;
-    background: color-mix(in srgb, var(--bg) 80%, transparent);
-    color: var(--fg);
+    background: color-mix(in srgb, hsl(var(--bg)) 80%, transparent);
+    color: hsl(var(--fg));
     font-size: 0.8125rem;
     cursor: pointer;
     opacity: 0.35;

--- a/saiku-ui/src/lib/views/dashboard/DashboardFilterBar.svelte
+++ b/saiku-ui/src/lib/views/dashboard/DashboardFilterBar.svelte
@@ -72,18 +72,18 @@
     align-items: center;
     gap: 0.25rem;
     padding: 0.25rem 0.5rem;
-    background: var(--bg-subtle);
+    background: hsl(var(--bg-subtle));
     border-radius: 999px;
     font-size: 0.8125rem;
-    color: var(--fg);
+    color: hsl(var(--fg));
   }
   /* Subtle source affordance — click filters look slightly bolder so users
      see which chips came from their interaction vs the dashboard's defaults. */
   .chip[data-source="click"] {
-    background: color-mix(in srgb, var(--accent) 18%, transparent);
+    background: color-mix(in srgb, hsl(var(--primary)) 18%, transparent);
   }
   .chip[data-source="panel"] {
-    background: var(--bg-subtle);
+    background: hsl(var(--bg-subtle));
   }
   .chip-x {
     border: none;
@@ -92,6 +92,6 @@
     font-size: 1rem;
     line-height: 1;
     padding: 0 0.125rem;
-    color: var(--fg-muted);
+    color: hsl(var(--fg-muted));
   }
 </style>

--- a/saiku-ui/src/lib/views/dashboard/DashboardFilterPanel.svelte
+++ b/saiku-ui/src/lib/views/dashboard/DashboardFilterPanel.svelte
@@ -887,9 +887,9 @@
 
 <style>
 .panel {
-    border: 1px solid var(--border);
+    border: 1px solid hsl(var(--border));
     border-radius: 6px;
-    background: var(--bg);
+    background: hsl(var(--bg));
     display: flex;
     flex-direction: column;
   }
@@ -898,8 +898,8 @@
     align-items: center;
     gap: 0.5rem;
     padding: 0.375rem 0.5rem;
-    border-bottom: 1px solid var(--border);
-    background: var(--bg-muted);
+    border-bottom: 1px solid hsl(var(--border));
+    background: hsl(var(--bg-muted));
     font-size: 0.8125rem;
   }
   .collapse-toggle {
@@ -910,7 +910,7 @@
     border: none;
     padding: 0.125rem 0.25rem;
     cursor: pointer;
-    color: var(--fg);
+    color: hsl(var(--fg));
     font-size: inherit;
     flex: 1;
     text-align: left;
@@ -919,14 +919,14 @@
     font-weight: var(--weight-medium, 500);
   }
   .count {
-    color: var(--fg-muted);
+    color: hsl(var(--fg-muted));
     font-weight: 400;
     margin-left: 0.125rem;
   }
   .add-btn {
     padding: 0.25rem 0.5rem;
-    border: 1px solid var(--border-strong, var(--border));
-    background: var(--bg);
+    border: 1px solid var(--border-strong, hsl(var(--border)));
+    background: hsl(var(--bg));
     border-radius: 4px;
     cursor: pointer;
     font-size: 0.75rem;
@@ -934,7 +934,7 @@
   .empty {
     margin: 0;
     padding: 0.5rem 0.75rem;
-    color: var(--fg-muted);
+    color: hsl(var(--fg-muted));
     font-size: 0.8125rem;
     font-style: italic;
   }
@@ -951,17 +951,17 @@
     align-items: center;
     gap: 0.25rem;
     padding: 0.25rem 0.375rem;
-    border: 1px solid var(--border);
+    border: 1px solid hsl(var(--border));
     border-radius: 4px;
-    background: var(--bg);
+    background: hsl(var(--bg));
     user-select: none;
   }
   .picker--hover {
-    box-shadow: 0 0 0 2px var(--accent, color-mix(in srgb, var(--fg) 30%, transparent));
+    box-shadow: 0 0 0 2px var(--accent, color-mix(in srgb, hsl(var(--fg)) 30%, transparent));
   }
   .grip {
     cursor: grab;
-    color: var(--fg-muted);
+    color: hsl(var(--fg-muted));
     display: inline-flex;
   }
   .grip:active {
@@ -971,7 +971,7 @@
     font-size: 0.75rem;
     text-transform: uppercase;
     letter-spacing: 0.04em;
-    color: var(--fg-muted);
+    color: hsl(var(--fg-muted));
   }
   /* issue #924: "affects N of M tiles" hover badge. */
   .affects-badge {
@@ -979,15 +979,15 @@
     line-height: 1;
     padding: 0.125rem 0.375rem;
     border-radius: 999px;
-    background: var(--accent);
+    background: hsl(var(--primary));
     color: var(--accent-fg, #fff);
     white-space: nowrap;
   }
   .picker-select {
     padding: 0.125rem 0.25rem;
-    border: 1px solid var(--border-strong, var(--border));
+    border: 1px solid var(--border-strong, hsl(var(--border)));
     border-radius: 4px;
-    background: var(--bg);
+    background: hsl(var(--bg));
     font-size: 0.8125rem;
     max-width: 200px;
   }
@@ -995,9 +995,9 @@
      (saiku#1230); its styles live alongside the markup there. */
   .picker-date {
     padding: 0.125rem 0.25rem;
-    border: 1px solid var(--border-strong, var(--border));
+    border: 1px solid var(--border-strong, hsl(var(--border)));
     border-radius: 4px;
-    background: var(--bg);
+    background: hsl(var(--bg));
     font-size: 0.8125rem;
     font-family: inherit;
   }
@@ -1011,21 +1011,21 @@
   .picker-num {
     width: 3.5rem;
     padding: 0.125rem 0.25rem;
-    border: 1px solid var(--border-strong, var(--border));
+    border: 1px solid var(--border-strong, hsl(var(--border)));
     border-radius: 4px;
-    background: var(--bg);
+    background: hsl(var(--bg));
     font-size: 0.8125rem;
     font-family: inherit;
   }
   .topn-state {
     font-size: 0.75rem;
-    color: var(--fg-muted);
+    color: hsl(var(--fg-muted));
   }
   .picker-remove {
     background: transparent;
     border: none;
     cursor: pointer;
-    color: var(--fg-muted);
+    color: hsl(var(--fg-muted));
     padding: 0.125rem;
     display: inline-flex;
   }
@@ -1039,15 +1039,15 @@
     font-size: 0.75rem;
   }
   .add-field > span:first-child {
-    color: var(--fg-muted);
+    color: hsl(var(--fg-muted));
     text-transform: uppercase;
     letter-spacing: 0.04em;
   }
   .add-field select {
     padding: 0.25rem 0.375rem;
-    border: 1px solid var(--border-strong, var(--border));
+    border: 1px solid var(--border-strong, hsl(var(--border)));
     border-radius: 4px;
-    background: var(--bg);
+    background: hsl(var(--bg));
     font-size: 0.8125rem;
     min-width: 8rem;
   }

--- a/saiku-ui/src/lib/views/dashboard/DashboardGrid.svelte
+++ b/saiku-ui/src/lib/views/dashboard/DashboardGrid.svelte
@@ -393,16 +393,16 @@
       135deg,
       transparent 0,
       transparent 6px,
-      var(--fg-muted) 6px,
-      var(--fg-muted) 7px,
+      hsl(var(--fg-muted)) 6px,
+      hsl(var(--fg-muted)) 7px,
       transparent 7px,
       transparent 9px,
-      var(--fg-muted) 9px,
-      var(--fg-muted) 10px,
+      hsl(var(--fg-muted)) 9px,
+      hsl(var(--fg-muted)) 10px,
       transparent 10px,
       transparent 12px,
-      var(--fg-muted) 12px,
-      var(--fg-muted) 13px,
+      hsl(var(--fg-muted)) 12px,
+      hsl(var(--fg-muted)) 13px,
       transparent 13px
     );
     opacity: 0.5;
@@ -413,8 +413,8 @@
     opacity: 1;
   }
   .ghost {
-    border: 2px dashed var(--accent, color-mix(in srgb, var(--fg) 30%, transparent));
-    background: color-mix(in srgb, var(--accent, var(--fg)) 12%, transparent);
+    border: 2px dashed var(--accent, color-mix(in srgb, hsl(var(--fg)) 30%, transparent));
+    background: color-mix(in srgb, var(--accent, hsl(var(--fg))) 12%, transparent);
     border-radius: 6px;
     pointer-events: none;
     z-index: 2;
@@ -454,8 +454,8 @@
   .empty {
     padding: 3rem 1rem;
     text-align: center;
-    color: var(--fg-muted);
-    border: 2px dashed var(--border);
+    color: hsl(var(--fg-muted));
+    border: 2px dashed hsl(var(--border));
     border-radius: 8px;
   }
   .empty p { margin: 0.25rem 0; }

--- a/saiku-ui/src/lib/views/dashboard/DashboardIndex.svelte
+++ b/saiku-ui/src/lib/views/dashboard/DashboardIndex.svelte
@@ -836,8 +836,8 @@
   }
   .error {
     padding: 0.5rem 0.75rem;
-    background: color-mix(in srgb, var(--danger) 14%, transparent);
-    color: var(--danger);
+    background: color-mix(in srgb, hsl(var(--danger)) 14%, transparent);
+    color: hsl(var(--danger));
     border-radius: 4px;
     font-size: 0.875rem;
   }
@@ -854,12 +854,12 @@
     align-items: center;
     gap: 0.75rem;
     padding: 0.5rem 0.75rem;
-    border: 1px solid var(--border);
+    border: 1px solid hsl(var(--border));
     border-radius: 6px;
-    background: var(--bg);
+    background: hsl(var(--bg));
   }
   .row:hover {
-    background: var(--bg-subtle);
+    background: hsl(var(--bg-subtle));
   }
   .link {
     flex: 1;
@@ -892,29 +892,29 @@
     font-size: 0.6875rem;
     text-transform: uppercase;
     letter-spacing: 0.04em;
-    color: var(--fg-muted);
+    color: hsl(var(--fg-muted));
     font-weight: var(--weight-medium);
     margin-right: 0.25rem;
   }
   .chip {
     padding: 0.25rem 0.625rem;
-    border: 1px solid var(--border);
+    border: 1px solid hsl(var(--border));
     border-radius: 999px;
-    background: var(--bg);
+    background: hsl(var(--bg));
     cursor: pointer;
     font-size: 0.75rem;
-    color: var(--fg);
+    color: hsl(var(--fg));
   }
   .chip:hover {
-    background: var(--bg-subtle);
+    background: hsl(var(--bg-subtle));
   }
   .chip--on {
-    background: var(--accent);
+    background: hsl(var(--primary));
     color: white;
-    border-color: var(--accent);
+    border-color: hsl(var(--primary));
   }
   .chip--on:hover {
-    background: var(--accent);
+    background: hsl(var(--primary));
   }
   /* #937 folder tree + #1234 pinned styles moved into their delegates
      (DashboardCatalogueTree / DashboardCataloguePinned). */

--- a/saiku-ui/src/lib/views/dashboard/DashboardIndexFilters.svelte
+++ b/saiku-ui/src/lib/views/dashboard/DashboardIndexFilters.svelte
@@ -84,9 +84,9 @@
     flex: 1;
     min-width: 12rem;
     padding: 0.5rem 0.75rem;
-    border: 1px solid var(--border-strong);
+    border: 1px solid hsl(var(--border-strong));
     border-radius: 4px;
-    background: var(--bg);
+    background: hsl(var(--bg));
     font-size: 0.875rem;
   }
   .catalogue-filters .sort {
@@ -94,13 +94,13 @@
     align-items: center;
     gap: 0.375rem;
     font-size: 0.8125rem;
-    color: var(--fg-muted);
+    color: hsl(var(--fg-muted));
   }
   .catalogue-filters select {
     padding: 0.375rem 0.5rem;
-    border: 1px solid var(--border-strong);
+    border: 1px solid hsl(var(--border-strong));
     border-radius: 4px;
-    background: var(--bg);
+    background: hsl(var(--bg));
     font-size: 0.8125rem;
   }
 </style>

--- a/saiku-ui/src/lib/views/dashboard/DashboardShareModal.svelte
+++ b/saiku-ui/src/lib/views/dashboard/DashboardShareModal.svelte
@@ -156,7 +156,7 @@
     flex-direction: column;
     gap: var(--space-1);
     font-size: var(--fs-sm);
-    color: var(--fg-muted);
+    color: hsl(var(--fg-muted));
   }
   .share__ttl input {
     width: 6rem;
@@ -170,7 +170,7 @@
     display: flex;
     flex-direction: column;
     gap: var(--space-2);
-    border-top: 1px solid var(--border);
+    border-top: 1px solid hsl(var(--border));
     padding-top: var(--space-2);
   }
   .share__row {

--- a/saiku-ui/src/lib/views/dashboard/DashboardToolbar.svelte
+++ b/saiku-ui/src/lib/views/dashboard/DashboardToolbar.svelte
@@ -520,7 +520,7 @@
     align-items: flex-start;
     gap: 0.75rem;
     padding: 0.5rem 0.25rem;
-    border-bottom: 1px solid var(--border);
+    border-bottom: 1px solid hsl(var(--border));
   }
   /* #1604: the title block absorbs the toolbar's free space (it replaces the
      old flex spacer) so the editable name / heading has room to show the full
@@ -550,8 +550,8 @@
     overflow-wrap: anywhere;
   }
   .name:hover, .name:focus {
-    border-color: var(--border-strong);
-    background: var(--bg);
+    border-color: hsl(var(--border-strong));
+    background: hsl(var(--bg));
     outline: none;
   }
   .tag-chip {
@@ -560,8 +560,8 @@
     gap: 0.25rem;
     padding: 0.125rem 0.5rem;
     border-radius: 999px;
-    background: var(--bg-subtle);
-    color: var(--fg);
+    background: hsl(var(--bg-subtle));
+    color: hsl(var(--fg));
     font-size: 0.6875rem;
     line-height: 1.4;
   }
@@ -569,13 +569,13 @@
     background: none;
     border: none;
     padding: 0;
-    color: var(--fg-muted);
+    color: hsl(var(--fg-muted));
     cursor: pointer;
     display: inline-flex;
     align-items: center;
   }
   .tag-remove:hover {
-    color: var(--danger);
+    color: hsl(var(--danger));
   }
   .tag-input {
     border: 1px dashed transparent;
@@ -583,10 +583,10 @@
     padding: 0.125rem 0.375rem;
     font-size: 0.6875rem;
     min-width: 6rem;
-    color: var(--fg);
+    color: hsl(var(--fg));
   }
   .tag-input:hover, .tag-input:focus {
-    border-color: var(--border-strong);
+    border-color: hsl(var(--border-strong));
     outline: none;
   }
   .actions {
@@ -609,8 +609,8 @@
     gap: 0.25rem;
     min-width: 12rem;
     padding: 0.375rem;
-    background: var(--bg);
-    border: 1px solid var(--border);
+    background: hsl(var(--bg));
+    border: 1px solid hsl(var(--border));
     border-radius: 6px;
     box-shadow: 0 8px 24px rgba(0, 0, 0, 0.18);
     z-index: 60;
@@ -651,8 +651,8 @@
     gap: 0.25rem;
     min-width: 10rem;
     padding: 0.375rem;
-    background: var(--bg);
-    border: 1px solid var(--border);
+    background: hsl(var(--bg));
+    border: 1px solid hsl(var(--border));
     border-radius: 6px;
     box-shadow: 0 8px 24px rgba(0, 0, 0, 0.18);
     z-index: 70;
@@ -667,9 +667,9 @@
     gap: 0.5rem;
     max-width: 24rem;
     padding: 0.5rem 0.75rem;
-    background: color-mix(in srgb, var(--danger) 14%, var(--bg));
-    color: var(--danger);
-    border: 1px solid var(--danger);
+    background: color-mix(in srgb, hsl(var(--danger)) 14%, hsl(var(--bg)));
+    color: hsl(var(--danger));
+    border: 1px solid hsl(var(--danger));
     border-radius: 6px;
     font-size: 0.8125rem;
   }

--- a/saiku-ui/src/lib/views/dashboard/EmptyDashboardGuidance.svelte
+++ b/saiku-ui/src/lib/views/dashboard/EmptyDashboardGuidance.svelte
@@ -44,7 +44,7 @@
         onclick={() => onAddTile("chart")}
         aria-label="Add a chart tile"
       >
-        <span class="inline-flex items-center justify-center text-accent mb-1" aria-hidden="true">
+        <span class="inline-flex items-center justify-center text-primary mb-1" aria-hidden="true">
           <BarChart3 size={28} strokeWidth={1.75} />
         </span>
         <span class="font-semibold text-base">Chart</span>
@@ -57,7 +57,7 @@
         onclick={() => onAddTile("table")}
         aria-label="Add a table tile"
       >
-        <span class="inline-flex items-center justify-center text-accent mb-1" aria-hidden="true">
+        <span class="inline-flex items-center justify-center text-primary mb-1" aria-hidden="true">
           <Table2 size={28} strokeWidth={1.75} />
         </span>
         <span class="font-semibold text-base">Table</span>
@@ -70,7 +70,7 @@
         onclick={() => onAddTile("kpi")}
         aria-label="Add a KPI tile"
       >
-        <span class="inline-flex items-center justify-center text-accent mb-1" aria-hidden="true">
+        <span class="inline-flex items-center justify-center text-primary mb-1" aria-hidden="true">
           <Gauge size={28} strokeWidth={1.75} />
         </span>
         <span class="font-semibold text-base">KPI</span>
@@ -94,15 +94,15 @@
     max-width: 56rem;
     width: 100%;
     padding: 2rem 1.5rem;
-    border: 1px dashed var(--border-strong);
+    border: 1px dashed hsl(var(--border-strong));
     border-radius: 8px;
-    background: var(--bg-subtle);
+    background: hsl(var(--bg-subtle));
     text-align: center;
   }
   .subtitle {
     margin: 0;
     max-width: 36rem;
-    color: var(--fg-muted);
+    color: hsl(var(--fg-muted));
     font-size: 0.875rem;
     line-height: 1.5;
   }
@@ -124,20 +124,20 @@
     align-items: center;
     gap: 0.375rem;
     padding: 1.25rem 1rem;
-    background: var(--bg);
-    border: 1px solid var(--border-strong);
+    background: hsl(var(--bg));
+    border: 1px solid hsl(var(--border-strong));
     border-radius: 6px;
     cursor: pointer;
-    color: var(--fg);
+    color: hsl(var(--fg));
     font-family: inherit;
     transition: border-color 120ms ease, background 120ms ease, transform 120ms ease;
   }
   .cta:hover {
-    border-color: var(--accent);
-    background: color-mix(in srgb, var(--accent) 6%, var(--bg));
+    border-color: hsl(var(--primary));
+    background: color-mix(in srgb, hsl(var(--primary)) 6%, hsl(var(--bg)));
   }
   .cta:focus-visible {
-    outline: 2px solid var(--accent);
+    outline: 2px solid hsl(var(--primary));
     outline-offset: 2px;
   }
   .cta:active {
@@ -145,16 +145,16 @@
   }
   .cta-hint {
     font-size: 0.75rem;
-    color: var(--fg-muted);
+    color: hsl(var(--fg-muted));
     line-height: 1.4;
   }
   .more {
     margin: 0.25rem 0 0;
-    color: var(--fg-muted);
+    color: hsl(var(--fg-muted));
     font-size: 0.8125rem;
   }
   .more strong {
     font-weight: var(--weight-medium);
-    color: var(--fg);
+    color: hsl(var(--fg));
   }
 </style>

--- a/saiku-ui/src/lib/views/dashboard/FilterSuggestionsModal.svelte
+++ b/saiku-ui/src/lib/views/dashboard/FilterSuggestionsModal.svelte
@@ -190,8 +190,8 @@
     left: 50%;
     transform: translate(-50%, -50%);
     z-index: 101;
-    background: var(--bg);
-    border: 1px solid var(--border);
+    background: hsl(var(--bg));
+    border: 1px solid hsl(var(--border));
     border-radius: 8px;
     box-shadow: 0 12px 40px rgba(0, 0, 0, 0.2);
     width: min(540px, 90vw);
@@ -204,7 +204,7 @@
     align-items: center;
     justify-content: space-between;
     padding: 0.75rem 1rem;
-    border-bottom: 1px solid var(--border);
+    border-bottom: 1px solid hsl(var(--border));
   }
   .head h2 {
     margin: 0;
@@ -213,19 +213,19 @@
   }
   .hint, .empty {
     padding: 0.75rem 1rem 0;
-    color: var(--fg-muted);
+    color: hsl(var(--fg-muted));
     font-size: 0.8125rem;
     margin: 0;
   }
   .bulk {
     padding: 0.5rem 1rem 0;
     font-size: 0.8125rem;
-    color: var(--fg-muted);
+    color: hsl(var(--fg-muted));
   }
   .link {
     border: none;
     background: transparent;
-    color: var(--accent);
+    color: hsl(var(--primary));
     cursor: pointer;
     padding: 0;
     font: inherit;
@@ -253,6 +253,6 @@
   }
   .path, .meta {
     font-size: 0.75rem;
-    color: var(--fg-muted);
+    color: hsl(var(--fg-muted));
   }
 </style>

--- a/saiku-ui/src/lib/views/dashboard/HistoryPanel.svelte
+++ b/saiku-ui/src/lib/views/dashboard/HistoryPanel.svelte
@@ -116,12 +116,12 @@
     flex-direction: column;
   }
   .hist__state {
-    color: var(--fg-muted);
+    color: hsl(var(--fg-muted));
     font-size: var(--fs-sm);
     padding: var(--space-3) 0;
   }
   .hist__author {
     font-size: var(--fs-xs, 0.75rem);
-    color: var(--fg-muted);
+    color: hsl(var(--fg-muted));
   }
 </style>

--- a/saiku-ui/src/lib/views/dashboard/Tile.svelte
+++ b/saiku-ui/src/lib/views/dashboard/Tile.svelte
@@ -362,9 +362,9 @@
     display: flex;
     flex-direction: column;
     height: 100%;
-    border: 1px solid var(--border);
+    border: 1px solid hsl(var(--border));
     border-radius: 6px;
-    background: var(--bg);
+    background: hsl(var(--bg));
     overflow: hidden;
     /* issue #924: smooth the highlight/dim when a filter is hovered. */
     transition:
@@ -375,8 +375,8 @@
      tiles get a 1px accent ring (inset, so layout doesn't shift), tiles
      it won't touch fade back. Purely transient; clears on mouse-out. */
   .tile--filter-hit {
-    box-shadow: inset 0 0 0 1px var(--accent);
-    border-color: var(--accent);
+    box-shadow: inset 0 0 0 1px hsl(var(--primary));
+    border-color: hsl(var(--primary));
   }
   /* issue #915: multi-select outline. A 2px accent ring drawn with
      box-shadow (not border) so it never shifts the tile's layout, plus a
@@ -384,8 +384,8 @@
      ring naturally — both use box-shadow, last-declared wins on overlap,
      and a selected tile reads as selected first. */
   .tile--selected {
-    box-shadow: inset 0 0 0 2px var(--accent);
-    border-color: var(--accent);
+    box-shadow: inset 0 0 0 2px hsl(var(--primary));
+    border-color: hsl(var(--primary));
   }
   /* #942: comment badge sits between the title and the edit actions. */
   .tile-comment-badge {
@@ -403,7 +403,7 @@
     height: 14px;
     padding: 0 3px;
     border-radius: 999px;
-    background: var(--accent);
+    background: hsl(var(--primary));
     color: #fff;
     font-size: 0.625rem;
     line-height: 14px;
@@ -414,8 +414,8 @@
     display: flex;
     align-items: center;
     padding: 0.375rem 0.5rem;
-    border-bottom: 1px solid var(--border);
-    background: var(--bg-muted);
+    border-bottom: 1px solid hsl(var(--border));
+    background: hsl(var(--bg-muted));
     font-size: 0.8125rem;
     /* Hint that the header doubles as the drag handle in edit mode.
        Read-only dashboards opt out via .tile-header--draggable. */
@@ -437,8 +437,8 @@
   .tile-menu {
     position: fixed;
     min-width: 10rem;
-    background: var(--bg);
-    border: 1px solid var(--border);
+    background: hsl(var(--bg));
+    border: 1px solid hsl(var(--border));
     border-radius: 6px;
     box-shadow: 0 8px 24px rgba(0, 0, 0, 0.18);
     padding: 0.25rem;
@@ -455,13 +455,13 @@
     text-align: left;
     cursor: pointer;
     border-radius: 4px;
-    color: var(--fg);
+    color: hsl(var(--fg));
     font: inherit;
     font-size: 0.8125rem;
   }
   .tile-menu__item:hover,
   .tile-menu__item:focus {
-    background: var(--bg-subtle);
+    background: hsl(var(--bg-subtle));
     outline: none;
   }
   /* #932/#1175: height stepper row. */
@@ -477,14 +477,14 @@
     justify-content: center;
     width: 1.5rem;
     height: 1.5rem;
-    border: 1px solid var(--border-strong, var(--border));
-    background: var(--bg);
+    border: 1px solid var(--border-strong, hsl(var(--border)));
+    background: hsl(var(--bg));
     border-radius: 4px;
-    color: var(--fg);
+    color: hsl(var(--fg));
     cursor: pointer;
   }
   .tile-menu__step:hover:not(:disabled) {
-    background: var(--bg-subtle);
+    background: hsl(var(--bg-subtle));
   }
   .tile-menu__step:disabled {
     opacity: 0.4;
@@ -494,7 +494,7 @@
     min-width: 1.25rem;
     text-align: center;
     font-size: 0.8125rem;
-    color: var(--fg);
+    color: hsl(var(--fg));
     font-variant-numeric: tabular-nums;
   }
 </style>

--- a/saiku-ui/src/lib/views/dashboard/TileEditorModal.svelte
+++ b/saiku-ui/src/lib/views/dashboard/TileEditorModal.svelte
@@ -1498,7 +1498,7 @@
     z-index: 50;
   }
   .modal {
-    background: var(--bg);
+    background: hsl(var(--bg));
     border-radius: 8px;
     box-shadow: 0 16px 48px rgba(0, 0, 0, 0.2);
     width: min(560px, 92vw);
@@ -1518,7 +1518,7 @@
     display: flex;
     align-items: center;
     padding: 0.75rem 1rem;
-    border-bottom: 1px solid var(--border);
+    border-bottom: 1px solid hsl(var(--border));
   }
   .modal-header h2 {
     margin: 0;
@@ -1535,7 +1535,7 @@
   }
   .field span:first-child {
     font-size: 0.75rem;
-    color: var(--fg-muted);
+    color: hsl(var(--fg-muted));
     text-transform: uppercase;
     letter-spacing: 0.04em;
   }
@@ -1543,14 +1543,14 @@
     display: flex;
     gap: 0.5rem;
     align-items: flex-end;
-    border: 1px solid var(--border);
+    border: 1px solid hsl(var(--border));
     border-radius: 4px;
     padding: 0.5rem 0.75rem;
     margin: 0;
   }
   .size legend {
     font-size: 0.75rem;
-    color: var(--fg-muted);
+    color: hsl(var(--fg-muted));
     text-transform: uppercase;
     letter-spacing: 0.04em;
     padding: 0 0.25rem;
@@ -1563,14 +1563,14 @@
     display: flex;
     gap: 1rem;
     align-items: center;
-    border: 1px solid var(--border);
+    border: 1px solid hsl(var(--border));
     border-radius: 4px;
     padding: 0.5rem 0.75rem;
     margin: 0;
   }
   .mode legend {
     font-size: 0.75rem;
-    color: var(--fg-muted);
+    color: hsl(var(--fg-muted));
     text-transform: uppercase;
     letter-spacing: 0.04em;
     padding: 0 0.25rem;
@@ -1580,14 +1580,14 @@
     display: flex;
     flex-direction: column;
     gap: 0.5rem;
-    border: 1px solid var(--border);
+    border: 1px solid hsl(var(--border));
     border-radius: 4px;
     padding: 0.5rem 0.75rem;
     margin: 0;
   }
   .anomaly legend {
     font-size: 0.75rem;
-    color: var(--fg-muted);
+    color: hsl(var(--fg-muted));
     text-transform: uppercase;
     letter-spacing: 0.04em;
     padding: 0 0.25rem;
@@ -1602,8 +1602,8 @@
   }
   .position-error {
     padding: 0.5rem 0.75rem;
-    background: color-mix(in srgb, var(--danger) 14%, transparent);
-    color: var(--danger);
+    background: color-mix(in srgb, hsl(var(--danger)) 14%, transparent);
+    color: hsl(var(--danger));
     border-radius: 4px;
     font-size: 0.8125rem;
   }
@@ -1612,7 +1612,7 @@
   }
   input, select, textarea {
     padding: 0.375rem 0.5rem;
-    border: 1px solid var(--border-strong);
+    border: 1px solid hsl(var(--border-strong));
     border-radius: 4px;
     font-size: 0.875rem;
     font-family: inherit;
@@ -1624,10 +1624,10 @@
   }
   .hint {
     font-size: 0.75rem;
-    color: var(--fg-muted);
+    color: hsl(var(--fg-muted));
   }
-  .hint.error { color: var(--danger); }
-  .hint.ok { color: var(--success, var(--accent)); }
+  .hint.error { color: hsl(var(--danger)); }
+  .hint.ok { color: var(--success, hsl(var(--primary))); }
   /* #1077, #919: chart-options + conditional-formatting styles moved
      into TileEditorChart / TileEditorTableConditional / TileEditorKpi /
      TileEditorTableSparkline (per saiku#1229). Svelte's scoped CSS
@@ -1648,7 +1648,7 @@
     display: flex;
     flex-direction: column;
     gap: 0.5rem;
-    border: 1px solid var(--border);
+    border: 1px solid hsl(var(--border));
     border-radius: 4px;
     padding: 0.5rem 0.75rem;
     margin: 0;
@@ -1658,7 +1658,7 @@
   }
   .qe-section legend {
     font-size: 0.75rem;
-    color: var(--fg-muted);
+    color: hsl(var(--fg-muted));
     text-transform: uppercase;
     letter-spacing: 0.04em;
     padding: 0 0.25rem;
@@ -1673,7 +1673,7 @@
     /* A floor so the drop zones + result preview are usable even before the
        modal's flex height resolves. */
     min-height: 360px;
-    border: 1px solid var(--border);
+    border: 1px solid hsl(var(--border));
     border-radius: 4px;
     overflow: hidden;
   }

--- a/saiku-ui/src/lib/views/dashboard/TileEditorTableConditional.svelte
+++ b/saiku-ui/src/lib/views/dashboard/TileEditorTableConditional.svelte
@@ -194,14 +194,14 @@
     display: flex;
     flex-direction: column;
     gap: 0.5rem;
-    border: 1px solid var(--border);
+    border: 1px solid hsl(var(--border));
     border-radius: 4px;
     padding: 0.5rem 0.75rem;
     margin: 0;
   }
   .cf-section legend {
     font-size: 0.75rem;
-    color: var(--fg-muted);
+    color: hsl(var(--fg-muted));
     text-transform: uppercase;
     letter-spacing: 0.04em;
     padding: 0 0.25rem;
@@ -210,14 +210,14 @@
     display: flex;
     flex-direction: column;
     gap: 0.5rem;
-    border: 1px solid var(--border);
+    border: 1px solid hsl(var(--border));
     border-radius: 4px;
     padding: 0.5rem 0.625rem;
-    background: var(--bg-subtle);
+    background: hsl(var(--bg-subtle));
   }
   .cf-rule-label {
     font-size: 0.75rem;
-    color: var(--fg-muted);
+    color: hsl(var(--fg-muted));
     text-transform: uppercase;
     letter-spacing: 0.04em;
   }

--- a/saiku-ui/src/lib/views/dashboard/TileEditorTableSparkline.svelte
+++ b/saiku-ui/src/lib/views/dashboard/TileEditorTableSparkline.svelte
@@ -49,14 +49,14 @@
     display: flex;
     flex-direction: column;
     gap: 0.5rem;
-    border: 1px solid var(--border);
+    border: 1px solid hsl(var(--border));
     border-radius: 4px;
     padding: 0.5rem 0.75rem;
     margin: 0;
   }
   .cf-section legend {
     font-size: 0.75rem;
-    color: var(--fg-muted);
+    color: hsl(var(--fg-muted));
     text-transform: uppercase;
     letter-spacing: 0.04em;
     padding: 0 0.25rem;

--- a/saiku-ui/src/lib/views/dashboard/tiles/ChartTile.svelte
+++ b/saiku-ui/src/lib/views/dashboard/tiles/ChartTile.svelte
@@ -835,8 +835,8 @@
     display: flex;
     align-items: center;
     justify-content: center;
-    background: color-mix(in srgb, var(--bg) 75%, transparent);
-    color: var(--fg-muted);
+    background: color-mix(in srgb, hsl(var(--bg)) 75%, transparent);
+    color: hsl(var(--fg-muted));
     font-size: 0.875rem;
     z-index: 1;
     pointer-events: none;
@@ -846,7 +846,7 @@
   /* Opaque, interactive overlay for the loading skeleton / error / empty
      states (which carry Retry / Reset buttons). #933 */
   .overlay.solid {
-    background: var(--bg);
+    background: hsl(var(--bg));
     pointer-events: auto;
     padding: 0;
   }
@@ -858,14 +858,14 @@
     right: 0.25rem;
     top: 0.25rem;
     z-index: 2;
-    background: color-mix(in srgb, var(--bg) 80%, transparent);
+    background: color-mix(in srgb, hsl(var(--bg)) 80%, transparent);
     border-radius: 4px;
     padding: 0.0625rem 0.25rem;
     pointer-events: none;
     max-width: calc(100% - 0.5rem);
   }
   code {
-    background: var(--bg-subtle);
+    background: hsl(var(--bg-subtle));
     padding: 0.0625em 0.25em;
     border-radius: 3px;
     font-size: 0.85em;

--- a/saiku-ui/src/lib/views/dashboard/tiles/ImageTile.svelte
+++ b/saiku-ui/src/lib/views/dashboard/tiles/ImageTile.svelte
@@ -81,7 +81,7 @@
     flex-shrink: 0;
     padding: 0.25rem 0.5rem;
     font-size: 0.75rem;
-    color: var(--fg-muted);
+    color: hsl(var(--fg-muted));
     text-align: center;
     overflow-wrap: anywhere;
   }
@@ -96,7 +96,7 @@
     gap: 0.5rem;
     padding: 0.75rem;
     text-align: center;
-    color: var(--fg-muted);
+    color: hsl(var(--fg-muted));
     font-size: 0.8125rem;
   }
   /* Render the real edit-button icon (lucide Settings2) inline so the
@@ -104,6 +104,6 @@
   .image-placeholder :global(.inline-gear) {
     display: inline-block;
     vertical-align: -2px;
-    color: var(--fg-subtle);
+    color: hsl(var(--fg-subtle));
   }
 </style>

--- a/saiku-ui/src/lib/views/dashboard/tiles/KpiTile.svelte
+++ b/saiku-ui/src/lib/views/dashboard/tiles/KpiTile.svelte
@@ -535,7 +535,7 @@
     font-weight: 600;
     line-height: 1.1;
     letter-spacing: -0.01em;
-    color: var(--fg);
+    color: hsl(var(--fg));
     text-align: center;
   }
   .delta {
@@ -543,7 +543,7 @@
     align-items: center;
     gap: 0.25rem;
     font-size: 0.8125rem;
-    color: var(--fg-muted);
+    color: hsl(var(--fg-muted));
   }
   .delta[data-tone="positive"] {
     color: var(--success, #1b8a3a);
@@ -552,13 +552,13 @@
     color: var(--danger, #c00);
   }
   .delta.delta--empty {
-    color: var(--fg-muted);
+    color: hsl(var(--fg-muted));
     font-style: italic;
     cursor: help;
   }
   .caption {
     font-size: 0.75rem;
-    color: var(--fg-muted);
+    color: hsl(var(--fg-muted));
     text-transform: uppercase;
     letter-spacing: 0.04em;
   }
@@ -571,7 +571,7 @@
     right: 0.25rem;
     top: 0.25rem;
     z-index: 2;
-    background: color-mix(in srgb, var(--bg) 80%, transparent);
+    background: color-mix(in srgb, hsl(var(--bg)) 80%, transparent);
     border-radius: 4px;
     padding: 0.0625rem 0.25rem;
     pointer-events: none;
@@ -579,13 +579,13 @@
   }
   .placeholder {
     padding: 0.75rem 1rem;
-    color: var(--fg-muted);
+    color: hsl(var(--fg-muted));
     font-size: 0.8125rem;
     text-align: center;
   }
   .placeholder :global(.placeholder__icon) {
     display: inline-block;
     vertical-align: -2px;
-    color: var(--fg-subtle);
+    color: hsl(var(--fg-subtle));
   }
 </style>

--- a/saiku-ui/src/lib/views/dashboard/tiles/TableTile.svelte
+++ b/saiku-ui/src/lib/views/dashboard/tiles/TableTile.svelte
@@ -465,21 +465,21 @@
                               y={bar.y}
                               width={bar.width}
                               height={bar.height}
-                              fill="var(--accent)"
+                              fill="hsl(var(--primary))"
                             />
                           {/each}
                         {:else}
                           <polyline
                             points={g.polyline}
                             fill="none"
-                            stroke="var(--accent)"
+                            stroke="hsl(var(--primary))"
                             stroke-width="1.25"
                             stroke-linejoin="round"
                             stroke-linecap="round"
                             vector-effect="non-scaling-stroke"
                           />
                           {#if g.last}
-                            <circle cx={g.last.x} cy={g.last.y} r="1.5" fill="var(--accent)" />
+                            <circle cx={g.last.x} cy={g.last.y} r="1.5" fill="hsl(var(--primary))" />
                           {/if}
                         {/if}
                       </svg>
@@ -521,7 +521,7 @@
     float: right;
     margin-right: 0.25rem;
     z-index: 2;
-    background: color-mix(in srgb, var(--bg) 80%, transparent);
+    background: color-mix(in srgb, hsl(var(--bg)) 80%, transparent);
     border-radius: 4px;
     padding: 0.0625rem 0.25rem;
     pointer-events: none;
@@ -535,10 +535,10 @@
   th, td {
     padding: 0.25rem 0.5rem;
     text-align: right;
-    border-bottom: 1px solid var(--border);
+    border-bottom: 1px solid hsl(var(--border));
   }
   th {
-    background: var(--bg-muted);
+    background: hsl(var(--bg-muted));
     font-weight: var(--weight-semibold);
     position: sticky;
     top: 0;
@@ -551,10 +551,10 @@
     cursor: pointer;
   }
   td.clickable:hover {
-    background: var(--bg-subtle);
+    background: hsl(var(--bg-subtle));
   }
   td.clickable:focus {
-    outline: 2px solid var(--accent);
+    outline: 2px solid hsl(var(--primary));
     outline-offset: -2px;
   }
   /* Issue #919 — conditional-format icon glyph prepended to a cell. */
@@ -571,6 +571,6 @@
     display: block;
     width: 64px;
     height: 18px;
-    color: var(--accent);
+    color: hsl(var(--primary));
   }
 </style>

--- a/saiku-ui/src/lib/views/dashboard/tiles/TextTile.svelte
+++ b/saiku-ui/src/lib/views/dashboard/tiles/TextTile.svelte
@@ -61,7 +61,7 @@
     padding: 0.25rem 0.5rem;
     font-size: 0.875rem;
     line-height: 1.5;
-    color: var(--fg);
+    color: hsl(var(--fg));
   }
   /* Heading / paragraph / list resets so analyst-written text doesn't
      inherit weird vertical rhythm from the surrounding tile chrome. */
@@ -80,13 +80,13 @@
     padding-left: 1.25rem;
   }
   .text-tile :global(code) {
-    background: var(--bg-subtle);
+    background: hsl(var(--bg-subtle));
     padding: 0.0625em 0.25em;
     border-radius: 3px;
     font-size: 0.85em;
   }
   .text-tile :global(a) {
-    color: var(--accent);
+    color: hsl(var(--primary));
     text-decoration: underline;
   }
 </style>

--- a/saiku-ui/src/lib/views/dashboard/tiles/TileEmpty.svelte
+++ b/saiku-ui/src/lib/views/dashboard/tiles/TileEmpty.svelte
@@ -49,17 +49,17 @@
     gap: 0.35rem;
     padding: 0.25rem 0.6rem;
     font-size: 0.8125rem;
-    color: var(--fg);
-    background: var(--bg-subtle);
-    border: 1px solid var(--border);
+    color: hsl(var(--fg));
+    background: hsl(var(--bg-subtle));
+    border: 1px solid hsl(var(--border));
     border-radius: 4px;
     cursor: pointer;
   }
   .reset:hover {
-    background: var(--bg-muted);
+    background: hsl(var(--bg-muted));
   }
   .reset:focus-visible {
-    outline: 2px solid var(--accent);
+    outline: 2px solid hsl(var(--primary));
     outline-offset: 1px;
   }
 </style>

--- a/saiku-ui/src/lib/views/dashboard/tiles/TileError.svelte
+++ b/saiku-ui/src/lib/views/dashboard/tiles/TileError.svelte
@@ -35,7 +35,7 @@
     /* Long backend errors shouldn't blow out the tile. */
     max-width: 100%;
     overflow-wrap: anywhere;
-    color: var(--danger);
+    color: hsl(var(--danger));
   }
   .retry {
     display: inline-flex;
@@ -43,17 +43,17 @@
     gap: 0.35rem;
     padding: 0.25rem 0.6rem;
     font-size: 0.8125rem;
-    color: var(--fg);
-    background: var(--bg-subtle);
-    border: 1px solid var(--border);
+    color: hsl(var(--fg));
+    background: hsl(var(--bg-subtle));
+    border: 1px solid hsl(var(--border));
     border-radius: 4px;
     cursor: pointer;
   }
   .retry:hover {
-    background: var(--bg-muted);
+    background: hsl(var(--bg-muted));
   }
   .retry:focus-visible {
-    outline: 2px solid var(--accent);
+    outline: 2px solid hsl(var(--primary));
     outline-offset: 1px;
   }
 </style>

--- a/saiku-ui/src/lib/views/dashboard/tiles/TileLoading.svelte
+++ b/saiku-ui/src/lib/views/dashboard/tiles/TileLoading.svelte
@@ -52,7 +52,7 @@
 <style>
 /* Shared shimmer fill. */
   .sk {
-    background: var(--bg-subtle);
+    background: hsl(var(--bg-subtle));
     border-radius: 4px;
     position: relative;
     overflow: hidden;
@@ -64,7 +64,7 @@
     background: linear-gradient(
       90deg,
       transparent 0%,
-      color-mix(in srgb, var(--fg) 8%, transparent) 50%,
+      color-mix(in srgb, hsl(var(--fg)) 8%, transparent) 50%,
       transparent 100%
     );
     transform: translateX(-100%);
@@ -108,7 +108,7 @@
   }
   .sk-row--head .skeleton-cell {
     height: 1.05rem;
-    background: var(--bg-muted);
+    background: hsl(var(--bg-muted));
   }
   /* KPI: a big number block + a small caption block. */
   .sk-kpi {

--- a/saiku-ui/src/lib/views/dashboard/tiles/TileRefreshIndicator.svelte
+++ b/saiku-ui/src/lib/views/dashboard/tiles/TileRefreshIndicator.svelte
@@ -46,7 +46,7 @@
     align-items: center;
     gap: 0.25rem;
     font-size: 0.6875rem;
-    color: var(--fg-muted);
+    color: hsl(var(--fg-muted));
     line-height: 1;
     pointer-events: none;
     max-width: 100%;

--- a/saiku-ui/src/lib/views/dashboard/tiles/custom/EChartsOptionTile.svelte
+++ b/saiku-ui/src/lib/views/dashboard/tiles/custom/EChartsOptionTile.svelte
@@ -302,8 +302,8 @@
     display: flex;
     align-items: center;
     justify-content: center;
-    background: var(--bg);
-    color: var(--fg-muted);
+    background: hsl(var(--bg));
+    color: hsl(var(--fg-muted));
     z-index: 1;
   }
   .overlay.solid {

--- a/saiku-ui/src/lib/views/dashboard/tiles/custom/GraphTile.svelte
+++ b/saiku-ui/src/lib/views/dashboard/tiles/custom/GraphTile.svelte
@@ -246,8 +246,8 @@
     display: flex;
     align-items: center;
     justify-content: center;
-    background: var(--bg);
-    color: var(--fg-muted);
+    background: hsl(var(--bg));
+    color: hsl(var(--fg-muted));
     z-index: 1;
   }
   .overlay.solid {

--- a/saiku-ui/src/lib/views/dashboard/tiles/custom/PluginTile.svelte
+++ b/saiku-ui/src/lib/views/dashboard/tiles/custom/PluginTile.svelte
@@ -332,7 +332,7 @@
     width: 100%;
     min-height: 40px;
     border: 0;
-    background: var(--bg);
+    background: hsl(var(--bg));
   }
   .plugin-error {
     position: absolute;
@@ -342,7 +342,7 @@
     padding: 4px 8px;
     font-size: 12px;
     color: var(--danger, #b91c1c);
-    background: var(--bg);
+    background: hsl(var(--bg));
     border-top: 1px solid var(--border, #e5e7eb);
     z-index: 2;
     white-space: pre-wrap;
@@ -354,8 +354,8 @@
     display: flex;
     align-items: center;
     justify-content: center;
-    background: var(--bg);
-    color: var(--fg-muted);
+    background: hsl(var(--bg));
+    color: hsl(var(--fg-muted));
     z-index: 1;
   }
   .overlay.solid {

--- a/saiku-ui/src/lib/views/dashboard/widgets/CascadingFilterPicker.svelte
+++ b/saiku-ui/src/lib/views/dashboard/widgets/CascadingFilterPicker.svelte
@@ -209,9 +209,9 @@
   }
   .picker-select {
     padding: 0.125rem 0.25rem;
-    border: 1px solid var(--border-strong, var(--border));
+    border: 1px solid var(--border-strong, hsl(var(--border)));
     border-radius: 4px;
-    background: var(--bg);
+    background: hsl(var(--bg));
     font-size: 0.8125rem;
     max-width: 200px;
   }

--- a/saiku-ui/src/routes/+layout.svelte
+++ b/saiku-ui/src/routes/+layout.svelte
@@ -136,7 +136,7 @@
         {#if page.url.pathname.startsWith(`${base}/admin`)}
           <a class={buttonVariants({ variant: "outline", size: "sm" })} href="{base}/"><Home size={14} /><span>{i18n.t("topbar.workspace")}</span></a>
         {/if}
-        <Button variant="outline" size="sm" onclick={() => session.logout()}>
+        <Button variant="outline" size="sm" data-testid="app-signout" onclick={() => session.logout()}>
           <LogOut size={14} /><span>{i18n.t("topbar.signOut")}</span>
         </Button>
       {/if}

--- a/saiku-ui/src/routes/+layout.svelte
+++ b/saiku-ui/src/routes/+layout.svelte
@@ -179,14 +179,14 @@
     justify-content: space-between;
     gap: var(--space-3);
     padding: var(--space-3) var(--space-5);
-    background: var(--bg-muted);
-    border-bottom: 1px solid var(--border);
+    background: hsl(var(--bg-muted));
+    border-bottom: 1px solid hsl(var(--border));
   }
   .topbar__brand {
     display: flex;
     align-items: center;
     gap: var(--space-2);
-    color: var(--fg);
+    color: hsl(var(--fg));
     text-decoration: none;
   }
   .topbar__brand:hover { text-decoration: none; }
@@ -224,11 +224,11 @@
     align-items: center;
     gap: var(--space-1);
     padding: 4px var(--space-2);
-    background: var(--bg-subtle);
-    border: 1px solid var(--border);
+    background: hsl(var(--bg-subtle));
+    border: 1px solid hsl(var(--border));
     border-radius: 999px;
-    color: var(--fg-muted);
+    color: hsl(var(--fg-muted));
     font-size: var(--fs-sm);
   }
-  .topbar__user :global(svg) { color: var(--fg-subtle); }
+  .topbar__user :global(svg) { color: hsl(var(--fg-subtle)); }
 </style>

--- a/saiku-ui/src/routes/admin/+page.svelte
+++ b/saiku-ui/src/routes/admin/+page.svelte
@@ -68,20 +68,20 @@
     display: flex;
     gap: var(--space-2);
     padding: var(--space-2) var(--space-5);
-    background: var(--bg-muted);
-    border-bottom: 1px solid var(--border);
+    background: hsl(var(--bg-muted));
+    border-bottom: 1px solid hsl(var(--border));
   }
   .admin__tabs button {
     padding: var(--space-2) var(--space-3);
     background: transparent;
     border: 0;
-    color: var(--fg-muted);
+    color: hsl(var(--fg-muted));
     font: inherit;
     cursor: pointer;
     border-bottom: 2px solid transparent;
   }
   .admin__tabs .active {
-    color: var(--fg);
-    border-bottom-color: var(--accent);
+    color: hsl(var(--fg));
+    border-bottom-color: hsl(var(--primary));
   }
 </style>

--- a/saiku-ui/src/routes/admin/cube-designer/[dataSourceId]/+page.svelte
+++ b/saiku-ui/src/routes/admin/cube-designer/[dataSourceId]/+page.svelte
@@ -28,8 +28,15 @@
   import { parseProfileTables } from "$lib/cube-designer/profile-types";
   import type { SourceTableCandidate } from "$lib/cube-designer/types";
   import { adminSchemas } from "$lib/api/admin";
+  import { platform } from "$lib/stores/platform.svelte";
   import Button from "$lib/components/ui/button.svelte";
   import FeedbackBanner from "$lib/design-system/FeedbackBanner.svelte";
+  import {
+    LayoutGrid,
+    ArrowLeftRight,
+    Sigma,
+    CheckCircle2,
+  } from "lucide-svelte";
   import type { PageData } from "./$types";
 
   let { data }: { data: PageData } = $props();
@@ -44,14 +51,19 @@
   let saving = $state(false);
   let saveMsg = $state<{ tone: "success" | "error"; text: string } | null>(null);
 
+  // saiku#1636: on a public demo, don't let visitors persist a (possibly broken)
+  // schema that would take cubes down for everyone. Save is disabled in demo mode.
+  const demoMode = $derived(platform.capabilities?.demoMode === true);
+
   const MODES = [
-    { m: "canvas", label: "Schema Canvas" },
-    { m: "workbench", label: "Dimensions & Hierarchies" },
-    { m: "facts", label: "Facts & Measures" },
-    { m: "validate", label: "Confirm cube" },
+    { m: "canvas", label: "Schema Canvas", Icon: LayoutGrid },
+    { m: "workbench", label: "Dimensions & Hierarchies", Icon: ArrowLeftRight },
+    { m: "facts", label: "Facts & Measures", Icon: Sigma },
+    { m: "validate", label: "Confirm cube", Icon: CheckCircle2 },
   ] as const;
 
   onMount(async () => {
+    if (!platform.capabilities) await platform.loadCapabilities();
     store.switchConnection(dataSourceId);
     store.sourceLoading = true;
     store.sourceError = null;
@@ -104,6 +116,7 @@
   }
 
   async function save() {
+    if (demoMode) return; // saving disabled in demo mode
     saving = true;
     saveMsg = null;
     let xml: string;
@@ -138,24 +151,38 @@
     <h1 class="mr-2 text-sm font-semibold text-foreground">
       Cube Designer <span class="text-muted-foreground">· {dataSourceId}</span>
     </h1>
-    <nav class="flex items-center gap-1" role="tablist" aria-label="Designer mode">
-      {#each MODES as { m, label } (m)}
+    <!-- Segmented mode tabs — one outer border, siblings share edges; active
+         tab is an inset red ring + glow (matches saiku-cloud's CanvasHeader). -->
+    <nav
+      class="flex items-stretch overflow-hidden rounded border border-border bg-background"
+      role="tablist"
+      aria-label="Designer mode"
+    >
+      {#each MODES as { m, label, Icon } (m)}
         {@const active = store.mode === m}
         <button
           type="button"
           role="tab"
           aria-selected={active}
-          class="rounded px-2 py-1 text-[11px] font-medium {active
-            ? 'bg-primary text-primary-foreground'
+          aria-label={label}
+          title={label}
+          class="relative inline-flex h-9 items-center justify-center gap-1.5 border-l border-border px-3 text-xs font-medium transition-colors first:border-l-0 {active
+            ? 'z-10 bg-card text-primary shadow-[0_0_12px_hsl(var(--primary)/0.35)] ring-2 ring-primary/60 ring-inset'
             : 'text-muted-foreground hover:bg-accent hover:text-accent-foreground'}"
           onclick={() => store.setMode(m)}
         >
-          {label}
+          <Icon class="h-3.5 w-3.5" aria-hidden="true" />
+          <span>{label}</span>
         </button>
       {/each}
     </nav>
     <div class="ml-auto flex items-center gap-2">
-      <Button size="sm" onclick={save} disabled={saving}>
+      <Button
+        size="sm"
+        onclick={save}
+        disabled={saving || demoMode}
+        title={demoMode ? "Saving is disabled in demo mode" : undefined}
+      >
         {saving ? "Saving…" : "Save"}
       </Button>
       <Button

--- a/saiku-ui/src/routes/admin/cube-designer/[dataSourceId]/+page.svelte
+++ b/saiku-ui/src/routes/admin/cube-designer/[dataSourceId]/+page.svelte
@@ -102,7 +102,10 @@
   }
 </script>
 
-<div class="flex h-svh flex-col overflow-hidden">
+<!-- flex-1 + min-w/h-0 so the designer fills the layout's <main> (a flex row)
+     across the full width AND height, instead of h-svh (which sized to the
+     viewport and left a right-hand gap / overran the topbar). -->
+<div class="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden">
   <header class="flex shrink-0 flex-wrap items-center gap-2 border-b border-border px-3 py-2">
     <h1 class="mr-2 text-sm font-semibold text-foreground">
       Cube Designer <span class="text-muted-foreground">· {dataSourceId}</span>

--- a/saiku-ui/src/routes/admin/cube-designer/[dataSourceId]/+page.svelte
+++ b/saiku-ui/src/routes/admin/cube-designer/[dataSourceId]/+page.svelte
@@ -21,7 +21,9 @@
   import {
     ossCubeDesignerBackend,
     ossCubeDesignerAI,
+    fetchDatasourceSchema,
   } from "$lib/cube-designer/oss-backend";
+  import { hydrateFromMondrianXml } from "./edit-load";
   import { exportToMondrianXml } from "$lib/cube-designer/mondrian-export";
   import { parseProfileTables } from "$lib/cube-designer/profile-types";
   import type { SourceTableCandidate } from "$lib/cube-designer/types";
@@ -73,7 +75,33 @@
     } finally {
       store.sourceLoading = false;
     }
+    // saiku#1634 edit mode: if this datasource already has a Mondrian schema,
+    // hydrate the canvas from it. Runs after profiling so the importer can
+    // enrich imported tables against the live source catalog.
+    await loadExistingSchema();
   });
+
+  /**
+   * Fetch the datasource's attached Mondrian schema (if any) and load it onto
+   * the canvas. A 404 (no schema attached) is the new-cube path — leave the
+   * canvas blank. A parse/read error surfaces in the source-error banner.
+   */
+  async function loadExistingSchema() {
+    try {
+      const r = await fetchDatasourceSchema(dataSourceId);
+      if (!r.ok) return; // 404 ⇒ no schema attached: start a new cube, blank canvas
+      const body = (await r.json()) as { mondrianXml?: string; label?: string };
+      const xml = body.mondrianXml ?? "";
+      if (!xml) return;
+      hydrateFromMondrianXml(store, xml, dataSourceId);
+      // Mark the canvas as editing a saved schema so the workbench shows saved
+      // (not draft) state; Save then writes back under this name.
+      store.doc.lineageId = body.label?.trim() || dataSourceId;
+    } catch (e) {
+      sourceError =
+        e instanceof Error ? e.message : "could not load the existing schema";
+    }
+  }
 
   async function save() {
     saving = true;

--- a/saiku-ui/src/routes/admin/cube-designer/[dataSourceId]/edit-load.test.ts
+++ b/saiku-ui/src/routes/admin/cube-designer/[dataSourceId]/edit-load.test.ts
@@ -1,0 +1,58 @@
+// @vitest-environment happy-dom
+import { describe, expect, it } from "vitest";
+import { SchemaCanvasStore } from "$lib/cube-designer/state.svelte";
+import { hydrateFromMondrianXml } from "./edit-load";
+
+/**
+ * saiku#1634 — the edit-existing-cube hydration path. Parsing an attached
+ * Mondrian-4 schema must populate the canvas doc, seed the workbench cubes, and
+ * recenter the viewport (so the loaded nodes aren't off-screen).
+ */
+
+const SCHEMA_XML = `<Schema name="Sales" metamodelVersion="4.0">
+  <PhysicalSchema>
+    <Table name="dim_date"><Key name="k"><Column name="date_key"/></Key></Table>
+    <Table name="fact"/>
+  </PhysicalSchema>
+  <Dimension name="Calendar" type="TIME" table="dim_date" key="Year">
+    <Attributes>
+      <Attribute name="Year" table="dim_date" keyColumn="year_num" levelType="TimeYears"/>
+    </Attributes>
+    <Hierarchies>
+      <Hierarchy name="Calendar" hasAll="true"><Level attribute="Year"/></Hierarchy>
+    </Hierarchies>
+  </Dimension>
+  <Cube name="C">
+    <Dimensions><Dimension source="Calendar"/></Dimensions>
+    <MeasureGroups>
+      <MeasureGroup name="G" table="fact">
+        <Measures><Measure name="Cnt" aggregator="count"/></Measures>
+      </MeasureGroup>
+    </MeasureGroups>
+  </Cube>
+</Schema>`;
+
+describe("hydrateFromMondrianXml", () => {
+  it("loads tables onto the canvas and recenters the viewport", () => {
+    const store = new SchemaCanvasStore("test-ds");
+    const result = hydrateFromMondrianXml(store, SCHEMA_XML, "test-ds", () => 4242);
+
+    expect(result.tableCount).toBe(2);
+    expect(store.doc.tables.map((t) => t.name).sort()).toEqual(["dim_date", "fact"]);
+    // Recenter so the freshly-loaded nodes are visible, not off in the corner.
+    expect(store.requestedCanvasAction).toEqual({ kind: "fit_view", ts: 4242 });
+  });
+
+  it("seeds the workbench cubes from the imported schema", () => {
+    const store = new SchemaCanvasStore("test-ds-2");
+    hydrateFromMondrianXml(store, SCHEMA_XML, "test-ds-2");
+
+    expect(store.cubes.map((c) => c.name)).toEqual(["C"]);
+    expect(store.cubes[0]?.measureGroups.map((mg) => mg.name)).toEqual(["G"]);
+  });
+
+  it("throws on malformed XML so the caller can surface it", () => {
+    const store = new SchemaCanvasStore("test-ds-3");
+    expect(() => hydrateFromMondrianXml(store, "not xml at all", "test-ds-3")).toThrow();
+  });
+});

--- a/saiku-ui/src/routes/admin/cube-designer/[dataSourceId]/edit-load.ts
+++ b/saiku-ui/src/routes/admin/cube-designer/[dataSourceId]/edit-load.ts
@@ -1,0 +1,56 @@
+/**
+ * OSS edit-existing-cube hydration (saiku#1634).
+ *
+ * When the Cube Designer is opened for a datasource that already has a Mondrian
+ * schema attached, the host fetches that schema's XML (see
+ * `oss-backend.ts#fetchDatasourceSchema`) and calls this helper to parse it and
+ * populate the canvas + workbench — mirroring saiku-cloud's
+ * `ImportController.loadFromLibrary` commit path, minus the library modal UI.
+ *
+ * Kept as host glue (not a shared `$lib/cube-designer` component) so saiku-cloud,
+ * which has its own library-based edit flow, is unaffected. Extracted from the
+ * route's `onMount` so the parse → hydrate transform is unit-testable.
+ */
+import type { SchemaCanvasStore } from "$lib/cube-designer/state.svelte";
+import { importFromMondrianXml } from "$lib/cube-designer/mondrian-import";
+import { mapWorkbenchDocCubes } from "./workbench-seed";
+
+export interface HydrateResult {
+  tableCount: number;
+  joinCount: number;
+  warnings: string[];
+}
+
+/**
+ * Parse `xml` and load it into the store as the canvas doc + workbench cubes,
+ * recentering the viewport on the freshly-loaded nodes. `connectionId` is the
+ * datasource the canvas is authoring against; `now` is injectable for tests.
+ *
+ * Throws whatever `importFromMondrianXml` throws (malformed XML,
+ * `AmbiguousSchemaError`) so the caller can surface a message.
+ */
+export function hydrateFromMondrianXml(
+  store: SchemaCanvasStore,
+  xml: string,
+  connectionId: string,
+  now: () => number = Date.now,
+): HydrateResult {
+  const { state, warnings, workbenchCubes } = importFromMondrianXml(xml, {
+    connectionId,
+    sourceTables: store.sourceTables,
+  });
+  store.loadDoc(state);
+  if (workbenchCubes.length > 0) {
+    store.setCubes(mapWorkbenchDocCubes(workbenchCubes));
+  }
+  if (state.tables.length > 0) {
+    // Recenter so the loaded nodes aren't rendered off-screen with only a
+    // minimap dot (saiku-cloud#1035 keeps fit_view on every import path).
+    store.requestedCanvasAction = { kind: "fit_view", ts: now() };
+  }
+  return {
+    tableCount: state.tables.length,
+    joinCount: state.joins.length,
+    warnings,
+  };
+}

--- a/saiku-ui/src/routes/admin/cube-designer/[dataSourceId]/workbench-seed.ts
+++ b/saiku-ui/src/routes/admin/cube-designer/[dataSourceId]/workbench-seed.ts
@@ -1,0 +1,47 @@
+/**
+ * Map freshly parsed Mondrian-4 import cubes into the trimmed `doc.cubes`
+ * model the workbench hydrates from (measure groups, factTableId,
+ * measureColumns, dimensionLinks, calcs, time-intelligence metrics). UI-only
+ * flags are re-derived when the workbench mounts.
+ *
+ * OSS host-glue mirror of saiku-cloud's
+ * `routes/schemas/new/canvas/workbench-seed.ts` — kept structurally identical
+ * so the edit-existing-cube flow behaves the same on both hosts (saiku#1634).
+ * Extracted from the route so the transform is unit-testable.
+ */
+import type { importFromMondrianXml } from "$lib/cube-designer/mondrian-import";
+import type { SchemaCanvasCube } from "$lib/cube-designer/types";
+
+type WorkbenchImportCubes = ReturnType<typeof importFromMondrianXml>["workbenchCubes"];
+
+export function mapWorkbenchDocCubes(cubes: WorkbenchImportCubes): SchemaCanvasCube[] {
+  return cubes.map((c) => ({
+    id: c.id,
+    name: c.name,
+    measureGroups: c.measureGroups.map((mg) => ({
+      id: mg.id,
+      name: mg.name,
+      measureColumns: mg.measureColumns,
+      factTableId: mg.factTableId,
+      // Preserve linkKind / viaDimension / viaAttribute so FactLink and
+      // ReferenceLink round-trip through the workbench → export.
+      dimensionLinks: mg.dimensionLinks.map((l) => ({
+        dimensionId: l.dimensionId,
+        foreignKeyColumn: l.foreignKeyColumn,
+        linkKind: l.linkKind,
+        viaDimension: l.viaDimension,
+        viaAttribute: l.viaAttribute,
+      })),
+      measureCaptions: {},
+    })),
+    calcs: c.factsCalcs.map((cc) => ({
+      id: cc.id,
+      name: cc.name,
+      tokens: [],
+      formula: cc.formula,
+    })),
+    // Carry declarative time-intelligence metrics onto the doc cube so they
+    // survive import (and setCubes preserves them across workbench syncs).
+    timeCalcs: c.timeCalcs,
+  }));
+}

--- a/saiku-ui/src/routes/admin/schema-generator/[dataSourceId]/+page.svelte
+++ b/saiku-ui/src/routes/admin/schema-generator/[dataSourceId]/+page.svelte
@@ -288,8 +288,8 @@
     flex: 1;
     min-height: 0;
     font-family: var(--font-sans);
-    color: var(--fg);
-    background: var(--bg);
+    color: hsl(var(--fg));
+    background: hsl(var(--bg));
   }
   .schemagen__title {
     display: flex;
@@ -304,7 +304,7 @@
   .schemagen__dsid {
     font-family: var(--font-mono);
     font-size: var(--fs-xs);
-    color: var(--fg-muted);
+    color: hsl(var(--fg-muted));
   }
   .schemagen__actions {
     display: flex;
@@ -314,14 +314,14 @@
   .schemagen__actions button {
     font: inherit;
     padding: var(--space-2) var(--space-3);
-    border: 1px solid var(--border);
+    border: 1px solid hsl(var(--border));
     border-radius: var(--radius-sm);
-    background: var(--bg);
-    color: var(--fg);
+    background: hsl(var(--bg));
+    color: hsl(var(--fg));
     cursor: pointer;
   }
   .schemagen__actions button:hover:not(:disabled) {
-    background: var(--bg-subtle);
+    background: hsl(var(--bg-subtle));
   }
   .schemagen__actions button:disabled {
     opacity: 0.5;
@@ -334,19 +334,19 @@
     border-radius: 999px;
     text-transform: uppercase;
     letter-spacing: 0.03em;
-    background: var(--fg-subtle);
-    color: var(--accent-fg);
+    background: hsl(var(--fg-subtle));
+    color: hsl(var(--primary-foreground));
   }
   .schemagen__pill[data-color="muted"] {
-    background: var(--border-strong);
-    color: var(--fg);
+    background: hsl(var(--border-strong));
+    color: hsl(var(--fg));
   }
   .schemagen__pill[data-color="info"] {
-    background: var(--accent);
-    color: var(--accent-fg);
+    background: hsl(var(--primary));
+    color: hsl(var(--primary-foreground));
   }
   .schemagen__pill[data-color="success"] {
-    background: var(--success);
+    background: hsl(var(--success));
     color: #fff;
   }
   .schemagen__pill[data-color="danger"] {
@@ -360,15 +360,15 @@
     justify-content: space-between;
     gap: var(--space-3);
     padding: var(--space-2) var(--space-5);
-    border-bottom: 1px solid var(--border);
+    border-bottom: 1px solid hsl(var(--border));
   }
   .schemagen__failure {
     background: var(--danger, #c0392b);
     color: #fff;
   }
   .schemagen__error {
-    background: var(--bg-muted);
-    color: var(--fg);
+    background: hsl(var(--bg-muted));
+    color: hsl(var(--fg));
   }
   .schemagen__delta {
     display: flex;
@@ -377,7 +377,7 @@
     padding: var(--space-2) var(--space-5);
     background: var(--accent, #2b6cb0);
     color: var(--accent-fg, #fff);
-    border-bottom: 1px solid var(--border);
+    border-bottom: 1px solid hsl(var(--border));
     font-size: var(--fs-sm);
   }
   .schemagen__error button {
@@ -407,8 +407,8 @@
     right: 0;
     bottom: 0;
     width: min(420px, 50%);
-    background: var(--bg);
-    border-left: 1px solid var(--border);
+    background: hsl(var(--bg));
+    border-left: 1px solid hsl(var(--border));
     box-shadow: -8px 0 16px -12px rgb(0 0 0 / 0.25);
     transform: translateX(100%);
     transition: transform 180ms ease;
@@ -431,9 +431,9 @@
     line-height: 1;
     padding: var(--space-1) var(--space-2);
     cursor: pointer;
-    color: var(--fg-muted);
+    color: hsl(var(--fg-muted));
   }
   .schemagen__drawer-close:hover {
-    color: var(--fg);
+    color: hsl(var(--fg));
   }
 </style>

--- a/saiku-ui/src/routes/preview/+page.svelte
+++ b/saiku-ui/src/routes/preview/+page.svelte
@@ -64,22 +64,22 @@
     min-height: 0;
     display: flex;
     flex-direction: column;
-    background: var(--bg);
+    background: hsl(var(--bg));
   }
   .preview__badge {
     font-size: var(--fs-sm);
-    color: var(--fg-muted);
+    color: hsl(var(--fg-muted));
     padding: 2px var(--space-2);
-    border: 1px solid var(--border);
+    border: 1px solid hsl(var(--border));
     border-radius: 999px;
-    background: var(--bg-subtle);
+    background: hsl(var(--bg-subtle));
   }
   .preview__state {
     flex: 1;
     display: flex;
     align-items: center;
     justify-content: center;
-    color: var(--fg-muted);
+    color: hsl(var(--fg-muted));
     font-size: var(--fs-md);
   }
 </style>

--- a/saiku-ui/src/routes/share/+page.svelte
+++ b/saiku-ui/src/routes/share/+page.svelte
@@ -77,22 +77,22 @@
     min-height: 0;
     display: flex;
     flex-direction: column;
-    background: var(--bg);
+    background: hsl(var(--bg));
   }
   .share-view__badge {
     font-size: var(--fs-sm);
-    color: var(--fg-muted);
+    color: hsl(var(--fg-muted));
     padding: 2px var(--space-2);
-    border: 1px solid var(--border);
+    border: 1px solid hsl(var(--border));
     border-radius: 999px;
-    background: var(--bg-subtle);
+    background: hsl(var(--bg-subtle));
   }
   .share-view__state {
     flex: 1;
     display: flex;
     align-items: center;
     justify-content: center;
-    color: var(--fg-muted);
+    color: hsl(var(--fg-muted));
     font-size: var(--fs-md);
   }
 </style>

--- a/saiku-webapp/pom.xml
+++ b/saiku-webapp/pom.xml
@@ -2,11 +2,11 @@
     <parent>
         <artifactId>saiku</artifactId>
         <groupId>org.saikuanalytics</groupId>
-        <version>4.7.0</version>
+        <version>4.7.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>saiku-webapp</artifactId>
-    <version>4.7.0</version>
+    <version>4.7.1</version>
     <name>saiku - webapp</name>
     <packaging>war</packaging>
     <build>


### PR DESCRIPTION
Patch release. Cuts **v4.7.1** to `main`.

Highlights (full detail in CHANGELOG.md):
- **Fixed** — Cube Designer edit-existing-cube load, Mondrian datasource driver/schema mis-parse, drag-to-canvas after pan/zoom (all saiku#1634); flat `<button>` reset.
- **Changed** — UI theme aligned with Saiku Cloud (3-tier tokens: red brand, subtle borders, layered dark); Cube Designer header segmented mode tabs.
- **Added** — demo-mode (`SAIKU_DEMO`) lockdown of datasource + schema mutations; Bombadil UI fuzz harness (dev-only).

After merge: tag `v4.7.1` on main → `release.yml` publishes (fat-jar + dist zip, module jars → GH Packages, `ghcr.io/spiculedata/saiku:4.7.1`, npm embed), then back-merge main → development.