### PR TITLE
chore: back-merge v4.7.1 into development

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,44 @@
 All notable changes to Saiku are documented here. This project follows
 [Semantic Versioning](https://semver.org/).
 
+## 4.7.1 — 2026-08-02
+
+Patch release — Cube Designer fixes, a UI theme refresh aligned with Saiku
+Cloud, and a demo-mode lockdown.
+
+### Fixed
+- **Cube Designer — edit an existing cube.** Opening the designer on a datasource
+  that already has a Mondrian schema now loads that schema onto the canvas
+  instead of showing a blank one. A new `GET /rest/saiku/admin/cube-designer/
+  schema/{dataSourceId}` endpoint resolves the attached catalog (external
+  `file:`, classpath `res:`, or repository) to its XML. (saiku#1634)
+- **Datasources admin — correct driver/schema/JDBC URL.** Mondrian datasources
+  whose inner `Jdbc=` URL carries its own `;`-params (e.g. H2 `;MODE=MySQL`) were
+  mis-parsed, showing the catalog file as the driver and a stray param as the
+  schema. Parsing is now key-based and order/param tolerant. (saiku#1634)
+- **Cube Designer — drag-to-canvas.** Dropping a table now lands it under the
+  cursor after the canvas has been panned or zoomed (drop coordinates are mapped
+  into flow space). (saiku#1634)
+- **UI — flat buttons.** Raw `<button>`s no longer fall back to the browser
+  default (a 2px outset border on a grey face); the base reset that Tailwind
+  preflight would apply is now in place.
+
+### Changed
+- **UI theme aligned with Saiku Cloud.** Adopted the shared three-tier design
+  tokens: Saiku-red brand, warm-neutral light / cool-neutral dark surfaces,
+  subtle border ramp, and layered dark elevation — replacing the previous
+  indigo-accented, harsh-bordered theme.
+- **Cube Designer header.** Mode tabs restyled to a segmented group with a
+  ringed active tab, matching the Cloud designer.
+
+### Added
+- **Demo-mode lockdown (`SAIKU_DEMO`).** On a public demo, visitors can no longer
+  create/edit/delete datasources or save a schema from the Cube Designer, so a
+  broken connection or schema can't take the shared instance down. Read-only
+  actions (Refresh, opening the designer) still work.
+- **Bombadil UI fuzz harness** (`saiku-ui/bombadil/`, dev-only, not shipped in
+  the runtime) — property-based headless-browser fuzzing of the UI.
+
 ## 4.7.0 — 2026-08-01
 
 Feature release.

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <groupId>org.saikuanalytics</groupId>
     <artifactId>saiku</artifactId>
     <packaging>pom</packaging>
-    <version>4.7.0</version>
+    <version>4.7.1</version>
     <name>Saiku Module Project</name>
     <scm>
         <developerConnection>

--- a/saiku-bom/pom.xml
+++ b/saiku-bom/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.saikuanalytics</groupId>
     <artifactId>saiku-bom</artifactId>
-    <version>4.7.0</version>
+    <version>4.7.1</version>
     <packaging>pom</packaging>
     <name>Saiku BOM</name>
     <description>Central dependency-version catalogue for Saiku modules.</description>

--- a/saiku-core/pom.xml
+++ b/saiku-core/pom.xml
@@ -2,14 +2,14 @@
     <parent>
         <artifactId>saiku</artifactId>
         <groupId>org.saikuanalytics</groupId>
-        <version>4.7.0</version>
+        <version>4.7.1</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>
     <artifactId>saiku-core</artifactId>
     <packaging>pom</packaging>
     <name>saiku - core libraries</name>
-    <version>4.7.0</version>
+    <version>4.7.1</version>
 
     <modules>
         <module>saiku-olap-util</module>

--- a/saiku-core/saiku-olap-util/pom.xml
+++ b/saiku-core/saiku-olap-util/pom.xml
@@ -3,11 +3,11 @@
     <parent>
         <artifactId>saiku-core</artifactId>
         <groupId>org.saikuanalytics</groupId>
-        <version>4.7.0</version>
+        <version>4.7.1</version>
     </parent>
 	<artifactId>saiku-olap-util</artifactId>
 	<packaging>jar</packaging>
-	<version>4.7.0</version>
+	<version>4.7.1</version>
 	<name>saiku olap util</name>
 	<properties>
 		<maven.compiler.source>1.8</maven.compiler.source>

--- a/saiku-core/saiku-semantic/pom.xml
+++ b/saiku-core/saiku-semantic/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <artifactId>saiku-core</artifactId>
         <groupId>org.saikuanalytics</groupId>
-        <version>4.7.0</version>
+        <version>4.7.1</version>
     </parent>
 
     <artifactId>saiku-semantic</artifactId>

--- a/saiku-core/saiku-service/pom.xml
+++ b/saiku-core/saiku-service/pom.xml
@@ -2,12 +2,12 @@
     <parent>
         <artifactId>saiku-core</artifactId>
         <groupId>org.saikuanalytics</groupId>
-        <version>4.7.0</version>
+        <version>4.7.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>jar</packaging>
     <artifactId>saiku-service</artifactId>
-    <version>4.7.0</version>
+    <version>4.7.1</version>
     <name>saiku - services</name>
     <build>
         <plugins>

--- a/saiku-core/saiku-sql/pom.xml
+++ b/saiku-core/saiku-sql/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.saikuanalytics</groupId>
         <artifactId>saiku-core</artifactId>
-        <version>4.7.0</version>
+        <version>4.7.1</version>
     </parent>
 
     <artifactId>saiku-sql</artifactId>

--- a/saiku-core/saiku-web/pom.xml
+++ b/saiku-core/saiku-web/pom.xml
@@ -2,11 +2,11 @@
     <parent>
         <artifactId>saiku-core</artifactId>
         <groupId>org.saikuanalytics</groupId>
-        <version>4.7.0</version>
+        <version>4.7.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>saiku-web</artifactId>
-    <version>4.7.0</version>
+    <version>4.7.1</version>
     <name>saiku - web</name>
     <packaging>jar</packaging>
 

--- a/saiku-launcher/pom.xml
+++ b/saiku-launcher/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.saikuanalytics</groupId>
         <artifactId>saiku</artifactId>
-        <version>4.7.0</version>
+        <version>4.7.1</version>
     </parent>
 
     <artifactId>saiku-launcher</artifactId>

--- a/saiku-proptest/pom.xml
+++ b/saiku-proptest/pom.xml
@@ -7,11 +7,11 @@
   <parent>
     <groupId>org.saikuanalytics</groupId>
     <artifactId>saiku</artifactId>
-    <version>4.7.0</version>
+    <version>4.7.1</version>
   </parent>
 
   <artifactId>saiku-proptest</artifactId>
-  <version>4.7.0</version>
+  <version>4.7.1</version>
   <packaging>jar</packaging>
   <name>saiku-proptest</name>
   <description>
@@ -31,7 +31,7 @@
       <dependency>
         <groupId>org.saikuanalytics</groupId>
         <artifactId>saiku-bom</artifactId>
-        <version>4.7.0</version>
+        <version>4.7.1</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/saiku-webapp/pom.xml
+++ b/saiku-webapp/pom.xml
@@ -2,11 +2,11 @@
     <parent>
         <artifactId>saiku</artifactId>
         <groupId>org.saikuanalytics</groupId>
-        <version>4.7.0</version>
+        <version>4.7.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>saiku-webapp</artifactId>
-    <version>4.7.0</version>
+    <version>4.7.1</version>
     <name>saiku - webapp</name>
     <packaging>war</packaging>
     <build>


### PR DESCRIPTION
Gitflow back-merge after the 4.7.1 release — brings the version bump (4.7.0 → 4.7.1) + CHANGELOG onto development. All feature commits are already on development; this is the version/release-commit sync.