### PR TITLE
fix(app-builder): usable Add-tile menu, first-tile onboarding, discoverable Apps list

### DIFF
--- a/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/apps/AppResource.java
+++ b/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/apps/AppResource.java
@@ -19,9 +19,11 @@ import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import org.saiku.repository.IRepositoryObject;
+import org.saiku.repository.RepositoryFolderObject;
 import org.saiku.service.datasource.DatasourceService;
 import org.saiku.web.service.SessionService;
 import org.slf4j.Logger;
@@ -83,8 +85,34 @@ public class AppResource {
     public Response list() {
         String username = currentUsername();
         List<String> roles = currentRoles();
-        List<IRepositoryObject> files = datasourceService.getFiles(List.of(APP_EXTENSION), username, roles);
-        return Response.ok(files).type(MediaType.APPLICATION_JSON).build();
+        // getFiles returns the repository TREE (top-level folders, with matching
+        // files nested inside), not a flat list — so returning it verbatim made
+        // the Apps catalogue show repository folders (dashboards/, homes/, …)
+        // instead of the .saikuapp files, hiding the seeded example app from new
+        // users (saiku#1636). Flatten to just the .saikuapp file nodes, honouring
+        // this endpoint's documented contract.
+        List<IRepositoryObject> tree = datasourceService.getFiles(List.of(APP_EXTENSION), username, roles);
+        List<IRepositoryObject> apps = new ArrayList<>();
+        flattenApps(tree, apps);
+        return Response.ok(apps).type(MediaType.APPLICATION_JSON).build();
+    }
+
+    /** Depth-first walk collecting only {@code .saikuapp} file nodes from the
+     *  repository tree {@link DatasourceService#getFiles} returns. */
+    private static void flattenApps(List<IRepositoryObject> nodes, List<IRepositoryObject> out) {
+        if (nodes == null) {
+            return;
+        }
+        for (IRepositoryObject node : nodes) {
+            if (node instanceof RepositoryFolderObject folder) {
+                flattenApps(folder.getRepoObjects(), out);
+            } else if (node != null
+                    && node.getType() == IRepositoryObject.Type.FILE
+                    && node.getName() != null
+                    && node.getName().endsWith(APP_EXTENSION)) {
+                out.add(node);
+            }
+        }
     }
 
     /**

--- a/saiku-core/saiku-web/src/test/java/org/saiku/web/rest/resources/apps/AppResourceTest.java
+++ b/saiku-core/saiku-web/src/test/java/org/saiku/web/rest/resources/apps/AppResourceTest.java
@@ -17,6 +17,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.saiku.repository.IRepositoryObject;
 import org.saiku.repository.RepositoryFileObject;
+import org.saiku.repository.RepositoryFolderObject;
 import org.saiku.service.datasource.DatasourceService;
 import org.saiku.web.service.SessionService;
 
@@ -93,6 +94,36 @@ public class AppResourceTest {
                 .equals(f.getName())));
         // The listing must be scoped to the .saikuapp extension only.
         assertEquals(List.of(".saikuapp"), stubDs.lastListType);
+    }
+
+    @Test
+    public void list_flattensRepositoryTreeToSaikuappFilesOnly() {
+        // getFiles returns the repository TREE — top-level folders with matching
+        // files nested inside. saiku#1636: the resource must flatten that to just
+        // the .saikuapp file nodes, not leak folders (which hid the seeded example
+        // app and filled the Apps catalogue with repository folder names).
+        RepositoryFileObject nested = new RepositoryFileObject(
+                "foodmart-ops.saikuapp",
+                "#homes/admin/foodmart-ops.saikuapp",
+                "saikuapp",
+                "homes/admin/foodmart-ops.saikuapp",
+                List.of());
+        RepositoryFolderObject admin =
+                new RepositoryFolderObject("admin", "#homes/admin", "homes/admin", List.of(), List.of(nested));
+        RepositoryFolderObject homes =
+                new RepositoryFolderObject("homes", "#homes", "homes", List.of(), List.of(admin));
+        RepositoryFolderObject dashboards =
+                new RepositoryFolderObject("dashboards", "#dashboards", "dashboards", List.of(), new ArrayList<>());
+        stubDs.treeOverride = List.of(dashboards, homes);
+
+        Response r = resource.list();
+        assertEquals(200, r.getStatus());
+        @SuppressWarnings("unchecked")
+        List<IRepositoryObject> apps = (List<IRepositoryObject>) r.getEntity();
+        // Exactly the one nested .saikuapp — no folders.
+        assertEquals(1, apps.size());
+        assertEquals("foodmart-ops.saikuapp", apps.get(0).getName());
+        assertEquals(IRepositoryObject.Type.FILE, apps.get(0).getType());
     }
 
     /* ---------------------------- delete ----------------------------- */
@@ -188,6 +219,8 @@ public class AppResourceTest {
         String savedContent;
         List<String> lastListType;
         boolean failOnSave;
+        /** When set, getFiles returns this tree verbatim (to exercise flattening). */
+        List<IRepositoryObject> treeOverride;
 
         @Override
         public String saveFile(String content, String path, String name, List<String> roles) {
@@ -214,6 +247,9 @@ public class AppResourceTest {
         @Override
         public List<IRepositoryObject> getFiles(List<String> type, String username, List<String> roles) {
             lastListType = type;
+            if (treeOverride != null) {
+                return treeOverride;
+            }
             List<IRepositoryObject> out = new ArrayList<>();
             for (String path : stored.keySet()) {
                 boolean matches =

--- a/saiku-ui/src/lib/views/app/AppPageView.svelte
+++ b/saiku-ui/src/lib/views/app/AppPageView.svelte
@@ -34,6 +34,7 @@
   import { pageGridToDashboard, dashboardToPageGrid } from "$lib/views/app/appPageView";
   import { encodeAppFilterState, decodeAppFilterState } from "$lib/dashboard/urlFilterState";
   import DashboardGrid from "$lib/views/dashboard/DashboardGrid.svelte";
+  import EmptyDashboardGuidance from "$lib/views/dashboard/EmptyDashboardGuidance.svelte";
   import DashboardFilterPanel from "$lib/views/dashboard/DashboardFilterPanel.svelte";
   import DashboardFilterBar from "$lib/views/dashboard/DashboardFilterBar.svelte";
   import AddTileMenu from "$lib/views/dashboard/AddTileMenu.svelte";
@@ -46,6 +47,14 @@
   let { page, editable = false }: Props = $props();
 
   const readOnly = $derived(!editable);
+
+  // Onboarding: an editable page with no tiles shows the same "Add your first
+  // tile" guidance the dashboard editor uses (Chart / Table / KPI CTAs wired to
+  // handleAddTile), instead of the grid's bare "No tiles yet" text — the App
+  // Builder previously left new authors with no clue how to start (saiku#1636).
+  const showEmptyGuidance = $derived(
+    editable && (dashboardStore.current?.layout.tiles.length ?? 0) === 0,
+  );
 
   // Per-page transient filter memory (click/cross layer), keyed by page id.
   // Plain object, not $state — it's imperative bookkeeping the effects read/
@@ -215,7 +224,14 @@
        mount — no wrapper condition needed here. -->
   <DashboardFilterPanel {readOnly} />
   <DashboardFilterBar {readOnly} />
-  <DashboardGrid {readOnly} />
+  {#if showEmptyGuidance}
+    <EmptyDashboardGuidance
+      onAddTile={handleAddTile}
+      subtitle="Pick a tile type to start building this page. Bind it to a cube and configure data, filters, and layout in the tile's ⚙ editor after it's dropped. Add more pages from the left rail; brand the app in the Inspector."
+    />
+  {:else}
+    <DashboardGrid {readOnly} />
+  {/if}
 </div>
 
 <style>

--- a/saiku-ui/src/lib/views/dashboard/AddTileMenu.svelte
+++ b/saiku-ui/src/lib/views/dashboard/AddTileMenu.svelte
@@ -139,6 +139,11 @@
     top: calc(100% + 4px);
     right: 0;
     background: hsl(var(--bg));
+    /* Explicit chrome foreground — the App Builder renders this menu inside a
+       light-themed app canvas, so without this the item LABELS (which set no
+       colour of their own) inherit the app's dark text and render nearly
+       invisible on the dark popover. saiku#1636. */
+    color: hsl(var(--fg));
     border: 1px solid hsl(var(--border));
     border-radius: 6px;
     box-shadow: 0 8px 24px rgba(0, 0, 0, 0.08);

--- a/saiku-ui/src/lib/views/dashboard/EmptyDashboardGuidance.svelte
+++ b/saiku-ui/src/lib/views/dashboard/EmptyDashboardGuidance.svelte
@@ -24,18 +24,22 @@
      *  dashboardStore.addTile() (already implemented as handleAddTile()
      *  in DashboardEditor — same callback wired to AddTileMenu). */
     onAddTile: (type: TileType) => void;
+    /** Override the subtitle line — the App Builder passes "page" copy since a
+     *  page isn't a dashboard from the author's point of view. Defaults to the
+     *  dashboard wording. */
+    subtitle?: string;
   }
 
-  let { onAddTile }: Props = $props();
+  let {
+    onAddTile,
+    subtitle = "Pick a tile type to start building this dashboard. You can configure data, filters, and layout after the tile is dropped.",
+  }: Props = $props();
 </script>
 
 <div class="flex items-start justify-center py-10 px-4 flex-1 min-h-0" role="region" aria-label="Add your first tile">
   <div class="card">
     <h2 class="m-0 text-xl font-semibold text-fg">Add your first tile</h2>
-    <p class="subtitle">
-      Pick a tile type to start building this dashboard. You can configure data,
-      filters, and layout after the tile is dropped.
-    </p>
+    <p class="subtitle">{subtitle}</p>
 
     <div class="cta-row">
       <button


### PR DESCRIPTION
App Builder polish from the demo review — new authors landed on the Apps area with "no clue how to start."

1. **Add-tile menu labels invisible** — the menu renders inside the light-themed app canvas; item labels set no colour, so they inherited the app's dark text on the dark popover (only the hint lines stayed readable). Forced explicit chrome foreground.
2. **First-tile onboarding** — an empty app page in edit mode showed only DashboardGrid's bare "No tiles yet". AppPageView now shows the rich "Add your first tile" guidance (Chart/Table/KPI CTAs) with app-specific copy (cube binding, pages, Inspector), mirroring the dashboard editor. `EmptyDashboardGuidance` gains an optional `subtitle` (default unchanged).
3. **Apps catalogue listed folders, not apps** — `AppResource.list()` returned the repository tree verbatim, so `/apps` showed `dashboards/`, `homes/`, … instead of `.saikuapp` files — hiding the seeded `foodmart-ops` reference app. Flattened to `.saikuapp` file nodes (depth-first) per the endpoint's contract.

## Verification
- `npm run check` 0 errors; `AppResourceTest` 13 green (incl. new tree-flattening test).
- Playwright: creating a new app → edit mode shows the guidance card with the three CTAs (was bare "No tiles yet"); the Add-tile menu labels render on the dark popover.
- Post-merge on demo: the Apps list will surface `foodmart-ops` (the reference app), which already renders fully (KPI row + trend + Movers + Ask assistant).