### PR TITLE
#1636 - Demo-only anonymous engagement analytics

### DIFF
--- a/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/InfoResource.java
+++ b/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/InfoResource.java
@@ -156,13 +156,61 @@ public class InfoResource {
         Map<String, Object> body = new LinkedHashMap<>();
         body.put("ai", ai);
         body.put("mcp", mcp);
-        body.put("demoMode", Boolean.parseBoolean(System.getProperty("saiku.demo", "false")));
+        boolean demoMode = Boolean.parseBoolean(System.getProperty("saiku.demo", "false"));
+        body.put("demoMode", demoMode);
         // saiku#1029: tell the SPA whether the demo email gate is in front of
         // login, and which provider, so the login page can render the gate form.
         boolean emailGate = demoGate != null && demoGate.isEnabled();
         body.put("emailGate", emailGate);
         body.put("emailGateProvider", emailGate ? demoGate.providerName() : null);
+        // saiku#1636: demo-only engagement analytics. The SPA fires anonymous,
+        // coarse interaction events ONLY when this is enabled — i.e. ONLY on the
+        // online demo (demoMode) AND only when telemetry isn't opted out (the same
+        // SAIKU_TELEMETRY / DO_NOT_TRACK switch the install heartbeat honours).
+        // Day-to-day self-hosted installs report enabled:false and never emit.
+        Map<String, Object> demoAnalytics = new LinkedHashMap<>();
+        demoAnalytics.put("enabled", demoMode && telemetryEnabled());
+        demoAnalytics.put("endpoint", demoAnalyticsEndpoint());
+        body.put("demoAnalytics", demoAnalytics);
         return Response.ok(body).build();
+    }
+
+    /**
+     * saiku#1636 — mirrors {@code TelemetryService.isEnabled()}: telemetry (and
+     * therefore demo analytics) is on by default and opted out by {@code
+     * DO_NOT_TRACK}, {@code SAIKU_TELEMETRY=off|false|0|no|disabled}, or
+     * {@code -Dsaiku.telemetry.enabled=false}. Kept in sync deliberately so one
+     * switch governs both the heartbeat and demo engagement events.
+     */
+    private static boolean telemetryEnabled() {
+        String dnt = System.getenv("DO_NOT_TRACK");
+        if (dnt != null) {
+            String v = dnt.trim().toLowerCase();
+            if (v.equals("1") || v.equals("true") || v.equals("yes")) {
+                return false;
+            }
+        }
+        String flag = System.getenv("SAIKU_TELEMETRY");
+        if (flag != null) {
+            String v = flag.trim().toLowerCase();
+            if (v.equals("off") || v.equals("false") || v.equals("0") || v.equals("no") || v.equals("disabled")) {
+                return false;
+            }
+        }
+        String prop = System.getProperty("saiku.telemetry.enabled");
+        return prop == null || !"false".equalsIgnoreCase(prop.trim());
+    }
+
+    /** Demo-analytics event collector URL. Defaults to the hosted collector;
+     *  overridable for a self-hosted demo via {@code -Dsaiku.telemetry.eventEndpoint}
+     *  or {@code SAIKU_TELEMETRY_EVENT_ENDPOINT}. */
+    private static String demoAnalyticsEndpoint() {
+        String prop = System.getProperty("saiku.telemetry.eventEndpoint");
+        if (prop != null && !prop.isBlank()) {
+            return prop.trim();
+        }
+        String env = System.getenv("SAIKU_TELEMETRY_EVENT_ENDPOINT");
+        return env != null && !env.isBlank() ? env.trim() : "https://telemetry.saiku.bi/v1/event";
     }
 
     /**

--- a/saiku-ui/.gitignore
+++ b/saiku-ui/.gitignore
@@ -34,3 +34,6 @@ bombadil/out/
 bombadil/out/
 .cache-chrome/
 chrome/
+
+# Chrome-for-Testing profile created by bombadil fuzz runs
+.cft-profile/

--- a/saiku-ui/src/lib/analytics/demoAnalytics.test.ts
+++ b/saiku-ui/src/lib/analytics/demoAnalytics.test.ts
@@ -1,0 +1,101 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// The module reads `browser` from $app/environment and the `platform` singleton.
+// Mock both so we can drive the capability gate deterministically in a node env.
+vi.mock("$app/environment", () => ({ browser: true }));
+
+const platform = { capabilities: null as unknown, version: "9.9.9" };
+vi.mock("$lib/stores/platform.svelte", () => ({ platform }));
+
+// A minimal in-memory sessionStorage + a stub navigator/document/crypto so the
+// module's browser-only paths run under vitest's node environment.
+function stubBrowserGlobals(): { fetch: ReturnType<typeof vi.fn> } {
+  const store = new Map<string, string>();
+  vi.stubGlobal("sessionStorage", {
+    getItem: (k: string) => store.get(k) ?? null,
+    setItem: (k: string, v: string) => void store.set(k, v),
+  });
+  vi.stubGlobal("crypto", { randomUUID: () => "test-uuid-1234" });
+  vi.stubGlobal("document", { addEventListener: vi.fn(), visibilityState: "visible" });
+  vi.stubGlobal("navigator", {}); // no sendBeacon → forces the fetch path
+  const fetch = vi.fn(() => Promise.resolve(new Response("{}")));
+  vi.stubGlobal("fetch", fetch);
+  return { fetch };
+}
+
+const ENABLED = { enabled: true, endpoint: "https://collector.test/v1/event" };
+
+async function loadTrack() {
+  // Fresh module each time so the module-level queue/timer/listener state resets.
+  vi.resetModules();
+  return (await import("./demoAnalytics")).trackDemo;
+}
+
+describe("demoAnalytics.trackDemo", () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    fetchMock = stubBrowserGlobals().fetch;
+    platform.capabilities = null;
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+  });
+
+  it("is a no-op when the demo-analytics capability is absent", async () => {
+    const trackDemo = await loadTrack();
+    trackDemo("query", "run");
+    vi.advanceTimersByTime(10_000);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("is a no-op when the capability is present but disabled", async () => {
+    platform.capabilities = { demoAnalytics: { enabled: false, endpoint: ENABLED.endpoint } };
+    const trackDemo = await loadTrack();
+    trackDemo("app", "open", "view");
+    vi.advanceTimersByTime(10_000);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("batches events and POSTs an anonymous, coarse payload when enabled", async () => {
+    platform.capabilities = { demoAnalytics: ENABLED };
+    const trackDemo = await loadTrack();
+
+    trackDemo("app", "open", "view");
+    trackDemo("query", "run");
+    expect(fetchMock).not.toHaveBeenCalled(); // still debouncing
+
+    vi.advanceTimersByTime(4000);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe(ENABLED.endpoint);
+    const payload = JSON.parse(init.body);
+    expect(payload.session).toBe("test-uuid-1234");
+    expect(payload.version).toBe("9.9.9");
+    expect(payload.events).toEqual([
+      { type: "app", name: "open", detail: "view" },
+      { type: "query", name: "run", detail: undefined },
+    ]);
+    // never sends credentials — coarse, anonymous, cross-origin
+    expect(init.credentials).toBe("omit");
+  });
+
+  it("reuses one anonymous session id across events (per-tab)", async () => {
+    platform.capabilities = { demoAnalytics: ENABLED };
+    const trackDemo = await loadTrack();
+
+    trackDemo("ai", "ask");
+    vi.advanceTimersByTime(4000);
+    trackDemo("cube-designer", "open");
+    vi.advanceTimersByTime(4000);
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    const s1 = JSON.parse(fetchMock.mock.calls[0][1].body).session;
+    const s2 = JSON.parse(fetchMock.mock.calls[1][1].body).session;
+    expect(s1).toBe(s2);
+  });
+});

--- a/saiku-ui/src/lib/analytics/demoAnalytics.ts
+++ b/saiku-ui/src/lib/analytics/demoAnalytics.ts
@@ -1,0 +1,130 @@
+/**
+ * Demo-only engagement analytics (saiku#1636).
+ *
+ * Fires anonymous, coarse interaction events — which surfaces a demo visitor
+ * explores — so we can see how the online demo is used. It is inert everywhere
+ * except the hosted demo:
+ *
+ *   - Gated on `platform.capabilities.demoAnalytics.enabled`, which the server
+ *     sets true ONLY when `demoMode` is on AND telemetry isn't opted out (the
+ *     same `SAIKU_TELEMETRY` / `DO_NOT_TRACK` switch as the install heartbeat).
+ *     A day-to-day self-hosted Saiku reports `enabled:false`, so `track()` is a
+ *     no-op there — we never spy on real users.
+ *
+ * Privacy by construction: no user id, no query data, no cube/member values —
+ * just a coarse `{type, name, detail?}` (e.g. `app/open/foodmart-ops`,
+ * `cube-designer/open`, `ai/ask`). The "session" is a random per-browser id kept
+ * in sessionStorage (cleared when the tab closes) and hashed server-side before
+ * storage, so it can't be correlated to anything.
+ *
+ * Events batch and flush on a short debounce, on tab-hide (sendBeacon), and when
+ * the queue fills. Failures are swallowed — analytics must never break the app.
+ */
+import { browser } from "$app/environment";
+import { platform } from "$lib/stores/platform.svelte";
+
+/** Coarse event category. Keep the set small + stable so the report stays useful. */
+export type DemoEventType = "app" | "cube-designer" | "ai" | "query" | "dashboard" | "nav";
+
+interface QueuedEvent {
+  type: DemoEventType;
+  name: string;
+  detail?: string;
+}
+
+const SESSION_KEY = "saiku.demo.session";
+const FLUSH_DEBOUNCE_MS = 4000;
+const MAX_QUEUE = 40; // matches the Worker's per-request cap
+
+let queue: QueuedEvent[] = [];
+let flushTimer: ReturnType<typeof setTimeout> | null = null;
+let listenersBound = false;
+
+/** Analytics config from the capabilities probe, or null when off/unknown. */
+function config(): { enabled: boolean; endpoint: string } | null {
+  const c = platform.capabilities?.demoAnalytics;
+  return c && c.enabled && c.endpoint ? c : null;
+}
+
+/** Random, anonymous, per-tab session id (sessionStorage). Coarse identifier the
+ *  server hashes before storing — never a user id. */
+function sessionId(): string {
+  if (!browser) return "ssr";
+  try {
+    let id = sessionStorage.getItem(SESSION_KEY);
+    if (!id) {
+      id = crypto.randomUUID();
+      sessionStorage.setItem(SESSION_KEY, id);
+    }
+    return id;
+  } catch {
+    return "no-storage";
+  }
+}
+
+function scheduleFlush(): void {
+  if (flushTimer) return;
+  flushTimer = setTimeout(() => {
+    flushTimer = null;
+    void flush();
+  }, FLUSH_DEBOUNCE_MS);
+}
+
+/** POST the queued events. `beacon` uses sendBeacon (for tab-hide) so the
+ *  request survives the page unloading. */
+function flush(beacon = false): void {
+  const cfg = config();
+  if (!cfg || queue.length === 0) return;
+  const events = queue;
+  queue = [];
+  const payload = JSON.stringify({
+    session: sessionId(),
+    version: platform.version ?? undefined,
+    events,
+  });
+  try {
+    if (beacon && browser && typeof navigator.sendBeacon === "function") {
+      navigator.sendBeacon(cfg.endpoint, new Blob([payload], { type: "application/json" }));
+      return;
+    }
+    void fetch(cfg.endpoint, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: payload,
+      keepalive: true,
+      // The collector is a different origin (telemetry.saiku.bi); we only send,
+      // never read the response, and carry no credentials.
+      credentials: "omit",
+      mode: "cors",
+    }).catch(() => {
+      /* analytics is best-effort */
+    });
+  } catch {
+    /* never throw from analytics */
+  }
+}
+
+function bindUnloadFlush(): void {
+  if (listenersBound || !browser) return;
+  listenersBound = true;
+  // Flush the tail on tab-hide — the most reliable "leaving" signal on mobile +
+  // desktop (visibilitychange > unload). sendBeacon so it survives teardown.
+  document.addEventListener("visibilitychange", () => {
+    if (document.visibilityState === "hidden") flush(true);
+  });
+}
+
+/**
+ * Record a coarse engagement event. No-op unless the demo-analytics capability
+ * is enabled. Safe to call from anywhere, any time — it never throws.
+ */
+export function trackDemo(type: DemoEventType, name: string, detail?: string): void {
+  if (!browser || !config()) return;
+  bindUnloadFlush();
+  queue.push({ type, name, detail });
+  if (queue.length >= MAX_QUEUE) {
+    flush();
+    return;
+  }
+  scheduleFlush();
+}

--- a/saiku-ui/src/lib/stores/platform.svelte.ts
+++ b/saiku-ui/src/lib/stores/platform.svelte.ts
@@ -18,6 +18,10 @@ export interface PlatformCapabilities {
   emailGate?: boolean;
   /** Provider backing the gate (e.g. "workos"), or null when off. */
   emailGateProvider?: string | null;
+  /** saiku#1636: demo-only engagement analytics. `enabled` is true ONLY on the
+   *  online demo (demoMode) with telemetry not opted out; day-to-day self-hosted
+   *  installs report `enabled:false` and the SPA never emits events. */
+  demoAnalytics?: { enabled: boolean; endpoint: string };
 }
 
 class PlatformStore {

--- a/saiku-ui/src/lib/views/AiQueryDrawer.svelte
+++ b/saiku-ui/src/lib/views/AiQueryDrawer.svelte
@@ -27,6 +27,7 @@
   import { classifyChainEnvelope } from "$lib/api/chainStep";
   import { renderTinyMarkdown } from "$lib/api/tinyMarkdown";
   import { query } from "$lib/stores/query.svelte";
+  import { trackDemo } from "$lib/analytics/demoAnalytics";
   import { X, Send, Sparkles, ChevronDown, ChevronRight, Copy, Trash2 } from "lucide-svelte";
 
   /**
@@ -748,6 +749,7 @@
   /** Route Send to the active mode. Dashboard wins over chained wins over the
    *  single ask; the toggles are mutually exclusive so at most one is on. */
   function runSend(): void {
+    trackDemo("ai", "ask", buildDashboard ? "dashboard" : buildAndReport ? "chained" : "single");
     void (buildDashboard ? submitDashboard() : buildAndReport ? submitChained() : submit());
   }
 

--- a/saiku-ui/src/lib/views/WorkspaceToolbar.svelte
+++ b/saiku-ui/src/lib/views/WorkspaceToolbar.svelte
@@ -46,6 +46,7 @@
   import { platform } from "$lib/stores/platform.svelte";
   import { mailHealth } from "$lib/stores/mailHealth.svelte";
   import { emailComposer } from "$lib/stores/emailComposer.svelte";
+  import { trackDemo } from "$lib/analytics/demoAnalytics";
   import { untrack } from "svelte";
 
   interface Props {
@@ -237,6 +238,9 @@
       warningOpen = true;
       return;
     }
+    // Demo-only, anonymous engagement signal (no query content). onRun is the
+    // explicit user click, so it doesn't count the markDirty auto-runs.
+    trackDemo("query", "run");
     await query.run();
   }
 

--- a/saiku-ui/src/lib/views/app/AppPageView.svelte
+++ b/saiku-ui/src/lib/views/app/AppPageView.svelte
@@ -33,6 +33,7 @@
   import { buildTile } from "$lib/dashboard/tilePlacement";
   import { pageGridToDashboard, dashboardToPageGrid } from "$lib/views/app/appPageView";
   import { encodeAppFilterState, decodeAppFilterState } from "$lib/dashboard/urlFilterState";
+  import { trackDemo } from "$lib/analytics/demoAnalytics";
   import DashboardGrid from "$lib/views/dashboard/DashboardGrid.svelte";
   import EmptyDashboardGuidance from "$lib/views/dashboard/EmptyDashboardGuidance.svelte";
   import DashboardFilterPanel from "$lib/views/dashboard/DashboardFilterPanel.svelte";
@@ -107,6 +108,9 @@
   // ------------------------------------------------------------------
   onMount(() => {
     if (typeof window === "undefined") return;
+    // Demo-only, anonymous: record that an app page was opened (no app id, just
+    // the coarse fact — inert off the hosted demo). See demoAnalytics.ts.
+    trackDemo("app", "open", editable ? "edit" : "view");
     const { activePageId, filtersByPage } = decodeAppFilterState(
       new URL(window.location.href).searchParams,
     );
@@ -190,6 +194,7 @@
   function handleAddTile(type: TileType): void {
     const layout = dashboardStore.current?.layout;
     if (!layout) return;
+    trackDemo("app", "tile-add", type);
     dashboardStore.addTile(buildTile(layout, type, newTileId()));
   }
 

--- a/saiku-ui/src/routes/+layout.svelte
+++ b/saiku-ui/src/routes/+layout.svelte
@@ -96,6 +96,11 @@
     if (session.current && platform.version == null) {
       platform.loadVersion();
     }
+    // Populate capabilities once per session so the demo-analytics gate (and any
+    // other capability-driven UI) has the flag without each surface re-probing.
+    if (session.current && platform.capabilities == null) {
+      platform.loadCapabilities();
+    }
   });
 </script>
 

--- a/saiku-ui/src/routes/admin/cube-designer/[dataSourceId]/+page.svelte
+++ b/saiku-ui/src/routes/admin/cube-designer/[dataSourceId]/+page.svelte
@@ -29,6 +29,7 @@
   import type { SourceTableCandidate } from "$lib/cube-designer/types";
   import { adminSchemas } from "$lib/api/admin";
   import { platform } from "$lib/stores/platform.svelte";
+  import { trackDemo } from "$lib/analytics/demoAnalytics";
   import Button from "$lib/components/ui/button.svelte";
   import FeedbackBanner from "$lib/design-system/FeedbackBanner.svelte";
   import {
@@ -64,6 +65,7 @@
 
   onMount(async () => {
     if (!platform.capabilities) await platform.loadCapabilities();
+    trackDemo("cube-designer", "open");
     store.switchConnection(dataSourceId);
     store.sourceLoading = true;
     store.sourceError = null;

--- a/telemetry/schema.sql
+++ b/telemetry/schema.sql
@@ -14,3 +14,20 @@ CREATE TABLE IF NOT EXISTS installs (
 
 -- the count query filters on last_seen (active in the last 30 days)
 CREATE INDEX IF NOT EXISTS idx_installs_last_seen ON installs (last_seen);
+
+-- Saiku#1636 — DEMO-ONLY engagement events. Only the online demo (SAIKU_DEMO)
+-- posts these; day-to-day self-hosted installs never do. No IP, no user id, no
+-- query data — just a coarse "what did an anonymous demo visitor look at?".
+-- `session_hash` is sha256 of a random per-browser id (anonymous, uncorrelatable).
+CREATE TABLE IF NOT EXISTS demo_event (
+  id           INTEGER PRIMARY KEY AUTOINCREMENT,
+  ts           INTEGER NOT NULL,   -- unix seconds, server receive time
+  session_hash TEXT NOT NULL,      -- sha256(random per-browser session id)
+  type         TEXT NOT NULL,      -- coarse category, e.g. 'app', 'cube-designer', 'ai'
+  name         TEXT NOT NULL,      -- coarse action, e.g. 'open', 'tile-add', 'ask'
+  detail       TEXT,               -- optional coarse qualifier (e.g. tile type)
+  version      TEXT                -- demo build version, for cohorting
+);
+
+-- engagement reporting filters on ts (recent) and groups by type/name
+CREATE INDEX IF NOT EXISTS idx_demo_event_ts ON demo_event (ts);

--- a/telemetry/src/index.ts
+++ b/telemetry/src/index.ts
@@ -28,6 +28,22 @@ const MAX_FIELD = 40;
 // coarse platform fields must look boring; anything else is dropped, not stored
 const SAFE = /^[A-Za-z0-9._+-]{1,40}$/;
 
+// --- demo engagement (saiku#1636) ------------------------------------------
+// The online demo posts anonymous interaction events here so we can see which
+// surfaces visitors explore. Never fired by day-to-day self-hosted installs
+// (client gates on demoMode + the telemetry opt-out). Coarse + capped.
+const MAX_EVENTS = 50; // per request
+const DEMO_WINDOW_SECONDS = 30 * 24 * 60 * 60;
+
+// The demo is browser-driven, so /v1/event is a cross-origin POST from the demo
+// origin. Allow it (the payload is anonymous + coarse); GET stats stays public.
+const CORS: Record<string, string> = {
+	'access-control-allow-origin': '*',
+	'access-control-allow-methods': 'GET, POST, OPTIONS',
+	'access-control-allow-headers': 'content-type',
+	'access-control-max-age': '86400'
+};
+
 function str(v: unknown, max: number): string | null {
 	if (typeof v !== 'string') return null;
 	const t = v.trim();
@@ -56,6 +72,83 @@ export default {
 	async fetch(request: Request, env: Env): Promise<Response> {
 		const url = new URL(request.url);
 		const now = Math.floor(Date.now() / 1000);
+
+		// CORS preflight for the browser-posted demo events.
+		if (request.method === 'OPTIONS') {
+			return new Response(null, { status: 204, headers: CORS });
+		}
+
+		// --- demo engagement events (saiku#1636) --------------------------------
+		// Anonymous, coarse interaction events from the online demo ONLY (the
+		// client gates on demoMode + the telemetry opt-out). Best-effort: a bad or
+		// oversized payload is dropped, never 5xx'd.
+		if (url.pathname === '/v1/event' && request.method === 'POST') {
+			let body: Record<string, unknown>;
+			try {
+				body = (await request.json()) as Record<string, unknown>;
+			} catch {
+				return json({ error: 'invalid json' }, 400, CORS);
+			}
+			const session = str(body.session, MAX_ID);
+			if (!session) return json({ error: 'session required' }, 400, CORS);
+			const version = coarse(body.version);
+			const sessionHash = await sha256Hex(session);
+			const rawEvents = Array.isArray(body.events) ? body.events : [];
+			const rows: Array<{ type: string; name: string; detail: string | null }> = [];
+			for (const e of rawEvents.slice(0, MAX_EVENTS)) {
+				if (!e || typeof e !== 'object') continue;
+				const ev = e as Record<string, unknown>;
+				const type = coarse(ev.type);
+				const name = coarse(ev.name);
+				if (!type || !name) continue; // coarse-only; drop anything odd
+				rows.push({ type, name, detail: coarse(ev.detail) });
+			}
+			if (rows.length === 0) return json({ ok: true, stored: 0 }, 200, CORS);
+			try {
+				const stmt = env.DB.prepare(
+					`INSERT INTO demo_event (ts, session_hash, type, name, detail, version)
+					 VALUES (?1, ?2, ?3, ?4, ?5, ?6)`
+				);
+				await env.DB.batch(
+					rows.map((r) => stmt.bind(now, sessionHash, r.type, r.name, r.detail, version))
+				);
+			} catch {
+				// best effort — never fail the caller
+			}
+			return json({ ok: true, stored: rows.length }, 200, CORS);
+		}
+
+		// --- demo engagement stats (public, cacheable) --------------------------
+		if (url.pathname === '/v1/demo-stats' && request.method === 'GET') {
+			const cutoff = now - DEMO_WINDOW_SECONDS;
+			try {
+				const totals = await env.DB.prepare(
+					`SELECT count(*) AS events, count(DISTINCT session_hash) AS sessions
+					 FROM demo_event WHERE ts > ?1`
+				)
+					.bind(cutoff)
+					.first<{ events: number; sessions: number }>();
+				const byAction = await env.DB.prepare(
+					`SELECT type, name, count(*) AS n FROM demo_event
+					 WHERE ts > ?1 GROUP BY type, name ORDER BY n DESC LIMIT 100`
+				)
+					.bind(cutoff)
+					.all();
+				return json(
+					{
+						events: totals?.events ?? 0,
+						sessions: totals?.sessions ?? 0,
+						windowDays: 30,
+						byAction: byAction.results,
+						generatedAt: now
+					},
+					200,
+					{ 'cache-control': 'public, max-age=300', ...CORS }
+				);
+			} catch {
+				return json({ error: 'stats unavailable' }, 500, CORS);
+			}
+		}
 
 		// --- heartbeat + update check -------------------------------------------
 		if (url.pathname === '/v1/check' && request.method === 'POST') {


### PR DESCRIPTION
## Summary

Adds **demo-only, anonymous, opt-out** engagement analytics so we can see which surfaces visitors explore on the online demo — without ever spying on day-to-day self-hosted users.

Amelia's ask: *"add analytics, but only to the online demo mode not to the standard day-to-day shit... tie it into that same process people can opt out of usage data."* This does exactly that — it rides the **same** `SAIKU_TELEMETRY` / `DO_NOT_TRACK` opt-out as the install heartbeat.

## How it stays demo-only + private

- `GET /info/capabilities` returns `demoAnalytics { enabled, endpoint }`. `enabled` is true **only** when `saiku.demo=true` **and** telemetry isn't opted out. A normal self-hosted install reports `enabled:false`, so the SPA's `track()` is a hard no-op — no events, ever.
- No user id, no query data, no cube/member values. Only a coarse `{type, name, detail?}` (e.g. `app/open/view`, `query/run`, `ai/ask`).
- The "session" is a random per-tab id in `sessionStorage`, hashed server-side (`sha256`) before storage — anonymous and uncorrelatable.
- Client is best-effort: batched + debounced POST, `sendBeacon` on tab-hide, all failures swallowed. Analytics can never break the app.

## Wired events (5)

`app/open`, `app/tile-add`, `cube-designer/open`, `ai/ask`, `query/run` (explicit Run click only — not the markDirty auto-runs).

## Collector (Cloudflare Worker + D1)

- `POST /v1/event` — coarse validation, `sha256(session)`, batch insert, capped, best-effort.
- `GET /v1/demo-stats` — public engagement report (events / sessions / byAction).
- New `demo_event` D1 table.

## Overridable endpoint

Defaults to `https://telemetry.saiku.bi/v1/event`; override via `-Dsaiku.telemetry.eventEndpoint` or `SAIKU_TELEMETRY_EVENT_ENDPOINT` for a self-hosted demo.

## Tests

- New `demoAnalytics.test.ts` (4 tests): no-op when capability absent, no-op when disabled, batched payload shape, per-tab session reuse.
- Full UI suite green (1644 tests); `npm run build` clean; `saiku-web` compiles + spotless clean.

## Deploy note (Tom's step — Cloudflare auth not available here)

Worker + D1 migration must be applied manually:
```
cd telemetry
wrangler d1 execute <db> --file schema.sql   # creates demo_event (idempotent)
wrangler deploy
```
Until the Worker is deployed, the client POSTs are simply dropped (best-effort) — nothing breaks.