### PR TITLE
chore(ci): bump workflow Node 20 -> 24 for saiku-ui jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,10 +129,10 @@ jobs:
         working-directory: saiku-ui
     steps:
       - uses: actions/checkout@v7
-      - name: Set up Node 20
+      - name: Set up Node 24
         uses: actions/setup-node@v7
         with:
-          node-version: "20"
+          node-version: "24"
           cache: npm
           cache-dependency-path: saiku-ui/package-lock.json
       - name: Install deps

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -276,10 +276,10 @@ jobs:
     needs: [jar]
     steps:
       - uses: actions/checkout@v7
-      - name: Set up Node 20
+      - name: Set up Node 24
         uses: actions/setup-node@v7
         with:
-          node-version: "20"
+          node-version: "24"
           registry-url: "https://registry.npmjs.org"
           cache: npm
           cache-dependency-path: saiku-ui/package-lock.json


### PR DESCRIPTION
## Summary
jsdom 30 (dependabot #1653) cannot run on our CI: its undici 8 webidl layer needs `worker_threads.markAsUncloneable`, which does not exist on Node 20, so every vitest forks worker crashes at startup (`TypeError: webidl.util.markAsUncloneable is not a function`). jsdom 30 raised its engines floor to `^22.22.2 || ^24.15.0 || >=26`.

## The change
- `.github/workflows/ci.yml` ui job: `node-version: 20` -> `24`
- `.github/workflows/release.yml` embed-bundle job: same bump, kept in lockstep

Node 24 is the active LTS, satisfies jsdom 30, and matches the `@types/node` 26 direction already merged in #1647.

## Verified
- Full saiku-ui suite runs green on Node 22+ against BOTH jsdom 29 (current dev baseline) and jsdom 30 (the #1653 branch): 1639/1640, the single failure being a pre-existing Windows-only load flake that reproduces identically on both jsdom versions and passes in isolation.
- No vitest or undici bumps required (vitest 4.1.10 is compatible).

## Test plan
- This PR's own CI run is the real test: the ui job must pass `npm ci` + svelte-check + vitest + build on Node 24.
- After merge: re-run #1653 (jsdom 30) CI - expected green, unblocking that bump.

## Notes
Workflow-only change; dependabot cannot modify workflows itself, which is why this lands separately from #1653.