### PR TITLE
fix(deps): bump angus-mail 2.0.3 -> 2.0.4 (CVE-2025-7962)

### DIFF
--- a/saiku-bom/pom.xml
+++ b/saiku-bom/pom.xml
@@ -808,7 +808,9 @@
             <dependency>
                 <groupId>org.eclipse.angus</groupId>
                 <artifactId>angus-mail</artifactId>
-                <version>2.0.3</version>
+                <!-- 2.0.4 fixes CVE-2025-7962 (SMTP CR/LF injection in the
+                     transport, GHSA-9342-92gg-6v29). Keep >= 2.0.4. -->
+                <version>2.0.4</version>
             </dependency>
             <!-- GreenMail 2.x: in-process SMTP server for SmtpMailSenderTest.
                  2.x supports the Jakarta namespace (1.x is javax) — required


### PR DESCRIPTION
## Summary
Our Jakarta Mail runtime implementation, angus-mail 2.0.3, carries CVE-2025-7962 / GHSA-9342-92gg-6v29 - SMTP CR/LF injection in the transport (CWE-147, CVSS4 6.0 Medium). Fixed upstream in 2.0.4. This is the actual vulnerability remediation companion to the dependabot #1650 jakarta.mail-api bump, which only touched the (never-vulnerable) API jar.

## The change
One line in `saiku-bom/pom.xml`: angus-mail 2.0.3 -> 2.0.4, plus a comment pinning the CVE context so a future downgrade trips over it. saiku-service inherits the version from the BOM; no other pom declares it.

## Verified
Mail suite green on the branch (JDK 21): `MailConfigTest` 10/0, `MailMessageTest` 3/0, `MailSenderFactoryTest` 2/0, `NoopMailSenderTest` 2/0, `SmtpMailSenderTest` 1/0 - 18/18 total. `SmtpMailSenderTest` is a GreenMail round-trip, so the bumped SMTP transport is exercised end-to-end, not just resolved.

## Test plan
- CI `build` job (full reactor verify) on this PR.
- Existing recipient-binding hardening tests continue to pass (nothing in that surface changes).

## Notes
Scanner blind spot worth remembering: OSV/dependabot flag the fine-grained `org.eclipse.angus:smtp` module, not the `angus-mail` uber-jar we depend on - which is why no bot ever offered this bump. Reachability today is low (server-configured recipient binding, strict address validation, CRLF-stripped subjects), but the transport-level fix removes the bug class underneath that hardening.