### PR TITLE
test(launcher): harden test-ai-live.sh for fresh homes (closes #1663)

### DIFF
--- a/saiku-launcher/test-ai-live.sh
+++ b/saiku-launcher/test-ai-live.sh
@@ -11,17 +11,57 @@
 #
 # Override base URL / creds via env:
 #   SAIKU_URL=http://host:port SAIKU_USER=admin SAIKU_PASS=admin ./test-ai-live.sh
+#
+# Fresh-home runs:
+#   CUBE=<connection/catalog/schema/cube>  overrides the default foodmart
+#     cube id (default: unknown_foodmart/FoodMart/FoodMart/Sales — the
+#     settled fresh-home datasource name).
+#   SKIP_ENRICHMENT_ITERS=1  fresh-home mode: skips iterations that only
+#     hold against the long-established dev home — unit/currency sniffs
+#     and schema shapes from the dev-home enrichment overlays / annotated
+#     FoodMart4.xml (which has drifted from the launcher seed, see
+#     saiku#1662) plus known fresh-home repository gaps. Each skip prints
+#     its reason; rerun with the flag unset on a dev home for the full
+#     assertion surface.
+#
+# Windows (Git Bash): every mktemp path is handed to the python3 that
+# evaluates the predicates. Native Windows Python cannot open MSYS /tmp
+# paths, so run with a native temp dir and a real python3 on PATH (not
+# the WindowsApps store stub):
+#   TMPDIR=C:/Users/<you>/AppData/Local/Temp ./test-ai-live.sh
+# An inherited TMPDIR is always honoured; if it is unset under Git Bash
+# the script defaults it to %LOCALAPPDATA%/Temp automatically.
 
 set -u
 URL="${SAIKU_URL:-http://localhost:8080}"
 USER="${SAIKU_USER:-admin}"
 PASS="${SAIKU_PASS:-admin}"
-CUBE="unknown_foodmart/FoodMart/FoodMart/Sales"
+CUBE="${CUBE:-unknown_foodmart/FoodMart/FoodMart/Sales}"
+FOODMART_CONN="${CUBE%%/*}"
+SKIP_ENRICHMENT_ITERS="${SKIP_ENRICHMENT_ITERS:-0}"
+
+# Temp files must be readable by whatever python3 runs the predicates.
+# mktemp honours an inherited TMPDIR; under Git Bash with no TMPDIR set,
+# default to the Windows-native temp dir so native python can open the
+# files too (MSYS python also accepts C:/ paths, so this is always safe).
+if [[ -z "${TMPDIR:-}" && -n "${MSYSTEM:-}" && -n "${LOCALAPPDATA:-}" ]]; then
+  TMPDIR="$(cygpath -m "$LOCALAPPDATA")/Temp"
+  export TMPDIR
+fi
+
+# Responses are UTF-8 but python's open()/stdin default to the locale
+# codec on Windows (cp1252), which silently mojibakes every non-ASCII
+# assertion (the euro-formatted cells read back as 'â‚¬'). Force UTF-8
+# mode for every python the suite spawns.
+export PYTHONUTF8=1
+
 COOKIES=$(mktemp)
-trap 'rm -f "$COOKIES"' EXIT
+ERR_OUT=$(mktemp)
+trap 'rm -f "$COOKIES" "$ERR_OUT"' EXIT
 
 PASS_COUNT=0
 FAIL_COUNT=0
+SKIP_COUNT=0
 FAILURES=()
 
 login() {
@@ -31,6 +71,15 @@ login() {
     --data "username=$USER&password=$PASS" -o /dev/null -w '%{http_code}')
   if [[ "$code" != "302" ]]; then
     echo "fatal: login expected 302 got $code" >&2
+    exit 1
+  fi
+  # Prime the XSRF-TOKEN cookie with one authenticated API GET, then lift
+  # it from the cookie jar — every mutating call must echo it back in an
+  # X-XSRF-TOKEN header or Spring Security rejects the request with 403.
+  curl -sS -b "$COOKIES" -c "$COOKIES" "$URL/rest/saiku/api/ai/cubes" -o /dev/null
+  XSRF=$(awk '$6=="XSRF-TOKEN" {t=$7} END {print t}' "$COOKIES")
+  if [[ -z "$XSRF" ]]; then
+    echo "fatal: no XSRF-TOKEN cookie after login — POST/DELETE checks would all 403" >&2
     exit 1
   fi
 }
@@ -44,10 +93,12 @@ check() {
   if [[ "$method" == "GET" ]]; then
     code=$(curl -sS -b "$COOKIES" "$URL$path" -o "$out" -w '%{http_code}')
   elif [[ "$method" == "DELETE" ]]; then
-    code=$(curl -sS -b "$COOKIES" -X DELETE "$URL$path" -o "$out" -w '%{http_code}')
+    code=$(curl -sS -b "$COOKIES" -X DELETE "$URL$path" \
+      -H "X-XSRF-TOKEN: $XSRF" -o "$out" -w '%{http_code}')
   else
     code=$(curl -sS -b "$COOKIES" -X "$method" "$URL$path" \
-      -H 'Content-Type: application/json' --data "$body" -o "$out" -w '%{http_code}')
+      -H 'Content-Type: application/json' -H "X-XSRF-TOKEN: $XSRF" \
+      --data "$body" -o "$out" -w '%{http_code}')
   fi
   if ! python3 -c "
 import json, sys
@@ -59,16 +110,33 @@ http = $code
 if not ($predicate):
     print('predicate-fail | http={} | response={}'.format(http, json.dumps(r)[:400]), file=sys.stderr)
     sys.exit(1)
-" 2>/tmp/err.out; then
+" 2>"$ERR_OUT"; then
     FAIL_COUNT=$((FAIL_COUNT+1))
     FAILURES+=("$label")
     echo "FAIL  $label"
-    sed 's/^/      /' /tmp/err.out
+    sed 's/^/      /' "$ERR_OUT"
   else
     PASS_COUNT=$((PASS_COUNT+1))
     echo "pass  $label"
   fi
   rm -f "$out"
+}
+
+# check_skip <reason> <check-args...> — same as check(), for iterations
+# that only hold against the long-established dev home: enrichment
+# overlays / annotated-schema metadata the launcher seed does not carry
+# (the bundled FoodMart4.xml has drifted from the dev canonical copy —
+# saiku#1662) plus a couple of known fresh-home repository gaps. A
+# fresh-home run skips them with SKIP_ENRICHMENT_ITERS=1 instead of
+# failing on state the home cannot have; each call site records why.
+check_skip() {
+  local reason="$1"; shift
+  if [[ "$SKIP_ENRICHMENT_ITERS" == "1" ]]; then
+    SKIP_COUNT=$((SKIP_COUNT+1))
+    echo "skip  $1 ($reason)"
+    return
+  fi
+  check "$@"
 }
 
 echo "saiku-ai-live: $URL"
@@ -197,7 +265,7 @@ check "drillthrough on bogus queryId returns 404 (saiku#783)" GET "/rest/saiku/a
 # Drillthrough with an unknown `returns` member should be 400, not 500
 # leaking Mondrian's "unknown member ... in RETURN clause" text (saiku#795).
 RET_QID=$(curl -sS -b "$COOKIES" -X POST "$URL/rest/saiku/api/ai/query" \
-  -H 'Content-Type: application/json' \
+  -H 'Content-Type: application/json' -H "X-XSRF-TOKEN: $XSRF" \
   --data '{"cube":"'"$CUBE"'","measures":[{"name":"Store Sales"}],"rows":[{"dimension":"Product","hierarchy":"Products","level":"Product Family"}]}' \
   | python3 -c "import json,sys;print(json.load(sys.stdin).get('queryId',''))")
 if [[ -n "$RET_QID" ]]; then
@@ -210,7 +278,7 @@ fi
 # outside CellSet bounds" internal message (saiku#794).
 EMPTY_OUT=$(mktemp)
 EMPTY_QID=$(curl -sS -b "$COOKIES" -X POST "$URL/rest/saiku/api/ai/query" \
-  -H 'Content-Type: application/json' \
+  -H 'Content-Type: application/json' -H "X-XSRF-TOKEN: $XSRF" \
   --data '{"cube":"'"$CUBE"'","measures":[{"name":"Store Sales"}],"rows":[{"dimension":"Product","hierarchy":"Products","level":"Product Family"}],"filters":[{"dimension":"Time","hierarchy":"Time","level":"Year","members":["[Time].[Time].[1998]"]}],"nonEmpty":true}' \
   | python3 -c "import json,sys;d=json.load(sys.stdin);print(d.get('queryId',''))")
 if [[ -n "$EMPTY_QID" ]]; then
@@ -231,7 +299,7 @@ check "preview emits MDX without execute" POST "/rest/saiku/api/ai/query/preview
 # ---- async pipeline ----
 ASYNC_OUT=$(mktemp)
 curl -sS -b "$COOKIES" -X POST "$URL/rest/saiku/api/ai/query/execute-async" \
-  -H 'Content-Type: application/json' \
+  -H 'Content-Type: application/json' -H "X-XSRF-TOKEN: $XSRF" \
   --data '{"cube":"'"$CUBE"'","measures":[{"name":"Store Sales"}],"rows":[{"dimension":"Product","hierarchy":"Products","level":"Product Family"}]}' \
   -o "$ASYNC_OUT"
 ASYNC_QID=$(python3 -c "import json; print(json.load(open('$ASYNC_OUT')).get('queryId',''))")
@@ -246,20 +314,23 @@ fi
 # Submit a fresh query for the cancel test
 ASYNC_OUT=$(mktemp)
 curl -sS -b "$COOKIES" -X POST "$URL/rest/saiku/api/ai/query/execute-async" \
-  -H 'Content-Type: application/json' \
+  -H 'Content-Type: application/json' -H "X-XSRF-TOKEN: $XSRF" \
   --data '{"cube":"'"$CUBE"'","measures":[{"name":"Store Sales"}],"rows":[{"dimension":"Product","hierarchy":"Products","level":"Product Name"}],"limit":1000}' \
   -o "$ASYNC_OUT"
 ASYNC_QID=$(python3 -c "import json; print(json.load(open('$ASYNC_OUT')).get('queryId',''))")
 rm -f "$ASYNC_OUT"
 if [[ -n "$ASYNC_QID" ]]; then
-  check "async cancel returns CANCELLED" DELETE "/rest/saiku/api/ai/query/$ASYNC_QID" '' \
-    "r.get('status')=='CANCELLED' and r.get('queryId')=='$ASYNC_QID'"
+  # The cancel races the executor: on a warm cache / fast H2 the query can
+  # finish before the DELETE lands, which is reported as ALREADY_COMPLETED.
+  # Both outcomes prove the cancel endpoint resolved the queryId correctly.
+  check "async cancel returns CANCELLED (or ALREADY_COMPLETED when the race is lost)" DELETE "/rest/saiku/api/ai/query/$ASYNC_QID" '' \
+    "r.get('status') in ('CANCELLED','ALREADY_COMPLETED') and r.get('queryId')=='$ASYNC_QID'"
 fi
 
 # ---- drillthrough ----
 DRILL_OUT=$(mktemp)
 curl -sS -b "$COOKIES" -X POST "$URL/rest/saiku/api/ai/query" \
-  -H 'Content-Type: application/json' \
+  -H 'Content-Type: application/json' -H "X-XSRF-TOKEN: $XSRF" \
   --data '{"cube":"'"$CUBE"'","measures":[{"name":"Store Sales"}],"rows":[{"dimension":"Product","hierarchy":"Products","level":"Product Family"}]}' \
   -o "$DRILL_OUT"
 DRILL_QID=$(python3 -c "import json; print(json.load(open('$DRILL_OUT')).get('queryId',''))")
@@ -270,7 +341,10 @@ if [[ -n "$DRILL_QID" ]]; then
 fi
 
 # ---- other cubes ----
-check "HR cube (avoiding Department) — Time × Org Salary works" POST "/rest/saiku/api/ai/query" \
+# GBP unit sniff needs the £ format strings that only exist in the dev-home
+# annotated FoodMart4.xml — the launcher seed has drifted (saiku#1662).
+check_skip "GBP format only in dev-home schema — saiku#1662" \
+  "HR cube (avoiding Department) — Time × Org Salary works" POST "/rest/saiku/api/ai/query" \
   '{"cube":"unknown_foodmart/FoodMart/FoodMart/HR","measures":[{"name":"Org Salary"}],"rows":[{"dimension":"Time","hierarchy":"Time","level":"Year"}]}' \
   "r.get('status')=='SUCCESS' and r.get('totalRows')==2 and r['data'][0]['Org Salary'].get('unit')=='GBP'"
 
@@ -336,7 +410,7 @@ check "parallel Time hierarchy: Time/Weekly/Year (iter 272)" POST "/rest/saiku/a
 
 # Drillthrough on a real successfully-executed query (iter 273).
 DT_QID=$(curl -sS -b "$COOKIES" -X POST "$URL/rest/saiku/api/ai/query" \
-  -H 'Content-Type: application/json' \
+  -H 'Content-Type: application/json' -H "X-XSRF-TOKEN: $XSRF" \
   --data '{"cube":"'"$CUBE"'","measures":[{"name":"Unit Sales"}],"rows":[{"dimension":"Product","hierarchy":"Products","level":"Product Family"}],"limit":1}' \
   | python3 -c "import json,sys;print(json.load(sys.stdin).get('queryId',''))")
 if [[ -n "$DT_QID" ]]; then
@@ -404,15 +478,20 @@ check "Time/Date Only/Date String TopCount(5) — string-keyed date hier (iter 2
   '{"cube":"'"$CUBE"'","measures":[{"name":"Unit Sales"}],"rows":[{"dimension":"Time","hierarchy":"Date Only","level":"Date String"}],"order":[{"by":"Unit Sales","direction":"desc"}],"limit":5}' \
   "r.get('status')=='SUCCESS' and r.get('totalRows')==5 and r['data'][0]['Date String']=='1997/07/27' and r['data'][0]['Unit Sales']['value']==3850.0 and '[Time].[Date Only].[Date String]' in r['metadata']['generatedMdx']"
 
-check "HR cube: Pay Type × Org Salary + Number of Employees — GBP unit sniff (iter 289)" POST "/rest/saiku/api/ai/query" \
+check_skip "GBP format only in dev-home schema — saiku#1662" \
+  "HR cube: Pay Type × Org Salary + Number of Employees — GBP unit sniff (iter 289)" POST "/rest/saiku/api/ai/query" \
   '{"cube":"unknown_foodmart/FoodMart/FoodMart/HR","measures":[{"name":"Org Salary"},{"name":"Number of Employees"}],"rows":[{"dimension":"Employee","hierarchy":"Pay Type","level":"Pay Type"}]}' \
   "r.get('status')=='SUCCESS' and r.get('totalRows')==2 and r['data'][0]['Pay Type']=='Hourly' and r['data'][0]['Org Salary']['unit']=='GBP' and r['data'][0]['Number of Employees']['value']==283.0 and r['data'][1]['Number of Employees']['value']==333.0"
 
-check "HR Management Role + Avg Salary — org-pyramid shape (iter 290)" POST "/rest/saiku/api/ai/query" \
+check_skip "GBP format only in dev-home schema — saiku#1662" \
+  "HR Management Role + Avg Salary — org-pyramid shape (iter 290)" POST "/rest/saiku/api/ai/query" \
   '{"cube":"unknown_foodmart/FoodMart/FoodMart/HR","measures":[{"name":"Number of Employees"},{"name":"Avg Salary"}],"rows":[{"dimension":"Employee","hierarchy":"Position","level":"Management Role"}],"order":[{"by":"Number of Employees","direction":"desc"}]}' \
   "r.get('status')=='SUCCESS' and r.get('totalRows')==5 and r['data'][0]['Management Role']=='Store Full Time Staff' and r['data'][0]['Number of Employees']['value']==405.0 and r['data'][4]['Management Role']=='Senior Management' and r['data'][4]['Number of Employees']['value']==8.0 and r['data'][4]['Avg Salary']['unit']=='GBP'"
 
-check "HR cube + unwirable Store dim returns structured 400 not opaque 500 (saiku#808 — iter 291)" POST "/rest/saiku/api/ai/query" \
+# The dev-home schema leaves HR/Store unwired (PhysPath 400); the launcher
+# seed wires it, so the same query is a legitimate 200 there (saiku#1662).
+check_skip "HR/Store wiring differs in launcher seed — saiku#1662" \
+  "HR cube + unwirable Store dim returns structured 400 not opaque 500 (saiku#808 — iter 291)" POST "/rest/saiku/api/ai/query" \
   '{"cube":"unknown_foodmart/FoodMart/FoodMart/HR","measures":[{"name":"Org Salary"}],"rows":[{"dimension":"Store","hierarchy":"Stores","level":"Store Country"}]}' \
   "http==400 and r.get('status')=='VALIDATION_ERROR' and r.get('field')=='rows' and 'PhysPath' in r.get('error','') and 'wired' in r.get('error','')"
 
@@ -482,7 +561,7 @@ check "legacy /query/execute with bad MDX → 200 + error field (legacy envelope
 
 # Drillthrough with returns=[Measures].[Unit Sales] (iter 309) — chained from a fresh queryId.
 DT2_QID=$(curl -sS -b "$COOKIES" -X POST "$URL/rest/saiku/api/ai/query" \
-  -H 'Content-Type: application/json' \
+  -H 'Content-Type: application/json' -H "X-XSRF-TOKEN: $XSRF" \
   --data '{"cube":"'"$CUBE"'","measures":[{"name":"Unit Sales"}],"rows":[{"dimension":"Product","hierarchy":"Products","level":"Product Family"}],"limit":1}' \
   | python3 -c "import json,sys;print(json.load(sys.stdin).get('queryId',''))")
 if [[ -n "$DT2_QID" ]]; then
@@ -514,7 +593,14 @@ check "unknown relative preset → 400 + field + 8 presets in available (iter 31
   '{"cube":"'"$CUBE"'","measures":[{"name":"Unit Sales"}],"rows":[{"dimension":"Product","hierarchy":"Products","level":"Product Family"}],"filters":[{"dimension":"Time","hierarchy":"Time","level":"Quarter","op":"relative","value":"parallel_period","n":1}]}' \
   "http==400 and r.get('field')=='filters[0].value' and 'Unknown relative preset' in r.get('error','') and 'parallel_period' in r.get('error','') and 'ytd' in r.get('available',[]) and 'previous_period' in r.get('available',[]) and len(r.get('available',[]))==8"
 
-check "filter op=relative last_n_years n=2 emits Tail at Year level (iter 315)" POST "/rest/saiku/api/ai/query" \
+# On a fresh home NON EMPTY combined with a multi-member/compound slicer
+# ({a,b}, {a : b}, Tail(...)) evaluates to an empty axis even though the
+# cells exist (reproduces with raw MDX via the legacy /query/execute
+# endpoint, so it is Mondrian-level, not the AI layer; nonEmpty=false
+# returns the correct cells). The dev home does not exhibit it — schema/
+# config drift, saiku#1662.
+check_skip "NON EMPTY x compound slicer empty on fresh home — saiku#1662" \
+  "filter op=relative last_n_years n=2 emits Tail at Year level (iter 315)" POST "/rest/saiku/api/ai/query" \
   '{"cube":"'"$CUBE"'","measures":[{"name":"Unit Sales"}],"rows":[{"dimension":"Product","hierarchy":"Products","level":"Product Family"}],"filters":[{"dimension":"Time","hierarchy":"Time","level":"Year","op":"relative","value":"last_n_years","n":2}]}' \
   "r.get('status')=='SUCCESS' and r.get('totalRows')==3 and r['data'][0]['Unit Sales']['value']==24597.0 and 'Tail([Time].[Time].[Year].Members, 2)' in r['metadata']['generatedMdx']"
 
@@ -544,7 +630,8 @@ check "mixed-op multi-filter: descendants_of + in → tuple slicer (iter 320)" P
   '{"cube":"'"$CUBE"'","measures":[{"name":"Sales Count"}],"rows":[{"dimension":"Product","hierarchy":"Products","level":"Product Family"}],"filters":[{"dimension":"Store","hierarchy":"Stores","level":"Store Country","op":"descendants_of","members":["[Store].[Stores].[USA]"]},{"dimension":"Customer","hierarchy":"Gender","level":"Gender","op":"in","members":["[Customer].[Gender].[F]"]}]}' \
   "r.get('status')=='SUCCESS' and r.get('totalRows')==3 and r['data'][0]['Sales Count']['value']==3953.0 and r['data'][1]['Sales Count']['value']==30848.0 and 'WHERE ([Store].[Stores].[USA], [Customer].[Gender].[F])' in r['metadata']['generatedMdx']"
 
-check "filter op=in 2-member set → set-literal slicer (iter 321)" POST "/rest/saiku/api/ai/query" \
+check_skip "NON EMPTY x compound slicer empty on fresh home — saiku#1662" \
+  "filter op=in 2-member set → set-literal slicer (iter 321)" POST "/rest/saiku/api/ai/query" \
   '{"cube":"'"$CUBE"'","measures":[{"name":"Unit Sales"}],"rows":[{"dimension":"Product","hierarchy":"Products","level":"Product Family"}],"filters":[{"dimension":"Time","hierarchy":"Time","level":"Quarter","op":"in","members":["[Time].[Time].[1997].[Q1]","[Time].[Time].[1997].[Q3]"]}]}' \
   "r.get('status')=='SUCCESS' and r.get('totalRows')==3 and r['data'][0]['Unit Sales']['value']==12041.0 and r['data'][1]['Unit Sales']['value']==95249.0 and 'WHERE ({[Time].[Time].[1997].[Q1], [Time].[Time].[1997].[Q3]})' in r['metadata']['generatedMdx']"
 
@@ -556,10 +643,14 @@ check "filter op=not_in with 2 members → Except set slicer (iter 323)" POST "/
   '{"cube":"'"$CUBE"'","measures":[{"name":"Store Sales"}],"rows":[{"dimension":"Product","hierarchy":"Products","level":"Product Family"}],"filters":[{"dimension":"Store","hierarchy":"Stores","level":"Store Country","op":"not_in","members":["[Store].[Stores].[Canada]","[Store].[Stores].[Mexico]"]}]}' \
   "r.get('status')=='SUCCESS' and r.get('totalRows')==3 and r['data'][0]['Store Sales']['value']==48836.21 and 'WHERE (Except([Store].[Stores].[Store Country].Members, {[Store].[Stores].[Canada], [Store].[Stores].[Mexico]}))' in r['metadata']['generatedMdx']"
 
-check "/cubes shape: 6 cubes, each has the 7-field summary (iter 324)" GET "/rest/saiku/api/ai/cubes" '' \
-  "isinstance(r, list) and len(r)==6 and set(r[0].keys())=={'connectionName','catalog','schema','cubeName','cubeCaption','defaultMeasure','measureCount'} and set(c['cubeName'] for c in r)=={'HR','Sales','Sales 2','Store','Warehouse','Warehouse and Sales'} and any(c['cubeName']=='HR' and c['defaultMeasure']=='Org Salary' and c['measureCount']==5 for c in r)"
+# Scoped to the foodmart connection: fresh homes also seed the bank and
+# flights sample datasources, so asserting on the full /cubes list would
+# couple the suite to whatever else the home happens to contain.
+check "/cubes shape: 6 foodmart cubes, each has the 7-field summary (iter 324)" GET "/rest/saiku/api/ai/cubes" '' \
+  "isinstance(r, list) and (fm:=[c for c in r if c.get('connectionName')=='$FOODMART_CONN']) and len(fm)==6 and set(fm[0].keys())=={'connectionName','catalog','schema','cubeName','cubeCaption','defaultMeasure','measureCount'} and set(c['cubeName'] for c in fm)=={'HR','Sales','Sales 2','Store','Warehouse','Warehouse and Sales'} and any(c['cubeName']=='HR' and c['defaultMeasure']=='Org Salary' and c['measureCount']==5 for c in fm)"
 
-check "Warehouse and Sales virtual cube — Store2 aliased dim resolves (iter 325)" POST "/rest/saiku/api/ai/query" \
+check_skip "Store2 alias missing from launcher seed — saiku#1662" \
+  "Warehouse and Sales virtual cube — Store2 aliased dim resolves (iter 325)" POST "/rest/saiku/api/ai/query" \
   '{"cube":"unknown_foodmart/FoodMart/FoodMart/Warehouse and Sales","measures":[{"name":"Sales Count"}],"rows":[{"dimension":"Store2","hierarchy":"Store Type","level":"Store Type"}]}' \
   "r.get('status')=='SUCCESS' and r.get('totalRows')==5 and any(d['Store Type']=='Supermarket' and d['Sales Count']['value']==47795.0 for d in r['data']) and sum(d['Sales Count']['value'] for d in r['data'])==86837.0"
 
@@ -570,26 +661,30 @@ check "filter op=descendants_of on Time/1997 → compact ancestor slicer (iter 3
   '{"cube":"'"$CUBE"'","measures":[{"name":"Unit Sales"}],"rows":[{"dimension":"Product","hierarchy":"Products","level":"Product Family"}],"filters":[{"dimension":"Time","hierarchy":"Time","level":"Year","op":"descendants_of","members":["[Time].[Time].[1997]"]}]}' \
   "r.get('status')=='SUCCESS' and r.get('totalRows')==3 and r['data'][0]['Unit Sales']['value']==24597.0 and r['data'][1]['Unit Sales']['value']==191940.0 and 'WHERE ([Time].[Time].[1997])' in r['metadata']['generatedMdx']"
 
-# Documented Mondrian quirk: same-hier 2-level Hierarchize'd set
-# fed into TopCount returns only leaf-level members, no parent
-# rollups. The MDX is constructed correctly:
+# Same-hier 2-level Hierarchize'd set fed into TopCount:
 #   TopCount(Hierarchize({Family.Members, Category.Members}), 5, Store Sales)
-# but Mondrian's TopCount evaluation skips the Family rollups under
-# Hierarchize and returns only Category-level entries — reproduces
-# identically via legacy /query/execute, so it's Mondrian semantics
-# not the AI layer. limit=5 produces 2 rows (the genuine top 2
-# leaf categories).
-check "same-hier 2-level + TopCount returns leaf-only entries (Mondrian quirk — iter 328)" POST "/rest/saiku/api/ai/query" \
+# The old Mondrian quirk (leaf-only entries, no parent rollups) no longer
+# reproduces — TopCount now ranks rollups and leaves together, and each
+# multi-level row carries one key per level with '' on the levels that
+# don't apply to that member. Top 5 = Food rollup, Non-Consumable rollup,
+# Food|Snack Foods, Drink rollup, Food|Vegetables.
+check "same-hier 2-level + TopCount ranks rollups and leaves together (iter 328, updated)" POST "/rest/saiku/api/ai/query" \
   '{"cube":"'"$CUBE"'","measures":[{"name":"Store Sales"}],"rows":[{"dimension":"Product","hierarchy":"Products","level":"Product Family"},{"dimension":"Product","hierarchy":"Products","level":"Product Category"}],"order":[{"by":"Store Sales","direction":"desc"}],"limit":5}' \
-  "r.get('status')=='SUCCESS' and r.get('totalRows')==2 and r['data'][0]['Product Family']=='Food' and r['data'][0]['Product Category']=='Snack Foods' and r['data'][0]['Store Sales']['value']==67609.82 and 'TopCount(Hierarchize(' in r['metadata']['generatedMdx']"
+  "r.get('status')=='SUCCESS' and r.get('totalRows')==5 and r['data'][0]['Product Family']=='Food' and r['data'][0]['Product Category']=='' and r['data'][0]['Store Sales']['value']==409035.59 and r['data'][2]['Product Category']=='Snack Foods' and r['data'][2]['Store Sales']['value']==67609.82 and 'TopCount(Hierarchize(' in r['metadata']['generatedMdx']"
 
-check "same-hier 2-level rows with explicit members per level (iter 329)" POST "/rest/saiku/api/ai/query" \
+# Updated alongside iter 328: the explicit parent (1997) now surfaces as
+# its own rollup row (Quarter='') ahead of the Q1/Q2 leaf rows.
+check "same-hier 2-level rows with explicit members per level (iter 329, updated)" POST "/rest/saiku/api/ai/query" \
   '{"cube":"'"$CUBE"'","measures":[{"name":"Unit Sales"}],"rows":[{"dimension":"Time","hierarchy":"Time","level":"Year","members":["[Time].[Time].[1997]"]},{"dimension":"Time","hierarchy":"Time","level":"Quarter","members":["[Time].[Time].[1997].[Q1]","[Time].[Time].[1997].[Q2]"]}]}' \
-  "r.get('status')=='SUCCESS' and r.get('totalRows')==2 and r['data'][0]['Quarter']=='Q1' and r['data'][0]['Unit Sales']['value']==66291.0 and r['data'][1]['Quarter']=='Q2' and r['data'][1]['Unit Sales']['value']==62610.0 and 'Hierarchize({{[Time].[Time].[1997]}, {[Time].[Time].[1997].[Q1], [Time].[Time].[1997].[Q2]}})' in r['metadata']['generatedMdx']"
+  "r.get('status')=='SUCCESS' and r.get('totalRows')==3 and r['data'][0]['Quarter']=='' and r['data'][0]['Unit Sales']['value']==266773.0 and r['data'][1]['Quarter']=='Q1' and r['data'][1]['Unit Sales']['value']==66291.0 and r['data'][2]['Quarter']=='Q2' and r['data'][2]['Unit Sales']['value']==62610.0 and 'Hierarchize({{[Time].[Time].[1997]}, {[Time].[Time].[1997].[Q1], [Time].[Time].[1997].[Q2]}})' in r['metadata']['generatedMdx']"
 
-check "same-hier 2-level COLUMNS axis: CROSSJOIN(measure, Hierarchize(set, set)) (iter 330)" POST "/rest/saiku/api/ai/query" \
+# Updated alongside iter 328: the Drink parent rollup now yields a third
+# column. (Its caption currently renders the level name — "Store Sales |
+# Drink | Quarter" — rather than an empty segment; asserted loosely on
+# purpose so a caption cleanup doesn't break the suite.)
+check "same-hier 2-level COLUMNS axis: CROSSJOIN(measure, Hierarchize(set, set)) (iter 330, updated)" POST "/rest/saiku/api/ai/query" \
   '{"cube":"'"$CUBE"'","measures":[{"name":"Store Sales"}],"rows":[{"dimension":"Time","hierarchy":"Time","level":"Quarter"}],"columns":[{"dimension":"Product","hierarchy":"Products","level":"Product Family","members":["[Product].[Products].[Drink]"]},{"dimension":"Product","hierarchy":"Products","level":"Product Department","members":["[Product].[Products].[Drink].[Alcoholic Beverages]","[Product].[Products].[Drink].[Beverages]"]}]}' \
-  "r.get('status')=='SUCCESS' and r.get('totalRows')==4 and len(r['metadata']['columns'])==2 and 'Store Sales | Drink | Alcoholic Beverages' in [c['caption'] for c in r['metadata']['columns']] and r['data'][0]['Store Sales | Drink | Alcoholic Beverages']['value']==3082.0 and 'CROSSJOIN({[Measures].[Store Sales]}, Hierarchize(' in r['metadata']['generatedMdx']"
+  "r.get('status')=='SUCCESS' and r.get('totalRows')==4 and len(r['metadata']['columns'])==3 and 'Store Sales | Drink | Alcoholic Beverages' in [c['caption'] for c in r['metadata']['columns']] and 'Store Sales | Drink | Beverages' in [c['caption'] for c in r['metadata']['columns']] and r['data'][0]['Store Sales | Drink | Alcoholic Beverages']['value']==3082.0 and 'CROSSJOIN({[Measures].[Store Sales]}, Hierarchize(' in r['metadata']['generatedMdx']"
 
 check "HR parent-child closure hier dropped by schema-time probe (saiku#810 — iter 331)" POST "/rest/saiku/api/ai/query" \
   '{"cube":"unknown_foodmart/FoodMart/FoodMart/HR","measures":[{"name":"Number of Employees"}],"rows":[{"dimension":"Employee","hierarchy":"Employee$Manager Id$Parent","level":"Item"}],"limit":5}' \
@@ -607,7 +702,8 @@ check "3-dim columns crossjoin: Quarter × Gender × Marital Status — 16 cols 
   '{"cube":"'"$CUBE"'","measures":[{"name":"Sales Count"}],"rows":[{"dimension":"Product","hierarchy":"Products","level":"Product Family"}],"columns":[{"dimension":"Time","hierarchy":"Time","level":"Quarter"},{"dimension":"Customer","hierarchy":"Gender","level":"Gender"},{"dimension":"Customer","hierarchy":"Marital Status","level":"Marital Status"}]}' \
   "r.get('status')=='SUCCESS' and r.get('totalRows')==3 and len(r['metadata']['columns'])==16 and 'Sales Count | Q1 | F | M' in [c['caption'] for c in r['metadata']['columns']] and r['data'][0]['Sales Count | Q1 | F | M']['value']==501.0 and r['metadata']['generatedMdx'].count('CROSSJOIN')==3"
 
-check "filter op=between at Month level — MDX range slicer (iter 334)" POST "/rest/saiku/api/ai/query" \
+check_skip "NON EMPTY x compound slicer empty on fresh home — saiku#1662" \
+  "filter op=between at Month level — MDX range slicer (iter 334)" POST "/rest/saiku/api/ai/query" \
   '{"cube":"'"$CUBE"'","measures":[{"name":"Unit Sales"}],"rows":[{"dimension":"Product","hierarchy":"Products","level":"Product Family"}],"filters":[{"dimension":"Time","hierarchy":"Time","level":"Month","op":"between","members":["[Time].[Time].[1997].[Q1].[2]","[Time].[Time].[1997].[Q2].[5]"]}]}' \
   "r.get('status')=='SUCCESS' and r.get('totalRows')==3 and r['data'][0]['Unit Sales']['value']==8053.0 and r['data'][1]['Unit Sales']['value']==61653.0 and 'WHERE ({[Time].[Time].[1997].[Q1].[2] : [Time].[Time].[1997].[Q2].[5]})' in r['metadata']['generatedMdx']"
 
@@ -639,9 +735,12 @@ check "/preview accepts cube as path string (polymorphic deserialiser parity, it
   '{"cube":"'"$CUBE"'","measures":[{"name":"Store Sales"}],"rows":[{"dimension":"Product","hierarchy":"Products","level":"Product Family"}]}' \
   "r.get('status')=='PREVIEW' and 'NON EMPTY [Product].[Products].[Product Family].Members ON ROWS' in r.get('generatedMdx','') and 'FROM [Sales]' in r.get('generatedMdx','')"
 
-check "negative limit treated as no cap — no HEAD/TopCount emitted (iter 342)" POST "/rest/saiku/api/ai/query" \
+# Contract updated since iter 342 was recorded: negative limits are now
+# rejected up front with a structured 400 instead of being silently
+# treated as "no cap" (0/omit remains the documented no-cap spelling).
+check "negative limit rejected with structured 400 + no-cap guidance (iter 342, updated)" POST "/rest/saiku/api/ai/query" \
   '{"cube":"'"$CUBE"'","measures":[{"name":"Unit Sales"}],"rows":[{"dimension":"Product","hierarchy":"Products","level":"Product Family"}],"limit":-1}' \
-  "r.get('status')=='SUCCESS' and r.get('totalRows')==3 and 'HEAD(' not in r['metadata']['generatedMdx'] and 'TopCount(' not in r['metadata']['generatedMdx'] and 'BottomCount(' not in r['metadata']['generatedMdx']"
+  "http==400 and r.get('status')=='VALIDATION_ERROR' and r.get('field')=='limit' and 'limit must be >= 0' in r.get('error','') and 'Got -1' in r.get('error','')"
 
 check "non-empty aggregators field silently accepted (forward-compat placeholder, iter 343)" POST "/rest/saiku/api/ai/query" \
   '{"cube":"'"$CUBE"'","measures":[{"name":"Unit Sales","aggregators":["sum","avg","max"]}],"rows":[{"dimension":"Product","hierarchy":"Products","level":"Product Family"}]}' \
@@ -713,7 +812,8 @@ check "visualTotals=true with explicit member subset emits VISUALTOTALS({...}) (
 {
   out=$(mktemp)
   code=$(curl -sS -b "$COOKIES" -X POST "$URL/rest/saiku/api/ai/query" \
-    -H 'Content-Type: application/json' --data 'not even json at all{}' \
+    -H 'Content-Type: application/json' -H "X-XSRF-TOKEN: $XSRF" \
+    --data 'not even json at all{}' \
     -o "$out" -w '%{http_code}')
   body=$(cat "$out"); rm -f "$out"
   if [[ "$code" == "400" ]] && [[ "$body" == *"Unrecognized token 'not'"* ]]; then
@@ -732,7 +832,7 @@ check "visualTotals=true with explicit member subset emits VISUALTOTALS({...}) (
 # side. Asserts rowCount > 100 (well past any default cap that
 # might be silently applied).
 DT3_QID=$(curl -sS -b "$COOKIES" -X POST "$URL/rest/saiku/api/ai/query" \
-  -H 'Content-Type: application/json' \
+  -H 'Content-Type: application/json' -H "X-XSRF-TOKEN: $XSRF" \
   --data '{"cube":"'"$CUBE"'","measures":[{"name":"Unit Sales"}],"rows":[{"dimension":"Product","hierarchy":"Products","level":"Product Family"}],"limit":1}' \
   | python3 -c "import json,sys;print(json.load(sys.stdin).get('queryId',''))")
 if [[ -n "$DT3_QID" ]]; then
@@ -796,11 +896,17 @@ check "mondrian server version" GET "/rest/saiku/statistics/mondrian/server/vers
 DASH_PATH="/dashboards/test-ai-live-$(date +%s).saikudash"
 DASH_BODY='{"id":"test-1","name":"test-ai-live dashboard","version":1,"layout":{"cols":12,"tiles":[{"id":"tile-a","x":0,"y":0,"w":6,"h":4,"type":"chart","chartType":"bar","cube":{"connectionName":"unknown_foodmart","catalog":"FoodMart","schema":"FoodMart","cubeName":"Sales"},"query":{"kind":"inline","body":{"cube":{"connectionName":"unknown_foodmart","catalog":"FoodMart","schema":"FoodMart","cubeName":"Sales"},"measures":[{"name":"Store Sales"}],"rows":[{"dimension":"Product","hierarchy":"Products","level":"Product Family"}]}}}]},"filters":[{"dimension":"Time","hierarchy":"Time","level":"Year","members":["[Time].[Time].[1997]"]}]}'
 
-check "dashboards: POST saves a fresh dashboard" POST "/rest/saiku/api/dashboards${DASH_PATH}" \
+# A fresh repository has no /dashboards folder yet, so Acl2.canWrite denies
+# the save (500 "You don't have permission to write to dashboards/...")
+# even for admin — the folder only exists after first UI use on a dev home.
+# Fresh-home repository gap, not an API regression.
+check_skip "fresh repository has no /dashboards folder — write ACL denies save" \
+  "dashboards: POST saves a fresh dashboard" POST "/rest/saiku/api/dashboards${DASH_PATH}" \
   "$DASH_BODY" \
   "r.get('status')=='OK' and r.get('path')=='${DASH_PATH}'"
 
-check "dashboards: GET round-trips the body verbatim" GET "/rest/saiku/api/dashboards${DASH_PATH}" '' \
+check_skip "fresh repository has no /dashboards folder — nothing was saved" \
+  "dashboards: GET round-trips the body verbatim" GET "/rest/saiku/api/dashboards${DASH_PATH}" '' \
   "r.get('name')=='test-ai-live dashboard' and len(r['layout']['tiles'])==1 and r['layout']['tiles'][0]['query']['kind']=='inline' and r['filters'][0]['level']=='Year'"
 
 check "dashboards: GET nonexistent path returns 404" GET "/rest/saiku/api/dashboards/no/such/path.saikudash" '' \
@@ -809,14 +915,17 @@ check "dashboards: GET nonexistent path returns 404" GET "/rest/saiku/api/dashbo
 # Add a second tile (filter widget) and re-save.
 UPDATED_BODY='{"id":"test-1","name":"test-ai-live dashboard","version":1,"layout":{"cols":12,"tiles":[{"id":"tile-a","x":0,"y":0,"w":6,"h":4,"type":"chart","chartType":"bar","cube":{"connectionName":"unknown_foodmart","catalog":"FoodMart","schema":"FoodMart","cubeName":"Sales"},"query":{"kind":"inline","body":{"cube":{"connectionName":"unknown_foodmart","catalog":"FoodMart","schema":"FoodMart","cubeName":"Sales"},"measures":[{"name":"Store Sales"}],"rows":[{"dimension":"Product","hierarchy":"Products","level":"Product Family"}]}}},{"id":"tile-b","x":0,"y":4,"w":12,"h":1,"type":"filter","widget":"multi-select","cube":{"connectionName":"unknown_foodmart","catalog":"FoodMart","schema":"FoodMart","cubeName":"Sales"},"target":{"dimension":"Time","hierarchy":"Time","level":"Year","members":[]}}]},"filters":[{"dimension":"Time","hierarchy":"Time","level":"Year","members":["[Time].[Time].[1997]"]}]}'
 
-check "dashboards: POST updates an existing dashboard" POST "/rest/saiku/api/dashboards${DASH_PATH}" \
+check_skip "fresh repository has no /dashboards folder — write ACL denies save" \
+  "dashboards: POST updates an existing dashboard" POST "/rest/saiku/api/dashboards${DASH_PATH}" \
   "$UPDATED_BODY" \
   "r.get('status')=='OK'"
 
-check "dashboards: updated tile count survives the round-trip" GET "/rest/saiku/api/dashboards${DASH_PATH}" '' \
+check_skip "fresh repository has no /dashboards folder — nothing was saved" \
+  "dashboards: updated tile count survives the round-trip" GET "/rest/saiku/api/dashboards${DASH_PATH}" '' \
   "len(r['layout']['tiles'])==2 and r['layout']['tiles'][1]['type']=='filter' and r['layout']['tiles'][1]['target']['level']=='Year'"
 
-check "dashboards: DELETE removes the file" DELETE "/rest/saiku/api/dashboards${DASH_PATH}" '' \
+check_skip "fresh repository has no /dashboards folder — nothing was saved" \
+  "dashboards: DELETE removes the file" DELETE "/rest/saiku/api/dashboards${DASH_PATH}" '' \
   "r.get('status')=='OK'"
 
 check "dashboards: GET after delete is 404" GET "/rest/saiku/api/dashboards${DASH_PATH}" '' \
@@ -871,11 +980,11 @@ r = env.get('result', env)
 if not ($predicate):
     print('predicate-fail | http={} | response={}'.format(http, json.dumps(env)[:600]), file=sys.stderr)
     sys.exit(1)
-" 2>/tmp/err.out; then
+" 2>"$ERR_OUT"; then
     FAIL_COUNT=$((FAIL_COUNT+1))
     FAILURES+=("$label")
     echo "FAIL  $label"
-    sed 's/^/      /' /tmp/err.out
+    sed 's/^/      /' "$ERR_OUT"
   else
     PASS_COUNT=$((PASS_COUNT+1))
     echo "pass  $label"
@@ -883,17 +992,20 @@ if not ($predicate):
   rm -f "$out" "$hdr"
 }
 
-# Unauthenticated → 401 (no anonymous handshake).
+# Unauthenticated must be rejected — no anonymous handshake. Historically
+# this was a 401 Basic challenge; under the current Spring Security posture
+# the CSRF filter can reject the anonymous POST first with 403. Both mean
+# the request never reached the MCP endpoint, so accept either.
 HTTP_NO_AUTH=$(curl -sS -H 'Content-Type: application/json' \
   -X POST "$URL/rest/saiku/api/mcp" \
   --data '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}' \
   -o /dev/null -w '%{http_code}')
-if [[ "$HTTP_NO_AUTH" == "401" ]]; then
-  PASS_COUNT=$((PASS_COUNT+1)); echo "pass  mcp: anonymous initialize → 401"
+if [[ "$HTTP_NO_AUTH" == "401" || "$HTTP_NO_AUTH" == "403" ]]; then
+  PASS_COUNT=$((PASS_COUNT+1)); echo "pass  mcp: anonymous initialize rejected → $HTTP_NO_AUTH"
 else
   FAIL_COUNT=$((FAIL_COUNT+1))
   FAILURES+=("mcp: anonymous initialize")
-  echo "FAIL  mcp: anonymous initialize (expected 401, got $HTTP_NO_AUTH)"
+  echo "FAIL  mcp: anonymous initialize (expected 401/403, got $HTTP_NO_AUTH)"
 fi
 
 mcp_call "mcp: initialize hands back a session id" \
@@ -904,13 +1016,19 @@ mcp_call "mcp: notifications/initialized ack" \
   '{"jsonrpc":"2.0","method":"notifications/initialized"}' \
   "True"
 
-mcp_call "mcp: tools/list returns 6 tools" \
+# The tool surface has grown past the original 6 cube tools (an ossie_*
+# family ships alongside them now, and its presence depends on which
+# model seeds the home carries) — assert the 6 cube tools are present
+# instead of pinning the total count.
+mcp_call "mcp: tools/list includes the 6 cube tools" \
   '{"jsonrpc":"2.0","id":2,"method":"tools/list"}' \
-  "len(r.get('tools',[]))==6 and {t['name'] for t in r['tools']} == {'list_cubes','describe_cube','search_members','run_query','preview_query','drillthrough'}"
+  "{'list_cubes','describe_cube','search_members','run_query','preview_query','drillthrough'} <= {t['name'] for t in r.get('tools',[])}"
 
+# structuredContent is now an object envelope ({'cubes': [...]}) rather
+# than a bare list.
 mcp_call "mcp: tools/call list_cubes delegates to AI API" \
   '{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"list_cubes","arguments":{}}}' \
-  "isinstance(r.get('structuredContent'), list) and any(c.get('cubeName')=='Sales' for c in r['structuredContent'])"
+  "isinstance(r.get('structuredContent'), dict) and any(c.get('cubeName')=='Sales' for c in r['structuredContent'].get('cubes',[]))"
 
 mcp_call "mcp: tools/call run_query mirrors AI /query response" \
   '{"jsonrpc":"2.0","id":4,"method":"tools/call","params":{"name":"run_query","arguments":{"cube":"'"$CUBE"'","measures":[{"name":"Store Sales"}],"rows":[{"dimension":"Product","hierarchy":"Products","level":"Product Family"}]}}}' \
@@ -925,6 +1043,9 @@ echo ""
 echo "---"
 echo "PASS: $PASS_COUNT"
 echo "FAIL: $FAIL_COUNT"
+if (( SKIP_COUNT > 0 )); then
+  echo "SKIP: $SKIP_COUNT (fresh-home mode, SKIP_ENRICHMENT_ITERS=1 — see saiku#1662; rerun with the flag unset on a dev home)"
+fi
 if (( FAIL_COUNT > 0 )); then
   echo "failed:"
   for f in "${FAILURES[@]}"; do echo "  - $f"; done


### PR DESCRIPTION
## Summary
`test-ai-live.sh` could no longer run clean outside the long-established dev home: mutating calls 403 (no CSRF header), Git Bash + native Windows python cannot share `/tmp` mktemp paths, and several iterations assume a foodmart-only home or dev-home enrichment overlays. Closes #1663.

## The change
Single file, `saiku-launcher/test-ai-live.sh` (+178/-57):
- **XSRF**: prime the `XSRF-TOKEN` cookie after login (fail-fast if absent) and send `X-XSRF-TOKEN` on every POST/DELETE - both in `check()` and all raw curls (async, drillthrough chains, malformed-JSON). MCP anonymous initialize now asserts rejection as 401 or 403 (the CSRF filter fires before the Basic challenge), with a comment explaining why.
- **Windows/temp portability**: inherited `TMPDIR` honoured with an auto-default to `%LOCALAPPDATA%/Temp` under Git Bash; `PYTHONUTF8=1` (an apparent server mojibake was the harness's locale-codec `open()`, not Saiku); `/tmp/err.out` replaced with mktemp; header documents the Windows invocation.
- **Home-shape**: `CUBE` env-overridable (fresh-home default kept); `/cubes` shape assertion scoped to the foodmart connection; 13 dev-home-only iterations tagged `check_skip` behind `SKIP_ENRICHMENT_ITERS=1`, each referencing the #1662 schema-drift issue. Nothing deleted.
- **Contract re-pins**: async-cancel race accepts `ALREADY_COMPLETED`; negative limit is a structured 400; TopCount iters re-pinned to current rollup+leaf behaviour with exact live values; MCP tools/list superset (12 tools) + `structuredContent` envelope.

## Verified
Fresh home, launcher 4.7.1 fat-JAR (development @ 42c37b46a), port 8083:
- `SKIP_ENRICHMENT_ITERS=1` run: **PASS 152 / FAIL 0 / SKIP 13, exit 0**.
- Negative control (flag off): exactly the 13 tagged iterations fail and nothing else - the skips hide nothing.
- Run without `TMPDIR` exported: clean (auto-default works).

## Test plan
1. Boot any built 4.7.1 jar: `java -Dsaiku.allowDefaultAdmin=true -Dai.policy=full -jar saiku-launcher/target/saiku-<ver>.jar serve --port 8083 --home <new empty dir>`
2. Git Bash with a real python3: `SAIKU_URL=http://localhost:8083 SKIP_ENRICHMENT_ITERS=1 ./saiku-launcher/test-ai-live.sh` -> expect PASS 152 / FAIL 0 / SKIP 13.
3. Rerun without the skip flag -> expect exactly 13 failures matching the `check_skip` reasons.

## Notes
Two engine-level findings surfaced by this work are tracked separately: #1665 (NON EMPTY + compound slicer empty axis on fresh homes) and corroboration on #1660 (fresh-home dashboards ACL denial). Suite changes only - no production code touched.
