### PR TITLE
fix(ui): send multipart schema upload matching AdminResource contract (closes #1655)

### DIFF
--- a/saiku-ui/src/lib/api/admin.schemas.test.ts
+++ b/saiku-ui/src/lib/api/admin.schemas.test.ts
@@ -1,0 +1,79 @@
+/*
+ * Regression tests for the schema upload wire contract (saiku#1655).
+ *
+ * The bug: adminSchemas.upload() posted application/x-www-form-urlencoded
+ * fields (`name` + `xml`), but the server's AdminResource `POST /admin/schema/{id}`
+ * is @Consumes("multipart/form-data") reading @FormDataParam("file") (InputStream)
+ * + @FormDataParam("name"). Jersey rejected every Cube Designer save and
+ * Admin > Schemas upload with HTTP 415 at the media-type gate. These tests lock
+ * the multipart shape so the body always carries a `file` part with the XML
+ * payload plus a `name` field, with no hand-set Content-Type header (the browser
+ * must generate the multipart boundary itself).
+ */
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { adminSchemas } from "./admin";
+
+const XML = '<?xml version="1.0"?><Schema name="TestSchema"><Cube name="C"/></Schema>';
+
+describe("adminSchemas.upload", () => {
+  let originalFetch: typeof globalThis.fetch;
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+  });
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  test("POSTs multipart FormData with a `file` part carrying the XML and a `name` field", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response("[]", { status: 200 }));
+    globalThis.fetch = fetchMock;
+
+    await adminSchemas.upload("TestSchema", XML);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe("/rest/saiku/admin/schema/TestSchema");
+    expect(init.method).toBe("POST");
+    expect(init.credentials).toBe("include");
+
+    const body = init.body;
+    expect(body).toBeInstanceOf(FormData);
+    const form = body as FormData;
+
+    // The `file` part must be a Blob/File whose bytes are the schema XML.
+    const file = form.get("file");
+    expect(file).toBeInstanceOf(Blob);
+    expect(await (file as Blob).text()).toBe(XML);
+    expect((file as File).name).toBe("TestSchema.xml");
+
+    // AdminResource builds `/datasources/{name}.xml` from the `name` field.
+    expect(form.get("name")).toBe("TestSchema");
+  });
+
+  test("does not hand-set a Content-Type header (browser must own the multipart boundary)", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response("[]", { status: 200 }));
+    globalThis.fetch = fetchMock;
+
+    await adminSchemas.upload("TestSchema", XML);
+
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    const headers = new Headers(init.headers ?? {});
+    expect(headers.get("Content-Type")).toBeNull();
+  });
+
+  test("URL-encodes the schema name in the path", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response("[]", { status: 200 }));
+    globalThis.fetch = fetchMock;
+
+    await adminSchemas.upload("My Schema", XML);
+
+    const [url] = fetchMock.mock.calls[0] as [string];
+    expect(url).toBe("/rest/saiku/admin/schema/My%20Schema");
+  });
+
+  test("throws with the status when the server rejects the upload", async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue(new Response("nope", { status: 415 }));
+    await expect(adminSchemas.upload("TestSchema", XML)).rejects.toThrow("schema upload -> 415");
+  });
+});

--- a/saiku-ui/src/lib/api/admin.ts
+++ b/saiku-ui/src/lib/api/admin.ts
@@ -188,13 +188,24 @@ export const adminDatasources = {
 export const adminSchemas = {
   list: () => get<AdminSchema[]>("/schema"),
   get: (id: string) => get<AdminSchema>(`/schema/${encodeURIComponent(id)}`),
-  upload: async (name: string, xml: string, path?: string) => {
-    const body = new URLSearchParams({ name, xml });
-    if (path) body.set("path", path);
+  /**
+   * saiku#1655: `AdminResource.uploadSchema` (`POST /admin/schema/{id}`) is
+   * `@Consumes("multipart/form-data")` and reads `@FormDataParam("file")` (an InputStream —
+   * the schema XML bytes) plus `@FormDataParam("name")`. The previous urlencoded
+   * `name`+`xml` body never got past Jersey's media-type gate, so every Cube Designer
+   * save and Admin > Schemas upload failed with HTTP 415. The server ignores the file
+   * part's filename and accepts no `path` field — it derives the repository path as
+   * `/datasources/{name}.xml` from the `name` field alone.
+   */
+  upload: async (name: string, xml: string) => {
+    const body = new FormData();
+    body.append("file", new Blob([xml], { type: "application/xml" }), `${name}.xml`);
+    body.append("name", name);
     const res = await fetch(`${BASE}/schema/${encodeURIComponent(name)}`, {
       method: "POST",
       credentials: "include",
-      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      // Deliberately no Content-Type header: the browser must generate the
+      // multipart boundary itself. Setting it manually breaks the upload.
       body,
     });
     if (!res.ok) throw new Error(`schema upload -> ${res.status}`);


### PR DESCRIPTION
## Summary
Cube Designer "Save" and the Admin > Schemas upload form both fail with HTTP 415 (reported in #1655, confirmed on 4.7.1 and current development). The UI client sent `application/x-www-form-urlencoded` with `name`+`xml` fields, while the backend (`AdminResource`, `POST /admin/schema/{id}`) consumes `multipart/form-data` with `file`+`name` parts - Jersey rejects at the media-type gate before any handler runs. Closes #1655.

## The change
`saiku-ui/src/lib/api/admin.ts` - `adminSchemas.upload()` now sends real `FormData`: the XML as a `file` part (`Blob` typed `application/xml`, filename `{name}.xml`) plus the `name` field, with no hand-set Content-Type so the browser generates the multipart boundary. The old optional `path` argument was removed - the server has no such parameter (it hardcodes `/datasources/{name}.xml`) and neither call site passed it. Both call sites (Cube Designer save, Schemas admin upload) are unchanged and typecheck.

New `saiku-ui/src/lib/api/admin.schemas.test.ts` - 4 tests locking the request contract: FormData body, `file` part bytes match the XML + filename, `name` field present, no explicit Content-Type header, URL-encoded path, error propagation. This is the regression net the 415 proved was missing: a client/server contract mismatch was invisible until runtime.

## Verified
- svelte-check: 0 errors. vitest: 1647 pass (the single failure is the pre-existing `saiku-embed.test.ts` beforeEach-timeout flake, which fails identically on clean development and passes in isolation - tracked separately).
- Live end-to-end: fresh-home launcher (4.7.1 fat-JAR) + vite dev, real Admin > Schemas form upload -> 2xx, schema listed, file persisted at `repository/data/unknown/datasources/<name>.xml`, confirmed via `/rest/saiku/admin/schema`. The same client function drives Cube Designer Save.

## Test plan
- CI ui job (svelte-check + vitest incl. the new contract tests + build).
- Manual: on this branch, Admin > Schemas > Upload with any small Mondrian 4 XML succeeds; on development the same action returns 415.

## Notes
The PUT variant (`uploadSchemaPut`) has the identical multipart contract - any future schema-update client code should follow the same shape; the new test file is the reference.
